### PR TITLE
backup service send in batch

### DIFF
--- a/crates/aptos-metrics-core/src/lib.rs
+++ b/crates/aptos-metrics-core/src/lib.rs
@@ -37,11 +37,21 @@ impl IntGaugeHelper for IntGaugeVec {
 }
 
 pub trait IntCounterHelper {
+    type IntType;
+
     fn inc_with(&self, labels: &[&str]);
+
+    fn inc_with_by(&self, labels: &[&str], by: Self::IntType);
 }
 
 impl IntCounterHelper for IntCounterVec {
+    type IntType = u64;
+
     fn inc_with(&self, labels: &[&str]) {
         self.with_label_values(labels).inc()
+    }
+
+    fn inc_with_by(&self, labels: &[&str], v: Self::IntType) {
+        self.with_label_values(labels).inc_by(v)
     }
 }

--- a/storage/backup/backup-service/src/handlers/utils.rs
+++ b/storage/backup/backup-service/src/handlers/utils.rs
@@ -5,10 +5,10 @@
 use aptos_db::backup::backup_handler::BackupHandler;
 use aptos_logger::prelude::*;
 use aptos_metrics_core::{
-    register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounterVec,
+    register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounterHelper, IntCounterVec,
 };
 use aptos_storage_interface::{AptosDbError, Result};
-use bytes::Bytes;
+use bytes::{BufMut, Bytes, BytesMut};
 use hyper::Body;
 use once_cell::sync::Lazy;
 use serde::Serialize;
@@ -44,30 +44,101 @@ pub(super) fn reply_with_bcs_bytes<R: Serialize>(
     Ok(Box::new(bytes))
 }
 
+#[must_use]
 pub(super) struct BytesSender {
-    endpoint: &'static str,
-    inner: hyper::body::Sender,
+    buffer: BytesMut,
+    batch_tx: Option<tokio::sync::mpsc::Sender<Bytes>>,
+    sender_task: Option<tokio::task::JoinHandle<(hyper::body::Sender, Result<()>)>>,
 }
 
 impl BytesSender {
-    fn new(endpoint: &'static str, inner: hyper::body::Sender) -> Self {
-        Self { endpoint, inner }
+    fn new(endpoint: &'static str, mut inner: hyper::body::Sender) -> Self {
+        let (batch_tx, mut batch_rx) = tokio::sync::mpsc::channel::<Bytes>(2);
+
+        let sender_task = tokio::spawn(async move {
+            let res = async {
+                while let Some(batch) = batch_rx.recv().await {
+                    let n_bytes = batch.len();
+
+                    inner.send_data(batch).await.into_db_res()?;
+
+                    THROUGHPUT_COUNTER.inc_with_by(&[endpoint], n_bytes as u64);
+                }
+                Ok(())
+            }
+            .await;
+
+            (inner, res)
+        });
+
+        Self {
+            buffer: BytesMut::new(),
+            batch_tx: Some(batch_tx),
+            sender_task: Some(sender_task),
+        }
     }
 
-    async fn send_data(&mut self, chunk: Bytes) -> Result<()> {
-        let n_bytes = chunk.len();
-        self.inner
-            .send_data(chunk)
+    async fn flush_buffer(&mut self) -> Result<()> {
+        self.batch_tx
+            .as_mut()
+            .expect("Batch sender gone.")
+            .send(self.buffer.split().freeze())
             .await
-            .map_err(|e| AptosDbError::Other(e.to_string()))?;
-        THROUGHPUT_COUNTER
-            .with_label_values(&[self.endpoint])
-            .inc_by(n_bytes as u64);
+            .into_db_res()
+    }
+
+    async fn send_data(&mut self, bytes: &[u8]) -> Result<()> {
+        let sender_task = self.sender_task.as_ref().expect("Sender task gone.");
+
+        if sender_task.is_finished() {
+            return Err(AptosDbError::Other(
+                "Sender task finished unexpectedly.".to_string(),
+            ));
+        }
+
+        self.buffer.put_slice(bytes);
+
+        const TARGET_BATCH_SIZE: usize = if cfg!(test) { 10 } else { 1024 * 1024 * 10 };
+        if self.buffer.len() >= TARGET_BATCH_SIZE {
+            self.flush_buffer().await?
+        }
+
         Ok(())
     }
 
-    fn abort(self) {
-        self.inner.abort()
+    async fn finish_impl(&mut self, abort: bool) -> Result<()> {
+        let mut ret = Ok(());
+
+        if !abort {
+            ret = self.flush_buffer().await
+        }
+
+        // drop sender to inform the sending task to quit
+        self.batch_tx.take().unwrap();
+
+        let (inner, res) = self
+            .sender_task
+            .take()
+            .unwrap()
+            .await
+            .expect("Sender task panicked.");
+
+        ret = ret.and(res);
+
+        if abort || ret.is_err() {
+            inner.abort();
+        }
+
+        ret
+    }
+
+    async fn finish(mut self) -> Result<()> {
+        self.finish_impl(false).await
+    }
+
+    async fn abort(mut self) {
+        // ignore error
+        let _ = self.finish_impl(true).await;
     }
 }
 
@@ -93,12 +164,17 @@ where
     I: Iterator<Item = Result<R>>,
     R: Serialize,
 {
-    send_size_prefixed_bcs_bytes_impl(iter_res, &mut sender)
-        .await
-        .unwrap_or_else(|e| {
-            warn!("Failed writing to output http body: {:?}", e);
-            sender.abort()
-        });
+    match send_size_prefixed_bcs_bytes_impl(iter_res, &mut sender).await {
+        Ok(()) => {
+            if let Err(e) = sender.finish().await {
+                warn!("Failed to finish http body: {:?}", e);
+            }
+        },
+        Err(e) => {
+            warn!("Failed writing http body: {:?}", e);
+            sender.abort().await;
+        },
+    }
 }
 
 async fn send_size_prefixed_bcs_bytes_impl<I, R>(
@@ -113,9 +189,11 @@ where
         let record = record_res?;
         let record_bytes = bcs::to_bytes(&record)?;
         let size_bytes = (record_bytes.len() as u32).to_be_bytes();
-        sender.send_data(Bytes::from(size_bytes.to_vec())).await?;
-        sender.send_data(Bytes::from(record_bytes)).await?;
+
+        sender.send_data(&size_bytes).await?;
+        sender.send_data(&record_bytes).await?;
     }
+
     Ok(())
 }
 
@@ -134,4 +212,14 @@ pub(super) fn unwrap_or_500(result: Result<Box<dyn Reply>>) -> Box<dyn Reply> {
 pub(super) async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
     warn!("bad request: {:?}", err);
     Ok(warp::http::StatusCode::BAD_REQUEST)
+}
+
+trait IntoDbResult<T> {
+    fn into_db_res(self) -> Result<T>;
+}
+
+impl<T, E: std::error::Error> IntoDbResult<T> for std::result::Result<T, E> {
+    fn into_db_res(self) -> Result<T> {
+        self.map_err(|e| AptosDbError::Other(e.to_string()))
+    }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Looks like hyper::body::Sender::send_data() waits for the ack in place without buffering, that could be the reason why our backup speed is so dependent on network latency.  Upgrading hyper is non-trivial (warp depends on the old version), so I did some manual buffering. 

Doubles the throughput.

![image](https://github.com/aptos-labs/aptos-core/assets/1943319/792491aa-ecb8-4a23-b6e7-b8ad1a6f857c)


## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [ ] Other (specify) -- backup service

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Existing unit tests (commenting out flush_buffer(), for example, does fail the tests)

patched testnet pfn0

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
