### PR TITLE
Add plan_builder for compiler-v2 and use it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10326,6 +10326,7 @@ dependencies = [
  "move-bytecode-viewer",
  "move-command-line-common",
  "move-compiler",
+ "move-compiler-v2",
  "move-core-types",
  "move-coverage",
  "move-disassembler",

--- a/third_party/move/move-analyzer/src/symbols.rs
+++ b/third_party/move/move-analyzer/src/symbols.rs
@@ -656,7 +656,7 @@ impl Symbolicator {
                         let failure = true;
                         diagnostics = Some((diags, failure));
                         eprintln!("typed AST compilation failed");
-                        return Ok((files, vec![]));
+                        return Ok((files, vec![], None));
                     },
                 };
                 eprintln!("compiled to typed AST");
@@ -670,7 +670,7 @@ impl Symbolicator {
                         let failure = false;
                         diagnostics = Some((diags, failure));
                         eprintln!("bytecode compilation failed");
-                        return Ok((files, vec![]));
+                        return Ok((files, vec![], None));
                     },
                 };
                 // warning diagnostics (if any) since compilation succeeded
@@ -680,7 +680,7 @@ impl Symbolicator {
                     diagnostics = Some((diags, failure));
                 }
                 eprintln!("compiled to bytecode");
-                Ok((files, units))
+                Ok((files, units, None))
             },
             unimplemented_v2_driver,
         )?;

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// Parts of the project are originally copyright © Meta Platforms, Inc.
+// Copyright (c) Aptos Foundation
+// Parts of the project are originally copyright (c) Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod acquires_checker;

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -15,6 +15,7 @@ pub mod inliner;
 pub mod logging;
 pub mod options;
 pub mod pipeline;
+pub mod plan_builder;
 pub mod recursive_struct_checker;
 pub mod unused_params_checker;
 
@@ -37,7 +38,7 @@ use crate::{
 };
 use anyhow::bail;
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream, WriteColor};
-pub use experiments::*;
+pub use experiments::Experiment;
 use log::{debug, info, log_enabled, Level};
 use move_binary_format::binary_views::BinaryIndexedView;
 use move_command_line_common::files::FileHash;
@@ -61,7 +62,7 @@ use move_stackless_bytecode::function_target_pipeline::{
     FunctionTargetPipeline, FunctionTargetsHolder, FunctionVariant,
 };
 use move_symbol_pool::Symbol;
-pub use options::*;
+pub use options::Options;
 use std::{collections::BTreeSet, io::Write, path::Path};
 
 /// Run Move compiler and print errors to stderr.

--- a/third_party/move/move-compiler-v2/src/options.rs
+++ b/third_party/move/move-compiler-v2/src/options.rs
@@ -2,7 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{experiments, DefaultValue, EXPERIMENTS};
+use crate::experiments::{DefaultValue, EXPERIMENTS};
 use clap::Parser;
 use codespan_reporting::diagnostic::Severity;
 use itertools::Itertools;
@@ -90,7 +90,7 @@ impl Options {
     pub fn set_experiment(self, name: impl AsRef<str>, on: bool) -> Self {
         let name = name.as_ref().to_string();
         assert!(
-            experiments::EXPERIMENTS.contains_key(&name),
+            EXPERIMENTS.contains_key(&name),
             "experiment `{}` not declared",
             name
         );
@@ -122,7 +122,7 @@ impl Options {
         if let Some(on) = self.experiment_cache.borrow().get(name).cloned() {
             return on;
         }
-        if let Some(exp) = experiments::EXPERIMENTS.get(&name.to_string()) {
+        if let Some(exp) = EXPERIMENTS.get(&name.to_string()) {
             // First we look at experiments provided via the command line, second
             // via the env var, and last we take the configured default.
             let on = if let Some(on) = find_experiment(&self.experiments, name) {

--- a/third_party/move/move-compiler-v2/src/plan_builder.rs
+++ b/third_party/move/move-compiler-v2/src/plan_builder.rs
@@ -1,0 +1,697 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    cfgir::ast as G,
+    diag,
+    expansion::ast::{
+        self as E, Address, Attribute, AttributeValue, ModuleAccess_, ModuleIdent, ModuleIdent_,
+    },
+    parser::ast::ConstantName,
+    shared::{
+        known_attributes::{AttributeKind, KnownAttribute, TestingAttribute},
+        unique_map::UniqueMap,
+        CompilationEnv, Identifier, NumericalAddress,
+    },
+    unit_test::{ExpectedFailure, ExpectedMoveError, ModuleTestPlan, TestCase},
+};
+use move_core_types::{
+    account_address::AccountAddress as MoveAddress, language_storage::ModuleId, u256::U256,
+    value::MoveValue, vm_status::StatusCode,
+};
+use move_ir_types::location::Loc;
+use move_symbol_pool::Symbol;
+use std::collections::BTreeMap;
+
+struct Context<'env> {
+    env: &'env mut CompilationEnv,
+    constants: UniqueMap<ModuleIdent, UniqueMap<ConstantName, (Loc, Option<u64>)>>,
+}
+
+impl<'env> Context<'env> {
+    fn new(compilation_env: &'env mut CompilationEnv, prog: &G::Program) -> Self {
+        let constants = prog.modules.ref_map(|_mident, module| {
+            module.constants.ref_map(|_name, constant| {
+                let v_opt = constant.value.as_ref().and_then(|v| match v {
+                    MoveValue::U64(u) => Some(*u),
+                    _ => None,
+                });
+                (constant.loc, v_opt)
+            })
+        });
+        Self {
+            env: compilation_env,
+            constants,
+        }
+    }
+
+    fn resolve_address(&self, addr: &Address) -> NumericalAddress {
+        (*addr).into_addr_bytes()
+    }
+
+    fn constants(&self) -> &UniqueMap<ModuleIdent, UniqueMap<ConstantName, (Loc, Option<u64>)>> {
+        &self.constants
+    }
+}
+
+//***************************************************************************
+// Test Plan Building
+//***************************************************************************
+
+// Constructs a test plan for each module in `prog`. This also validates the structure of the
+// attributes as the test plan is constructed.
+pub fn construct_test_plan(
+    compilation_env: &mut CompilationEnv,
+    package_filter: Option<Symbol>,
+    prog: &G::Program,
+) -> Option<Vec<ModuleTestPlan>> {
+    if !compilation_env.flags().is_testing() {
+        return None;
+    }
+
+    let mut context = Context::new(compilation_env, prog);
+    Some(
+        prog.modules
+            .key_cloned_iter()
+            .flat_map(|(module_ident, module_def)| {
+                construct_module_test_plan(&mut context, package_filter, module_ident, module_def)
+            })
+            .collect(),
+    )
+}
+
+fn construct_module_test_plan(
+    context: &mut Context,
+    package_filter: Option<Symbol>,
+    module_ident: ModuleIdent,
+    module: &G::ModuleDefinition,
+) -> Option<ModuleTestPlan> {
+    if package_filter.is_some() && module.package_name != package_filter {
+        return None;
+    }
+    let tests: BTreeMap<_, _> = module
+        .functions
+        .iter()
+        .filter_map(|(loc, fn_name, func)| {
+            build_test_info(context, loc, fn_name, func)
+                .map(|test_case| (fn_name.to_string(), test_case))
+        })
+        .collect();
+
+    if tests.is_empty() {
+        None
+    } else {
+        let sp!(_, ModuleIdent_ { address, module }) = &module_ident;
+        let addr_bytes = context.resolve_address(address);
+        Some(ModuleTestPlan::new(&addr_bytes, &module.0.value, tests))
+    }
+}
+
+fn build_test_info<'func>(
+    context: &mut Context,
+    fn_loc: Loc,
+    fn_name: &str,
+    function: &'func G::Function,
+) -> Option<TestCase> {
+    let get_attrs = |attr: TestingAttribute| -> Option<&'func E::Attribute> {
+        function
+            .attributes
+            .get_(&E::AttributeName_::Known(KnownAttribute::Testing(attr)))
+    };
+
+    const PREVIOUSLY_ANNOTATED_MSG: &str = "Previously annotated here";
+    const IN_THIS_TEST_MSG: &str = "Error found in this test";
+
+    let test_attribute_opt = get_attrs(TestingAttribute::Test);
+    let abort_attribute_opt = get_attrs(TestingAttribute::ExpectedFailure);
+    let test_only_attribute_opt = get_attrs(TestingAttribute::TestOnly);
+
+    let test_attribute = match test_attribute_opt {
+        None => {
+            // expected failures cannot be annotated on non-#[test] functions
+            if let Some(abort_attribute) = abort_attribute_opt {
+                let fn_msg = "Only functions defined as a test with #[test] can also have an \
+                              #[expected_failure] attribute";
+                let abort_msg = "Attributed as #[expected_failure] here";
+                context.env.add_diag(diag!(
+                    Attributes::InvalidUsage,
+                    (fn_loc, fn_msg),
+                    (abort_attribute.loc, abort_msg),
+                ))
+            }
+            return None;
+        },
+        Some(test_attribute) => test_attribute,
+    };
+
+    // A #[test] function cannot also be annotated #[test_only]
+    if let Some(test_only_attribute) = test_only_attribute_opt {
+        let msg = "Function annotated as both #[test(...)] and #[test_only]. You need to declare \
+                   it as either one or the other";
+        context.env.add_diag(diag!(
+            Attributes::InvalidUsage,
+            (test_only_attribute.loc, msg),
+            (test_attribute.loc, PREVIOUSLY_ANNOTATED_MSG),
+            (fn_loc, IN_THIS_TEST_MSG),
+        ))
+    }
+
+    let test_annotation_params = parse_test_attribute(context, test_attribute, 0);
+    let mut arguments = Vec::new();
+    for (var, _) in &function.signature.parameters {
+        match test_annotation_params.get(&var.value()) {
+            Some(value) => arguments.push(value.clone()),
+            None => {
+                let missing_param_msg = "Missing test parameter assignment in test. Expected a \
+                                         parameter to be assigned in this attribute";
+                context.env.add_diag(diag!(
+                    Attributes::InvalidTest,
+                    (test_attribute.loc, missing_param_msg),
+                    (var.loc(), "Corresponding to this parameter"),
+                    (fn_loc, IN_THIS_TEST_MSG),
+                ))
+            },
+        }
+    }
+
+    let expected_failure = match abort_attribute_opt {
+        None => None,
+        Some(abort_attribute) => parse_failure_attribute(context, abort_attribute),
+    };
+
+    Some(TestCase {
+        test_name: fn_name.to_string(),
+        arguments,
+        expected_failure,
+    })
+}
+
+//***************************************************************************
+// Attribute parsers
+//***************************************************************************
+
+fn parse_test_attribute(
+    context: &mut Context,
+    sp!(aloc, test_attribute): &E::Attribute,
+    depth: usize,
+) -> BTreeMap<Symbol, MoveValue> {
+    use E::Attribute_ as EA;
+
+    match test_attribute {
+        EA::Name(_) | EA::Parameterized(_, _) if depth > 0 => {
+            context.env.add_diag(diag!(
+                Attributes::InvalidTest,
+                (*aloc, "Unexpected nested attribute in test declaration"),
+            ));
+            BTreeMap::new()
+        },
+        EA::Name(nm) => {
+            assert!(
+                nm.value.as_str() == TestingAttribute::Test.name() && depth == 0,
+                "ICE: We should only be parsing a raw test attribute"
+            );
+            BTreeMap::new()
+        },
+        EA::Assigned(nm, attr_value) => {
+            if depth != 1 {
+                context.env.add_diag(diag!(
+                    Attributes::InvalidTest,
+                    (*aloc, "Unexpected nested attribute in test declaration"),
+                ));
+                return BTreeMap::new();
+            }
+            let sp!(assign_loc, attr_value) = &**attr_value;
+            let value = match convert_attribute_value_to_move_value(context, attr_value) {
+                Some(move_value) => move_value,
+                None => {
+                    context.env.add_diag(diag!(
+                        Attributes::InvalidValue,
+                        (*assign_loc, "Unsupported attribute value"),
+                        (*aloc, "Assigned in this attribute"),
+                    ));
+                    return BTreeMap::new();
+                },
+            };
+
+            let mut args = BTreeMap::new();
+            args.insert(nm.value, value);
+            args
+        },
+        EA::Parameterized(nm, attributes) => {
+            assert!(
+                nm.value.as_str() == TestingAttribute::Test.name() && depth == 0,
+                "ICE: We should only be parsing a raw test attribute"
+            );
+            attributes
+                .iter()
+                .flat_map(|(_, _, attr)| parse_test_attribute(context, attr, depth + 1))
+                .collect()
+        },
+    }
+}
+
+const BAD_ABORT_VALUE_WARNING: &str = "WARNING: passes for an abort from any module.";
+const INVALID_VALUE: &str = "Invalid value in attribute assignment";
+
+fn parse_failure_attribute(
+    context: &mut Context,
+    sp!(aloc, expected_attr): &E::Attribute,
+) -> Option<ExpectedFailure> {
+    use E::Attribute_ as EA;
+    match expected_attr {
+        EA::Name(nm) => {
+            assert!(
+                nm.value.as_str() == TestingAttribute::ExpectedFailure.name(),
+                "ICE: We should only be parsing a raw expected failure attribute"
+            );
+            Some(ExpectedFailure::Expected)
+        },
+        EA::Assigned(_, value) => {
+            let assign_loc = value.loc;
+            let invalid_assignment_msg = "Invalid expected failure code assignment";
+            let expected_msg =
+                "Expect an #[expected_failure(...)] attribute for error specification";
+            context.env.add_diag(diag!(
+                Attributes::InvalidValue,
+                (assign_loc, invalid_assignment_msg),
+                (*aloc, expected_msg),
+            ));
+            None
+        },
+        EA::Parameterized(sp!(_, nm), attrs) => {
+            assert!(
+                nm.as_str() == TestingAttribute::ExpectedFailure.name(),
+                "ICE: expected failure attribute must have the right name"
+            );
+            let mut attrs: BTreeMap<String, (Loc, Attribute)> = attrs
+                .key_cloned_iter()
+                .map(|(sp!(kloc, k_), v)| (k_.to_string(), (kloc, v.clone())))
+                .collect();
+            let mut expected_failure_kind_vec = TestingAttribute::expected_failure_cases()
+                .iter()
+                .filter_map(|k| {
+                    let k = k.to_string();
+                    let attr_opt = attrs.remove(&k)?;
+                    Some((k, attr_opt))
+                })
+                .collect::<Vec<_>>();
+            if expected_failure_kind_vec.len() != 1 {
+                let invalid_attr_msg = format!(
+                    "Invalid #[expected_failure(...)] attribute, expected 1 failure kind but found {}. Expected one of: {}",
+                    expected_failure_kind_vec.len(),
+                    TestingAttribute::expected_failure_cases().to_vec().join(", ")
+                );
+                context
+                    .env
+                    .add_diag(diag!(Attributes::InvalidValue, (*aloc, invalid_attr_msg)));
+                return None;
+            }
+            let (expected_failure_kind, (attr_loc, attr)) =
+                expected_failure_kind_vec.pop().unwrap();
+            let location_opt = attrs.remove(TestingAttribute::ERROR_LOCATION);
+            let (status_code, sub_status_code, location) = match expected_failure_kind.as_str() {
+                TestingAttribute::ABORT_CODE_NAME => {
+                    let (value_name_loc, attr_value) = get_assigned_attribute(
+                        context,
+                        TestingAttribute::ABORT_CODE_NAME,
+                        attr_loc,
+                        attr,
+                    )?;
+                    let (value_loc, const_location_opt, u) =
+                        convert_constant_value_u64_constant_or_value(
+                            context,
+                            value_name_loc,
+                            &attr_value,
+                        )?;
+                    let location = if let Some((location_loc, location_attr)) = location_opt {
+                        convert_location(context, location_loc, location_attr)?
+                    } else if let Some(location) = const_location_opt {
+                        location
+                    } else {
+                        let tip = format!(
+                            "Replace value with constant from expected module or add `{}=...` \
+                            attribute.",
+                            TestingAttribute::ERROR_LOCATION
+                        );
+                        context.env.add_diag(diag!(
+                            Attributes::ValueWarning,
+                            (attr_loc, BAD_ABORT_VALUE_WARNING),
+                            (value_loc, tip)
+                        ));
+                        return Some(ExpectedFailure::ExpectedWithCodeDEPRECATED(u));
+                    };
+                    (StatusCode::ABORTED, Some(u), location)
+                },
+                TestingAttribute::ARITHMETIC_ERROR_NAME => {
+                    check_attribute_unassigned(
+                        context,
+                        TestingAttribute::ARITHMETIC_ERROR_NAME,
+                        attr_loc,
+                        attr,
+                    )?;
+                    let (location_loc, location_attr) = check_location(
+                        context,
+                        attr_loc,
+                        TestingAttribute::ARITHMETIC_ERROR_NAME,
+                        location_opt,
+                    )?;
+                    let location = convert_location(context, location_loc, location_attr)?;
+                    (StatusCode::ARITHMETIC_ERROR, None, location)
+                },
+                TestingAttribute::OUT_OF_GAS_NAME => {
+                    check_attribute_unassigned(
+                        context,
+                        TestingAttribute::OUT_OF_GAS_NAME,
+                        attr_loc,
+                        attr,
+                    )?;
+                    let (location_loc, location_attr) = check_location(
+                        context,
+                        attr_loc,
+                        TestingAttribute::OUT_OF_GAS_NAME,
+                        location_opt,
+                    )?;
+                    let location = convert_location(context, location_loc, location_attr)?;
+                    (StatusCode::OUT_OF_GAS, None, location)
+                },
+                TestingAttribute::VECTOR_ERROR_NAME => {
+                    check_attribute_unassigned(
+                        context,
+                        TestingAttribute::VECTOR_ERROR_NAME,
+                        attr_loc,
+                        attr,
+                    )?;
+                    let minor_attr_opt = attrs.remove(TestingAttribute::MINOR_STATUS_NAME);
+                    let minor_status = if let Some((minor_loc, minor_attr)) = minor_attr_opt {
+                        let (minor_value_loc, minor_value) = get_assigned_attribute(
+                            context,
+                            TestingAttribute::MINOR_STATUS_NAME,
+                            minor_loc,
+                            minor_attr,
+                        )?;
+                        let (_, _, minor_status) = convert_constant_value_u64_constant_or_value(
+                            context,
+                            minor_value_loc,
+                            &minor_value,
+                        )?;
+                        Some(minor_status)
+                    } else {
+                        None
+                    };
+                    let (location_loc, location_attr) = check_location(
+                        context,
+                        attr_loc,
+                        TestingAttribute::VECTOR_ERROR_NAME,
+                        location_opt,
+                    )?;
+                    let location = convert_location(context, location_loc, location_attr)?;
+                    (StatusCode::VECTOR_OPERATION_ERROR, minor_status, location)
+                },
+                TestingAttribute::MAJOR_STATUS_NAME => {
+                    let (value_name_loc, attr_value) = get_assigned_attribute(
+                        context,
+                        TestingAttribute::MAJOR_STATUS_NAME,
+                        attr_loc,
+                        attr,
+                    )?;
+                    let (major_value_loc, _, major_status_u64) =
+                        convert_constant_value_u64_constant_or_value(
+                            context,
+                            value_name_loc,
+                            &attr_value,
+                        )?;
+                    let major_status = if let Ok(c) = StatusCode::try_from(major_status_u64) {
+                        c
+                    } else {
+                        let bad_value = format!(
+                            "Invalid value for '{}'",
+                            TestingAttribute::MAJOR_STATUS_NAME,
+                        );
+                        let no_code =
+                            format!("No status code associated with value '{major_status_u64}'");
+                        context.env.add_diag(diag!(
+                            Attributes::InvalidValue,
+                            (value_name_loc, bad_value),
+                            (major_value_loc, no_code)
+                        ));
+                        return None;
+                    };
+                    let minor_attr_opt = attrs.remove(TestingAttribute::MINOR_STATUS_NAME);
+                    let minor_status = if let Some((minor_loc, minor_attr)) = minor_attr_opt {
+                        let (minor_value_loc, minor_value) = get_assigned_attribute(
+                            context,
+                            TestingAttribute::MINOR_STATUS_NAME,
+                            minor_loc,
+                            minor_attr,
+                        )?;
+                        let (_, _, minor_status) = convert_constant_value_u64_constant_or_value(
+                            context,
+                            minor_value_loc,
+                            &minor_value,
+                        )?;
+                        Some(minor_status)
+                    } else {
+                        None
+                    };
+                    let (location_loc, location_attr) = check_location(
+                        context,
+                        attr_loc,
+                        TestingAttribute::MAJOR_STATUS_NAME,
+                        location_opt,
+                    )?;
+                    let location = convert_location(context, location_loc, location_attr)?;
+                    (major_status, minor_status, location)
+                },
+                _ => unreachable!(),
+            };
+            // warn for any remaining attrs
+            for (_, (loc, _)) in attrs {
+                let msg = format!(
+                    "Unused attribute for {}",
+                    TestingAttribute::ExpectedFailure.name()
+                );
+                context
+                    .env
+                    .add_diag(diag!(UnusedItem::Attribute, (loc, msg)));
+            }
+            Some(ExpectedFailure::ExpectedWithError(ExpectedMoveError(
+                status_code,
+                sub_status_code,
+                move_binary_format::errors::Location::Module(location),
+            )))
+        },
+    }
+}
+
+fn check_attribute_unassigned(
+    context: &mut Context,
+    kind: &str,
+    attr_loc: Loc,
+    attr: Attribute,
+) -> Option<()> {
+    use E::Attribute_ as EA;
+    match attr {
+        sp!(_, EA::Name(sp!(_, nm))) => {
+            assert!(nm.as_str() == kind);
+            Some(())
+        },
+        sp!(loc, _) => {
+            let msg = format!(
+                "Expected no assigned value, e.g. '{}', for expected failure attribute",
+                kind
+            );
+            context.env.add_diag(diag!(
+                Attributes::InvalidValue,
+                (attr_loc, "Unsupported attribute in this location"),
+                (loc, msg)
+            ));
+            None
+        },
+    }
+}
+
+fn get_assigned_attribute(
+    context: &mut Context,
+    kind: &str,
+    attr_loc: Loc,
+    attr: Attribute,
+) -> Option<(Loc, AttributeValue)> {
+    use E::Attribute_ as EA;
+    match attr {
+        sp!(assign_loc, EA::Assigned(sp!(_, nm), value)) => {
+            assert!(nm.as_str() == kind);
+            Some((assign_loc, *value))
+        },
+        sp!(loc, _) => {
+            let msg = format!(
+                "Expected assigned value, e.g. '{}=...', for expected failure attribute",
+                kind
+            );
+            context.env.add_diag(diag!(
+                Attributes::InvalidValue,
+                (attr_loc, "Unsupported attribute in this location"),
+                (loc, msg)
+            ));
+            None
+        },
+    }
+}
+
+fn convert_location(context: &mut Context, attr_loc: Loc, attr: Attribute) -> Option<ModuleId> {
+    use E::AttributeValue_ as EAV;
+    let (loc, value) =
+        get_assigned_attribute(context, TestingAttribute::ERROR_LOCATION, attr_loc, attr)?;
+    match value {
+        sp!(vloc, EAV::Module(module)) => convert_module_id(context, vloc, &module),
+        sp!(vloc, _) => {
+            context.env.add_diag(diag!(
+                Attributes::InvalidValue,
+                (loc, INVALID_VALUE),
+                (vloc, "Expected a module identifier, e.g. 'std::vector'")
+            ));
+            None
+        },
+    }
+}
+
+fn convert_constant_value_u64_constant_or_value(
+    context: &mut Context,
+    loc: Loc,
+    value: &AttributeValue,
+) -> Option<(Loc, Option<ModuleId>, u64)> {
+    use E::AttributeValue_ as EAV;
+    let (vloc, module, member) = match value {
+        sp!(
+            vloc,
+            EAV::ModuleAccess(sp!(_, ModuleAccess_::ModuleAccess(m, n)))
+        ) => (*vloc, m, n),
+        _ => {
+            let (vloc, u) = convert_attribute_value_u64(context, loc, value)?;
+            return Some((vloc, None, u));
+        },
+    };
+    let module_id = convert_module_id(context, vloc, module)?;
+    let modules_constants = context.constants().get(module).unwrap();
+    let constant = match modules_constants.get_(&member.value) {
+        None => {
+            context.env.add_diag(diag!(
+                Attributes::InvalidValue,
+                (vloc, INVALID_VALUE),
+                (
+                    module.loc,
+                    format!("Unbound constant '{member}' in module '{module}'")
+                ),
+            ));
+            return None;
+        },
+        Some(c) => c,
+    };
+    match constant {
+        (cloc, None) => {
+            let msg = format!(
+                "Constant '{module}::{member}' has a non-u64 value. \
+                Only 'u64' values are permitted"
+            );
+            context.env.add_diag(diag!(
+                Attributes::InvalidValue,
+                (vloc, INVALID_VALUE),
+                (*cloc, msg),
+            ));
+            None
+        },
+        (_, Some(u)) => Some((vloc, Some(module_id), *u)),
+    }
+}
+
+fn convert_module_id(context: &mut Context, vloc: Loc, module: &ModuleIdent) -> Option<ModuleId> {
+    if !context.constants.contains_key(module) {
+        context.env.add_diag(diag!(
+            Attributes::InvalidValue,
+            (vloc, INVALID_VALUE),
+            (module.loc, format!("Unbound module '{module}'")),
+        ));
+        return None;
+    }
+    let sp!(mloc, ModuleIdent_ { address, module }) = module;
+    let addr = match address {
+        Address::Numerical(_, sp!(_, a)) => a.into_inner(),
+        Address::NamedUnassigned(addr) => {
+            context.env.add_diag(diag!(
+                Attributes::InvalidValue,
+                (vloc, INVALID_VALUE),
+                (*mloc, format!("Unbound address '{addr}'")),
+            ));
+            return None;
+        },
+    };
+    let mname = move_core_types::identifier::Identifier::new(module.value().to_string()).unwrap();
+    let mid = ModuleId::new(addr, mname);
+    Some(mid)
+}
+
+fn convert_attribute_value_u64(
+    context: &mut Context,
+    loc: Loc,
+    value: &AttributeValue,
+) -> Option<(Loc, u64)> {
+    use E::{AttributeValue_ as EAV, Value_ as EV};
+    match value {
+        sp!(vloc, EAV::Value(sp!(_, EV::InferredNum(u)))) if *u <= U256::from(std::u64::MAX) => {
+            Some((*vloc, u.down_cast_lossy()))
+        },
+        sp!(vloc, EAV::Value(sp!(_, EV::U64(u)))) => Some((*vloc, *u)),
+        sp!(vloc, EAV::Value(sp!(_, EV::U8(_))))
+        | sp!(vloc, EAV::Value(sp!(_, EV::U16(_))))
+        | sp!(vloc, EAV::Value(sp!(_, EV::U32(_))))
+        | sp!(vloc, EAV::Value(sp!(_, EV::U128(_))))
+        | sp!(vloc, EAV::Value(sp!(_, EV::U256(_)))) => {
+            context.env.add_diag(diag!(
+                Attributes::InvalidValue,
+                (loc, INVALID_VALUE),
+                (*vloc, "Annotated non-u64 literals are not permitted"),
+            ));
+            None
+        },
+        sp!(vloc, _) => {
+            context.env.add_diag(diag!(
+                Attributes::InvalidValue,
+                (loc, INVALID_VALUE),
+                (*vloc, "Unsupported value in this assignment"),
+            ));
+            None
+        },
+    }
+}
+
+fn convert_attribute_value_to_move_value(
+    context: &mut Context,
+    value: &E::AttributeValue_,
+) -> Option<MoveValue> {
+    use E::{AttributeValue_ as EAV, Value_ as EV};
+    match value {
+        // Only addresses are allowed
+        EAV::Value(sp!(_, EV::Address(a))) => Some(MoveValue::Address(MoveAddress::new(
+            context.resolve_address(a).into_bytes(),
+        ))),
+        _ => None,
+    }
+}
+
+fn check_location<T>(
+    context: &mut Context,
+    loc: Loc,
+    attr: &str,
+    location: Option<T>,
+) -> Option<T> {
+    if location.is_none() {
+        let msg = format!(
+            "Expected '{}' following '{attr}'",
+            TestingAttribute::ERROR_LOCATION
+        );
+        context
+            .env
+            .add_diag(diag!(Attributes::InvalidUsage, (loc, msg)));
+    }
+    location
+}

--- a/third_party/move/move-compiler-v2/src/plan_builder.rs
+++ b/third_party/move/move-compiler-v2/src/plan_builder.rs
@@ -64,7 +64,7 @@ fn construct_module_test_plan(
     _package_filter: Option<Symbol>,
     module: ModuleEnv,
 ) -> Option<ModuleTestPlan> {
-    // BUGBUG: TODO: what is a package?
+    // TODO (#12885): what is a package?  Do we need this code?
     // if package_filter.is_some() && module.package_name != package_filter {
     // return None;
     // }

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -8,7 +8,8 @@ use itertools::Itertools;
 use log::debug;
 use move_compiler_v2::{
     annotate_units, disassemble_compiled_units, env_pipeline::rewrite_target::RewritingScope,
-    logging, pipeline, run_bytecode_verifier, run_file_format_gen, Experiment, Options,
+    logging, pipeline, plan_builder, run_bytecode_verifier, run_file_format_gen, Experiment,
+    Options,
 };
 use move_model::{metadata::LanguageVersion, model::GlobalEnv};
 use move_prover_test_utils::{baseline_test, extract_test_directives};
@@ -607,6 +608,10 @@ fn run_test(path: &Path, config: TestConfig) -> datatest_stable::Result<()> {
                 ));
             }
         }
+    }
+
+    if options.compile_test_code {
+        plan_builder::construct_test_plan(&env, None);
     }
 
     if ok && config.stop_after > StopAfter::AstPipeline {

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -611,7 +611,11 @@ fn run_test(path: &Path, config: TestConfig) -> datatest_stable::Result<()> {
     }
 
     if options.compile_test_code {
+        // Build the test plan here to parse and validate any test-related attributes in the AST.
+        // In real use, this is run outside of the compilation process, but the needed info is
+        // available in `env` once we finish the AST.
         plan_builder::construct_test_plan(&env, None);
+        ok = check_diags(&mut test_output.borrow_mut(), &env);
     }
 
     if ok && config.stop_after > StopAfter::AstPipeline {

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/attribute_location_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/attribute_location_invalid.exp
@@ -23,3 +23,6 @@ error: invalid attribute
    │       │
    │       Attribute 'expected_failure' is not expected with a struct
    │       Expected to be used with one of the following: function
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_bad_value.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_bad_value.exp
@@ -1,2 +1,31 @@
 
-============ bytecode verification succeeded ========
+Diagnostics:
+error: Invalid attribute value: only u64 literal values permitted
+  ┌─ tests/unit_test/test/expected_failure_bad_value.move:7:35
+  │
+7 │     #[expected_failure(abort_code=true)]
+  │                                   ^^^^
+
+error: Invalid attribute value: only u64 literal values permitted
+   ┌─ tests/unit_test/test/expected_failure_bad_value.move:11:35
+   │
+11 │     #[expected_failure(abort_code=x"")]
+   │                                   ^^^
+
+error: Invalid attribute value: only u64 literal values permitted
+   ┌─ tests/unit_test/test/expected_failure_bad_value.move:15:35
+   │
+15 │     #[expected_failure(abort_code=b"")]
+   │                                   ^^^
+
+error: Unbound constant `Foo` in module `0x1::A`
+   ┌─ tests/unit_test/test/expected_failure_bad_value.move:19:35
+   │
+19 │     #[expected_failure(abort_code=Foo)]
+   │                                   ^^^
+
+error: Invalid attribute value: only u64 literal values permitted
+   ┌─ tests/unit_test/test/expected_failure_bad_value.move:23:35
+   │
+23 │     #[expected_failure(abort_code=@0xC0FFEE)]
+   │                                   ^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_constants_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_constants_invalid.exp
@@ -1,2 +1,19 @@
 
-============ bytecode verification succeeded ========
+Diagnostics:
+error: Constant `0x2::m::C` has a non-u64 value.  Only `u64` values are permitted
+  ┌─ tests/unit_test/test/expected_failure_constants_invalid.move:9:35
+  │
+9 │     #[expected_failure(abort_code=0x2::m::C)]
+  │                                   ^^^^^^^^^
+
+error: Unbound module `0x2::x` in constant
+   ┌─ tests/unit_test/test/expected_failure_constants_invalid.move:13:35
+   │
+13 │     #[expected_failure(abort_code=0x2::x::C)]
+   │                                   ^^^^^^^^^
+
+error: Unbound constant `C0` in module `0x1::A`
+   ┌─ tests/unit_test/test/expected_failure_constants_invalid.move:17:35
+   │
+17 │     #[expected_failure(abort_code=0x1::A::C0)]
+   │                                   ^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_not_test.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_not_test.exp
@@ -1,2 +1,17 @@
 
-============ bytecode verification succeeded ========
+Diagnostics:
+error: Only functions defined as a test with #[test] can also have an #[expected_failure] attribute
+  ┌─ tests/unit_test/test/expected_failure_not_test.move:4:9
+  │
+3 │     #[expected_failure]
+  │       ---------------- Attributed as #[expected_failure] here
+4 │     fun foo() { }
+  │         ^^^
+
+error: Only functions defined as a test with #[test] can also have an #[expected_failure] attribute
+  ┌─ tests/unit_test/test/expected_failure_not_test.move:7:9
+  │
+6 │     #[test_only, expected_failure]
+  │                  ---------------- Attributed as #[expected_failure] here
+7 │     fun bar() { }
+  │         ^^^

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_on_non_function.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_on_non_function.exp
@@ -26,3 +26,6 @@ error: invalid attribute
   │       │
   │       Attribute 'expected_failure' is not expected with a constant
   │       Expected to be used with one of the following: function
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_out_of_range_value.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_out_of_range_value.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-warning: WARNING: passes for an abort from any module.
+warning: Test will pass on an abort from *any* module.
   ┌─ tests/unit_test/test/expected_failure_out_of_range_value.move:6:24
   │
 6 │     #[expected_failure(abort_code=18446744073709551614)]
@@ -8,7 +8,7 @@ warning: WARNING: passes for an abort from any module.
   │                                   │
   │                                   Replace value with constant from expected module or add `location=...` attribute.
 
-warning: WARNING: passes for an abort from any module.
+warning: Test will pass on an abort from *any* module.
    ┌─ tests/unit_test/test/expected_failure_out_of_range_value.move:11:24
    │
 11 │     #[expected_failure(abort_code=18446744073709551615)]

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_out_of_range_value.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/expected_failure_out_of_range_value.exp
@@ -1,2 +1,23 @@
 
-============ bytecode verification succeeded ========
+Diagnostics:
+warning: WARNING: passes for an abort from any module.
+  ┌─ tests/unit_test/test/expected_failure_out_of_range_value.move:6:24
+  │
+6 │     #[expected_failure(abort_code=18446744073709551614)]
+  │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │                                   │
+  │                                   Replace value with constant from expected module or add `location=...` attribute.
+
+warning: WARNING: passes for an abort from any module.
+   ┌─ tests/unit_test/test/expected_failure_out_of_range_value.move:11:24
+   │
+11 │     #[expected_failure(abort_code=18446744073709551615)]
+   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │                                   │
+   │                                   Replace value with constant from expected module or add `location=...` attribute.
+
+error: Invalid attribute value: only u64 literal values permitted
+   ┌─ tests/unit_test/test/expected_failure_out_of_range_value.move:16:35
+   │
+16 │     #[expected_failure(abort_code=18446744073709551616)]
+   │                                   ^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/extra_attributes.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/extra_attributes.exp
@@ -1,2 +1,34 @@
 
+Diagnostics:
+warning: Unused attribute for expected_failure
+  ┌─ tests/unit_test/test/extra_attributes.move:8:60
+  │
+8 │     #[expected_failure(vector_error, location=std::vector, hello=0)]
+  │                                                            ^^^^^^^
+
+warning: Unused attribute for expected_failure
+   ┌─ tests/unit_test/test/extra_attributes.move:12:54
+   │
+12 │     #[expected_failure(arithmetic_error, location=n, wowza)]
+   │                                                      ^^^^^
+
+warning: Unused attribute for expected_failure
+   ┌─ tests/unit_test/test/extra_attributes.move:16:51
+   │
+16 │     #[expected_failure(out_of_gas, location=Self, so_many_attrs)]
+   │                                                   ^^^^^^^^^^^^^
+
+warning: Unused attribute for expected_failure
+   ┌─ tests/unit_test/test/extra_attributes.move:20:43
+   │
+20 │     #[expected_failure(major_status=4004, an_attr_here_is_unused, location=Self)]
+   │                                           ^^^^^^^^^^^^^^^^^^^^^^
+
+warning: Unused attribute for expected_failure
+   ┌─ tests/unit_test/test/extra_attributes.move:24:43
+   │
+24 │     #[expected_failure(major_status=4016, minor_code=0, location=Self)]
+   │                                           ^^^^^^^^^^^^
+
+
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/extra_attributes2.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/extra_attributes2.exp
@@ -23,3 +23,6 @@ error: invalid attribute
    │
 21 │     #[expected_failure(verify_only)]
    │                        ^^^^^^^^^^^ Attribute 'verify_only' is not expected in a nested attribute position
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/invalid_expected_code_name.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/invalid_expected_code_name.exp
@@ -1,2 +1,19 @@
 
-============ bytecode verification succeeded ========
+Diagnostics:
+error: Invalid #[expected_failure(...)] attribute, expected 1 failure kind but found 0. Expected one of: abort_code, arithmetic_error, vector_error, out_of_gas, major_status
+  ┌─ tests/unit_test/test/invalid_expected_code_name.move:4:7
+  │
+4 │     #[expected_failure(cod=1)]
+  │       ^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid #[expected_failure(...)] attribute, expected 1 failure kind but found 0. Expected one of: abort_code, arithmetic_error, vector_error, out_of_gas, major_status
+  ┌─ tests/unit_test/test/invalid_expected_code_name.move:8:7
+  │
+8 │     #[expected_failure(code=1)]
+  │       ^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Invalid #[expected_failure(...)] attribute, expected 1 failure kind but found 0. Expected one of: abort_code, arithmetic_error, vector_error, out_of_gas, major_status
+   ┌─ tests/unit_test/test/invalid_expected_code_name.move:12:7
+   │
+12 │     #[expected_failure(abort_cod=1)]
+   │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/invalid_expected_failure_name.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/invalid_expected_failure_name.exp
@@ -1,2 +1,9 @@
 
-============ bytecode verification succeeded ========
+Diagnostics:
+error: Invalid expected failure code assignment
+  ┌─ tests/unit_test/test/invalid_expected_failure_name.move:4:7
+  │
+4 │     #[expected_failure=1]
+  │       ^^^^^^^^^^^^^^^^^^
+  │       │
+  │       Expect an #[expected_failure(...)] attribute for error specification

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/multiple_errors.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/multiple_errors.exp
@@ -15,3 +15,6 @@ error: duplicate declaration, item, or annotation
    │       ---------------- Attribute previously given here
 42 │     #[expected_failure]
    │       ^^^^^^^^^^^^^^^^ Duplicate attribute 'expected_failure' attached to the same item
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/multiple_test_annotations.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/multiple_test_annotations.exp
@@ -15,3 +15,6 @@ error: duplicate declaration, item, or annotation
    │       ---- Attribute previously given here
 10 │     #[test(_a=@0x1, _b=@0x2)]
    │       ^^^^^^^^^^^^^^^^^^^^^^ Duplicate attribute 'test' attached to the same item
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/named_address_no_value_in_annotation.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/named_address_no_value_in_annotation.exp
@@ -5,3 +5,6 @@ error: address with no value
   │
 2 │     #[test(_a = @UnboundAddr)]
   │                  ^^^^^^^^^^^ address 'UnboundAddr' is not assigned a value. Try assigning it a value when calling the compiler
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_assignment.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_assignment.exp
@@ -1,2 +1,31 @@
 
-============ bytecode verification succeeded ========
+Diagnostics:
+error: Expected no assigned value, e.g. `vector_error`, for expected failure attribute
+  ┌─ tests/unit_test/test/other_failures_invalid_assignment.move:9:24
+  │
+9 │     #[expected_failure(vector_error=0, location=std::vector)]
+  │                        ^^^^^^^^^^^^^^
+
+error: Invalid attribute value: only u64 literal values permitted
+   ┌─ tests/unit_test/test/other_failures_invalid_assignment.move:13:51
+   │
+13 │     #[expected_failure(vector_error, minor_status=x"", location=std::vector)]
+   │                                                   ^^^
+
+error: Expected no assigned value, e.g. `arithmetic_error`, for expected failure attribute
+   ┌─ tests/unit_test/test/other_failures_invalid_assignment.move:17:24
+   │
+17 │     #[expected_failure(arithmetic_error=@0, location=n)]
+   │                        ^^^^^^^^^^^^^^^^^^^
+
+error: Expected no assigned value, e.g. `out_of_gas`, for expected failure attribute
+   ┌─ tests/unit_test/test/other_failures_invalid_assignment.move:21:24
+   │
+21 │     #[expected_failure(out_of_gas=bool, location=Self)]
+   │                        ^^^^^^^^^^^^^^^
+
+error: Invalid attribute value: only u64 literal values permitted
+   ┌─ tests/unit_test/test/other_failures_invalid_assignment.move:29:56
+   │
+29 │     #[expected_failure(major_status=4016, minor_status=b"", location=Self)]
+   │                                                        ^^^

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_location.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_location.exp
@@ -1,2 +1,39 @@
 
-============ bytecode verification succeeded ========
+Diagnostics:
+error: Expected `location` following `vector_error`
+  ┌─ tests/unit_test/test/other_failures_invalid_location.move:6:24
+  │
+6 │     #[expected_failure(vector_error)]
+  │                        ^^^^^^^^^^^^
+
+error: Expected `location` following `arithmetic_error`
+   ┌─ tests/unit_test/test/other_failures_invalid_location.move:10:24
+   │
+10 │     #[expected_failure(arithmetic_error)]
+   │                        ^^^^^^^^^^^^^^^^
+
+error: Expected `location` following `out_of_gas`
+   ┌─ tests/unit_test/test/other_failures_invalid_location.move:14:24
+   │
+14 │     #[expected_failure(out_of_gas)]
+   │                        ^^^^^^^^^^
+
+error: Expected `location` following `major_status`
+   ┌─ tests/unit_test/test/other_failures_invalid_location.move:18:24
+   │
+18 │     #[expected_failure(major_status=4004)]
+   │                        ^^^^^^^^^^^^^^^^^
+
+error: Expected `location` following `major_status`
+   ┌─ tests/unit_test/test/other_failures_invalid_location.move:22:24
+   │
+22 │     #[expected_failure(major_status=4016, minor_code=0)]
+   │                        ^^^^^^^^^^^^^^^^^
+
+error: invalid attribute value
+   ┌─ tests/unit_test/test/other_failures_invalid_location.move:38:59
+   │
+38 │     #[expected_failure(major_status=4016, minor_status=0, location=0)]
+   │                                                           ^^^^^^^^^^
+   │                                                                    │
+   │                                                                    Expected a module identifier, e.g. 'std::vector'

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_location_module.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_location_module.exp
@@ -5,3 +5,6 @@ error: unbound module
   │
 6 │     #[expected_failure(arithmetic_error, location=0x2::m)]
   │                                                   ^^^^^^ Unbound module '0x2::m'
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/script_with_multiple_on_main.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/script_with_multiple_on_main.exp
@@ -17,3 +17,6 @@ error: unable to generate test
   │
 5 │     #[test_only, test]
   │                  ^^^^ Testing attributes are not allowed in scripts.
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/script_with_multiple_top_level.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/script_with_multiple_top_level.exp
@@ -17,3 +17,6 @@ error: unable to generate test
   │
 4 │ #[test_only]
   │   ^^^^^^^^^ Testing attributes are not allowed in scripts.
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/script_with_test_on_main.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/script_with_test_on_main.exp
@@ -5,3 +5,6 @@ error: unable to generate test
   │
 3 │     #[test]
   │       ^^^^ Testing attributes are not allowed in scripts.
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/script_with_test_top_level.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/script_with_test_top_level.exp
@@ -5,3 +5,6 @@ error: unable to generate test
   │
 2 │ #[test_only]
   │   ^^^^^^^^^ Testing attributes are not allowed in scripts.
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/test_and_test_only_annotation.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/test_and_test_only_annotation.exp
@@ -1,2 +1,11 @@
 
-============ bytecode verification succeeded ========
+Diagnostics:
+error: invalid usage of known attribute
+  ┌─ tests/unit_test/test/test_and_test_only_annotation.move:6:16
+  │
+4 │     #[test(_a=@0x1, _b=@0x2)]
+  │       ---------------------- Previously annotated here
+5 │     #[test_only]
+  │       --------- Function annotated as both #[test(...)] and #[test_only]. You need to declare it as either one or the other
+6 │     public fun boo(_a: signer, _b: signer) { }
+  │                ^^^

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -87,6 +87,12 @@ impl Attribute {
     pub fn has(attrs: &[Attribute], pred: impl Fn(&Attribute) -> bool) -> bool {
         attrs.iter().any(pred)
     }
+
+    pub fn node_id(&self) -> NodeId {
+        match self {
+            Attribute::Assign(id, _, _) | Attribute::Apply(id, _, _) => *id,
+        }
+    }
 }
 
 // =================================================================================================

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -2553,6 +2553,7 @@ impl<'env> ModuleEnv<'env> {
     }
 
     /// Checks whether this item is only used in tests.
+    /// NOTE: THIS IS SURPRISINGLY EXPENSIVE
     pub fn is_test_only(&self) -> bool {
         self.has_attribute(|a| {
             let s = self.symbol_pool().string(a.name());
@@ -2561,6 +2562,7 @@ impl<'env> ModuleEnv<'env> {
     }
 
     /// Checks whether this item is only used in verification.
+    /// NOTE: THIS IS SURPRISINGLY EXPENSIVE
     pub fn is_verify_only(&self) -> bool {
         self.has_attribute(|a| {
             let s = self.symbol_pool().string(a.name());
@@ -3264,6 +3266,7 @@ impl<'env> StructEnv<'env> {
     }
 
     /// Checks whether this item is only used in tests.
+    /// NOTE: THIS IS SURPRISINGLY EXPENSIVE
     pub fn is_test_only(&self) -> bool {
         self.has_attribute(|a| {
             let s = self.symbol_pool().string(a.name());
@@ -3272,6 +3275,7 @@ impl<'env> StructEnv<'env> {
     }
 
     /// Checks whether this item is only used in verification.
+    /// NOTE: THIS IS SURPRISINGLY EXPENSIVE
     pub fn is_verify_only(&self) -> bool {
         self.has_attribute(|a| {
             let s = self.symbol_pool().string(a.name());
@@ -3824,6 +3828,7 @@ impl<'env> FunctionEnv<'env> {
     }
 
     /// Checks whether this item is only used in tests.
+    /// NOTE: THIS IS SURPRISINGLY EXPENSIVE
     pub fn is_test_only(&self) -> bool {
         self.has_attribute(|a| {
             let s = self.symbol_pool().string(a.name());
@@ -3832,6 +3837,7 @@ impl<'env> FunctionEnv<'env> {
     }
 
     /// Checks whether this item is only used in verification.
+    /// NOTE: THIS IS SURPRISINGLY EXPENSIVE
     pub fn is_verify_only(&self) -> bool {
         self.has_attribute(|a| {
             let s = self.symbol_pool().string(a.name());

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -2553,7 +2553,6 @@ impl<'env> ModuleEnv<'env> {
     }
 
     /// Checks whether this item is only used in tests.
-    /// NOTE: THIS IS SURPRISINGLY EXPENSIVE
     pub fn is_test_only(&self) -> bool {
         self.has_attribute(|a| {
             let s = self.symbol_pool().string(a.name());
@@ -2562,7 +2561,6 @@ impl<'env> ModuleEnv<'env> {
     }
 
     /// Checks whether this item is only used in verification.
-    /// NOTE: THIS IS SURPRISINGLY EXPENSIVE
     pub fn is_verify_only(&self) -> bool {
         self.has_attribute(|a| {
             let s = self.symbol_pool().string(a.name());
@@ -3266,7 +3264,6 @@ impl<'env> StructEnv<'env> {
     }
 
     /// Checks whether this item is only used in tests.
-    /// NOTE: THIS IS SURPRISINGLY EXPENSIVE
     pub fn is_test_only(&self) -> bool {
         self.has_attribute(|a| {
             let s = self.symbol_pool().string(a.name());
@@ -3275,7 +3272,6 @@ impl<'env> StructEnv<'env> {
     }
 
     /// Checks whether this item is only used in verification.
-    /// NOTE: THIS IS SURPRISINGLY EXPENSIVE
     pub fn is_verify_only(&self) -> bool {
         self.has_attribute(|a| {
             let s = self.symbol_pool().string(a.name());
@@ -3828,7 +3824,6 @@ impl<'env> FunctionEnv<'env> {
     }
 
     /// Checks whether this item is only used in tests.
-    /// NOTE: THIS IS SURPRISINGLY EXPENSIVE
     pub fn is_test_only(&self) -> bool {
         self.has_attribute(|a| {
             let s = self.symbol_pool().string(a.name());
@@ -3837,7 +3832,6 @@ impl<'env> FunctionEnv<'env> {
     }
 
     /// Checks whether this item is only used in verification.
-    /// NOTE: THIS IS SURPRISINGLY EXPENSIVE
     pub fn is_verify_only(&self) -> bool {
         self.has_attribute(|a| {
             let s = self.symbol_pool().string(a.name());

--- a/third_party/move/move-model/src/well_known.rs
+++ b/third_party/move/move-model/src/well_known.rs
@@ -14,6 +14,17 @@ pub fn is_test_only_attribute_name(s: &str) -> bool {
 }
 
 /// Function identifying the name of an attribute which declares an
+/// item to be a test.
+pub fn is_test_attribute_name(s: &str) -> bool {
+    s == "test"
+}
+
+/// Function identifying the name of an attribute which is related to a test.
+pub fn is_testing_attribute_name(s: &str) -> bool {
+    s == "test" || s == "test_only" || s == "expected_failure"
+}
+
+/// Function identifying the name of an attribute which declares an
 /// item to be part of verification only.
 pub fn is_verify_only_attribute_name(s: &str) -> bool {
     s == "verify_only"

--- a/third_party/move/move-model/src/well_known.rs
+++ b/third_party/move/move-model/src/well_known.rs
@@ -19,11 +19,6 @@ pub fn is_test_attribute_name(s: &str) -> bool {
     s == "test"
 }
 
-/// Function identifying the name of an attribute which is related to a test.
-pub fn is_testing_attribute_name(s: &str) -> bool {
-    s == "test" || s == "test_only" || s == "expected_failure"
-}
-
 /// Function identifying the name of an attribute which declares an
 /// item to be part of verification only.
 pub fn is_verify_only_attribute_name(s: &str) -> bool {

--- a/third_party/move/tools/move-cli/Cargo.toml
+++ b/third_party/move/tools/move-cli/Cargo.toml
@@ -33,6 +33,7 @@ move-bytecode-verifier = { path = "../../move-bytecode-verifier" }
 move-bytecode-viewer = { path = "../move-bytecode-viewer" }
 move-command-line-common = { path = "../../move-command-line-common" }
 move-compiler = { path = "../../move-compiler" }
+move-compiler-v2 = { path = "../../move-compiler-v2" }
 move-core-types = { path = "../../move-core/types" }
 move-coverage = { path = "../move-coverage" }
 move-disassembler = { path = "../move-disassembler" }
@@ -44,6 +45,7 @@ move-package = { path = "../move-package" }
 move-prover = { path = "../../move-prover" }
 move-resource-viewer = { path = "../move-resource-viewer" }
 move-stdlib = { path = "../../move-stdlib" }
+# move-symbol-pool = { path = "../../move-symbol-pool" }
 move-unit-test = { path = "../move-unit-test" }
 move-vm-runtime = { path = "../../move-vm/runtime", features = ["debugging"] }
 move-vm-test-utils = { path = "../../move-vm/test-utils" }

--- a/third_party/move/tools/move-cli/src/base/test.rs
+++ b/third_party/move/tools/move-cli/src/base/test.rs
@@ -20,7 +20,6 @@ use move_package::{
     compilation::{build_plan::BuildPlan, compiled_package::build_and_report_v2_driver},
     BuildConfig,
 };
-// use move_symbol_pool::Symbol;
 use move_unit_test::UnitTestingConfig;
 use move_vm_runtime::tracing::{LOGGING_FILE_WRITER, TRACING_ENABLED};
 use move_vm_test_utils::gas_schedule::CostTable;

--- a/third_party/move/tools/move-cli/src/base/test.rs
+++ b/third_party/move/tools/move-cli/src/base/test.rs
@@ -9,17 +9,18 @@ use codespan_reporting::term::{termcolor, termcolor::StandardStream};
 use move_command_line_common::files::{FileHash, MOVE_COVERAGE_MAP_EXTENSION};
 use move_compiler::{
     diagnostics::{self, codes::Severity},
-    shared::{known_attributes::KnownAttribute, NumberFormat, NumericalAddress, PackagePaths},
+    shared::{NumberFormat, NumericalAddress},
     unit_test::{plan_builder::construct_test_plan, TestPlan},
-    Compiler, Flags, PASS_CFGIR,
+    PASS_CFGIR,
 };
+use move_compiler_v2::plan_builder as plan_builder_v2;
 use move_core_types::effects::ChangeSet;
 use move_coverage::coverage_map::{output_map_to_file, CoverageMap};
-use move_model::PackageInfo;
 use move_package::{
     compilation::{build_plan::BuildPlan, compiled_package::build_and_report_v2_driver},
     BuildConfig,
 };
+// use move_symbol_pool::Symbol;
 use move_unit_test::UnitTestingConfig;
 use move_vm_runtime::tracing::{LOGGING_FILE_WRITER, TRACING_ENABLED};
 use move_vm_test_utils::gas_schedule::CostTable;
@@ -33,6 +34,7 @@ use std::{
     collections::HashMap,
     fs,
     io::Write,
+    ops::Deref,
     path::{Path, PathBuf},
     process::ExitStatus,
 };
@@ -238,52 +240,17 @@ pub fn run_move_unit_tests<W: Write + Send>(
 
             let (units, _) = diagnostics::unwrap_or_report_diagnostics(&files, compilation_result);
             test_plan = Some((built_test_plan, files.clone(), units.clone()));
-            Ok((files, units))
+            Ok((files, units, None))
         },
         |options| {
-            let addrs =
-                move_model::parse_addresses_from_options(options.named_address_mapping.clone())?;
-            let to_package_paths = |PackageInfo {
-                                        sources,
-                                        address_map,
-                                    }| PackagePaths {
-                name: Some(root_package),
-                paths: sources,
-                named_address_map: address_map,
-            };
-            let source = PackageInfo {
-                sources: options.sources.clone(),
-                address_map: addrs.clone(),
-            };
-            let deps = vec![PackageInfo {
-                sources: options.dependencies.clone(),
-                address_map: addrs.clone(),
-            }];
+            let (files, units, opt_env) = build_and_report_v2_driver(options).unwrap();
+            let env = opt_env.expect("v2 driver should return env");
+            let root_package_in_model = env.symbol_pool().make(root_package.deref());
+            let built_test_plan =
+                plan_builder_v2::construct_test_plan(&env, Some(root_package_in_model));
 
-            let known_attributes =
-                if !options.skip_attribute_checks && options.known_attributes.is_empty() {
-                    KnownAttribute::get_all_attribute_names()
-                } else {
-                    &options.known_attributes
-                };
-            let mut flags = Flags::testing();
-            flags = flags.set_skip_attribute_checks(true);
-            let compiler = Compiler::from_package_paths(
-                vec![to_package_paths(source)],
-                deps.into_iter().map(to_package_paths).collect(),
-                flags,
-                known_attributes,
-            );
-            let (files, comments_and_compiler_res) = compiler.run::<PASS_CFGIR>().unwrap();
-            let (_, compiler) =
-                diagnostics::unwrap_or_report_diagnostics(&files, comments_and_compiler_res);
-            let (mut compiler, cfgir) = compiler.into_ast();
-            let compilation_env = compiler.compilation_env();
-            let built_test_plan = construct_test_plan(compilation_env, Some(root_package), &cfgir);
-
-            let (files, units) = build_and_report_v2_driver(options).unwrap();
             test_plan_v2 = Some((built_test_plan, files.clone(), units.clone()));
-            Ok((files, units))
+            Ok((files, units, Some(env)))
         },
     )?;
 

--- a/third_party/move/tools/move-package/src/compilation/build_plan.rs
+++ b/third_party/move/tools/move-package/src/compilation/build_plan.rs
@@ -1,3 +1,4 @@
+// Copyright (c) Aptos Foundation
 // Copyright (c) The Diem Core Contributors
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
@@ -36,9 +37,14 @@ pub struct BuildPlan {
     resolution_graph: ResolvedGraph,
 }
 
+/// A container for compiler results from either V1 or V2,
+/// with all info needed for building various artifacts.
 pub type CompilerDriverResult = anyhow::Result<(
+    // The names and contents of all source files.
     FilesSourceText,
+    // The compilation artifacts, including V1 intermediate ASTs.
     Vec<AnnotatedCompiledUnit>,
+    // For compilation with V2, compiled program model.
     Option<model::GlobalEnv>,
 )>;
 

--- a/third_party/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/third_party/move/tools/move-package/src/compilation/compiled_package.rs
@@ -637,7 +637,10 @@ impl CompiledPackage {
         let effective_language_version = config.language_version.unwrap_or_default();
         effective_compiler_version.check_language_support(effective_language_version)?;
 
-        let (file_map, all_compiled_units) = match config.compiler_version.unwrap_or_default() {
+        let (file_map, all_compiled_units, _optional_global_env) = match config
+            .compiler_version
+            .unwrap_or_default()
+        {
             CompilerVersion::V1 => {
                 let compiler =
                     Compiler::from_package_paths(paths, bytecode_deps, flags, &known_attributes);
@@ -1095,7 +1098,11 @@ pub fn unimplemented_v2_driver(_options: move_compiler_v2::Options) -> CompilerD
 pub fn build_and_report_v2_driver(options: move_compiler_v2::Options) -> CompilerDriverResult {
     let mut writer = StandardStream::stderr(ColorChoice::Auto);
     match move_compiler_v2::run_move_compiler(&mut writer, options) {
-        Ok((env, units)) => Ok((move_compiler_v2::make_files_source_text(&env), units)),
+        Ok((env, units)) => Ok((
+            move_compiler_v2::make_files_source_text(&env),
+            units,
+            Some(env),
+        )),
         Err(_) => {
             // Error reported, exit
             std::process::exit(1);
@@ -1109,5 +1116,9 @@ pub fn build_and_report_no_exit_v2_driver(
 ) -> CompilerDriverResult {
     let mut writer = StandardStream::stderr(ColorChoice::Auto);
     let (env, units) = move_compiler_v2::run_move_compiler(&mut writer, options)?;
-    Ok((move_compiler_v2::make_files_source_text(&env), units))
+    Ok((
+        move_compiler_v2::make_files_source_text(&env),
+        units,
+        Some(env),
+    ))
 }


### PR DESCRIPTION
## Description

Add an implementation of `construct_test_plan` in `move-compiler-v2` so that it need not depend on the V1 compiler to build test plans for it.

There are still some direct uses of
`unit_test::plan_builder::construct_test_plan` in `move-unit-test`
that need to be cleaned up.

Note that this PR is divided into 3 commits:
- **update test config, check in new test output**
- **copy plan_builder.rs from move-compiler/src/unit_test for customization in v2**
- **finish modifying plan_builder for v2**

Fixes #12789
Fixes #11589
Fixes #11706 

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Other (specify)
   move-compiler-v2
## How Has This Been Tested?
So far, cargo test of various packages.

## Key Areas to Review

Note that the second commit in this PR copies `plan_builder.rs` from `third_party/move/move-compiler/src/unit_test/` to `third_party/move/move-compiler-v2/src`.

The third commit does some plumbing surrounding the plan builder, but
mainly modifies that file to use the move-model's `GlobalEnv` instead
of compiler V1 data structures to build the test plan.

The code is mostly rewritten in place to make verification of preserved
functionality easier.  For this PR, I'd prefer to focus on local code
issues to keep it simpler, but suggestions about global cleanups are
welcome (but may be deferred to a later PR).

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
