### PR TITLE
jwk updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,6 +2277,7 @@ dependencies = [
  "aptos-enum-conversion-derive",
  "aptos-event-notifications",
  "aptos-infallible",
+ "aptos-jwk-utils",
  "aptos-logger",
  "aptos-metrics-core",
  "aptos-network",
@@ -2292,11 +2293,23 @@ dependencies = [
  "futures-util",
  "move-core-types",
  "once_cell",
+ "serde",
+ "tokio",
+ "tokio-retry",
+]
+
+[[package]]
+name = "aptos-jwk-utils"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-types",
+ "http",
+ "move-core-types",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
- "tokio-retry",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ members = [
     "crates/crash-handler",
     "crates/fallible",
     "crates/indexer",
+    "crates/jwk-utils",
     "crates/node-resource-metrics",
     "crates/num-variants",
     "crates/proxy",
@@ -359,6 +360,7 @@ aptos-infallible = { path = "crates/aptos-infallible" }
 aptos-inspection-service = { path = "crates/aptos-inspection-service" }
 aptos-jellyfish-merkle = { path = "storage/jellyfish-merkle" }
 aptos-jwk-consensus = { path = "crates/aptos-jwk-consensus" }
+aptos-jwk-utils = { path = "crates/jwk-utils" }
 aptos-keygen = { path = "crates/aptos-keygen" }
 aptos-language-e2e-tests = { path = "aptos-move/e2e-tests" }
 aptos-ledger = { path = "crates/aptos-ledger" }

--- a/crates/aptos-jwk-consensus/Cargo.toml
+++ b/crates/aptos-jwk-consensus/Cargo.toml
@@ -23,6 +23,7 @@ aptos-crypto = { workspace = true }
 aptos-enum-conversion-derive = { workspace = true }
 aptos-event-notifications = { workspace = true }
 aptos-infallible = { workspace = true }
+aptos-jwk-utils = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-network = { workspace = true }
@@ -38,9 +39,7 @@ futures-channel = { workspace = true }
 futures-util = { workspace = true }
 move-core-types = { workspace = true }
 once_cell = { workspace = true }
-reqwest = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-retry = { workspace = true }
 

--- a/crates/aptos-jwk-consensus/src/jwk_manager/mod.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager/mod.rs
@@ -10,13 +10,13 @@ use crate::{
 use anyhow::{anyhow, bail, Result};
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_crypto::{bls12381::PrivateKey, SigningKey};
-use aptos_logger::{debug, error, info};
+use aptos_logger::{debug, error, info, warn};
 use aptos_types::{
     account_address::AccountAddress,
     epoch_state::EpochState,
     jwks::{
-        jwk::JWKMoveStruct, AllProvidersJWKs, Issuer, ObservedJWKs, ObservedJWKsUpdated,
-        ProviderJWKs, QuorumCertifiedUpdate, SupportedOIDCProviders,
+        jwk::JWKMoveStruct, AllProvidersJWKs, Issuer, OIDCProvider, ObservedJWKs,
+        ObservedJWKsUpdated, ProviderJWKs, QuorumCertifiedUpdate, SupportedOIDCProviders,
     },
     validator_txn::{Topic, ValidatorTransaction},
 };
@@ -103,15 +103,27 @@ impl JWKManager {
             .unwrap_or_default()
             .into_provider_vec()
             .into_iter()
-            .map(|provider| {
-                JWKObserver::spawn(
-                    self.epoch_state.epoch,
-                    self.my_addr,
-                    provider.name.clone(),
-                    provider.config_url.clone(),
-                    Duration::from_secs(10),
-                    local_observation_tx.clone(),
-                )
+            .filter_map(|provider| {
+                let OIDCProvider { name, config_url } = provider;
+                let maybe_issuer = String::from_utf8(name);
+                let maybe_config_url = String::from_utf8(config_url);
+                match (maybe_issuer, maybe_config_url) {
+                    (Ok(issuer), Ok(config_url)) => Some(JWKObserver::spawn(
+                        self.epoch_state.epoch,
+                        self.my_addr,
+                        issuer,
+                        config_url,
+                        Duration::from_secs(10),
+                        local_observation_tx.clone(),
+                    )),
+                    (maybe_issuer, maybe_config_url) => {
+                        warn!(
+                            "unable to spawn observer, issuer={:?}, config_url={:?}",
+                            maybe_issuer, maybe_config_url
+                        );
+                        None
+                    },
+                }
             })
             .collect();
 

--- a/crates/aptos-jwk-consensus/src/jwk_observer.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_observer.rs
@@ -2,54 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::counters::OBSERVATION_SECONDS;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use aptos_channels::aptos_channel;
+use aptos_jwk_utils::{fetch_jwks_from_jwks_uri, fetch_jwks_uri_from_openid_config};
 use aptos_logger::{debug, info};
 use aptos_types::jwks::{jwk::JWK, Issuer};
 use futures::{FutureExt, StreamExt};
 use move_core_types::account_address::AccountAddress;
-use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
 use tokio::{sync::oneshot, task::JoinHandle, time::MissedTickBehavior};
-
-#[derive(Serialize, Deserialize)]
-struct OpenIDConfiguration {
-    issuer: String,
-    jwks_uri: String,
-}
-
-#[derive(Serialize, Deserialize)]
-struct JWKsResponse {
-    keys: Vec<serde_json::Value>,
-}
-
-/// Given an Open ID configuration URL, fetch its JWKs.
-pub async fn fetch_jwks(my_addr: AccountAddress, config_url: Vec<u8>) -> Result<Vec<JWK>> {
-    if cfg!(feature = "smoke-test") {
-        use reqwest::header;
-        let maybe_url = String::from_utf8(config_url);
-        let jwk_url = maybe_url?;
-        let client = reqwest::Client::new();
-        let JWKsResponse { keys } = client
-            .get(jwk_url.as_str())
-            .header(header::COOKIE, my_addr.to_hex())
-            .send()
-            .await?
-            .json()
-            .await?;
-        let jwks = keys.into_iter().map(JWK::from).collect();
-        Ok(jwks)
-    } else {
-        let maybe_url = String::from_utf8(config_url);
-        let config_url = maybe_url?;
-        let client = reqwest::Client::new();
-        let OpenIDConfiguration { jwks_uri, .. } =
-            client.get(config_url.as_str()).send().await?.json().await?;
-        let JWKsResponse { keys } = client.get(jwks_uri.as_str()).send().await?.json().await?;
-        let jwks = keys.into_iter().map(JWK::from).collect();
-        Ok(jwks)
-    }
-}
 
 /// A process thread that periodically fetch JWKs of a provider and push it back to JWKManager.
 pub struct JWKObserver {
@@ -61,8 +22,8 @@ impl JWKObserver {
     pub fn spawn(
         epoch: u64,
         my_addr: AccountAddress,
-        issuer: Issuer,
-        config_url: Vec<u8>,
+        issuer: String,
+        config_url: String,
         fetch_interval: Duration,
         observation_tx: aptos_channel::Sender<(), (Issuer, Vec<JWK>)>,
     ) -> Self {
@@ -77,8 +38,8 @@ impl JWKObserver {
         ));
         info!(
             epoch = epoch,
-            issuer = String::from_utf8(issuer).ok(),
-            config_url = String::from_utf8(config_url).ok(),
+            issuer = issuer,
+            config_url = config_url,
             "JWKObserver spawned."
         );
         Self {
@@ -90,29 +51,35 @@ impl JWKObserver {
     async fn start(
         fetch_interval: Duration,
         my_addr: AccountAddress,
-        issuer: Issuer,
-        open_id_config_url: Vec<u8>,
+        issuer: String,
+        open_id_config_url: String,
         observation_tx: aptos_channel::Sender<(), (Issuer, Vec<JWK>)>,
         close_rx: oneshot::Receiver<()>,
     ) {
-        let issuer_str =
-            String::from_utf8(issuer.clone()).unwrap_or_else(|_e| "UNKNOWN_ISSUER".to_string());
         let mut interval = tokio::time::interval(fetch_interval);
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         let mut close_rx = close_rx.into_stream();
+        let my_addr = if cfg!(feature = "smoke-test") {
+            // Include self validator address in JWK request,
+            // so dummy OIDC providers in smoke tests can do things like "key A for validator 1, key B for validator 2".
+            Some(my_addr)
+        } else {
+            None
+        };
+
         loop {
             tokio::select! {
                 _ = interval.tick().fuse() => {
                     let timer = Instant::now();
-                    let result = fetch_jwks(my_addr, open_id_config_url.clone()).await;
+                    let result = fetch_jwks(open_id_config_url.as_str(), my_addr).await;
+                    debug!(issuer = issuer, "observe_result={:?}", result);
                     let secs = timer.elapsed().as_secs_f64();
-                    debug!(issuer = issuer_str, "observe_result={:?}", result);
                     if let Ok(mut jwks) = result {
-                        OBSERVATION_SECONDS.with_label_values(&[&issuer_str, "ok"]).observe(secs);
+                        OBSERVATION_SECONDS.with_label_values(&[issuer.as_str(), "ok"]).observe(secs);
                         jwks.sort();
-                        let _ = observation_tx.push((), (issuer.clone(), jwks));
+                        let _ = observation_tx.push((), (issuer.as_bytes().to_vec(), jwks));
                     } else {
-                        OBSERVATION_SECONDS.with_label_values(&[&issuer_str, "err"]).observe(secs);
+                        OBSERVATION_SECONDS.with_label_values(&[issuer.as_str(), "err"]).observe(secs);
                     }
                 },
                 _ = close_rx.select_next_some() => {
@@ -132,16 +99,12 @@ impl JWKObserver {
     }
 }
 
-#[ignore]
-#[tokio::test]
-async fn test_fetch_real_jwks() {
-    let jwks = fetch_jwks(
-        AccountAddress::ZERO,
-        "https://www.facebook.com/.well-known/openid-configuration/"
-            .as_bytes()
-            .to_vec(),
-    )
-    .await
-    .unwrap();
-    println!("{:?}", jwks);
+async fn fetch_jwks(open_id_config_url: &str, my_addr: Option<AccountAddress>) -> Result<Vec<JWK>> {
+    let jwks_uri = fetch_jwks_uri_from_openid_config(open_id_config_url)
+        .await
+        .map_err(|e| anyhow!("fetch_jwks failed with open-id config request: {e}"))?;
+    let jwks = fetch_jwks_from_jwks_uri(my_addr, jwks_uri.as_str())
+        .await
+        .map_err(|e| anyhow!("fetch_jwks failed with jwks uri request: {e}"))?;
+    Ok(jwks)
 }

--- a/crates/jwk-utils/Cargo.toml
+++ b/crates/jwk-utils/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "aptos-jwk-utils"
+description = "JWK utils"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+aptos-types = { workspace = true }
+http = { workspace = true }
+move-core-types = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/crates/jwk-utils/src/lib.rs
+++ b/crates/jwk-utils/src/lib.rs
@@ -1,0 +1,58 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use aptos_types::jwks::jwk::JWK;
+use http::header::COOKIE;
+use move_core_types::account_address::AccountAddress;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct OpenIDConfiguration {
+    issuer: String,
+    jwks_uri: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct JWKsResponse {
+    keys: Vec<serde_json::Value>,
+}
+
+/// Given a JWK URL, fetch its JWKs.
+///
+/// Optionally, if an address is given, send it as the cookie payload.
+/// The optional logic is only used in smoke tests, e.g., `jwk_consensus_basic`.
+pub async fn fetch_jwks_from_jwks_uri(
+    my_addr: Option<AccountAddress>,
+    jwks_uri: &str,
+) -> Result<Vec<JWK>> {
+    let client = reqwest::Client::new();
+    let mut request_builder = client.get(jwks_uri);
+    if let Some(addr) = my_addr {
+        request_builder = request_builder.header(COOKIE, addr.to_hex());
+    }
+    let JWKsResponse { keys } = request_builder.send().await?.json().await?;
+    let jwks = keys.into_iter().map(JWK::from).collect();
+    Ok(jwks)
+}
+
+/// Given an Open ID configuration URL, fetch its JWK url.
+pub async fn fetch_jwks_uri_from_openid_config(config_url: &str) -> Result<String> {
+    let client = reqwest::Client::new();
+    let OpenIDConfiguration { jwks_uri, .. } = client.get(config_url).send().await?.json().await?;
+    Ok(jwks_uri)
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_fetch_real_jwks() {
+    let jwks_uri = fetch_jwks_uri_from_openid_config(
+        "https://www.facebook.com/.well-known/openid-configuration/",
+    )
+    .await
+    .unwrap();
+    let jwks = fetch_jwks_from_jwks_uri(None, jwks_uri.as_str())
+        .await
+        .unwrap();
+    println!("{:?}", jwks);
+}

--- a/keyless/pepper/service/src/main.rs
+++ b/keyless/pepper/service/src/main.rs
@@ -75,13 +75,8 @@ async fn main() {
         Duration::from_secs(10),
     );
     jwk::start_jwk_refresh_loop(
-        "https://www.facebook.com",
-        "https://www.facebook.com/.well-known/oauth/openid/jwks",
-        Duration::from_secs(10),
-    );
-    jwk::start_jwk_refresh_loop(
-        "https://id.twitch.tv/oauth2",
-        "https://id.twitch.tv/oauth2/keys",
+        "https://appleid.apple.com",
+        "https://appleid.apple.com/.well-known/openid-configuration",
         Duration::from_secs(10),
     );
 

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -1223,7 +1223,8 @@ async fn test_owner_create_and_delegate_flow() {
             genesis_config.epoch_duration_secs = 5;
             genesis_config.recurring_lockup_duration_secs = 10;
             genesis_config.voting_duration_secs = 5;
-            genesis_config.min_stake = 500000
+            genesis_config.min_stake = 500000;
+            genesis_config.randomness_config_override = Some(OnChainRandomnessConfig::Off);
         }))
         .build_with_cli(0)
         .await;

--- a/testsuite/smoke-test/src/jwks/jwk_consensus_basic.rs
+++ b/testsuite/smoke-test/src/jwks/jwk_consensus_basic.rs
@@ -5,7 +5,7 @@ use crate::{
     jwks::{
         dummy_provider::{
             request_handler::{EquivocatingServer, StaticContentServer},
-            DummyProvider,
+            DummyHttpServer,
         },
         get_patched_jwks, update_jwk_consensus_config,
     },
@@ -55,10 +55,32 @@ async fn jwk_consensus_basic() {
     assert!(patched_jwks.jwks.entries.len() == 1);
 
     info!("Adding some providers.");
-    let (provider_alice, provider_bob) =
-        tokio::join!(DummyProvider::spawn(), DummyProvider::spawn());
+    let (alice_config_server, alice_jwks_server, bob_config_server, bob_jwks_server) = tokio::join!(
+        DummyHttpServer::spawn(),
+        DummyHttpServer::spawn(),
+        DummyHttpServer::spawn(),
+        DummyHttpServer::spawn()
+    );
+    let alice_issuer_id = "https://alice.io";
+    let bob_issuer_id = "https://bob.dev";
+    alice_config_server.update_request_handler(Some(Arc::new(StaticContentServer::new_str(
+        format!(
+            r#"{{"issuer": "{}", "jwks_uri": "{}"}}"#,
+            alice_issuer_id,
+            alice_jwks_server.url()
+        )
+        .as_str(),
+    ))));
+    bob_config_server.update_request_handler(Some(Arc::new(StaticContentServer::new_str(
+        format!(
+            r#"{{"issuer": "{}", "jwks_uri": "{}"}}"#,
+            bob_issuer_id,
+            bob_jwks_server.url()
+        )
+        .as_str(),
+    ))));
 
-    provider_alice.update_request_handler(Some(Arc::new(StaticContentServer::new_str(
+    alice_jwks_server.update_request_handler(Some(Arc::new(StaticContentServer::new_str(
         r#"
 {
     "keys": [
@@ -68,18 +90,20 @@ async fn jwk_consensus_basic() {
 }
 "#,
     ))));
-    provider_bob.update_request_handler(Some(Arc::new(StaticContentServer::new(
+
+    bob_jwks_server.update_request_handler(Some(Arc::new(StaticContentServer::new(
         r#"{"keys": ["BOB_JWK_V0"]}"#.as_bytes().to_vec(),
     ))));
+
     let config = OnChainJWKConsensusConfig::V1(JWKConsensusConfigV1 {
         oidc_providers: vec![
             OIDCProvider {
-                name: "https://alice.io".to_string(),
-                config_url: provider_alice.open_id_config_url(),
+                name: alice_issuer_id.to_string(),
+                config_url: alice_config_server.url(),
             },
             OIDCProvider {
-                name: "https://bob.dev".to_string(),
-                config_url: provider_bob.open_id_config_url(),
+                name: bob_issuer_id.to_string(),
+                config_url: bob_config_server.url(),
             },
         ],
     });
@@ -95,7 +119,7 @@ async fn jwk_consensus_basic() {
         AllProvidersJWKs {
             entries: vec![
                 ProviderJWKs {
-                    issuer: b"https://alice.io".to_vec(),
+                    issuer: alice_issuer_id.as_bytes().to_vec(),
                     version: 1,
                     jwks: vec![
                         JWK::RSA(RSA_JWK::new_256_aqab("kid0", "n0")).into(),
@@ -104,7 +128,7 @@ async fn jwk_consensus_basic() {
                     ],
                 },
                 ProviderJWKs {
-                    issuer: b"https://bob.dev".to_vec(),
+                    issuer: bob_issuer_id.as_bytes().to_vec(),
                     version: 1,
                     jwks: vec![JWK::Unsupported(UnsupportedJWK::new_with_payload(
                         "\"BOB_JWK_V0\""
@@ -122,7 +146,7 @@ async fn jwk_consensus_basic() {
     );
 
     info!("Rotating Alice keys. Also making https://alice.io gently equivocate.");
-    provider_alice.update_request_handler(Some(Arc::new(EquivocatingServer::new(
+    alice_jwks_server.update_request_handler(Some(Arc::new(EquivocatingServer::new(
         r#"{"keys": ["ALICE_JWK_V1A"]}"#.as_bytes().to_vec(),
         r#"{"keys": ["ALICE_JWK_V1B"]}"#.as_bytes().to_vec(),
         1,
@@ -136,7 +160,7 @@ async fn jwk_consensus_basic() {
         AllProvidersJWKs {
             entries: vec![
                 ProviderJWKs {
-                    issuer: b"https://alice.io".to_vec(),
+                    issuer: alice_issuer_id.as_bytes().to_vec(),
                     version: 2,
                     jwks: vec![JWK::Unsupported(UnsupportedJWK::new_with_payload(
                         "\"ALICE_JWK_V1B\""
@@ -144,7 +168,7 @@ async fn jwk_consensus_basic() {
                     .into()],
                 },
                 ProviderJWKs {
-                    issuer: b"https://bob.dev".to_vec(),
+                    issuer: bob_issuer_id.as_bytes().to_vec(),
                     version: 1,
                     jwks: vec![JWK::Unsupported(UnsupportedJWK::new_with_payload(
                         "\"BOB_JWK_V0\""
@@ -162,5 +186,10 @@ async fn jwk_consensus_basic() {
     );
 
     info!("Tear down.");
-    provider_alice.shutdown().await;
+    tokio::join!(
+        alice_jwks_server.shutdown(),
+        alice_config_server.shutdown(),
+        bob_jwks_server.shutdown(),
+        bob_config_server.shutdown()
+    );
 }

--- a/testsuite/smoke-test/src/jwks/jwk_consensus_per_issuer.rs
+++ b/testsuite/smoke-test/src/jwks/jwk_consensus_per_issuer.rs
@@ -5,7 +5,7 @@ use crate::{
     jwks::{
         dummy_provider::{
             request_handler::{EquivocatingServer, StaticContentServer},
-            DummyProvider,
+            DummyHttpServer,
         },
         get_patched_jwks, update_jwk_consensus_config,
     },
@@ -55,25 +55,48 @@ async fn jwk_consensus_per_issuer() {
     assert!(patched_jwks.jwks.entries.len() == 1);
 
     info!("Adding some providers, one seriously equivocating, the other well behaving.");
-    let (provider_alice, provider_bob) =
-        tokio::join!(DummyProvider::spawn(), DummyProvider::spawn());
-    provider_alice.update_request_handler(Some(Arc::new(EquivocatingServer::new(
+    let (alice_config_server, alice_jwks_server, bob_config_server, bob_jwks_server) = tokio::join!(
+        DummyHttpServer::spawn(),
+        DummyHttpServer::spawn(),
+        DummyHttpServer::spawn(),
+        DummyHttpServer::spawn()
+    );
+    let alice_issuer_id = "https://alice.io";
+    let bob_issuer_id = "https://bob.dev";
+    alice_config_server.update_request_handler(Some(Arc::new(StaticContentServer::new_str(
+        format!(
+            r#"{{"issuer": "{}", "jwks_uri": "{}"}}"#,
+            alice_issuer_id,
+            alice_jwks_server.url()
+        )
+        .as_str(),
+    ))));
+    bob_config_server.update_request_handler(Some(Arc::new(StaticContentServer::new_str(
+        format!(
+            r#"{{"issuer": "{}", "jwks_uri": "{}"}}"#,
+            bob_issuer_id,
+            bob_jwks_server.url()
+        )
+        .as_str(),
+    ))));
+
+    alice_jwks_server.update_request_handler(Some(Arc::new(EquivocatingServer::new(
         r#"{"keys": ["ALICE_JWK_V1A"]}"#.as_bytes().to_vec(),
         r#"{"keys": ["ALICE_JWK_V1B"]}"#.as_bytes().to_vec(),
         2,
     ))));
-    provider_bob.update_request_handler(Some(Arc::new(StaticContentServer::new(
+    bob_jwks_server.update_request_handler(Some(Arc::new(StaticContentServer::new(
         r#"{"keys": ["BOB_JWK_V0"]}"#.as_bytes().to_vec(),
     ))));
     let config = OnChainJWKConsensusConfig::V1(JWKConsensusConfigV1 {
         oidc_providers: vec![
             OIDCProvider {
-                name: "https://alice.io".to_string(),
-                config_url: provider_alice.open_id_config_url(),
+                name: alice_issuer_id.to_string(),
+                config_url: alice_config_server.url(),
             },
             OIDCProvider {
-                name: "https://bob.dev".to_string(),
-                config_url: provider_bob.open_id_config_url(),
+                name: bob_issuer_id.to_string(),
+                config_url: bob_config_server.url(),
             },
         ],
     });
@@ -89,7 +112,7 @@ async fn jwk_consensus_per_issuer() {
         AllProvidersJWKs {
             entries: vec![
                 ProviderJWKs {
-                    issuer: b"https://bob.dev".to_vec(),
+                    issuer: bob_issuer_id.as_bytes().to_vec(),
                     version: 1,
                     jwks: vec![JWK::Unsupported(UnsupportedJWK::new_with_payload(
                         "\"BOB_JWK_V0\""
@@ -107,5 +130,10 @@ async fn jwk_consensus_per_issuer() {
     );
 
     info!("Tear down.");
-    provider_alice.shutdown().await;
+    tokio::join!(
+        alice_jwks_server.shutdown(),
+        alice_config_server.shutdown(),
+        bob_jwks_server.shutdown(),
+        bob_config_server.shutdown()
+    );
 }

--- a/testsuite/smoke-test/src/jwks/jwk_consensus_provider_change_mind.rs
+++ b/testsuite/smoke-test/src/jwks/jwk_consensus_provider_change_mind.rs
@@ -5,7 +5,7 @@ use crate::{
     jwks::{
         dummy_provider::{
             request_handler::{MindChangingServer, StaticContentServer},
-            DummyProvider,
+            DummyHttpServer,
         },
         get_patched_jwks, update_jwk_consensus_config,
     },
@@ -57,12 +57,34 @@ async fn jwk_consensus_provider_change_mind() {
     assert!(patched_jwks.jwks.entries.len() == 1);
 
     info!("Adding some providers.");
-    let (provider_alice, provider_bob) =
-        tokio::join!(DummyProvider::spawn(), DummyProvider::spawn());
-    provider_alice.update_request_handler(Some(Arc::new(StaticContentServer::new(
+    let (alice_config_server, alice_jwks_server, bob_config_server, bob_jwks_server) = tokio::join!(
+        DummyHttpServer::spawn(),
+        DummyHttpServer::spawn(),
+        DummyHttpServer::spawn(),
+        DummyHttpServer::spawn()
+    );
+    let alice_issuer_id = "https://alice.io";
+    let bob_issuer_id = "https://bob.dev";
+    alice_config_server.update_request_handler(Some(Arc::new(StaticContentServer::new_str(
+        format!(
+            r#"{{"issuer": "{}", "jwks_uri": "{}"}}"#,
+            alice_issuer_id,
+            alice_jwks_server.url()
+        )
+        .as_str(),
+    ))));
+    bob_config_server.update_request_handler(Some(Arc::new(StaticContentServer::new_str(
+        format!(
+            r#"{{"issuer": "{}", "jwks_uri": "{}"}}"#,
+            bob_issuer_id,
+            bob_jwks_server.url()
+        )
+        .as_str(),
+    ))));
+    alice_jwks_server.update_request_handler(Some(Arc::new(StaticContentServer::new(
         r#"{"keys": ["ALICE_JWK_V0"]}"#.as_bytes().to_vec(),
     ))));
-    provider_bob.update_request_handler(Some(Arc::new(MindChangingServer::new(
+    bob_jwks_server.update_request_handler(Some(Arc::new(MindChangingServer::new(
         r#"{"keys": ["BOB_JWK_V0"]}"#.as_bytes().to_vec(),
         r#"{"keys": ["BOB_JWK_V0_1"]}"#.as_bytes().to_vec(),
         2,
@@ -70,12 +92,12 @@ async fn jwk_consensus_provider_change_mind() {
     let config = OnChainJWKConsensusConfig::V1(JWKConsensusConfigV1 {
         oidc_providers: vec![
             OIDCProvider {
-                name: "https://alice.io".to_string(),
-                config_url: provider_alice.open_id_config_url(),
+                name: alice_issuer_id.to_string(),
+                config_url: alice_config_server.url(),
             },
             OIDCProvider {
-                name: "https://bob.dev".to_string(),
-                config_url: provider_bob.open_id_config_url(),
+                name: bob_issuer_id.to_string(),
+                config_url: bob_config_server.url(),
             },
         ],
     });
@@ -91,7 +113,7 @@ async fn jwk_consensus_provider_change_mind() {
         AllProvidersJWKs {
             entries: vec![
                 ProviderJWKs {
-                    issuer: b"https://alice.io".to_vec(),
+                    issuer: alice_issuer_id.as_bytes().to_vec(),
                     version: 1,
                     jwks: vec![JWK::Unsupported(UnsupportedJWK::new_with_payload(
                         "\"ALICE_JWK_V0\""
@@ -99,7 +121,7 @@ async fn jwk_consensus_provider_change_mind() {
                     .into()],
                 },
                 ProviderJWKs {
-                    issuer: b"https://bob.dev".to_vec(),
+                    issuer: bob_issuer_id.as_bytes().to_vec(),
                     version: 1,
                     jwks: vec![JWK::Unsupported(UnsupportedJWK::new_with_payload(
                         "\"BOB_JWK_V0_1\""
@@ -114,5 +136,13 @@ async fn jwk_consensus_provider_change_mind() {
             ]
         },
         patched_jwks.jwks
+    );
+
+    info!("Tear down.");
+    tokio::join!(
+        alice_jwks_server.shutdown(),
+        alice_config_server.shutdown(),
+        bob_jwks_server.shutdown(),
+        bob_config_server.shutdown()
     );
 }


### PR DESCRIPTION
- Pull some shared JWK logic out into a crate and make it a dependency of pepper service and jwk-consensus.
- Start fetching apple jwks in pepper service.