### PR TITLE
[Draft] Remove commit and ordered root in block tree

### DIFF
--- a/consensus/consensus-types/src/block_test_utils.rs
+++ b/consensus/consensus-types/src/block_test_utils.rs
@@ -191,14 +191,10 @@ pub fn gen_test_certificate(
     parent_block: BlockInfo,
     committed_block: Option<BlockInfo>,
 ) -> QuorumCert {
-    let vote_data = VoteData::new(block, parent_block);
+    let vote_data = VoteData::new(block, parent_block.clone());
     let ledger_info = match committed_block {
         Some(info) => LedgerInfo::new(info, vote_data.hash()),
-        None => {
-            let mut placeholder = placeholder_ledger_info();
-            placeholder.set_consensus_data_hash(vote_data.hash());
-            placeholder
-        },
+        None => LedgerInfo::new(parent_block, vote_data.hash()),
     };
 
     QuorumCert::new(

--- a/consensus/src/test_utils/mod.rs
+++ b/consensus/src/test_utils/mod.rs
@@ -59,26 +59,30 @@ pub async fn build_simple_tree() -> (Vec<Arc<PipelinedBlock>>, Arc<BlockStore>) 
     assert_eq!(block_store.child_links(), block_store.len() - 1);
     assert!(block_store.block_exists(genesis_block.id()));
 
-    //       ╭--> A1--> A2--> A3
-    // Genesis--> B1--> B2
+    //       ╭--> A1--> A2--> A3--> A4
+    // Genesis--> B1--> B2 --> B3
     //             ╰--> C1
     let a1 = inserter
         .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 1)
         .await;
     let a2 = inserter.insert_block(&a1, 2, None).await;
-    let a3 = inserter
-        .insert_block(&a2, 3, Some(genesis.block_info()))
-        .await;
+    let a3 = inserter.insert_block(&a2, 3, None).await;
+    let a4 = inserter.insert_block(&a3, 4, None).await;
+
     let b1 = inserter
         .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 4)
         .await;
     let b2 = inserter.insert_block(&b1, 5, None).await;
+    let b3 = inserter.insert_block(&b2, 7, None).await;
     let c1 = inserter.insert_block(&b1, 6, None).await;
 
-    assert_eq!(block_store.len(), 7);
+    assert_eq!(block_store.len(), 9);
     assert_eq!(block_store.child_links(), block_store.len() - 1);
 
-    (vec![genesis_block, a1, a2, a3, b1, b2, c1], block_store)
+    (
+        vec![genesis_block, a1, a2, a3, a4, b1, b2, b3, c1],
+        block_store,
+    )
 }
 
 pub fn build_empty_tree() -> Arc<BlockStore> {


### PR DESCRIPTION
## Description
The block tree stores ordered_root, ordered_cert, commit_root, commit_cert although root could be derived from cert. When root and cert are updated independently, this could lead to bugs. This PR removes the ordered_root and commit_root from the block tree.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
