### PR TITLE
[Coverage] Don't fail job on codecov upload failure

### DIFF
--- a/.github/workflows/coverage-move-only.yaml
+++ b/.github/workflows/coverage-move-only.yaml
@@ -61,6 +61,7 @@ jobs:
         with:
           name: lcov_unit
       - name: Upload coverage to Codecov
+        continue-on-error: true # Don't fail if the codecov upload fails
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3
         with:
           files: lcov_unit.info

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -77,6 +77,7 @@ jobs:
       && !cancelled()
     needs: [ rust-unit-coverage, rust-smoke-coverage ]
     runs-on: ubuntu-latest
+    continue-on-error: true # Don't fail if the codecov upload fails
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
## Description
This PR updates the code coverage GHA jobs not to fail if the codecov upload step fails. This can happen for various reasons (and the current set of failures still needs to be debugged). Unblocking this for now.

## Testing Plan
Manual verification and existing test infrastructure.