### PR TITLE
Update release.yaml and the forge test base node hash for the v1.13 release

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -312,7 +312,7 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: compat
-      IMAGE_TAG: 01b24e7e3548382dd25440b39a0438a993387f12 #aptos-node-v1.11 with randomness disabled in genesis
+      IMAGE_TAG: c90dafdb2f450e4d3aa16b1a7cff8e3cad2b882e #aptos-node-v1.12.0
       FORGE_RUNNER_DURATION_SECS: 300
       COMMENT_HEADER: forge-compat
       FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
@@ -340,7 +340,7 @@ jobs:
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: framework_upgrade
-      IMAGE_TAG: 01b24e7e3548382dd25440b39a0438a993387f12 #aptos-node-v1.11 with randomness disabled in genesis
+      IMAGE_TAG: c90dafdb2f450e4d3aa16b1a7cff8e3cad2b882e #aptos-node-v1.12.0
       FORGE_RUNNER_DURATION_SECS: 3600
       COMMENT_HEADER: forge-framework-upgrade
       FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -128,7 +128,7 @@ jobs:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
-      IMAGE_TAG: 01b24e7e3548382dd25440b39a0438a993387f12 #aptos-node-v1.11 with randomness disabled in genesis
+      IMAGE_TAG: c90dafdb2f450e4d3aa16b1a7cff8e3cad2b882e #aptos-node-v1.12.0
       FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-test-metadata.outputs.BRANCH_HASH }}
       FORGE_RUNNER_DURATION_SECS: 7200 # Run for 2 hours
       FORGE_TEST_SUITE: framework_upgrade
@@ -270,7 +270,7 @@ jobs:
       FORGE_RUNNER_DURATION_SECS: 300 # Run for 5 minutes
       # This will upgrade from testnet branch to the latest main
       FORGE_TEST_SUITE: compat
-      IMAGE_TAG: 01b24e7e3548382dd25440b39a0438a993387f12 #aptos-node-v1.11 with randomness disabled in genesis
+      IMAGE_TAG: c90dafdb2f450e4d3aa16b1a7cff8e3cad2b882e #aptos-node-v1.12.0
       GIT_SHA: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }} # this is the git ref to checkout
       POST_TO_SLACK: true
 

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -1,26 +1,20 @@
 ---
 remote_endpoint: ~
-name: "v1.12"
+name: "v1.13"
 proposals:
-  - name: step_1_increase_max_txn_gas
+  - name: step_1_upgrade_gas_schedule
     metadata:
-      title: "Increase max txn gas temporarily for framework upgrade"
-      description: "Increase max txn gas temporarily for framework upgrade"
+      title: "Gas schedule upgrade"
+      description: "Upgrades the gas schedule to version 18, enabling separate limits for governance proposals"
     execution_mode: MultiStep
     update_sequence:
-      - DefaultGasWithOverride:
-          feature_version: 16
-          overrides:
-            - name: "txn.max_execution_gas"
-              value: 4000000000
+      - DefaultGas
   - name: step_2_upgrade_framework
     metadata:
-      title: "Multi-step proposal to upgrade mainnet framework to v1.12"
-      description: "This includes changes in https://github.com/aptos-labs/aptos-core/commits/aptos-release-v1.12"
+      title: "Multi-step proposal to upgrade mainnet framework to v1.13"
+      description: "This includes changes in https://github.com/aptos-labs/aptos-core/commits/aptos-release-v1.13"
     execution_mode: MultiStep
     update_sequence:
       - Framework:
           bytecode_version: 6
           git_hash: ~
-      - DefaultGasWithOverride:
-          feature_version: 17

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -8,7 +8,11 @@ proposals:
       description: "Upgrades the gas schedule to version 18, enabling separate limits for governance proposals"
     execution_mode: MultiStep
     update_sequence:
-      - DefaultGas
+      - DefaultGasWithOverride:
+          feature_version: 17
+          overrides:
+            - name: "txn.max_execution_gas"
+              value: 4000000000
   - name: step_2_upgrade_framework
     metadata:
       title: "Multi-step proposal to upgrade mainnet framework to v1.13"


### PR DESCRIPTION
## Description
This PR reset `release.yaml` for the v1.13 release