### PR TITLE
[Compiler-v2] borrow analysis for function call

### DIFF
--- a/third_party/move/move-compiler-v2/tests/reference-safety/function_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/function_ref.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/function_ref.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/function_ref.move
@@ -1,0 +1,19 @@
+module 0x42::m {
+    public fun g(x: &mut u64, _y: &address): &mut u64 {
+        x
+    }
+
+    public fun f(x: &u64, _y: &address): &u64 {
+        x
+    }
+
+    public fun f1(
+        addr: address,
+    ){
+        let h = 5;
+        let au = g(&mut 3, &addr);
+        let du = f(&h, &addr);
+        *du > 0;
+        *au > 1;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/function_ref.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/function_ref.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/function_ref_err.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/function_ref_err.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: cannot immutably borrow since mutable references exist
+   ┌─ tests/reference-safety/function_ref_err.move:15:18
+   │
+14 │         let au = g_mut(&mut 3, &mut addr);
+   │                  ------------------------ previous mutable call result
+15 │         let du = f_mut(&h, &mut addr);
+   │                  ^^^^^^^^^^^^^^^^^^^^ immutable borrow attempted here
+16 │         *du > 0;
+   │         --- requirement enforced here
+17 │         *au > 1;
+   │         --- conflicting reference `au` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/function_ref_err.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/function_ref_err.move
@@ -1,0 +1,19 @@
+module 0x42::m {
+    public fun g_mut(x: &mut u64, _y: &mut address): &mut u64 {
+        x
+    }
+
+    public fun f_mut(x: &u64, _y: &mut address): &u64 {
+        x
+    }
+
+    public fun f2(
+        addr: address,
+    ){
+        let h = 5;
+        let au = g_mut(&mut 3, &mut addr);
+        let du = f_mut(&h, &mut addr);
+        *du > 0;
+        *au > 1;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/function_ref_err.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/function_ref_err.no-opt.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: cannot immutably borrow since mutable references exist
+   ┌─ tests/reference-safety/function_ref_err.move:15:18
+   │
+14 │         let au = g_mut(&mut 3, &mut addr);
+   │                  ------------------------ previous mutable call result
+15 │         let du = f_mut(&h, &mut addr);
+   │                  ^^^^^^^^^^^^^^^^^^^^ immutable borrow attempted here
+16 │         *du > 0;
+   │         --- requirement enforced here
+17 │         *au > 1;
+   │         --- conflicting reference `au` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_transfer_borrows.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_transfer_borrows.exp
@@ -1,19 +1,5 @@
 
 Diagnostics:
-error: cannot move local `x` which is still borrowed
-   ┌─ tests/reference-safety/v1-tests/call_transfer_borrows.move:17:9
-   │
-13 │         let x_ref = &x;
-   │                     -- previous local borrow
-14 │         let y_ref = &mut y;
-15 │         let r = take_imm_mut_give_mut(x_ref, y_ref);
-   │                 ----------------------------------- used by mutable call result
-16 │         *x_ref;
-17 │         move x; // error in v2 (bug in v1)?
-   │         ^^^^^^ moved here
-18 │         *r = 1;
-   │         ------ conflicting reference `r` used here
-
 error: mutable reference in local `y_ref` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/call_transfer_borrows.move:29:9
    │

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_transfer_borrows.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_transfer_borrows.move
@@ -14,7 +14,7 @@ module 0x8675309::M {
         let y_ref = &mut y;
         let r = take_imm_mut_give_mut(x_ref, y_ref);
         *x_ref;
-        move x; // error in v2 (bug in v1)?
+        move x;
         *r = 1;
     }
 

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_transfer_borrows.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_transfer_borrows.no-opt.exp
@@ -1,19 +1,5 @@
 
 Diagnostics:
-error: cannot move local `x` which is still borrowed
-   ┌─ tests/reference-safety/v1-tests/call_transfer_borrows.move:17:9
-   │
-13 │         let x_ref = &x;
-   │                     -- previous local borrow
-14 │         let y_ref = &mut y;
-15 │         let r = take_imm_mut_give_mut(x_ref, y_ref);
-   │                 ----------------------------------- used by mutable call result
-16 │         *x_ref;
-17 │         move x; // error in v2 (bug in v1)?
-   │         ^^^^^^ moved here
-18 │         *r = 1;
-   │         ------ conflicting reference `r` used here
-
 error: mutable reference in local `y_ref` requires exclusive access but is borrowed
    ┌─ tests/reference-safety/v1-tests/call_transfer_borrows.move:29:9
    │


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR makes a slight change on the relation between input and output references for a function call: if an output reference is mutable, it is a child of all input mutable references.

Close #12828 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

1) Existing test cases. Note that the output of `call_transfer_borrows` is updated
2) Added a new test case `function_ref`.
 

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
