### PR TITLE
[forge] fix info logs for validators and fullnodes

### DIFF
--- a/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml
+++ b/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml
@@ -2,7 +2,7 @@ validator:
   enableNetworkPolicy: false
   # Add debug here to enable debug logs
   # rust_log: debug,hyper=off
-  rust_log: hyper=off
+  rust_log: info,hyper=off
   # force enable the telemetry service to try to send telemetry
   force_enable_telemetry: true
 
@@ -13,7 +13,7 @@ fullnode:
       replicas: 1
   # Add debug herer to enable debug logs
   # rust_log: debug,hyper=off
-  rust_log: hyper=off
+  rust_log: info,hyper=off
   # force enable the telemetry service to try to send telemetry
   force_enable_telemetry: true
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Fix forward for https://github.com/aptos-labs/aptos-core/pull/12917.

The `rust_log` helm value sets the `RUST_LOG` env var. Setting just `hyper=off` actually overwrites the default log level. Thus we need to set it to `info`

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Forge logs from the PR. The logs must include those from the validators/fullnodes from the Forge test's k8s namespace, as well as the test runner

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

The config

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
