### PR TITLE
Add versioned proposal message, vote message and syncinfo for backward compatibility of consensus message upgrades

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -300,7 +300,7 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: compat
-      IMAGE_TAG: aptos-node-v1.10.1 # test against a previous testnet release
+      IMAGE_TAG: aptos-node-v1.11 # test against a previous testnet release
       FORGE_RUNNER_DURATION_SECS: 300
       COMMENT_HEADER: forge-compat
       FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
@@ -327,7 +327,7 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: framework_upgrade
-      IMAGE_TAG: aptos-node-v1.10.1 # This workflow will test the upgradability from the current tip of the release branch to the current main branch.
+      IMAGE_TAG: aptos-node-v1.11 # This workflow will test the upgradability from the current tip of the release branch to the current main branch.
       FORGE_RUNNER_DURATION_SECS: 3600
       COMMENT_HEADER: forge-framework-upgrade
       FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -74,7 +74,6 @@ pub struct ConsensusConfig {
     pub broadcast_vote: bool,
     pub proof_cache_capacity: u64,
     pub rand_rb_config: ReliableBroadcastConfig,
-    pub versioned_messages: bool,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -321,7 +320,6 @@ impl Default for ConsensusConfig {
                 backoff_policy_max_delay_ms: 10000,
                 rpc_timeout_ms: 10000,
             },
-            versioned_messages: false,
         }
     }
 }

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -74,6 +74,7 @@ pub struct ConsensusConfig {
     pub broadcast_vote: bool,
     pub proof_cache_capacity: u64,
     pub rand_rb_config: ReliableBroadcastConfig,
+    pub versioned_messages: bool,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
@@ -320,6 +321,7 @@ impl Default for ConsensusConfig {
                 backoff_policy_max_delay_ms: 10000,
                 rpc_timeout_ms: 10000,
             },
+            versioned_messages: false,
         }
     }
 }

--- a/consensus/consensus-types/src/lib.rs
+++ b/consensus/consensus-types/src/lib.rs
@@ -10,6 +10,7 @@ pub mod block_retrieval;
 pub mod common;
 pub mod delayed_qc_msg;
 pub mod epoch_retrieval;
+pub mod order_vote;
 pub mod pipeline;
 pub mod pipelined_block;
 pub mod proof_of_store;

--- a/consensus/consensus-types/src/order_vote.rs
+++ b/consensus/consensus-types/src/order_vote.rs
@@ -1,0 +1,100 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::Author;
+use anyhow::Context;
+use aptos_crypto::{bls12381, CryptoMaterialError};
+use aptos_short_hex_str::AsShortHexStr;
+use aptos_types::{
+    ledger_info::LedgerInfo, validator_signer::ValidatorSigner,
+    validator_verifier::ValidatorVerifier,
+};
+use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Display, Formatter};
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct OrderVote {
+    /// The identity of the voter.
+    author: Author,
+    /// LedgerInfo of a block that is going to be ordered in case this vote gathers QC.
+    ledger_info: LedgerInfo,
+    /// Signature of the LedgerInfo.
+    signature: bls12381::Signature,
+}
+
+impl Display for OrderVote {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "OrderVote: [author: {}, ledger_info: {}]",
+            self.author.short_str(),
+            self.ledger_info
+        )
+    }
+}
+
+// this is required by structured log
+impl Debug for OrderVote {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl OrderVote {
+    pub fn new(
+        author: Author,
+        ledger_info: LedgerInfo,
+        validator_signer: &ValidatorSigner,
+    ) -> Result<Self, CryptoMaterialError> {
+        let signature = validator_signer.sign(&ledger_info)?;
+        Ok(Self {
+            author,
+            ledger_info,
+            signature,
+        })
+    }
+
+    /// Generates a new Vote using a signature over the specified ledger_info
+    pub fn new_with_signature(
+        author: Author,
+        ledger_info: LedgerInfo,
+        signature: bls12381::Signature,
+    ) -> Self {
+        Self {
+            author,
+            ledger_info,
+            signature,
+        }
+    }
+
+    pub fn author(&self) -> Author {
+        self.author
+    }
+
+    pub fn ledger_info(&self) -> &LedgerInfo {
+        &self.ledger_info
+    }
+
+    pub fn signature(&self) -> &bls12381::Signature {
+        &self.signature
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.ledger_info.epoch()
+    }
+
+    pub fn round_to_be_committed(&self) -> u64 {
+        self.ledger_info.round()
+    }
+
+    /// Verifies that the consensus data hash of LedgerInfo corresponds to the vote info,
+    /// and then verifies the signature.
+    pub fn verify(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
+        validator
+            .verify(self.author(), &self.ledger_info, &self.signature)
+            .context("Failed to verify OrderVote")?;
+
+        Ok(())
+    }
+}

--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -290,13 +290,6 @@ impl SyncInfo {
     pub fn epoch(&self) -> u64 {
         self.highest_quorum_cert.certified_block().epoch()
     }
-
-    pub fn has_newer_certificates(&self, other: &SyncInfo) -> bool {
-        self.highest_certified_round() > other.highest_certified_round()
-            || self.highest_timeout_round() > other.highest_timeout_round()
-            || self.highest_ordered_round() > other.highest_ordered_round()
-            || self.highest_commit_round() > other.highest_commit_round()
-    }
 }
 
 #[derive(Deserialize, Serialize, Clone, Eq, PartialEq)]
@@ -481,12 +474,5 @@ impl SyncInfoV2 {
 
     pub fn epoch(&self) -> u64 {
         self.highest_quorum_cert.certified_block().epoch()
-    }
-
-    pub fn has_newer_certificates(&self, other: &SyncInfo) -> bool {
-        self.highest_certified_round() > other.highest_certified_round()
-            || self.highest_timeout_round() > other.highest_timeout_round()
-            || self.highest_ordered_round() > other.highest_ordered_round()
-            || self.highest_commit_round() > other.highest_commit_round()
     }
 }

--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -4,9 +4,116 @@
 
 use crate::{common::Round, quorum_cert::QuorumCert, timeout_2chain::TwoChainTimeoutCertificate};
 use anyhow::{ensure, Context};
-use aptos_types::{block_info::BlockInfo, validator_verifier::ValidatorVerifier};
+use aptos_types::{
+    block_info::BlockInfo, ledger_info::LedgerInfoWithSignatures,
+    validator_verifier::ValidatorVerifier,
+};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
+
+/// This struct describes basic synchronization metadata. This struct is versioned to allow
+/// upgrades.
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq)]
+pub enum VersionedSyncInfo {
+    V1(SyncInfo),
+    V2(SyncInfoV2),
+}
+
+// this is required by structured log
+impl Debug for VersionedSyncInfo {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl Display for VersionedSyncInfo {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            VersionedSyncInfo::V1(sync_info) => write!(f, "V1({})", sync_info),
+            VersionedSyncInfo::V2(sync_info) => write!(f, "V2({})", sync_info),
+        }
+    }
+}
+
+impl VersionedSyncInfo {
+    pub fn new_v1(sync_info: SyncInfo) -> Self {
+        VersionedSyncInfo::V1(sync_info)
+    }
+
+    pub fn new_v2(sync_info: SyncInfoV2) -> Self {
+        VersionedSyncInfo::V2(sync_info)
+    }
+
+    pub fn verify(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
+        match self {
+            VersionedSyncInfo::V1(sync_info) => sync_info.verify(validator),
+            VersionedSyncInfo::V2(sync_info) => sync_info.verify(validator),
+        }
+    }
+
+    pub fn highest_round(&self) -> Round {
+        match self {
+            VersionedSyncInfo::V1(sync_info) => sync_info.highest_round(),
+            VersionedSyncInfo::V2(sync_info) => sync_info.highest_round(),
+        }
+    }
+
+    pub fn highest_certified_round(&self) -> Round {
+        match self {
+            VersionedSyncInfo::V1(sync_info) => sync_info.highest_certified_round(),
+            VersionedSyncInfo::V2(sync_info) => sync_info.highest_certified_round(),
+        }
+    }
+
+    pub fn highest_timeout_round(&self) -> Round {
+        match self {
+            VersionedSyncInfo::V1(sync_info) => sync_info.highest_timeout_round(),
+            VersionedSyncInfo::V2(sync_info) => sync_info.highest_timeout_round(),
+        }
+    }
+
+    pub fn highest_ordered_round(&self) -> Round {
+        match self {
+            VersionedSyncInfo::V1(sync_info) => sync_info.highest_ordered_round(),
+            VersionedSyncInfo::V2(sync_info) => sync_info.highest_ordered_round(),
+        }
+    }
+
+    pub fn highest_commit_round(&self) -> Round {
+        match self {
+            VersionedSyncInfo::V1(sync_info) => sync_info.highest_commit_round(),
+            VersionedSyncInfo::V2(sync_info) => sync_info.highest_commit_round(),
+        }
+    }
+
+    pub fn highest_quorum_cert(&self) -> &QuorumCert {
+        match self {
+            VersionedSyncInfo::V1(sync_info) => sync_info.highest_quorum_cert(),
+            VersionedSyncInfo::V2(sync_info) => sync_info.highest_quorum_cert(),
+        }
+    }
+
+    pub fn epoch(&self) -> u64 {
+        match self {
+            VersionedSyncInfo::V1(sync_info) => sync_info.epoch(),
+            VersionedSyncInfo::V2(sync_info) => sync_info.epoch(),
+        }
+    }
+
+    pub fn highest_2chain_timeout_cert(&self) -> Option<&TwoChainTimeoutCertificate> {
+        match self {
+            VersionedSyncInfo::V1(sync_info) => sync_info.highest_2chain_timeout_cert(),
+            VersionedSyncInfo::V2(sync_info) => sync_info.highest_2chain_timeout_cert(),
+        }
+    }
+
+    pub fn has_newer_certificates(&self, other: &VersionedSyncInfo) -> bool {
+        self.highest_certified_round() > other.highest_certified_round()
+            || self.highest_timeout_round() > other.highest_timeout_round()
+            || self.highest_ordered_round() > other.highest_ordered_round()
+            || self.highest_commit_round() > other.highest_commit_round()
+    }
+}
 
 #[derive(Deserialize, Serialize, Clone, Eq, PartialEq)]
 /// This struct describes basic synchronization metadata.
@@ -167,6 +274,202 @@ impl SyncInfo {
                 // we do not verify genesis ledger info
                 if self.highest_commit_cert.commit_info().round() > 0 {
                     self.highest_commit_cert.verify(validator)?;
+                }
+                Ok(())
+            })
+            .and_then(|_| {
+                if let Some(tc) = &self.highest_2chain_timeout_cert {
+                    tc.verify(validator)?;
+                }
+                Ok(())
+            })
+            .context("Fail to verify SyncInfo")?;
+        Ok(())
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.highest_quorum_cert.certified_block().epoch()
+    }
+
+    pub fn has_newer_certificates(&self, other: &SyncInfo) -> bool {
+        self.highest_certified_round() > other.highest_certified_round()
+            || self.highest_timeout_round() > other.highest_timeout_round()
+            || self.highest_ordered_round() > other.highest_ordered_round()
+            || self.highest_commit_round() > other.highest_commit_round()
+    }
+}
+
+#[derive(Deserialize, Serialize, Clone, Eq, PartialEq)]
+/// This struct describes basic synchronization metadata.
+pub struct SyncInfoV2 {
+    /// Highest quorum certificate known to the peer.
+    highest_quorum_cert: QuorumCert,
+    /// Highest ordered decision known to the peer.
+    highest_ordered_decision: Option<LedgerInfoWithSignatures>,
+    /// Highest commit decision (ordered decision with execution result) known to the peer.
+    highest_commit_decision: LedgerInfoWithSignatures,
+    /// Optional highest timeout certificate if available.
+    highest_2chain_timeout_cert: Option<TwoChainTimeoutCertificate>,
+}
+
+// this is required by structured log
+impl Debug for SyncInfoV2 {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl Display for SyncInfoV2 {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "SyncInfo[highest_quorum_cert: {:?}, highest_ordered_decision: {:?}, highest_commit_decision: {:?}, highest_2chain_timeout_cert: {:?}, certified_round: {}, ordered_round: {}, timeout round: {}, commit_info: {}]",
+            self.highest_quorum_cert,
+            self.highest_ordered_decision,
+            self.highest_commit_decision.commit_info(),
+            self.highest_2chain_timeout_cert,
+            self.highest_certified_round(),
+            self.highest_ordered_round(),
+            self.highest_timeout_round(),
+            self.highest_commit_decision().commit_info(),
+        )
+    }
+}
+
+impl SyncInfoV2 {
+    pub fn new_decoupled(
+        highest_quorum_cert: QuorumCert,
+        highest_ordered_decision: LedgerInfoWithSignatures,
+        highest_commit_decision: LedgerInfoWithSignatures,
+        highest_2chain_timeout_cert: Option<TwoChainTimeoutCertificate>,
+    ) -> Self {
+        // No need to include HTC if it's lower than HQC
+        let highest_2chain_timeout_cert = highest_2chain_timeout_cert
+            .filter(|tc| tc.round() > highest_quorum_cert.certified_block().round());
+
+        // TODO: Is this an okay check to do? Here we are also check if consensus_data_hash is matching.
+        let highest_ordered_decision =
+            Some(highest_ordered_decision).filter(|hoc| hoc != highest_quorum_cert.ledger_info());
+
+        Self {
+            highest_quorum_cert,
+            highest_ordered_decision,
+            highest_commit_decision,
+            highest_2chain_timeout_cert,
+        }
+    }
+
+    pub fn new(
+        highest_quorum_cert: QuorumCert,
+        highest_ordered_decision: LedgerInfoWithSignatures,
+        highest_2chain_timeout_cert: Option<TwoChainTimeoutCertificate>,
+    ) -> Self {
+        let highest_commit_decision = highest_ordered_decision.clone();
+        Self::new_decoupled(
+            highest_quorum_cert,
+            highest_ordered_decision,
+            highest_commit_decision,
+            highest_2chain_timeout_cert,
+        )
+    }
+
+    /// Highest quorum certificate
+    pub fn highest_quorum_cert(&self) -> &QuorumCert {
+        &self.highest_quorum_cert
+    }
+
+    /// Highest ordered certificate
+    pub fn highest_ordered_decision(&self) -> &LedgerInfoWithSignatures {
+        self.highest_ordered_decision
+            .as_ref()
+            .unwrap_or(self.highest_quorum_cert.ledger_info())
+    }
+
+    /// Highest ledger info
+    pub fn highest_commit_decision(&self) -> &LedgerInfoWithSignatures {
+        &self.highest_commit_decision
+    }
+
+    /// Highest 2-chain timeout certificate
+    pub fn highest_2chain_timeout_cert(&self) -> Option<&TwoChainTimeoutCertificate> {
+        self.highest_2chain_timeout_cert.as_ref()
+    }
+
+    pub fn highest_certified_round(&self) -> Round {
+        self.highest_quorum_cert.certified_block().round()
+    }
+
+    pub fn highest_timeout_round(&self) -> Round {
+        self.highest_2chain_timeout_cert()
+            .map_or(0, |tc| tc.round())
+    }
+
+    pub fn highest_ordered_round(&self) -> Round {
+        self.highest_ordered_decision().commit_info().round()
+    }
+
+    pub fn highest_commit_round(&self) -> Round {
+        self.highest_commit_decision().commit_info().round()
+    }
+
+    /// The highest round the SyncInfo carries.
+    pub fn highest_round(&self) -> Round {
+        std::cmp::max(self.highest_certified_round(), self.highest_timeout_round())
+    }
+
+    pub fn verify(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
+        let epoch = self.highest_quorum_cert.certified_block().epoch();
+        // TODO: Is it okay to change highest_ordered_cert -> highest_ordered_decision here?
+        // Does it break when epoch changes?
+        ensure!(
+            epoch == self.highest_ordered_decision().commit_info().epoch(),
+            "Multi epoch in SyncInfo - HOC and HQC"
+        );
+        ensure!(
+            epoch == self.highest_commit_decision().commit_info().epoch(),
+            "Multi epoch in SyncInfo - HOC and HCC"
+        );
+        if let Some(tc) = &self.highest_2chain_timeout_cert {
+            ensure!(epoch == tc.epoch(), "Multi epoch in SyncInfo - TC and HQC");
+        }
+
+        ensure!(
+            self.highest_quorum_cert.certified_block().round()
+                >= self.highest_ordered_decision().commit_info().round(),
+            "HQC has lower round than HOC"
+        );
+
+        ensure!(
+            self.highest_ordered_decision().commit_info().round() >= self.highest_commit_round(),
+            "HOC has lower round than HLI"
+        );
+
+        ensure!(
+            *self.highest_ordered_decision().commit_info() != BlockInfo::empty(),
+            "HOC has no committed block"
+        );
+
+        ensure!(
+            *self.highest_commit_decision().commit_info() != BlockInfo::empty(),
+            "HLI has empty commit info"
+        );
+
+        self.highest_quorum_cert
+            .verify(validator)
+            .and_then(|_| {
+                if let Some(highest_ordered_decision) = &self.highest_ordered_decision {
+                    // TODO: Earlier, quroum_cert.verify() compares if the certified_block.round() is 0.
+                    // Here, we are comparing commit_info.round() > 0. Is this okay?
+                    if highest_ordered_decision.commit_info().round() > 0 {
+                        highest_ordered_decision.verify_signatures(validator)?;
+                    }
+                }
+                Ok(())
+            })
+            .and_then(|_| {
+                // we do not verify genesis ledger info
+                if self.highest_commit_decision.commit_info().round() > 0 {
+                    self.highest_commit_decision.verify_signatures(validator)?;
                 }
                 Ok(())
             })

--- a/consensus/consensus-types/src/sync_info.rs
+++ b/consensus/consensus-types/src/sync_info.rs
@@ -323,11 +323,7 @@ impl Display for SyncInfoV2 {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "SyncInfo[highest_quorum_cert: {:?}, highest_ordered_decision: {:?}, highest_commit_decision: {:?}, highest_2chain_timeout_cert: {:?}, certified_round: {}, ordered_round: {}, timeout round: {}, commit_info: {}]",
-            self.highest_quorum_cert,
-            self.highest_ordered_decision,
-            self.highest_commit_decision.commit_info(),
-            self.highest_2chain_timeout_cert,
+            "SyncInfoV2[certified_round: {}, ordered_round: {}, timeout round: {}, commit_info: {}]",
             self.highest_certified_round(),
             self.highest_ordered_round(),
             self.highest_timeout_round(),

--- a/consensus/consensus-types/src/vote_msg.rs
+++ b/consensus/consensus-types/src/vote_msg.rs
@@ -2,12 +2,63 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{sync_info::SyncInfo, vote::Vote};
+use crate::{
+    sync_info::{SyncInfo, VersionedSyncInfo},
+    vote::Vote,
+};
 use anyhow::ensure;
 use aptos_crypto::HashValue;
 use aptos_types::validator_verifier::ValidatorVerifier;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
+
+/// VoteMsg is the struct that is ultimately sent by the voter in response for
+/// receiving a proposal.
+/// VoteMsg carries the `LedgerInfo` of a block that is going to be committed in case this vote
+/// is gathers QuorumCertificate (see the detailed explanation in the comments of `LedgerInfo`).
+/// This struct is versioned to support upgrades.
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub enum VersionedVoteMsg {
+    V1(VoteMsg),
+    V2(VoteMsgV2),
+}
+
+impl VersionedVoteMsg {
+    pub fn vote(&self) -> &Vote {
+        match self {
+            VersionedVoteMsg::V1(msg) => msg.vote(),
+            VersionedVoteMsg::V2(msg) => msg.vote(),
+        }
+    }
+
+    pub fn sync_info(&self) -> VersionedSyncInfo {
+        match self {
+            VersionedVoteMsg::V1(msg) => VersionedSyncInfo::new_v1(msg.sync_info().clone()),
+            VersionedVoteMsg::V2(msg) => msg.sync_info().clone(),
+        }
+    }
+
+    pub fn epoch(&self) -> u64 {
+        match self {
+            VersionedVoteMsg::V1(msg) => msg.epoch(),
+            VersionedVoteMsg::V2(msg) => msg.epoch(),
+        }
+    }
+
+    pub fn proposed_block_id(&self) -> HashValue {
+        match self {
+            VersionedVoteMsg::V1(msg) => msg.proposed_block_id(),
+            VersionedVoteMsg::V2(msg) => msg.proposed_block_id(),
+        }
+    }
+
+    pub fn verify(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
+        match self {
+            VersionedVoteMsg::V1(msg) => msg.verify(validator),
+            VersionedVoteMsg::V2(msg) => msg.verify(validator),
+        }
+    }
+}
 
 /// VoteMsg is the struct that is ultimately sent by the voter in response for
 /// receiving a proposal.
@@ -44,6 +95,56 @@ impl VoteMsg {
 
     pub fn epoch(&self) -> u64 {
         self.vote.epoch()
+    }
+
+    pub fn proposed_block_id(&self) -> HashValue {
+        self.vote.vote_data().proposed().id()
+    }
+
+    pub fn verify(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
+        ensure!(
+            self.vote().epoch() == self.sync_info.epoch(),
+            "VoteMsg has different epoch"
+        );
+        ensure!(
+            self.vote().vote_data().proposed().round() > self.sync_info.highest_round(),
+            "Vote Round should be higher than SyncInfo"
+        );
+        if let Some((timeout, _)) = self.vote().two_chain_timeout() {
+            ensure!(
+                timeout.hqc_round() <= self.sync_info.highest_certified_round(),
+                "2-chain Timeout hqc should be less or equal than the sync info hqc"
+            );
+        }
+        // We're not verifying SyncInfo here yet: we are going to verify it only in case we need
+        // it. This way we avoid verifying O(n) SyncInfo messages while aggregating the votes
+        // (O(n^2) signature verifications).
+        self.vote().verify(validator)
+    }
+}
+
+// TODO: There is a lot of duplicaition of code between VoteMsg and VoteMsgV2.
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct VoteMsgV2 {
+    vote: Vote,
+    sync_info: VersionedSyncInfo,
+}
+
+impl VoteMsgV2 {
+    pub fn new(vote: Vote, sync_info: VersionedSyncInfo) -> Self {
+        Self { vote, sync_info }
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.vote.epoch()
+    }
+
+    pub fn vote(&self) -> &Vote {
+        &self.vote
+    }
+
+    pub fn sync_info(&self) -> &VersionedSyncInfo {
+        &self.sync_info
     }
 
     pub fn proposed_block_id(&self) -> HashValue {

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -18,8 +18,12 @@ use crate::{
 };
 use anyhow::{bail, ensure, format_err, Context};
 use aptos_consensus_types::{
-    block::Block, common::Round, pipelined_block::PipelinedBlock, quorum_cert::QuorumCert,
-    sync_info::SyncInfo, timeout_2chain::TwoChainTimeoutCertificate,
+    block::Block,
+    common::Round,
+    pipelined_block::PipelinedBlock,
+    quorum_cert::QuorumCert,
+    sync_info::{SyncInfo, VersionedSyncInfo},
+    timeout_2chain::TwoChainTimeoutCertificate,
 };
 use aptos_crypto::{hash::ACCUMULATOR_PLACEHOLDER_HASH, HashValue};
 use aptos_executor_types::StateComputeResult;
@@ -578,6 +582,16 @@ impl BlockReader for BlockStore {
             self.highest_2chain_timeout_cert()
                 .map(|tc| tc.as_ref().clone()),
         )
+    }
+
+    fn versioned_sync_info(&self) -> VersionedSyncInfo {
+        VersionedSyncInfo::new_v1(SyncInfo::new_decoupled(
+            self.highest_quorum_cert().as_ref().clone(),
+            self.highest_ordered_cert().as_ref().clone(),
+            self.highest_commit_cert().as_ref().clone(),
+            self.highest_2chain_timeout_cert()
+                .map(|tc| tc.as_ref().clone()),
+        ))
     }
 
     fn vote_back_pressure(&self) -> bool {

--- a/consensus/src/block_storage/mod.rs
+++ b/consensus/src/block_storage/mod.rs
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_consensus_types::{
-    pipelined_block::PipelinedBlock, quorum_cert::QuorumCert, sync_info::SyncInfo,
+    pipelined_block::PipelinedBlock,
+    quorum_cert::QuorumCert,
+    sync_info::{SyncInfo, VersionedSyncInfo},
     timeout_2chain::TwoChainTimeoutCertificate,
 };
 use aptos_crypto::HashValue;
@@ -57,6 +59,9 @@ pub trait BlockReader: Send + Sync {
 
     /// Return the combination of highest quorum cert, timeout cert and commit cert.
     fn sync_info(&self) -> SyncInfo;
+
+    /// Return the combination of highest quorum cert, timeout cert and commit cert.
+    fn versioned_sync_info(&self) -> VersionedSyncInfo;
 
     /// Return if the consensus is backpressured
     fn vote_back_pressure(&self) -> bool;

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1431,8 +1431,12 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
     ) -> anyhow::Result<Option<UnverifiedEvent>> {
         match msg {
             ConsensusMsg::ProposalMsg(_)
+            | ConsensusMsg::VersionedProposalMsg(_)
             | ConsensusMsg::SyncInfo(_)
+            | ConsensusMsg::VersionedSyncInfo(_)
             | ConsensusMsg::VoteMsg(_)
+            | ConsensusMsg::VersionedVoteMsg(_)
+            | ConsensusMsg::OrderVoteMsg(_)
             | ConsensusMsg::CommitVoteMsg(_)
             | ConsensusMsg::CommitDecisionMsg(_)
             | ConsensusMsg::BatchMsg(_)

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -753,21 +753,39 @@ impl NetworkTask {
                             };
                         },
                         consensus_msg @ (ConsensusMsg::ProposalMsg(_)
+                        | ConsensusMsg::VersionedProposalMsg(_)
                         | ConsensusMsg::VoteMsg(_)
+                        | ConsensusMsg::VersionedVoteMsg(_)
                         | ConsensusMsg::SyncInfo(_)
+                        | ConsensusMsg::VersionedSyncInfo(_)
                         | ConsensusMsg::EpochRetrievalRequest(_)
                         | ConsensusMsg::EpochChangeProof(_)) => {
-                            if let ConsensusMsg::ProposalMsg(proposal) = &consensus_msg {
-                                observe_block(
-                                    proposal.proposal().timestamp_usecs(),
-                                    BlockStage::NETWORK_RECEIVED,
-                                );
-                                info!(
-                                    LogSchema::new(LogEvent::NetworkReceiveProposal)
-                                        .remote_peer(peer_id),
-                                    block_round = proposal.proposal().round(),
-                                    block_hash = proposal.proposal().id(),
-                                );
+                            match &consensus_msg {
+                                ConsensusMsg::ProposalMsg(proposal) => {
+                                    observe_block(
+                                        proposal.proposal().timestamp_usecs(),
+                                        BlockStage::NETWORK_RECEIVED,
+                                    );
+                                    info!(
+                                        LogSchema::new(LogEvent::NetworkReceiveProposal)
+                                            .remote_peer(peer_id),
+                                        block_round = proposal.proposal().round(),
+                                        block_hash = proposal.proposal().id(),
+                                    );
+                                },
+                                ConsensusMsg::VersionedProposalMsg(proposal) => {
+                                    observe_block(
+                                        proposal.proposal().timestamp_usecs(),
+                                        BlockStage::NETWORK_RECEIVED,
+                                    );
+                                    info!(
+                                        LogSchema::new(LogEvent::NetworkReceiveProposal)
+                                            .remote_peer(peer_id),
+                                        block_round = proposal.proposal().round(),
+                                        block_hash = proposal.proposal().id(),
+                                    );
+                                },
+                                _ => {},
                             }
                             Self::push_msg(peer_id, consensus_msg, &self.consensus_messages_tx);
                         },

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -382,21 +382,9 @@ impl NetworkSender {
         self.broadcast(msg).await
     }
 
-    pub async fn broadcast_versioned_proposal(&self, proposal_msg: VersionedProposalMsg) {
-        fail_point!("consensus::send::broadcast_proposal", |_| ());
-        let msg = ConsensusMsg::VersionedProposalMsg(Box::new(proposal_msg));
-        self.broadcast(msg).await
-    }
-
     pub async fn broadcast_sync_info(&self, sync_info_msg: SyncInfo) {
         fail_point!("consensus::send::broadcast_sync_info", |_| ());
         let msg = ConsensusMsg::SyncInfo(Box::new(sync_info_msg));
-        self.broadcast(msg).await
-    }
-
-    pub async fn broadcast_versioned_sync_info(&self, sync_info_msg: VersionedSyncInfo) {
-        fail_point!("consensus::send::broadcast_sync_info", |_| ());
-        let msg = ConsensusMsg::VersionedSyncInfo(Box::new(sync_info_msg));
         self.broadcast(msg).await
     }
 
@@ -427,12 +415,6 @@ impl NetworkSender {
     pub async fn broadcast_vote(&self, vote_msg: VoteMsg) {
         fail_point!("consensus::send::vote", |_| ());
         let msg = ConsensusMsg::VoteMsg(Box::new(vote_msg));
-        self.broadcast(msg).await
-    }
-
-    pub async fn broadcast_versioned_vote(&self, vote_msg: VersionedVoteMsg) {
-        fail_point!("consensus::send::vote", |_| ());
-        let msg = ConsensusMsg::VersionedVoteMsg(Box::new(vote_msg));
         self.broadcast(msg).await
     }
 

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -27,9 +27,9 @@ use aptos_consensus_types::{
     common::Author,
     pipeline::{commit_decision::CommitDecision, commit_vote::CommitVote},
     proof_of_store::{ProofOfStore, ProofOfStoreMsg, SignedBatchInfo, SignedBatchInfoMsg},
-    proposal_msg::ProposalMsg,
-    sync_info::SyncInfo,
-    vote_msg::VoteMsg,
+    proposal_msg::{ProposalMsg, VersionedProposalMsg},
+    sync_info::{SyncInfo, VersionedSyncInfo},
+    vote_msg::{VersionedVoteMsg, VoteMsg},
 };
 use aptos_logger::prelude::*;
 use aptos_network::{
@@ -382,9 +382,21 @@ impl NetworkSender {
         self.broadcast(msg).await
     }
 
+    pub async fn broadcast_versioned_proposal(&self, proposal_msg: VersionedProposalMsg) {
+        fail_point!("consensus::send::broadcast_proposal", |_| ());
+        let msg = ConsensusMsg::VersionedProposalMsg(Box::new(proposal_msg));
+        self.broadcast(msg).await
+    }
+
     pub async fn broadcast_sync_info(&self, sync_info_msg: SyncInfo) {
         fail_point!("consensus::send::broadcast_sync_info", |_| ());
         let msg = ConsensusMsg::SyncInfo(Box::new(sync_info_msg));
+        self.broadcast(msg).await
+    }
+
+    pub async fn broadcast_versioned_sync_info(&self, sync_info_msg: VersionedSyncInfo) {
+        fail_point!("consensus::send::broadcast_sync_info", |_| ());
+        let msg = ConsensusMsg::VersionedSyncInfo(Box::new(sync_info_msg));
         self.broadcast(msg).await
     }
 
@@ -415,6 +427,12 @@ impl NetworkSender {
     pub async fn broadcast_vote(&self, vote_msg: VoteMsg) {
         fail_point!("consensus::send::vote", |_| ());
         let msg = ConsensusMsg::VoteMsg(Box::new(vote_msg));
+        self.broadcast(msg).await
+    }
+
+    pub async fn broadcast_versioned_vote(&self, vote_msg: VersionedVoteMsg) {
+        fail_point!("consensus::send::vote", |_| ());
+        let msg = ConsensusMsg::VersionedVoteMsg(Box::new(vote_msg));
         self.broadcast(msg).await
     }
 

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -60,9 +60,11 @@ pub enum ConsensusMsg {
     /// VersionedVoteMsg is the struct that is ultimately sent by the voter in response for
     /// receiving a proposal. This struct is versioned to support upgrades.
     VersionedVoteMsg(Box<VersionedVoteMsg>),
+    /// OrderVoteMsg is the struct that is broadcasted by a validator on receiving quorum certificate
+    /// on a block.
+    OrderVoteMsg(Box<OrderVote>),
     /// CommitProposal is the struct that is sent by the validator after execution to propose
     /// on the committed state hash root.
-    OrderVoteMsg(Box<OrderVote>),
     CommitVoteMsg(Box<CommitVote>),
     /// CommitDecision is the struct that is sent by the validator after collecting no fewer
     /// than 2f + 1 signatures on the commit proposal. This part is not on the critical path, but

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -14,11 +14,12 @@ use aptos_config::network_id::{NetworkId, PeerNetworkId};
 use aptos_consensus_types::{
     block_retrieval::{BlockRetrievalRequest, BlockRetrievalResponse},
     epoch_retrieval::EpochRetrievalRequest,
+    order_vote::OrderVote,
     pipeline::{commit_decision::CommitDecision, commit_vote::CommitVote},
     proof_of_store::{ProofOfStoreMsg, SignedBatchInfoMsg},
-    proposal_msg::ProposalMsg,
-    sync_info::SyncInfo,
-    vote_msg::VoteMsg,
+    proposal_msg::{ProposalMsg, VersionedProposalMsg},
+    sync_info::{SyncInfo, VersionedSyncInfo},
+    vote_msg::{VersionedVoteMsg, VoteMsg},
 };
 use aptos_network::{
     application::{error::Error, interface::NetworkClientInterface},
@@ -41,16 +42,27 @@ pub enum ConsensusMsg {
     /// ProposalMsg contains the required information for the proposer election protocol to make
     /// its choice (typically depends on round and proposer info).
     ProposalMsg(Box<ProposalMsg>),
+    /// ProposalMsg contains the required information for the proposer election protocol to make
+    /// its choice (typically depends on round and proposer info). This struct is versioned to
+    /// support upgrades.
+    VersionedProposalMsg(Box<VersionedProposalMsg>),
     /// This struct describes basic synchronization metadata.
     SyncInfo(Box<SyncInfo>),
+    /// This struct describes basic synchronization metadata. This struct is versioned to support
+    /// upgrades.
+    VersionedSyncInfo(Box<VersionedSyncInfo>),
     /// A vector of LedgerInfo with contiguous increasing epoch numbers to prove a sequence of
     /// epoch changes from the first LedgerInfo's epoch.
     EpochChangeProof(Box<EpochChangeProof>),
     /// VoteMsg is the struct that is ultimately sent by the voter in response for receiving a
     /// proposal.
     VoteMsg(Box<VoteMsg>),
+    /// VersionedVoteMsg is the struct that is ultimately sent by the voter in response for
+    /// receiving a proposal. This struct is versioned to support upgrades.
+    VersionedVoteMsg(Box<VersionedVoteMsg>),
     /// CommitProposal is the struct that is sent by the validator after execution to propose
     /// on the committed state hash root.
+    OrderVoteMsg(Box<OrderVote>),
     CommitVoteMsg(Box<CommitVote>),
     /// CommitDecision is the struct that is sent by the validator after collecting no fewer
     /// than 2f + 1 signatures on the commit proposal. This part is not on the critical path, but
@@ -87,9 +99,13 @@ impl ConsensusMsg {
             ConsensusMsg::BlockRetrievalResponse(_) => "BlockRetrievalResponse",
             ConsensusMsg::EpochRetrievalRequest(_) => "EpochRetrievalRequest",
             ConsensusMsg::ProposalMsg(_) => "ProposalMsg",
+            ConsensusMsg::VersionedProposalMsg(_) => "VersionedProposalMsg",
             ConsensusMsg::SyncInfo(_) => "SyncInfo",
+            ConsensusMsg::VersionedSyncInfo(_) => "VersionedSyncInfo",
             ConsensusMsg::EpochChangeProof(_) => "EpochChangeProof",
             ConsensusMsg::VoteMsg(_) => "VoteMsg",
+            ConsensusMsg::VersionedVoteMsg(_) => "VersionedVoteMsg",
+            ConsensusMsg::OrderVoteMsg(_) => "OrderVoteMsg",
             ConsensusMsg::CommitVoteMsg(_) => "CommitVoteMsg",
             ConsensusMsg::CommitDecisionMsg(_) => "CommitDecisionMsg",
             ConsensusMsg::BatchMsg(_) => "BatchMsg",

--- a/consensus/src/recovery_manager.rs
+++ b/consensus/src/recovery_manager.rs
@@ -139,28 +139,13 @@ impl RecoveryManager {
                         VerifiedEvent::ProposalMsg(proposal_msg) => {
                             monitor!(
                                 "process_recovery",
-                                self.process_proposal_msg(VersionedProposalMsg::V1(*proposal_msg)).await
-                            )
-                        }
-                        VerifiedEvent::VersionedProposalMsg(proposal_msg) => {
-                            monitor!(
-                                "process_recovery",
                                 self.process_proposal_msg(*proposal_msg).await
                             )
                         }
                         VerifiedEvent::VoteMsg(vote_msg) => {
-                            monitor!("process_recovery", self.process_vote_msg(VersionedVoteMsg::V1(*vote_msg)).await)
-                        }
-                        VerifiedEvent::VersionedVoteMsg(vote_msg) => {
                             monitor!("process_recovery", self.process_vote_msg(*vote_msg).await)
                         }
                         VerifiedEvent::UnverifiedSyncInfo(sync_info) => {
-                            monitor!(
-                                "process_recovery",
-                                self.sync_up(&VersionedSyncInfo::V1(sync_info.as_ref().clone()), peer_id).await
-                            )
-                        }
-                        VerifiedEvent::UnverifiedVersionedSyncInfo(sync_info) => {
                             monitor!(
                                 "process_recovery",
                                 self.sync_up(&sync_info, peer_id).await

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -26,7 +26,7 @@ use aptos_config::{
     config::{ConsensusConfig, QcAggregatorType},
     network_id::NetworkId,
 };
-use aptos_consensus_types::proposal_msg::ProposalMsg;
+use aptos_consensus_types::proposal_msg::VersionedProposalMsg;
 use aptos_infallible::Mutex;
 use aptos_network::{
     application::{interface::NetworkClient, storage::PeersAndMetadata},
@@ -227,7 +227,7 @@ pub fn fuzz_proposal(data: &[u8]) {
     // create node
     let mut round_manager = create_node_for_fuzzing();
 
-    let proposal: ProposalMsg = match serde_json::from_slice(data) {
+    let proposal = VersionedProposalMsg::V1(match serde_json::from_slice(data) {
         Ok(xx) => xx,
         Err(_) => {
             if cfg!(test) {
@@ -235,7 +235,7 @@ pub fn fuzz_proposal(data: &[u8]) {
             }
             return;
         },
-    };
+    });
 
     let proposal = match proposal.verify_well_formed() {
         Ok(_) => proposal,

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -2058,8 +2058,8 @@ pub fn forking_retrieval_test() {
             nodes[proposal_node]
                 .pending_network_events
                 .push(Event::Message(
-                    peer, 
-                    ConsensusMsg::VersionedProposalMsg(msg)
+                    peer,
+                    ConsensusMsg::VersionedProposalMsg(msg),
                 ))
         },
         _ => panic!("unexpected network message {:?}", next_message),

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -2051,6 +2051,14 @@ pub fn forking_retrieval_test() {
                 .pending_network_events
                 .push(Event::Message(peer, ConsensusMsg::ProposalMsg(msg)))
         },
+        ConsensusMsg::VersionedProposalMsg(msg) => {
+            // put the message back in the queue.
+            // actual peer doesn't matter, it is ignored, so use self.
+            let peer = nodes[proposal_node].signer.author();
+            nodes[proposal_node]
+                .pending_network_events
+                .push(Event::Message(peer, ConsensusMsg::VersionedProposalMsg(msg)))
+        },
         _ => panic!("unexpected network message {:?}", next_message),
     }
     process_and_vote_on_proposal(

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -2057,7 +2057,10 @@ pub fn forking_retrieval_test() {
             let peer = nodes[proposal_node].signer.author();
             nodes[proposal_node]
                 .pending_network_events
-                .push(Event::Message(peer, ConsensusMsg::VersionedProposalMsg(msg)))
+                .push(Event::Message(
+                    peer, 
+                    ConsensusMsg::VersionedProposalMsg(msg)
+                ))
         },
         _ => panic!("unexpected network message {:?}", next_message),
     }

--- a/testsuite/generate-format/src/consensus.rs
+++ b/testsuite/generate-format/src/consensus.rs
@@ -117,7 +117,9 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<aptos_consensus_types::block_data::BlockType>(&samples)?;
     tracer.trace_type::<aptos_consensus_types::block_retrieval::BlockRetrievalStatus>(&samples)?;
     tracer.trace_type::<aptos_consensus_types::common::Payload>(&samples)?;
-
+    tracer.trace_type::<aptos_consensus_types::vote_msg::VersionedVoteMsg>(&samples)?;
+    tracer.trace_type::<aptos_consensus_types::sync_info::VersionedSyncInfo>(&samples)?;
+    tracer.trace_type::<aptos_consensus_types::proposal_msg::VersionedProposalMsg>(&samples)?;
     // aliases within StructTag
     tracer.ignore_aliases("StructTag", &["type_params"])?;
 

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -332,58 +332,74 @@ ConsensusMsg:
         NEWTYPE:
           TYPENAME: ProposalMsg
     4:
+      VersionedProposalMsg:
+        NEWTYPE:
+          TYPENAME: VersionedProposalMsg
+    5:
       SyncInfo:
         NEWTYPE:
           TYPENAME: SyncInfo
-    5:
+    6:
+      VersionedSyncInfo:
+        NEWTYPE:
+          TYPENAME: VersionedSyncInfo
+    7:
       EpochChangeProof:
         NEWTYPE:
           TYPENAME: EpochChangeProof
-    6:
+    8:
       VoteMsg:
         NEWTYPE:
           TYPENAME: VoteMsg
-    7:
+    9:
+      VersionedVoteMsg:
+        NEWTYPE:
+          TYPENAME: VersionedVoteMsg
+    10:
+      OrderVoteMsg:
+        NEWTYPE:
+          TYPENAME: OrderVote
+    11:
       CommitVoteMsg:
         NEWTYPE:
           TYPENAME: CommitVote
-    8:
+    12:
       CommitDecisionMsg:
         NEWTYPE:
           TYPENAME: CommitDecision
-    9:
+    13:
       BatchMsg:
         NEWTYPE:
           TYPENAME: BatchMsg
-    10:
+    14:
       BatchRequestMsg:
         NEWTYPE:
           TYPENAME: BatchRequest
-    11:
+    15:
       BatchResponse:
         NEWTYPE:
           TYPENAME: Batch
-    12:
+    16:
       SignedBatchInfo:
         NEWTYPE:
           TYPENAME: SignedBatchInfoMsg
-    13:
+    17:
       ProofOfStoreMsg:
         NEWTYPE:
           TYPENAME: ProofOfStoreMsg
-    14:
+    18:
       DAGMessage:
         NEWTYPE:
           TYPENAME: DAGNetworkMessage
-    15:
+    19:
       CommitMessage:
         NEWTYPE:
           TYPENAME: CommitMessage
-    16:
+    20:
       RandGenMessage:
         NEWTYPE:
           TYPENAME: RandGenMessage
-    17:
+    21:
       BatchResponseV2:
         NEWTYPE:
           TYPENAME: BatchResponse
@@ -690,6 +706,22 @@ ProposalMsg:
         TYPENAME: Block
     - sync_info:
         TYPENAME: SyncInfo
+ProposalMsgV2:
+  STRUCT:
+    - proposal:
+        TYPENAME: Block
+    - sync_info:
+        TYPENAME: VersionedSyncInfo
+VersionedProposalMsg:
+  ENUM:
+    0:
+      V1:
+        NEWTYPE:
+          TYPENAME: ProposalMsg
+    1:
+      V2:
+        NEWTYPE:
+          TYPENAME: ProposalMsgV2
 ProviderJWKs:
   STRUCT:
     - issuer: BYTES
@@ -835,6 +867,28 @@ SyncInfo:
     - highest_2chain_timeout_cert:
         OPTION:
           TYPENAME: TwoChainTimeoutCertificate
+SyncInfoV2:
+  STRUCT:
+    - highest_quorum_cert:
+        TYPENAME: QuorumCert
+    - highest_ordered_decision:
+        OPTION:
+          TYPENAME: LedgerInfoWithSignatures
+    - highest_commit_decision:
+        TYPENAME: LedgerInfoWithSignatures
+    - highest_2chain_timeout_cert:
+        OPTION:
+          TYPENAME: TwoChainTimeoutCertificate
+VersionedSyncInfo:
+  ENUM:
+    0:
+      V1:
+        NEWTYPE:
+          TYPENAME: SyncInfo
+    1:
+      V2:
+        NEWTYPE:
+          TYPENAME: SyncInfoV2
 TableHandle:
   NEWTYPESTRUCT:
     TYPENAME: AccountAddress
@@ -1024,6 +1078,14 @@ ValidatorVerifier:
     - validator_infos:
         SEQ:
           TYPENAME: ValidatorConsensusInfo
+OrderVote:
+  STRUCT:
+    - author:
+        TYPENAME: AccountAddress
+    - ledger_info:
+        TYPENAME: LedgerInfo
+    - signature:
+        TYPENAME: Signature
 Vote:
   STRUCT:
     - vote_data:
@@ -1051,6 +1113,22 @@ VoteMsg:
         TYPENAME: Vote
     - sync_info:
         TYPENAME: SyncInfo
+VoteMsgV2:
+  STRUCT:
+    - vote:
+        TYPENAME: Vote
+    - sync_info:
+        TYPENAME: VersionedSyncInfo
+VersionedVoteMsg:
+  ENUM:
+    0:
+      V1:
+        NEWTYPE:
+          TYPENAME: VoteMsg
+    1:
+      V2:
+        NEWTYPE:
+          TYPENAME: VoteMsgV2
 WriteOp:
   ENUM:
     0:


### PR DESCRIPTION
## Description
This PR adds versioned proposal message, versioned vote message and versioned SyncInfo. This change lets changing the structure of consensus messages for future upgrades. Order vote optimization changes the structure of sync info. This PR is prerequisite for deploying the order vote optimization.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
