### PR TITLE
Rename run-local-testnet to run-localnet, keep alias for old name

### DIFF
--- a/aptos-move/aptos-release-builder/src/main.rs
+++ b/aptos-move/aptos-release-builder/src/main.rs
@@ -88,7 +88,7 @@ pub enum Commands {
 #[derive(Subcommand, Debug)]
 pub enum InputOptions {
     FromDirectory {
-        /// Path to the local testnet folder. If you are running local testnet via cli, it should be `.aptos/testnet`.
+        /// Path to the localnet folder. If you are running localnet via cli, it should be `.aptos/testnet`.
         #[clap(short, long)]
         test_dir: PathBuf,
     },

--- a/aptos-move/move-examples/large_packages/large_package_example/sources/five.move
+++ b/aptos-move/move-examples/large_packages/large_package_example/sources/five.move
@@ -30,20 +30,20 @@
 ///
 /// There are four well-supported networks for integrating with the Aptos blockchain:
 ///
-/// 1. [Local testnet](http://127.0.0.1:8080) -- our standalone tool for local development against a known version of the codebase with no external network.
+/// 1. [Localnet](http://127.0.0.1:8080) -- our standalone tool for local development against a known version of the codebase with no external network.
 /// 1. [Devnet](https://fullnode.devnet.aptoslabs.com/v1/spec#/) -- a shared resource for the community, data resets weekly, weekly update from aptos-core main branch.
 /// 1. [Testnet](https://fullnode.testnet.aptoslabs.com/v1/spec#/) -- a shared resource for the community, data will be preserved, network configuration will mimic Mainnet.
 /// 1. [Mainnet](https://fullnode.mainnet.aptoslabs.com/v1/spec#/) -- a production network with real assets.
 ///
 /// See [Aptos Blockchain Networks](../nodes/networks.md) for full details on each environment.
 ///
-/// ### Run a local testnet
+/// ### Run a localnet
 ///
-/// There are two options for running a local testnet:
-/// * Directly [run a local testnet](../nodes/local-testnet/run-a-local-testnet.md) using either the [Aptos-core source code](../nodes/local-testnet/run-a-local-testnet.md#using-the-aptos-core-source-code) or a [Docker image](../nodes/local-testnet/run-a-local-testnet.md#using-docker). These paths are useful for testing changes to the Aptos-core codebase or framework, or for building services on top of the Aptos blockchain, respectively.
+/// There are two options for running a localnet:
+/// * Directly [run a localnet](../nodes/local-testnet/run-a-local-testnet.md) using either the [Aptos-core source code](../nodes/local-testnet/run-a-local-testnet.md#using-the-aptos-core-source-code) or a [Docker image](../nodes/local-testnet/run-a-local-testnet.md#using-docker). These paths are useful for testing changes to the Aptos-core codebase or framework, or for building services on top of the Aptos blockchain, respectively.
 /// * [Install the Aptos CLI](../tools/install-cli/index.md) and 2) start a [local node with a faucet](../nodes/local-testnet/using-cli-to-run-a-local-testnet.md#starting-a-local-testnet-with-a-faucet). This path is useful for developing on the Aptos blockchain, debugging Move contracts, and testing node operations.
 ///
-/// Either of these methods will expose a [REST API service](../integration/fullnode-rest-api.md) at `http://127.0.0.1:8080` and a Faucet API service at `http://127.0.0.1:8000` for option 1 run a local testnet or `http://127.0.0.1:8081` for option 2 install the Aptos CLI. The applications will output the location of the services.
+/// Either of these methods will expose a [REST API service](../integration/fullnode-rest-api.md) at `http://127.0.0.1:8080` and a Faucet API service at `http://127.0.0.1:8000` for option 1 run a localnet or `http://127.0.0.1:8081` for option 2 install the Aptos CLI. The applications will output the location of the services.
 ///
 /// ### Production network access
 ///

--- a/crates/aptos-faucet/DEV.md
+++ b/crates/aptos-faucet/DEV.md
@@ -77,7 +77,7 @@ First, install redis 6.x (e.g. `brew install redis@6.2`) and run a local redis (
 redis-server --save 60 1 --loglevel warning
 ```
 
-Then run a local testnet:
+Then run a localnet:
 ```
 cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes
 ```
@@ -95,7 +95,7 @@ curl -H 'Content-Type: application/json' -d '{"amount": 100, "address": "3c769ea
 Keep doing so and eventually you'll get rejected. See also that if you induce a 500 in the funder, the counter ultimately does not get incremented, so we don't punish users for issues on our side. I have also verified that the key does indeed get expired next day, so we don't track ratelimit information beyond when we need it. For historical investigation we can look at the application logs instead.
 
 ## Manually testing MintFunder
-Run a local testnet:
+Run a localnet:
 ```
 cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes
 ```

--- a/crates/aptos-faucet/README.md
+++ b/crates/aptos-faucet/README.md
@@ -34,7 +34,7 @@ To run the faucet, the simplest way to start is with this command:
 cargo run -p aptos-faucet-service -- run-simple --key <private_key> --node-url <api_url> --chain-id TESTING
 ```
 
-Another example, running alongside a local testnet (without `--use-faucet`):
+Another example, running alongside a localnet (without `--use-faucet`):
 ```
 cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes
 cargo run -p aptos-faucet-service -- run-simple --key ~/.aptos/testnet/mint.key --node-url http://127.0.0.1:8080 --chain-id TESTING

--- a/crates/aptos-faucet/configs/testing_redis_minter_local.yaml
+++ b/crates/aptos-faucet/configs/testing_redis_minter_local.yaml
@@ -1,4 +1,4 @@
-# Local redis instance with a local testnet.
+# Local redis instance with a localnet.
 ---
 server_config:
   api_path_base: ""

--- a/crates/aptos-faucet/core/src/server/run.rs
+++ b/crates/aptos-faucet/core/src/server/run.rs
@@ -606,14 +606,14 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_redis_ratelimiter() -> Result<()> {
-        // Assert that a local testnet is alive.
+        // Assert that a localnet is alive.
         let aptos_node_api_client = aptos_sdk::rest_client::Client::new(
             reqwest::Url::from_str("http://127.0.0.1:8080").unwrap(),
         );
         aptos_node_api_client
             .get_index_bcs()
             .await
-            .context("Local testnet API couldn't be reached at port 8080, have you started one?")?;
+            .context("Localnet API couldn't be reached at port 8080, have you started one?")?;
 
         init();
         let config_content = include_str!("../../../configs/testing_redis.yaml");
@@ -769,14 +769,14 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_mint_funder() -> Result<()> {
-        // Assert that a local testnet is alive.
+        // Assert that a localnet is alive.
         let aptos_node_api_client = aptos_sdk::rest_client::Client::new(
             reqwest::Url::from_str("http://127.0.0.1:8080").unwrap(),
         );
         aptos_node_api_client
             .get_index_bcs()
             .await
-            .context("Local testnet API couldn't be reached at port 8080, have you started one?")?;
+            .context("Localnet API couldn't be reached at port 8080, have you started one?")?;
 
         init();
         let (port, _handle) = {
@@ -831,14 +831,14 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_mint_funder_wait_for_txns() -> Result<()> {
-        // Assert that a local testnet is alive.
+        // Assert that a localnet is alive.
         let aptos_node_api_client = aptos_sdk::rest_client::Client::new(
             reqwest::Url::from_str("http://127.0.0.1:8080").unwrap(),
         );
         aptos_node_api_client
             .get_index_bcs()
             .await
-            .context("Local testnet API couldn't be reached at port 8080, have you started one?")?;
+            .context("Localnet API couldn't be reached at port 8080, have you started one?")?;
 
         init();
         let (port, _handle) = {
@@ -891,14 +891,14 @@ mod test {
     async fn test_maximum_amount_with_bypass() -> Result<()> {
         make_auth_tokens_file(&["test_token"])?;
 
-        // Assert that a local testnet is alive.
+        // Assert that a localnet is alive.
         let aptos_node_api_client = aptos_sdk::rest_client::Client::new(
             reqwest::Url::from_str("http://127.0.0.1:8080").unwrap(),
         );
         aptos_node_api_client
             .get_index_bcs()
             .await
-            .context("Local testnet API couldn't be reached at port 8080, have you started one?")?;
+            .context("Localnet API couldn't be reached at port 8080, have you started one?")?;
 
         init();
         let (port, _handle) = {

--- a/crates/aptos-faucet/integration-tests/README.md
+++ b/crates/aptos-faucet/integration-tests/README.md
@@ -1,5 +1,5 @@
 # Faucet integration tests
-This directory contains Python code to help with running the faucet integration tests. It takes care of spinning up a local testnet, moving the mint key where it is expected, checking that a Redis server is up, and running the integration tests.
+This directory contains Python code to help with running the faucet integration tests. It takes care of spinning up a localnet, moving the mint key where it is expected, checking that a Redis server is up, and running the integration tests.
 
 ## Requirements
 We use [Poetry](https://python-poetry.org/docs/#installation) for packaging and dependency management:

--- a/crates/aptos-faucet/integration-tests/local_testnet.py
+++ b/crates/aptos-faucet/integration-tests/local_testnet.py
@@ -1,7 +1,7 @@
 # Copyright © Aptos Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-# This file contains functions for running the local testnet.
+# This file contains functions for running the localnet.
 
 import logging
 import subprocess
@@ -12,14 +12,14 @@ from common import NODE_PORT, Network, build_image_name
 
 LOG = logging.getLogger(__name__)
 
-# Run a local testnet in a docker container. We choose to detach here and we'll
+# Run a localnet in a docker container. We choose to detach here and we'll
 # stop running it later using the container name. For an explanation of these
 # arguments, see the argument parser in main.py.
 def run_node(network: Network, image_repo_with_project: str, external_test_dir: str):
     image_name = build_image_name(image_repo_with_project, network)
     container_name = f"local-testnet-{network}"
     internal_mount_path = "/mymount"
-    LOG.info(f"Trying to run local testnet from image: {image_name}")
+    LOG.info(f"Trying to run localnet from image: {image_name}")
 
     # Confirm that the Docker daemon is running.
     try:
@@ -66,7 +66,7 @@ def run_node(network: Network, image_repo_with_project: str, external_test_dir: 
             "--no-txn-stream",
         ],
     )
-    LOG.info(f"Running local testnet from image: {image_name}")
+    LOG.info(f"Running localnet from image: {image_name}")
     return container_name
 
 

--- a/crates/aptos-faucet/integration-tests/main.py
+++ b/crates/aptos-faucet/integration-tests/main.py
@@ -4,13 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-This script is how we orchestrate running a local testnet and then the faucet
+This script is how we orchestrate running a localnet and then the faucet
 integration tests against it.
 
 Example invocation:
   python3 main.py --local-testnet-network devnet
 
-This would run a local testnet built from the devnet release branch and then run the
+This would run a localnet built from the devnet release branch and then run the
 faucet integration tests against it.
 
 The script confirms that pre-existing conditions are suitable, e.g. checking that a
@@ -50,7 +50,7 @@ def parse_args():
         "--image-repo-with-project",
         default="aptoslabs",
         help=(
-            "What docker image repo (+ project) to use for the local testnet. "
+            "What docker image repo (+ project) to use for the localnet. "
             "By default we use Docker Hub: %(default)s (so, just aptoslabs for the "
             "project since Docker Hub is the implied default repo). If you want to "
             "specify a different repo, it might look like this: "
@@ -62,7 +62,7 @@ def parse_args():
         required=True,
         choices=VALID_NETWORK_OPTIONS,
         help=(
-            "What branch the Aptos CLI used for the local testnet should be built "
+            "What branch the Aptos CLI used for the localnet should be built "
             'from. If "custom", --tag must be set.'
         ),
     )
@@ -126,7 +126,7 @@ def main():
     # Build and run the faucet integration tests.
     run_faucet_integration_tests()
 
-    # Stop the local testnet.
+    # Stop the localnet.
     stop_node(container_name)
 
     return True

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,14 +3,15 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Renamed `run-local-testnet` to `run-localnet`. `run-local-testnet` is still supported for backwards compatibility.
 
 ## [3.1.0] - 2024/03/21
 - Update `self_update` dependency to support situations where relevant directories (e.g. `/tmp`) exist on different filesystems.
 - [bugfix] Rename `--value` back to `--override-size-check` for publishing packages
-- Upgraded indexer processors for local testnet from cc764f83e26aed1d83ccad0cee3ab579792a0538. This adds support for the `TransactionMetadataProcessor` among other improvements.
+- Upgraded indexer processors for localnet from cc764f83e26aed1d83ccad0cee3ab579792a0538. This adds support for the `TransactionMetadataProcessor` among other improvements.
 
 ## [3.0.2] - 2024/03/12
-- Increased `max_connections` for postgres container created as part of local testnet to address occasional startup failures due to overloaded DB.
+- Increased `max_connections` for postgres container created as part of localnet to address occasional startup failures due to overloaded DB.
 
 ## [3.0.1] - 2024/03/05
 - Fix bug in `aptos update revela` if default install directory doesn't exist.
@@ -19,46 +20,46 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 - **Breaking Change**: `aptos update` is now `aptos update aptos`.
 - Added `aptos update revela`. This installs / updates the `revela` binary, which is needed for the new `aptos move decompile` subcommand.
 - Extended `aptos move download` with an option `--bytecode` to also download the bytecode of a module
-- Integrated the Revela decompiler which is now available via `aptos move decompile` 
+- Integrated the Revela decompiler which is now available via `aptos move decompile`
 - Extended `aptos move disassemble` and the new `aptos move decompile` to also work on entire packages instead of only single files
 
 ## [2.5.0] - 2024/02/27
 - Updated CLI source compilation to use rust toolchain version 1.75.0 (from 1.74.1).
-- Upgraded indexer processors for local testnet from 9936ec73cef251fb01fd2c47412e064cad3975c2 to d44b2d209f57872ac593299c34751a5531b51352. Upgraded Hasura metadata accordingly.
-- Added support for objects processor in local testnet and enabled it by default.
+- Upgraded indexer processors for localnet from 9936ec73cef251fb01fd2c47412e064cad3975c2 to d44b2d209f57872ac593299c34751a5531b51352. Upgraded Hasura metadata accordingly.
+- Added support for objects processor in localnet and enabled it by default.
 
 ## [2.4.0] - 2024/01/05
 - Hide the V2 compiler from input options until the V2 compiler is ready for release
 - Updated CLI source compilation to use rust toolchain version 1.74.1 (from 1.72.1).
-- Added `for` loop. 
+- Added `for` loop.
   - Syntax: `for (iter in lower_bound..upper_bound) { loop_body }` with integer bounds.
   - Documentation: https://aptos.dev/move/book/loops
-- Upgraded indexer processors for local testnet from 2d5cb211a89a8705674e9e1e741c841dd899c558 to 4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf. Upgraded Hasura metadata accordingly.
+- Upgraded indexer processors for localnet from 2d5cb211a89a8705674e9e1e741c841dd899c558 to 4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf. Upgraded Hasura metadata accordingly.
 - Upgraded Hasura GraphQL engine image from 2.35.0 to 2.36.1.
 
 ## [2.3.2] - 2023/11/28
-- Services in the local testnet now bind to 127.0.0.1 by default (unless the CLI is running inside a container, which most users should not do) rather than 0.0.0.0. You can override this behavior with the `--bind-to` flag. This fixes an issue preventing the local testnet from working on Windows.
+- Services in the localnet now bind to 127.0.0.1 by default (unless the CLI is running inside a container, which most users should not do) rather than 0.0.0.0. You can override this behavior with the `--bind-to` flag. This fixes an issue preventing the localnet from working on Windows.
 
 ## [2.3.1] - 2023/11/07
 ### Updated
-- Updated processor code from https://github.com/aptos-labs/aptos-indexer-processors for the local testnet to 2d5cb211a89a8705674e9e1e741c841dd899c558. 
-- Improved reliability of inter-container networking with local testnet.
+- Updated processor code from https://github.com/aptos-labs/aptos-indexer-processors for the localnet to 2d5cb211a89a8705674e9e1e741c841dd899c558.
+- Improved reliability of inter-container networking with localnet.
 
 ## [2.3.0] - 2023/10/25
 ### Added
 - Added `--node-api-key`. This lets you set an API key for the purpose of not being ratelimited.
 
 ### Updated
-- Made the local testnet exit more quickly if a service fails to start.
-- Updated processor code from https://github.com/aptos-labs/aptos-indexer-processors for the local testnet to bcba94c26c8a6372056d2b69ce411c5719f98965.
+- Made the localnet exit more quickly if a service fails to start.
+- Updated processor code from https://github.com/aptos-labs/aptos-indexer-processors for the localnet to bcba94c26c8a6372056d2b69ce411c5719f98965.
 
 ### Fixed
-- Fixed an infrequent bug that caused startup failures for the local testnet with `--force-restart` + `--with-indexer-api` by using a Docker volume rather than a bind mount for the postgres storage.
+- Fixed an infrequent bug that caused startup failures for the localnet with `--force-restart` + `--with-indexer-api` by using a Docker volume rather than a bind mount for the postgres storage.
 - Fixed an issue where the CLI could not find the Docker socket with some Docker Desktop configurations.
 
 ## [2.2.2] - 2023/10/16
 ### Updated
-- Updated processor code from https://github.com/aptos-labs/aptos-indexer-processors for the local testnet to d6f55d4baba32960ea7be60878552e73ffbe8b7e.
+- Updated processor code from https://github.com/aptos-labs/aptos-indexer-processors for the localnet to d6f55d4baba32960ea7be60878552e73ffbe8b7e.
 
 ## [2.2.1] - 2023/10/13
 ### Fixed
@@ -66,7 +67,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 ## [2.2.0] - 2023/10/11
 ### Added
-- Added `--with-indexer-api` to `aptos node run-local-testnet`. With this flag you can run a full processor + indexer API stack as part of your local testnet. You must have Docker installed to use this feature. For more information, see https://aptos.dev/nodes/local-testnet/local-testnet-index.
+- Added `--with-indexer-api` to `aptos node run-local-testnet`. With this flag you can run a full processor + indexer API stack as part of your localnet. You must have Docker installed to use this feature. For more information, see https://aptos.dev/nodes/local-testnet/local-testnet-index.
 ### Updated
 - Updated CLI source compilation to use rust toolchain version 1.72.1 (from 1.71.1).
 
@@ -112,7 +113,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 ## [2.0.1] - 2023/06/05
 ### Fixed
-- Updated txn expiration configuration for the faucet built into the CLI to make local testnet startup more reliable.
+- Updated txn expiration configuration for the faucet built into the CLI to make localnet startup more reliable.
 
 ## [2.0.0] - 2023/06/01
 ### Added

--- a/crates/aptos/e2e/cases/init.py
+++ b/crates/aptos/e2e/cases/init.py
@@ -35,12 +35,12 @@ def test_init(run_helper: RunHelper, test_name=None):
     if not account_info:
         raise TestError("Failed to read account info from newly created config file")
 
-    # Confirm with the local testnet that it was created.
+    # Confirm with the localnet that it was created.
     try:
         run_helper.api_client.account(account_info.account_address)
     except Exception as e:
         raise TestError(
-            f"Failed to query local testnet for account {account_info.account_address}"
+            f"Failed to query localnet for account {account_info.account_address}"
         ) from e
 
 

--- a/crates/aptos/e2e/local_testnet.py
+++ b/crates/aptos/e2e/local_testnet.py
@@ -1,7 +1,7 @@
 # Copyright © Aptos Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-# This file contains functions for running the local testnet.
+# This file contains functions for running the localnet.
 
 import logging
 import subprocess
@@ -12,12 +12,12 @@ from common import FAUCET_PORT, METRICS_PORT, NODE_PORT, Network, build_image_na
 
 LOG = logging.getLogger(__name__)
 
-# Run a local testnet in a docker container. We choose to detach here and we'll
+# Run a localnet in a docker container. We choose to detach here and we'll
 # stop running it later using the container name.
 def run_node(network: Network, image_repo_with_project: str, pull=True):
     image_name = build_image_name(image_repo_with_project, network)
     container_name = f"aptos-tools-{network}"
-    LOG.info(f"Trying to run aptos CLI local testnet from image: {image_name}")
+    LOG.info(f"Trying to run aptos CLI localnet from image: {image_name}")
 
     # Confirm that the Docker daemon is running.
     try:
@@ -74,7 +74,7 @@ def run_node(network: Network, image_repo_with_project: str, pull=True):
         **kwargs,
     )
 
-    LOG.info(f"Running aptos CLI local testnet from image: {image_name}")
+    LOG.info(f"Running aptos CLI localnet from image: {image_name}")
     return container_name
 
 
@@ -95,7 +95,7 @@ def wait_for_startup(container_name: str, timeout: int):
         try:
             api_response = requests.get(f"http://127.0.0.1:{NODE_PORT}/v1")
             # Try to query the legacy faucet health endpoint first. TODO: Remove this
-            # once all local testnet images we use have the new faucet in them.
+            # once all localnet images we use have the new faucet in them.
             faucet_response = requests.get(f"http://127.0.0.1:{FAUCET_PORT}/health")
             if faucet_response.status_code == 404:
                 # If that fails, try the new faucet health endpoint.

--- a/crates/aptos/e2e/main.py
+++ b/crates/aptos/e2e/main.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-This script is how we orchestrate running a local testnet and then running CLI tests against it. There are two different CLIs used for this:
+This script is how we orchestrate running a localnet and then running CLI tests against it. There are two different CLIs used for this:
 
-1. Base: For running the local testnet. This is what the --base-network flag and all other flags starting with --base are for.
+1. Base: For running the localnet. This is what the --base-network flag and all other flags starting with --base are for.
 2. Test: The CLI that we're testing. This is what the --test-cli-tag / --test-cli-path and all other flags starting with --test are for.
 
 Example (testing CLI in image):
@@ -15,7 +15,7 @@ Example (testing CLI in image):
 Example (testing locally built CLI binary):
   python3 main.py --base-network devnet --test-cli-path ~/aptos-core/target/release/aptos
 
-This means, run the CLI test suite using a CLI built from mainnet_0431e2251d0b42920d89a52c63439f7b9eda6ac3 against a local testnet built from the testnet branch of aptos-core.
+This means, run the CLI test suite using a CLI built from mainnet_0431e2251d0b42920d89a52c63439f7b9eda6ac3 against a localnet built from the testnet branch of aptos-core.
 
 Example (using a different image repo):
   See ~/.github/workflows/cli-e2e-tests.yaml
@@ -91,7 +91,7 @@ def parse_args():
         "--image-repo-with-project",
         default="aptoslabs",
         help=(
-            "What docker image repo (+ project) to use for the local testnet. "
+            "What docker image repo (+ project) to use for the localnet. "
             "By default we use Docker Hub: %(default)s (so, just aptoslabs for the "
             "project since Docker Hub is the implied default repo). If you want to "
             "specify a different repo, it might look like this: "
@@ -103,7 +103,7 @@ def parse_args():
         required=True,
         type=Network,
         choices=list(Network),
-        help="What branch the Aptos CLI used for the local testnet should be built from",
+        help="What branch the Aptos CLI used for the localnet should be built from",
     )
     parser.add_argument(
         "--base-startup-timeout",
@@ -128,7 +128,7 @@ def parse_args():
     parser.add_argument(
         "--no-pull-always",
         action="store_true",
-        help='If set, do not set "--pull always" when running the local testnet. Necessary for using local images.',
+        help='If set, do not set "--pull always" when running the localnet. Necessary for using local images.',
     )
     args = parser.parse_args()
     return args
@@ -211,7 +211,7 @@ def main():
     )
 
     # We run these in a try finally so that if something goes wrong, such as the
-    # local testnet not starting up correctly or some unexpected error in the
+    # localnet not starting up correctly or some unexpected error in the
     # test framework, we still stop the node + faucet.
     try:
         wait_for_startup(container_name, args.base_startup_timeout)

--- a/crates/aptos/e2e/test_helpers.py
+++ b/crates/aptos/e2e/test_helpers.py
@@ -30,7 +30,7 @@ class RunHelper:
 
     test_count: int
 
-    # This can be used by the tests to query the local testnet node.
+    # This can be used by the tests to query the localnet node.
     api_client: RestClient
 
     def __init__(

--- a/crates/aptos/src/main.rs
+++ b/crates/aptos/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
 
     // Shutdown the runtime with a timeout. We do this to make sure that we don't sit
     // here waiting forever waiting for tasks that sometimes don't want to exit on
-    // their own (e.g. telemetry, containers spawned by the local testnet, etc).
+    // their own (e.g. telemetry, containers spawned by the localnet, etc).
     runtime.shutdown_timeout(Duration::from_millis(50));
 
     match result {

--- a/crates/aptos/src/node/local_testnet/docker.rs
+++ b/crates/aptos/src/node/local_testnet/docker.rs
@@ -288,7 +288,7 @@ pub fn setup_docker_logging(test_dir: &Path, dir_name: &str, container_name: &st
 /// This shutdown step stops a container with the given name. If no container is found
 /// we continue without error. We choose to stop the container on shutdown rather than
 /// totally delete it so the user can check the logs if it was an unexpected shutdown.
-/// When the local testnet is started again, any leftover container will be deleted.
+/// When the localnet is started again, any leftover container will be deleted.
 #[derive(Clone, Debug)]
 pub struct StopContainerShutdownStep {
     container_name: &'static str,

--- a/crates/aptos/src/node/local_testnet/faucet.rs
+++ b/crates/aptos/src/node/local_testnet/faucet.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{health_checker::HealthChecker, traits::ServiceManager, RunLocalTestnet};
+use super::{health_checker::HealthChecker, traits::ServiceManager, RunLocalnet};
 use anyhow::Result;
 use aptos_faucet_core::server::{FunderKeyEnum, RunConfig};
 use async_trait::async_trait;
@@ -10,7 +10,7 @@ use maplit::hashset;
 use reqwest::Url;
 use std::{collections::HashSet, net::Ipv4Addr, path::PathBuf};
 
-/// Args related to running a faucet in the local testnet.
+/// Args related to running a faucet in the localnet.
 #[derive(Debug, Parser)]
 pub struct FaucetArgs {
     /// Do not run a faucet alongside the node.
@@ -46,7 +46,7 @@ pub struct FaucetManager {
 
 impl FaucetManager {
     pub fn new(
-        args: &RunLocalTestnet,
+        args: &RunLocalnet,
         prerequisite_health_checkers: HashSet<HealthChecker>,
         bind_to: Ipv4Addr,
         test_dir: PathBuf,

--- a/crates/aptos/src/node/local_testnet/indexer_api.rs
+++ b/crates/aptos/src/node/local_testnet/indexer_api.rs
@@ -8,7 +8,7 @@ use super::{
     },
     health_checker::HealthChecker,
     traits::{PostHealthyStep, ServiceManager, ShutdownStep},
-    RunLocalTestnet,
+    RunLocalnet,
 };
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -34,17 +34,17 @@ const HASURA_IMAGE: &str = "hasura/graphql-engine:v2.36.1";
 /// any references to tables that aren't created by the Rust processor migrations.
 ///
 /// To arrive at the final edited file I normally start with the new metadata file,
-/// try to start the local testnet, and check .aptos/testnet/main/tracing.log to
+/// try to start the localnet, and check .aptos/testnet/main/tracing.log to
 /// see what error Hasura returned. Remove the culprit from the metadata, which is
 /// generally a few tables and relations to those tables, and try again. Repeat until
 /// it accepts the metadata.
 ///
-/// This works fine today since all the key processors you'd need in a local testnet
+/// This works fine today since all the key processors you'd need in a localnet
 /// are in the set of processors written in Rust. If this changes, we can explore
 /// alternatives, e.g. running processors in other languages using containers.
 const HASURA_METADATA: &str = include_str!("hasura_metadata.json");
 
-/// Args related to running an indexer API for the local testnet.
+/// Args related to running an indexer API for the localnet.
 #[derive(Debug, Parser)]
 pub struct IndexerApiArgs {
     /// If set, we will run a postgres DB using Docker (unless
@@ -70,7 +70,7 @@ pub struct IndexerApiManager {
 
 impl IndexerApiManager {
     pub fn new(
-        args: &RunLocalTestnet,
+        args: &RunLocalnet,
         prerequisite_health_checkers: HashSet<HealthChecker>,
         test_dir: PathBuf,
         postgres_connection_string: String,

--- a/crates/aptos/src/node/local_testnet/mod.rs
+++ b/crates/aptos/src/node/local_testnet/mod.rs
@@ -52,13 +52,13 @@ use tracing_subscriber::fmt::MakeWriter;
 
 const TESTNET_FOLDER: &str = "testnet";
 
-/// Run a local testnet
+/// Run a localnet
 ///
-/// This local testnet will run it's own genesis and run as a single node network
+/// This localnet will run it's own genesis and run as a single node network
 /// locally. A faucet and grpc transaction stream will run alongside the node unless
 /// you specify otherwise with --no-faucet and --no-txn-stream respectively.
 #[derive(Parser)]
-pub struct RunLocalTestnet {
+pub struct RunLocalnet {
     /// The directory to save all files for the node
     ///
     /// Defaults to .aptos/testnet
@@ -105,7 +105,7 @@ pub struct RunLocalTestnet {
     log_to_stdout: bool,
 }
 
-impl RunLocalTestnet {
+impl RunLocalnet {
     /// Wait for many services to start up. This prints a message like "X is starting,
     /// please wait..." for each service and then "X is ready. Endpoint: <url>"
     /// when it's ready.
@@ -176,9 +176,9 @@ impl RunLocalTestnet {
 }
 
 #[async_trait]
-impl CliCommand<()> for RunLocalTestnet {
+impl CliCommand<()> for RunLocalnet {
     fn command_name(&self) -> &'static str {
-        "RunLocalTestnet"
+        "RunLocalnet"
     }
 
     fn jsonify_error_output(&self) -> bool {
@@ -201,7 +201,7 @@ impl CliCommand<()> for RunLocalTestnet {
         // If asked, remove the current test directory and start with a new node.
         if self.force_restart && test_dir.exists() {
             prompt_yes_with_override(
-                "Are you sure you want to delete the existing local testnet data?",
+                "Are you sure you want to delete the existing localnet data?",
                 self.prompt_options,
             )?;
             remove_dir_all(test_dir.as_path()).map_err(|err| {
@@ -391,7 +391,7 @@ impl CliCommand<()> for RunLocalTestnet {
                 .context("Failed to run post startup step")?;
         }
 
-        eprintln!("\nSetup is complete, you can now use the local testnet!");
+        eprintln!("\nSetup is complete, you can now use the localnet!");
 
         // Create a task that listens for ctrl-c. We want to intercept it so we can run
         // the shutdown steps before properly exiting. This is of course best effort,

--- a/crates/aptos/src/node/local_testnet/node.rs
+++ b/crates/aptos/src/node/local_testnet/node.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{health_checker::HealthChecker, traits::ServiceManager, RunLocalTestnet};
+use super::{health_checker::HealthChecker, traits::ServiceManager, RunLocalnet};
 use crate::node::local_testnet::utils::socket_addr_to_url;
 use anyhow::{anyhow, Context, Result};
 use aptos_config::config::{NodeConfig, DEFAULT_GRPC_STREAM_PORT};
@@ -20,12 +20,12 @@ use std::{
 };
 
 /// Args specific to running a node (and its components, e.g. the txn stream) in the
-/// local testnet.
+/// localnet.
 #[derive(Debug, Parser)]
 pub struct NodeArgs {
     /// An overridable config template for the test node
     ///
-    /// If provided, the config will be used, and any needed configuration for the local testnet
+    /// If provided, the config will be used, and any needed configuration for the localnet
     /// will override the config's values
     #[clap(long, value_parser)]
     pub config_path: Option<PathBuf>,
@@ -63,7 +63,7 @@ pub struct NodeArgs {
 
     /// If set we won't run the node at all.
     //
-    // Note: I decided that since running multiple partial local testnets is a rare
+    // Note: I decided that since running multiple partial localnets is a rare
     // case that only core devs would ever really want, it wasn't worth making the code
     // much more complex to support that case "first class". Instead, we have this flag
     // that does everything else to set up running the node, but never actually runs
@@ -71,7 +71,7 @@ pub struct NodeArgs {
     // and invoke it again to run processors + indexer API. You might want to do this
     // for compatibility testing. If you use this flag and there _isn't_ a node already
     // running at the expected port, the processors will fail to connect to the txn
-    // stream (since there isn't one) and the local testnet will crash.
+    // stream (since there isn't one) and the localnet will crash.
     //
     // If we do change our minds on this one day, the correct way to do this would be
     // to let the user instead pass in a bunch of flags that declare where an existing
@@ -91,7 +91,7 @@ pub struct NodeManager {
 }
 
 impl NodeManager {
-    pub fn new(args: &RunLocalTestnet, bind_to: Ipv4Addr, test_dir: PathBuf) -> Result<Self> {
+    pub fn new(args: &RunLocalnet, bind_to: Ipv4Addr, test_dir: PathBuf) -> Result<Self> {
         let rng = args
             .node_args
             .seed

--- a/crates/aptos/src/node/local_testnet/postgres.rs
+++ b/crates/aptos/src/node/local_testnet/postgres.rs
@@ -8,7 +8,7 @@ use super::{
     },
     health_checker::HealthChecker,
     traits::{ServiceManager, ShutdownStep},
-    RunLocalTestnet,
+    RunLocalnet,
 };
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
@@ -29,7 +29,7 @@ const POSTGRES_IMAGE: &str = "postgres:14.11";
 const DATA_PATH_IN_CONTAINER: &str = "/var/lib/mydata";
 const POSTGRES_DEFAULT_PORT: u16 = 5432;
 
-/// Args related to running postgres in the local testnet.
+/// Args related to running postgres in the localnet.
 #[derive(Clone, Debug, Parser)]
 pub struct PostgresArgs {
     /// This is the database to connect to, both when --use-host-postgres is set
@@ -83,7 +83,7 @@ impl PostgresArgs {
     /// we will use that rather than `self.postgres_database`. If `external` is true,
     /// it will give you the string for connecting from the host. If it is false, it
     /// will give you the string for connecting from another container in the network
-    /// we create for all containers in the local testnet.
+    /// we create for all containers in the localnet.
     pub fn get_connection_string(&self, database: Option<&str>, external: bool) -> String {
         let password = match self.use_host_postgres {
             true => match &self.host_postgres_password {
@@ -119,7 +119,7 @@ pub struct PostgresManager {
 }
 
 impl PostgresManager {
-    pub fn new(args: &RunLocalTestnet, test_dir: PathBuf) -> Result<Self> {
+    pub fn new(args: &RunLocalnet, test_dir: PathBuf) -> Result<Self> {
         if args.postgres_args.use_host_postgres
             && args.postgres_args.postgres_database == "postgres"
         {
@@ -275,7 +275,7 @@ impl ServiceManager for PostgresManager {
                 vec![
                     "postgres",
                     "-c",
-                    // The default is 100 as of Postgres 14.11. Given the local testnet
+                    // The default is 100 as of Postgres 14.11. Given the localnet
                     // can be composed of many different processors all with their own
                     // connection pools, 100 is insufficient.
                     "max_connections=200",

--- a/crates/aptos/src/node/local_testnet/processors.rs
+++ b/crates/aptos/src/node/local_testnet/processors.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{health_checker::HealthChecker, traits::ServiceManager, RunLocalTestnet};
+use super::{health_checker::HealthChecker, traits::ServiceManager, RunLocalnet};
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use clap::Parser;
@@ -30,7 +30,7 @@ static RUN_MIGRATIONS_ONCE: OnceCell<bool> = OnceCell::const_new();
 pub struct ProcessorArgs {
     /// The value of this flag determines which processors we will run if
     /// --with-indexer-api is set. Note that some processors are not supported in the
-    /// local testnet (e.g. ANS). If you try to set those an error will be thrown
+    /// localnet (e.g. ANS). If you try to set those an error will be thrown
     /// immediately.
     #[clap(
         long,
@@ -71,17 +71,17 @@ impl ProcessorManager {
                 ProcessorConfig::AccountTransactionsProcessor
             },
             ProcessorName::AnsProcessor => {
-                bail!("ANS processor is not supported in the local testnet")
+                bail!("ANS processor is not supported in the localnet")
             },
             ProcessorName::CoinProcessor => ProcessorConfig::CoinProcessor,
             ProcessorName::DefaultProcessor => ProcessorConfig::DefaultProcessor,
             ProcessorName::EventsProcessor => ProcessorConfig::EventsProcessor,
             ProcessorName::FungibleAssetProcessor => ProcessorConfig::FungibleAssetProcessor,
             ProcessorName::MonitoringProcessor => {
-                bail!("Monitoring processor is not supported in the local testnet")
+                bail!("Monitoring processor is not supported in the localnet")
             },
             ProcessorName::NftMetadataProcessor => {
-                bail!("NFT Metadata processor is not supported in the local testnet")
+                bail!("NFT Metadata processor is not supported in the localnet")
             },
             ProcessorName::ObjectsProcessor => {
                 ProcessorConfig::ObjectsProcessor(ObjectsProcessorConfig {
@@ -97,7 +97,7 @@ impl ProcessorManager {
             },
             ProcessorName::TokenProcessor => {
                 ProcessorConfig::TokenProcessor(TokenProcessorConfig {
-                    // This NFT points contract doesn't exist on local testnets.
+                    // This NFT points contract doesn't exist on localnets.
                     nft_points_contract: None,
                     query_retries: Default::default(),
                     query_retry_delay_ms: Default::default(),
@@ -125,7 +125,7 @@ impl ProcessorManager {
             number_concurrent_processing_tasks: None,
             enable_verbose_logging: None,
             // The default at the time of writing is 30 but we don't need that
-            // many in a local testnet environment.
+            // many in a localnet environment.
             db_pool_size: Some(8),
             gap_detection_batch_size: 50,
             pb_channel_txn_chunk_size: 100_000,
@@ -141,7 +141,7 @@ impl ProcessorManager {
 
     /// This function returns many new ProcessorManagers, one for each processor.
     pub fn many_new(
-        args: &RunLocalTestnet,
+        args: &RunLocalnet,
         prerequisite_health_checkers: HashSet<HealthChecker>,
         data_service_url: Url,
         postgres_connection_string: String,

--- a/crates/aptos/src/node/local_testnet/ready_server.rs
+++ b/crates/aptos/src/node/local_testnet/ready_server.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{health_checker::HealthChecker, traits::ServiceManager, RunLocalTestnet};
+use super::{health_checker::HealthChecker, traits::ServiceManager, RunLocalnet};
 use anyhow::Result;
 use async_trait::async_trait;
 use clap::Parser;
@@ -22,13 +22,13 @@ use std::{
 };
 use tokio::time::timeout;
 
-/// Args related to running a ready server in the local testnet. The ready server lets
-/// users / clients check that if all the services in the local testnet are ready
+/// Args related to running a ready server in the localnet. The ready server lets
+/// users / clients check that if all the services in the localnet are ready
 /// without having to ping each service individually.
 #[derive(Debug, Clone, Parser)]
 pub struct ReadyServerArgs {
     /// The port to run the ready server. This exposes an endpoint at `/` that you can
-    /// use to check if the entire local testnet is ready.
+    /// use to check if the entire localnet is ready.
     #[clap(long, default_value_t = 8070)]
     pub ready_server_listen_port: u16,
 }
@@ -42,7 +42,7 @@ pub struct ReadyServerManager {
 
 impl ReadyServerManager {
     pub fn new(
-        args: &RunLocalTestnet,
+        args: &RunLocalnet,
         bind_to: Ipv4Addr,
         health_checkers: HashSet<HealthChecker>,
     ) -> Result<Self> {

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -4,7 +4,7 @@
 pub mod analyze;
 pub mod local_testnet;
 
-use self::local_testnet::RunLocalTestnet;
+use self::local_testnet::RunLocalnet;
 use crate::{
     common::{
         types::{
@@ -76,7 +76,8 @@ pub enum NodeTool {
     ShowValidatorConfig(ShowValidatorConfig),
     ShowValidatorSet(ShowValidatorSet),
     ShowValidatorStake(ShowValidatorStake),
-    RunLocalTestnet(RunLocalTestnet),
+    #[clap(aliases = &["run-local-testnet"])]
+    RunLocalnet(RunLocalnet),
     UpdateConsensusKey(UpdateConsensusKey),
     UpdateValidatorNetworkAddresses(UpdateValidatorNetworkAddresses),
 }
@@ -100,7 +101,7 @@ impl NodeTool {
             ShowValidatorSet(tool) => tool.execute_serialized().await,
             ShowValidatorStake(tool) => tool.execute_serialized().await,
             ShowValidatorConfig(tool) => tool.execute_serialized().await,
-            RunLocalTestnet(tool) => tool
+            RunLocalnet(tool) => tool
                 .execute_serialized_without_logger()
                 .await
                 .map(|_| "".to_string()),

--- a/docker/compose/indexer-grpc/README.md
+++ b/docker/compose/indexer-grpc/README.md
@@ -16,7 +16,7 @@ Relevant ports are exposed on the docker host for testing purposes
 
 ## Reset
 
-A simple script is provided to kill and remove all relevant docker containers and volumes, to reset the whole local testnet and indexer setup:
+A simple script is provided to kill and remove all relevant docker containers and volumes, to reset the whole localnet and indexer setup:
 
 ```
 ./reset_indexer_grpc_testnet.sh

--- a/ecosystem/indexer-grpc/indexer-grpc-integration-tests/src/tests/fullnode_tests.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-integration-tests/src/tests/fullnode_tests.rs
@@ -76,7 +76,7 @@ async fn reset_redis() -> Result<()> {
     Ok(())
 }
 
-/// Fetch the mint key from the running local testnet and dump it into the path specified
+/// Fetch the mint key from the running localnet and dump it into the path specified
 async fn dump_mint_key_to_file(path: &PathBuf) -> Result<String> {
     let validator_containers =
         get_container_by_name_regex(Regex::new(r"validator-testnet.*validator.*")?)?;
@@ -100,7 +100,7 @@ async fn dump_mint_key_to_file(path: &PathBuf) -> Result<String> {
     Ok(mint_key_path_string)
 }
 
-/// Emit transactions to the local testnet to invoke certain indexer actions, such as writing
+/// Emit transactions to the localnet to invoke certain indexer actions, such as writing
 /// to filestore
 async fn emit_transactions_for_test() -> Result<()> {
     // dump the key to a tempfile

--- a/ecosystem/typescript/sdk/examples/typescript/call_aptos_cli.ts
+++ b/ecosystem/typescript/sdk/examples/typescript/call_aptos_cli.ts
@@ -15,7 +15,7 @@ const args_aptos_info = ["aptos", "info"];
   const run_local_testnet = lib.run_aptos_async(args_run_local_testnet.join(" "));
   try {
     console.log(`Aptos Info: ${aptos_info.readCString()}`);
-    console.log(`Run Local Testnet: ${run_local_testnet.readCString()}`);
+    console.log(`Run Localnet: ${run_local_testnet.readCString()}`);
   } catch (error) {
     console.error(error);
   } finally {

--- a/ecosystem/typescript/sdk/scripts/publish_ans_contract.ts
+++ b/ecosystem/typescript/sdk/scripts/publish_ans_contract.ts
@@ -3,7 +3,7 @@ require("dotenv").config();
 
 /**
  * TS SDK supports ANS. Since ANS contract is not part of aptos-framework
- * we need to get the ANS contract, publish it to local testnet and test against it.
+ * we need to get the ANS contract, publish it to localnet and test against it.
  * This script clones the aptos-names-contracts repo {@link https://github.com/aptos-labs/aptos-names-contracts},
  * uses a pre created account address and private key to fund that account and
  * then publish the contract under that account.

--- a/ecosystem/typescript/sdk/src/tests/e2e/fungible_asset_client.test.ts
+++ b/ecosystem/typescript/sdk/src/tests/e2e/fungible_asset_client.test.ts
@@ -27,7 +27,7 @@ if (process.env.NETWORK?.toLowerCase() == "testnet" || process.env.NETWORK?.toLo
 /**
  * Since there is no ready-to-use fungible asset contract/module on an aptos framework address
  * we pre compiled the ../../../aptos-move/move-examples/fungible_asset/managed_fungible_token
- * contract and publish it here to local testnet so we can interact with it to mint a fungible
+ * contract and publish it here to localnet so we can interact with it to mint a fungible
  * asset and then test FungibleAssetClient class
  */
 maybe("fungible asset", () => {


### PR DESCRIPTION
## Description
"Local testnet" is a consistently confusing name because many users assume it has something to do with the production testnet. "Localnet" is much clearer.

`run-local-testnet` will continue to work so it doesn't break anything, but we'll refer to `run-localnet` and call it a localnet (or in a long form a "local development environment", which is what the docs do) moving forward.

For now we still use `run-local-testnet` when actually invoking the CLI.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
```
cargo run -p aptos -- node run-localnet -h
cargo run -p aptos -- node run-local-testnet -h
```

## Key Areas to Review
Just thoughts on the naming.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
