### PR TITLE
[INC-600] fix state db truncation when db-sharding is not enabled.

### DIFF
--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -196,6 +196,14 @@ impl StateKvDb {
         NUM_STATE_SHARDS as u8
     }
 
+    pub(crate) fn hack_num_real_shards(&self) -> usize {
+        if self.enabled_sharding {
+            NUM_STATE_SHARDS
+        } else {
+            1
+        }
+    }
+
     pub(crate) fn commit_single_shard(
         &self,
         version: Version,

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -550,6 +550,14 @@ impl StateMerkleDb {
         NUM_STATE_SHARDS as u8
     }
 
+    pub(crate) fn hack_num_real_shards(&self) -> usize {
+        if self.enable_sharding {
+            NUM_STATE_SHARDS
+        } else {
+            1
+        }
+    }
+
     fn db_by_key(&self, node_key: &NodeKey) -> &DB {
         if let Some(shard_id) = node_key.get_shard_id() {
             self.db_shard(shard_id)
@@ -694,11 +702,7 @@ impl StateMerkleDb {
         }
 
         // traverse all shards in a naive way
-        // if sharding is not enable, we only need to search once.
-        let shards = self
-            .enable_sharding
-            .then(|| (0..NUM_STATE_SHARDS))
-            .unwrap_or(0..1);
+        let shards = 0..self.hack_num_real_shards();
         let start_num_of_nibbles = if self.enable_sharding { 1 } else { 0 };
         for shard_id in shards.rev() {
             let shard_db = self.state_merkle_db_shards[shard_id].clone();
@@ -846,11 +850,7 @@ impl TreeReader<StateKey> for StateMerkleDb {
         };
 
         let ret = None;
-        // if sharding is not enable, we only need to search once.
-        let shards = self
-            .enable_sharding
-            .then(|| (0..NUM_STATE_SHARDS))
-            .unwrap_or(0..1);
+        let shards = 0..self.hack_num_real_shards();
 
         // Search from right to left to find the first leaf node.
         for shard_id in shards.rev() {

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -383,7 +383,7 @@ impl StateStore {
                 &state_kv_db,
                 state_kv_commit_progress,
                 overall_commit_progress,
-                difference as usize,
+                std::cmp::max(difference as usize, 1), /* batch_size */
             )
             .expect("Failed to truncate state K/V db.");
         } else {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Fix that state tree / kv truncator do duplicated work when db sharding is not enabled.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Validator Node

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

forge test fullnode_reboot_stress_test were broken since last fix (where state kv db truncation is always attempted), this fixes that.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
