### PR TITLE
Fix #13242 by cleaning up error messages about `#[view]` function parameters

### DIFF
--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/bad_parameter.exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/bad_parameter.exp
@@ -3,7 +3,7 @@ processed 2 tasks
 task 1 'publish'. lines 4-10:
 Error: extended checks failed:
 
-error: `init_module` function can only take signers as parameters
+error: `init_module` function can only take values of type `signer` or `&signer` as parameters
   ┌─ TEMPFILE:6:16
   │
 6 │     public fun init_module(value: u64): u64 { value }
@@ -21,16 +21,10 @@ error: `init_module` function must be private
 6 │     public fun init_module(value: u64): u64 { value }
   │                ^^^^^^^^^^^
 
-error: type `&mut signer` is not supported as a parameter type
-  ┌─ TEMPFILE:8:9
+error: type `&mut signer` is not supported as a transaction parameter type
+  ┌─ TEMPFILE:8:14
   │
 8 │     fun view(_:&mut signer,value: u64): u64 { value }
-  │         ^^^^
-
-error: view function cannot use `signer` parameter
-  ┌─ TEMPFILE:8:9
-  │
-8 │     fun view(_:&mut signer,value: u64): u64 { value }
-  │         ^^^^
+  │              ^
 
 

--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/bad_parameter.v2_exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/bad_parameter.v2_exp
@@ -1,0 +1,30 @@
+processed 2 tasks
+
+task 1 'publish'. lines 4-10:
+Error: extended checks failed:
+
+error: `init_module` function can only take values of type `signer` or `&signer` as parameters
+  ┌─ TEMPFILE:6:16
+  │
+6 │     public fun init_module(value: u64): u64 { value }
+  │                ^^^^^^^^^^^
+
+error: `init_module` function cannot return values
+  ┌─ TEMPFILE:6:16
+  │
+6 │     public fun init_module(value: u64): u64 { value }
+  │                ^^^^^^^^^^^
+
+error: `init_module` function must be private
+  ┌─ TEMPFILE:6:16
+  │
+6 │     public fun init_module(value: u64): u64 { value }
+  │                ^^^^^^^^^^^
+
+error: type `&mut signer` is not supported as a transaction parameter type
+  ┌─ TEMPFILE:8:14
+  │
+8 │     fun view(_:&mut signer,value: u64): u64 { value }
+  │              ^
+
+

--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/randomness_safety.v2_exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/randomness_safety.v2_exp
@@ -1,0 +1,18 @@
+processed 3 tasks
+
+task 2 'publish'. lines 19-43:
+Error: extended checks failed:
+
+error: public function exposes functionality of the `randomness` module which can be unsafe. Consult the randomness documentation for an explanation of this error. To skip this check, add attribute `#[lint::allow_unsafe_randomness]`.
+   ┌─ TEMPFILE1:23:16
+   │
+23 │     public fun randomness_error(): u8 {
+   │                ^^^^^^^^^^^^^^^^
+
+error: entry function calling randomness features must use the `#[randomness]` attribute.
+   ┌─ TEMPFILE1:36:30
+   │
+36 │     public(friend) entry fun missing_randomness_attribute(_s: &signer) {
+   │                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+

--- a/aptos-move/aptos-transactional-test-harness/tests/v2-tests/bad_parameter.exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/v2-tests/bad_parameter.exp
@@ -3,7 +3,7 @@ processed 2 tasks
 task 1 'publish'. lines 4-10:
 Error: extended checks failed:
 
-error: `init_module` function can only take signers as parameters
+error: `init_module` function can only take values of type `signer` or `&signer` as parameters
   ┌─ TEMPFILE:6:16
   │
 6 │     public fun init_module(value: u64): u64 { value }
@@ -21,16 +21,10 @@ error: `init_module` function must be private
 6 │     public fun init_module(value: u64): u64 { value }
   │                ^^^^^^^^^^^
 
-error: type `&mut signer` is not supported as a parameter type
-  ┌─ TEMPFILE:8:9
+error: type `&mut signer` is not supported as a transaction parameter type
+  ┌─ TEMPFILE:8:14
   │
 8 │     fun view(_:&mut signer,value: u64): u64 { value }
-  │         ^^^^
-
-error: view function cannot use `signer` parameter
-  ┌─ TEMPFILE:8:9
-  │
-8 │     fun view(_:&mut signer,value: u64): u64 { value }
-  │         ^^^^
+  │              ^
 
 

--- a/aptos-move/framework/src/extended_checks.rs
+++ b/aptos-move/framework/src/extended_checks.rs
@@ -156,7 +156,7 @@ impl<'a> ExtendedChecker<'a> {
                 if !ok {
                     self.env.error(
                         &fun.get_id_loc(),
-                        "`init_module` function can only take signers as parameters",
+                        "`init_module` function can only take `signer` values and immutable references as parameters",
                     );
                 }
             }
@@ -185,7 +185,7 @@ impl<'a> ExtendedChecker<'a> {
                 continue;
             }
 
-            self.check_transaction_args(&fun.get_id_loc(), &fun.get_parameter_types());
+            self.check_transaction_args(&fun.get_id_loc(), &fun.get_parameters());
             if fun.get_return_count() > 0 {
                 self.env
                     .error(&fun.get_id_loc(), "entry function cannot return values")
@@ -193,9 +193,9 @@ impl<'a> ExtendedChecker<'a> {
         }
     }
 
-    fn check_transaction_args(&self, loc: &Loc, arg_tys: &[Type]) {
-        for ty in arg_tys {
-            self.check_transaction_input_type(loc, ty)
+    fn check_transaction_args(&self, _loc: &Loc, arg_tys: &[Parameter]) {
+        for Parameter(_sym, ty, param_loc) in arg_tys {
+            self.check_transaction_input_type(param_loc, ty)
         }
     }
 
@@ -222,7 +222,7 @@ impl<'a> ExtendedChecker<'a> {
                 self.env.error(
                     loc,
                     &format!(
-                        "type `{}` is not supported as a parameter type",
+                        "type `{}` is not supported as an transaction parameter type",
                         ty.display(&self.env.get_type_display_ctx())
                     ),
                 );
@@ -651,35 +651,39 @@ impl<'a> ExtendedChecker<'a> {
             if !self.has_attribute(fun, VIEW_FUN_ATTRIBUTE) {
                 continue;
             }
-            self.check_transaction_args(&fun.get_id_loc(), &fun.get_parameter_types());
+            self.check_transaction_args(&fun.get_id_loc(), &fun.get_parameters());
             if fun.get_return_count() == 0 {
                 self.env
-                    .error(&fun.get_id_loc(), "view function must return values")
+                    .error(&fun.get_id_loc(), "`#[view]` function must return values")
             }
 
-            fun.get_parameter_types()
+            fun.get_parameters()
                 .iter()
-                .for_each(|parameter_type| match parameter_type {
-                    Type::Primitive(inner) => {
-                        if inner == &PrimitiveType::Signer {
-                            self.env.error(
-                                &fun.get_id_loc(),
-                                "view function cannot use a `signer` parameter",
-                            )
-                        }
-                    },
-                    Type::Reference(_, inner) => {
-                        if let Type::Primitive(inner) = inner.as_ref() {
+                .for_each(
+                    |Parameter(_sym, parameter_type, param_loc)| match parameter_type {
+                        Type::Primitive(inner) => {
                             if inner == &PrimitiveType::Signer {
                                 self.env.error(
-                                    &fun.get_id_loc(),
-                                    "view function cannot use `signer` parameter",
+                                    param_loc,
+                                    "`#[view]` function cannot use a `signer` parameter",
                                 )
                             }
-                        }
+                        },
+                        Type::Reference(mutability, inner) => {
+                            if let Type::Primitive(inner) = inner.as_ref() {
+                                if inner == &PrimitiveType::Signer
+                                    && mutability == &ReferenceKind::Immutable
+                                {
+                                    self.env.error(
+                                        param_loc,
+                                        "`#[view]` function cannot use the `&signer` parameter",
+                                    )
+                                }
+                            }
+                        },
+                        _ => (),
                     },
-                    _ => (),
-                });
+                );
 
             // Remember the runtime info that this is a view function
             let module_id = self.get_runtime_module_id(module);


### PR DESCRIPTION
## Description

Clean up error messages about `#[view]` function parameters.

See #13242 for old error messages.

New test output looks like:
```
error: `#[view]` function must return values
  ┌─ /var/folders/hx/_s_6fyh529bgmvl6z4m8m9fm0000gn/T/.tmpTfNXod/sources/m.move:4:17
  │
4 │             fun view(_value: u64) { }
  │                 ^^^^

test tests::attributes::test_view_attribute_on_non_view - should panic ... ok
test tests::attributes::test_view_attribute ... ok
BUILDING Package
error: type `&mut signer` is not supported as a transaction parameter type
  ┌─ /var/folders/hx/_s_6fyh529bgmvl6z4m8m9fm0000gn/T/.tmpFo5Hs8/sources/m.move:4:22
  │
4 │             fun view(_:&mut signer,value: u64): u64 { value }
  │                      ^

test tests::aggregator_v2_events::test_events_with_snapshots_not_emitted_on_abort::_2_expects ... ok
test tests::attributes::test_view_attribute_with_mut_ref_signer - should panic ... ok
BUILDING Package
error: `#[view]` function cannot use the `&signer` parameter
  ┌─ /var/folders/hx/_s_6fyh529bgmvl6z4m8m9fm0000gn/T/.tmpv6fPE1/sources/m.move:4:22
  │
4 │             fun view(_:&signer,value: u64): u64 { value }
  │                      ^

test tests::attributes::test_view_attribute_with_ref_signer - should panic ... ok
BUILDING Package
error: `#[view]` function cannot use the `signer` parameter
  ┌─ /var/folders/hx/_s_6fyh529bgmvl6z4m8m9fm0000gn/T/.tmpwicG9I/sources/m.move:4:22
  │
4 │             fun view(_:signer,value: u64): u64 { value }
  │                      ^

test tests::attributes::test_view_attribute_with_signer - should panic ... ok

```

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
CI tests + some manual testing.

## Key Areas to Review
Is there any potential impact on other cases not tested?

