### PR TITLE
[forge] move haproxy test to unstable

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -136,7 +136,7 @@ jobs:
 
   run-forge-realistic-env-max-load-long:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-framework-upgrade-test] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-framework-upgrade-test ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -148,7 +148,7 @@ jobs:
 
   run-forge-realistic-env-load-sweep:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-realistic-env-max-load-long] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-realistic-env-max-load-long ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -160,7 +160,7 @@ jobs:
 
   run-forge-realistic-env-workload-sweep:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-realistic-env-load-sweep] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-realistic-env-load-sweep ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -172,7 +172,7 @@ jobs:
 
   run-forge-realistic-env-graceful-overload:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-realistic-env-workload-sweep] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-realistic-env-workload-sweep ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -184,7 +184,7 @@ jobs:
 
   run-forge-realistic-network-tuned-for-throughput:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-realistic-env-graceful-overload] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-realistic-env-graceful-overload ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -199,7 +199,7 @@ jobs:
 
   run-forge-consensus-stress-test:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-realistic-network-tuned-for-throughput] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-realistic-network-tuned-for-throughput ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -211,7 +211,7 @@ jobs:
 
   run-forge-workload-mix-test:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-consensus-stress-test] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-consensus-stress-test ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -223,7 +223,7 @@ jobs:
 
   run-forge-single-vfn-perf:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-workload-mix-test] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-workload-mix-test ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -233,22 +233,9 @@ jobs:
       FORGE_TEST_SUITE: single_vfn_perf
       POST_TO_SLACK: true
 
-  run-forge-haproxy:
-    if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-single-vfn-perf] # Only run after the previous job completes
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
-    secrets: inherit
-    with:
-      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
-      FORGE_NAMESPACE: forge-haproxy-${{ needs.determine-test-metadata.outputs.BRANCH_HASH }}
-      FORGE_RUNNER_DURATION_SECS: 600 # Run for 10 minutes
-      FORGE_ENABLE_HAPROXY: true
-      FORGE_TEST_SUITE: realistic_env_max_load
-      POST_TO_SLACK: true
-
   run-forge-fullnode-reboot-stress-test:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-haproxy] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-single-vfn-perf ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -262,7 +249,7 @@ jobs:
 
   run-forge-compat:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-fullnode-reboot-stress-test] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-fullnode-reboot-stress-test ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -278,7 +265,7 @@ jobs:
 
   run-forge-changing-working-quorum-test:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-compat] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-compat ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -291,7 +278,7 @@ jobs:
 
   run-forge-changing-working-quorum-test-high-load:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-changing-working-quorum-test] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-changing-working-quorum-test ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -305,7 +292,7 @@ jobs:
   # Measures PFN latencies with a constant TPS (with a realistic environment)
   run-forge-pfn-const-tps-realistic-env:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-changing-working-quorum-test-high-load] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-changing-working-quorum-test-high-load ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:

--- a/.github/workflows/forge-unstable.yaml
+++ b/.github/workflows/forge-unstable.yaml
@@ -101,7 +101,7 @@ jobs:
 
   run-forge-state-sync-slow-processing-catching-up-test:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, forge-continuous] # Only run after the previous job completes
+    needs: [ determine-test-metadata, forge-continuous ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -116,7 +116,7 @@ jobs:
 
   run-forge-twin-validator-test:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-state-sync-slow-processing-catching-up-test] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-state-sync-slow-processing-catching-up-test ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -130,7 +130,7 @@ jobs:
 
   run-forge-state-sync-failures-catching-up-test:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-twin-validator-test] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-twin-validator-test ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -145,7 +145,7 @@ jobs:
 
   run-forge-validator-reboot-stress-test:
     if: ${{ github.event_name != 'pull_request' && always() }}
-    needs: [determine-test-metadata, run-forge-state-sync-failures-catching-up-test] # Only run after the previous job completes
+    needs: [ determine-test-metadata, run-forge-state-sync-failures-catching-up-test ] # Only run after the previous job completes
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
     secrets: inherit
     with:
@@ -155,4 +155,19 @@ jobs:
       FORGE_NAMESPACE: forge-validator-reboot-stress-${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
       FORGE_RUNNER_DURATION_SECS: 2400 # Run for 40 minutes
       FORGE_TEST_SUITE: validator_reboot_stress_test
+      POST_TO_SLACK: true
+
+  run-forge-haproxy:
+    if: ${{ github.event_name != 'pull_request' && always() }}
+    needs: [ determine-test-metadata, run-forge-validator-reboot-stress-test ] # Only run after the previous job completes
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      IMAGE_TAG: ${{ needs.determine-test-metadata.outputs.IMAGE_TAG }}
+      # GCP cluster
+      FORGE_CLUSTER_NAME: aptos-forge-1
+      FORGE_NAMESPACE: forge-haproxy-${{ needs.determine-test-metadata.outputs.BRANCH_HASH }}
+      FORGE_RUNNER_DURATION_SECS: 600 # Run for 10 minutes
+      FORGE_ENABLE_HAPROXY: true
+      FORGE_TEST_SUITE: realistic_env_max_load
       POST_TO_SLACK: true


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
