### PR TITLE
[aptos-node] add --performance mode for --test

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -453,12 +453,22 @@ where
         .consensus
         .quorum_store
         .num_workers_for_remote_batches = 1;
-    node_config.consensus.quorum_store_poll_time_ms = 1000;
 
-    if !enable_performance_mode {
+    if enable_performance_mode {
+        // Setting to a pretty conservative concurrency level. It can be tuned locally.
+        node_config.execution.concurrency_level = 4;
+        // Don't constrain the TPS of Quorum Store for this single node.
+        node_config
+            .consensus
+            .quorum_store
+            .back_pressure
+            .dynamic_max_txn_per_s = 10_000;
+    } else {
         node_config.execution.concurrency_level = 1;
         node_config.execution.num_proof_reading_threads = 1;
+        node_config.consensus.quorum_store_poll_time_ms = 1000;
     }
+
     node_config.execution.paranoid_hot_potato_verification = false;
     node_config.execution.paranoid_type_verification = false;
     node_config

--- a/aptos-node/src/tests.rs
+++ b/aptos-node/src/tests.rs
@@ -93,6 +93,7 @@ fn test_create_single_node_test_config() {
         &test_dir,
         false,
         false,
+        false,
         aptos_cached_packages::head_release_bundle(),
         rand::rngs::StdRng::from_entropy(),
     )

--- a/crates/aptos/src/node/local_testnet/node.rs
+++ b/crates/aptos/src/node/local_testnet/node.rs
@@ -37,6 +37,12 @@ pub struct NodeArgs {
     #[clap(long, value_parser, conflicts_with("config_path"))]
     pub test_config_override: Option<PathBuf>,
 
+    /// Optimize the node for higher performance.
+    ///
+    /// Note: This is only useful for e2e performance testing, and should not be used in production.
+    #[clap(long)]
+    pub performance: bool,
+
     /// Random seed for key generation in test mode
     ///
     /// This allows you to have deterministic keys for testing
@@ -101,6 +107,7 @@ impl NodeManager {
             &test_dir,
             false,
             false,
+            args.node_args.performance,
             aptos_cached_packages::head_release_bundle(),
             rng,
         )


### PR DESCRIPTION
## Description

Introduces a `performance` mode for `test` where you need a single node network that can run a fair bit of load. On my macbook, this was ~5K TPS.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Other (specify)

## How Has This Been Tested?

`cargo run -p aptos-node --release -- --test --performance`

Then run txn emitter:
`cargo run -p aptos-transaction-emitter --release -- emit-tx -t http://localhost:8080 --mint-file <path to mint.key from above command> --chain-id 4 --duration 120 --txn-expiration-time-secs 60 --mempool-backlog=22000 --expected-max-txns 1200000 --init-gas-price-multiplier=1 --max-transactions-per-account 5 --transaction-type coin-transfer`


## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
