### PR TITLE
update raffle example to fix undergasing

### DIFF
--- a/aptos-move/move-examples/tests/move_unit_tests.rs
+++ b/aptos-move/move-examples/tests/move_unit_tests.rs
@@ -123,6 +123,11 @@ fn test_drand_lottery() {
 }
 
 #[test]
+fn test_raffle() {
+    test_common("raffle");
+}
+
+#[test]
 fn test_marketplace() {
     test_common("marketplace")
 }


### PR DESCRIPTION
## Description

The `raffle` example for [AIP-41](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-41.md) used `smart_vector::borrow(&v, i)` when selecting the winner. The problem is this function has variable gas cost based on `i`, which creates an undergasing attack vector that can bias the distribution of winners..

This PR fixes it by switching to `vector`.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Other (specify): Examples

## How Has This Been Tested?

```
cd aptos-move/move-examples
cargo test -- raffle --nocapture
```

## Key Areas to Review

Are there any other attack vectors?

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
