### PR TITLE
TxnStatsRate fields as f64

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/stats.rs
+++ b/crates/transaction-emitter-lib/src/emitter/stats.rs
@@ -17,23 +17,23 @@ pub struct TxnStats {
     pub committed: u64,
     pub expired: u64,
     pub failed_submission: u64,
-    pub latency: u64,
-    pub latency_samples: u64,
-    pub latency_buckets: AtomicHistogramSnapshot,
+    pub latency: u64, // total milliseconds across all latency measurements
+    pub latency_samples: u64, // number of events with latency measured
+    pub latency_buckets: AtomicHistogramSnapshot, // millisecond snapshot buckets
     pub lasted: Duration,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct TxnStatsRate {
-    pub submitted: u64,
-    pub committed: u64,
-    pub expired: u64,
-    pub failed_submission: u64,
-    pub latency: u64,
-    pub latency_samples: u64,
-    pub p50_latency: u64,
-    pub p90_latency: u64,
-    pub p99_latency: u64,
+    pub submitted: f64, // per second
+    pub committed: f64, // per second
+    pub expired: f64, // per second
+    pub failed_submission: f64, // per second
+    pub latency: f64, // mean latency (milliseconds)
+    pub latency_samples: u64, // number latency-measured events
+    pub p50_latency: u64, // milliseconds, 50% this or better
+    pub p90_latency: u64, // milliseconds, 90% this or better
+    pub p99_latency: u64, // milliseconds, 99% this or better
 }
 
 impl fmt::Display for TxnStatsRate {
@@ -43,8 +43,8 @@ impl fmt::Display for TxnStatsRate {
             "committed: {} txn/s{}{}{}, latency: {} ms, (p50: {} ms, p90: {} ms, p99: {} ms), latency samples: {}",
             self.committed,
             if self.submitted != self.committed { format!(", submitted: {} txn/s", self.submitted) } else { "".to_string()},
-            if self.failed_submission != 0 { format!(", failed submission: {} txn/s", self.failed_submission) } else { "".to_string()},
-            if self.expired != 0 { format!(", expired: {} txn/s", self.expired) } else { "".to_string()},
+            if self.failed_submission != 0.0 { format!(", failed submission: {} txn/s", self.failed_submission) } else { "".to_string()},
+            if self.expired != 0.0 { format!(", expired: {} txn/s", self.expired) } else { "".to_string()},
             self.latency, self.p50_latency, self.p90_latency, self.p99_latency, self.latency_samples,
         )
     }
@@ -52,19 +52,16 @@ impl fmt::Display for TxnStatsRate {
 
 impl TxnStats {
     pub fn rate(&self) -> TxnStatsRate {
-        let mut window_secs = self.lasted.as_secs();
-        if window_secs < 1 {
-            window_secs = 1;
-        }
+        let window_secs = self.lasted.as_secs_f64();
         TxnStatsRate {
-            submitted: self.submitted / window_secs,
-            committed: self.committed / window_secs,
-            expired: self.expired / window_secs,
-            failed_submission: self.failed_submission / window_secs,
+            submitted: (self.submitted as f64) / window_secs,
+            committed: (self.committed as f64) / window_secs,
+            expired: (self.expired as f64) / window_secs,
+            failed_submission: (self.failed_submission as f64) / window_secs,
             latency: if self.latency_samples == 0 {
-                0u64
+                0.0
             } else {
-                self.latency / self.latency_samples
+                (self.latency as f64) / (self.latency_samples as f64)
             },
             latency_samples: self.latency_samples,
             p50_latency: self.latency_buckets.percentile(50, 100),
@@ -124,9 +121,9 @@ pub struct StatsAccumulator {
     pub committed: AtomicU64,
     pub expired: AtomicU64,
     pub failed_submission: AtomicU64,
-    pub latency: AtomicU64,
-    pub latency_samples: AtomicU64,
-    pub latencies: Arc<AtomicHistogramAccumulator>,
+    pub latency: AtomicU64, // total milliseconds across all latency measurements
+    pub latency_samples: AtomicU64, // number of events with latency measured
+    pub latencies: Arc<AtomicHistogramAccumulator>, // millisecond histogram buckets
 }
 
 impl StatsAccumulator {

--- a/crates/transaction-emitter-lib/src/emitter/stats.rs
+++ b/crates/transaction-emitter-lib/src/emitter/stats.rs
@@ -17,7 +17,7 @@ pub struct TxnStats {
     pub committed: u64,
     pub expired: u64,
     pub failed_submission: u64,
-    pub latency: u64, // total milliseconds across all latency measurements
+    pub latency: u64,         // total milliseconds across all latency measurements
     pub latency_samples: u64, // number of events with latency measured
     pub latency_buckets: AtomicHistogramSnapshot, // millisecond snapshot buckets
     pub lasted: Duration,
@@ -25,15 +25,15 @@ pub struct TxnStats {
 
 #[derive(Debug, Clone, Default)]
 pub struct TxnStatsRate {
-    pub submitted: f64, // per second
-    pub committed: f64, // per second
-    pub expired: f64, // per second
+    pub submitted: f64,         // per second
+    pub committed: f64,         // per second
+    pub expired: f64,           // per second
     pub failed_submission: f64, // per second
-    pub latency: f64, // mean latency (milliseconds)
-    pub latency_samples: u64, // number latency-measured events
-    pub p50_latency: u64, // milliseconds, 50% this or better
-    pub p90_latency: u64, // milliseconds, 90% this or better
-    pub p99_latency: u64, // milliseconds, 99% this or better
+    pub latency: f64,           // mean latency (milliseconds)
+    pub latency_samples: u64,   // number latency-measured events
+    pub p50_latency: u64,       // milliseconds, 50% this or better
+    pub p90_latency: u64,       // milliseconds, 90% this or better
+    pub p99_latency: u64,       // milliseconds, 99% this or better
 }
 
 impl fmt::Display for TxnStatsRate {

--- a/crates/transaction-emitter-lib/src/emitter/submission_worker.rs
+++ b/crates/transaction-emitter-lib/src/emitter/submission_worker.rs
@@ -268,14 +268,14 @@ impl SubmissionWorker {
         }
 
         if num_committed > 0 {
-            let sum_latency = sum_of_completion_timestamps_millis
-                - (avg_txn_offset_time as u128 * num_committed as u128);
-            let avg_latency = (sum_latency / num_committed as u128) as u64;
             loop_stats
                 .committed
                 .fetch_add(num_committed as u64, Ordering::Relaxed);
 
             if !skip_latency_stats {
+                let sum_latency = sum_of_completion_timestamps_millis
+                    - (avg_txn_offset_time as u128 * num_committed as u128);
+                let avg_latency = (sum_latency / num_committed as u128) as u64;
                 loop_stats
                     .latency
                     .fetch_add(sum_latency as u64, Ordering::Relaxed);

--- a/ecosystem/node-checker/src/checker/tps.rs
+++ b/ecosystem/node-checker/src/checker/tps.rs
@@ -141,9 +141,9 @@ impl Checker for TpsChecker {
         // AKA stats per second.
         let rate = stats.rate();
 
-        if rate.submitted < self.config.minimum_tps {
+        if rate.submitted < (self.config.minimum_tps as f64) {
             return Err(TpsCheckerError::InsufficientSubmittedTransactionsError(
-                rate.submitted,
+                rate.submitted as u64,
                 self.config.minimum_tps,
             )
             .into());
@@ -151,7 +151,7 @@ impl Checker for TpsChecker {
 
         let mut description = format!("The minimum TPS (transactions per second) \
             required of nodes is {}, your node hit: {} (out of {} transactions submitted per second).", self.config.minimum_tps, rate.committed, rate.submitted);
-        let evaluation_result = if rate.committed >= self.config.minimum_tps {
+        let evaluation_result = if rate.committed >= (self.config.minimum_tps as f64) {
             if stats.committed == stats.submitted {
                 description.push_str(
                     " Your node could theoretically hit \

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -484,8 +484,8 @@ impl EphemeralKeyPair {
         )?;
 
         Ok(Self {
-            private_key: private_key.clone(),
-            public_key: EphemeralPublicKey::ed25519(private_key.public_key()),
+            private_key,
+            public_key: epk,
             nonce,
             expiry_date_secs,
             blinder,

--- a/testsuite/forge/src/report.rs
+++ b/testsuite/forge/src/report.rs
@@ -45,8 +45,8 @@ impl TestReport {
         let rate = stats.rate();
         self.report_metric(test_name.clone(), "submitted_txn", stats.submitted as f64);
         self.report_metric(test_name.clone(), "expired_txn", stats.expired as f64);
-        self.report_metric(test_name.clone(), "avg_tps", rate.committed as f64);
-        self.report_metric(test_name.clone(), "avg_latency", rate.latency as f64);
+        self.report_metric(test_name.clone(), "avg_tps", rate.committed);
+        self.report_metric(test_name.clone(), "avg_latency", rate.latency);
         self.report_metric(test_name.clone(), "p50_latency", rate.p50_latency as f64);
         self.report_metric(test_name.clone(), "p90_latency", rate.p90_latency as f64);
         self.report_metric(test_name.clone(), "p99_latency", rate.p99_latency as f64);

--- a/testsuite/forge/src/success_criteria.rs
+++ b/testsuite/forge/src/success_criteria.rs
@@ -432,7 +432,7 @@ impl SuccessCriteriaChecker {
         traffic_name_addition: &String,
     ) -> anyhow::Result<()> {
         let avg_tps = stats_rate.committed;
-        if avg_tps < min_avg_tps as u64 {
+        if avg_tps < min_avg_tps as f64 {
             bail!(
                 "TPS requirement{} failed. Average TPS {}, minimum TPS requirement {}. Full stats: {}",
                 traffic_name_addition,
@@ -452,12 +452,12 @@ impl SuccessCriteriaChecker {
     fn check_max_value(
         max_config: Option<usize>,
         stats_rate: &TxnStatsRate,
-        value: u64,
+        value: f64,
         value_desc: &str,
         traffic_name_addition: &String,
     ) -> anyhow::Result<()> {
         if let Some(max) = max_config {
-            if value > max as u64 {
+            if value > max as f64 {
                 bail!(
                     "{} requirement{} failed. {} TPS: average {}, maximum requirement {}. Full stats: {}",
                     value_desc,
@@ -512,7 +512,7 @@ impl SuccessCriteriaChecker {
         let mut failures = Vec::new();
         for (latency_threshold, latency_type) in latency_thresholds {
             let latency = Duration::from_millis(match latency_type {
-                LatencyType::Average => stats_rate.latency,
+                LatencyType::Average => stats_rate.latency as u64,
                 LatencyType::P50 => stats_rate.p50_latency,
                 LatencyType::P90 => stats_rate.p90_latency,
                 LatencyType::P99 => stats_rate.p99_latency,


### PR DESCRIPTION
and some helpful comments

## Description
In a 30 second sample, rounding to int can be 3-4% off. Use float64.

## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [X] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
unit tests, forge tests

## Key Areas to Review
Variable meaning comments are accurate

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X] I tested both happy and unhappy path of the functionality
- [X] I have made corresponding changes to the documentation