### PR TITLE
[Indexer gRPC] Data Service Live Mode

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -153,7 +153,11 @@ impl RawData for RawDataServerWrapper {
         let current_version = match &request.starting_version {
             Some(version) => *version,
             // Live mode if starting version isn't specified
-            None => (self.in_memory_cache.latest_version().await - 1).max(0), // Smallest version is 0 (genesis)
+            None => self
+                .in_memory_cache
+                .latest_version()
+                .await
+                .saturating_sub(1),
         };
 
         let file_store_operator: Box<dyn FileStoreOperator> = self.file_store_config.create();

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -152,9 +152,8 @@ impl RawData for RawDataServerWrapper {
         let (tx, rx) = channel(self.data_service_response_channel_size);
         let current_version = match &request.starting_version {
             Some(version) => *version,
-            None => {
-                return Result::Err(Status::aborted("Starting version is not set"));
-            },
+            // Live mode if starting version isn't specified
+            None => (self.in_memory_cache.latest_version().await - 1).max(0), // Smallest version is 0 (genesis)
         };
 
         let file_store_operator: Box<dyn FileStoreOperator> = self.file_store_config.create();

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/in_memory_cache.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/in_memory_cache.rs
@@ -80,7 +80,7 @@ impl InMemoryCache {
         })
     }
 
-    async fn latest_version(&self) -> u64 {
+    pub async fn latest_version(&self) -> u64 {
         self.cache_metadata.read().await.latest_version
     }
 


### PR DESCRIPTION
## Description
For the data service, Instead of returning an error when not specifying a starting version, we just start from the latest transaction (live mode). We get the latest version from the in-memory cache. 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
<img width="819" alt="image" src="https://github.com/aptos-labs/aptos-core/assets/37165464/bc761239-173d-4257-a6b8-3088b7b373de">

Data is live!

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
