### PR TITLE
Distinguish synced version and committed version

### DIFF
--- a/api/src/tests/state_test.rs
+++ b/api/src/tests/state_test.rs
@@ -171,7 +171,7 @@ async fn test_merkle_leaves_with_nft_transfer() {
 
     let num_leaves_at_beginning = ctx
         .db
-        .get_state_leaf_count(ctx.db.get_committed_version().unwrap())
+        .get_state_leaf_count(ctx.db.get_latest_ledger_info_version().unwrap())
         .unwrap();
 
     let transfer_to_owner_txn = creator.sign_multi_agent_with_transaction_builder(
@@ -188,7 +188,7 @@ async fn test_merkle_leaves_with_nft_transfer() {
     ctx.commit_block(&vec![transfer_to_owner_txn]).await;
     let num_leaves_after_transfer_nft = ctx
         .db
-        .get_state_leaf_count(ctx.db.get_committed_version().unwrap())
+        .get_state_leaf_count(ctx.db.get_latest_ledger_info_version().unwrap())
         .unwrap();
     assert_eq!(
         num_leaves_after_transfer_nft,
@@ -209,7 +209,7 @@ async fn test_merkle_leaves_with_nft_transfer() {
     ctx.commit_block(&vec![transfer_to_creator_txn]).await;
     let num_leaves_after_return_nft = ctx
         .db
-        .get_state_leaf_count(ctx.db.get_committed_version().unwrap())
+        .get_state_leaf_count(ctx.db.get_latest_ledger_info_version().unwrap())
         .unwrap();
 
     assert_eq!(

--- a/api/src/tests/state_test.rs
+++ b/api/src/tests/state_test.rs
@@ -171,7 +171,7 @@ async fn test_merkle_leaves_with_nft_transfer() {
 
     let num_leaves_at_beginning = ctx
         .db
-        .get_state_leaf_count(ctx.db.get_latest_version().unwrap())
+        .get_state_leaf_count(ctx.db.get_committed_version().unwrap())
         .unwrap();
 
     let transfer_to_owner_txn = creator.sign_multi_agent_with_transaction_builder(
@@ -188,7 +188,7 @@ async fn test_merkle_leaves_with_nft_transfer() {
     ctx.commit_block(&vec![transfer_to_owner_txn]).await;
     let num_leaves_after_transfer_nft = ctx
         .db
-        .get_state_leaf_count(ctx.db.get_latest_version().unwrap())
+        .get_state_leaf_count(ctx.db.get_committed_version().unwrap())
         .unwrap();
     assert_eq!(
         num_leaves_after_transfer_nft,
@@ -209,7 +209,7 @@ async fn test_merkle_leaves_with_nft_transfer() {
     ctx.commit_block(&vec![transfer_to_creator_txn]).await;
     let num_leaves_after_return_nft = ctx
         .db
-        .get_state_leaf_count(ctx.db.get_latest_version().unwrap())
+        .get_state_leaf_count(ctx.db.get_committed_version().unwrap())
         .unwrap();
 
     assert_eq!(

--- a/aptos-move/aptos-debugger/src/aptos_debugger.rs
+++ b/aptos-move/aptos-debugger/src/aptos_debugger.rs
@@ -212,10 +212,6 @@ impl AptosDebugger {
         Ok(ret)
     }
 
-    pub async fn get_latest_version(&self) -> Result<Version> {
-        self.debugger.get_latest_version().await
-    }
-
     pub async fn get_version_by_account_sequence(
         &self,
         account: AccountAddress,

--- a/aptos-move/aptos-validator-interface/src/lib.rs
+++ b/aptos-move/aptos-validator-interface/src/lib.rs
@@ -73,7 +73,7 @@ pub trait AptosValidatorInterface: Sync {
         )>,
     >;
 
-    async fn get_committed_version(&self) -> Result<Version>;
+    async fn get_latest_ledger_info_version(&self) -> Result<Version>;
 
     async fn get_version_by_account_sequence(
         &self,

--- a/aptos-move/aptos-validator-interface/src/lib.rs
+++ b/aptos-move/aptos-validator-interface/src/lib.rs
@@ -73,7 +73,7 @@ pub trait AptosValidatorInterface: Sync {
         )>,
     >;
 
-    async fn get_latest_version(&self) -> Result<Version>;
+    async fn get_committed_version(&self) -> Result<Version>;
 
     async fn get_version_by_account_sequence(
         &self,

--- a/aptos-move/aptos-validator-interface/src/rest_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/rest_interface.rs
@@ -343,7 +343,7 @@ impl AptosValidatorInterface for RestDebuggerInterface {
         return Ok(txns);
     }
 
-    async fn get_committed_version(&self) -> Result<Version> {
+    async fn get_latest_ledger_info_version(&self) -> Result<Version> {
         Ok(self.0.get_ledger_information().await?.into_inner().version)
     }
 

--- a/aptos-move/aptos-validator-interface/src/rest_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/rest_interface.rs
@@ -343,7 +343,7 @@ impl AptosValidatorInterface for RestDebuggerInterface {
         return Ok(txns);
     }
 
-    async fn get_latest_version(&self) -> Result<Version> {
+    async fn get_committed_version(&self) -> Result<Version> {
         Ok(self.0.get_ledger_information().await?.into_inner().version)
     }
 

--- a/aptos-move/aptos-validator-interface/src/storage_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/storage_interface.rs
@@ -94,8 +94,8 @@ impl AptosValidatorInterface for DBDebuggerInterface {
         unimplemented!();
     }
 
-    async fn get_latest_version(&self) -> Result<Version> {
-        self.0.get_latest_version().map_err(Into::into)
+    async fn get_committed_version(&self) -> Result<Version> {
+        self.0.get_committed_version().map_err(Into::into)
     }
 
     async fn get_version_by_account_sequence(
@@ -103,7 +103,7 @@ impl AptosValidatorInterface for DBDebuggerInterface {
         account: AccountAddress,
         seq: u64,
     ) -> Result<Option<Version>> {
-        let ledger_version = self.get_latest_version().await?;
+        let ledger_version = self.get_committed_version().await?;
         self.0
             .get_account_transaction(account, seq, false, ledger_version)
             .map_or_else(

--- a/aptos-move/aptos-validator-interface/src/storage_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/storage_interface.rs
@@ -94,8 +94,8 @@ impl AptosValidatorInterface for DBDebuggerInterface {
         unimplemented!();
     }
 
-    async fn get_committed_version(&self) -> Result<Version> {
-        self.0.get_committed_version().map_err(Into::into)
+    async fn get_latest_ledger_info_version(&self) -> Result<Version> {
+        self.0.get_latest_ledger_info_version().map_err(Into::into)
     }
 
     async fn get_version_by_account_sequence(
@@ -103,7 +103,7 @@ impl AptosValidatorInterface for DBDebuggerInterface {
         account: AccountAddress,
         seq: u64,
     ) -> Result<Option<Version>> {
-        let ledger_version = self.get_committed_version().await?;
+        let ledger_version = self.get_latest_ledger_info_version().await?;
         self.0
             .get_account_transaction(account, seq, false, ledger_version)
             .map_or_else(

--- a/consensus/src/dag/adapter.rs
+++ b/consensus/src/dag/adapter.rs
@@ -378,7 +378,7 @@ impl DAGStorage for StorageAdapter {
 
     fn get_latest_k_committed_events(&self, k: u64) -> anyhow::Result<Vec<CommitEvent>> {
         let timer = counters::FETCH_COMMIT_HISTORY_DURATION.start_timer();
-        let version = self.aptos_db.get_latest_version()?;
+        let version = self.aptos_db.get_committed_version()?;
         let resource = self.get_commit_history_resource(version)?;
         let handle = resource.table_handle();
         let mut commit_events = vec![];

--- a/consensus/src/dag/adapter.rs
+++ b/consensus/src/dag/adapter.rs
@@ -378,7 +378,7 @@ impl DAGStorage for StorageAdapter {
 
     fn get_latest_k_committed_events(&self, k: u64) -> anyhow::Result<Vec<CommitEvent>> {
         let timer = counters::FETCH_COMMIT_HISTORY_DURATION.start_timer();
-        let version = self.aptos_db.get_committed_version()?;
+        let version = self.aptos_db.get_latest_ledger_info_version()?;
         let resource = self.get_commit_history_resource(version)?;
         let handle = resource.table_handle();
         let mut commit_events = vec![];

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -181,7 +181,7 @@ impl MetadataBackend for AptosDBBackend {
         let has_larger = events.first().map_or(false, |e| {
             (e.event.epoch(), e.event.round()) >= (target_epoch, target_round)
         });
-        let latest_db_version = self.aptos_db.get_latest_version().unwrap_or(0);
+        let latest_db_version = self.aptos_db.get_committed_version().unwrap_or(0);
         // check if fresher data has potential to give us different result
         if !has_larger && version < latest_db_version {
             let fresh_db_result = self.refresh_db_result(locked, latest_db_version);

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -181,7 +181,7 @@ impl MetadataBackend for AptosDBBackend {
         let has_larger = events.first().map_or(false, |e| {
             (e.event.epoch(), e.event.round()) >= (target_epoch, target_round)
         });
-        let latest_db_version = self.aptos_db.get_committed_version().unwrap_or(0);
+        let latest_db_version = self.aptos_db.get_latest_ledger_info_version().unwrap_or(0);
         // check if fresher data has potential to give us different result
         if !has_larger && version < latest_db_version {
             let fresh_db_result = self.refresh_db_result(locked, latest_db_version);

--- a/consensus/src/liveness/leader_reputation_test.rs
+++ b/consensus/src/liveness/leader_reputation_test.rs
@@ -499,7 +499,7 @@ impl DbReader for MockDbReader {
     }
 
     /// Returns the latest version, error on on non-bootstrapped DB.
-    fn get_latest_version(&self) -> aptos_storage_interface::Result<Version> {
+    fn get_committed_version(&self) -> aptos_storage_interface::Result<Version> {
         let version = *self.idx.lock();
         let mut to_add = self.to_add_event_after_call.lock();
         if let Some((epoch, round)) = *to_add {

--- a/consensus/src/liveness/leader_reputation_test.rs
+++ b/consensus/src/liveness/leader_reputation_test.rs
@@ -499,7 +499,7 @@ impl DbReader for MockDbReader {
     }
 
     /// Returns the latest version, error on on non-bootstrapped DB.
-    fn get_committed_version(&self) -> aptos_storage_interface::Result<Version> {
+    fn get_latest_ledger_info_version(&self) -> aptos_storage_interface::Result<Version> {
         let version = *self.idx.lock();
         let mut to_add = self.to_add_event_after_call.lock();
         if let Some((epoch, round)) = *to_add {

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -163,7 +163,7 @@ pub fn run_benchmark<V>(
         ((0..pipeline_config.num_generator_workers).map(|_| transaction_generator_creator.create_transaction_generator()).collect::<Vec<_>>(), phase)
     });
 
-    let version = db.reader.get_latest_version().unwrap();
+    let version = db.reader.get_synced_version().unwrap();
 
     let (pipeline, block_sender) =
         Pipeline::new(executor, version, &pipeline_config, Some(num_blocks));
@@ -230,7 +230,7 @@ pub fn run_benchmark<V>(
         }
     );
 
-    let num_txns = db.reader.get_latest_version().unwrap() - version - num_blocks_created as u64;
+    let num_txns = db.reader.get_synced_version().unwrap() - version - num_blocks_created as u64;
     overall_measuring.print_end("Overall", num_txns);
 
     if verify_sequence_numbers {
@@ -254,7 +254,7 @@ fn init_workload<V>(
 where
     V: TransactionBlockExecutor + 'static,
 {
-    let version = db.reader.get_latest_version().unwrap();
+    let version = db.reader.get_synced_version().unwrap();
     let (pipeline, block_sender) = Pipeline::<V>::new(
         BlockExecutor::new(db.clone()),
         version,
@@ -341,7 +341,7 @@ fn add_accounts_impl<V>(
     config.storage.rocksdb_configs.enable_storage_sharding = enable_storage_sharding;
     let (db, executor) = init_db_and_executor::<V>(&config);
 
-    let start_version = db.reader.get_latest_version().unwrap();
+    let start_version = db.reader.get_committed_version().unwrap();
 
     let (pipeline, block_sender) = Pipeline::new(
         executor,
@@ -372,7 +372,7 @@ fn add_accounts_impl<V>(
     pipeline.join();
 
     let elapsed = start_time.elapsed().as_secs_f32();
-    let now_version = db.reader.get_latest_version().unwrap();
+    let now_version = db.reader.get_committed_version().unwrap();
     let delta_v = now_version - start_version;
     info!(
         "Overall TPS: create_db: account creation: {} txn/s",

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -341,7 +341,7 @@ fn add_accounts_impl<V>(
     config.storage.rocksdb_configs.enable_storage_sharding = enable_storage_sharding;
     let (db, executor) = init_db_and_executor::<V>(&config);
 
-    let start_version = db.reader.get_committed_version().unwrap();
+    let start_version = db.reader.get_latest_ledger_info_version().unwrap();
 
     let (pipeline, block_sender) = Pipeline::new(
         executor,
@@ -372,7 +372,7 @@ fn add_accounts_impl<V>(
     pipeline.join();
 
     let elapsed = start_time.elapsed().as_secs_f32();
-    let now_version = db.reader.get_committed_version().unwrap();
+    let now_version = db.reader.get_latest_ledger_info_version().unwrap();
     let delta_v = now_version - start_version;
     info!(
         "Overall TPS: create_db: account creation: {} txn/s",

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -101,7 +101,7 @@ impl VMExecutor for FakeVM {
 pub struct FakeDb;
 
 impl DbReader for FakeDb {
-    fn get_committed_version(&self) -> aptos_storage_interface::Result<Version> {
+    fn get_latest_ledger_info_version(&self) -> aptos_storage_interface::Result<Version> {
         Ok(self.get_latest_ledger_info()?.ledger_info().version())
     }
 

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -101,7 +101,7 @@ impl VMExecutor for FakeVM {
 pub struct FakeDb;
 
 impl DbReader for FakeDb {
-    fn get_latest_version(&self) -> aptos_storage_interface::Result<Version> {
+    fn get_committed_version(&self) -> aptos_storage_interface::Result<Version> {
         Ok(self.get_latest_ledger_info()?.ledger_info().version())
     }
 

--- a/execution/executor/src/tests/chunk_executor_tests.rs
+++ b/execution/executor/src/tests/chunk_executor_tests.rs
@@ -106,7 +106,7 @@ fn test_executor_execute_or_apply_and_commit_chunk() {
         } = TestExecutor::new();
         execute_and_commit_chunks(chunks, ledger_info.clone(), &db, &executor);
 
-        let ledger_version = db.reader.get_latest_version().unwrap();
+        let ledger_version = db.reader.get_synced_version().unwrap();
         let output1 = db
             .reader
             .get_transaction_outputs(first_batch_start, first_batch_size, ledger_version)

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -781,7 +781,7 @@ proptest! {
 
             // get txn_infos from db
             let db = executor.db.reader.clone();
-            prop_assert_eq!(db.get_latest_version().unwrap(), ledger_version);
+            prop_assert_eq!(db.get_synced_version().unwrap(), ledger_version);
             let txn_list = db.get_transactions(1 /* start version */, ledger_version, ledger_version /* ledger version */, false /* fetch events */).unwrap();
             prop_assert_eq!(&block.inner_txns(), &txn_list.transactions[..num_input_txns as usize]);
             let txn_infos = txn_list.proof.transaction_infos;

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -46,7 +46,7 @@ fn test_genesis() {
         .reader
         .get_state_value_with_proof_by_version(&account_resource_path, 0)
         .unwrap();
-    let latest_version = db.reader.get_committed_version().unwrap();
+    let latest_version = db.reader.get_latest_ledger_info_version().unwrap();
     assert_eq!(latest_version, 0);
     let txn_info = db
         .reader

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -46,7 +46,7 @@ fn test_genesis() {
         .reader
         .get_state_value_with_proof_by_version(&account_resource_path, 0)
         .unwrap();
-    let latest_version = db.reader.get_latest_version().unwrap();
+    let latest_version = db.reader.get_committed_version().unwrap();
     assert_eq!(latest_version, 0);
     let txn_info = db
         .reader

--- a/peer-monitoring-service/server/src/tests.rs
+++ b/peer-monitoring-service/server/src/tests.rs
@@ -680,7 +680,9 @@ mod database_mock {
 
             fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures>;
 
-            fn get_latest_version(&self) -> Result<Version>;
+            fn get_synced_version(&self) -> Result<Version>;
+
+            fn get_committed_version(&self) -> Result<Version>;
 
             fn get_latest_commit_metadata(&self) -> Result<(Version, u64)>;
 

--- a/peer-monitoring-service/server/src/tests.rs
+++ b/peer-monitoring-service/server/src/tests.rs
@@ -682,7 +682,7 @@ mod database_mock {
 
             fn get_synced_version(&self) -> Result<Version>;
 
-            fn get_committed_version(&self) -> Result<Version>;
+            fn get_latest_ledger_info_version(&self) -> Result<Version>;
 
             fn get_latest_commit_metadata(&self) -> Result<(Version, u64)>;
 

--- a/state-sync/aptos-data-client/src/latency_monitor.rs
+++ b/state-sync/aptos-data-client/src/latency_monitor.rs
@@ -67,8 +67,9 @@ impl LatencyMonitor {
             // Wait for the next round
             loop_ticker.next().await;
 
-            // Get the highest synced version from storage
-            let highest_synced_version = match self.storage.get_latest_version() {
+            // Get the highest committed version from storage (storage doesn't know for sure
+            //   the timestamp for the latest synced version)
+            let highest_committed_version = match self.storage.get_committed_version() {
                 Ok(version) => version,
                 Err(error) => {
                     sample!(
@@ -76,7 +77,7 @@ impl LatencyMonitor {
                         warn!(
                             (LogSchema::new(LogEntry::LatencyMonitor)
                                 .event(LogEvent::StorageReadFailed)
-                                .message(&format!("Unable to read the highest synced version: {:?}", error)))
+                                .message(&format!("Unable to read the highest committed version: {:?}", error)))
                         );
                     );
                     continue; // Continue to the next round
@@ -86,7 +87,7 @@ impl LatencyMonitor {
             // Get the latest block timestamp from storage
             let latest_block_timestamp_usecs = match self
                 .storage
-                .get_block_timestamp(highest_synced_version)
+                .get_block_timestamp(highest_committed_version)
             {
                 Ok(block_timestamp_usecs) => block_timestamp_usecs,
                 Err(error) => {
@@ -106,7 +107,7 @@ impl LatencyMonitor {
             self.update_block_timestamp_lag(latest_block_timestamp_usecs);
 
             // Update the latency metrics for all versions that we've now synced
-            self.update_latency_metrics(highest_synced_version);
+            self.update_latency_metrics(highest_committed_version);
 
             // Get the highest advertised version from the global data summary
             let advertised_data = &self.data_client.get_global_data_summary().advertised_data;
@@ -127,7 +128,7 @@ impl LatencyMonitor {
 
             // Update the advertised version timestamps
             self.update_advertised_version_timestamps(
-                highest_synced_version,
+                highest_committed_version,
                 highest_advertised_version,
             );
         }

--- a/state-sync/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/tests/bootstrapper.rs
@@ -1612,7 +1612,7 @@ fn create_bootstrapper(
         .expect_get_latest_ledger_info()
         .returning(|| Ok(create_epoch_ending_ledger_info()));
     mock_database_reader
-        .expect_get_latest_version()
+        .expect_get_synced_version()
         .returning(|| Ok(0));
 
     // Create the output fallback handler
@@ -1669,7 +1669,7 @@ fn create_bootstrapper_with_storage(
         .expect_get_latest_ledger_info()
         .returning(move || Ok(epoch_ending_ledger_info.clone()));
     mock_database_reader
-        .expect_get_latest_version()
+        .expect_get_synced_version()
         .returning(move || Ok(latest_synced_version));
 
     // Create the output fallback handler

--- a/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
+++ b/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
@@ -502,7 +502,7 @@ fn create_continuous_syncer(
     // Create the mock db reader with the given synced version
     let mut mock_database_reader = create_mock_db_reader();
     mock_database_reader
-        .expect_get_latest_version()
+        .expect_get_synced_version()
         .returning(move || Ok(synced_version));
     mock_database_reader
         .expect_get_latest_epoch_state()

--- a/state-sync/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-driver/src/tests/mocks.rs
@@ -237,7 +237,7 @@ mock! {
 
         fn get_synced_version(&self) -> Result<Version>;
 
-        fn get_committed_version(&self) -> Result<Version>;
+        fn get_latest_ledger_info_version(&self) -> Result<Version>;
 
         fn get_latest_commit_metadata(&self) -> Result<(Version, u64)>;
 

--- a/state-sync/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-driver/src/tests/mocks.rs
@@ -81,7 +81,7 @@ pub fn create_mock_reader_writer_with_version(
 ) -> DbReaderWriter {
     let mut reader = reader.unwrap_or_else(create_mock_db_reader);
     reader
-        .expect_get_latest_version()
+        .expect_get_synced_version()
         .returning(move || Ok(highest_synced_version));
     reader
         .expect_get_latest_epoch_state()
@@ -235,7 +235,9 @@ mock! {
 
         fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures>;
 
-        fn get_latest_version(&self) -> Result<Version>;
+        fn get_synced_version(&self) -> Result<Version>;
+
+        fn get_committed_version(&self) -> Result<Version>;
 
         fn get_latest_commit_metadata(&self) -> Result<(Version, u64)>;
 

--- a/state-sync/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-driver/src/utils.rs
@@ -279,7 +279,7 @@ pub fn fetch_latest_synced_ledger_info(
 
 /// Fetches the latest synced version from the specified storage
 pub fn fetch_latest_synced_version(storage: Arc<dyn DbReader>) -> Result<Version, Error> {
-    storage.get_latest_version().map_err(|e| {
+    storage.get_synced_version().map_err(|e| {
         Error::StorageError(format!("Failed to get latest version from storage: {e:?}"))
     })
 }

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -287,7 +287,9 @@ mock! {
 
         fn get_latest_ledger_info(&self) -> aptos_storage_interface::Result<LedgerInfoWithSignatures>;
 
-        fn get_latest_version(&self) -> aptos_storage_interface::Result<Version>;
+        fn get_synced_version(&self) -> aptos_storage_interface::Result<Version>;
+
+        fn get_committed_version(&self) -> aptos_storage_interface::Result<Version>;
 
         fn get_latest_commit_metadata(&self) -> aptos_storage_interface::Result<(Version, u64)>;
 

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -289,7 +289,7 @@ mock! {
 
         fn get_synced_version(&self) -> aptos_storage_interface::Result<Version>;
 
-        fn get_committed_version(&self) -> aptos_storage_interface::Result<Version>;
+        fn get_latest_ledger_info_version(&self) -> aptos_storage_interface::Result<Version>;
 
         fn get_latest_commit_metadata(&self) -> aptos_storage_interface::Result<(Version, u64)>;
 

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -119,7 +119,7 @@ impl RestoreHandler {
     }
 
     pub fn get_next_expected_transaction_version(&self) -> Result<Version> {
-        Ok(self.aptosdb.get_latest_version().map_or(0, |ver| ver + 1))
+        Ok(self.aptosdb.get_synced_version().map_or(0, |ver| ver + 1))
     }
 
     pub fn get_state_snapshot_before(

--- a/storage/aptosdb/src/db/fake_aptosdb.rs
+++ b/storage/aptosdb/src/db/fake_aptosdb.rs
@@ -236,7 +236,7 @@ impl FakeAptosDB {
             .current_version
             .map(|version| version + 1)
             .unwrap_or(0);
-        let num_transactions_in_db = self.get_latest_version().map_or(0, |v| v + 1);
+        let num_transactions_in_db = self.get_synced_version().map_or(0, |v| v + 1);
         ensure!(num_transactions_in_db == first_version && num_transactions_in_db == next_version_in_buffered_state,
             "The first version {} passed in, the next version in buffered state {} and the next version in db {} are inconsistent.",
             first_version,
@@ -667,7 +667,7 @@ impl DbReader for FakeAptosDB {
     fn get_block_timestamp(&self, version: Version) -> Result<u64> {
         gauged_api("get_block_timestamp", || {
             ensure!(
-                version <= self.get_latest_version()?,
+                version <= self.get_synced_version()?,
                 "version older than latest version"
             );
 
@@ -835,7 +835,7 @@ impl DbReader for FakeAptosDB {
         // This is because when we call save_transactions for the genesis block, we call [AptosDB::save_transactions]
         // where there is an expectation that the root of the SMTs are the same pointers. Here,
         // we get from the inner AptosDB which ensures that the pointers match when save_transactions is called.
-        if self.get_latest_version().unwrap_or_default() == 0 {
+        if self.get_synced_version().unwrap_or_default() == 0 {
             return self.inner.get_latest_executed_trees();
         }
 

--- a/storage/aptosdb/src/db/include/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_internal.rs
@@ -108,7 +108,7 @@ impl AptosDB {
         rocksdb_config: RocksdbConfig,
     ) -> Result<()> {
         let indexer = Indexer::open(&db_root_path, rocksdb_config)?;
-        let ledger_next_version = self.get_latest_version().map_or(0, |v| v + 1);
+        let ledger_next_version = self.get_synced_version().map_or(0, |v| v + 1);
         info!(
             indexer_next_version = indexer.next_version(),
             ledger_next_version = ledger_next_version,

--- a/storage/aptosdb/src/db/include/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_internal.rs
@@ -259,7 +259,7 @@ impl AptosDB {
     fn to_api_block_info(&self, block_height: u64, block_info: BlockInfo) -> Result<(Version, Version, NewBlockEvent)> {
         // N.b. Must use committed_version because if synced version is used, we won't be able
         // to tell the end of the latest block.
-        let committed_version = self.get_committed_version()?;
+        let committed_version = self.get_latest_ledger_info_version()?;
         ensure!(
             block_info.first_version() <= committed_version,
             "block first version {} > committed version {committed_version}",

--- a/storage/aptosdb/src/db/include/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_internal.rs
@@ -1,6 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_storage_interface::block_info::BlockInfo;
+
 impl AptosDB {
     fn new_with_dbs(
         ledger_db: LedgerDb,
@@ -213,6 +215,74 @@ impl AptosDB {
             min_readable_version
         );
         Ok(())
+    }
+
+    fn get_raw_block_info_by_height(&self, block_height: u64) -> Result<BlockInfo> {
+        if !self.skip_index_and_usage {
+            let (first_version, new_block_event) = self.event_store.get_event_by_key(&new_block_event_key(), block_height, self.get_synced_version()?)?;
+            let new_block_event = bcs::from_bytes(new_block_event.event_data())?;
+            Ok(BlockInfo::from_new_block_event(first_version, &new_block_event))
+        } else {
+            Ok(self
+                .ledger_db
+                .metadata_db()
+                .get_block_info(block_height)?
+                .ok_or(AptosDbError::NotFound(format!("BlockInfo not found at height {block_height}")))?)
+        }
+    }
+
+    fn get_raw_block_info_by_version(&self, version: Version) -> Result<(u64 /* block_height */, BlockInfo)> {
+        let synced_version = self.get_synced_version()?;
+        ensure!(
+            version <= synced_version,
+            "Requested version {version} > synced version {synced_version}",
+        );
+
+        if !self.skip_index_and_usage {
+            let (first_version, event_index, block_height) = self.event_store
+                .lookup_event_before_or_at_version(&new_block_event_key(), version)?
+                .ok_or_else(|| AptosDbError::NotFound("NewBlockEvent".to_string()))?;
+            let new_block_event = self.event_store.get_event_by_version_and_index(first_version, event_index)?;
+            let new_block_event = bcs::from_bytes(new_block_event.event_data())?;
+            Ok((block_height, BlockInfo::from_new_block_event(first_version, &new_block_event)))
+        } else {
+            let block_height = self
+                .ledger_db
+                .metadata_db()
+                .get_block_height_by_version(version)?;
+
+            let block_info = self.get_raw_block_info_by_height(block_height)?;
+            Ok((block_height, block_info))
+        }
+    }
+
+    fn to_api_block_info(&self, block_height: u64, block_info: BlockInfo) -> Result<(Version, Version, NewBlockEvent)> {
+        // N.b. Must use committed_version because if synced version is used, we won't be able
+        // to tell the end of the latest block.
+        let committed_version = self.get_committed_version()?;
+        ensure!(
+            block_info.first_version() <= committed_version,
+            "block first version {} > committed version {committed_version}",
+            block_info.first_version(),
+        );
+
+        // TODO(grao): Consider return BlockInfo instead of NewBlockEvent.
+        let new_block_event = self
+            .ledger_db
+            .event_db()
+            .expect_new_block_event(block_info.first_version())?;
+
+        let last_version = match self.get_raw_block_info_by_height(block_height + 1) {
+            Ok(next_block_info) => next_block_info.first_version() - 1,
+            Err(AptosDbError::NotFound(..)) => committed_version,
+            Err(err) => return Err(err),
+        };
+
+        Ok((
+            block_info.first_version(),
+            last_version,
+            bcs::from_bytes(new_block_event.event_data())?
+        ))
     }
 }
 

--- a/storage/aptosdb/src/db/include/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_reader.rs
@@ -525,9 +525,9 @@ impl DbReader for AptosDB {
     fn get_block_timestamp(&self, version: u64) -> Result<u64> {
         gauged_api("get_block_timestamp", || {
             self.error_if_ledger_pruned("NewBlockEvent", version)?;
+            let (_block_height, block_info) = self.get_raw_block_info_by_version(version)?;
 
-            let (_first_version, _last_version, new_block_event) = self.get_block_info_by_version(version)?;
-            Ok(new_block_event.proposed_time())
+            Ok(block_info.timestamp_usecs())
         })
     }
 
@@ -568,32 +568,8 @@ impl DbReader for AptosDB {
         gauged_api("get_block_info", || {
             self.error_if_ledger_pruned("NewBlockEvent", version)?;
 
-            // N.b. Must use committed_version because if synced version is used, we won't be able
-            // to tell the end of the latest block.
-            let committed_version = self.get_committed_version()?;
-            ensure!(
-                version <= committed_version,
-                "Requested version {version} > committed version {committed_version}",
-            );
-
-            if !self.skip_index_and_usage {
-                let (first_version, new_block_event) =
-                    self.event_store.get_block_metadata(version)?;
-
-                let last_version = self
-                    .event_store
-                    .lookup_event_after_version(&new_block_event_key(), version)?
-                    .map_or(committed_version, |(v, _, _)| v - 1);
-
-                return Ok((first_version, last_version, new_block_event));
-            }
-
-            let block_height = self
-                .ledger_db
-                .metadata_db()
-                .get_block_height_by_version(version)?;
-
-            self.get_block_info_by_height(block_height)
+            let (block_height, block_info) = self.get_raw_block_info_by_version(version)?;
+            self.to_api_block_info(block_height, block_info)
         })
     }
 
@@ -602,65 +578,8 @@ impl DbReader for AptosDB {
         block_height: u64,
     ) -> Result<(Version, Version, NewBlockEvent)> {
         gauged_api("get_block_info_by_height", || {
-            // N.b. Must use committed_version because if synced version is used, we won't be able
-            // to tell the end of the latest block.
-            let committed_version = self.get_committed_version()?;
-
-            if !self.skip_index_and_usage {
-                let event_key = new_block_event_key();
-                let (first_version, new_block_event) = self.event_store.get_event_by_key(
-                    &event_key,
-                    block_height,
-                    committed_version,
-                )?;
-                let last_version = self
-                    .event_store
-                    .lookup_event_after_version(&event_key, first_version)?
-                    .map_or(committed_version, |(v, _, _)| v - 1);
-                return Ok((
-                    first_version,
-                    last_version,
-                    bcs::from_bytes(new_block_event.event_data())?,
-                ));
-            };
-
-            let first_version = self
-                .ledger_db
-                .metadata_db()
-                .get_block_info(block_height)?
-                .ok_or(anyhow!(
-                    "Block is not found at height {block_height}, maybe pruned?"
-                ))?
-                .first_version();
-            let last_version = self
-                .ledger_db
-                .metadata_db()
-                .get_block_info(block_height + 1)?
-                .map_or(committed_version, |block_info| {
-                    block_info.first_version() - 1
-                });
-
-            // TODO(grao): Consider return BlockInfo instead of NewBlockEvent.
-            let new_block_event = self
-                .ledger_db
-                .event_db()
-                .get_events_by_version(first_version)?
-                .into_iter()
-                .find(|event| {
-                    if let Some(key) = event.event_key() {
-                        if *key == new_block_event_key() {
-                            return true;
-                        }
-                    }
-                    false
-                })
-            .ok_or_else(|| anyhow!("Event for block_height {block_height} at version {first_version} is not found."))?;
-
-            Ok((
-                first_version,
-                last_version,
-                bcs::from_bytes(new_block_event.event_data())?,
-            ))
+            let block_info = self.get_raw_block_info_by_height(block_height)?;
+            self.to_api_block_info(block_height, block_info)
         })
     }
 

--- a/storage/aptosdb/src/db/include/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_writer.rs
@@ -227,7 +227,7 @@ impl AptosDB {
             .current_version
             .map(|version| version + 1)
             .unwrap_or(0);
-        let num_transactions_in_db = self.get_latest_version().map_or(0, |v| v + 1);
+        let num_transactions_in_db = self.get_synced_version().map_or(0, |v| v + 1);
         ensure!(num_transactions_in_db == first_version && num_transactions_in_db == next_version_in_buffered_state,
             "The first version {} passed in, the next version in buffered state {} and the next version in db {} are inconsistent.",
             first_version,

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -39,9 +39,9 @@ use aptos_resource_viewer::AptosValueAnnotator;
 use aptos_schemadb::{ReadOptions, SchemaBatch};
 use aptos_scratchpad::SparseMerkleTree;
 use aptos_storage_interface::{
-    cached_state_view::ShardedStateCache, db_anyhow as anyhow, db_ensure as ensure,
-    db_other_bail as bail, state_delta::StateDelta, AptosDbError, DbReader, DbWriter,
-    ExecutedTrees, Order, Result, StateSnapshotReceiver, MAX_REQUEST_LIMIT,
+    cached_state_view::ShardedStateCache, db_ensure as ensure, db_other_bail as bail,
+    state_delta::StateDelta, AptosDbError, DbReader, DbWriter, ExecutedTrees, Order, Result,
+    StateSnapshotReceiver, MAX_REQUEST_LIMIT,
 };
 use aptos_types::{
     account_address::AccountAddress,

--- a/storage/aptosdb/src/db_debugger/examine/print_db_versions.rs
+++ b/storage/aptosdb/src/db_debugger/examine/print_db_versions.rs
@@ -49,7 +49,7 @@ impl Cmd {
 
         println!(
             "Overall Progress: {:?}",
-            ledger_db.metadata_db().get_latest_version()?
+            ledger_db.metadata_db().get_synced_version()?
         );
 
         println!(

--- a/storage/aptosdb/src/db_debugger/state_kv/get_value.rs
+++ b/storage/aptosdb/src/db_debugger/state_kv/get_value.rs
@@ -36,7 +36,7 @@ impl Cmd {
 
         let ledger_db = self.db_dir.open_ledger_db()?;
         let db = self.db_dir.open_state_kv_db()?;
-        let latest_version = ledger_db.metadata_db().get_latest_version()?;
+        let latest_version = ledger_db.metadata_db().get_synced_version()?;
         println!("latest version: {latest_version}");
         if self.version != Version::MAX && self.version > latest_version {
             println!(

--- a/storage/aptosdb/src/db_debugger/truncate/mod.rs
+++ b/storage/aptosdb/src/db_debugger/truncate/mod.rs
@@ -88,7 +88,7 @@ impl Cmd {
         let state_kv_db = Arc::new(state_kv_db);
         let overall_version = ledger_db
             .metadata_db()
-            .get_latest_version()
+            .get_synced_version()
             .expect("Overall commit progress must exist.");
         let ledger_db_version = ledger_db
             .metadata_db()
@@ -273,7 +273,7 @@ mod test {
                 version += txns_to_commit.len() as u64;
             }
 
-            let db_version = db.get_latest_version().unwrap();
+            let db_version = db.get_synced_version().unwrap();
             prop_assert_eq!(db_version, version - 1);
 
             drop(db);
@@ -292,7 +292,7 @@ mod test {
             cmd.run().unwrap();
 
             let db = if input.1 { AptosDB::new_for_test_with_sharding(&tmp_dir, DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD) } else { AptosDB::new_for_test(&tmp_dir) };
-            let db_version = db.get_latest_version().unwrap();
+            let db_version = db.get_synced_version().unwrap();
             prop_assert!(db_version <= target_version);
             target_version = db_version;
 

--- a/storage/aptosdb/src/event_store/mod.rs
+++ b/storage/aptosdb/src/event_store/mod.rs
@@ -256,16 +256,6 @@ impl EventStore {
         }
     }
 
-    pub fn get_block_metadata(&self, version: Version) -> Result<(Version, NewBlockEvent)> {
-        let (first_version, event_index, seq_num) = self
-            .lookup_event_before_or_at_version(&new_block_event_key(), version)?
-            .ok_or_else(|| AptosDbError::NotFound("NewBlockEvent".to_string()))?;
-
-        let new_block_event = self.get_event_by_version_and_index(first_version, event_index)?;
-        let payload = bcs::from_bytes(new_block_event.event_data())?;
-        Ok((first_version, payload))
-    }
-
     /// Finds the first event sequence number in a specified stream on which `comp` returns false.
     /// (assuming the whole stream is partitioned by `comp`)
     fn search_for_event_lower_bound<C>(

--- a/storage/aptosdb/src/fast_sync_storage_wrapper.rs
+++ b/storage/aptosdb/src/fast_sync_storage_wrapper.rs
@@ -62,7 +62,7 @@ impl FastSyncStorageWrapper {
             && (db_main
                 .ledger_db
                 .metadata_db()
-                .get_latest_version()
+                .get_synced_version()
                 .map_or(0, |v| v)
                 == 0)
         {

--- a/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
+++ b/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
@@ -14,10 +14,7 @@ use crate::{
 };
 use anyhow::anyhow;
 use aptos_schemadb::{ReadOptions, SchemaBatch, DB};
-use aptos_storage_interface::{
-    block_info::{BlockInfo, BlockInfoV0},
-    db_ensure as ensure, AptosDbError, Result,
-};
+use aptos_storage_interface::{block_info::BlockInfo, db_ensure as ensure, AptosDbError, Result};
 use aptos_types::{
     account_config::NewBlockEvent, block_info::BlockHeight, contract_event::ContractEvent,
     epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
@@ -310,19 +307,7 @@ impl LedgerMetadataDb {
     ) -> Result<()> {
         let new_block_event = NewBlockEvent::try_from_bytes(event.event_data())?;
         let block_height = new_block_event.height();
-        let id = new_block_event.hash()?;
-        let epoch = new_block_event.epoch();
-        let round = new_block_event.round();
-        let proposer = new_block_event.proposer();
-        let block_timestamp_usecs = new_block_event.proposed_time();
-        let block_info = BlockInfo::V0(BlockInfoV0::new(
-            id,
-            epoch,
-            round,
-            proposer,
-            block_timestamp_usecs,
-            version,
-        ));
+        let block_info = BlockInfo::from_new_block_event(version, &new_block_event);
         batch.put::<BlockInfoSchema>(&block_height, &block_info)?;
         batch.put::<BlockByVersionSchema>(&version, &block_height)?;
 

--- a/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
+++ b/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
@@ -76,7 +76,7 @@ impl LedgerMetadataDb {
         self.db.write_schemas(batch)
     }
 
-    pub(crate) fn get_latest_version(&self) -> Result<Version> {
+    pub(crate) fn get_synced_version(&self) -> Result<Version> {
         get_progress(&self.db, &DbMetadataKey::OverallCommitProgress)?.ok_or(
             AptosDbError::NotFound("No OverallCommitProgress in db.".to_string()),
         )

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -342,7 +342,7 @@ impl StateStore {
         crash_if_difference_is_too_large: bool,
     ) {
         let ledger_metadata_db = ledger_db.metadata_db();
-        if let Ok(overall_commit_progress) = ledger_metadata_db.get_latest_version() {
+        if let Ok(overall_commit_progress) = ledger_metadata_db.get_synced_version() {
             info!(
                 overall_commit_progress = overall_commit_progress,
                 "Start syncing databases..."
@@ -440,7 +440,7 @@ impl StateStore {
         let num_transactions = state_db
             .ledger_db
             .metadata_db()
-            .get_latest_version()
+            .get_synced_version()
             .map_or(0, |v| v + 1);
 
         let latest_snapshot_version = state_db

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -41,7 +41,7 @@ struct TestData {
 
 fn test_data_strategy() -> impl Strategy<Value = TestData> {
     let db = test_execution_with_storage_impl();
-    let latest_ver = db.get_latest_version().unwrap();
+    let latest_ver = db.get_synced_version().unwrap();
 
     let latest_epoch_state = db.get_latest_epoch_state().unwrap();
     let epoch_ending_lis = db

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -137,7 +137,7 @@ fn end_to_end() {
         assert_eq!(restore_ws, org_ws);
     }
 
-    assert_eq!(tgt_db.get_latest_version().unwrap(), target_version);
+    assert_eq!(tgt_db.get_synced_version().unwrap(), target_version);
     let recovered_transactions = tgt_db
         .get_transactions(
             0,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -286,8 +286,8 @@ pub trait DbReader: Send + Sync {
         /// Returns the latest ledger info, if any.
         fn get_latest_ledger_info_option(&self) -> Result<Option<LedgerInfoWithSignatures>>;
 
-        /// Returns the latest committed version, error on on non-bootstrapped/empty DB.
-        fn get_latest_version(&self) -> Result<Version>;
+        /// Returns the latest "synced" transaction version, potentially not "committed" yet.
+        fn get_synced_version(&self) -> Result<Version>;
 
         /// Returns the latest state checkpoint version if any.
         fn get_latest_state_checkpoint_version(&self) -> Result<Option<Version>>;
@@ -462,6 +462,13 @@ pub trait DbReader: Send + Sync {
         self.get_latest_ledger_info_option().and_then(|opt| {
             opt.ok_or_else(|| AptosDbError::Other("Latest LedgerInfo not found.".to_string()))
         })
+    }
+
+    /// Returns the latest committed version, error on on non-bootstrapped/empty DB.
+    /// N.b. different from `get_synced_version()`.
+    fn get_committed_version(&self) -> Result<Version> {
+        self.get_latest_ledger_info()
+            .map(|li| li.ledger_info().version())
     }
 
     /// Returns the latest version and committed block timestamp

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -466,7 +466,7 @@ pub trait DbReader: Send + Sync {
 
     /// Returns the latest committed version, error on on non-bootstrapped/empty DB.
     /// N.b. different from `get_synced_version()`.
-    fn get_committed_version(&self) -> Result<Version> {
+    fn get_latest_ledger_info_version(&self) -> Result<Version> {
         self.get_latest_ledger_info()
             .map(|li| li.ledger_info().version())
     }

--- a/types/src/account_config/events/new_block.rs
+++ b/types/src/account_config/events/new_block.rs
@@ -21,15 +21,15 @@ use serde::{Deserialize, Serialize};
 /// Should be kept in-sync with NewBlockEvent move struct in block.move.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NewBlockEvent {
-    hash: AccountAddress,
-    epoch: u64,
-    round: u64,
-    height: u64,
-    previous_block_votes_bitvec: Vec<u8>,
-    proposer: AccountAddress,
-    failed_proposer_indices: Vec<u64>,
+    pub hash: AccountAddress,
+    pub epoch: u64,
+    pub round: u64,
+    pub height: u64,
+    pub previous_block_votes_bitvec: Vec<u8>,
+    pub proposer: AccountAddress,
+    pub failed_proposer_indices: Vec<u64>,
     // usecs (microseconds)
-    timestamp: u64,
+    pub timestamp: u64,
 }
 
 impl NewBlockEvent {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

There's confusion in the code between the committed version and the synced version.  In particular, the `get_latest_version()` API returns the synced version while commented otherwise.

An issue related this is the latency monitor calls get_block_info_by_version API which expects a version no larger than the committed version which results in repeated warnings in the log.


## Type of Change
- [x] Bug fix
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

unit tests

patching one of our own fullnodes

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
