### PR TITLE
[CI/CD] Adopt targeted compiler v2 tests

### DIFF
--- a/.github/actions/move-tests-compiler-v2/action.yaml
+++ b/.github/actions/move-tests-compiler-v2/action.yaml
@@ -9,9 +9,10 @@ runs:
   using: composite
   steps:
     # Checkout the repository and setup the rust toolchain
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
-        fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0 # Fetch all git history for accurate target determination
     - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       with:
         GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
@@ -21,9 +22,19 @@ runs:
       with:
         tool: nextest
 
+    # Output the changed files
+    - name: Output the changed files
+      run: cargo x changed-files -vv
+      shell: bash
+
+    # Output the affected packages
+    - name: Output the affected packages
+      run: cargo x affected-packages -vv
+      shell: bash
+
     # Run Aptos Move tests with compiler V2
     - name: Run Aptos Move tests with compiler V2
-      run: cargo nextest run --release --profile ci --locked -p e2e-move-tests -p aptos-framework --no-fail-fast
+      run: cargo x targeted-compiler-v2-tests -vv --release --profile ci --locked --no-fail-fast
       shell: bash
       env:
         MOVE_COMPILER_V2: true


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
