### PR TITLE
[cargo] Enable LTO on release profile

### DIFF
--- a/.github/actions/rust-smoke-tests/action.yaml
+++ b/.github/actions/rust-smoke-tests/action.yaml
@@ -29,7 +29,7 @@ runs:
       # Prebuild the aptos-node binary so that tests don't start before the node is built.
       # Also, prebuild the aptos-node binary as a separate step to avoid feature unification issues.
       # Note: --test-threads is intentionally set to reduce resource contention in ci jobs. Increasing this, increases job failures and retries.
-      run: cargo build --locked --package=aptos-node --features=failpoints,indexer --release && LOCAL_SWARM_NODE_RELEASE=1 cargo nextest run --release --profile smoke-test --package smoke-test
+      run: cargo build --locked --package=aptos-node --features=failpoints,indexer --release && LOCAL_SWARM_NODE_RELEASE=1 cargo nextest run --release --profile smoke-test --package smoke-test --test-threads 6 --retries 3
       shell: bash
       env:
         INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -778,29 +778,28 @@ move-vm-test-utils = { path = "third_party/move/move-vm/test-utils", features = 
 move-vm-types = { path = "third_party/move/move-vm/types" }
 
 [profile.release]
+codegen-units = 1
 debug = true
+lto = "thin"
 overflow-checks = true
 
 # The performance build is not currently recommended
 # for production deployments. It has not been widely tested.
 [profile.performance]
 inherits = "release"
-opt-level = 3
 debug = true
-overflow-checks = true
-lto = "thin"
-codegen-units = 1
 
 [profile.cli]
 inherits = "release"
+lto = false
 debug = false
 opt-level = "z"
-lto = "thin"
 strip = true
-codegen-units = 1
 
 [profile.ci]
 inherits = "release"
+codegen-units = 16
+lto = "off"
 debug = "line-tables-only"
 overflow-checks = true
 debug-assertions = true


### PR DESCRIPTION
The goal here is to make the default release profile the same as the performance profile so anyone using the release profile gets the optimally optimized binary.

We expect build time to regress a little bit as a tradeoff for consistency and performance, if the increase is too much we may have to abandon this and split the build pipeline but we'd really love to avoid doing so.

Test Plan:

The performance profile has been run in devnet and testnet before so it has been tested, this will need to go into v1.12 or another release to fully test in testnet / mainnet