### PR TITLE
Adding ordered_decision and commit_decision fields in SyncInfo

### DIFF
--- a/consensus/consensus-types/src/lib.rs
+++ b/consensus/consensus-types/src/lib.rs
@@ -10,6 +10,7 @@ pub mod block_retrieval;
 pub mod common;
 pub mod delayed_qc_msg;
 pub mod epoch_retrieval;
+pub mod order_vote;
 pub mod pipeline;
 pub mod pipelined_block;
 pub mod proof_of_store;

--- a/consensus/consensus-types/src/order_vote.rs
+++ b/consensus/consensus-types/src/order_vote.rs
@@ -1,0 +1,100 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::Author;
+use anyhow::Context;
+use aptos_crypto::{bls12381, CryptoMaterialError};
+use aptos_short_hex_str::AsShortHexStr;
+use aptos_types::{
+    ledger_info::LedgerInfo, validator_signer::ValidatorSigner,
+    validator_verifier::ValidatorVerifier,
+};
+use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Display, Formatter};
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct OrderVote {
+    /// The identity of the voter.
+    author: Author,
+    /// LedgerInfo of a block that is going to be ordered in case this vote gathers QC.
+    ledger_info: LedgerInfo,
+    /// Signature of the LedgerInfo.
+    signature: bls12381::Signature,
+}
+
+impl Display for OrderVote {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "OrderVote: [author: {}, ledger_info: {}]",
+            self.author.short_str(),
+            self.ledger_info
+        )
+    }
+}
+
+// this is required by structured log
+impl Debug for OrderVote {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl OrderVote {
+    pub fn new(
+        author: Author,
+        ledger_info: LedgerInfo,
+        validator_signer: &ValidatorSigner,
+    ) -> Result<Self, CryptoMaterialError> {
+        let signature = validator_signer.sign(&ledger_info)?;
+        Ok(Self {
+            author,
+            ledger_info,
+            signature,
+        })
+    }
+
+    /// Generates a new Vote using a signature over the specified ledger_info
+    pub fn new_with_signature(
+        author: Author,
+        ledger_info: LedgerInfo,
+        signature: bls12381::Signature,
+    ) -> Self {
+        Self {
+            author,
+            ledger_info,
+            signature,
+        }
+    }
+
+    pub fn author(&self) -> Author {
+        self.author
+    }
+
+    pub fn ledger_info(&self) -> &LedgerInfo {
+        &self.ledger_info
+    }
+
+    pub fn signature(&self) -> &bls12381::Signature {
+        &self.signature
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.ledger_info.epoch()
+    }
+
+    pub fn round_to_be_committed(&self) -> u64 {
+        self.ledger_info.round()
+    }
+
+    /// Verifies that the consensus data hash of LedgerInfo corresponds to the vote info,
+    /// and then verifies the signature.
+    pub fn verify(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
+        validator
+            .verify(self.author(), &self.ledger_info, &self.signature)
+            .context("Failed to verify OrderVote")?;
+
+        Ok(())
+    }
+}

--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -4,7 +4,10 @@
 
 use crate::{common::Round, quorum_cert::QuorumCert, timeout_2chain::TwoChainTimeoutCertificate};
 use anyhow::{ensure, Context};
-use aptos_types::{block_info::BlockInfo, validator_verifier::ValidatorVerifier};
+use aptos_types::{
+    block_info::BlockInfo, ledger_info::LedgerInfoWithSignatures,
+    validator_verifier::ValidatorVerifier,
+};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 
@@ -19,6 +22,10 @@ pub struct SyncInfo {
     highest_commit_cert: QuorumCert,
     /// Optional highest timeout certificate if available.
     highest_2chain_timeout_cert: Option<TwoChainTimeoutCertificate>,
+    /// Highest ordered decision known to the peer.
+    highest_ordered_decision: Option<LedgerInfoWithSignatures>,
+    /// Highest commit decision known to the peer.
+    highest_commit_decision: Option<LedgerInfoWithSignatures>,
 }
 
 // this is required by structured log
@@ -32,11 +39,13 @@ impl Display for SyncInfo {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "SyncInfo[certified_round: {}, ordered_round: {}, timeout round: {}, commit_info: {}]",
+            "SyncInfo[certified_round: {}, ordered_round: {}, timeout round: {}, commit_info: {}, ordered_decision: {:?}, commit_decision: {:?}]",
             self.highest_certified_round(),
             self.highest_ordered_round(),
             self.highest_timeout_round(),
             self.highest_commit_cert().commit_info(),
+            self.highest_ordered_decision(),
+            self.highest_commit_decision(),
         )
     }
 }
@@ -47,6 +56,8 @@ impl SyncInfo {
         highest_ordered_cert: QuorumCert,
         highest_commit_cert: QuorumCert,
         highest_2chain_timeout_cert: Option<TwoChainTimeoutCertificate>,
+        highest_ordered_decision: Option<LedgerInfoWithSignatures>,
+        highest_commit_decision: Option<LedgerInfoWithSignatures>,
     ) -> Self {
         // No need to include HTC if it's lower than HQC
         let highest_2chain_timeout_cert = highest_2chain_timeout_cert
@@ -60,6 +71,8 @@ impl SyncInfo {
             highest_ordered_cert,
             highest_commit_cert,
             highest_2chain_timeout_cert,
+            highest_ordered_decision,
+            highest_commit_decision,
         }
     }
 
@@ -67,13 +80,17 @@ impl SyncInfo {
         highest_quorum_cert: QuorumCert,
         highest_ordered_cert: QuorumCert,
         highest_2chain_timeout_cert: Option<TwoChainTimeoutCertificate>,
+        highest_ordered_decision: Option<LedgerInfoWithSignatures>,
     ) -> Self {
         let highest_commit_cert = highest_ordered_cert.clone();
+        let highest_commit_decision = highest_ordered_decision.clone();
         Self::new_decoupled(
             highest_quorum_cert,
             highest_ordered_cert,
             highest_commit_cert,
             highest_2chain_timeout_cert,
+            highest_ordered_decision,
+            highest_commit_decision,
         )
     }
 
@@ -94,6 +111,10 @@ impl SyncInfo {
         &self.highest_commit_cert
     }
 
+    pub fn highest_commit_decision(&self) -> &Option<LedgerInfoWithSignatures> {
+        &self.highest_commit_decision
+    }
+
     /// Highest 2-chain timeout certificate
     pub fn highest_2chain_timeout_cert(&self) -> Option<&TwoChainTimeoutCertificate> {
         self.highest_2chain_timeout_cert.as_ref()
@@ -109,11 +130,35 @@ impl SyncInfo {
     }
 
     pub fn highest_ordered_round(&self) -> Round {
-        self.highest_ordered_cert().commit_info().round()
+        self.highest_ordered_decision.as_ref().map_or(
+            self.highest_ordered_cert().commit_info().round(),
+            |decision| decision.commit_info().round(),
+        )
+    }
+
+    pub fn highest_ordered_decision(&self) -> &Option<LedgerInfoWithSignatures> {
+        &self.highest_ordered_decision
     }
 
     pub fn highest_commit_round(&self) -> Round {
-        self.highest_commit_cert().commit_info().round()
+        self.highest_commit_decision.as_ref().map_or(
+            self.highest_commit_cert().commit_info().round(),
+            |decision| decision.commit_info().round(),
+        )
+    }
+
+    fn highest_commit_epoch(&self) -> u64 {
+        self.highest_commit_decision.as_ref().map_or(
+            self.highest_commit_cert().commit_info().epoch(),
+            |decision| decision.commit_info().epoch(),
+        )
+    }
+
+    fn highest_ordered_epoch(&self) -> u64 {
+        self.highest_ordered_decision.as_ref().map_or(
+            self.highest_ordered_cert().commit_info().epoch(),
+            |decision| decision.commit_info().epoch(),
+        )
     }
 
     /// The highest round the SyncInfo carries.
@@ -123,12 +168,14 @@ impl SyncInfo {
 
     pub fn verify(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
         let epoch = self.highest_quorum_cert.certified_block().epoch();
+        // TODO: Earlier, we compred highest_ordered_cert.certified_block().epoch() with epoch.
+        // Now, we are comparing highest_ordered_cert.commit_info().epoch() with epoch. Is this okay?
         ensure!(
-            epoch == self.highest_ordered_cert().certified_block().epoch(),
+            epoch == self.highest_ordered_epoch(),
             "Multi epoch in SyncInfo - HOC and HQC"
         );
         ensure!(
-            epoch == self.highest_commit_cert().commit_info().epoch(),
+            epoch == self.highest_commit_epoch(),
             "Multi epoch in SyncInfo - HOC and HCC"
         );
         if let Some(tc) = &self.highest_2chain_timeout_cert {
@@ -136,37 +183,61 @@ impl SyncInfo {
         }
 
         ensure!(
-            self.highest_quorum_cert.certified_block().round()
-                >= self.highest_ordered_cert().certified_block().round(),
+            self.highest_quorum_cert.certified_block().round() >= self.highest_ordered_round(),
             "HQC has lower round than HOC"
         );
 
         ensure!(
-            self.highest_ordered_cert().certified_block().round() >= self.highest_commit_round(),
+            self.highest_ordered_round() >= self.highest_commit_round(),
             "HOC has lower round than HLI"
         );
 
         ensure!(
-            *self.highest_ordered_cert().commit_info() != BlockInfo::empty(),
+            *self
+                .highest_ordered_decision
+                .as_ref()
+                .map_or(self.highest_ordered_cert().commit_info(), |decision| {
+                    decision.commit_info()
+                })
+                != BlockInfo::empty(),
             "HOC has no committed block"
         );
 
         ensure!(
-            *self.highest_commit_cert().commit_info() != BlockInfo::empty(),
+            *self
+                .highest_commit_decision
+                .as_ref()
+                .map_or(self.highest_commit_cert().commit_info(), |decision| {
+                    decision.commit_info()
+                })
+                != BlockInfo::empty(),
             "HLI has empty commit info"
         );
 
         self.highest_quorum_cert
             .verify(validator)
             .and_then(|_| {
-                self.highest_ordered_cert
-                    .as_ref()
-                    .map_or(Ok(()), |cert| cert.verify(validator))
+                if let Some(highest_ordered_decision) = &self.highest_ordered_decision {
+                    // TODO: Earlier, quroum_cert.verify() compares if the certified_block.round() is 0.
+                    // Here, we are comparing commit_info.round() > 0. Is this okay?
+                    if highest_ordered_decision.commit_info().round() > 0 {
+                        highest_ordered_decision.verify_signatures(validator)?;
+                    }
+                } else {
+                    self.highest_ordered_cert
+                        .as_ref()
+                        .map_or(Ok(()), |cert| cert.verify(validator))?
+                }
+                Ok(())
             })
             .and_then(|_| {
                 // we do not verify genesis ledger info
-                if self.highest_commit_cert.commit_info().round() > 0 {
-                    self.highest_commit_cert.verify(validator)?;
+                if self.highest_commit_round() > 0 {
+                    if let Some(highest_commit_decision) = &self.highest_commit_decision {
+                        highest_commit_decision.verify_signatures(validator)?;
+                    } else {
+                        self.highest_commit_cert.verify(validator)?
+                    }
                 }
                 Ok(())
             })

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -577,6 +577,8 @@ impl BlockReader for BlockStore {
             self.highest_commit_cert().as_ref().clone(),
             self.highest_2chain_timeout_cert()
                 .map(|tc| tc.as_ref().clone()),
+            Some(self.highest_ordered_cert().as_ref().ledger_info().clone()),
+            Some(self.highest_commit_cert().as_ref().ledger_info().clone()),
         )
     }
 

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1411,6 +1411,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             ConsensusMsg::ProposalMsg(_)
             | ConsensusMsg::SyncInfo(_)
             | ConsensusMsg::VoteMsg(_)
+            | ConsensusMsg::OrderVoteMsg(_)
             | ConsensusMsg::CommitVoteMsg(_)
             | ConsensusMsg::CommitDecisionMsg(_)
             | ConsensusMsg::BatchMsg(_)

--- a/consensus/src/liveness/round_state_test.rs
+++ b/consensus/src/liveness/round_state_test.rs
@@ -155,5 +155,10 @@ fn generate_sync_info(
         timeout_round,
         quorum_cert.clone(),
     ));
-    SyncInfo::new(quorum_cert, commit_cert, Some(tc))
+    SyncInfo::new(
+        quorum_cert,
+        commit_cert.clone(),
+        Some(tc),
+        Some(commit_cert.ledger_info().clone()),
+    )
 }

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -736,6 +736,7 @@ impl NetworkTask {
                         },
                         consensus_msg @ (ConsensusMsg::ProposalMsg(_)
                         | ConsensusMsg::VoteMsg(_)
+                        | ConsensusMsg::OrderVoteMsg(_)
                         | ConsensusMsg::SyncInfo(_)
                         | ConsensusMsg::EpochRetrievalRequest(_)
                         | ConsensusMsg::EpochChangeProof(_)) => {

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -14,6 +14,7 @@ use aptos_config::network_id::{NetworkId, PeerNetworkId};
 use aptos_consensus_types::{
     block_retrieval::{BlockRetrievalRequest, BlockRetrievalResponse},
     epoch_retrieval::EpochRetrievalRequest,
+    order_vote::OrderVote,
     pipeline::{commit_decision::CommitDecision, commit_vote::CommitVote},
     proof_of_store::{ProofOfStoreMsg, SignedBatchInfoMsg},
     proposal_msg::ProposalMsg,
@@ -49,6 +50,9 @@ pub enum ConsensusMsg {
     /// VoteMsg is the struct that is ultimately sent by the voter in response for receiving a
     /// proposal.
     VoteMsg(Box<VoteMsg>),
+    /// OrderVoteMsg is the struct that is broadcasted by a validator on receiving quorum certificate
+    /// on a block.
+    OrderVoteMsg(Box<OrderVote>),
     /// CommitProposal is the struct that is sent by the validator after execution to propose
     /// on the committed state hash root.
     CommitVoteMsg(Box<CommitVote>),
@@ -90,6 +94,7 @@ impl ConsensusMsg {
             ConsensusMsg::SyncInfo(_) => "SyncInfo",
             ConsensusMsg::EpochChangeProof(_) => "EpochChangeProof",
             ConsensusMsg::VoteMsg(_) => "VoteMsg",
+            ConsensusMsg::OrderVoteMsg(_) => "OrderVoteMsg",
             ConsensusMsg::CommitVoteMsg(_) => "CommitVoteMsg",
             ConsensusMsg::CommitDecisionMsg(_) => "CommitDecisionMsg",
             ConsensusMsg::BatchMsg(_) => "BatchMsg",

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -302,6 +302,9 @@ impl NetworkPlayground {
         match msg {
             ConsensusMsg::ProposalMsg(proposal_msg) => Some(proposal_msg.proposal().round()),
             ConsensusMsg::VoteMsg(vote_msg) => Some(vote_msg.vote().vote_data().proposed().round()),
+            ConsensusMsg::OrderVoteMsg(order_vote_msg) => {
+                Some(order_vote_msg.ledger_info().round())
+            },
             ConsensusMsg::SyncInfo(sync_info) => Some(sync_info.highest_certified_round()),
             ConsensusMsg::CommitVoteMsg(commit_vote) => Some(commit_vote.commit_info().round()),
             _ => None,
@@ -648,7 +651,12 @@ mod tests {
                 Vec::new(),
             )
             .unwrap(),
-            SyncInfo::new(previous_qc.clone(), previous_qc, None),
+            SyncInfo::new(
+                previous_qc.clone(),
+                previous_qc.clone(),
+                None,
+                Some(previous_qc.ledger_info().clone()),
+            ),
         );
         timed_block_on(&runtime, async {
             nodes[0]

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -34,6 +34,7 @@ use aptos_consensus_types::{
     block_data::BlockType,
     common::{Author, Round},
     delayed_qc_msg::DelayedQcMsg,
+    order_vote::OrderVote,
     proof_of_store::{ProofCache, ProofOfStoreMsg, SignedBatchInfoMsg},
     proposal_msg::ProposalMsg,
     quorum_cert::QuorumCert,
@@ -71,6 +72,7 @@ use tokio::{
 pub enum UnverifiedEvent {
     ProposalMsg(Box<ProposalMsg>),
     VoteMsg(Box<VoteMsg>),
+    OrderVoteMsg(Box<OrderVote>),
     SyncInfo(Box<SyncInfo>),
     BatchMsg(Box<BatchMsg>),
     SignedBatchInfo(Box<SignedBatchInfoMsg>),
@@ -110,6 +112,15 @@ impl UnverifiedEvent {
                         .observe(start_time.elapsed().as_secs_f64());
                 }
                 VerifiedEvent::VoteMsg(v)
+            },
+            UnverifiedEvent::OrderVoteMsg(v) => {
+                if !self_message {
+                    v.verify(validator)?;
+                    counters::VERIFY_MSG
+                        .with_label_values(&["order_vote"])
+                        .observe(start_time.elapsed().as_secs_f64());
+                }
+                VerifiedEvent::OrderVoteMsg(v)
             },
             // sync info verification is on-demand (verified when it's used)
             UnverifiedEvent::SyncInfo(s) => VerifiedEvent::UnverifiedSyncInfo(s),
@@ -152,6 +163,7 @@ impl UnverifiedEvent {
         match self {
             UnverifiedEvent::ProposalMsg(p) => Ok(p.epoch()),
             UnverifiedEvent::VoteMsg(v) => Ok(v.epoch()),
+            UnverifiedEvent::OrderVoteMsg(v) => Ok(v.epoch()),
             UnverifiedEvent::SyncInfo(s) => Ok(s.epoch()),
             UnverifiedEvent::BatchMsg(b) => b.epoch(),
             UnverifiedEvent::SignedBatchInfo(sd) => sd.epoch(),
@@ -165,6 +177,7 @@ impl From<ConsensusMsg> for UnverifiedEvent {
         match value {
             ConsensusMsg::ProposalMsg(m) => UnverifiedEvent::ProposalMsg(m),
             ConsensusMsg::VoteMsg(m) => UnverifiedEvent::VoteMsg(m),
+            ConsensusMsg::OrderVoteMsg(m) => UnverifiedEvent::OrderVoteMsg(m),
             ConsensusMsg::SyncInfo(m) => UnverifiedEvent::SyncInfo(m),
             ConsensusMsg::BatchMsg(m) => UnverifiedEvent::BatchMsg(m),
             ConsensusMsg::SignedBatchInfo(m) => UnverifiedEvent::SignedBatchInfo(m),
@@ -180,6 +193,7 @@ pub enum VerifiedEvent {
     ProposalMsg(Box<ProposalMsg>),
     VerifiedProposalMsg(Box<Block>),
     VoteMsg(Box<VoteMsg>),
+    OrderVoteMsg(Box<OrderVote>),
     UnverifiedSyncInfo(Box<SyncInfo>),
     BatchMsg(Box<BatchMsg>),
     SignedBatchInfo(Box<SignedBatchInfoMsg>),
@@ -922,6 +936,11 @@ impl RoundManager {
         Ok(vote)
     }
 
+    /// Process the order vote message
+    async fn process_order_vote_msg(&mut self, _order_vote: OrderVote) -> anyhow::Result<()> {
+        Ok(())
+    }
+
     /// Upon new vote:
     /// 1. Ensures we're processing the vote from the same round as local round
     /// 2. Filter out votes for rounds that should not be processed by this validator (to avoid
@@ -1173,6 +1192,12 @@ impl RoundManager {
                     let result = match event {
                         VerifiedEvent::VoteMsg(vote_msg) => {
                             monitor!("process_vote", self.process_vote_msg(*vote_msg).await)
+                        }
+                        VerifiedEvent::OrderVoteMsg(order_vote_msg) => {
+                            monitor!(
+                                "process_order_vote",
+                                self.process_order_vote_msg(*order_vote_msg).await
+                            )
                         }
                         VerifiedEvent::UnverifiedSyncInfo(sync_info) => {
                             monitor!(

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -905,7 +905,12 @@ fn no_vote_on_mismatch_round() {
     timed_block_on(&runtime, async {
         let bad_proposal = ProposalMsg::new(
             block_skip_round,
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+            SyncInfo::new(
+                genesis_qc.clone(),
+                genesis_qc.clone(),
+                None,
+                Some(genesis_qc.ledger_info().clone()),
+            ),
         );
         assert!(node
             .round_manager
@@ -914,7 +919,12 @@ fn no_vote_on_mismatch_round() {
             .is_err());
         let good_proposal = ProposalMsg::new(
             correct_block.clone(),
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+            SyncInfo::new(
+                genesis_qc.clone(),
+                genesis_qc.clone(),
+                None,
+                Some(genesis_qc.ledger_info().clone()),
+            ),
         );
         node.round_manager
             .process_proposal_msg(good_proposal)
@@ -972,6 +982,7 @@ fn sync_info_carried_on_timeout_vote() {
                 block_0_quorum_cert.clone(),
                 block_0_quorum_cert.clone(),
                 None,
+                Some(block_0_quorum_cert.ledger_info().clone()),
             ));
         node.round_manager
             .process_local_timeout(2)
@@ -1027,7 +1038,12 @@ fn no_vote_on_invalid_proposer() {
     timed_block_on(&runtime, async {
         let bad_proposal = ProposalMsg::new(
             block_incorrect_proposer,
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+            SyncInfo::new(
+                genesis_qc.clone(),
+                genesis_qc.clone(),
+                None,
+                Some(genesis_qc.ledger_info().clone()),
+            ),
         );
         assert!(node
             .round_manager
@@ -1036,7 +1052,12 @@ fn no_vote_on_invalid_proposer() {
             .is_err());
         let good_proposal = ProposalMsg::new(
             correct_block.clone(),
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+            SyncInfo::new(
+                genesis_qc.clone(),
+                genesis_qc.clone(),
+                None,
+                Some(genesis_qc.ledger_info().clone()),
+            ),
         );
 
         node.round_manager
@@ -1096,7 +1117,12 @@ fn new_round_on_timeout_certificate() {
     timed_block_on(&runtime, async {
         let skip_round_proposal = ProposalMsg::new(
             block_skip_round,
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), Some(tc)),
+            SyncInfo::new(
+                genesis_qc.clone(),
+                genesis_qc.clone(),
+                Some(tc),
+                Some(genesis_qc.ledger_info().clone()),
+            ),
         );
         node.round_manager
             .process_proposal_msg(skip_round_proposal)
@@ -1104,7 +1130,12 @@ fn new_round_on_timeout_certificate() {
             .unwrap();
         let old_good_proposal = ProposalMsg::new(
             correct_block.clone(),
-            SyncInfo::new(genesis_qc.clone(), genesis_qc.clone(), None),
+            SyncInfo::new(
+                genesis_qc.clone(),
+                genesis_qc.clone(),
+                None,
+                Some(genesis_qc.ledger_info().clone()),
+            ),
         );
         assert!(node
             .round_manager
@@ -1166,6 +1197,7 @@ fn reject_invalid_failed_authors() {
                 } else {
                     None
                 },
+                Some(genesis_qc.ledger_info().clone()),
             ),
         )
     };
@@ -1241,7 +1273,15 @@ fn response_on_block_retrieval() {
     )
     .unwrap();
     let block_id = block.id();
-    let proposal = ProposalMsg::new(block, SyncInfo::new(genesis_qc.clone(), genesis_qc, None));
+    let proposal = ProposalMsg::new(
+        block,
+        SyncInfo::new(
+            genesis_qc.clone(),
+            genesis_qc.clone(),
+            None,
+            Some(genesis_qc.ledger_info().clone()),
+        ),
+    );
 
     timed_block_on(&runtime, async {
         node.round_manager
@@ -1381,6 +1421,7 @@ fn recover_on_restart() {
                     proposal.quorum_cert().clone(),
                     genesis_qc.clone(),
                     Some(tc.clone()),
+                    Some(genesis_qc.ledger_info().clone()),
                 ),
             );
             node.round_manager
@@ -1534,7 +1575,12 @@ fn sync_on_partial_newer_sync_info() {
             None,
         );
         // Create a sync info with newer quorum cert but older commit cert
-        let sync_info = SyncInfo::new(block_4_qc.clone(), certificate_for_genesis(), None);
+        let sync_info = SyncInfo::new(
+            block_4_qc.clone(),
+            certificate_for_genesis(),
+            None,
+            Some(certificate_for_genesis().ledger_info().clone()),
+        );
         node.round_manager
             .ensure_round_and_sync_up(
                 sync_info.highest_round() + 1,

--- a/consensus/src/test_utils/mod.rs
+++ b/consensus/src/test_utils/mod.rs
@@ -201,7 +201,12 @@ pub fn placeholder_ledger_info() -> LedgerInfo {
 }
 
 pub fn placeholder_sync_info() -> SyncInfo {
-    SyncInfo::new(certificate_for_genesis(), certificate_for_genesis(), None)
+    SyncInfo::new(
+        certificate_for_genesis(),
+        certificate_for_genesis(),
+        None,
+        Some(certificate_for_genesis().ledger_info().clone()),
+    )
 }
 
 fn nocapture() -> bool {

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -344,53 +344,53 @@ ConsensusMsg:
         NEWTYPE:
           TYPENAME: VoteMsg
     7:
-      CommitVoteMsg:
-        NEWTYPE:
-          TYPENAME: CommitVote
-    8:
-      CommitDecisionMsg:
-        NEWTYPE:
-          TYPENAME: CommitDecision
-    9:
-      BatchMsg:
-        NEWTYPE:
-          TYPENAME: BatchMsg
-    10:
-      BatchRequestMsg:
-        NEWTYPE:
-          TYPENAME: BatchRequest
-    11:
-      BatchResponse:
-        NEWTYPE:
-          TYPENAME: Batch
-    12:
-      SignedBatchInfo:
-        NEWTYPE:
-          TYPENAME: SignedBatchInfoMsg
-    13:
-      ProofOfStoreMsg:
-        NEWTYPE:
-          TYPENAME: ProofOfStoreMsg
-    14:
-      DAGMessage:
-        NEWTYPE:
-          TYPENAME: DAGNetworkMessage
-    15:
-      CommitMessage:
-        NEWTYPE:
-          TYPENAME: CommitMessage
-    16:
-      RandGenMessage:
-        NEWTYPE:
-          TYPENAME: RandGenMessage
-    17:
-      BatchResponseV2:
-        NEWTYPE:
-          TYPENAME: BatchResponse
-    18:
       OrderVoteMsg:
         NEWTYPE:
           TYPENAME: OrderVote
+    8:
+      CommitVoteMsg:
+        NEWTYPE:
+          TYPENAME: CommitVote
+    9:
+      CommitDecisionMsg:
+        NEWTYPE:
+          TYPENAME: CommitDecision
+    10:
+      BatchMsg:
+        NEWTYPE:
+          TYPENAME: BatchMsg
+    11:
+      BatchRequestMsg:
+        NEWTYPE:
+          TYPENAME: BatchRequest
+    12:
+      BatchResponse:
+        NEWTYPE:
+          TYPENAME: Batch
+    13:
+      SignedBatchInfo:
+        NEWTYPE:
+          TYPENAME: SignedBatchInfoMsg
+    14:
+      ProofOfStoreMsg:
+        NEWTYPE:
+          TYPENAME: ProofOfStoreMsg
+    15:
+      DAGMessage:
+        NEWTYPE:
+          TYPENAME: DAGNetworkMessage
+    16:
+      CommitMessage:
+        NEWTYPE:
+          TYPENAME: CommitMessage
+    17:
+      RandGenMessage:
+        NEWTYPE:
+          TYPENAME: RandGenMessage
+    18:
+      BatchResponseV2:
+        NEWTYPE:
+          TYPENAME: BatchResponse
 ContractEvent:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -387,6 +387,10 @@ ConsensusMsg:
       BatchResponseV2:
         NEWTYPE:
           TYPENAME: BatchResponse
+    18:
+      OrderVoteMsg:
+        NEWTYPE:
+          TYPENAME: OrderVote
 ContractEvent:
   ENUM:
     0:
@@ -842,6 +846,12 @@ SyncInfo:
     - highest_2chain_timeout_cert:
         OPTION:
           TYPENAME: TwoChainTimeoutCertificate
+    - highest_ordered_decision:
+        OPTION:
+          TYPENAME: LedgerInfoWithSignatures
+    - highest_commit_decision:
+        OPTION:
+          TYPENAME: LedgerInfoWithSignatures
 TableHandle:
   NEWTYPESTRUCT:
     TYPENAME: AccountAddress
@@ -1058,6 +1068,16 @@ VoteMsg:
         TYPENAME: Vote
     - sync_info:
         TYPENAME: SyncInfo
+OrderVote:
+  STRUCT:
+    - vote_data:
+        TYPENAME: VoteData
+    - author:
+        TYPENAME: AccountAddress
+    - ledger_info:
+        TYPENAME: LedgerInfo
+    - signature:
+        TYPENAME: Signature
 WriteOp:
   ENUM:
     0:

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -174,6 +174,21 @@ impl LedgerInfoWithSignatures {
             validator_set,
         ))
     }
+
+    pub fn commit_info(&self) -> &BlockInfo {
+        match self {
+            LedgerInfoWithSignatures::V0(ledger) => ledger.commit_info(),
+        }
+    }
+
+    pub fn verify_signatures(
+        &self,
+        validator: &ValidatorVerifier,
+    ) -> ::std::result::Result<(), VerifyError> {
+        match self {
+            LedgerInfoWithSignatures::V0(ledger) => ledger.verify_signatures(validator),
+        }
+    }
 }
 
 /// Helper function to generate LedgerInfoWithSignature from a set of validator signers used for testing


### PR DESCRIPTION
## Description
This PR is prerequsite for execution shadowing feature with order votes. To ensure backward compatibility, we needed to break the execution shadowing feature deployment into multiple phases. In the first phase (this PR), we add ordered_decision and commit_decision fields in SyncInfo, and we add OrderVote struct. Validators do not broadcast order votes in this PR. Validators can receive order votes but do not process them.
Before deploying this PR, we first need to ensure that the validators can only communicate using the JSON protocol.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
