### PR TITLE
Fix SMT proof fetching for lifted leaf

### DIFF
--- a/aptos-move/e2e-benchmark/src/main.rs
+++ b/aptos-move/e2e-benchmark/src/main.rs
@@ -139,8 +139,8 @@ fn main() {
         (26, EntryPoints::ResourceGroupsSenderMultiChange {
             string_length: 1024,
         }),
-        (287, EntryPoints::TokenV1MintAndTransferFT),
-        (458, EntryPoints::TokenV1MintAndTransferNFTSequential),
+        (350, EntryPoints::TokenV1MintAndTransferFT),
+        (536, EntryPoints::TokenV1MintAndTransferNFTSequential),
         (401, EntryPoints::TokenV2AmbassadorMint { numbered: true }),
         (467, EntryPoints::LiquidityPoolSwap { is_stable: true }),
         (415, EntryPoints::LiquidityPoolSwap { is_stable: false }),

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -448,6 +448,9 @@ pub enum StateStoreStatus<V> {
     /// Tree nodes only exist until `depth` on the route from the root to the leaf address, needs
     /// to check the DB for the rest.
     UnknownSubtreeRoot { hash: HashValue, depth: usize },
+
+    /// Found leaf node, but the value is only in the DB.
+    UnknownValue,
 }
 
 /// In the entire lifetime of this, in-mem nodes won't be dropped because a reference to the oldest
@@ -552,10 +555,7 @@ where
                                         Some(value) => StateStoreStatus::ExistsInScratchPad(
                                             value.as_ref().clone(),
                                         ),
-                                        None => StateStoreStatus::UnknownSubtreeRoot {
-                                            hash,
-                                            depth: next_depth - 1,
-                                        },
+                                        None => StateStoreStatus::UnknownValue,
                                     }
                                 } else {
                                     StateStoreStatus::DoesNotExist

--- a/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
+++ b/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
@@ -247,10 +247,7 @@ fn test_update_256_siblings_in_proof() {
         new_smt.get(key1),
         StateStoreStatus::ExistsInScratchPad(new_value1)
     );
-    assert_eq!(new_smt.get(key2), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf2.hash(),
-        depth: 256
-    });
+    assert_eq!(new_smt.get(key2), StateStoreStatus::UnknownValue);
 }
 
 #[test]
@@ -331,10 +328,7 @@ fn test_update() {
         hash: x_hash,
         depth: 2
     });
-    assert_eq!(smt1.get(key3), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf3.hash(),
-        depth: 1
-    });
+    assert_eq!(smt1.get(key3), StateStoreStatus::UnknownValue);
     assert_eq!(
         smt1.get(key4),
         StateStoreStatus::ExistsInScratchPad(value4.clone())
@@ -371,14 +365,8 @@ fn test_update() {
     //             / \
     //    key2(indb)  key4 (weak data)
     assert_eq!(smt2.get(key1), StateStoreStatus::DoesNotExist,);
-    assert_eq!(smt2.get(key2), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf2.hash(),
-        depth: 2
-    });
-    assert_eq!(smt2.get(key3), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf3.hash(),
-        depth: 1
-    });
+    assert_eq!(smt2.get(key2), StateStoreStatus::UnknownValue);
+    assert_eq!(smt2.get(key3), StateStoreStatus::UnknownValue);
     assert_eq!(smt2.get(key4), StateStoreStatus::ExistsInScratchPad(value4));
 
     // Verify root hash.
@@ -405,10 +393,7 @@ fn test_update() {
         hash: x_hash,
         depth: 2
     });
-    assert_eq!(smt22.get(key3), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf3.hash(),
-        depth: 1
-    });
+    assert_eq!(smt22.get(key3), StateStoreStatus::UnknownValue);
     assert_eq!(
         smt22.get(key4),
         StateStoreStatus::ExistsInScratchPad(value4.clone())
@@ -420,18 +405,9 @@ fn test_update() {
 
     // For smt2, no key should be available since smt2 was constructed by deleting key1.
     assert_eq!(smt2.get(key1), StateStoreStatus::DoesNotExist);
-    assert_eq!(smt2.get(key2), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf2.hash(),
-        depth: 2
-    });
-    assert_eq!(smt2.get(key3), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf3.hash(),
-        depth: 1
-    });
-    assert_eq!(smt2.get(key4), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf4_hash,
-        depth: 2
-    });
+    assert_eq!(smt2.get(key2), StateStoreStatus::UnknownValue);
+    assert_eq!(smt2.get(key3), StateStoreStatus::UnknownValue);
+    assert_eq!(smt2.get(key4), StateStoreStatus::UnknownValue);
 
     // For smt22, only key4 should be available since smt22 was constructed by updating smt1 with
     // key4.
@@ -443,10 +419,7 @@ fn test_update() {
         hash: x_hash,
         depth: 2
     });
-    assert_eq!(smt22.get(key3), StateStoreStatus::UnknownSubtreeRoot {
-        hash: leaf3.hash(),
-        depth: 1
-    });
+    assert_eq!(smt22.get(key3), StateStoreStatus::UnknownValue);
     assert_eq!(
         smt22.get(key4),
         StateStoreStatus::ExistsInScratchPad(value4)

--- a/storage/storage-interface/src/async_proof_fetcher.rs
+++ b/storage/storage-interface/src/async_proof_fetcher.rs
@@ -55,6 +55,19 @@ impl AsyncProofFetcher {
         }
     }
 
+    pub fn fetch_state_value(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> Result<Option<(Version, StateValue)>> {
+        let _timer = TIMER
+            .with_label_values(&["async_proof_fetcher_fetch"])
+            .start_timer();
+        Ok(self
+            .reader
+            .get_state_value_with_version_by_version(state_key, version)?)
+    }
+
     pub fn fetch_state_value_with_version_and_schedule_proof_read(
         &self,
         state_key: &StateKey,
@@ -62,12 +75,7 @@ impl AsyncProofFetcher {
         subtree_root_depth: usize,
         subtree_root_hash: Option<HashValue>,
     ) -> Result<Option<(Version, StateValue)>> {
-        let _timer = TIMER
-            .with_label_values(&["async_proof_fetcher_fetch"])
-            .start_timer();
-        let version_and_value_opt = self
-            .reader
-            .get_state_value_with_version_by_version(state_key, version)?;
+        let version_and_value_opt = self.fetch_state_value(state_key, version)?;
         self.schedule_proof_read(
             state_key.clone(),
             version,

--- a/storage/storage-interface/src/cached_state_view.rs
+++ b/storage/storage-interface/src/cached_state_view.rs
@@ -220,31 +220,47 @@ impl CachedStateView {
     ) -> Result<(Option<Version>, Option<StateValue>)> {
         // Do most of the work outside the write lock.
         let key_hash = state_key.hash();
-        Ok(match self.speculative_state.get(key_hash) {
-            StateStoreStatus::ExistsInScratchPad(value) => (None, Some(value)),
-            StateStoreStatus::DoesNotExist => (None, None),
-            // No matter it is in db or unknown, we have to query from db since even the
-            // former case, we don't have the blob data but only its hash.
+        match self.speculative_state.get(key_hash) {
+            StateStoreStatus::ExistsInScratchPad(value) => Ok((None, Some(value))),
+            StateStoreStatus::DoesNotExist => Ok((None, None)),
+            // Part of the tree is unknown, need to request proof for later usage (updating the tree)
             StateStoreStatus::UnknownSubtreeRoot {
                 hash: subtree_root_hash,
                 depth: subtree_root_depth,
-            } => match self.snapshot {
-                Some((version, _root_hash)) => {
-                    let version_and_value_opt = self
-                        .proof_fetcher
-                        .fetch_state_value_with_version_and_schedule_proof_read(
-                            state_key,
-                            version,
-                            subtree_root_depth,
-                            Some(subtree_root_hash),
-                        )?;
-                    match version_and_value_opt {
-                        Some((version, value)) => (Some(version), Some(value)),
-                        None => (None, None),
-                    }
-                },
-                None => (None, None),
+            } => self.fetch_value_and_maybe_proof_in_snapshot(
+                state_key,
+                Some((subtree_root_hash, subtree_root_depth)),
+            ),
+            // Tree is known, but we only know the hash of the value, need to request the actual
+            // StateValue.
+            StateStoreStatus::UnknownValue => {
+                self.fetch_value_and_maybe_proof_in_snapshot(state_key, None)
             },
+        }
+    }
+
+    fn fetch_value_and_maybe_proof_in_snapshot(
+        &self,
+        state_key: &StateKey,
+        fetch_proof: Option<(HashValue, usize)>,
+    ) -> Result<(Option<Version>, Option<StateValue>)> {
+        let version_and_value_opt = match self.snapshot {
+            None => None,
+            Some((version, _root_hash)) => match fetch_proof {
+                None => self.proof_fetcher.fetch_state_value(state_key, version)?,
+                Some((subtree_root_hash, subtree_depth)) => self
+                    .proof_fetcher
+                    .fetch_state_value_with_version_and_schedule_proof_read(
+                        state_key,
+                        version,
+                        subtree_depth,
+                        Some(subtree_root_hash),
+                    )?,
+            },
+        };
+        Ok(match version_and_value_opt {
+            None => (None, None),
+            Some((version, value)) => (Some(version), Some(value)),
         })
     }
 }

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -379,7 +379,8 @@ impl SparseMerkleProof {
                     leaf.key,
                 );
                 ensure!(
-                    element_key.common_prefix_bits_len(leaf.key) >= self.siblings.len(),
+                    element_key.common_prefix_bits_len(leaf.key)
+                        >= root_depth + self.siblings.len(),
                     "Key would not have ended up in the subtree where the provided key in proof \
                      is the only existing key, if it existed. So this is not a valid \
                      non-inclusion proof. Key: {:x}. Key in proof: {:x}.",


### PR DESCRIPTION
In the presence of deletion, a leaf node on the SMT can be lifted, so
the hash value won't be matching that in the DB.

Examining more, it's obvious that in such cases proof fetching is not
needed in the first place.

## Type of Change
- [x] Bug fix - blaming https://github.com/aptos-labs/aptos-core/pull/13274


## Which Components or Systems Does This Change Impact?
- [x] Validator Node

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
updated unit tests.
replay-verify.

it's unfortunate unit tests don't have much coverage for state deletion -- a tech debt I'm gonna fix as a follow up.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
