### PR TITLE
[CLI][E2E] Disable staking tests

### DIFF
--- a/crates/aptos/e2e/main.py
+++ b/crates/aptos/e2e/main.py
@@ -54,6 +54,7 @@ from cases.node import (
     test_node_update_consensus_key,
     test_node_update_validator_network_address,
 )
+"""
 from cases.stake import (
     test_stake_add_stake,
     test_stake_create_staking_contract,
@@ -66,6 +67,7 @@ from cases.stake import (
     test_stake_withdraw_stake_after_unlock,
     test_stake_withdraw_stake_before_unlock,
 )
+"""
 from common import Network
 from local_testnet import run_node, stop_node, wait_for_startup
 from test_helpers import RunHelper
@@ -163,6 +165,7 @@ async def run_tests(run_helper):
     test_move_view(run_helper)
 
     # Run stake subcommand group tests.
+    """
     test_stake_initialize_stake_owner(run_helper)
     test_stake_add_stake(run_helper)
     test_stake_withdraw_stake_before_unlock(run_helper)
@@ -173,6 +176,7 @@ async def run_tests(run_helper):
     test_stake_set_voter(run_helper)
     await test_stake_create_staking_contract(run_helper)
     test_stake_request_commission(run_helper)
+    """
 
     # Run node subcommand group tests.
     test_node_show_validator_set(run_helper)


### PR DESCRIPTION
## Description
These tests are too flaky due to this reconfiguration + simulation problem ([here](https://github.com/aptos-labs/aptos-core/actions/runs/9280793012/job/25564873884) is an instance of it happening, look for `Move abort in 0x1::stake: ERECONFIGURATION_IN_PROGRESS(0x30014): Validator set change temporarily disabled because of in-progress reconfiguration`). Theoretically https://github.com/aptos-labs/aptos-core/pull/13389 is able to fix it if applied properly (e.g. waiting for reconfiguration in all the necessary places) but unfortunately CLI is understaffed and no one has time to investigate this properly. So let's just disable the staking tests.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
See CI. All tests pass, and quickly.

## Key Areas to Review
N/A

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
