### PR TITLE
flatten json log fields in indexer logs.

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-server-framework/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-server-framework/src/lib.rs
@@ -166,6 +166,7 @@ pub fn setup_logging(make_writer: Option<Box<dyn Fn() -> Box<dyn std::io::Write>
 
     let subscriber = tracing_subscriber::fmt()
         .json()
+        .flatten_event(true)
         .with_file(true)
         .with_line_number(true)
         .with_thread_ids(true)


### PR DESCRIPTION
This will change emitted logs from:
`{ .... fields: { foo: "bar", bla: "baz" } }`
to
`{ foo: "bar", bla: "baz" }`

i.e. it will put all "fields" emitted into the root of the json object. We do more or less the same in api-gateway and kind of the rest of aptos-core which makes querying emitted logs a bit easier/intuitive as you don't need to prefix every single query field with `fields.` when querying.

### remark
If we have any humio dashboards that use `fields.` in their query, they probably need adjustment.