### PR TITLE
Increase stack for test from 8 to 32 MB

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -41,7 +41,7 @@ jobs:
       - run: cargo llvm-cov --ignore-run-fail --workspace --exclude smoke-test --exclude aptos-testcases --lcov --jobs 32 --output-path lcov_unit.info -vv
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
-          RUST_MIN_STACK: 8388608
+          RUST_MIN_STACK: 33554432 # 32 MB of stack
       - uses: actions/upload-artifact@v3
         with:
           name: lcov_unit
@@ -66,7 +66,7 @@ jobs:
       - run: cargo llvm-cov --ignore-run-fail --package smoke-test --lcov --output-path lcov_smoke.info -vv
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
-          RUST_MIN_STACK: 8388608
+          RUST_MIN_STACK: 33554432
       - uses: actions/upload-artifact@v3
         with:
           name: lcov_smoke


### PR DESCRIPTION
## Description
Ongoing effort in fixing tests coverage on codecov, some tests hit a stack overflow trying to bump the stack size to 4 times the current size.
https://github.com/aptos-labs/aptos-core/pull/13013

## Type of Change
- [ ] New feature
- [ X] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ X] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [X ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Running CI/CD on this PR.

## Key Areas to Review
N.A.

## Checklist
- [X ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X ] I tested both happy and unhappy path of the functionality
- [ X] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
