### PR TITLE
[CI/CD] Add simple target determination for framework upgrade test.

### DIFF
--- a/.github/actions/framework-upgrade-determinator/action.yaml
+++ b/.github/actions/framework-upgrade-determinator/action.yaml
@@ -1,0 +1,41 @@
+name: Framework Upgrade Test Determinator
+description: Runs the framework upgrade test determinator
+inputs:
+  GIT_CREDENTIALS:
+    description: "Optional credentials to pass to git. Useful if you need to pull private repos for dependencies"
+    required: false
+outputs:
+  run_framework_upgrade_test:
+    description: "Returns true if the framework upgrade test should be run"
+    value: ${{ steps.framework_upgrade_determinator.outputs.run_framework_upgrade_test }}
+
+runs:
+  using: composite
+  steps:
+    # Checkout the repository and setup the rust toolchain
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0 # Fetch all git history for accurate target determination
+    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+      with:
+        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
+
+    # Output the changed files
+    - name: Output the changed files
+      run: cargo x changed-files -vv
+      shell: bash
+
+    # Output the affected packages
+    - name: Output the affected packages
+      run: cargo x affected-packages -vv
+      shell: bash
+
+    # Run the framework upgrade test determinator
+    - name: Run the framework upgrade test determinator
+      id: framework_upgrade_determinator
+      run: |
+        export RESULT=$(cargo x targeted-framework-upgrade-tests | awk -F'Framework upgrade test required: ' '{print $2}')
+        echo "Framework upgrade test required: $RESULT"
+        echo "run_framework_upgrade_test=$RESULT" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -125,6 +125,18 @@ jobs:
         id: determine_file_changes
         uses: ./.github/actions/file-change-determinator
 
+  # This job determines if the framework upgrade test should be run
+  framework-upgrade-determinator:
+    needs: [permission-check]
+    runs-on: ubuntu-latest
+    outputs:
+      run_framework_upgrade_test: ${{ steps.determine_framework_upgrade_test.outputs.run_framework_upgrade_test }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run the framework upgrade test determinator
+        id: determine_framework_upgrade_test
+        uses: ./.github/actions/framework-upgrade-determinator
+
   # This is a PR required job.
   rust-images:
     needs: [permission-check, determine-docker-build-metadata]
@@ -315,12 +327,13 @@ jobs:
       - rust-images-failpoints
       - rust-images-performance
       - rust-images-consensus-only-perf-test
-      - file_change_determinator
+      - framework-upgrade-determinator
     if: |
       !failure() && !cancelled() && needs.permission-check.result == 'success' && (
         (github.event_name == 'push' && github.ref_name != 'main') ||
         github.event_name == 'workflow_dispatch' ||
-        contains(github.event.pull_request.labels.*.name, 'CICD:run-framework-upgrade-test')
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-framework-upgrade-test') ||
+        github.event.pull_request.auto_merge != null
       )
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
@@ -331,7 +344,7 @@ jobs:
       FORGE_RUNNER_DURATION_SECS: 3600
       COMMENT_HEADER: forge-framework-upgrade
       FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
-      SKIP_JOB: ${{ needs.file_change_determinator.outputs.only_docs_changed == 'true' }}
+      SKIP_JOB: ${{ !contains(github.event.pull_request.labels.*.name, 'CICD:run-framework-upgrade-test') && (needs.framework-upgrade-determinator.outputs.run_framework_upgrade_test == 'false') }}
 
   forge-consensus-only-perf-test:
     needs:

--- a/devtools/aptos-cargo-cli/src/lib.rs
+++ b/devtools/aptos-cargo-cli/src/lib.rs
@@ -27,9 +27,13 @@ const RELEVANT_FILE_PATHS_FOR_COMPILER_V2: [&str; 7] = [
     ".github/workflows/move-test-compiler-v2.yaml",
     ".github/actions/move-tests-compiler-v2",
 ];
+const RELEVANT_FILE_PATHS_FOR_FRAMEWORK_UPGRADE_TESTS: [&str; 2] =
+    ["aptos-move/aptos-release-builder", "aptos-move/framework"];
 
 // Relevant packages to monitor when deciding to run the targeted tests
 const RELEVANT_PACKAGES_FOR_COMPILER_V2: [&str; 2] = ["aptos-framework", "e2e-move-tests"];
+const RELEVANT_PACKAGES_FOR_FRAMEWORK_UPGRADE_TESTS: [&str; 2] =
+    ["aptos-framework", "aptos-release-builder"];
 
 // The targeted unit test packages to ignore (these will be run separately, by other jobs)
 const TARGETED_UNIT_TEST_PACKAGES_TO_IGNORE: [&str; 2] = ["aptos-testcases", "smoke-test"];
@@ -62,6 +66,7 @@ pub enum AptosCargoCommand {
     Nextest(CommonArgs),
     TargetedCLITests(CommonArgs),
     TargetedCompilerV2Tests(CommonArgs),
+    TargetedFrameworkUpgradeTests(CommonArgs),
     TargetedUnitTests(CommonArgs),
     Test(CommonArgs),
 }
@@ -88,6 +93,7 @@ impl AptosCargoCommand {
             AptosCargoCommand::Nextest(args) => args,
             AptosCargoCommand::TargetedCLITests(args) => args,
             AptosCargoCommand::TargetedCompilerV2Tests(args) => args,
+            AptosCargoCommand::TargetedFrameworkUpgradeTests(args) => args,
             AptosCargoCommand::TargetedUnitTests(args) => args,
             AptosCargoCommand::Test(args) => args,
         }
@@ -196,6 +202,31 @@ impl AptosCargoCommand {
 
                 // Otherwise, skip the targeted compiler v2 tests
                 println!("Skipping targeted compiler v2 tests because no relevant files or packages were affected!");
+                Ok(())
+            },
+            AptosCargoCommand::TargetedFrameworkUpgradeTests(_) => {
+                // Determine if the framework upgrade tests should be run.
+                // Start by calculating the changed files and affected packages.
+                let (_, _, changed_files) = package_args.identify_changed_files()?;
+                let (_, _, affected_package_paths) =
+                    self.get_args_and_affected_packages(package_args)?;
+
+                // Determine if any relevant files or packages were changed
+                let relevant_changes_detected = detect_relevant_changes(
+                    RELEVANT_FILE_PATHS_FOR_FRAMEWORK_UPGRADE_TESTS.to_vec(),
+                    RELEVANT_PACKAGES_FOR_FRAMEWORK_UPGRADE_TESTS.to_vec(),
+                    changed_files,
+                    affected_package_paths,
+                );
+
+                // Output if relevant changes were detected that require the framework upgrade
+                // test. This will be consumed by Github Actions and used to run the test.
+                // TODO: is there a cleaner way to output this for Github Actions?
+                println!(
+                    "Framework upgrade test required: {}",
+                    relevant_changes_detected
+                );
+
                 Ok(())
             },
             AptosCargoCommand::TargetedUnitTests(_) => {


### PR DESCRIPTION
## Description
This PR updates the framework upgrade test to use target determination. This should help to reduce unnecessary CI/CD runs by skipping the job if irrelevant changes are detected.

To achieve this, the PR adds a new command (`cargo x targeted-framework-upgrade-tests`) to the `aptos-cargo-cli`. The command will output if relevant changes are detected and the framework upgrade test should be performed. For example:
```
% cargo x targeted-framework-upgrade-tests
Framework upgrade test required: true
```

We define "relevant changes" for running the framework upgrade test as: (i) touching the list of file paths we care about (as provided by @runtian-zhou); or (ii) affecting the `aptos-framework` or `aptos-release-builder` rust packages.

Note:
- If target determination finds that the framework upgrade test should not run, it sets the `SKIP_JOB` variable for the forge workflow, so that even though the forge workflow starts, it skips all steps and passes trivially.

## Testing Plan
Manual verification and existing test infrastructure.