### PR TITLE
[forge] Decrease log level to info

### DIFF
--- a/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml
+++ b/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml
@@ -1,15 +1,19 @@
 validator:
   enableNetworkPolicy: false
-  rust_log: debug,hyper=off
+  # Add debug here to enable debug logs
+  # rust_log: debug,hyper=off
+  rust_log: hyper=off
   # force enable the telemetry service to try to send telemetry
   force_enable_telemetry: true
 
 fullnode:
   # at most one VFN per validator, depending on numFullnodeGroups
   groups:
-  - name: fullnode
-    replicas: 1
-  rust_log: debug,hyper=off
+    - name: fullnode
+      replicas: 1
+  # Add debug herer to enable debug logs
+  # rust_log: debug,hyper=off
+  rust_log: hyper=off
   # force enable the telemetry service to try to send telemetry
   force_enable_telemetry: true
 


### PR DESCRIPTION
Remove the debug override for forge debug logs

This is to cut down the log volume, debug logs around 30% of forge logs (which is the current top contributor to log volume)

Test Plan: check logs from the PR job
