### PR TITLE
config to disable randomness in a chain halt

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/overview.md
+++ b/aptos-move/framework/aptos-framework/doc/overview.md
@@ -47,6 +47,7 @@ This is the reference documentation of the Aptos framework.
 -  [`0x1::primary_fungible_store`](primary_fungible_store.md#0x1_primary_fungible_store)
 -  [`0x1::randomness`](randomness.md#0x1_randomness)
 -  [`0x1::randomness_config`](randomness_config.md#0x1_randomness_config)
+-  [`0x1::randomness_config_seqnum`](randomness_config_seqnum.md#0x1_randomness_config_seqnum)
 -  [`0x1::reconfiguration`](reconfiguration.md#0x1_reconfiguration)
 -  [`0x1::reconfiguration_state`](reconfiguration_state.md#0x1_reconfiguration_state)
 -  [`0x1::reconfiguration_with_dkg`](reconfiguration_with_dkg.md#0x1_reconfiguration_with_dkg)

--- a/aptos-move/framework/aptos-framework/doc/randomness_config_seqnum.md
+++ b/aptos-move/framework/aptos-framework/doc/randomness_config_seqnum.md
@@ -1,0 +1,142 @@
+
+<a id="0x1_randomness_config_seqnum"></a>
+
+# Module `0x1::randomness_config_seqnum`
+
+Randomness stall recovery utils.
+
+When randomness generation is stuck due to a bug, the chain is also stuck. Below is the recovery procedure.
+1. Ensure more than 2/3 stakes are stuck at the same version.
+1. Every validator restarts with <code>randomness_override_seq_num</code> set to <code>X+1</code> in the node config file,
+where <code>X</code> is the current <code><a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a></code> on chain.
+1. The chain should then be unblocked.
+1. Once the bug is fixed and the binary + framework have been patched,
+a governance proposal is needed to set <code><a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a></code> to be <code>X+2</code>.
+
+
+-  [Resource `RandomnessConfigSeqNum`](#0x1_randomness_config_seqnum_RandomnessConfigSeqNum)
+-  [Function `set_for_next_epoch`](#0x1_randomness_config_seqnum_set_for_next_epoch)
+-  [Function `initialize`](#0x1_randomness_config_seqnum_initialize)
+-  [Function `on_new_epoch`](#0x1_randomness_config_seqnum_on_new_epoch)
+
+
+<pre><code><b>use</b> <a href="config_buffer.md#0x1_config_buffer">0x1::config_buffer</a>;
+<b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
+</code></pre>
+
+
+
+<a id="0x1_randomness_config_seqnum_RandomnessConfigSeqNum"></a>
+
+## Resource `RandomnessConfigSeqNum`
+
+If this seqnum is smaller than a validator local override, the on-chain <code>RandomnessConfig</code> will be ignored.
+Useful in a chain recovery from randomness stall.
+
+
+<pre><code><b>struct</b> <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a> <b>has</b> drop, store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>seq_num: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_randomness_config_seqnum_set_for_next_epoch"></a>
+
+## Function `set_for_next_epoch`
+
+Update <code><a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a></code>.
+Used when re-enable randomness after an emergency randomness disable via local override.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_set_for_next_epoch">set_for_next_epoch</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, seq_num: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_set_for_next_epoch">set_for_next_epoch</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, seq_num: u64) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
+    <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(<a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a> { seq_num });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_randomness_config_seqnum_initialize"></a>
+
+## Function `initialize`
+
+Initialize the configuration. Used in genesis or governance.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_initialize">initialize</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_initialize">initialize</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
+    <b>if</b> (!<b>exists</b>&lt;<a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a>&gt;(@aptos_framework)) {
+        <b>move_to</b>(framework, <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a> { seq_num: 0 })
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_randomness_config_seqnum_on_new_epoch"></a>
+
+## Function `on_new_epoch`
+
+Only used in reconfigurations to apply the pending <code>RandomnessConfig</code>, if there is any.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_on_new_epoch">on_new_epoch</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_on_new_epoch">on_new_epoch</a>() <b>acquires</b> <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a> {
+    <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a>&gt;()) {
+        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a>&gt;();
+        <b>borrow_global_mut</b>&lt;<a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a>&gt;(@aptos_framework).seq_num = new_config.seq_num;
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/reconfiguration_with_dkg.md
+++ b/aptos-move/framework/aptos-framework/doc/reconfiguration_with_dkg.md
@@ -24,6 +24,7 @@ Reconfiguration with DKG helper functions.
 <b>use</b> <a href="jwks.md#0x1_jwks">0x1::jwks</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
 <b>use</b> <a href="randomness_config.md#0x1_randomness_config">0x1::randomness_config</a>;
+<b>use</b> <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum">0x1::randomness_config_seqnum</a>;
 <b>use</b> <a href="reconfiguration.md#0x1_reconfiguration">0x1::reconfiguration</a>;
 <b>use</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state">0x1::reconfiguration_state</a>;
 <b>use</b> <a href="stake.md#0x1_stake">0x1::stake</a>;
@@ -100,6 +101,7 @@ Run the default reconfiguration to enter the new epoch.
     std::version::on_new_epoch();
     <a href="jwk_consensus_config.md#0x1_jwk_consensus_config_on_new_epoch">jwk_consensus_config::on_new_epoch</a>();
     <a href="jwks.md#0x1_jwks_on_new_epoch">jwks::on_new_epoch</a>();
+    <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_on_new_epoch">randomness_config_seqnum::on_new_epoch</a>();
     <a href="randomness_config.md#0x1_randomness_config_on_new_epoch">randomness_config::on_new_epoch</a>();
     <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_on_new_epoch">features::on_new_epoch</a>(<a href="account.md#0x1_account">account</a>);
     <a href="reconfiguration.md#0x1_reconfiguration_reconfigure">reconfiguration::reconfigure</a>();

--- a/aptos-move/framework/aptos-framework/sources/configs/config_buffer.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/config_buffer.move
@@ -24,6 +24,7 @@ module aptos_framework::config_buffer {
     friend aptos_framework::jwks;
     friend aptos_framework::jwk_consensus_config;
     friend aptos_framework::randomness_config;
+    friend aptos_framework::randomness_config_seqnum;
     friend aptos_framework::version;
 
     /// Config buffer operations failed with permission denied.

--- a/aptos-move/framework/aptos-framework/sources/configs/randomness_config_seqnum.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/randomness_config_seqnum.move
@@ -1,0 +1,44 @@
+/// Randomness stall recovery utils.
+///
+/// When randomness generation is stuck due to a bug, the chain is also stuck. Below is the recovery procedure.
+/// 1. Ensure more than 2/3 stakes are stuck at the same version.
+/// 1. Every validator restarts with `randomness_override_seq_num` set to `X+1` in the node config file,
+///    where `X` is the current `RandomnessConfigSeqNum` on chain.
+/// 1. The chain should then be unblocked.
+/// 1. Once the bug is fixed and the binary + framework have been patched,
+///    a governance proposal is needed to set `RandomnessConfigSeqNum` to be `X+2`.
+module aptos_framework::randomness_config_seqnum {
+    use aptos_framework::config_buffer;
+    use aptos_framework::system_addresses;
+
+    friend aptos_framework::reconfiguration_with_dkg;
+
+    /// If this seqnum is smaller than a validator local override, the on-chain `RandomnessConfig` will be ignored.
+    /// Useful in a chain recovery from randomness stall.
+    struct RandomnessConfigSeqNum has drop, key, store {
+        seq_num: u64,
+    }
+
+    /// Update `RandomnessConfigSeqNum`.
+    /// Used when re-enable randomness after an emergency randomness disable via local override.
+    public fun set_for_next_epoch(framework: &signer, seq_num: u64) {
+        system_addresses::assert_aptos_framework(framework);
+        config_buffer::upsert(RandomnessConfigSeqNum { seq_num });
+    }
+
+    /// Initialize the configuration. Used in genesis or governance.
+    public fun initialize(framework: &signer) {
+        system_addresses::assert_aptos_framework(framework);
+        if (!exists<RandomnessConfigSeqNum>(@aptos_framework)) {
+            move_to(framework, RandomnessConfigSeqNum { seq_num: 0 })
+        }
+    }
+
+    /// Only used in reconfigurations to apply the pending `RandomnessConfig`, if there is any.
+    public(friend) fun on_new_epoch() acquires RandomnessConfigSeqNum {
+        if (config_buffer::does_exist<RandomnessConfigSeqNum>()) {
+            let new_config = config_buffer::extract<RandomnessConfigSeqNum>();
+            borrow_global_mut<RandomnessConfigSeqNum>(@aptos_framework).seq_num = new_config.seq_num;
+        }
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration_with_dkg.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration_with_dkg.move
@@ -9,6 +9,7 @@ module aptos_framework::reconfiguration_with_dkg {
     use aptos_framework::jwk_consensus_config;
     use aptos_framework::jwks;
     use aptos_framework::randomness_config;
+    use aptos_framework::randomness_config_seqnum;
     use aptos_framework::reconfiguration;
     use aptos_framework::reconfiguration_state;
     use aptos_framework::stake;
@@ -47,6 +48,7 @@ module aptos_framework::reconfiguration_with_dkg {
         std::version::on_new_epoch();
         jwk_consensus_config::on_new_epoch();
         jwks::on_new_epoch();
+        randomness_config_seqnum::on_new_epoch();
         randomness_config::on_new_epoch();
         features::on_new_epoch(account);
         reconfiguration::reconfigure();

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -65,6 +65,7 @@ const JWK_CONSENSUS_CONFIG_MODULE_NAME: &str = "jwk_consensus_config";
 const JWKS_MODULE_NAME: &str = "jwks";
 const CONFIG_BUFFER_MODULE_NAME: &str = "config_buffer";
 const DKG_MODULE_NAME: &str = "dkg";
+const RANDOMNESS_CONFIG_SEQNUM_MODULE_NAME: &str = "randomness_config_seqnum";
 const RANDOMNESS_CONFIG_MODULE_NAME: &str = "randomness_config";
 const RANDOMNESS_MODULE_NAME: &str = "randomness";
 const RECONFIGURATION_STATE_MODULE_NAME: &str = "reconfiguration_state";
@@ -285,6 +286,7 @@ pub fn encode_genesis_change_set(
         .randomness_config_override
         .clone()
         .unwrap_or_else(OnChainRandomnessConfig::default_for_genesis);
+    initialize_randomness_config_seqnum(&mut session);
     initialize_randomness_config(&mut session, randomness_config);
     initialize_randomness_resources(&mut session);
     initialize_on_chain_governance(&mut session, genesis_config);
@@ -499,6 +501,16 @@ fn initialize_dkg(session: &mut SessionExt) {
     exec_function(
         session,
         DKG_MODULE_NAME,
+        "initialize",
+        vec![],
+        serialize_values(&vec![MoveValue::Signer(CORE_CODE_ADDRESS)]),
+    );
+}
+
+fn initialize_randomness_config_seqnum(session: &mut SessionExt) {
+    exec_function(
+        session,
+        RANDOMNESS_CONFIG_SEQNUM_MODULE_NAME,
         "initialize",
         vec![],
         serialize_values(&vec![MoveValue::Signer(CORE_CODE_ADDRESS)]),

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -737,6 +737,7 @@ pub fn setup_environment_and_start_node(
                 dkg_start_events,
                 vtxn_pool.clone(),
                 rb_config,
+                node_config.randomness_override_seq_num,
             );
             Some(dkg_runtime)
         },

--- a/config/src/config/node_config.rs
+++ b/config/src/config/node_config.rs
@@ -71,6 +71,10 @@ pub struct NodeConfig {
     pub node_startup: NodeStartupConfig,
     #[serde(default)]
     pub peer_monitoring_service: PeerMonitoringServiceConfig,
+    /// In a randomness stall, set this to be on-chain `RandomnessConfigSeqNum` + 1.
+    /// Once enough nodes restarted with the new value, the chain should unblock with randomness disabled.
+    #[serde(default)]
+    pub randomness_override_seq_num: u64,
     #[serde(default)]
     pub state_sync: StateSyncConfig,
     #[serde(default)]

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -86,7 +86,8 @@ use aptos_types::{
     on_chain_config::{
         Features, LeaderReputationType, OnChainConfigPayload, OnChainConfigProvider,
         OnChainConsensusConfig, OnChainExecutionConfig, OnChainJWKConsensusConfig,
-        OnChainRandomnessConfig, ProposerElectionType, RandomnessConfigMoveStruct, ValidatorSet,
+        OnChainRandomnessConfig, ProposerElectionType, RandomnessConfigMoveStruct,
+        RandomnessConfigSeqNum, ValidatorSet,
     },
     randomness::{RandKeys, WvufPP, WVUF},
     validator_signer::ValidatorSigner,
@@ -133,6 +134,7 @@ pub struct EpochManager<P: OnChainConfigProvider> {
     config: ConsensusConfig,
     #[allow(unused)]
     execution_config: ExecutionConfig,
+    randomness_override_seq_num: u64,
     time_service: Arc<dyn TimeService>,
     self_sender: aptos_channels::UnboundedSender<Event<ConsensusMsg>>,
     network_sender: ConsensusNetworkClient<NetworkClient<ConsensusMsg>>,
@@ -200,6 +202,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             author,
             config,
             execution_config,
+            randomness_override_seq_num: node_config.randomness_override_seq_num,
             time_service,
             self_sender,
             network_sender,
@@ -1048,7 +1051,10 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
         let onchain_consensus_config: anyhow::Result<OnChainConsensusConfig> = payload.get();
         let onchain_execution_config: anyhow::Result<OnChainExecutionConfig> = payload.get();
-        let onchain_randomness_config: anyhow::Result<RandomnessConfigMoveStruct> = payload.get();
+        let onchain_randomness_config_seq_num: anyhow::Result<RandomnessConfigSeqNum> =
+            payload.get();
+        let randomness_config_move_struct: anyhow::Result<RandomnessConfigMoveStruct> =
+            payload.get();
         let onchain_jwk_consensus_config: anyhow::Result<OnChainJWKConsensusConfig> = payload.get();
         let dkg_state = payload.get::<DKGState>();
 
@@ -1060,7 +1066,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             error!("Failed to read on-chain execution config {}", error);
         }
 
-        if let Err(error) = &onchain_randomness_config {
+        if let Err(error) = &randomness_config_move_struct {
             error!("Failed to read on-chain randomness config {}", error);
         }
 
@@ -1069,9 +1075,25 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         let consensus_config = onchain_consensus_config.unwrap_or_default();
         let execution_config = onchain_execution_config
             .unwrap_or_else(|_| OnChainExecutionConfig::default_if_missing());
-        let onchain_randomness_config = onchain_randomness_config
-            .and_then(OnChainRandomnessConfig::try_from)
-            .unwrap_or_else(|_| OnChainRandomnessConfig::default_if_missing());
+        let onchain_randomness_config_seq_num = onchain_randomness_config_seq_num
+            .unwrap_or_else(|_| RandomnessConfigSeqNum::default_if_missing());
+
+        info!(
+            epoch = epoch_state.epoch,
+            local = self.randomness_override_seq_num,
+            onchain = onchain_randomness_config_seq_num.seq_num,
+            "Checking randomness config override."
+        );
+        if self.randomness_override_seq_num > onchain_randomness_config_seq_num.seq_num {
+            warn!("Randomness will be force-disabled by local config!");
+        }
+
+        let onchain_randomness_config = OnChainRandomnessConfig::from_configs(
+            self.randomness_override_seq_num,
+            onchain_randomness_config_seq_num.seq_num,
+            randomness_config_move_struct.ok(),
+        );
+
         let jwk_consensus_config = onchain_jwk_consensus_config.unwrap_or_else(|_| {
             // `jwk_consensus_config` not yet initialized, falling back to the old configs.
             Self::equivalent_jwk_consensus_config_from_deprecated_resources(&payload)

--- a/consensus/src/rand/rand_gen/rand_manager.rs
+++ b/consensus/src/rand/rand_gen/rand_manager.rs
@@ -33,6 +33,7 @@ use aptos_types::{
     validator_signer::ValidatorSigner,
 };
 use bytes::Bytes;
+use fail::fail_point;
 use futures::{
     future::{AbortHandle, Abortable},
     FutureExt, StreamExt,
@@ -170,6 +171,7 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
             .iter()
             .flat_map(|b| b.ordered_blocks.iter().map(|b3| b3.round()))
             .collect();
+        fail_point!("rand_manager::process_ready_blocks", |_| {});
         info!(rounds = rounds, "Processing rand-ready blocks.");
 
         for blocks in ready_blocks {

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -959,6 +959,25 @@ impl CliTestFramework {
         .await
     }
 
+    pub async fn run_script_with_gas_options(
+        &self,
+        index: usize,
+        script_contents: &str,
+        gas_options: Option<GasOptions>,
+    ) -> CliTypedResult<TransactionSummary> {
+        self.run_script_with_framework_package_and_gas_options(
+            index,
+            script_contents,
+            FrameworkPackageArgs {
+                framework_git_rev: None,
+                framework_local_dir: Some(Self::aptos_framework_dir()),
+                skip_fetch_latest_git_deps: false,
+            },
+            gas_options,
+        )
+        .await
+    }
+
     /// Runs the given script contents using the aptos_framework from aptos-core git repository.
     pub async fn run_script_with_default_framework(
         &self,
@@ -980,6 +999,22 @@ impl CliTestFramework {
         script_contents: &str,
         framework_package_args: FrameworkPackageArgs,
     ) -> CliTypedResult<TransactionSummary> {
+        self.run_script_with_framework_package_and_gas_options(
+            index,
+            script_contents,
+            framework_package_args,
+            None,
+        )
+        .await
+    }
+
+    pub async fn run_script_with_framework_package_and_gas_options(
+        &self,
+        index: usize,
+        script_contents: &str,
+        framework_package_args: FrameworkPackageArgs,
+        gas_options: Option<GasOptions>,
+    ) -> CliTypedResult<TransactionSummary> {
         // Make a temporary directory for compilation
         let temp_dir = TempDir::new().map_err(|err| {
             CliError::UnexpectedError(format!("Failed to create temporary directory {}", err))
@@ -994,7 +1029,7 @@ impl CliTestFramework {
         .unwrap();
 
         RunScript {
-            txn_options: self.transaction_options(index, None),
+            txn_options: self.transaction_options(index, gas_options),
             compile_proposal_args: CompileScriptFunction {
                 script_path: Some(source_path),
                 compiled_script_path: None,

--- a/dkg/src/lib.rs
+++ b/dkg/src/lib.rs
@@ -33,6 +33,7 @@ pub fn start_dkg_runtime(
     dkg_start_events: EventNotificationListener,
     vtxn_pool: VTxnPoolState,
     rb_config: ReliableBroadcastConfig,
+    randomness_override_seq_num: u64,
 ) -> Runtime {
     let runtime = aptos_runtimes::spawn_named_runtime("dkg".into(), Some(4));
     let (self_sender, self_receiver) = aptos_channels::new(1_024, &counters::PENDING_SELF_MESSAGES);
@@ -47,6 +48,7 @@ pub fn start_dkg_runtime(
         dkg_network_client,
         vtxn_pool,
         rb_config,
+        randomness_override_seq_num,
     );
     let (network_task, network_receiver) = NetworkTask::new(network_service_events, self_receiver);
     runtime.spawn(network_task.start());

--- a/testsuite/smoke-test/src/randomness/mod.rs
+++ b/testsuite/smoke-test/src/randomness/mod.rs
@@ -28,6 +28,7 @@ mod e2e_correctness;
 mod enable_feature_0;
 mod enable_feature_1;
 mod enable_feature_2;
+mod randomness_stall_recovery;
 mod validator_restart_during_dkg;
 
 #[allow(dead_code)]

--- a/testsuite/smoke-test/src/randomness/randomness_stall_recovery.rs
+++ b/testsuite/smoke-test/src/randomness/randomness_stall_recovery.rs
@@ -1,0 +1,155 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{randomness::get_on_chain_resource, smoke_test_environment::SwarmBuilder};
+use aptos::common::types::GasOptions;
+use aptos_config::config::{OverrideNodeConfig, PersistableConfig};
+use aptos_forge::{NodeExt, Swarm, SwarmExt};
+use aptos_logger::{debug, info};
+use aptos_rest_client::Client;
+use aptos_types::{on_chain_config::OnChainRandomnessConfig, randomness::PerBlockRandomness};
+use futures::future::join_all;
+use std::{
+    ops::Add,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+/// Chain recovery using a local config from randomness stall should work.
+/// See `randomness_config_seqnum.move` for more details.
+#[tokio::test]
+async fn randomness_stall_recovery() {
+    let epoch_duration_secs = 20;
+
+    let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(4)
+        .with_num_fullnodes(1)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, conf, _| {
+            conf.api.failpoints_enabled = true;
+        }))
+        .with_init_genesis_config(Arc::new(move |conf| {
+            conf.epoch_duration_secs = epoch_duration_secs;
+
+            // Ensure randomness is enabled.
+            conf.consensus_config.enable_validator_txns();
+            conf.randomness_config_override = Some(OnChainRandomnessConfig::default_enabled());
+        }))
+        .build_with_cli(0)
+        .await;
+
+    let root_addr = swarm.chain_info().root_account().address();
+    let root_idx = cli.add_account_with_address_to_cli(swarm.root_key(), root_addr);
+
+    let rest_client = swarm.validators().next().unwrap().rest_client();
+
+    info!("Wait for epoch 2.");
+    swarm
+        .wait_for_all_nodes_to_catchup_to_epoch(2, Duration::from_secs(epoch_duration_secs * 2))
+        .await
+        .expect("Epoch 2 taking too long to arrive!");
+
+    info!("Inject RandManager fault to every node.");
+    let validator_clients: Vec<Client> =
+        swarm.validators().map(|node| node.rest_client()).collect();
+    let tasks = validator_clients
+        .iter()
+        .map(|client| {
+            client.set_failpoint(
+                "rand_manager::process_ready_blocks".to_string(),
+                "return".to_string(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let aptos_results = join_all(tasks).await;
+    debug!("aptos_results={:?}", aptos_results);
+
+    // Bake the fault injection...
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    info!("Chain should have halted.");
+    let liveness_check_result = swarm
+        .liveness_check(Instant::now().add(Duration::from_secs(20)))
+        .await;
+    info!("liveness_check_result={:?}", liveness_check_result);
+    assert!(liveness_check_result.is_err());
+
+    for (idx, validator) in swarm.validators_mut().enumerate() {
+        info!("Stopping validator {}.", idx);
+        validator.stop();
+        let config_path = validator.config_path();
+        let mut validator_override_config =
+            OverrideNodeConfig::load_config(config_path.clone()).unwrap();
+        validator_override_config
+            .override_config_mut()
+            .randomness_override_seq_num = 1;
+        info!("Updating validator {} config.", idx);
+        validator_override_config.save_config(config_path).unwrap();
+        info!("Restarting validator {}.", idx);
+        validator.start().unwrap();
+        info!("Let validator {} bake for 5 secs.", idx);
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+
+    let liveness_check_result = swarm
+        .liveness_check(Instant::now().add(Duration::from_secs(30)))
+        .await;
+    assert!(liveness_check_result.is_ok());
+
+    info!("There should be no randomness at the moment.");
+    let block_randomness_seed = get_on_chain_resource::<PerBlockRandomness>(&rest_client).await;
+    assert!(block_randomness_seed.seed.is_none());
+
+    info!("Bump on-chain conig seqnum to re-enable randomness.");
+    let script = r#"
+script {
+    use aptos_framework::aptos_governance;
+    use aptos_framework::randomness_config_seqnum;
+
+    fun main(core_resources: &signer) {
+        let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @0x1);
+        randomness_config_seqnum::set_for_next_epoch(&framework_signer, 2);
+        aptos_governance::force_end_epoch(&framework_signer); // reconfigure() won't work at the moment.
+    }
+}
+    "#;
+    let gas_options = GasOptions {
+        gas_unit_price: Some(1),
+        max_gas: Some(2000000),
+        expiration_secs: 60,
+    };
+    let txn_summary = cli
+        .run_script_with_gas_options(root_idx, script, Some(gas_options))
+        .await
+        .expect("Txn execution error.");
+    debug!("txn_summary={:?}", txn_summary);
+
+    tokio::time::sleep(Duration::from_secs(10)).await;
+
+    let epoch = rest_client
+        .get_ledger_information()
+        .await
+        .unwrap()
+        .into_inner()
+        .epoch;
+    info!(
+        "Current epoch is {}. Wait until epoch {}, and randomness should be back.",
+        epoch,
+        epoch + 1
+    );
+
+    swarm
+        .wait_for_all_nodes_to_catchup_to_epoch(
+            epoch + 1,
+            Duration::from_secs(epoch_duration_secs * 2),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("Epoch {} taking too long to arrive!", epoch + 1));
+
+    let PerBlockRandomness {
+        epoch: actual_epoch,
+        seed,
+        ..
+    } = get_on_chain_resource::<PerBlockRandomness>(&rest_client).await;
+    assert!(seed.is_some());
+    assert_eq!(epoch + 1, actual_epoch);
+}

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -55,7 +55,9 @@ pub use self::{
     jwk_consensus_config::{
         ConfigV1 as JWKConsensusConfigV1, OIDCProvider, OnChainJWKConsensusConfig,
     },
-    randomness_config::{OnChainRandomnessConfig, RandomnessConfigMoveStruct},
+    randomness_config::{
+        OnChainRandomnessConfig, RandomnessConfigMoveStruct, RandomnessConfigSeqNum,
+    },
     timed_features::{TimedFeatureFlag, TimedFeatureOverride, TimedFeatures, TimedFeaturesBuilder},
     timestamp::CurrentTimeMicroseconds,
     transaction_fee::TransactionFeeBurnCap,

--- a/types/src/on_chain_config/randomness_config.rs
+++ b/types/src/on_chain_config/randomness_config.rs
@@ -70,6 +70,22 @@ impl AsMoveAny for ConfigV2 {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct RandomnessConfigSeqNum {
+    pub seq_num: u64,
+}
+
+impl RandomnessConfigSeqNum {
+    pub fn default_if_missing() -> Self {
+        Self { seq_num: 0 }
+    }
+}
+
+impl OnChainConfig for RandomnessConfigSeqNum {
+    const MODULE_IDENTIFIER: &'static str = "randomness_config_seqnum";
+    const TYPE_IDENTIFIER: &'static str = "RandomnessConfigSeqNum";
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct RandomnessConfigMoveStruct {
     variant: MoveAny,
 }
@@ -96,6 +112,21 @@ impl OnChainRandomnessConfig {
             secrecy_threshold,
             reconstruction_threshold,
         })
+    }
+
+    /// Used by DKG and Consensus on a new epoch to determine the actual `OnChainRandomnessConfig` to be used.
+    pub fn from_configs(
+        local_seqnum: u64,
+        onchain_seqnum: u64,
+        onchain_raw_config: Option<RandomnessConfigMoveStruct>,
+    ) -> Self {
+        if local_seqnum > onchain_seqnum {
+            Self::default_disabled()
+        } else {
+            onchain_raw_config
+                .and_then(|onchain_raw| OnChainRandomnessConfig::try_from(onchain_raw).ok())
+                .unwrap_or_else(OnChainRandomnessConfig::default_if_missing)
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Adding:
- a local config to disable randomness at a chain halt caused by randomness generation failure,
- an on-chain config to re-enable randomness after the recovery.


## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Aptos Framework

## How Has This Been Tested?
new smoke test.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
