### PR TITLE
[indexer-grpc] filestore can use subdirectories

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/config.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/config.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct GcsFileStore {
     pub gcs_file_store_bucket_name: String,
+    pub gcs_file_store_bucket_sub_dir: Option<String>,
     // Required to operate on GCS.
     pub gcs_file_store_service_account_key_path: String,
     #[serde(default = "default_enable_compression")]
@@ -47,6 +48,7 @@ impl IndexerGrpcFileStoreConfig {
             IndexerGrpcFileStoreConfig::GcsFileStore(gcs_file_store) => {
                 Box::new(crate::file_store_operator::gcs::GcsFileStoreOperator::new(
                     gcs_file_store.gcs_file_store_bucket_name.clone(),
+                    gcs_file_store.gcs_file_store_bucket_sub_dir.clone(),
                     gcs_file_store
                         .gcs_file_store_service_account_key_path
                         .clone(),

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/config.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/config.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct GcsFileStore {
     pub gcs_file_store_bucket_name: String,
-    pub gcs_file_store_bucket_sub_dir: Option<String>,
+    pub gcs_file_store_bucket_sub_dir: Option<PathBuf>,
     // Required to operate on GCS.
     pub gcs_file_store_service_account_key_path: String,
     #[serde(default = "default_enable_compression")]

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator/gcs.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator/gcs.rs
@@ -19,13 +19,16 @@ const FILE_STORE_METADATA_TIMEOUT_MILLIS: u128 = 200;
 #[derive(Clone)]
 pub struct GcsFileStoreOperator {
     bucket_name: String,
+    bucket_sub_dir: Option<String>,
     file_store_metadata_last_updated: std::time::Instant,
     storage_format: StorageFormat,
+    metadata_file_path: String,
 }
 
 impl GcsFileStoreOperator {
     pub fn new(
         bucket_name: String,
+        bucket_sub_dir: Option<String>,
         service_account_path: String,
         enable_compression: bool,
     ) -> Self {
@@ -35,10 +38,27 @@ impl GcsFileStoreOperator {
         } else {
             StorageFormat::JsonBase64UncompressedProto
         };
+        let metadata_file_path = match &bucket_sub_dir {
+            Some(sub_dir) => format!("{}/{}", sub_dir, METADATA_FILE_NAME),
+            None => METADATA_FILE_NAME.to_string(),
+        };
         Self {
             bucket_name,
+            bucket_sub_dir,
             file_store_metadata_last_updated: std::time::Instant::now(),
             storage_format,
+            metadata_file_path,
+        }
+    }
+
+    /// Given a version number, builds the key path for the file entry. This is dependent on the storage format and whether we opt
+    /// to use a sub directory, in the case of a shared bucket. The key path can be used directly as a GCS bucket file path.
+    fn get_file_entry_key_path(&self, version: u64) -> String {
+        let file_entry_key = FileEntry::build_key(version, self.storage_format).to_string();
+        // If the sub directory is set, the file entry key will be prefixed with the sub directory.
+        match &self.bucket_sub_dir {
+            Some(sub_dir) => format!("{}/{}", sub_dir, file_entry_key),
+            None => file_entry_key,
         }
     }
 }
@@ -66,8 +86,8 @@ impl FileStoreOperator for GcsFileStoreOperator {
     }
 
     async fn get_raw_file(&self, version: u64) -> anyhow::Result<Vec<u8>> {
-        let file_entry_key = FileEntry::build_key(version, self.storage_format).to_string();
-        match Object::download(&self.bucket_name, file_entry_key.as_str()).await {
+        let file_entry_key_path = self.get_file_entry_key_path(version);
+        match Object::download(&self.bucket_name, file_entry_key_path.as_str()).await {
             Ok(file) => Ok(file),
             Err(cloud_storage::Error::Other(err)) => {
                 if err.contains("No such object: ") {
@@ -90,7 +110,7 @@ impl FileStoreOperator for GcsFileStoreOperator {
 
     /// Gets the metadata from the file store. Operator will panic if error happens when accessing the metadata file(except not found).
     async fn get_file_store_metadata(&self) -> Option<FileStoreMetadata> {
-        match Object::download(&self.bucket_name, METADATA_FILE_NAME).await {
+        match Object::download(&self.bucket_name, &self.metadata_file_path).await {
             Ok(metadata) => {
                 let metadata: FileStoreMetadata =
                     serde_json::from_slice(&metadata).expect("Expected metadata to be valid JSON.");
@@ -150,7 +170,7 @@ impl FileStoreOperator for GcsFileStoreOperator {
         Object::create(
             self.bucket_name.as_str(),
             serde_json::to_vec(&metadata).unwrap(),
-            METADATA_FILE_NAME,
+            &self.metadata_file_path,
             JSON_FILE_TYPE,
         )
         .await?;
@@ -179,7 +199,7 @@ impl FileStoreOperator for GcsFileStoreOperator {
         let start_time = std::time::Instant::now();
         let bucket_name = self.bucket_name.clone();
         let file_entry = FileEntry::from_transactions(transactions, self.storage_format);
-        let file_entry_key = FileEntry::build_key(start_version, self.storage_format).to_string();
+        let file_entry_key_path = self.get_file_entry_key_path(start_version);
         log_grpc_step(
             "file_worker",
             IndexerGrpcStep::FileStoreEncodedTxns,
@@ -195,7 +215,7 @@ impl FileStoreOperator for GcsFileStoreOperator {
         Object::create(
             bucket_name.clone().as_str(),
             file_entry.into_inner(),
-            file_entry_key.as_str(),
+            file_entry_key_path.as_str(),
             JSON_FILE_TYPE,
         )
         .await?;


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This allows a single GCS bucket to be shared by multiple instances of indexer GRPC (file store operator), each using a different subdirectory/namespace. With this, we can enable many ephemeral indexer GRPC service stacks running at a time, sharing a bucket. This is for Forge-like testing of indexer. Subdirectories can be pruned using bucket lifecycle policies, or backed up if needed

A new optional config `gcs_file_store_bucket_sub_dir` enables this functionality. Otherwise, no-op

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Other (Indexer GRPC)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Deploy ephemeral indexer stacks e2e

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
