### PR TITLE
[cherrypick][1.13] Revert "Event simplification conn subs (#12730)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,7 +2748,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-retry",
- "tokio-stream",
  "tokio-util 0.7.10",
 ]
 

--- a/consensus/src/dag/tests/integration_tests.rs
+++ b/consensus/src/dag/tests/integration_tests.rs
@@ -17,7 +17,7 @@ use aptos_consensus_types::common::Author;
 use aptos_logger::debug;
 use aptos_network::{
     application::interface::NetworkClient,
-    peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
+    peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
     protocols::{
         network::{self, Event, NetworkEvents, NewNetworkEvents, NewNetworkSender},
         wire::handshake::v1::ProtocolIdSet,
@@ -147,6 +147,7 @@ fn create_network(
     let (connection_reqs_tx, _) = aptos_channel::new(QueueStyle::FIFO, 8, None);
     let (consensus_tx, consensus_rx) = aptos_channel::new(QueueStyle::FIFO, 8, None);
     let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = aptos_channels::new_test(8);
+    let (_, conn_status_rx) = conn_notifs_channel::new();
     let network_sender = network::NetworkSender::new(
         PeerManagerRequestSender::new(network_reqs_tx),
         ConnectionRequestSender::new(connection_reqs_tx),
@@ -158,7 +159,7 @@ fn create_network(
         playground.peer_protocols(),
     );
     let consensus_network_client = ConsensusNetworkClient::new(network_client);
-    let network_events = NetworkEvents::new(consensus_rx, None);
+    let network_events = NetworkEvents::new(consensus_rx, conn_status_rx, None);
 
     let (self_sender, self_receiver) = aptos_channels::new_unbounded_test();
     let network = NetworkSender::new(author, consensus_network_client, self_sender, validators);

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -844,6 +844,9 @@ impl NetworkTask {
                         warn!(error = ?e, "aptos channel closed");
                     };
                 },
+                _ => {
+                    // Ignore `NewPeer` and `LostPeer` events
+                },
             });
         }
     }

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -22,7 +22,7 @@ use aptos_infallible::{Mutex, RwLock};
 use aptos_network::{
     application::storage::PeersAndMetadata,
     peer_manager::{
-        ConnectionRequestSender, PeerManagerNotification, PeerManagerRequest,
+        conn_notifs_channel, ConnectionRequestSender, PeerManagerNotification, PeerManagerRequest,
         PeerManagerRequestSender,
     },
     protocols::{
@@ -585,6 +585,7 @@ mod tests {
             let (connection_reqs_tx, _) = aptos_channel::new(QueueStyle::FIFO, 8, None);
             let (consensus_tx, consensus_rx) = aptos_channel::new(QueueStyle::FIFO, 8, None);
             let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = aptos_channels::new_test(1024);
+            let (_, conn_status_rx) = conn_notifs_channel::new();
 
             add_peer_to_storage(&peers_and_metadata, peer, &[
                 ProtocolId::ConsensusDirectSendJson,
@@ -618,7 +619,7 @@ mod tests {
                 validator_verifier.clone(),
             );
 
-            let network_events = NetworkEvents::new(consensus_rx, None);
+            let network_events = NetworkEvents::new(consensus_rx, conn_status_rx, None);
             let network_service_events =
                 NetworkServiceEvents::new(hashmap! {NetworkId::Validator => network_events});
             let (task, receiver) = NetworkTask::new(network_service_events, self_receiver);
@@ -697,6 +698,7 @@ mod tests {
             let (connection_reqs_tx, _) = aptos_channel::new(QueueStyle::FIFO, 8, None);
             let (consensus_tx, consensus_rx) = aptos_channel::new(QueueStyle::FIFO, 8, None);
             let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = aptos_channels::new_test(1024);
+            let (_, conn_status_rx) = conn_notifs_channel::new();
             let network_sender = network::NetworkSender::new(
                 PeerManagerRequestSender::new(network_reqs_tx),
                 ConnectionRequestSender::new(connection_reqs_tx),
@@ -730,7 +732,7 @@ mod tests {
                 validator_verifier.clone(),
             );
 
-            let network_events = NetworkEvents::new(consensus_rx, None);
+            let network_events = NetworkEvents::new(consensus_rx, conn_status_rx, None);
             let network_service_events =
                 NetworkServiceEvents::new(hashmap! {NetworkId::Validator => network_events});
             let (task, receiver) = NetworkTask::new(network_service_events, self_receiver);
@@ -800,7 +802,9 @@ mod tests {
 
         let (peer_mgr_notifs_tx, peer_mgr_notifs_rx) =
             aptos_channel::new(QueueStyle::FIFO, 8, None);
-        let network_events = NetworkEvents::new(peer_mgr_notifs_rx, None);
+        let (connection_notifs_tx, connection_notifs_rx) =
+            aptos_channel::new(QueueStyle::FIFO, 8, None);
+        let network_events = NetworkEvents::new(peer_mgr_notifs_rx, connection_notifs_rx, None);
         let network_service_events =
             NetworkServiceEvents::new(hashmap! {NetworkId::Validator => network_events});
         let (self_sender, self_receiver) = aptos_channels::new_unbounded_test();
@@ -839,6 +843,7 @@ mod tests {
             assert!(network_receivers.rpc_rx.next().await.is_some());
 
             drop(peer_mgr_notifs_tx);
+            drop(connection_notifs_tx);
             drop(self_sender);
 
             assert!(network_receivers.rpc_rx.next().await.is_none());

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -50,7 +50,7 @@ use aptos_infallible::Mutex;
 use aptos_logger::prelude::info;
 use aptos_network::{
     application::interface::NetworkClient,
-    peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
+    peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
     protocols::{
         network,
         network::{Event, NetworkEvents, NewNetworkEvents, NewNetworkSender},
@@ -232,6 +232,7 @@ impl NodeSetup {
         let (connection_reqs_tx, _) = aptos_channel::new(QueueStyle::FIFO, 8, None);
         let (consensus_tx, consensus_rx) = aptos_channel::new(QueueStyle::FIFO, 8, None);
         let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = aptos_channels::new_test(8);
+        let (_, conn_status_rx) = conn_notifs_channel::new();
         let network_sender = network::NetworkSender::new(
             PeerManagerRequestSender::new(network_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
@@ -243,7 +244,7 @@ impl NodeSetup {
             playground.peer_protocols(),
         );
         let consensus_network_client = ConsensusNetworkClient::new(network_client);
-        let network_events = NetworkEvents::new(consensus_rx, None);
+        let network_events = NetworkEvents::new(consensus_rx, conn_status_rx, None);
         let author = signer.author();
 
         let twin_id = TwinId { id, author };
@@ -401,6 +402,7 @@ impl NodeSetup {
                     self.identity_desc()
                 )
             },
+            _ => panic!("Unexpected Network Event"),
         }
     }
 
@@ -411,6 +413,7 @@ impl NodeSetup {
                 msg,
                 self.identity_desc()
             ),
+            Some(_) => panic!("Unexpected Network Event"),
             None => {},
         }
     }
@@ -473,6 +476,7 @@ impl NodeSetup {
                 msg,
                 self.identity_desc()
             ),
+            Some(_) => panic!("Unexpected Network Event"),
             None => None,
         }
     }

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -27,7 +27,7 @@ use aptos_event_notifications::{ReconfigNotification, ReconfigNotificationListen
 use aptos_mempool::mocks::MockSharedMempool;
 use aptos_network::{
     application::interface::{NetworkClient, NetworkServiceEvents},
-    peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
+    peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
     protocols::{
         network,
         network::{NetworkEvents, NewNetworkEvents, NewNetworkSender},
@@ -87,6 +87,7 @@ impl SMRNode {
         let (connection_reqs_tx, _) = aptos_channel::new(QueueStyle::FIFO, 8, None);
         let (consensus_tx, consensus_rx) = aptos_channel::new(QueueStyle::FIFO, 8, None);
         let (_conn_mgr_reqs_tx, conn_mgr_reqs_rx) = aptos_channels::new_test(8);
+        let (_, conn_notifs_channel) = conn_notifs_channel::new();
         let network_sender = network::NetworkSender::new(
             PeerManagerRequestSender::new(network_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
@@ -98,7 +99,7 @@ impl SMRNode {
             playground.peer_protocols(),
         );
         let consensus_network_client = ConsensusNetworkClient::new(network_client);
-        let network_events = NetworkEvents::new(consensus_rx, None);
+        let network_events = NetworkEvents::new(consensus_rx, conn_notifs_channel, None);
         let network_service_events =
             NetworkServiceEvents::new(hashmap! {NetworkId::Validator => network_events});
 

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -254,7 +254,9 @@ async fn handle_mempool_reconfig_event<NetworkClient, TransactionValidator, Conf
         .await;
 }
 
-/// Handles all network messages.
+/// Handles all NewPeer, LostPeer, and network messages.
+/// - NewPeer events start new automatic broadcasts if the peer is upstream. If the peer is not upstream, we ignore it.
+/// - LostPeer events disable the upstream peer, which will cancel ongoing broadcasts.
 /// - Network messages follow a simple Request/Response framework to accept new transactions
 /// TODO: Move to RPC off of DirectSend
 async fn handle_network_event<NetworkClient, TransactionValidator>(
@@ -267,6 +269,12 @@ async fn handle_network_event<NetworkClient, TransactionValidator>(
     TransactionValidator: TransactionValidation + 'static,
 {
     match event {
+        Event::NewPeer(_) => {
+            // TODO: remove Event
+        },
+        Event::LostPeer(_) => {
+            // TODO: remove Event
+        },
         Event::Message(peer_id, msg) => {
             counters::shared_mempool_event_inc("message");
             match msg {

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -11,7 +11,7 @@ use crate::{
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::{
     config::{Identity, NodeConfig, PeerRole, RoleType},
-    network_id::{NetworkId, PeerNetworkId},
+    network_id::{NetworkContext, NetworkId, PeerNetworkId},
 };
 use aptos_crypto::{x25519::PrivateKey, Uniform};
 use aptos_event_notifications::{ReconfigNotification, ReconfigNotificationListener};
@@ -23,8 +23,8 @@ use aptos_network::{
         storage::PeersAndMetadata,
     },
     peer_manager::{
-        ConnectionRequestSender, PeerManagerNotification, PeerManagerRequest,
-        PeerManagerRequestSender,
+        conn_notifs_channel, ConnectionNotification, ConnectionRequestSender,
+        PeerManagerNotification, PeerManagerRequest, PeerManagerRequestSender,
     },
     protocols::{
         network::{NetworkEvents, NetworkSender, NewNetworkEvents, NewNetworkSender},
@@ -402,9 +402,16 @@ impl Node {
         metadata
             .application_protocols
             .insert(ProtocolId::MempoolDirectSend);
+        let notif = ConnectionNotification::NewPeer(metadata.clone(), NetworkContext::mock());
         self.peers_and_metadata
             .insert_connection_metadata(peer_network_id, metadata)
             .unwrap();
+        self.send_connection_event(peer_network_id.network_id(), notif);
+    }
+
+    /// Sends a connection event, and waits for the notification to arrive
+    fn send_connection_event(&mut self, network_id: NetworkId, notif: ConnectionNotification) {
+        self.send_network_notif(network_id, notif);
         self.wait_for_event(SharedMempoolNotification::PeerStateChange);
     }
 
@@ -459,6 +466,12 @@ impl Node {
         self.get_network_interface(network_id)
             .send_network_req(protocol, notif);
     }
+
+    /// Sends a `ConnectionNotification` to the local node
+    pub fn send_network_notif(&mut self, network_id: NetworkId, notif: ConnectionNotification) {
+        self.get_network_interface(network_id)
+            .send_connection_notif(notif)
+    }
 }
 
 /// A simplistic view of the entire network stack for a given `NetworkId`
@@ -469,6 +482,8 @@ pub struct NodeNetworkInterface {
     /// Peer notification sender for sending outgoing messages to other peers
     pub(crate) network_notifs_tx:
         aptos_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>,
+    /// Sender for connecting / disconnecting peers
+    pub(crate) network_conn_event_notifs_tx: conn_notifs_channel::Sender,
 }
 
 impl NodeNetworkInterface {
@@ -484,6 +499,18 @@ impl NodeNetworkInterface {
 
         self.network_notifs_tx
             .push((remote_peer_id, protocol), message)
+            .unwrap()
+    }
+
+    /// Send a notification specifying, where a remote peer has it's state changed
+    fn send_connection_notif(&mut self, notif: ConnectionNotification) {
+        let peer_id = match &notif {
+            ConnectionNotification::NewPeer(metadata, _) => metadata.remote_peer_id,
+            ConnectionNotification::LostPeer(metadata, _, _) => metadata.remote_peer_id,
+        };
+
+        self.network_conn_event_notifs_tx
+            .push(peer_id, notif)
             .unwrap()
     }
 }
@@ -544,16 +571,18 @@ fn setup_node_network_interface(
     let (connection_reqs_tx, _) = aptos_channel::new(QueueStyle::FIFO, MAX_QUEUE_SIZE, None);
     let (network_notifs_tx, network_notifs_rx) =
         aptos_channel::new(QueueStyle::FIFO, MAX_QUEUE_SIZE, None);
+    let (network_conn_event_notifs_tx, conn_status_rx) = conn_notifs_channel::new();
     let network_sender = NetworkSender::new(
         PeerManagerRequestSender::new(network_reqs_tx),
         ConnectionRequestSender::new(connection_reqs_tx),
     );
-    let network_events = NetworkEvents::new(network_notifs_rx, None);
+    let network_events = NetworkEvents::new(network_notifs_rx, conn_status_rx, None);
 
     (
         NodeNetworkInterface {
             network_reqs_rx,
             network_notifs_tx,
+            network_conn_event_notifs_tx,
         },
         (peer_network_id.network_id(), network_sender, network_events),
     )

--- a/network/benchmark/src/lib.rs
+++ b/network/benchmark/src/lib.rs
@@ -13,7 +13,6 @@ use aptos_logger::{
 use aptos_metrics_core::{register_int_counter_vec, IntCounter, IntCounterVec};
 use aptos_network::{
     application::interface::{NetworkClient, NetworkClientInterface, NetworkServiceEvents},
-    peer_manager::ConnectionNotification,
     protocols::{network::Event, rpc::error::RpcError, wire::handshake::v1::ProtocolId},
 };
 use aptos_time_service::{TimeService, TimeServiceTrait};
@@ -26,7 +25,7 @@ use futures::{
 use once_cell::sync::Lazy;
 use rand::{rngs::OsRng, Rng};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, ops::DerefMut, sync::Arc, time::Duration};
+use std::{ops::DerefMut, sync::Arc, time::Duration};
 use tokio::{runtime::Handle, select, sync::RwLock};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -181,11 +180,13 @@ async fn handle_rpc(
 
 /// handle work split out by source_loop()
 async fn handler_task(
+    node_config: NodeConfig,
     network_client: NetworkClient<NetbenchMessage>,
     work_rx: async_channel::Receiver<(NetworkId, Event<NetbenchMessage>)>,
     time_service: TimeService,
     shared: Arc<RwLock<NetbenchSharedState>>,
 ) {
+    let config = node_config.netbench.unwrap();
     loop {
         let (network_id, event) = match work_rx.recv().await {
             Ok(v) => v,
@@ -217,6 +218,29 @@ async fn handler_task(
                 )
                 .await;
             },
+            Event::NewPeer(wat) => {
+                if config.enable_direct_send_testing {
+                    Handle::current().spawn(direct_sender(
+                        node_config.clone(),
+                        network_client.clone(),
+                        time_service.clone(),
+                        network_id,
+                        wat.remote_peer_id,
+                        shared.clone(),
+                    ));
+                }
+                if config.enable_rpc_testing {
+                    Handle::current().spawn(rpc_sender(
+                        node_config.clone(),
+                        network_client.clone(),
+                        time_service.clone(),
+                        network_id,
+                        wat.remote_peer_id,
+                        shared.clone(),
+                    ));
+                }
+            },
+            Event::LostPeer(_) => {}, // don't care
         }
     }
 }
@@ -250,89 +274,23 @@ pub async fn run_netbench_service(
     };
     let (work_sender, work_receiver) = async_channel::bounded(num_threads * 2);
     let runtime_handle = Handle::current();
-    let listener_task = runtime_handle.spawn(connection_listener(
-        node_config.clone(),
-        network_client.clone(),
-        time_service.clone(),
-        shared.clone(),
-        runtime_handle.clone(),
-    ));
     let source_task = runtime_handle.spawn(source_loop(network_requests, work_sender));
     let mut handlers = vec![];
     for _ in 0..num_threads {
         handlers.push(runtime_handle.spawn(handler_task(
+            node_config.clone(),
             network_client.clone(),
             work_receiver.clone(),
             time_service.clone(),
             shared.clone(),
         )));
     }
-    let listener_task_result = listener_task.await;
-    info!("netbench listener_task exited {:?}", listener_task_result);
     if let Err(err) = source_task.await {
         warn!("benchmark source_thread join: {}", err);
     }
     for hai in handlers {
         if let Err(err) = hai.await {
             warn!("benchmark handler_thread join: {}", err);
-        }
-    }
-}
-
-async fn connection_listener(
-    node_config: NodeConfig,
-    network_client: NetworkClient<NetbenchMessage>,
-    time_service: TimeService,
-    shared: Arc<RwLock<NetbenchSharedState>>,
-    handle: Handle,
-) {
-    let config = node_config.netbench.unwrap();
-    let peers_and_metadata = network_client.get_peers_and_metadata();
-    let mut connected_peers = HashSet::new();
-    let mut connection_notifications = peers_and_metadata.subscribe();
-    loop {
-        match connection_notifications.recv().await {
-            None => {
-                info!("netbench connection_listener exit");
-                return;
-            },
-            Some(note) => match note {
-                ConnectionNotification::NewPeer(meta, network_id) => {
-                    let peer_network_id = PeerNetworkId::new(network_id, meta.remote_peer_id);
-                    if connected_peers.contains(&peer_network_id) {
-                        continue;
-                    }
-                    info!(
-                        "netbench connection_listener new {:?} {:?}",
-                        meta, network_id
-                    );
-                    if config.enable_direct_send_testing {
-                        handle.spawn(direct_sender(
-                            node_config.clone(),
-                            network_client.clone(),
-                            time_service.clone(),
-                            network_id,
-                            meta.remote_peer_id,
-                            shared.clone(),
-                        ));
-                    }
-                    if config.enable_rpc_testing {
-                        handle.spawn(rpc_sender(
-                            node_config.clone(),
-                            network_client.clone(),
-                            time_service.clone(),
-                            network_id,
-                            meta.remote_peer_id,
-                            shared.clone(),
-                        ));
-                    }
-                    connected_peers.insert(peer_network_id);
-                },
-                ConnectionNotification::LostPeer(meta, network_id) => {
-                    let peer_network_id = PeerNetworkId::new(network_id, meta.remote_peer_id);
-                    connected_peers.remove(&peer_network_id);
-                },
-            },
         }
     }
 }

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -462,8 +462,13 @@ impl NetworkBuilder {
         config: &NetworkServiceConfig,
         max_parallel_deserialization_tasks: Option<usize>,
     ) -> EventsT {
-        let peer_mgr_reqs_rx = self.peer_manager_builder.add_service(config);
-        EventsT::new(peer_mgr_reqs_rx, max_parallel_deserialization_tasks)
+        let (peer_mgr_reqs_rx, connection_notifs_rx) =
+            self.peer_manager_builder.add_service(config);
+        EventsT::new(
+            peer_mgr_reqs_rx,
+            connection_notifs_rx,
+            max_parallel_deserialization_tasks,
+        )
     }
 }
 

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -14,15 +14,15 @@ use aptos_crypto::{test_utils::TEST_SEED, x25519, Uniform};
 use aptos_netcore::transport::ConnectionOrigin;
 use aptos_network::{
     application::{interface::NetworkClient, storage::PeersAndMetadata},
-    peer_manager::{builder::AuthenticationMode, ConnectionNotification},
+    peer_manager::builder::AuthenticationMode,
     protocols::network::{
-        NetworkApplicationConfig, NetworkClientConfig, NetworkEvents, NetworkServiceConfig,
+        Event, NetworkApplicationConfig, NetworkClientConfig, NetworkEvents, NetworkServiceConfig,
     },
     ProtocolId,
 };
 use aptos_time_service::TimeService;
 use aptos_types::{chain_id::ChainId, network_address::NetworkAddress, PeerId};
-use futures::executor::block_on;
+use futures::{executor::block_on, StreamExt};
 use maplit::hashmap;
 use rand::{rngs::StdRng, SeedableRng};
 use serde::{Deserialize, Serialize};
@@ -97,8 +97,7 @@ pub fn setup_network() -> DummyNetwork {
     );
 
     let authentication_mode = AuthenticationMode::Mutual(listener_identity_private_key);
-    let listener_peers_and_metadata = PeersAndMetadata::new(&[network_id]);
-    let mut listener_connection_events = listener_peers_and_metadata.subscribe();
+    let peers_and_metadata = PeersAndMetadata::new(&[network_id]);
     // Set up the listener network
     let network_context = NetworkContext::new(role, network_id, listener_peer.peer_id());
     let mut network_builder = NetworkBuilder::new_for_test(
@@ -108,17 +107,17 @@ pub fn setup_network() -> DummyNetwork {
         TimeService::real(),
         listener_addr,
         authentication_mode,
-        listener_peers_and_metadata.clone(),
+        peers_and_metadata.clone(),
     );
 
-    let (listener_sender, listener_events) = network_builder
+    let (listener_sender, mut listener_events) = network_builder
         .add_client_and_service::<_, DummyNetworkEvents>(&dummy_network_config(), None);
     network_builder.build(runtime.handle().clone()).start();
     let listener_network_client = NetworkClient::new(
         vec![TEST_DIRECT_SEND_PROTOCOL],
         vec![TEST_RPC_PROTOCOL],
         hashmap! {network_id => listener_sender},
-        listener_peers_and_metadata.clone(),
+        peers_and_metadata,
     );
 
     // Add the listener address with port
@@ -144,9 +143,7 @@ pub fn setup_network() -> DummyNetwork {
         peers_and_metadata.clone(),
     );
 
-    let mut connection_events = peers_and_metadata.subscribe();
-
-    let (dialer_sender, dialer_events) = network_builder
+    let (dialer_sender, mut dialer_events) = network_builder
         .add_client_and_service::<_, DummyNetworkEvents>(&dummy_network_config(), None);
     network_builder.build(runtime.handle().clone()).start();
     let dialer_network_client = NetworkClient::new(
@@ -157,8 +154,8 @@ pub fn setup_network() -> DummyNetwork {
     );
 
     // Wait for establishing connection
-    let first_dialer_event = block_on(connection_events.recv()).unwrap();
-    if let ConnectionNotification::NewPeer(metadata, _network_id) = first_dialer_event {
+    let first_dialer_event = block_on(dialer_events.next()).unwrap();
+    if let Event::NewPeer(metadata) = first_dialer_event {
         assert_eq!(metadata.remote_peer_id, listener_peer.peer_id());
         assert_eq!(metadata.origin, ConnectionOrigin::Outbound);
         assert_eq!(metadata.role, PeerRole::Validator);
@@ -169,8 +166,8 @@ pub fn setup_network() -> DummyNetwork {
         );
     }
 
-    let first_listener_event = block_on(listener_connection_events.recv()).unwrap();
-    if let ConnectionNotification::NewPeer(metadata, _network_id) = first_listener_event {
+    let first_listener_event = block_on(listener_events.next()).unwrap();
+    if let Event::NewPeer(metadata) = first_listener_event {
         assert_eq!(metadata.remote_peer_id, dialer_peer.peer_id());
         assert_eq!(metadata.origin, ConnectionOrigin::Inbound);
         assert_eq!(metadata.role, PeerRole::Validator);

--- a/network/framework/Cargo.toml
+++ b/network/framework/Cargo.toml
@@ -56,7 +56,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-retry = { workspace = true }
-tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 
 [dev-dependencies]

--- a/network/framework/src/application/storage.rs
+++ b/network/framework/src/application/storage.rs
@@ -7,7 +7,6 @@ use crate::{
         error::Error,
         metadata::{ConnectionState, PeerMetadata},
     },
-    peer_manager::ConnectionNotification,
     transport::{ConnectionId, ConnectionMetadata},
     ProtocolId,
 };
@@ -15,8 +14,7 @@ use aptos_config::{
     config::{Peer, PeerSet},
     network_id::{NetworkId, PeerNetworkId},
 };
-use aptos_infallible::{Mutex, RwLock};
-use aptos_logger::{sample, sample::SampleRate, warn};
+use aptos_infallible::RwLock;
 use aptos_peer_monitoring_service_types::PeerMonitoringMetadata;
 use aptos_types::{account_address::AccountAddress, PeerId};
 use arc_swap::ArcSwap;
@@ -24,15 +22,7 @@ use std::{
     collections::{hash_map::Entry, HashMap},
     ops::Deref,
     sync::{Arc, RwLockWriteGuard},
-    time::Duration,
 };
-use tokio::sync::mpsc::error::TrySendError;
-
-// notification_backlog is how many ConnectionNotification items can be queued waiting for an app to receive them.
-// Beyond this, new messages will be dropped if the app is not handling them fast enough.
-// We make this big enough to fit an initial burst of _all_ the connected peers getting notified.
-// Having 100 connected peers is common, 500 not unexpected
-const NOTIFICATION_BACKLOG: usize = 1000;
 
 /// A simple container that tracks all peers and peer metadata for the node.
 /// This container is updated by both the networking code (e.g., for new
@@ -49,8 +39,6 @@ pub struct PeersAndMetadata {
     //
     // TODO: should we remove this when generational versioning is supported?
     cached_peers_and_metadata: Arc<ArcSwap<HashMap<NetworkId, HashMap<PeerId, PeerMetadata>>>>,
-
-    subscribers: Mutex<Vec<tokio::sync::mpsc::Sender<ConnectionNotification>>>,
 }
 
 impl PeersAndMetadata {
@@ -60,7 +48,6 @@ impl PeersAndMetadata {
             peers_and_metadata: RwLock::new(HashMap::new()),
             trusted_peers: HashMap::new(),
             cached_peers_and_metadata: Arc::new(ArcSwap::from(Arc::new(HashMap::new()))),
-            subscribers: Mutex::new(vec![]),
         };
 
         // Initialize each network mapping and trusted peer set
@@ -201,14 +188,10 @@ impl PeersAndMetadata {
             .and_modify(|peer_metadata| {
                 peer_metadata.connection_metadata = connection_metadata.clone()
             })
-            .or_insert_with(|| PeerMetadata::new(connection_metadata.clone()));
+            .or_insert_with(|| PeerMetadata::new(connection_metadata));
 
         // Update the cached peers and metadata
         self.set_cached_peers_and_metadata(peers_and_metadata.clone());
-
-        let event =
-            ConnectionNotification::NewPeer(connection_metadata, peer_network_id.network_id());
-        self.broadcast(event);
 
         Ok(())
     }
@@ -237,13 +220,7 @@ impl PeersAndMetadata {
             // have multiple connections for a peer
             let active_connection_id = entry.get().connection_metadata.connection_id;
             if active_connection_id == connection_id {
-                let peer_metadata = entry.remove();
-                let event = ConnectionNotification::LostPeer(
-                    peer_metadata.connection_metadata.clone(),
-                    peer_network_id.network_id(),
-                );
-                self.broadcast(event);
-                peer_metadata
+                entry.remove()
             } else {
                 return Err(Error::UnexpectedError(format!(
                     "The peer connection id did not match! Given: {:?}, found: {:?}.",
@@ -366,63 +343,6 @@ impl PeersAndMetadata {
         let trusted_peers = self.get_trusted_peer_set_for_network(network_id)?;
         trusted_peers.store(Arc::new(trusted_peer_set));
         Ok(())
-    }
-
-    fn broadcast(&self, event: ConnectionNotification) {
-        let mut listeners = self.subscribers.lock();
-        let mut to_del = vec![];
-        for i in 0..listeners.len() {
-            let dest = listeners.get_mut(i).unwrap();
-            if let Err(err) = dest.try_send(event.clone()) {
-                match err {
-                    TrySendError::Full(_) => {
-                        // Tried to send to an app, but the app isn't handling its messages fast enough.
-                        // Drop message. Maybe increment a metrics counter?
-                        sample!(
-                            SampleRate::Duration(Duration::from_secs(1)),
-                            warn!("PeersAndMetadata.broadcast() failed, some app is slow"),
-                        );
-                    },
-                    TrySendError::Closed(_) => {
-                        to_del.push(i);
-                    },
-                }
-            }
-        }
-        for evict in to_del.into_iter() {
-            listeners.swap_remove(evict);
-        }
-    }
-
-    /// subscribe() returns a channel for receiving NewPeer/LostPeer events.
-    /// subscribe() immediately sends all* current connections as NewPeer events.
-    /// (* capped at NOTIFICATION_BACKLOG, currently 1000, use get_connected_peers() to be sure)
-    pub fn subscribe(&self) -> tokio::sync::mpsc::Receiver<ConnectionNotification> {
-        let (sender, receiver) = tokio::sync::mpsc::channel(NOTIFICATION_BACKLOG);
-        let peers_and_metadata = self.peers_and_metadata.read();
-        'outer: for (network_id, network_peers_and_metadata) in peers_and_metadata.iter() {
-            for (_addr, peer_metadata) in network_peers_and_metadata.iter() {
-                let event = ConnectionNotification::NewPeer(
-                    peer_metadata.connection_metadata.clone(),
-                    *network_id,
-                );
-                if let Err(err) = sender.try_send(event) {
-                    warn!("could not send initial NewPeer on subscribe(): {:?}", err);
-                    break 'outer;
-                }
-            }
-        }
-        // I expect the peers_and_metadata read lock to still be in effect until after listeners.push() below
-        let mut listeners = self.subscribers.lock();
-        listeners.push(sender);
-        receiver
-    }
-
-    #[cfg(test)]
-    pub fn close_subscribers(&self) {
-        let mut listeners = self.subscribers.lock();
-        // drop all the senders to close them
-        listeners.clear();
     }
 
     #[cfg(test)]

--- a/network/framework/src/application/tests.rs
+++ b/network/framework/src/application/tests.rs
@@ -10,8 +10,8 @@ use crate::{
         storage::PeersAndMetadata,
     },
     peer_manager::{
-        ConnectionNotification, ConnectionRequestSender, PeerManagerNotification,
-        PeerManagerRequest, PeerManagerRequestSender,
+        ConnectionRequestSender, PeerManagerNotification, PeerManagerRequest,
+        PeerManagerRequestSender,
     },
     protocols::{
         network::{Event, NetworkEvents, NetworkSender, NewNetworkEvents, NewNetworkSender},
@@ -39,7 +39,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tokio::{sync::mpsc::error::TryRecvError, time::timeout};
+use tokio::time::timeout;
 
 // Useful test constants for timeouts
 const MAX_CHANNEL_TIMEOUT_SECS: u64 = 1;
@@ -425,110 +425,6 @@ fn test_peers_and_metadata_caching() {
         PeerSet::new(),
         expected_peers_and_metadata.clone(),
     );
-}
-
-#[tokio::test]
-async fn test_peers_and_metadata_subscriptions() {
-    // Create the peers and metadata container
-    let network_ids = vec![NetworkId::Validator, NetworkId::Vfn];
-    let peers_and_metadata = PeersAndMetadata::new(&network_ids);
-
-    let mut connection_events = peers_and_metadata.subscribe();
-
-    match connection_events.try_recv() {
-        Ok(unwanted_event) => {
-            panic!(
-                "connection_events should be empty but got {:?}",
-                unwanted_event,
-            )
-        },
-        Err(tre) => match tre {
-            TryRecvError::Empty => {
-                // ok
-            },
-            TryRecvError::Disconnected => {
-                panic!("connection_events disconnected early")
-            },
-        },
-    }
-
-    let (peer_network_id_1, connection_1) = create_peer_and_connection(
-        NetworkId::Validator,
-        vec![ProtocolId::MempoolDirectSend, ProtocolId::StorageServiceRpc],
-        peers_and_metadata.clone(),
-    );
-    match tokio::time::timeout(Duration::from_secs(1), connection_events.recv()).await {
-        Ok(msg) => match msg {
-            None => {
-                panic!("no pending connection event")
-            },
-            Some(notif) => match notif {
-                ConnectionNotification::NewPeer(conn_meta, network_id) => {
-                    assert_eq!(network_id, NetworkId::Validator);
-                    assert_eq!(conn_meta, connection_1);
-                },
-                ConnectionNotification::LostPeer(_, _) => {
-                    panic!("should get connect but got lost")
-                },
-            },
-        },
-        Err(te) => {
-            panic!("timeout waiting for connection event: {:?}", te);
-        },
-    }
-
-    // new subscripton should immediately get notified of existing connection
-    let mut sub2 = peers_and_metadata.subscribe();
-    match sub2.try_recv() {
-        Ok(notif) => match notif {
-            ConnectionNotification::NewPeer(conn_meta, network_id) => {
-                assert_eq!(network_id, NetworkId::Validator);
-                assert_eq!(conn_meta, connection_1);
-            },
-            ConnectionNotification::LostPeer(_, _) => {
-                panic!("should get connect but got lost");
-            },
-        },
-        Err(_) => {
-            panic!("should have pending NewPeer");
-        },
-    }
-    // but not more than that
-    match sub2.try_recv() {
-        Ok(unwanted_event) => {
-            panic!(
-                "connection_events should be empty but got {:?}",
-                unwanted_event,
-            )
-        },
-        Err(tre) => match tre {
-            TryRecvError::Empty => {
-                // ok
-            },
-            TryRecvError::Disconnected => {
-                panic!("connection_events disconnected early")
-            },
-        },
-    }
-    sub2.close();
-
-    peers_and_metadata
-        .remove_peer_metadata(peer_network_id_1, connection_1.connection_id)
-        .unwrap();
-    match connection_events.try_recv() {
-        Ok(notif) => match notif {
-            ConnectionNotification::NewPeer(_, _) => {
-                panic!("expecting lost but got new")
-            },
-            ConnectionNotification::LostPeer(conn_meta, network_id) => {
-                assert_eq!(network_id, NetworkId::Validator);
-                assert_eq!(conn_meta, connection_1);
-            },
-        },
-        Err(_tre) => {
-            panic!("no pending connection event")
-        },
-    }
 }
 
 #[test]
@@ -1018,13 +914,15 @@ fn create_network_sender_and_events(
         let (inbound_request_sender, inbound_request_receiver) = create_aptos_channel();
         let (outbound_request_sender, outbound_request_receiver) = create_aptos_channel();
         let (connection_outbound_sender, _connection_outbound_receiver) = create_aptos_channel();
+        let (_connection_inbound_sender, connection_inbound_receiver) = create_aptos_channel();
 
         // Create the network sender and events
         let network_sender = NetworkSender::new(
             PeerManagerRequestSender::new(outbound_request_sender),
             ConnectionRequestSender::new(connection_outbound_sender),
         );
-        let network_events = NetworkEvents::new(inbound_request_receiver, None);
+        let network_events =
+            NetworkEvents::new(inbound_request_receiver, connection_inbound_receiver, None);
 
         // Save the sender, events and receivers
         network_senders.insert(*network_id, network_sender);
@@ -1244,6 +1142,7 @@ async fn wait_for_network_event(
                 assert_eq!(dummy_message, expected_dummy_message);
                 assert_eq!(Some(protocol_id), expected_rpc_protocol_id);
             },
+            _ => panic!("Invalid dummy event found: {:?}", dummy_event),
         },
         Err(elapsed) => panic!(
             "Timed out while waiting to receive a message on the network events receiver. Elapsed: {:?}",

--- a/network/framework/src/connectivity_manager/mod.rs
+++ b/network/framework/src/connectivity_manager/mod.rs
@@ -1006,7 +1006,7 @@ where
             "Connection notification"
         );
         match notif {
-            peer_manager::ConnectionNotification::NewPeer(metadata, _network_id) => {
+            peer_manager::ConnectionNotification::NewPeer(metadata, _context) => {
                 let peer_id = metadata.remote_peer_id;
                 counters::peer_connected(&self.network_context, &peer_id, 1);
                 self.connected.insert(peer_id, metadata);
@@ -1015,7 +1015,7 @@ where
                 self.dial_states.remove(&peer_id);
                 self.dial_queue.remove(&peer_id);
             },
-            peer_manager::ConnectionNotification::LostPeer(metadata, _network_id) => {
+            peer_manager::ConnectionNotification::LostPeer(metadata, _context, _reason) => {
                 let peer_id = metadata.remote_peer_id;
                 if let Some(stored_metadata) = self.connected.get(&peer_id) {
                     // Remove node from connected peers list.

--- a/network/framework/src/peer_manager/builder.rs
+++ b/network/framework/src/peer_manager/builder.rs
@@ -417,7 +417,10 @@ impl PeerManagerBuilder {
     pub fn add_service(
         &mut self,
         config: &NetworkServiceConfig,
-    ) -> aptos_channel::Receiver<(PeerId, ProtocolId), PeerManagerNotification> {
+    ) -> (
+        aptos_channel::Receiver<(PeerId, ProtocolId), PeerManagerNotification>,
+        conn_notifs_channel::Receiver,
+    ) {
         // Register the direct send and rpc protocols
         self.transport_context()
             .add_protocols(&config.direct_send_protocols_and_preferences);
@@ -434,7 +437,8 @@ impl PeerManagerBuilder {
         {
             pm_context.add_upstream_handler(*protocol, network_notifs_tx.clone());
         }
+        let connection_notifs_rx = pm_context.add_connection_event_listener();
 
-        network_notifs_rx
+        (network_notifs_rx, connection_notifs_rx)
     }
 }

--- a/network/framework/src/peer_manager/mod.rs
+++ b/network/framework/src/peer_manager/mod.rs
@@ -325,7 +325,8 @@ where
                 if !self.active_peers.contains_key(&peer_id) {
                     let notif = ConnectionNotification::LostPeer(
                         lost_conn_metadata,
-                        self.network_context.network_id(),
+                        self.network_context,
+                        reason,
                     );
                     self.send_conn_notification(peer_id, notif);
                 }
@@ -686,8 +687,7 @@ where
         )?;
         // Send NewPeer notification to connection event handlers.
         if send_new_peer_notification {
-            let notif =
-                ConnectionNotification::NewPeer(conn_meta, self.network_context.network_id());
+            let notif = ConnectionNotification::NewPeer(conn_meta, self.network_context);
             self.send_conn_notification(peer_id, notif);
         }
 

--- a/network/framework/src/peer_manager/tests.rs
+++ b/network/framework/src/peer_manager/tests.rs
@@ -645,7 +645,10 @@ fn test_dial_disconnect() {
 
         // Expect LostPeer notification from PeerManager.
         let conn_notif = conn_status_rx.next().await.unwrap();
-        assert!(matches!(conn_notif, ConnectionNotification::LostPeer(_, _)));
+        assert!(matches!(
+            conn_notif,
+            ConnectionNotification::LostPeer(_, _, _)
+        ));
 
         // Sender of disconnect request should receive acknowledgement once connection is closed.
         disconnect_resp_rx.await.unwrap().unwrap();

--- a/network/framework/src/peer_manager/types.rs
+++ b/network/framework/src/peer_manager/types.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     transport::{Connection, ConnectionMetadata},
 };
-use aptos_config::network_id::NetworkId;
+use aptos_config::network_id::NetworkContext;
 use aptos_types::{network_address::NetworkAddress, PeerId};
 use futures::channel::oneshot;
 use serde::Serialize;
@@ -60,9 +60,9 @@ pub enum ConnectionRequest {
 #[derive(Clone, PartialEq, Eq, Serialize)]
 pub enum ConnectionNotification {
     /// Connection with a new peer has been established.
-    NewPeer(ConnectionMetadata, NetworkId),
+    NewPeer(ConnectionMetadata, NetworkContext),
     /// Connection to a peer has been terminated. This could have been triggered from either end.
-    LostPeer(ConnectionMetadata, NetworkId),
+    LostPeer(ConnectionMetadata, NetworkContext, DisconnectReason),
 }
 
 impl fmt::Debug for ConnectionNotification {
@@ -74,11 +74,11 @@ impl fmt::Debug for ConnectionNotification {
 impl fmt::Display for ConnectionNotification {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ConnectionNotification::NewPeer(metadata, network_id) => {
-                write!(f, "[{},{}]", metadata, network_id)
+            ConnectionNotification::NewPeer(metadata, context) => {
+                write!(f, "[{},{}]", metadata, context)
             },
-            ConnectionNotification::LostPeer(metadata, network_id) => {
-                write!(f, "[{},{}]", metadata, network_id)
+            ConnectionNotification::LostPeer(metadata, context, reason) => {
+                write!(f, "[{},{},{}]", metadata, context, reason)
             },
         }
     }

--- a/network/framework/src/protocols/health_checker/interface.rs
+++ b/network/framework/src/protocols/health_checker/interface.rs
@@ -3,10 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    application::{
-        error::Error, interface::NetworkClientInterface, metadata::ConnectionState,
-        storage::PeersAndMetadata,
-    },
+    application::{error::Error, interface::NetworkClientInterface, metadata::ConnectionState},
     protocols::{
         health_checker::{HealthCheckerMsg, HealthCheckerNetworkEvents},
         network::Event,
@@ -19,7 +16,6 @@ use futures::{stream::FusedStream, Stream};
 use std::{
     collections::HashMap,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -136,10 +132,6 @@ impl<NetworkClient: NetworkClientInterface<HealthCheckerMsg>>
             .read()
             .get(&peer_id)
             .map(|health_check_data| health_check_data.failures)
-    }
-
-    pub fn get_peers_and_metadata(&self) -> Arc<PeersAndMetadata> {
-        self.network_client.get_peers_and_metadata()
     }
 
     // TODO: we shouldn't need to expose this

--- a/network/framework/src/protocols/health_checker/mod.rs
+++ b/network/framework/src/protocols/health_checker/mod.rs
@@ -23,7 +23,6 @@ use crate::{
     constants::NETWORK_CHANNEL_SIZE,
     counters,
     logging::NetworkSchema,
-    peer_manager::ConnectionNotification,
     protocols::{
         health_checker::interface::HealthCheckNetworkInterface,
         network::{
@@ -110,9 +109,6 @@ pub struct HealthChecker<NetworkClient> {
     ping_failures_tolerated: u64,
     /// Counter incremented in each round of health checks
     round: u64,
-
-    /// This should normally be None and is only used in testing to inject test events.
-    connection_events_injection: Option<tokio::sync::mpsc::Receiver<ConnectionNotification>>,
 }
 
 impl<NetworkClient: NetworkClientInterface<HealthCheckerMsg> + Unpin> HealthChecker<NetworkClient> {
@@ -134,20 +130,9 @@ impl<NetworkClient: NetworkClientInterface<HealthCheckerMsg> + Unpin> HealthChec
             ping_timeout,
             ping_failures_tolerated,
             round: 0,
-            connection_events_injection: None,
         }
     }
 
-    #[cfg(test)]
-    /// Set source of mock connection events for testing.
-    pub fn set_connection_source(
-        &mut self,
-        connection_events: tokio::sync::mpsc::Receiver<ConnectionNotification>,
-    ) {
-        self.connection_events_injection = Some(connection_events);
-    }
-
-    /// testing_connection_events should be None except in unit test code
     pub async fn start(mut self) {
         let mut tick_handlers = FuturesUnordered::new();
         info!(
@@ -157,13 +142,6 @@ impl<NetworkClient: NetworkClientInterface<HealthCheckerMsg> + Unpin> HealthChec
 
         let ticker = self.time_service.interval(self.ping_interval);
         tokio::pin!(ticker);
-
-        let connection_events = self
-            .connection_events_injection
-            .take()
-            .unwrap_or_else(|| self.network_interface.get_peers_and_metadata().subscribe());
-        let mut connection_events =
-            tokio_stream::wrappers::ReceiverStream::new(connection_events).fuse();
 
         loop {
             futures::select! {
@@ -176,6 +154,16 @@ impl<NetworkClient: NetworkClientInterface<HealthCheckerMsg> + Unpin> HealthChec
                     };
 
                     match event {
+                        Event::NewPeer(metadata) => {
+                            self.network_interface.create_peer_and_health_data(
+                                metadata.remote_peer_id, self.round
+                            );
+                        }
+                        Event::LostPeer(metadata) => {
+                            self.network_interface.remove_peer_and_health_data(
+                                &metadata.remote_peer_id
+                            );
+                        }
                         Event::RpcRequest(peer_id, msg, protocol, res_tx) => {
                             match msg {
                                 HealthCheckerMsg::Ping(ping) => self.handle_ping_request(peer_id, ping, protocol, res_tx),
@@ -202,20 +190,6 @@ impl<NetworkClient: NetworkClientInterface<HealthCheckerMsg> + Unpin> HealthChec
                                 msg,
                             );
                             debug_assert!(false, "Unexpected network event");
-                        }
-                    }
-                }
-                conn_event = connection_events.select_next_some() => {
-                    match conn_event {
-                        ConnectionNotification::NewPeer(metadata, _network_id) => {
-                            self.network_interface.create_peer_and_health_data(
-                                metadata.remote_peer_id, self.round
-                            );
-                        }
-                        ConnectionNotification::LostPeer(metadata, _network_id) => {
-                            self.network_interface.remove_peer_and_health_data(
-                                &metadata.remote_peer_id
-                            );
                         }
                     }
                 }

--- a/network/framework/src/protocols/health_checker/test.rs
+++ b/network/framework/src/protocols/health_checker/test.rs
@@ -6,8 +6,8 @@ use super::*;
 use crate::{
     application::{interface::NetworkClient, storage::PeersAndMetadata},
     peer_manager::{
-        self, ConnectionRequest, ConnectionRequestSender, PeerManagerNotification,
-        PeerManagerRequest, PeerManagerRequestSender,
+        self, conn_notifs_channel, ConnectionRequest, ConnectionRequestSender,
+        PeerManagerNotification, PeerManagerRequest, PeerManagerRequestSender,
     },
     protocols::{
         network::{NetworkSender, NewNetworkEvents, NewNetworkSender},
@@ -31,7 +31,7 @@ struct TestHarness {
     peer_mgr_reqs_rx: aptos_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>,
     peer_mgr_notifs_tx: aptos_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>,
     connection_reqs_rx: aptos_channel::Receiver<PeerId, ConnectionRequest>,
-    connection_notifs_tx: tokio::sync::mpsc::Sender<ConnectionNotification>,
+    connection_notifs_tx: conn_notifs_channel::Sender,
     peers_and_metadata: Arc<PeersAndMetadata>,
 }
 
@@ -47,13 +47,14 @@ impl TestHarness {
             aptos_channel::new(QueueStyle::FIFO, 1, None);
         let (peer_mgr_notifs_tx, peer_mgr_notifs_rx) =
             aptos_channel::new(QueueStyle::FIFO, 1, None);
-        let (connection_notifs_tx, connection_notifs_rx) = tokio::sync::mpsc::channel(10);
+        let (connection_notifs_tx, connection_notifs_rx) = conn_notifs_channel::new();
 
         let network_sender = NetworkSender::new(
             PeerManagerRequestSender::new(peer_mgr_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
         );
-        let hc_network_rx = HealthCheckerNetworkEvents::new(peer_mgr_notifs_rx, None);
+        let hc_network_rx =
+            HealthCheckerNetworkEvents::new(peer_mgr_notifs_rx, connection_notifs_rx, None);
 
         let network_context = NetworkContext::mock();
         let peers_and_metadata = PeersAndMetadata::new(&[network_context.network_id()]);
@@ -64,7 +65,7 @@ impl TestHarness {
             peers_and_metadata.clone(),
         );
 
-        let mut health_checker = HealthChecker::new(
+        let health_checker = HealthChecker::new(
             network_context,
             mock_time.clone(),
             HealthCheckNetworkInterface::new(network_client, hc_network_rx),
@@ -72,7 +73,6 @@ impl TestHarness {
             PING_TIMEOUT,
             ping_failures_tolerated,
         );
-        health_checker.set_connection_source(connection_notifs_rx);
 
         (
             Self {
@@ -165,15 +165,16 @@ impl TestHarness {
     }
 
     async fn send_new_peer_notification(&mut self, peer_id: PeerId) {
+        let (delivered_tx, delivered_rx) = oneshot::channel();
         let network_context = NetworkContext::mock();
         let notif = peer_manager::ConnectionNotification::NewPeer(
             ConnectionMetadata::mock(peer_id),
-            network_context.network_id(),
+            network_context,
         );
-        self.connection_notifs_tx.send(notif).await.unwrap();
-
-        // hacky `yield` to let thread on other side run, fast enough to make the test not suck, long enough it should almost always work
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        self.connection_notifs_tx
+            .push_with_feedback(peer_id, notif, Some(delivered_tx))
+            .unwrap();
+        delivered_rx.await.unwrap();
 
         // Insert a new connection metadata into the peers and metadata
         let mut connection_metadata = ConnectionMetadata::mock(peer_id);

--- a/peer-monitoring-service/server/src/tests.rs
+++ b/peer-monitoring-service/server/src/tests.rs
@@ -505,8 +505,13 @@ impl MockClient {
             .queue_style(QueueStyle::FIFO)
             .counters(&metrics::PENDING_PEER_MONITORING_SERVER_NETWORK_EVENTS);
             let (peer_manager_notifier, peer_manager_notification_receiver) = queue_cfg.build();
+            let (_, connection_notification_receiver) = queue_cfg.build();
 
-            let network_events = NetworkEvents::new(peer_manager_notification_receiver, None);
+            let network_events = NetworkEvents::new(
+                peer_manager_notification_receiver,
+                connection_notification_receiver,
+                None,
+            );
             network_and_events.insert(network_id, network_events);
             peer_manager_notifiers.insert(network_id, peer_manager_notifier);
         }

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -97,8 +97,13 @@ impl MockClient {
             .queue_style(QueueStyle::FIFO)
             .counters(&metrics::PENDING_STORAGE_SERVER_NETWORK_EVENTS);
             let (peer_manager_notifier, peer_manager_notification_receiver) = queue_cfg.build();
+            let (_, connection_notification_receiver) = queue_cfg.build();
 
-            let network_events = NetworkEvents::new(peer_manager_notification_receiver, None);
+            let network_events = NetworkEvents::new(
+                peer_manager_notification_receiver,
+                connection_notification_receiver,
+                None,
+            );
             network_and_events.insert(network_id, network_events);
             peer_manager_notifiers.insert(network_id, peer_manager_notifier);
         }


### PR DESCRIPTION
This reverts commit f5de7609d50860e42b4b2dcd72e968cd6c57071e.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
