### PR TITLE
[compiler-v2] Adding full compiler pipeline to many test configs

### DIFF
--- a/third_party/move/move-compiler-v2/tests/ability-check/drop_on_abort.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-check/drop_on_abort.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/ability-check/resources.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-check/resources.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/ability-check/unused_var.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-check/unused_var.exp
@@ -5,3 +5,6 @@ warning: Unused parameter `x`. Consider removing or prefixing with an underscore
   │
 6 │     fun unused_arg<T: drop>(x: T) {
   │                             ^
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/acquires_error_msg.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/acquires_error_msg.exp
@@ -16,3 +16,6 @@ module 0x42::test {
         Tuple()
     }
 } // end 0x42::test
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11112.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11112.exp
@@ -34,3 +34,6 @@ module 0xcafe::vectors {
         }
     }
 } // end 0xcafe::vectors
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11223.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_11223.exp
@@ -17,3 +17,6 @@ module 0xcafe::vectors {
         }
     }
 } // end 0xcafe::vectors
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717.exp
@@ -130,3 +130,6 @@ module 0xcafe::vectors {
         Tuple()
     }
 } // end 0xcafe::vectors
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717_looponly.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/bug_9717_looponly.exp
@@ -38,3 +38,6 @@ module 0xcafe::vectors {
         }
     }
 } // end 0xcafe::vectors
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/deep_exp.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/deep_exp.exp
@@ -4,3 +4,6 @@ module 0x42::Test {
         625
     }
 } // end 0x42::Test
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/double_nesting.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/double_nesting.exp
@@ -15,3 +15,6 @@ module 0x42::test {
         Tuple()
     }
 } // end 0x42::test
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/inline_accessing_constant.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/inline_accessing_constant.exp
@@ -6,3 +6,6 @@ module 0xc0ffee::dummy2 {
         1
     }
 } // end 0xc0ffee::dummy2
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda.exp
@@ -43,3 +43,6 @@ module 0x42::LambdaTest {
         Tuple()
     }
 } // end 0x42::LambdaTest
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_cast.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_cast.exp
@@ -58,3 +58,6 @@ module 0x12391283::M {
         }
     }
 } // end 0x12391283::M
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/nested_mul.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/nested_mul.exp
@@ -12,3 +12,6 @@ module 0x42::test {
         Tuple()
     }
 } // end 0x42::test
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/order_sensitive.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/order_sensitive.exp
@@ -40,3 +40,6 @@ module 0x42::OrderSensitiveTest3 {
         }))
     }
 } // end 0x42::OrderSensitiveTest3
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/recursive_nesting.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/recursive_nesting.exp
@@ -20,3 +20,6 @@ module 0x42::test {
         Tuple()
     }
 } // end 0x42::test
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/resources_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/resources_invalid.exp
@@ -18,3 +18,11 @@ module 0x42::token {
         })
     }
 } // end 0x42::token
+
+
+Diagnostics:
+bug: struct not defined
+   ┌─ tests/checking/inlining/resources_invalid.move:17:16
+   │
+17 │     public fun get_value(ref: &obj::ReaderRef<Token>): u64 acquires Token {
+   │                ^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/shadowing_unused.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/shadowing_unused.exp
@@ -26,3 +26,6 @@ module 0x42::Test {
         }
     }
 } // end 0x42::Test
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/shadowing_unused_nodecl.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/shadowing_unused_nodecl.exp
@@ -34,3 +34,6 @@ module 0x42::Test {
         }
     }
 } // end 0x42::Test
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/spec_inlining.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/spec_inlining.exp
@@ -48,3 +48,6 @@ module 0x42::Test {
         }
     }
 } // end 0x42::Test
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/temp_shadowing.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/temp_shadowing.exp
@@ -41,3 +41,6 @@ module 0x42::Test {
         }
     }
 } // end 0x42::Test
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/test_12670.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/test_12670.exp
@@ -29,3 +29,6 @@ module 0x1::Test {
         }
     }
 } // end 0x1::Test
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/unused_inline.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/unused_inline.exp
@@ -20,3 +20,6 @@ module 0xc0ffee::m {
         }
     }
 } // end 0xc0ffee::m
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/folding/constant_values.exp
+++ b/third_party/move/move-compiler-v2/tests/folding/constant_values.exp
@@ -19,3 +19,6 @@ module 0x8675309::M {
         1
     }
 } // end 0x8675309::M
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/folding/non_constant_empty_vec.exp
+++ b/third_party/move/move-compiler-v2/tests/folding/non_constant_empty_vec.exp
@@ -22,3 +22,6 @@ module 0x42::M {
         Vector<vector<M::S>>()
     }
 } // end 0x42::M
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/no-simplifier/constant_folding_ristretto.exp
+++ b/third_party/move/move-compiler-v2/tests/no-simplifier/constant_folding_ristretto.exp
@@ -15,3 +15,6 @@ module 0xcafe::Ristretto {
         }
     }
 } // end 0xcafe::Ristretto
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/no-simplifier/moved_var_not_simplified3.exp
+++ b/third_party/move/move-compiler-v2/tests/no-simplifier/moved_var_not_simplified3.exp
@@ -13,3 +13,6 @@ module 0xc0ffee::m {
         }
     }
 } // end 0xc0ffee::m
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/always_false_branch.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/always_false_branch.exp
@@ -13,3 +13,6 @@ module 0xc0ffee::m {
         0
     }
 } // end 0xc0ffee::m
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/binary_add.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/binary_add.exp
@@ -63,3 +63,6 @@ module 0x8675309::M {
         }
     }
 } // end 0x8675309::M
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/bind_with_type_annot.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/bind_with_type_annot.exp
@@ -36,3 +36,6 @@ module 0x8675309::M {
         }
     }
 } // end 0x8675309::M
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/constant_all_valid_types.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/constant_all_valid_types.exp
@@ -71,3 +71,6 @@ module <SELF>_0 {
         Tuple()
     }
 } // end <SELF>_0
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/double_nesting.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/double_nesting.exp
@@ -15,3 +15,6 @@ module 0x42::test {
         Tuple()
     }
 } // end 0x42::test
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/else_assigns_if_doesnt.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/else_assigns_if_doesnt.exp
@@ -23,3 +23,11 @@ module <SELF>_0 {
         }
     }
 } // end <SELF>_0
+
+
+Diagnostics:
+error: use of possibly unassigned local `y`
+   ┌─ tests/simplifier-elimination/else_assigns_if_doesnt.move:11:13
+   │
+11 │     assert!(y == 0, 42);
+   │             ^^^^^^

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/if_assigns_else_doesnt.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/if_assigns_else_doesnt.exp
@@ -23,3 +23,11 @@ module <SELF>_0 {
         }
     }
 } // end <SELF>_0
+
+
+Diagnostics:
+error: use of possibly unassigned local `x`
+   ┌─ tests/simplifier-elimination/if_assigns_else_doesnt.move:11:13
+   │
+11 │     assert!(x == 42, 42);
+   │             ^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/if_assigns_no_else.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/if_assigns_no_else.exp
@@ -24,3 +24,6 @@ module <SELF>_0 {
         }
     }
 } // end <SELF>_0
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/if_condition.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/if_condition.exp
@@ -53,3 +53,6 @@ module 0x8675309::M {
         Tuple()
     }
 } // end 0x8675309::M
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/recursive_nesting.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/recursive_nesting.exp
@@ -20,3 +20,6 @@ module 0x42::test {
         Tuple()
     }
 } // end 0x42::test
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/use_before_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/use_before_assign.exp
@@ -18,3 +18,11 @@ module <SELF>_0 {
         }
     }
 } // end <SELF>_0
+
+
+Diagnostics:
+error: use of unassigned local `x`
+  ┌─ tests/simplifier-elimination/use_before_assign.move:4:13
+  │
+4 │     let y = x;
+  │             ^

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/use_before_assign_loop.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/use_before_assign_loop.exp
@@ -63,3 +63,35 @@ module 0x8675309::M {
         }
     }
 } // end 0x8675309::M
+
+
+Diagnostics:
+error: use of possibly unassigned local `x`
+  ┌─ tests/simplifier-elimination/use_before_assign_loop.move:4:24
+  │
+4 │         loop { let y = move x + 1; x = 0; y; }
+  │                        ^^^^^^
+
+error: use of possibly unassigned local `x`
+  ┌─ tests/simplifier-elimination/use_before_assign_loop.move:9:24
+  │
+9 │         loop { let y = x + 1; if (cond) { continue }; x = 0; y; }
+  │                        ^^^^^
+
+error: use of possibly unassigned local `x`
+   ┌─ tests/simplifier-elimination/use_before_assign_loop.move:14:24
+   │
+14 │         loop { let y = &x; _ = move y; x = 0 }
+   │                        ^^
+
+error: use of unassigned local `x`
+   ┌─ tests/simplifier-elimination/use_before_assign_loop.move:19:24
+   │
+19 │         loop { let y = &x; _ = move y; if (cond) { x = 0 }; break };
+   │                        ^^
+
+error: use of possibly unassigned local `x`
+   ┌─ tests/simplifier-elimination/use_before_assign_loop.move:20:9
+   │
+20 │         x;
+   │         ^

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/use_before_assign_while.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/use_before_assign_while.exp
@@ -80,6 +80,32 @@ module 0x8675309::M {
 
 
 Diagnostics:
+error: use of possibly unassigned local `x`
+  ┌─ tests/simplifier-elimination/use_before_assign_while.move:4:32
+  │
+4 │         while (cond) { let y = move x + 1; x = 0; y; }
+  │                                ^^^^^^
+
+error: use of possibly unassigned local `x`
+  ┌─ tests/simplifier-elimination/use_before_assign_while.move:9:32
+  │
+9 │         while (cond) { let y = move x + 1; if (cond) { continue }; x = 0; y; }
+  │                                ^^^^^^
+
+error: use of possibly unassigned local `x`
+   ┌─ tests/simplifier-elimination/use_before_assign_while.move:14:32
+   │
+14 │         while (cond) { let y = &x; _ = move y; x = 0 }
+   │                                ^^
+
+error: use of unassigned local `x`
+   ┌─ tests/simplifier-elimination/use_before_assign_while.move:19:32
+   │
+19 │         while (cond) { let y = &x; _ = move y; if (cond) { x = 0 }; break }
+   │                                ^^
+
+
+Diagnostics:
 error: cannot move local `x` since it is still in use
   ┌─ tests/simplifier-elimination/use_before_assign_while.move:9:32
   │

--- a/third_party/move/move-compiler-v2/tests/simplifier/bug_11112.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier/bug_11112.exp
@@ -34,3 +34,6 @@ module 0xcafe::vectors {
         }
     }
 } // end 0xcafe::vectors
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier/conditional_borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier/conditional_borrow.exp
@@ -95,3 +95,6 @@ module 0x8675::M {
         Add<u64>(M::test1b(pack M::S(7)), M::test1b(pack M::S(2)))
     }
 } // end 0x8675::M
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier/constant_folding_ristretto.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier/constant_folding_ristretto.exp
@@ -9,3 +9,6 @@ module 0xcafe::Ristretto {
         Tuple()
     }
 } // end 0xcafe::Ristretto
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier/deep_exp.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier/deep_exp.exp
@@ -4,3 +4,6 @@ module 0x42::Test {
         625
     }
 } // end 0x42::Test
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier/simplifier_test1.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier/simplifier_test1.exp
@@ -28,3 +28,6 @@ module 0x8675::M {
         }
     }
 } // end 0x8675::M
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier/simplifier_test2.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier/simplifier_test2.exp
@@ -28,3 +28,6 @@ module 0x8675::M {
         }
     }
 } // end 0x8675::M
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier/simplifier_test3.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier/simplifier_test3.exp
@@ -28,3 +28,6 @@ module 0x8675::M {
         }
     }
 } // end 0x8675::M
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/skip_attribute_checks/aptos_stdlib_attributes2.exp
+++ b/third_party/move/move-compiler-v2/tests/skip_attribute_checks/aptos_stdlib_attributes2.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/skip_attribute_checks/attribute_placement.exp
+++ b/third_party/move/move-compiler-v2/tests/skip_attribute_checks/attribute_placement.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/skip_attribute_checks/attribute_variants.exp
+++ b/third_party/move/move-compiler-v2/tests/skip_attribute_checks/attribute_variants.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/skip_attribute_checks/extra_attributes.exp
+++ b/third_party/move/move-compiler-v2/tests/skip_attribute_checks/extra_attributes.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/skip_attribute_checks/extra_attributes2.exp
+++ b/third_party/move/move-compiler-v2/tests/skip_attribute_checks/extra_attributes2.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/skip_attribute_checks/testonly.exp
+++ b/third_party/move/move-compiler-v2/tests/skip_attribute_checks/testonly.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -515,7 +515,8 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
                 .clone()
                 .set_experiment(Experiment::AST_SIMPLIFY, true)
                 .set_compile_test_code(false),
-            stop_after: StopAfter::BytecodePipeline(None),
+            // Run the entire compiler pipeline to double-check the result
+            stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::None,
             dump_bytecode: DumpLevel::None,
             dump_bytecode_filter: None,

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -435,7 +435,8 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             options: opts
                 .clone()
                 .set_experiment(Experiment::ABILITY_CHECK, false),
-            stop_after: StopAfter::BytecodePipeline(None),
+            // Run the entire compiler pipeline to double-check the result
+            stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::None,
             dump_bytecode: DumpLevel::AllStages,
             dump_bytecode_filter: Some(vec![

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -38,8 +38,8 @@ struct TestConfig {
     runner: fn(&Path) -> datatest_stable::Result<()>,
     /// Path substring for tests to include.
     include: Vec<&'static str>,
-    /// Path substring for tests to exclude. The set of tests included is that
-    /// which match any of the include strings and do _not_ match ony of
+    /// Path substring for tests to exclude. The set of tests included are those
+    /// which match any of the include strings and do _not_ match any of
     /// the exclude strings.
     exclude: Vec<&'static str>,
     /// If set, a suffix for the baseline file used for these tests.
@@ -194,8 +194,8 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             exclude: vec![],
             exp_suffix: None,
             options: opts.clone().set_experiment(Experiment::AST_SIMPLIFY, true),
-            // Run the bytecode pipeline as well for double-checking the result
-            stop_after: StopAfter::BytecodePipeline(None),
+            // Run the entire compiler pipeline to double-check the result
+            stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::EndStage,
             dump_bytecode: DumpLevel::None, // do not dump anything
             dump_bytecode_filter: None,
@@ -336,7 +336,8 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             exclude: vec![],
             exp_suffix: None,
             options: opts.clone(),
-            stop_after: StopAfter::AstPipeline,
+            // Run the full compiler pipeline to double-check the result.
+            stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::None,
             dump_bytecode: DumpLevel::None,
             dump_bytecode_filter: None,

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -432,9 +432,7 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             include: vec!["/unreachable-code-remover/"],
             exclude: vec![],
             exp_suffix: None,
-            options: opts
-                .clone()
-                .set_experiment(Experiment::ABILITY_CHECK, false),
+            options: opts.clone(),
             // Run the entire compiler pipeline to double-check the result
             stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::None,

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -531,7 +531,8 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
                 .clone()
                 .set_experiment(Experiment::AST_SIMPLIFY, true)
                 .set_skip_attribute_checks(true),
-            stop_after: StopAfter::BytecodePipeline(None),
+            // Run the entire compiler pipeline to double-check the result
+            stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::None,
             dump_bytecode: DumpLevel::None,
             dump_bytecode_filter: None,

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -499,7 +499,8 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
                 .clone()
                 .set_experiment(Experiment::AST_SIMPLIFY, true)
                 .set_compile_test_code(true),
-            stop_after: StopAfter::BytecodePipeline(None),
+            // Run the entire compiler pipeline to double-check the result
+            stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::None,
             dump_bytecode: DumpLevel::None,
             dump_bytecode_filter: None,

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -176,12 +176,9 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             exp_suffix: None,
             options: opts
                 .clone()
-                .set_experiment(Experiment::AST_SIMPLIFY_FULL, true)
-                // TODO: this check should not need to be turned off, but some
-                //   tests rely on it. Those tests should be fixed.
-                .set_experiment(Experiment::UNINITIALIZED_CHECK, false),
-            // Run the full bytecode pipeline as well for double-checking the result
-            stop_after: StopAfter::BytecodePipeline(None),
+                .set_experiment(Experiment::AST_SIMPLIFY_FULL, true),
+            // Run the entire compiler pipeline to double-check the result
+            stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::EndStage,
             dump_bytecode: DumpLevel::None, // do not dump anything
             dump_bytecode_filter: None,

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -208,8 +208,8 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             exclude: vec![],
             exp_suffix: None,
             options: opts.clone().set_experiment(Experiment::AST_SIMPLIFY, false),
-            // Run the bytecode pipeline as well for double-checking the result
-            stop_after: StopAfter::BytecodePipeline(None),
+            // Run the entire compiler pipeline to double-check the result
+            stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::EndStage,
             dump_bytecode: DumpLevel::None, // do not dump anything
             dump_bytecode_filter: None,

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -302,7 +302,8 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             exclude: vec![],
             exp_suffix: None,
             options: opts.clone(),
-            stop_after: StopAfter::BytecodePipeline(None),
+            // Run the entire compiler pipeline to double-check the result
+            stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::None,
             dump_bytecode: DumpLevel::None,
             dump_bytecode_filter: None,

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/attribute_location.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/attribute_location.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/cross_module_members.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/cross_module_members.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/expected_failure_bad_value.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/expected_failure_bad_value.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/expected_failure_constants.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/expected_failure_constants.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/expected_failure_constants_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/expected_failure_constants_invalid.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/expected_failure_invalid_literals.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/expected_failure_invalid_literals.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/expected_failure_not_test.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/expected_failure_not_test.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/expected_failure_out_of_range_value.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/expected_failure_out_of_range_value.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/extra_attributes.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/extra_attributes.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/extra_attributes2.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/extra_attributes2.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/invalid_expected_code_name.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/invalid_expected_code_name.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/invalid_expected_failure_name.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/invalid_expected_failure_name.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/multiple_errors.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/multiple_errors.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/multiple_test_annotations.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/multiple_test_annotations.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/named_address_no_value_in_annotation.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/named_address_no_value_in_annotation.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/other_failures_invalid_assignment.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/other_failures_invalid_assignment.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/other_failures_invalid_location.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/other_failures_invalid_location.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/other_failures_invalid_location_module.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/other_failures_invalid_location_module.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/other_failures_valid.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/other_failures_valid.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/test_and_test_only_annotation.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/test_and_test_only_annotation.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/notest/valid_test_module.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/notest/valid_test_module.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/attribute_location.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/attribute_location.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/cross_module_members.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/cross_module_members.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/cross_module_members_non_test_function.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/cross_module_members_non_test_function.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/cross_module_test_only_module.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/cross_module_test_only_module.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_bad_value.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_bad_value.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_constants.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_constants.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_constants_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_constants_invalid.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_invalid_literals.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_invalid_literals.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_not_test.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_not_test.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_out_of_range_value.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_out_of_range_value.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/extra_attributes.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/extra_attributes.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/invalid_expected_code_name.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/invalid_expected_code_name.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/invalid_expected_failure_name.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/invalid_expected_failure_name.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_assignment.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_assignment.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_location.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_location.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_valid.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_valid.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/test_and_test_only_annotation.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/test_and_test_only_annotation.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/test_filter_function.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/test_filter_function.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/test_filter_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/test_filter_struct.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/valid_test_module.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/valid_test_module.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/abort_only.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/abort_only.exp
@@ -13,25 +13,10 @@ fun m::test() {
 [variant baseline]
 fun m::test() {
      var $t0: u64
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   0: $t0 := 0
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   1: abort($t0)
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
   2: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/abort_only.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/abort_only.exp
@@ -44,3 +44,6 @@ fun m::test() {
   0: $t0 := 0
   1: abort($t0)
 }
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/abort_or_return_always.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/abort_or_return_always.exp
@@ -23,81 +23,26 @@ fun m::test($t0: bool): u64 {
 fun m::test($t0: bool): u64 {
      var $t1: u64
      var $t2: u64
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   0: if ($t0) goto 1 else goto 5
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   1: label L0
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   2: $t2 := 0
-     # live vars: $t2
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   3: abort($t2)
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
   4: goto 8
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   5: label L1
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   6: $t1 := 1
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   7: return $t1
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
   8: label L2
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
   9: $t1 := 42
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
  10: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/abort_or_return_always.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/abort_or_return_always.exp
@@ -116,3 +116,6 @@ fun m::test($t0: bool): u64 {
   5: $t1 := 1
   6: return $t1
 }
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/always_false_branch.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/always_false_branch.exp
@@ -32,102 +32,32 @@ fun m::test(): u64 {
      var $t2: u64
      var $t3: u64
      var $t4: u64
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   0: $t1 := false
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   1: if ($t1) goto 2 else goto 10
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   2: label L0
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   3: $t2 := 0
-     # live vars: $t2
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   4: $t4 := 1
-     # live vars: $t2, $t4
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   5: $t3 := +($t2, $t4)
-     # live vars: $t3
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
-  6: $t2 := infer($t3)
-     # live vars: $t2
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
+  6: $t2 := move($t3)
      # maybe
-  7: $t0 := infer($t2)
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
+  7: $t0 := move($t2)
      # maybe
   8: return $t0
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
   9: goto 11
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
  10: label L1
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
  11: label L2
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
  12: $t0 := 0
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
  13: return $t0
 }
@@ -147,8 +77,8 @@ fun m::test(): u64 {
   3: $t2 := 0
   4: $t4 := 1
   5: $t3 := +($t2, $t4)
-  6: $t2 := infer($t3)
-  7: $t0 := infer($t2)
+  6: $t2 := move($t3)
+  7: $t0 := move($t2)
   8: return $t0
   9: label L1
  10: label L2

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/always_false_branch.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/always_false_branch.exp
@@ -155,3 +155,6 @@ fun m::test(): u64 {
  11: $t0 := 0
  12: return $t0
 }
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/break_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/break_unreachable.exp
@@ -270,3 +270,6 @@ fun m::test() {
  12: label L1
  13: return ()
 }
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/break_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/break_unreachable.exp
@@ -56,186 +56,56 @@ fun m::test() {
      var $t8: u64
      var $t9: u64
      var $t10: u64
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   0: $t0 := 0
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   1: label L0
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   2: $t2 := 1
-     # live vars: $t0, $t2
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   3: $t1 := +($t0, $t2)
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
-  4: $t0 := infer($t1)
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
+  4: $t0 := move($t1)
      # maybe
   5: $t4 := 10
-     # live vars: $t0, $t4
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   6: $t3 := ==($t0, $t4)
-     # live vars: $t0, $t3
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   7: if ($t3) goto 8 else goto 14
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   8: label L2
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   9: goto 24
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
  10: $t6 := 1
-     # live vars: $t0, $t6
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
  11: $t5 := +($t0, $t6)
-     # live vars: $t5
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
- 12: $t0 := infer($t5)
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
+ 12: $t0 := move($t5)
      # no
  13: goto 19
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
  14: label L3
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
  15: goto 1
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
  16: $t8 := 1
-     # live vars: $t0, $t8
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
  17: $t7 := +($t0, $t8)
-     # live vars: $t7
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
- 18: $t0 := infer($t7)
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
+ 18: $t0 := move($t7)
      # no
  19: label L4
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
  20: $t10 := 1
-     # live vars: $t0, $t10
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
  21: $t9 := +($t0, $t10)
-     # live vars: $t9
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
- 22: $t0 := infer($t9)
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
+ 22: $t0 := move($t9)
      # no
  23: goto 1
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
  24: label L1
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
  25: return ()
 }
@@ -259,7 +129,7 @@ fun m::test() {
   1: label L0
   2: $t2 := 1
   3: $t1 := +($t0, $t2)
-  4: $t0 := infer($t1)
+  4: $t0 := move($t1)
   5: $t4 := 10
   6: $t3 := ==($t0, $t4)
   7: if ($t3) goto 8 else goto 10

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/conditional_loop_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/conditional_loop_unreachable.exp
@@ -47,193 +47,58 @@ fun m::test($t0: bool, $t1: bool) {
      var $t5: u64
      var $t6: u64
      var $t7: u64
-     # live vars: $t0, $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   0: label L0
-     # live vars: $t0, $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   1: if ($t0) goto 2 else goto 21
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   2: label L2
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   3: if ($t1) goto 4 else goto 13
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   4: label L5
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   5: label L8
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   6: goto 5
-     # live vars: $t0, $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
   7: label L9
-     # live vars: $t0, $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
   8: $t2 := 0
-     # live vars: $t0, $t1, $t2
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
   9: $t4 := 1
-     # live vars: $t0, $t1, $t2, $t4
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
  10: $t3 := +($t2, $t4)
-     # live vars: $t0, $t1, $t3
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
- 11: $t2 := infer($t3)
-     # live vars: $t0, $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
+ 11: $t2 := move($t3)
      # no
  12: goto 15
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
  13: label L6
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
  14: goto 25
-     # live vars: $t0, $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
  15: label L7
-     # live vars: $t0, $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
  16: $t5 := 0
-     # live vars: $t0, $t1, $t5
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
  17: $t7 := 1
-     # live vars: $t0, $t1, $t5, $t7
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
  18: $t6 := +($t5, $t7)
-     # live vars: $t0, $t1, $t6
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
- 19: $t5 := infer($t6)
-     # live vars: $t0, $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
+ 19: $t5 := move($t6)
      # no
  20: goto 23
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
  21: label L3
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
  22: goto 25
-     # live vars: $t0, $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
  23: label L4
-     # live vars: $t0, $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
  24: goto 0
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
  25: label L1
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
  26: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/conditional_loop_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/conditional_loop_unreachable.exp
@@ -262,3 +262,6 @@ fun m::test($t0: bool, $t1: bool) {
  11: label L1
  12: return ()
 }
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/inter_procedural_abort.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/inter_procedural_abort.exp
@@ -29,25 +29,10 @@ fun m::test(): u64 {
 [variant baseline]
 fun m::always_abort() {
      var $t0: u64
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   0: $t0 := 0
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   1: abort($t0)
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
   2: return ()
 }
@@ -59,53 +44,18 @@ fun m::test(): u64 {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   0: m::always_abort()
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   1: $t1 := 0
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   2: $t3 := 1
-     # live vars: $t1, $t3
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   3: $t2 := +($t1, $t3)
-     # live vars: $t2
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
-  4: $t1 := infer($t2)
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
+  4: $t1 := move($t2)
      # maybe
-  5: $t0 := infer($t1)
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
+  5: $t0 := move($t1)
      # maybe
   6: return $t0
 }
@@ -130,8 +80,8 @@ fun m::test(): u64 {
   1: $t1 := 0
   2: $t3 := 1
   3: $t2 := +($t1, $t3)
-  4: $t1 := infer($t2)
-  5: $t0 := infer($t1)
+  4: $t1 := move($t2)
+  5: $t0 := move($t1)
   6: return $t0
 }
 

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/inter_procedural_abort.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/inter_procedural_abort.exp
@@ -134,3 +134,6 @@ fun m::test(): u64 {
   5: $t0 := infer($t1)
   6: return $t0
 }
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/loop_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/loop_unreachable.exp
@@ -60,3 +60,6 @@ fun m::test(): u64 {
   0: label L0
   1: goto 0
 }
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/loop_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/loop_unreachable.exp
@@ -15,39 +15,14 @@ fun m::test(): u64 {
 [variant baseline]
 fun m::test(): u64 {
      var $t0: u64
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   0: label L0
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   1: goto 0
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
   2: label L1
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
   3: $t0 := 42
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
   4: return $t0
 }

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/return_after_abort.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/return_after_abort.exp
@@ -55,3 +55,6 @@ fun m::test(): u32 {
   0: $t1 := 0
   1: abort($t1)
 }
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/return_after_abort.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/return_after_abort.exp
@@ -16,32 +16,12 @@ fun m::test(): u32 {
 fun m::test(): u32 {
      var $t0: u32
      var $t1: u64
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   0: $t1 := 0
-     # live vars: $t1
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # maybe
   1: abort($t1)
-     # live vars:
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
   2: $t0 := 0
-     # live vars: $t0
-     # graph: {}
-     # locals: {}
-     # globals: {}
-     #
      # no
   3: return $t0
 }


### PR DESCRIPTION
## Description

This PR adds full compiler pipeline to many test configs. This allows double checking that bytecode verification does not fail for any code that we successfully compile in v2 without reporting blocking errors.

As a result, we found this bug: https://github.com/aptos-labs/aptos-core/issues/12820.

Note that adding full compiler pipeline to "bytecode-gen" is being done here - https://github.com/aptos-labs/aptos-core/pull/12818, so not done in this PR.

Closes https://github.com/aptos-labs/aptos-core/issues/12830.

## Type of Change
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## How Has This Been Tested?
Existing tests, which have all been updated with new baselines.

## Key Areas to Review
Output of the baseline files: I have tried to explain why the changes (other than "bytecode verification succeeded" messages) are okay once per directory, using github comments.

