### PR TITLE
stablecoin deposit/withdraw hook fix

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
+++ b/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
@@ -290,6 +290,7 @@ Return whether the given account's primary store exists.
 ## Function `primary_store_address_inlined`
 
 Get the address of the primary store for the given account.
+Use instead of the corresponding view functions for dispatchable hooks to avoid circular dependencies of modules.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_address_inlined">primary_store_address_inlined</a>&lt;T: key&gt;(owner: <b>address</b>, metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): <b>address</b>
@@ -316,6 +317,7 @@ Get the address of the primary store for the given account.
 ## Function `primary_store_inlined`
 
 Get the primary store object for the given account.
+Use instead of the corresponding view functions for dispatchable hooks to avoid circular dependencies of modules.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_inlined">primary_store_inlined</a>&lt;T: key&gt;(owner: <b>address</b>, metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">fungible_asset::FungibleStore</a>&gt;
@@ -329,7 +331,7 @@ Get the primary store object for the given account.
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_inlined">primary_store_inlined</a>&lt;T: key&gt;(owner: <b>address</b>, metadata: Object&lt;T&gt;): Object&lt;FungibleStore&gt; {
     <b>let</b> store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_address_inlined">primary_store_address_inlined</a>(owner, metadata);
-    <a href="object.md#0x1_object_address_to_object">object::address_to_object</a>&lt;FungibleStore&gt;(store)
+    <a href="object.md#0x1_object_address_to_object">object::address_to_object</a>(store)
 }
 </code></pre>
 
@@ -342,6 +344,7 @@ Get the primary store object for the given account.
 ## Function `primary_store_exists_inlined`
 
 Return whether the given account's primary store exists.
+Use instead of the corresponding view functions for dispatchable hooks to avoid circular dependencies of modules.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_exists_inlined">primary_store_exists_inlined</a>&lt;T: key&gt;(<a href="account.md#0x1_account">account</a>: <b>address</b>, metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): bool

--- a/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
+++ b/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
@@ -25,6 +25,9 @@ fungible asset to it. This emits an deposit event.
 -  [Function `primary_store_address`](#0x1_primary_fungible_store_primary_store_address)
 -  [Function `primary_store`](#0x1_primary_fungible_store_primary_store)
 -  [Function `primary_store_exists`](#0x1_primary_fungible_store_primary_store_exists)
+-  [Function `primary_store_address_inlined`](#0x1_primary_fungible_store_primary_store_address_inlined)
+-  [Function `primary_store_inlined`](#0x1_primary_fungible_store_primary_store_inlined)
+-  [Function `primary_store_exists_inlined`](#0x1_primary_fungible_store_primary_store_exists_inlined)
 -  [Function `balance`](#0x1_primary_fungible_store_balance)
 -  [Function `is_balance_at_least`](#0x1_primary_fungible_store_is_balance_at_least)
 -  [Function `is_frozen`](#0x1_primary_fungible_store_is_frozen)
@@ -275,6 +278,83 @@ Return whether the given account's primary store exists.
 
 <pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_exists">primary_store_exists</a>&lt;T: key&gt;(<a href="account.md#0x1_account">account</a>: <b>address</b>, metadata: Object&lt;T&gt;): bool {
     <a href="fungible_asset.md#0x1_fungible_asset_store_exists">fungible_asset::store_exists</a>(<a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_address">primary_store_address</a>(<a href="account.md#0x1_account">account</a>, metadata))
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_primary_fungible_store_primary_store_address_inlined"></a>
+
+## Function `primary_store_address_inlined`
+
+Get the address of the primary store for the given account.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_address_inlined">primary_store_address_inlined</a>&lt;T: key&gt;(owner: <b>address</b>, metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_address_inlined">primary_store_address_inlined</a>&lt;T: key&gt;(owner: <b>address</b>, metadata: Object&lt;T&gt;): <b>address</b> {
+    <b>let</b> metadata_addr = <a href="object.md#0x1_object_object_address">object::object_address</a>(&metadata);
+    <a href="object.md#0x1_object_create_user_derived_object_address">object::create_user_derived_object_address</a>(owner, metadata_addr)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_primary_fungible_store_primary_store_inlined"></a>
+
+## Function `primary_store_inlined`
+
+Get the primary store object for the given account.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_inlined">primary_store_inlined</a>&lt;T: key&gt;(owner: <b>address</b>, metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">fungible_asset::FungibleStore</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_inlined">primary_store_inlined</a>&lt;T: key&gt;(owner: <b>address</b>, metadata: Object&lt;T&gt;): Object&lt;FungibleStore&gt; {
+    <b>let</b> store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_address_inlined">primary_store_address_inlined</a>(owner, metadata);
+    <a href="object.md#0x1_object_address_to_object">object::address_to_object</a>&lt;FungibleStore&gt;(store)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_primary_fungible_store_primary_store_exists_inlined"></a>
+
+## Function `primary_store_exists_inlined`
+
+Return whether the given account's primary store exists.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_exists_inlined">primary_store_exists_inlined</a>&lt;T: key&gt;(<a href="account.md#0x1_account">account</a>: <b>address</b>, metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_exists_inlined">primary_store_exists_inlined</a>&lt;T: key&gt;(<a href="account.md#0x1_account">account</a>: <b>address</b>, metadata: Object&lt;T&gt;): bool {
+    <a href="fungible_asset.md#0x1_fungible_asset_store_exists">fungible_asset::store_exists</a>(<a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_address_inlined">primary_store_address_inlined</a>(<a href="account.md#0x1_account">account</a>, metadata))
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
@@ -105,21 +105,21 @@ module aptos_framework::primary_fungible_store {
     }
 
     /// Get the address of the primary store for the given account.
-    /// Use instead of the corresponding view functions for dispatchable hooks to avoid circular dependencies of modules. 
+    /// Use instead of the corresponding view functions for dispatchable hooks to avoid circular dependencies of modules.
     public inline fun primary_store_address_inlined<T: key>(owner: address, metadata: Object<T>): address {
         let metadata_addr = object::object_address(&metadata);
         object::create_user_derived_object_address(owner, metadata_addr)
     }
 
     /// Get the primary store object for the given account.
-    /// Use instead of the corresponding view functions for dispatchable hooks to avoid circular dependencies of modules. 
+    /// Use instead of the corresponding view functions for dispatchable hooks to avoid circular dependencies of modules.
     public inline fun primary_store_inlined<T: key>(owner: address, metadata: Object<T>): Object<FungibleStore> {
         let store = primary_store_address_inlined(owner, metadata);
         object::address_to_object(store)
     }
 
     /// Return whether the given account's primary store exists.
-    /// Use instead of the corresponding view functions for dispatchable hooks to avoid circular dependencies of modules. 
+    /// Use instead of the corresponding view functions for dispatchable hooks to avoid circular dependencies of modules.
     public inline fun primary_store_exists_inlined<T: key>(account: address, metadata: Object<T>): bool {
         fungible_asset::store_exists(primary_store_address_inlined(account, metadata))
     }

--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
@@ -104,6 +104,17 @@ module aptos_framework::primary_fungible_store {
         fungible_asset::store_exists(primary_store_address(account, metadata))
     }
 
+    /// Get the primary store object for the given account.
+    public inline fun primary_store_inlined<T: key>(owner: address, metadata: Object<T>): Object<FungibleStore> {
+        let store = primary_store_address(owner, metadata);
+        object::address_to_object<FungibleStore>(store)
+    }
+
+    /// Return whether the given account's primary store exists.
+    public inline fun primary_store_exists_inlined<T: key>(account: address, metadata: Object<T>): bool {
+        fungible_asset::store_exists(primary_store_address(account, metadata))
+    }
+
     #[view]
     /// Get the balance of `account`'s primary store.
     public fun balance<T: key>(account: address, metadata: Object<T>): u64 {

--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
@@ -104,20 +104,22 @@ module aptos_framework::primary_fungible_store {
         fungible_asset::store_exists(primary_store_address(account, metadata))
     }
 
-    
     /// Get the address of the primary store for the given account.
+    /// Use instead of the corresponding view functions for dispatchable hooks to avoid circular dependencies of modules. 
     public inline fun primary_store_address_inlined<T: key>(owner: address, metadata: Object<T>): address {
         let metadata_addr = object::object_address(&metadata);
         object::create_user_derived_object_address(owner, metadata_addr)
     }
 
     /// Get the primary store object for the given account.
+    /// Use instead of the corresponding view functions for dispatchable hooks to avoid circular dependencies of modules. 
     public inline fun primary_store_inlined<T: key>(owner: address, metadata: Object<T>): Object<FungibleStore> {
         let store = primary_store_address_inlined(owner, metadata);
-        object::address_to_object<FungibleStore>(store)
+        object::address_to_object(store)
     }
 
     /// Return whether the given account's primary store exists.
+    /// Use instead of the corresponding view functions for dispatchable hooks to avoid circular dependencies of modules. 
     public inline fun primary_store_exists_inlined<T: key>(account: address, metadata: Object<T>): bool {
         fungible_asset::store_exists(primary_store_address_inlined(account, metadata))
     }

--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
@@ -104,15 +104,22 @@ module aptos_framework::primary_fungible_store {
         fungible_asset::store_exists(primary_store_address(account, metadata))
     }
 
+    
+    /// Get the address of the primary store for the given account.
+    public inline fun primary_store_address_inlined<T: key>(owner: address, metadata: Object<T>): address {
+        let metadata_addr = object::object_address(&metadata);
+        object::create_user_derived_object_address(owner, metadata_addr)
+    }
+
     /// Get the primary store object for the given account.
     public inline fun primary_store_inlined<T: key>(owner: address, metadata: Object<T>): Object<FungibleStore> {
-        let store = primary_store_address(owner, metadata);
+        let store = primary_store_address_inlined(owner, metadata);
         object::address_to_object<FungibleStore>(store)
     }
 
     /// Return whether the given account's primary store exists.
     public inline fun primary_store_exists_inlined<T: key>(account: address, metadata: Object<T>): bool {
-        fungible_asset::store_exists(primary_store_address(account, metadata))
+        fungible_asset::store_exists(primary_store_address_inlined(account, metadata))
     }
 
     #[view]

--- a/aptos-move/move-examples/fungible_asset/stablecoin/sources/usdk.move
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/sources/usdk.move
@@ -93,8 +93,6 @@ module stablecoin::usdk {
         object::address_to_object(usdk_address())
     }
 
-
-
     /// Called as part of deployment to initialize the stablecoin.
     /// Note: The signer has to be the account where the module is published.
     /// Create a stablecoin token (a new Fungible Asset)

--- a/aptos-move/move-examples/fungible_asset/stablecoin/sources/usdk.move
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/sources/usdk.move
@@ -93,6 +93,8 @@ module stablecoin::usdk {
         object::address_to_object(usdk_address())
     }
 
+
+
     /// Called as part of deployment to initialize the stablecoin.
     /// Note: The signer has to be the account where the module is published.
     /// Create a stablecoin token (a new Fungible Asset)
@@ -328,11 +330,10 @@ module stablecoin::usdk {
     // Check that the account is not denylisted by checking the frozen flag on the primary store
     fun assert_not_denylisted(account: address) {
         let metadata = metadata();
-        let metadata_addr = object::object_address(&metadata);
-        let primary_store_address = object::create_user_derived_object_address(account, metadata_addr);
-        if (fungible_asset::store_exists(primary_store_address)) {
-            let primary_store = object::address_to_object<FungibleStore>(primary_store_address);
-            assert!(!fungible_asset::is_frozen(primary_store), EDENYLISTED);
+        // CANNOT call into pfs::store_exists in our withdraw/deposit hooks as it creates possibility of a circular dependency. 
+        // Instead, we will call the inlined version of the function.
+        if (primary_fungible_store::primary_store_exists_inlined(account, metadata)) {
+            assert!(!fungible_asset::is_frozen(primary_fungible_store::primary_store_inlined(account, metadata)), EDENYLISTED);
         }
     }
 

--- a/aptos-move/move-examples/fungible_asset/stablecoin/sources/usdk.move
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/sources/usdk.move
@@ -328,8 +328,11 @@ module stablecoin::usdk {
     // Check that the account is not denylisted by checking the frozen flag on the primary store
     fun assert_not_denylisted(account: address) {
         let metadata = metadata();
-        if (primary_fungible_store::primary_store_exists(account, metadata)) {
-            assert!(!fungible_asset::is_frozen(primary_fungible_store::primary_store(account, metadata)), EDENYLISTED);
+        let metadata_addr = object::object_address(&metadata);
+        let primary_store_address = object::create_user_derived_object_address(account, metadata_addr);
+        if (fungible_asset::store_exists(primary_store_address)) {
+            let primary_store = object::address_to_object<FungibleStore>(primary_store_address);
+            assert!(!fungible_asset::is_frozen(primary_store), EDENYLISTED);
         }
     }
 

--- a/aptos-move/move-examples/fungible_asset/stablecoin/sources/usdk.move
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/sources/usdk.move
@@ -328,7 +328,7 @@ module stablecoin::usdk {
     // Check that the account is not denylisted by checking the frozen flag on the primary store
     fun assert_not_denylisted(account: address) {
         let metadata = metadata();
-        // CANNOT call into pfs::store_exists in our withdraw/deposit hooks as it creates possibility of a circular dependency. 
+        // CANNOT call into pfs::store_exists in our withdraw/deposit hooks as it creates possibility of a circular dependency.
         // Instead, we will call the inlined version of the function.
         if (primary_fungible_store::primary_store_exists_inlined(account, metadata)) {
             assert!(!fungible_asset::is_frozen(primary_fungible_store::primary_store_inlined(account, metadata)), EDENYLISTED);


### PR DESCRIPTION
## Description

### primary_fungible_store.move
Add public inline functions for the existing view functions in the module. This enables calls to pfs in deposit/withdraw hooks and avoids circular dependencies. 

### usdk.move
Change `assert_not_denylisted` to use PFS `priamary_store_exists_inlined`. 

user calls `pfs::withdraw` -> withdraw hook -> `assert_not_denylisted` -> `pfs::primary_store exists_inlined`



## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## How Has This Been Tested?
Unit Tests

