### PR TITLE
Fix hash_cache miss when leaf is brought up on sibling deletion

### DIFF
--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -556,29 +556,12 @@ where
 
                 let children: Vec<_> = internal_node
                     .children_sorted()
-                    .merge_join_by(new_child_nodes_or_deletes.iter(), |(n, _), (m, _)| {
-                        (*n).cmp(m)
-                    })
-                    .filter_map(|old_and_new| {
-                        match old_and_new {
-                            // old child untouched
-                            EitherOrBoth::Left((nibble, old_child)) => {
-                                Some((*nibble, old_child.clone()))
-                            },
-                            // child updated or new child
-                            EitherOrBoth::Right((nibble, new_child_node_opt))
-                            | EitherOrBoth::Both((_, _), (nibble, new_child_node_opt)) => {
-                                match new_child_node_opt {
-                                    None => None, // child deleted
-                                    Some(child_node) => {
-                                        let child = Child::for_node(
-                                            node_key, *nibble, child_node, hash_cache, version,
-                                        );
-                                        Some((*nibble, child))
-                                    },
-                                }
-                            },
-                        } // end match old_and_new
+                    .merge_join_by(new_child_nodes_or_deletes, |(n, _), (m, _)| (*n).cmp(m))
+                    .filter(|old_or_new| {
+                        !matches!(
+                            old_or_new,
+                            EitherOrBoth::Right((_, None)) | EitherOrBoth::Both((_, _), (_, None))
+                        )
                     })
                     .collect();
 
@@ -587,40 +570,49 @@ where
                     return Ok(None);
                 }
 
-                let new_child_nodes: Vec<_> = new_child_nodes_or_deletes
-                    .into_iter()
-                    .filter_map(|(nibble, node_opt)| node_opt.map(|node| (nibble, node)))
-                    .collect();
-
                 if children.len() == 1 {
                     // only one child left, could be a leaf node that we need to push up one level.
-                    let (nibble, only_child) = children.first().unwrap();
-                    if only_child.is_leaf() {
-                        return if !new_child_nodes.is_empty() {
-                            // it's a new leaf
-                            assert_eq!(new_child_nodes.len(), 1);
-                            let (_nibble, new_child_node) =
-                                new_child_nodes.into_iter().next().unwrap();
-                            assert!(new_child_node.is_leaf());
-                            Ok(Some(new_child_node))
-                        } else {
-                            // it's an old leaf
-                            assert!(new_child_nodes.is_empty());
-                            let old_child_node_key =
-                                node_key.gen_child_node_key(only_child.version, *nibble);
-                            let old_child_node = self
-                                .reader
-                                .get_node_with_tag(&old_child_node_key, "commit")?;
-                            batch.put_stale_node(old_child_node_key, version);
-                            Ok(Some(old_child_node))
-                        };
+                    let only_child = children.first().unwrap();
+                    match only_child {
+                        EitherOrBoth::Left((nibble, old_child)) => {
+                            if old_child.is_leaf() {
+                                // it's an old leaf
+                                let child_key =
+                                    node_key.gen_child_node_key(old_child.version, **nibble);
+                                let node = self.reader.get_node_with_tag(&child_key, "commit")?;
+                                batch.put_stale_node(child_key, version);
+                                return Ok(Some(node));
+                            }
+                        },
+                        EitherOrBoth::Right((_nibble, new_node))
+                        | EitherOrBoth::Both((_, _), (_nibble, new_node)) => {
+                            let new_node =
+                                new_node.as_ref().expect("Deletion already filtered out.");
+                            if new_node.is_leaf() {
+                                // it's a new leaf
+                                return Ok(Some(new_node.clone()));
+                            }
+                        },
                     }
                 }
 
-                for (nibble, node) in new_child_nodes {
-                    let child_key = node_key.gen_child_node_key(version, nibble);
-                    batch.put_node(child_key, node);
-                }
+                let children = children.into_iter().map(|old_or_new| {
+                    match old_or_new {
+                        // an old child
+                        EitherOrBoth::Left((nibble, old_child)) => (*nibble, old_child.clone()),
+                        // a new or updated child
+                        EitherOrBoth::Right((nibble, new_node))
+                        | EitherOrBoth::Both((_, _), (nibble, new_node)) => {
+                            let new_node =
+                                new_node.as_ref().expect("Deletion already filtered out.");
+                            let child_key = node_key.gen_child_node_key(version, nibble);
+                            batch.put_node(child_key, new_node.clone());
+                            let child =
+                                Child::for_node(node_key, nibble, new_node, hash_cache, version);
+                            (nibble, child)
+                        },
+                    }
+                });
 
                 let new_internal_node = InternalNode::new(Children::from_sorted(children));
                 Ok(Some(new_internal_node.into()))

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -448,6 +448,9 @@ pub enum StateStoreStatus<V> {
     /// Tree nodes only exist until `depth` on the route from the root to the leaf address, needs
     /// to check the DB for the rest.
     UnknownSubtreeRoot { hash: HashValue, depth: usize },
+
+    /// Found leaf node, but the value is only in the DB.
+    UnknownValue,
 }
 
 /// In the entire lifetime of this, in-mem nodes won't be dropped because a reference to the oldest
@@ -552,10 +555,7 @@ where
                                         Some(value) => StateStoreStatus::ExistsInScratchPad(
                                             value.as_ref().clone(),
                                         ),
-                                        None => StateStoreStatus::UnknownSubtreeRoot {
-                                            hash,
-                                            depth: next_depth - 1,
-                                        },
+                                        None => StateStoreStatus::UnknownValue,
                                     }
                                 } else {
                                     StateStoreStatus::DoesNotExist

--- a/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
+++ b/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
@@ -247,10 +247,7 @@ fn test_update_256_siblings_in_proof() {
         new_smt.get(key1),
         StateStoreStatus::ExistsInScratchPad(new_value1)
     );
-    assert_eq!(new_smt.get(key2), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf2.hash(),
-        depth: 256
-    });
+    assert_eq!(new_smt.get(key2), StateStoreStatus::UnknownValue);
 }
 
 #[test]
@@ -331,10 +328,7 @@ fn test_update() {
         hash: x_hash,
         depth: 2
     });
-    assert_eq!(smt1.get(key3), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf3.hash(),
-        depth: 1
-    });
+    assert_eq!(smt1.get(key3), StateStoreStatus::UnknownValue);
     assert_eq!(
         smt1.get(key4),
         StateStoreStatus::ExistsInScratchPad(value4.clone())
@@ -371,14 +365,8 @@ fn test_update() {
     //             / \
     //    key2(indb)  key4 (weak data)
     assert_eq!(smt2.get(key1), StateStoreStatus::DoesNotExist,);
-    assert_eq!(smt2.get(key2), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf2.hash(),
-        depth: 2
-    });
-    assert_eq!(smt2.get(key3), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf3.hash(),
-        depth: 1
-    });
+    assert_eq!(smt2.get(key2), StateStoreStatus::UnknownValue);
+    assert_eq!(smt2.get(key3), StateStoreStatus::UnknownValue);
     assert_eq!(smt2.get(key4), StateStoreStatus::ExistsInScratchPad(value4));
 
     // Verify root hash.
@@ -405,10 +393,7 @@ fn test_update() {
         hash: x_hash,
         depth: 2
     });
-    assert_eq!(smt22.get(key3), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf3.hash(),
-        depth: 1
-    });
+    assert_eq!(smt22.get(key3), StateStoreStatus::UnknownValue);
     assert_eq!(
         smt22.get(key4),
         StateStoreStatus::ExistsInScratchPad(value4.clone())
@@ -420,18 +405,9 @@ fn test_update() {
 
     // For smt2, no key should be available since smt2 was constructed by deleting key1.
     assert_eq!(smt2.get(key1), StateStoreStatus::DoesNotExist);
-    assert_eq!(smt2.get(key2), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf2.hash(),
-        depth: 2
-    });
-    assert_eq!(smt2.get(key3), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf3.hash(),
-        depth: 1
-    });
-    assert_eq!(smt2.get(key4), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf4_hash,
-        depth: 2
-    });
+    assert_eq!(smt2.get(key2), StateStoreStatus::UnknownValue);
+    assert_eq!(smt2.get(key3), StateStoreStatus::UnknownValue);
+    assert_eq!(smt2.get(key4), StateStoreStatus::UnknownValue);
 
     // For smt22, only key4 should be available since smt22 was constructed by updating smt1 with
     // key4.
@@ -443,10 +419,7 @@ fn test_update() {
         hash: x_hash,
         depth: 2
     });
-    assert_eq!(smt22.get(key3), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf3.hash(),
-        depth: 1
-    });
+    assert_eq!(smt22.get(key3), StateStoreStatus::UnknownValue);
     assert_eq!(
         smt22.get(key4),
         StateStoreStatus::ExistsInScratchPad(value4)

--- a/storage/storage-interface/src/async_proof_fetcher.rs
+++ b/storage/storage-interface/src/async_proof_fetcher.rs
@@ -55,6 +55,19 @@ impl AsyncProofFetcher {
         }
     }
 
+    pub fn fetch_state_value(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> Result<Option<(Version, StateValue)>> {
+        let _timer = TIMER
+            .with_label_values(&["async_proof_fetcher_fetch"])
+            .start_timer();
+        Ok(self
+            .reader
+            .get_state_value_with_version_by_version(state_key, version)?)
+    }
+
     pub fn fetch_state_value_with_version_and_schedule_proof_read(
         &self,
         state_key: &StateKey,
@@ -62,12 +75,7 @@ impl AsyncProofFetcher {
         subtree_root_depth: usize,
         subtree_root_hash: Option<HashValue>,
     ) -> Result<Option<(Version, StateValue)>> {
-        let _timer = TIMER
-            .with_label_values(&["async_proof_fetcher_fetch"])
-            .start_timer();
-        let version_and_value_opt = self
-            .reader
-            .get_state_value_with_version_by_version(state_key, version)?;
+        let version_and_value_opt = self.fetch_state_value(state_key, version)?;
         self.schedule_proof_read(
             state_key.clone(),
             version,

--- a/storage/storage-interface/src/cached_state_view.rs
+++ b/storage/storage-interface/src/cached_state_view.rs
@@ -220,31 +220,47 @@ impl CachedStateView {
     ) -> Result<(Option<Version>, Option<StateValue>)> {
         // Do most of the work outside the write lock.
         let key_hash = state_key.hash();
-        Ok(match self.speculative_state.get(key_hash) {
-            StateStoreStatus::ExistsInScratchPad(value) => (None, Some(value)),
-            StateStoreStatus::DoesNotExist => (None, None),
-            // No matter it is in db or unknown, we have to query from db since even the
-            // former case, we don't have the blob data but only its hash.
+        match self.speculative_state.get(key_hash) {
+            StateStoreStatus::ExistsInScratchPad(value) => Ok((None, Some(value))),
+            StateStoreStatus::DoesNotExist => Ok((None, None)),
+            // Part of the tree is unknown, need to request proof for later usage (updating the tree)
             StateStoreStatus::UnknownSubtreeRoot {
                 hash: subtree_root_hash,
                 depth: subtree_root_depth,
-            } => match self.snapshot {
-                Some((version, _root_hash)) => {
-                    let version_and_value_opt = self
-                        .proof_fetcher
-                        .fetch_state_value_with_version_and_schedule_proof_read(
-                            state_key,
-                            version,
-                            subtree_root_depth,
-                            Some(subtree_root_hash),
-                        )?;
-                    match version_and_value_opt {
-                        Some((version, value)) => (Some(version), Some(value)),
-                        None => (None, None),
-                    }
-                },
-                None => (None, None),
+            } => self.fetch_value_and_maybe_proof_in_snapshot(
+                state_key,
+                Some((subtree_root_hash, subtree_root_depth)),
+            ),
+            // Tree is known, but we only know the hash of the value, need to request the actual
+            // StateValue.
+            StateStoreStatus::UnknownValue => {
+                self.fetch_value_and_maybe_proof_in_snapshot(state_key, None)
             },
+        }
+    }
+
+    fn fetch_value_and_maybe_proof_in_snapshot(
+        &self,
+        state_key: &StateKey,
+        fetch_proof: Option<(HashValue, usize)>,
+    ) -> Result<(Option<Version>, Option<StateValue>)> {
+        let version_and_value_opt = match self.snapshot {
+            None => None,
+            Some((version, _root_hash)) => match fetch_proof {
+                None => self.proof_fetcher.fetch_state_value(state_key, version)?,
+                Some((subtree_root_hash, subtree_depth)) => self
+                    .proof_fetcher
+                    .fetch_state_value_with_version_and_schedule_proof_read(
+                        state_key,
+                        version,
+                        subtree_depth,
+                        Some(subtree_root_hash),
+                    )?,
+            },
+        };
+        Ok(match version_and_value_opt {
+            None => (None, None),
+            Some((version, value)) => (Some(version), Some(value)),
         })
     }
 }

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -379,7 +379,8 @@ impl SparseMerkleProof {
                     leaf.key,
                 );
                 ensure!(
-                    element_key.common_prefix_bits_len(leaf.key) >= self.siblings.len(),
+                    element_key.common_prefix_bits_len(leaf.key)
+                        >= root_depth + self.siblings.len(),
                     "Key would not have ended up in the subtree where the provided key in proof \
                      is the only existing key, if it existed. So this is not a valid \
                      non-inclusion proof. Key: {:x}. Key in proof: {:x}.",


### PR DESCRIPTION
Original thought was in these rare cases we just waste a constructed
Child to make the code simply, however it wasn't considered that there's
a panic on hash_cache miss. I think the panic is valuable assertion so
this is fixing it by some extra code.## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
