### PR TITLE
[forge] remove latency breakdown thresholds from haproxy test

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1949,6 +1949,35 @@ fn realistic_env_max_load_test(
     let duration_secs = duration.as_secs();
     let long_running = duration_secs >= 2400;
 
+    let mut success_criteria = SuccessCriteria::new(95)
+        .add_no_restarts()
+        .add_wait_for_catchup_s(
+            // Give at least 60s for catchup, give 10% of the run for longer durations.
+            (duration.as_secs() / 10).max(60),
+        )
+        .add_latency_threshold(3.4, LatencyType::P50)
+        .add_latency_threshold(4.5, LatencyType::P90)
+        .add_chain_progress(StateProgressThreshold {
+            max_no_progress_secs: 15.0,
+            max_round_gap: 4,
+        });
+    if !ha_proxy {
+        success_criteria = success_criteria.add_latency_breakdown_threshold(
+            LatencyBreakdownThreshold::new_with_breach_pct(
+                vec![
+                    (LatencyBreakdownSlice::QsBatchToPos, 0.35),
+                    // only reaches close to threshold during epoch change
+                    (LatencyBreakdownSlice::QsPosToProposal, 0.6),
+                    // can be adjusted down if less backpressure
+                    (LatencyBreakdownSlice::ConsensusProposalToOrdered, 0.85),
+                    // can be adjusted down if less backpressure
+                    (LatencyBreakdownSlice::ConsensusOrderedToCommit, 0.75),
+                ],
+                5,
+            ),
+        )
+    }
+
     // Create the test
     ForgeConfig::default()
         .with_initial_validator_count(NonZeroUsize::new(num_validators).unwrap())
@@ -1989,38 +2018,7 @@ fn realistic_env_max_load_test(
                 .gas_price(5 * aptos_global_constants::GAS_UNIT_PRICE)
                 .latency_polling_interval(Duration::from_millis(100)),
         )
-        .with_success_criteria(
-            SuccessCriteria::new(95)
-                .add_no_restarts()
-                .add_wait_for_catchup_s(
-                    // Give at least 60s for catchup, give 10% of the run for longer durations.
-                    (duration.as_secs() / 10).max(60),
-                )
-                .add_latency_threshold(3.4, LatencyType::P50)
-                .add_latency_threshold(4.5, LatencyType::P90)
-                .add_latency_breakdown_threshold(LatencyBreakdownThreshold::new_with_breach_pct(
-                    vec![
-                        (LatencyBreakdownSlice::QsBatchToPos, 0.35),
-                        // only reaches close to threshold during epoch change
-                        (
-                            LatencyBreakdownSlice::QsPosToProposal,
-                            if ha_proxy { 0.7 } else { 0.6 },
-                        ),
-                        // can be adjusted down if less backpressure
-                        (LatencyBreakdownSlice::ConsensusProposalToOrdered, 0.85),
-                        // can be adjusted down if less backpressure
-                        (
-                            LatencyBreakdownSlice::ConsensusOrderedToCommit,
-                            if ha_proxy { 1.3 } else { 0.75 },
-                        ),
-                    ],
-                    5,
-                ))
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 15.0,
-                    max_round_gap: 4,
-                }),
-        )
+        .with_success_criteria(success_criteria)
 }
 
 fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {


### PR DESCRIPTION
## Description
The haproxy test runs in a completely different network topology (effectively all close to each other). It doesn't seem to make sense to have detailed thresholds in this environment, and to spend time investigating threshold violations.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Run forge.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
