### PR TITLE
[Compiler-V2] [Bugfix] Improve cyclic instantiation checker error messages

### DIFF
--- a/third_party/move/move-compiler-v2/src/cyclic_instantiation_checker.rs
+++ b/third_party/move/move-compiler-v2/src/cyclic_instantiation_checker.rs
@@ -173,30 +173,31 @@ impl<'a> CyclicInstantiationChecker<'a> {
     /// Precondition: `callers_chain` is not empty
     fn report_error(
         &self,
-        _nid: NodeId,
+        nid: NodeId,
         callee: QualifiedInstId<FunId>,
         callers_chain: &mut Vec<(Loc, QualifiedInstId<FunId>)>,
     ) {
         let root = callers_chain[0].1.id;
         let mut labels = (0..callers_chain.len() - 1)
             .map(|i| {
-                let (caller_loc, caller) = &callers_chain[i];
+                let (_caller_loc, caller) = &callers_chain[i];
                 // callee of `caller`
-                let callee = &callers_chain[i + 1].1;
+                let (callee_loc, callee) = &callers_chain[i + 1];
                 format!(
                     "`{}` calls `{}` {}",
                     self.display_call(caller, root),
                     self.display_call(callee, root),
-                    caller_loc.display_line_only(self.mod_env.env)
+                    callee_loc.display_line_only(self.mod_env.env)
                 )
             })
             .collect_vec();
-        let (caller_loc, caller) = &callers_chain.last().expect("parent");
+        let (_caller_loc, caller) = &callers_chain.last().expect("parent");
+        let callee_loc = self.mod_env.env.get_node_loc(nid);
         labels.push(format!(
             "`{}` calls `{}` {}",
             self.display_call(caller, root),
             self.display_call(&callee, root),
-            caller_loc.display_line_only(self.mod_env.env)
+            callee_loc.display_line_only(self.mod_env.env)
         ));
         let root_loc = self
             .mod_env

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/recursive_type_instantiation.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/recursive_type_instantiation.exp
@@ -6,7 +6,7 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 6 │     public fun simple_recursion<T>() {
   │                ^^^^^^^^^^^^^^^^
   │
-  = `simple_recursion<T>` calls `simple_recursion<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:6
+  = `simple_recursion<T>` calls `simple_recursion<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:7
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/recursive_type_instantiation.move:10:9
@@ -14,8 +14,8 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 10 │     fun two_level_recursion_0<T>() {
    │         ^^^^^^^^^^^^^^^^^^^^^
    │
-   = `two_level_recursion_0<T>` calls `two_level_recursion_1<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:10
-   = `two_level_recursion_1<T>` calls `two_level_recursion_0<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:11
+   = `two_level_recursion_0<T>` calls `two_level_recursion_1<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:11
+   = `two_level_recursion_1<T>` calls `two_level_recursion_0<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:15
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/recursive_type_instantiation.move:14:9
@@ -23,8 +23,8 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 14 │     fun two_level_recursion_1<T>() {
    │         ^^^^^^^^^^^^^^^^^^^^^
    │
-   = `two_level_recursion_1<T>` calls `two_level_recursion_0<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:14
-   = `two_level_recursion_0<m0::S<T>>` calls `two_level_recursion_1<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:15
+   = `two_level_recursion_1<T>` calls `two_level_recursion_0<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:15
+   = `two_level_recursion_0<m0::S<T>>` calls `two_level_recursion_1<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:11
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/recursive_type_instantiation.move:18:9
@@ -32,9 +32,9 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 18 │     fun three_level_recursion_0<T>() {
    │         ^^^^^^^^^^^^^^^^^^^^^^^
    │
-   = `three_level_recursion_0<T>` calls `three_level_recursion_1<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:18
-   = `three_level_recursion_1<T>` calls `three_level_recursion_2<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:19
-   = `three_level_recursion_2<T>` calls `three_level_recursion_0<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:23
+   = `three_level_recursion_0<T>` calls `three_level_recursion_1<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:19
+   = `three_level_recursion_1<T>` calls `three_level_recursion_2<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:23
+   = `three_level_recursion_2<T>` calls `three_level_recursion_0<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:27
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/recursive_type_instantiation.move:22:9
@@ -42,9 +42,9 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 22 │     fun three_level_recursion_1<T>() {
    │         ^^^^^^^^^^^^^^^^^^^^^^^
    │
-   = `three_level_recursion_1<T>` calls `three_level_recursion_2<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:22
-   = `three_level_recursion_2<T>` calls `three_level_recursion_0<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:23
-   = `three_level_recursion_0<m0::S<T>>` calls `three_level_recursion_1<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:27
+   = `three_level_recursion_1<T>` calls `three_level_recursion_2<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:23
+   = `three_level_recursion_2<T>` calls `three_level_recursion_0<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:27
+   = `three_level_recursion_0<m0::S<T>>` calls `three_level_recursion_1<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:19
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/recursive_type_instantiation.move:26:9
@@ -52,9 +52,9 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 26 │     fun three_level_recursion_2<T>() {
    │         ^^^^^^^^^^^^^^^^^^^^^^^
    │
-   = `three_level_recursion_2<T>` calls `three_level_recursion_0<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:26
-   = `three_level_recursion_0<m0::S<T>>` calls `three_level_recursion_1<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:27
-   = `three_level_recursion_1<m0::S<T>>` calls `three_level_recursion_2<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:19
+   = `three_level_recursion_2<T>` calls `three_level_recursion_0<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:27
+   = `three_level_recursion_0<m0::S<T>>` calls `three_level_recursion_1<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:19
+   = `three_level_recursion_1<m0::S<T>>` calls `three_level_recursion_2<m0::S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:23
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/recursive_type_instantiation.move:30:9
@@ -62,7 +62,7 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 30 │     fun recurse_at_different_position<T1, T2>() {
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   = `recurse_at_different_position<T1, T2>` calls `recurse_at_different_position<T2, m0::S<T1>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:30
+   = `recurse_at_different_position<T1, T2>` calls `recurse_at_different_position<T2, m0::S<T1>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:31
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/recursive_type_instantiation.move:44:9
@@ -70,4 +70,4 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 44 │     fun test_vec<T>() {
    │         ^^^^^^^^
    │
-   = `test_vec<T>` calls `test_vec<vector<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:44
+   = `test_vec<T>` calls `test_vec<vector<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:45

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/complex_1.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/complex_1.exp
@@ -6,9 +6,9 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 13 │     fun c<T1, T2>() {
    │         ^
    │
-   = `c<T1, T2>` calls `d<T2>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:13
-   = `d<T2>` calls `b<u64, T2>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:15
-   = `b<u64, T2>` calls `c<M::S<T2>, bool>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:20
+   = `c<T1, T2>` calls `d<T2>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:15
+   = `d<T2>` calls `b<u64, T2>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:20
+   = `b<u64, T2>` calls `c<M::S<T2>, bool>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:10
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-tests/complex_1.move:26:9
@@ -16,8 +16,8 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 26 │     fun f<T>() {
    │         ^
    │
-   = `f<T>` calls `g<T>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:26
-   = `g<T>` calls `f<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:27
+   = `f<T>` calls `g<T>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:27
+   = `g<T>` calls `f<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:31
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-tests/complex_1.move:30:9
@@ -25,5 +25,5 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 30 │     fun g<T>() {
    │         ^
    │
-   = `g<T>` calls `f<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:30
-   = `f<M::S<T>>` calls `g<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:31
+   = `g<T>` calls `f<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:31
+   = `f<M::S<T>>` calls `g<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:27

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.exp
@@ -6,9 +6,9 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 4 │     fun f<T1, T2, T3>() {
   │         ^
   │
-  = `f<T1, T2, T3>` calls `g<T2, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:4
-  = `g<T2, T3, T1>` calls `h<T2, T3, M::S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:5
-  = `h<T2, T3, M::S<T1>>` calls `f<T2, bool, M::S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:9
+  = `f<T1, T2, T3>` calls `g<T2, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:5
+  = `g<T2, T3, T1>` calls `h<T2, T3, M::S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:9
+  = `h<T2, T3, M::S<T1>>` calls `f<T2, bool, M::S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:14
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:8:9
@@ -16,9 +16,9 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 8 │     fun g<T1, T2, T3>() {
   │         ^
   │
-  = `g<T1, T2, T3>` calls `h<T1, T2, M::S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:8
-  = `h<T1, T2, M::S<T3>>` calls `f<T1, bool, M::S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:9
-  = `f<T1, bool, M::S<T3>>` calls `g<bool, M::S<T3>, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:14
+  = `g<T1, T2, T3>` calls `h<T1, T2, M::S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:9
+  = `h<T1, T2, M::S<T3>>` calls `f<T1, bool, M::S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:14
+  = `f<T1, bool, M::S<T3>>` calls `g<bool, M::S<T3>, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:5
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:12:9
@@ -26,6 +26,6 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 12 │     fun h<T1, T2, T3>() {
    │         ^
    │
-   = `h<T1, T2, T3>` calls `f<T1, bool, T3>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:12
-   = `f<T1, bool, T3>` calls `g<bool, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:14
-   = `g<bool, T3, T1>` calls `h<bool, T3, M::S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:5
+   = `h<T1, T2, T3>` calls `f<T1, bool, T3>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:14
+   = `f<T1, bool, T3>` calls `g<bool, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:5
+   = `g<bool, T3, T1>` calls `h<bool, T3, M::S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:9

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.exp
@@ -6,9 +6,9 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 4 │     fun f<T1, T2, T3>() {
   │         ^
   │
-  = `f<T1, T2, T3>` calls `g<T2, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:4
-  = `g<T2, T3, T1>` calls `h<T2, T3, M::S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:5
-  = `h<T2, T3, M::S<T1>>` calls `f<T2, T3, M::S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:9
+  = `f<T1, T2, T3>` calls `g<T2, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:5
+  = `g<T2, T3, T1>` calls `h<T2, T3, M::S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:9
+  = `h<T2, T3, M::S<T1>>` calls `f<T2, T3, M::S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:13
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:8:9
@@ -16,9 +16,9 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 8 │     fun g<T1, T2, T3>() {
   │         ^
   │
-  = `g<T1, T2, T3>` calls `h<T1, T2, M::S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:8
-  = `h<T1, T2, M::S<T3>>` calls `f<T1, T2, M::S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:9
-  = `f<T1, T2, M::S<T3>>` calls `g<T2, M::S<T3>, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:13
+  = `g<T1, T2, T3>` calls `h<T1, T2, M::S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:9
+  = `h<T1, T2, M::S<T3>>` calls `f<T1, T2, M::S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:13
+  = `f<T1, T2, M::S<T3>>` calls `g<T2, M::S<T3>, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:5
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:12:9
@@ -26,6 +26,6 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 12 │     fun h<T1, T2, T3>() {
    │         ^
    │
-   = `h<T1, T2, T3>` calls `f<T1, T2, T3>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:12
-   = `f<T1, T2, T3>` calls `g<T2, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:13
-   = `g<T2, T3, T1>` calls `h<T2, T3, M::S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:5
+   = `h<T1, T2, T3>` calls `f<T1, T2, T3>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:13
+   = `f<T1, T2, T3>` calls `g<T2, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:5
+   = `g<T2, T3, T1>` calls `h<T2, T3, M::S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:9

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.exp
@@ -6,8 +6,8 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 4 │     fun f<T1, T2, T3>() {
   │         ^
   │
-  = `f<T1, T2, T3>` calls `g<T2, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:4
-  = `g<T2, T1>` calls `f<T2, M::S<T1>, u64>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:5
+  = `f<T1, T2, T3>` calls `g<T2, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:5
+  = `g<T2, T1>` calls `f<T2, M::S<T1>, u64>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:9
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:8:9
@@ -15,5 +15,5 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 8 │     fun g<T1, T2>() {
   │         ^
   │
-  = `g<T1, T2>` calls `f<T1, M::S<T2>, u64>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:8
-  = `f<T1, M::S<T2>, u64>` calls `g<M::S<T2>, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:9
+  = `g<T1, T2>` calls `f<T1, M::S<T2>, u64>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:9
+  = `f<T1, M::S<T2>, u64>` calls `g<M::S<T2>, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:5

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.exp
@@ -6,8 +6,8 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 7 │     fun f<T>() {
   │         ^
   │
-  = `f<T>` calls `g<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:7
-  = `g<M::S<T>>` calls `f<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:8
+  = `f<T>` calls `g<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:8
+  = `g<M::S<T>>` calls `f<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:12
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:11:9
@@ -15,5 +15,5 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 11 │     fun g<T>() {
    │         ^
    │
-   = `g<T>` calls `f<T>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:11
-   = `f<T>` calls `g<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:12
+   = `g<T>` calls `f<T>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:12
+   = `f<T>` calls `g<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:8

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/nested_types_1.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/nested_types_1.exp
@@ -6,4 +6,4 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 4 │     fun foo<T>() {
   │         ^^^
   │
-  = `foo<T>` calls `foo<M::S<M::S<T>>>` at tests/cyclic-instantiation-checker/v1-tests/nested_types_1.move:4
+  = `foo<T>` calls `foo<M::S<M::S<T>>>` at tests/cyclic-instantiation-checker/v1-tests/nested_types_1.move:5

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/nested_types_2.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/nested_types_2.exp
@@ -6,4 +6,4 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 5 │     fun foo<T>() {
   │         ^^^
   │
-  = `foo<T>` calls `foo<M::R<u64, M::S<M::S<T>>>>` at tests/cyclic-instantiation-checker/v1-tests/nested_types_2.move:5
+  = `foo<T>` calls `foo<M::R<u64, M::S<M::S<T>>>>` at tests/cyclic-instantiation-checker/v1-tests/nested_types_2.move:6

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/recursive_infinite_type_terminates.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/recursive_infinite_type_terminates.exp
@@ -6,4 +6,4 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 9 │     fun f<T>(n: u64, x: T): T {
   │         ^
   │
-  = `f<T>` calls `f<M::Box<T>>` at tests/cyclic-instantiation-checker/v1-tests/recursive_infinite_type_terminates.move:9
+  = `f<T>` calls `f<M::Box<T>>` at tests/cyclic-instantiation-checker/v1-tests/recursive_infinite_type_terminates.move:11

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/recursive_one_arg_type_con.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/recursive_one_arg_type_con.exp
@@ -6,4 +6,4 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 6 │     fun f<T>(x: T) {
   │         ^
   │
-  = `f<T>` calls `f<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/recursive_one_arg_type_con.move:6
+  = `f<T>` calls `f<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/recursive_one_arg_type_con.move:7

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/recursive_two_args_swapping_type_con.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/recursive_two_args_swapping_type_con.exp
@@ -6,4 +6,4 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 7 │     fun f<T1, T2>(a: T1, x: T2) {
   │         ^
   │
-  = `f<T1, T2>` calls `f<M::S<T2>, T1>` at tests/cyclic-instantiation-checker/v1-tests/recursive_two_args_swapping_type_con.move:7
+  = `f<T1, T2>` calls `f<M::S<T2>, T1>` at tests/cyclic-instantiation-checker/v1-tests/recursive_two_args_swapping_type_con.move:8

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/two_loops.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/two_loops.exp
@@ -6,7 +6,7 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 7 │     fun f<T>() {
   │         ^
   │
-  = `f<T>` calls `f<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/two_loops.move:7
+  = `f<T>` calls `f<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/two_loops.move:8
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-tests/two_loops.move:11:9
@@ -14,4 +14,4 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 11 │     fun g<T>() {
    │         ^
    │
-   = `g<T>` calls `g<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/two_loops.move:11
+   = `g<T>` calls `g<M::S<T>>` at tests/cyclic-instantiation-checker/v1-tests/two_loops.move:12

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.exp
@@ -6,7 +6,7 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 6 │     public fun t<T>() {
   │                ^
   │
-  = `t<T>` calls `t<X::Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:6
+  = `t<T>` calls `t<X::Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:7
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:10:16
@@ -14,8 +14,8 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 10 │     public fun x<T>() {
    │                ^
    │
-   = `x<T>` calls `y<X::Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:10
-   = `y<X::Box<T>>` calls `x<X::Box<X::Box<T>>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:11
+   = `x<T>` calls `y<X::Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:11
+   = `y<X::Box<T>>` calls `x<X::Box<X::Box<T>>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:14
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:13:16
@@ -23,8 +23,8 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 13 │     public fun y<T>() {
    │                ^
    │
-   = `y<T>` calls `x<X::Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:13
-   = `x<X::Box<T>>` calls `y<X::Box<X::Box<T>>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:14
+   = `y<T>` calls `x<X::Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:14
+   = `x<X::Box<T>>` calls `y<X::Box<X::Box<T>>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:11
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:17:16
@@ -32,9 +32,9 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 17 │     public fun a<A>() {
    │                ^
    │
-   = `a<A>` calls `b<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:17
-   = `b<A>` calls `c<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:18
-   = `c<A>` calls `a<X::Box<A>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:21
+   = `a<A>` calls `b<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:18
+   = `b<A>` calls `c<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:21
+   = `c<A>` calls `a<X::Box<A>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:24
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:20:16
@@ -42,9 +42,9 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 20 │     public fun b<B>() {
    │                ^
    │
-   = `b<B>` calls `c<B>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:20
-   = `c<B>` calls `a<X::Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:21
-   = `a<X::Box<B>>` calls `b<X::Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:24
+   = `b<B>` calls `c<B>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:21
+   = `c<B>` calls `a<X::Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:24
+   = `a<X::Box<B>>` calls `b<X::Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:18
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:23:16
@@ -52,9 +52,9 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 23 │     public fun c<C>() {
    │                ^
    │
-   = `c<C>` calls `a<X::Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:23
-   = `a<X::Box<C>>` calls `b<X::Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:24
-   = `b<X::Box<C>>` calls `c<X::Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:18
+   = `c<C>` calls `a<X::Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:24
+   = `a<X::Box<C>>` calls `b<X::Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:18
+   = `b<X::Box<C>>` calls `c<X::Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:21
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:37:16
@@ -62,7 +62,7 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 37 │     public fun z<T>() {
    │                ^
    │
-   = `z<T>` calls `z<Y::Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:37
+   = `z<T>` calls `z<Y::Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:38
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:41:16
@@ -70,10 +70,10 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 41 │     public fun a<A>() {
    │                ^
    │
-   = `a<A>` calls `b<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:41
-   = `b<A>` calls `c<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:42
-   = `c<A>` calls `d<Y::Box<A>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:45
-   = `d<Y::Box<A>>` calls `a<Y::Box<A>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:48
+   = `a<A>` calls `b<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:42
+   = `b<A>` calls `c<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:45
+   = `c<A>` calls `d<Y::Box<A>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:48
+   = `d<Y::Box<A>>` calls `a<Y::Box<A>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:51
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:44:16
@@ -81,10 +81,10 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 44 │     public fun b<B>() {
    │                ^
    │
-   = `b<B>` calls `c<B>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:44
-   = `c<B>` calls `d<Y::Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:45
-   = `d<Y::Box<B>>` calls `a<Y::Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:48
-   = `a<Y::Box<B>>` calls `b<Y::Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:51
+   = `b<B>` calls `c<B>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:45
+   = `c<B>` calls `d<Y::Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:48
+   = `d<Y::Box<B>>` calls `a<Y::Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:51
+   = `a<Y::Box<B>>` calls `b<Y::Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:42
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:47:16
@@ -92,10 +92,10 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 47 │     public fun c<C>() {
    │                ^
    │
-   = `c<C>` calls `d<Y::Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:47
-   = `d<Y::Box<C>>` calls `a<Y::Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:48
-   = `a<Y::Box<C>>` calls `b<Y::Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:51
-   = `b<Y::Box<C>>` calls `c<Y::Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:42
+   = `c<C>` calls `d<Y::Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:48
+   = `d<Y::Box<C>>` calls `a<Y::Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:51
+   = `a<Y::Box<C>>` calls `b<Y::Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:42
+   = `b<Y::Box<C>>` calls `c<Y::Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:45
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:50:16
@@ -103,10 +103,10 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 50 │     public fun d<D>() {
    │                ^
    │
-   = `d<D>` calls `a<D>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:50
-   = `a<D>` calls `b<D>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:51
-   = `b<D>` calls `c<D>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:42
-   = `c<D>` calls `d<Y::Box<D>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:45
+   = `d<D>` calls `a<D>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:51
+   = `a<D>` calls `b<D>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:42
+   = `b<D>` calls `c<D>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:45
+   = `c<D>` calls `d<Y::Box<D>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:48
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:58:16
@@ -114,9 +114,9 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 58 │     public fun tl<TL>() {
    │                ^^
    │
-   = `tl<TL>` calls `tr<TL>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:58
-   = `tr<TL>` calls `bl<Z::Box<TL>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:59
-   = `bl<Z::Box<TL>>` calls `tl<Z::Box<TL>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:62
+   = `tl<TL>` calls `tr<TL>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:59
+   = `tr<TL>` calls `bl<Z::Box<TL>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:62
+   = `bl<Z::Box<TL>>` calls `tl<Z::Box<TL>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:69
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:61:16
@@ -124,9 +124,9 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 61 │     public fun tr<TR>() {
    │                ^^
    │
-   = `tr<TR>` calls `bl<Z::Box<TR>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:61
-   = `bl<Z::Box<TR>>` calls `tl<Z::Box<TR>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:62
-   = `tl<Z::Box<TR>>` calls `tr<Z::Box<TR>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:69
+   = `tr<TR>` calls `bl<Z::Box<TR>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:62
+   = `bl<Z::Box<TR>>` calls `tl<Z::Box<TR>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:69
+   = `tl<Z::Box<TR>>` calls `tr<Z::Box<TR>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:59
 
 error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:68:16
@@ -134,6 +134,6 @@ error: cyclic type instantiation: a cycle of recursive calls causes a type to gr
 68 │     public fun bl<BL>() {
    │                ^^
    │
-   = `bl<BL>` calls `tl<BL>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:68
-   = `tl<BL>` calls `tr<BL>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:69
-   = `tr<BL>` calls `bl<Z::Box<BL>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:59
+   = `bl<BL>` calls `tl<BL>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:69
+   = `tl<BL>` calls `tr<BL>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:59
+   = `tr<BL>` calls `bl<Z::Box<BL>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:62


### PR DESCRIPTION
## Description

For error messages like "f calls g at loc", the loc is previously the location of f, the caller, but it better be the location of g, the callee. See the updated test outputs for examples.

Fixes #12903.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)