### PR TITLE
[move] introduce bytecode specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10413,6 +10413,7 @@ dependencies = [
  "arbitrary",
  "backtrace",
  "indexmap 1.9.3",
+ "move-bytecode-spec",
  "move-core-types",
  "proptest",
  "proptest-derive",
@@ -10438,6 +10439,15 @@ dependencies = [
  "move-ir-types",
  "move-symbol-pool",
  "serde",
+]
+
+[[package]]
+name = "move-bytecode-spec"
+version = "0.1.0"
+dependencies = [
+ "once_cell",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,7 @@ members = [
     "third_party/move/move-binary-format",
     "third_party/move/move-binary-format/serializer-tests",
     "third_party/move/move-borrow-graph",
+    "third_party/move/move-bytecode-spec",
     "third_party/move/move-bytecode-verifier",
     "third_party/move/move-bytecode-verifier/bytecode-verifier-tests",
     "third_party/move/move-bytecode-verifier/fuzz",
@@ -803,6 +804,7 @@ z3tracer = "0.8.0"
 # MOVE DEPENDENCIES
 move-abigen = { path = "third_party/move/move-prover/move-abigen" }
 move-binary-format = { path = "third_party/move/move-binary-format" }
+move-bytecode-spec = { path = "third_party/move/move-bytecode-spec" }
 move-bytecode-verifier = { path = "third_party/move/move-bytecode-verifier" }
 move-bytecode-utils = { path = "third_party/move/tools/move-bytecode-utils" }
 move-cli = { path = "third_party/move/tools/move-cli" }

--- a/third_party/move/move-binary-format/Cargo.toml
+++ b/third_party/move/move-binary-format/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = { workspace = true }
 arbitrary = { workspace = true, optional = true, features = ["derive"] }
 backtrace = { workspace = true }
 indexmap = { workspace = true }
+move-bytecode-spec = { workspace = true }
 move-core-types = { path = "../move-core/types" }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }

--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -36,6 +36,7 @@ use crate::{
     internals::ModuleIndex,
     IndexKind, SignatureTokenKind,
 };
+use move_bytecode_spec::bytecode_spec;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
@@ -1340,499 +1341,1254 @@ pub struct CodeUnit {
 ///
 /// Bytecodes operate on a stack machine and each bytecode has side effect on the stack and the
 /// instruction stream.
+#[bytecode_spec]
 #[derive(Clone, Hash, Eq, VariantCount, PartialEq)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 #[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub enum Bytecode {
-    /// Pop and discard the value at the top of the stack.
-    /// The value on the stack must be an copyable type.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., value -> ...```
+    #[group = "stack_and_local"]
+    #[description = "Pop and discard the value at the top of the stack. The value on the stack must be an copyable type."]
+    #[semantics = "stack >> _"]
+    #[paranoid_post = r#"
+        ty_stack >> ty
+        assert ty has drop
+    "#]
     Pop,
-    /// Return from function, possibly with values according to the return types in the
-    /// function signature. The returned values are pushed on the stack.
-    /// The function signature of the function being executed defines the semantic of
-    /// the Ret opcode.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., arg_val(1), ..., arg_val(n) -> ..., return_val(1), ..., return_val(n)```
+
+    // TODO: double check semantics
+    #[group = "control_flow"]
+    #[description = r#"
+        Return from current function call, possibly with values according to the return types in the function signature. 
+
+        The returned values need to be pushed on the stack prior to the return instruction.
+    "#]
+    #[semantics = r#"
+        call_stack >> current_frame 
+        // The frame of the function being return from is dropped.
+        
+        current_frame.pc += 1
+    "#]
     Ret,
-    /// Branch to the instruction at position `CodeOffset` if the value at the top of the stack
-    /// is true. Code offsets are relative to the start of the instruction stream.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., bool_value -> ...```
+
+    #[group = "control_flow"]
+    #[description = r#"
+        Branch to the instruction at position `code_offset` if the value at the top of the stack is true. 
+        Code offsets are relative to the start of the function body.
+    "#]
+    #[static_operands = "[code_offset]"]
+    #[semantics = r#"
+        stack >> flag
+        if flag is true
+            current_frame.pc = code_offset
+        else
+            current_frame.pc += 1
+    "#]
+    #[paranoid_pre = "ty_stack >> _"]
     BrTrue(CodeOffset),
-    /// Branch to the instruction at position `CodeOffset` if the value at the top of the stack
-    /// is false. Code offsets are relative to the start of the instruction stream.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., bool_value -> ...```
+
+    #[group = "control_flow"]
+    #[description = r#"
+        Branch to the instruction at position `code_offset` if the value at the top of the stack is false. 
+        Code offsets are relative to the start of the function body.
+    "#]
+    #[static_operands = "[code_offset]"]
+    #[semantics = r#"
+        stack >> flag
+        if flag is false
+            current_frame.pc = code_offset
+        else
+            current_frame += 1
+    "#]
+    #[paranoid_pre = "ty_stack >> _"]
     BrFalse(CodeOffset),
-    /// Branch unconditionally to the instruction at position `CodeOffset`. Code offsets are
-    /// relative to the start of the instruction stream.
-    ///
-    /// Stack transition: none
+
+    #[group = "control_flow"]
+    #[description = r#"
+        Branch unconditionally to the instruction at position `code_offset`. 
+        Code offsets are relative to the start of a function body.
+    "#]
+    #[static_operands = "[code_offset]"]
+    #[semantics = "current_frame.pc = code_offset"]
     Branch(CodeOffset),
-    /// Push a U8 constant onto the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```... -> ..., u8_value```
+
+    #[group = "stack_and_local"]
+    #[description = "Push a u8 constant onto the stack."]
+    #[static_operands = "[u8_value]"]
+    #[semantics = "stack << u8_value"]
+    #[paranoid_post = "ty_stack << u8"]
     LdU8(u8),
-    /// Push a U64 constant onto the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```... -> ..., u64_value```
+
+    #[group = "stack_and_local"]
+    #[description = "Push a u64 constant onto the stack."]
+    #[static_operands = "[u64_value]"]
+    #[semantics = "stack << u64_value"]
+    #[paranoid_post = "ty_stack << u64"]
     LdU64(u64),
-    /// Push a U128 constant onto the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```... -> ..., u128_value```
+
+    #[group = "stack_and_local"]
+    #[description = "Push a u128 constant onto the stack."]
+    #[static_operands = "[u128_value]"]
+    #[semantics = "stack << u128_value"]
+    #[paranoid_post = "ty_stack << u128"]
     LdU128(u128),
-    /// Convert the value at the top of the stack into u8.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., integer_value -> ..., u8_value```
+
+    #[group = "casting"]
+    #[description = r#"
+        Convert the integer value at the top of the stack into a u8. 
+        An arithmetic error will be raised if the value cannot be represented as a u8.
+    "#]
+    #[semantics = r#"
+        stack >> int_val
+        if int_val > u8::MAX:
+            arithmetic error
+        else:
+            stack << int_val as u8
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> _
+        ty_stack << u8
+    "#]
     CastU8,
-    /// Convert the value at the top of the stack into u64.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., integer_value -> ..., u8_value```
+
+    #[group = "casting"]
+    #[description = r#"
+        Convert the integer value at the top of the stack into a u64. 
+        An arithmetic error will be raised if the value cannot be represented as a u64.
+    "#]
+    #[semantics = r#"
+        stack >> int_val
+        if int_val > u64::MAX:
+            arithmetic error
+        else:
+            stack << int_val as u64
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> _
+        ty_stack << u64
+    "#]
     CastU64,
-    /// Convert the value at the top of the stack into u128.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., integer_value -> ..., u128_value```
+
+    #[group = "casting"]
+    #[description = r#"
+        Convert the integer value at the top of the stack into a u128. 
+        An arithmetic error will be raised if the value cannot be represented as a u128.
+    "#]
+    #[semantics = r#"
+        stack >> int_val
+        if int_val > u128::MAX:
+            arithmetic error
+        else:
+            stack << int_val as u128
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> _
+        ty_stack << u128
+    "#]
     CastU128,
-    /// Push a `Constant` onto the stack. The value is loaded and deserialized (according to its
-    /// type) from the `ConstantPool` via `ConstantPoolIndex`
-    ///
-    /// Stack transition:
-    ///
-    /// ```... -> ..., value```
+
+    #[group = "stack_and_local"]
+    #[description = r#"
+        Push a constant value onto the stack. 
+        The value is loaded and deserialized (according to its type) from the the file format.
+    "#]
+    #[static_operands = "[const_idx]"]
+    #[semantics = "stack << constants[const_idx]"]
+    #[paranoid_post = "ty_stack << const_ty"]
+    #[gas_type_creation_tier_1 = "const_ty"]
     LdConst(ConstantPoolIndex),
-    /// Push `true` onto the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```... -> ..., true```
+
+    #[group = "stack_and_local"]
+    #[description = "Push a true value onto the stack."]
+    #[semantics = "stack << true"]
+    #[paranoid_post = "ty_stack << bool"]
     LdTrue,
-    /// Push `false` onto the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```... -> ..., false```
+
+    #[group = "stack_and_local"]
+    #[description = "Push a false value onto the stack."]
+    #[semantics = "stack << false"]
+    #[paranoid_post = "ty_stack << bool"]
     LdFalse,
-    /// Push the local identified by `LocalIndex` onto the stack. The value is copied and the
-    /// local is still safe to use.
-    ///
-    /// Stack transition:
-    ///
-    /// ```... -> ..., value```
+
+    #[group = "stack_and_local"]
+    #[description = r#"
+        Push the local identified by the local index onto the stack.
+        The value must be copyable and the local remains safe to use.
+    "#]
+    #[semantics = r#"
+        stack << locals[local_idx]
+    "#]
+    #[paranoid_post = r#"
+        ty = clone local_ty
+        assert ty has copy 
+        ty_stack << ty
+    "#]
     CopyLoc(LocalIndex),
-    /// Push the local identified by `LocalIndex` onto the stack. The local is moved and it is
-    /// invalid to use from that point on, unless a store operation writes to the local before
-    /// any read to that local.
-    ///
-    /// Stack transition:
-    ///
-    /// ```... -> ..., value```
+
+    #[group = "stack_and_local"]
+    #[description = r#"
+        Move the local identified by the local index onto the stack. 
+
+        Once moved, the local becomes invalid to use, unless a store operation writes 
+        to the local before any read to that local.
+    "#]
+    #[static_operands = "[local_idx]"]
+    #[semantics = r#"
+        stack << locals[local_idx]
+        locals[local_idx] = invalid
+    "#]
+    #[paranoid_post = r#"
+        ty = clone local_ty 
+        ty_stack << ty
+    "#]
     MoveLoc(LocalIndex),
-    /// Pop value from the top of the stack and store it into the function locals at
-    /// position `LocalIndex`.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., value -> ...```
+
+    #[group = "stack_and_local"]
+    #[description = r#"
+        Pop value from the top of the stack and store it into the local identified by the local index. 
+        
+        If the local contains an old value, then that value is dropped.
+    "#]
+    #[static_operands = "[local_idx]"]
+    #[semantics = r#"
+        stack >> val
+        locals[local_idx] = val
+    "#]
+    #[paranoid_pre = r#"
+        ty << clone local_ty
+        ty_stack >> val_ty
+        assert ty == val_ty
+        assert ty has drop
+    "#]
     StLoc(LocalIndex),
-    /// Call a function. The stack has the arguments pushed first to last.
-    /// The arguments are consumed and pushed to the locals of the function.
-    /// Return values are pushed on the stack and available to the caller.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., arg(1), arg(2), ...,  arg(n) -> ..., return_value(1), return_value(2), ...,
-    /// return_value(k)```
+
+    #[group = "control_flow"]
+    #[static_operands = "[func_handle_idx]"]
+    #[description = r#"
+        Call a function. The stack has the arguments pushed first to last. 
+        The arguments are consumed and pushed to the locals of the function. 
+
+        Return values are pushed on the stack and available to the caller after returning from the callee.    
+    "#]
+    #[semantics = r#"
+        func = <func from handle or instantiation>
+        // Here `func` is a prototype containinig information like the
+        // the function signature, the locals, and the body.
+        
+        ty_args = if func.is_generic then func.ty_args else []
+        
+        n = func.num_params
+        stack >> arg_n
+        ..
+        stack >> arg_1
+        
+        if func.is_native()
+            call_native(func.name, ty_args, args = [arg_1, .., arg_n])
+            current_frame.pc += 1
+        else
+            call_stack << current_frame
+        
+            current_frame = new_frame_from_func(
+                func, 
+                ty_args, 
+                locals = [arg_1, .., arg_n, null, ..]
+                                        // ^ other locals
+            )
+    "#]
+    #[paranoid_post = r#"
+        assert func visibility rules
+        for i in 0..#args:
+            ty_stack >> ty
+            assert ty == locals[#args -  i - 1]
+    "#]
+    #[gas_type_creation_tier_1 = "local_tys"]
     Call(FunctionHandleIndex),
+    #[group = "control_flow"]
+    #[static_operands = "[func_inst_idx]"]
+    #[description = "Generic version of `Call`."]
+    #[semantics = "See `Call`."]
+    #[paranoid_post = "See `Call`."]
+    #[gas_type_creation_tier_0 = "ty_args"]
+    #[gas_type_creation_tier_1 = "local_tys"]
     CallGeneric(FunctionInstantiationIndex),
-    /// Create an instance of the type specified via `StructHandleIndex` and push it on the stack.
-    /// The values of the fields of the struct, in the order they appear in the struct declaration,
-    /// must be pushed on the stack. All fields must be provided.
-    ///
-    /// A Pack instruction must fully initialize an instance.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., field(1)_value, field(2)_value, ..., field(n)_value -> ..., instance_value```
+
+    #[group = "struct"]
+    #[static_operands = "[struct_def_idx]"]
+    #[description = r#"
+        Create an instance of the struct specified by the struct def index and push it on the stack. 
+        The values of the fields of the struct, in the order they appear in the struct declaration, 
+        must be pushed on the stack. All fields must be provided. 
+    "#]
+    #[semantics = r#"
+        stack >> field_n
+        ...
+        stack >> field_1
+        stack << struct { field_1, ..., field_n }    
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> tys 
+        assert tys == field_tys 
+        check field abilities 
+        ty_stack << struct_ty
+    "#]
     Pack(StructDefinitionIndex),
+    #[group = "struct"]
+    #[static_operands = "[struct_inst_idx]"]
+    #[description = "Generic version of `Pack`."]
+    #[semantics = "See `Pack`."]
+    #[paranoid_post = "See `Pack`."]
+    #[gas_type_creation_tier_0 = "struct_ty"]
+    #[gas_type_creation_tier_1 = "field_tys"]
     PackGeneric(StructDefInstantiationIndex),
-    /// Destroy an instance of a type and push the values bound to each field on the
-    /// stack.
-    ///
-    /// The values of the fields of the instance appear on the stack in the order defined
-    /// in the struct definition.
-    ///
-    /// This order makes `Unpack<T>` the inverse of `Pack<T>`. So `Unpack<T>; Pack<T>` is the identity
-    /// for struct `T`.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., instance_value -> ..., field(1)_value, field(2)_value, ..., field(n)_value```
+
+    #[group = "struct"]
+    #[static_operands = "[struct_def_idx]"]
+    #[description = "Destroy an instance of a struct and push the values bound to each field onto the stack."]
+    #[semantics = r#"
+        stack >> struct { field_1, .., field_n }
+        stack << field_1
+        ...
+        stack << field_n
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ty 
+        assert ty == struct_ty 
+        ty_stack << field_tys
+    "#]
     Unpack(StructDefinitionIndex),
+    #[group = "struct"]
+    #[static_operands = "[struct_inst_idx]"]
+    #[description = "Generic version of `Unpack`."]
+    #[semantics = "See `Unpack`."]
+    #[paranoid_post = "See `Unpack`."]
+    #[gas_type_creation_tier_0 = "struct_ty"]
+    #[gas_type_creation_tier_1 = "field_tys"]
     UnpackGeneric(StructDefInstantiationIndex),
-    /// Read a reference. The reference is on the stack, it is consumed and the value read is
-    /// pushed on the stack.
-    ///
-    /// Reading a reference performs a copy of the value referenced.
-    /// As such, ReadRef requires that the type of the value has the `Copy` ability.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., reference_value -> ..., value```
+
+    #[group = "reference"]
+    #[description = r#"
+        Consume the reference at the top of the stack, read the value referenced, and push the value onto the stack.
+
+        Reading a reference performs a copy of the value referenced.
+        As such, ReadRef requires that the type of the value has the `copy` ability.
+    "#]
+    #[semantics = r#"
+        stack >> ref
+        stack << copy *ref
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ref_ty
+        assert ty has copy
+    "#]
     ReadRef,
-    /// Write to a reference. The reference and the value are on the stack and are consumed.
-    ///
-    ///
-    /// WriteRef requires that the type of the value has the `Drop` ability as the previous value
-    /// is lost
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., value, reference_value -> ...```
+
+    #[group = "reference"]
+    #[description = r#"
+        Pop a reference and a value off the stack, and write the value to the reference.
+
+        It is required that the type of the value has the `drop` ability, as the previous value is dropped.
+    "#]
+    #[semantics = r#"
+        stack >> ref
+        stack >> val
+        *ref = val
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ref_ty 
+        ty_stack >> val_ty 
+        assert ref_ty == &val_ty 
+        assert val_ty has drop
+    "#]
     WriteRef,
-    /// Convert a mutable reference to an immutable reference.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., reference_value -> ..., reference_value```
+
+    #[group = "reference"]
+    #[description = r#"
+        Convert a mutable reference into an immutable reference.
+    "#]
+    #[semantics = r#"
+        stack >> mutable_ref
+        stack << mutable_ref.into_immutable()
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> &mut ty 
+        ty_stack << &ty
+    "#]
     FreezeRef,
-    /// Load a mutable reference to a local identified by LocalIndex.
-    ///
-    /// The local must not be a reference.
-    ///
-    /// Stack transition:
-    ///
-    /// ```... -> ..., reference```
+
+    #[group = "stack_and_local"]
+    #[description = "Load a mutable reference to a local identified by the local index."]
+    #[static_operands = "[local_idx]"]
+    #[semantics = "stack << &mut locals[local_idx]"]
+    #[paranoid_post = r#"
+        ty << clone local_ty 
+        ty_stack << &mut ty
+    "#]
     MutBorrowLoc(LocalIndex),
-    /// Load an immutable reference to a local identified by LocalIndex.
-    ///
-    /// The local must not be a reference.
-    ///
-    /// Stack transition:
-    ///
-    /// ```... -> ..., reference```
+
+    #[group = "stack_and_local"]
+    #[description = "Load an immutable reference to a local identified by the local index."]
+    #[static_operands = "[local_idx]"]
+    #[semantics = "stack << &locals[local_idx]"]
+    #[paranoid_post = r#"
+        ty << clone local_ty 
+        ty_stack << &ty
+    "#]
     ImmBorrowLoc(LocalIndex),
-    /// Load a mutable reference to a field identified by `FieldHandleIndex`.
-    /// The top of the stack must be a mutable reference to a type that contains the field
-    /// definition.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., reference -> ..., field_reference```
+
+    #[group = "struct"]
+    #[static_operands = "[field_handle_idx]"]
+    #[description = r#"
+        Consume the reference to a struct at the top of the stack,
+        and load a mutable reference to the field identifierd by the field handle index.
+    "#]
+    #[semantics = r#"
+        stack >> struct_ref
+        stack << &mut (*struct_ref).field(field_index)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ty 
+        assert ty == &mut struct_ty 
+        ty_stack << &mut field_ty
+    "#]
     MutBorrowField(FieldHandleIndex),
-    /// Load a mutable reference to a field identified by `FieldInstantiationIndex`.
-    /// The top of the stack must be a mutable reference to a type that contains the field
-    /// definition.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., reference -> ..., field_reference```
+
+    #[group = "struct"]
+    #[static_operands = "[field_inst_idx]"]
+    #[description = r#"
+        Consume the reference to a generic struct at the top of the stack,
+        and load a mutable reference to the field identifierd by the field handle index.
+    "#]
+    #[semantics = r#"
+        stack >> struct_ref
+        stack << &mut (*struct_ref).field(field_index)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ty 
+        assert ty == &struct_ty 
+        ty_stack << &mut field_ty
+    "#]
+    #[gas_type_creation_tier_0 = "struct_ty"]
+    #[gas_type_creation_tier_1 = "field_ty"]
     MutBorrowFieldGeneric(FieldInstantiationIndex),
-    /// Load an immutable reference to a field identified by `FieldHandleIndex`.
-    /// The top of the stack must be a reference to a type that contains the field definition.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., reference -> ..., field_reference```
+
+    #[group = "struct"]
+    #[static_operands = "[field_handle_idx]"]
+    #[description = r#"
+        Consume the reference to a struct at the top of the stack, 
+        and load an immutable reference to the field identifierd by the field handle index.
+    "#]
+    #[semantics = r#"
+        stack >> struct_ref
+        stack << &(*struct_ref).field(field_index)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ty 
+        assert ty == &struct_ty 
+        ty_stack << &field_ty
+    "#]
     ImmBorrowField(FieldHandleIndex),
-    /// Load an immutable reference to a field identified by `FieldInstantiationIndex`.
-    /// The top of the stack must be a reference to a type that contains the field definition.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., reference -> ..., field_reference```
+
+    #[group = "struct"]
+    #[static_operands = "[field_inst_idx]"]
+    #[description = r#"
+        Consume the reference to a generic struct at the top of the stack,
+        and load an immutable reference to the field identifierd by the field handle index.
+    "#]
+    #[semantics = r#"
+        stack >> struct_ref
+        stack << &(*struct_ref).field(field_index)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ty 
+        assert ty == &struct_ty 
+        ty_stack << &field_ty
+    "#]
+    #[gas_type_creation_tier_0 = "struct_ty"]
+    #[gas_type_creation_tier_1 = "field_ty"]
     ImmBorrowFieldGeneric(FieldInstantiationIndex),
-    /// Return a mutable reference to an instance of type `StructDefinitionIndex` published at the
-    /// address passed as argument. Abort execution if such an object does not exist or if a
-    /// reference has already been handed out.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., address_value -> ..., reference_value```
+
+    #[group = "global"]
+    #[static_operands = "[struct_def_idx]"]
+    #[description = r#"
+        Return a mutable reference to an instance of the specified type under the address passed as argument.
+
+        Abort execution if such an object does not exist.
+    "#]
+    #[semantics = r#"
+        stack >> addr
+
+        if global_state[addr] contains struct_type
+            stack << &global_state[addr][struct_type]
+        else
+            error
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ty 
+        assert ty == address 
+        assert struct_ty has key 
+        ty_stack << &struct_ty
+    "#]
     MutBorrowGlobal(StructDefinitionIndex),
+    #[group = "global"]
+    #[static_operands = "[struct_inst_idx]"]
+    #[description = "Generic version of `mut_borrow_global`."]
+    #[semantics = "See `mut_borrow_global`."]
+    #[paranoid_post = "See `mut_borrow_global`."]
+    #[gas_type_creation_tier_0 = "resource_ty"]
     MutBorrowGlobalGeneric(StructDefInstantiationIndex),
-    /// Return an immutable reference to an instance of type `StructDefinitionIndex` published at
-    /// the address passed as argument. Abort execution if such an object does not exist or if a
-    /// reference has already been handed out.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., address_value -> ..., reference_value```
+
+    #[group = "global"]
+    #[static_operands = "[struct_def_idx]"]
+    #[description = r#"
+        Return am immutable reference to an instance of the specified type under the address passed as argument.
+
+        Abort execution if such an object does not exist.
+    "#]
+    #[semantics = r#"
+        stack >> addr
+
+        if global_state[addr] contains struct_type
+            stack << &mut global_state[addr][struct_type]
+        else
+            error
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ty 
+        assert ty == address 
+        assert struct_ty has key 
+        ty_stack << &mut struct_ty
+    "#]
     ImmBorrowGlobal(StructDefinitionIndex),
+    #[group = "global"]
+    #[static_operands = "[struct_inst_idx]"]
+    #[description = "Generic version of `imm_borrow_global`."]
+    #[semantics = "See `imm_borrow_global`."]
+    #[paranoid_post = "See `imm_borrow_global`."]
+    #[gas_type_creation_tier_0 = "resource_ty"]
     ImmBorrowGlobalGeneric(StructDefInstantiationIndex),
-    /// Add the 2 u64 at the top of the stack and pushes the result on the stack.
-    /// The operation aborts the transaction in case of overflow.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., u64_value(1), u64_value(2) -> ..., u64_value```
+
+    #[group = "arithmetic"]
+    #[description = r#"
+        Add the two integer values at the top of the stack and push the result on the stack. 
+        
+        This operation aborts the transaction in case of overflow.
+    "#]
+    #[semantics = r#"
+        stack >> rhs
+        stack >> lhs
+        if lhs + rhs > int_ty::max
+            arithmetic error
+        else
+            stack << (lhs + rhs)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty
+        ty_stack << left_ty
+    "#]
     Add,
-    /// Subtract the 2 u64 at the top of the stack and pushes the result on the stack.
-    /// The operation aborts the transaction in case of underflow.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., u64_value(1), u64_value(2) -> ..., u64_value```
+
+    #[group = "arithmetic"]
+    #[description = r#"
+        Subtract the two integer value at the top of the stack and push the result on the stack. 
+
+        This operation aborts the transaction in case of underflow.
+    "#]
+    #[semantics = r#"
+        stack >> rhs
+        stack >> lhs
+        if lhs < rhs
+            arithmetic error
+        else
+            stack << (lhs - rhs)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty
+        ty_stack << left_ty
+    "#]
     Sub,
-    /// Multiply the 2 u64 at the top of the stack and pushes the result on the stack.
-    /// The operation aborts the transaction in case of overflow.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., u64_value(1), u64_value(2) -> ..., u64_value```
+
+    #[group = "arithmetic"]
+    #[description = r#"
+        Multiply the two integer values at the top of the stack and push the result on the stack. 
+
+        This operation aborts the transaction in case of overflow.
+    "#]
+    #[semantics = r#"
+        stack >> rhs
+        stack >> lhs
+        if lhs * rhs > int_ty::max
+            arithmetic error
+        else
+            stack << (lhs * rhs)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty
+        ty_stack << left_ty
+    "#]
     Mul,
-    /// Perform a modulo operation on the 2 u64 at the top of the stack and pushes the
-    /// result on the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., u64_value(1), u64_value(2) -> ..., u64_value```
+
+    #[group = "arithmetic"]
+    #[description = r#"
+        Perform a modulo operation on the two integer values at the top of the stack and push the result on the stack. 
+
+        This operation aborts the transaction in case the right hand side is zero.
+    "#]
+    #[semantics = r#"
+        stack >> rhs
+        stack >> lhs
+        if rhs == 0
+            arithmetic error
+        else
+            stack << (lhs % rhs)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty
+        ty_stack << left_ty
+    "#]
     Mod,
-    /// Divide the 2 u64 at the top of the stack and pushes the result on the stack.
-    /// The operation aborts the transaction in case of "divide by 0".
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., u64_value(1), u64_value(2) -> ..., u64_value```
+
+    #[group = "arithmetic"]
+    #[description = r#"
+        Divide the two integer values at the top of the stack and push the result on the stack. 
+
+        This operation aborts the transaction in case the right hand side is zero.
+    "#]
+    #[semantics = r#"
+        stack >> rhs
+        stack >> lhs
+        if rhs == 0
+            arithmetic error
+        else
+            stack << (lhs / rhs)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty
+        ty_stack << left_ty
+    "#]
     Div,
-    /// Bitwise OR the 2 u64 at the top of the stack and pushes the result on the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., u64_value(1), u64_value(2) -> ..., u64_value```
+
+    #[group = "bitwise"]
+    #[description = r#"
+        Perform a bitwise OR operation on the two integer values at the top of the stack
+        and push the result on the stack. 
+
+        The operands can be of any primitive integer type.
+    "#]
+    #[semantics = r#"
+        stack >> rhs
+        stack >> lhs
+        stack << lhs | rhs
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty
+        ty_stack << left_ty
+    "#]
     BitOr,
-    /// Bitwise AND the 2 u64 at the top of the stack and pushes the result on the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., u64_value(1), u64_value(2) -> ..., u64_value```
+
+    #[group = "bitwise"]
+    #[description = r#"
+        Perform a bitwise AND operation on the two integer values at the top of the stack
+        and push the result on the stack. 
+
+        The operands can be of any primitive integer type.
+    "#]
+    #[semantics = r#"
+        stack >> rhs
+        stack >> lhs
+        stack << lhs & rhs
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty
+        ty_stack << left_ty
+    "#]
     BitAnd,
-    /// Bitwise XOR the 2 u64 at the top of the stack and pushes the result on the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., u64_value(1), u64_value(2) -> ..., u64_value```
+
+    // TODO: Rename the enum variant to BitXor for consistency.
+    #[name = "bit_xor"]
+    #[group = "bitwise"]
+    #[description = r#"
+        Perform a bitwise XOR operation on the two integer values at the top of the stack
+        and push the result on the stack. 
+
+        The operands can be of any primitive integer type.
+    "#]
+    #[semantics = r#"
+        stack >> rhs
+        stack >> lhs
+        stack << lhs ^ rhs
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty
+        ty_stack << left_ty
+    "#]
     Xor,
-    /// Logical OR the 2 bool at the top of the stack and pushes the result on the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., bool_value(1), bool_value(2) -> ..., bool_value```
+
+    #[group = "boolean"]
+    #[description = r#"
+        Perform a boolean OR operation on the two bool values at the top of the stack 
+        and push the result on the stack. 
+    "#]
+    #[semantics = r#"
+        stack >> rhs
+        stack >> lhs
+        stack << lhs || rhs
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty
+        ty_stack << left_ty
+    "#]
     Or,
-    /// Logical AND the 2 bool at the top of the stack and pushes the result on the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., bool_value(1), bool_value(2) -> ..., bool_value```
+
+    #[group = "boolean"]
+    #[description = r#"
+        Perform a boolean AND operation on the two bool values at the top of the stack 
+        and push the result on the stack. 
+    "#]
+    #[semantics = r#"
+        stack >> rhs
+        stack >> lhs
+        stack << lhs && rhs
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty
+        ty_stack << left_ty
+    "#]
     And,
-    /// Logical NOT the bool at the top of the stack and pushes the result on the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., bool_value -> ..., bool_value```
+
+    #[group = "boolean"]
+    #[description = r#"
+        Invert the bool value at the top of the stack and push the result on the stack. 
+    "#]
+    #[semantics = r#"
+        stack >> bool_val
+        stack << (not bool_val)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ty 
+        assert ty == bool 
+        ty_stack << bool
+    "#]
     Not,
-    /// Compare for equality the 2 value at the top of the stack and pushes the
-    /// result on the stack.
-    /// The values on the stack must have `Drop` as they will be consumed and destroyed.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., value(1), value(2) -> ..., bool_value```
+
+    #[group = "comparison"]
+    #[description = r#"
+        Compare for equality the two values at the top of the stack and push the result on the stack.
+
+        The values must have the `drop` ability as they will be consumed and destroyed.
+    "#]
+    #[semantics = r#"
+        stack >> rhs
+        stack >> lhs
+        stack << (lhs == rhs)
+
+        Note that equality is only defined for
+            - Simple primitive types: u8, u16, u32, u64, u128, u256, bool, address
+            - vector<T> where equality is defined for T
+            - &T (or &mut T) where equality is defined for T
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty 
+        assert left_ty has drop 
+        ty_stack << bool
+    "#]
     Eq,
-    /// Compare for inequality the 2 value at the top of the stack and pushes the
-    /// result on the stack.
-    /// The values on the stack must have `Drop` as they will be consumed and destroyed.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., value(1), value(2) -> ..., bool_value```
+
+    #[group = "comparison"]
+    #[description = r#"
+        Similar to `eq`, but with the result being inverted.
+    "#]
+    #[semantics = r#"
+        stack >> rhs
+        stack >> lhs
+        stack << (lhs != rhs)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty 
+        assert left_ty has drop 
+        ty_stack << bool
+    "#]
     Neq,
-    /// Perform a "less than" operation of the 2 u64 at the top of the stack and pushes the
-    /// result on the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., u64_value(1), u64_value(2) -> ..., bool_value```
+
+    #[group = "comparison"]
+    #[description = r#"
+        Perform a "less than" operation of the two integer values at the top of the stack
+        and push the boolean result on the stack.
+    "#]
+    #[semantics = r#"
+        stack >> (rhs: int_ty)
+        stack >> (lhs: int_ty)
+        stack << (lhs < rhs)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty 
+        assert left_ty has drop 
+        ty_stack << bool
+    "#]
     Lt,
-    /// Perform a "greater than" operation of the 2 u64 at the top of the stack and pushes the
-    /// result on the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., u64_value(1), u64_value(2) -> ..., bool_value```
+
+    #[group = "comparison"]
+    #[description = r#"
+        Perform a "greater than" operation of the two integer values at the top of the stack
+        and push the boolean result on the stack.
+    "#]
+    #[semantics = r#"
+        stack >> (rhs: int_ty)
+        stack >> (lhs: int_ty)
+        stack << (lhs > rhs)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty 
+        assert left_ty has drop 
+        ty_stack << bool
+    "#]
     Gt,
-    /// Perform a "less than or equal" operation of the 2 u64 at the top of the stack and pushes
-    /// the result on the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., u64_value(1), u64_value(2) -> ..., bool_value```
+
+    #[group = "comparison"]
+    #[description = r#"
+        Perform a "less than or equal to" operation of the two integer values at the top of the stack
+        and push the boolean result on the stack.
+    "#]
+    #[semantics = r#"
+        stack >> (rhs: int_ty)
+        stack >> (lhs: int_ty)
+        stack << (lhs <= rhs)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty 
+        assert left_ty has drop 
+        ty_stack << bool
+    "#]
     Le,
-    /// Perform a "greater than or equal" than operation of the 2 u64 at the top of the stack
-    /// and pushes the result on the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., u64_value(1), u64_value(2) -> ..., bool_value```
+
+    #[group = "comparison"]
+    #[description = r#"
+        Perform a "greater than or equal to" operation of the two integer values at the top of the stack
+        and push the boolean result on the stack.
+    "#]
+    #[semantics = r#"
+        stack >> (rhs: int_ty)
+        stack >> (lhs: int_ty)
+        stack << (lhs >= rhs)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty 
+        assert left_ty == right_ty 
+        assert left_ty has drop 
+        ty_stack << bool
+    "#]
     Ge,
-    /// Abort execution with errorcode
-    ///
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., errorcode -> ...```
+
+    #[group = "control_flow"]
+    #[description = r#"
+        Abort the transaction with an error code.
+    "#]
+    #[semantics = r#"
+        stack >> (error_code: u64)
+        abort transaction with error_code
+    "#]
     Abort,
-    /// No operation.
-    ///
-    /// Stack transition: none
+
+    #[group = "control_flow"]
+    #[description = r#"
+        A "no operation" -- an instruction that does not perform any meaningful operation. 
+        It can be however, useful as a placeholder in certain cases.
+    "#]
+    #[semantics = "current_frame.pc += 1"]
+    #[paranoid_pre = "ty_stack >> _"]
     Nop,
-    /// Returns whether or not a given address has an object of type StructDefinitionIndex
-    /// published already
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., address_value -> ..., bool_value```
+
+    #[group = "global"]
+    #[static_operands = "[struct_def_idx]"]
+    #[description = "Check whether or not a given address in the global storage has an object of the specified type already."]
+    #[semantics = r#"
+        stack >> addr
+        stack << (global_state[addr] contains struct_type)    
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ty 
+        assert ty == address 
+        ty_stack << bool
+    "#]
     Exists(StructDefinitionIndex),
+    #[group = "global"]
+    #[static_operands = "[struct_inst_idx]"]
+    #[description = "Generic version of `Exists`"]
+    #[semantics = "See `Exists`."]
+    #[paranoid_post = "See `Exists`."]
+    #[gas_type_creation_tier_0 = "resource_ty"]
     ExistsGeneric(StructDefInstantiationIndex),
-    /// Move the instance of type StructDefinitionIndex, at the address at the top of the stack.
-    /// Abort execution if such an object does not exist.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., address_value -> ..., value```
+
+    #[group = "global"]
+    #[static_operands = "[struct_def_idx]"]
+    #[description = r#"
+        Move the value of the specified type under the address in the global storage onto the top of the stack. 
+
+        Abort execution if such an value does not exist.    
+    "#]
+    #[semantics = r#"
+        stack >> addr
+
+        if global_state[addr] contains struct_type
+            stack << global_state[addr][struct_type]
+            global_state[addr][struct_type] = null
+        else
+            error
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ty 
+        assert ty == signer 
+        assert struct_ty has key 
+        ty_stack << struct_ty
+    "#]
     MoveFrom(StructDefinitionIndex),
+    #[group = "global"]
+    #[static_operands = "[struct_inst_idx]"]
+    #[description = "Generic version of `MoveFrom`"]
+    #[semantics = "See `MoveFrom`."]
+    #[paranoid_post = "See `MoveFrom`."]
+    #[gas_type_creation_tier_0 = "resource_ty"]
     MoveFromGeneric(StructDefInstantiationIndex),
-    /// Move the instance at the top of the stack to the address of the `Signer` on the stack below
-    /// it
-    /// Abort execution if an object of type StructDefinitionIndex already exists in address.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., signer_value, value -> ...```
+
+    #[group = "global"]
+    #[static_operands = "[struct_def_idx]"]
+    #[description = r#"
+        Move the value at the top of the stack into the global storage,
+        under the address of the `signer` on the stack below it. 
+
+        Abort execution if an object of the same type already exists under that address.
+    "#]
+    #[semantics = r#"
+        stack >> struct_val
+        stack >> &signer
+        
+        if global_state[signer.addr] contains struct_type
+            error
+        else
+            global_state[signer.addr][struct_type] = struct_val
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ty1 
+        assert ty1 == signer 
+        ty_stack >> ty2 
+        assert ty == struct_ty 
+        assert struct_ty has key
+    "#]
     MoveTo(StructDefinitionIndex),
+    #[group = "global"]
+    #[static_operands = "[struct_inst_idx]"]
+    #[description = "Generic version of `MoveTo`"]
+    #[semantics = "See `MoveTo`."]
+    #[paranoid_post = "See `MoveTo`."]
+    #[gas_type_creation_tier_0 = "resource_ty"]
     MoveToGeneric(StructDefInstantiationIndex),
-    /// Shift the (second top value) left (top value) bits and pushes the result on the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., u64_value(1), u64_value(2) -> ..., u64_value```
+
+    #[group = "bitwise"]
+    #[description = r#"
+        Shift the (second top value) right (top value) bits and pushes the result on the stack.
+
+        The number of bits shifted must be less than the number of bits in the integer value being shifted, 
+        or the transaction will be aborted with an arithmetic error.
+    "#]
+    #[semantics = r#"
+        stack >> (rhs: u8)
+        stack >> (lhs: int_ty)
+        if rhs >= num_bits_in(int_ty)
+            arithmetic error
+        else
+            stack << (lhs __shift_left__ rhs)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty
+        ty_stack << left_ty
+    "#]
     Shl,
-    /// Shift the (second top value) right (top value) bits and pushes the result on the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., u64_value(1), u64_value(2) -> ..., u64_value```
+
+    #[group = "bitwise"]
+    #[description = r#"
+        Shift the (second top value) left (top value) bits and pushes the result on the stack.
+
+        The number of bits shifted must be less than the number of bits in the integer value being shifted, 
+        or the transaction will be aborted with an arithmetic error.
+    "#]
+    #[semantics = r#"
+        stack >> (rhs: u8)
+        stack >> (lhs: int_ty)
+        if rhs >= num_bits_in(int_ty)
+            arithmetic error
+        else
+            stack << (lhs __shift_right__ rhs)
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> left_ty 
+        ty_stack >> right_ty
+        ty_stack << left_ty
+    "#]
     Shr,
-    /// Create a vector by packing a statically known number of elements from the stack. Abort the
-    /// execution if there are not enough number of elements on the stack to pack from or they don't
-    /// have the same type identified by the SignatureIndex.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., e1, e2, ..., eN -> ..., vec[e1, e2, ..., eN]```
+
+    #[group = "vector"]
+    #[description = r#"
+        Create a vector by packing a statically known number of elements from the stack. 
+
+        Abort the execution if there are not enough number of elements on the stack 
+        to pack from or they do not have the same type identified by the `elem_ty_idx`.
+    "#]
+    #[static_operands = "[elem_ty_idx] [n]"]
+    #[semantics = r#"
+        stack >> elem_n
+        ..
+        stack >> elem_1
+        stack << vector[elem_1, .., elem_n]
+    "#]
+    #[paranoid_post = r#"
+        elem_ty << instantiate elem_ty 
+        for i in 1..=n: 
+            ty_stack >> ty  
+            assert ty == elem_ty 
+        ty_stack << vector<elem_ty>
+    "#]
+    #[gas_type_creation_tier_0 = "elem_ty"]
     VecPack(SignatureIndex, u64),
-    /// Return the length of the vector,
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., vector_reference -> ..., u64_value```
+
+    #[group = "vector"]
+    #[description = "Get the length of a vector."]
+    #[static_operands = "[elem_ty_idx]"]
+    #[semantics = r#"
+        stack >> vec_ref
+        stack << (*vec_ref).len
+    "#]
+    #[paranoid_post = r#"
+        elem_ty << instantiate elem_ty 
+        ty_stack >> ty 
+        assert ty == &elem_ty 
+        ty_stack << u64
+    "#]
+    #[gas_type_creation_tier_0 = "elem_ty"]
     VecLen(SignatureIndex),
-    /// Acquire an immutable reference to the element at a given index of the vector. Abort the
-    /// execution if the index is out of bounds.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., vector_reference, u64_value -> .., element_reference```
+
+    #[group = "vector"]
+    #[description = r#"
+        Acquire an immutable reference to the element at a given index of the vector. 
+        Abort the execution if the index is out of bounds.
+    "#]
+    #[static_operands = "[elem_ty_idx]"]
+    #[semantics = r#"
+        stack >> i
+        stack >> vec_ref
+        stack << &((*vec_ref)[i])
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> idx_ty 
+        assert idx_ty == u64 
+        ty_stack >> ref_ty 
+        assert ref_ty == &vector<elem_ty> 
+        ty_stack << &elem_ty
+    "#]
+    #[gas_type_creation_tier_0 = "elem_ty"]
     VecImmBorrow(SignatureIndex),
-    /// Acquire a mutable reference to the element at a given index of the vector. Abort the
-    /// execution if the index is out of bounds.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., vector_reference, u64_value -> .., element_reference```
+
+    #[group = "vector"]
+    #[description = r#"
+        Acquire a mutable reference to the element at a given index of the vector. 
+        Abort the execution if the index is out of bounds.
+    "#]
+    #[static_operands = "[elem_ty_idx]"]
+    #[semantics = r#"
+        stack >> i
+        stack >> vec_ref
+        stack << &mut ((*vec_ref)[i])
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> idx_ty 
+        assert idx_ty == u64 
+        ty_stack >> ref_ty 
+        assert ref_ty == &vector<elem_ty> 
+        ty_stack << &mut elem_ty
+    "#]
+    #[gas_type_creation_tier_0 = "elem_ty"]
     VecMutBorrow(SignatureIndex),
-    /// Add an element to the end of the vector.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., vector_reference, element -> ...```
+
+    #[group = "vector"]
+    #[description = "Add an element to the end of the vector."]
+    #[static_operands = "[elem_ty_idx]"]
+    #[semantics = r#"
+        stack >> val
+        stack >> vec_ref
+        (*vec_ref) << val
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> val_ty 
+        assert val_ty == elem_ty 
+        ty_stack >> ref_ty 
+        assert ref_ty == &mut vector<elem_ty>
+    "#]
     VecPushBack(SignatureIndex),
-    /// Pop an element from the end of vector. Aborts if the vector is empty.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., vector_reference -> ..., element```
+
+    #[group = "vector"]
+    #[description = r#"
+        Pop an element from the end of vector. 
+        Aborts if the vector is empty.
+    "#]
+    #[static_operands = "[elem_ty_idx]"]
+    #[semantics = r#"
+        stack >> vec_ref
+        (*vec_ref) >> val
+        stack << val
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ref_ty 
+        assert ref_ty == &mut vector<elem_ty> 
+        ty_stack << val_ty
+    "#]
     VecPopBack(SignatureIndex),
-    /// Destroy the vector and unpack a statically known number of elements onto the stack. Aborts
-    /// if the vector does not have a length N.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., vec[e1, e2, ..., eN] -> ..., e1, e2, ..., eN```
+
+    #[group = "vector"]
+    #[description = r#"
+        Destroy the vector and unpack a statically known number of elements onto the stack. 
+        Abort if the vector does not have a length `n`.
+    "#]
+    #[static_operands = "[elem_ty_idx] [n]"]
+    #[semantics = r#"
+        stack >> vector[elem_1, ..., elem_n]
+        stack << elem_1
+        ...
+        stack << elem_n
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ty 
+        assert ty == vector<elem_ty> 
+        ty_stack << [elem_ty]*n
+    "#]
     VecUnpack(SignatureIndex, u64),
-    /// Swaps the elements at two indices in the vector. Abort the execution if any of the indice
-    /// is out of bounds.
-    ///
-    /// ```..., vector_reference, u64_value(1), u64_value(2) -> ...```
+
+    #[group = "vector"]
+    #[description = r#"
+        Swaps the elements at two indices in the vector. 
+        Abort the execution if any of the indice is out of bounds.
+    "#]
+    #[static_operands = "[elem_ty_idx]"]
+    #[semantics = r#"
+        stack >> j
+        stack >> i
+        stack >> vec_ref
+        (*vec_ref)[i], (*vec_ref)[j] = (*vec_ref)[j], (*vec_ref)[i]
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> ty1
+        ty_stack >> ty2
+        ty_stack >> ty3
+        assert ty1 == u64
+        assert ty2 == u64
+        assert ty3 == &vector<elem_ty>
+    "#]
     VecSwap(SignatureIndex),
-    /// Push a U16 constant onto the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```... -> ..., u16_value```
+
+    #[group = "stack_and_local"]
+    #[description = "Push a u16 constant onto the stack."]
+    #[static_operands = "[u16_value]"]
+    #[semantics = "stack << u16_value"]
+    #[paranoid_post = "ty_stack << u16"]
     LdU16(u16),
-    /// Push a U32 constant onto the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```... -> ..., u32_value```
+
+    #[group = "stack_and_local"]
+    #[description = "Push a u32 constant onto the stack."]
+    #[static_operands = "[u32_value]"]
+    #[semantics = "stack << u32_value"]
+    #[paranoid_post = "ty_stack << u32"]
     LdU32(u32),
-    /// Push a U256 constant onto the stack.
-    ///
-    /// Stack transition:
-    ///
-    /// ```... -> ..., u256_value```
+
+    #[group = "stack_and_local"]
+    #[description = "Push a u256 constant onto the stack."]
+    #[static_operands = "[u256_value]"]
+    #[semantics = "stack << u256_value"]
+    #[paranoid_post = "ty_stack << u256"]
     LdU256(move_core_types::u256::U256),
-    /// Convert the value at the top of the stack into u16.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., integer_value -> ..., u16_value```
+
+    #[group = "casting"]
+    #[description = r#"
+        Convert the integer value at the top of the stack into a u16. 
+        An arithmetic error will be raised if the value cannot be represented as a u16.
+    "#]
+    #[semantics = r#"
+        stack >> int_val
+        if int_val > u16::MAX:
+            arithmetic error
+        else:
+            stack << int_val as u16
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> _
+        ty_stack << u16
+    "#]
     CastU16,
-    /// Convert the value at the top of the stack into u32.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., integer_value -> ..., u32_value```
+
+    #[group = "casting"]
+    #[description = r#"
+        Convert the integer value at the top of the stack into a u32. 
+        An arithmetic error will be raised if the value cannot be represented as a u32.
+    "#]
+    #[semantics = r#"
+        stack >> int_val
+        if int_val > u32::MAX:
+            arithmetic error
+        else:
+            stack << int_val as u32
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> _
+        ty_stack << u32
+    "#]
     CastU32,
-    /// Convert the value at the top of the stack into u256.
-    ///
-    /// Stack transition:
-    ///
-    /// ```..., integer_value -> ..., u256_value```
+
+    #[group = "casting"]
+    #[description = r#"
+        Convert the integer value at the top of the stack into a u256.
+    "#]
+    #[semantics = r#"
+        stack >> int_val
+        stack << int_val as u256
+    "#]
+    #[paranoid_post = r#"
+        ty_stack >> _
+        ty_stack << u256
+    "#]
     CastU256,
+}
+
+#[test]
+fn tttt() {
+    println!("{:#?}", Bytecode::spec());
 }
 
 impl ::std::fmt::Debug for Bytecode {

--- a/third_party/move/move-bytecode-spec/Cargo.toml
+++ b/third_party/move/move-bytecode-spec/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "move-bytecode-spec"
+version = "0.1.0"
+authors = ["Aptos Labs"]
+description = "Move compiler based on stackless bytecode"
+repository = "https://github.com/aptos-labs/aptos-core"
+homepage = "https://aptosfoundation.org/"
+license = "Apache-2.0"
+publish = false
+edition = "2021"
+
+[dependencies]
+once_cell = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
+
+[lib]
+proc-macro = true

--- a/third_party/move/move-bytecode-spec/Cargo.toml
+++ b/third_party/move/move-bytecode-spec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "move-bytecode-spec"
 version = "0.1.0"
 authors = ["Aptos Labs"]
-description = "Move compiler based on stackless bytecode"
+description = "Procedural macros to generate Move bytecode specification"
 repository = "https://github.com/aptos-labs/aptos-core"
 homepage = "https://aptosfoundation.org/"
 license = "Apache-2.0"

--- a/third_party/move/move-bytecode-spec/src/lib.rs
+++ b/third_party/move/move-bytecode-spec/src/lib.rs
@@ -1,0 +1,191 @@
+extern crate proc_macro;
+
+use once_cell::sync::Lazy;
+use proc_macro::TokenStream;
+use quote::quote;
+use std::collections::{btree_map, BTreeMap};
+use syn::{parse_macro_input, Data, DeriveInput, Meta};
+
+/// Helper function to convert upper camel case to lower snake case.
+/// This is programmed using a state machine, capable of handling edge cases like
+//  `StudentIDCard -> student_id_card`.
+fn upper_camel_to_lower_snake_case(s: &str) -> String {
+    let mut res = String::new();
+
+    let mut chars = s.chars();
+
+    let mut buffer = match chars.next() {
+        Some(c) => c,
+        None => return res,
+    };
+    let mut ends_with_upper = false;
+
+    for c in chars {
+        match (buffer.is_ascii_uppercase(), c.is_ascii_uppercase()) {
+            (true, true) => {
+                res.push(buffer.to_ascii_lowercase());
+                ends_with_upper = true;
+            },
+            (false, true) => {
+                res.push(buffer);
+                if buffer != '_' {
+                    res.push('_');
+                }
+                ends_with_upper = false;
+            },
+            (true, false) => {
+                if ends_with_upper {
+                    res.push('_');
+                }
+                res.push(buffer.to_ascii_lowercase());
+                ends_with_upper = true;
+            },
+            (false, false) => {
+                res.push(buffer);
+                ends_with_upper = false;
+            },
+        }
+        buffer = c;
+    }
+
+    res.push(buffer.to_ascii_lowercase());
+
+    res
+}
+
+fn trim_leading_indentation(input: &str) -> String {
+    // Split the input into lines and collect into a vector with trailing spaces trimmed
+    let lines: Vec<&str> = input.lines().map(|line| line.trim_end()).collect();
+    if lines.is_empty() {
+        return "".to_string();
+    }
+
+    // Find the first non-empty line
+    let start = lines.iter().position(|line| !line.is_empty()).unwrap_or(0);
+    // Find the last non-empty line
+    let end = lines.iter().rposition(|line| !line.is_empty()).unwrap_or(0);
+
+    // Slice the lines to remove leading and trailing empty lines
+    let trimmed_lines: &[&str] = &lines[start..=end];
+
+    // Determine the minimum indentation (number of leading spaces) across all non-empty lines
+    let min_indent = trimmed_lines
+        .iter()
+        .filter(|line| !line.is_empty())
+        .map(|line| line.chars().take_while(|c| *c == ' ').count())
+        .min()
+        .unwrap_or(0);
+
+    // Create a new string with the leading spaces trimmed according to the minimum indentation
+    let result_lines: Vec<String> = trimmed_lines
+        .iter()
+        .map(|line| {
+            if line.len() > min_indent {
+                line[min_indent..].to_string()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect();
+
+    // Join the lines back together with newline characters
+    result_lines.join("\n")
+}
+
+static KNOWN_ATTRIBUTES: Lazy<BTreeMap<&str, ()>> = Lazy::new(|| {
+    [
+        "name",
+        "group",
+        "description",
+        "static_operands",
+        "semantics",
+        "paranoid_pre",
+        "paranoid_post",
+        "gas_type_creation_tier_0",
+        "gas_type_creation_tier_1",
+    ]
+    .into_iter()
+    .map(|attr_name| (attr_name, ()))
+    .collect()
+});
+
+#[proc_macro_attribute]
+pub fn bytecode_spec(_attr: TokenStream, tokens: TokenStream) -> TokenStream {
+    let mut input = parse_macro_input!(tokens as DeriveInput);
+
+    let enum_name = &input.ident;
+    let data = match &mut input.data {
+        Data::Enum(data) => data,
+        _ => panic!("#[bytecode_spec] can only be applied to enums"),
+    };
+
+    let mut maps = Vec::new();
+    for variant in &mut data.variants {
+        let variant_name = variant.ident.to_string();
+
+        let mut map_entries = BTreeMap::new();
+        variant.attrs.retain(|attr| {
+            if let Ok(Meta::NameValue(nv)) = attr.parse_meta() {
+                if let Some(attr_name) = nv.path.get_ident() {
+                    let attr_name = attr_name.to_string();
+                    if KNOWN_ATTRIBUTES.contains_key(attr_name.as_str()) {
+                        match nv.lit {
+                            syn::Lit::Str(s) => {
+                                match map_entries.entry(attr_name) {
+                                    btree_map::Entry::Occupied(entry) => {
+                                        panic!(
+                                            "Attribute \"{}\" defined more than once.",
+                                            entry.key()
+                                        );
+                                    },
+                                    btree_map::Entry::Vacant(entry) => {
+                                        entry.insert(trim_leading_indentation(&s.value()));
+                                    },
+                                }
+                                return false;
+                            },
+                            _ => panic!("Invalid value. Expected string literal."),
+                        }
+                    }
+                }
+            }
+            true
+        });
+
+        match map_entries.entry("name".to_string()) {
+            btree_map::Entry::Occupied(_entry) => (),
+            btree_map::Entry::Vacant(entry) => {
+                entry.insert(upper_camel_to_lower_snake_case(&variant_name));
+            },
+        }
+
+        let mut code = quote! {};
+        for (attr_name, val) in map_entries {
+            code.extend(quote! {
+                map.insert(#attr_name.to_string(), #val.to_string());
+            })
+        }
+
+        maps.push(quote! {
+            {
+                let mut map = std::collections::BTreeMap::new();
+                #code
+                map
+            }
+        });
+    }
+
+    let output = quote! {
+        #input
+
+        impl #enum_name {
+            pub fn spec() -> Vec<std::collections::BTreeMap<String, String>> {
+                vec![
+                    #(#maps),*
+                ]
+            }
+        }
+    };
+
+    output.into()
+}

--- a/third_party/move/move-bytecode-spec/tests/tests.rs
+++ b/third_party/move/move-bytecode-spec/tests/tests.rs
@@ -1,0 +1,140 @@
+use move_bytecode_spec::bytecode_spec;
+use std::collections::BTreeMap;
+
+fn test_map(
+    entries: impl IntoIterator<Item = (&'static str, &'static str)>,
+) -> BTreeMap<String, String> {
+    entries
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+}
+
+#[test]
+fn test_empty_enum() {
+    #[bytecode_spec]
+    enum Empty {}
+
+    assert_eq!(Empty::spec(), vec![]);
+}
+
+#[test]
+#[allow(dead_code)]
+fn test_simple_1() {
+    #[bytecode_spec]
+    enum Bytecode {
+        Add,
+    }
+
+    assert_eq!(Bytecode::spec(), vec![test_map([("name", "add")])]);
+}
+
+#[test]
+#[allow(dead_code)]
+fn test_simple_2() {
+    #[bytecode_spec]
+    enum Bytecode {
+        #[group = "arithmetic"]
+        Add,
+        Sub,
+    }
+
+    assert_eq!(Bytecode::spec(), vec![
+        test_map([("name", "add"), ("group", "arithmetic")]),
+        test_map([("name", "sub")]),
+    ]);
+}
+
+#[test]
+#[allow(dead_code)]
+fn test_simple_3() {
+    #[bytecode_spec]
+    enum Bytecode {
+        #[group = "arithmetic"]
+        #[description = "add two numbers up"]
+        Add,
+        #[group = "arithmetic"]
+        Sub,
+    }
+
+    assert_eq!(Bytecode::spec(), vec![
+        test_map([
+            ("name", "add"),
+            ("group", "arithmetic"),
+            ("description", "add two numbers up"),
+        ]),
+        test_map([("name", "sub"), ("group", "arithmetic")]),
+    ]);
+}
+
+#[test]
+#[allow(dead_code)]
+fn test_indentation() {
+    #[bytecode_spec]
+    enum Bytecode {
+        #[description = r#"
+             first line
+               second line
+              third line
+        "#]
+        Add,
+    }
+
+    assert_eq!(Bytecode::spec(), vec![test_map([
+        ("name", "add"),
+        ("description", "first line\n  second line\n third line")
+    ])]);
+}
+
+#[test]
+#[allow(dead_code)]
+fn test_empty_lines_in_between() {
+    #[bytecode_spec]
+    enum Bytecode {
+        #[description = r#"
+
+             first line
+
+
+               second line
+
+
+        "#]
+        Add,
+    }
+
+    assert_eq!(Bytecode::spec(), vec![test_map([
+        ("name", "add"),
+        ("description", "first line\n\n\n  second line")
+    ])]);
+}
+
+#[test]
+#[allow(dead_code)]
+fn test_empty_entry_1() {
+    #[bytecode_spec]
+    enum Bytecode {
+        #[description = ""]
+        Add,
+    }
+
+    assert_eq!(Bytecode::spec(), vec![test_map([
+        ("name", "add"),
+        ("description", "")
+    ])]);
+}
+
+#[test]
+#[allow(dead_code)]
+fn test_empty_entry_2() {
+    #[bytecode_spec]
+    enum Bytecode {
+        #[description = "  "]
+        Add,
+    }
+
+    assert_eq!(Bytecode::spec(), vec![test_map([
+        ("name", "add"),
+        ("description", "")
+    ])]);
+}

--- a/third_party/move/move-bytecode-spec/tests/tests.rs
+++ b/third_party/move/move-bytecode-spec/tests/tests.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
 use move_bytecode_spec::bytecode_spec;
 use std::collections::BTreeMap;
 
@@ -20,40 +23,16 @@ fn test_empty_enum() {
 
 #[test]
 #[allow(dead_code)]
-fn test_simple_1() {
-    #[bytecode_spec]
-    enum Bytecode {
-        Add,
-    }
-
-    assert_eq!(Bytecode::spec(), vec![test_map([("name", "add")])]);
-}
-
-#[test]
-#[allow(dead_code)]
-fn test_simple_2() {
-    #[bytecode_spec]
-    enum Bytecode {
-        #[group = "arithmetic"]
-        Add,
-        Sub,
-    }
-
-    assert_eq!(Bytecode::spec(), vec![
-        test_map([("name", "add"), ("group", "arithmetic")]),
-        test_map([("name", "sub")]),
-    ]);
-}
-
-#[test]
-#[allow(dead_code)]
-fn test_simple_3() {
+fn test_two_instructions() {
     #[bytecode_spec]
     enum Bytecode {
         #[group = "arithmetic"]
         #[description = "add two numbers up"]
+        #[semantics = "stack >> a; stack >> b; stack << a + b;"]
         Add,
         #[group = "arithmetic"]
+        #[description = "subtract two numbers"]
+        #[semantics = "stack >> a; stack >> b; stack << b - a;"]
         Sub,
     }
 
@@ -62,9 +41,54 @@ fn test_simple_3() {
             ("name", "add"),
             ("group", "arithmetic"),
             ("description", "add two numbers up"),
+            ("semantics", "stack >> a; stack >> b; stack << a + b;")
         ]),
-        test_map([("name", "sub"), ("group", "arithmetic")]),
+        test_map([
+            ("name", "sub"),
+            ("group", "arithmetic"),
+            ("description", "subtract two numbers"),
+            ("semantics", "stack >> a; stack >> b; stack << b - a;")
+        ]),
     ]);
+}
+
+#[test]
+#[allow(dead_code)]
+fn test_name_optional() {
+    #[bytecode_spec]
+    enum Bytecode {
+        #[group = "arithmetic"]
+        #[description = ""]
+        #[semantics = ""]
+        Add,
+    }
+
+    assert_eq!(Bytecode::spec(), vec![test_map([
+        ("name", "add"),
+        ("description", ""),
+        ("semantics", ""),
+        ("group", "arithmetic"),
+    ])]);
+}
+
+#[test]
+#[allow(dead_code)]
+fn test_name_override() {
+    #[bytecode_spec]
+    enum Bytecode {
+        #[name = "ADD"]
+        #[group = "arithmetic"]
+        #[description = ""]
+        #[semantics = ""]
+        Add,
+    }
+
+    assert_eq!(Bytecode::spec(), vec![test_map([
+        ("name", "ADD"),
+        ("description", ""),
+        ("semantics", ""),
+        ("group", "arithmetic"),
+    ])]);
 }
 
 #[test]
@@ -72,17 +96,21 @@ fn test_simple_3() {
 fn test_indentation() {
     #[bytecode_spec]
     enum Bytecode {
+        #[group = "arithmetic"]
         #[description = r#"
              first line
                second line
               third line
         "#]
+        #[semantics = ""]
         Add,
     }
 
     assert_eq!(Bytecode::spec(), vec![test_map([
         ("name", "add"),
-        ("description", "first line\n  second line\n third line")
+        ("group", "arithmetic"),
+        ("description", "first line\n  second line\n third line"),
+        ("semantics", ""),
     ])]);
 }
 
@@ -91,6 +119,7 @@ fn test_indentation() {
 fn test_empty_lines_in_between() {
     #[bytecode_spec]
     enum Bytecode {
+        #[group = "arithmetic"]
         #[description = r#"
 
              first line
@@ -100,12 +129,15 @@ fn test_empty_lines_in_between() {
 
 
         "#]
+        #[semantics = ""]
         Add,
     }
 
     assert_eq!(Bytecode::spec(), vec![test_map([
         ("name", "add"),
-        ("description", "first line\n\n\n  second line")
+        ("group", "arithmetic"),
+        ("description", "first line\n\n\n  second line"),
+        ("semantics", ""),
     ])]);
 }
 
@@ -114,13 +146,17 @@ fn test_empty_lines_in_between() {
 fn test_empty_entry_1() {
     #[bytecode_spec]
     enum Bytecode {
+        #[group = "arithmetic"]
         #[description = ""]
+        #[semantics = ""]
         Add,
     }
 
     assert_eq!(Bytecode::spec(), vec![test_map([
         ("name", "add"),
-        ("description", "")
+        ("group", "arithmetic"),
+        ("description", ""),
+        ("semantics", ""),
     ])]);
 }
 
@@ -129,12 +165,16 @@ fn test_empty_entry_1() {
 fn test_empty_entry_2() {
     #[bytecode_spec]
     enum Bytecode {
+        #[group = "arithmetic"]
         #[description = "  "]
+        #[semantics = ""]
         Add,
     }
 
     assert_eq!(Bytecode::spec(), vec![test_map([
         ("name", "add"),
-        ("description", "")
+        ("group", "arithmetic"),
+        ("description", ""),
+        ("semantics", ""),
     ])]);
 }

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1868,29 +1868,29 @@ impl Frame {
             | Bytecode::Xor
             | Bytecode::Or
             | Bytecode::And => {
-                let lhs_ty = interpreter.operand_stack.pop_ty()?;
                 let rhs_ty = interpreter.operand_stack.pop_ty()?;
-                lhs_ty.paranoid_check_eq(&rhs_ty)?;
-                interpreter.operand_stack.push_ty(lhs_ty)?;
+                let lhs_ty = interpreter.operand_stack.pop_ty()?;
+                rhs_ty.paranoid_check_eq(&lhs_ty)?;
+                interpreter.operand_stack.push_ty(rhs_ty)?;
             },
             Bytecode::Shl | Bytecode::Shr => {
-                interpreter.operand_stack.pop_ty()?;
-                let ty = interpreter.operand_stack.pop_ty()?;
-                interpreter.operand_stack.push_ty(ty)?;
+                let _rhs = interpreter.operand_stack.pop_ty()?;
+                let lhs = interpreter.operand_stack.pop_ty()?;
+                interpreter.operand_stack.push_ty(lhs)?;
             },
             Bytecode::Lt | Bytecode::Le | Bytecode::Gt | Bytecode::Ge => {
-                let lhs_ty = interpreter.operand_stack.pop_ty()?;
                 let rhs_ty = interpreter.operand_stack.pop_ty()?;
-                lhs_ty.paranoid_check_eq(&rhs_ty)?;
+                let lhs_ty = interpreter.operand_stack.pop_ty()?;
+                rhs_ty.paranoid_check_eq(&lhs_ty)?;
 
                 let bool_ty = ty_builder.create_bool_ty();
                 interpreter.operand_stack.push_ty(bool_ty)?;
             },
             Bytecode::Eq | Bytecode::Neq => {
-                let lhs_ty = interpreter.operand_stack.pop_ty()?;
                 let rhs_ty = interpreter.operand_stack.pop_ty()?;
-                lhs_ty.paranoid_check_eq(&rhs_ty)?;
-                lhs_ty.paranoid_check_has_ability(Ability::Drop)?;
+                let lhs_ty = interpreter.operand_stack.pop_ty()?;
+                rhs_ty.paranoid_check_eq(&lhs_ty)?;
+                rhs_ty.paranoid_check_has_ability(Ability::Drop)?;
 
                 let bool_ty = ty_builder.create_bool_ty();
                 interpreter.operand_stack.push_ty(bool_ty)?;


### PR DESCRIPTION
## Description
This introduces a procedural macro `bytecode_spec` that allows us to add inline specifications to the Move bytecode instructions defined in Rust:
```rust
#[bytecode_spec]
pub enum Bytecode {
    #[group = "stack_and_local"]
    #[description = "Pop and discard the value at the top of the stack. The value on the stack must be an copyable type."]
    #[semantics = "stack >> _"]
    #[paranoid_post = r#"
        ty_stack >> ty
        assert ty has drop
    "#]
    Pop,

    ..
}
```
The macro will generate a `pub fn spec() -> Vec<BTreeMap<String, String>>`, which can be used to extract the specification defined using the the attributes. 
```json
[
    {
        "description": "Pop and discard the value at the top of the stack. The value on the stack must be an copyable type.",
        "group": "stack_and_local",
        "name": "pop",
        "paranoid_post": "ty_stack >> ty\nassert ty has drop",
        "semantics": "stack >> _",
    },
]
```
The extracted specification can then be used to generate other human readable docs (e.g. pdf, html, LaTeX etc.) The generator(s) will come in future PRs.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [x] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Unit tests

## Key Areas to Review
- `move-binary-format/src/file_format.rs`: full specification for all current bytecode instructions
- `move-bytecode-spec`: procedural macro to allow the specification to be extracted

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation