### PR TITLE
[Executor Benchmark] Instrumentation to override 'on-chain' config (#13378)

### DIFF
--- a/crates/aptos-genesis/src/test_utils.rs
+++ b/crates/aptos-genesis/src/test_utils.rs
@@ -1,19 +1,21 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
 use crate::builder::InitGenesisConfigFn;
 use aptos_config::config::{IdentityBlob, NodeConfig};
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_temppath::TempPath;
-use rand::{rngs::StdRng, SeedableRng};
 use aptos_types::on_chain_config::Features;
+use rand::{rngs::StdRng, SeedableRng};
+use std::sync::Arc;
 
 pub fn test_config() -> (NodeConfig, Ed25519PrivateKey) {
     test_config_with_custom_onchain(None)
 }
 
-pub fn test_config_with_custom_features(init_features: Features) -> (NodeConfig, Ed25519PrivateKey) {
+pub fn test_config_with_custom_features(
+    init_features: Features,
+) -> (NodeConfig, Ed25519PrivateKey) {
     test_config_with_custom_onchain(Some(Arc::new(move |config| {
         config.initial_features_override = Some(init_features.clone());
     })))

--- a/crates/aptos-genesis/src/test_utils.rs
+++ b/crates/aptos-genesis/src/test_utils.rs
@@ -1,14 +1,22 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
 use crate::builder::InitGenesisConfigFn;
 use aptos_config::config::{IdentityBlob, NodeConfig};
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_temppath::TempPath;
 use rand::{rngs::StdRng, SeedableRng};
+use aptos_types::on_chain_config::Features;
 
 pub fn test_config() -> (NodeConfig, Ed25519PrivateKey) {
     test_config_with_custom_onchain(None)
+}
+
+pub fn test_config_with_custom_features(init_features: Features) -> (NodeConfig, Ed25519PrivateKey) {
+    test_config_with_custom_onchain(Some(Arc::new(move |config| {
+        config.initial_features_override = Some(init_features.clone());
+    })))
 }
 
 pub fn test_config_with_custom_onchain(

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -16,9 +16,9 @@ use aptos_executor::{
     db_bootstrapper::{generate_waypoint, maybe_bootstrap},
 };
 use aptos_storage_interface::DbReaderWriter;
+use aptos_types::on_chain_config::Features;
 use aptos_vm::AptosVM;
 use std::{fs, path::Path};
-use aptos_types::on_chain_config::Features;
 
 pub fn create_db_with_accounts<V>(
     num_accounts: usize,
@@ -62,8 +62,13 @@ pub fn create_db_with_accounts<V>(
     );
 }
 
-fn bootstrap_with_genesis(db_dir: impl AsRef<Path>, enable_storage_sharding: bool, init_features: Features) {
-    let (config, _genesis_key) = aptos_genesis::test_utils::test_config_with_custom_features(init_features);
+fn bootstrap_with_genesis(
+    db_dir: impl AsRef<Path>,
+    enable_storage_sharding: bool,
+    init_features: Features,
+) {
+    let (config, _genesis_key) =
+        aptos_genesis::test_utils::test_config_with_custom_features(init_features);
 
     let mut rocksdb_configs = RocksdbConfigs::default();
     rocksdb_configs.state_merkle_db_config.max_open_files = -1;

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -18,6 +18,7 @@ use aptos_executor::{
 use aptos_storage_interface::DbReaderWriter;
 use aptos_vm::AptosVM;
 use std::{fs, path::Path};
+use aptos_types::on_chain_config::Features;
 
 pub fn create_db_with_accounts<V>(
     num_accounts: usize,
@@ -28,6 +29,7 @@ pub fn create_db_with_accounts<V>(
     verify_sequence_numbers: bool,
     enable_storage_sharding: bool,
     pipeline_config: PipelineConfig,
+    init_features: Features,
 ) where
     V: TransactionBlockExecutor + 'static,
 {
@@ -39,7 +41,7 @@ pub fn create_db_with_accounts<V>(
     // create if not exists
     fs::create_dir_all(db_dir.as_ref()).unwrap();
 
-    bootstrap_with_genesis(&db_dir, enable_storage_sharding);
+    bootstrap_with_genesis(&db_dir, enable_storage_sharding, init_features.clone());
 
     println!(
         "Finished empty DB creation, DB dir: {}. Creating accounts now...",
@@ -56,11 +58,12 @@ pub fn create_db_with_accounts<V>(
         verify_sequence_numbers,
         enable_storage_sharding,
         pipeline_config,
+        init_features,
     );
 }
 
-fn bootstrap_with_genesis(db_dir: impl AsRef<Path>, enable_storage_sharding: bool) {
-    let (config, _genesis_key) = aptos_genesis::test_utils::test_config();
+fn bootstrap_with_genesis(db_dir: impl AsRef<Path>, enable_storage_sharding: bool, init_features: Features) {
+    let (config, _genesis_key) = aptos_genesis::test_utils::test_config_with_custom_features(init_features);
 
     let mut rocksdb_configs = RocksdbConfigs::default();
     rocksdb_configs.state_merkle_db_config.max_open_files = -1;

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -711,6 +711,7 @@ mod tests {
     use aptos_executor::block_executor::TransactionBlockExecutor;
     use aptos_temppath::TempPath;
     use aptos_transaction_generator_lib::{args::TransactionTypeArg, WorkflowProgress};
+    use aptos_types::on_chain_config::Features;
     use aptos_vm::AptosVM;
 
     fn test_generic_benchmark<E>(
@@ -736,6 +737,7 @@ mod tests {
             verify_sequence_numbers,
             false,
             PipelineConfig::default(),
+            Features::default(),
         );
 
         println!("run_benchmark");
@@ -757,6 +759,7 @@ mod tests {
             NO_OP_STORAGE_PRUNER_CONFIG,
             false,
             PipelineConfig::default(),
+            Features::default(),
         );
     }
 

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -108,6 +108,7 @@ pub fn run_benchmark<V>(
     pruner_config: PrunerConfig,
     enable_storage_sharding: bool,
     pipeline_config: PipelineConfig,
+
 ) where
     V: TransactionBlockExecutor + 'static,
 {
@@ -123,6 +124,7 @@ pub fn run_benchmark<V>(
     config.storage.rocksdb_configs.enable_storage_sharding = enable_storage_sharding;
 
     let (db, executor) = init_db_and_executor::<V>(&config);
+
     let mut root_account = TransactionGenerator::read_root_account(genesis_key, &db);
     let transaction_generators = transaction_mix.clone().map(|transaction_mix| {
         let num_existing_accounts = TransactionGenerator::read_meta(&source_dir);

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -108,7 +108,6 @@ pub fn run_benchmark<V>(
     pruner_config: PrunerConfig,
     enable_storage_sharding: bool,
     pipeline_config: PipelineConfig,
-
 ) where
     V: TransactionBlockExecutor + 'static,
 {

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -52,6 +52,7 @@ use std::{
     time::Instant,
 };
 use tokio::runtime::Runtime;
+use aptos_types::on_chain_config::Features;
 
 pub fn init_db_and_executor<V>(config: &NodeConfig) -> (DbReaderWriter, BlockExecutor<V>)
 where
@@ -108,6 +109,7 @@ pub fn run_benchmark<V>(
     pruner_config: PrunerConfig,
     enable_storage_sharding: bool,
     pipeline_config: PipelineConfig,
+    init_features: Features,
 ) where
     V: TransactionBlockExecutor + 'static,
 {
@@ -116,12 +118,10 @@ pub fn run_benchmark<V>(
         checkpoint_dir.as_ref(),
         enable_storage_sharding,
     );
-
-    let (mut config, genesis_key) = aptos_genesis::test_utils::test_config();
+    let (mut config, genesis_key) = aptos_genesis::test_utils::test_config_with_custom_features(init_features);
     config.storage.dir = checkpoint_dir.as_ref().to_path_buf();
     config.storage.storage_pruner_config = pruner_config;
     config.storage.rocksdb_configs.enable_storage_sharding = enable_storage_sharding;
-
     let (db, executor) = init_db_and_executor::<V>(&config);
 
     let mut root_account = TransactionGenerator::read_root_account(genesis_key, &db);
@@ -301,6 +301,7 @@ pub fn add_accounts<V>(
     verify_sequence_numbers: bool,
     enable_storage_sharding: bool,
     pipeline_config: PipelineConfig,
+    init_features: Features,
 ) where
     V: TransactionBlockExecutor + 'static,
 {
@@ -320,6 +321,7 @@ pub fn add_accounts<V>(
         verify_sequence_numbers,
         enable_storage_sharding,
         pipeline_config,
+        init_features,
     );
 }
 
@@ -333,10 +335,11 @@ fn add_accounts_impl<V>(
     verify_sequence_numbers: bool,
     enable_storage_sharding: bool,
     pipeline_config: PipelineConfig,
+    init_features: Features,
 ) where
     V: TransactionBlockExecutor + 'static,
 {
-    let (mut config, genesis_key) = aptos_genesis::test_utils::test_config();
+    let (mut config, genesis_key) = aptos_genesis::test_utils::test_config_with_custom_features(init_features);
     config.storage.dir = output_dir.as_ref().to_path_buf();
     config.storage.storage_pruner_config = pruner_config;
     config.storage.rocksdb_configs.enable_storage_sharding = enable_storage_sharding;

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -42,6 +42,7 @@ use aptos_transaction_generator_lib::{
     create_txn_generator_creator, AlwaysApproveRootAccountHandle, TransactionGeneratorCreator,
     TransactionType::{self, NonConflictingCoinTransfer},
 };
+use aptos_types::on_chain_config::Features;
 use db_reliable_submitter::DbReliableTransactionSubmitter;
 use pipeline::PipelineConfig;
 use std::{
@@ -52,7 +53,6 @@ use std::{
     time::Instant,
 };
 use tokio::runtime::Runtime;
-use aptos_types::on_chain_config::Features;
 
 pub fn init_db_and_executor<V>(config: &NodeConfig) -> (DbReaderWriter, BlockExecutor<V>)
 where
@@ -118,7 +118,8 @@ pub fn run_benchmark<V>(
         checkpoint_dir.as_ref(),
         enable_storage_sharding,
     );
-    let (mut config, genesis_key) = aptos_genesis::test_utils::test_config_with_custom_features(init_features);
+    let (mut config, genesis_key) =
+        aptos_genesis::test_utils::test_config_with_custom_features(init_features);
     config.storage.dir = checkpoint_dir.as_ref().to_path_buf();
     config.storage.storage_pruner_config = pruner_config;
     config.storage.rocksdb_configs.enable_storage_sharding = enable_storage_sharding;
@@ -339,7 +340,8 @@ fn add_accounts_impl<V>(
 ) where
     V: TransactionBlockExecutor + 'static,
 {
-    let (mut config, genesis_key) = aptos_genesis::test_utils::test_config_with_custom_features(init_features);
+    let (mut config, genesis_key) =
+        aptos_genesis::test_utils::test_config_with_custom_features(init_features);
     config.storage.dir = output_dir.as_ref().to_path_buf();
     config.storage.storage_pruner_config = pruner_config;
     config.storage.rocksdb_configs.enable_storage_sharding = enable_storage_sharding;

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -373,7 +373,10 @@ enum Command {
     },
 }
 
-fn get_init_features(enable_feature: Vec<FeatureFlag>, disable_feature: Vec<FeatureFlag>) -> Features {
+fn get_init_features(
+    enable_feature: Vec<FeatureFlag>,
+    disable_feature: Vec<FeatureFlag>,
+) -> Features {
     // this check is O(|enable_feature| * |disable_feature|)
     assert!(
         enable_feature.iter().all(|f| !disable_feature.contains(f)),

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -23,6 +23,7 @@ use aptos_metrics_core::{register_int_gauge, IntGauge};
 use aptos_profiler::{ProfilerConfig, ProfilerHandler};
 use aptos_push_metrics::MetricsPusher;
 use aptos_transaction_generator_lib::{args::TransactionTypeArg, WorkflowProgress};
+use aptos_types::on_chain_config::FeatureFlag;
 use aptos_vm::AptosVM;
 use clap::{ArgGroup, Parser, Subcommand};
 use once_cell::sync::Lazy;
@@ -31,8 +32,6 @@ use std::{
     path::PathBuf,
     time::{SystemTime, UNIX_EPOCH},
 };
-
-use aptos_types::on_chain_config::FeatureFlag;
 
 #[cfg(unix)]
 #[global_allocator]
@@ -399,7 +398,9 @@ where
                 "Enable and disable feature flags cannot overlap."
             );
             aptos_types::on_chain_config::hack_enable_default_features_for_genesis(enable_feature);
-            aptos_types::on_chain_config::hack_disable_default_features_for_genesis(disable_feature);
+            aptos_types::on_chain_config::hack_disable_default_features_for_genesis(
+                disable_feature,
+            );
 
             let transaction_mix = if transaction_type.is_empty() {
                 None
@@ -418,7 +419,9 @@ where
 
             if let Some(hotspot_probability) = opt.hotspot_probability {
                 if !(0.5..1.0).contains(&hotspot_probability) {
-                    panic!("Parameter hotspot-probability has to be a decimal number in [0.5, 1.0).");
+                    panic!(
+                        "Parameter hotspot-probability has to be a decimal number in [0.5, 1.0)."
+                    );
                 }
             }
 

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -32,6 +32,8 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+use aptos_types::on_chain_config::FeatureFlag;
+
 #[cfg(unix)]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
@@ -324,6 +326,20 @@ enum Command {
 
         #[clap(long, value_parser)]
         checkpoint_dir: PathBuf,
+
+        #[clap(
+            long,
+            num_args=1..,
+            value_delimiter = ' ',
+            help = "Custom enabling/disabling of the feature flags in the Move source. Disabling is stronger than enabling")]
+        enable_feature: Vec<FeatureFlag>,
+
+        #[clap(
+            long,
+            num_args=1..,
+            value_delimiter = ' ',
+            help = "Custom enabling/disabling of the feature flags in the Move source. Disabling is stronger than enabling")]
+        disable_feature: Vec<FeatureFlag>,
     },
     AddAccounts {
         #[clap(long, value_parser)]
@@ -371,7 +387,13 @@ where
             use_sender_account_pool,
             data_dir,
             checkpoint_dir,
+            enable_feature,
+            disable_feature,
         } => {
+            // setting custom feature flags
+            aptos_types::on_chain_config::enable_features(enable_feature);
+            aptos_types::on_chain_config::disable_features(disable_feature);
+
             let transaction_mix = if transaction_type.is_empty() {
                 None
             } else {
@@ -389,7 +411,7 @@ where
 
             if let Some(hotspot_probability) = opt.hotspot_probability {
                 if !(0.5..1.0).contains(&hotspot_probability) {
-                    panic!("Parameter hotspot-probability has to a decimal number in [0.5, 1.0).");
+                    panic!("Parameter hotspot-probability has to be a decimal number in [0.5, 1.0).");
                 }
             }
 

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -331,14 +331,16 @@ enum Command {
             long,
             num_args=1..,
             value_delimiter = ' ',
-            help = "Custom enabling/disabling of the feature flags in the Move source. Disabling is stronger than enabling")]
+            help = "Optional custom enabling/disabling of the feature flags in the Move source. Enable / disable flags cannot overlap.\
+            Sample usage: --enable-feature=V1 --disable-feature=V2 V3 where V1, V2, V3 are FeatureFlag enum variants.")]
         enable_feature: Vec<FeatureFlag>,
 
         #[clap(
             long,
             num_args=1..,
             value_delimiter = ' ',
-            help = "Custom enabling/disabling of the feature flags in the Move source. Disabling is stronger than enabling")]
+            help = "Optional custom enabling/disabling of the feature flags in the Move source. Enable / disable flags cannot overlap.\
+            Sample usage: --enable-feature=V1 --disable-feature=V2 V3 where V1, V2, V3 are FeatureFlag enum variants.")]
         disable_feature: Vec<FeatureFlag>,
     },
     AddAccounts {
@@ -391,8 +393,13 @@ where
             disable_feature,
         } => {
             // setting custom feature flags
-            aptos_types::on_chain_config::enable_features(enable_feature);
-            aptos_types::on_chain_config::disable_features(disable_feature);
+            // this check is O(|enable_feature| * |disable_feature|)
+            assert!(
+                enable_feature.iter().all(|f| !disable_feature.contains(f)),
+                "Enable and disable feature flags cannot overlap."
+            );
+            aptos_types::on_chain_config::hack_enable_default_features_for_genesis(enable_feature);
+            aptos_types::on_chain_config::hack_disable_default_features_for_genesis(disable_feature);
 
             let transaction_mix = if transaction_type.is_empty() {
                 None

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -162,7 +162,7 @@ pub fn enable_features(enable_features: Vec<FeatureFlag>) {
 }
 static DISABLED_FEATURES: OnceCell<Vec<FeatureFlag>> = OnceCell::new();
 pub fn disable_features(disable_features: Vec<FeatureFlag>) {
-    ENABLED_FEATURES.set(disable_features).ok();
+    DISABLED_FEATURES.set(disable_features).ok();
 }
 
 
@@ -182,21 +182,15 @@ impl Default for Features {
         for feature in FeatureFlag::default_features() {
             features.enable(feature);
         }
-        match ENABLED_FEATURES.get() {
-            Some(enabled_features) => {
-                for feature in enabled_features.iter() {
-                    features.enable(*feature);
-                }
+        if let Some(enabled_features) = ENABLED_FEATURES.get() {
+            for feature in enabled_features.iter() {
+                features.enable(*feature);
             }
-            None => (),
         }
-        match DISABLED_FEATURES.get() {
-            Some(disabled_features) => {
-                for feature in disabled_features.iter() {
-                    features.disable(*feature);
-                }
+        if let Some(disabled_features) = DISABLED_FEATURES.get() {
+            for feature in disabled_features.iter() {
+                features.disable(*feature);
             }
-            None => (),
         }
         features
     }
@@ -383,4 +377,24 @@ mod test {
             file_format_common::VERSION_MAX
         );
     }
+}
+
+#[test]
+fn test_enabling_disabling_features() {
+    enable_features(vec![FeatureFlag::BLS12_381_STRUCTURES, FeatureFlag::BN254_STRUCTURES, FeatureFlag::CODE_DEPENDENCY_CHECK]);
+    disable_features(vec![FeatureFlag::BN254_STRUCTURES, FeatureFlag::TREAT_FRIEND_AS_PRIVATE]);
+    let features = Features::default();
+    assert_eq!(
+        features.is_enabled(FeatureFlag::BLS12_381_STRUCTURES),
+        true
+    );
+    assert_eq!(
+        features.is_enabled(FeatureFlag::BULLETPROOFS_NATIVES),
+        true
+    );
+    assert_eq!(
+        features.is_enabled(FeatureFlag::BN254_STRUCTURES),
+        false
+    );
+
 }

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -1,7 +1,6 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use once_cell::sync::OnceCell;
 use crate::on_chain_config::OnChainConfig;
 use move_binary_format::{
     file_format_common,
@@ -11,11 +10,9 @@ use move_core_types::{
     effects::{ChangeSet, Op},
     language_storage::CORE_CODE_ADDRESS,
 };
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-
-use strum_macros::FromRepr;
-use strum_macros::EnumString;
-
+use strum_macros::{EnumString, FromRepr};
 /// The feature flags define in the Move source. This must stay aligned with the constants there.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, FromRepr, EnumString)]
 #[allow(non_camel_case_types)]
@@ -164,7 +161,6 @@ static DISABLED_FEATURES: OnceCell<Vec<FeatureFlag>> = OnceCell::new();
 pub fn hack_disable_default_features_for_genesis(disable_features: Vec<FeatureFlag>) {
     DISABLED_FEATURES.set(disable_features).ok();
 }
-
 
 /// Representation of features on chain as a bitset.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize)]
@@ -381,20 +377,16 @@ mod test {
 
 #[test]
 fn test_enabling_disabling_features() {
-    enable_features(vec![FeatureFlag::BLS12_381_STRUCTURES, FeatureFlag::BN254_STRUCTURES, FeatureFlag::CODE_DEPENDENCY_CHECK]);
-    disable_features(vec![FeatureFlag::BN254_STRUCTURES, FeatureFlag::TREAT_FRIEND_AS_PRIVATE]);
+    hack_enable_default_features_for_genesis(vec![
+        FeatureFlag::BLS12_381_STRUCTURES,
+        FeatureFlag::CODE_DEPENDENCY_CHECK,
+    ]);
+    hack_disable_default_features_for_genesis(vec![
+        FeatureFlag::BN254_STRUCTURES,
+        FeatureFlag::TREAT_FRIEND_AS_PRIVATE,
+    ]);
     let features = Features::default();
-    assert_eq!(
-        features.is_enabled(FeatureFlag::BLS12_381_STRUCTURES),
-        true
-    );
-    assert_eq!(
-        features.is_enabled(FeatureFlag::BULLETPROOFS_NATIVES),
-        true
-    );
-    assert_eq!(
-        features.is_enabled(FeatureFlag::BN254_STRUCTURES),
-        false
-    );
-
+    assert_eq!(features.is_enabled(FeatureFlag::BLS12_381_STRUCTURES), true);
+    assert_eq!(features.is_enabled(FeatureFlag::BULLETPROOFS_NATIVES), true);
+    assert_eq!(features.is_enabled(FeatureFlag::BN254_STRUCTURES), false);
 }

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -157,11 +157,11 @@ impl FeatureFlag {
 }
 
 static ENABLED_FEATURES: OnceCell<Vec<FeatureFlag>> = OnceCell::new();
-pub fn enable_features(enable_features: Vec<FeatureFlag>) {
+pub fn hack_enable_default_features_for_genesis(enable_features: Vec<FeatureFlag>) {
     ENABLED_FEATURES.set(enable_features).ok();
 }
 static DISABLED_FEATURES: OnceCell<Vec<FeatureFlag>> = OnceCell::new();
-pub fn disable_features(disable_features: Vec<FeatureFlag>) {
+pub fn hack_disable_default_features_for_genesis(disable_features: Vec<FeatureFlag>) {
     DISABLED_FEATURES.set(disable_features).ok();
 }
 


### PR DESCRIPTION
## Description
While running exe benchmark, adds instrumentation to override 'on-chain' config.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Other (specify): Execution

## How Has This Been Tested?
A unit test in [aptos-core/types/src/on_chain_config/aptos_features.rs](https://github.com/aptos-labs/aptos-core/blob/8ddb8453d44e1d0f56e6fd61cee785e705b0f229/types/src/on_chain_config/aptos_features.rs#L83)

and

cargo run --profile performance -p aptos-executor-benchmark -- --generate-then-execute run-executor --enable-feature CODE_DEPENDENCY_CHECK MULTI_ED25519_PK_VALIDATE_V2_NATIVES --disable-feature CODE_DEPENDENCY_CHECK --data-dir ~/workspace/db_dirs/db/ --checkpoint-dir ~/workspace/db_dirs/chk --blocks 50 --main-signer-accounts 100001


## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
