### PR TITLE
[release-builder] reduce compilation time by generating blobs as hex strings as opposed to vectors

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/consensus_config.rs
+++ b/aptos-move/aptos-release-builder/src/components/consensus_config.rs
@@ -30,7 +30,7 @@ pub fn generate_consensus_upgrade_proposal(
             assert!(consensus_config_blob.len() < 65536);
 
             emit!(writer, "let consensus_blob: vector<u8> = ");
-            generate_blob(writer, &consensus_config_blob);
+            generate_blob_as_hex_string(writer, &consensus_config_blob);
             emitln!(writer, ";\n");
 
             emitln!(

--- a/aptos-move/aptos-release-builder/src/components/execution_config.rs
+++ b/aptos-move/aptos-release-builder/src/components/execution_config.rs
@@ -30,7 +30,7 @@ pub fn generate_execution_config_upgrade_proposal(
             assert!(execution_config_blob.len() < 65536);
 
             emit!(writer, "let execution_blob: vector<u8> = ");
-            generate_blob(writer, &execution_config_blob);
+            generate_blob_as_hex_string(writer, &execution_config_blob);
             emitln!(writer, ";\n");
 
             emitln!(

--- a/aptos-move/aptos-release-builder/src/components/gas.rs
+++ b/aptos-move/aptos-release-builder/src/components/gas.rs
@@ -51,7 +51,7 @@ pub fn generate_gas_upgrade_proposal(
             let gas_schedule_blob = bcs::to_bytes(gas_schedule).unwrap();
             assert!(gas_schedule_blob.len() < 65536);
             emit!(writer, "let gas_schedule_blob: vector<u8> = ");
-            generate_blob(writer, &gas_schedule_blob);
+            generate_blob_as_hex_string(writer, &gas_schedule_blob);
             emitln!(writer, ";\n");
             if !post_randomness_framework {
                 emitln!(

--- a/aptos-move/aptos-release-builder/src/utils.rs
+++ b/aptos-move/aptos-release-builder/src/utils.rs
@@ -4,22 +4,12 @@
 use move_core_types::account_address::AccountAddress;
 use move_model::{code_writer::CodeWriter, emit, emitln};
 
-pub(crate) fn generate_blob(writer: &CodeWriter, data: &[u8]) {
-    emitln!(writer, "vector[");
-    writer.indent();
-    for (i, b) in data.iter().enumerate() {
-        if i % 20 == 0 {
-            if i > 0 {
-                emitln!(writer);
-            }
-        } else {
-            emit!(writer, " ");
-        }
-        emit!(writer, "{},", b);
+pub(crate) fn generate_blob_as_hex_string(writer: &CodeWriter, data: &[u8]) {
+    emit!(writer, "x\"");
+    for b in data.iter() {
+        emit!(writer, "{:02x}", b);
     }
-    emitln!(writer);
-    writer.unindent();
-    emit!(writer, "]")
+    emit!(writer, "\"");
 }
 
 pub(crate) fn generate_next_execution_hash_blob(
@@ -43,11 +33,8 @@ pub(crate) fn generate_next_execution_hash_blob(
         writer.indent();
         emitln!(writer, "proposal_id,");
         emitln!(writer, "@{},", for_address);
-        emit!(writer, "vector[");
-        for b in next_execution_hash.iter() {
-            emit!(writer, "{}u8,", b);
-        }
-        emitln!(writer, "],");
+        generate_blob_as_hex_string(writer, &next_execution_hash);
+        emit!(writer, ",");
         writer.unindent();
         emitln!(writer, ");");
     }

--- a/aptos-move/framework/src/release_bundle.rs
+++ b/aptos-move/framework/src/release_bundle.rs
@@ -232,7 +232,7 @@ impl ReleasePackage {
 
         for i in 0..self.code.len() {
             emitln!(writer, "let chunk{} = ", i);
-            Self::generate_blob(&writer, &self.code[i]);
+            Self::generate_blob_as_hex_string(&writer, &self.code[i]);
             emitln!(writer, ";");
             emitln!(writer, "vector::push_back(&mut code, chunk{});", i);
         }
@@ -253,7 +253,7 @@ impl ReleasePackage {
             };
             let chunk = metadata.drain(0..to_drain).collect::<Vec<_>>();
             emit!(writer, "let chunk{} = ", i);
-            Self::generate_blob(&writer, &chunk);
+            Self::generate_blob_as_hex_string(&writer, &chunk);
             emitln!(writer, ";")
         }
 
@@ -273,18 +273,12 @@ impl ReleasePackage {
         Ok(())
     }
 
-    fn generate_blob(writer: &CodeWriter, data: &[u8]) {
-        emitln!(writer, "vector[");
-        writer.indent();
-        for (i, b) in data.iter().enumerate() {
-            if (i + 1) % 20 == 0 {
-                emitln!(writer);
-            }
-            emit!(writer, "{}u8,", b);
+    fn generate_blob_as_hex_string(writer: &CodeWriter, data: &[u8]) {
+        emit!(writer, "x\"");
+        for b in data.iter() {
+            emit!(writer, "{:02x}", b);
         }
-        emitln!(writer);
-        writer.unindent();
-        emit!(writer, "]")
+        emit!(writer, "\"");
     }
 
     fn generate_next_execution_hash_blob(


### PR DESCRIPTION
Currently it takes an excruciatingly long time to generate the governance proposals for releases. This is because we generate all blobs as `vector<u8>`, and compiler v1 presumably runs some non-linear algorithms on these vectors.

This changes all `vector<u8>` to hex strings, greatly reducing compilation time (before: 13 minutes, after: 26 seconds, release mode). 