### PR TITLE
[Not for review] Check NACK messages

### DIFF
--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -442,6 +442,7 @@ impl BlockStore {
         }
         let commit_round = self.commit_root().round();
         let ordered_round = self.ordered_root().round();
+        info!("hqc_round: {}, ordered_root_round: {}, ordered_cert_round: {}, commit_root_round: {}, commit_cert_round: {}, backpressure_limit: {}", self.highest_quorum_cert().certified_block().round(), ordered_round, self.highest_ordered_cert().commit_info().round(), commit_round, self.highest_commit_cert().commit_info().round(), self.vote_back_pressure_limit);
         counters::OP_COUNTERS
             .gauge("back_pressure")
             .set((ordered_round - commit_round) as i64);

--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -602,6 +602,7 @@ impl BufferManager {
                         return None;
                     }
                 } else {
+                    warn!("Reply NACK for commit vote {}", vote.ledger_info());
                     reply_nack(protocol, response_sender); // TODO: send_commit_vote() doesn't care about the response and this should be direct send not RPC
                 }
             },

--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -591,6 +591,10 @@ impl BufferManager {
                                 commit_info = commit_info,
                                 "Failed to add commit vote",
                             );
+                            warn!(
+                                "Reply NACK for commit vote {}. Unable to add signature, error: {}",
+                                commit_info, e
+                            );
                             reply_nack(protocol, response_sender);
                             item
                         },
@@ -631,6 +635,10 @@ impl BufferManager {
                         return Some(target_block_id);
                     }
                 }
+                warn!(
+                    "Rejecting commit decision with NACK for {}",
+                    commit_proof.ledger_info()
+                );
                 reply_nack(protocol, response_sender); // TODO: send_commit_proof() doesn't care about the response and this should be direct send not RPC
             },
             CommitMessage::Ack(_) => {

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -580,6 +580,12 @@ impl RoundManager {
 
     fn sync_only(&self) -> bool {
         let sync_or_not = self.local_config.sync_only || self.block_store.vote_back_pressure();
+        info!(
+            "sync_only: {}, local_config_sync_only: {}, vote backpressure: {}",
+            sync_or_not,
+            self.local_config.sync_only,
+            self.block_store.vote_back_pressure()
+        );
         counters::OP_COUNTERS
             .gauge("sync_only")
             .set(sync_or_not as i64);


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
