### PR TITLE
Propagate resolver errors, instead of transforming into invariant error

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -2786,11 +2786,7 @@ pub(crate) fn is_account_init_for_sponsored_transaction(
             && resolver
                 .get_resource(&txn_data.sender(), &AccountResource::struct_tag())
                 .map(|data| data.is_none())
-                .map_err(|e| {
-                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                        .with_message(format!("{}", e))
-                        .finish(Location::Undefined)
-                })?,
+                .map_err(|e| e.finish(Location::Undefined))?,
     )
 }
 


### PR DESCRIPTION
get_resource already returns PartialVMError, with appropriate exception - whether speculative error, storage error, etc.
not all of those are invariant violations. 

I forgot is this the way to convert PartialVMError to VMError (via `finish()`), or should I use `into()` or something else?

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## How Has This Been Tested?
Failures here should never happen on transactions to be committed on-chain (and replay verify should confirm that), so change in logic here is fine.

There are speculative transactions (that will later be invalidated) where this might fail, and fix here avoids error logs, and allows BlockSTM to handle them correctly. 

## Key Areas to Review


## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
