### PR TITLE
[gha] Fix forge stable concurrency

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -8,6 +8,10 @@ permissions:
   id-token: write
   actions: write #required for workflow cancellation via check-aptos-core
 
+concurrency:
+  group: forge-stable-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   # Allow triggering manually
   workflow_dispatch:


### PR DESCRIPTION
We made a change to make sure there is only one forge stable running by using the same namespace depending on the branch name, however we forgot the other half of that change

Currently this means all forge stable runs collide with each other, but are not cancelled at workflow level leading to them racing and cancelling each other

This change ensures the entire workflow is cancelled in favor of the other job.

Test Plan: runs on PR
