### PR TITLE
[Compiler-v2] Generate bytecode version V7 when using compiler V2

### DIFF
--- a/.github/actions/move-tests-compiler-v2/action.yaml
+++ b/.github/actions/move-tests-compiler-v2/action.yaml
@@ -37,6 +37,7 @@ runs:
       run: cargo x targeted-compiler-v2-tests -vv --release --profile ci --locked --no-fail-fast
       shell: bash
       env:
+        DISABLE_GEN_BINARY_V7: true
         MOVE_COMPILER_V2: true
         RUST_MIN_STACK: 4297152
         MVP_TEST_ON_CI: true

--- a/aptos-move/e2e-move-tests/src/tests/metadata.rs
+++ b/aptos-move/e2e-move-tests/src/tests/metadata.rs
@@ -16,7 +16,11 @@ use aptos_types::{
     on_chain_config::{FeatureFlag, OnChainConfig},
     transaction::TransactionStatus,
 };
-use move_binary_format::CompiledModule;
+use move_binary_format::{
+    deserializer::DeserializerConfig,
+    file_format_common::{IDENTIFIER_SIZE_MAX, VERSION_MAX},
+    CompiledModule,
+};
 use move_core_types::{
     account_address::AccountAddress, language_storage::CORE_CODE_ADDRESS, metadata::Metadata,
     vm_status::StatusCode,
@@ -185,7 +189,9 @@ fn test_compilation_metadata_with_changes(
     )
     .expect("building package must succeed");
     let origin_code = package.extract_code();
-    let mut compiled_module = CompiledModule::deserialize(&origin_code[0]).unwrap();
+    let config = DeserializerConfig::new(VERSION_MAX, IDENTIFIER_SIZE_MAX);
+    let mut compiled_module =
+        CompiledModule::deserialize_with_config(&origin_code[0], &config).unwrap();
     let metadata = f();
     let mut invalid_code = vec![];
     compiled_module.metadata.push(metadata);

--- a/third_party/move/move-binary-format/src/file_format_common.rs
+++ b/third_party/move/move-binary-format/src/file_format_common.rs
@@ -478,6 +478,10 @@ pub const VERSION_6: u32 = 6;
 /// + access specifiers (read/write set)
 pub const VERSION_7: u32 = 7;
 
+/// Version 8: changes compare to version 7
+/// placeholder for the next version
+pub const VERSION_8: u32 = 8;
+
 /// Mark which version is the default version
 pub const VERSION_DEFAULT: u32 = VERSION_6;
 
@@ -488,9 +492,9 @@ pub const VERSION_MAX: u32 = VERSION_7;
 /// production. The bytecode deserializer accepts modules with this version only when the
 /// cargo feature `testing` is enabled.
 ///
-/// This is currently set to VERSION_7, the next major version, and should be updated once
+/// This is currently set to VERSION_8, the next major version, and should be updated once
 /// this version is ready for production.
-pub const VERSION_NEXT: u32 = VERSION_7;
+pub const VERSION_NEXT: u32 = VERSION_8;
 
 // Mark which oldest version is supported.
 // TODO(#145): finish v4 compatibility; as of now, only metadata is implemented

--- a/third_party/move/move-binary-format/src/serializer.rs
+++ b/third_party/move/move-binary-format/src/serializer.rs
@@ -34,7 +34,13 @@ impl CompiledScript {
         bytecode_version: Option<u32>,
         binary: &mut Vec<u8>,
     ) -> Result<()> {
-        let version = bytecode_version.unwrap_or(VERSION_DEFAULT);
+        // If the bytecode is V7, do not downgrade it
+        // so that it cannot be deployed on any network unless VM_BINARY_FORMAT_V7 feature flag is set
+        let version = if self.version == VERSION_MAX {
+            VERSION_MAX
+        } else {
+            bytecode_version.unwrap_or(VERSION_DEFAULT)
+        };
         validate_version(version)?;
         let mut binary_data = BinaryData::from(binary.clone());
         let mut ser = ScriptSerializer::new(version);
@@ -243,7 +249,13 @@ impl CompiledModule {
         bytecode_version: Option<u32>,
         binary: &mut Vec<u8>,
     ) -> Result<()> {
-        let version = bytecode_version.unwrap_or(VERSION_DEFAULT);
+        // If the bytecode is V7, do not downgrade it
+        // so that it cannot be deployed on any network unless VM_BINARY_FORMAT_V7 feature flag is set
+        let version = if self.version == VERSION_MAX {
+            VERSION_MAX
+        } else {
+            bytecode_version.unwrap_or(VERSION_DEFAULT)
+        };
         validate_version(version)?;
         let mut binary_data = BinaryData::from(binary.clone());
         let mut ser = ModuleSerializer::new(version);

--- a/third_party/move/move-command-line-common/src/testing.rs
+++ b/third_party/move/move-command-line-common/src/testing.rs
@@ -18,6 +18,8 @@ pub const UPDATE_BASELINE: &str = "UPDATE_BASELINE";
 pub const UPBL: &str = "UPBL";
 pub const UB: &str = "UB";
 
+/// Env variable to disable generation of V7 in tests
+pub const DISABLE_GEN_BINARY_V7: &str = "DISABLE_GEN_BINARY_V7";
 pub const PRETTY: &str = "PRETTY";
 pub const FILTER: &str = "FILTER";
 

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -17,6 +17,7 @@
 //! turns on or off a bunch of other experiments, unless those are
 //! defined explicitly.
 
+use move_command_line_common::{env::read_bool_env_var, testing::DISABLE_GEN_BINARY_V7};
 use once_cell::sync::Lazy;
 use std::collections::BTreeMap;
 
@@ -182,6 +183,13 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             description: "Whether to attach the compiled module to the global env.".to_string(),
             default: Given(false),
         },
+        Experiment {
+            name: Experiment::GEN_BYTECODE_V7.to_string(),
+            description: "Whether to generate bytecode V7 in the file format.\
+             This is currently on by default."
+                .to_string(),
+            default: Given(!read_bool_env_var(DISABLE_GEN_BINARY_V7)),
+        },
     ];
     experiments
         .into_iter()
@@ -202,6 +210,7 @@ impl Experiment {
     pub const DEAD_CODE_ELIMINATION: &'static str = "dead-code-elimination";
     pub const DUPLICATE_STRUCT_PARAMS_CHECK: &'static str = "duplicate-struct-params-check";
     pub const GEN_ACCESS_SPECIFIERS: &'static str = "gen-access-specifiers";
+    pub const GEN_BYTECODE_V7: &'static str = "generate-bytecode-v7";
     pub const INLINING: &'static str = "inlining";
     pub const KEEP_INLINE_FUNS: &'static str = "keep-inline-funs";
     pub const KEEP_UNINIT_ANNOTATIONS: &'static str = "keep-uninit-annotations";

--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -114,8 +114,14 @@ impl ModuleGenerator {
             value: bcs::to_bytes(&compilation_metadata)
                 .expect("Serialization of CompilationMetadata should succeed"),
         };
+        // Generate V7 bytecode if the experimental flag is set
+        let gen_v7 = options.experiment_on(Experiment::GEN_BYTECODE_V7);
         let module = move_binary_format::CompiledModule {
-            version: file_format_common::VERSION_NEXT,
+            version: if gen_v7 {
+                file_format_common::VERSION_MAX
+            } else {
+                file_format_common::VERSION_DEFAULT
+            },
             self_module_handle_idx: FF::ModuleHandleIndex(0),
             metadata: vec![metadata],
             ..Default::default()

--- a/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
@@ -4,7 +4,7 @@
 use move_binary_format::{
     deserializer::DeserializerConfig,
     file_format::{basic_test_module, basic_test_script},
-    file_format_common::{IDENTIFIER_SIZE_MAX, VERSION_MAX},
+    file_format_common::{IDENTIFIER_SIZE_MAX, VERSION_DEFAULT, VERSION_MAX},
 };
 use move_core_types::{account_address::AccountAddress, vm_status::StatusCode};
 use move_vm_runtime::{config::VMConfig, module_traversal::*, move_vm::MoveVM};
@@ -13,11 +13,12 @@ use move_vm_types::gas::UnmeteredGasMeter;
 
 #[test]
 fn test_publish_module_with_custom_max_binary_format_version() {
-    let m = basic_test_module();
+    let mut m = basic_test_module();
     let mut b_new = vec![];
     let mut b_old = vec![];
     m.serialize_for_version(Some(VERSION_MAX), &mut b_new)
         .unwrap();
+    m.version = VERSION_DEFAULT;
     m.serialize_for_version(Some(VERSION_MAX.checked_sub(1).unwrap()), &mut b_old)
         .unwrap();
 
@@ -87,11 +88,12 @@ fn test_publish_module_with_custom_max_binary_format_version() {
 
 #[test]
 fn test_run_script_with_custom_max_binary_format_version() {
-    let s = basic_test_script();
+    let mut s = basic_test_script();
     let mut b_new = vec![];
     let mut b_old = vec![];
     s.serialize_for_version(Some(VERSION_MAX), &mut b_new)
         .unwrap();
+    s.version = VERSION_DEFAULT;
     s.serialize_for_version(Some(VERSION_MAX.checked_sub(1).unwrap()), &mut b_old)
         .unwrap();
     let traversal_storage = TraversalStorage::new();

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -135,6 +135,7 @@ impl FeatureFlag {
             FeatureFlag::COIN_TO_FUNGIBLE_ASSET_MIGRATION,
             FeatureFlag::OBJECT_NATIVE_DERIVED_ADDRESS,
             FeatureFlag::DISPATCHABLE_FUNGIBLE_ASSET,
+            FeatureFlag::VM_BINARY_FORMAT_V7,
         ]
     }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR guarantees that the CompiledModule/Script generated by the compiler V2 must be 7 so that only when the feature flag VM_BINARY_FORMAT_V7 is set, the module can be published.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Added an e2e move test

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

1) V2 compiler generates bytecode version 7 by default;
2) the newly added e2e move test checks that V2 generated code can only be published when VM_BINARY_FORMAT_V7 is set;
3) V1 compiler is not affected.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
