### PR TITLE
[Compiler-v2] Relax check on whether a local can be written

### DIFF
--- a/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest.move
@@ -1,0 +1,19 @@
+module 0x42::m {
+
+    fun foo(x: &vector<u64>): (vector<u64>, u64) {
+        (*x, 0)
+    }
+
+
+    fun test_call() {
+        let y = vector[];
+        (y, _) = foo(&y);
+        assert!(y == vector[], 0);
+    }
+
+    fun test_assign() {
+        let y = vector[1];
+        (y, _) = (*&y, 1);
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest_err.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest_err.exp
@@ -6,10 +6,7 @@ error: cannot assign to borrowed local `_y`
 17 │         let z = &_y;
    │                 --- previous local borrow
 18 │         (_y, _) = foo(&_y);
-   │                   ^^^^^^^^
-   │                   │   │
-   │                   │   previous local borrow
-   │                   attempted to assign here
+   │                   ^^^^^^^^ attempted to assign here
 19 │         *z;
    │         -- conflicting reference `z` used here
 

--- a/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest_err.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest_err.exp
@@ -1,0 +1,24 @@
+
+Diagnostics:
+error: cannot assign to borrowed local `_y`
+   ┌─ tests/reference-safety/write_ref_dest_err.move:18:19
+   │
+17 │         let z = &_y;
+   │                 --- previous local borrow
+18 │         (_y, _) = foo(&_y);
+   │                   ^^^^^^^^
+   │                   │   │
+   │                   │   previous local borrow
+   │                   attempted to assign here
+19 │         *z;
+   │         -- conflicting reference `z` used here
+
+error: cannot assign to borrowed local `_y`
+   ┌─ tests/reference-safety/write_ref_dest_err.move:25:9
+   │
+24 │         let z = &_y;
+   │                 --- previous local borrow
+25 │         _y = vector[2];
+   │         ^^^^^^^^^^^^^^ attempted to assign here
+26 │         *z;
+   │         -- conflicting reference `z` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest_err.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest_err.move
@@ -1,0 +1,29 @@
+module 0x42::m {
+
+    struct S has key, drop {
+
+    }
+
+    fun g(s: &S): &S {
+        s
+    }
+
+    fun foo(x: &vector<u64>): (vector<u64>, u64) {
+        (*x, 0)
+    }
+
+    fun test_call() {
+        let _y = vector[1];
+        let z = &_y;
+        (_y, _) = foo(&_y);
+        *z;
+    }
+
+    fun test_assign() {
+        let _y = vector[1];
+        let z = &_y;
+        _y = vector[2];
+        *z;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest_err.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest_err.no-opt.exp
@@ -6,10 +6,7 @@ error: cannot assign to borrowed local `_y`
 17 │         let z = &_y;
    │                 --- previous local borrow
 18 │         (_y, _) = foo(&_y);
-   │                   ^^^^^^^^
-   │                   │   │
-   │                   │   previous local borrow
-   │                   attempted to assign here
+   │                   ^^^^^^^^ attempted to assign here
 19 │         *z;
    │         -- conflicting reference `z` used here
 

--- a/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest_err.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest_err.no-opt.exp
@@ -1,0 +1,24 @@
+
+Diagnostics:
+error: cannot assign to borrowed local `_y`
+   ┌─ tests/reference-safety/write_ref_dest_err.move:18:19
+   │
+17 │         let z = &_y;
+   │                 --- previous local borrow
+18 │         (_y, _) = foo(&_y);
+   │                   ^^^^^^^^
+   │                   │   │
+   │                   │   previous local borrow
+   │                   attempted to assign here
+19 │         *z;
+   │         -- conflicting reference `z` used here
+
+error: cannot assign to borrowed local `_y`
+   ┌─ tests/reference-safety/write_ref_dest_err.move:25:9
+   │
+24 │         let z = &_y;
+   │                 --- previous local borrow
+25 │         _y = vector[2];
+   │         ^^^^^^^^^^^^^^ attempted to assign here
+26 │         *z;
+   │         -- conflicting reference `z` used here

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/write_ref_dest.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/write_ref_dest.exp
@@ -1,0 +1,3 @@
+processed 3 tasks
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/write_ref_dest.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/write_ref_dest.move
@@ -1,0 +1,25 @@
+//# publish
+module 0x42::m {
+
+    fun foo(x: &vector<u64>): (vector<u64>, u64) {
+        (*x, 0)
+    }
+
+
+    fun test_call() {
+        let y = vector[];
+        (y, _) = foo(&y);
+        assert!(y == vector[], 0);
+    }
+
+    fun test_assign() {
+        let y = vector[1];
+        (y, _) = (*&y, 1);
+        assert!(y == vector[1], 0);
+    }
+
+}
+
+//# run 0x42::m::test_call --check-runtime-types
+
+//# run 0x42::m::test_assign --check-runtime-types


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Previously, as long as the temp is borrowed, it cannot be written. This PR relaxes the condition that if all borrowing temps are not alive after the statement, it can be written.

close #12888 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Existing test cases and newly added test cases

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

Whether this change can be applied to all checks on local writes.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
