### PR TITLE
move VK check into feature gating

### DIFF
--- a/aptos-move/aptos-vm/src/keyless_validation.rs
+++ b/aptos-move/aptos-vm/src/keyless_validation.rs
@@ -121,19 +121,21 @@ fn get_jwk_for_authenticator(
 
 /// Ensures that **all** keyless authenticators in the transaction are valid.
 pub(crate) fn validate_authenticators(
-    pvk: &PreparedVerifyingKey<Bn254>,
+    pvk: &Option<PreparedVerifyingKey<Bn254>>,
     authenticators: &Vec<(KeylessPublicKey, KeylessSignature)>,
     features: &Features,
     resolver: &impl AptosMoveResolver,
 ) -> Result<(), VMStatus> {
+    let mut with_zk = false;
     for (_, sig) in authenticators {
         // Feature-gating for keyless TXNs (whether ZK or ZKless, whether passkey-based or not)
-        if matches!(sig.cert, EphemeralCertificate::ZeroKnowledgeSig { .. })
-            && !features.is_zk_keyless_enabled()
-        {
-            return Err(VMStatus::error(StatusCode::FEATURE_UNDER_GATING, None));
-        }
+        if matches!(sig.cert, EphemeralCertificate::ZeroKnowledgeSig { .. }) {
+            if !features.is_zk_keyless_enabled() {
+                return Err(VMStatus::error(StatusCode::FEATURE_UNDER_GATING, None));
+            }
 
+            with_zk = true;
+        }
         if matches!(sig.cert, EphemeralCertificate::OpenIdSig { .. })
             && !features.is_zkless_keyless_enabled()
         {
@@ -144,6 +146,11 @@ pub(crate) fn validate_authenticators(
         {
             return Err(VMStatus::error(StatusCode::FEATURE_UNDER_GATING, None));
         }
+    }
+
+    // If there are ZK authenticators, the Groth16 VK must have been set on-chain.
+    if with_zk && pvk.is_none() {
+        return Err(invalid_signature!("Groth16 VK has not been set on-chain"));
     }
 
     let config = &get_configs_onchain(resolver)?;
@@ -234,7 +241,8 @@ pub(crate) fn validate_authenticators(
                                 }
                             }
 
-                            let result = zksig.verify_groth16_proof(public_inputs_hash, pvk);
+                            let result = zksig
+                                .verify_groth16_proof(public_inputs_hash, pvk.as_ref().unwrap());
 
                             result.map_err(|_| {
                                 // println!("[aptos-vm][groth16] ZKP verification failed");


### PR DESCRIPTION
## Description

Before this PR, if the VK was **unset**:
1. When ZK mode was _disabled_, our code would  return `TransactionStatus::Discard(StatusCode::INVALID_SIGNATURE)` when verifying keyless TXNs. 
   - This is incorrect/unecessary, since the (lack of a) VK is irrelevant when  ZK mode is _disabled_. 
   - More importantly, if the TXN had only ZK**less** signatures, this would incorrectly discard it!
3. When ZK mode was _enabled_ , our code would return `TransactionStatus::Discard(StatusCode::INVALID_SIGNATURE)`. This is incorrect when the TXN contains **only** ZK**less** signatures that are all valid.

After this PR, if the VK is **unset**:
1. When ZK mode is _disabled_,
    a. If the TXN has one or more keyless ZK signatures, it returns `TransactionStatus::Discard(StatusCode::FEATURE_UNDER_GATING)`
    b. Otherwise, if the TXN had **only** keyless ZK**less** signatures, it continues the feature-gated ZK**less** validation work. (Since ZK**less** mode is off on `mainnet` and `testnet`, this also returns `TransactionStatus::Discard(StatusCode::FEATURE_UNDER_GATING)`)
2. When ZK mode is _enabled_,
    a. If the TXN has one or more keyless ZK signatures, it returns `TransactionStatus::Discard(StatusCode::INVALID_SIGNATURE)`, since the ZKP cannot verified without a VK.
    b. Same as in (1b) above ☝️ 

See [backwards compatibility discussion below](#Key-Areas-to-Review).

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

I am running the replay tests.

## Key Areas to Review

**Backwards compatibility**: AFAICT, since ZK**less** mode has been off on mainnet and testnet, the only thing this PR does is it changes a `TransactionStatus::Discard(StatusCode::INVALID_SIGNATURE)` into a `TransactionStatus::Discard(StatusCode::FEATURE_UNDER_GATING)`, but only when the VK is **unset.**

Therefore, this should be okay since the VK has been set on `testnet` and `mainnet`.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
