### PR TITLE
[forge] fix chaos-mesh injection direction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9172,9 +9172,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.8"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
 dependencies = [
  "console",
  "instant",
@@ -14051,7 +14051,7 @@ version = "0.39.0"
 source = "git+https://github.com/banool/self_update.git?rev=8306158ad0fd5b9d4766a3c6bf967e7ef0ea5c4b#8306158ad0fd5b9d4766a3c6bf967e7ef0ea5c4b"
 dependencies = [
  "hyper",
- "indicatif 0.17.8",
+ "indicatif 0.17.7",
  "log",
  "quick-xml 0.23.1",
  "regex",

--- a/testsuite/forge/src/backend/k8s/chaos/netem.yaml
+++ b/testsuite/forge/src/backend/k8s/chaos/netem.yaml
@@ -22,7 +22,7 @@ spec:
     rate: "{rate}mbps"
     limit: 20971520 # placeholder value. not supported by tc netem
     buffer: 10000 # placeholder value. not supported by tc netem
-  direction: both
+  direction: to 
   target:
     selector:
       namespaces:
@@ -30,3 +30,5 @@ spec:
       expressionSelectors:
         - {{ key: app.kubernetes.io/instance, operator: In, values: [{target_instance_labels}] }}
     mode: all
+  # This is required to ensure that the network chaos is applied when using service IPs instead of pod IPs
+  externalTargets: [{service_targets}]

--- a/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml
+++ b/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml
@@ -17,22 +17,20 @@ fullnode:
   # force enable the telemetry service to try to send telemetry
   force_enable_telemetry: true
 
-# Make all services internal NodePort and open all ports
-# NodePort is required for ChaosMesh to function correctly: https://github.com/chaos-mesh/chaos-mesh/issues/3278#issuecomment-1134248492
 service:
   validator:
     external:
-      type: "NodePort"
+      type: "ClusterIP"
     internal:
-      type: "NodePort"
+      type: "ClusterIP"
     enableRestApi: true
     enableMetricsPort: true
 
   fullnode:
     external:
-      type: "NodePort"
+      type: "ClusterIP"
     internal:
-      type: "NodePort"
+      type: "ClusterIP"
     enableRestApi: true
     enableMetricsPort: true
 

--- a/testsuite/forge/src/backend/k8s/node.rs
+++ b/testsuite/forge/src/backend/k8s/node.rs
@@ -268,6 +268,10 @@ impl Node for K8sNode {
         )
         .await
     }
+
+    fn service_name(&self) -> Option<String> {
+        Some(self.service_name.clone())
+    }
 }
 
 impl Validator for K8sNode {}

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -367,6 +367,10 @@ impl Node for LocalNode {
     fn expose_metric(&self) -> Result<u64> {
         Ok(0)
     }
+
+    fn service_name(&self) -> Option<String> {
+        None
+    }
 }
 
 impl Validator for LocalNode {}

--- a/testsuite/forge/src/interface/node.rs
+++ b/testsuite/forge/src/interface/node.rs
@@ -72,6 +72,8 @@ pub trait Node: Send + Sync {
     fn counter(&self, counter: &str, port: u64) -> Result<f64>;
 
     fn expose_metric(&self) -> Result<u64>;
+
+    fn service_name(&self) -> Option<String>;
 }
 
 /// Trait used to represent a running Validator

--- a/testsuite/testcases/src/multi_region_network_test.rs
+++ b/testsuite/testcases/src/multi_region_network_test.rs
@@ -120,25 +120,39 @@ impl InterRegionNetEmConfig {
         let group_netems: Vec<GroupNetEm> = peer_groups
             .iter()
             .combinations(2)
-            .map(|comb| {
+            .flat_map(|comb| {
                 let (from_region, from_chunk, stats) = &comb[0];
                 let (to_region, to_chunk, _) = &comb[1];
 
-                let (bandwidth, latency) = stats.get(to_region).unwrap();
-                let netem = GroupNetEm {
-                    name: format!("{}-to-{}-netem", from_region, to_region),
-                    source_nodes: from_chunk.to_vec(),
-                    target_nodes: to_chunk.to_vec(),
-                    delay_latency_ms: *latency as u64,
-                    delay_jitter_ms: self.delay_jitter_ms,
-                    delay_correlation_percentage: self.delay_correlation_percentage,
-                    loss_percentage: self.loss_percentage,
-                    loss_correlation_percentage: self.loss_correlation_percentage,
-                    rate_in_mbps: *bandwidth / 1e6 as u64,
-                };
-                info!("inter-region netem {:?}", netem);
+                let (bandwidth, rtt_latency) = stats.get(to_region).unwrap();
+                let hop_latency = rtt_latency / 2.0;
+                let netems = [
+                    GroupNetEm {
+                        name: format!("{}-to-{}-netem", from_region, to_region),
+                        source_nodes: from_chunk.to_vec(),
+                        target_nodes: to_chunk.to_vec(),
+                        delay_latency_ms: hop_latency as u64,
+                        delay_jitter_ms: self.delay_jitter_ms,
+                        delay_correlation_percentage: self.delay_correlation_percentage,
+                        loss_percentage: self.loss_percentage,
+                        loss_correlation_percentage: self.loss_correlation_percentage,
+                        rate_in_mbps: *bandwidth / 1e6 as u64,
+                    },
+                    GroupNetEm {
+                        name: format!("{}-to-{}-netem", to_region, from_region),
+                        source_nodes: to_chunk.to_vec(),
+                        target_nodes: from_chunk.to_vec(),
+                        delay_latency_ms: hop_latency as u64,
+                        delay_jitter_ms: self.delay_jitter_ms,
+                        delay_correlation_percentage: self.delay_correlation_percentage,
+                        loss_percentage: self.loss_percentage,
+                        loss_correlation_percentage: self.loss_correlation_percentage,
+                        rate_in_mbps: *bandwidth / 1e6 as u64,
+                    },
+                ];
+                info!("inter-region netem {:?}", netems);
 
-                netem
+                netems
             })
             .collect();
 

--- a/testsuite/testcases/src/network_bandwidth_test.rs
+++ b/testsuite/testcases/src/network_bandwidth_test.rs
@@ -6,6 +6,7 @@ use aptos_forge::{
     GroupNetworkBandwidth, NetworkContext, NetworkTest, SwarmChaos, SwarmNetworkBandwidth, Test,
 };
 
+/// This is deprecated. Use [crate::multi_region_network_test::MultiRegionNetworkEmulationTest] instead
 pub struct NetworkBandwidthTest;
 
 // Bandwidth

--- a/testsuite/testcases/src/network_loss_test.rs
+++ b/testsuite/testcases/src/network_loss_test.rs
@@ -4,6 +4,7 @@
 use crate::{LoadDestination, NetworkLoadTest};
 use aptos_forge::{NetworkContext, NetworkTest, SwarmChaos, SwarmNetworkLoss, Test};
 
+/// This is deprecated. Use [crate::multi_region_network_test::MultiRegionNetworkEmulationTest] instead
 pub struct NetworkLossTest;
 
 // Loss parameters

--- a/testsuite/testcases/src/network_partition_test.rs
+++ b/testsuite/testcases/src/network_partition_test.rs
@@ -4,6 +4,7 @@
 use crate::{LoadDestination, NetworkLoadTest};
 use aptos_forge::{NetworkContext, NetworkTest, SwarmChaos, SwarmNetworkPartition, Test};
 
+/// This is deprecated. Use [crate::multi_region_network_test::MultiRegionNetworkEmulationTest] instead
 pub struct NetworkPartitionTest;
 
 // Partition

--- a/testsuite/testcases/src/three_region_simulation_test.rs
+++ b/testsuite/testcases/src/three_region_simulation_test.rs
@@ -22,6 +22,8 @@ impl Test for ThreeRegionSameCloudSimulationTest {
 /// 2. Each region has minimal network delay amongst its nodes
 /// 3. Each region has a network delay to the other two regions, as estimated by https://www.cloudping.co/grid
 /// 4. Currently simulating a 50 percentile network delay between us-west <--> af-south <--> eu-north
+///
+/// This is deprecated and flawed. Use [crate::multi_region_network_test::MultiRegionNetworkEmulationTest] instead
 fn create_three_region_swarm_network_delay(swarm: &dyn Swarm) -> SwarmNetworkDelay {
     let all_validators = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

It turns out, network chaos is only applied based on the source and destination pod IPs, however, we use k8s services in Forge cluster, which resolve to service IPs that are different from pod IPs. In order to support them, this PR extends the targets to include the service IPs. To do so, it leverages the `externalTargets` field which can either be domains or IP address and populates them with the service domains of the stateful sets. 

`externalTargets` are only supported with `to` direction, so it splits the chaos with `both` direction into two each with `to` direction.

Also, fixes a bug where we applied the RTT delay in each direction instead of dividing it.

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [X] Other (specify) Forge

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

On Forge

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
