### PR TITLE
fix bug 13201 by emitting an empty vector constant load as a VecPack instead

### DIFF
--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -703,6 +703,19 @@ impl<'a> FunctionGenerator<'a> {
             U256(n) => self.emit(FF::Bytecode::LdU256(
                 move_core_types::u256::U256::from_le_bytes(&n.to_le_bytes()),
             )),
+            Vector(vec) if vec.is_empty() => {
+                let fun_ctx = ctx.fun_ctx;
+                let elem_type = if let Type::Vector(el) = fun_ctx.fun.get_local_type(*dest) {
+                    el.as_ref().clone()
+                } else {
+                    fun_ctx.internal_error("expected vector type");
+                    Type::new_prim(PrimitiveType::Bool)
+                };
+                let sign = self
+                    .gen
+                    .signature(&fun_ctx.module, &fun_ctx.loc, vec![elem_type]);
+                self.emit(FF::Bytecode::VecPack(sign, 0u64));
+            },
             _ => {
                 let cons = self.gen.constant_index(
                     &ctx.fun_ctx.module,

--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -686,6 +686,11 @@ impl<'a> FunctionGenerator<'a> {
     /// Generate code for the load instruction.
     fn gen_load(&mut self, ctx: &BytecodeContext, dest: &TempIndex, cons: &Constant) {
         self.flush_any_conflicts(ctx, std::slice::from_ref(dest), &[]);
+        self.gen_load_push(ctx, cons, ctx.fun_ctx.fun.get_local_type(*dest));
+        self.abstract_push_result(ctx, vec![*dest]);
+    }
+
+    fn gen_load_push(&mut self, ctx: &BytecodeContext, cons: &Constant, dest_type: &Type) {
         use Constant::*;
         match cons {
             Bool(b) => {
@@ -703,30 +708,46 @@ impl<'a> FunctionGenerator<'a> {
             U256(n) => self.emit(FF::Bytecode::LdU256(
                 move_core_types::u256::U256::from_le_bytes(&n.to_le_bytes()),
             )),
-            Vector(vec) if vec.is_empty() => {
-                let fun_ctx = ctx.fun_ctx;
-                let elem_type = if let Type::Vector(el) = fun_ctx.fun.get_local_type(*dest) {
-                    el.as_ref().clone()
-                } else {
-                    fun_ctx.internal_error("expected vector type");
-                    Type::new_prim(PrimitiveType::Bool)
-                };
-                let sign = self
-                    .gen
-                    .signature(&fun_ctx.module, &fun_ctx.loc, vec![elem_type]);
-                self.emit(FF::Bytecode::VecPack(sign, 0u64));
+            Vector(vec) if Self::vector_is_empty_or_contains_empty_vector(vec) => {
+                self.gen_vector_load_push(ctx, vec, dest_type);
             },
             _ => {
-                let cons = self.gen.constant_index(
-                    &ctx.fun_ctx.module,
-                    &ctx.fun_ctx.loc,
-                    cons,
-                    ctx.fun_ctx.fun.get_local_type(*dest),
-                );
+                let cons =
+                    self.gen
+                        .constant_index(&ctx.fun_ctx.module, &ctx.fun_ctx.loc, cons, dest_type);
                 self.emit(FF::Bytecode::LdConst(cons));
             },
         }
-        self.abstract_push_result(ctx, vec![*dest]);
+    }
+
+    fn vector_is_empty_or_contains_empty_vector(cons: &Vec<Constant>) -> bool {
+        cons.is_empty()
+            || cons.iter().any(|cons| match cons {
+                Constant::Vector(vec) => Self::vector_is_empty_or_contains_empty_vector(vec),
+                _ => false,
+            })
+    }
+
+    fn gen_vector_load_push(
+        &mut self,
+        ctx: &BytecodeContext,
+        vec: &Vec<Constant>,
+        vec_type: &Type,
+    ) {
+        let fun_ctx = ctx.fun_ctx;
+        let elem_type = if let Type::Vector(el) = vec_type {
+            el.as_ref().clone()
+        } else {
+            fun_ctx.internal_error("expected vector type");
+            Type::new_prim(PrimitiveType::Bool)
+        };
+        for cons in vec.iter() {
+            self.gen_load_push(ctx, cons, &elem_type);
+        }
+        let sign = self
+            .gen
+            .signature(&fun_ctx.module, &fun_ctx.loc, vec![elem_type]);
+        self.emit(FF::Bytecode::VecPack(sign, vec.len() as u64));
     }
 
     /// Generates code for an inline spec block. The spec block needs

--- a/third_party/move/move-compiler-v2/tests/folding/empty_tvectors.exp
+++ b/third_party/move/move-compiler-v2/tests/folding/empty_tvectors.exp
@@ -1,0 +1,68 @@
+// -- Model dump before bytecode pipeline
+module 0x42::m {
+    use std::bcs;
+    use std::string::{Self};
+    use std::vector;
+    public entry fun init() {
+        {
+          let _: vector<string::String> = {
+            let result: vector<string::String> = Vector<string::String>();
+            {
+              let (v: vector<vector<u8>>): (vector<vector<u8>>) = Tuple([]);
+              vector::reverse<vector<u8>>(Borrow(Mutable)(v));
+              loop {
+                if Not(vector::is_empty<vector<u8>>(Borrow(Immutable)(v))) {
+                  {
+                    let e: vector<u8> = vector::pop_back<vector<u8>>(Borrow(Mutable)(v));
+                    {
+                      let (elem: vector<u8>): (vector<u8>) = Tuple(e);
+                      vector::push_back<string::String>(Borrow(Mutable)(result), {
+                        let (key: vector<u8>): (vector<u8>) = Tuple(elem);
+                        string::utf8(key)
+                      })
+                    };
+                    Tuple()
+                  }
+                } else {
+                  break
+                }
+              };
+              Tuple()
+            };
+            result
+          };
+          {
+            let _: vector<vector<u8>> = {
+              let result: vector<vector<u8>> = Vector<vector<u8>>();
+              {
+                let (v: vector<u64>): (vector<u64>) = Tuple([]);
+                vector::reverse<u64>(Borrow(Mutable)(v));
+                loop {
+                  if Not(vector::is_empty<u64>(Borrow(Immutable)(v))) {
+                    {
+                      let e: u64 = vector::pop_back<u64>(Borrow(Mutable)(v));
+                      {
+                        let (elem: u64): (u64) = Tuple(e);
+                        vector::push_back<vector<u8>>(Borrow(Mutable)(result), {
+                          let (v: u64): (u64) = Tuple(elem);
+                          bcs::to_bytes<u64>(Borrow(Immutable)(v))
+                        })
+                      };
+                      Tuple()
+                    }
+                  } else {
+                    break
+                  }
+                };
+                Tuple()
+              };
+              result
+            };
+            Tuple()
+          }
+        }
+    }
+} // end 0x42::m
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/folding/empty_tvectors.move
+++ b/third_party/move/move-compiler-v2/tests/folding/empty_tvectors.move
@@ -1,0 +1,17 @@
+//# publish
+module 0x42::m {
+    use std::bcs;
+    use std::string::{Self};
+    use std::vector;
+
+    const KEYS: vector<vector<u8>> = vector[];
+    const VALUES: vector<u64> = vector[];
+
+    public entry fun init(
+    ) {
+        let _ = vector::map(KEYS, |key|{ string::utf8(key)});
+        let _ = vector::map(VALUES, |v|{ bcs::to_bytes<u64>(&v)});
+    }
+}
+
+//# run 0x42::m::init

--- a/third_party/move/move-compiler-v2/tests/folding/empty_vectors.exp
+++ b/third_party/move/move-compiler-v2/tests/folding/empty_vectors.exp
@@ -1,0 +1,69 @@
+// -- Model dump before bytecode pipeline
+module 0x42::m {
+    use std::vector;
+    public entry fun init() {
+        {
+          let _x: vector<u64> = {
+            let result: vector<u64> = Vector<u64>();
+            {
+              let (v: vector<vector<u8>>): (vector<vector<u8>>) = Tuple([]);
+              vector::reverse<vector<u8>>(Borrow(Mutable)(v));
+              loop {
+                if Not(vector::is_empty<vector<u8>>(Borrow(Immutable)(v))) {
+                  {
+                    let e: vector<u8> = vector::pop_back<vector<u8>>(Borrow(Mutable)(v));
+                    {
+                      let (elem: vector<u8>): (vector<u8>) = Tuple(e);
+                      vector::push_back<u64>(Borrow(Mutable)(result), {
+                        let (key: vector<u8>): (vector<u8>) = Tuple(elem);
+                        {
+                          let t: vector<u8> = key;
+                          Add<u64>(vector::length<u8>(Borrow(Immutable)(t)), 2)
+                        }
+                      })
+                    };
+                    Tuple()
+                  }
+                } else {
+                  break
+                }
+              };
+              Tuple()
+            };
+            result
+          };
+          {
+            let _y: vector<u64> = {
+              let result: vector<u64> = Vector<u64>();
+              {
+                let (v: vector<u64>): (vector<u64>) = Tuple([]);
+                vector::reverse<u64>(Borrow(Mutable)(v));
+                loop {
+                  if Not(vector::is_empty<u64>(Borrow(Immutable)(v))) {
+                    {
+                      let e: u64 = vector::pop_back<u64>(Borrow(Mutable)(v));
+                      {
+                        let (elem: u64): (u64) = Tuple(e);
+                        vector::push_back<u64>(Borrow(Mutable)(result), {
+                          let (v: u64): (u64) = Tuple(elem);
+                          Add<u64>(v, 3)
+                        })
+                      };
+                      Tuple()
+                    }
+                  } else {
+                    break
+                  }
+                };
+                Tuple()
+              };
+              result
+            };
+            Tuple()
+          }
+        }
+    }
+} // end 0x42::m
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/folding/empty_vectors.move
+++ b/third_party/move/move-compiler-v2/tests/folding/empty_vectors.move
@@ -1,0 +1,13 @@
+//# publish
+module 0x42::m {
+    use std::vector;
+    const KEYS: vector<vector<u8>> = vector[];
+    const VALUES: vector<u64> = vector[];
+
+    public entry fun init() {
+        let _x: vector<u64> = vector::map<vector<u8>, u64>(KEYS, |key| { let t: vector<u8> = key; (vector::length<u8>(&t) + 2) });
+        let _y: vector<u64> = vector::map<u64, u64>(VALUES, |v| { (v + 3u64) });
+    }
+}
+
+//# run 0x42::m::init

--- a/third_party/move/move-compiler-v2/tests/folding/empty_vectors2.exp
+++ b/third_party/move/move-compiler-v2/tests/folding/empty_vectors2.exp
@@ -1,0 +1,75 @@
+// -- Model dump before bytecode pipeline
+module 0x42::m {
+    use std::vector;
+    public entry fun init() {
+        {
+          let _x: vector<u64> = {
+            let (v: vector<vector<u8>>): (vector<vector<u8>>) = Tuple(Deref(vector::borrow<vector<vector<u8>>>(Borrow(Immutable)([Vector([])]), 0)));
+            {
+              let result: vector<u64> = Vector<u64>();
+              {
+                let (v: vector<vector<u8>>): (vector<vector<u8>>) = Tuple(v);
+                vector::reverse<vector<u8>>(Borrow(Mutable)(v));
+                loop {
+                  if Not(vector::is_empty<vector<u8>>(Borrow(Immutable)(v))) {
+                    {
+                      let e: vector<u8> = vector::pop_back<vector<u8>>(Borrow(Mutable)(v));
+                      {
+                        let (elem: vector<u8>): (vector<u8>) = Tuple(e);
+                        vector::push_back<u64>(Borrow(Mutable)(result), {
+                          let (key: vector<u8>): (vector<u8>) = Tuple(elem);
+                          {
+                            let t: vector<u8> = key;
+                            Add<u64>(vector::length<u8>(Borrow(Immutable)(t)), 2)
+                          }
+                        })
+                      };
+                      Tuple()
+                    }
+                  } else {
+                    break
+                  }
+                };
+                Tuple()
+              };
+              result
+            }
+          };
+          {
+            let _y: vector<u64> = {
+              let (v: vector<u64>): (vector<u64>) = Tuple(Deref(vector::borrow<vector<u64>>(Borrow(Immutable)([Vector([])]), 0)));
+              {
+                let result: vector<u64> = Vector<u64>();
+                {
+                  let (v: vector<u64>): (vector<u64>) = Tuple(v);
+                  vector::reverse<u64>(Borrow(Mutable)(v));
+                  loop {
+                    if Not(vector::is_empty<u64>(Borrow(Immutable)(v))) {
+                      {
+                        let e: u64 = vector::pop_back<u64>(Borrow(Mutable)(v));
+                        {
+                          let (elem: u64): (u64) = Tuple(e);
+                          vector::push_back<u64>(Borrow(Mutable)(result), {
+                            let (v: u64): (u64) = Tuple(elem);
+                            Add<u64>(v, 3)
+                          })
+                        };
+                        Tuple()
+                      }
+                    } else {
+                      break
+                    }
+                  };
+                  Tuple()
+                };
+                result
+              }
+            };
+            Tuple()
+          }
+        }
+    }
+} // end 0x42::m
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/folding/empty_vectors2.move
+++ b/third_party/move/move-compiler-v2/tests/folding/empty_vectors2.move
@@ -1,0 +1,13 @@
+//# publish
+module 0x42::m {
+    use std::vector;
+    const KEYS: vector<vector<vector<u8>>> = vector[vector[]];
+    const VALUES: vector<vector<u64>> = vector[vector[]];
+
+    public entry fun init() {
+        let _x: vector<u64> = vector::map<vector<u8>, u64>(*vector::borrow(&KEYS, 0), |key| { let t: vector<u8> = key; (vector::length<u8>(&t) + 2) });
+        let _y: vector<u64> = vector::map<u64, u64>(*vector::borrow(&VALUES, 0), |v| { (v + 3u64) });
+    }
+}
+
+//# run 0x42::m::init

--- a/third_party/move/move-compiler-v2/tests/folding/nonempty_tvectors.exp
+++ b/third_party/move/move-compiler-v2/tests/folding/nonempty_tvectors.exp
@@ -1,0 +1,68 @@
+// -- Model dump before bytecode pipeline
+module 0x42::m {
+    use std::bcs;
+    use std::string::{Self};
+    use std::vector;
+    public entry fun init() {
+        {
+          let _: vector<string::String> = {
+            let result: vector<string::String> = Vector<string::String>();
+            {
+              let (v: vector<vector<u8>>): (vector<vector<u8>>) = Tuple([Vector([Number(3)])]);
+              vector::reverse<vector<u8>>(Borrow(Mutable)(v));
+              loop {
+                if Not(vector::is_empty<vector<u8>>(Borrow(Immutable)(v))) {
+                  {
+                    let e: vector<u8> = vector::pop_back<vector<u8>>(Borrow(Mutable)(v));
+                    {
+                      let (elem: vector<u8>): (vector<u8>) = Tuple(e);
+                      vector::push_back<string::String>(Borrow(Mutable)(result), {
+                        let (key: vector<u8>): (vector<u8>) = Tuple(elem);
+                        string::utf8(key)
+                      })
+                    };
+                    Tuple()
+                  }
+                } else {
+                  break
+                }
+              };
+              Tuple()
+            };
+            result
+          };
+          {
+            let _: vector<vector<u8>> = {
+              let result: vector<vector<u8>> = Vector<vector<u8>>();
+              {
+                let (v: vector<u64>): (vector<u64>) = Tuple([Number(3)]);
+                vector::reverse<u64>(Borrow(Mutable)(v));
+                loop {
+                  if Not(vector::is_empty<u64>(Borrow(Immutable)(v))) {
+                    {
+                      let e: u64 = vector::pop_back<u64>(Borrow(Mutable)(v));
+                      {
+                        let (elem: u64): (u64) = Tuple(e);
+                        vector::push_back<vector<u8>>(Borrow(Mutable)(result), {
+                          let (v: u64): (u64) = Tuple(elem);
+                          bcs::to_bytes<u64>(Borrow(Immutable)(v))
+                        })
+                      };
+                      Tuple()
+                    }
+                  } else {
+                    break
+                  }
+                };
+                Tuple()
+              };
+              result
+            };
+            Tuple()
+          }
+        }
+    }
+} // end 0x42::m
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/folding/nonempty_tvectors.move
+++ b/third_party/move/move-compiler-v2/tests/folding/nonempty_tvectors.move
@@ -1,0 +1,16 @@
+//# publish
+module 0x42::m {
+    use std::bcs;
+    use std::string::{Self};
+    use std::vector;
+
+    const KEYS: vector<vector<u8>> = vector[vector[3u8]];
+    const VALUES: vector<u64> = vector[3];
+
+    public entry fun init(
+    ) {
+        let _ = vector::map(KEYS, |key|{ string::utf8(key)});
+        let _ = vector::map(VALUES, |v|{ bcs::to_bytes<u64>(&v)});
+    }
+}
+//# run 0x42::m::init

--- a/third_party/move/move-compiler-v2/tests/folding/nonempty_vectors.exp
+++ b/third_party/move/move-compiler-v2/tests/folding/nonempty_vectors.exp
@@ -1,0 +1,69 @@
+// -- Model dump before bytecode pipeline
+module 0x42::m {
+    use std::vector;
+    public entry fun init() {
+        {
+          let _x: vector<u64> = {
+            let result: vector<u64> = Vector<u64>();
+            {
+              let (v: vector<vector<u8>>): (vector<vector<u8>>) = Tuple([Vector([Number(1)])]);
+              vector::reverse<vector<u8>>(Borrow(Mutable)(v));
+              loop {
+                if Not(vector::is_empty<vector<u8>>(Borrow(Immutable)(v))) {
+                  {
+                    let e: vector<u8> = vector::pop_back<vector<u8>>(Borrow(Mutable)(v));
+                    {
+                      let (elem: vector<u8>): (vector<u8>) = Tuple(e);
+                      vector::push_back<u64>(Borrow(Mutable)(result), {
+                        let (key: vector<u8>): (vector<u8>) = Tuple(elem);
+                        {
+                          let t: vector<u8> = key;
+                          Add<u64>(vector::length<u8>(Borrow(Immutable)(t)), 2)
+                        }
+                      })
+                    };
+                    Tuple()
+                  }
+                } else {
+                  break
+                }
+              };
+              Tuple()
+            };
+            result
+          };
+          {
+            let _y: vector<u64> = {
+              let result: vector<u64> = Vector<u64>();
+              {
+                let (v: vector<u64>): (vector<u64>) = Tuple([Number(3)]);
+                vector::reverse<u64>(Borrow(Mutable)(v));
+                loop {
+                  if Not(vector::is_empty<u64>(Borrow(Immutable)(v))) {
+                    {
+                      let e: u64 = vector::pop_back<u64>(Borrow(Mutable)(v));
+                      {
+                        let (elem: u64): (u64) = Tuple(e);
+                        vector::push_back<u64>(Borrow(Mutable)(result), {
+                          let (v: u64): (u64) = Tuple(elem);
+                          Add<u64>(v, 3)
+                        })
+                      };
+                      Tuple()
+                    }
+                  } else {
+                    break
+                  }
+                };
+                Tuple()
+              };
+              result
+            };
+            Tuple()
+          }
+        }
+    }
+} // end 0x42::m
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/folding/nonempty_vectors.move
+++ b/third_party/move/move-compiler-v2/tests/folding/nonempty_vectors.move
@@ -1,0 +1,13 @@
+//# publish
+module 0x42::m {
+    use std::vector;
+    const KEYS: vector<vector<u8>> = vector[vector[1u8]];
+    const VALUES: vector<u64> = vector[3u64];
+
+    public entry fun init() {
+        let _x: vector<u64> = vector::map<vector<u8>, u64>(KEYS, |key| { let t: vector<u8> = key; (vector::length<u8>(&t) + 2) });
+        let _y: vector<u64> = vector::map<u64, u64>(VALUES, |v| { (v + 3u64) });
+    }
+}
+
+//# run 0x42::m::init

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/constants/empty_tvectors.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/constants/empty_tvectors.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/constants/empty_tvectors.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/constants/empty_tvectors.move
@@ -1,0 +1,17 @@
+//# publish
+module 0x42::m {
+    use std::bcs;
+    use std::string::{Self};
+    use std::vector;
+
+    const KEYS: vector<vector<u8>> = vector[];
+    const VALUES: vector<u64> = vector[];
+
+    public entry fun init(
+    ) {
+        let _ = vector::map(KEYS, |key|{ string::utf8(key)});
+        let _ = vector::map(VALUES, |v|{ bcs::to_bytes<u64>(&v)});
+    }
+}
+
+//# run 0x42::m::init

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/constants/empty_vectors.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/constants/empty_vectors.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/constants/empty_vectors.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/constants/empty_vectors.move
@@ -1,0 +1,13 @@
+//# publish
+module 0x42::m {
+    use std::vector;
+    const KEYS: vector<vector<u8>> = vector[];
+    const VALUES: vector<u64> = vector[];
+
+    public entry fun init() {
+        let _x: vector<u64> = vector::map<vector<u8>, u64>(KEYS, |key| { let t: vector<u8> = key; (vector::length<u8>(&t) + 2) });
+        let _y: vector<u64> = vector::map<u64, u64>(VALUES, |v| { (v + 3u64) });
+    }
+}
+
+//# run 0x42::m::init

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/constants/empty_vectors2.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/constants/empty_vectors2.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/constants/empty_vectors2.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/constants/empty_vectors2.move
@@ -1,0 +1,13 @@
+//# publish
+module 0x42::m {
+    use std::vector;
+    const KEYS: vector<vector<vector<u8>>> = vector[vector[]];
+    const VALUES: vector<vector<u64>> = vector[vector[]];
+
+    public entry fun init() {
+        let _x: vector<u64> = vector::map<vector<u8>, u64>(*vector::borrow(&KEYS, 0), |key| { let t: vector<u8> = key; (vector::length<u8>(&t) + 2) });
+        let _y: vector<u64> = vector::map<u64, u64>(*vector::borrow(&VALUES, 0), |v| { (v + 3u64) });
+    }
+}
+
+//# run 0x42::m::init

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/constants/nonempty_tvectors.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/constants/nonempty_tvectors.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/constants/nonempty_tvectors.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/constants/nonempty_tvectors.move
@@ -1,0 +1,16 @@
+//# publish
+module 0x42::m {
+    use std::bcs;
+    use std::string::{Self};
+    use std::vector;
+
+    const KEYS: vector<vector<u8>> = vector[vector[3u8]];
+    const VALUES: vector<u64> = vector[3];
+
+    public entry fun init(
+    ) {
+        let _ = vector::map(KEYS, |key|{ string::utf8(key)});
+        let _ = vector::map(VALUES, |v|{ bcs::to_bytes<u64>(&v)});
+    }
+}
+//# run 0x42::m::init

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/constants/nonempty_vectors.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/constants/nonempty_vectors.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+
+==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/constants/nonempty_vectors.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/constants/nonempty_vectors.move
@@ -1,0 +1,13 @@
+//# publish
+module 0x42::m {
+    use std::vector;
+    const KEYS: vector<vector<u8>> = vector[vector[1u8]];
+    const VALUES: vector<u64> = vector[3u64];
+
+    public entry fun init() {
+        let _x: vector<u64> = vector::map<vector<u8>, u64>(KEYS, |key| { let t: vector<u8> = key; (vector::length<u8>(&t) + 2) });
+        let _y: vector<u64> = vector::map<u64, u64>(VALUES, |v| { (v + 3u64) });
+    }
+}
+
+//# run 0x42::m::init

--- a/third_party/move/move-compiler/tests/move_check/folding/empty_vectors.move
+++ b/third_party/move/move-compiler/tests/move_check/folding/empty_vectors.move
@@ -1,0 +1,13 @@
+//# publish
+module 0x42::m {
+    use std::vector;
+    const KEYS: vector<vector<u8>> = vector[];
+    const VALUES: vector<u64> = vector[];
+
+    public entry fun init() {
+        let _x: vector<u64> = vector::map<vector<u8>, u64>(KEYS, |key| { let t: vector<u8> = key; (vector::length<u8>(&t) + 2) });
+        let _y: vector<u64> = vector::map<u64, u64>(VALUES, |v| { (v + 3u64) });
+    }
+}
+
+//# run 0x42::m::init

--- a/third_party/move/move-compiler/tests/move_check/folding/empty_vectors2.move
+++ b/third_party/move/move-compiler/tests/move_check/folding/empty_vectors2.move
@@ -1,0 +1,13 @@
+//# publish
+module 0x42::m {
+    use std::vector;
+    const KEYS: vector<vector<vector<u8>>> = vector[vector[]];
+    const VALUES: vector<vector<u64>> = vector[vector[]];
+
+    public entry fun init() {
+        let _x: vector<u64> = vector::map<vector<u8>, u64>(*vector::borrow(&KEYS, 0), |key| { let t: vector<u8> = key; (vector::length<u8>(&t) + 2) });
+        let _y: vector<u64> = vector::map<u64, u64>(*vector::borrow(&VALUES, 0), |v| { (v + 3u64) });
+    }
+}
+
+//# run 0x42::m::init

--- a/third_party/move/move-compiler/tests/move_check/folding/nonempty_vectors.move
+++ b/third_party/move/move-compiler/tests/move_check/folding/nonempty_vectors.move
@@ -1,0 +1,13 @@
+//# publish
+module 0x42::m {
+    use std::vector;
+    const KEYS: vector<vector<u8>> = vector[vector[1u8]];
+    const VALUES: vector<u64> = vector[3u64];
+
+    public entry fun init() {
+        let _x: vector<u64> = vector::map<vector<u8>, u64>(KEYS, |key| { let t: vector<u8> = key; (vector::length<u8>(&t) + 2) });
+        let _y: vector<u64> = vector::map<u64, u64>(VALUES, |v| { (v + 3u64) });
+    }
+}
+
+//# run 0x42::m::init

--- a/third_party/move/move-compiler/transactional-tests/tests/constants/empty_vectors.exp
+++ b/third_party/move/move-compiler/transactional-tests/tests/constants/empty_vectors.exp
@@ -1,0 +1,1 @@
+processed 2 tasks

--- a/third_party/move/move-compiler/transactional-tests/tests/constants/empty_vectors.move
+++ b/third_party/move/move-compiler/transactional-tests/tests/constants/empty_vectors.move
@@ -1,0 +1,13 @@
+//# publish
+module 0x42::m {
+    use std::vector;
+    const KEYS: vector<vector<u8>> = vector[];
+    const VALUES: vector<u64> = vector[];
+
+    public entry fun init() {
+        let _x: vector<u64> = vector::map<vector<u8>, u64>(KEYS, |key| { let t: vector<u8> = key; (vector::length<u8>(&t) + 2) });
+        let _y: vector<u64> = vector::map<u64, u64>(VALUES, |v| { (v + 3u64) });
+    }
+}
+
+//# run 0x42::m::init

--- a/third_party/move/move-compiler/transactional-tests/tests/constants/empty_vectors2.exp
+++ b/third_party/move/move-compiler/transactional-tests/tests/constants/empty_vectors2.exp
@@ -1,0 +1,1 @@
+processed 2 tasks

--- a/third_party/move/move-compiler/transactional-tests/tests/constants/empty_vectors2.move
+++ b/third_party/move/move-compiler/transactional-tests/tests/constants/empty_vectors2.move
@@ -1,0 +1,13 @@
+//# publish
+module 0x42::m {
+    use std::vector;
+    const KEYS: vector<vector<vector<u8>>> = vector[vector[]];
+    const VALUES: vector<vector<u64>> = vector[vector[]];
+
+    public entry fun init() {
+        let _x: vector<u64> = vector::map<vector<u8>, u64>(*vector::borrow(&KEYS, 0), |key| { let t: vector<u8> = key; (vector::length<u8>(&t) + 2) });
+        let _y: vector<u64> = vector::map<u64, u64>(*vector::borrow(&VALUES, 0), |v| { (v + 3u64) });
+    }
+}
+
+//# run 0x42::m::init

--- a/third_party/move/move-compiler/transactional-tests/tests/constants/nonempty_vectors.exp
+++ b/third_party/move/move-compiler/transactional-tests/tests/constants/nonempty_vectors.exp
@@ -1,0 +1,1 @@
+processed 2 tasks

--- a/third_party/move/move-compiler/transactional-tests/tests/constants/nonempty_vectors.move
+++ b/third_party/move/move-compiler/transactional-tests/tests/constants/nonempty_vectors.move
@@ -1,0 +1,13 @@
+//# publish
+module 0x42::m {
+    use std::vector;
+    const KEYS: vector<vector<u8>> = vector[vector[1u8]];
+    const VALUES: vector<u64> = vector[3u64];
+
+    public entry fun init() {
+        let _x: vector<u64> = vector::map<vector<u8>, u64>(KEYS, |key| { let t: vector<u8> = key; (vector::length<u8>(&t) + 2) });
+        let _y: vector<u64> = vector::map<u64, u64>(VALUES, |v| { (v + 3u64) });
+    }
+}
+
+//# run 0x42::m::init

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -855,8 +855,10 @@ impl GlobalEnv {
     fn add_backtrace(msg: &str, _is_bug: bool) -> String {
         // Note that you need both MOVE_COMPILER_BACKTRACE=1 and RUST_BACKTRACE=1 for this to
         // actually generate a backtrace.
-        static DUMP_BACKTRACE: Lazy<bool> =
-            Lazy::new(|| read_bool_env_var(cli::MOVE_COMPILER_BACKTRACE_ENV_VAR));
+        static DUMP_BACKTRACE: Lazy<bool> = Lazy::new(|| {
+            read_bool_env_var(cli::MOVE_COMPILER_BACKTRACE_ENV_VAR)
+                | read_bool_env_var(cli::MVC_BACKTRACE_ENV_VAR)
+        });
         if *DUMP_BACKTRACE {
             let bt = Backtrace::capture();
             if BacktraceStatus::Captured == bt.status() {


### PR DESCRIPTION
## Description

Handle empty vector constants by using `VecPack` instead of `LdConst` since the run-time vector constant doesn't have a type if it's empty.

Fixes #13201.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [X] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Added tests showing the original bug, some simplified tests, and re-ran existing tests.

## Key Areas to Review
Whatever

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
