### PR TITLE
trivial: storage-interface not depend on rocksdb::Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3587,7 +3587,6 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rayon",
- "rocksdb",
  "serde",
  "thiserror",
  "threadpool",

--- a/storage/schemadb/src/iterator.rs
+++ b/storage/schemadb/src/iterator.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    KeyCodec, Schema, SeekKeyCodec, ValueCodec, APTOS_SCHEMADB_ITER_BYTES,
+    IntoDbResult, KeyCodec, Schema, SeekKeyCodec, ValueCodec, APTOS_SCHEMADB_ITER_BYTES,
     APTOS_SCHEMADB_ITER_LATENCY_SECONDS, APTOS_SCHEMADB_SEEK_LATENCY_SECONDS,
 };
 use std::marker::PhantomData;
@@ -84,7 +84,7 @@ where
             .start_timer();
 
         if !self.db_iter.valid() {
-            self.db_iter.status()?;
+            self.db_iter.status().into_db_res()?;
             return Ok(None);
         }
 

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -30,7 +30,6 @@ parking_lot = { workspace = true }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 rayon = { workspace = true }
-rocksdb = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 threadpool = { workspace = true }

--- a/storage/storage-interface/src/errors.rs
+++ b/storage/storage-interface/src/errors.rs
@@ -45,12 +45,6 @@ impl From<bcs::Error> for AptosDbError {
     }
 }
 
-impl From<rocksdb::Error> for AptosDbError {
-    fn from(error: rocksdb::Error) -> Self {
-        Self::RocksDbError(format!("{}", error))
-    }
-}
-
 impl From<RecvError> for AptosDbError {
     fn from(error: RecvError) -> Self {
         Self::RecvError(format!("{}", error))


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

as requested in https://github.com/aptos-labs/aptos-core/issues/12451

## Type of Change
- [x] Refactoring


## Which Components or Systems Does This Change Impact?
- [x] Validator Node


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
build
existing coverage

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
