### PR TITLE
reverse state proof siblings

### DIFF
--- a/storage/jellyfish-merkle/src/node_type/mod.rs
+++ b/storage/jellyfish-merkle/src/node_type/mod.rs
@@ -597,10 +597,10 @@ impl InternalNode {
         node_key: &NodeKey,
         n: Nibble,
         reader: Option<&R>,
-    ) -> Result<(Option<NodeKey>, Vec<NodeInProof>)> {
+        out_siblings: &mut Vec<NodeInProof>,
+    ) -> Result<Option<NodeKey>> {
         assert!(self.leaf_count > 1);
 
-        let mut siblings = vec![];
         let (existence_bitmap, leaf_bitmap) = self.generate_bitmaps();
 
         // Nibble height from 3 to 0.
@@ -611,14 +611,14 @@ impl InternalNode {
             let (child_half_start, sibling_half_start) = get_child_and_sibling_half_start(n, h);
             // Compute the root hash of the subtree rooted at the sibling of `r`.
             if let Some(reader) = reader {
-                siblings.push(self.gen_node_in_proof(
+                out_siblings.push(self.gen_node_in_proof(
                     sibling_half_start,
                     width,
                     (existence_bitmap, leaf_bitmap),
                     (reader, node_key),
                 )?);
             } else {
-                siblings.push(
+                out_siblings.push(
                     self.merkle_hash(sibling_half_start, width, (existence_bitmap, leaf_bitmap))
                         .into(),
                 );
@@ -629,7 +629,7 @@ impl InternalNode {
 
             if range_existence_bitmap == 0 {
                 // No child in this range.
-                return Ok((None, siblings));
+                return Ok(None);
             } else if width == 1
                 || (range_existence_bitmap.count_ones() == 1 && range_leaf_bitmap != 0)
             {
@@ -638,27 +638,36 @@ impl InternalNode {
                 // `None` because it's existence indirectly proves the n-th child doesn't exist.
                 // Please read proof format for details.
                 let only_child_index = Nibble::from(range_existence_bitmap.trailing_zeros() as u8);
-                return Ok((
-                    {
-                        let only_child_version = self
-                            .child(only_child_index)
-                            // Should be guaranteed by the self invariants, but these are not easy to express at the moment
-                            .with_context(|| {
-                                format!(
-                                    "Corrupted internal node: child_bitmap indicates \
-                                     the existence of a non-exist child at index {:x}",
-                                    only_child_index
-                                )
-                            })
-                            .unwrap()
-                            .version;
-                        Some(node_key.gen_child_node_key(only_child_version, only_child_index))
-                    },
-                    siblings,
+                let only_child_version = self
+                    .child(only_child_index)
+                    // Should be guaranteed by the self invariants, but these are not easy to express at the moment
+                    .with_context(|| {
+                        format!(
+                            "Corrupted internal node: child_bitmap indicates \
+                                 the existence of a non-exist child at index {:x}",
+                            only_child_index
+                        )
+                    })
+                    .unwrap()
+                    .version;
+                return Ok(Some(
+                    node_key.gen_child_node_key(only_child_version, only_child_index),
                 ));
             }
         }
         unreachable!("Impossible to get here without returning even at the lowest level.")
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_child_with_siblings_for_test<K: crate::Key, R: TreeReader<K>>(
+        &self,
+        node_key: &NodeKey,
+        n: Nibble,
+        reader: Option<&R>,
+    ) -> Result<(Option<NodeKey>, Vec<NodeInProof>)> {
+        let mut sibilings = vec![];
+        self.get_child_with_siblings(node_key, n, reader, &mut sibilings)
+            .map(|n| (n, sibilings))
     }
 }
 

--- a/storage/jellyfish-merkle/src/node_type/node_type_test.rs
+++ b/storage/jellyfish-merkle/src/node_type/node_type_test.rs
@@ -196,13 +196,13 @@ proptest! {
 
         for i in 0..8 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
                 (Some(leaf1_node_key.clone()), vec![hash2.into()])
             );
         }
         for i in 8..16 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
                 (Some(leaf2_node_key.clone()), vec![hash1.into()])
             );
         }
@@ -243,14 +243,14 @@ proptest! {
 
         for i in 0..4 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
                 (None, vec![(*SPARSE_MERKLE_PLACEHOLDER_HASH).into(), hash_x1.into()])
             );
         }
 
         for i in 4..6 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
                 (
                     Some(leaf1_node_key.clone()),
                     vec![
@@ -264,7 +264,7 @@ proptest! {
 
         for i in 6..8 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
                 (
                     Some(leaf2_node_key.clone()),
                     vec![
@@ -278,7 +278,7 @@ proptest! {
 
         for i in 8..16 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
                 (None, vec![hash_x2.into()])
             );
         }
@@ -317,21 +317,21 @@ proptest! {
 
         for i in 0..4 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
                 (Some(leaf1_node_key.clone()),vec![hash3.into(), hash2.into()])
             );
         }
 
         for i in 4..8 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
                 (Some(leaf2_node_key.clone()),vec![hash3.into(), hash1.into()])
             );
         }
 
         for i in 8..16 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
                 (Some(leaf3_node_key.clone()),vec![hash_x.into()])
             );
         }
@@ -382,7 +382,7 @@ proptest! {
 
         for i in 0..2 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
                 (
                     Some(leaf1_node_key.clone()),
                     vec![hash4.into(), hash_x4.into(), hash_x1.into()]
@@ -391,7 +391,7 @@ proptest! {
         }
 
         prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, 2.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, 2.into(), None).unwrap(),
             (
                 Some(internal2_node_key),
                 vec![
@@ -404,7 +404,7 @@ proptest! {
         );
 
         prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, 3.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, 3.into(), None).unwrap(),
 
             (
                 None,
@@ -414,7 +414,7 @@ proptest! {
 
         for i in 4..6 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
                 (
                     None,
                     vec![hash4.into(), hash_x2.into(), hash_x3.into()]
@@ -423,7 +423,7 @@ proptest! {
         }
 
         prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, 6.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, 6.into(), None).unwrap(),
             (
                 None,
                 vec![
@@ -436,7 +436,7 @@ proptest! {
         );
 
         prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, 7.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, 7.into(), None).unwrap(),
             (
                 Some(internal3_node_key),
                 vec![
@@ -450,7 +450,7 @@ proptest! {
 
         for i in 8..16 {
             prop_assert_eq!(
-                internal_node.get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
+                internal_node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&internal_node_key, i.into(), None).unwrap(),
                 (Some(leaf4_node_key.clone()), vec![hash_x5.into()])
             );
         }
@@ -525,7 +525,7 @@ fn test_internal_hash_and_proof() {
         for i in 0..4 {
             assert_eq!(
                 internal_node
-                    .get_child_with_siblings::<StateKey, DummyReader>(
+                    .get_child_with_siblings_for_test::<StateKey, DummyReader>(
                         &internal_node_key,
                         i.into(),
                         None
@@ -537,7 +537,11 @@ fn test_internal_hash_and_proof() {
 
         assert_eq!(
             internal_node
-                .get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, index1, None)
+                .get_child_with_siblings_for_test::<StateKey, DummyReader>(
+                    &internal_node_key,
+                    index1,
+                    None
+                )
                 .unwrap(),
             (Some(child1_node_key), vec![
                 hash_x6.into(),
@@ -549,7 +553,7 @@ fn test_internal_hash_and_proof() {
 
         assert_eq!(
             internal_node
-                .get_child_with_siblings::<StateKey, DummyReader>(
+                .get_child_with_siblings_for_test::<StateKey, DummyReader>(
                     &internal_node_key,
                     5.into(),
                     None
@@ -565,7 +569,7 @@ fn test_internal_hash_and_proof() {
         for i in 6..8 {
             assert_eq!(
                 internal_node
-                    .get_child_with_siblings::<StateKey, DummyReader>(
+                    .get_child_with_siblings_for_test::<StateKey, DummyReader>(
                         &internal_node_key,
                         i.into(),
                         None
@@ -582,7 +586,7 @@ fn test_internal_hash_and_proof() {
         for i in 8..12 {
             assert_eq!(
                 internal_node
-                    .get_child_with_siblings::<StateKey, DummyReader>(
+                    .get_child_with_siblings_for_test::<StateKey, DummyReader>(
                         &internal_node_key,
                         i.into(),
                         None
@@ -595,7 +599,7 @@ fn test_internal_hash_and_proof() {
         for i in 12..14 {
             assert_eq!(
                 internal_node
-                    .get_child_with_siblings::<StateKey, DummyReader>(
+                    .get_child_with_siblings_for_test::<StateKey, DummyReader>(
                         &internal_node_key,
                         i.into(),
                         None
@@ -610,7 +614,7 @@ fn test_internal_hash_and_proof() {
         }
         assert_eq!(
             internal_node
-                .get_child_with_siblings::<StateKey, DummyReader>(
+                .get_child_with_siblings_for_test::<StateKey, DummyReader>(
                     &internal_node_key,
                     14.into(),
                     None
@@ -625,7 +629,11 @@ fn test_internal_hash_and_proof() {
         );
         assert_eq!(
             internal_node
-                .get_child_with_siblings::<StateKey, DummyReader>(&internal_node_key, index2, None)
+                .get_child_with_siblings_for_test::<StateKey, DummyReader>(
+                    &internal_node_key,
+                    index2,
+                    None
+                )
                 .unwrap(),
             (Some(child2_node_key), vec![
                 hash_x3.into(),
@@ -701,7 +709,7 @@ fn test_internal_hash_and_proof() {
 
         assert_eq!(
             internal_node
-                .get_child_with_siblings::<StateKey, DummyReader>(
+                .get_child_with_siblings_for_test::<StateKey, DummyReader>(
                     &internal_node_key,
                     0.into(),
                     None
@@ -717,7 +725,7 @@ fn test_internal_hash_and_proof() {
 
         assert_eq!(
             internal_node
-                .get_child_with_siblings::<StateKey, DummyReader>(
+                .get_child_with_siblings_for_test::<StateKey, DummyReader>(
                     &internal_node_key,
                     1.into(),
                     None
@@ -734,7 +742,7 @@ fn test_internal_hash_and_proof() {
         for i in 2..4 {
             assert_eq!(
                 internal_node
-                    .get_child_with_siblings::<StateKey, DummyReader>(
+                    .get_child_with_siblings_for_test::<StateKey, DummyReader>(
                         &internal_node_key,
                         i.into(),
                         None
@@ -751,7 +759,7 @@ fn test_internal_hash_and_proof() {
         for i in 4..6 {
             assert_eq!(
                 internal_node
-                    .get_child_with_siblings::<StateKey, DummyReader>(
+                    .get_child_with_siblings_for_test::<StateKey, DummyReader>(
                         &internal_node_key,
                         i.into(),
                         None
@@ -767,7 +775,7 @@ fn test_internal_hash_and_proof() {
 
         assert_eq!(
             internal_node
-                .get_child_with_siblings::<StateKey, DummyReader>(
+                .get_child_with_siblings_for_test::<StateKey, DummyReader>(
                     &internal_node_key,
                     6.into(),
                     None
@@ -783,7 +791,7 @@ fn test_internal_hash_and_proof() {
 
         assert_eq!(
             internal_node
-                .get_child_with_siblings::<StateKey, DummyReader>(
+                .get_child_with_siblings_for_test::<StateKey, DummyReader>(
                     &internal_node_key,
                     7.into(),
                     None
@@ -800,7 +808,7 @@ fn test_internal_hash_and_proof() {
         for i in 8..16 {
             assert_eq!(
                 internal_node
-                    .get_child_with_siblings::<StateKey, DummyReader>(
+                    .get_child_with_siblings_for_test::<StateKey, DummyReader>(
                         &internal_node_key,
                         i.into(),
                         None
@@ -984,7 +992,7 @@ proptest! {
     ) {
         for n in 0..16u8 {
             prop_assert_eq!(
-                node.get_child_with_siblings::<StateKey, DummyReader>(&node_key, n.into(), None).unwrap(),
+                node.get_child_with_siblings_for_test::<StateKey, DummyReader>(&node_key, n.into(), None).unwrap(),
                 NaiveInternalNode::from_clever_node(&node).get_child_with_siblings(&node_key, n)
             )
         }

--- a/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
+++ b/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
@@ -214,11 +214,11 @@ fn test_update_256_siblings_in_proof() {
             .take(255)
             .collect();
     siblings.push(leaf2.into());
-    siblings.reverse();
     let proof_of_key1 = SparseMerkleProofExt::new(Some(leaf1), siblings.clone());
 
     let old_root_hash = siblings
         .iter()
+        .rev()
         .fold(leaf1.hash(), |previous_hash, node_in_proof| {
             hash_internal(previous_hash, node_in_proof.hash())
         });
@@ -237,6 +237,7 @@ fn test_update_256_siblings_in_proof() {
     let new_leaf1_hash = hash_leaf(key1, new_value1_hash);
     let new_root_hash = siblings
         .iter()
+        .rev()
         .fold(new_leaf1_hash, |previous_hash, node_in_proof| {
             hash_internal(previous_hash, node_in_proof.hash())
         });
@@ -300,8 +301,8 @@ fn test_update() {
     let y_hash = hash_internal(x_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH);
     let old_root_hash = hash_internal(y_hash, leaf3.hash());
     let proof = SparseMerkleProofExt::new(None, vec![
-        NodeInProof::Other(x_hash),
         NodeInProof::Leaf(leaf3),
+        NodeInProof::Other(x_hash),
     ]);
     assert!(proof
         .verify::<StateValue>(old_root_hash, key4, None)
@@ -340,9 +341,9 @@ fn test_update() {
 
     // Next, we are going to delete key1. Create a proof for key1.
     let proof = SparseMerkleProofExt::new(Some(leaf1), vec![
-        leaf2.into(),
-        (*SPARSE_MERKLE_PLACEHOLDER_HASH).into(),
         leaf3.into(),
+        (*SPARSE_MERKLE_PLACEHOLDER_HASH).into(),
+        leaf2.into(),
     ]);
     assert!(proof.verify(old_root_hash, key1, Some(&value1)).is_ok());
 

--- a/storage/scratchpad/src/sparse_merkle/test_utils/naive_smt.rs
+++ b/storage/scratchpad/src/sparse_merkle/test_utils/naive_smt.rs
@@ -26,6 +26,15 @@ impl<'a> NaiveSubTree<'a> {
         key: &HashValue,
         cache: &mut Cache,
     ) -> (Option<SparseMerkleLeafNode>, Vec<NodeInProof>) {
+        let (leaf, rev_proof) = self.get_proof_(key, cache);
+        (leaf, rev_proof.into_iter().rev().collect())
+    }
+
+    fn get_proof_(
+        &'a self,
+        key: &HashValue,
+        cache: &mut Cache,
+    ) -> (Option<SparseMerkleLeafNode>, Vec<NodeInProof>) {
         if self.is_empty() {
             (None, Vec::new())
         } else if self.leaves.len() == 1 {
@@ -37,11 +46,11 @@ impl<'a> NaiveSubTree<'a> {
         } else {
             let (left, right) = self.children();
             if key.bit(self.depth) {
-                let (ret_leaf, mut ret_siblings) = right.get_proof(key, cache);
+                let (ret_leaf, mut ret_siblings) = right.get_proof_(key, cache);
                 ret_siblings.push(left.get_node_in_proof(cache));
                 (ret_leaf, ret_siblings)
             } else {
-                let (ret_leaf, mut ret_siblings) = left.get_proof(key, cache);
+                let (ret_leaf, mut ret_siblings) = left.get_proof_(key, cache);
                 ret_siblings.push(right.get_node_in_proof(cache));
                 (ret_leaf, ret_siblings)
             }

--- a/storage/scratchpad/src/sparse_merkle/updater.rs
+++ b/storage/scratchpad/src/sparse_merkle/updater.rs
@@ -246,8 +246,7 @@ impl<'a, V: Clone + CryptoHash + Send + Sync + 'static> SubTreeInfo<'a, V> {
                 PersistedSubTreeInfo::ProofPathInternal { proof } => {
                     let siblings = proof.siblings();
                     assert!(siblings.len() > depth);
-                    let sibling_child =
-                        SubTreeInfo::new_proof_sibling(&siblings[siblings.len() - depth - 1]);
+                    let sibling_child = SubTreeInfo::new_proof_sibling(&siblings[depth]);
                     let on_path_child = SubTreeInfo::new_on_proof_path(proof, depth + 1);
                     swap_if(on_path_child, sibling_child, a_descendent_key.bit(depth))
                 },

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -146,8 +146,8 @@ pub struct SparseMerkleProof {
     ///       empty.
     leaf: Option<SparseMerkleLeafNode>,
 
-    /// All siblings in this proof, including the default ones. Siblings are ordered from the bottom
-    /// level to the root level.
+    /// All siblings in this proof, including the default ones. Siblings are ordered from the root
+    /// level to the bottom level.
     siblings: Vec<HashValue>,
 }
 
@@ -183,8 +183,8 @@ impl NodeInProof {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SparseMerkleProofExt {
     leaf: Option<SparseMerkleLeafNode>,
-    /// All siblings in this proof, including the default ones. Siblings are ordered from the bottom
-    /// level to the root level.
+    /// All siblings in this proof, including the default ones. Siblings are ordered from the root
+    /// level to the bottom level.
     siblings: Vec<NodeInProof>,
 }
 
@@ -349,6 +349,7 @@ impl SparseMerkleProof {
         let actual_root_hash = self
             .siblings
             .iter()
+            .rev()
             .zip(
                 element_key
                     .iter_bits()

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -226,8 +226,8 @@ fn test_verify_three_element_sparse_merkle() {
     {
         // Construct a proof of key1.
         let proof = SparseMerkleProof::new(Some(leaf1), vec![
-            internal_b_hash,
             *SPARSE_MERKLE_PLACEHOLDER_HASH,
+            internal_b_hash,
         ]);
 
         // The exact key value exists.


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Our implementation outputs the new order natually without the need for
reversing.

Lucky that we didn't expose the state proof to outside of the node

The range proof unfortunately is already exposed, so not gonna be
changed.


## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Validator Node

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

unit tests updated.
checked code as far as I can, and I don't think the proof is exposed anywhere, including db backups.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
