### PR TITLE
[compiler-v2] Add access specifier check to reference safety

### DIFF
--- a/third_party/move/move-compiler-v2/tests/reference-safety/call_access_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/call_access_invalid.exp
@@ -1,0 +1,47 @@
+
+Diagnostics:
+error: function reads global `m::R<u64>` which is currently mutably borrowed
+   ┌─ tests/reference-safety/call_access_invalid.move:27:9
+   │
+ 5 │     fun reads_any_R(addr: address) reads R {
+   │                                          -- access declared here
+   ·
+26 │         let _r1 = borrow_global_mut<R<u64>>(addr);
+   │                   ------------------------------- previous mutable global borrow
+27 │         reads_any_R(addr);
+   │         ^^^^^^^^^^^^^^^^^ function called here
+
+error: function reads global `m::R<u64>` which is currently mutably borrowed
+   ┌─ tests/reference-safety/call_access_invalid.move:28:9
+   │
+ 9 │     fun reads_any_cafe(addr: address) reads 0xcafe::*::* {
+   │                                             ------------- access declared here
+   ·
+26 │         let _r1 = borrow_global_mut<R<u64>>(addr);
+   │                   ------------------------------- previous mutable global borrow
+27 │         reads_any_R(addr);
+28 │         reads_any_cafe(addr);
+   │         ^^^^^^^^^^^^^^^^^^^^ function called here
+
+error: function reads global `m::R<u64>` which is currently mutably borrowed
+   ┌─ tests/reference-safety/call_access_invalid.move:29:9
+   │
+13 │     fun reads_any_m(addr: address) reads 0xcafe::m::* {
+   │                                          ------------- access declared here
+   ·
+26 │         let _r1 = borrow_global_mut<R<u64>>(addr);
+   │                   ------------------------------- previous mutable global borrow
+   ·
+29 │         reads_any_m(addr);
+   │         ^^^^^^^^^^^^^^^^^ function called here
+
+error: function writes global `m::R<u64>` which is currently borrowed
+   ┌─ tests/reference-safety/call_access_invalid.move:45:9
+   │
+21 │     fun writes_any_R_u64(addr: address) writes R<u64>(addr) {
+   │                                                ------------ access declared here
+   ·
+44 │         let _r1 = borrow_global<R<u64>>(addr);
+   │                   --------------------------- previous global borrow
+45 │         writes_any_R_u64(addr);
+   │         ^^^^^^^^^^^^^^^^^^^^^^ function called here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/call_access_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/call_access_invalid.move
@@ -1,0 +1,55 @@
+module 0xcafe::m {
+
+    struct R<phantom T> has key, copy, drop { }
+
+    fun reads_any_R(addr: address) reads R {
+        let _x = borrow_global<R<u64>>(addr);
+    }
+
+    fun reads_any_cafe(addr: address) reads 0xcafe::*::* {
+        let _x = borrow_global<R<u64>>(addr);
+    }
+
+    fun reads_any_m(addr: address) reads 0xcafe::m::* {
+        let _x = borrow_global<R<u64>>(addr);
+    }
+
+    fun reads_not_any_m(addr: address) !reads 0xcafe::m::* {
+       let _x = borrow_global<R<u64>>(addr);
+    }
+
+    fun writes_any_R_u64(addr: address) writes R<u64>(addr) {
+        let _x = borrow_global_mut<R<u64>>(addr);
+    }
+
+    fun t0_invalid(addr: address) acquires R {
+        let _r1 = borrow_global_mut<R<u64>>(addr);
+        reads_any_R(addr);
+        reads_any_cafe(addr);
+        reads_any_m(addr);
+        reads_not_any_m(addr); // no error
+        *_r1;
+    }
+
+    fun t1_valid(addr: address) acquires R {
+        let _r1 = borrow_global<R<u64>>(addr);
+        reads_any_R(addr);
+        reads_any_cafe(addr);
+        reads_any_m(addr);
+        reads_not_any_m(addr);
+        *_r1;
+    }
+
+    fun t2_invalid(addr: address) acquires R {
+        let _r1 = borrow_global<R<u64>>(addr);
+        writes_any_R_u64(addr);
+        *_r1;
+    }
+
+    fun t3_valid(addr: address) acquires R {
+        let _r1 = borrow_global<R<u128>>(addr);
+        writes_any_R_u64(addr);
+        *_r1;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/call_access_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/call_access_invalid.no-opt.exp
@@ -1,0 +1,47 @@
+
+Diagnostics:
+error: function reads global `m::R<u64>` which is currently mutably borrowed
+   ┌─ tests/reference-safety/call_access_invalid.move:27:9
+   │
+ 5 │     fun reads_any_R(addr: address) reads R {
+   │                                          -- access declared here
+   ·
+26 │         let _r1 = borrow_global_mut<R<u64>>(addr);
+   │                   ------------------------------- previous mutable global borrow
+27 │         reads_any_R(addr);
+   │         ^^^^^^^^^^^^^^^^^ function called here
+
+error: function reads global `m::R<u64>` which is currently mutably borrowed
+   ┌─ tests/reference-safety/call_access_invalid.move:28:9
+   │
+ 9 │     fun reads_any_cafe(addr: address) reads 0xcafe::*::* {
+   │                                             ------------- access declared here
+   ·
+26 │         let _r1 = borrow_global_mut<R<u64>>(addr);
+   │                   ------------------------------- previous mutable global borrow
+27 │         reads_any_R(addr);
+28 │         reads_any_cafe(addr);
+   │         ^^^^^^^^^^^^^^^^^^^^ function called here
+
+error: function reads global `m::R<u64>` which is currently mutably borrowed
+   ┌─ tests/reference-safety/call_access_invalid.move:29:9
+   │
+13 │     fun reads_any_m(addr: address) reads 0xcafe::m::* {
+   │                                          ------------- access declared here
+   ·
+26 │         let _r1 = borrow_global_mut<R<u64>>(addr);
+   │                   ------------------------------- previous mutable global borrow
+   ·
+29 │         reads_any_m(addr);
+   │         ^^^^^^^^^^^^^^^^^ function called here
+
+error: function writes global `m::R<u64>` which is currently borrowed
+   ┌─ tests/reference-safety/call_access_invalid.move:45:9
+   │
+21 │     fun writes_any_R_u64(addr: address) writes R<u64>(addr) {
+   │                                                ------------ access declared here
+   ·
+44 │         let _r1 = borrow_global<R<u64>>(addr);
+   │                   --------------------------- previous global borrow
+45 │         writes_any_R_u64(addr);
+   │         ^^^^^^^^^^^^^^^^^^^^^^ function called here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_acquires_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_acquires_invalid.exp
@@ -1,34 +1,118 @@
 
-============ bytecode verification failed ========
-
 Diagnostics:
-bug: BYTECODE VERIFICATION FAILED
+error: function acquires global `M::R` which is currently mutably borrowed
    ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:16:23
    │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+15 │         let r1 = borrow_global_mut<R>(addr);
+   │                  -------------------------- previous mutable global borrow
 16 │         let R { f } = acq(addr);
-   │                       ^^^^^^^^^ ICE failed bytecode verifier: VMError {
-    major_status: GLOBAL_REFERENCE_ERROR,
-    sub_status: None,
-    message: None,
-    exec_state: None,
-    location: Module(
-        ModuleId {
-            address: 0000000000000000000000000000000000000000000000000000000008675309,
-            name: Identifier(
-                "M",
-            ),
-        },
-    ),
-    indices: [
-        (
-            FunctionDefinition,
-            3,
-        ),
-    ],
-    offsets: [
-        (
-            FunctionDefinitionIndex(3),
-            3,
-        ),
-    ],
-}
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently mutably borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:22:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+21 │         let f_ref = &mut borrow_global_mut<R>(addr).f;
+   │                     ---------------------------------
+   │                     │    │
+   │                     │    previous mutable global borrow
+   │                     used by mutable field borrow
+22 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently mutably borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:28:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+27 │         let r1 = id_mut(borrow_global_mut<R>(addr));
+   │                  ----------------------------------
+   │                  │      │
+   │                  │      previous mutable global borrow
+   │                  used by mutable call result
+28 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently mutably borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:34:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+33 │         let f_ref = id_mut(&mut borrow_global_mut<R>(addr).f);
+   │                            ---------------------------------
+   │                            │    │
+   │                            │    previous mutable global borrow
+   │                            used by mutable field borrow
+34 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:40:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+39 │         let r1 = borrow_global<R>(addr);
+   │                  ---------------------- previous global borrow
+40 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:46:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+45 │         let f_ref = &borrow_global<R>(addr).f;
+   │                     -------------------------
+   │                     ││
+   │                     │previous global borrow
+   │                     used by field borrow
+46 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:52:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+51 │         let r1 = id(borrow_global<R>(addr));
+   │                  --------------------------
+   │                  │  │
+   │                  │  previous global borrow
+   │                  used by call result
+52 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:58:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+57 │         let f_ref = id(&borrow_global<R>(addr).f);
+   │                        -------------------------
+   │                        ││
+   │                        │previous global borrow
+   │                        used by field borrow
+58 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently mutably borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:66:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+65 │         let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
+   │                                -------------------------- previous mutable global borrow
+66 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_acquires_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_acquires_invalid.no-opt.exp
@@ -1,34 +1,118 @@
 
-============ bytecode verification failed ========
-
 Diagnostics:
-bug: BYTECODE VERIFICATION FAILED
+error: function acquires global `M::R` which is currently mutably borrowed
    ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:16:23
    │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+15 │         let r1 = borrow_global_mut<R>(addr);
+   │                  -------------------------- previous mutable global borrow
 16 │         let R { f } = acq(addr);
-   │                       ^^^^^^^^^ ICE failed bytecode verifier: VMError {
-    major_status: GLOBAL_REFERENCE_ERROR,
-    sub_status: None,
-    message: None,
-    exec_state: None,
-    location: Module(
-        ModuleId {
-            address: 0000000000000000000000000000000000000000000000000000000008675309,
-            name: Identifier(
-                "M",
-            ),
-        },
-    ),
-    indices: [
-        (
-            FunctionDefinition,
-            3,
-        ),
-    ],
-    offsets: [
-        (
-            FunctionDefinitionIndex(3),
-            3,
-        ),
-    ],
-}
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently mutably borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:22:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+21 │         let f_ref = &mut borrow_global_mut<R>(addr).f;
+   │                     ---------------------------------
+   │                     │    │
+   │                     │    previous mutable global borrow
+   │                     used by mutable field borrow
+22 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently mutably borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:28:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+27 │         let r1 = id_mut(borrow_global_mut<R>(addr));
+   │                  ----------------------------------
+   │                  │      │
+   │                  │      previous mutable global borrow
+   │                  used by mutable call result
+28 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently mutably borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:34:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+33 │         let f_ref = id_mut(&mut borrow_global_mut<R>(addr).f);
+   │                            ---------------------------------
+   │                            │    │
+   │                            │    previous mutable global borrow
+   │                            used by mutable field borrow
+34 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:40:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+39 │         let r1 = borrow_global<R>(addr);
+   │                  ---------------------- previous global borrow
+40 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:46:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+45 │         let f_ref = &borrow_global<R>(addr).f;
+   │                     -------------------------
+   │                     ││
+   │                     │previous global borrow
+   │                     used by field borrow
+46 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:52:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+51 │         let r1 = id(borrow_global<R>(addr));
+   │                  --------------------------
+   │                  │  │
+   │                  │  previous global borrow
+   │                  used by call result
+52 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:58:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+57 │         let f_ref = id(&borrow_global<R>(addr).f);
+   │                        -------------------------
+   │                        ││
+   │                        │previous global borrow
+   │                        used by field borrow
+58 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here
+
+error: function acquires global `M::R` which is currently mutably borrowed
+   ┌─ tests/reference-safety/v1-tests/call_acquires_invalid.move:66:23
+   │
+10 │     fun acq(addr: address): R acquires R {
+   │                                        -- access declared here
+   ·
+65 │         let r1; if (cond) r1 = borrow_global_mut<R>(addr) else r1 = &mut r;
+   │                                -------------------------- previous mutable global borrow
+66 │         let R { f } = acq(addr);
+   │                       ^^^^^^^^^ function called here

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -247,7 +247,8 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             include: vec!["/reference-safety/"],
             exclude: vec![],
             exp_suffix: None,
-            options: opts.clone(),
+            // TODO(#13485): Need to turn off acquires check for now to test 2.0 access specifiers
+            options: opts.clone().set_experiment(Experiment::ACQUIRES_CHECK, false),
             stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::None,
             dump_bytecode: DumpLevel::None,
@@ -269,7 +270,8 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             // Some reference tests create different errors since variable names are
             // known without optimizations, so we need to have a different exp file
             exp_suffix: Some("no-opt.exp"),
-            options: opts.clone().set_experiment(Experiment::OPTIMIZE, false),
+            options: opts.clone().set_experiment(Experiment::OPTIMIZE, false)
+                .set_experiment(Experiment::ACQUIRES_CHECK, false),
             stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::None,
             dump_bytecode: DumpLevel::None,


### PR DESCRIPTION
## Description

Closes #13146

Adds a check that a global resource is not borrowed when it is declared in the access specifier list of a function.

This implements the full semantics of Move 2.0 access specifiers. However, if the 2.0 language is not enabled, access specifiers other then `acquires` will be rejected by the context checker, and for that special case the behavior is equivalent.

In order to test the extended access specifier semantics, we need to disable the existing acquires checker, which is not yet implemented for general access specifiers.


## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Existing failing test now works plus new tests
