### PR TITLE
[Draft] Validators broadcast order votes upon receiving proposal votes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3342,6 +3342,7 @@ dependencies = [
  "aptos-config",
  "aptos-consensus-types",
  "aptos-crypto",
+ "aptos-executor-types",
  "aptos-global-constants",
  "aptos-infallible",
  "aptos-logger",

--- a/consensus/consensus-types/src/lib.rs
+++ b/consensus/consensus-types/src/lib.rs
@@ -10,6 +10,7 @@ pub mod block_retrieval;
 pub mod common;
 pub mod delayed_qc_msg;
 pub mod epoch_retrieval;
+pub mod order_vote;
 pub mod pipeline;
 pub mod pipelined_block;
 pub mod proof_of_store;

--- a/consensus/consensus-types/src/order_vote.rs
+++ b/consensus/consensus-types/src/order_vote.rs
@@ -1,0 +1,119 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{common::Author, vote_data::VoteData};
+use anyhow::{ensure, Context};
+use aptos_crypto::{bls12381, hash::CryptoHash, CryptoMaterialError};
+use aptos_short_hex_str::AsShortHexStr;
+use aptos_types::{
+    ledger_info::LedgerInfo, validator_signer::ValidatorSigner,
+    validator_verifier::ValidatorVerifier,
+};
+use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Display, Formatter};
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct OrderVote {
+    /// The data of the vote
+    vote_data: VoteData,
+    /// The identity of the voter.
+    author: Author,
+    /// LedgerInfo of a block that is going to be ordered in case this vote gathers QC.
+    ledger_info: LedgerInfo,
+    /// Signature of the LedgerInfo.
+    signature: bls12381::Signature,
+}
+
+impl Display for OrderVote {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "OrderVote: [vote data: {}, author: {}, ledger_info: {}]",
+            self.vote_data,
+            self.author.short_str(),
+            self.ledger_info
+        )
+    }
+}
+
+// this is required by structured log
+impl Debug for OrderVote {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl OrderVote {
+    pub fn new(
+        vote_data: VoteData,
+        author: Author,
+        mut ledger_info_placeholder: LedgerInfo,
+        validator_signer: &ValidatorSigner,
+    ) -> Result<Self, CryptoMaterialError> {
+        ledger_info_placeholder.set_consensus_data_hash(vote_data.hash());
+        let signature = validator_signer.sign(&ledger_info_placeholder)?;
+        Ok(Self {
+            vote_data,
+            author,
+            ledger_info: ledger_info_placeholder,
+            signature,
+        })
+    }
+
+    /// Generates a new Vote using a signature over the specified ledger_info
+    pub fn new_with_signature(
+        vote_data: VoteData,
+        author: Author,
+        ledger_info: LedgerInfo,
+        signature: bls12381::Signature,
+    ) -> Self {
+        Self {
+            vote_data,
+            author,
+            ledger_info,
+            signature,
+        }
+    }
+
+    pub fn author(&self) -> Author {
+        self.author
+    }
+
+    pub fn vote_data(&self) -> &VoteData {
+        &self.vote_data
+    }
+
+    pub fn ledger_info(&self) -> &LedgerInfo {
+        &self.ledger_info
+    }
+
+    pub fn signature(&self) -> &bls12381::Signature {
+        &self.signature
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.ledger_info.epoch()
+    }
+
+    pub fn round_to_be_committed(&self) -> u64 {
+        self.ledger_info.round()
+    }
+
+    /// Verifies that the consensus data hash of LedgerInfo corresponds to the vote info,
+    /// and then verifies the signature.
+    pub fn verify(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
+        ensure!(
+            self.ledger_info.consensus_data_hash() == self.vote_data.hash(),
+            "OrderVote's hash mismatch with LedgerInfo"
+        );
+
+        validator
+            .verify(self.author(), &self.ledger_info, &self.signature)
+            .context("Failed to verify OrderVote")?;
+
+        self.vote_data().verify()?;
+
+        Ok(())
+    }
+}

--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -160,6 +160,7 @@ impl PipelinedBlock {
             self.block.clone(),
             self.compute_result().epoch_state().clone(),
             true,
+            self.block_info(),
         )
     }
 

--- a/consensus/consensus-types/src/safety_data.rs
+++ b/consensus/consensus-types/src/safety_data.rs
@@ -2,7 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::vote::Vote;
+use crate::{order_vote::OrderVote, vote::Vote};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -17,6 +17,7 @@ pub struct SafetyData {
     #[serde(default)]
     pub one_chain_round: u64,
     pub last_vote: Option<Vote>,
+    pub last_order_vote: Option<OrderVote>,
 }
 
 impl SafetyData {
@@ -26,6 +27,7 @@ impl SafetyData {
         preferred_round: u64,
         one_chain_round: u64,
         last_vote: Option<Vote>,
+        last_order_vote: Option<OrderVote>,
     ) -> Self {
         Self {
             epoch,
@@ -33,6 +35,7 @@ impl SafetyData {
             preferred_round,
             one_chain_round,
             last_vote,
+            last_order_vote,
         }
     }
 }

--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -168,7 +168,7 @@ impl SyncInfo {
             .verify(validator)
             .and_then(|_| {
                 if let Some(highest_ordered_decision) = &self.highest_ordered_decision {
-                    // TODO: Earlier, quroum_cert.verify() compares if the certified_block.round() is 0. 
+                    // TODO: Earlier, quroum_cert.verify() compares if the certified_block.round() is 0.
                     // Here, we are comparing commit_info.round() > 0. Is this okay?
                     if highest_ordered_decision.commit_info().round() > 0 {
                         highest_ordered_decision.verify_signatures(validator)?;

--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -37,7 +37,11 @@ impl Display for SyncInfo {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "SyncInfo[certified_round: {}, ordered_round: {}, timeout round: {}, commit_info: {}]",
+            "SyncInfo[highest_quorum_cert: {:?}, highest_ordered_decision: {:?}, highest_commit_decision: {:?}, highest_2chain_timeout_cert: {:?}, certified_round: {}, ordered_round: {}, timeout round: {}, commit_info: {}]",
+            self.highest_quorum_cert,
+            self.highest_ordered_decision,
+            self.highest_commit_decision.commit_info(),
+            self.highest_2chain_timeout_cert,
             self.highest_certified_round(),
             self.highest_ordered_round(),
             self.highest_timeout_round(),

--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -168,7 +168,11 @@ impl SyncInfo {
             .verify(validator)
             .and_then(|_| {
                 if let Some(highest_ordered_decision) = &self.highest_ordered_decision {
-                    highest_ordered_decision.verify_signatures(validator)?;
+                    // TODO: Earlier, quroum_cert.verify() compares if the certified_block.round() is 0. 
+                    // Here, we are comparing commit_info.round() > 0. Is this okay?
+                    if highest_ordered_decision.commit_info().round() > 0 {
+                        highest_ordered_decision.verify_signatures(validator)?;
+                    }
                 }
                 Ok(())
             })

--- a/consensus/consensus-types/src/vote_proposal.rs
+++ b/consensus/consensus-types/src/vote_proposal.rs
@@ -6,6 +6,7 @@ use crate::{block::Block, vote_data::VoteData};
 use aptos_crypto::hash::{TransactionAccumulatorHasher, ACCUMULATOR_PLACEHOLDER_HASH};
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use aptos_types::{
+    block_info::BlockInfo,
     epoch_state::EpochState,
     proof::{accumulator::InMemoryTransactionAccumulator, AccumulatorExtensionProof},
 };
@@ -26,6 +27,8 @@ pub struct VoteProposal {
     next_epoch_state: Option<EpochState>,
     /// Represents whether the executed state id is dummy or not.
     decoupled_execution: bool,
+    /// BlockInfo for the above block
+    block_info: BlockInfo,
 }
 
 impl VoteProposal {
@@ -34,12 +37,14 @@ impl VoteProposal {
         block: Block,
         next_epoch_state: Option<EpochState>,
         decoupled_execution: bool,
+        block_info: BlockInfo,
     ) -> Self {
         Self {
             accumulator_extension_proof,
             block,
             next_epoch_state,
             decoupled_execution,
+            block_info,
         }
     }
 
@@ -51,6 +56,10 @@ impl VoteProposal {
 
     pub fn block(&self) -> &Block {
         &self.block
+    }
+
+    pub fn block_info(&self) -> &BlockInfo {
+        &self.block_info
     }
 
     pub fn next_epoch_state(&self) -> Option<&EpochState> {

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = { workspace = true }
 aptos-config = { workspace = true }
 aptos-consensus-types = { workspace = true }
 aptos-crypto = { workspace = true }
+aptos-executor-types = { workspace = true }
 aptos-global-constants = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-logger = { workspace = true }

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -44,6 +44,8 @@ pub enum Error {
     VoteProposalSignatureNotFound,
     #[error("Does not satisfy 2-chain voting rule. Round {0}, Quorum round {1}, TC round {2},  HQC round in TC {3}")]
     NotSafeToVote(u64, u64, u64, u64),
+    #[error("Does not satisfy order vote rule. Round {0}, Quorum round {1}")]
+    NotSafeToOrderVote(u64, u64),
     #[error("Does not satisfy 2-chain timeout rule. Round {0}, Quorum round {1}, TC round {2}, one-chain round {3}")]
     NotSafeToTimeout(u64, u64, u64, u64),
     #[error("Invalid TC: {0}")]

--- a/consensus/safety-rules/src/fuzzing_utils.rs
+++ b/consensus/safety-rules/src/fuzzing_utils.rs
@@ -21,6 +21,7 @@ use aptos_crypto::{
     test_utils::TEST_SEED,
     traits::{SigningKey, Uniform},
 };
+use aptos_executor_types::StateComputeResult;
 use aptos_types::{
     account_address::AccountAddress,
     epoch_change::EpochChangeProof,
@@ -128,7 +129,9 @@ prop_compose! {
         block in arb_block(),
         next_epoch_state in arb_epoch_state(),
     ) -> VoteProposal {
-        VoteProposal::new(accumulator_extension_proof, block, next_epoch_state, false)
+        // TODO: Is this right way to generate BlockInfo here?
+        let block_info = block.gen_block_info(StateComputeResult::new_dummy().root_hash(), StateComputeResult::new_dummy().version(), next_epoch_state.clone());
+        VoteProposal::new(accumulator_extension_proof, block, next_epoch_state, false, block_info)
     }
 }
 

--- a/consensus/safety-rules/src/local_client.rs
+++ b/consensus/safety-rules/src/local_client.rs
@@ -5,6 +5,7 @@
 use crate::{ConsensusState, Error, SafetyRules, TSafetyRules};
 use aptos_consensus_types::{
     block_data::BlockData,
+    order_vote::OrderVote,
     timeout_2chain::{TwoChainTimeout, TwoChainTimeoutCertificate},
     vote::Vote,
     vote_proposal::VoteProposal,
@@ -61,6 +62,15 @@ impl TSafetyRules for LocalClient {
         self.internal
             .write()
             .construct_and_sign_vote_two_chain(vote_proposal, timeout_cert)
+    }
+
+    fn construct_and_sign_order_vote(
+        &mut self,
+        vote_proposal: &VoteProposal,
+    ) -> Result<OrderVote, Error> {
+        self.internal
+            .write()
+            .construct_and_sign_order_vote(vote_proposal)
     }
 
     fn sign_commit_vote(

--- a/consensus/safety-rules/src/logging.rs
+++ b/consensus/safety-rules/src/logging.rs
@@ -43,6 +43,7 @@ impl<'a> SafetyLogSchema<'a> {
 pub enum LogEntry {
     ConsensusState,
     ConstructAndSignVoteTwoChain,
+    ConstructAndSignOrderVote,
     Epoch,
     Initialize,
     KeyReconciliation,
@@ -61,6 +62,7 @@ impl LogEntry {
         match self {
             LogEntry::ConsensusState => "consensus_state",
             LogEntry::ConstructAndSignVoteTwoChain => "construct_and_sign_vote_2chain",
+            LogEntry::ConstructAndSignOrderVote => "construct_and_sign_order_vote",
             LogEntry::Epoch => "epoch",
             LogEntry::Initialize => "initialize",
             LogEntry::LastVotedRound => "last_voted_round",

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -43,7 +43,7 @@ impl PersistentSafetyStorage {
             .expect("Unable to initialize keys and accounts in storage");
 
         // Create the new persistent safety storage
-        let safety_data = SafetyData::new(1, 0, 0, 0, None);
+        let safety_data = SafetyData::new(1, 0, 0, 0, None, None);
         let mut persisent_safety_storage = Self {
             enable_cached_safety_data,
             cached_safety_data: Some(safety_data.clone()),
@@ -208,7 +208,7 @@ mod tests {
         assert_eq!(counters::get_state(counters::PREFERRED_ROUND), 0);
 
         safety_storage
-            .set_safety_data(SafetyData::new(9, 8, 1, 0, None))
+            .set_safety_data(SafetyData::new(9, 8, 1, 0, None, None))
             .unwrap();
 
         let safety_data = safety_storage.safety_data().unwrap();

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -13,6 +13,7 @@ use crate::{
 use aptos_consensus_types::{
     block_data::BlockData,
     common::{Author, Round},
+    order_vote::OrderVote,
     quorum_cert::QuorumCert,
     safety_data::SafetyData,
     timeout_2chain::{TwoChainTimeout, TwoChainTimeoutCertificate},
@@ -250,6 +251,7 @@ impl SafetyRules {
                     0,
                     0,
                     None,
+                    None,
                 ))?;
 
                 info!(SafetyLogSchema::new(LogEntry::Epoch, LogEvent::Update)
@@ -404,6 +406,14 @@ impl TSafetyRules for SafetyRules {
             |log| log.round(round),
             LogEntry::ConstructAndSignVoteTwoChain,
         )
+    }
+
+    fn construct_and_sign_order_vote(
+        &mut self,
+        vote_proposal: &VoteProposal,
+    ) -> Result<OrderVote, Error> {
+        let cb = || self.guarded_construct_and_sign_order_vote(vote_proposal);
+        run_and_log(cb, |log| log, LogEntry::ConstructAndSignOrderVote)
     }
 
     fn sign_commit_vote(

--- a/consensus/safety-rules/src/safety_rules_2chain.rs
+++ b/consensus/safety-rules/src/safety_rules_2chain.rs
@@ -98,7 +98,7 @@ impl SafetyRules {
     ) -> Result<OrderVote, Error> {
         // Exit early if we cannot sign
         self.signer()?;
-        let vote_data = self.verify_proposal(vote_proposal)?;
+        self.verify_proposal(vote_proposal)?;
         let proposed_block = vote_proposal.block();
         let mut safety_data = self.persistent_storage.safety_data()?;
 
@@ -112,10 +112,9 @@ impl SafetyRules {
 
         // Construct and sign order vote
         let author = self.signer()?.author();
-        let ledger_info = self.construct_ledger_info_2chain(proposed_block, vote_data.hash())?;
+        let ledger_info = self.construct_ledger_info_2chain(proposed_block, HashValue::zero())?;
         let signature = self.sign(&ledger_info)?;
-        let order_vote =
-            OrderVote::new_with_signature(vote_data, author, ledger_info.clone(), signature);
+        let order_vote = OrderVote::new_with_signature(author, ledger_info.clone(), signature);
 
         safety_data.last_order_vote = Some(order_vote.clone());
         self.persistent_storage.set_safety_data(safety_data)?;

--- a/consensus/safety-rules/src/safety_rules_2chain.rs
+++ b/consensus/safety-rules/src/safety_rules_2chain.rs
@@ -112,7 +112,7 @@ impl SafetyRules {
 
         // Construct and sign order vote
         let author = self.signer()?.author();
-        let ledger_info = self.construct_ledger_info_2chain(proposed_block, HashValue::zero())?;
+        let ledger_info = LedgerInfo::new(vote_proposal.block_info().clone(), HashValue::zero());
         let signature = self.sign(&ledger_info)?;
         let order_vote = OrderVote::new_with_signature(author, ledger_info.clone(), signature);
 

--- a/consensus/safety-rules/src/safety_rules_2chain.rs
+++ b/consensus/safety-rules/src/safety_rules_2chain.rs
@@ -5,6 +5,7 @@
 use crate::{error::Error, safety_rules::next_round, SafetyRules};
 use aptos_consensus_types::{
     block::Block,
+    order_vote::OrderVote,
     safety_data::SafetyData,
     timeout_2chain::{TwoChainTimeout, TwoChainTimeoutCertificate},
     vote::Vote,
@@ -90,6 +91,38 @@ impl SafetyRules {
         Ok(vote)
     }
 
+    // TODO: Are these safety rules exhaustive?
+    pub(crate) fn guarded_construct_and_sign_order_vote(
+        &mut self,
+        vote_proposal: &VoteProposal,
+    ) -> Result<OrderVote, Error> {
+        // Exit early if we cannot sign
+        self.signer()?;
+        let vote_data = self.verify_proposal(vote_proposal)?;
+        let proposed_block = vote_proposal.block();
+        let mut safety_data = self.persistent_storage.safety_data()?;
+
+        // if already voted on this round, send back the previous vote
+        if let Some(order_vote) = safety_data.last_order_vote.clone() {
+            if order_vote.ledger_info().round() == proposed_block.round() {
+                return Ok(order_vote);
+            }
+        }
+        self.safe_to_order_vote(proposed_block)?;
+
+        // Construct and sign order vote
+        let author = self.signer()?.author();
+        let ledger_info = self.construct_ledger_info_2chain(proposed_block, vote_data.hash())?;
+        let signature = self.sign(&ledger_info)?;
+        let order_vote =
+            OrderVote::new_with_signature(vote_data, author, ledger_info.clone(), signature);
+
+        safety_data.last_order_vote = Some(order_vote.clone());
+        self.persistent_storage.set_safety_data(safety_data)?;
+
+        Ok(order_vote)
+    }
+
     /// Core safety timeout rule for 2-chain protocol. Return success if 1 and 2 are true
     /// 1. round == timeout.qc.round + 1 || round == tc.round + 1
     /// 2. timeout.qc.round >= one_chain_round
@@ -134,6 +167,16 @@ impl SafetyRules {
             Ok(())
         } else {
             Err(Error::NotSafeToVote(round, qc_round, tc_round, hqc_round))
+        }
+    }
+
+    fn safe_to_order_vote(&self, block: &Block) -> Result<(), Error> {
+        let round = block.round();
+        let qc_round = block.quorum_cert().certified_block().round();
+        if round == next_round(qc_round)? {
+            Ok(())
+        } else {
+            Err(Error::NotSafeToOrderVote(round, qc_round))
         }
     }
 

--- a/consensus/safety-rules/src/t_safety_rules.rs
+++ b/consensus/safety-rules/src/t_safety_rules.rs
@@ -5,6 +5,7 @@
 use crate::{ConsensusState, Error};
 use aptos_consensus_types::{
     block_data::BlockData,
+    order_vote::OrderVote,
     timeout_2chain::{TwoChainTimeout, TwoChainTimeoutCertificate},
     vote::Vote,
     vote_proposal::VoteProposal,
@@ -44,6 +45,12 @@ pub trait TSafetyRules {
         vote_proposal: &VoteProposal,
         timeout_cert: Option<&TwoChainTimeoutCertificate>,
     ) -> Result<Vote, Error>;
+
+    /// Attempts to create an order vote for a block given the quroum certificate for the block.
+    fn construct_and_sign_order_vote(
+        &mut self,
+        vote_proposal: &VoteProposal,
+    ) -> Result<OrderVote, Error>;
 
     /// As the holder of the private key, SafetyRules also signs a commit vote.
     /// This returns the signature for the commit vote.

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -18,6 +18,7 @@ use aptos_consensus_types::{
     vote_proposal::VoteProposal,
 };
 use aptos_crypto::hash::{CryptoHash, TransactionAccumulatorHasher};
+use aptos_executor_types::StateComputeResult;
 use aptos_secure_storage::{InMemoryStorage, Storage};
 use aptos_types::{
     aggregate_signature::{AggregateSignature, PartialSignatures},
@@ -58,20 +59,22 @@ pub fn make_proposal_with_qc_and_proof(
     qc: QuorumCert,
     validator_signer: &ValidatorSigner,
 ) -> VoteProposal {
-    VoteProposal::new(
-        proof,
-        Block::new_proposal(
-            payload,
-            round,
-            qc.certified_block().timestamp_usecs() + 1,
-            qc,
-            validator_signer,
-            Vec::new(),
-        )
-        .unwrap(),
-        None,
-        false,
+    let block = Block::new_proposal(
+        payload,
+        round,
+        qc.certified_block().timestamp_usecs() + 1,
+        qc,
+        validator_signer,
+        Vec::new(),
     )
+    .unwrap();
+    // TODO: Is this right way to generate BlockInfo here?
+    let block_info = block.gen_block_info(
+        StateComputeResult::new_dummy().root_hash(),
+        StateComputeResult::new_dummy().version(),
+        None,
+    );
+    VoteProposal::new(proof, block, None, false, block_info)
 }
 
 pub fn make_proposal_with_qc(

--- a/consensus/src/block_storage/mod.rs
+++ b/consensus/src/block_storage/mod.rs
@@ -48,7 +48,7 @@ pub trait BlockReader: Send + Sync {
     fn highest_quorum_cert(&self) -> Arc<QuorumCert>;
 
     /// Return the quorum certificate that carries ledger info with the highest round
-    fn highest_ordered_cert(&self) -> Arc<QuorumCert>;
+    fn highest_ordered_decision(&self) -> Arc<LedgerInfoWithSignatures>;
 
     /// Return the highest timeout certificate if available.
     fn highest_2chain_timeout_cert(&self) -> Option<Arc<TwoChainTimeoutCertificate>>;

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -328,26 +328,26 @@ impl BlockStore {
         }
 
         // Check early that recovery will succeed, and return before corrupting our state in case it will not.
-        LedgerRecoveryData::new(highest_commit_decision.clone())
-            .find_root(&mut blocks.clone(), &mut quorum_certs.clone())
-            .with_context(|| {
-                // for better readability
-                quorum_certs.sort_by_key(|qc| qc.certified_block().round());
-                format!(
-                    "\nRoot: {:?}\nBlocks in db: {}\nQuorum Certs in db: {}\n",
-                    highest_commit_decision.commit_info(),
-                    blocks
-                        .iter()
-                        .map(|b| format!("\n\t{}", b))
-                        .collect::<Vec<String>>()
-                        .concat(),
-                    quorum_certs
-                        .iter()
-                        .map(|qc| format!("\n\t{}", qc))
-                        .collect::<Vec<String>>()
-                        .concat(),
-                )
-            })?;
+        // LedgerRecoveryData::new(highest_commit_decision.clone())
+        //     .find_root(&mut blocks.clone(), &mut quorum_certs.clone())
+        //     .with_context(|| {
+        //         // for better readability
+        //         quorum_certs.sort_by_key(|qc| qc.certified_block().round());
+        //         format!(
+        //             "\nRoot: {:?}\nBlocks in db: {}\nQuorum Certs in db: {}\n",
+        //             highest_commit_decision.commit_info(),
+        //             blocks
+        //                 .iter()
+        //                 .map(|b| format!("\n\t{}", b))
+        //                 .collect::<Vec<String>>()
+        //                 .concat(),
+        //             quorum_certs
+        //                 .iter()
+        //                 .map(|qc| format!("\n\t{}", qc))
+        //                 .collect::<Vec<String>>()
+        //                 .concat(),
+        //         )
+        //     })?;
 
         storage.save_tree(blocks.clone(), quorum_certs.clone())?;
 

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -3,7 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    block_storage::{BlockReader, BlockStore}, counters::{EXECUTED_WITH_ORDER_VOTE_QC, SUCCESSFUL_EXECUTED_WITH_ORDER_VOTE_QC}, epoch_manager::LivenessStorageData, logging::{LogEvent, LogSchema}, monitor, network::{IncomingBlockRetrievalRequest, NetworkSender}, network_interface::ConsensusMsg, payload_manager::PayloadManager, persistent_liveness_storage::{LedgerRecoveryData, PersistentLivenessStorage, RecoveryData}, pipeline::execution_client::TExecutionClient
+    block_storage::{BlockReader, BlockStore},
+    counters::{EXECUTED_WITH_ORDER_VOTE_QC, SUCCESSFUL_EXECUTED_WITH_ORDER_VOTE_QC},
+    epoch_manager::LivenessStorageData,
+    logging::{LogEvent, LogSchema},
+    monitor,
+    network::{IncomingBlockRetrievalRequest, NetworkSender},
+    network_interface::ConsensusMsg,
+    payload_manager::PayloadManager,
+    persistent_liveness_storage::{LedgerRecoveryData, PersistentLivenessStorage, RecoveryData},
+    pipeline::execution_client::TExecutionClient,
 };
 use anyhow::{bail, Context};
 use aptos_consensus_types::{

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -265,9 +265,9 @@ impl BlockStore {
 
         assert_eq!(
             blocks.first().expect("blocks are empty").id(),
-            highest_qc.commit_info().id(),
+            highest_qc.certified_block().id(),
             "Expecting in the retrieval response, first block should be {}, but got {}",
-            highest_qc.commit_info().id(),
+            highest_qc.certified_block().id(),
             blocks.first().expect("blocks are empty").id(),
         );
 

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -76,7 +76,7 @@ impl BlockStore {
     }
 
     /// Fetches dependencies for given sync_info.quorum_cert
-    /// If gap is large, performs state sync using sync_to_highest_ordered_cert
+    /// If gap is large, performs state sync using sync_to_highest_ordered_decision
     /// Inserts sync_info.quorum_cert into block store as the last step
     pub async fn add_certs(
         &self,
@@ -88,15 +88,12 @@ impl BlockStore {
             &retriever.network,
         )
         .await;
-        self.sync_to_highest_ordered_cert(
-            sync_info.highest_ordered_cert().clone(),
+        self.sync_to_highest_ordered_decision(
+            sync_info.highest_ordered_decision().clone(),
             sync_info.highest_commit_decision().clone(),
             &mut retriever,
         )
         .await?;
-
-        self.insert_quorum_cert(sync_info.highest_ordered_cert(), &mut retriever)
-            .await?;
 
         self.insert_quorum_cert(sync_info.highest_quorum_cert(), &mut retriever)
             .await?;
@@ -194,13 +191,13 @@ impl BlockStore {
     /// Check the highest ordered cert sent by peer to see if we're behind and start a fast
     /// forward sync if the committed block doesn't exist in our tree.
     /// It works as follows:
-    /// 1. request the gap blocks from the peer (from highest_ledger_info to highest_ordered_cert)
+    /// 1. request the gap blocks from the peer (from highest_ledger_info to highest_ordered_decision)
     /// 2. We persist the gap blocks to storage before start sync to ensure we could restart if we
     /// crash in the middle of the sync.
     /// 3. We prune the old tree and replace with a new tree built with the 3-chain.
-    async fn sync_to_highest_ordered_cert(
+    async fn sync_to_highest_ordered_decision(
         &self,
-        highest_ordered_cert: QuorumCert,
+        highest_ordered_decision: LedgerInfoWithSignatures,
         highest_commit_decision: LedgerInfoWithSignatures,
         retriever: &mut BlockRetriever,
     ) -> anyhow::Result<()> {
@@ -208,7 +205,7 @@ impl BlockStore {
             return Ok(());
         }
         let (root, root_metadata, blocks, quorum_certs) = Self::fast_forward_sync(
-            &highest_ordered_cert,
+            &highest_ordered_decision,
             &highest_commit_decision,
             retriever,
             self.storage.clone(),
@@ -229,7 +226,7 @@ impl BlockStore {
             retriever
                 .network
                 .send_epoch_change(EpochChangeProof::new(
-                    vec![highest_ordered_cert.ledger_info().clone()],
+                    vec![highest_ordered_decision.clone()],
                     /* more = */ false,
                 ))
                 .await;
@@ -238,7 +235,7 @@ impl BlockStore {
     }
 
     pub async fn fast_forward_sync<'a>(
-        highest_ordered_cert: &'a QuorumCert,
+        highest_ordered_decision: &'a LedgerInfoWithSignatures,
         highest_commit_decision: &'a LedgerInfoWithSignatures,
         retriever: &'a mut BlockRetriever,
         storage: Arc<dyn PersistentLivenessStorage>,
@@ -247,13 +244,13 @@ impl BlockStore {
     ) -> anyhow::Result<RecoveryData> {
         info!(
             LogSchema::new(LogEvent::StateSync).remote_peer(retriever.preferred_peer),
-            "Start state sync to commit decision: {}, ordered cert: {}",
+            "Start state sync to commit decision: {}, ordered decision: {}",
             highest_commit_decision,
-            highest_ordered_cert,
+            highest_ordered_decision,
         );
 
         // we fetch the blocks from
-        let num_blocks = highest_ordered_cert.certified_block().round()
+        let num_blocks = highest_ordered_decision.commit_info().round()
             - highest_commit_decision.ledger_info().round()
             + 1;
 
@@ -261,8 +258,8 @@ impl BlockStore {
         assert!(num_blocks < std::usize::MAX as u64);
 
         let blocks = retriever
-            .retrieve_block_for_qc(
-                highest_ordered_cert,
+            .retrieve_block_for_li_with_sig(
+                highest_ordered_decision,
                 num_blocks,
                 highest_commit_decision.commit_info().id(),
             )
@@ -270,9 +267,9 @@ impl BlockStore {
 
         assert_eq!(
             blocks.first().expect("blocks are empty").id(),
-            highest_ordered_cert.certified_block().id(),
+            highest_ordered_decision.commit_info().id(),
             "Expecting in the retrieval response, first block should be {}, but got {}",
-            highest_ordered_cert.certified_block().id(),
+            highest_ordered_decision.commit_info().id(),
             blocks.first().expect("blocks are empty").id(),
         );
 
@@ -282,7 +279,7 @@ impl BlockStore {
             highest_commit_decision.commit_info().id()
         );
 
-        let mut quorum_certs = vec![highest_ordered_cert.clone()];
+        let mut quorum_certs = vec![];
         quorum_certs.extend(
             blocks
                 .iter()
@@ -617,6 +614,23 @@ impl BlockRetriever {
         let peers = qc.ledger_info().get_voters(&self.validator_addresses);
         self.retrieve_block_for_id(
             qc.certified_block().id(),
+            target_block_id,
+            peers,
+            num_blocks,
+        )
+        .await
+    }
+
+    /// Retrieve chain of n blocks for given LedgerInfoWithSignatures
+    async fn retrieve_block_for_li_with_sig<'a>(
+        &'a mut self,
+        li_with_sig: &'a LedgerInfoWithSignatures,
+        num_blocks: u64,
+        target_block_id: HashValue,
+    ) -> anyhow::Result<Vec<Block>> {
+        let peers = li_with_sig.get_voters(&self.validator_addresses);
+        self.retrieve_block_for_id(
+            li_with_sig.commit_info().id(),
             target_block_id,
             peers,
             num_blocks,

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -330,7 +330,8 @@ impl BlockStore {
         }
 
         // Check early that recovery will succeed, and return before corrupting our state in case it will not.
-        LedgerRecoveryData::new(highest_commit_decision.clone())
+        if num_blocks > 1 {
+            LedgerRecoveryData::new(highest_commit_decision.clone())
             .find_root(&mut blocks.clone(), &mut quorum_certs.clone())
             .with_context(|| {
                 // for better readability
@@ -356,7 +357,7 @@ impl BlockStore {
                     highest_commit_decision,
                 )
             })?;
-
+        }
         storage.save_tree(blocks.clone(), quorum_certs.clone())?;
 
         execution_client

--- a/consensus/src/block_storage/tracing.rs
+++ b/consensus/src/block_storage/tracing.rs
@@ -16,6 +16,7 @@ impl BlockStage {
     pub const EXECUTED: &'static str = "executed";
     pub const NETWORK_RECEIVED: &'static str = "network_received";
     pub const ORDERED: &'static str = "ordered";
+    pub const ORDER_VOTED: &'static str = "order_voted";
     pub const QC_ADDED: &'static str = "qc_added";
     pub const QC_AGGREGATED: &'static str = "qc_aggregated";
     pub const RAND_ADD_DECISION: &'static str = "rand_add_decision";

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -95,6 +95,38 @@ pub static SYNC_TO_HIGHEST_QC: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static SUCCESSFUL_EXECUTED_WITH_REGULAR_QC_ADD_CERTS: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_successful_executed_with_regular_qc_add_certs",
+        "Count of the number of blocks successfully executed with regular QC and added certs"
+    )
+    .unwrap()
+});
+
+pub static SUCCESSFUL_EXECUTED_WITH_REGULAR_QC_FROM_VOTES: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_successful_executed_with_regular_qc_from_votes",
+        "Count of the number of blocks successfully executed with regular QC from votes"
+    )
+    .unwrap()
+});
+
+pub static SUCCESSFUL_EXECUTED_WITH_ORDER_VOTE_QC_ADD_CERTS: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_successful_executed_with_order_vote_qc_add_certs",
+        "Count of the number of blocks successfully executed with order vote QC and added certs"
+    )
+    .unwrap()
+});
+
+pub static SUCCESSFUL_EXECUTED_WITH_ORDER_VOTE_QC_FROM_VOTES: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_successful_executed_with_order_vote_qc_from_votes",
+        "Count of the number of blocks successfully executed with order vote QC from votes"
+    )
+    .unwrap()
+});
+
 pub static ORDER_VOTE_ADDED: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "aptos_consensus_order_vote_added",

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -95,6 +95,14 @@ pub static ORDER_VOTE_VERY_OLD: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static ORDER_VOTE_OTHER_ERRORS: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_order_vote_other_errors",
+        "Count of the number of order votes that have other errors"
+    )
+    .unwrap()
+});
+
 pub static ORDER_VOTE_BROADCASTED: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "aptos_consensus_order_vote_broadcasted",

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -63,6 +63,54 @@ pub static LAST_COMMITTED_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static EXECUTED_WITH_ORDER_VOTE_QC: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_executed_with_order_vote_qc",
+        "Count of the number of blocks executed with order vote QC"
+    )
+    .unwrap()
+});
+
+pub static SUCCESSFUL_EXECUTED_WITH_ORDER_VOTE_QC: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_successful_executed_with_order_vote_qc",
+        "Count of the number of blocks successfully executed with order vote QC"
+    )
+    .unwrap()
+});
+
+pub static ORDER_VOTE_ADDED: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_order_vote_added",
+        "Count of the number of order votes added"
+    )
+    .unwrap()
+});
+
+pub static ORDER_VOTE_BROADCASTED: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_order_vote_broadcasted",
+        "Count of the number of order votes broadcasted"
+    )
+    .unwrap()
+});
+
+pub static FAILED_ORDER_VOTE_BROADCASTED: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_failed_order_vote_broadcasted",
+        "Count of the number of failed order vote broadcasts"
+    )
+    .unwrap()
+});
+
+pub static ORDER_VOTE_BRODCAST_DIDNT_START: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_order_vote_broadcast_didnt_start",
+        "Count of the number of order vote broadcasts that didn't start"
+    )
+    .unwrap()
+});
+
 /// Count of the committed failed rounds since last restart.
 pub static COMMITTED_FAILED_ROUNDS_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -79,6 +79,22 @@ pub static SUCCESSFUL_EXECUTED_WITH_ORDER_VOTE_QC: Lazy<IntCounter> = Lazy::new(
     .unwrap()
 });
 
+pub static SUCCESSFUL_EXECUTED_WITH_REGULAR_QC: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_successful_executed_with_regular_qc",
+        "Count of the number of blocks successfully executed with regular QC"
+    )
+    .unwrap()
+});
+
+pub static SYNC_TO_HIGHEST_QC: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_sync_to_highest_qc",
+        "Count of the number of times we sync to highest QC"
+    )
+    .unwrap()
+});
+
 pub static ORDER_VOTE_ADDED: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "aptos_consensus_order_vote_added",

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -87,6 +87,14 @@ pub static ORDER_VOTE_ADDED: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static ORDER_VOTE_VERY_OLD: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_order_vote_very_old",
+        "Count of the number of order votes that are very old"
+    )
+    .unwrap()
+});
+
 pub static ORDER_VOTE_BROADCASTED: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "aptos_consensus_order_vote_broadcasted",

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1326,6 +1326,8 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             Err(anyhow::anyhow!("Injected error in process_message"))
         });
 
+        info!("ConsensusMsg::{}", consensus_msg.name());
+
         if let ConsensusMsg::ProposalMsg(proposal) = &consensus_msg {
             observe_block(
                 proposal.proposal().timestamp_usecs(),
@@ -1402,6 +1404,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             ConsensusMsg::ProposalMsg(_)
             | ConsensusMsg::SyncInfo(_)
             | ConsensusMsg::VoteMsg(_)
+            | ConsensusMsg::OrderVoteMsg(_)
             | ConsensusMsg::CommitVoteMsg(_)
             | ConsensusMsg::CommitDecisionMsg(_)
             | ConsensusMsg::BatchMsg(_)

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -29,6 +29,7 @@ mod network;
 #[cfg(test)]
 mod network_tests;
 mod payload_client;
+mod pending_order_votes;
 mod pending_votes;
 pub mod persistent_liveness_storage;
 mod pipeline;

--- a/consensus/src/liveness/round_state.rs
+++ b/consensus/src/liveness/round_state.rs
@@ -327,7 +327,7 @@ impl RoundState {
         order_vote: &OrderVote,
         verifier: &ValidatorVerifier,
     ) -> OrderVoteReceptionResult {
-        if order_vote.ledger_info().round() + 2 >= self.current_round {
+        if order_vote.ledger_info().round() + 3 >= self.current_round {
             self.pending_order_votes
                 .insert_order_vote(order_vote, verifier)
         } else {

--- a/consensus/src/liveness/round_state.rs
+++ b/consensus/src/liveness/round_state.rs
@@ -16,7 +16,8 @@ use aptos_consensus_types::{
 use aptos_crypto::HashValue;
 use aptos_logger::{prelude::*, Schema};
 use aptos_types::{
-    ledger_info::LedgerInfoWithPartialSignatures, validator_verifier::ValidatorVerifier,
+    ledger_info::{LedgerInfo, LedgerInfoWithPartialSignatures},
+    validator_verifier::ValidatorVerifier,
 };
 use futures::future::AbortHandle;
 use futures_channel::mpsc::UnboundedSender;
@@ -254,6 +255,10 @@ impl RoundState {
         counters::TIMEOUT_COUNT.inc();
         self.setup_timeout(1);
         true
+    }
+
+    pub fn has_enough_order_votes(&self, ledger_info: &LedgerInfo) -> bool {
+        self.pending_order_votes.has_enough_order_votes(ledger_info)
     }
 
     /// Notify the RoundState about the potentially new QC, TC, and highest committed round.

--- a/consensus/src/liveness/round_state.rs
+++ b/consensus/src/liveness/round_state.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    counters,
+    counters::{self, ORDER_VOTE_VERY_OLD},
     pending_order_votes::{OrderVoteReceptionResult, PendingOrderVotes},
     pending_votes::{PendingVotes, VoteReceptionResult},
     util::time_service::{SendTask, TimeService},
@@ -322,10 +322,11 @@ impl RoundState {
         order_vote: &OrderVote,
         verifier: &ValidatorVerifier,
     ) -> OrderVoteReceptionResult {
-        if order_vote.ledger_info().round() >= self.current_round - 1 {
+        if order_vote.ledger_info().round() >= self.current_round - 2 {
             self.pending_order_votes
                 .insert_order_vote(order_vote, verifier)
         } else {
+            ORDER_VOTE_VERY_OLD.inc();
             OrderVoteReceptionResult::UnexpectedRound(
                 order_vote.ledger_info().round(),
                 self.current_round,

--- a/consensus/src/liveness/round_state.rs
+++ b/consensus/src/liveness/round_state.rs
@@ -322,7 +322,7 @@ impl RoundState {
         order_vote: &OrderVote,
         verifier: &ValidatorVerifier,
     ) -> OrderVoteReceptionResult {
-        if order_vote.ledger_info().round() >= self.current_round - 2 {
+        if order_vote.ledger_info().round() + 2 >= self.current_round {
             self.pending_order_votes
                 .insert_order_vote(order_vote, verifier)
         } else {

--- a/consensus/src/liveness/round_state_test.rs
+++ b/consensus/src/liveness/round_state_test.rs
@@ -149,11 +149,11 @@ fn generate_sync_info(
         ),
         ledger_info,
     );
-    let highest_ordered_cert = quorum_cert.clone();
+    let highest_ordered_decision = quorum_cert.ledger_info().clone();
     let tc = TwoChainTimeoutCertificate::new(TwoChainTimeout::new(
         1,
         timeout_round,
         quorum_cert.clone(),
     ));
-    SyncInfo::new(quorum_cert, highest_ordered_cert, Some(tc))
+    SyncInfo::new(quorum_cert, highest_ordered_decision, Some(tc))
 }

--- a/consensus/src/logging.rs
+++ b/consensus/src/logging.rs
@@ -38,6 +38,7 @@ pub enum LogEvent {
     ReceiveProposal,
     ReceiveSyncInfo,
     ReceiveVote,
+    ReceiveOrderVote,
     RetrieveBlock,
     StateSync,
     Timeout,
@@ -51,6 +52,7 @@ pub enum LogEvent {
     ReceiveAugData,
     BroadcastCertifiedAugData,
     ReceiveCertifiedAugData,
+    SendOrderVote,
     // randomness fast path
     BroadcastRandShareFastPath,
     ReceiveRandShareFastPath,

--- a/consensus/src/metrics_safety_rules.rs
+++ b/consensus/src/metrics_safety_rules.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use aptos_consensus_types::{
     block_data::BlockData,
+    order_vote::OrderVote,
     timeout_2chain::{TwoChainTimeout, TwoChainTimeoutCertificate},
     vote::Vote,
     vote_proposal::VoteProposal,
@@ -123,6 +124,18 @@ impl TSafetyRules for MetricsSafetyRules {
         })
     }
 
+    fn construct_and_sign_order_vote(
+        &mut self,
+        vote_proposal: &VoteProposal,
+    ) -> Result<OrderVote, Error> {
+        self.retry(|inner| {
+            monitor!(
+                "safety_rules",
+                inner.construct_and_sign_order_vote(vote_proposal)
+            )
+        })
+    }
+
     fn sign_commit_vote(
         &mut self,
         ledger_info: LedgerInfoWithSignatures,
@@ -152,6 +165,7 @@ mod tests {
     use crate::{metrics_safety_rules::MetricsSafetyRules, test_utils::EmptyStorage};
     use aptos_consensus_types::{
         block_data::BlockData,
+        order_vote::OrderVote,
         timeout_2chain::{TwoChainTimeout, TwoChainTimeoutCertificate},
         vote::Vote,
         vote_proposal::VoteProposal,
@@ -224,6 +238,10 @@ mod tests {
             _: &VoteProposal,
             _: Option<&TwoChainTimeoutCertificate>,
         ) -> Result<Vote, Error> {
+            unimplemented!()
+        }
+
+        fn construct_and_sign_order_vote(&mut self, _: &VoteProposal) -> Result<OrderVote, Error> {
             unimplemented!()
         }
 

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -14,6 +14,7 @@ use aptos_config::network_id::{NetworkId, PeerNetworkId};
 use aptos_consensus_types::{
     block_retrieval::{BlockRetrievalRequest, BlockRetrievalResponse},
     epoch_retrieval::EpochRetrievalRequest,
+    order_vote::OrderVote,
     pipeline::{commit_decision::CommitDecision, commit_vote::CommitVote},
     proof_of_store::{ProofOfStoreMsg, SignedBatchInfoMsg},
     proposal_msg::ProposalMsg,
@@ -49,6 +50,9 @@ pub enum ConsensusMsg {
     /// VoteMsg is the struct that is ultimately sent by the voter in response for receiving a
     /// proposal.
     VoteMsg(Box<VoteMsg>),
+    /// OrderVoteMsg is the struct that is broadcasted by a validator on receiving quorum certificate
+    /// on a block.
+    OrderVoteMsg(Box<OrderVote>),
     /// CommitProposal is the struct that is sent by the validator after execution to propose
     /// on the committed state hash root.
     CommitVoteMsg(Box<CommitVote>),
@@ -90,6 +94,7 @@ impl ConsensusMsg {
             ConsensusMsg::SyncInfo(_) => "SyncInfo",
             ConsensusMsg::EpochChangeProof(_) => "EpochChangeProof",
             ConsensusMsg::VoteMsg(_) => "VoteMsg",
+            ConsensusMsg::OrderVoteMsg(_) => "OrderVoteMsg",
             ConsensusMsg::CommitVoteMsg(_) => "CommitVoteMsg",
             ConsensusMsg::CommitDecisionMsg(_) => "CommitDecisionMsg",
             ConsensusMsg::BatchMsg(_) => "BatchMsg",

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -302,7 +302,9 @@ impl NetworkPlayground {
         match msg {
             ConsensusMsg::ProposalMsg(proposal_msg) => Some(proposal_msg.proposal().round()),
             ConsensusMsg::VoteMsg(vote_msg) => Some(vote_msg.vote().vote_data().proposed().round()),
-            ConsensusMsg::OrderVoteMsg(order_vote_msg) => Some(order_vote_msg.ledger_info().round()),
+            ConsensusMsg::OrderVoteMsg(order_vote_msg) => {
+                Some(order_vote_msg.ledger_info().round())
+            },
             ConsensusMsg::SyncInfo(sync_info) => Some(sync_info.highest_certified_round()),
             ConsensusMsg::CommitVoteMsg(commit_vote) => Some(commit_vote.commit_info().round()),
             _ => None,

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -302,6 +302,7 @@ impl NetworkPlayground {
         match msg {
             ConsensusMsg::ProposalMsg(proposal_msg) => Some(proposal_msg.proposal().round()),
             ConsensusMsg::VoteMsg(vote_msg) => Some(vote_msg.vote().vote_data().proposed().round()),
+            ConsensusMsg::OrderVoteMsg(order_vote_msg) => Some(order_vote_msg.ledger_info().round()),
             ConsensusMsg::SyncInfo(sync_info) => Some(sync_info.highest_certified_round()),
             ConsensusMsg::CommitVoteMsg(commit_vote) => Some(commit_vote.commit_info().round()),
             _ => None,

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -652,7 +652,7 @@ mod tests {
                 Vec::new(),
             )
             .unwrap(),
-            SyncInfo::new(previous_qc.clone(), previous_qc, None),
+            SyncInfo::new(previous_qc.clone(), previous_qc.ledger_info().clone(), None),
         );
         timed_block_on(&runtime, async {
             nodes[0]

--- a/consensus/src/pending_order_votes.rs
+++ b/consensus/src/pending_order_votes.rs
@@ -150,8 +150,8 @@ impl PendingOrderVotes {
     // Removes votes older than round-1
     pub fn set_round(&mut self, round: u64) {
         self.li_digest_to_votes
-            .retain(|_, (_, li)| li.ledger_info().round() >= round - 2);
+            .retain(|_, (_, li)| li.ledger_info().round() + 2 >= round);
         self.author_to_order_vote
-            .retain(|&(_, r), _| r >= round - 2);
+            .retain(|&(_, r), _| r + 2 >= round);
     }
 }

--- a/consensus/src/pending_order_votes.rs
+++ b/consensus/src/pending_order_votes.rs
@@ -1,0 +1,147 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_consensus_types::{common::Author, order_vote::OrderVote, quorum_cert::QuorumCert};
+use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_logger::prelude::*;
+use aptos_types::{
+    aggregate_signature::PartialSignatures,
+    ledger_info::LedgerInfoWithPartialSignatures,
+    validator_verifier::{ValidatorVerifier, VerifyError},
+};
+use std::{collections::HashMap, sync::Arc};
+
+/// Result of the order vote processing. The failure case (Verification error) is returned
+/// as the Error part of the result.
+#[derive(Debug, PartialEq, Eq)]
+pub enum OrderVoteReceptionResult {
+    /// The vote has been added but QC has not been formed yet. Return the amount of voting power
+    /// QC currently has.
+    VoteAdded(u128),
+    /// The very same vote message has been processed in past.
+    DuplicateVote,
+    /// The very same author has already voted for another proposal in this round (equivocation).
+    EquivocateVote,
+    /// This block has just been certified after adding the vote.
+    NewQuorumCertificate(Arc<QuorumCert>),
+    /// There might be some issues adding a vote
+    ErrorAddingVote(VerifyError),
+    /// The vote is not for the current round.
+    UnexpectedRound(u64, u64),
+    /// Error happens when aggregating signature
+    ErrorAggregatingSignature(VerifyError),
+}
+
+/// A PendingVotes structure keep track of votes
+pub struct PendingOrderVotes {
+    /// Maps LedgerInfo digest to associated signatures (contained in a partial LedgerInfoWithSignatures).
+    /// This might keep multiple LedgerInfos for the current round: either due to different proposals (byzantine behavior)
+    /// or due to different NIL proposals (clients can have a different view of what block to extend).
+    li_digest_to_votes:
+        HashMap<HashValue /* LedgerInfo digest */, (usize, LedgerInfoWithPartialSignatures)>,
+    /// Map of Author to (vote, li_digest). This is useful to discard multiple votes.
+    author_to_order_vote: HashMap<Author, (OrderVote, HashValue)>,
+}
+
+impl PendingOrderVotes {
+    /// Creates an empty PendingOrderVotes structure for a specific epoch and round
+    pub fn new() -> Self {
+        Self {
+            li_digest_to_votes: HashMap::new(),
+            author_to_order_vote: HashMap::new(),
+        }
+    }
+
+    /// Add a vote to the pending votes
+    // TODO: Should we add any counters here?
+    pub fn insert_order_vote(
+        &mut self,
+        order_vote: &OrderVote,
+        validator_verifier: &ValidatorVerifier,
+    ) -> OrderVoteReceptionResult {
+        // derive data from vote
+        let li_digest = order_vote.ledger_info().hash();
+
+        if let Some((previously_seen_vote, previous_li_digest)) =
+            self.author_to_order_vote.get(&order_vote.author())
+        {
+            // is it the same vote?
+            if &li_digest == previous_li_digest {
+                return OrderVoteReceptionResult::DuplicateVote;
+            } else {
+                // we have seen a different vote for the same round
+                error!(
+                    SecurityEvent::ConsensusEquivocatingOrderVote,
+                    remote_peer = order_vote.author(),
+                    order_vote = order_vote,
+                    previous_vote = previously_seen_vote
+                );
+
+                return OrderVoteReceptionResult::EquivocateVote;
+            }
+        }
+
+        self.author_to_order_vote
+            .insert(order_vote.author(), (order_vote.clone(), li_digest));
+
+        let len = self.li_digest_to_votes.len() + 1;
+        // obtain the ledger info with signatures associated to the order vote's ledger info
+        let (_hash_index, li_with_sig) =
+            self.li_digest_to_votes.entry(li_digest).or_insert_with(|| {
+                // if the ledger info with signatures doesn't exist yet, create it
+                (
+                    len,
+                    LedgerInfoWithPartialSignatures::new(
+                        order_vote.ledger_info().clone(),
+                        PartialSignatures::empty(),
+                    ),
+                )
+            });
+
+        let validator_voting_power = validator_verifier
+            .get_voting_power(&order_vote.author())
+            .unwrap_or(0);
+        if validator_voting_power == 0 {
+            warn!(
+                "Received vote with no voting power, from {}",
+                order_vote.author()
+            );
+        }
+        li_with_sig.add_signature(order_vote.author(), order_vote.signature().clone());
+
+        // check if we have enough signatures to create a QC
+        match validator_verifier.check_voting_power(li_with_sig.signatures().keys(), true) {
+            // a quorum of signature was reached, a new QC is formed
+            Ok(aggregated_voting_power) => {
+                assert!(
+                    aggregated_voting_power >= validator_verifier.quorum_voting_power(),
+                    "QC aggregation should not be triggered if we don't have enough votes to form a QC"
+                );
+                match li_with_sig.aggregate_signatures(validator_verifier) {
+                    Ok(ledger_info_with_sig) => {
+                        OrderVoteReceptionResult::NewQuorumCertificate(Arc::new(QuorumCert::new(
+                            order_vote.vote_data().clone(),
+                            ledger_info_with_sig,
+                        )))
+                    },
+                    Err(e) => OrderVoteReceptionResult::ErrorAggregatingSignature(e),
+                }
+            },
+
+            // not enough votes
+            Err(VerifyError::TooLittleVotingPower { voting_power, .. }) => {
+                OrderVoteReceptionResult::VoteAdded(voting_power)
+            },
+
+            // error
+            Err(error) => {
+                error!(
+                    "MUST_FIX: order vote received could not be added: {}, order vote: {}",
+                    error, order_vote
+                );
+                OrderVoteReceptionResult::ErrorAddingVote(error)
+            },
+        }
+    }
+}

--- a/consensus/src/pending_order_votes.rs
+++ b/consensus/src/pending_order_votes.rs
@@ -2,12 +2,12 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_consensus_types::{common::Author, order_vote::OrderVote, quorum_cert::QuorumCert};
+use aptos_consensus_types::{common::Author, order_vote::OrderVote};
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_logger::prelude::*;
 use aptos_types::{
     aggregate_signature::PartialSignatures,
-    ledger_info::LedgerInfoWithPartialSignatures,
+    ledger_info::{LedgerInfoWithPartialSignatures, LedgerInfoWithSignatures},
     validator_verifier::{ValidatorVerifier, VerifyError},
 };
 use std::{collections::HashMap, sync::Arc};
@@ -24,10 +24,10 @@ pub enum OrderVoteReceptionResult {
     /// The very same author has already voted for another proposal in this round (equivocation).
     EquivocateVote,
     /// This block has just been certified after adding the vote.
-    NewQuorumCertificate(Arc<QuorumCert>),
+    NewLedgerInfoWithSignatures(Arc<LedgerInfoWithSignatures>),
     /// There might be some issues adding a vote
     ErrorAddingVote(VerifyError),
-    /// The vote is not for the current round.
+    /// The vote is not for one of the last 2 rounds
     UnexpectedRound(u64, u64),
     /// Error happens when aggregating signature
     ErrorAggregatingSignature(VerifyError),
@@ -41,11 +41,11 @@ pub struct PendingOrderVotes {
     li_digest_to_votes:
         HashMap<HashValue /* LedgerInfo digest */, (usize, LedgerInfoWithPartialSignatures)>,
     /// Map of Author to (vote, li_digest). This is useful to discard multiple votes.
-    author_to_order_vote: HashMap<Author, (OrderVote, HashValue)>,
+    author_to_order_vote: HashMap<(Author, u64), (OrderVote, HashValue)>,
 }
 
 impl PendingOrderVotes {
-    /// Creates an empty PendingOrderVotes structure for a specific epoch and round
+    /// Creates an empty PendingOrderVotes structure
     pub fn new() -> Self {
         Self {
             li_digest_to_votes: HashMap::new(),
@@ -62,9 +62,10 @@ impl PendingOrderVotes {
     ) -> OrderVoteReceptionResult {
         // derive data from vote
         let li_digest = order_vote.ledger_info().hash();
+        let round = order_vote.ledger_info().round();
 
         if let Some((previously_seen_vote, previous_li_digest)) =
-            self.author_to_order_vote.get(&order_vote.author())
+            self.author_to_order_vote.get(&(order_vote.author(), round))
         {
             // is it the same vote?
             if &li_digest == previous_li_digest {
@@ -82,8 +83,10 @@ impl PendingOrderVotes {
             }
         }
 
-        self.author_to_order_vote
-            .insert(order_vote.author(), (order_vote.clone(), li_digest));
+        self.author_to_order_vote.insert(
+            (order_vote.author(), round),
+            (order_vote.clone(), li_digest),
+        );
 
         let len = self.li_digest_to_votes.len() + 1;
         // obtain the ledger info with signatures associated to the order vote's ledger info
@@ -120,10 +123,9 @@ impl PendingOrderVotes {
                 );
                 match li_with_sig.aggregate_signatures(validator_verifier) {
                     Ok(ledger_info_with_sig) => {
-                        OrderVoteReceptionResult::NewQuorumCertificate(Arc::new(QuorumCert::new(
-                            order_vote.vote_data().clone(),
+                        OrderVoteReceptionResult::NewLedgerInfoWithSignatures(Arc::new(
                             ledger_info_with_sig,
-                        )))
+                        ))
                     },
                     Err(e) => OrderVoteReceptionResult::ErrorAggregatingSignature(e),
                 }
@@ -143,5 +145,13 @@ impl PendingOrderVotes {
                 OrderVoteReceptionResult::ErrorAddingVote(error)
             },
         }
+    }
+
+    // Removes votes older than round-1
+    pub fn set_round(&mut self, round: u64) {
+        self.li_digest_to_votes
+            .retain(|_, (_, li)| li.ledger_info().round() >= round - 1);
+        self.author_to_order_vote
+            .retain(|&(_, r), _| r >= round - 1);
     }
 }

--- a/consensus/src/pending_order_votes.rs
+++ b/consensus/src/pending_order_votes.rs
@@ -150,8 +150,8 @@ impl PendingOrderVotes {
     // Removes votes older than round-1
     pub fn set_round(&mut self, round: u64) {
         self.li_digest_to_votes
-            .retain(|_, (_, li)| li.ledger_info().round() >= round - 1);
+            .retain(|_, (_, li)| li.ledger_info().round() >= round - 2);
         self.author_to_order_vote
-            .retain(|&(_, r), _| r >= round - 1);
+            .retain(|&(_, r), _| r >= round - 2);
     }
 }

--- a/consensus/src/pending_order_votes.rs
+++ b/consensus/src/pending_order_votes.rs
@@ -159,9 +159,9 @@ impl PendingOrderVotes {
     // Removes votes older than round-1
     pub fn set_round(&mut self, round: u64) {
         self.li_digest_to_votes
-            .retain(|_, (_, _, li)| li.ledger_info().round() + 2 >= round);
+            .retain(|_, (_, _, li)| li.ledger_info().round() + 3 >= round);
         self.author_to_order_vote
-            .retain(|&(_, r), _| r + 2 >= round);
+            .retain(|&(_, r), _| r + 3 >= round);
     }
 
     pub fn has_enough_order_votes(&self, ledger_info: &LedgerInfo) -> bool {

--- a/consensus/src/recovery_manager.rs
+++ b/consensus/src/recovery_manager.rs
@@ -91,7 +91,7 @@ impl RecoveryManager {
             self.max_blocks_to_request,
         );
         let recovery_data = BlockStore::fast_forward_sync(
-            sync_info.highest_ordered_decision(),
+            sync_info.highest_quorum_cert(),
             sync_info.highest_commit_decision(),
             &mut retriever,
             self.storage.clone(),

--- a/consensus/src/recovery_manager.rs
+++ b/consensus/src/recovery_manager.rs
@@ -90,7 +90,7 @@ impl RecoveryManager {
                 .collect(),
             self.max_blocks_to_request,
         );
-        let recovery_data = BlockStore::fast_forward_sync(
+        let recovery_data = BlockStore::fast_forward_sync_2(
             sync_info.highest_quorum_cert(),
             sync_info.highest_commit_decision(),
             &mut retriever,

--- a/consensus/src/recovery_manager.rs
+++ b/consensus/src/recovery_manager.rs
@@ -91,7 +91,7 @@ impl RecoveryManager {
             self.max_blocks_to_request,
         );
         let recovery_data = BlockStore::fast_forward_sync(
-            sync_info.highest_ordered_cert(),
+            sync_info.highest_ordered_decision(),
             sync_info.highest_commit_decision(),
             &mut retriever,
             self.storage.clone(),

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -1160,7 +1160,7 @@ impl RoundManager {
     ) -> anyhow::Result<()> {
         let result = self
             .block_store
-            .insert_quorum_cert(&qc, &mut self.create_block_retriever(preferred_peer))
+            .insert_quorum_cert(&qc, &mut self.create_block_retriever(preferred_peer), 1)
             .await
             .context("[RoundManager] Failed to process a newly aggregated QC");
         self.process_certificates().await?;
@@ -1176,6 +1176,7 @@ impl RoundManager {
             .insert_aggregated_order_vote(
                 &ledger_info_with_sig,
                 &mut self.create_block_retriever(preferred_peer),
+                1,
             )
             .await
             .context("[RoundManager] Failed to process a new OrderVoteAggregate")

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -695,6 +695,7 @@ impl RoundManager {
             .author()
             .expect("Proposal should be verified having an author");
 
+        info!("Processing proposal round {}, proposal {:?}", proposal.round(), proposal);
         if !self.vtxn_config.enabled()
             && matches!(
                 proposal.block_data().block_type(),

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -481,7 +481,7 @@ impl RoundManager {
             self.process_proposal(proposal_msg.take_proposal()).await
         } else {
             bail!(
-                "Stale proposal {}, Sync info {}, Self sync info {}, current round {}, proposed round {}",
+                "Stale proposal {},\n Sync info {},\n Self sync info {},\n current round {},\n proposed round {}\n",
                 proposal_msg.proposal(),
                 proposal_msg.sync_info(),
                 self.block_store.sync_info(),

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -8,7 +8,7 @@ use crate::{
         BlockReader, BlockRetriever, BlockStore,
     },
     counters::{
-        self, EXECUTED_WITH_ORDER_VOTE_QC, FAILED_ORDER_VOTE_BROADCASTED, ORDER_VOTE_ADDED, ORDER_VOTE_BROADCASTED, ORDER_VOTE_BRODCAST_DIDNT_START, ORDER_VOTE_OTHER_ERRORS, PROPOSED_VTXN_BYTES, PROPOSED_VTXN_COUNT, SUCCESSFUL_EXECUTED_WITH_ORDER_VOTE_QC
+        self, FAILED_ORDER_VOTE_BROADCASTED, ORDER_VOTE_ADDED, ORDER_VOTE_BROADCASTED, ORDER_VOTE_BRODCAST_DIDNT_START, ORDER_VOTE_OTHER_ERRORS, PROPOSED_VTXN_BYTES, PROPOSED_VTXN_COUNT
     },
     error::{error_kind, VerifyError},
     liveness::{
@@ -1122,10 +1122,6 @@ impl RoundManager {
                         order_vote.author(),
                     )
                     .await;
-                EXECUTED_WITH_ORDER_VOTE_QC.inc();
-                if result.is_ok() {
-                    SUCCESSFUL_EXECUTED_WITH_ORDER_VOTE_QC.inc();
-                }
                 result
             },
             OrderVoteReceptionResult::VoteAdded(_) => {

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -121,9 +121,7 @@ impl UnverifiedEvent {
             },
             UnverifiedEvent::OrderVoteMsg(v) => {
                 if !self_message {
-                    info!("ReceivedOrderVoteUnverifiedEvent");
-                    v.verify(validator)?;
-                    info!("VerifiedOrderVoteUnverifiedEvent");
+                    // v.verify(validator)?;
                     counters::VERIFY_MSG
                         .with_label_values(&["order_vote"])
                         .observe(start_time.elapsed().as_secs_f64());

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -339,7 +339,7 @@ impl RoundManager {
         {
             self.log_collected_vote_stats(&new_round_event);
             self.round_state.setup_leader_timeout();
-            info!("Generating proposal for round {}. Self sync info {:?}", new_round_event.round, self.sync_info());
+            info!("Generating proposal for round {}. Self sync info {:?}", new_round_event.round, self.block_store.sync_info());
             let proposal_msg = self.generate_proposal(new_round_event).await?;
             #[cfg(feature = "failpoints")]
             {

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -8,9 +8,7 @@ use crate::{
         BlockReader, BlockRetriever, BlockStore,
     },
     counters::{
-        self, EXECUTED_WITH_ORDER_VOTE_QC, FAILED_ORDER_VOTE_BROADCASTED, ORDER_VOTE_ADDED,
-        ORDER_VOTE_BROADCASTED, ORDER_VOTE_BRODCAST_DIDNT_START, PROPOSED_VTXN_BYTES,
-        PROPOSED_VTXN_COUNT, SUCCESSFUL_EXECUTED_WITH_ORDER_VOTE_QC,
+        self, EXECUTED_WITH_ORDER_VOTE_QC, FAILED_ORDER_VOTE_BROADCASTED, ORDER_VOTE_ADDED, ORDER_VOTE_BROADCASTED, ORDER_VOTE_BRODCAST_DIDNT_START, ORDER_VOTE_OTHER_ERRORS, PROPOSED_VTXN_BYTES, PROPOSED_VTXN_COUNT, SUCCESSFUL_EXECUTED_WITH_ORDER_VOTE_QC
     },
     error::{error_kind, VerifyError},
     liveness::{
@@ -1134,7 +1132,10 @@ impl RoundManager {
                 ORDER_VOTE_ADDED.inc();
                 Ok(())
             },
-            e => Err(anyhow::anyhow!("{:?}", e)),
+            e => {
+                ORDER_VOTE_OTHER_ERRORS.inc();
+                Err(anyhow::anyhow!("{:?}", e))
+            },
         }
     }
 

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -481,9 +481,12 @@ impl RoundManager {
             self.process_proposal(proposal_msg.take_proposal()).await
         } else {
             bail!(
-                "Stale proposal {}, current round {}",
+                "Stale proposal {}, Sync info {}, Self sync info {}, current round {}, proposed round {}",
                 proposal_msg.proposal(),
-                self.round_state.current_round()
+                proposal_msg.sync_info(),
+                self.block_store.sync_info(),
+                self.round_state.current_round(),
+                proposal_msg.proposal().round(),
             );
         }
     }

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -339,7 +339,11 @@ impl RoundManager {
         {
             self.log_collected_vote_stats(&new_round_event);
             self.round_state.setup_leader_timeout();
-            info!("Generating proposal for round {}. Self sync info {:?}", new_round_event.round, self.block_store.sync_info());
+            info!(
+                "Generating proposal for round {}. Self sync info {:?}",
+                new_round_event.round,
+                self.block_store.sync_info()
+            );
             let proposal_msg = self.generate_proposal(new_round_event).await?;
             #[cfg(feature = "failpoints")]
             {
@@ -696,7 +700,12 @@ impl RoundManager {
             .author()
             .expect("Proposal should be verified having an author");
 
-        info!("Processing proposal round {}, proposal {:?}", proposal.round(), proposal);
+        info!(
+            "Processing proposal round {}, proposal {:?}, self sync info {:?}",
+            proposal.round(),
+            proposal,
+            self.block_store.sync_info()
+        );
         if !self.vtxn_config.enabled()
             && matches!(
                 proposal.block_data().block_type(),

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -1055,6 +1055,12 @@ impl RoundManager {
         });
         info!(self.new_log(LogEvent::ReceiveOrderVote), "{}", order_vote);
 
+        if self
+            .round_state
+            .has_enough_order_votes(order_vote.ledger_info())
+        {
+            return Ok(());
+        }
         let vote_reception_result = self
             .round_state
             .insert_order_vote(&order_vote, &self.epoch_state.verifier);

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -8,7 +8,9 @@ use crate::{
         BlockReader, BlockRetriever, BlockStore,
     },
     counters::{
-        self, FAILED_ORDER_VOTE_BROADCASTED, ORDER_VOTE_ADDED, ORDER_VOTE_BROADCASTED, ORDER_VOTE_BRODCAST_DIDNT_START, ORDER_VOTE_OTHER_ERRORS, PROPOSED_VTXN_BYTES, PROPOSED_VTXN_COUNT
+        self, FAILED_ORDER_VOTE_BROADCASTED, ORDER_VOTE_ADDED, ORDER_VOTE_BROADCASTED,
+        ORDER_VOTE_BRODCAST_DIDNT_START, ORDER_VOTE_OTHER_ERRORS, PROPOSED_VTXN_BYTES,
+        PROPOSED_VTXN_COUNT,
     },
     error::{error_kind, VerifyError},
     liveness::{
@@ -1116,13 +1118,11 @@ impl RoundManager {
                         );
                     }
                 }
-                let result = self
-                    .new_order_vote_aggregated(
-                        ledger_info_with_signatures.clone(),
-                        order_vote.author(),
-                    )
-                    .await;
-                result
+                self.new_order_vote_aggregated(
+                    ledger_info_with_signatures.clone(),
+                    order_vote.author(),
+                )
+                .await
             },
             OrderVoteReceptionResult::VoteAdded(_) => {
                 ORDER_VOTE_ADDED.inc();

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -339,6 +339,7 @@ impl RoundManager {
         {
             self.log_collected_vote_stats(&new_round_event);
             self.round_state.setup_leader_timeout();
+            info!("Generating proposal for round {}. Self sync info {:?}", new_round_event.round, self.sync_info());
             let proposal_msg = self.generate_proposal(new_round_event).await?;
             #[cfg(feature = "failpoints")]
             {

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -121,7 +121,7 @@ impl UnverifiedEvent {
             },
             UnverifiedEvent::OrderVoteMsg(v) => {
                 if !self_message {
-                    // v.verify(validator)?;
+                    v.verify(validator)?;
                     counters::VERIFY_MSG
                         .with_label_values(&["order_vote"])
                         .observe(start_time.elapsed().as_secs_f64());
@@ -1165,8 +1165,6 @@ impl RoundManager {
             )
             .await
             .context("[RoundManager] Failed to process a new OrderVoteAggregate")
-        // TODO: Should we process certificates here?
-        // self.process_certificates().await?;
     }
 
     async fn new_2chain_tc_aggregated(

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -909,7 +909,7 @@ fn no_vote_on_mismatch_round() {
     timed_block_on(&runtime, async {
         let bad_proposal = ProposalMsg::new(
             block_skip_round,
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+            SyncInfo::new(genesis_qc.clone(), genesis_qc.ledger_info().clone(), None),
         );
         assert!(node
             .round_manager
@@ -918,7 +918,7 @@ fn no_vote_on_mismatch_round() {
             .is_err());
         let good_proposal = ProposalMsg::new(
             correct_block.clone(),
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+            SyncInfo::new(genesis_qc.clone(), genesis_qc.ledger_info().clone(), None),
         );
         node.round_manager
             .process_proposal_msg(good_proposal)
@@ -974,7 +974,7 @@ fn sync_info_carried_on_timeout_vote() {
             .round_state
             .process_certificates(SyncInfo::new(
                 block_0_quorum_cert.clone(),
-                block_0_quorum_cert.clone(),
+                block_0_quorum_cert.ledger_info().clone(),
                 None,
             ));
         node.round_manager
@@ -1031,7 +1031,7 @@ fn no_vote_on_invalid_proposer() {
     timed_block_on(&runtime, async {
         let bad_proposal = ProposalMsg::new(
             block_incorrect_proposer,
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+            SyncInfo::new(genesis_qc.clone(), genesis_qc.ledger_info().clone(), None),
         );
         assert!(node
             .round_manager
@@ -1040,7 +1040,7 @@ fn no_vote_on_invalid_proposer() {
             .is_err());
         let good_proposal = ProposalMsg::new(
             correct_block.clone(),
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+            SyncInfo::new(genesis_qc.clone(), genesis_qc.ledger_info().clone(), None),
         );
 
         node.round_manager
@@ -1100,7 +1100,11 @@ fn new_round_on_timeout_certificate() {
     timed_block_on(&runtime, async {
         let skip_round_proposal = ProposalMsg::new(
             block_skip_round,
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), Some(tc)),
+            SyncInfo::new(
+                genesis_qc.clone(),
+                genesis_qc.ledger_info().clone(),
+                Some(tc),
+            ),
         );
         node.round_manager
             .process_proposal_msg(skip_round_proposal)
@@ -1108,7 +1112,7 @@ fn new_round_on_timeout_certificate() {
             .unwrap();
         let old_good_proposal = ProposalMsg::new(
             correct_block.clone(),
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+            SyncInfo::new(genesis_qc.clone(), genesis_qc.ledger_info().clone(), None),
         );
         assert!(node
             .round_manager
@@ -1164,7 +1168,7 @@ fn reject_invalid_failed_authors() {
             block,
             SyncInfo::new(
                 genesis_qc.clone(),
-                genesis_qc.clone(),
+                genesis_qc.ledger_info().clone(),
                 if round > 1 {
                     Some(create_timeout(round - 1))
                 } else {
@@ -1245,7 +1249,10 @@ fn response_on_block_retrieval() {
     )
     .unwrap();
     let block_id = block.id();
-    let proposal = ProposalMsg::new(block, SyncInfo::new(genesis_qc.clone(), genesis_qc, None));
+    let proposal = ProposalMsg::new(
+        block,
+        SyncInfo::new(genesis_qc.clone(), genesis_qc.ledger_info().clone(), None),
+    );
 
     timed_block_on(&runtime, async {
         node.round_manager
@@ -1383,7 +1390,7 @@ fn recover_on_restart() {
                 proposal.clone(),
                 SyncInfo::new(
                     proposal.quorum_cert().clone(),
-                    genesis_qc.clone(),
+                    genesis_qc.ledger_info().clone(),
                     Some(tc.clone()),
                 ),
             );
@@ -1538,7 +1545,11 @@ fn sync_on_partial_newer_sync_info() {
             None,
         );
         // Create a sync info with newer quorum cert but older commit cert
-        let sync_info = SyncInfo::new(block_4_qc.clone(), certificate_for_genesis(), None);
+        let sync_info = SyncInfo::new(
+            block_4_qc.clone(),
+            certificate_for_genesis().ledger_info().clone(),
+            None,
+        );
         node.round_manager
             .ensure_round_and_sync_up(
                 sync_info.highest_round() + 1,

--- a/consensus/src/test_utils/mod.rs
+++ b/consensus/src/test_utils/mod.rs
@@ -201,7 +201,11 @@ pub fn placeholder_ledger_info() -> LedgerInfo {
 }
 
 pub fn placeholder_sync_info() -> SyncInfo {
-    SyncInfo::new(certificate_for_genesis(), certificate_for_genesis(), None)
+    SyncInfo::new(
+        certificate_for_genesis(),
+        certificate_for_genesis().ledger_info().clone(),
+        None,
+    )
 }
 
 fn nocapture() -> bool {

--- a/crates/aptos-logger/src/security.rs
+++ b/crates/aptos-logger/src/security.rs
@@ -41,6 +41,9 @@ pub enum SecurityEvent {
     /// Consensus received an equivocating vote
     ConsensusEquivocatingVote,
 
+    /// Consensus received an equivocating order vote
+    ConsensusEquivocatingOrderVote,
+
     /// Consensus received an invalid proposal
     InvalidConsensusProposal,
 

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1041,28 +1041,22 @@ fn realistic_env_sweep_wrap(
 }
 
 fn realistic_env_load_sweep_test() -> ForgeConfig {
-    realistic_env_sweep_wrap(20, 10, LoadVsPerfBenchmark {
+    realistic_env_sweep_wrap(100, 10, LoadVsPerfBenchmark {
         test: Box::new(PerformanceBenchmark),
-        workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000]),
-        criteria: [
-            (9, 1.5, 3., 4., 0),
-            (95, 1.5, 3., 4., 0),
-            (950, 2., 3., 4., 0),
-            (2750, 2.5, 3.5, 4.5, 0),
-            (4600, 3., 4., 6., 10), // Allow some expired transactions (high-load)
-        ]
-        .into_iter()
-        .map(
-            |(min_tps, max_lat_p50, max_lat_p90, max_lat_p99, max_expired_tps)| {
-                SuccessCriteria::new(min_tps)
-                    .add_max_expired_tps(max_expired_tps)
-                    .add_max_failed_submission_tps(0)
-                    .add_latency_threshold(max_lat_p50, LatencyType::P50)
-                    .add_latency_threshold(max_lat_p90, LatencyType::P90)
-                    .add_latency_threshold(max_lat_p99, LatencyType::P99)
-            },
-        )
-        .collect(),
+        workloads: Workloads::TPS(vec![10]),
+        criteria: [(9, 1.5, 3., 4., 0)]
+            .into_iter()
+            .map(
+                |(min_tps, max_lat_p50, max_lat_p90, max_lat_p99, max_expired_tps)| {
+                    SuccessCriteria::new(min_tps)
+                        .add_max_expired_tps(max_expired_tps)
+                        .add_max_failed_submission_tps(0)
+                        .add_latency_threshold(max_lat_p50, LatencyType::P50)
+                        .add_latency_threshold(max_lat_p90, LatencyType::P90)
+                        .add_latency_threshold(max_lat_p99, LatencyType::P99)
+                },
+            )
+            .collect(),
         continuous_traffic: None,
     })
 }

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1043,13 +1043,14 @@ fn realistic_env_sweep_wrap(
 fn realistic_env_load_sweep_test() -> ForgeConfig {
     realistic_env_sweep_wrap(100, 10, LoadVsPerfBenchmark {
         test: Box::new(PerformanceBenchmark),
-        workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000]),
+        workloads: Workloads::TPS(vec![10]),
+        // workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000]),
         criteria: [
             (9, 1.5, 3., 4., 0),
-            (95, 1.5, 3., 4., 0),
-            (950, 2., 3., 4., 0),
-            (2750, 2.5, 3.5, 4.5, 0),
-            (4600, 3., 4., 6., 10), // Allow some expired transactions (high-load)
+            // (95, 1.5, 3., 4., 0),
+            // (950, 2., 3., 4., 0),
+            // (2750, 2.5, 3.5, 4.5, 0),
+            // (4600, 3., 4., 6., 10), // Allow some expired transactions (high-load)
         ]
         .into_iter()
         .map(

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1041,15 +1041,16 @@ fn realistic_env_sweep_wrap(
 }
 
 fn realistic_env_load_sweep_test() -> ForgeConfig {
-    realistic_env_sweep_wrap(100, 10, LoadVsPerfBenchmark {
+    realistic_env_sweep_wrap(20, 10, LoadVsPerfBenchmark {
         test: Box::new(PerformanceBenchmark),
-        workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000]),
+        workloads: Workloads::TPS(vec![10]),
+        // workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000]),
         criteria: [
             (9, 1.5, 3., 4., 0),
-            (95, 1.5, 3., 4., 0),
-            (950, 2., 3., 4., 0),
-            (2750, 2.5, 3.5, 4.5, 0),
-            (4600, 3., 4., 6., 10), // Allow some expired transactions (high-load)
+            // (95, 1.5, 3., 4., 0),
+            // (950, 2., 3., 4., 0),
+            // (2750, 2.5, 3.5, 4.5, 0),
+            // (4600, 3., 4., 6., 10), // Allow some expired transactions (high-load)
         ]
         .into_iter()
         .map(

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1041,16 +1041,16 @@ fn realistic_env_sweep_wrap(
 }
 
 fn realistic_env_load_sweep_test() -> ForgeConfig {
-    realistic_env_sweep_wrap(20, 10, LoadVsPerfBenchmark {
+    realistic_env_sweep_wrap(100, 10, LoadVsPerfBenchmark {
         test: Box::new(PerformanceBenchmark),
-        workloads: Workloads::TPS(vec![10]),
-        // workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000]),
+        // workloads: Workloads::TPS(vec![10]),
+        workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000]),
         criteria: [
             (9, 1.5, 3., 4., 0),
-            // (95, 1.5, 3., 4., 0),
-            // (950, 2., 3., 4., 0),
-            // (2750, 2.5, 3.5, 4.5, 0),
-            // (4600, 3., 4., 6., 10), // Allow some expired transactions (high-load)
+            (95, 1.5, 3., 4., 0),
+            (950, 2., 3., 4., 0),
+            (2750, 2.5, 3.5, 4.5, 0),
+            (4600, 3., 4., 6., 10), // Allow some expired transactions (high-load)
         ]
         .into_iter()
         .map(

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1043,20 +1043,26 @@ fn realistic_env_sweep_wrap(
 fn realistic_env_load_sweep_test() -> ForgeConfig {
     realistic_env_sweep_wrap(100, 10, LoadVsPerfBenchmark {
         test: Box::new(PerformanceBenchmark),
-        workloads: Workloads::TPS(vec![10]),
-        criteria: [(9, 1.5, 3., 4., 0)]
-            .into_iter()
-            .map(
-                |(min_tps, max_lat_p50, max_lat_p90, max_lat_p99, max_expired_tps)| {
-                    SuccessCriteria::new(min_tps)
-                        .add_max_expired_tps(max_expired_tps)
-                        .add_max_failed_submission_tps(0)
-                        .add_latency_threshold(max_lat_p50, LatencyType::P50)
-                        .add_latency_threshold(max_lat_p90, LatencyType::P90)
-                        .add_latency_threshold(max_lat_p99, LatencyType::P99)
-                },
-            )
-            .collect(),
+        workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000]),
+        criteria: [
+            (9, 1.5, 3., 4., 0),
+            (95, 1.5, 3., 4., 0),
+            (950, 2., 3., 4., 0),
+            (2750, 2.5, 3.5, 4.5, 0),
+            (4600, 3., 4., 6., 10), // Allow some expired transactions (high-load)
+        ]
+        .into_iter()
+        .map(
+            |(min_tps, max_lat_p50, max_lat_p90, max_lat_p99, max_expired_tps)| {
+                SuccessCriteria::new(min_tps)
+                    .add_max_expired_tps(max_expired_tps)
+                    .add_max_failed_submission_tps(0)
+                    .add_latency_threshold(max_lat_p50, LatencyType::P50)
+                    .add_latency_threshold(max_lat_p90, LatencyType::P90)
+                    .add_latency_threshold(max_lat_p99, LatencyType::P99)
+            },
+        )
+        .collect(),
         continuous_traffic: None,
     })
 }

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1043,14 +1043,13 @@ fn realistic_env_sweep_wrap(
 fn realistic_env_load_sweep_test() -> ForgeConfig {
     realistic_env_sweep_wrap(100, 10, LoadVsPerfBenchmark {
         test: Box::new(PerformanceBenchmark),
-        workloads: Workloads::TPS(vec![10]),
-        // workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000]),
+        workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000]),
         criteria: [
             (9, 1.5, 3., 4., 0),
-            // (95, 1.5, 3., 4., 0),
-            // (950, 2., 3., 4., 0),
-            // (2750, 2.5, 3.5, 4.5, 0),
-            // (4600, 3., 4., 6., 10), // Allow some expired transactions (high-load)
+            (95, 1.5, 3., 4., 0),
+            (950, 2., 3., 4., 0),
+            (2750, 2.5, 3.5, 4.5, 0),
+            (4600, 3., 4., 6., 10), // Allow some expired transactions (high-load)
         ]
         .into_iter()
         .map(

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -838,9 +838,9 @@ SyncInfo:
   STRUCT:
     - highest_quorum_cert:
         TYPENAME: QuorumCert
-    - highest_ordered_cert:
+    - highest_ordered_decision:
         OPTION:
-          TYPENAME: QuorumCert
+          TYPENAME: LedgerInfoWithSignatures
     - highest_commit_decision:
         TYPENAME: LedgerInfoWithSignatures
     - highest_2chain_timeout_cert:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -344,46 +344,50 @@ ConsensusMsg:
         NEWTYPE:
           TYPENAME: VoteMsg
     7:
+      OrderVoteMsg:
+        NEWTYPE:
+          TYPENAME: OrderVote
+    8:
       CommitVoteMsg:
         NEWTYPE:
           TYPENAME: CommitVote
-    8:
+    9:
       CommitDecisionMsg:
         NEWTYPE:
           TYPENAME: CommitDecision
-    9:
+    10:
       BatchMsg:
         NEWTYPE:
           TYPENAME: BatchMsg
-    10:
+    11:
       BatchRequestMsg:
         NEWTYPE:
           TYPENAME: BatchRequest
-    11:
+    12:
       BatchResponse:
         NEWTYPE:
           TYPENAME: Batch
-    12:
+    13:
       SignedBatchInfo:
         NEWTYPE:
           TYPENAME: SignedBatchInfoMsg
-    13:
+    14:
       ProofOfStoreMsg:
         NEWTYPE:
           TYPENAME: ProofOfStoreMsg
-    14:
+    15:
       DAGMessage:
         NEWTYPE:
           TYPENAME: DAGNetworkMessage
-    15:
+    16:
       CommitMessage:
         NEWTYPE:
           TYPENAME: CommitMessage
-    16:
+    17:
       RandGenMessage:
         NEWTYPE:
           TYPENAME: RandGenMessage
-    17:
+    18:
       BatchResponseV2:
         NEWTYPE:
           TYPENAME: BatchResponse
@@ -1058,6 +1062,16 @@ VoteMsg:
         TYPENAME: Vote
     - sync_info:
         TYPENAME: SyncInfo
+OrderVote:
+  STRUCT:
+    - vote_data:
+        TYPENAME: VoteData
+    - author:
+        TYPENAME: AccountAddress
+    - ledger_info:
+        TYPENAME: LedgerInfo
+    - signature:
+        TYPENAME: Signature
 WriteOp:
   ENUM:
     0:

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -313,10 +313,8 @@ impl LedgerInfoWithV0 {
                     "Fail to verify signatures for LedgerInfo with error: {:?}, LedgerInfo: {:?}, signatures: {:?}, num_votes: {}",
                     e, self.ledger_info(), self.signatures, self.signatures.get_num_voters()
                 );
-                use std::backtrace::Backtrace;
-                println!("Custom backtrace: {}", Backtrace::capture());
                 Err(e)
-            }
+            },
         }
     }
 

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -306,7 +306,18 @@ impl LedgerInfoWithV0 {
         &self,
         validator: &ValidatorVerifier,
     ) -> ::std::result::Result<(), VerifyError> {
-        validator.verify_multi_signatures(self.ledger_info(), &self.signatures)
+        match validator.verify_multi_signatures(self.ledger_info(), &self.signatures) {
+            Ok(result) => Ok(result),
+            Err(e) => {
+                println!(
+                    "Fail to verify signatures for LedgerInfo with error: {:?}, LedgerInfo: {:?}, signatures: {:?}, num_votes: {}",
+                    e, self.ledger_info(), self.signatures, self.signatures.get_num_voters()
+                );
+                use std::backtrace::Backtrace;
+                println!("Custom backtrace: {}", Backtrace::capture());
+                Err(e)
+            }
+        }
     }
 
     pub fn check_voting_power(

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -180,6 +180,15 @@ impl LedgerInfoWithSignatures {
             LedgerInfoWithSignatures::V0(ledger) => ledger.commit_info(),
         }
     }
+
+    pub fn verify_signatures(
+        &self,
+        validator: &ValidatorVerifier,
+    ) -> ::std::result::Result<(), VerifyError> {
+        match self {
+            LedgerInfoWithSignatures::V0(ledger) => ledger.verify_signatures(validator),
+        }
+    }
 }
 
 /// Helper function to generate LedgerInfoWithSignature from a set of validator signers used for testing


### PR DESCRIPTION
## Description
Upon receiving quorum certificate for a block, all the validators immediately broadcast order votes. When the validators receive 2f+1 order votes, they will execute the block. This will reduce the end to end latency as the validators don't have to wait for 2 chain rule to execute the block. We expect that this PR will reduce the end to end latency by 100ms.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
100 node forge run on this PR: https://github.com/aptos-labs/aptos-core/actions/runs/8696327088
100 node forge run on main: https://github.com/aptos-labs/aptos-core/actions/runs/8694531534
We can observe that this PR reduces the average end to end latency by about 50 ms.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
