### PR TITLE
[Compiler-v2] Generate compiler warnings for primary modules only

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/naming/warning_dependency.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/warning_dependency.exp
@@ -1,0 +1,33 @@
+
+Diagnostics:
+warning: unused alias
+  ┌─ tests/checking/naming/warning_dependency.move:3:21
+  │
+3 │     use 0x42::test::S0;
+  │                     ^^ Unused 'use' of alias 'S0'. Consider removing it
+
+// -- Model dump before bytecode pipeline
+module 0x42::dependency {
+    use 0x42::test::{S0};
+} // end 0x42::dependency
+module 0x42::test {
+    struct S0 {
+        dummy_field: bool,
+    }
+    struct S1 {
+        dummy_field: bool,
+    }
+    struct S2 {
+        f: test::S3<#1>,
+    }
+    struct S3 {
+        dummy_field: bool,
+    }
+    struct S4 {
+        f: vector<#0>,
+    }
+    struct S5 {
+        f: vector<#0>,
+        g: vector<#1>,
+    }
+} // end 0x42::test

--- a/third_party/move/move-compiler-v2/tests/checking/naming/warning_dependency.move
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/warning_dependency.move
@@ -1,0 +1,4 @@
+// dep: tests/checking/naming/unused_type_parameter_struct.move
+module 0x42::dependency {
+    use 0x42::test::S0;
+}

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -1249,12 +1249,14 @@ impl GlobalEnv {
                 reported_ordering
             }
         });
-        for (diag, reported) in self
-            .diags
-            .borrow_mut()
-            .iter_mut()
-            .filter(|(d, reported)| !reported && filter(d))
-        {
+        for (diag, reported) in self.diags.borrow_mut().iter_mut().filter(|(d, reported)| {
+            !reported
+                && filter(d)
+                && (d.severity >= Severity::Error
+                    || d.labels
+                        .iter()
+                        .any(|label| self.file_id_is_primary_target.contains(&label.file_id)))
+        }) {
             if !*reported {
                 // Avoid showing the same message twice. This can happen e.g. because of
                 // duplication of expressions via schema inclusion.


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR closes #13193 by printing out a diagnosis only when it is from a primary module or it is an error.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

1) Existing tests pass;
2) Added a new test `warning_dependency` of which the exp file does not contain warnings from the module it depends.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

The logic added to filter out diagnoses which are not an error and not raised from primary modules.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
