### PR TITLE
StateKeyRegistry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3959,12 +3959,15 @@ dependencies = [
 name = "aptos-types"
 version = "0.0.3"
 dependencies = [
+ "ahash 0.8.11",
  "anyhow",
  "aptos-bitvec",
  "aptos-crypto",
  "aptos-crypto-derive",
  "aptos-dkg",
  "aptos-experimental-runtimes",
+ "aptos-infallible",
+ "aptos-proptest-helpers",
  "ark-bn254",
  "ark-ff",
  "ark-groth16",
@@ -3980,6 +3983,8 @@ dependencies = [
  "criterion",
  "derivative",
  "fixed",
+ "fxhash",
+ "hashbrown 0.14.3",
  "hex",
  "itertools 0.12.1",
  "jsonwebtoken 8.3.0",
@@ -7973,6 +7978,15 @@ dependencies = [
  "move-core-types",
  "move-vm-types",
  "once_cell",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,6 +450,7 @@ aptos-cargo-cli = { path = "devtools/aptos-cargo-cli" }
 # External crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.
 aes-gcm = "0.10.3"
+ahash = "0.8.11"
 atty = "0.2.14"
 nalgebra = "0.32"
 float-cmp = "0.9.0"
@@ -562,6 +563,7 @@ futures = "0.3.29"
 futures-channel = "0.3.29"
 futures-core = "0.3.29"
 futures-util = "0.3.29"
+fxhash = "0.2.1"
 getrandom = "0.2.2"
 gcp-bigquery-client = "0.13.0"
 get_if_addrs = "0.5.3"

--- a/api/types/src/wrappers.rs
+++ b/api/types/src/wrappers.rs
@@ -119,12 +119,7 @@ pub struct StateKeyWrapper(pub StateKey);
 
 impl fmt::Display for StateKeyWrapper {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let hex_string = hex::encode(
-            self.0
-                .encode()
-                .context("Failed to encode StateKey")
-                .map_err(|_| fmt::Error)?,
-        );
+        let hex_string = hex::encode(self.0.encoded());
         write!(f, "{}", hex_string)
     }
 }

--- a/aptos-move/aptos-vm-types/src/storage/io_pricing.rs
+++ b/aptos-move/aptos-vm-types/src/storage/io_pricing.rs
@@ -61,12 +61,7 @@ impl IoPricingV1 {
         let mut cost = self.write_data_per_op * NumArgs::new(1);
 
         if self.write_data_per_byte_in_key > 0.into() {
-            cost += self.write_data_per_byte_in_key
-                * NumBytes::new(
-                    key.encode()
-                        .expect("Should be able to serialize state key")
-                        .len() as u64,
-                );
+            cost += self.write_data_per_byte_in_key * NumBytes::new(key.encoded().len() as u64);
         }
 
         match op_size {
@@ -135,11 +130,7 @@ impl IoPricingV2 {
                 .checked_sub(self.free_write_bytes_quota)
                 .unwrap_or(NumBytes::zero())
         } else {
-            let key_size = NumBytes::new(
-                key.encode()
-                    .expect("Should be able to serialize state key")
-                    .len() as u64,
-            );
+            let key_size = NumBytes::new(key.encoded().len() as u64);
             key_size + value_size
         }
     }

--- a/aptos-move/e2e-move-tests/src/tests/access_path_test.rs
+++ b/aptos-move/e2e-move-tests/src/tests/access_path_test.rs
@@ -18,8 +18,6 @@ use move_binary_format::{
 };
 use move_core_types::{identifier::Identifier, vm_status::StatusCode};
 
-/// FIXME(aldenhu): fix or remove
-#[ignore]
 #[test]
 fn access_path_panic() {
     // github.com/aptos-labs/aptos-core/security/advisories/GHSA-rpw2-84hq-48jj

--- a/storage/aptosdb/src/schema/stale_state_value_index/mod.rs
+++ b/storage/aptosdb/src/schema/stale_state_value_index/mod.rs
@@ -43,7 +43,7 @@ impl KeyCodec<StaleStateValueIndexSchema> for StaleStateValueIndex {
         let mut encoded = vec![];
         encoded.write_u64::<BigEndian>(self.stale_since_version)?;
         encoded.write_u64::<BigEndian>(self.version)?;
-        encoded.write_all(&self.state_key.encode()?)?;
+        encoded.write_all(self.state_key.encoded())?;
 
         Ok(encoded)
     }

--- a/storage/aptosdb/src/schema/state_value/mod.rs
+++ b/storage/aptosdb/src/schema/state_value/mod.rs
@@ -42,7 +42,7 @@ define_schema!(
 impl KeyCodec<StateValueSchema> for Key {
     fn encode_key(&self) -> Result<Vec<u8>> {
         let mut encoded = vec![];
-        encoded.write_all(&self.0.encode()?)?;
+        encoded.write_all(self.0.encoded())?;
         encoded.write_u64::<BigEndian>(!self.1)?;
         Ok(encoded)
     }

--- a/storage/aptosdb/src/schema/state_value_index/mod.rs
+++ b/storage/aptosdb/src/schema/state_value_index/mod.rs
@@ -30,7 +30,7 @@ define_schema!(StateValueIndexSchema, Key, (), STATE_VALUE_INDEX_CF_NAME);
 impl KeyCodec<StateValueIndexSchema> for Key {
     fn encode_key(&self) -> Result<Vec<u8>> {
         let mut encoded = vec![];
-        encoded.write_all(&self.0.encode()?)?;
+        encoded.write_all(self.0.encoded())?;
         encoded.write_u64::<BigEndian>(!self.1)?;
         Ok(encoded)
     }

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -20,7 +20,7 @@ aptos-consensus-types = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-crypto-derive = { workspace = true }
 aptos-network = { workspace = true }
-aptos-types = { workspace = true }
+aptos-types = { workspace = true, features = ["fuzzing"] }
 bcs = { workspace = true }
 clap = { workspace = true }
 move-core-types = { workspace = true, features = ["fuzzing"] }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -19,6 +19,7 @@ aptos-crypto = { workspace = true }
 aptos-crypto-derive = { workspace = true }
 aptos-dkg = { workspace = true }
 aptos-experimental-runtimes = { workspace = true }
+aptos-infallible = { workspace = true }
 ark-bn254 = { workspace = true }
 ark-ff = { workspace = true }
 ark-groth16 = { workspace = true }
@@ -27,9 +28,9 @@ arr_macro = { workspace = true }
 base64 = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
-criterion = { workspace = true }
-derivative = { workspace = true }
 fixed = { workspace = true }
+fxhash = { workspace = true }
+hashbrown = { workspace = true }
 hex = { workspace = true }
 itertools = { workspace = true }
 jsonwebtoken = { workspace = true }
@@ -60,11 +61,15 @@ strum_macros = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+ahash = { workspace = true }
 aptos-crypto = { workspace = true, features = ["fuzzing", "testing"] }
+aptos-proptest-helpers = { workspace = true }
 async-trait = { workspace = true }
 ciborium = { workspace = true }
 claims = { workspace = true }
 coset = { workspace = true }
+criterion = { workspace = true }
+derivative = { workspace = true }
 move-core-types = { workspace = true, features = ["fuzzing"] }
 p256 = { workspace = true }
 passkey-authenticator = { workspace = true }
@@ -83,4 +88,8 @@ fuzzing = ["proptest", "proptest-derive", "aptos-crypto/fuzzing", "move-core-typ
 
 [[bench]]
 name = "keyless"
+harness = false
+
+[[bench]]
+name = "state_key"
 harness = false

--- a/types/benches/state_key.rs
+++ b/types/benches/state_key.rs
@@ -1,0 +1,196 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(clippy::non_canonical_partial_ord_impl)]
+
+use aptos_crypto::HashValue;
+use aptos_proptest_helpers::ValueGenerator;
+use aptos_types::{
+    access_path::AccessPath,
+    account_config::AccountResource,
+    state_store::state_key::{inner::StateKeyInner, registry::StateKeyRegistry, StateKey},
+};
+use criterion::{criterion_group, criterion_main, Criterion};
+use derivative::Derivative;
+use fxhash::FxHasher;
+use move_core_types::{
+    account_address::AccountAddress, language_storage::StructTag, move_resource::MoveStructType,
+};
+use once_cell::sync::OnceCell;
+use proptest::prelude::*;
+use std::{
+    collections::{hash_map::DefaultHasher, HashSet},
+    hash::{Hash, Hasher},
+};
+
+#[derive(Clone, Derivative, Eq)]
+#[derivative(Hash, PartialEq, PartialOrd, Ord)]
+pub struct UnCached {
+    inner: StateKeyInner,
+    #[derivative(
+        Hash = "ignore",
+        Ord = "ignore",
+        PartialEq = "ignore",
+        PartialOrd = "ignore"
+    )]
+    hash: OnceCell<HashValue>,
+}
+
+fn hashing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hashing");
+    let address = AccountAddress::from_hex_literal("0xA550C18").unwrap();
+    let struct_tag = AccountResource::struct_tag();
+
+    group.bench_function("hash_address_and_name", |b| {
+        b.iter(|| StateKeyRegistry::hash_address_and_name(&address, struct_tag.name.as_bytes()))
+    });
+
+    group.bench_function("default_hasher_struct_tag", |b| {
+        b.iter(|| {
+            let mut hasher = DefaultHasher::default();
+            Hash::hash(&struct_tag, &mut hasher);
+            hasher.finish()
+        })
+    });
+
+    group.bench_function("fxhasher_struct_tag", |b| {
+        b.iter(|| {
+            let mut hasher = FxHasher::default();
+            Hash::hash(&struct_tag, &mut hasher);
+            hasher.finish()
+        })
+    });
+
+    group.bench_function("ahasher_struct_tag", |b| {
+        b.iter(|| {
+            let mut hasher = ahash::AHasher::default();
+            Hash::hash(&struct_tag, &mut hasher);
+            hasher.finish()
+        })
+    });
+}
+
+fn construct(c: &mut Criterion) {
+    let keys = ValueGenerator::new().generate(proptest::collection::hash_set(
+        (any::<AccountAddress>(), any::<StructTag>()),
+        1_000,
+    ));
+
+    let mut group = c.benchmark_group("construct");
+    group.throughput(criterion::Throughput::Elements(keys.len() as u64));
+
+    group.bench_function("construct_once_uncached", |b| {
+        b.iter(|| {
+            keys.iter()
+                .map(|(address, struct_tag)| UnCached {
+                    inner: StateKeyInner::AccessPath(
+                        AccessPath::resource_access_path(*address, struct_tag.clone()).unwrap(),
+                    ),
+                    hash: OnceCell::new(),
+                })
+                .collect::<Vec<_>>()
+        })
+    });
+
+    group.bench_function("construct_once_cached", |b| {
+        b.iter(|| {
+            keys.iter()
+                .map(|(address, struct_tag)| StateKey::resource(address, struct_tag).unwrap())
+                .collect::<Vec<_>>()
+        })
+    });
+
+    group.bench_function("construct_twice_uncached", |b| {
+        b.iter(|| {
+            keys.iter()
+                .chain(keys.iter())
+                .map(|(address, struct_tag)| UnCached {
+                    inner: StateKeyInner::AccessPath(
+                        AccessPath::resource_access_path(*address, struct_tag.clone()).unwrap(),
+                    ),
+                    hash: OnceCell::new(),
+                })
+                .collect::<Vec<_>>()
+        })
+    });
+
+    group.bench_function("construct_twice_cached", |b| {
+        b.iter(|| {
+            keys.iter()
+                .chain(keys.iter())
+                .map(|(address, struct_tag)| StateKey::resource(address, struct_tag).unwrap())
+                .collect::<Vec<_>>()
+        })
+    });
+
+    group.bench_function("construct_thrice_uncached", |b| {
+        b.iter(|| {
+            keys.iter()
+                .chain(keys.iter())
+                .chain(keys.iter())
+                .map(|(address, struct_tag)| UnCached {
+                    inner: StateKeyInner::AccessPath(
+                        AccessPath::resource_access_path(*address, struct_tag.clone()).unwrap(),
+                    ),
+                    hash: OnceCell::new(),
+                })
+                .collect::<Vec<_>>()
+        })
+    });
+
+    group.bench_function("construct_thrice_cached", |b| {
+        b.iter(|| {
+            keys.iter()
+                .chain(keys.iter())
+                .chain(keys.iter())
+                .map(|(address, struct_tag)| StateKey::resource(address, struct_tag).unwrap())
+                .collect::<Vec<_>>()
+        })
+    });
+}
+
+fn hashset(c: &mut Criterion) {
+    let keys = ValueGenerator::new().generate(proptest::collection::hash_set(
+        any::<StateKeyInner>(),
+        1_000,
+    ));
+
+    let mut group = c.benchmark_group("hashset");
+    group.throughput(criterion::Throughput::Elements(keys.len() as u64));
+
+    let uncached = keys
+        .iter()
+        .map(|inner| UnCached {
+            inner: inner.clone(),
+            hash: OnceCell::new(),
+        })
+        .collect::<hashbrown::HashSet<_>>();
+    let cached = keys
+        .iter()
+        .map(|inner| StateKey::from_deserialized(inner.clone()).unwrap())
+        .collect::<hashbrown::HashSet<_>>();
+
+    group.bench_function("hashset_uncached", |b| {
+        b.iter(|| uncached.iter().cloned().collect::<HashSet<_>>())
+    });
+
+    group.bench_function("hashset_cached", |b| {
+        b.iter(|| cached.iter().cloned().collect::<HashSet<_>>())
+    });
+
+    group.bench_function("hashbrown_uncached", |b| {
+        b.iter(|| uncached.iter().cloned().collect::<hashbrown::HashSet<_>>())
+    });
+
+    group.bench_function("hashbrown_cached", |b| {
+        b.iter(|| cached.iter().cloned().collect::<hashbrown::HashSet<_>>())
+    });
+}
+
+criterion_group!(
+    name = state_key;
+    config = Criterion::default();
+    targets = hashing, construct, hashset
+);
+
+criterion_main!(state_key);

--- a/types/src/state_store/state_key/mod.rs
+++ b/types/src/state_store/state_key/mod.rs
@@ -5,19 +5,29 @@
 
 pub mod inner;
 pub mod prefix;
+pub mod registry;
 #[cfg(test)]
 mod tests;
 
 use crate::{
-    access_path::AccessPath, on_chain_config::OnChainConfig, state_store::table::TableHandle,
+    access_path,
+    access_path::AccessPath,
+    on_chain_config::OnChainConfig,
+    state_store::{
+        state_key::{
+            inner::{StateKeyDecodeErr, StateKeyTag},
+            registry::{Entry, REGISTRY},
+        },
+        table::TableHandle,
+    },
 };
 use anyhow::Result;
 use aptos_crypto::{
     hash::{CryptoHash, DummyHasher},
     HashValue,
 };
-use derivative::Derivative;
-use inner::{StateKeyDecodeErr, StateKeyInner, StateKeyTag};
+use bytes::Bytes;
+use inner::StateKeyInner;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,
@@ -25,55 +35,48 @@ use move_core_types::{
     move_resource::MoveResource,
 };
 use num_traits::FromPrimitive;
-use once_cell::sync::OnceCell;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use std::{
-    convert::TryInto,
+    cmp::Ordering,
     fmt,
     fmt::{Debug, Formatter},
-    ops::Deref,
+    hash::Hash,
+    sync::Arc,
 };
 
-#[derive(Clone, Derivative)]
-#[derivative(PartialEq, PartialOrd, Hash, Ord)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
-pub struct StateKey {
-    inner: StateKeyInner,
-    #[derivative(
-        Hash = "ignore",
-        Ord = "ignore",
-        PartialEq = "ignore",
-        PartialOrd = "ignore"
-    )]
-    #[cfg_attr(any(test, feature = "fuzzing"), proptest(value = "OnceCell::new()"))]
-    hash: OnceCell<HashValue>,
-}
+#[derive(Clone)]
+pub struct StateKey(Arc<Entry>);
 
 impl Debug for StateKey {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)
+        self.inner().fmt(f)
     }
 }
 
 impl StateKey {
-    pub fn new(inner: StateKeyInner) -> Self {
-        Self {
-            inner,
-            hash: OnceCell::new(),
-        }
+    pub fn encoded(&self) -> &Bytes {
+        &self.0.encoded
     }
 
     /// Recovers from serialized bytes in physical storage.
     pub fn decode(val: &[u8]) -> Result<StateKey, StateKeyDecodeErr> {
+        use access_path::Path;
+
         if val.is_empty() {
             return Err(StateKeyDecodeErr::EmptyInput);
         }
         let tag = val[0];
         let state_key_tag =
             StateKeyTag::from_u8(tag).ok_or(StateKeyDecodeErr::UnknownTag { unknown_tag: tag })?;
-        match state_key_tag {
+        let myself = match state_key_tag {
             StateKeyTag::AccessPath => {
-                Ok(StateKeyInner::AccessPath(bcs::from_bytes(&val[1..])?).into())
+                let AccessPath { address, path } = bcs::from_bytes(&val[1..])?;
+                let path: Path = bcs::from_bytes(&path)?;
+                match path {
+                    Path::Code(ModuleId { address, name }) => Self::module(&address, &name),
+                    Path::Resource(struct_tag) => Self::resource(&address, &struct_tag)?,
+                    Path::ResourceGroup(struct_tag) => Self::resource_group(&address, &struct_tag),
+                }
             },
             StateKeyTag::TableItem => {
                 const HANDLE_SIZE: usize = std::mem::size_of::<TableHandle>();
@@ -83,33 +86,55 @@ impl StateKey {
                         num_bytes: val.len(),
                     });
                 }
-                let handle = bcs::from_bytes(
-                    val[1..1 + HANDLE_SIZE]
-                        .try_into()
-                        .expect("Bytes too short."),
-                )?;
-                Ok(StateKey::table_item(&handle, &val[1 + HANDLE_SIZE..]))
+                let handle = bcs::from_bytes(&val[1..1 + HANDLE_SIZE])?;
+                Self::table_item(&handle, &val[1 + HANDLE_SIZE..])
             },
-            StateKeyTag::Raw => Ok(StateKey::raw(&val[1..])),
-        }
+            StateKeyTag::Raw => Self::raw(&val[1..]),
+        };
+        Ok(myself)
+    }
+
+    fn crypto_hash(&self) -> &HashValue {
+        &self.0.hash_value
     }
 
     pub fn size(&self) -> usize {
-        match &self.inner {
+        match self.inner() {
             StateKeyInner::AccessPath(access_path) => access_path.size(),
             StateKeyInner::TableItem { handle, key } => handle.size() + key.len(),
             StateKeyInner::Raw(bytes) => bytes.len(),
         }
     }
 
-    fn access_path(access_path: AccessPath) -> Self {
-        Self::new(StateKeyInner::AccessPath(access_path))
+    /// This is `pub` only for benchmarking, don't use in production. Use `::resource()`, etc. instead.
+    pub fn from_deserialized(deserialized: StateKeyInner) -> Result<Self> {
+        use access_path::Path;
+
+        let myself = match deserialized {
+            StateKeyInner::AccessPath(AccessPath { address, path }) => {
+                match bcs::from_bytes::<Path>(&path)? {
+                    Path::Code(module_id) => Self::module_id(&module_id),
+                    Path::Resource(struct_tag) => Self::resource(&address, &struct_tag)?,
+                    Path::ResourceGroup(struct_tag) => Self::resource_group(&address, &struct_tag),
+                }
+            },
+            StateKeyInner::TableItem { handle, key } => Self::table_item(&handle, &key),
+            StateKeyInner::Raw(bytes) => Self::raw(&bytes),
+        };
+
+        Ok(myself)
     }
 
     pub fn resource(address: &AccountAddress, struct_tag: &StructTag) -> Result<Self> {
-        Ok(Self::access_path(AccessPath::resource_access_path(
-            *address,
-            struct_tag.to_owned(),
+        Ok(Self(REGISTRY.resource(struct_tag, address).get_or_add(
+            struct_tag,
+            address,
+            || {
+                Ok(StateKeyInner::AccessPath(AccessPath::resource_access_path(
+                    *address,
+                    struct_tag.clone(),
+                )?))
+            },
         )?))
     }
 
@@ -117,45 +142,69 @@ impl StateKey {
         Self::resource(address, &T::struct_tag())
     }
 
-    pub fn resource_group(address: &AccountAddress, struct_tag: &StructTag) -> Self {
-        Self::access_path(AccessPath::resource_group_access_path(
-            *address,
-            struct_tag.to_owned(),
-        ))
-    }
-
-    pub fn module(address: &AccountAddress, name: &IdentStr) -> Self {
-        Self::access_path(AccessPath::code_access_path(ModuleId::new(
-            *address,
-            name.to_owned(),
-        )))
-    }
-
-    pub fn module_id(module_id: &ModuleId) -> Self {
-        Self::module(module_id.address(), module_id.name())
-    }
-
     pub fn on_chain_config<T: OnChainConfig>() -> Result<Self> {
         Self::resource(T::address(), &T::struct_tag())
     }
 
-    pub fn table_item(handle: &TableHandle, key: &[u8]) -> Self {
-        Self::new(StateKeyInner::TableItem {
-            handle: *handle,
-            key: key.to_vec(),
-        })
+    pub fn resource_group(address: &AccountAddress, struct_tag: &StructTag) -> Self {
+        Self(
+            REGISTRY
+                .resource_group(struct_tag, address)
+                .get_or_add(struct_tag, address, || {
+                    Ok(StateKeyInner::AccessPath(
+                        AccessPath::resource_group_access_path(*address, struct_tag.clone()),
+                    ))
+                })
+                .expect("only possible error is resource path serialization"),
+        )
     }
 
-    pub fn raw(raw_key: &[u8]) -> Self {
-        Self::new(StateKeyInner::Raw(raw_key.to_vec()))
+    pub fn module(address: &AccountAddress, name: &IdentStr) -> Self {
+        Self(
+            REGISTRY
+                .module(address, name)
+                .get_or_add(address, name, || {
+                    Ok(StateKeyInner::AccessPath(AccessPath::code_access_path(
+                        ModuleId::new(*address, name.to_owned()),
+                    )))
+                })
+                .expect("only possible error is resource path serialization"),
+        )
+    }
+
+    pub fn module_id(module_id: &ModuleId) -> Self {
+        Self::module(&module_id.address, &module_id.name)
+    }
+
+    pub fn table_item(handle: &TableHandle, key: &[u8]) -> Self {
+        Self(
+            REGISTRY
+                .table_item(handle, key)
+                .get_or_add(handle, key, || {
+                    Ok(StateKeyInner::TableItem {
+                        handle: *handle,
+                        key: key.to_vec(),
+                    })
+                })
+                .expect("only possible error is resource path serialization"),
+        )
+    }
+
+    pub fn raw(bytes: &[u8]) -> Self {
+        Self(
+            REGISTRY
+                .raw(bytes)
+                .get_or_add(bytes, &(), || Ok(StateKeyInner::Raw(bytes.to_vec())))
+                .expect("only possible error is resource path serialization"),
+        )
     }
 
     pub fn inner(&self) -> &StateKeyInner {
-        &self.inner
+        &self.0.deserialized
     }
 
     pub fn get_shard_id(&self) -> u8 {
-        CryptoHash::hash(self).nibble(0)
+        self.crypto_hash().nibble(0)
     }
 
     pub fn is_aptos_code(&self) -> bool {
@@ -175,7 +224,7 @@ impl CryptoHash for StateKey {
     type Hasher = DummyHasher;
 
     fn hash(&self) -> HashValue {
-        *self.hash.get_or_init(|| CryptoHash::hash(&self.inner))
+        *self.crypto_hash()
     }
 }
 
@@ -184,7 +233,7 @@ impl Serialize for StateKey {
     where
         S: Serializer,
     {
-        self.inner.serialize(serializer)
+        self.inner().serialize(serializer)
     }
 }
 
@@ -194,22 +243,48 @@ impl<'de> Deserialize<'de> for StateKey {
         D: Deserializer<'de>,
     {
         let inner = StateKeyInner::deserialize(deserializer)?;
-        Ok(Self::new(inner))
+        Self::from_deserialized(inner).map_err(Error::custom)
     }
 }
 
-impl Deref for StateKey {
-    type Target = StateKeyInner;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
+impl PartialEq for StateKey {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
     }
 }
 
 impl Eq for StateKey {}
 
-impl From<StateKeyInner> for StateKey {
-    fn from(inner: StateKeyInner) -> Self {
-        StateKey::new(inner)
+impl Hash for StateKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write(self.crypto_hash().as_ref())
+    }
+}
+
+impl PartialOrd for StateKey {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        // TODO: consider more efficient PartialOrd && Ord, maybe on another wrapper type, so keys
+        //       can be hosted more cheaply in a BTreeSet
+        self.0.deserialized.partial_cmp(&other.0.deserialized)
+    }
+}
+
+impl Ord for StateKey {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.deserialized.cmp(&other.0.deserialized)
+    }
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+impl proptest::arbitrary::Arbitrary for StateKey {
+    type Parameters = ();
+    type Strategy = proptest::strategy::BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: ()) -> Self::Strategy {
+        use proptest::strategy::Strategy;
+
+        proptest::prelude::any::<StateKeyInner>()
+            .prop_map(|inner| StateKey::from_deserialized(inner).unwrap())
+            .boxed()
     }
 }

--- a/types/src/state_store/state_key/prefix.rs
+++ b/types/src/state_store/state_key/prefix.rs
@@ -26,7 +26,7 @@ impl StateKeyPrefix {
 
     /// Checks if the current prefix is a valid prefix of a particular state_key
     pub fn is_prefix(&self, state_key: &StateKey) -> anyhow::Result<bool> {
-        let encoded_key = state_key.encode()?;
+        let encoded_key = state_key.encoded();
         let encoded_prefix = self.encode()?;
         // Check if bytes is a sub-vector of encoded key.
         if encoded_prefix.len() > encoded_key.len() {

--- a/types/src/state_store/state_key/registry.rs
+++ b/types/src/state_store/state_key/registry.rs
@@ -1,0 +1,260 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    access_path::AccessPath,
+    state_store::{
+        state_key::inner::{StateKeyInner, StateKeyInnerHasher},
+        table::TableHandle,
+    },
+};
+use anyhow::Result;
+use aptos_crypto::{hash::CryptoHasher, HashValue};
+use aptos_infallible::RwLock;
+use bytes::Bytes;
+use hashbrown::HashMap;
+use move_core_types::{
+    account_address::AccountAddress,
+    identifier::{IdentStr, Identifier},
+    language_storage::StructTag,
+};
+use once_cell::sync::Lazy;
+use std::{
+    borrow::Borrow,
+    hash::{Hash, Hasher},
+    sync::{Arc, Weak},
+};
+
+#[derive(Debug)]
+pub struct Entry {
+    pub deserialized: StateKeyInner,
+    pub encoded: Bytes,
+    pub hash_value: HashValue,
+}
+
+impl Drop for Entry {
+    fn drop(&mut self) {
+        match &self.deserialized {
+            StateKeyInner::AccessPath(AccessPath { address, path }) => {
+                use crate::access_path::Path;
+
+                match &bcs::from_bytes::<Path>(path).expect("Failed to deserialize Path.") {
+                    Path::Code(module_id) => REGISTRY
+                        .module(address, &module_id.name)
+                        .remove(&module_id.address, &module_id.name),
+                    Path::Resource(struct_tag) => REGISTRY
+                        .resource(struct_tag, address)
+                        .remove(struct_tag, address),
+                    Path::ResourceGroup(struct_tag) => REGISTRY
+                        .resource_group(struct_tag, address)
+                        .remove(struct_tag, address),
+                }
+            },
+            StateKeyInner::TableItem { handle, key } => {
+                REGISTRY.table_item(handle, key).remove(handle, key)
+            },
+            StateKeyInner::Raw(bytes) => REGISTRY.raw(bytes).remove(bytes, &()),
+        }
+    }
+}
+
+pub(crate) struct TwoKeyRegistry<Key1, Key2> {
+    inner: RwLock<HashMap<Key1, HashMap<Key2, Weak<Entry>>>>,
+}
+
+impl<Key1, Key2> TwoKeyRegistry<Key1, Key2>
+where
+    Key1: Clone + Eq + Hash,
+    Key2: Clone + Eq + Hash,
+{
+    fn read_lock_try_get<Ref1, Ref2>(&self, key1: &Ref1, key2: &Ref2) -> Option<Arc<Entry>>
+    where
+        Key1: Borrow<Ref1>,
+        Key2: Borrow<Ref2>,
+        Ref1: Eq + Hash + ?Sized,
+        Ref2: Eq + Hash + ?Sized,
+    {
+        self.inner
+            .read()
+            .get(key1)
+            .and_then(|m| m.get(key2))
+            .and_then(|weak| weak.upgrade())
+    }
+
+    fn write_lock_get_or_add<Ref1, Ref2, Gen>(
+        &self,
+        key1: &Ref1,
+        key2: &Ref2,
+        inner_gen: Gen,
+    ) -> Result<Arc<Entry>>
+    where
+        Key1: Borrow<Ref1>,
+        Key2: Borrow<Ref2>,
+        Ref1: Eq + Hash + ToOwned<Owned = Key1> + ?Sized,
+        Ref2: Eq + Hash + ToOwned<Owned = Key2> + ?Sized,
+        Gen: FnOnce() -> Result<StateKeyInner>,
+    {
+        const MAX_TRIES: usize = 1024;
+
+        // generate the entry content outside the lock
+        let deserialized = inner_gen()?;
+        let encoded = deserialized.encode().expect("Failed to encode StateKey.");
+        let hash_value = {
+            let mut state = StateKeyInnerHasher::default();
+            state.update(&encoded);
+            state.finish()
+        };
+
+        for _ in 0..MAX_TRIES {
+            let mut locked = self.inner.write();
+
+            match locked.get_mut(key1) {
+                None => {
+                    let mut map2 = locked.entry(key1.to_owned()).insert(HashMap::new());
+                    let entry = Arc::new(Entry {
+                        deserialized,
+                        encoded,
+                        hash_value,
+                    });
+                    map2.get_mut()
+                        .insert(key2.to_owned(), Arc::downgrade(&entry));
+                    return Ok(entry);
+                },
+                Some(map2) => match map2.get(key2) {
+                    None => {
+                        let entry = Arc::new(Entry {
+                            deserialized,
+                            encoded,
+                            hash_value,
+                        });
+                        map2.insert(key2.to_owned(), Arc::downgrade(&entry));
+                        return Ok(entry);
+                    },
+                    Some(weak) => match weak.upgrade() {
+                        Some(entry) => {
+                            // some other thread has added it
+                            return Ok(entry);
+                        },
+                        None => {
+                            // the key is being dropped, release lock and retry
+                            continue;
+                        },
+                    },
+                },
+            }
+        }
+        unreachable!("Looks like deadlock??");
+    }
+
+    fn remove(&self, key1: &Key1, key2: &Key2) {
+        let mut locked = self.inner.write();
+        let map2 = locked
+            .get_mut(key1)
+            .expect("Level 1 map must exist when an entry is to be dropped from it.");
+        assert!(
+            map2.remove(key2).is_some(),
+            "Entry missing in registry when dropping."
+        );
+        if map2.is_empty() {
+            locked.remove(key1).expect("Just saw it, can't be gone.");
+        }
+    }
+
+    pub fn get_or_add<Ref1, Ref2, Gen>(
+        &self,
+        key1: &Ref1,
+        key2: &Ref2,
+        inner_gen: Gen,
+    ) -> Result<Arc<Entry>>
+    where
+        Key1: Borrow<Ref1>,
+        Key2: Borrow<Ref2>,
+        Ref1: Eq + Hash + ToOwned<Owned = Key1> + ?Sized,
+        Ref2: Eq + Hash + ToOwned<Owned = Key2> + ?Sized,
+        Gen: FnOnce() -> Result<StateKeyInner>,
+    {
+        if let Some(entry) = self.read_lock_try_get(key1, key2) {
+            return Ok(entry);
+        }
+
+        self.write_lock_get_or_add(key1, key2, inner_gen)
+    }
+}
+
+impl<Key1, Key2> Default for TwoKeyRegistry<Key1, Key2> {
+    fn default() -> Self {
+        Self {
+            inner: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+pub static REGISTRY: Lazy<StateKeyRegistry> = Lazy::new(StateKeyRegistry::default);
+
+const NUM_RESOURCE_SHARDS: usize = 16;
+const NUM_RESOURCE_GROUP_SHARDS: usize = 16;
+const NUM_MODULE_SHARDS: usize = 16;
+const NUM_TABLE_ITEM_SHARDS: usize = 16;
+const NUM_RAW_SHARDS: usize = 4;
+
+#[derive(Default)]
+pub struct StateKeyRegistry {
+    resource_shards: [TwoKeyRegistry<StructTag, AccountAddress>; NUM_RESOURCE_SHARDS],
+    resource_group_shards: [TwoKeyRegistry<StructTag, AccountAddress>; NUM_RESOURCE_GROUP_SHARDS],
+    module_shards: [TwoKeyRegistry<AccountAddress, Identifier>; NUM_MODULE_SHARDS],
+    table_item_shards: [TwoKeyRegistry<TableHandle, Vec<u8>>; NUM_TABLE_ITEM_SHARDS],
+    raw_shards: [TwoKeyRegistry<Vec<u8>, ()>; NUM_RAW_SHARDS], // for tests only
+}
+
+impl StateKeyRegistry {
+    pub fn hash_address_and_name(address: &AccountAddress, name: &[u8]) -> usize {
+        let mut hasher = fxhash::FxHasher::default();
+        hasher.write_u8(address.as_ref()[AccountAddress::LENGTH - 1]);
+        if !name.is_empty() {
+            hasher.write_u8(name[0]);
+            hasher.write_u8(name[name.len() - 1]);
+        }
+        hasher.finish() as usize
+    }
+
+    pub(crate) fn resource(
+        &self,
+        struct_tag: &StructTag,
+        address: &AccountAddress,
+    ) -> &TwoKeyRegistry<StructTag, AccountAddress> {
+        &self.resource_shards
+            [Self::hash_address_and_name(address, struct_tag.name.as_bytes()) % NUM_RESOURCE_SHARDS]
+    }
+
+    pub(crate) fn resource_group(
+        &self,
+        struct_tag: &StructTag,
+        address: &AccountAddress,
+    ) -> &TwoKeyRegistry<StructTag, AccountAddress> {
+        &self.resource_group_shards[Self::hash_address_and_name(
+            address,
+            struct_tag.name.as_bytes(),
+        ) % NUM_RESOURCE_GROUP_SHARDS]
+    }
+
+    pub(crate) fn module(
+        &self,
+        address: &AccountAddress,
+        name: &IdentStr,
+    ) -> &TwoKeyRegistry<AccountAddress, Identifier> {
+        &self.module_shards
+            [Self::hash_address_and_name(address, name.as_bytes()) % NUM_MODULE_SHARDS]
+    }
+
+    pub(crate) fn table_item(
+        &self,
+        handle: &TableHandle,
+        key: &[u8],
+    ) -> &TwoKeyRegistry<TableHandle, Vec<u8>> {
+        &self.table_item_shards[Self::hash_address_and_name(&handle.0, key) % NUM_MODULE_SHARDS]
+    }
+
+    pub(crate) fn raw(&self, bytes: &[u8]) -> &TwoKeyRegistry<Vec<u8>, ()> {
+        &self.raw_shards[Self::hash_address_and_name(&AccountAddress::ONE, bytes) % NUM_RAW_SHARDS]
+    }
+}

--- a/types/src/state_store/state_key/registry.rs
+++ b/types/src/state_store/state_key/registry.rs
@@ -195,10 +195,10 @@ impl<Key1, Key2> Default for TwoKeyRegistry<Key1, Key2> {
 
 pub static REGISTRY: Lazy<StateKeyRegistry> = Lazy::new(StateKeyRegistry::default);
 
-const NUM_RESOURCE_SHARDS: usize = 16;
-const NUM_RESOURCE_GROUP_SHARDS: usize = 16;
-const NUM_MODULE_SHARDS: usize = 16;
-const NUM_TABLE_ITEM_SHARDS: usize = 16;
+const NUM_RESOURCE_SHARDS: usize = 8;
+const NUM_RESOURCE_GROUP_SHARDS: usize = 8;
+const NUM_MODULE_SHARDS: usize = 8;
+const NUM_TABLE_ITEM_SHARDS: usize = 8;
 const NUM_RAW_SHARDS: usize = 4;
 
 #[derive(Default)]

--- a/types/src/state_store/state_key/registry.rs
+++ b/types/src/state_store/state_key/registry.rs
@@ -32,6 +32,16 @@ pub struct Entry {
     pub hash_value: HashValue,
 }
 
+impl Entry {
+    fn new(deserialized: StateKeyInner, encoded: Bytes, hash_value: HashValue) -> Self {
+        Entry {
+            deserialized,
+            encoded,
+            hash_value,
+        }
+    }
+}
+
 impl Drop for Entry {
     fn drop(&mut self) {
         match &self.deserialized {
@@ -115,20 +125,12 @@ where
         Ok(match locked.get_mut(key1) {
             None => {
                 let mut map2 = locked.entry(key1.to_owned()).insert(HashMap::new());
-                let entry = Entry {
-                    deserialized,
-                    encoded,
-                    hash_value,
-                };
+                let entry = Entry::new(deserialized, encoded, hash_value);
                 Self::insert_key2(map2.get_mut(), key2.to_owned(), entry)
             },
             Some(map2) => match map2.get(key2) {
                 None => {
-                    let entry = Entry {
-                        deserialized,
-                        encoded,
-                        hash_value,
-                    };
+                    let entry = Entry::new(deserialized, encoded, hash_value);
                     Self::insert_key2(map2, key2.to_owned(), entry)
                 },
                 Some(weak) => match weak.upgrade() {
@@ -138,11 +140,7 @@ where
                     },
                     None => {
                         // previous version of this key is being dropped.
-                        let entry = Entry {
-                            deserialized,
-                            encoded,
-                            hash_value,
-                        };
+                        let entry = Entry::new(deserialized, encoded, hash_value);
                         Self::insert_key2(map2, key2.to_owned(), entry)
                     },
                 },


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

1. StateKey is an Arc, so super cheap to clone.
1. StateKeyRegistry to cache actual state key instances. 
1. `StateKey::resource()` etc. tries to fetch a cached entry from the registry rather than constructing a new instance.

results:
1. single-node-performance has a 6% -ish TPS gain on average
2. inserting existing (cached) keys to a new set is 10x -ish faster as observed in a Criterion benchmark introduced in the same PR, which is the purpose of this in the first place.
3. didn't observe any significant gain in a cluster setting.

txn | ws | vm? | block size | expected | Baseline | with Registry | pct
-- | -- | -- | -- | -- | -- | -- | --
warmup | 1 | VM | 10000 | 0 | 10771.8 | 11225.7 | 4.21%
no-op | 1 | VM | 10000 | 22200 | 20552.3 | 22046.7 | 7.27%
no-op | 1000 | VM | 10000 | 11500 | 11066.5 | 11722.7 | 5.93%
coin-transfer | 1 | VM | 10000 | 14200 | 12214.8 | 12977.7 | 6.25%
coin-transfer | 1 | native | 10000 | 37000 | 36478.3 | 39303.3 | 7.74%
account-generation | 1 | VM | 10000 | 12000 | 10892.5 | 11610.0 | 6.59%
account-resource32-b | 1 | VM | 10000 | 19200 | 17696.8 | 19254.3 | 8.80%
modify-global-resource | 1 | VM | 4170 | 4170 | 3680.8 | 4119.0 | 11.91%
publish-package | 1 | VM | 155 | 155 | 145.8 | 146.0 | 0.17%
mix_publish_transfer | 1 | VM | 2450 | 2450 | 2017.3 | 2072.7 | 2.75%
batch100-transfer | 1 | VM | 353 | 353 | 296.8 | 306.3 | 3.23%
vector-picture30k | 1 | VM | 151 | 151 | 144.8 | 150.0 | 3.63%
smart-table-picture30-k-with200-change | 1 | VM | 23 | 23 | 22.5 | 23.0 | 2.22%
modify-global-resource-agg-v2 | 1 | VM | 10000 | 20000 | 18418.5 | 19887.7 | 7.98%
resource-groups-global-write-tag1-kb | 1 | VM | 3600 | 3600 | 3239.3 | 3550.0 | 9.59%
resource-groups-sender-multi-change1-kb | 1 | VM | 10000 | 14000 | 12963.8 | 13989.7 | 7.91%
coin-init-and-mint | 1 | VM | 10000 | 14500 | 13225.8 | 14341.7 | 8.44%
fungible-asset-mint | 1 | VM | 1590 | 1590 | 1776.8 | 1898.3 | 6.84%
token-v2-ambassador-mint | 1 | VM | 7006 | 7006 | 6529.0 | 6816.3 | 4.40%
liquidity-pool-swap | 1 | VM | 1030 | 1030 | 1029.5 | 1074.0 | 4.32%
no-op-fee-payer | 1 | VM | 3120 | 3120 | 2883.3 | 3108.0 | 7.80%
  |   |   |   |   |   |   | 6.09%


```bash
00:54 $ cargo criterion -p aptos-types --features fuzzing -- hashset
    Finished bench [optimized + debuginfo] target(s) in 0.57s
                                                                                                                                                                                                        running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 185 filtered out; finished in 0.00s

Gnuplot not found, using plotters backend
hashset/hashset_uncached
                        time:   [350.18 _s 350.24 _s 350.31 _s]
                        thrpt:  [2.8546 Melem/s 2.8552 Melem/s 2.8557 Melem/s]
                 change:
                        time:   [-4.9007% -4.7659% -4.6313%] (p = 0.00 < 0.05)
                        thrpt:  [+4.8562% +5.0044% +5.1533%]
                        Performance has improved.
hashset/hashset_cached  time:   [29.939 _s 30.058 _s 30.186 _s]
                        thrpt:  [33.128 Melem/s 33.269 Melem/s 33.402 Melem/s]
                 change:
                        time:   [+1.3762% +1.6495% +1.8808%] (p = 0.00 < 0.05)
                        thrpt:  [-1.8460% -1.6227% -1.3575%]
                        Performance has regressed.
```


https://docs.google.com/spreadsheets/d/1NlvGcBymmmPYLcYGixeu6O4PgNbmRzyqo1yspI1dJnA/edit#gid=0



## Type of Change
- [x] Refactoring


## Which Components or Systems Does This Change Impact?
- [x] Validator Node

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Existing coverage.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
