### PR TITLE
[network][reliable-broadcast] separate RPC sending from serialization for efficiency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3310,6 +3310,8 @@ dependencies = [
  "aptos-time-service",
  "aptos-types",
  "async-trait",
+ "bytes",
+ "claims",
  "futures",
  "futures-channel",
  "tokio",

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -566,6 +566,7 @@ impl DagBootstrapper {
             .factor(rb_config.backoff_policy_factor)
             .max_delay(Duration::from_millis(rb_config.backoff_policy_max_delay_ms));
         let rb = Arc::new(ReliableBroadcast::new(
+            self.self_peer,
             validators.clone(),
             self.rb_network_sender.clone(),
             rb_backoff_policy,

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -326,7 +326,9 @@ impl DagDriver {
             debug!(LogSchema::new(LogEvent::BroadcastNode), id = node.id());
 
             defer!( observe_round(timestamp, RoundStage::NodeBroadcasted); );
-            rb.broadcast(node, signature_builder).await
+            rb.broadcast(node, signature_builder)
+                .await
+                .expect("Broadcast cannot fail")
         };
         let certified_broadcast = async move {
             let Ok(certificate) = rx.await else {
@@ -346,7 +348,9 @@ impl DagDriver {
                 certified_node,
                 latest_ledger_info.get_latest_ledger_info(),
             );
-            rb2.broadcast(certified_node_msg, cert_ack_set).await
+            rb2.broadcast(certified_node_msg, cert_ack_set)
+                .await
+                .expect("Broadcast cannot fail until cancelled")
         };
         let core_task = join(node_broadcast, certified_broadcast);
         let author = self.author;

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -49,7 +49,7 @@ struct MockNetworkSender {
 
 #[async_trait]
 impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockNetworkSender {
-    async fn send_rb_rpc(
+    async fn send_rb_rpc_raw(
         &self,
         _receiver: Author,
         _messages: Bytes,
@@ -58,8 +58,9 @@ impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockNetworkSender {
         Ok(DAGRpcResult(Ok(DAGMessage::TestAck(TestAck(Vec::new())))))
     }
 
-    async fn send_rb_rpc_to_self(
+    async fn send_rb_rpc(
         &self,
+        _receiver: Author,
         _message: DAGMessage,
         _timeout: Duration,
     ) -> anyhow::Result<DAGRpcResult> {

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -153,7 +153,7 @@ fn setup(
 
     let validators: Vec<_> = signers.iter().map(|s| s.author()).collect();
     let rb = Arc::new(ReliableBroadcast::new(
-        validators[0].clone(),
+        validators[0],
         validators,
         network_sender.clone(),
         ExponentialBackoff::from_millis(10),

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -66,7 +66,7 @@ impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockNetworkSender {
         Ok(DAGRpcResult(Ok(DAGMessage::TestAck(TestAck(Vec::new())))))
     }
 
-    fn to_bytes(
+    fn to_bytes_by_protocol(
         &self,
         peers: Vec<Author>,
         _message: DAGMessage,

--- a/consensus/src/dag/tests/dag_network_test.rs
+++ b/consensus/src/dag/tests/dag_network_test.rs
@@ -50,7 +50,7 @@ impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockDAGNetworkSender {
         unimplemented!()
     }
 
-    fn to_bytes(
+    fn to_bytes_by_protocol(
         &self,
         peers: Vec<Author>,
         message: DAGMessage,

--- a/consensus/src/dag/tests/dag_network_test.rs
+++ b/consensus/src/dag/tests/dag_network_test.rs
@@ -13,6 +13,7 @@ use aptos_reliable_broadcast::RBNetworkSender;
 use aptos_time_service::{TimeService, TimeServiceTrait};
 use aptos_types::validator_verifier::random_validator_verifier;
 use async_trait::async_trait;
+use bytes::Bytes;
 use claims::{assert_err, assert_ok};
 use futures::StreamExt;
 use std::{collections::HashMap, sync::Arc, time::Duration};
@@ -35,9 +36,25 @@ impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockDAGNetworkSender {
     async fn send_rb_rpc(
         &self,
         _receiver: Author,
-        _message: DAGMessage,
+        _message: Bytes,
         _timeout: Duration,
     ) -> anyhow::Result<DAGRpcResult> {
+        unimplemented!()
+    }
+
+    async fn send_rb_rpc_to_self(
+        &self,
+        message: DAGMessage,
+        timeout: Duration,
+    ) -> anyhow::Result<DAGRpcResult> {
+        unimplemented!()
+    }
+
+    fn to_bytes(
+        &self,
+        peers: Vec<Author>,
+        message: DAGMessage,
+    ) -> anyhow::Result<HashMap<Author, Bytes>> {
         unimplemented!()
     }
 }

--- a/consensus/src/dag/tests/dag_network_test.rs
+++ b/consensus/src/dag/tests/dag_network_test.rs
@@ -33,7 +33,7 @@ struct MockDAGNetworkSender {
 
 #[async_trait]
 impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockDAGNetworkSender {
-    async fn send_rb_rpc(
+    async fn send_rb_rpc_raw(
         &self,
         _receiver: Author,
         _message: Bytes,
@@ -42,8 +42,9 @@ impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockDAGNetworkSender {
         unimplemented!()
     }
 
-    async fn send_rb_rpc_to_self(
+    async fn send_rb_rpc(
         &self,
+        _receiver: Author,
         _message: DAGMessage,
         _timeout: Duration,
     ) -> anyhow::Result<DAGRpcResult> {

--- a/consensus/src/dag/tests/dag_network_test.rs
+++ b/consensus/src/dag/tests/dag_network_test.rs
@@ -44,16 +44,16 @@ impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockDAGNetworkSender {
 
     async fn send_rb_rpc_to_self(
         &self,
-        message: DAGMessage,
-        timeout: Duration,
+        _message: DAGMessage,
+        _timeout: Duration,
     ) -> anyhow::Result<DAGRpcResult> {
         unimplemented!()
     }
 
     fn to_bytes_by_protocol(
         &self,
-        peers: Vec<Author>,
-        message: DAGMessage,
+        _peers: Vec<Author>,
+        _message: DAGMessage,
     ) -> anyhow::Result<HashMap<Author, Bytes>> {
         unimplemented!()
     }

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -31,8 +31,9 @@ use aptos_types::{
     validator_verifier::random_validator_verifier,
 };
 use async_trait::async_trait;
+use bytes::Bytes;
 use claims::assert_none;
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 struct MockDAGNetworkSender {}
 
@@ -41,9 +42,25 @@ impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockDAGNetworkSender {
     async fn send_rb_rpc(
         &self,
         _receiver: Author,
-        _message: DAGMessage,
+        _message: Bytes,
         _timeout: Duration,
     ) -> anyhow::Result<DAGRpcResult> {
+        unimplemented!()
+    }
+
+    async fn send_rb_rpc_to_self(
+        &self,
+        message: DAGMessage,
+        timeout: Duration,
+    ) -> anyhow::Result<DAGRpcResult> {
+        unimplemented!()
+    }
+
+    fn to_bytes(
+        &self,
+        peers: Vec<Author>,
+        message: DAGMessage,
+    ) -> anyhow::Result<HashMap<Author, Bytes>> {
         unimplemented!()
     }
 }

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -39,7 +39,7 @@ struct MockDAGNetworkSender {}
 
 #[async_trait]
 impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockDAGNetworkSender {
-    async fn send_rb_rpc(
+    async fn send_rb_rpc_raw(
         &self,
         _receiver: Author,
         _message: Bytes,
@@ -48,8 +48,9 @@ impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockDAGNetworkSender {
         unimplemented!()
     }
 
-    async fn send_rb_rpc_to_self(
+    async fn send_rb_rpc(
         &self,
+        _receiver: Author,
         _message: DAGMessage,
         _timeout: Duration,
     ) -> anyhow::Result<DAGRpcResult> {

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -50,16 +50,16 @@ impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockDAGNetworkSender {
 
     async fn send_rb_rpc_to_self(
         &self,
-        message: DAGMessage,
-        timeout: Duration,
+        _message: DAGMessage,
+        _timeout: Duration,
     ) -> anyhow::Result<DAGRpcResult> {
         unimplemented!()
     }
 
     fn to_bytes_by_protocol(
         &self,
-        peers: Vec<Author>,
-        message: DAGMessage,
+        _peers: Vec<Author>,
+        _message: DAGMessage,
     ) -> anyhow::Result<HashMap<Author, Bytes>> {
         unimplemented!()
     }

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -56,7 +56,7 @@ impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockDAGNetworkSender {
         unimplemented!()
     }
 
-    fn to_bytes(
+    fn to_bytes_by_protocol(
         &self,
         peers: Vec<Author>,
         message: DAGMessage,

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -620,9 +620,14 @@ impl<Req: TConsensusMsg + RBMessage + 'static, Res: TConsensusMsg + RBMessage + 
         tokio::task::spawn_blocking(|| TConsensusMsg::from_network_message(response_msg)).await?
     }
 
-    fn to_bytes(&self, peers: Vec<Author>, message: Req) -> anyhow::Result<HashMap<Author, Bytes>> {
+    fn to_bytes_by_protocol(
+        &self,
+        peers: Vec<Author>,
+        message: Req,
+    ) -> anyhow::Result<HashMap<Author, Bytes>> {
         let consensus_msg = message.into_network_message();
-        self.consensus_network_client.to_bytes(peers, consensus_msg)
+        self.consensus_network_client
+            .to_bytes_by_protocol(peers, consensus_msg)
     }
 }
 

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -53,6 +53,7 @@ use futures::{
 };
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
+    collections::HashMap,
     mem::{discriminant, Discriminant},
     sync::Arc,
     time::Duration,
@@ -197,7 +198,7 @@ pub trait QuorumStoreSender: Send + Clone {
 #[derive(Clone)]
 pub struct NetworkSender {
     author: Author,
-    consensus_network_client: ConsensusNetworkClient<NetworkClient<ConsensusMsg>>,
+    pub(crate) consensus_network_client: ConsensusNetworkClient<NetworkClient<ConsensusMsg>>,
     // Self sender and self receivers provide a shortcut for sending the messages to itself.
     // (self sending is not supported by the networking API).
     self_sender: aptos_channels::UnboundedSender<Event<ConsensusMsg>>,
@@ -241,12 +242,7 @@ impl NetworkSender {
         counters::CONSENSUS_SENT_MSGS
             .with_label_values(&[msg.name()])
             .inc();
-        let response_msg = monitor!(
-            "block_retrieval",
-            self.consensus_network_client
-                .send_rpc(from, msg, timeout)
-                .await
-        )?;
+        let response_msg = monitor!("block_retrieval", self.send_rpc(from, msg, timeout).await)?;
         let response = match response_msg {
             ConsensusMsg::BlockRetrievalResponse(resp) => *resp,
             _ => return Err(anyhow!("Invalid response to request")),
@@ -265,6 +261,24 @@ impl NetworkSender {
         Ok(response)
     }
 
+    pub async fn send_rpc_to_self(
+        &self,
+        msg: ConsensusMsg,
+        timeout_duration: Duration,
+    ) -> anyhow::Result<ConsensusMsg> {
+        let (tx, rx) = oneshot::channel();
+        let protocol = RPC[0];
+        let self_msg = Event::RpcRequest(self.author, msg.clone(), RPC[0], tx);
+        self.self_sender.clone().send(self_msg).await?;
+        if let Ok(Ok(Ok(bytes))) = timeout(timeout_duration, rx).await {
+            let response_msg =
+                tokio::task::spawn_blocking(move || protocol.from_bytes(&bytes)).await??;
+            Ok(response_msg)
+        } else {
+            bail!("self rpc failed");
+        }
+    }
+
     pub async fn send_rpc(
         &self,
         receiver: Author,
@@ -278,17 +292,7 @@ impl NetworkSender {
             .with_label_values(&[msg.name()])
             .inc();
         if receiver == self.author() {
-            let (tx, rx) = oneshot::channel();
-            let protocol = RPC[0];
-            let self_msg = Event::RpcRequest(receiver, msg.clone(), RPC[0], tx);
-            self.self_sender.clone().send(self_msg).await?;
-            if let Ok(Ok(Ok(bytes))) = timeout(timeout_duration, rx).await {
-                let response_msg =
-                    tokio::task::spawn_blocking(move || protocol.from_bytes(&bytes)).await??;
-                Ok(response_msg)
-            } else {
-                bail!("self rpc failed");
-            }
+            self.send_rpc_to_self(msg, timeout_duration).await
         } else {
             Ok(monitor!(
                 "send_rpc",
@@ -430,7 +434,11 @@ impl NetworkSender {
 
     pub async fn broadcast_fast_share(&self, share: FastShare<Share>) {
         fail_point!("consensus::send::broadcast_share", |_| ());
-        let msg = RandMessage::<Share, AugmentedData>::FastShare(share).into_network_message();
+        let msg = tokio::task::spawn_blocking(|| {
+            RandMessage::<Share, AugmentedData>::FastShare(share).into_network_message()
+        })
+        .await
+        .expect("task cannot fail to execute");
         self.broadcast(msg).await
     }
 
@@ -493,10 +501,7 @@ impl QuorumStoreSender for NetworkSender {
     ) -> anyhow::Result<BatchResponse> {
         let request_digest = request.digest();
         let msg = ConsensusMsg::BatchRequestMsg(Box::new(request));
-        let response = self
-            .consensus_network_client
-            .send_rpc(recipient, msg, timeout)
-            .await?;
+        let response = self.send_rpc(recipient, msg, timeout).await?;
         match response {
             // TODO: deprecated, remove after another release (likely v1.11)
             ConsensusMsg::BatchResponse(batch) => {
@@ -595,15 +600,29 @@ impl<Req: TConsensusMsg + RBMessage + 'static, Res: TConsensusMsg + RBMessage + 
     async fn send_rb_rpc(
         &self,
         receiver: Author,
-        message: Req,
+        raw_message: Bytes,
         timeout: Duration,
     ) -> anyhow::Result<Res> {
-        let outbound_msg = tokio::task::spawn_blocking(|| message.into_network_message()).await?;
         let response_msg = self
-            .send_rpc(receiver, outbound_msg, timeout)
+            .consensus_network_client
+            .send_rpc_raw(receiver, raw_message, timeout)
             .await
             .map_err(|e| anyhow!("invalid rpc response: {}", e))?;
         tokio::task::spawn_blocking(|| TConsensusMsg::from_network_message(response_msg)).await?
+    }
+
+    async fn send_rb_rpc_to_self(&self, message: Req, timeout: Duration) -> anyhow::Result<Res> {
+        let consensus_msg = message.into_network_message();
+        let response_msg = self
+            .send_rpc_to_self(consensus_msg, timeout)
+            .await
+            .map_err(|e| anyhow!("invalid rpc response: {}", e))?;
+        tokio::task::spawn_blocking(|| TConsensusMsg::from_network_message(response_msg)).await?
+    }
+
+    fn to_bytes(&self, peers: Vec<Author>, message: Req) -> anyhow::Result<HashMap<Author, Bytes>> {
+        let consensus_msg = message.into_network_message();
+        self.consensus_network_client.to_bytes(peers, consensus_msg)
     }
 }
 

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -187,7 +187,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusMsg>> ConsensusNetworkClient
             .await
     }
 
-    pub fn to_bytes(
+    pub fn to_bytes_by_protocol(
         &self,
         peers: Vec<PeerId>,
         message: ConsensusMsg,
@@ -198,7 +198,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusMsg>> ConsensusNetworkClient
             .collect();
         Ok(self
             .network_client
-            .to_bytes(peer_network_ids, message)?
+            .to_bytes_by_protocol(peer_network_ids, message)?
             .into_iter()
             .map(|(peer_network_id, bytes)| (peer_network_id.peer_id(), bytes))
             .collect())

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -26,9 +26,10 @@ use aptos_network::{
     ProtocolId,
 };
 use aptos_types::{epoch_change::EpochChangeProof, PeerId};
+use bytes::Bytes;
 pub use pipeline::commit_reliable_broadcast::CommitMessage;
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 /// Network type for consensus
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -158,8 +159,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusMsg>> ConsensusNetworkClient
         let peer_network_ids: Vec<PeerNetworkId> = peers
             .map(|peer| self.get_peer_network_id_for_peer(peer))
             .collect();
-        self.network_client
-            .send_to_peers(message, &peer_network_ids)
+        self.network_client.send_to_peers(message, peer_network_ids)
     }
 
     /// Send a RPC to the destination peer
@@ -173,6 +173,35 @@ impl<NetworkClient: NetworkClientInterface<ConsensusMsg>> ConsensusNetworkClient
         self.network_client
             .send_to_peer_rpc(message, rpc_timeout, peer_network_id)
             .await
+    }
+
+    pub async fn send_rpc_raw(
+        &self,
+        peer: PeerId,
+        message: Bytes,
+        rpc_timeout: Duration,
+    ) -> Result<ConsensusMsg, Error> {
+        let peer_network_id = self.get_peer_network_id_for_peer(peer);
+        self.network_client
+            .send_to_peer_rpc_raw(message, rpc_timeout, peer_network_id)
+            .await
+    }
+
+    pub fn to_bytes(
+        &self,
+        peers: Vec<PeerId>,
+        message: ConsensusMsg,
+    ) -> anyhow::Result<HashMap<PeerId, Bytes>> {
+        let peer_network_ids: Vec<PeerNetworkId> = peers
+            .into_iter()
+            .map(|peer| self.get_peer_network_id_for_peer(peer))
+            .collect();
+        Ok(self
+            .network_client
+            .to_bytes(peer_network_ids, message)?
+            .into_iter()
+            .map(|(peer_network_id, bytes)| (peer_network_id.peer_id(), bytes))
+            .collect())
     }
 
     // TODO: we shouldn't need to expose this. Migrate the code to handle

--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -196,6 +196,7 @@ impl BufferManager {
             signing_phase_rx,
 
             reliable_broadcast: ReliableBroadcast::new(
+                author,
                 epoch_state.verifier.get_ordered_account_addresses(),
                 commit_msg_tx.clone(),
                 rb_backoff_policy,

--- a/consensus/src/pipeline/commit_reliable_broadcast.rs
+++ b/consensus/src/pipeline/commit_reliable_broadcast.rs
@@ -11,8 +11,13 @@ use aptos_infallible::Mutex;
 use aptos_reliable_broadcast::{BroadcastStatus, RBMessage, RBNetworkSender};
 use aptos_types::validator_verifier::ValidatorVerifier;
 use async_trait::async_trait;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 /// Network message for the pipeline phase
@@ -99,11 +104,14 @@ impl RBNetworkSender<CommitMessage> for NetworkSender {
     async fn send_rb_rpc(
         &self,
         receiver: Author,
-        message: CommitMessage,
+        raw_message: Bytes,
         timeout_duration: Duration,
     ) -> anyhow::Result<CommitMessage> {
-        let msg = ConsensusMsg::CommitMessage(Box::new(message));
-        let response = match self.send_rpc(receiver, msg, timeout_duration).await? {
+        let response = match self
+            .consensus_network_client
+            .send_rpc_raw(receiver, raw_message, timeout_duration)
+            .await?
+        {
             ConsensusMsg::CommitMessage(resp) if matches!(*resp, CommitMessage::Ack(_)) => *resp,
             ConsensusMsg::CommitMessage(resp) if matches!(*resp, CommitMessage::Nack) => {
                 bail!("Received nack, will retry")
@@ -112,5 +120,33 @@ impl RBNetworkSender<CommitMessage> for NetworkSender {
         };
 
         Ok(response)
+    }
+
+    async fn send_rb_rpc_to_self(
+        &self,
+        message: CommitMessage,
+        timeout: Duration,
+    ) -> anyhow::Result<CommitMessage> {
+        let consensus_msg = ConsensusMsg::CommitMessage(Box::new(message));
+        let response_msg = self.send_rpc_to_self(consensus_msg, timeout).await?;
+
+        let response = match response_msg {
+            ConsensusMsg::CommitMessage(resp) if matches!(*resp, CommitMessage::Ack(_)) => *resp,
+            ConsensusMsg::CommitMessage(resp) if matches!(*resp, CommitMessage::Nack) => {
+                bail!("Received nack, will retry")
+            },
+            _ => bail!("Invalid response to request"),
+        };
+
+        Ok(response)
+    }
+
+    fn to_bytes(
+        &self,
+        peers: Vec<Author>,
+        message: CommitMessage,
+    ) -> Result<HashMap<Author, bytes::Bytes>, anyhow::Error> {
+        let msg = ConsensusMsg::CommitMessage(Box::new(message));
+        self.consensus_network_client.to_bytes(peers, msg)
     }
 }

--- a/consensus/src/pipeline/commit_reliable_broadcast.rs
+++ b/consensus/src/pipeline/commit_reliable_broadcast.rs
@@ -147,6 +147,7 @@ impl RBNetworkSender<CommitMessage> for NetworkSender {
         message: CommitMessage,
     ) -> Result<HashMap<Author, bytes::Bytes>, anyhow::Error> {
         let msg = ConsensusMsg::CommitMessage(Box::new(message));
-        self.consensus_network_client.to_bytes_by_protocol(peers, msg)
+        self.consensus_network_client
+            .to_bytes_by_protocol(peers, msg)
     }
 }

--- a/consensus/src/pipeline/commit_reliable_broadcast.rs
+++ b/consensus/src/pipeline/commit_reliable_broadcast.rs
@@ -141,12 +141,12 @@ impl RBNetworkSender<CommitMessage> for NetworkSender {
         Ok(response)
     }
 
-    fn to_bytes(
+    fn to_bytes_by_protocol(
         &self,
         peers: Vec<Author>,
         message: CommitMessage,
     ) -> Result<HashMap<Author, bytes::Bytes>, anyhow::Error> {
         let msg = ConsensusMsg::CommitMessage(Box::new(message));
-        self.consensus_network_client.to_bytes(peers, msg)
+        self.consensus_network_client.to_bytes_by_protocol(peers, msg)
     }
 }

--- a/crates/aptos-jwk-consensus/src/epoch_manager.rs
+++ b/crates/aptos-jwk-consensus/src/epoch_manager.rs
@@ -201,6 +201,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 self.self_sender.clone(),
             );
             let rb = ReliableBroadcast::new(
+                self.my_addr,
                 epoch_state.verifier.get_ordered_account_addresses(),
                 Arc::new(network_sender),
                 ExponentialBackoff::from_millis(5),

--- a/crates/aptos-jwk-consensus/src/network.rs
+++ b/crates/aptos-jwk-consensus/src/network.rs
@@ -88,12 +88,12 @@ impl RBNetworkSender<JWKConsensusMsg> for NetworkSender {
         }
     }
 
-    fn to_bytes(
+    fn to_bytes_by_protocol(
         &self,
         peers: Vec<Author>,
         message: JWKConsensusMsg,
     ) -> Result<HashMap<Author, bytes::Bytes>, anyhow::Error> {
-        self.jwk_network_client.to_bytes(peers, message)
+        self.jwk_network_client.to_bytes_by_protocol(peers, message)
     }
 }
 

--- a/crates/aptos-jwk-consensus/src/network_interface.rs
+++ b/crates/aptos-jwk-consensus/src/network_interface.rs
@@ -7,8 +7,9 @@ use aptos_network::{
     application::{error::Error, interface::NetworkClientInterface},
     ProtocolId,
 };
+use bytes::Bytes;
 use move_core_types::account_address::AccountAddress as PeerId;
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 /// Supported protocols in preferred order (from highest priority to lowest).
 pub const DIRECT_SEND: &[ProtocolId] = &[
@@ -36,15 +37,37 @@ impl<NetworkClient: NetworkClientInterface<JWKConsensusMsg>>
         Self { network_client }
     }
 
-    pub async fn send_rpc(
+    pub async fn send_rpc_raw(
         &self,
         peer: PeerId,
-        message: JWKConsensusMsg,
+        message: Bytes,
         rpc_timeout: Duration,
     ) -> Result<JWKConsensusMsg, Error> {
-        let peer_network_id = PeerNetworkId::new(NetworkId::Validator, peer);
+        let peer_network_id = self.get_peer_network_id_for_peer(peer);
         self.network_client
-            .send_to_peer_rpc(message, rpc_timeout, peer_network_id)
+            .send_to_peer_rpc_raw(message, rpc_timeout, peer_network_id)
             .await
+    }
+
+    pub fn to_bytes(
+        &self,
+        peers: Vec<PeerId>,
+        message: JWKConsensusMsg,
+    ) -> anyhow::Result<HashMap<PeerId, Bytes>> {
+        let peer_network_ids: Vec<PeerNetworkId> = peers
+            .into_iter()
+            .map(|peer| self.get_peer_network_id_for_peer(peer))
+            .collect();
+        Ok(self
+            .network_client
+            .to_bytes(peer_network_ids, message)?
+            .into_iter()
+            .map(|(peer_network_id, bytes)| (peer_network_id.peer_id(), bytes))
+            .collect())
+    }
+
+    // TODO: we shouldn't need to expose this. Migrate the code to handle peer and network ids.
+    fn get_peer_network_id_for_peer(&self, peer: PeerId) -> PeerNetworkId {
+        PeerNetworkId::new(NetworkId::Validator, peer)
     }
 }

--- a/crates/aptos-jwk-consensus/src/network_interface.rs
+++ b/crates/aptos-jwk-consensus/src/network_interface.rs
@@ -37,6 +37,18 @@ impl<NetworkClient: NetworkClientInterface<JWKConsensusMsg>>
         Self { network_client }
     }
 
+    pub async fn send_rpc(
+        &self,
+        peer: PeerId,
+        message: JWKConsensusMsg,
+        rpc_timeout: Duration,
+    ) -> Result<JWKConsensusMsg, Error> {
+        let peer_network_id = self.get_peer_network_id_for_peer(peer);
+        self.network_client
+            .send_to_peer_rpc(message, rpc_timeout, peer_network_id)
+            .await
+    }
+
     pub async fn send_rpc_raw(
         &self,
         peer: PeerId,

--- a/crates/aptos-jwk-consensus/src/network_interface.rs
+++ b/crates/aptos-jwk-consensus/src/network_interface.rs
@@ -49,7 +49,7 @@ impl<NetworkClient: NetworkClientInterface<JWKConsensusMsg>>
             .await
     }
 
-    pub fn to_bytes(
+    pub fn to_bytes_by_protocol(
         &self,
         peers: Vec<PeerId>,
         message: JWKConsensusMsg,
@@ -60,7 +60,7 @@ impl<NetworkClient: NetworkClientInterface<JWKConsensusMsg>>
             .collect();
         Ok(self
             .network_client
-            .to_bytes(peer_network_ids, message)?
+            .to_bytes_by_protocol(peer_network_ids, message)?
             .into_iter()
             .map(|(peer_network_id, bytes)| (peer_network_id.peer_id(), bytes))
             .collect())

--- a/crates/aptos-jwk-consensus/src/update_certifier.rs
+++ b/crates/aptos-jwk-consensus/src/update_certifier.rs
@@ -64,7 +64,7 @@ impl TUpdateCertifier for UpdateCertifier {
         };
         let agg_state = Arc::new(ObservationAggregationState::new(epoch_state, payload));
         let task = async move {
-            let qc_update = rb.broadcast(req, agg_state).await;
+            let qc_update = rb.broadcast(req, agg_state).await.expect("cannot fail");
             info!(
                 epoch = epoch,
                 issuer = String::from_utf8(issuer.clone()).ok(),

--- a/crates/reliable-broadcast/Cargo.toml
+++ b/crates/reliable-broadcast/Cargo.toml
@@ -22,6 +22,8 @@ aptos-logger = { workspace = true }
 aptos-time-service = { workspace = true }
 aptos-types = { workspace = true }
 async-trait = { workspace = true }
+bytes = { workspace = true }
+claims = { workspace = true }
 futures = { workspace = true }
 futures-channel = { workspace = true }
 tokio = { workspace = true }

--- a/crates/reliable-broadcast/src/lib.rs
+++ b/crates/reliable-broadcast/src/lib.rs
@@ -143,16 +143,10 @@ where
                     }
                     let send_fut = if receiver == self_author {
                         network_sender.send_rb_rpc(receiver, message, rpc_timeout_duration)
+                    } else if let Some(raw_message) = protocols.get(&receiver).cloned() {
+                        network_sender.send_rb_rpc_raw(receiver, raw_message, rpc_timeout_duration)
                     } else {
-                        if let Some(raw_message) = protocols.get(&receiver).cloned() {
-                            network_sender.send_rb_rpc_raw(
-                                receiver,
-                                raw_message,
-                                rpc_timeout_duration,
-                            )
-                        } else {
-                            network_sender.send_rb_rpc(receiver, message, rpc_timeout_duration)
-                        }
+                        network_sender.send_rb_rpc(receiver, message, rpc_timeout_duration)
                     };
                     (receiver, send_fut.await)
                 }

--- a/crates/reliable-broadcast/src/lib.rs
+++ b/crates/reliable-broadcast/src/lib.rs
@@ -113,7 +113,7 @@ where
             .map(|author| (author, self.backoff_policy.clone()))
             .collect();
         let executor = self.executor.clone();
-        let self_author = self.self_author.clone();
+        let self_author = self.self_author;
         async move {
             let message: Req = message.into();
 

--- a/crates/reliable-broadcast/src/tests.rs
+++ b/crates/reliable-broadcast/src/tests.rs
@@ -10,6 +10,8 @@ use aptos_infallible::Mutex;
 use aptos_time_service::TimeService;
 use aptos_types::validator_verifier::random_validator_verifier;
 use async_trait::async_trait;
+use bytes::Bytes;
+use claims::assert_ok_eq;
 use futures::{
     stream::{AbortHandle, Abortable},
     FutureExt,
@@ -64,6 +66,7 @@ where
 }
 
 struct TestRBSender<M> {
+    self_author: Author,
     failures: Mutex<HashMap<Author, u8>>,
     received: Mutex<HashMap<Author, TestMessage>>,
     _marker: PhantomData<M>,
@@ -73,8 +76,9 @@ impl<M> TestRBSender<M>
 where
     M: Send + Sync,
 {
-    fn new(failures: HashMap<Author, u8>) -> Self {
+    fn new(self_author: Author, failures: HashMap<Author, u8>) -> Self {
         Self {
+            self_author,
             failures: Mutex::new(failures),
             received: Mutex::new(HashMap::new()),
             _marker: PhantomData,
@@ -92,7 +96,7 @@ where
     async fn send_rb_rpc(
         &self,
         receiver: Author,
-        message: M,
+        raw_message: Bytes,
         _timeout: Duration,
     ) -> anyhow::Result<M> {
         match self.failures.lock().entry(receiver) {
@@ -106,9 +110,25 @@ where
             },
             Entry::Vacant(_) => (),
         };
-        let message: TestMessage = message.try_into()?;
+        let message = TestMessage(raw_message.to_vec());
         self.received.lock().insert(receiver, message.clone());
         Ok(TestAck(message.0).into())
+    }
+
+    async fn send_rb_rpc_to_self(&self, message: M, timeout: Duration) -> anyhow::Result<M> {
+        let message: TestMessage = message.try_into()?;
+        let raw_message: Bytes = message.0.into();
+        self.send_rb_rpc(self.self_author, raw_message, timeout)
+            .await
+    }
+
+    fn to_bytes(&self, peers: Vec<Author>, message: M) -> anyhow::Result<HashMap<Author, Bytes>> {
+        let message: TestMessage = message.try_into()?;
+        let raw_message: Bytes = message.0.into();
+        Ok(peers
+            .into_iter()
+            .map(|peer| (peer, raw_message.clone()))
+            .collect())
     }
 }
 
@@ -116,9 +136,11 @@ where
 async fn test_reliable_broadcast() {
     let (_, validator_verifier) = random_validator_verifier(5, None, false);
     let validators = validator_verifier.get_ordered_account_addresses();
+    let self_author = validators[0].clone();
     let failures = HashMap::from([(validators[0], 1), (validators[2], 3)]);
-    let sender = Arc::new(TestRBSender::<TestRBMessage>::new(failures));
+    let sender = Arc::new(TestRBSender::<TestRBMessage>::new(self_author, failures));
     let rb = ReliableBroadcast::new(
+        self_author,
         validators.clone(),
         sender,
         FixedInterval::from_millis(10),
@@ -132,16 +154,18 @@ async fn test_reliable_broadcast() {
         received: Arc::new(Mutex::new(HashSet::new())),
     });
     let fut = rb.broadcast(message, aggregating);
-    assert_eq!(fut.await, validators.into_iter().collect());
+    assert_ok_eq!(fut.await, validators.into_iter().collect());
 }
 
 #[tokio::test]
 async fn test_chaining_reliable_broadcast() {
     let (_, validator_verifier) = random_validator_verifier(5, None, false);
     let validators = validator_verifier.get_ordered_account_addresses();
+    let self_author = validators[0].clone();
     let failures = HashMap::from([(validators[0], 1), (validators[2], 3)]);
-    let sender = Arc::new(TestRBSender::<TestRBMessage>::new(failures));
+    let sender = Arc::new(TestRBSender::<TestRBMessage>::new(self_author, failures));
     let rb = Arc::new(ReliableBroadcast::new(
+        self_author,
         validators.clone(),
         sender,
         FixedInterval::from_millis(10),
@@ -159,23 +183,25 @@ async fn test_chaining_reliable_broadcast() {
     let fut = rb1
         .broadcast(message.clone(), aggregating)
         .then(|aggregated| async move {
-            assert_eq!(aggregated, expected);
+            assert_ok_eq!(aggregated, expected);
             let aggregating = Arc::new(TestBroadcastStatus {
                 threshold: validator_verifier.len(),
                 received: Arc::new(Mutex::new(HashSet::new())),
             });
             rb.broadcast(message, aggregating).await
         });
-    assert_eq!(fut.await, validators.into_iter().collect());
+    assert_ok_eq!(fut.await, validators.into_iter().collect());
 }
 
 #[tokio::test]
 async fn test_abort_reliable_broadcast() {
     let (_, validator_verifier) = random_validator_verifier(5, None, false);
     let validators = validator_verifier.get_ordered_account_addresses();
+    let self_author = validators[0].clone();
     let failures = HashMap::from([(validators[0], 1), (validators[2], 3)]);
-    let sender = Arc::new(TestRBSender::<TestRBMessage>::new(failures));
+    let sender = Arc::new(TestRBSender::<TestRBMessage>::new(self_author, failures));
     let rb = Arc::new(ReliableBroadcast::new(
+        self_author,
         validators.clone(),
         sender,
         FixedInterval::from_millis(10),

--- a/crates/reliable-broadcast/src/tests.rs
+++ b/crates/reliable-broadcast/src/tests.rs
@@ -122,7 +122,11 @@ where
             .await
     }
 
-    fn to_bytes_by_protocol(&self, peers: Vec<Author>, message: M) -> anyhow::Result<HashMap<Author, Bytes>> {
+    fn to_bytes_by_protocol(
+        &self,
+        peers: Vec<Author>,
+        message: M,
+    ) -> anyhow::Result<HashMap<Author, Bytes>> {
         let message: TestMessage = message.try_into()?;
         let raw_message: Bytes = message.0.into();
         Ok(peers
@@ -136,7 +140,7 @@ where
 async fn test_reliable_broadcast() {
     let (_, validator_verifier) = random_validator_verifier(5, None, false);
     let validators = validator_verifier.get_ordered_account_addresses();
-    let self_author = validators[0].clone();
+    let self_author = validators[0];
     let failures = HashMap::from([(validators[0], 1), (validators[2], 3)]);
     let sender = Arc::new(TestRBSender::<TestRBMessage>::new(self_author, failures));
     let rb = ReliableBroadcast::new(
@@ -161,7 +165,7 @@ async fn test_reliable_broadcast() {
 async fn test_chaining_reliable_broadcast() {
     let (_, validator_verifier) = random_validator_verifier(5, None, false);
     let validators = validator_verifier.get_ordered_account_addresses();
-    let self_author = validators[0].clone();
+    let self_author = validators[0];
     let failures = HashMap::from([(validators[0], 1), (validators[2], 3)]);
     let sender = Arc::new(TestRBSender::<TestRBMessage>::new(self_author, failures));
     let rb = Arc::new(ReliableBroadcast::new(
@@ -197,7 +201,7 @@ async fn test_chaining_reliable_broadcast() {
 async fn test_abort_reliable_broadcast() {
     let (_, validator_verifier) = random_validator_verifier(5, None, false);
     let validators = validator_verifier.get_ordered_account_addresses();
-    let self_author = validators[0].clone();
+    let self_author = validators[0];
     let failures = HashMap::from([(validators[0], 1), (validators[2], 3)]);
     let sender = Arc::new(TestRBSender::<TestRBMessage>::new(self_author, failures));
     let rb = Arc::new(ReliableBroadcast::new(

--- a/crates/reliable-broadcast/src/tests.rs
+++ b/crates/reliable-broadcast/src/tests.rs
@@ -122,7 +122,7 @@ where
             .await
     }
 
-    fn to_bytes(&self, peers: Vec<Author>, message: M) -> anyhow::Result<HashMap<Author, Bytes>> {
+    fn to_bytes_by_protocol(&self, peers: Vec<Author>, message: M) -> anyhow::Result<HashMap<Author, Bytes>> {
         let message: TestMessage = message.try_into()?;
         let raw_message: Bytes = message.0.into();
         Ok(peers

--- a/dkg/src/agg_trx_producer.rs
+++ b/dkg/src/agg_trx_producer.rs
@@ -61,7 +61,10 @@ impl<DKG: DKGTrait + 'static> TAggTranscriptProducer<DKG> for AggTranscriptProdu
             epoch_state,
         ));
         let task = async move {
-            let agg_trx = rb.broadcast(req, agg_state).await;
+            let agg_trx = rb
+                .broadcast(req, agg_state)
+                .await
+                .expect("broadcast cannot fail");
             info!(
                 epoch = epoch,
                 my_addr = my_addr,

--- a/dkg/src/epoch_manager.rs
+++ b/dkg/src/epoch_manager.rs
@@ -206,6 +206,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
             let network_sender = self.create_network_sender();
             let rb = ReliableBroadcast::new(
+                self.my_addr,
                 epoch_state.verifier.get_ordered_account_addresses(),
                 Arc::new(network_sender),
                 ExponentialBackoff::from_millis(self.rb_config.backoff_policy_base_ms)

--- a/dkg/src/network.rs
+++ b/dkg/src/network.rs
@@ -24,7 +24,7 @@ use futures::{
 };
 use futures_channel::oneshot;
 use move_core_types::account_address::AccountAddress;
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::time::timeout;
 
 pub struct IncomingRpcRequest {
@@ -60,29 +60,21 @@ impl NetworkSender {
         self.author
     }
 
-    pub async fn send_rpc(
+    pub async fn send_rpc_to_self(
         &self,
-        receiver: AccountAddress,
         msg: DKGMessage,
         timeout_duration: Duration,
     ) -> anyhow::Result<DKGMessage> {
-        if receiver == self.author() {
-            let (tx, rx) = oneshot::channel();
-            let protocol = RPC[0];
-            let self_msg = Event::RpcRequest(receiver, msg.clone(), RPC[0], tx);
-            self.self_sender.clone().send(self_msg).await?;
-            if let Ok(Ok(Ok(bytes))) = timeout(timeout_duration, rx).await {
-                let response_msg =
-                    tokio::task::spawn_blocking(move || protocol.from_bytes(&bytes)).await??;
-                Ok(response_msg)
-            } else {
-                bail!("self rpc failed");
-            }
+        let (tx, rx) = oneshot::channel();
+        let protocol = RPC[0];
+        let self_msg = Event::RpcRequest(self.author, msg.clone(), RPC[0], tx);
+        self.self_sender.clone().send(self_msg).await?;
+        if let Ok(Ok(Ok(bytes))) = timeout(timeout_duration, rx).await {
+            let response_msg =
+                tokio::task::spawn_blocking(move || protocol.from_bytes(&bytes)).await??;
+            Ok(response_msg)
         } else {
-            Ok(self
-                .dkg_network_client
-                .send_rpc(receiver, msg, timeout_duration)
-                .await?)
+            bail!("self rpc failed");
         }
     }
 }
@@ -92,10 +84,29 @@ impl RBNetworkSender<DKGMessage> for NetworkSender {
     async fn send_rb_rpc(
         &self,
         receiver: AccountAddress,
+        raw_message: Bytes,
+        timeout: Duration,
+    ) -> anyhow::Result<DKGMessage> {
+        Ok(self
+            .dkg_network_client
+            .send_rpc_raw(receiver, raw_message, timeout)
+            .await?)
+    }
+
+    async fn send_rb_rpc_to_self(
+        &self,
         message: DKGMessage,
         timeout: Duration,
     ) -> anyhow::Result<DKGMessage> {
-        self.send_rpc(receiver, message, timeout).await
+        self.send_rpc_to_self(message, timeout).await
+    }
+
+    fn to_bytes(
+        &self,
+        peers: Vec<AccountAddress>,
+        message: DKGMessage,
+    ) -> anyhow::Result<HashMap<AccountAddress, Bytes>> {
+        self.dkg_network_client.to_bytes(peers, message)
     }
 }
 

--- a/dkg/src/network.rs
+++ b/dkg/src/network.rs
@@ -101,12 +101,12 @@ impl RBNetworkSender<DKGMessage> for NetworkSender {
         self.send_rpc_to_self(message, timeout).await
     }
 
-    fn to_bytes(
+    fn to_bytes_by_protocol(
         &self,
         peers: Vec<AccountAddress>,
         message: DKGMessage,
     ) -> anyhow::Result<HashMap<AccountAddress, Bytes>> {
-        self.dkg_network_client.to_bytes(peers, message)
+        self.dkg_network_client.to_bytes_by_protocol(peers, message)
     }
 }
 

--- a/dkg/src/network.rs
+++ b/dkg/src/network.rs
@@ -72,7 +72,9 @@ impl NetworkSender {
             let self_msg = Event::RpcRequest(receiver, msg.clone(), RPC[0], tx);
             self.self_sender.clone().send(self_msg).await?;
             if let Ok(Ok(Ok(bytes))) = timeout(timeout_duration, rx).await {
-                Ok(protocol.from_bytes(&bytes)?)
+                let response_msg =
+                    tokio::task::spawn_blocking(move || protocol.from_bytes(&bytes)).await??;
+                Ok(response_msg)
             } else {
                 bail!("self rpc failed");
             }

--- a/dkg/src/network_interface.rs
+++ b/dkg/src/network_interface.rs
@@ -47,7 +47,7 @@ impl<NetworkClient: NetworkClientInterface<DKGMessage>> DKGNetworkClient<Network
             .await
     }
 
-    pub fn to_bytes(
+    pub fn to_bytes_by_protocol(
         &self,
         peers: Vec<PeerId>,
         message: DKGMessage,
@@ -58,7 +58,7 @@ impl<NetworkClient: NetworkClientInterface<DKGMessage>> DKGNetworkClient<Network
             .collect();
         Ok(self
             .network_client
-            .to_bytes(peer_network_ids, message)?
+            .to_bytes_by_protocol(peer_network_ids, message)?
             .into_iter()
             .map(|(peer_network_id, bytes)| (peer_network_id.peer_id(), bytes))
             .collect())

--- a/dkg/src/network_interface.rs
+++ b/dkg/src/network_interface.rs
@@ -34,6 +34,18 @@ impl<NetworkClient: NetworkClientInterface<DKGMessage>> DKGNetworkClient<Network
         Self { network_client }
     }
 
+    pub async fn send_rpc(
+        &self,
+        peer: PeerId,
+        message: DKGMessage,
+        rpc_timeout: Duration,
+    ) -> Result<DKGMessage, Error> {
+        let peer_network_id = self.get_peer_network_id_for_peer(peer);
+        self.network_client
+            .send_to_peer_rpc(message, rpc_timeout, peer_network_id)
+            .await
+    }
+
     /// Send a RPC to the destination peer
     pub async fn send_rpc_raw(
         &self,

--- a/network/framework/src/application/interface.rs
+++ b/network/framework/src/application/interface.rs
@@ -74,7 +74,7 @@ pub trait NetworkClientInterface<Message: NetworkMessageTrait>: Clone + Send + S
         _peer: PeerNetworkId,
     ) -> Result<Message, Error>;
 
-    fn to_bytes(
+    fn to_bytes_by_protocol(
         &self,
         _peers: Vec<PeerNetworkId>,
         _message: Message,
@@ -262,7 +262,7 @@ impl<Message: NetworkMessageTrait> NetworkClientInterface<Message> for NetworkCl
             .await?)
     }
 
-    fn to_bytes<'a>(
+    fn to_bytes_by_protocol(
         &self,
         peers: Vec<PeerNetworkId>,
         message: Message,

--- a/network/framework/src/application/interface.rs
+++ b/network/framework/src/application/interface.rs
@@ -13,6 +13,7 @@ use aptos_config::network_id::{NetworkId, PeerNetworkId};
 use aptos_logger::{prelude::*, sample, sample::SampleRate};
 use aptos_types::network_address::NetworkAddress;
 use async_trait::async_trait;
+use bytes::Bytes;
 use itertools::Itertools;
 use std::{collections::HashMap, fmt::Debug, sync::Arc, time::Duration};
 
@@ -54,7 +55,7 @@ pub trait NetworkClientInterface<Message: NetworkMessageTrait>: Clone + Send + S
 
     /// Sends the given message to each peer in the specified peer list.
     /// Note: this method does not guarantee message delivery or handle responses.
-    fn send_to_peers(&self, _message: Message, _peers: &[PeerNetworkId]) -> Result<(), Error>;
+    fn send_to_peers(&self, _message: Message, _peers: Vec<PeerNetworkId>) -> Result<(), Error>;
 
     /// Sends the given message to the specified peer with the corresponding
     /// timeout. Awaits a response from the peer, or hits the timeout
@@ -65,6 +66,19 @@ pub trait NetworkClientInterface<Message: NetworkMessageTrait>: Clone + Send + S
         _rpc_timeout: Duration,
         _peer: PeerNetworkId,
     ) -> Result<Message, Error>;
+
+    async fn send_to_peer_rpc_raw(
+        &self,
+        _message: Bytes,
+        _rpc_timeout: Duration,
+        _peer: PeerNetworkId,
+    ) -> Result<Message, Error>;
+
+    fn to_bytes(
+        &self,
+        _peers: Vec<PeerNetworkId>,
+        _message: Message,
+    ) -> anyhow::Result<HashMap<PeerNetworkId, Bytes>>;
 }
 
 /// A network component that can be used by client applications (e.g., consensus,
@@ -132,6 +146,39 @@ impl<Message: NetworkMessageTrait + Clone> NetworkClient<Message> {
             peer, protocols_supported_by_peer
         )))
     }
+
+    fn group_peers_by_protocol(
+        &self,
+        peers: Vec<PeerNetworkId>,
+    ) -> HashMap<ProtocolId, Vec<PeerNetworkId>> {
+        // Sort peers by protocol
+        let mut peers_per_protocol = HashMap::new();
+        let mut peers_without_a_protocol = vec![];
+        for peer in peers {
+            match self
+                .get_preferred_protocol_for_peer(&peer, &self.direct_send_protocols_and_preferences)
+            {
+                Ok(protocol) => peers_per_protocol
+                    .entry(protocol)
+                    .or_insert_with(Vec::new)
+                    .push(peer),
+                Err(_) => peers_without_a_protocol.push(peer),
+            }
+        }
+
+        // We only periodically log any unavailable peers (to prevent log spamming)
+        if !peers_without_a_protocol.is_empty() {
+            sample!(
+                SampleRate::Duration(Duration::from_secs(10)),
+                warn!(
+                    "Unavailable peers (without a common network protocol): {:?}",
+                    peers_without_a_protocol
+                )
+            );
+        }
+
+        peers_per_protocol
+    }
 }
 
 #[async_trait]
@@ -170,32 +217,8 @@ impl<Message: NetworkMessageTrait> NetworkClientInterface<Message> for NetworkCl
         Ok(network_sender.send_to(peer.peer_id(), direct_send_protocol_id, message)?)
     }
 
-    fn send_to_peers(&self, message: Message, peers: &[PeerNetworkId]) -> Result<(), Error> {
-        // Sort peers by protocol
-        let mut peers_per_protocol = HashMap::new();
-        let mut peers_without_a_protocol = vec![];
-        for peer in peers {
-            match self
-                .get_preferred_protocol_for_peer(peer, &self.direct_send_protocols_and_preferences)
-            {
-                Ok(protocol) => peers_per_protocol
-                    .entry(protocol)
-                    .or_insert_with(Vec::new)
-                    .push(peer),
-                Err(_) => peers_without_a_protocol.push(peer),
-            }
-        }
-
-        // We only periodically log any unavailable peers (to prevent log spamming)
-        if !peers_without_a_protocol.is_empty() {
-            sample!(
-                SampleRate::Duration(Duration::from_secs(10)),
-                warn!(
-                    "Unavailable peers (without a common network protocol): {:?}",
-                    peers_without_a_protocol
-                )
-            );
-        }
+    fn send_to_peers(&self, message: Message, peers: Vec<PeerNetworkId>) -> Result<(), Error> {
+        let peers_per_protocol = self.group_peers_by_protocol(peers);
 
         // Send to all peers in each protocol group and network
         for (protocol_id, peers) in peers_per_protocol {
@@ -223,6 +246,38 @@ impl<Message: NetworkMessageTrait> NetworkClientInterface<Message> for NetworkCl
         Ok(network_sender
             .send_rpc(peer.peer_id(), rpc_protocol_id, message, rpc_timeout)
             .await?)
+    }
+
+    async fn send_to_peer_rpc_raw(
+        &self,
+        message: Bytes,
+        rpc_timeout: Duration,
+        peer: PeerNetworkId,
+    ) -> Result<Message, Error> {
+        let network_sender = self.get_sender_for_network_id(&peer.network_id())?;
+        let rpc_protocol_id =
+            self.get_preferred_protocol_for_peer(&peer, &self.rpc_protocols_and_preferences)?;
+        Ok(network_sender
+            .send_rpc_raw(peer.peer_id(), rpc_protocol_id, message, rpc_timeout)
+            .await?)
+    }
+
+    fn to_bytes<'a>(
+        &self,
+        peers: Vec<PeerNetworkId>,
+        message: Message,
+    ) -> anyhow::Result<HashMap<PeerNetworkId, Bytes>> {
+        let peers_per_protocol = self.group_peers_by_protocol(peers);
+        // Convert to bytes per protocol
+        let mut bytes_per_peer = HashMap::new();
+        for (protocol_id, peers) in peers_per_protocol {
+            let bytes: Bytes = protocol_id.to_bytes(&message)?.into();
+            for peer in peers {
+                bytes_per_peer.insert(peer, bytes.clone());
+            }
+        }
+
+        Ok(bytes_per_peer)
     }
 }
 

--- a/network/framework/src/application/tests.rs
+++ b/network/framework/src/application/tests.rs
@@ -584,7 +584,7 @@ async fn test_network_client_missing_network_sender() {
 
     // Verify that sending a message to all peers without a network simply logs the errors
     network_client
-        .send_to_peers(DummyMessage::new_empty(), &[bad_peer_network_id])
+        .send_to_peers(DummyMessage::new_empty(), vec![bad_peer_network_id])
         .unwrap();
 }
 
@@ -716,7 +716,7 @@ async fn test_network_client_network_senders_direct_send() {
     // Verify that broadcast messages are sent on matching networks and protocols
     let dummy_message = DummyMessage::new(2323);
     network_client
-        .send_to_peers(dummy_message.clone(), &[
+        .send_to_peers(dummy_message.clone(), vec![
             peer_network_id_1,
             peer_network_id_2,
         ])


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR separates RPC sending from serialization by introducing two methods on `NetworkClient`: `send_rpc_raw` and `to_bytes`. The intent is to prevent serialization `N` times for Reliable Broadcast. Reliable Broadcast uses this to serialize once and send to many peers.

`send_rpc_raw` takes in Bytes as an argument instead of an actual message.
`to_bytes` takes in a message struct and returns Bytes. It serializes based on Peer Protocol.
`send_rpc_to_self` takes in the message struct, because self messages don't have to be serialized.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [X] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
