### PR TITLE
[sharded][3] use state value with key hash

### DIFF
--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -528,6 +528,7 @@ impl Builder {
 
         // Generate validator configs
         let template = NodeConfig::get_default_validator_config();
+
         let mut validators: Vec<ValidatorNodeConfig> = (0..self.num_validators.get())
             .map(|i| self.generate_validator_config(i, &mut rng, &template))
             .collect::<anyhow::Result<Vec<ValidatorNodeConfig>>>()?;

--- a/storage/aptosdb/src/db_debugger/state_kv/scan_snapshot.rs
+++ b/storage/aptosdb/src/db_debugger/state_kv/scan_snapshot.rs
@@ -1,7 +1,11 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{db_debugger::common::DbDir, schema::state_value::StateValueSchema};
+use crate::{
+    db_debugger::common::DbDir,
+    schema::{state_value::StateValueSchema, state_value_by_key_hash::StateValueByKeyHashSchema},
+};
+use aptos_crypto::hash::CryptoHash;
 use aptos_jellyfish_merkle::iterator::JellyfishMerkleIterator;
 use aptos_schemadb::ReadOptions;
 use aptos_storage_interface::Result;
@@ -75,21 +79,38 @@ impl Cmd {
                             let mut read_opts = ReadOptions::default();
                             // We want `None` if the state_key changes in iteration.
                             read_opts.set_prefix_same_as_start(true);
-                            let mut iter = state_kv_db
-                                .db_shard(key.get_shard_id())
-                                .iter_with_opts::<StateValueSchema>(read_opts)
-                                .unwrap();
-                            iter.seek(&(key.clone(), key_version)).unwrap();
-                            let (value_version, value) = iter
-                                .next()
-                                .transpose()
-                                .unwrap()
-                                .and_then(|((_, version), value_opt)| {
-                                    value_opt.map(|value| (version, value))
-                                })
-                                .expect("Value must exist.");
-                            let elapsed = t.elapsed();
 
+                            let enable_sharding = state_kv_db.enabled_sharding();
+
+                            let (value_version, value) = if enable_sharding {
+                                let mut iter = state_kv_db
+                                    .db_shard(key.get_shard_id())
+                                    .iter::<StateValueByKeyHashSchema>()
+                                    .unwrap();
+                                iter.seek(&(key.hash(), key_version)).unwrap();
+                                iter.next()
+                                    .transpose()
+                                    .unwrap()
+                                    .and_then(|((_, version), value_opt)| {
+                                        value_opt.map(|value| (version, value))
+                                    })
+                                    .expect("Value must exist.")
+                            } else {
+                                let mut iter = state_kv_db
+                                    .db_shard(key.get_shard_id())
+                                    .iter::<StateValueSchema>()
+                                    .unwrap();
+                                iter.seek(&(key.clone(), key_version)).unwrap();
+                                iter.next()
+                                    .transpose()
+                                    .unwrap()
+                                    .and_then(|((_, version), value_opt)| {
+                                        value_opt.map(|value| (version, value))
+                                    })
+                                    .expect("Value must exist.")
+                            };
+
+                            let elapsed = t.elapsed();
                             result_tx
                                 .send((index, key, key_version, value_version, value, elapsed))
                                 .unwrap();

--- a/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_metadata_pruner.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_metadata_pruner.rs
@@ -5,8 +5,8 @@ use crate::{
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
         stale_state_value_index::StaleStateValueIndexSchema,
+        stale_state_value_index_by_key_hash::StaleStateValueIndexByKeyHashSchema,
         state_value::StateValueSchema,
-        state_value_index::StateValueIndexSchema,
     },
     state_kv_db::StateKvDb,
     utils::get_progress,
@@ -39,14 +39,13 @@ impl StateKvMetadataPruner {
                 let mut iter = self
                     .state_kv_db
                     .db_shard(shard_id)
-                    .iter::<StaleStateValueIndexSchema>()?;
+                    .iter::<StaleStateValueIndexByKeyHashSchema>()?;
                 iter.seek(&current_progress)?;
                 for item in iter {
                     let (index, _) = item?;
                     if index.stale_since_version > target_version {
                         break;
                     }
-                    batch.delete::<StateValueIndexSchema>(&(index.state_key, index.version))?;
                 }
             }
         } else {

--- a/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_shard_pruner.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_shard_pruner.rs
@@ -5,8 +5,8 @@ use crate::{
     pruner::pruner_utils::get_or_initialize_subpruner_progress,
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
-        stale_state_value_index::StaleStateValueIndexSchema,
-        state_value::StateValueSchema,
+        stale_state_value_index_by_key_hash::StaleStateValueIndexByKeyHashSchema,
+        state_value_by_key_hash::StateValueByKeyHashSchema,
     },
 };
 use aptos_logger::info;
@@ -15,6 +15,7 @@ use aptos_storage_interface::Result;
 use aptos_types::transaction::Version;
 use std::sync::Arc;
 
+// This pruner is only used when enable_sharding flag is true
 pub(in crate::pruner) struct StateKvShardPruner {
     shard_id: u8,
     db_shard: Arc<DB>,
@@ -50,15 +51,17 @@ impl StateKvShardPruner {
     ) -> Result<()> {
         let batch = SchemaBatch::new();
 
-        let mut iter = self.db_shard.iter::<StaleStateValueIndexSchema>()?;
+        let mut iter = self
+            .db_shard
+            .iter::<StaleStateValueIndexByKeyHashSchema>()?;
         iter.seek(&current_progress)?;
         for item in iter {
             let (index, _) = item?;
             if index.stale_since_version > target_version {
                 break;
             }
-            batch.delete::<StaleStateValueIndexSchema>(&index)?;
-            batch.delete::<StateValueSchema>(&(index.state_key, index.version))?;
+            batch.delete::<StaleStateValueIndexByKeyHashSchema>(&index)?;
+            batch.delete::<StateValueByKeyHashSchema>(&(index.state_key_hash, index.version))?;
         }
         batch.put::<DbMetadataSchema>(
             &DbMetadataKey::StateKvShardPrunerProgress(self.shard_id as usize),

--- a/storage/aptosdb/src/rocksdb_property_reporter.rs
+++ b/storage/aptosdb/src/rocksdb_property_reporter.rs
@@ -6,9 +6,10 @@ use crate::{
     common::NUM_STATE_SHARDS,
     db_options::{
         event_db_column_families, ledger_db_column_families, ledger_metadata_db_column_families,
-        skip_reporting_cf, state_kv_db_column_families, state_merkle_db_column_families,
-        transaction_accumulator_db_column_families, transaction_db_column_families,
-        transaction_info_db_column_families, write_set_db_column_families,
+        skip_reporting_cf, state_kv_db_column_families, state_kv_db_new_key_column_families,
+        state_merkle_db_column_families, transaction_accumulator_db_column_families,
+        transaction_db_column_families, transaction_info_db_column_families,
+        write_set_db_column_families,
     },
     ledger_db::LedgerDb,
     metrics::{
@@ -139,9 +140,13 @@ fn update_rocksdb_properties(
             set_property(cf, ledger_db.transaction_accumulator_db_raw())?;
         }
 
-        for cf in state_kv_db_column_families() {
-            set_property(cf, state_kv_db.metadata_db())?;
-            if state_kv_db.enabled_sharding() {
+        if !state_kv_db.enabled_sharding() {
+            for cf in state_kv_db_column_families() {
+                set_property(cf, state_kv_db.metadata_db())?;
+            }
+        } else {
+            for cf in state_kv_db_new_key_column_families() {
+                set_property(cf, state_kv_db.metadata_db())?;
                 for shard in 0..NUM_STATE_SHARDS {
                     set_shard_property(
                         cf,

--- a/storage/aptosdb/src/schema/mod.rs
+++ b/storage/aptosdb/src/schema/mod.rs
@@ -100,10 +100,16 @@ pub mod fuzzing {
             assert_no_panic_decoding::<
                 super::stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema,
             >(data);
+            assert_no_panic_decoding::<
+                super::stale_state_value_index_by_key_hash::StaleStateValueIndexByKeyHashSchema,
+            >(data);
             assert_no_panic_decoding::<super::stale_state_value_index::StaleStateValueIndexSchema>(
                 data,
             );
             assert_no_panic_decoding::<super::state_value::StateValueSchema>(data);
+            assert_no_panic_decoding::<super::state_value_by_key_hash::StateValueByKeyHashSchema>(
+                data,
+            );
             assert_no_panic_decoding::<super::state_value_index::StateValueIndexSchema>(data);
             assert_no_panic_decoding::<super::transaction::TransactionSchema>(data);
             assert_no_panic_decoding::<super::transaction_accumulator::TransactionAccumulatorSchema>(

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -5,15 +5,19 @@
 
 use crate::{
     common::NUM_STATE_SHARDS,
-    db_options::{gen_state_kv_cfds, state_kv_db_column_families},
+    db_options::{
+        gen_state_kv_cfds, state_kv_db_column_families, state_kv_db_new_key_column_families,
+    },
     metrics::OTHER_TIMERS_SECONDS,
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
         state_value::StateValueSchema,
+        state_value_by_key_hash::StateValueByKeyHashSchema,
     },
     utils::truncation_helper::{get_state_kv_commit_progress, truncate_state_kv_db_shards},
 };
 use aptos_config::config::{RocksdbConfig, RocksdbConfigs, StorageDirPaths};
+use aptos_crypto::hash::CryptoHash;
 use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_logger::prelude::info;
 use aptos_rocksdb_options::gen_rocksdb_options;
@@ -55,13 +59,19 @@ impl StateKvDb {
             });
         }
 
-        Self::open(db_paths, rocksdb_configs.state_kv_db_config, readonly)
+        Self::open(
+            db_paths,
+            rocksdb_configs.state_kv_db_config,
+            readonly,
+            sharding,
+        )
     }
 
     pub(crate) fn open(
         db_paths: &StorageDirPaths,
         state_kv_db_config: RocksdbConfig,
         readonly: bool,
+        enable_sharding: bool,
     ) -> Result<Self> {
         let state_kv_metadata_db_path =
             Self::metadata_db_path(db_paths.state_kv_db_metadata_root_path());
@@ -71,6 +81,7 @@ impl StateKvDb {
             STATE_KV_METADATA_DB_NAME,
             &state_kv_db_config,
             readonly,
+            enable_sharding,
         )?);
 
         info!(
@@ -82,7 +93,7 @@ impl StateKvDb {
         let state_kv_db_shards = {
             arr![{
                 let shard_root_path = db_paths.state_kv_db_shard_root_path(shard_id as u8);
-                let db = Self::open_shard(shard_root_path, shard_id as u8, &state_kv_db_config, readonly)?;
+                let db = Self::open_shard(shard_root_path, shard_id as u8, &state_kv_db_config, readonly, enable_sharding)?;
                 shard_id += 1;
                 Arc::new(db)
             }; 16]
@@ -161,6 +172,7 @@ impl StateKvDb {
             &StorageDirPaths::from_path(db_root_path),
             RocksdbConfig::default(),
             false,
+            true,
         )?;
         let cp_state_kv_db_path = cp_root_path.as_ref().join(STATE_KV_DB_FOLDER_NAME);
 
@@ -228,6 +240,7 @@ impl StateKvDb {
         shard_id: u8,
         state_kv_db_config: &RocksdbConfig,
         readonly: bool,
+        enable_sharding: bool,
     ) -> Result<DB> {
         let db_name = format!("state_kv_db_shard_{}", shard_id);
         Self::open_db(
@@ -235,6 +248,7 @@ impl StateKvDb {
             &db_name,
             state_kv_db_config,
             readonly,
+            enable_sharding,
         )
     }
 
@@ -243,20 +257,25 @@ impl StateKvDb {
         name: &str,
         state_kv_db_config: &RocksdbConfig,
         readonly: bool,
+        enable_sharding: bool,
     ) -> Result<DB> {
         Ok(if readonly {
             DB::open_cf_readonly(
                 &gen_rocksdb_options(state_kv_db_config, true),
                 path,
                 name,
-                state_kv_db_column_families(),
+                if enable_sharding {
+                    state_kv_db_new_key_column_families()
+                } else {
+                    state_kv_db_column_families()
+                },
             )?
         } else {
             DB::open_cf(
                 &gen_rocksdb_options(state_kv_db_config, false),
                 path,
                 name,
-                gen_state_kv_cfds(state_kv_db_config),
+                gen_state_kv_cfds(state_kv_db_config, enable_sharding),
             )?
         })
     }
@@ -285,14 +304,24 @@ impl StateKvDb {
 
         // We want `None` if the state_key changes in iteration.
         read_opts.set_prefix_same_as_start(true);
-
-        let mut iter = self
-            .db_shard(state_key.get_shard_id())
-            .iter_with_opts::<StateValueSchema>(read_opts)?;
-        iter.seek(&(state_key.clone(), version))?;
-        Ok(iter
-            .next()
-            .transpose()?
-            .and_then(|((_, version), value_opt)| value_opt.map(|value| (version, value))))
+        if !self.enabled_sharding() {
+            let mut iter = self
+                .db_shard(state_key.get_shard_id())
+                .iter_with_opts::<StateValueSchema>(read_opts)?;
+            iter.seek(&(state_key.clone(), version))?;
+            Ok(iter
+                .next()
+                .transpose()?
+                .and_then(|((_, version), value_opt)| value_opt.map(|value| (version, value))))
+        } else {
+            let mut iter = self
+                .db_shard(state_key.get_shard_id())
+                .iter_with_opts::<StateValueByKeyHashSchema>(read_opts)?;
+            iter.seek(&(state_key.hash(), version))?;
+            Ok(iter
+                .next()
+                .transpose()?
+                .and_then(|((_, version), value_opt)| value_opt.map(|value| (version, value))))
+        }
     }
 }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -14,7 +14,9 @@ use crate::{
         stale_node_index::StaleNodeIndexSchema,
         stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema,
         stale_state_value_index::StaleStateValueIndexSchema,
+        stale_state_value_index_by_key_hash::StaleStateValueIndexByKeyHashSchema,
         state_value::StateValueSchema,
+        state_value_by_key_hash::StateValueByKeyHashSchema,
         state_value_index::StateValueIndexSchema,
         version_data::VersionDataSchema,
     },
@@ -56,7 +58,10 @@ use aptos_types::{
         create_empty_sharded_state_updates,
         state_key::{prefix::StateKeyPrefix, StateKey},
         state_storage_usage::StateStorageUsage,
-        state_value::{StaleStateValueIndex, StateValue, StateValueChunkWithProof},
+        state_value::{
+            StaleStateValueByKeyHashIndex, StaleStateValueIndex, StateValue,
+            StateValueChunkWithProof,
+        },
         ShardedStateUpdates, StateViewId,
     },
     transaction::Version,
@@ -595,7 +600,7 @@ impl StateStore {
         batch: &SchemaBatch,
         sharded_state_kv_batches: &ShardedStateKvSchemaBatch,
         state_kv_metadata_batch: &SchemaBatch,
-        put_state_value_indices: bool,
+        enable_sharding: bool,
     ) -> Result<()> {
         let _timer = OTHER_TIMERS_SECONDS
             .with_label_values(&["put_writesets"])
@@ -625,6 +630,7 @@ impl StateStore {
             sharded_state_kv_batches,
             /*skip_usage=*/ false,
             None,
+            enable_sharding,
         )?;
 
         self.put_state_values(
@@ -632,7 +638,7 @@ impl StateStore {
             first_version,
             sharded_state_kv_batches,
             state_kv_metadata_batch,
-            put_state_value_indices,
+            enable_sharding,
         )?;
 
         Ok(())
@@ -648,7 +654,7 @@ impl StateStore {
         ledger_batch: &SchemaBatch,
         sharded_state_kv_batches: &ShardedStateKvSchemaBatch,
         state_kv_metadata_batch: &SchemaBatch,
-        put_state_value_indices: bool,
+        enable_sharding: bool,
         skip_usage: bool,
         last_checkpoint_index: Option<usize>,
     ) -> Result<()> {
@@ -665,6 +671,7 @@ impl StateStore {
             sharded_state_kv_batches,
             skip_usage,
             last_checkpoint_index,
+            enable_sharding,
         )?;
 
         let _timer = OTHER_TIMERS_SECONDS
@@ -676,7 +683,7 @@ impl StateStore {
             first_version,
             sharded_state_kv_batches,
             state_kv_metadata_batch,
-            put_state_value_indices,
+            enable_sharding,
         )
     }
 
@@ -686,7 +693,7 @@ impl StateStore {
         first_version: Version,
         sharded_state_kv_batches: &ShardedStateKvSchemaBatch,
         state_kv_metadata_batch: &SchemaBatch,
-        put_state_value_indices: bool,
+        enable_sharding: bool,
     ) -> Result<()> {
         sharded_state_kv_batches
             .par_iter()
@@ -699,7 +706,14 @@ impl StateStore {
                         let version = first_version + i as Version;
                         let kvs = &shards[shard_id];
                         kvs.iter().map(move |(k, v)| {
-                            batch.put::<StateValueSchema>(&(k.clone(), version), v)
+                            if enable_sharding {
+                                batch.put::<StateValueByKeyHashSchema>(
+                                    &(k.clone().hash(), version),
+                                    v,
+                                )
+                            } else {
+                                batch.put::<StateValueSchema>(&(k.clone(), version), v)
+                            }
                         })
                     })
                     .collect::<Result<_>>()
@@ -708,7 +722,7 @@ impl StateStore {
         // Eventually this index will move to indexer side. For now we temporarily write this into
         // metadata db to unblock the sharded DB migration.
         // TODO(grao): Remove when we are ready.
-        if put_state_value_indices {
+        if enable_sharding {
             value_state_sets
                 .par_iter()
                 .enumerate()
@@ -752,6 +766,7 @@ impl StateStore {
         sharded_state_kv_batches: &ShardedStateKvSchemaBatch,
         skip_usage: bool,
         last_checkpoint_index: Option<usize>,
+        enable_sharding: bool,
     ) -> Result<()> {
         let _timer = OTHER_TIMERS_SECONDS
             .with_label_values(&["put_stats_and_indices"])
@@ -827,16 +842,29 @@ impl StateStore {
                         } else {
                             // Update the stale index of the tombstone at current version to
                             // current version.
-                            sharded_state_kv_batches[shard_id]
-                                .put::<StaleStateValueIndexSchema>(
-                                    &StaleStateValueIndex {
-                                        stale_since_version: version,
-                                        version,
-                                        state_key: key.clone(),
-                                    },
-                                    &(),
-                                )
-                                .unwrap();
+                            if enable_sharding {
+                                sharded_state_kv_batches[shard_id]
+                                    .put::<StaleStateValueIndexByKeyHashSchema>(
+                                        &StaleStateValueByKeyHashIndex {
+                                            stale_since_version: version,
+                                            version,
+                                            state_key_hash: key.hash(),
+                                        },
+                                        &(),
+                                    )
+                                    .unwrap();
+                            } else {
+                                sharded_state_kv_batches[shard_id]
+                                    .put::<StaleStateValueIndexSchema>(
+                                        &StaleStateValueIndex {
+                                            stale_since_version: version,
+                                            version,
+                                            state_key: key.clone(),
+                                        },
+                                        &(),
+                                    )
+                                    .unwrap();
+                            }
                         }
 
                         let old_version_and_value_opt = if let Some((old_version, old_value_opt)) =
@@ -854,16 +882,29 @@ impl StateStore {
                             items_delta -= 1;
                             bytes_delta -= (key.size() + old_value.size()) as i64;
                             // stale index of the old value at its version.
-                            sharded_state_kv_batches[shard_id]
-                                .put::<StaleStateValueIndexSchema>(
-                                    &StaleStateValueIndex {
-                                        stale_since_version: version,
-                                        version: old_version,
-                                        state_key: key.clone(),
-                                    },
-                                    &(),
-                                )
-                                .unwrap();
+                            if enable_sharding {
+                                sharded_state_kv_batches[shard_id]
+                                    .put::<StaleStateValueIndexByKeyHashSchema>(
+                                        &StaleStateValueByKeyHashIndex {
+                                            stale_since_version: version,
+                                            version: old_version,
+                                            state_key_hash: key.hash(),
+                                        },
+                                        &(),
+                                    )
+                                    .unwrap();
+                            } else {
+                                sharded_state_kv_batches[shard_id]
+                                    .put::<StaleStateValueIndexSchema>(
+                                        &StaleStateValueIndex {
+                                            stale_since_version: version,
+                                            version: old_version,
+                                            state_key: key.clone(),
+                                        },
+                                        &(),
+                                    )
+                                    .unwrap();
+                            }
                         }
                     }
                     usage_delta.push((items_delta, bytes_delta));
@@ -917,9 +958,9 @@ impl StateStore {
 
     pub(crate) fn shard_state_value_batch(
         &self,
-        metadata_batch: &SchemaBatch,
         sharded_batch: &ShardedStateKvSchemaBatch,
         values: &StateValueBatch,
+        enable_sharding: bool,
     ) -> Result<()> {
         values.iter().for_each(|((key, version), value)| {
             let shard_id = key.get_shard_id() as usize;
@@ -928,14 +969,14 @@ impl StateStore {
                 "Invalid shard id: {}",
                 shard_id
             );
-            sharded_batch[shard_id]
-                .put::<StateValueSchema>(&(key.clone(), *version), value)
-                .expect("Inserting into sharded schema batch should never fail");
-
-            if self.state_kv_db.enabled_sharding() {
-                metadata_batch
-                    .put::<StateValueIndexSchema>(&(key.clone(), *version), &())
-                    .expect("Inserting into state value index schema batch should never fail");
+            if enable_sharding {
+                sharded_batch[shard_id]
+                    .put::<StateValueByKeyHashSchema>(&(key.hash(), *version), value)
+                    .expect("Inserting into sharded schema batch should never fail");
+            } else {
+                sharded_batch[shard_id]
+                    .put::<StateValueSchema>(&(key.clone(), *version), value)
+                    .expect("Inserting into sharded schema batch should never fail");
             }
         });
         Ok(())
@@ -1127,6 +1168,7 @@ impl StateStore {
 }
 
 impl StateValueWriter<StateKey, StateValue> for StateStore {
+    // This already turns on sharded KV
     fn write_kv_batch(
         &self,
         version: Version,
@@ -1144,7 +1186,11 @@ impl StateValueWriter<StateKey, StateValue> for StateStore {
             &DbMetadataValue::StateSnapshotProgress(progress),
         )?;
 
-        self.shard_state_value_batch(&batch, &sharded_schema_batch, node_batch)?;
+        self.shard_state_value_batch(
+            &sharded_schema_batch,
+            node_batch,
+            self.state_kv_db.enabled_sharding(),
+        )?;
 
         self.state_kv_db
             .commit(version, batch, sharded_schema_batch)

--- a/testsuite/replay_verify.py
+++ b/testsuite/replay_verify.py
@@ -114,6 +114,7 @@ def replay_verify_partition(
             "target/release/aptos-debugger",
             "aptos-db",
             "replay-verify",
+            # "--enable-storage-sharding",
             *txns_to_skip_args,
             "--concurrent-downloads",
             "8",

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -89,7 +89,7 @@ TESTS = [
     RunGroupConfig(expected_tps=21300, key=RunGroupKey("no-op"), included_in=LAND_BLOCKING_AND_C),
     RunGroupConfig(expected_tps=11500, key=RunGroupKey("no-op", module_working_set_size=1000), included_in=LAND_BLOCKING_AND_C),
     RunGroupConfig(expected_tps=12800, key=RunGroupKey("coin-transfer"), included_in=LAND_BLOCKING_AND_C | Flow.REPRESENTATIVE),
-    RunGroupConfig(expected_tps=36200, key=RunGroupKey("coin-transfer", executor_type="native"), included_in=LAND_BLOCKING_AND_C),
+    RunGroupConfig(expected_tps=36820, key=RunGroupKey("coin-transfer", executor_type="native"), included_in=LAND_BLOCKING_AND_C),
     RunGroupConfig(expected_tps=9000, key=RunGroupKey("account-generation"), included_in=LAND_BLOCKING_AND_C | Flow.REPRESENTATIVE),
     RunGroupConfig(expected_tps=27873, key=RunGroupKey("account-generation", executor_type="native"), included_in=Flow.CONTINUOUS),
     RunGroupConfig(expected_tps=18600, key=RunGroupKey("account-resource32-b"), included_in=Flow.CONTINUOUS),


### PR DESCRIPTION
## Description
StateValueIndex is removed from writing in this PR. 

backup and restore shouldn't be impacted 
https://github.com/aptos-labs/aptos-core/blob/populate_new_state_kv_schema/storage/aptosdb/src/state_store/mod.rs#L1049 
backup uses jmt get keys and then use state key to state store to get state value 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
Existing test and spot check generated DBs

replay-verify with sharding mode on and no error except timeout
https://github.com/aptos-labs/aptos-core/actions/runs/9585888369

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
