### PR TITLE
[gas] fix gas feature version for function info and dispatchable token gas params

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/aptos_framework.rs
@@ -3,7 +3,10 @@
 
 //! This module defines the gas parameters for Aptos Framework & Stdlib.
 
-use crate::{gas_schedule::NativeGasParameters, ver::gas_feature_versions::RELEASE_V1_12};
+use crate::{
+    gas_schedule::NativeGasParameters,
+    ver::gas_feature_versions::{RELEASE_V1_12, RELEASE_V1_13},
+};
 use aptos_gas_algebra::{
     InternalGas, InternalGasPerAbstractValueUnit, InternalGasPerArg, InternalGasPerByte,
 };
@@ -242,11 +245,11 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [type_info_chain_id_base: InternalGas, { 4.. => "type_info.chain_id.base" }, 551],
 
         // TODO(Gas): Fix my cost
-        [function_info_check_is_identifier_base: InternalGas, { RELEASE_V1_12.. => "function_info.is_identifier.base" }, 551],
-        [function_info_check_is_identifier_per_byte: InternalGasPerByte, { RELEASE_V1_12.. => "function_info.is_identifier.per_byte" }, 3],
-        [function_info_check_dispatch_type_compatibility_impl_base: InternalGas, { RELEASE_V1_12.. => "function_info.check_dispatch_type_compatibility_impl.base" }, 1002],
-        [function_info_load_function_base: InternalGas, { RELEASE_V1_12.. => "function_info.load_function.base" }, 551],
-        [dispatchable_fungible_asset_dispatch_base: InternalGas, { RELEASE_V1_12.. => "dispatchable_fungible_asset.dispatch.base" }, 551],
+        [function_info_check_is_identifier_base: InternalGas, { RELEASE_V1_13.. => "function_info.is_identifier.base" }, 551],
+        [function_info_check_is_identifier_per_byte: InternalGasPerByte, { RELEASE_V1_13.. => "function_info.is_identifier.per_byte" }, 3],
+        [function_info_check_dispatch_type_compatibility_impl_base: InternalGas, { RELEASE_V1_13.. => "function_info.check_dispatch_type_compatibility_impl.base" }, 1002],
+        [function_info_load_function_base: InternalGas, { RELEASE_V1_13.. => "function_info.load_function.base" }, 551],
+        [dispatchable_fungible_asset_dispatch_base: InternalGas, { RELEASE_V1_13.. => "dispatchable_fungible_asset.dispatch.base" }, 551],
 
         // Reusing SHA2-512's cost from Ristretto
         [hash_sha2_512_base: InternalGas, { 4.. => "hash.sha2_512.base" }, 11910],  // 3_240 * 20

--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -10,6 +10,7 @@
 /// Change log:
 /// - V18
 ///   - Separate limits for governance scripts
+///   - Function info & dispatchable token gas params
 /// - V17
 ///   - Gas for keyless
 /// - V16


### PR DESCRIPTION
These gas params were reverted for 1.12 and should now target 1.13 (gas feature version 18).