### PR TITLE
[fungible_asset] add uri getters

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/fungible_asset.md
@@ -37,6 +37,8 @@ metadata object can be any object that equipped with <code><a href="fungible_ass
 -  [Function `name`](#0x1_fungible_asset_name)
 -  [Function `symbol`](#0x1_fungible_asset_symbol)
 -  [Function `decimals`](#0x1_fungible_asset_decimals)
+-  [Function `icon_uri`](#0x1_fungible_asset_icon_uri)
+-  [Function `project_uri`](#0x1_fungible_asset_project_uri)
 -  [Function `store_exists`](#0x1_fungible_asset_store_exists)
 -  [Function `store_exists_inline`](#0x1_fungible_asset_store_exists_inline)
 -  [Function `metadata_from_asset`](#0x1_fungible_asset_metadata_from_asset)
@@ -1504,7 +1506,7 @@ Get the symbol of the fungible asset from the <code>metadata</code> object.
 
 ## Function `decimals`
 
-Get the decimals from the <code>metadata</code> object.
+Get the decimals of the fungible asset from the <code>metadata</code> object.
 
 
 <pre><code>#[view]
@@ -1519,6 +1521,58 @@ Get the decimals from the <code>metadata</code> object.
 
 <pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_decimals">decimals</a>&lt;T: key&gt;(metadata: Object&lt;T&gt;): u8 <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a> {
     <a href="fungible_asset.md#0x1_fungible_asset_borrow_fungible_metadata">borrow_fungible_metadata</a>(&metadata).decimals
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_fungible_asset_icon_uri"></a>
+
+## Function `icon_uri`
+
+Get the icon_uri of the fungible asset from the <code>metadata</code> object.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_icon_uri">icon_uri</a>&lt;T: key&gt;(metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_icon_uri">icon_uri</a>&lt;T: key&gt;(metadata: Object&lt;T&gt;): String <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a> {
+    <a href="fungible_asset.md#0x1_fungible_asset_borrow_fungible_metadata">borrow_fungible_metadata</a>(&metadata).icon_uri
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_fungible_asset_project_uri"></a>
+
+## Function `project_uri`
+
+Get the project_uri of the fungible asset from the <code>metadata</code> object.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_project_uri">project_uri</a>&lt;T: key&gt;(metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_project_uri">project_uri</a>&lt;T: key&gt;(metadata: Object&lt;T&gt;): String <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a> {
+    <a href="fungible_asset.md#0x1_fungible_asset_borrow_fungible_metadata">borrow_fungible_metadata</a>(&metadata).project_uri
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -428,9 +428,21 @@ module aptos_framework::fungible_asset {
     }
 
     #[view]
-    /// Get the decimals from the `metadata` object.
+    /// Get the decimals of the fungible asset from the `metadata` object.
     public fun decimals<T: key>(metadata: Object<T>): u8 acquires Metadata {
         borrow_fungible_metadata(&metadata).decimals
+    }
+
+    #[view]
+    /// Get the icon_uri of the fungible asset from the `metadata` object.
+    public fun icon_uri<T: key>(metadata: Object<T>): String acquires Metadata {
+        borrow_fungible_metadata(&metadata).icon_uri
+    }
+
+    #[view]
+    /// Get the project_uri of the fungible asset from the `metadata` object.
+    public fun project_uri<T: key>(metadata: Object<T>): String acquires Metadata {
+        borrow_fungible_metadata(&metadata).project_uri
     }
 
     #[view]
@@ -1020,6 +1032,9 @@ module aptos_framework::fungible_asset {
         assert!(maximum(metadata) == option::some(100), 2);
         assert!(name(metadata) == string::utf8(b"TEST"), 3);
         assert!(symbol(metadata) == string::utf8(b"@@"), 4);
+        assert!(icon_uri(metadata) == string::utf8(b"http://www.example.com/favicon.ico"), 8);
+        assert!(project_uri(metadata) == string::utf8(b"http://www.example.com"), 9);
+
         assert!(decimals(metadata) == 0, 5);
 
         increase_supply(&metadata, 50);


### PR DESCRIPTION
## Description
This change adds URI getters to fungible assets.  Without this change, there is no way to access these fields outside of fungible_asset.move.  This will be primarily useful for testing custom code that sets these URIs with business logic.  There may be some contract-to-contract use cases I don't foresee, so I didn't keep them test-only. 

Both token and collection already have this so I think its a reasonable change:

- https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token-objects/sources/token.move#L568
- https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token-objects/sources/collection.move#L664


## Type of Change
- [ X] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ X] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

I updated the unit test that checks the metadata to include validating these getters.  

## Key Areas to Review
It's a very small change so I don't have any specific area.  The only real question to me is should these be annotated test-only as testing is the main motivation.  I argue no because token/collection both have the equivalent fun be accessible outside of tests.

## Checklist
- [X ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
  - where do I find the list of stakeholders?
- [ X] I tested both happy and unhappy path of the functionality
- [ X] I have made corresponding changes to the documentation
