### PR TITLE
Use only JSON protocol for consensus messages

### DIFF
--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -126,11 +126,7 @@ pub const RPC: &[ProtocolId] = &[
 ];
 
 /// Supported protocols in preferred order (from highest priority to lowest).
-pub const DIRECT_SEND: &[ProtocolId] = &[
-    ProtocolId::ConsensusDirectSendCompressed,
-    ProtocolId::ConsensusDirectSendBcs,
-    ProtocolId::ConsensusDirectSendJson,
-];
+pub const DIRECT_SEND: &[ProtocolId] = &[ProtocolId::ConsensusDirectSendJson];
 
 impl<NetworkClient: NetworkClientInterface<ConsensusMsg>> ConsensusNetworkClient<NetworkClient> {
     /// Returns a new consensus network client


### PR DESCRIPTION
## Description
This PR lets the networking layer use only JSON encoding for consensus messages. This is part of the deployment process for the execution shadowing feature for latency reduction. The execution shadowing feature changes the SyncInfo struct, and there by changes the consensus message structure. To ensure backward compatibility, we first let the node communicate via JSON only, and then enable the execution shadowing feature.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
