### PR TITLE
[aptosvm] hack to charge more for keyless

### DIFF
--- a/aptos-move/aptos-gas-meter/src/meter.rs
+++ b/aptos-move/aptos-gas-meter/src/meter.rs
@@ -545,13 +545,19 @@ where
             .map_err(|e| e.finish(Location::Undefined))
     }
 
-    fn charge_intrinsic_gas_for_transaction(&mut self, txn_size: NumBytes) -> VMResult<()> {
+    fn charge_intrinsic_gas_for_transaction(
+        &mut self,
+        txn_size: NumBytes,
+        multiplier: NumBytes,
+    ) -> VMResult<()> {
         let excess = txn_size
             .checked_sub(self.vm_gas_params().txn.large_transaction_cutoff)
             .unwrap_or_else(|| 0.into());
 
         self.algebra
-            .charge_execution(MIN_TRANSACTION_GAS_UNITS + INTRINSIC_GAS_PER_BYTE * excess)
+            .charge_execution(
+                MIN_TRANSACTION_GAS_UNITS * multiplier + INTRINSIC_GAS_PER_BYTE * excess,
+            )
             .map_err(|e| e.finish(Location::Undefined))
     }
 }

--- a/aptos-move/aptos-gas-meter/src/traits.rs
+++ b/aptos-move/aptos-gas-meter/src/traits.rs
@@ -110,8 +110,13 @@ pub trait AptosGasMeter: MoveGasMeter {
     /// Charges an intrinsic cost for executing the transaction.
     ///
     /// The cost stays constant for transactions below a certain size, but will grow proportionally
-    /// for bigger ones.
-    fn charge_intrinsic_gas_for_transaction(&mut self, txn_size: NumBytes) -> VMResult<()>;
+    /// for bigger ones. THe multiplier can be used to increase the unit cost for exceptional
+    /// transactions like keyless.
+    fn charge_intrinsic_gas_for_transaction(
+        &mut self,
+        txn_size: NumBytes,
+        multiplier: NumBytes,
+    ) -> VMResult<()>;
 
     /// Charges IO gas for the transaction itself.
     fn charge_io_gas_for_transaction(&mut self, txn_size: NumBytes) -> VMResult<()>;

--- a/aptos-move/aptos-gas-profiling/src/profiler.rs
+++ b/aptos-move/aptos-gas-profiling/src/profiler.rs
@@ -642,9 +642,14 @@ where
         Ok(total_refund)
     }
 
-    fn charge_intrinsic_gas_for_transaction(&mut self, txn_size: NumBytes) -> VMResult<()> {
-        let (cost, res) =
-            self.delegate_charge(|base| base.charge_intrinsic_gas_for_transaction(txn_size));
+    fn charge_intrinsic_gas_for_transaction(
+        &mut self,
+        txn_size: NumBytes,
+        multiplier: NumBytes,
+    ) -> VMResult<()> {
+        let (cost, res) = self.delegate_charge(|base| {
+            base.charge_intrinsic_gas_for_transaction(txn_size, multiplier)
+        });
 
         self.intrinsic_cost = Some(cost);
 

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
@@ -22,8 +22,9 @@ crate::gas_schedule::macros::define_gas_parameters!(
     [
         // The flat minimum amount of gas required for any transaction.
         // Charged at the start of execution.
+        // It is variable to charge more for more expensive authenticators, e.g., keyless
         [
-            min_transaction_gas_units: InternalGas,
+            min_transaction_gas_units: InternalGasPerByte,
             "min_transaction_gas_units",
             2_760_000
         ],
@@ -230,6 +231,11 @@ crate::gas_schedule::macros::define_gas_parameters!(
             { 15.. => "max_total_dependency_size" },
             1024 * 1024 * 12 / 10, // 1.2 MB
         ],
+        [
+            keyless_multiplier: NumBytes,
+            { 16.. => "keyless_multiplier" },
+            150,
+        ]
     ]
 );
 
@@ -249,12 +255,13 @@ impl TransactionGasParameters {
     pub fn calculate_intrinsic_gas(
         &self,
         transaction_size: NumBytes,
+        multiplier: NumBytes,
     ) -> impl GasExpression<VMGasParameters, Unit = InternalGasUnit> {
         let excess = transaction_size
             .checked_sub(self.large_transaction_cutoff)
             .unwrap_or_else(|| 0.into());
 
-        MIN_TRANSACTION_GAS_UNITS + INTRINSIC_GAS_PER_BYTE * excess
+        MIN_TRANSACTION_GAS_UNITS * multiplier + INTRINSIC_GAS_PER_BYTE * excess
     }
 }
 

--- a/aptos-move/aptos-memory-usage-tracker/src/lib.rs
+++ b/aptos-move/aptos-memory-usage-tracker/src/lib.rs
@@ -488,6 +488,6 @@ where
             gas_unit_price: FeePerGasUnit,
         ) -> PartialVMResult<()>;
 
-        fn charge_intrinsic_gas_for_transaction(&mut self, txn_size: NumBytes) -> VMResult<()>;
+        fn charge_intrinsic_gas_for_transaction(&mut self, txn_size: NumBytes, multiplier: NumBytes) -> VMResult<()>;
     }
 }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -816,7 +816,13 @@ impl AptosVM {
             })
         });
 
-        gas_meter.charge_intrinsic_gas_for_transaction(txn_data.transaction_size())?;
+        let multiplier = if txn_data.is_keyless() {
+            let gas_params = get_or_vm_startup_failure(&self.gas_params, log_context)?;
+            gas_params.vm.txn.keyless_multiplier
+        } else {
+            NumBytes::one()
+        };
+        gas_meter.charge_intrinsic_gas_for_transaction(txn_data.transaction_size(), multiplier)?;
 
         match payload {
             TransactionPayload::Script(script) => {
@@ -1000,7 +1006,13 @@ impl AptosVM {
             ))
         });
 
-        gas_meter.charge_intrinsic_gas_for_transaction(txn_data.transaction_size())?;
+        let multiplier = if txn_data.is_keyless() {
+            let gas_params = get_or_vm_startup_failure(&self.gas_params, log_context)?;
+            gas_params.vm.txn.keyless_multiplier
+        } else {
+            NumBytes::one()
+        };
+        gas_meter.charge_intrinsic_gas_for_transaction(txn_data.transaction_size(), multiplier)?;
 
         // Step 1: Obtain the payload. If any errors happen here, the entire transaction should fail
         let invariant_violation_error = || {

--- a/aptos-move/aptos-vm/src/gas.rs
+++ b/aptos-move/aptos-vm/src/gas.rs
@@ -15,7 +15,7 @@ use aptos_vm_types::storage::{
     io_pricing::IoPricing, space_pricing::DiskSpacePricing, StorageGasParameters,
 };
 use move_core_types::{
-    gas_algebra::NumArgs,
+    gas_algebra::{NumArgs, NumBytes},
     language_storage::CORE_CODE_ADDRESS,
     vm_status::{StatusCode, VMStatus},
 };
@@ -186,8 +186,13 @@ pub(crate) fn check_gas(
     // The submitted transactions max gas units needs to be at least enough to cover the
     // intrinsic cost of the transaction as calculated against the size of the
     // underlying `RawTransaction`.
+    let multiplier = if txn_metadata.is_keyless() {
+        txn_gas_params.keyless_multiplier
+    } else {
+        NumBytes::one()
+    };
     let intrinsic_gas = txn_gas_params
-        .calculate_intrinsic_gas(raw_bytes_len)
+        .calculate_intrinsic_gas(raw_bytes_len, multiplier)
         .evaluate(gas_feature_version, &gas_params.vm)
         .to_unit_round_up_with_params(txn_gas_params);
 

--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -26,6 +26,7 @@ pub struct TransactionMetadata {
     pub script_hash: Vec<u8>,
     pub script_size: NumBytes,
     pub required_deposit: Option<u64>,
+    pub is_keyless: bool,
 }
 
 impl TransactionMetadata {
@@ -65,6 +66,9 @@ impl TransactionMetadata {
                 _ => NumBytes::zero(),
             },
             required_deposit: None,
+            is_keyless: aptos_types::keyless::get_authenticators(txn)
+                .map(|res| !res.is_empty())
+                .unwrap_or(false),
         }
     }
 
@@ -124,5 +128,9 @@ impl TransactionMetadata {
 
     pub fn set_required_deposit(&mut self, required_deposit: Option<u64>) {
         self.required_deposit = required_deposit;
+    }
+
+    pub fn is_keyless(&self) -> bool {
+        self.is_keyless
     }
 }

--- a/aptos-move/e2e-tests/src/account_universe/bad_transaction.rs
+++ b/aptos-move/e2e-tests/src/account_universe/bad_transaction.rs
@@ -11,7 +11,7 @@ use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     test_utils::KeyPair,
 };
-use aptos_gas_algebra::{FeePerGasUnit, Gas, GasExpression};
+use aptos_gas_algebra::{FeePerGasUnit, Gas, GasExpression, NumBytes};
 use aptos_gas_schedule::{AptosGasParameters, InitialGasSchedule, LATEST_GAS_FEATURE_VERSION};
 use aptos_proptest_helpers::Index;
 use aptos_types::{
@@ -92,7 +92,7 @@ impl AUTransactionGen for InsufficientBalanceGen {
         let txn_gas_params = &gas_params.vm.txn;
         let raw_bytes_len = txn.raw_txn_bytes_len() as u64;
         let min_cost: Gas = txn_gas_params
-            .calculate_intrinsic_gas(raw_bytes_len.into())
+            .calculate_intrinsic_gas(raw_bytes_len.into(), NumBytes::one())
             .evaluate(LATEST_GAS_FEATURE_VERSION, &gas_params.vm)
             .to_unit_round_up_with_params(txn_gas_params);
 

--- a/aptos-move/e2e-testsuite/src/tests/verify_txn.rs
+++ b/aptos-move/e2e-testsuite/src/tests/verify_txn.rs
@@ -4,7 +4,7 @@
 
 use aptos_cached_packages::aptos_stdlib;
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
-use aptos_gas_algebra::Gas;
+use aptos_gas_algebra::{Gas, NumBytes};
 use aptos_gas_schedule::{InitialGasSchedule, TransactionGasParameters};
 use aptos_language_e2e_tests::{
     assert_prologue_disparity, assert_prologue_parity, common_transactions::EMPTY_SCRIPT,
@@ -304,8 +304,7 @@ fn verify_simple_payment() {
 
     // Test for a max_gas_amount that is insufficient to pay the minimum fee.
     // Find the minimum transaction gas units and subtract 1.
-    let mut gas_limit: Gas = txn_gas_params
-        .min_transaction_gas_units
+    let mut gas_limit: Gas = (txn_gas_params.min_transaction_gas_units * NumBytes::one())
         .to_unit_round_up_with_params(&txn_gas_params);
 
     if gas_limit > 0.into() {


### PR DESCRIPTION
## Description
add a 150x multiplier for intrinsic gas for keyless txns
* Swap `min_transaction_gas_units` from `InternalGas` to `InternalGasPerByte` -- that has no underlying change but the semantic change allows for it to be multiplied
* Add in a multiplier for all intrinsic gas charges which will be 1 by default
* Set a gas schedule of 150 for keyless -- defaults to 150 since this is live on testnet already...

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
* went to e2e-move-tests
* added a println to output the gas consumed to a keyless transaction
* Without the change the gas cost was 7
* With the change it was 

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
