### PR TITLE
[consensus] send to distant peers first on broadcast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8561,9 +8561,9 @@ checksum = "92620684d99f750bae383ecb3be3748142d6095760afd5cbcf2261e9a279d780"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -9230,9 +9230,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.8"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
 dependencies = [
  "console",
  "instant",
@@ -14099,7 +14099,7 @@ version = "0.39.0"
 source = "git+https://github.com/banool/self_update.git?rev=8306158ad0fd5b9d4766a3c6bf967e7ef0ea5c4b#8306158ad0fd5b9d4766a3c6bf967e7ef0ea5c4b"
 dependencies = [
  "hyper",
- "indicatif 0.17.8",
+ "indicatif 0.17.7",
  "log",
  "quick-xml 0.23.1",
  "regex",
@@ -16633,9 +16633,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.5.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+checksum = "0fec781d48b41f8163426ed18e8fc2864c12937df9ce54c88ede7bd47270893e"
 dependencies = [
  "redox_syscall 0.4.1",
  "wasite",

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -74,6 +74,8 @@ impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockNetworkSender {
     ) -> anyhow::Result<HashMap<Author, Bytes>> {
         Ok(peers.into_iter().map(|peer| (peer, Bytes::new())).collect())
     }
+
+    fn sort_peers_by_latency(&self, _: &mut [Author]) {}
 }
 
 #[async_trait]

--- a/consensus/src/dag/tests/dag_network_test.rs
+++ b/consensus/src/dag/tests/dag_network_test.rs
@@ -58,6 +58,8 @@ impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockDAGNetworkSender {
     ) -> anyhow::Result<HashMap<Author, Bytes>> {
         unimplemented!()
     }
+
+    fn sort_peers_by_latency(&self, _: &mut [Author]) {}
 }
 
 #[async_trait]

--- a/consensus/src/dag/tests/dag_state_sync_tests.rs
+++ b/consensus/src/dag/tests/dag_state_sync_tests.rs
@@ -64,6 +64,8 @@ impl RBNetworkSender<DAGMessage, DAGRpcResult> for MockDAGNetworkSender {
     ) -> anyhow::Result<HashMap<Author, Bytes>> {
         unimplemented!()
     }
+
+    fn sort_peers_by_latency(&self, _: &mut [Author]) {}
 }
 
 #[async_trait]

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -151,12 +151,9 @@ impl<NetworkClient: NetworkClientInterface<ConsensusMsg>> ConsensusNetworkClient
     }
 
     /// Send a single message to the destination peers
-    pub fn send_to_many(
-        &self,
-        peers: impl Iterator<Item = PeerId>,
-        message: ConsensusMsg,
-    ) -> Result<(), Error> {
+    pub fn send_to_many(&self, peers: Vec<PeerId>, message: ConsensusMsg) -> Result<(), Error> {
         let peer_network_ids: Vec<PeerNetworkId> = peers
+            .into_iter()
             .map(|peer| self.get_peer_network_id_for_peer(peer))
             .collect();
         self.network_client.send_to_peers(message, peer_network_ids)
@@ -208,5 +205,10 @@ impl<NetworkClient: NetworkClientInterface<ConsensusMsg>> ConsensusNetworkClient
     // peer and network ids.
     fn get_peer_network_id_for_peer(&self, peer: PeerId) -> PeerNetworkId {
         PeerNetworkId::new(NetworkId::Validator, peer)
+    }
+
+    pub fn sort_peers_by_latency(&self, peers: &mut [PeerId]) {
+        self.network_client
+            .sort_peers_by_latency(NetworkId::Validator, peers);
     }
 }

--- a/consensus/src/pipeline/commit_reliable_broadcast.rs
+++ b/consensus/src/pipeline/commit_reliable_broadcast.rs
@@ -9,7 +9,7 @@ use aptos_consensus_types::{
 };
 use aptos_infallible::Mutex;
 use aptos_reliable_broadcast::{BroadcastStatus, RBMessage, RBNetworkSender};
-use aptos_types::validator_verifier::ValidatorVerifier;
+use aptos_types::{validator_verifier::ValidatorVerifier, PeerId};
 use async_trait::async_trait;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
@@ -148,5 +148,9 @@ impl RBNetworkSender<CommitMessage> for NetworkSender {
         let msg = ConsensusMsg::CommitMessage(Box::new(message));
         self.consensus_network_client
             .to_bytes_by_protocol(peers, msg)
+    }
+
+    fn sort_peers_by_latency(&self, peers: &mut [PeerId]) {
+        self.sort_peers_by_latency(peers);
     }
 }

--- a/crates/aptos-jwk-consensus/src/network.rs
+++ b/crates/aptos-jwk-consensus/src/network.rs
@@ -104,6 +104,10 @@ impl RBNetworkSender<JWKConsensusMsg> for NetworkSender {
     ) -> Result<HashMap<Author, bytes::Bytes>, anyhow::Error> {
         self.jwk_network_client.to_bytes_by_protocol(peers, message)
     }
+
+    fn sort_peers_by_latency(&self, peers: &mut [AccountAddress]) {
+        self.jwk_network_client.sort_peers_by_latency(peers)
+    }
 }
 
 pub trait RpcResponseSender: Send + Sync {

--- a/crates/aptos-jwk-consensus/src/network_interface.rs
+++ b/crates/aptos-jwk-consensus/src/network_interface.rs
@@ -82,4 +82,9 @@ impl<NetworkClient: NetworkClientInterface<JWKConsensusMsg>>
     fn get_peer_network_id_for_peer(&self, peer: PeerId) -> PeerNetworkId {
         PeerNetworkId::new(NetworkId::Validator, peer)
     }
+
+    pub fn sort_peers_by_latency(&self, peers: &mut [PeerId]) {
+        self.network_client
+            .sort_peers_by_latency(NetworkId::Validator, peers)
+    }
 }

--- a/crates/reliable-broadcast/src/lib.rs
+++ b/crates/reliable-broadcast/src/lib.rs
@@ -37,6 +37,8 @@ pub trait RBNetworkSender<Req: RBMessage, Res: RBMessage = Req>: Send + Sync {
         peers: Vec<Author>,
         message: Req,
     ) -> anyhow::Result<HashMap<Author, Bytes>>;
+
+    fn sort_peers_by_latency(&self, peers: &mut [Author]);
 }
 
 pub trait BroadcastStatus<Req: RBMessage, Res: RBMessage = Req>: Send + Sync + Clone {
@@ -155,6 +157,10 @@ where
 
             let mut rpc_futures = FuturesUnordered::new();
             let mut aggregate_futures = FuturesUnordered::new();
+
+            let mut receivers = receivers;
+            network_sender.sort_peers_by_latency(&mut receivers);
+
             for receiver in receivers {
                 rpc_futures.push(send_message(receiver, None));
             }

--- a/crates/reliable-broadcast/src/tests.rs
+++ b/crates/reliable-broadcast/src/tests.rs
@@ -136,6 +136,8 @@ where
             .map(|peer| (peer, raw_message.clone()))
             .collect())
     }
+
+    fn sort_peers_by_latency(&self, _: &mut [Author]) {}
 }
 
 #[tokio::test]

--- a/dkg/src/network.rs
+++ b/dkg/src/network.rs
@@ -117,6 +117,10 @@ impl RBNetworkSender<DKGMessage> for NetworkSender {
     ) -> anyhow::Result<HashMap<AccountAddress, Bytes>> {
         self.dkg_network_client.to_bytes_by_protocol(peers, message)
     }
+
+    fn sort_peers_by_latency(&self, peers: &mut [AccountAddress]) {
+        self.dkg_network_client.sort_peers_by_latency(peers)
+    }
 }
 
 pub struct NetworkReceivers {

--- a/dkg/src/network_interface.rs
+++ b/dkg/src/network_interface.rs
@@ -80,4 +80,9 @@ impl<NetworkClient: NetworkClientInterface<DKGMessage>> DKGNetworkClient<Network
     fn get_peer_network_id_for_peer(&self, peer: PeerId) -> PeerNetworkId {
         PeerNetworkId::new(NetworkId::Validator, peer)
     }
+
+    pub fn sort_peers_by_latency(&self, peers: &mut [PeerId]) {
+        self.network_client
+            .sort_peers_by_latency(NetworkId::Validator, peers)
+    }
 }

--- a/mempool/src/shared_mempool/priority.rs
+++ b/mempool/src/shared_mempool/priority.rs
@@ -617,11 +617,7 @@ mod test {
         let public_peer = (create_public_peer(), None);
 
         // Verify that peers are prioritized by network ID first
-        let all_peers = vec![
-            vfn_peer.clone(),
-            public_peer.clone(),
-            validator_peer.clone(),
-        ];
+        let all_peers = vec![vfn_peer, public_peer, validator_peer];
         let prioritized_peers = prioritized_peers_state.sort_peers_by_priority(&all_peers);
         let expected_peers = vec![validator_peer.0, vfn_peer.0, public_peer.0];
         assert_eq!(prioritized_peers, expected_peers);
@@ -643,12 +639,7 @@ mod test {
         let public_peer_4 = (create_public_peer(), Some(&peer_metadata_4));
 
         // Verify that peers on the same network ID are prioritized by validator distance
-        let all_peers = vec![
-            public_peer_1.clone(),
-            public_peer_2.clone(),
-            public_peer_3.clone(),
-            public_peer_4.clone(),
-        ];
+        let all_peers = vec![public_peer_1, public_peer_2, public_peer_3, public_peer_4];
         let prioritized_peers = prioritized_peers_state.sort_peers_by_priority(&all_peers);
         let expected_peers = vec![
             public_peer_3.0,
@@ -675,12 +666,7 @@ mod test {
         );
 
         // Verify that peers on the same network ID and validator distance are prioritized by ping latency
-        let all_peers = vec![
-            public_peer_1.clone(),
-            public_peer_2.clone(),
-            public_peer_3.clone(),
-            public_peer_4.clone(),
-        ];
+        let all_peers = vec![public_peer_1, public_peer_2, public_peer_3, public_peer_4];
         let prioritized_peers = prioritized_peers_state.sort_peers_by_priority(&all_peers);
         let expected_peers = vec![
             public_peer_3.0,
@@ -710,11 +696,7 @@ mod test {
         let public_peer = (create_public_peer(), None);
 
         // Verify that peers are prioritized by network ID first
-        let all_peers = vec![
-            vfn_peer.clone(),
-            public_peer.clone(),
-            validator_peer.clone(),
-        ];
+        let all_peers = vec![vfn_peer, public_peer, validator_peer];
         let prioritized_peers = prioritized_peers_state.sort_peers_by_priority(&all_peers);
         let expected_peers = vec![validator_peer.0, vfn_peer.0, public_peer.0];
         assert_eq!(prioritized_peers, expected_peers);
@@ -767,12 +749,7 @@ mod test {
         );
 
         // Update the prioritized peers
-        let all_peers = vec![
-            public_peer_1.clone(),
-            public_peer_2.clone(),
-            public_peer_3.clone(),
-            public_peer_4.clone(),
-        ];
+        let all_peers = vec![public_peer_1, public_peer_2, public_peer_3, public_peer_4];
         prioritized_peers_state.update_prioritized_peers(all_peers);
 
         // Verify that the prioritized peers were updated correctly
@@ -799,11 +776,7 @@ mod test {
         time_service.advance_secs(100);
 
         // Update the prioritized peers for only peers with ping latencies
-        let all_peers = vec![
-            public_peer_1.clone(),
-            public_peer_2.clone(),
-            public_peer_3.clone(),
-        ];
+        let all_peers = vec![public_peer_1, public_peer_2, public_peer_3];
         prioritized_peers_state.update_prioritized_peers(all_peers);
 
         // Verify that the prioritized peers were updated correctly
@@ -841,11 +814,7 @@ mod test {
         let public_peer = (create_public_peer(), None);
 
         // Update the prioritized peers
-        let all_peers = vec![
-            validator_peer.clone(),
-            vfn_peer.clone(),
-            public_peer.clone(),
-        ];
+        let all_peers = vec![validator_peer, vfn_peer, public_peer];
         prioritized_peers_state.update_prioritized_peers(all_peers);
 
         // Verify that the prioritized peers were updated correctly

--- a/mempool/src/shared_mempool/priority.rs
+++ b/mempool/src/shared_mempool/priority.rs
@@ -36,8 +36,8 @@ impl PrioritizedPeersComparator {
     /// Higher priority peers are greater than lower priority peers.
     fn compare_simple(
         &self,
-        peer_a: &(PeerNetworkId, Option<PeerMonitoringMetadata>),
-        peer_b: &(PeerNetworkId, Option<PeerMonitoringMetadata>),
+        peer_a: &(PeerNetworkId, Option<&PeerMonitoringMetadata>),
+        peer_b: &(PeerNetworkId, Option<&PeerMonitoringMetadata>),
     ) -> Ordering {
         // Deconstruct the peer tuples
         let (peer_network_id_a, _) = peer_a;
@@ -60,8 +60,8 @@ impl PrioritizedPeersComparator {
     /// Higher priority peers are greater than lower priority peers.
     fn compare_intelligent(
         &self,
-        peer_a: &(PeerNetworkId, Option<PeerMonitoringMetadata>),
-        peer_b: &(PeerNetworkId, Option<PeerMonitoringMetadata>),
+        peer_a: &(PeerNetworkId, Option<&PeerMonitoringMetadata>),
+        peer_b: &(PeerNetworkId, Option<&PeerMonitoringMetadata>),
     ) -> Ordering {
         // Deconstruct the peer tuples
         let (peer_network_id_a, monitoring_metadata_a) = peer_a;
@@ -191,7 +191,7 @@ impl PrioritizedPeersState {
     /// The peers are sorted in descending order (i.e., higher values are prioritized).
     fn sort_peers_by_priority(
         &self,
-        peers_and_metadata: &[(PeerNetworkId, Option<PeerMonitoringMetadata>)],
+        peers_and_metadata: &[(PeerNetworkId, Option<&PeerMonitoringMetadata>)],
     ) -> Vec<PeerNetworkId> {
         peers_and_metadata
             .iter()
@@ -211,7 +211,7 @@ impl PrioritizedPeersState {
     /// Updates the prioritized peers list
     pub fn update_prioritized_peers(
         &mut self,
-        peers_and_metadata: Vec<(PeerNetworkId, Option<PeerMonitoringMetadata>)>,
+        peers_and_metadata: Vec<(PeerNetworkId, Option<&PeerMonitoringMetadata>)>,
     ) {
         // Calculate the new set of prioritized peers
         let new_prioritized_peers = self.sort_peers_by_priority(&peers_and_metadata);
@@ -257,9 +257,9 @@ impl PrioritizedPeersState {
 /// Returns the distance from the validators for the
 /// given monitoring metadata (if one exists).
 fn get_distance_from_validators(
-    monitoring_metadata: &Option<PeerMonitoringMetadata>,
+    monitoring_metadata: &Option<&PeerMonitoringMetadata>,
 ) -> Option<u64> {
-    monitoring_metadata.as_ref().and_then(|metadata| {
+    monitoring_metadata.and_then(|metadata| {
         metadata
             .latest_network_info_response
             .as_ref()
@@ -269,10 +269,8 @@ fn get_distance_from_validators(
 
 /// Returns the ping latency for the given monitoring
 /// metadata (if one exists).
-fn get_peer_ping_latency(monitoring_metadata: &Option<PeerMonitoringMetadata>) -> Option<f64> {
-    monitoring_metadata
-        .as_ref()
-        .and_then(|metadata| metadata.average_ping_latency_secs)
+fn get_peer_ping_latency(monitoring_metadata: &Option<&PeerMonitoringMetadata>) -> Option<f64> {
+    monitoring_metadata.and_then(|metadata| metadata.average_ping_latency_secs)
 }
 
 /// Compares the network ID for the given pair of peers.
@@ -285,8 +283,8 @@ fn compare_network_id(network_id_a: &NetworkId, network_id_b: &NetworkId) -> Ord
 /// Compares the ping latency for the given pair of monitoring metadata.
 /// The peer with the lowest ping latency is prioritized.
 fn compare_ping_latency(
-    monitoring_metadata_a: &Option<PeerMonitoringMetadata>,
-    monitoring_metadata_b: &Option<PeerMonitoringMetadata>,
+    monitoring_metadata_a: &Option<&PeerMonitoringMetadata>,
+    monitoring_metadata_b: &Option<&PeerMonitoringMetadata>,
 ) -> Ordering {
     // Get the ping latency from the monitoring metadata
     let ping_latency_a = get_peer_ping_latency(monitoring_metadata_a);
@@ -313,8 +311,8 @@ fn compare_ping_latency(
 /// Compares the validator distance for the given pair of monitoring metadata.
 /// The peer with the lowest validator distance is prioritized.
 fn compare_validator_distance(
-    monitoring_metadata_a: &Option<PeerMonitoringMetadata>,
-    monitoring_metadata_b: &Option<PeerMonitoringMetadata>,
+    monitoring_metadata_a: &Option<&PeerMonitoringMetadata>,
+    monitoring_metadata_b: &Option<&PeerMonitoringMetadata>,
 ) -> Ordering {
     // Get the validator distance from the monitoring metadata
     let validator_distance_a = get_distance_from_validators(monitoring_metadata_a);
@@ -387,7 +385,10 @@ mod test {
         // Verify that the metadata is equal
         assert_eq!(
             Ordering::Equal,
-            compare_validator_distance(&Some(monitoring_metadata_1), &Some(monitoring_metadata_2))
+            compare_validator_distance(
+                &Some(&monitoring_metadata_1),
+                &Some(&monitoring_metadata_2)
+            )
         );
 
         // Create monitoring metadata with different distances
@@ -398,13 +399,16 @@ mod test {
         assert_eq!(
             Ordering::Greater,
             compare_validator_distance(
-                &Some(monitoring_metadata_1.clone()),
-                &Some(monitoring_metadata_2.clone())
+                &Some(&monitoring_metadata_1),
+                &Some(&monitoring_metadata_2)
             )
         );
         assert_eq!(
             Ordering::Less,
-            compare_validator_distance(&Some(monitoring_metadata_2), &Some(monitoring_metadata_1))
+            compare_validator_distance(
+                &Some(&monitoring_metadata_2),
+                &Some(&monitoring_metadata_1)
+            )
         );
 
         // Create monitoring metadata with and without distances
@@ -415,26 +419,26 @@ mod test {
         assert_eq!(
             Ordering::Greater,
             compare_validator_distance(
-                &Some(monitoring_metadata_1.clone()),
-                &Some(monitoring_metadata_2.clone())
+                &Some(&monitoring_metadata_1),
+                &Some(&monitoring_metadata_2)
             )
         );
         assert_eq!(
             Ordering::Less,
             compare_validator_distance(
-                &Some(monitoring_metadata_2.clone()),
-                &Some(monitoring_metadata_1.clone())
+                &Some(&monitoring_metadata_2),
+                &Some(&monitoring_metadata_1)
             )
         );
 
         // Compare monitoring metadata that is missing entirely
         assert_eq!(
             Ordering::Greater,
-            compare_validator_distance(&Some(monitoring_metadata_1.clone()), &None)
+            compare_validator_distance(&Some(&monitoring_metadata_1), &None)
         );
         assert_eq!(
             Ordering::Less,
-            compare_validator_distance(&None, &Some(monitoring_metadata_1))
+            compare_validator_distance(&None, &Some(&monitoring_metadata_1))
         );
     }
 
@@ -447,7 +451,7 @@ mod test {
         // Verify that the metadata is equal
         assert_eq!(
             Ordering::Equal,
-            compare_ping_latency(&Some(monitoring_metadata_1), &Some(monitoring_metadata_2))
+            compare_ping_latency(&Some(&monitoring_metadata_1), &Some(&monitoring_metadata_2))
         );
 
         // Create monitoring metadata with different ping latencies
@@ -457,14 +461,11 @@ mod test {
         // Verify that the metadata has different ordering
         assert_eq!(
             Ordering::Greater,
-            compare_ping_latency(
-                &Some(monitoring_metadata_1.clone()),
-                &Some(monitoring_metadata_2.clone())
-            )
+            compare_ping_latency(&Some(&monitoring_metadata_1), &Some(&monitoring_metadata_2))
         );
         assert_eq!(
             Ordering::Less,
-            compare_ping_latency(&Some(monitoring_metadata_2), &Some(monitoring_metadata_1))
+            compare_ping_latency(&Some(&monitoring_metadata_2), &Some(&monitoring_metadata_1))
         );
 
         // Create monitoring metadata with and without ping latencies
@@ -474,27 +475,21 @@ mod test {
         // Verify that the metadata with a ping latency has a higher ordering
         assert_eq!(
             Ordering::Greater,
-            compare_ping_latency(
-                &Some(monitoring_metadata_1.clone()),
-                &Some(monitoring_metadata_2.clone())
-            )
+            compare_ping_latency(&Some(&monitoring_metadata_1), &Some(&monitoring_metadata_2))
         );
         assert_eq!(
             Ordering::Less,
-            compare_ping_latency(
-                &Some(monitoring_metadata_2.clone()),
-                &Some(monitoring_metadata_1.clone())
-            )
+            compare_ping_latency(&Some(&monitoring_metadata_2), &Some(&monitoring_metadata_1))
         );
 
         // Compare monitoring metadata that is missing entirely
         assert_eq!(
             Ordering::Greater,
-            compare_ping_latency(&Some(monitoring_metadata_1.clone()), &None)
+            compare_ping_latency(&Some(&monitoring_metadata_1), &None)
         );
         assert_eq!(
             Ordering::Less,
-            compare_ping_latency(&None, &Some(monitoring_metadata_1))
+            compare_ping_latency(&None, &Some(&monitoring_metadata_1))
         );
     }
 
@@ -632,22 +627,20 @@ mod test {
         assert_eq!(prioritized_peers, expected_peers);
 
         // Create a list of peers with the same network ID, but different validator distances
-        let public_peer_1 = (
-            create_public_peer(),
-            Some(create_metadata_with_distance(Some(1))),
-        );
+        let peer_metadata_1 = create_metadata_with_distance(Some(1));
+        let public_peer_1 = (create_public_peer(), Some(&peer_metadata_1));
+
+        let peer_metadata_2 = create_metadata_with_distance(None);
         let public_peer_2 = (
             create_public_peer(),
-            Some(create_metadata_with_distance(None)), // No validator distance
+            Some(&peer_metadata_2), // No validator distance
         );
-        let public_peer_3 = (
-            create_public_peer(),
-            Some(create_metadata_with_distance(Some(0))),
-        );
-        let public_peer_4 = (
-            create_public_peer(),
-            Some(create_metadata_with_distance(Some(2))),
-        );
+
+        let peer_metadata_3 = create_metadata_with_distance(Some(0));
+        let public_peer_3 = (create_public_peer(), Some(&peer_metadata_3));
+
+        let peer_metadata_4 = create_metadata_with_distance(Some(2));
+        let public_peer_4 = (create_public_peer(), Some(&peer_metadata_4));
 
         // Verify that peers on the same network ID are prioritized by validator distance
         let all_peers = vec![
@@ -666,21 +659,19 @@ mod test {
         assert_eq!(prioritized_peers, expected_peers);
 
         // Create a list of peers with the same network ID and validator distance, but different ping latencies
-        let public_peer_1 = (
-            create_public_peer(),
-            Some(create_metadata_with_distance_and_latency(1, 0.5)),
-        );
-        let public_peer_2 = (
-            create_public_peer(),
-            Some(create_metadata_with_distance_and_latency(1, 2.0)),
-        );
-        let public_peer_3 = (
-            create_public_peer(),
-            Some(create_metadata_with_distance_and_latency(1, 0.4)),
-        );
+        let peer_metadata_1 = create_metadata_with_distance_and_latency(1, 0.5);
+        let public_peer_1 = (create_public_peer(), Some(&peer_metadata_1));
+
+        let peer_metadata_2 = create_metadata_with_distance_and_latency(1, 2.0);
+        let public_peer_2 = (create_public_peer(), Some(&peer_metadata_2));
+
+        let peer_metadata_3 = create_metadata_with_distance_and_latency(1, 0.4);
+        let public_peer_3 = (create_public_peer(), Some(&peer_metadata_3));
+
+        let peer_metadata_4 = create_metadata_with_distance(Some(1));
         let public_peer_4 = (
             create_public_peer(),
-            Some(create_metadata_with_distance(Some(1))), // No ping latency
+            Some(&peer_metadata_4), // No ping latency
         );
 
         // Verify that peers on the same network ID and validator distance are prioritized by ping latency
@@ -760,21 +751,19 @@ mod test {
         assert!(prioritized_peers_state.last_peer_priority_update.is_none());
 
         // Create a list of peers with and without ping latencies
-        let public_peer_1 = (
-            create_public_peer(),
-            Some(create_metadata_with_distance_and_latency(1, 0.5)),
-        );
-        let public_peer_2 = (
-            create_public_peer(),
-            Some(create_metadata_with_distance_and_latency(1, 2.0)),
-        );
-        let public_peer_3 = (
-            create_public_peer(),
-            Some(create_metadata_with_distance_and_latency(1, 0.4)),
-        );
+        let peer_metadata_1 = create_metadata_with_distance_and_latency(1, 0.5);
+        let public_peer_1 = (create_public_peer(), Some(&peer_metadata_1));
+
+        let peer_metadata_2 = create_metadata_with_distance_and_latency(1, 2.0);
+        let public_peer_2 = (create_public_peer(), Some(&peer_metadata_2));
+
+        let peer_metadata_3 = create_metadata_with_distance_and_latency(1, 0.4);
+        let public_peer_3 = (create_public_peer(), Some(&peer_metadata_3));
+
+        let peer_metadata_4 = create_metadata_with_distance(Some(1));
         let public_peer_4 = (
             create_public_peer(),
-            Some(create_metadata_with_distance(Some(1))), // No ping latency
+            Some(&peer_metadata_4), // No ping latency
         );
 
         // Update the prioritized peers
@@ -865,13 +854,15 @@ mod test {
         assert_eq!(prioritized_peers, expected_peers);
 
         // Create a list of peers with the same network ID but different metadata
-        let mut all_peers = vec![];
+        let mut all_metadata = Vec::new();
         for i in 0..100 {
-            all_peers.push((
-                create_public_peer(),
-                Some(create_metadata_with_distance_and_latency(i, i as f64)),
-            ));
+            let metadata = create_metadata_with_distance_and_latency(i, i as f64);
+            all_metadata.push(metadata);
         }
+        let all_peers: Vec<_> = all_metadata
+            .iter()
+            .map(|metadata| (create_public_peer(), Some(metadata)))
+            .collect();
 
         // Update the prioritized peers multiple times and verify that the order is consistent
         let prioritized_peers = prioritized_peers_state.sort_peers_by_priority(&all_peers);

--- a/network/framework/src/application/interface.rs
+++ b/network/framework/src/application/interface.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use aptos_config::network_id::{NetworkId, PeerNetworkId};
 use aptos_logger::{prelude::*, sample, sample::SampleRate};
-use aptos_types::network_address::NetworkAddress;
+use aptos_types::{network_address::NetworkAddress, PeerId};
 use async_trait::async_trait;
 use bytes::Bytes;
 use itertools::Itertools;
@@ -79,6 +79,8 @@ pub trait NetworkClientInterface<Message: NetworkMessageTrait>: Clone + Send + S
         _peers: Vec<PeerNetworkId>,
         _message: Message,
     ) -> anyhow::Result<HashMap<PeerNetworkId, Bytes>>;
+
+    fn sort_peers_by_latency(&self, _network: NetworkId, _peers: &mut [PeerId]);
 }
 
 /// A network component that can be used by client applications (e.g., consensus,
@@ -278,6 +280,11 @@ impl<Message: NetworkMessageTrait> NetworkClientInterface<Message> for NetworkCl
         }
 
         Ok(bytes_per_peer)
+    }
+
+    fn sort_peers_by_latency(&self, network_id: NetworkId, peers: &mut [PeerId]) {
+        self.peers_and_metadata
+            .sort_peers_by_latency(network_id, peers)
     }
 }
 

--- a/network/framework/src/application/metadata.rs
+++ b/network/framework/src/application/metadata.rs
@@ -85,8 +85,8 @@ impl PeerMetadata {
         self.connection_metadata.clone()
     }
 
-    /// Returns a copy of the peer monitoring metadata
-    pub fn get_peer_monitoring_metadata(&self) -> PeerMonitoringMetadata {
-        self.peer_monitoring_metadata.clone()
+    /// Returns a reference to the peer monitoring metadata
+    pub fn get_peer_monitoring_metadata(&self) -> &PeerMonitoringMetadata {
+        &self.peer_monitoring_metadata
     }
 }

--- a/network/framework/src/counters.rs
+++ b/network/framework/src/counters.rs
@@ -628,3 +628,12 @@ fn observe_ping_time(network_context: &NetworkContext, ping_latency_secs: f64, l
         .with_label_values(&[network_context.network_id().as_str(), label])
         .observe(ping_latency_secs);
 }
+
+pub static OP_MEASURE: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_network_measure",
+        "Measures the time and count of an operation",
+        &["op"]
+    )
+    .unwrap()
+});

--- a/peer-monitoring-service/client/src/tests/utils.rs
+++ b/peer-monitoring-service/client/src/tests/utils.rs
@@ -1014,7 +1014,7 @@ pub async fn wait_for_monitoring_network_update(
             let peer_monitoring_metadata = peer_metadata.get_peer_monitoring_metadata();
 
             // Check if the distance from validators matches the expected value
-            if let Some(latest_network_info_response) =
+            if let Some(ref latest_network_info_response) =
                 peer_monitoring_metadata.latest_network_info_response
             {
                 if latest_network_info_response.distance_from_validators

--- a/peer-monitoring-service/server/src/lib.rs
+++ b/peer-monitoring-service/server/src/lib.rs
@@ -321,7 +321,7 @@ fn get_distance_from_validators(
     // Otherwise, go through our peers, find the min, and return a distance relative to the min
     let mut min_peer_distance_from_validators = MAX_DISTANCE_FROM_VALIDATORS;
     for peer_metadata in connected_peers_and_metadata.values() {
-        if let Some(latest_network_info_response) = peer_metadata
+        if let Some(ref latest_network_info_response) = peer_metadata
             .get_peer_monitoring_metadata()
             .latest_network_info_response
         {

--- a/state-sync/aptos-data-client/src/tests/utils.rs
+++ b/state-sync/aptos-data-client/src/tests/utils.rs
@@ -298,7 +298,7 @@ pub fn get_peer_monitoring_metadata(
     let peer_metadata = peers_and_metadata.get_metadata_for_peer(peer).unwrap();
 
     // Return the peer monitoring metadata
-    peer_metadata.get_peer_monitoring_metadata()
+    peer_metadata.get_peer_monitoring_metadata().clone()
 }
 
 /// Returns the peer priority for polling based on if `poll_priority_peers` is true

--- a/state-sync/aptos-data-client/src/utils.rs
+++ b/state-sync/aptos-data-client/src/utils.rs
@@ -237,6 +237,7 @@ fn get_distance_and_latency_for_peer(
         let peer_monitoring_metadata = peer_metadata.get_peer_monitoring_metadata();
         let distance = peer_monitoring_metadata
             .latest_network_info_response
+            .as_ref()
             .map(|response| response.distance_from_validators);
         let latency = peer_monitoring_metadata.average_ping_latency_secs;
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

It seems beneficial to prioritize sending messages to distant peers first during a broadcast.

This PR introduces a method to `PeersAndMetadata` to sort peers by latency. 

- NetworkClient uses this sorting for `send_to_many` calls. 
- RBNetworkSender trait exposes a method to sort peers by latency for Reliable Broadcast RPCs.
- Removes cloning for `PeerMonitoringMetadata` in `PeerMetadata`, because the clone is expensive about 9 microseconds per clone with 100 validators.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
