### PR TITLE
[framework] A few minor fix for dispatchable token 

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/dispatchable_fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/dispatchable_fungible_asset.md
@@ -44,6 +44,7 @@ See AIP-73 for further discussion
 <b>use</b> <a href="fungible_asset.md#0x1_fungible_asset">0x1::fungible_asset</a>;
 <b>use</b> <a href="object.md#0x1_object">0x1::object</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
 </code></pre>
 
 
@@ -87,6 +88,16 @@ Feature is not activated yet on the network.
 
 
 <pre><code><b>const</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_ENOT_ACTIVATED">ENOT_ACTIVATED</a>: u64 = 3;
+</code></pre>
+
+
+
+<a id="0x1_dispatchable_fungible_asset_ENOT_STORE_OWNER"></a>
+
+Account is not the store's owner.
+
+
+<pre><code><b>const</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_ENOT_STORE_OWNER">ENOT_STORE_OWNER</a>: u64 = 5;
 </code></pre>
 
 
@@ -191,6 +202,8 @@ The semantics of deposit will be governed by the function specified in DispatchF
             <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_dispatchable_fungible_asset_enabled">features::dispatchable_fungible_asset_enabled</a>(),
             <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_aborted">error::aborted</a>(<a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_ENOT_ACTIVATED">ENOT_ACTIVATED</a>)
         );
+        <a href="fungible_asset.md#0x1_fungible_asset_assert_not_frozen">fungible_asset::assert_not_frozen</a>(store);
+        <b>assert</b>!(<a href="object.md#0x1_object_owns">object::owns</a>(store, <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_ENOT_STORE_OWNER">ENOT_STORE_OWNER</a>));
         <b>let</b> start_balance = <a href="fungible_asset.md#0x1_fungible_asset_balance">fungible_asset::balance</a>(store);
         <b>let</b> func = <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&func_opt);
         <a href="function_info.md#0x1_function_info_load_module_from_function">function_info::load_module_from_function</a>(func);
@@ -238,6 +251,7 @@ The semantics of deposit will be governed by the function specified in DispatchF
             <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_dispatchable_fungible_asset_enabled">features::dispatchable_fungible_asset_enabled</a>(),
             <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_aborted">error::aborted</a>(<a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_ENOT_ACTIVATED">ENOT_ACTIVATED</a>)
         );
+        <a href="fungible_asset.md#0x1_fungible_asset_assert_not_frozen">fungible_asset::assert_not_frozen</a>(store);
         <b>let</b> func = <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&func_opt);
         <a href="function_info.md#0x1_function_info_load_module_from_function">function_info::load_module_from_function</a>(func);
         <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_dispatchable_deposit">dispatchable_deposit</a>(

--- a/aptos-move/framework/aptos-framework/doc/dispatchable_fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/dispatchable_fungible_asset.md
@@ -44,7 +44,6 @@ See AIP-73 for further discussion
 <b>use</b> <a href="fungible_asset.md#0x1_fungible_asset">0x1::fungible_asset</a>;
 <b>use</b> <a href="object.md#0x1_object">0x1::object</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
-<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
 </code></pre>
 
 
@@ -88,16 +87,6 @@ Feature is not activated yet on the network.
 
 
 <pre><code><b>const</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_ENOT_ACTIVATED">ENOT_ACTIVATED</a>: u64 = 3;
-</code></pre>
-
-
-
-<a id="0x1_dispatchable_fungible_asset_ENOT_STORE_OWNER"></a>
-
-Account is not the store's owner.
-
-
-<pre><code><b>const</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_ENOT_STORE_OWNER">ENOT_STORE_OWNER</a>: u64 = 5;
 </code></pre>
 
 
@@ -196,14 +185,13 @@ The semantics of deposit will be governed by the function specified in DispatchF
     store: Object&lt;T&gt;,
     amount: u64,
 ): FungibleAsset <b>acquires</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_TransferRefStore">TransferRefStore</a> {
+    <a href="fungible_asset.md#0x1_fungible_asset_withdraw_sanity_check">fungible_asset::withdraw_sanity_check</a>(owner, store, <b>false</b>);
     <b>let</b> func_opt = <a href="fungible_asset.md#0x1_fungible_asset_withdraw_dispatch_function">fungible_asset::withdraw_dispatch_function</a>(store);
     <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&func_opt)) {
         <b>assert</b>!(
             <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_dispatchable_fungible_asset_enabled">features::dispatchable_fungible_asset_enabled</a>(),
             <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_aborted">error::aborted</a>(<a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_ENOT_ACTIVATED">ENOT_ACTIVATED</a>)
         );
-        <a href="fungible_asset.md#0x1_fungible_asset_assert_not_frozen">fungible_asset::assert_not_frozen</a>(store);
-        <b>assert</b>!(<a href="object.md#0x1_object_owns">object::owns</a>(store, <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_ENOT_STORE_OWNER">ENOT_STORE_OWNER</a>));
         <b>let</b> start_balance = <a href="fungible_asset.md#0x1_fungible_asset_balance">fungible_asset::balance</a>(store);
         <b>let</b> func = <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&func_opt);
         <a href="function_info.md#0x1_function_info_load_module_from_function">function_info::load_module_from_function</a>(func);
@@ -217,7 +205,7 @@ The semantics of deposit will be governed by the function specified in DispatchF
         <b>assert</b>!(amount &lt;= start_balance - end_balance, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_aborted">error::aborted</a>(<a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_EAMOUNT_MISMATCH">EAMOUNT_MISMATCH</a>));
         fa
     } <b>else</b> {
-        <a href="fungible_asset.md#0x1_fungible_asset_withdraw_non_dispatch">fungible_asset::withdraw_non_dispatch</a>(owner, store, amount)
+        <a href="fungible_asset.md#0x1_fungible_asset_withdraw_internal">fungible_asset::withdraw_internal</a>(<a href="object.md#0x1_object_object_address">object::object_address</a>(&store), amount)
     }
 }
 </code></pre>
@@ -245,13 +233,13 @@ The semantics of deposit will be governed by the function specified in DispatchF
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_deposit">deposit</a>&lt;T: key&gt;(store: Object&lt;T&gt;, fa: FungibleAsset) <b>acquires</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_TransferRefStore">TransferRefStore</a> {
+    <a href="fungible_asset.md#0x1_fungible_asset_deposit_sanity_check">fungible_asset::deposit_sanity_check</a>(store, <b>false</b>);
     <b>let</b> func_opt = <a href="fungible_asset.md#0x1_fungible_asset_deposit_dispatch_function">fungible_asset::deposit_dispatch_function</a>(store);
     <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&func_opt)) {
         <b>assert</b>!(
             <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_dispatchable_fungible_asset_enabled">features::dispatchable_fungible_asset_enabled</a>(),
             <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_aborted">error::aborted</a>(<a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_ENOT_ACTIVATED">ENOT_ACTIVATED</a>)
         );
-        <a href="fungible_asset.md#0x1_fungible_asset_assert_not_frozen">fungible_asset::assert_not_frozen</a>(store);
         <b>let</b> func = <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&func_opt);
         <a href="function_info.md#0x1_function_info_load_module_from_function">function_info::load_module_from_function</a>(func);
         <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_dispatchable_deposit">dispatchable_deposit</a>(
@@ -261,7 +249,7 @@ The semantics of deposit will be governed by the function specified in DispatchF
             func
         )
     } <b>else</b> {
-        <a href="fungible_asset.md#0x1_fungible_asset_deposit_non_dispatch">fungible_asset::deposit_non_dispatch</a>(store, fa)
+        <a href="fungible_asset.md#0x1_fungible_asset_deposit_internal">fungible_asset::deposit_internal</a>(store, fa)
     }
 }
 </code></pre>

--- a/aptos-move/framework/aptos-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/fungible_asset.md
@@ -727,6 +727,16 @@ Cannot destroy non-empty fungible assets.
 
 
 
+<a id="0x1_fungible_asset_EAPT_NOT_DISPATCHABLE"></a>
+
+Cannot register dispatch hook for APT.
+
+
+<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_EAPT_NOT_DISPATCHABLE">EAPT_NOT_DISPATCHABLE</a>: u64 = 31;
+</code></pre>
+
+
+
 <a id="0x1_fungible_asset_EBALANCE_IS_NOT_ZERO"></a>
 
 Cannot destroy fungible stores with a non-zero balance.
@@ -1240,7 +1250,7 @@ Create a fungible asset store whose transfer rule would be overloaded by the pro
     // Cannot register hook for APT.
     <b>assert</b>!(
         <a href="object.md#0x1_object_address_from_constructor_ref">object::address_from_constructor_ref</a>(constructor_ref) != @aptos_fungible_asset,
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_EALREADY_REGISTERED">EALREADY_REGISTERED</a>)
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="fungible_asset.md#0x1_fungible_asset_EAPT_NOT_DISPATCHABLE">EAPT_NOT_DISPATCHABLE</a>)
     );
     <b>assert</b>!(
         !<a href="object.md#0x1_object_can_generate_delete_ref">object::can_generate_delete_ref</a>(constructor_ref),
@@ -1256,7 +1266,7 @@ Create a fungible asset store whose transfer rule would be overloaded by the pro
         <b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a>&gt;(
             <a href="object.md#0x1_object_address_from_constructor_ref">object::address_from_constructor_ref</a>(constructor_ref)
         ),
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="fungible_asset.md#0x1_fungible_asset_ENOT_METADATA_OWNER">ENOT_METADATA_OWNER</a>),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="fungible_asset.md#0x1_fungible_asset_EFUNGIBLE_METADATA_EXISTENCE">EFUNGIBLE_METADATA_EXISTENCE</a>),
     );
 
     <b>let</b> store_obj = &<a href="object.md#0x1_object_generate_signer">object::generate_signer</a>(constructor_ref);

--- a/aptos-move/framework/aptos-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/fungible_asset.md
@@ -44,6 +44,7 @@ metadata object can be any object that equipped with <code><a href="fungible_ass
 -  [Function `balance`](#0x1_fungible_asset_balance)
 -  [Function `is_balance_at_least`](#0x1_fungible_asset_is_balance_at_least)
 -  [Function `is_frozen`](#0x1_fungible_asset_is_frozen)
+-  [Function `assert_not_frozen`](#0x1_fungible_asset_assert_not_frozen)
 -  [Function `is_dispatchable`](#0x1_fungible_asset_is_dispatchable)
 -  [Function `deposit_dispatch_function`](#0x1_fungible_asset_deposit_dispatch_function)
 -  [Function `has_deposit_dispatch_function`](#0x1_fungible_asset_has_deposit_dispatch_function)
@@ -849,7 +850,8 @@ Insufficient balance to withdraw or transfer.
 
 <a id="0x1_fungible_asset_EINVALID_DISPATCHABLE_OPERATIONS"></a>
 
-Invalid withdraw/deposit on dispatchable token.
+Invalid withdraw/deposit on dispatchable token. The specified token has a dispatchable function hook.
+Need to invoke dispatchable_fungible_asset::withdraw/deposit to perform transfer.
 
 
 <pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_EINVALID_DISPATCHABLE_OPERATIONS">EINVALID_DISPATCHABLE_OPERATIONS</a>: u64 = 28;
@@ -1690,6 +1692,31 @@ If the store has not been created, we default to returning false so deposits can
 
 <pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_is_frozen">is_frozen</a>&lt;T: key&gt;(store: Object&lt;T&gt;): bool <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a> {
     <a href="fungible_asset.md#0x1_fungible_asset_store_exists">store_exists</a>(<a href="object.md#0x1_object_object_address">object::object_address</a>(&store)) && <a href="fungible_asset.md#0x1_fungible_asset_borrow_store_resource">borrow_store_resource</a>(&store).frozen
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_fungible_asset_assert_not_frozen"></a>
+
+## Function `assert_not_frozen`
+
+Abort when a store is frozen.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_assert_not_frozen">assert_not_frozen</a>&lt;T: key&gt;(store: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_assert_not_frozen">assert_not_frozen</a>&lt;T: key&gt;(store: Object&lt;T&gt;) <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a> {
+    <b>assert</b>!(!<a href="fungible_asset.md#0x1_fungible_asset_is_frozen">is_frozen</a>(store), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESTORE_IS_FROZEN">ESTORE_IS_FROZEN</a>));
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/fungible_asset.md
@@ -44,8 +44,7 @@ metadata object can be any object that equipped with <code><a href="fungible_ass
 -  [Function `balance`](#0x1_fungible_asset_balance)
 -  [Function `is_balance_at_least`](#0x1_fungible_asset_is_balance_at_least)
 -  [Function `is_frozen`](#0x1_fungible_asset_is_frozen)
--  [Function `assert_not_frozen`](#0x1_fungible_asset_assert_not_frozen)
--  [Function `is_dispatchable`](#0x1_fungible_asset_is_dispatchable)
+-  [Function `is_store_dispatchable`](#0x1_fungible_asset_is_store_dispatchable)
 -  [Function `deposit_dispatch_function`](#0x1_fungible_asset_deposit_dispatch_function)
 -  [Function `has_deposit_dispatch_function`](#0x1_fungible_asset_has_deposit_dispatch_function)
 -  [Function `withdraw_dispatch_function`](#0x1_fungible_asset_withdraw_dispatch_function)
@@ -59,9 +58,9 @@ metadata object can be any object that equipped with <code><a href="fungible_ass
 -  [Function `create_store`](#0x1_fungible_asset_create_store)
 -  [Function `remove_store`](#0x1_fungible_asset_remove_store)
 -  [Function `withdraw`](#0x1_fungible_asset_withdraw)
+-  [Function `withdraw_sanity_check`](#0x1_fungible_asset_withdraw_sanity_check)
+-  [Function `deposit_sanity_check`](#0x1_fungible_asset_deposit_sanity_check)
 -  [Function `deposit`](#0x1_fungible_asset_deposit)
--  [Function `withdraw_non_dispatch`](#0x1_fungible_asset_withdraw_non_dispatch)
--  [Function `deposit_non_dispatch`](#0x1_fungible_asset_deposit_non_dispatch)
 -  [Function `mint`](#0x1_fungible_asset_mint)
 -  [Function `mint_internal`](#0x1_fungible_asset_mint_internal)
 -  [Function `mint_to`](#0x1_fungible_asset_mint_to)
@@ -1253,6 +1252,12 @@ Create a fungible asset store whose transfer rule would be overloaded by the pro
         ),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_already_exists">error::already_exists</a>(<a href="fungible_asset.md#0x1_fungible_asset_EALREADY_REGISTERED">EALREADY_REGISTERED</a>)
     );
+    <b>assert</b>!(
+        <b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a>&gt;(
+            <a href="object.md#0x1_object_address_from_constructor_ref">object::address_from_constructor_ref</a>(constructor_ref)
+        ),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="fungible_asset.md#0x1_fungible_asset_EFUNGIBLE_STORE_EXISTENCE">EFUNGIBLE_STORE_EXISTENCE</a>),
+    );
 
     <b>let</b> store_obj = &<a href="object.md#0x1_object_generate_signer">object::generate_signer</a>(constructor_ref);
 
@@ -1699,40 +1704,15 @@ If the store has not been created, we default to returning false so deposits can
 
 </details>
 
-<a id="0x1_fungible_asset_assert_not_frozen"></a>
+<a id="0x1_fungible_asset_is_store_dispatchable"></a>
 
-## Function `assert_not_frozen`
-
-Abort when a store is frozen.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_assert_not_frozen">assert_not_frozen</a>&lt;T: key&gt;(store: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_assert_not_frozen">assert_not_frozen</a>&lt;T: key&gt;(store: Object&lt;T&gt;) <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a> {
-    <b>assert</b>!(!<a href="fungible_asset.md#0x1_fungible_asset_is_frozen">is_frozen</a>(store), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESTORE_IS_FROZEN">ESTORE_IS_FROZEN</a>));
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_fungible_asset_is_dispatchable"></a>
-
-## Function `is_dispatchable`
+## Function `is_store_dispatchable`
 
 Return whether a fungible asset type is dispatchable.
 
 
 <pre><code>#[view]
-<b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_is_dispatchable">is_dispatchable</a>(store: <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;): bool
+<b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_is_store_dispatchable">is_store_dispatchable</a>&lt;T: key&gt;(store: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): bool
 </code></pre>
 
 
@@ -1741,7 +1721,7 @@ Return whether a fungible asset type is dispatchable.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_is_dispatchable">is_dispatchable</a>(store: Object&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a>&gt;): bool <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_is_store_dispatchable">is_store_dispatchable</a>&lt;T: key&gt;(store: Object&lt;T&gt;): bool <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a> {
     <b>let</b> fa_store = <a href="fungible_asset.md#0x1_fungible_asset_borrow_store_resource">borrow_store_resource</a>(&store);
     <b>let</b> metadata_addr = <a href="object.md#0x1_object_object_address">object::object_address</a>(&fa_store.metadata);
     <b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a>&gt;(metadata_addr)
@@ -2132,15 +2112,76 @@ Withdraw <code>amount</code> of the fungible asset from <code>store</code> by th
     store: Object&lt;T&gt;,
     amount: u64,
 ): <a href="fungible_asset.md#0x1_fungible_asset_FungibleAsset">FungibleAsset</a> <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>, <a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a> {
+    <a href="fungible_asset.md#0x1_fungible_asset_withdraw_sanity_check">withdraw_sanity_check</a>(owner, store, <b>true</b>);
+    <a href="fungible_asset.md#0x1_fungible_asset_withdraw_internal">withdraw_internal</a>(<a href="object.md#0x1_object_object_address">object::object_address</a>(&store), amount)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_fungible_asset_withdraw_sanity_check"></a>
+
+## Function `withdraw_sanity_check`
+
+Check the permission for withdraw operation.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_withdraw_sanity_check">withdraw_sanity_check</a>&lt;T: key&gt;(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, store: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;, abort_on_dispatch: bool)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_withdraw_sanity_check">withdraw_sanity_check</a>&lt;T: key&gt;(
+    owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    store: Object&lt;T&gt;,
+    abort_on_dispatch: bool,
+) <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>, <a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a> {
     <b>assert</b>!(<a href="object.md#0x1_object_owns">object::owns</a>(store, <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="fungible_asset.md#0x1_fungible_asset_ENOT_STORE_OWNER">ENOT_STORE_OWNER</a>));
-    <b>assert</b>!(<a href="fungible_asset.md#0x1_fungible_asset_store_exists">store_exists</a>(<a href="object.md#0x1_object_object_address">object::object_address</a>(&store)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESTORE_IS_FROZEN">ESTORE_IS_FROZEN</a>));
     <b>let</b> fa_store = <a href="fungible_asset.md#0x1_fungible_asset_borrow_store_resource">borrow_store_resource</a>(&store);
     <b>assert</b>!(
-        !<a href="fungible_asset.md#0x1_fungible_asset_has_withdraw_dispatch_function">has_withdraw_dispatch_function</a>(fa_store.metadata),
+        !abort_on_dispatch || !<a href="fungible_asset.md#0x1_fungible_asset_has_withdraw_dispatch_function">has_withdraw_dispatch_function</a>(fa_store.metadata),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_EINVALID_DISPATCHABLE_OPERATIONS">EINVALID_DISPATCHABLE_OPERATIONS</a>)
     );
-    <b>assert</b>!(!fa_store.frozen, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESTORE_IS_FROZEN">ESTORE_IS_FROZEN</a>));
-    <a href="fungible_asset.md#0x1_fungible_asset_withdraw_internal">withdraw_internal</a>(<a href="object.md#0x1_object_object_address">object::object_address</a>(&store), amount)
+    <b>assert</b>!(!fa_store.frozen, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESTORE_IS_FROZEN">ESTORE_IS_FROZEN</a>));
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_fungible_asset_deposit_sanity_check"></a>
+
+## Function `deposit_sanity_check`
+
+Deposit <code>amount</code> of the fungible asset to <code>store</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_deposit_sanity_check">deposit_sanity_check</a>&lt;T: key&gt;(store: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;, abort_on_dispatch: bool)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_deposit_sanity_check">deposit_sanity_check</a>&lt;T: key&gt;(
+    store: Object&lt;T&gt;,
+    abort_on_dispatch: bool
+) <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>, <a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a> {
+    <b>let</b> fa_store = <a href="fungible_asset.md#0x1_fungible_asset_borrow_store_resource">borrow_store_resource</a>(&store);
+    <b>assert</b>!(
+        !abort_on_dispatch || !<a href="fungible_asset.md#0x1_fungible_asset_has_deposit_dispatch_function">has_deposit_dispatch_function</a>(fa_store.metadata),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_EINVALID_DISPATCHABLE_OPERATIONS">EINVALID_DISPATCHABLE_OPERATIONS</a>)
+    );
+    <b>assert</b>!(!fa_store.frozen, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESTORE_IS_FROZEN">ESTORE_IS_FROZEN</a>));
 }
 </code></pre>
 
@@ -2165,70 +2206,7 @@ Deposit <code>amount</code> of the fungible asset to <code>store</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_deposit">deposit</a>&lt;T: key&gt;(store: Object&lt;T&gt;, fa: <a href="fungible_asset.md#0x1_fungible_asset_FungibleAsset">FungibleAsset</a>) <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>, <a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a> {
-    <b>assert</b>!(<a href="fungible_asset.md#0x1_fungible_asset_store_exists">store_exists</a>(<a href="object.md#0x1_object_object_address">object::object_address</a>(&store)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESTORE_IS_FROZEN">ESTORE_IS_FROZEN</a>));
-    <b>let</b> fa_store = <a href="fungible_asset.md#0x1_fungible_asset_borrow_store_resource">borrow_store_resource</a>(&store);
-    <b>assert</b>!(
-        !<a href="fungible_asset.md#0x1_fungible_asset_has_deposit_dispatch_function">has_deposit_dispatch_function</a>(fa_store.metadata),
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_EINVALID_DISPATCHABLE_OPERATIONS">EINVALID_DISPATCHABLE_OPERATIONS</a>)
-    );
-    <b>assert</b>!(!fa_store.frozen, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESTORE_IS_FROZEN">ESTORE_IS_FROZEN</a>));
-    <a href="fungible_asset.md#0x1_fungible_asset_deposit_internal">deposit_internal</a>(store, fa);
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_fungible_asset_withdraw_non_dispatch"></a>
-
-## Function `withdraw_non_dispatch`
-
-Withdraw <code>amount</code> of the fungible asset from <code>store</code> by the owner.
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_withdraw_non_dispatch">withdraw_non_dispatch</a>&lt;T: key&gt;(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, store: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;, amount: u64): <a href="fungible_asset.md#0x1_fungible_asset_FungibleAsset">fungible_asset::FungibleAsset</a>
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_withdraw_non_dispatch">withdraw_non_dispatch</a>&lt;T: key&gt;(
-    owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
-    store: Object&lt;T&gt;,
-    amount: u64,
-): <a href="fungible_asset.md#0x1_fungible_asset_FungibleAsset">FungibleAsset</a> <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a> {
-    <b>assert</b>!(<a href="object.md#0x1_object_owns">object::owns</a>(store, <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="fungible_asset.md#0x1_fungible_asset_ENOT_STORE_OWNER">ENOT_STORE_OWNER</a>));
-    <b>assert</b>!(!<a href="fungible_asset.md#0x1_fungible_asset_is_frozen">is_frozen</a>(store), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESTORE_IS_FROZEN">ESTORE_IS_FROZEN</a>));
-    <a href="fungible_asset.md#0x1_fungible_asset_withdraw_internal">withdraw_internal</a>(<a href="object.md#0x1_object_object_address">object::object_address</a>(&store), amount)
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_fungible_asset_deposit_non_dispatch"></a>
-
-## Function `deposit_non_dispatch`
-
-Deposit <code>amount</code> of the fungible asset to <code>store</code>.
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_deposit_non_dispatch">deposit_non_dispatch</a>&lt;T: key&gt;(store: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;, fa: <a href="fungible_asset.md#0x1_fungible_asset_FungibleAsset">fungible_asset::FungibleAsset</a>)
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_deposit_non_dispatch">deposit_non_dispatch</a>&lt;T: key&gt;(store: Object&lt;T&gt;, fa: <a href="fungible_asset.md#0x1_fungible_asset_FungibleAsset">FungibleAsset</a>) <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a> {
-    <b>assert</b>!(!<a href="fungible_asset.md#0x1_fungible_asset_is_frozen">is_frozen</a>(store), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESTORE_IS_FROZEN">ESTORE_IS_FROZEN</a>));
+    <a href="fungible_asset.md#0x1_fungible_asset_deposit_sanity_check">deposit_sanity_check</a>(store, <b>true</b>);
     <a href="fungible_asset.md#0x1_fungible_asset_deposit_internal">deposit_internal</a>(store, fa);
 }
 </code></pre>

--- a/aptos-move/framework/aptos-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/fungible_asset.md
@@ -1256,7 +1256,7 @@ Create a fungible asset store whose transfer rule would be overloaded by the pro
         <b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a>&gt;(
             <a href="object.md#0x1_object_address_from_constructor_ref">object::address_from_constructor_ref</a>(constructor_ref)
         ),
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="fungible_asset.md#0x1_fungible_asset_EFUNGIBLE_STORE_EXISTENCE">EFUNGIBLE_STORE_EXISTENCE</a>),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="fungible_asset.md#0x1_fungible_asset_ENOT_METADATA_OWNER">ENOT_METADATA_OWNER</a>),
     );
 
     <b>let</b> store_obj = &<a href="object.md#0x1_object_generate_signer">object::generate_signer</a>(constructor_ref);

--- a/aptos-move/framework/aptos-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/fungible_asset.md
@@ -2290,8 +2290,8 @@ Mint the specified <code>amount</code> of the fungible asset to a destination st
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_mint_to">mint_to</a>&lt;T: key&gt;(ref: &<a href="fungible_asset.md#0x1_fungible_asset_MintRef">MintRef</a>, store: Object&lt;T&gt;, amount: u64)
-<b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>, <a href="fungible_asset.md#0x1_fungible_asset_Supply">Supply</a>, <a href="fungible_asset.md#0x1_fungible_asset_ConcurrentSupply">ConcurrentSupply</a>, <a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a> {
-    <a href="fungible_asset.md#0x1_fungible_asset_deposit">deposit</a>(store, <a href="fungible_asset.md#0x1_fungible_asset_mint">mint</a>(ref, amount));
+<b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>, <a href="fungible_asset.md#0x1_fungible_asset_Supply">Supply</a>, <a href="fungible_asset.md#0x1_fungible_asset_ConcurrentSupply">ConcurrentSupply</a> {
+    <a href="fungible_asset.md#0x1_fungible_asset_deposit_internal">deposit_internal</a>(store, <a href="fungible_asset.md#0x1_fungible_asset_mint">mint</a>(ref, amount));
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/fungible_asset.md
@@ -2290,7 +2290,8 @@ Mint the specified <code>amount</code> of the fungible asset to a destination st
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_mint_to">mint_to</a>&lt;T: key&gt;(ref: &<a href="fungible_asset.md#0x1_fungible_asset_MintRef">MintRef</a>, store: Object&lt;T&gt;, amount: u64)
-<b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>, <a href="fungible_asset.md#0x1_fungible_asset_Supply">Supply</a>, <a href="fungible_asset.md#0x1_fungible_asset_ConcurrentSupply">ConcurrentSupply</a> {
+<b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>, <a href="fungible_asset.md#0x1_fungible_asset_Supply">Supply</a>, <a href="fungible_asset.md#0x1_fungible_asset_ConcurrentSupply">ConcurrentSupply</a>, <a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a> {
+    <a href="fungible_asset.md#0x1_fungible_asset_deposit_sanity_check">deposit_sanity_check</a>(store, <b>false</b>);
     <a href="fungible_asset.md#0x1_fungible_asset_deposit_internal">deposit_internal</a>(store, <a href="fungible_asset.md#0x1_fungible_asset_mint">mint</a>(ref, amount));
 }
 </code></pre>

--- a/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
+++ b/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
@@ -556,8 +556,7 @@ Mint to the primary store of <code>owner</code>.
 
 <pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_mint">mint</a>(mint_ref: &MintRef, owner: <b>address</b>, amount: u64) <b>acquires</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_DeriveRefPod">DeriveRefPod</a> {
     <b>let</b> primary_store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">ensure_primary_store_exists</a>(owner, <a href="fungible_asset.md#0x1_fungible_asset_mint_ref_metadata">fungible_asset::mint_ref_metadata</a>(mint_ref));
-    <b>let</b> fa = <a href="fungible_asset.md#0x1_fungible_asset_mint">fungible_asset::mint</a>(mint_ref, amount);
-    <a href="fungible_asset.md#0x1_fungible_asset_deposit_internal">fungible_asset::deposit_internal</a>(primary_store, fa);
+    <a href="fungible_asset.md#0x1_fungible_asset_mint_to">fungible_asset::mint_to</a>(mint_ref, primary_store, amount);
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
+++ b/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
@@ -556,7 +556,8 @@ Mint to the primary store of <code>owner</code>.
 
 <pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_mint">mint</a>(mint_ref: &MintRef, owner: <b>address</b>, amount: u64) <b>acquires</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_DeriveRefPod">DeriveRefPod</a> {
     <b>let</b> primary_store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">ensure_primary_store_exists</a>(owner, <a href="fungible_asset.md#0x1_fungible_asset_mint_ref_metadata">fungible_asset::mint_ref_metadata</a>(mint_ref));
-    <a href="fungible_asset.md#0x1_fungible_asset_mint_to">fungible_asset::mint_to</a>(mint_ref, primary_store, amount);
+    <b>let</b> fa = <a href="fungible_asset.md#0x1_fungible_asset_mint">fungible_asset::mint</a>(mint_ref, amount);
+    <a href="fungible_asset.md#0x1_fungible_asset_deposit_internal">fungible_asset::deposit_internal</a>(primary_store, fa);
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/staking_config.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_config.md
@@ -1304,9 +1304,9 @@ StakingRewardsConfig does not exist under the aptos_framework before creating it
 
 
 
-<pre><code><b>requires</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_periodical_reward_rate_decrease_enabled">features::spec_periodical_reward_rate_decrease_enabled</a>();
+<pre><code><b>pragma</b> verify_duration_estimate = 120;
+<b>requires</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_periodical_reward_rate_decrease_enabled">features::spec_periodical_reward_rate_decrease_enabled</a>();
 <b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">StakingRewardsConfigRequirement</a>;
-<b>pragma</b> verify_duration_estimate = 120;
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/staking_config.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_config.md
@@ -1306,6 +1306,7 @@ StakingRewardsConfig does not exist under the aptos_framework before creating it
 
 <pre><code><b>requires</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_periodical_reward_rate_decrease_enabled">features::spec_periodical_reward_rate_decrease_enabled</a>();
 <b>include</b> <a href="staking_config.md#0x1_staking_config_StakingRewardsConfigRequirement">StakingRewardsConfigRequirement</a>;
+<b>pragma</b> verify_duration_estimate = 120;
 <b>aborts_if</b> !<b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/storage_gas.md
+++ b/aptos-move/framework/aptos-framework/doc/storage_gas.md
@@ -1545,6 +1545,7 @@ and exists after the function is executed.
 
 
 <pre><code><b>include</b> <a href="system_addresses.md#0x1_system_addresses_AbortsIfNotAptosFramework">system_addresses::AbortsIfNotAptosFramework</a>{ <a href="account.md#0x1_account">account</a>: aptos_framework };
+<b>pragma</b> verify_duration_estimate = 120;
 <b>aborts_if</b> <b>exists</b>&lt;<a href="storage_gas.md#0x1_storage_gas_StorageGasConfig">StorageGasConfig</a>&gt;(@aptos_framework);
 <b>aborts_if</b> <b>exists</b>&lt;<a href="storage_gas.md#0x1_storage_gas_StorageGas">StorageGas</a>&gt;(@aptos_framework);
 // This enforces <a id="high-level-req-1" href="#high-level-req">high-level requirement 1</a>:

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
@@ -163,6 +163,7 @@ spec aptos_framework::staking_config {
     }
 
     spec calculate_and_save_latest_rewards_config(): StakingRewardsConfig {
+        pragma verify_duration_estimate = 120;
         requires features::spec_periodical_reward_rate_decrease_enabled();
         include StakingRewardsConfigRequirement;
         aborts_if !exists<StakingRewardsConfig>(@aptos_framework);

--- a/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.move
@@ -21,6 +21,7 @@ module aptos_framework::dispatchable_fungible_asset {
 
     use std::error;
     use std::features;
+    use std::signer;
     use std::option::{Self, Option};
 
     /// TransferRefStore doesn't exist on the fungible asset type.
@@ -31,6 +32,8 @@ module aptos_framework::dispatchable_fungible_asset {
     const ENOT_ACTIVATED: u64 = 3;
     /// Dispatch target is not loaded.
     const ENOT_LOADED: u64 = 4;
+    /// Account is not the store's owner.
+    const ENOT_STORE_OWNER: u64 = 5;
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct TransferRefStore has key {
@@ -73,6 +76,7 @@ module aptos_framework::dispatchable_fungible_asset {
                 error::aborted(ENOT_ACTIVATED)
             );
             fungible_asset::assert_not_frozen(store);
+            assert!(object::owns(store, signer::address_of(owner)), error::permission_denied(ENOT_STORE_OWNER));
             let start_balance = fungible_asset::balance(store);
             let func = option::borrow(&func_opt);
             function_info::load_module_from_function(func);

--- a/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.move
@@ -72,6 +72,7 @@ module aptos_framework::dispatchable_fungible_asset {
                 features::dispatchable_fungible_asset_enabled(),
                 error::aborted(ENOT_ACTIVATED)
             );
+            fungible_asset::assert_not_frozen(store);
             let start_balance = fungible_asset::balance(store);
             let func = option::borrow(&func_opt);
             function_info::load_module_from_function(func);
@@ -99,6 +100,7 @@ module aptos_framework::dispatchable_fungible_asset {
                 features::dispatchable_fungible_asset_enabled(),
                 error::aborted(ENOT_ACTIVATED)
             );
+            fungible_asset::assert_not_frozen(store);
             let func = option::borrow(&func_opt);
             function_info::load_module_from_function(func);
             dispatchable_deposit(

--- a/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.move
@@ -21,8 +21,8 @@ module aptos_framework::dispatchable_fungible_asset {
 
     use std::error;
     use std::features;
-    use std::signer;
     use std::option::{Self, Option};
+    use std::signer;
 
     /// TransferRefStore doesn't exist on the fungible asset type.
     const ESTORE_NOT_FOUND: u64 = 1;
@@ -75,6 +75,11 @@ module aptos_framework::dispatchable_fungible_asset {
                 features::dispatchable_fungible_asset_enabled(),
                 error::aborted(ENOT_ACTIVATED)
             );
+            // ** IMPORTANT **
+            //
+            // For any changes in the access control logic here, make sure we duplicate them in
+            // fungible_asset::withdraw as that will be a separate entrypoint.
+            //
             fungible_asset::assert_not_frozen(store);
             assert!(object::owns(store, signer::address_of(owner)), error::permission_denied(ENOT_STORE_OWNER));
             let start_balance = fungible_asset::balance(store);
@@ -104,6 +109,11 @@ module aptos_framework::dispatchable_fungible_asset {
                 features::dispatchable_fungible_asset_enabled(),
                 error::aborted(ENOT_ACTIVATED)
             );
+            // ** IMPORTANT **
+            //
+            // For any changes in the access control logic here, make sure we duplicate them in
+            // fungible_asset::withdraw as that will be a separate entrypoint.
+            //
             fungible_asset::assert_not_frozen(store);
             let func = option::borrow(&func_opt);
             function_info::load_module_from_function(func);

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -672,8 +672,8 @@ module aptos_framework::fungible_asset {
 
     /// Mint the specified `amount` of the fungible asset to a destination store.
     public fun mint_to<T: key>(ref: &MintRef, store: Object<T>, amount: u64)
-    acquires FungibleStore, Supply, ConcurrentSupply, DispatchFunctionStore {
-        deposit(store, mint(ref, amount));
+    acquires FungibleStore, Supply, ConcurrentSupply {
+        deposit_internal(store, mint(ref, amount));
     }
 
     /// Enable/disable a store's ability to do direct transfers of the fungible asset.

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -334,6 +334,12 @@ module aptos_framework::fungible_asset {
             ),
             error::already_exists(EALREADY_REGISTERED)
         );
+        assert!(
+            exists<Metadata>(
+                object::address_from_constructor_ref(constructor_ref)
+            ),
+            error::not_found(ENOT_METADATA_OWNER),
+        );
 
         let store_obj = &object::generate_signer(constructor_ref);
 

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -613,6 +613,11 @@ module aptos_framework::fungible_asset {
         store: Object<T>,
         amount: u64,
     ): FungibleAsset acquires FungibleStore, DispatchFunctionStore {
+        // ** IMPORTANT **
+        //
+        // For any changes in the access control logic here, make sure we duplicate them in
+        // dispatchable_fungible_asset::withdraw as that will be a separate entrypoint.
+        //
         assert!(object::owns(store, signer::address_of(owner)), error::permission_denied(ENOT_STORE_OWNER));
         assert!(store_exists(object::object_address(&store)), error::invalid_argument(ESTORE_IS_FROZEN));
         let fa_store = borrow_store_resource(&store);
@@ -626,6 +631,11 @@ module aptos_framework::fungible_asset {
 
     /// Deposit `amount` of the fungible asset to `store`.
     public fun deposit<T: key>(store: Object<T>, fa: FungibleAsset) acquires FungibleStore, DispatchFunctionStore {
+        // ** IMPORTANT **
+        //
+        // For any changes in the access control logic here, make sure we duplicate them in
+        // dispatchable_fungible_asset::withdraw as that will be a separate entrypoint.
+        //
         assert!(store_exists(object::object_address(&store)), error::permission_denied(ESTORE_IS_FROZEN));
         let fa_store = borrow_store_resource(&store);
         assert!(

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -72,7 +72,8 @@ module aptos_framework::fungible_asset {
     const EDEPOSIT_FUNCTION_SIGNATURE_MISMATCH: u64 = 26;
     /// Provided derived_balance function type doesn't meet the signature requirement.
     const EDERIVED_BALANCE_FUNCTION_SIGNATURE_MISMATCH: u64 = 27;
-    /// Invalid withdraw/deposit on dispatchable token.
+    /// Invalid withdraw/deposit on dispatchable token. The specified token has a dispatchable function hook.
+    /// Need to invoke dispatchable_fungible_asset::withdraw/deposit to perform transfer.
     const EINVALID_DISPATCHABLE_OPERATIONS: u64 = 28;
     /// Trying to re-register dispatch hook on a fungible asset.
     const EALREADY_REGISTERED: u64 = 29;

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -475,6 +475,11 @@ module aptos_framework::fungible_asset {
         store_exists(object::object_address(&store)) && borrow_store_resource(&store).frozen
     }
 
+    /// Abort when a store is frozen.
+    public fun assert_not_frozen<T: key>(store: Object<T>) acquires FungibleStore {
+        assert!(!is_frozen(store), error::invalid_argument(ESTORE_IS_FROZEN));
+    }
+
     #[view]
     /// Return whether a fungible asset type is dispatchable.
     public fun is_dispatchable(store: Object<Metadata>): bool acquires FungibleStore {

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -79,6 +79,8 @@ module aptos_framework::fungible_asset {
     const EALREADY_REGISTERED: u64 = 29;
     /// Fungible metadata does not exist on this account.
     const EFUNGIBLE_METADATA_EXISTENCE: u64 = 30;
+    /// Cannot register dispatch hook for APT.
+    const EAPT_NOT_DISPATCHABLE: u64 = 31;
 
     //
     // Constants
@@ -322,7 +324,7 @@ module aptos_framework::fungible_asset {
         // Cannot register hook for APT.
         assert!(
             object::address_from_constructor_ref(constructor_ref) != @aptos_fungible_asset,
-            error::invalid_argument(EALREADY_REGISTERED)
+            error::permission_denied(EAPT_NOT_DISPATCHABLE)
         );
         assert!(
             !object::can_generate_delete_ref(constructor_ref),
@@ -338,7 +340,7 @@ module aptos_framework::fungible_asset {
             exists<Metadata>(
                 object::address_from_constructor_ref(constructor_ref)
             ),
-            error::not_found(ENOT_METADATA_OWNER),
+            error::not_found(EFUNGIBLE_METADATA_EXISTENCE),
         );
 
         let store_obj = &object::generate_signer(constructor_ref);

--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
@@ -203,7 +203,8 @@ module aptos_framework::primary_fungible_store {
     /// Mint to the primary store of `owner`.
     public fun mint(mint_ref: &MintRef, owner: address, amount: u64) acquires DeriveRefPod {
         let primary_store = ensure_primary_store_exists(owner, fungible_asset::mint_ref_metadata(mint_ref));
-        fungible_asset::mint_to(mint_ref, primary_store, amount);
+        let fa = fungible_asset::mint(mint_ref, amount);
+        fungible_asset::deposit_internal(primary_store, fa);
     }
 
     /// Burn from the primary store of `owner`.

--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
@@ -203,8 +203,7 @@ module aptos_framework::primary_fungible_store {
     /// Mint to the primary store of `owner`.
     public fun mint(mint_ref: &MintRef, owner: address, amount: u64) acquires DeriveRefPod {
         let primary_store = ensure_primary_store_exists(owner, fungible_asset::mint_ref_metadata(mint_ref));
-        let fa = fungible_asset::mint(mint_ref, amount);
-        fungible_asset::deposit_internal(primary_store, fa);
+        fungible_asset::mint_to(mint_ref, primary_store, amount);
     }
 
     /// Burn from the primary store of `owner`.

--- a/aptos-move/framework/aptos-framework/sources/storage_gas.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/storage_gas.spec.move
@@ -129,6 +129,7 @@ spec aptos_framework::storage_gas {
     /// and exists after the function is executed.
     spec initialize(aptos_framework: &signer) {
         include system_addresses::AbortsIfNotAptosFramework{ account: aptos_framework };
+        pragma verify_duration_estimate = 120;
         aborts_if exists<StorageGasConfig>(@aptos_framework);
         aborts_if exists<StorageGas>(@aptos_framework);
 

--- a/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
@@ -286,7 +286,7 @@ module 0xcafe::deflation_token_tests {
     }
 
     #[test(creator = @0xcafe)]
-    #[expected_failure(abort_code=0x60018, location = aptos_framework::fungible_asset)]
+    #[expected_failure(abort_code=0x6001E, location = aptos_framework::fungible_asset)]
     fun test_register_on_non_metadata_object(
         creator: &signer,
     ) {

--- a/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
@@ -24,6 +24,7 @@ module 0xcafe::deflation_token_tests {
 
         deflation_token::initialize(creator, &creator_ref);
 
+        assert!(fungible_asset::is_store_dispatchable(creator_store), 1);
         assert!(fungible_asset::supply(metadata) == option::some(0), 1);
         // Mint
         let fa = fungible_asset::mint(&mint, 100);
@@ -365,7 +366,7 @@ module 0xcafe::deflation_token_tests {
     }
 
     #[test(creator = @0xcafe, aaron = @0xface)]
-    #[expected_failure(abort_code = 0x50005, location = aptos_framework::dispatchable_fungible_asset)]
+    #[expected_failure(abort_code = 0x50008, location = aptos_framework::fungible_asset)]
     fun test_deflation_wrong_withdraw(
         creator: &signer,
         aaron: &signer,

--- a/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
@@ -363,4 +363,27 @@ module 0xcafe::deflation_token_tests {
         let fa = dispatchable_fungible_asset::withdraw(creator, creator_store, 5);
         dispatchable_fungible_asset::deposit(aaron_store, fa);
     }
+
+    #[test(creator = @0xcafe, aaron = @0xface)]
+    #[expected_failure(abort_code = 0x50005, location = aptos_framework::dispatchable_fungible_asset)]
+    fun test_deflation_wrong_withdraw(
+        creator: &signer,
+        aaron: &signer,
+    ) {
+        let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
+        fungible_asset::init_test_metadata(&creator_ref);
+        let metadata = object::convert<TestToken, Metadata>(token_object);
+
+        let creator_store = fungible_asset::create_test_store(creator, metadata);
+        let aaron_store = fungible_asset::create_test_store(aaron, metadata);
+
+        deflation_token::initialize(creator, &creator_ref);
+
+        assert!(fungible_asset::supply(metadata) == option::some(0), 1);
+
+        // Withdraw
+        let fa = dispatchable_fungible_asset::withdraw(aaron, creator_store, 5);
+        assert!(fungible_asset::supply(metadata) == option::some(100), 3);
+        dispatchable_fungible_asset::deposit(aaron_store, fa);
+    }
 }

--- a/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
@@ -223,7 +223,7 @@ module 0xcafe::deflation_token_tests {
     }
 
     #[test(creator = @0xcafe, aaron = @0xface)]
-    #[expected_failure(major_status=1091, location = aptos_framework::function_info)]
+    #[expected_failure(major_status=1081, location = aptos_framework::function_info)]
     fun test_register_bad_withdraw_non_exist(
         creator: &signer,
         aaron: &signer,

--- a/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
@@ -218,6 +218,51 @@ module 0xcafe::deflation_token_tests {
         );
     }
 
+    #[test(creator = @0xcafe, aaron = @0xface)]
+    #[expected_failure(major_status=1091, location = aptos_framework::function_info)]
+    fun test_register_bad_withdraw_non_exist(
+        creator: &signer,
+        aaron: &signer,
+    ) {
+        let (creator_ref, _) = fungible_asset::create_test_token(creator);
+
+        let withdraw = function_info::new_function_info(
+            aaron,
+            string::utf8(b"deflation_token"),
+            string::utf8(b"withdraw"),
+        );
+
+        // Change the deposit and withdraw function. Should give a type mismatch error.
+        dispatchable_fungible_asset::register_dispatch_functions(
+            &creator_ref,
+            option::some(withdraw),
+            option::none(),
+            option::none(),
+        );
+    }
+
+    #[test(creator = @0xcafe)]
+    #[expected_failure(abort_code=2, location = aptos_framework::function_info)]
+    fun test_register_bad_withdraw_non_exist_2(
+        creator: &signer,
+    ) {
+        let (creator_ref, _) = fungible_asset::create_test_token(creator);
+
+        let withdraw = function_info::new_function_info(
+            creator,
+            string::utf8(b"deflation_token"),
+            string::utf8(b"withdraw2"),
+        );
+
+        // Change the deposit and withdraw function. Should give a type mismatch error.
+        dispatchable_fungible_asset::register_dispatch_functions(
+            &creator_ref,
+            option::some(withdraw),
+            option::none(),
+            option::none(),
+        );
+    }
+
     #[test(creator = @0xcafe)]
     fun test_calling_overloadable_api_on_regular_fa(
         creator: &signer,

--- a/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token.move
+++ b/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token.move
@@ -1,0 +1,50 @@
+#[test_only]
+module 0xcafe::simple_token {
+    use aptos_framework::fungible_asset::{Self, FungibleAsset, TransferRef};
+    use aptos_framework::dispatchable_fungible_asset;
+    use aptos_framework::object::{ConstructorRef, Object};
+    use aptos_framework::function_info;
+
+    use std::option;
+    use std::signer;
+    use std::string;
+
+    public fun initialize(account: &signer, constructor_ref: &ConstructorRef) {
+        assert!(signer::address_of(account) == @0xcafe, 1);
+
+        let withdraw = function_info::new_function_info(
+            account,
+            string::utf8(b"simple_token"),
+            string::utf8(b"withdraw"),
+        );
+
+        let deposit = function_info::new_function_info(
+            account,
+            string::utf8(b"simple_token"),
+            string::utf8(b"deposit"),
+        );
+
+        dispatchable_fungible_asset::register_dispatch_functions(
+            constructor_ref,
+            option::some(withdraw),
+            option::some(deposit),
+            option::none(),
+        );
+    }
+
+    public fun withdraw<T: key>(
+        store: Object<T>,
+        amount: u64,
+        transfer_ref: &TransferRef,
+    ): FungibleAsset {
+        fungible_asset::withdraw_with_ref(transfer_ref, store, amount)
+    }
+
+    public fun deposit<T: key>(
+        store: Object<T>,
+        fa: FungibleAsset,
+        transfer_ref: &TransferRef,
+    ) {
+        fungible_asset::deposit_with_ref(transfer_ref, store, fa)
+    }
+}

--- a/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_fa_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_fa_tests.move
@@ -2,7 +2,7 @@
 module aptos_framework::simple_token_fa_tests {
     use aptos_framework::fungible_asset::{
         amount, balance, burn, destroy_zero, extract, create_test_token, init_test_metadata,
-        supply, create_store, create_test_store, remove_store, deposit_with_ref, mint, merge,
+        supply, create_store, create_test_store, remove_store, deposit_with_ref, mint, mint_to, merge,
         set_frozen_flag, is_frozen, transfer_with_ref, upgrade_to_concurrent, Metadata, TestToken
     };
     use aptos_framework::object;
@@ -94,5 +94,21 @@ module aptos_framework::simple_token_fa_tests {
         assert!(supply(test_token) == option::some(50), 3);
 
         deposit_with_ref(&transfer_ref, creator_store, fb);
+    }
+
+    #[test(creator = @0xcafe)]
+    #[expected_failure(abort_code = 0x50003, location = aptos_framework::fungible_asset)]
+    fun test_mint_to_frozen(
+        creator: &signer
+    ) {
+        let (creator_ref, test_token) = create_test_token(creator);
+        let (mint_ref, transfer_ref, _burn_ref) = init_test_metadata(&creator_ref);
+        let metadata = object::convert<TestToken, Metadata>(test_token);
+        simple_token::initialize(creator, &creator_ref);
+
+        let creator_store = create_test_store(creator, metadata);
+
+        set_frozen_flag(&transfer_ref, creator_store, true);
+        mint_to(&mint_ref, creator_store, 100);
     }
 }

--- a/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_fa_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_fa_tests.move
@@ -1,0 +1,98 @@
+#[test_only]
+module aptos_framework::simple_token_fa_tests {
+    use aptos_framework::fungible_asset::{
+        amount, balance, burn, destroy_zero, extract, create_test_token, init_test_metadata,
+        supply, create_store, create_test_store, remove_store, deposit_with_ref, mint, merge,
+        set_frozen_flag, is_frozen, transfer_with_ref, upgrade_to_concurrent, Metadata, TestToken
+    };
+    use aptos_framework::object;
+    use 0xcafe::simple_token;
+    use std::option;
+    use std::features;
+
+    #[test(creator = @0xcafe)]
+    fun test_create_and_remove_store(creator: &signer) {
+        let (creator_ref, metadata) = create_test_token(creator);
+        init_test_metadata(&creator_ref);
+        simple_token::initialize(creator, &creator_ref);
+
+        let creator_ref = object::create_object_from_account(creator);
+        create_store(&creator_ref, metadata);
+        let delete_ref = object::generate_delete_ref(&creator_ref);
+        remove_store(&delete_ref);
+    }
+
+    #[test(creator = @0xcafe, aaron = @0xface)]
+    fun test_transfer_with_ref(
+        creator: &signer,
+        aaron: &signer,
+    ) {
+        let (creator_ref, test_token) = create_test_token(creator);
+        let (mint_ref, transfer_ref, _burn_ref) = init_test_metadata(&creator_ref);
+        let metadata = object::convert<TestToken, Metadata>(test_token);
+        simple_token::initialize(creator, &creator_ref);
+
+        let creator_store = create_test_store(creator, metadata);
+        let aaron_store = create_test_store(aaron, metadata);
+
+        let fa = mint(&mint_ref, 100);
+        set_frozen_flag(&transfer_ref, creator_store, true);
+        set_frozen_flag(&transfer_ref, aaron_store, true);
+        deposit_with_ref(&transfer_ref, creator_store, fa);
+        transfer_with_ref(&transfer_ref, creator_store, aaron_store, 80);
+        assert!(balance(creator_store) == 20, 1);
+        assert!(balance(aaron_store) == 80, 2);
+        assert!(!!is_frozen(creator_store), 3);
+        assert!(!!is_frozen(aaron_store), 4);
+    }
+
+    #[test(creator = @0xcafe)]
+    fun test_merge_and_exact(creator: &signer) {
+        let (creator_ref, _test_token) = create_test_token(creator);
+        let (mint_ref, _transfer_ref, burn_ref) = init_test_metadata(&creator_ref);
+        simple_token::initialize(creator, &creator_ref);
+
+        let fa = mint(&mint_ref, 100);
+        let cash = extract(&mut fa, 80);
+        assert!(amount(&fa) == 20, 1);
+        assert!(amount(&cash) == 80, 2);
+        let more_cash = extract(&mut fa, 20);
+        destroy_zero(fa);
+        merge(&mut cash,
+         more_cash);
+        assert!(amount(&cash) == 100, 3);
+        burn(&burn_ref, cash);
+    }
+
+    #[test(fx = @aptos_framework, creator = @0xcafe)]
+    fun test_fungible_asset_upgrade(
+        fx: &signer,
+        creator: &signer
+    ) {
+        let feature = features::get_concurrent_fungible_assets_feature();
+        let agg_feature = features::get_aggregator_v2_api_feature();
+        features::change_feature_flags_for_testing(fx, vector[], vector[feature, agg_feature]);
+
+        let (creator_ref, token_object) = create_test_token(creator);
+        let (mint_ref, transfer_ref, _burn) = init_test_metadata(&creator_ref);
+        let test_token = object::convert<TestToken, Metadata>(token_object);
+        simple_token::initialize(creator, &creator_ref);
+
+        let creator_store = create_test_store(creator, test_token);
+
+        let fa = mint(&mint_ref, 30);
+        assert!(supply(test_token) == option::some(30), 2);
+
+        deposit_with_ref(&transfer_ref, creator_store, fa);
+
+        features::change_feature_flags_for_testing(fx, vector[feature, agg_feature], vector[]);
+
+        let extend_ref = object::generate_extend_ref(&creator_ref);
+        upgrade_to_concurrent(&extend_ref);
+
+        let fb = mint(&mint_ref, 20);
+        assert!(supply(test_token) == option::some(50), 3);
+
+        deposit_with_ref(&transfer_ref, creator_store, fb);
+    }
+}

--- a/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_pfs_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_pfs_tests.move
@@ -1,0 +1,134 @@
+#[test_only]
+module aptos_framework::simple_token_pfs_tests {
+    use aptos_framework::fungible_asset::{create_test_token};
+    use aptos_framework::primary_fungible_store::{
+        balance, burn, deposit, mint, primary_store, transfer, transfer_assert_minimum_deposit,
+        withdraw, init_test_metadata_with_primary_store_enabled, is_frozen, set_frozen_flag,
+        transfer_with_ref, deposit_with_ref, withdraw_with_ref, primary_store_exists,
+        ensure_primary_store_exists
+    };
+    use aptos_framework::object;
+    use 0xcafe::simple_token;
+    use std::signer;
+
+    // Copied from primary_fungible_store tests.
+    #[test(user_1 = @0xcafe, user_2 = @0xface)]
+    fun test_transfer_to_burnt_store(
+        user_1: &signer,
+        user_2: &signer,
+    ) {
+        let (creator_ref, metadata) = create_test_token(user_1);
+        let (mint_ref, _, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
+        simple_token::initialize(user_1, &creator_ref);
+
+        let user_1_address = signer::address_of(user_1);
+        let user_2_address = signer::address_of(user_2);
+        mint(&mint_ref, user_1_address, 100);
+        transfer(user_1, metadata, user_2_address, 80);
+
+        // User 2 burns their primary store but should still be able to transfer afterward.
+        let user_2_primary_store = primary_store(user_2_address, metadata);
+        object::burn(user_2, user_2_primary_store);
+        assert!(object::is_burnt(user_2_primary_store), 0);
+        // Balance still works
+        assert!(balance(user_2_address, metadata) == 80, 0);
+        // Deposit still works
+        transfer(user_1, metadata, user_2_address, 20);
+        transfer(user_2, metadata, user_1_address, 90);
+        assert!(balance(user_2_address, metadata) == 10, 0);
+    }
+
+    #[test(user_1 = @0xcafe, user_2 = @0xface)]
+    fun test_withdraw_from_burnt_store(
+        user_1: &signer,
+        user_2: &signer,
+    ) {
+        let (creator_ref, metadata) = create_test_token(user_1);
+        let (mint_ref, _, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
+        simple_token::initialize(user_1, &creator_ref);
+
+        let user_1_address = signer::address_of(user_1);
+        let user_2_address = signer::address_of(user_2);
+        mint(&mint_ref, user_1_address, 100);
+        transfer(user_1, metadata, user_2_address, 80);
+
+        // User 2 burns their primary store but should still be able to withdraw afterward.
+        let user_2_primary_store = primary_store(user_2_address, metadata);
+        object::burn(user_2, user_2_primary_store);
+        assert!(object::is_burnt(user_2_primary_store), 0);
+        let coins = withdraw(user_2, metadata, 70);
+        assert!(balance(user_2_address, metadata) == 10, 0);
+        deposit(user_2_address, coins);
+    }
+
+    #[test(creator = @0xcafe, aaron = @0xface)]
+    fun test_default_behavior(creator: &signer, aaron: &signer) {
+        let (creator_ref, metadata) = create_test_token(creator);
+        init_test_metadata_with_primary_store_enabled(&creator_ref);
+        simple_token::initialize(creator, &creator_ref);
+
+        let creator_address = signer::address_of(creator);
+        let aaron_address = signer::address_of(aaron);
+        assert!(!primary_store_exists(creator_address, metadata), 1);
+        assert!(!primary_store_exists(aaron_address, metadata), 2);
+        assert!(balance(creator_address, metadata) == 0, 3);
+        assert!(balance(aaron_address, metadata) == 0, 4);
+        assert!(!is_frozen(creator_address, metadata), 5);
+        assert!(!is_frozen(aaron_address, metadata), 6);
+        ensure_primary_store_exists(creator_address, metadata);
+        ensure_primary_store_exists(aaron_address, metadata);
+        assert!(primary_store_exists(creator_address, metadata), 7);
+        assert!(primary_store_exists(aaron_address, metadata), 8);
+    }
+
+    #[test(creator = @0xcafe, aaron = @0xface)]
+    fun test_basic_flow(
+        creator: &signer,
+        aaron: &signer,
+    ) {
+        let (creator_ref, metadata) = create_test_token(creator);
+        let (mint_ref, transfer_ref, burn_ref) = init_test_metadata_with_primary_store_enabled(&creator_ref);
+        simple_token::initialize(creator, &creator_ref);
+
+        let creator_address = signer::address_of(creator);
+        let aaron_address = signer::address_of(aaron);
+        assert!(balance(creator_address, metadata) == 0, 1);
+        assert!(balance(aaron_address, metadata) == 0, 2);
+        mint(&mint_ref, creator_address, 100);
+        transfer(creator, metadata, aaron_address, 80);
+        let fa = withdraw(aaron, metadata, 10);
+        deposit(creator_address, fa);
+        assert!(balance(creator_address, metadata) == 30, 3);
+        assert!(balance(aaron_address, metadata) == 70, 4);
+        set_frozen_flag(&transfer_ref, aaron_address, true);
+        assert!(is_frozen(aaron_address, metadata), 5);
+        let fa = withdraw_with_ref(&transfer_ref, aaron_address, 30);
+        deposit_with_ref(&transfer_ref, aaron_address, fa);
+        transfer_with_ref(&transfer_ref, aaron_address, creator_address, 20);
+        set_frozen_flag(&transfer_ref, aaron_address, false);
+        assert!(!is_frozen(aaron_address, metadata), 6);
+        burn(&burn_ref, aaron_address, 50);
+        assert!(balance(aaron_address, metadata) == 0, 7);
+    }
+
+    #[test(creator = @0xcafe, aaron = @0xface)]
+    fun test_basic_flow_with_min_balance(
+        creator: &signer,
+        aaron: &signer,
+    ) {
+        let (creator_ref, metadata) = create_test_token(creator);
+        let (mint_ref, _transfer_ref, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
+        simple_token::initialize(creator, &creator_ref);
+
+        let creator_address = signer::address_of(creator);
+        let aaron_address = signer::address_of(aaron);
+        assert!(balance(creator_address, metadata) == 0, 1);
+        assert!(balance(aaron_address, metadata) == 0, 2);
+        mint(&mint_ref, creator_address, 100);
+        transfer_assert_minimum_deposit(creator, metadata, aaron_address, 80, 80);
+        let fa = withdraw(aaron, metadata, 10);
+        deposit(creator_address, fa);
+        assert!(balance(creator_address, metadata) == 30, 3);
+        assert!(balance(aaron_address, metadata) == 70, 4);
+    }
+}

--- a/third_party/move/move-compiler-v2/src/plan_builder.rs
+++ b/third_party/move/move-compiler-v2/src/plan_builder.rs
@@ -442,6 +442,7 @@ fn parse_failure_attribute(
                 status_code,
                 sub_status_code,
                 move_binary_format::errors::Location::Module(location),
+                None,
             )))
         },
     }

--- a/third_party/move/move-compiler/src/unit_test/mod.rs
+++ b/third_party/move/move-compiler/src/unit_test/mod.rs
@@ -155,7 +155,9 @@ impl<'a> fmt::Display for ExpectedMoveErrorDisplay<'a> {
             write!(f, " with sub-status {code}")?
         };
         if let Some(msg) = msg {
-            write!(f, " with error message: \"{}\". Error", msg)?;
+            if status != &StatusCode::ABORTED {
+                write!(f, " with error message: \"{}\". Error", msg)?;
+            }
         }
         if status != &StatusCode::OUT_OF_GAS {
             write!(f, " originating")?;

--- a/third_party/move/move-compiler/src/unit_test/mod.rs
+++ b/third_party/move/move-compiler/src/unit_test/mod.rs
@@ -48,12 +48,19 @@ pub enum ExpectedFailure {
     ExpectedWithError(ExpectedMoveError),
 }
 
-#[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq)]
 pub struct ExpectedMoveError(
     pub StatusCode,
     pub Option<u64>,
     pub move_binary_format::errors::Location,
+    pub Option<String>,
 );
+
+impl PartialEq for ExpectedMoveError {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0 && self.1 == other.1 && self.2 == other.2
+    }
+}
 
 pub struct ExpectedMoveErrorDisplay<'a> {
     error: &'a ExpectedMoveError,
@@ -119,7 +126,7 @@ impl<'a> fmt::Display for ExpectedMoveErrorDisplay<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use move_binary_format::errors::Location;
         let Self {
-            error: ExpectedMoveError(status, sub_status, location),
+            error: ExpectedMoveError(status, sub_status, location, msg),
             is_past_tense,
         } = self;
         let status_val: u64 = (*status).into();
@@ -147,6 +154,9 @@ impl<'a> fmt::Display for ExpectedMoveErrorDisplay<'a> {
         } else if let Some(code) = sub_status {
             write!(f, " with sub-status {code}")?
         };
+        if let Some(msg) = msg {
+            write!(f, " with error message: \"{}\". Error", msg)?;
+        }
         if status != &StatusCode::OUT_OF_GAS {
             write!(f, " originating")?;
         }

--- a/third_party/move/move-compiler/src/unit_test/plan_builder.rs
+++ b/third_party/move/move-compiler/src/unit_test/plan_builder.rs
@@ -479,6 +479,7 @@ fn parse_failure_attribute(
                 status_code,
                 sub_status_code,
                 move_binary_format::errors::Location::Module(location),
+                None,
             )))
         },
     }

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -61,10 +61,8 @@ fn load_module_impl(
         }
     }
     remote.get_module(module_id)?.ok_or_else(|| {
-        PartialVMError::new(StatusCode::LINKER_ERROR).with_message(format!(
-            "Linker Error: Module {} doesn't exist",
-            module_id
-        ))
+        PartialVMError::new(StatusCode::LINKER_ERROR)
+            .with_message(format!("Linker Error: Module {} doesn't exist", module_id))
     })
 }
 

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -62,7 +62,7 @@ fn load_module_impl(
     }
     remote.get_module(module_id)?.ok_or_else(|| {
         PartialVMError::new(StatusCode::LINKER_ERROR).with_message(format!(
-            "Linker Error: Cannot find {:?} in data cache",
+            "Linker Error: Module {} doesn't exist",
             module_id
         ))
     })

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -673,7 +673,11 @@ impl Interpreter {
                         traversal_context.referenced_modules,
                         [(arena_id.address(), arena_id.name())],
                     )
-                    .map_err(|err| err.to_partial())?;
+                    .map_err(|err| err
+                        .to_partial()
+                        .append_message_with_separator('.',
+                            format!("Failed to charge transitive dependency for {}. Does this module exists?", module_name)
+                        ))?;
                 resolver
                     .loader()
                     .load_module(&module_name, data_store, module_store)

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -663,37 +663,27 @@ impl Interpreter {
                 let arena_id = traversal_context
                     .referenced_module_ids
                     .alloc(module_name.clone());
-                if let Ok(true) = data_store.exists_module(&module_name) {
-                    resolver
-                        .loader()
-                        .check_dependencies_and_charge_gas(
-                            module_store,
-                            data_store,
-                            gas_meter,
-                            &mut traversal_context.visited,
-                            traversal_context.referenced_modules,
-                            [(arena_id.address(), arena_id.name())],
-                        )
-                        .map_err(|err| {
-                            PartialVMError::new(err.major_status()).with_message(format!(
-                                "Module {} failed to be charged",
-                                module_name
-                            ))
-                        })?;
-                    resolver
-                        .loader()
-                        .load_module(&module_name, data_store, module_store)
-                        .map_err(|_| {
-                            PartialVMError::new(StatusCode::FUNCTION_RESOLUTION_FAILURE)
-                                .with_message(format!("Module {} doesn't exist", module_name))
-                        })?;
+                resolver
+                    .loader()
+                    .check_dependencies_and_charge_gas(
+                        module_store,
+                        data_store,
+                        gas_meter,
+                        &mut traversal_context.visited,
+                        traversal_context.referenced_modules,
+                        [(arena_id.address(), arena_id.name())],
+                    )
+                    .map_err(|err| err.to_partial())?;
+                resolver
+                    .loader()
+                    .load_module(&module_name, data_store, module_store)
+                    .map_err(|_| {
+                        PartialVMError::new(StatusCode::FUNCTION_RESOLUTION_FAILURE)
+                            .with_message(format!("Module {} doesn't exist", module_name))
+                    })?;
 
-                    current_frame.pc += 1; // advance past the Call instruction in the caller
-                    Ok(())
-                } else {
-                    Err(PartialVMError::new(StatusCode::FUNCTION_RESOLUTION_FAILURE)
-                        .with_message(format!("Module {} doesn't exist", module_name)))
-                }
+                current_frame.pc += 1; // advance past the Call instruction in the caller
+                Ok(())
             },
         }
     }

--- a/third_party/move/tools/move-cli/tests/sandbox_tests/multi_module_publish/args.exp
+++ b/third_party/move/tools/move-cli/tests/sandbox_tests/multi_module_publish/args.exp
@@ -1,12 +1,12 @@
 Command `sandbox publish --bundle --override-ordering A -v`:
 Found 2 modules
-Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Linker Error: Cannot find ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000002, name: Identifier("B") } in data cache
+Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000002::B doesn't exist
 Command `sandbox publish --bundle --override-ordering B -v`:
 Found 2 modules
-Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Linker Error: Cannot find ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000002, name: Identifier("A") } in data cache
+Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000002::A doesn't exist
 Command `sandbox publish --bundle --override-ordering B --override-ordering A -v`:
 Found 2 modules
-Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Linker Error: Cannot find ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000002, name: Identifier("A") } in data cache
+Invalid multi-module publishing: VMError with status LINKER_ERROR at location UNDEFINED and message Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000002::A doesn't exist
 Command `sandbox publish --bundle --override-ordering A --override-ordering B -v`:
 Found 2 modules
 Publishing a new module 0000000000000000000000000000000000000000000000000000000000000002::A (wrote 121 bytes)

--- a/third_party/move/tools/move-unit-test/src/test_runner.rs
+++ b/third_party/move/tools/move-unit-test/src/test_runner.rs
@@ -351,8 +351,12 @@ impl SharedTestingConfig {
             };
             match exec_result {
                 Err(err) => {
-                    let actual_err =
-                        MoveError(err.major_status(), err.sub_status(), err.location().clone());
+                    let actual_err = MoveError(
+                        err.major_status(),
+                        err.sub_status(),
+                        err.location().clone(),
+                        err.message().cloned(),
+                    );
                     assert!(err.major_status() != StatusCode::EXECUTED);
                     match test_info.expected_failure.as_ref() {
                         Some(ExpectedFailure::Expected) => {

--- a/third_party/move/tools/move-unit-test/tests/test_sources/missing_data.exp
+++ b/third_party/move/tools/move-unit-test/tests/test_sources/missing_data.exp
@@ -23,7 +23,7 @@ Failures in 0x1::MissingData:
 │ 5 │     fun missing_data() acquires Missing {
 │   │         ------------ In this function in 0x1::MissingData
 │ 6 │         borrow_global<Missing>(@0x0);
-│   │         ^^^^^^^^^^^^^ Test was not expected to error, but it gave a MISSING_DATA (code 4008) error originating in the module 0000000000000000000000000000000000000000000000000000000000000001::MissingData rooted here
+│   │         ^^^^^^^^^^^^^ Test was not expected to error, but it gave a MISSING_DATA (code 4008) error with error message: "Failed to borrow global resource from 0000000000000000000000000000000000000000000000000000000000000000". Error originating in the module 0000000000000000000000000000000000000000000000000000000000000001::MissingData rooted here
 │ 
 │ 
 └──────────────────
@@ -36,7 +36,7 @@ Failures in 0x1::MissingData:
 │ 5 │     fun missing_data() acquires Missing {
 │   │         ------------ In this function in 0x1::MissingData
 │ 6 │         borrow_global<Missing>(@0x0);
-│   │         ^^^^^^^^^^^^^ Test was not expected to error, but it gave a MISSING_DATA (code 4008) error originating in the module 0000000000000000000000000000000000000000000000000000000000000001::MissingData rooted here
+│   │         ^^^^^^^^^^^^^ Test was not expected to error, but it gave a MISSING_DATA (code 4008) error with error message: "Failed to borrow global resource from 0000000000000000000000000000000000000000000000000000000000000000". Error originating in the module 0000000000000000000000000000000000000000000000000000000000000001::MissingData rooted here
 │ 
 │ 
 │ stack trace

--- a/third_party/move/tools/move-unit-test/tests/test_sources/non_exsistent_native.exp
+++ b/third_party/move/tools/move-unit-test/tests/test_sources/non_exsistent_native.exp
@@ -15,7 +15,7 @@ Failures in 0x1::M:
 │   │                ^^^
 │   │                │
 │   │                INTERNAL TEST ERROR: Unexpected Verification Error
-│ Test was not expected to error, but it gave a MISSING_DEPENDENCY (code 1021) error originating in the module 0000000000000000000000000000000000000000000000000000000000000001::M rooted here
+│ Test was not expected to error, but it gave a MISSING_DEPENDENCY (code 1021) error with error message: "Missing Native Function `foo`". Error originating in the module 0000000000000000000000000000000000000000000000000000000000000001::M rooted here
 │   │                In this function in 0x1::M
 │ 
 │ 

--- a/third_party/move/tools/move-unit-test/tests/test_sources/out_of_gas.exp
+++ b/third_party/move/tools/move-unit-test/tests/test_sources/out_of_gas.exp
@@ -38,7 +38,7 @@ Failures in 0x42::m:
 │ 15 │ fun t2() {
 │    │     -- In this function in 0x42::m
 │ 16 │     0 - 1;
-│    │       ^ Test did not error as expected. Expected test to run out of gas in the module 0000000000000000000000000000000000000000000000000000000000000042::m but instead it gave an arithmetic error originating in the module 0000000000000000000000000000000000000000000000000000000000000042::m rooted here
+│    │       ^ Test did not error as expected. Expected test to run out of gas in the module 0000000000000000000000000000000000000000000000000000000000000042::m but instead it gave an arithmetic error with error message: "Subtraction overflow". Error originating in the module 0000000000000000000000000000000000000000000000000000000000000042::m rooted here
 │ 
 │ 
 └──────────────────


### PR DESCRIPTION
## Description

Fixes a bunch of issues:
1. Updated move-unit-test to include full error msg on test failure so we can see the detailed error msg.
2. Fix error msg when the module that contains the hook function doesn't exist.
3. Fix error msg when invoking FS api on assets with hook registered.
4. Fix PFS mint to invoke withdraw_internal.
5. Fix transfer api in dispatchable api to check for the frozen bit.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Added tests for each affected cases.

## Key Areas to Review
N/A

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
