### PR TITLE
[Logging] Reduce noisy logs.

### DIFF
--- a/consensus/src/rand/rand_gen/rand_manager.rs
+++ b/consensus/src/rand/rand_gen/rand_manager.rs
@@ -23,7 +23,7 @@ use aptos_channels::aptos_channel;
 use aptos_config::config::ReliableBroadcastConfig;
 use aptos_consensus_types::common::{Author, Round};
 use aptos_infallible::Mutex;
-use aptos_logger::{error, info, spawn_named, warn};
+use aptos_logger::{debug, error, info, spawn_named, warn};
 use aptos_network::{protocols::network::RpcError, ProtocolId};
 use aptos_reliable_broadcast::{DropGuard, ReliableBroadcast};
 use aptos_time_service::TimeService;
@@ -404,7 +404,7 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
                             }
                         }
                         RandMessage::Share(share) => {
-                            info!(LogSchema::new(LogEvent::ReceiveProactiveRandShare)
+                            debug!(LogSchema::new(LogEvent::ReceiveProactiveRandShare)
                                 .author(self.author)
                                 .epoch(share.epoch())
                                 .round(share.metadata().round)
@@ -415,7 +415,7 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
                             }
                         }
                         RandMessage::FastShare(share) => {
-                            info!(LogSchema::new(LogEvent::ReceiveRandShareFastPath)
+                            debug!(LogSchema::new(LogEvent::ReceiveRandShareFastPath)
                                 .author(self.author)
                                 .epoch(share.epoch())
                                 .round(share.metadata().round)

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -954,7 +954,7 @@ impl RoundManager {
     async fn process_vote(&mut self, vote: &Vote) -> anyhow::Result<()> {
         let round = vote.vote_data().proposed().round();
 
-        info!(
+        debug!(
             self.new_log(LogEvent::ReceiveVote)
                 .remote_peer(vote.author()),
             vote = %vote,


### PR DESCRIPTION
## Description
This (opinionated) PR reduces the log frequencies of the ~15 most spammy logs in `aptos-node`. In most cases, we reduce the logs from `info` level logs to `debug` logs (so that they can be dropped in various environments, e.g., `forge`). This seems superior to using `sample` because it still allows developers who care about these logs to read/process all of them when `debug` logs are enabled.

Note: if there's any changes in this PR you disagree with, please let us know so that we can discuss it 😄 This PR is a starting point.

## Testing Plan
Existing test infrastructure.