### PR TITLE
[Fuzzing] Do publish with official flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7976,6 +7976,7 @@ version = "0.1.0"
 name = "fuzzer-fuzz"
 version = "0.0.0"
 dependencies = [
+ "aptos-framework",
  "aptos-language-e2e-tests",
  "aptos-types",
  "aptos-vm",
@@ -7987,6 +7988,7 @@ dependencies = [
  "move-core-types",
  "move-vm-types",
  "once_cell",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7976,6 +7976,7 @@ version = "0.1.0"
 name = "fuzzer-fuzz"
 version = "0.0.0"
 dependencies = [
+ "aptos-cached-packages",
  "aptos-framework",
  "aptos-language-e2e-tests",
  "aptos-types",
@@ -7986,6 +7987,7 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-verifier",
  "move-core-types",
+ "move-vm-runtime",
  "move-vm-types",
  "once_cell",
  "rayon",

--- a/aptos-move/e2e-tests/Cargo.toml
+++ b/aptos-move/e2e-tests/Cargo.toml
@@ -51,3 +51,7 @@ proptest-derive = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
+
+[features]
+default = []
+fuzzing = []

--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-aptos-language-e2e-tests = { workspace = true }
+aptos-framework = { workspace = true }
+aptos-language-e2e-tests = { workspace = true, features = ["fuzzing"] }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
 arbitrary = "1.3.2"
@@ -19,6 +20,7 @@ move-bytecode-verifier = { workspace = true }
 move-core-types = { workspace = true, features = ["fuzzing"] }
 move-vm-types = { workspace = true, features = ["fuzzing"] }
 once_cell = { workspace = true }
+rayon = { workspace = true }
 
 [[bin]]
 name = "move_bytecode_verifier_code_unit"

--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
+aptos-cached-packages = { workspace = true }
 aptos-framework = { workspace = true }
 aptos-language-e2e-tests = { workspace = true, features = ["fuzzing"] }
 aptos-types = { workspace = true }
@@ -18,6 +19,7 @@ libfuzzer-sys = "0.4"
 move-binary-format = { workspace = true, features = ["fuzzing"] }
 move-bytecode-verifier = { workspace = true }
 move-core-types = { workspace = true, features = ["fuzzing"] }
+move-vm-runtime = { workspace = true }
 move-vm-types = { workspace = true, features = ["fuzzing"] }
 once_cell = { workspace = true }
 rayon = { workspace = true }

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
@@ -3,6 +3,9 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_framework::natives::code::{
+    ModuleMetadata, MoveOption, PackageDep, PackageMetadata, UpgradePolicy,
+};
 use aptos_language_e2e_tests::{
     account::Account, data_store::GENESIS_CHANGE_SET_HEAD, executor::FakeExecutor,
 };
@@ -19,17 +22,22 @@ use arbitrary::Arbitrary;
 use libfuzzer_sys::{fuzz_target, Corpus};
 use move_binary_format::{
     access::ModuleAccess,
+    errors::VMError,
     file_format::{CompiledModule, CompiledScript, FunctionDefinitionIndex, SignatureToken},
+    file_format_common::VERSION_MAX,
 };
+use move_bytecode_verifier::VerifierConfig;
 use move_core_types::{
+    ident_str,
     language_storage::{ModuleId, TypeTag},
     value::MoveValue,
     vm_status::{StatusCode, StatusType, VMStatus},
 };
 use once_cell::sync::Lazy;
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     convert::TryInto,
+    sync::Arc,
 };
 
 #[derive(Debug, Arbitrary, Eq, PartialEq, Clone, Copy)]
@@ -121,6 +129,16 @@ pub struct RunnableState {
 // genesis write set generated once for each fuzzing session
 static VM: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
+const FUZZER_CONCURRENCY_LEVEL: usize = 1;
+static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
+    Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(FUZZER_CONCURRENCY_LEVEL)
+            .build()
+            .unwrap(),
+    )
+});
+
 // small debug macro which can be enabled or disabled
 const DEBUG: bool = false;
 macro_rules! tdbg {
@@ -143,7 +161,7 @@ macro_rules! tdbg {
     };
 }
 
-const MAX_TYPE_PARAMETER_VALUE: u16 = 64 * 16; // third_party/move/move-bytecode-verifier/src/signature_v2.rs#L1306-L1312
+const MAX_TYPE_PARAMETER_VALUE: u16 = 64 / 4 * 16; // third_party/move/move-bytecode-verifier/src/signature_v2.rs#L1306-L1312
 
 // used for ordering modules topologically
 fn sort_by_deps(
@@ -182,6 +200,17 @@ fn check_for_invariant_violation(e: VMStatus) {
     }
 }
 
+fn check_for_invariant_violation_vmerror(e: VMError) {
+    if e.status_type() == StatusType::InvariantViolation
+        // ignore known false positive
+        && !e
+            .message()
+            .is_some_and(|m| m.starts_with("too many type parameters/arguments in the program"))
+    {
+        panic!("invariant violation {:?}", e);
+    }
+}
+
 // filter modules
 fn filter_modules(input: &RunnableState) -> Result<(), Corpus> {
     // reject any TypeParameter exceeds the maximum allowed value (Avoid known Ivariant Violation)
@@ -205,21 +234,108 @@ fn filter_modules(input: &RunnableState) -> Result<(), Corpus> {
     Ok(())
 }
 
+pub fn code_publish_package_txn(
+    metadata_serialized: Vec<u8>,
+    code: Vec<Vec<u8>>,
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            move_core_types::account_address::AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("code").to_owned(),
+        ),
+        ident_str!("publish_package_txn").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&metadata_serialized).unwrap(),
+            bcs::to_bytes(&code).unwrap(),
+        ],
+    ))
+}
+
+fn publish_transaction_payload(modules: &[CompiledModule]) -> TransactionPayload {
+    let modules_metadatas: Vec<_> = modules
+        .iter()
+        .map(|cm| ModuleMetadata {
+            name: cm.name().to_string(),
+            source: vec![],
+            source_map: vec![],
+            extension: MoveOption::default(),
+        })
+        .collect();
+
+    let all_immediate_deps: Vec<_> = modules
+        .iter()
+        .flat_map(|cm| cm.immediate_dependencies())
+        .map(|mi| PackageDep {
+            account: mi.address,
+            package_name: mi.name.to_string(),
+        })
+        .collect::<BTreeSet<_>>() // leave only uniques
+        .into_iter()
+        .filter(|c| &c.account != modules[0].address()) // filter out package itself
+        .collect::<Vec<_>>();
+
+    let metadata = PackageMetadata {
+        name: "fuzz_package".to_string(),
+        upgrade_policy: UpgradePolicy::compat(), // TODO: currently does not matter. Maybe fuzz compat checks specifically at some point.
+        upgrade_number: 1,
+        source_digest: "".to_string(),
+        manifest: vec![],
+        modules: modules_metadatas,
+        deps: all_immediate_deps,
+        extension: MoveOption::default(),
+    };
+    let pkg_metadata = bcs::to_bytes(&metadata).expect("PackageMetadata must serialize");
+    let mut pkg_code: Vec<Vec<u8>> = vec![];
+    for module in modules {
+        let mut module_code: Vec<u8> = vec![];
+        module
+            .serialize(&mut module_code)
+            .expect("Module must serialize");
+        pkg_code.push(module_code);
+    }
+    code_publish_package_txn(pkg_metadata, pkg_code)
+}
+
 fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     tdbg!(&input);
-    AptosVM::set_concurrency_level_once(2);
-    let mut vm = FakeExecutor::from_genesis(&VM, ChainId::mainnet()).set_not_parallel();
 
     // filter modules
     filter_modules(&input)?;
 
     for m in input.dep_modules.iter_mut() {
         // m.metadata = vec![]; // we could optimize metadata to only contain aptos metadata
-        m.version = 6; // others don't matter
-    }
-    for module in input.dep_modules.iter() {
+        m.version = VERSION_MAX;
+
         // reject bad modules fast
-        move_bytecode_verifier::verify_module(module).map_err(|_| Corpus::Keep)?;
+        let mut module_code: Vec<u8> = vec![];
+        m.serialize(&mut module_code).map_err(|_| Corpus::Keep)?;
+        let m_de = CompiledModule::deserialize(&module_code).map_err(|_| Corpus::Keep)?;
+        move_bytecode_verifier::verify_module_with_config(&VerifierConfig::production(), &m_de)
+            .map_err(|e| {
+                check_for_invariant_violation_vmerror(e);
+                Corpus::Keep
+            })?
+    }
+
+    if let ExecVariant::Script {
+        script: s,
+        type_args: _,
+        args: _,
+    } = &input.exec_variant
+    {
+        // reject bad scripts fast
+        let mut script_code: Vec<u8> = vec![];
+        s.serialize(&mut script_code).map_err(|_| Corpus::Keep)?;
+        let s_de = CompiledScript::deserialize(&script_code).map_err(|_| Corpus::Keep)?;
+        move_bytecode_verifier::verify_script_with_config(&VerifierConfig::production(), &s_de)
+            .map_err(|e| {
+                check_for_invariant_violation_vmerror(e);
+                Corpus::Keep
+            })?
     }
 
     // check no duplicates
@@ -260,16 +376,62 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
         packages.push(cur)
     }
 
+    AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
+    let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
+        &VM,
+        ChainId::mainnet(),
+        Arc::clone(&TP),
+    )
+    .set_not_parallel();
+
     // publish all packages
     for group in packages {
-        // TODO: Publish modules through native context instead.
+        let sender = *group[0].address();
+        let acc = vm.new_account_at(sender);
+        let tx = acc
+            .transaction()
+            .gas_unit_price(100)
+            .sequence_number(0)
+            .payload(publish_transaction_payload(&group))
+            .sign();
+
         tdbg!("publishing");
-        for module in group.iter() {
-            let mut b = vec![];
-            module.serialize(&mut b).map_err(|_| Corpus::Reject)?;
-            CompiledModule::deserialize(&b).map_err(|_| Corpus::Reject)?;
-            vm.add_module(&module.self_id(), b);
-        }
+        let res = vm
+            .execute_block(vec![tx])
+            .map_err(|e| {
+                check_for_invariant_violation(e);
+                Corpus::Keep
+            })?
+            .pop()
+            .expect("expected 1 output");
+        // if error exit gracefully
+        tdbg!(&res);
+        let status = match tdbg!(res.status()) {
+            TransactionStatus::Keep(status) => status,
+            TransactionStatus::Discard(e) => {
+                if e.status_type() == StatusType::InvariantViolation {
+                    panic!("invariant violation {:?}", e);
+                }
+                return Err(Corpus::Keep);
+            },
+            _ => return Err(Corpus::Keep),
+        };
+        tdbg!(&status);
+        // apply write set to commit published packages
+        vm.apply_write_set(res.write_set());
+        match tdbg!(status) {
+            ExecutionStatus::Success => (),
+            ExecutionStatus::MiscellaneousError(e) => {
+                if let Some(e) = e {
+                    if e.status_type() == StatusType::InvariantViolation {
+                        panic!("invariant violation {:?}", e);
+                    }
+                }
+                return Err(Corpus::Keep);
+            },
+            _ => return Err(Corpus::Keep),
+        };
+
         tdbg!("published");
     }
 


### PR DESCRIPTION
## Description
* Updated the fuzzer to use official publish flow for deploying module
* Additional improvements which improve performance by a good margin at an expense of small patch to `FakeExecutor`
* Verify the modules with production config to reject bad modules quicker

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
N/A

## Key Areas to Review
The patch to `FakeExecutor` and it's feature gating.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
