### PR TITLE
fix:Correct ECDSA signature malleability handling

### DIFF
--- a/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_sigs.rs
+++ b/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_sigs.rs
@@ -65,14 +65,14 @@ impl Signature {
         if bytes.len() != SIGNATURE_LENGTH {
             return Err(CryptoMaterialError::WrongLengthError);
         }
-        if !Signature::check_s_lt_order_half(&bytes[32..]) {
+        if !Signature::check_s_le_order_half(&bytes[32..]) {
             return Err(CryptoMaterialError::CanonicalRepresentationError);
         }
         Ok(())
     }
 
     /// Check if S <= ORDER_HALF to capture invalid signatures.
-    fn check_s_lt_order_half(s: &[u8]) -> bool {
+    fn check_s_le_order_half(s: &[u8]) -> bool {
         for i in 0..32 {
             match s[i].cmp(&ORDER_HALF[i]) {
                 Ordering::Less => return true,

--- a/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_sigs.rs
+++ b/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_sigs.rs
@@ -71,7 +71,7 @@ impl Signature {
         Ok(())
     }
 
-    /// Check if S < ORDER_HALF to capture invalid signatures.
+    /// Check if S <= ORDER_HALF to capture invalid signatures.
     fn check_s_lt_order_half(s: &[u8]) -> bool {
         for i in 0..32 {
             match s[i].cmp(&ORDER_HALF[i]) {
@@ -80,8 +80,8 @@ impl Signature {
                 _ => {},
             }
         }
-        // At this stage S == ORDER_HALF which implies a non canonical S.
-        false
+        // At this stage S == ORDER_HALF , it is still considered a canonical value.
+        true
     }
 
     /// If the signature {R,S} does not have S < n/2 where n is the Ristretto255 order, return

--- a/crates/aptos-crypto/src/unit_tests/secp256r1_ecdsa_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/secp256r1_ecdsa_test.rs
@@ -208,13 +208,11 @@ proptest! {
         let sig_unchecked = Signature::from_bytes_unchecked(&serialized);
         prop_assert!(sig_unchecked.is_ok());
 
-        // Update the signature by setting S = L to make it invalid.
+        // S = ORDER_HALF should be a canonical signature.
         serialized[32..].copy_from_slice(&ORDER_HALF);
-        let serialized_malleable_l: &[u8] = &serialized;
-        // try_from will fail with CanonicalRepresentationError.
-        prop_assert_eq!(
-            Signature::try_from(serialized_malleable_l),
-            Err(CryptoMaterialError::CanonicalRepresentationError)
+        let canonical: &[u8] = &serialized;
+        prop_assert!(
+            Signature::try_from(canonical).is_ok()
         );
     }
 }


### PR DESCRIPTION
## Description
The function `check_s_lt_order_half` is intended to ensure that the value of S in an ECDSA signature is less than the order of the Secp256r1 curve divided by 2 to eliminate signature malleability. However, there's a boundary condition issue in the function's return logic.

At the end of the function, the return value is set to false when `S == ORDER_HALF`. This decision seems incorrect. To eliminate ECDSA signature malleability, S is required to be less than `n/2`, where n is the curve order. Since the curve's order is a prime number and cannot be divided by 2 evenly, `ORDER_HALF` effectively represents the `floor(n/2)`. Therefore, `ORDER_HALF` should be considered a valid S value, and its corresponding invalid S would be `ORDER_HALF + 1`. This boundary value consideration aligns with the approach taken in [BIP62](https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki#low-s-values-in-signatures)(despite the curve and its order being different, both are prime numbers).

If `ORDER_HALF` is treated as an invalid S value, then computing `n - S` tries to convert it to a valid S, resulting in `ORDER_HALF + 1`, which remains an invalid S.

This issue could potentially render signatures invalid when they should be considered valid, impacting the reliability of the system. Although the probability of S exactly equaling ORDER_HALF in a signature is very low, ORDER_HALF should not be considered a invalid S value. If the repository is referenced by other developers in specific business scenarios, it could pose a potential security risk.



## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
We can verify using the following Python code that `half_order` and `half_order + 1` form a pair of associated malleable S values. Among them, `half_order` is considered a valid S value, while `half_order + 1` is an invalid S value.
```python
order = 0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
print("order:",hex(order))
print("order is odd:",order%2 == 1)

helf_order = hex(order>>1)
print("helf_order:",helf_order)

s = 0x7fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a8
print("s:",hex(s))
print("is equal:",helf_order == hex(s))

new_s = hex(order - s)

print("new_s:",new_s)

print("is low s values:",new_s<=helf_order)

```

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
