### PR TITLE
governance proposal to enable privacy-preserving keyless accounts

### DIFF
--- a/aptos-move/aptos-release-builder/data/keyless.yaml
+++ b/aptos-move/aptos-release-builder/data/keyless.yaml
@@ -1,0 +1,16 @@
+---
+remote_endpoint: ~
+name: keyless
+proposals:
+  - name: enable_keyless
+    metadata:
+      title: "Enable privacy-preserving keyless accounts"
+      description: "Enables the changes in AIP-61 https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-61.md and related AIPs (75, 81)"
+      source_code_url: ""
+      discussion_url: "https://github.com/aptos-foundation/AIPs/issues/297"
+    execution_mode: RootSigner
+    update_sequence:
+      - FeatureFlag:
+          enabled:
+            - keyless_accounts
+


### PR DESCRIPTION
## Description

Adds governance proposal to enable keyless accounts ([AIP-61](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-61.md)) in v1.12.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests
- [x] Governance proposal 

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Thoroughly, in other keyless PRs.

## Key Areas to Review

Review the .yaml file, since I am no expert on it.

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
