### PR TITLE
[CI/CD] Adopt targeted CLI windows build test.

### DIFF
--- a/.github/actions/rust-targeted-unit-tests/action.yaml
+++ b/.github/actions/rust-targeted-unit-tests/action.yaml
@@ -36,7 +36,7 @@ runs:
     # Run only the targeted rust unit tests
     - name: Run only the targeted unit tests
       run: |
-        cargo x targeted-unit-tests -vv run --profile ci --cargo-profile ci --locked --no-fail-fast --retries 3
+        cargo x targeted-unit-tests -vv --profile ci --cargo-profile ci --locked --no-fail-fast --retries 3
       shell: bash
       env:
         INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -23,7 +23,10 @@ jobs:
       run:
         shell: pwsh
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 # Fetch all git history for accurate target determination
 
       # This action will cache ~/.cargo and ./target (or the equivalent on Windows in
       # this case). See more here:
@@ -41,8 +44,17 @@ jobs:
       - name: Install OpenSSL
         run: vcpkg install openssl:x64-windows-static-md --clean-after-build
 
-      - name: Build the Aptos CLI
-        run: cargo build -p aptos
+      # Output the changed files
+      - name: Output the changed files
+        run: cargo x changed-files -vv
+        shell: bash
 
-      - name: Run the Aptos CLI help command
-        run: cargo run -p aptos -- --help
+      # Output the affected packages
+      - name: Output the affected packages
+        run: cargo x affected-packages -vv
+        shell: bash
+
+      # Build and test the Aptos CLI (if it has changed)
+      - name: Build and test the CLI
+        run: cargo x targeted-cli-tests -vv
+        shell: bash

--- a/devtools/aptos-cargo-cli/src/cargo.rs
+++ b/devtools/aptos-cargo-cli/src/cargo.rs
@@ -46,7 +46,7 @@ impl Cargo {
         self
     }
 
-    pub fn run(&mut self) {
+    pub fn run(&mut self, ignore_failed_exit_status: bool) {
         // Set up the output and arguments
         self.inner.stdout(Stdio::inherit()).stderr(Stdio::inherit());
         if !self.pass_through_args.is_empty() {
@@ -64,7 +64,7 @@ impl Cargo {
         // This will ensure that failures are not dropped silently.
         match result {
             Ok(output) => {
-                if !output.status.success() {
+                if !ignore_failed_exit_status && !output.status.success() {
                     panic!(
                         "Command failed: {:?}. Output: {:?}",
                         command_to_execute, output


### PR DESCRIPTION
## Description
This PR updates the CLI test and build job in Windows to use target determination. This should help to reduce unnecessary CI/CD compute times by skipping the job if irrelevant changes are detected (currently, the entire job takes around ~20 minutes to run).

To achieve this, the PR adds a new command (`cargo x targeted-cli-tests`) to the `aptos-cargo-cli` which will test and build the Aptos CLI iff relevant rust changes are detected. If no relevant changes are detected the command returns early, e.g.:
```
% cargo x targeted-cli-tests -vv
[2024-04-10T18:10:23Z INFO  aptos_cargo_cli::common] Identified the merge base: "d7c50d7d4928e510e23710784325fa94e3392c9e"
Skipping CLI tests as the CLI package was not affected!
```

The PR also makes some small cleanups along the way with regards to the `cargo x targeted-unit-tests` command.

## Testing Plan
Manual verification and existing test infrastructure.