### PR TITLE
schemadb: ignore unrecognized CF on opening

### DIFF
--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -40,7 +40,11 @@ pub use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamilyDescriptor, DBCompressionType, Options, ReadOptions,
     SliceTransform, DEFAULT_COLUMN_FAMILY_NAME,
 };
-use std::{collections::HashMap, iter::Iterator, path::Path};
+use std::{
+    collections::{HashMap, HashSet},
+    iter::Iterator,
+    path::Path,
+};
 
 pub type ColumnFamilyName = &'static str;
 
@@ -114,7 +118,7 @@ impl DB {
         path: impl AsRef<Path>,
         name: &str,
         column_families: Vec<ColumnFamilyName>,
-        db_opts: &rocksdb::Options,
+        db_opts: &Options,
     ) -> DbResult<Self> {
         let db = DB::open_cf(
             db_opts,
@@ -123,9 +127,9 @@ impl DB {
             column_families
                 .iter()
                 .map(|cf_name| {
-                    let mut cf_opts = rocksdb::Options::default();
-                    cf_opts.set_compression_type(rocksdb::DBCompressionType::Lz4);
-                    rocksdb::ColumnFamilyDescriptor::new((*cf_name).to_string(), cf_opts)
+                    let mut cf_opts = Options::default();
+                    cf_opts.set_compression_type(DBCompressionType::Lz4);
+                    ColumnFamilyDescriptor::new((*cf_name).to_string(), cf_opts)
                 })
                 .collect(),
         )?;
@@ -133,12 +137,30 @@ impl DB {
     }
 
     pub fn open_cf(
-        db_opts: &rocksdb::Options,
+        db_opts: &Options,
         path: impl AsRef<Path>,
         name: &str,
-        cfds: Vec<rocksdb::ColumnFamilyDescriptor>,
+        cfds: Vec<ColumnFamilyDescriptor>,
     ) -> DbResult<DB> {
-        let inner = rocksdb::DB::open_cf_descriptors(db_opts, path.de_unc(), cfds)?;
+        // ignore error, since it'll fail to list cfs on the first open
+        let existing_cfs = rocksdb::DB::list_cf(db_opts, path.de_unc()).unwrap_or_default();
+
+        let unrecognized_cfds = existing_cfs
+            .iter()
+            .map(AsRef::as_ref)
+            .collect::<HashSet<&str>>()
+            .difference(&cfds.iter().map(|cfd| cfd.name()).collect())
+            .map(|cf| {
+                warn!("Unrecognized CF: {}", cf);
+
+                let mut cf_opts = Options::default();
+                cf_opts.set_compression_type(DBCompressionType::Lz4);
+                ColumnFamilyDescriptor::new(cf.to_string(), cf_opts)
+            })
+            .collect::<Vec<_>>();
+        let all_cfds = cfds.into_iter().chain(unrecognized_cfds);
+
+        let inner = rocksdb::DB::open_cf_descriptors(db_opts, path.de_unc(), all_cfds)?;
         Ok(Self::log_construct(name, inner))
     }
 
@@ -146,7 +168,7 @@ impl DB {
     /// Note that this still assumes there's only one process that opens the same DB.
     /// See `open_as_secondary`
     pub fn open_cf_readonly(
-        opts: &rocksdb::Options,
+        opts: &Options,
         path: impl AsRef<Path>,
         name: &str,
         cfs: Vec<ColumnFamilyName>,
@@ -159,7 +181,7 @@ impl DB {
     }
 
     pub fn open_cf_as_secondary<P: AsRef<Path>>(
-        opts: &rocksdb::Options,
+        opts: &Options,
         primary_path: P,
         secondary_path: P,
         name: &str,

--- a/storage/schemadb/tests/db.rs
+++ b/storage/schemadb/tests/db.rs
@@ -389,3 +389,17 @@ fn test_checkpoint() {
         assert_eq!(db.get::<TestSchema1>(&TestField(1)).unwrap(), None);
     }
 }
+
+#[test]
+fn test_unrecognised_column_family() {
+    let tmpdir = aptos_temppath::TempPath::new();
+
+    let mut opts = rocksdb::Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+
+    let db = DB::open(tmpdir.path(), "test", vec!["cf1", "cf2"], &opts).unwrap();
+    drop(db);
+
+    DB::open(tmpdir.path(), "test", vec!["cf1"], &opts).unwrap();
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

as titled. if we had this, reverting from 1.11 to 1.10 binary wouldn't have been a problem.

## Type of Change
- [x] New feature


## Which Components or Systems Does This Change Impact?
- [x] Validator Node


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

unit test

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
