### PR TITLE
[mempool] add a delay when broadcasting txns to failover nodes

### DIFF
--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -46,6 +46,8 @@ pub struct MempoolConfig {
     pub shared_mempool_peer_update_interval_ms: u64,
     /// Interval to update peer priorities in shared mempool (seconds).
     pub shared_mempool_priority_update_interval_secs: u64,
+    /// The amount of time to wait after transaction insertion to broadcast to a failover peer.
+    pub shared_mempool_failover_delay_ms: u64,
     /// Number of seconds until the transaction will be removed from the Mempool ignoring if the transaction has expired.
     ///
     /// This ensures that the Mempool isn't just full of non-expiring transactions that are way off into the future.
@@ -79,6 +81,7 @@ impl Default for MempoolConfig {
             enable_intelligent_peer_prioritization: true,
             shared_mempool_peer_update_interval_ms: 1_000,
             shared_mempool_priority_update_interval_secs: 600, // 10 minutes (frequent reprioritization is expensive)
+            shared_mempool_failover_delay_ms: 200,
             system_transaction_timeout_secs: 600,
             system_transaction_gc_interval_ms: 60_000,
             broadcast_buckets: DEFAULT_BUCKETS.to_vec(),

--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -81,7 +81,7 @@ impl Default for MempoolConfig {
             enable_intelligent_peer_prioritization: true,
             shared_mempool_peer_update_interval_ms: 1_000,
             shared_mempool_priority_update_interval_secs: 600, // 10 minutes (frequent reprioritization is expensive)
-            shared_mempool_failover_delay_ms: 300,
+            shared_mempool_failover_delay_ms: 500,
             system_transaction_timeout_secs: 600,
             system_transaction_gc_interval_ms: 60_000,
             broadcast_buckets: DEFAULT_BUCKETS.to_vec(),

--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -81,7 +81,7 @@ impl Default for MempoolConfig {
             enable_intelligent_peer_prioritization: true,
             shared_mempool_peer_update_interval_ms: 1_000,
             shared_mempool_priority_update_interval_secs: 600, // 10 minutes (frequent reprioritization is expensive)
-            shared_mempool_failover_delay_ms: 200,
+            shared_mempool_failover_delay_ms: 500,
             system_transaction_timeout_secs: 600,
             system_transaction_gc_interval_ms: 60_000,
             broadcast_buckets: DEFAULT_BUCKETS.to_vec(),

--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -81,7 +81,7 @@ impl Default for MempoolConfig {
             enable_intelligent_peer_prioritization: true,
             shared_mempool_peer_update_interval_ms: 1_000,
             shared_mempool_priority_update_interval_secs: 600, // 10 minutes (frequent reprioritization is expensive)
-            shared_mempool_failover_delay_ms: 500,
+            shared_mempool_failover_delay_ms: 300,
             system_transaction_timeout_secs: 600,
             system_transaction_gc_interval_ms: 60_000,
             broadcast_buckets: DEFAULT_BUCKETS.to_vec(),

--- a/mempool/src/core_mempool/index.rs
+++ b/mempool/src/core_mempool/index.rs
@@ -19,7 +19,7 @@ use std::{
     collections::{btree_set::Iter, BTreeMap, BTreeSet, HashMap},
     iter::Rev,
     ops::Bound,
-    time::{Duration, SystemTime},
+    time::{Duration, Instant, SystemTime},
 };
 
 pub type AccountTransactions = BTreeMap<u64, MempoolTransaction>;
@@ -208,7 +208,7 @@ impl Ord for TTLOrderingKey {
 /// logical reference to transaction content in main storage.
 pub struct TimelineIndex {
     timeline_id: u64,
-    timeline: BTreeMap<u64, (AccountAddress, u64)>,
+    timeline: BTreeMap<u64, (AccountAddress, u64, Instant)>,
 }
 
 impl TimelineIndex {
@@ -221,20 +221,27 @@ impl TimelineIndex {
 
     /// Read all transactions from the timeline since <timeline_id>.
     /// At most `count` transactions will be returned.
+    /// If `before` is set, only transactions inserted before this time will be returned.
     pub(crate) fn read_timeline(
         &self,
         timeline_id: u64,
         count: usize,
+        before: Option<Instant>,
     ) -> Vec<(AccountAddress, u64)> {
         let mut batch = vec![];
-        for (_id, &(address, sequence_number)) in self
+        for (_id, &(address, sequence_number, insertion_time)) in self
             .timeline
             .range((Bound::Excluded(timeline_id), Bound::Unbounded))
         {
-            batch.push((address, sequence_number));
+            if let Some(before) = before {
+                if insertion_time >= before {
+                    break;
+                }
+            }
             if batch.len() == count {
                 break;
             }
+            batch.push((address, sequence_number));
         }
         batch
     }
@@ -243,8 +250,7 @@ impl TimelineIndex {
     pub(crate) fn timeline_range(&self, start_id: u64, end_id: u64) -> Vec<(AccountAddress, u64)> {
         self.timeline
             .range((Bound::Excluded(start_id), Bound::Included(end_id)))
-            .map(|(_idx, txn)| txn)
-            .cloned()
+            .map(|(_idx, &(address, sequence, _))| (address, sequence))
             .collect()
     }
 
@@ -254,6 +260,7 @@ impl TimelineIndex {
             (
                 txn.get_sender(),
                 txn.sequence_info.transaction_sequence_number,
+                Instant::now(),
             ),
         );
         txn.timeline_state = TimelineState::Ready(self.timeline_id);
@@ -310,6 +317,7 @@ impl MultiBucketTimelineIndex {
         &self,
         timeline_id: &MultiBucketTimelineIndexIds,
         count: usize,
+        before: Option<Instant>,
     ) -> Vec<Vec<(AccountAddress, u64)>> {
         assert!(timeline_id.id_per_bucket.len() == self.bucket_mins.len());
 
@@ -321,7 +329,7 @@ impl MultiBucketTimelineIndex {
             .zip(timeline_id.id_per_bucket.iter())
             .rev()
         {
-            let txns = timeline.read_timeline(timeline_id, count - added);
+            let txns = timeline.read_timeline(timeline_id, count - added, before);
             added += txns.len();
             returned.push(txns);
 

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -459,8 +459,9 @@ impl Mempool {
         &self,
         timeline_id: &MultiBucketTimelineIndexIds,
         count: usize,
+        before: Option<Instant>,
     ) -> (Vec<SignedTransaction>, MultiBucketTimelineIndexIds) {
-        self.transactions.read_timeline(timeline_id, count)
+        self.transactions.read_timeline(timeline_id, count, before)
     }
 
     /// Read transactions from timeline from `start_id` (exclusive) to `end_id` (inclusive).

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -29,7 +29,7 @@ use std::{
     collections::HashMap,
     mem::size_of,
     ops::Bound,
-    time::{Duration, SystemTime},
+    time::{Duration, Instant, SystemTime},
 };
 
 /// Estimated per-txn overhead of indexes. Needs to be updated if additional indexes are added.
@@ -560,6 +560,7 @@ impl TransactionStore {
         &self,
         timeline_id: &MultiBucketTimelineIndexIds,
         count: usize,
+        before: Option<Instant>,
     ) -> (Vec<SignedTransaction>, MultiBucketTimelineIndexIds) {
         let mut batch = vec![];
         let mut batch_total_bytes: u64 = 0;
@@ -568,7 +569,7 @@ impl TransactionStore {
         // Add as many transactions to the batch as possible
         for (i, bucket) in self
             .timeline_index
-            .read_timeline(timeline_id, count)
+            .read_timeline(timeline_id, count, before)
             .iter()
             .enumerate()
             .rev()

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -401,6 +401,8 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
                     let (txns, new_timeline_id) = mempool.read_timeline(
                         &state.timeline_id,
                         self.mempool_config.shared_mempool_batch_size,
+                        // TODO: hardcoded... do it whether peer is primary or failover
+                        Some(Instant::now() - Duration::from_millis(200)),
                     );
                     (
                         MultiBatchId::from_timeline_ids(&state.timeline_id, &new_timeline_id),

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -412,9 +412,12 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
                     // Fresh broadcast
                     let before = match peer_priority {
                         BroadcastPeerPriority::Primary => None,
-                        BroadcastPeerPriority::Failover => {
-                            Some(Instant::now() - Duration::from_millis(200))
-                        },
+                        BroadcastPeerPriority::Failover => Some(
+                            Instant::now()
+                                - Duration::from_millis(
+                                    self.mempool_config.shared_mempool_failover_delay_ms,
+                                ),
+                        ),
                     };
                     let (txns, new_timeline_id) = mempool.read_timeline(
                         &state.timeline_id,

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -76,6 +76,11 @@ pub enum BroadcastError {
     TooManyPendingBroadcasts(PeerNetworkId),
 }
 
+pub enum BroadcastPeerPriority {
+    Primary,
+    Failover,
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct MempoolNetworkInterface<NetworkClient> {
     network_client: NetworkClient,
@@ -299,15 +304,22 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
 
     /// Peers are prioritized when the local is a validator, or it's within the default failovers.
     /// One is added for the primary peer
-    fn check_peer_prioritized(&self, peer: PeerNetworkId) -> Result<(), BroadcastError> {
-        if !self.role.is_validator() {
-            let peer_priority = self.prioritized_peers_state.get_peer_priority(&peer);
-            if peer_priority > self.mempool_config.default_failovers {
-                return Err(BroadcastError::PeerNotPrioritized(peer, peer_priority));
-            }
+    fn check_peer_prioritized(
+        &self,
+        peer: PeerNetworkId,
+    ) -> Result<BroadcastPeerPriority, BroadcastError> {
+        if self.role.is_validator() {
+            return Ok(BroadcastPeerPriority::Primary);
         }
 
-        Ok(())
+        let peer_priority = self.prioritized_peers_state.get_peer_priority(&peer);
+        if peer_priority == 0 {
+            Ok(BroadcastPeerPriority::Primary)
+        } else if peer_priority <= self.mempool_config.default_failovers {
+            Ok(BroadcastPeerPriority::Failover)
+        } else {
+            Err(BroadcastError::PeerNotPrioritized(peer, peer_priority))
+        }
     }
 
     /// Determines the broadcast batch.  There are three types of batches:
@@ -327,7 +339,7 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
             .ok_or(BroadcastError::PeerNotFound(peer))?;
 
         // If the peer isn't prioritized, lets not broadcast
-        self.check_peer_prioritized(peer)?;
+        let peer_priority = self.check_peer_prioritized(peer)?;
 
         // If backoff mode is on for this peer, only execute broadcasts that were scheduled as a backoff broadcast.
         // This is to ensure the backoff mode is actually honored (there is a chance a broadcast was scheduled
@@ -398,11 +410,16 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
                 },
                 None => {
                     // Fresh broadcast
+                    let before = match peer_priority {
+                        BroadcastPeerPriority::Primary => None,
+                        BroadcastPeerPriority::Failover => {
+                            Some(Instant::now() - Duration::from_millis(200))
+                        },
+                    };
                     let (txns, new_timeline_id) = mempool.read_timeline(
                         &state.timeline_id,
                         self.mempool_config.shared_mempool_batch_size,
-                        // TODO: hardcoded... do it whether peer is primary or failover
-                        Some(Instant::now() - Duration::from_millis(200)),
+                        before,
                     );
                     (
                         MultiBatchId::from_timeline_ids(&state.timeline_id, &new_timeline_id),

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -364,25 +364,25 @@ fn test_timeline() {
         TestTransaction::new(1, 5, 1),
     ]);
 
-    let (timeline, _) = pool.read_timeline(&vec![0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0].into(), 10, None);
     assert_eq!(view(timeline), vec![0, 1]);
     // Txns 3 and 5 should be in parking lot.
     assert_eq!(2, pool.get_parking_lot_size());
 
     // Add txn 2 to unblock txn3.
     add_txns_to_mempool(&mut pool, vec![TestTransaction::new(1, 2, 1)]);
-    let (timeline, _) = pool.read_timeline(&vec![0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0].into(), 10, None);
     assert_eq!(view(timeline), vec![0, 1, 2, 3]);
     // Txn 5 should be in parking lot.
     assert_eq!(1, pool.get_parking_lot_size());
 
     // Try different start read position.
-    let (timeline, _) = pool.read_timeline(&vec![2].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![2].into(), 10, None);
     assert_eq!(view(timeline), vec![2, 3]);
 
     // Simulate callback from consensus to unblock txn 5.
     pool.commit_transaction(&TestTransaction::get_address(1), 4);
-    let (timeline, _) = pool.read_timeline(&vec![0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0].into(), 10, None);
     assert_eq!(view(timeline), vec![5]);
     // check parking lot is empty
     assert_eq!(0, pool.get_parking_lot_size());
@@ -398,41 +398,41 @@ fn test_multi_bucket_timeline() {
         TestTransaction::new(1, 5, 300), // bucket 2
     ]);
 
-    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10, None);
     assert_eq!(view(timeline), vec![0, 1]);
     // Txns 3 and 5 should be in parking lot.
     assert_eq!(2, pool.get_parking_lot_size());
 
     // Add txn 2 to unblock txn3.
     add_txns_to_mempool(&mut pool, vec![TestTransaction::new(1, 2, 1)]);
-    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10, None);
     assert_eq!(view(timeline), vec![0, 1, 2, 3]);
     // Txn 5 should be in parking lot.
     assert_eq!(1, pool.get_parking_lot_size());
 
     // Try different start read positions. Expected buckets: [[0, 1, 2], [3], []]
-    let (timeline, _) = pool.read_timeline(&vec![1, 0, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![1, 0, 0].into(), 10, None);
     assert_eq!(view(timeline), vec![1, 2, 3]);
-    let (timeline, _) = pool.read_timeline(&vec![2, 0, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![2, 0, 0].into(), 10, None);
     assert_eq!(view(timeline), vec![2, 3]);
-    let (timeline, _) = pool.read_timeline(&vec![0, 1, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0, 1, 0].into(), 10, None);
     assert_eq!(view(timeline), vec![0, 1, 2]);
-    let (timeline, _) = pool.read_timeline(&vec![1, 1, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![1, 1, 0].into(), 10, None);
     assert_eq!(view(timeline), vec![1, 2]);
-    let (timeline, _) = pool.read_timeline(&vec![2, 1, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![2, 1, 0].into(), 10, None);
     assert_eq!(view(timeline), vec![2]);
-    let (timeline, _) = pool.read_timeline(&vec![3, 0, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![3, 0, 0].into(), 10, None);
     assert_eq!(view(timeline), vec![3]);
-    let (timeline, _) = pool.read_timeline(&vec![3, 1, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![3, 1, 0].into(), 10, None);
     assert!(view(timeline).is_empty());
 
     // Ensure high gas is prioritized.
-    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 1);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 1, None);
     assert_eq!(view(timeline), vec![3]);
 
     // Simulate callback from consensus to unblock txn 5.
     pool.commit_transaction(&TestTransaction::get_address(1), 4);
-    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10, None);
     assert_eq!(view(timeline), vec![5]);
     // check parking lot is empty
     assert_eq!(0, pool.get_parking_lot_size());
@@ -449,26 +449,26 @@ fn test_multi_bucket_gas_ranking_update() {
     ]);
 
     // txn 2 and 3 are prioritized
-    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 2);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 2, None);
     assert_eq!(view(timeline), vec![2, 3]);
     // read only bucket 2
-    let (timeline, _) = pool.read_timeline(&vec![10, 10, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![10, 10, 0].into(), 10, None);
     assert!(view(timeline).is_empty());
 
     // resubmit with higher gas: move txn 2 to bucket 2
     add_txns_to_mempool(&mut pool, vec![TestTransaction::new(1, 2, 400)]);
 
     // txn 2 is now prioritized
-    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 1);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 1, None);
     assert_eq!(view(timeline), vec![2]);
     // then txn 3 is prioritized
-    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 2);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 2, None);
     assert_eq!(view(timeline), vec![2, 3]);
     // read only bucket 2
-    let (timeline, _) = pool.read_timeline(&vec![10, 10, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![10, 10, 0].into(), 10, None);
     assert_eq!(view(timeline), vec![2]);
     // read only bucket 1
-    let (timeline, _) = pool.read_timeline(&vec![10, 0, 10].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![10, 0, 10].into(), 10, None);
     assert_eq!(view(timeline), vec![3]);
 }
 
@@ -482,23 +482,23 @@ fn test_multi_bucket_removal() {
         TestTransaction::new(1, 3, 200), // bucket 1
     ]);
 
-    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10, None);
     assert_eq!(view(timeline), vec![0, 1, 2, 3]);
 
     pool.commit_transaction(&TestTransaction::get_address(1), 0);
-    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10, None);
     assert_eq!(view(timeline), vec![1, 2, 3]);
 
     pool.commit_transaction(&TestTransaction::get_address(1), 1);
-    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10, None);
     assert_eq!(view(timeline), vec![2, 3]);
 
     pool.commit_transaction(&TestTransaction::get_address(1), 2);
-    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10, None);
     assert_eq!(view(timeline), vec![3]);
 
     pool.commit_transaction(&TestTransaction::get_address(1), 3);
-    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10, None);
     assert!(view(timeline).is_empty());
 }
 
@@ -671,7 +671,7 @@ fn test_gc_ready_transaction() {
     add_txn(&mut pool, TestTransaction::new(1, 3, 1)).unwrap();
 
     // Check that all txns are ready.
-    let (timeline, _) = pool.read_timeline(&vec![0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0].into(), 10, None);
     assert_eq!(timeline.len(), 4);
 
     // GC expired transaction.
@@ -682,7 +682,7 @@ fn test_gc_ready_transaction() {
     assert_eq!(block.len(), 1);
     assert_eq!(block[0].sequence_number(), 0);
 
-    let (timeline, _) = pool.read_timeline(&vec![0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0].into(), 10, None);
     assert_eq!(timeline.len(), 1);
     assert_eq!(timeline[0].sequence_number(), 0);
 
@@ -690,7 +690,7 @@ fn test_gc_ready_transaction() {
     add_txn(&mut pool, TestTransaction::new(1, 1, 1)).unwrap();
 
     // Make sure txns 2 and 3 can be broadcast after txn 1 is resubmitted
-    let (timeline, _) = pool.read_timeline(&vec![0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0].into(), 10, None);
     assert_eq!(timeline.len(), 4);
 }
 

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -17,10 +17,7 @@ use aptos_types::{
 };
 use itertools::Itertools;
 use maplit::btreemap;
-use std::{
-    thread::sleep,
-    time::{Duration, Instant, SystemTime},
-};
+use std::time::{Duration, Instant, SystemTime};
 
 #[test]
 fn test_transaction_ordering_only_seqnos() {

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -48,7 +48,7 @@ async fn test_consensus_events_rejected_txns() {
 
     let pool = smp.mempool.lock();
     // TODO: make less brittle to broadcast buckets changes
-    let (timeline, _) = pool.read_timeline(&vec![0; 10].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0; 10].into(), 10, None);
     assert_eq!(timeline.len(), 2);
     assert_eq!(timeline.first().unwrap(), &kept_txn);
 }
@@ -89,7 +89,7 @@ async fn test_mempool_notify_committed_txns() {
     let wait_for_commit = async {
         let pool = smp.mempool.lock();
         // TODO: make less brittle to broadcast buckets changes
-        let (timeline, _) = pool.read_timeline(&vec![0; 10].into(), 10);
+        let (timeline, _) = pool.read_timeline(&vec![0; 10].into(), 10, None);
         if timeline.len() == 10 && timeline.first().unwrap() == &kept_txn {
             return; // Mempool handled the commit notification
         }

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -2523,9 +2523,6 @@ fn pfn_performance(
         .with_genesis_helm_config_fn(Arc::new(move |helm_values| {
             helm_values["chain"]["epoch_duration_secs"] = epoch_duration_secs.into();
         }))
-        .with_emit_job(EmitJobRequest::default().mode(EmitJobMode::MaxLoad {
-            mempool_backlog: 20000,
-        }))
         .with_success_criteria(
             SuccessCriteria::new(min_expected_tps)
                 .add_no_restarts()

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -605,7 +605,7 @@ fn get_land_blocking_test(
 ) -> Option<ForgeConfig> {
     let test = match test_name {
         "land_blocking" | "realistic_env_max_load" => {
-            realistic_env_max_load_test(duration, test_cmd, 7, 5)
+            pfn_performance(duration, true, true, false, 7, 1, false)
         },
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -2523,6 +2523,9 @@ fn pfn_performance(
         .with_genesis_helm_config_fn(Arc::new(move |helm_values| {
             helm_values["chain"]["epoch_duration_secs"] = epoch_duration_secs.into();
         }))
+        .with_emit_job(EmitJobRequest::default().mode(EmitJobMode::MaxLoad {
+            mempool_backlog: 20000,
+        }))
         .with_success_criteria(
             SuccessCriteria::new(min_expected_tps)
                 .add_no_restarts()

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -605,7 +605,7 @@ fn get_land_blocking_test(
 ) -> Option<ForgeConfig> {
     let test = match test_name {
         "land_blocking" | "realistic_env_max_load" => {
-            pfn_performance(duration, true, true, false, 7, 1, false)
+            realistic_env_max_load_test(duration, test_cmd, 7, 5)
         },
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),


### PR DESCRIPTION
## Description
This reduces the number of duplicate transactions due to PFN duplication. In most cases, the upstream VFN will have already seen the txn via the primary VFN's quorum store batch.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Ran PFN performance and see ~1K TPS reduction in duplicates (to < 100 TPS)

Added unit test.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
