### PR TITLE
[quorum store] better handling of proofs in proof coordinator

### DIFF
--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -244,8 +244,8 @@ impl SignedBatchInfo {
         Ok(validator.verify(self.signer, &self.info, &self.signature)?)
     }
 
-    pub fn signature(self) -> bls12381::Signature {
-        self.signature
+    pub fn signature(&self) -> &bls12381::Signature {
+        &self.signature
     }
 
     pub fn batch_info(&self) -> &BatchInfo {

--- a/consensus/src/logging.rs
+++ b/consensus/src/logging.rs
@@ -28,6 +28,7 @@ pub enum LogEvent {
     NewRound,
     ProofOfStoreInit,
     ProofOfStoreReady,
+    ProofOfStoreCommit,
     Propose,
     ReceiveBatchRetrieval,
     ReceiveBlockRetrieval,

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -713,3 +713,11 @@ pub static BATCH_RECEIVED_REPLIES_VOTING_POWER: Lazy<Histogram> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub static BATCH_RECEIVED_LATE_REPLIES_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "quorum_store_batch_received_late_replies",
+        "Number of votes that came late."
+    )
+    .unwrap()
+});

--- a/consensus/src/quorum_store/proof_coordinator.rs
+++ b/consensus/src/quorum_store/proof_coordinator.rs
@@ -317,6 +317,8 @@ impl ProofCoordinator {
                                         let incremental_proof = existing_proof.get();
                                         if incremental_proof.completed {
                                             counters::BATCH_SUCCESSFUL_CREATION.observe(1.0);
+                                        } else {
+                                            info!("QS: received commit notification for batch that did not complete: {}, self_voted: {}", digest, incremental_proof.self_voted);
                                         }
                                         debug!(
                                             LogSchema::new(LogEvent::ProofOfStoreCommit),

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -277,7 +277,7 @@ fn main() -> Result<()> {
     logger.build();
 
     let args = Args::parse();
-    let duration = Duration::from_secs(args.duration_secs as u64);
+    let duration = Duration::from_secs(1600);
     let suite_name: &str = args.suite.as_ref();
 
     let runtime = Runtime::new()?;

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -604,9 +604,7 @@ fn get_land_blocking_test(
     test_cmd: &TestCommand,
 ) -> Option<ForgeConfig> {
     let test = match test_name {
-        "land_blocking" | "realistic_env_max_load" => {
-            realistic_env_max_load_test(duration, test_cmd, 7, 5)
-        },
+        "land_blocking" | "realistic_env_max_load" => realistic_env_graceful_overload(),
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),
         _ => return None, // The test name does not match a land-blocking test

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -604,7 +604,7 @@ fn get_land_blocking_test(
     test_cmd: &TestCommand,
 ) -> Option<ForgeConfig> {
     let test = match test_name {
-        "land_blocking" | "realistic_env_max_load" => realistic_env_graceful_overload(),
+        "land_blocking" | "realistic_env_max_load" => realistic_env_workload_sweep_test(),
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),
         _ => return None, // The test name does not match a land-blocking test

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -277,7 +277,7 @@ fn main() -> Result<()> {
     logger.build();
 
     let args = Args::parse();
-    let duration = Duration::from_secs(1600);
+    let duration = Duration::from_secs(args.duration_secs as u64);
     let suite_name: &str = args.suite.as_ref();
 
     let runtime = Runtime::new()?;
@@ -604,7 +604,9 @@ fn get_land_blocking_test(
     test_cmd: &TestCommand,
 ) -> Option<ForgeConfig> {
     let test = match test_name {
-        "land_blocking" | "realistic_env_max_load" => realistic_env_workload_sweep_test(),
+        "land_blocking" | "realistic_env_max_load" => {
+            realistic_env_max_load_test(duration, test_cmd, 7, 5)
+        },
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),
         _ => return None, // The test name does not match a land-blocking test


### PR DESCRIPTION
## Description
The motivation is our metrics show failed quorums when there are late votes, even if the quorum was in fact reached before the late votes. There were subtle bugs in metrics when inline batches are used (before getting quorum) and/or batches with the same digests (either remotely or locally) are created.

Thinking a bit more, there's no reason to use digest in proof coordinator, so changing to use the batch info instead. This means we no longer have to disambiguate between batches that are possibly created with the same digests (either remotely or locally). This simplifies the code significantly while dealing with the above issues.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Ran forge stable workload sweep test, which has gas cut

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
