### PR TITLE
1.12 patch: higher execution gas limit

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -12,7 +12,7 @@ proposals:
           feature_version: 16
           overrides:
             - name: "txn.max_execution_gas"
-              value: 3676000000
+              value: 4000000000
   - name: step_2_upgrade_framework
     metadata:
       title: "Multi-step proposal to upgrade mainnet framework to v1.12"


### PR DESCRIPTION
Based on my simulation **3739 gas units** are needed for execution of framework upgrade with #13040 and #13027 .
Bumping the execution gas limit.

```
{"execution_gas_units":"3739","io_gas_units":"161","storage_fee_octas":"46320","storage_fee_refund_octas":"0","total_charge_gas_units":"4363"}
```
