### PR TITLE
nextest smoke-test profile

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,3 +18,13 @@ junit = { path = "junit.xml" }
 [profile.default.slow-timeout]
 period = "600s"
 terminate-after = 1
+
+[profile.smoke-test]
+# like profile.ci
+status-level = "skip"
+failure-output = "immediate-final"
+fail-fast = true
+# different than ci
+test-threads = 6
+retries = 3
+slow-timeout = { period = "1800s", terminate-after = 1 }

--- a/.github/actions/rust-smoke-tests/action.yaml
+++ b/.github/actions/rust-smoke-tests/action.yaml
@@ -29,7 +29,7 @@ runs:
       # Prebuild the aptos-node binary so that tests don't start before the node is built.
       # Also, prebuild the aptos-node binary as a separate step to avoid feature unification issues.
       # Note: --test-threads is intentionally set to reduce resource contention in ci jobs. Increasing this, increases job failures and retries.
-      run: cargo build --locked --package=aptos-node --features=failpoints,indexer --release && LOCAL_SWARM_NODE_RELEASE=1 cargo nextest run --release --profile ci --package smoke-test --test-threads 6 --retries 3
+      run: cargo build --locked --package=aptos-node --features=failpoints,indexer --release && LOCAL_SWARM_NODE_RELEASE=1 cargo nextest run --release --profile smoke-test --package smoke-test
       shell: bash
       env:
         INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres


### PR DESCRIPTION
## Description
Add `nextest` profile for smoke-test with 30 minute timeout for long tests.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [X] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [X] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Ran locally, will need to pass in GHA too

## Key Areas to Review
Is this the setting we want?

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X] I tested both happy and unhappy path of the functionality
- [X] I have made corresponding changes to the documentation