### PR TITLE
Fix hash_cache miss when leaf is brought up on sibling deletion

### DIFF
--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -556,29 +556,12 @@ where
 
                 let children: Vec<_> = internal_node
                     .children_sorted()
-                    .merge_join_by(new_child_nodes_or_deletes.iter(), |(n, _), (m, _)| {
-                        (*n).cmp(m)
-                    })
-                    .filter_map(|old_and_new| {
-                        match old_and_new {
-                            // old child untouched
-                            EitherOrBoth::Left((nibble, old_child)) => {
-                                Some((*nibble, old_child.clone()))
-                            },
-                            // child updated or new child
-                            EitherOrBoth::Right((nibble, new_child_node_opt))
-                            | EitherOrBoth::Both((_, _), (nibble, new_child_node_opt)) => {
-                                match new_child_node_opt {
-                                    None => None, // child deleted
-                                    Some(child_node) => {
-                                        let child = Child::for_node(
-                                            node_key, *nibble, child_node, hash_cache, version,
-                                        );
-                                        Some((*nibble, child))
-                                    },
-                                }
-                            },
-                        } // end match old_and_new
+                    .merge_join_by(new_child_nodes_or_deletes, |(n, _), (m, _)| (*n).cmp(m))
+                    .filter(|old_or_new| {
+                        !matches!(
+                            old_or_new,
+                            EitherOrBoth::Right((_, None)) | EitherOrBoth::Both((_, _), (_, None))
+                        )
                     })
                     .collect();
 
@@ -587,40 +570,49 @@ where
                     return Ok(None);
                 }
 
-                let new_child_nodes: Vec<_> = new_child_nodes_or_deletes
-                    .into_iter()
-                    .filter_map(|(nibble, node_opt)| node_opt.map(|node| (nibble, node)))
-                    .collect();
-
                 if children.len() == 1 {
                     // only one child left, could be a leaf node that we need to push up one level.
-                    let (nibble, only_child) = children.first().unwrap();
-                    if only_child.is_leaf() {
-                        return if !new_child_nodes.is_empty() {
-                            // it's a new leaf
-                            assert_eq!(new_child_nodes.len(), 1);
-                            let (_nibble, new_child_node) =
-                                new_child_nodes.into_iter().next().unwrap();
-                            assert!(new_child_node.is_leaf());
-                            Ok(Some(new_child_node))
-                        } else {
-                            // it's an old leaf
-                            assert!(new_child_nodes.is_empty());
-                            let old_child_node_key =
-                                node_key.gen_child_node_key(only_child.version, *nibble);
-                            let old_child_node = self
-                                .reader
-                                .get_node_with_tag(&old_child_node_key, "commit")?;
-                            batch.put_stale_node(old_child_node_key, version);
-                            Ok(Some(old_child_node))
-                        };
+                    let only_child = children.first().unwrap();
+                    match only_child {
+                        EitherOrBoth::Left((nibble, old_child)) => {
+                            if old_child.is_leaf() {
+                                // it's an old leaf
+                                let child_key =
+                                    node_key.gen_child_node_key(old_child.version, **nibble);
+                                let node = self.reader.get_node_with_tag(&child_key, "commit")?;
+                                batch.put_stale_node(child_key, version);
+                                return Ok(Some(node));
+                            }
+                        },
+                        EitherOrBoth::Right((_nibble, new_node))
+                        | EitherOrBoth::Both((_, _), (_nibble, new_node)) => {
+                            let new_node =
+                                new_node.as_ref().expect("Deletion already filtered out.");
+                            if new_node.is_leaf() {
+                                // it's a new leaf
+                                return Ok(Some(new_node.clone()));
+                            }
+                        },
                     }
                 }
 
-                for (nibble, node) in new_child_nodes {
-                    let child_key = node_key.gen_child_node_key(version, nibble);
-                    batch.put_node(child_key, node);
-                }
+                let children = children.into_iter().map(|old_or_new| {
+                    match old_or_new {
+                        // an old child
+                        EitherOrBoth::Left((nibble, old_child)) => (*nibble, old_child.clone()),
+                        // a new or updated child
+                        EitherOrBoth::Right((nibble, new_node))
+                        | EitherOrBoth::Both((_, _), (nibble, new_node)) => {
+                            let new_node =
+                                new_node.as_ref().expect("Deletion already filtered out.");
+                            let child_key = node_key.gen_child_node_key(version, nibble);
+                            batch.put_node(child_key, new_node.clone());
+                            let child =
+                                Child::for_node(node_key, nibble, new_node, hash_cache, version);
+                            (nibble, child)
+                        },
+                    }
+                });
 
                 let new_internal_node = InternalNode::new(Children::from_sorted(children));
                 Ok(Some(new_internal_node.into()))


### PR DESCRIPTION

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->


Original thought was in these rare cases we just waste a constructed Child to make the code simply, however it wasn't considered that there's a panic on hash_cache miss. I think the panic is valuable assertion so this is fixing it by some extra code.



## Type of Change
- [x] Bug fix -- blaming https://github.com/aptos-labs/aptos-core/pull/13249


## Which Components or Systems Does This Change Impact?
- [x] Validator Node


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

locally tested by running the replay tool.

unit test coverage was not able to catch this because deletion is not tested enough. Gonna update proptest separately though, to fix forward quickly.


## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
