### PR TITLE
[Feature #13378] Implement overriding on-chain config for exe benchmark

### DIFF
--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -31,6 +31,7 @@ use std::{
     path::PathBuf,
     time::{SystemTime, UNIX_EPOCH},
 };
+use aptos_types::on_chain_config::FeatureFlag;
 
 #[cfg(unix)]
 #[global_allocator]
@@ -324,6 +325,20 @@ enum Command {
 
         #[clap(long, value_parser)]
         checkpoint_dir: PathBuf,
+
+        #[clap(
+            long,
+            num_args=1..,
+            value_delimiter = ' ',
+            help = "Custom enabling/disabling of the feature flags in the Move source. Disabling is stronger than enabling")]
+        enable_feature: Vec<FeatureFlag>,
+
+        #[clap(
+            long,
+            num_args=1..,
+            value_delimiter = ' ',
+            help = "Custom enabling/disabling of the feature flags in the Move source. Disabling is stronger than enabling")]
+        disable_feature: Vec<FeatureFlag>,
     },
     AddAccounts {
         #[clap(long, value_parser)]
@@ -371,7 +386,13 @@ where
             use_sender_account_pool,
             data_dir,
             checkpoint_dir,
+            enable_feature,
+            disable_feature,
         } => {
+            // setting custom feature flags
+            aptos_types::on_chain_config::enable_features(enable_feature);
+            aptos_types::on_chain_config::disable_features(disable_feature);
+
             let transaction_mix = if transaction_type.is_empty() {
                 None
             } else {

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use once_cell::sync::OnceCell;
 use crate::on_chain_config::OnChainConfig;
 use move_binary_format::{
     file_format_common,
@@ -12,9 +13,10 @@ use move_core_types::{
 };
 use serde::{Deserialize, Serialize};
 use strum_macros::FromRepr;
+use strum_macros::EnumString;
 
 /// The feature flags define in the Move source. This must stay aligned with the constants there.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, FromRepr)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, FromRepr, EnumString)]
 #[allow(non_camel_case_types)]
 pub enum FeatureFlag {
     CODE_DEPENDENCY_CHECK = 1,
@@ -146,6 +148,15 @@ impl FeatureFlag {
     }
 }
 
+static ENABLED_FEATURES: OnceCell<Vec<FeatureFlag>> = OnceCell::new();
+pub fn enable_features(enable_features: Vec<FeatureFlag>) {
+    ENABLED_FEATURES.set(enable_features).ok();
+}
+static DISABLED_FEATURES: OnceCell<Vec<FeatureFlag>> = OnceCell::new();
+pub fn disable_features(disable_features: Vec<FeatureFlag>) {
+    ENABLED_FEATURES.set(disable_features).ok();
+}
+
 /// Representation of features on chain as a bitset.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct Features {
@@ -161,6 +172,22 @@ impl Default for Features {
 
         for feature in FeatureFlag::default_features() {
             features.enable(feature);
+        }
+        match ENABLED_FEATURES.get() {
+            Some(enabled_features) => {
+                for feature in enabled_features.iter() {
+                    features.enable(*feature);
+                }
+            }
+            None => (),
+        }
+        match DISABLED_FEATURES.get() {
+            Some(disabled_features) => {
+                for feature in disabled_features.iter() {
+                    features.disable(*feature);
+                }
+            }
+            None => (),
         }
         features
     }


### PR DESCRIPTION
## Description
Enables overriding on-chain configs when running the executor benchmark command. If the command is to run execution either: 
--enable-feature=<FeatureFlag>.. or, 
--disable-feature=<FeatureFlag>..
can be specified to enable / disable features beyond the default options.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Other (Execution)

## How Has This Been Tested?
cargo run --profile performance -p aptos-executor-benchmark -- --enable-storage-sharding create-db --data-dir ~/workspace/db_dirs/db/ --num-accounts 1000

cargo run --profile performance -p aptos-executor-benchmark -- --block-size 50 --enable-storage-sharding --execution-threads 48 --connected-tx-grps 50 --generate-then-execute run-executor --enable-feature CODE_DEPENDENCY_CHECK MULTI_ED25519_PK_VALIDATE_V2_NATIVES --disable-feature CODE_DEPENDENCY_CHECK --data-dir ~/workspace/db_dirs/db/ --checkpoint-dir ~/workspace/db_dirs/chk --blocks 50 --main-signer-accounts 101


## Key Areas to Review

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
