### PR TITLE
Add test-only code publish function

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/code.md
+++ b/aptos-move/framework/aptos-framework/doc/code.md
@@ -23,6 +23,7 @@ This module supports functionality related to code management.
 -  [Function `can_change_upgrade_policy_to`](#0x1_code_can_change_upgrade_policy_to)
 -  [Function `initialize`](#0x1_code_initialize)
 -  [Function `publish_package`](#0x1_code_publish_package)
+-  [Function `publish_package_inner`](#0x1_code_publish_package_inner)
 -  [Function `freeze_code_object`](#0x1_code_freeze_code_object)
 -  [Function `publish_package_txn`](#0x1_code_publish_package_txn)
 -  [Function `check_upgradability`](#0x1_code_check_upgradability)
@@ -692,6 +693,35 @@ package.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="code.md#0x1_code_publish_package">publish_package</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, pack: <a href="code.md#0x1_code_PackageMetadata">PackageMetadata</a>, <a href="code.md#0x1_code">code</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;) <b>acquires</b> <a href="code.md#0x1_code_PackageRegistry">PackageRegistry</a> {
+    <a href="code.md#0x1_code_publish_package_inner">publish_package_inner</a>(owner, pack, <a href="code.md#0x1_code">code</a>, <b>true</b>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_code_publish_package_inner"></a>
+
+## Function `publish_package_inner`
+
+
+
+<pre><code><b>fun</b> <a href="code.md#0x1_code_publish_package_inner">publish_package_inner</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, pack: <a href="code.md#0x1_code_PackageMetadata">code::PackageMetadata</a>, <a href="code.md#0x1_code">code</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;, request_publish: bool)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>inline <b>fun</b> <a href="code.md#0x1_code_publish_package_inner">publish_package_inner</a>(
+    owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    pack: <a href="code.md#0x1_code_PackageMetadata">PackageMetadata</a>,
+    <a href="code.md#0x1_code">code</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
+    request_publish: bool,
+) <b>acquires</b> <a href="code.md#0x1_code_PackageRegistry">PackageRegistry</a> {
     <a href="code.md#0x1_code_check_code_publishing_permission">check_code_publishing_permission</a>(owner);
     // Disallow incompatible upgrade mode. Governance can decide later <b>if</b> this should be reconsidered.
     <b>assert</b>!(
@@ -745,12 +775,14 @@ package.
     });
 
     // Request publish
-    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_code_dependency_check_enabled">features::code_dependency_check_enabled</a>())
-        <a href="code.md#0x1_code_request_publish_with_allowed_deps">request_publish_with_allowed_deps</a>(addr, module_names, allowed_deps, <a href="code.md#0x1_code">code</a>, policy.policy)
-    <b>else</b>
-    // The new `request_publish_with_allowed_deps` <b>has</b> not yet rolled out, so call downwards
-    // compatible <a href="code.md#0x1_code">code</a>.
-        <a href="code.md#0x1_code_request_publish">request_publish</a>(addr, module_names, <a href="code.md#0x1_code">code</a>, policy.policy)
+    <b>if</b> (request_publish) {
+        <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_code_dependency_check_enabled">features::code_dependency_check_enabled</a>())
+            <a href="code.md#0x1_code_request_publish_with_allowed_deps">request_publish_with_allowed_deps</a>(addr, module_names, allowed_deps, <a href="code.md#0x1_code">code</a>, policy.policy)
+        <b>else</b>
+        // The new `request_publish_with_allowed_deps` <b>has</b> not yet rolled out, so call downwards
+        // compatible <a href="code.md#0x1_code">code</a>.
+            <a href="code.md#0x1_code_request_publish">request_publish</a>(addr, module_names, <a href="code.md#0x1_code">code</a>, policy.policy)
+    }
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/code.move
+++ b/aptos-move/framework/aptos-framework/sources/code.move
@@ -166,6 +166,15 @@ module aptos_framework::code {
     /// Publishes a package at the given signer's address. The caller must provide package metadata describing the
     /// package.
     public fun publish_package(owner: &signer, pack: PackageMetadata, code: vector<vector<u8>>) acquires PackageRegistry {
+        publish_package_inner(owner, pack, code, true)
+    }
+
+    inline fun publish_package_inner(
+        owner: &signer,
+        pack: PackageMetadata,
+        code: vector<vector<u8>>,
+        request_publish: bool,
+    ) acquires PackageRegistry {
         check_code_publishing_permission(owner);
         // Disallow incompatible upgrade mode. Governance can decide later if this should be reconsidered.
         assert!(
@@ -219,12 +228,14 @@ module aptos_framework::code {
         });
 
         // Request publish
-        if (features::code_dependency_check_enabled())
-            request_publish_with_allowed_deps(addr, module_names, allowed_deps, code, policy.policy)
-        else
-        // The new `request_publish_with_allowed_deps` has not yet rolled out, so call downwards
-        // compatible code.
-            request_publish(addr, module_names, code, policy.policy)
+        if (request_publish) {
+            if (features::code_dependency_check_enabled())
+                request_publish_with_allowed_deps(addr, module_names, allowed_deps, code, policy.policy)
+            else
+            // The new `request_publish_with_allowed_deps` has not yet rolled out, so call downwards
+            // compatible code.
+                request_publish(addr, module_names, code, policy.policy)
+        }
     }
 
     public fun freeze_code_object(publisher: &signer, code_object: Object<PackageRegistry>) acquires PackageRegistry {
@@ -387,4 +398,21 @@ module aptos_framework::code {
         bundle: vector<vector<u8>>,
         policy: u8
     );
+
+    #[test_only]
+    /// Allows publication of multiple packages during a single txn for testing purposes, by
+    /// circumventing the request publish native function, which only allows publication of one
+    /// package during a single transaction.
+    public fun publish_package_txn_for_testing(
+        owner: &signer,
+        metadata_serialized: vector<u8>,
+        code: vector<vector<u8>>,
+    ) acquires PackageRegistry {
+        publish_package_inner(
+            owner,
+            util::from_bytes<PackageMetadata>(metadata_serialized),
+            code,
+            false,
+        )
+    }
 }


### PR DESCRIPTION
# Current problem

Currently the `code` module lacks test-only functions, making it difficult for devs to mock out or stub behaviors that depend on autonomous publication during runtime.

In particular, when a package is published via `code::publish_package_txn()`, an inner call to `check_dependencies` verifies that each of its dependencies have a `code::PackageRegistry` resource under their accounts:

https://github.com/aptos-labs/aptos-core/blob/66d9efb7d30b7c6916f79b6ef65f0bdcbe9c6acb/aptos-move/framework/aptos-framework/sources/code.move#L273

In the general case, the only way to ensure that a `PackageRegistry` exists under an account is to call `code::publish_package_txn()`:

https://github.com/aptos-labs/aptos-core/blob/66d9efb7d30b7c6916f79b6ef65f0bdcbe9c6acb/aptos-move/framework/aptos-framework/sources/code.move#L155-L157

Hence, to run a test that calls `code::publish_package_txn()`, there first needs to be setup that calls the same function for each of the expected dependencies. Problematically, however, this function relies on an inner call to the `native_request_publish` native function in `code.rs`, which errors out with `EALREADY_REQUESTED` when one attempts to publish two packages in the same txn:

https://github.com/aptos-labs/aptos-core/blob/66d9efb7d30b7c6916f79b6ef65f0bdcbe9c6acb/aptos-move/framework/aptos-framework/sources/code.move#L199-L205

https://github.com/aptos-labs/aptos-core/blob/66d9efb7d30b7c6916f79b6ef65f0bdcbe9c6acb/aptos-move/framework/src/natives/code.rs#L319-L323

Hence it is impossible to write unit tests for code that publishes a package with even a single dependency (because it is impossible to publish both the dependency and the relevant package during the same unit test, since `native_request_publish` throws `EALREADY_REQUESTED`).

For packages that have more than one dependency, it is impossible to publish *even the dependencies* (e.g. to ensure that  a `code::PackageRegistry` exists under each relevant account) for the same reason.

# Solution

- This PR adds a test-only code publish function, `code::publish_package_txn_for_testing()` which circumvents the above hassle by simply ignoring the blocking native function call (which appears to mainly serve metering purposes and occurs after all other extensive validation)
- Abstract out the publish func inner logic so that identical code (except for the offending native function call) is used both in tests and during runtime

This approach will allow developers to write unit tests for code that calls `code::publish_package_txn()`

# Housekeeping

The following was run from repository root to ensure CI passes:

```sh
cargo build -p aptos-cached-packages
pre-commit run --all-files
scripts/rust_lint.sh
aptos move test --package-dir aptos-move/framework/aptos-framework/ --dev
```