### PR TITLE
[Waypoint] Support non-genesis waypoints in the node configs.

### DIFF
--- a/aptos-node/src/utils.rs
+++ b/aptos-node/src/utils.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
-use aptos_config::config::{NodeConfig, DEFAULT_CONCURRENCY_LEVEL};
+use aptos_config::config::{NodeConfig, DEFAULT_EXECUTION_CONCURRENCY_LEVEL};
 use aptos_storage_interface::{state_view::LatestDbStateCheckpointView, DbReaderWriter};
 use aptos_types::{
     account_config::CORE_CODE_ADDRESS, account_view::AccountView, chain_id::ChainId,
@@ -51,7 +51,10 @@ pub fn fetch_chain_id(db: &DbReaderWriter) -> anyhow::Result<ChainId> {
 pub fn set_aptos_vm_configurations(node_config: &NodeConfig) {
     AptosVM::set_paranoid_type_checks(node_config.execution.paranoid_type_verification);
     let effective_concurrency_level = if node_config.execution.concurrency_level == 0 {
-        min(DEFAULT_CONCURRENCY_LEVEL, (num_cpus::get() / 2) as u16)
+        min(
+            DEFAULT_EXECUTION_CONCURRENCY_LEVEL,
+            (num_cpus::get() / 2) as u16,
+        )
     } else {
         node_config.execution.concurrency_level
     };

--- a/config/src/config/config_optimizer.rs
+++ b/config/src/config/config_optimizer.rs
@@ -5,8 +5,8 @@ use super::{Identity, IdentityFromConfig, IdentitySource, IndexerGrpcConfig};
 use crate::{
     config::{
         node_config_loader::NodeType, utils::get_config_name, AdminServiceConfig, Error,
-        IndexerConfig, InspectionServiceConfig, LoggerConfig, MempoolConfig, NodeConfig, Peer,
-        PeerRole, PeerSet, StateSyncConfig,
+        ExecutionConfig, IndexerConfig, InspectionServiceConfig, LoggerConfig, MempoolConfig,
+        NodeConfig, Peer, PeerRole, PeerSet, StateSyncConfig,
     },
     network_id::NetworkId,
 };
@@ -105,6 +105,9 @@ impl ConfigOptimizer for NodeConfig {
 
         // Optimize only the relevant sub-configs
         let mut optimizers_with_modifications = vec![];
+        if ExecutionConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
+            optimizers_with_modifications.push(ExecutionConfig::get_optimizer_name());
+        }
         if IndexerConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
             optimizers_with_modifications.push(IndexerConfig::get_optimizer_name());
         }
@@ -308,11 +311,13 @@ fn build_seed_peer(
 mod tests {
     use super::*;
     use crate::{
-        config::{node_startup_config::NodeStartupConfig, NetworkConfig, StorageConfig},
+        config::{
+            node_startup_config::NodeStartupConfig, NetworkConfig, StorageConfig, WaypointConfig,
+        },
         network_id::NetworkId,
     };
     use aptos_crypto::{Uniform, ValidCryptoMaterial};
-    use aptos_types::account_address::AccountAddress;
+    use aptos_types::{account_address::AccountAddress, waypoint::Waypoint};
     use rand::rngs::OsRng;
     use std::{io::Write, path::PathBuf};
     use tempfile::{tempdir, NamedTempFile};
@@ -328,6 +333,9 @@ mod tests {
     fn test_disable_optimizer() {
         // Create a default node config (with optimization enabled)
         let mut node_config = NodeConfig::default();
+
+        // Set the base waypoint config
+        node_config.base.waypoint = WaypointConfig::FromConfig(Waypoint::default());
 
         // Optimize the node config for mainnet VFNs and verify modifications are made
         let modified_config = NodeConfig::optimize(

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -4,19 +4,30 @@
 
 use super::WaypointConfig;
 use crate::config::{
-    config_sanitizer::ConfigSanitizer, node_config_loader::NodeType,
-    transaction_filter_type::Filter, utils::RootPath, Error, NodeConfig,
+    config_optimizer::ConfigOptimizer, config_sanitizer::ConfigSanitizer,
+    node_config_loader::NodeType, transaction_filter_type::Filter, utils::RootPath, Error,
+    NodeConfig,
 };
-use aptos_types::{chain_id::ChainId, transaction::Transaction};
+use aptos_types::{chain_id::ChainId, transaction::Transaction, waypoint::Waypoint};
 use serde::{Deserialize, Serialize};
+use serde_yaml::Value;
 use std::{
     fs::File,
     io::{Read, Write},
     path::PathBuf,
+    str::FromStr,
 };
 
-const GENESIS_DEFAULT: &str = "genesis.blob";
-pub const DEFAULT_CONCURRENCY_LEVEL: u16 = 32;
+// Default execution concurrency level
+pub const DEFAULT_EXECUTION_CONCURRENCY_LEVEL: u16 = 32;
+
+// Genesis constants
+const GENESIS_BLOB_FILENAME: &str = "genesis.blob";
+const GENESIS_VERSION: u64 = 0;
+const MAINNET_GENESIS_WAYPOINT: &str =
+    "0:6072b68a942aace147e0655c5704beaa255c84a7829baa4e72a500f1516584c4";
+const TESTNET_GENESIS_WAYPOINT: &str =
+    "0:4b56f15c1dcef7f9f3eb4b4798c0cba0f1caacc0d35f1c80ad9b7a21f1f8b454";
 
 #[derive(Clone, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -125,7 +136,7 @@ impl ExecutionConfig {
     pub fn save_to_path(&mut self, root_dir: &RootPath) -> Result<(), Error> {
         if let Some(genesis) = &self.genesis {
             if self.genesis_file_location.as_os_str().is_empty() {
-                self.genesis_file_location = PathBuf::from(GENESIS_DEFAULT);
+                self.genesis_file_location = PathBuf::from(GENESIS_BLOB_FILENAME);
             }
             let path = root_dir.full_path(&self.genesis_file_location);
             let mut file = File::create(path).map_err(|e| Error::IO("genesis".into(), e))?;
@@ -169,6 +180,57 @@ impl ConfigSanitizer for ExecutionConfig {
     }
 }
 
+impl ConfigOptimizer for ExecutionConfig {
+    fn optimize(
+        node_config: &mut NodeConfig,
+        local_config_yaml: &Value,
+        _node_type: NodeType,
+        chain_id: Option<ChainId>,
+    ) -> Result<bool, Error> {
+        let execution_config = &mut node_config.execution;
+        let local_execution_config_yaml = &local_config_yaml["execution"];
+
+        // If the base config has a non-genesis waypoint, we should automatically
+        // inject the genesis waypoint into the execution config (if it doesn't exist).
+        // We do this for testnet and mainnet only (as they are long lived networks).
+        if node_config.base.waypoint.waypoint().version() != GENESIS_VERSION
+            && execution_config.genesis_waypoint.is_none()
+            && local_execution_config_yaml["genesis_waypoint"].is_null()
+        {
+            // Determine the genesis waypoint string to use
+            let genesis_waypoint_str = match chain_id {
+                Some(chain_id) => {
+                    if chain_id.is_mainnet() {
+                        MAINNET_GENESIS_WAYPOINT
+                    } else if chain_id.is_testnet() {
+                        TESTNET_GENESIS_WAYPOINT
+                    } else {
+                        return Ok(false); // Return early (this is not testnet or mainnet)
+                    }
+                },
+                None => return Ok(false), // Return early (no chain ID was specified!)
+            };
+
+            // Construct a genesis waypoint from the string
+            let genesis_waypoint = match Waypoint::from_str(genesis_waypoint_str) {
+                Ok(waypoint) => waypoint,
+                Err(error) => panic!(
+                    "Invalid genesis waypoint string: {:?}. Error: {:?}",
+                    genesis_waypoint_str, error
+                ),
+            };
+            let genesis_waypoint_config = WaypointConfig::FromConfig(genesis_waypoint);
+
+            // Inject the genesis waypoint into the execution config
+            execution_config.genesis_waypoint = Some(genesis_waypoint_config);
+
+            return Ok(true); // The config was modified
+        }
+
+        Ok(false) // The config was not modified
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -177,6 +239,140 @@ mod test {
         transaction::{ChangeSet, Transaction, WriteSetPayload},
         write_set::WriteSetMut,
     };
+    use std::{assert_eq, matches, vec};
+
+    // Useful test constants
+    const GENESIS_WAYPOINT: &str =
+        "0:00000000002aace147e0655c5704beaa255c84a7829baa4e72a5000000000000";
+    const NON_GENESIS_WAYPOINT: &str =
+        "100:aaaaaaaaaa2aace147e0655c5704beaa255c84a7829baa4e72a500aaaaaaaaaa";
+
+    #[test]
+    fn test_optimize_execution_config_genesis() {
+        // Create a default node config
+        let mut node_config = NodeConfig::default();
+
+        // Verify the execution config does not have a genesis waypoint
+        assert!(&node_config.execution.genesis_waypoint.is_none());
+
+        // Inject a genesis waypoint into the base config
+        let genesis_waypoint = Waypoint::from_str(GENESIS_WAYPOINT).unwrap();
+        node_config.base.waypoint = WaypointConfig::FromConfig(genesis_waypoint);
+
+        // Optimize the config and verify that no modifications are made
+        let modified_config = ExecutionConfig::optimize(
+            &mut node_config,
+            &serde_yaml::from_str("{}").unwrap(), // An empty local config,
+            NodeType::Validator,
+            Some(ChainId::testnet()),
+        )
+        .unwrap();
+        assert!(!modified_config);
+    }
+
+    #[test]
+    fn test_optimize_execution_config_non_genesis_mainnet() {
+        // Create a default node config
+        let mut node_config = NodeConfig::default();
+
+        // Verify the execution config does not have a genesis waypoint
+        assert!(&node_config.execution.genesis_waypoint.is_none());
+
+        // Inject a non-genesis waypoint into the base config
+        let non_genesis_waypoint = Waypoint::from_str(NON_GENESIS_WAYPOINT).unwrap();
+        node_config.base.waypoint = WaypointConfig::FromConfig(non_genesis_waypoint);
+
+        // Optimize the config for mainnet and verify modifications are made
+        let modified_config = ExecutionConfig::optimize(
+            &mut node_config,
+            &serde_yaml::from_str("{}").unwrap(), // An empty local config,
+            NodeType::Validator,
+            Some(ChainId::mainnet()),
+        )
+        .unwrap();
+        assert!(modified_config);
+
+        // Verify that the mainnet genesis waypoint was injected into the execution config
+        let expected_genesis_waypoint =
+            WaypointConfig::FromConfig(Waypoint::from_str(MAINNET_GENESIS_WAYPOINT).unwrap());
+        assert_eq!(
+            &node_config.execution.genesis_waypoint,
+            &Some(expected_genesis_waypoint)
+        );
+    }
+
+    #[test]
+    fn test_optimize_execution_config_non_genesis_testnet() {
+        // Create a default node config
+        let mut node_config = NodeConfig::default();
+
+        // Verify the execution config does not have a genesis waypoint
+        assert!(&node_config.execution.genesis_waypoint.is_none());
+
+        // Inject a non-genesis waypoint into the base config
+        let non_genesis_waypoint = Waypoint::from_str(NON_GENESIS_WAYPOINT).unwrap();
+        node_config.base.waypoint = WaypointConfig::FromConfig(non_genesis_waypoint);
+
+        // Optimize the config for testnet and verify modifications are made
+        let modified_config = ExecutionConfig::optimize(
+            &mut node_config,
+            &serde_yaml::from_str("{}").unwrap(), // An empty local config,
+            NodeType::PublicFullnode,
+            Some(ChainId::testnet()),
+        )
+        .unwrap();
+        assert!(modified_config);
+
+        // Verify that the testnet genesis waypoint was injected into the execution config
+        let expected_genesis_waypoint =
+            WaypointConfig::FromConfig(Waypoint::from_str(TESTNET_GENESIS_WAYPOINT).unwrap());
+        assert_eq!(
+            &node_config.execution.genesis_waypoint,
+            &Some(expected_genesis_waypoint)
+        );
+    }
+
+    #[test]
+    fn test_optimize_execution_config_skipped() {
+        // Create a default node config
+        let mut node_config = NodeConfig::default();
+
+        // Verify the execution config does not have a genesis waypoint
+        assert!(&node_config.execution.genesis_waypoint.is_none());
+
+        // Inject a non-genesis waypoint into the base config
+        let non_genesis_waypoint = Waypoint::from_str(NON_GENESIS_WAYPOINT).unwrap();
+        node_config.base.waypoint = WaypointConfig::FromConfig(non_genesis_waypoint);
+
+        // Optimize the config for a local network and verify that no modifications are made
+        let modified_config = ExecutionConfig::optimize(
+            &mut node_config,
+            &serde_yaml::from_str("{}").unwrap(), // An empty local config,
+            NodeType::Validator,
+            Some(ChainId::new(100)), // Neither testnet or mainnet
+        )
+        .unwrap();
+        assert!(!modified_config);
+
+        // Create a local config YAML with an execution config explicitly setting the genesis waypoint
+        let local_config_yaml = serde_yaml::from_str(
+            r#"
+            execution:
+                genesis_waypoint: "0:aaaaaaaa"
+            "#,
+        )
+        .unwrap();
+
+        // Optimize the config for mainnet and verify that no modifications are made
+        let modified_config = ExecutionConfig::optimize(
+            &mut node_config,
+            &local_config_yaml, // The local config with an explicit genesis waypoint
+            NodeType::Validator,
+            Some(ChainId::mainnet()),
+        )
+        .unwrap();
+        assert!(!modified_config);
+    }
 
     #[test]
     fn test_sanitize_valid_execution_config() {
@@ -253,7 +449,10 @@ mod test {
         let root_dir = RootPath::new_path(path.path());
         config.save_to_path(&root_dir).expect("Unable to save");
         // Verifies some without path
-        assert_eq!(config.genesis_file_location, PathBuf::from(GENESIS_DEFAULT));
+        assert_eq!(
+            config.genesis_file_location,
+            PathBuf::from(GENESIS_BLOB_FILENAME)
+        );
 
         config.genesis = None;
         let result = config.load_from_path(&root_dir);

--- a/state-sync/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/tests/bootstrapper.rs
@@ -752,6 +752,122 @@ async fn test_data_stream_transactions_or_outputs_fallback() {
 
 #[tokio::test]
 async fn test_fetch_epoch_ending_ledger_infos() {
+    // Create a driver configuration
+    let mut driver_configuration = create_full_node_driver_configuration();
+
+    // Update the driver configuration to use a waypoint in the future
+    let waypoint_version = 100;
+    let waypoint_epoch = 100;
+    let waypoint = create_random_epoch_ending_ledger_info(waypoint_version, waypoint_epoch);
+    driver_configuration.waypoint = Waypoint::new_any(waypoint.ledger_info());
+
+    // Create the mock streaming client
+    let mut mock_streaming_client = create_mock_streaming_client();
+    let (mut notification_sender, data_stream_listener) = create_data_stream_listener();
+    mock_streaming_client
+        .expect_get_all_epoch_ending_ledger_infos()
+        .with(eq(1))
+        .return_once(move |_| Ok(data_stream_listener));
+    mock_streaming_client
+        .expect_terminate_stream_with_feedback()
+        .return_const(Ok(()));
+
+    // Create the bootstrapper
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, mock_streaming_client, None, true);
+
+    // Create a global data summary where epoch 100 has ended
+    let global_data_summary =
+        create_global_summary_with_version(waypoint_epoch, waypoint_version + 1);
+
+    // Drive progress to initialize the epoch ending data stream
+    drive_progress(&mut bootstrapper, &global_data_summary, false)
+        .await
+        .unwrap();
+
+    // Create the first set of epoch ending ledger infos and send them across the stream
+    let num_ledger_infos_to_send = waypoint_epoch / 2;
+    let mut epoch_ending_ledger_infos = vec![];
+    for index in 0..num_ledger_infos_to_send {
+        epoch_ending_ledger_infos.push(create_random_epoch_ending_ledger_info(index, index));
+    }
+    let data_notification = DataNotification::new(
+        0,
+        DataPayload::EpochEndingLedgerInfos(epoch_ending_ledger_infos.clone()),
+    );
+    notification_sender.send(data_notification).await.unwrap();
+
+    // Drive progress to process the first set of epoch ending ledger infos
+    let error = drive_progress(&mut bootstrapper, &global_data_summary, false)
+        .await
+        .unwrap_err();
+    assert_matches!(error, Error::DataStreamNotificationTimeout(_));
+
+    // Verify we're not bootstrapped yet
+    assert!(!bootstrapper.is_bootstrapped());
+
+    // Verify the bootstrapper has not fetched all ledger infos or verified the waypoint
+    let verified_epoch_states = bootstrapper.get_verified_epoch_states().clone();
+    assert!(!verified_epoch_states.fetched_epoch_ending_ledger_infos());
+    assert!(!verified_epoch_states.verified_waypoint());
+
+    // Verify the epoch states contains the first set of epoch ending ledger infos
+    let verified_ledger_infos = verified_epoch_states.all_epoch_ending_ledger_infos();
+    assert_eq!(verified_ledger_infos.len() as u64, num_ledger_infos_to_send);
+    for epoch_ending_ledger_info in epoch_ending_ledger_infos {
+        assert!(verified_ledger_infos.contains(&epoch_ending_ledger_info));
+    }
+
+    // Create the second set of epoch ending ledger infos and send them across the stream
+    let mut epoch_ending_ledger_infos = vec![];
+    for index in num_ledger_infos_to_send..waypoint_epoch + 1 {
+        epoch_ending_ledger_infos.push(create_random_epoch_ending_ledger_info(index, index));
+    }
+    let data_notification = DataNotification::new(
+        1,
+        DataPayload::EpochEndingLedgerInfos(epoch_ending_ledger_infos.clone()),
+    );
+    notification_sender.send(data_notification).await.unwrap();
+
+    // Artificially overwrite the waypoint hash so that verification passes
+    let last_ledger_info = epoch_ending_ledger_infos.last().unwrap().ledger_info();
+    bootstrapper.set_waypoint(Waypoint::new_any(last_ledger_info));
+
+    // Drive progress to process the second set of epoch ending ledger infos
+    let error = drive_progress(&mut bootstrapper, &global_data_summary, false)
+        .await
+        .unwrap_err();
+    assert_matches!(error, Error::DataStreamNotificationTimeout(_));
+
+    // Ensure the bootstrapper verified the waypoint
+    let verified_epoch_states = bootstrapper.get_verified_epoch_states().clone();
+    assert!(verified_epoch_states.verified_waypoint());
+
+    // Verify the epoch states contains all epoch ending ledger infos
+    let verified_ledger_infos = verified_epoch_states.all_epoch_ending_ledger_infos();
+    assert_eq!(verified_ledger_infos.len() as u64, waypoint_epoch + 1);
+    for epoch_ending_ledger_info in epoch_ending_ledger_infos {
+        assert!(verified_ledger_infos.contains(&epoch_ending_ledger_info));
+    }
+
+    // Send the end of stream notification
+    let data_notification = DataNotification::new(2, DataPayload::EndOfStream);
+    notification_sender.send(data_notification).await.unwrap();
+
+    // Drive progress to process the end of stream notification
+    for _ in 0..2 {
+        drive_progress(&mut bootstrapper, &global_data_summary, false)
+            .await
+            .unwrap();
+    }
+
+    // Verify the bootstrapper has fetched all ledger infos
+    let verified_epoch_states = bootstrapper.get_verified_epoch_states().clone();
+    assert!(verified_epoch_states.fetched_epoch_ending_ledger_infos());
+}
+
+#[tokio::test]
+async fn test_fetch_epoch_ending_ledger_infos_timeout() {
     // Create a driver configuration with a genesis waypoint and a stream timeout of 1 second
     let mut driver_configuration = create_full_node_driver_configuration();
     driver_configuration.config.max_stream_wait_time_ms = 1000;
@@ -785,6 +901,56 @@ async fn test_fetch_epoch_ending_ledger_infos() {
         .await
         .unwrap_err();
     assert_matches!(error, Error::DataStreamNotificationTimeout(_));
+}
+
+#[tokio::test]
+#[should_panic(expected = "Failed to verify the waypoint: Waypoint value mismatch")]
+async fn test_fetch_epoch_ending_ledger_infos_waypoint_mismatch() {
+    // Create a driver configuration
+    let mut driver_configuration = create_full_node_driver_configuration();
+
+    // Update the driver configuration to use a waypoint in the future
+    let waypoint_version = 100;
+    let waypoint_epoch = 100;
+    let waypoint = create_random_epoch_ending_ledger_info(waypoint_version, waypoint_epoch);
+    driver_configuration.waypoint = Waypoint::new_any(waypoint.ledger_info());
+
+    // Create the mock streaming client
+    let mut mock_streaming_client = create_mock_streaming_client();
+    let (mut notification_sender, data_stream_listener) = create_data_stream_listener();
+    mock_streaming_client
+        .expect_get_all_epoch_ending_ledger_infos()
+        .with(eq(1))
+        .return_once(move |_| Ok(data_stream_listener));
+
+    // Create the bootstrapper
+    let (mut bootstrapper, _) =
+        create_bootstrapper(driver_configuration, mock_streaming_client, None, true);
+
+    // Create a global data summary where epoch 100 has ended
+    let global_data_summary =
+        create_global_summary_with_version(waypoint_epoch, waypoint_version + 1);
+
+    // Drive progress to initialize the epoch ending data stream
+    drive_progress(&mut bootstrapper, &global_data_summary, false)
+        .await
+        .unwrap();
+
+    // Create a full set of epoch ending ledger infos and send them across the stream
+    let mut epoch_ending_ledger_infos = vec![];
+    for index in 0..waypoint_epoch + 1 {
+        epoch_ending_ledger_infos.push(create_random_epoch_ending_ledger_info(index, index));
+    }
+    let data_notification = DataNotification::new(
+        0,
+        DataPayload::EpochEndingLedgerInfos(epoch_ending_ledger_infos.clone()),
+    );
+    notification_sender.send(data_notification).await.unwrap();
+
+    // Drive progress to process the set of epoch ending ledger infos and panic at the waypoint mismatch
+    drive_progress(&mut bootstrapper, &global_data_summary, false)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/state-sync/state-sync-driver/src/tests/utils.rs
+++ b/state-sync/state-sync-driver/src/tests/utils.rs
@@ -35,6 +35,7 @@ use aptos_types::{
         TransactionAuxiliaryData, TransactionInfo, TransactionListWithProof, TransactionOutput,
         TransactionOutputListWithProof, TransactionPayload, TransactionStatus, Version,
     },
+    validator_verifier::ValidatorVerifier,
     waypoint::Waypoint,
     write_set::WriteSet,
 };
@@ -145,14 +146,15 @@ pub fn create_random_epoch_ending_ledger_info(
     version: Version,
     epoch: Epoch,
 ) -> LedgerInfoWithSignatures {
+    let next_epoch_state = EpochState::new(epoch + 1, ValidatorVerifier::new(vec![]));
     let block_info = BlockInfo::new(
         epoch,
         0,
         HashValue::zero(),
         HashValue::random(),
         version,
-        0,
-        Some(EpochState::empty()),
+        version,
+        Some(next_epoch_state),
     );
     let ledger_info = LedgerInfo::new(block_info, HashValue::random());
     LedgerInfoWithSignatures::new(ledger_info, AggregateSignature::empty())

--- a/types/src/epoch_state.rs
+++ b/types/src/epoch_state.rs
@@ -23,6 +23,10 @@ pub struct EpochState {
 }
 
 impl EpochState {
+    pub fn new(epoch: u64, verifier: ValidatorVerifier) -> Self {
+        Self { epoch, verifier }
+    }
+
     pub fn empty() -> Self {
         Self {
             epoch: 0,


### PR DESCRIPTION
## Description
This PR extends support for non-genesis waypoints in two ways (each offered in their own commit):
1. Add a config optimizer for the `ExecutionConfig` so that if a node operator specifies a non-genesis waypoint in the node base config, the genesis waypoint will be automatically injected into the execution config (this is required by storage).
2. Add additional unit tests for state sync around waypoint verification and mismatches.

## Testing Plan
New and existing unit tests.