### PR TITLE
[delegated voting] hotfix pending voter applying instantly on delegation pools

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/delegation_pool.md
+++ b/aptos-move/framework/aptos-framework/doc/delegation_pool.md
@@ -158,6 +158,7 @@ transferred to A
 -  [Function `calculate_and_update_voter_total_voting_power`](#0x1_delegation_pool_calculate_and_update_voter_total_voting_power)
 -  [Function `calculate_and_update_remaining_voting_power`](#0x1_delegation_pool_calculate_and_update_remaining_voting_power)
 -  [Function `calculate_and_update_delegator_voter`](#0x1_delegation_pool_calculate_and_update_delegator_voter)
+-  [Function `calculate_and_update_voting_delegation`](#0x1_delegation_pool_calculate_and_update_voting_delegation)
 -  [Function `get_expected_stake_pool_address`](#0x1_delegation_pool_get_expected_stake_pool_address)
 -  [Function `min_remaining_secs_for_commission_change`](#0x1_delegation_pool_min_remaining_secs_for_commission_change)
 -  [Function `allowlisting_enabled`](#0x1_delegation_pool_allowlisting_enabled)
@@ -2274,6 +2275,42 @@ latest state.
 
 </details>
 
+<a id="0x1_delegation_pool_calculate_and_update_voting_delegation"></a>
+
+## Function `calculate_and_update_voting_delegation`
+
+Return the current state of a voting delegation of a delegator in a delegation pool.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_calculate_and_update_voting_delegation">calculate_and_update_voting_delegation</a>(pool_address: <b>address</b>, delegator_address: <b>address</b>): (<b>address</b>, <b>address</b>, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_calculate_and_update_voting_delegation">calculate_and_update_voting_delegation</a>(
+    pool_address: <b>address</b>,
+    delegator_address: <b>address</b>
+): (<b>address</b>, <b>address</b>, u64) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>, <a href="delegation_pool.md#0x1_delegation_pool_GovernanceRecords">GovernanceRecords</a> {
+    <a href="delegation_pool.md#0x1_delegation_pool_assert_partial_governance_voting_enabled">assert_partial_governance_voting_enabled</a>(pool_address);
+    <b>let</b> vote_delegation = <a href="delegation_pool.md#0x1_delegation_pool_update_and_borrow_mut_delegator_vote_delegation">update_and_borrow_mut_delegator_vote_delegation</a>(
+        <b>borrow_global</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address),
+        <b>borrow_global_mut</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_GovernanceRecords">GovernanceRecords</a>&gt;(pool_address),
+        delegator_address
+    );
+
+    (vote_delegation.voter, vote_delegation.pending_voter, vote_delegation.last_locked_until_secs)
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_delegation_pool_get_expected_stake_pool_address"></a>
 
 ## Function `get_expected_stake_pool_address`
@@ -3231,9 +3268,9 @@ Update VoteDelegation of a delegator to up-to-date then borrow_mut it.
 
     <b>let</b> vote_delegation = <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_borrow_mut">smart_table::borrow_mut</a>(vote_delegation_table, delegator);
     // A lockup period <b>has</b> passed since last time `vote_delegation` was updated. Pending voter takes effect.
-    <b>if</b> (vote_delegation.last_locked_until_secs &lt; locked_until_secs &&
-        vote_delegation.voter != vote_delegation.pending_voter) {
+    <b>if</b> (vote_delegation.last_locked_until_secs &lt; locked_until_secs) {
         vote_delegation.voter = vote_delegation.pending_voter;
+        vote_delegation.last_locked_until_secs = locked_until_secs;
     };
     vote_delegation
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
The specs of delegating voting power (VP) from a delegation pool state that the pending voter of a delegator becomes effective next lockup cycle. However, due to some missing logic in `update_and_borrow_mut_delegator_vote_delegation` of `delegation_pool.move`, the pending voter of a delegator may take effect immediately without waiting for the current lockup cycle to end.
`VoteDelegation.last_locked_until_secs` is the timestamp when `VoteDelegation.pending_voter` takes effect. Currently, `last_locked_until_secs` is not updated to be the end timestamp of the current lockup cycle on the delegation pool. It is correctly initialized and, consequently, everything works as expected during the first lockup cycle when `VoteDelegation` has been created, but remains immutable and outdated afterwards.
This bug doesn't cause any double spending of VP. However, there are some inconsistencies resulting from it:
- a delegator may be unable to unlock/reactivate stake if their VP is distributed across multiple voters during a lockup cycle.
Steps to reproduce: delegator sets a new voter which applies directly, then adds stake which is distributed as VP to this voter and repeats with a different voter address. Delegator's total VP is now owned by multiple addresses and the delegator is unable to unlock/reactivate their stake as the VP on the current voter < total stake of delegator.
- misleading UX: a voter observes an incoming VP delegation, but the voting power is still not transferred

The fix doesn't introduce breaking changes.

A new `view` function `calculate_and_update_voting_delegation` is added to expose the complete VP delegation of a delegator in a delegation pool.
 
## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
New UTs test that the pending voter always apply next lockup cycle, advancing multiple lockup cycles on the pool in order to validate that the corner case described above is addressed.
All existing UTs testing VP accounting and voting functionality passed.
Moreover, there is an additional UT testing the voter change on an inactive delegation pool for additional coverage.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->
A delegator with inconsistent delegated VP is still able to unblock themselves: firstly unlock all VP on the current voter, then switch their voter to a previous one, unlock all VP on that voter too and so on until all stake is unlocked.
This won't be possible after the fix is released as the delegator will not be able to switch their voter during that lockup cycle. Currently, there is no such delegator on mainnet and it is important to note that the consistency of delegated VP is restored automatically for all delegators when the lockup cycle ends on the pool.
## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
