### PR TITLE
[Aptos Data Client] Ignore flaky test.

### DIFF
--- a/state-sync/aptos-data-client/src/tests/peers.rs
+++ b/state-sync/aptos-data-client/src/tests/peers.rs
@@ -374,6 +374,7 @@ async fn bad_peer_is_eventually_added_back() {
     }
 }
 
+#[ignore] // TODO: This test seems flaky. Debug and fix it.
 #[tokio::test]
 async fn disable_ignoring_low_score_peers() {
     // Ensure the properties hold for all peer priorities


### PR DESCRIPTION
## Description

This PR disables a flaky test in the Aptos Data Client. At some point, I'll return to debug it, but for now, let's move it off the critical path.

## Testing Plan
Existing test infrastructure.