### PR TITLE
fix state kv truncate

### DIFF
--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -89,7 +89,7 @@ impl StateKvDb {
         };
 
         if let Some(overall_kv_commit_progress) = get_state_kv_commit_progress(&state_kv_db)? {
-            truncate_state_kv_db_shards(&state_kv_db, overall_kv_commit_progress, None)?;
+            truncate_state_kv_db_shards(&state_kv_db, overall_kv_commit_progress)?;
         }
 
         Ok(state_kv_db)


### PR DESCRIPTION
1. between batches, the progress should be updated after the deletions on shards.
2. in a single batch, the record is possible to equal "current_version"

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Validator Node

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

eyeing. it's rare except in Zhoujun's bulk testing. will observe if this fixes his seeing truncation failure.


## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
