### PR TITLE
Install Google Cloud SDK in the tools image

### DIFF
--- a/docker/builder/tools.Dockerfile
+++ b/docker/builder/tools.Dockerfile
@@ -17,7 +17,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     ca-certificates \
     socat \
     python3-botocore/bullseye \
-    awscli/bullseye
+    awscli/bullseye \
+    gnupg2
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get -y update && \
+    apt-get -y install google-cloud-sdk
 
 RUN ln -s /usr/bin/python3 /usr/local/bin/python
 COPY --link docker/tools/boto.cfg /etc/boto.cfg


### PR DESCRIPTION
## Description

The backup tool has switched from the deprecated `gsutil` CLI to `gcloud storage`.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Developer Infrastructure
