### PR TITLE
[scripts] Fix libudev-devel package name for Fedora users

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -731,7 +731,11 @@ function install_libdw {
 function install_libudev-dev {
   # Need to install libudev-dev for linux
   if [[ "$(uname)" == "Linux" && "$PACKAGE_MANAGER" != "pacman" ]]; then
-    install_pkg libudev-dev "$PACKAGE_MANAGER"
+    if [[ "$PACKAGE_MANAGER" == "dnf" || "$PACKAGE_MANAGER" == "yum" ]]; then
+      install_pkg libudev-devel "$PACKAGE_MANAGER" # Fedora
+    else
+      install_pkg libudev-dev "$PACKAGE_MANAGER"
+    fi
   fi
 }
 


### PR DESCRIPTION
## Description
In `scripts/dev_setup.sh`.
Package `libudev-dev` is called `libudev-devel` on Fedora (dnf, yum).

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [x] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
On a Fedora 40 system.

Before changes:
- Script `scripts/dev_setup.sh -yp` fails.
- Move prover tests fail.

After changes:
- Script `scripts/dev_setup.sh -yp` succeeds.
- Move prover tests succeed.

## Key Areas to Review

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
