### PR TITLE
Fix the simulation API not showing detail error info

### DIFF
--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -1376,12 +1376,7 @@ impl TransactionsApi {
         let version = ledger_info.version();
 
         // Ensure that all known statuses return their values in the output (even if they aren't supposed to)
-        let exe_status = match vm_status.clone().keep_or_discard() {
-            Ok(kept_vm_status) => kept_vm_status.into(),
-            Err(discarded_vm_status) => {
-                ExecutionStatus::MiscellaneousError(Some(discarded_vm_status))
-            },
-        };
+        let exe_status = ExecutionStatus::convert_vm_status_for_simulation(vm_status.clone());
 
         let stats_key = match txn.payload() {
             TransactionPayload::Script(_) => {

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -922,6 +922,17 @@ impl ExecutionStatus {
         matches!(self, ExecutionStatus::Success)
     }
 
+    // Used by simulation API for showing detail error message. Should not be used by production code.
+    pub fn convert_vm_status_for_simulation(vm_status: VMStatus) -> Self {
+        let mut show_error_flags = Features::default();
+        show_error_flags.disable(FeatureFlag::REMOVE_DETAILED_ERROR_FROM_HASH);
+        let (txn_status, _aux_data) =
+            TransactionStatus::from_vm_status(vm_status, true, &show_error_flags);
+        txn_status.status().unwrap_or_else(|discarded_code| {
+            ExecutionStatus::MiscellaneousError(Some(discarded_code))
+        })
+    }
+
     pub fn remove_error_detail(self) -> Self {
         match self {
             ExecutionStatus::MoveAbort {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

we try to get the detail error from VM status directly, the detail error in txn output may be lost after feature turned on

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
Added new test cover simulation API detail error info

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
