### PR TITLE
[Compiler-V2] [Bugfix] Fix bug in unused parameter checker

### DIFF
--- a/third_party/move/move-compiler-v2/src/unused_params_checker.rs
+++ b/third_party/move/move-compiler-v2/src/unused_params_checker.rs
@@ -17,7 +17,9 @@ pub fn unused_params_checker(env: &GlobalEnv) {
     for module in env.get_modules() {
         if module.is_target() {
             for struct_env in module.get_structs() {
-                check_unused_params(&struct_env);
+                if !struct_env.is_ghost_memory() {
+                    check_unused_params(&struct_env);
+                }
             }
         }
     }

--- a/third_party/move/move-prover/src/lib.rs
+++ b/third_party/move/move-prover/src/lib.rs
@@ -85,8 +85,7 @@ pub fn run_move_prover_v2<W: WriteColor>(
         warn_unused: false,
         whole_program: false,
         compile_test_code: false,
-    }
-    .set_experiment(Experiment::UNUSED_STRUCT_PARAMS_CHECK, false);
+    };
 
     let mut env = move_compiler_v2::run_move_compiler_for_analysis(error_writer, compiler_options)?;
     run_move_prover_with_model_v2(&mut env, error_writer, options, now)
@@ -120,8 +119,7 @@ pub fn run_move_prover_with_model<W: WriteColor>(
     // Run the compiler v2 checking and rewriting pipeline
     let compiler_options = move_compiler_v2::Options::default()
         .set_experiment(Experiment::OPTIMIZE, false)
-        .set_experiment(Experiment::SPEC_REWRITE, true)
-        .set_experiment(Experiment::UNUSED_STRUCT_PARAMS_CHECK, false);
+        .set_experiment(Experiment::SPEC_REWRITE, true);
     env.set_extension(compiler_options.clone());
     let pipeline = move_compiler_v2::check_and_rewrite_pipeline(
         &compiler_options,


### PR DESCRIPTION
## Description

Fixes #13093 by not checking for structures generated from ghost variables.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)