### PR TITLE
add extended_checks to aptos-transactional-test-harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3956,7 +3956,6 @@ dependencies = [
  "move-compiler-v2",
  "move-core-types",
  "move-model",
- "move-resource-viewer",
  "move-symbol-pool",
  "move-transactional-test-runner",
  "move-vm-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3946,6 +3946,7 @@ dependencies = [
  "aptos-vm-genesis",
  "bcs 0.1.4",
  "clap 4.4.14",
+ "codespan-reporting",
  "datatest-stable",
  "hex",
  "move-binary-format",
@@ -3955,10 +3956,13 @@ dependencies = [
  "move-compiler-v2",
  "move-core-types",
  "move-model",
+ "move-resource-viewer",
+ "move-symbol-pool",
  "move-transactional-test-runner",
  "move-vm-runtime",
  "once_cell",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/aptos-move/aptos-transactional-test-harness/Cargo.toml
+++ b/aptos-move/aptos-transactional-test-harness/Cargo.toml
@@ -36,7 +36,6 @@ move-compiler = { workspace = true }
 move-compiler-v2 = { workspace = true }
 move-core-types = { workspace = true, features = ["fuzzing"] }
 move-model = { workspace = true }
-move-resource-viewer = { workspace = true }
 move-symbol-pool = { workspace = true }
 move-transactional-test-runner = { workspace = true }
 move-vm-runtime = { workspace = true }

--- a/aptos-move/aptos-transactional-test-harness/Cargo.toml
+++ b/aptos-move/aptos-transactional-test-harness/Cargo.toml
@@ -27,6 +27,7 @@ aptos-vm = { workspace = true }
 aptos-vm-genesis = { workspace = true }
 bcs = { workspace = true }
 clap = { workspace = true }
+codespan-reporting = { workspace = true }
 hex = { workspace = true }
 move-binary-format = { workspace = true, features = ["fuzzing"] }
 move-bytecode-verifier = { workspace = true }
@@ -35,10 +36,13 @@ move-compiler = { workspace = true }
 move-compiler-v2 = { workspace = true }
 move-core-types = { workspace = true, features = ["fuzzing"] }
 move-model = { workspace = true }
+move-resource-viewer = { workspace = true }
+move-symbol-pool = { workspace = true }
 move-transactional-test-runner = { workspace = true }
 move-vm-runtime = { workspace = true }
 once_cell = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 
 [dev-dependencies]
 aptos-types = { workspace = true, features = ["fuzzing"] }

--- a/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
+++ b/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
@@ -53,7 +53,6 @@ use move_core_types::{
     value::{MoveTypeLayout, MoveValue},
 };
 use move_model::metadata::LanguageVersion;
-use move_resource_viewer::{AnnotatedMoveValue, MoveValueAnnotator};
 use move_symbol_pool::Symbol as MoveSymbol;
 use move_transactional_test_runner::{
     framework::{run_test_impl, CompiledState, MoveTestAdapter},
@@ -1129,13 +1128,10 @@ pub fn run_aptos_test_with_config(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (suffix, config) =
         if get_move_compiler_v2_from_env() && !matches!(config, TestRunConfig::CompilerV2 { .. }) {
-            (
-                Some(EXP_EXT_V2.to_owned()),
-                TestRunConfig::CompilerV2 {
-                    language_version: LanguageVersion::default(),
-                    v2_experiments: vec![("attach-compiled-module".to_owned(), true)],
-                },
-            )
+            (Some(EXP_EXT_V2.to_owned()), TestRunConfig::CompilerV2 {
+                language_version: LanguageVersion::default(),
+                v2_experiments: vec![("attach-compiled-module".to_owned(), true)],
+            })
         } else {
             (Some(EXP_EXT.to_owned()), config)
         };

--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/bad_parameter.exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/bad_parameter.exp
@@ -1,0 +1,36 @@
+processed 2 tasks
+
+task 1 'publish'. lines 4-10:
+Error: extended checks failed:
+
+error: `init_module` function can only take signers as parameters
+  ┌─ TEMPFILE:6:16
+  │
+6 │     public fun init_module(value: u64): u64 { value }
+  │                ^^^^^^^^^^^
+
+error: `init_module` function cannot return values
+  ┌─ TEMPFILE:6:16
+  │
+6 │     public fun init_module(value: u64): u64 { value }
+  │                ^^^^^^^^^^^
+
+error: `init_module` function must be private
+  ┌─ TEMPFILE:6:16
+  │
+6 │     public fun init_module(value: u64): u64 { value }
+  │                ^^^^^^^^^^^
+
+error: type `&mut signer` is not supported as a parameter type
+  ┌─ TEMPFILE:8:9
+  │
+8 │     fun view(_:&mut signer,value: u64): u64 { value }
+  │         ^^^^
+
+error: view function cannot use the & signer paremter
+  ┌─ TEMPFILE:8:9
+  │
+8 │     fun view(_:&mut signer,value: u64): u64 { value }
+  │         ^^^^
+
+

--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/bad_parameter.move
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/bad_parameter.move
@@ -1,0 +1,10 @@
+//# init --addresses Alice=0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6
+//#      --private-keys Alice=56a26140eb233750cd14fb168c3eb4bd0782b099cde626ec8aff7f3cceb6364f
+
+//# publish --private-key Alice
+module Alice::M {
+    public fun init_module(value: u64): u64 { value }
+
+    #[view]
+    fun view(_:&mut signer,value: u64): u64 { value }
+}

--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/diamond_clicker.exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/diamond_clicker.exp
@@ -1,68 +1,76 @@
 processed 4 tasks
 
 task 1 'print-bytecode'. lines 4-35:
-// Move bytecode v6
-module f75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6.game {
-use 0000000000000000000000000000000000000000000000000000000000000001::debug;
-use 0000000000000000000000000000000000000000000000000000000000000001::signer;
+Error: extended checks failed:
+
+bug: BYTECODE VERIFICATION FAILED
+   ┌─ TEMPFILE:25:13
+   │
+25 │             debug::print(field); // INTERNAL TEST ERROR: INTERNAL VM INVARIANT VIOLATION
+   │             ^^^^^^^^^^^^^^^^^^^ ICE failed bytecode verifier: VMError {
+    major_status: CALL_TYPE_MISMATCH_ERROR,
+    sub_status: None,
+    message: None,
+    exec_state: None,
+    location: Module(
+        ModuleId {
+            address: f75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6,
+            name: Identifier(
+                "game",
+            ),
+        },
+    ),
+    indices: [
+        (
+            FunctionDefinition,
+            0,
+        ),
+    ],
+    offsets: [
+        (
+            FunctionDefinitionIndex(0),
+            25,
+        ),
+    ],
+}
 
 
-struct InnerStruct has copy, store, key {
-	amount: u64
-}
-struct OuterStruct has key {
-	any_field: vector<InnerStruct>
-}
-
-entry public test_upgrade(Arg0: &signer) /* def_idx: 0 */ {
-L1:	loc0: address
-L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: &mut vector<InnerStruct>
-B0:
-	0: CopyLoc[0](Arg0: &signer)
-	1: Call signer::address_of(&signer): address
-	2: StLoc[1](loc0: address)
-	3: MoveLoc[0](Arg0: &signer)
-	4: VecPack(4, 0)
-	5: Pack[1](OuterStruct)
-	6: MoveTo[1](OuterStruct)
-	7: MoveLoc[1](loc0: address)
-	8: MutBorrowGlobal[1](OuterStruct)
-	9: MutBorrowField[0](OuterStruct.any_field: vector<InnerStruct>)
-	10: StLoc[4](loc3: &mut vector<InnerStruct>)
-	11: LdU64(0)
-	12: StLoc[2](loc1: u64)
-	13: CopyLoc[4](loc3: &mut vector<InnerStruct>)
-	14: FreezeRef
-	15: VecLen(4)
-	16: StLoc[3](loc2: u64)
-B1:
-	17: CopyLoc[2](loc1: u64)
-	18: CopyLoc[3](loc2: u64)
-	19: Lt
-	20: BrFalse(31)
-B2:
-	21: Branch(22)
-B3:
-	22: CopyLoc[4](loc3: &mut vector<InnerStruct>)
-	23: CopyLoc[2](loc1: u64)
-	24: VecMutBorrow(4)
-	25: Call debug::print<InnerStruct>(&InnerStruct)
-	26: MoveLoc[2](loc1: u64)
-	27: LdU64(1)
-	28: Add
-	29: StLoc[2](loc1: u64)
-	30: Branch(17)
-B4:
-	31: MoveLoc[4](loc3: &mut vector<InnerStruct>)
-	32: Pop
-	33: Ret
-}
-}
 
 task 2 'publish'. lines 37-68:
-Error: VMError with status CALL_TYPE_MISMATCH_ERROR at location Module ModuleId { address: f75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6, name: Identifier("game") } at index 0 for function definition at code offset 25 in function definition 0
+Error: extended checks failed:
+
+bug: BYTECODE VERIFICATION FAILED
+   ┌─ TEMPFILE1:58:13
+   │
+58 │             debug::print(field); // INTERNAL TEST ERROR: INTERNAL VM INVARIANT VIOLATION
+   │             ^^^^^^^^^^^^^^^^^^^ ICE failed bytecode verifier: VMError {
+    major_status: CALL_TYPE_MISMATCH_ERROR,
+    sub_status: None,
+    message: None,
+    exec_state: None,
+    location: Module(
+        ModuleId {
+            address: f75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6,
+            name: Identifier(
+                "game",
+            ),
+        },
+    ),
+    indices: [
+        (
+            FunctionDefinition,
+            0,
+        ),
+    ],
+    offsets: [
+        (
+            FunctionDefinitionIndex(0),
+            25,
+        ),
+    ],
+}
+
+
 
 task 3 'run'. lines 70-70:
 Error: Failed to execute transaction. ExecutionStatus: MiscellaneousError(None)

--- a/aptos-move/aptos-transactional-test-harness/tests/tests.rs
+++ b/aptos-move/aptos-transactional-test-harness/tests/tests.rs
@@ -15,7 +15,7 @@ fn runner(path: &Path) -> anyhow::Result<(), Box<dyn std::error::Error>> {
         //    interested in debugging v2 bytecode.
         run_aptos_test_with_config(path, TestRunConfig::CompilerV2 {
             language_version: LanguageVersion::default(),
-            v2_experiments: vec![],
+            v2_experiments: vec![("attach-compiled-module".to_owned(), true)],
         })
     } else {
         run_aptos_test_with_config(path, TestRunConfig::CompilerV1)

--- a/aptos-move/aptos-transactional-test-harness/tests/v2-tests/bad_parameter.exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/v2-tests/bad_parameter.exp
@@ -1,0 +1,36 @@
+processed 2 tasks
+
+task 1 'publish'. lines 4-10:
+Error: extended checks failed:
+
+error: `init_module` function can only take signers as parameters
+  ┌─ TEMPFILE:6:16
+  │
+6 │     public fun init_module(value: u64): u64 { value }
+  │                ^^^^^^^^^^^
+
+error: `init_module` function cannot return values
+  ┌─ TEMPFILE:6:16
+  │
+6 │     public fun init_module(value: u64): u64 { value }
+  │                ^^^^^^^^^^^
+
+error: `init_module` function must be private
+  ┌─ TEMPFILE:6:16
+  │
+6 │     public fun init_module(value: u64): u64 { value }
+  │                ^^^^^^^^^^^
+
+error: type `&mut signer` is not supported as a parameter type
+  ┌─ TEMPFILE:8:9
+  │
+8 │     fun view(_:&mut signer,value: u64): u64 { value }
+  │         ^^^^
+
+error: view function cannot use the & signer paremter
+  ┌─ TEMPFILE:8:9
+  │
+8 │     fun view(_:&mut signer,value: u64): u64 { value }
+  │         ^^^^
+
+

--- a/aptos-move/aptos-transactional-test-harness/tests/v2-tests/bad_parameter.move
+++ b/aptos-move/aptos-transactional-test-harness/tests/v2-tests/bad_parameter.move
@@ -1,0 +1,10 @@
+//# init --addresses Alice=0xf75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6
+//#      --private-keys Alice=56a26140eb233750cd14fb168c3eb4bd0782b099cde626ec8aff7f3cceb6364f
+
+//# publish --private-key Alice
+module Alice::M {
+    public fun init_module(value: u64): u64 { value }
+
+    #[view]
+    fun view(_:&mut signer,value: u64): u64 { value }
+}

--- a/aptos-move/framework/src/extended_checks.rs
+++ b/aptos-move/framework/src/extended_checks.rs
@@ -113,7 +113,7 @@ impl<'a> ExtendedChecker<'a> {
 
     fn run(&mut self) {
         for ref module in self.env.get_modules() {
-            if module.is_target() {
+            if module.is_primary_target() {
                 self.check_and_record_resource_groups(module);
                 self.check_and_record_resource_group_members(module);
                 self.check_and_record_view_functions(module);

--- a/third_party/move/move-compiler/src/shared/mod.rs
+++ b/third_party/move/move-compiler/src/shared/mod.rs
@@ -193,7 +193,7 @@ pub fn string_packagepath_to_symbol_packagepath<T: Clone>(
     input: &PackagePaths<String, String>,
 ) -> PackagePaths {
     PackagePaths {
-        name: input.name.clone(),
+        name: input.name,
         paths: string_vec_to_symbol_vec(&input.paths),
         named_address_map: string_map_to_symbol_map(&input.named_address_map),
     }

--- a/third_party/move/move-compiler/src/shared/mod.rs
+++ b/third_party/move/move-compiler/src/shared/mod.rs
@@ -174,6 +174,31 @@ pub struct IndexedPackagePath {
     pub named_address_map: NamedAddressMapIndex,
 }
 
+// Convenient helper functions for dealing with PackagePaths
+pub fn string_vec_to_symbol_vec(string_vec: &[String]) -> Vec<Symbol> {
+    string_vec
+        .iter()
+        .map(|s| Symbol::from(s.as_str()))
+        .collect()
+}
+
+pub fn string_map_to_symbol_map<T: Clone>(string_map: &BTreeMap<String, T>) -> BTreeMap<Symbol, T> {
+    string_map
+        .iter()
+        .map(|(s, v)| (Symbol::from(s.as_str()), v.clone()))
+        .collect()
+}
+
+pub fn string_packagepath_to_symbol_packagepath<T: Clone>(
+    input: &PackagePaths<String, String>,
+) -> PackagePaths {
+    PackagePaths {
+        name: input.name.clone(),
+        paths: string_vec_to_symbol_vec(&input.paths),
+        named_address_map: string_map_to_symbol_map(&input.named_address_map),
+    }
+}
+
 pub type AttributeDeriver = dyn Fn(&mut CompilationEnv, &mut ModuleDefinition);
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
@@ -919,7 +919,7 @@ fn compile_source_unit(
                     }];
                     let deps_target_package = vec![PackagePaths {
                         name: None,
-                        paths: string_vec_to_symbol_vec(&deps),
+                        paths: string_vec_to_symbol_vec(deps),
                         named_address_map: symbol_map.clone(),
                     }];
                     let model_options = ModelBuilderOptions::default();
@@ -995,10 +995,13 @@ where
     } = config.clone()
     {
         (
-            vec![TestRunConfig::CompilerV1, TestRunConfig::CompilerV2 {
-                language_version,
-                v2_experiments,
-            }],
+            vec![
+                TestRunConfig::CompilerV1,
+                TestRunConfig::CompilerV2 {
+                    language_version,
+                    v2_experiments,
+                },
+            ],
             true,
         )
     } else {

--- a/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
@@ -32,7 +32,9 @@ use move_command_line_common::{
 use move_compiler::{
     compiled_unit::{AnnotatedCompiledModule, AnnotatedCompiledUnit},
     diagnostics::{Diagnostics, FilesSourceText},
-    shared::NumericalAddress,
+    shared::{
+        string_map_to_symbol_map, string_vec_to_symbol_vec, Flags, NumericalAddress, PackagePaths,
+    },
     FullyCompiledProgram,
 };
 use move_core_types::{
@@ -42,7 +44,10 @@ use move_core_types::{
 };
 use move_disassembler::disassembler::{Disassembler, DisassemblerOptions};
 use move_ir_types::location::Spanned;
-use move_model::metadata::LanguageVersion;
+use move_model::{
+    metadata::LanguageVersion, model::GlobalEnv, options::ModelBuilderOptions,
+    run_model_builder_with_options_and_compilation_flags,
+};
 use move_symbol_pool::Symbol;
 use move_vm_runtime::session::SerializedReturnValues;
 use once_cell::sync::Lazy;
@@ -61,7 +66,7 @@ pub struct ProcessedModule {
 }
 
 pub struct CompiledState<'a> {
-    pre_compiled_deps_v1: Option<&'a FullyCompiledProgram>,
+    pre_compiled_deps_v1: Option<&'a (FullyCompiledProgram, Vec<PackagePaths>)>,
     pre_compiled_deps_v2: Option<&'a PrecompiledFilesModules>,
     pre_compiled_ids: BTreeSet<(AccountAddress, String)>,
     compiled_module_named_address_mapping: BTreeMap<ModuleId, Symbol>,
@@ -130,9 +135,10 @@ fn annotated_module_from_unit(unit: &AnnotatedCompiledUnit) -> Option<&Annotated
     }
 }
 
-impl PreCompiledModules for FullyCompiledProgram {
+impl PreCompiledModules for (FullyCompiledProgram, Vec<PackagePaths>) {
     fn get_pre_compiled_modules(&self) -> Vec<&AnnotatedCompiledModule> {
-        self.compiled
+        self.0
+            .compiled
             .iter()
             .filter_map(annotated_module_from_unit)
             .collect()
@@ -178,7 +184,7 @@ pub trait MoveTestAdapter<'a>: Sized {
         default_syntax: SyntaxChoice,
         comparison_mode: bool,
         run_config: TestRunConfig,
-        pre_compiled_deps_v1: Option<&'a FullyCompiledProgram>,
+        pre_compiled_deps_v1: Option<&'a (FullyCompiledProgram, Vec<PackagePaths>)>,
         pre_compiled_deps_v2: Option<&'a PrecompiledFilesModules>,
         init_data: Option<TaskInput<(InitCommand, Self::ExtraInitArgs)>>,
     ) -> (Self, Option<String>);
@@ -233,6 +239,25 @@ pub trait MoveTestAdapter<'a>: Sized {
         CompiledModule,
         Option<String>,
     )> {
+        let (data, named_addr_opt, module, _opt_model, warnings_opt) =
+            self.compile_module_default(syntax, data, start_line, command_lines_stop, false)?;
+        Ok((data, named_addr_opt, module, warnings_opt))
+    }
+
+    fn compile_module_default(
+        &mut self,
+        syntax: SyntaxChoice,
+        data: Option<NamedTempFile>,
+        start_line: usize,
+        command_lines_stop: usize,
+        need_model: bool,
+    ) -> Result<(
+        NamedTempFile,
+        Option<Symbol>,
+        CompiledModule,
+        Option<GlobalEnv>,
+        Option<String>,
+    )> {
         let data = match data {
             Some(f) => f,
             None => panic!(
@@ -243,9 +268,9 @@ pub trait MoveTestAdapter<'a>: Sized {
         let data_path = data.path().to_str().unwrap();
         let run_config = self.run_config();
         let state = self.compiled_state();
-        let (named_addr_opt, module, warnings_opt) = match syntax {
+        let (named_addr_opt, module, opt_model, warnings_opt) = match syntax {
             SyntaxChoice::Source => {
-                let (unit, warnings_opt) = match run_config {
+                let (unit, opt_model, warnings_opt) = match run_config {
                     // Run the V2 compiler if requested
                     TestRunConfig::CompilerV2 {
                         language_version,
@@ -266,6 +291,7 @@ pub trait MoveTestAdapter<'a>: Sized {
                         &state.source_files().cloned().collect::<Vec<_>>(),
                         data_path.to_owned(),
                         self.known_attributes(),
+                        need_model,
                     )?,
                 };
                 let (named_addr_opt, module) = match unit {
@@ -282,15 +308,15 @@ pub trait MoveTestAdapter<'a>: Sized {
                         start_line, command_lines_stop
                     ),
                 };
-                (named_addr_opt, module, warnings_opt)
+                (named_addr_opt, module, opt_model, warnings_opt)
             },
             SyntaxChoice::IR => {
                 let module = compile_ir_module(state.dep_modules(), data_path)?;
-                (None, module, None)
+                (None, module, None, None)
             },
         };
         self.register_temp_filename(&data);
-        Ok((data, named_addr_opt, module, warnings_opt))
+        Ok((data, named_addr_opt, module, opt_model, warnings_opt))
     }
 
     fn compile_script(
@@ -300,6 +326,19 @@ pub trait MoveTestAdapter<'a>: Sized {
         start_line: usize,
         command_lines_stop: usize,
     ) -> Result<(CompiledScript, Option<String>)> {
+        let (compiled_script, _opt_model, warnings_opt) =
+            self.compile_script_default(syntax, data, start_line, command_lines_stop, false)?;
+        Ok((compiled_script, warnings_opt))
+    }
+
+    fn compile_script_default(
+        &mut self,
+        syntax: SyntaxChoice,
+        data: Option<NamedTempFile>,
+        start_line: usize,
+        command_lines_stop: usize,
+        need_model: bool,
+    ) -> Result<(CompiledScript, Option<GlobalEnv>, Option<String>)> {
         let data = match data {
             Some(f) => f,
             None => panic!(
@@ -310,9 +349,9 @@ pub trait MoveTestAdapter<'a>: Sized {
         let data_path = data.path().to_str().unwrap();
         let run_config = self.run_config();
         let state = self.compiled_state();
-        let (script, warning_opt) = match syntax {
+        let (script, opt_model, warning_opt) = match syntax {
             SyntaxChoice::Source => {
-                let (unit, warning_opt) = match run_config {
+                let (unit, opt_model, warning_opt) = match run_config {
                     // Run the V2 compiler if requested.
                     TestRunConfig::CompilerV2 {
                         language_version,
@@ -333,19 +372,23 @@ pub trait MoveTestAdapter<'a>: Sized {
                         &state.source_files().cloned().collect::<Vec<_>>(),
                         data_path.to_owned(),
                         self.known_attributes(),
+                        need_model,
                     )?,
                 };
                 match unit {
-                    AnnotatedCompiledUnit::Script(annot_script) => (annot_script.named_script.script, warning_opt),
+                    AnnotatedCompiledUnit::Script(annot_script) => (annot_script.named_script.script, opt_model, warning_opt),
                     AnnotatedCompiledUnit::Module(_) => panic!(
                         "Expected a script text block, not a module, following 'run' starting on lines {}-{}",
                         start_line, command_lines_stop
                     ),
                 }
             },
-            SyntaxChoice::IR => (compile_ir_script(state.dep_modules(), data_path)?, None),
+            SyntaxChoice::IR => {
+                let script = compile_ir_script(state.dep_modules(), data_path)?;
+                (script, None, None)
+            },
         };
-        Ok((script, warning_opt))
+        Ok((script, opt_model, warning_opt))
     }
 
     fn handle_command(
@@ -622,7 +665,7 @@ fn display_return_values(return_values: SerializedReturnValues) -> Option<String
 impl<'a> CompiledState<'a> {
     pub fn new(
         named_address_mapping: BTreeMap<String, NumericalAddress>,
-        pre_compiled_deps_v1: Option<&'a FullyCompiledProgram>,
+        pre_compiled_deps_v1: Option<&'a (FullyCompiledProgram, Vec<PackagePaths>)>,
         pre_compiled_deps_v2: Option<&'a PrecompiledFilesModules>,
         default_named_address_mapping: Option<NumericalAddress>,
     ) -> Self {
@@ -746,7 +789,7 @@ fn compile_source_unit_v2(
     known_attributes: &BTreeSet<String>,
     language_version: LanguageVersion,
     experiments: Vec<(String, bool)>,
-) -> Result<(AnnotatedCompiledUnit, Option<String>)> {
+) -> Result<(AnnotatedCompiledUnit, Option<GlobalEnv>, Option<String>)> {
     let deps = if let Some(p) = pre_compiled_deps {
         // The v2 compiler does not really support precompiled programs, so we must include all the
         // dependent sources with their directories here.
@@ -783,7 +826,7 @@ fn compile_source_unit_v2(
     let mut error_writer = termcolor::Buffer::no_color();
     let result = move_compiler_v2::run_move_compiler(&mut error_writer, options);
     let error_str = String::from_utf8_lossy(&error_writer.into_inner()).to_string();
-    let (_, mut units) =
+    let (model, mut units) =
         result.map_err(|_| anyhow::anyhow!("compilation errors:\n {}", error_str))?;
     let unit = if units.len() != 1 {
         anyhow::bail!("expected either one script or one module")
@@ -791,9 +834,9 @@ fn compile_source_unit_v2(
         units.pop().unwrap()
     };
     if error_str.is_empty() {
-        Ok((unit, None))
+        Ok((unit, Some(model), None))
     } else {
-        Ok((unit, Some(error_str)))
+        Ok((unit, None, Some(error_str)))
     }
 }
 
@@ -809,12 +852,13 @@ fn remove_sub_dirs(dirs: &mut BTreeSet<String>) {
 }
 
 fn compile_source_unit(
-    pre_compiled_deps: Option<&FullyCompiledProgram>,
+    pre_compiled_deps: Option<&(FullyCompiledProgram, Vec<PackagePaths>)>,
     named_address_mapping: BTreeMap<String, NumericalAddress>,
     deps: &[String],
     path: String,
     known_attributes: &BTreeSet<String>,
-) -> Result<(AnnotatedCompiledUnit, Option<String>)> {
+    need_model: bool,
+) -> Result<(AnnotatedCompiledUnit, Option<GlobalEnv>, Option<String>)> {
     fn rendered_diags(files: &FilesSourceText, diags: Diagnostics) -> Option<String> {
         if diags.is_empty() {
             return None;
@@ -829,23 +873,25 @@ fn compile_source_unit(
     }
 
     use move_compiler::PASS_COMPILATION;
+    let flags = move_compiler::Flags::empty()
+        .set_sources_shadow_deps(true)
+        .set_skip_attribute_checks(false);
+
     let (mut files, comments_and_compiler_res) = move_compiler::Compiler::from_files(
-        vec![path],
+        vec![path.clone()],
         deps.to_vec(),
-        named_address_mapping,
-        move_compiler::Flags::empty()
-            .set_sources_shadow_deps(true)
-            .set_skip_attribute_checks(false), // In case of bugs in transactional test code.
+        named_address_mapping.clone(),
+        flags,
         known_attributes,
     )
-    .set_pre_compiled_lib_opt(pre_compiled_deps)
+    .set_pre_compiled_lib_opt(pre_compiled_deps.map(|(prog, _)| prog))
     .run::<PASS_COMPILATION>()?;
     let units_or_diags = comments_and_compiler_res
         .map(|(_comments, move_compiler)| move_compiler.into_compiled_units());
 
     match units_or_diags {
         Err(diags) => {
-            if let Some(pcd) = pre_compiled_deps {
+            if let Some((pcd, _paths)) = pre_compiled_deps {
                 for (file_name, text) in &pcd.files {
                     // TODO This is bad. Rethink this when errors are redone
                     if !files.contains_key(file_name) {
@@ -863,7 +909,38 @@ fn compile_source_unit(
                 panic!("Invalid input. Expected 1 compiled unit but got {}", len)
             }
             let unit = units.pop().unwrap();
-            Ok((unit, warnings))
+            let opt_model = if need_model {
+                if let Some((_fully_compiled_program, lib_paths)) = pre_compiled_deps {
+                    let symbol_map = string_map_to_symbol_map(&named_address_mapping);
+                    let move_target_package = vec![PackagePaths {
+                        name: None,
+                        paths: vec![Symbol::from(path)],
+                        named_address_map: symbol_map.clone(),
+                    }];
+                    let deps_target_package = vec![PackagePaths {
+                        name: None,
+                        paths: string_vec_to_symbol_vec(&deps),
+                        named_address_map: symbol_map.clone(),
+                    }];
+                    let model_options = ModelBuilderOptions::default();
+                    // This choice of flags matches that used to build model in `CompiledPackage::build_all()`
+                    let flags = Flags::verification();
+                    let model = run_model_builder_with_options_and_compilation_flags(
+                        move_target_package,
+                        deps_target_package,
+                        lib_paths.to_vec(),
+                        model_options,
+                        flags,
+                        known_attributes,
+                    )?;
+                    Some(model)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+            Ok((unit, opt_model, warnings))
         },
     }
 }
@@ -874,7 +951,8 @@ fn compile_ir_module<'a>(
 ) -> Result<CompiledModule> {
     use move_ir_compiler::Compiler as IRCompiler;
     let code = std::fs::read_to_string(file_name).unwrap();
-    IRCompiler::new(deps.collect()).into_compiled_module(&code)
+    let module = IRCompiler::new(deps.collect()).into_compiled_module(&code)?;
+    Ok(module)
 }
 
 fn compile_ir_script<'a>(
@@ -890,7 +968,7 @@ fn compile_ir_script<'a>(
 pub fn run_test_impl<'a, Adapter>(
     config: TestRunConfig,
     path: &Path,
-    pre_compiled_deps_v1: Option<&'a FullyCompiledProgram>,
+    pre_compiled_deps_v1: Option<&'a (FullyCompiledProgram, Vec<PackagePaths>)>,
     pre_compiled_deps_v2: Option<&'a PrecompiledFilesModules>,
     exp_suffix: &Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>>

--- a/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
@@ -951,8 +951,7 @@ fn compile_ir_module<'a>(
 ) -> Result<CompiledModule> {
     use move_ir_compiler::Compiler as IRCompiler;
     let code = std::fs::read_to_string(file_name).unwrap();
-    let module = IRCompiler::new(deps.collect()).into_compiled_module(&code)?;
-    Ok(module)
+    IRCompiler::new(deps.collect()).into_compiled_module(&code)
 }
 
 fn compile_ir_script<'a>(
@@ -995,13 +994,10 @@ where
     } = config.clone()
     {
         (
-            vec![
-                TestRunConfig::CompilerV1,
-                TestRunConfig::CompilerV2 {
-                    language_version,
-                    v2_experiments,
-                },
-            ],
+            vec![TestRunConfig::CompilerV1, TestRunConfig::CompilerV2 {
+                language_version,
+                v2_experiments,
+            }],
             true,
         )
     } else {

--- a/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -20,7 +20,10 @@ use move_command_line_common::{
 };
 use move_compiler::{
     compiled_unit::AnnotatedCompiledUnit,
-    shared::{known_attributes::KnownAttribute, Flags, PackagePaths},
+    shared::{
+        known_attributes::KnownAttribute, string_packagepath_to_symbol_packagepath, Flags,
+        NumericalAddress, PackagePaths,
+    },
     FullyCompiledProgram,
 };
 use move_core_types::{
@@ -115,7 +118,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
         default_syntax: SyntaxChoice,
         comparison_mode: bool,
         run_config: TestRunConfig,
-        pre_compiled_deps_v1: Option<&'a FullyCompiledProgram>,
+        pre_compiled_deps_v1: Option<&'a (FullyCompiledProgram, Vec<PackagePaths>)>,
         pre_compiled_deps_v2: Option<&'a PrecompiledFilesModules>,
         task_opt: Option<TaskInput<(InitCommand, EmptyCommand)>>,
     ) -> (Self, Option<String>) {
@@ -411,29 +414,33 @@ impl<'a> SimpleVMTestAdapter<'a> {
     }
 }
 
-static PRECOMPILED_MOVE_STDLIB: Lazy<Option<FullyCompiledProgram>> = Lazy::new(|| {
-    if get_move_compiler_block_v1_from_env() {
-        return None;
-    }
-    let program_res = move_compiler::construct_pre_compiled_lib(
-        vec![PackagePaths {
+static PRECOMPILED_MOVE_STDLIB: Lazy<Option<(FullyCompiledProgram, Vec<PackagePaths>)>> =
+    Lazy::new(|| {
+        if get_move_compiler_block_v1_from_env() {
+            return None;
+        }
+        let lib_paths = PackagePaths {
             name: None,
             paths: move_stdlib::move_stdlib_files(),
             named_address_map: move_stdlib::move_stdlib_named_addresses(),
-        }],
-        None,
-        Flags::empty().set_skip_attribute_checks(true), // no point in checking.
-        KnownAttribute::get_all_attribute_names(),
-    )
-    .unwrap();
-    match program_res {
-        Ok(stdlib) => Some(stdlib),
-        Err((files, errors)) => {
-            eprintln!("!!!Standard library failed to compile!!!");
-            move_compiler::diagnostics::report_diagnostics(&files, errors)
-        },
-    }
-});
+        };
+        let lib_paths_movesym =
+            string_packagepath_to_symbol_packagepath::<NumericalAddress>(&lib_paths);
+        let program_res = move_compiler::construct_pre_compiled_lib(
+            vec![lib_paths],
+            None,
+            Flags::empty().set_skip_attribute_checks(true), // no point in checking.
+            KnownAttribute::get_all_attribute_names(),
+        )
+        .unwrap();
+        match program_res {
+            Ok(stdlib) => Some((stdlib, vec![lib_paths_movesym])),
+            Err((files, errors)) => {
+                eprintln!("!!!Standard library failed to compile!!!");
+                move_compiler::diagnostics::report_diagnostics(&files, errors)
+            },
+        }
+    });
 
 pub struct PrecompiledFilesModules(Vec<String>, Vec<AnnotatedCompiledUnit>);
 
@@ -486,7 +493,7 @@ pub fn run_test(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
 
 fn precompiled_v1_stdlib_if_needed(
     config: &TestRunConfig,
-) -> Option<&'static FullyCompiledProgram> {
+) -> Option<&'static (FullyCompiledProgram, Vec<PackagePaths>)> {
     match config {
         TestRunConfig::CompilerV1 { .. } => PRECOMPILED_MOVE_STDLIB.as_ref(),
         TestRunConfig::ComparisonV1V2 { .. } => PRECOMPILED_MOVE_STDLIB.as_ref(),


### PR DESCRIPTION
## Description

Run `extended_checks` as part of the `aptos-transactional-test-harness`.

Fixes #13297.

To run `extended_checks` we need a model (`GlobalEnv`) to be generated
by compilation.  For Compiler V2 this is pretty straightforward, as we
just have to enable the `"attach-compiled-module"` experiment.  For
Compiler V1, the compilation entry point currently used by the test
framework doesn't generate a model as part of compilation, and reusing
the process used in `BuiltPackage::build()` (defined in
`aptos-move/framework/src/build_package.rs`) is overly complex.

So instead, we follow the process that was used in
`CompiledPackage::build_all()` (defined in
`third_party/move/tools/move-package/src/compilation/compiled_package.rs`)
to build a model under compiler V1, needed for ABIs or Docgen with
compiler V1.

The main implication is that we need input `PackagePaths` for
dependencies, notably the Stdlibs, so we make a copy of that in the
framework to be re-used in `compile_source_unit()` (defined in
`third_party/move/testing-infra/transactional-test-runner/src/framework.rs`)
if `need_model` is `true`.
    
We just learned that Rust Traits can't call a default implementation
from a specialized implementation, so we must rename the default
implementations of `MoveTestAdapter` trait functions `compile_module`
and `compile_script` as `*_default()`, leaving the original functions
as forwarders that can be overwritten by new implementations for
`AptosTestAdapter` (defined in
`aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs`)
to call the default compile methods and then run extended checks as
appropriate.

## How Has This Been Tested?
Added a new test that should fails extended checks.

Was reminded that an existing test (`diamond_clicker.move`) should have been failing
extended checks, as it now fails in bytcode verification.

## Key Areas to Review

It's a little messy, but much of the mess relates to compiler-v1 and
the third_party/aptos-move boundary which both should be going away
soonish, so let's not get hung up on it. :-) We really need to
refactor to simplify the compiler/module-building interfaces, but skip
that for now.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [] I have made corresponding changes to the documentation
