### PR TITLE
[Mempool] Use a pool of VMs for transaction validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2495,6 +2495,7 @@ dependencies = [
  "futures",
  "itertools 0.12.1",
  "maplit",
+ "num_cpus",
  "once_cell",
  "proptest",
  "rand 0.7.3",

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -39,6 +39,7 @@ fail = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
 maplit = { workspace = true }
+num_cpus = { workspace = true }
 once_cell = { workspace = true }
 proptest = { workspace = true, optional = true }
 rand = { workspace = true }

--- a/mempool/src/shared_mempool/runtime.rs
+++ b/mempool/src/shared_mempool/runtime.rs
@@ -22,7 +22,7 @@ use aptos_network::application::{
 };
 use aptos_storage_interface::DbReader;
 use aptos_types::on_chain_config::OnChainConfigProvider;
-use aptos_vm_validator::vm_validator::{TransactionValidation, VMValidator};
+use aptos_vm_validator::vm_validator::{PooledVMValidator, TransactionValidation};
 use futures::channel::mpsc::{Receiver, UnboundedSender};
 use std::sync::Arc;
 use tokio::runtime::{Handle, Runtime};
@@ -99,7 +99,10 @@ pub fn bootstrap(
 ) -> Runtime {
     let runtime = aptos_runtimes::spawn_named_runtime("shared-mem".into(), None);
     let mempool = Arc::new(Mutex::new(CoreMempool::new(config)));
-    let vm_validator = Arc::new(RwLock::new(VMValidator::new(Arc::clone(&db))));
+    let vm_validator = Arc::new(RwLock::new(PooledVMValidator::new(
+        Arc::clone(&db),
+        num_cpus::get(),
+    )));
     start_shared_mempool(
         runtime.handle(),
         config,

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -20,6 +20,7 @@ aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
 aptos-vm-logging = { workspace = true }
 fail = { workspace = true }
+rand = { workspace = true }
 
 [dev-dependencies]
 aptos-cached-packages = { workspace = true }

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -18,7 +18,7 @@ use aptos_types::{
 use aptos_vm::{data_cache::AsMoveResolver, AptosVM};
 use aptos_vm_logging::log_schema::AdapterLogSchema;
 use fail::fail_point;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 #[cfg(test)]
 #[path = "unit_tests/vm_validator_test.rs"]
@@ -119,5 +119,55 @@ pub fn get_account_sequence_number(
     match AccountResource::fetch_move_resource(state_view, &address)? {
         Some(account_resource) => Ok(account_resource.sequence_number()),
         None => Ok(0),
+    }
+}
+
+// A pool of VMValidators that can be used to validate transactions concurrently. This is done because
+// the VM is not thread safe today. This is a temporary solution until the VM is made thread safe.
+#[derive(Clone)]
+pub struct PooledVMValidator {
+    vm_validators: Vec<Arc<Mutex<VMValidator>>>,
+    // Index of the next VM to use for validation
+    next_vm: Arc<Mutex<usize>>,
+}
+
+impl PooledVMValidator {
+    pub fn new(db_reader: Arc<dyn DbReader>, pool_size: usize) -> Self {
+        let mut vm_validators = Vec::new();
+        for _ in 0..pool_size {
+            vm_validators.push(Arc::new(Mutex::new(VMValidator::new(db_reader.clone()))));
+        }
+        PooledVMValidator {
+            vm_validators,
+            next_vm: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    pub fn get_next_vm(&self) -> Arc<Mutex<VMValidator>> {
+        let mut next_vm = self.next_vm.lock().unwrap();
+        let vm = self.vm_validators[*next_vm].clone();
+        *next_vm = (*next_vm + 1) % self.vm_validators.len();
+        vm
+    }
+}
+
+impl TransactionValidation for PooledVMValidator {
+    type ValidationInstance = AptosVM;
+
+    fn validate_transaction(&self, txn: SignedTransaction) -> Result<VMValidatorResult> {
+        self.get_next_vm().lock().unwrap().validate_transaction(txn)
+    }
+
+    fn restart(&mut self) -> Result<()> {
+        for vm_validator in &self.vm_validators {
+            vm_validator.lock().unwrap().restart()?;
+        }
+        Ok(())
+    }
+
+    fn notify_commit(&mut self) {
+        for vm_validator in &self.vm_validators {
+            vm_validator.lock().unwrap().notify_commit();
+        }
     }
 }


### PR DESCRIPTION
## Description

https://github.com/aptos-labs/aptos-core/pull/12940 introduced transaction validation to be done in parallel, however, the VM is not threadsafe. This change introduces a pool of VMs so that we can avoid race conditions in the VM. 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Existing UTs and Forge.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
