### PR TITLE
convert UnknownAttribute from a warning into an error

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/attributes.rs
+++ b/aptos-move/e2e-move-tests/src/tests/attributes.rs
@@ -128,7 +128,11 @@ fn test_bad_attribute_in_code() {
     let path = builder.write_to_temp().unwrap();
 
     // unknown attributes are not compiled into the code
-    assert_success!(h.publish_package(&account, path.path()));
+    let options = BuildOptions {
+        skip_attribute_checks: true,
+        ..BuildOptions::default()
+    };
+    assert_success!(h.publish_package_with_options(&account, path.path(), options));
 }
 
 #[test]

--- a/aptos-move/e2e-move-tests/src/tests/attributes.rs
+++ b/aptos-move/e2e-move-tests/src/tests/attributes.rs
@@ -147,8 +147,12 @@ fn test_bad_fun_attribute_in_compiled_module() {
     );
     let path = builder.write_to_temp().unwrap();
 
-    let package = build_package(path.path().to_path_buf(), BuildOptions::default())
-        .expect("building package must succeed");
+    let options = BuildOptions {
+        skip_attribute_checks: true,
+        ..BuildOptions::default()
+    };
+    let package =
+        build_package(path.path().to_path_buf(), options).expect("building package must succeed");
     let code = package.extract_code();
     // There should only be the above module
     assert!(code.len() == 1);

--- a/third_party/move/move-compiler-v2/tests/checking/attributes/aptos_stdlib_attributes.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/attributes/aptos_stdlib_attributes.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/aptos_stdlib_attributes.move:4:7
   │
 4 │     #[a, a(x = 0)]
   │       ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/aptos_stdlib_attributes.move:4:10
   │
 4 │     #[a, a(x = 0)]
@@ -20,13 +20,13 @@ error: duplicate declaration, item, or annotation
   │       │
   │       Attribute previously given here
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/aptos_stdlib_attributes.move:7:7
   │
 7 │     #[testonly]
   │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/aptos_stdlib_attributes.move:8:7
   │
 8 │     #[b(a, a = 0, a(x = 1))]

--- a/third_party/move/move-compiler-v2/tests/checking/attributes/aptos_stdlib_attributes2.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/attributes/aptos_stdlib_attributes2.exp
@@ -1,17 +1,7 @@
 
 Diagnostics:
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/aptos_stdlib_attributes2.move:4:7
   │
 4 │     #[testonly]
   │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
-
-// -- Model dump before bytecode pipeline
-module 0x1::M {
-    private fun bar() {
-        Tuple()
-    }
-    private fun foo() {
-        Tuple()
-    }
-} // end 0x1::M

--- a/third_party/move/move-compiler-v2/tests/checking/attributes/attribute_placement.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/attributes/attribute_placement.exp
@@ -1,108 +1,85 @@
 
 Diagnostics:
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/attribute_placement.move:3:3
   │
 3 │ #[attr]
   │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/attribute_placement.move:5:7
   │
 5 │     #[attr]
   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/attribute_placement.move:8:7
   │
 8 │     #[attr]
   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:11:7
    │
 11 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:14:7
    │
 14 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:17:7
    │
 17 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:22:3
    │
 22 │ #[attr]
    │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:24:7
    │
 24 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:27:7
    │
 27 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:31:3
    │
 31 │ #[attr]
    │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:33:7
    │
 33 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:36:7
    │
 36 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:39:7
    │
 39 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:44:7
    │
 44 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
-
-// -- Model dump before bytecode pipeline
-module 0x42::N {
-    public fun bar() {
-        Tuple()
-    }
-} // end 0x42::N
-module 0x42::M {
-    use 0x42::N; // resolved as: 0x42::N
-    struct S {
-        dummy_field: bool,
-    }
-    public fun foo() {
-        N::bar()
-    }
-} // end 0x42::M
-module <SELF>_0 {
-    use 0x42::M; // resolved as: 0x42::M
-    private fun main() {
-        M::foo();
-        Tuple()
-    }
-} // end <SELF>_0

--- a/third_party/move/move-compiler-v2/tests/checking/attributes/attribute_variants.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/attributes/attribute_variants.exp
@@ -1,65 +1,61 @@
 
 Diagnostics:
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:2:3
   │
 2 │ #[attr0]
   │   ^^^^^ Attribute name 'attr0' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:3:3
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
   │   ^^^^^ Attribute name 'attr1' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:3:12
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
   │            ^^^^^ Attribute name 'attr2' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:3:28
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
   │                            ^^^^^ Attribute name 'attr3' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:3:41
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
   │                                         ^^^^^ Attribute name 'attr4' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:3:53
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
   │                                                     ^^^^^ Attribute name 'attr5' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:4:3
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]
   │   ^^^^^ Attribute name 'bttr0' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:4:16
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]
   │                ^^^^^ Attribute name 'bttr1' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:4:27
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]
   │                           ^^^^^ Attribute name 'bttr2' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:4:39
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]
   │                                       ^^^^^ Attribute name 'bttr3' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
-
-// -- Model dump before bytecode pipeline
-module 0x42::M {
-} // end 0x42::M

--- a/third_party/move/move-compiler-v2/tests/checking/attributes/duplicate_attributes.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/attributes/duplicate_attributes.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/duplicate_attributes.move:2:7
   │
 2 │     #[a, a(x = 0)]
   │       ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/duplicate_attributes.move:2:10
   │
 2 │     #[a, a(x = 0)]
@@ -20,7 +20,7 @@ error: duplicate declaration, item, or annotation
   │       │
   │       Attribute previously given here
 
-warning: unknown attribute
+error: unknown attribute
   ┌─ tests/checking/attributes/duplicate_attributes.move:5:7
   │
 5 │     #[b(a, a = 0, a(x = 1))]

--- a/third_party/move/move-compiler/src/diagnostics/codes.rs
+++ b/third_party/move/move-compiler/src/diagnostics/codes.rs
@@ -139,8 +139,7 @@ codes!(
         InvalidNonPhantomUse:
             { msg: "invalid non-phantom type parameter usage", severity: Warning },
         InvalidAttribute: { msg: "invalid attribute", severity: NonblockingError },
-        // TODO(https://github.com/aptos-labs/aptos-core/issues/9411) turn into NonblockingError when safe to do so.
-        UnknownAttribute: { msg: "unknown attribute", severity: Warning },
+        UnknownAttribute: { msg: "unknown attribute", severity: NonblockingError },
     ],
     // errors name resolution, mostly expansion/translate and naming/translate
     NameResolution: [

--- a/third_party/move/move-compiler/tests/move_check/parser/aptos_stdlib_attributes.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/aptos_stdlib_attributes.exp
@@ -1,10 +1,10 @@
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:4:7
   │
 4 │     #[a, a(x = 0)]
   │       ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:4:10
   │
 4 │     #[a, a(x = 0)]
@@ -18,13 +18,13 @@ error[E02001]: duplicate declaration, item, or annotation
   │       │   
   │       Attribute previously given here
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:7:7
   │
 7 │     #[testonly]
   │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:8:7
   │
 8 │     #[b(a, a = 0, a(x = 1))]

--- a/third_party/move/move-compiler/tests/move_check/parser/aptos_stdlib_attributes2.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/aptos_stdlib_attributes2.exp
@@ -1,4 +1,4 @@
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/aptos_stdlib_attributes2.move:4:7
   │
 4 │     #[testonly]

--- a/third_party/move/move-compiler/tests/move_check/parser/attribute_placement.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/attribute_placement.exp
@@ -1,82 +1,82 @@
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_placement.move:3:3
   │
 3 │ #[attr]
   │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_placement.move:5:7
   │
 5 │     #[attr]
   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_placement.move:8:7
   │
 8 │     #[attr]
   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:11:7
    │
 11 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:14:7
    │
 14 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:17:7
    │
 17 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:22:3
    │
 22 │ #[attr]
    │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:24:7
    │
 24 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:27:7
    │
 27 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:31:3
    │
 31 │ #[attr]
    │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:33:7
    │
 33 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:36:7
    │
 36 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:39:7
    │
 39 │     #[attr]
    │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:44:7
    │
 44 │     #[attr]

--- a/third_party/move/move-compiler/tests/move_check/parser/attribute_variants.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/attribute_variants.exp
@@ -1,58 +1,58 @@
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:2:3
   │
 2 │ #[attr0]
   │   ^^^^^ Attribute name 'attr0' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:3:3
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
   │   ^^^^^ Attribute name 'attr1' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:3:12
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
   │            ^^^^^ Attribute name 'attr2' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:3:28
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
   │                            ^^^^^ Attribute name 'attr3' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:3:41
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
   │                                         ^^^^^ Attribute name 'attr4' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:3:53
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
   │                                                     ^^^^^ Attribute name 'attr5' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:4:3
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]
   │   ^^^^^ Attribute name 'bttr0' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:4:16
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]
   │                ^^^^^ Attribute name 'bttr1' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:4:27
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]
   │                           ^^^^^ Attribute name 'bttr2' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:4:39
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]

--- a/third_party/move/move-compiler/tests/move_check/parser/duplicate_attributes.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/duplicate_attributes.exp
@@ -1,10 +1,10 @@
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/duplicate_attributes.move:2:7
   │
 2 │     #[a, a(x = 0)]
   │       ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/duplicate_attributes.move:2:10
   │
 2 │     #[a, a(x = 0)]
@@ -18,7 +18,7 @@ error[E02001]: duplicate declaration, item, or annotation
   │       │   
   │       Attribute previously given here
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/duplicate_attributes.move:5:7
   │
 5 │     #[b(a, a = 0, a(x = 1))]

--- a/third_party/move/move-compiler/tests/move_check/parser/testonly.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/testonly.exp
@@ -1,10 +1,10 @@
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ tests/move_check/parser/testonly.move:5:7
   │
 5 │     #[testonly]
   │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
 
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
    ┌─ tests/move_check/parser/testonly.move:15:7
    │
 15 │     #[view]

--- a/third_party/move/tools/move-cli/tests/build_tests/dependency_chain/args.exp
+++ b/third_party/move/tools/move-cli/tests/build_tests/dependency_chain/args.exp
@@ -2,7 +2,7 @@ Command `build -v`:
 INCLUDING DEPENDENCY Bar
 INCLUDING DEPENDENCY Foo
 BUILDING A
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ ./sources/A.move:1:3
   │
 1 │ #[evm_contract] // for passing evm test flavor

--- a/third_party/move/tools/move-cli/tests/build_tests/dev_address/args.exp
+++ b/third_party/move/tools/move-cli/tests/build_tests/dev_address/args.exp
@@ -1,6 +1,6 @@
 Command `build -v -d`:
 BUILDING A
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ ./sources/A.move:1:3
   │
 1 │ #[evm_contract] // for passing evm test flavor

--- a/third_party/move/tools/move-cli/tests/build_tests/empty_module_no_deps/args.exp
+++ b/third_party/move/tools/move-cli/tests/build_tests/empty_module_no_deps/args.exp
@@ -1,6 +1,6 @@
 Command `build -v`:
 BUILDING A
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ ./sources/A.move:1:3
   │
 1 │ #[evm_contract] // for passing evm test flavor

--- a/third_party/move/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.exp
+++ b/third_party/move/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.exp
@@ -1,6 +1,6 @@
 Command `build -v`:
 BUILDING build_include_exclude_stdlib
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ ./sources/UseSigner.move:1:3
   │
 1 │ #[evm_contract] // for passing evm test flavor
@@ -21,7 +21,7 @@ error[E03002]: unbound module
 Command `-d -v build`:
 INCLUDING DEPENDENCY MoveStdlib
 BUILDING build_include_exclude_stdlib
-warning[W02016]: unknown attribute
+error[E02016]: unknown attribute
   ┌─ ./sources/UseSigner.move:1:3
   │
 1 │ #[evm_contract] // for passing evm test flavor


### PR DESCRIPTION
## Description

Convert "Unknown attribute" warning into an error.

Fixes #9411

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [X] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Usual tests.  Warnings have been deployed and tested for a while.  This just turns it into an error.

## Key Areas to Review
Consider security issues versus user convenience (notably, partners who use their own attributes for some reason).
Note that those using their own attributes are probably customizing the code and can disable this.

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X] I tested both happy and unhappy path of the functionality
- [X] I have made corresponding changes to the functionalitydocumentation

<!-- Thank you for your contribution! -->
