### PR TITLE
[pipeline] pre commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,6 +969,7 @@ dependencies = [
  "aptos-short-hex-str",
  "aptos-types",
  "bcs 0.1.4",
+ "derivative",
  "fail",
  "futures",
  "itertools 0.13.0",

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -23,6 +23,7 @@ aptos-logger = { workspace = true }
 aptos-short-hex-str = { workspace = true }
 aptos-types = { workspace = true }
 bcs = { workspace = true }
+derivative = { workspace = true }
 fail = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }

--- a/consensus/consensus-types/src/lib.rs
+++ b/consensus/consensus-types/src/lib.rs
@@ -15,6 +15,7 @@ pub mod order_vote_msg;
 pub mod order_vote_proposal;
 pub mod payload;
 pub mod pipeline;
+pub mod pipeline_execution_result;
 pub mod pipelined_block;
 pub mod proof_of_store;
 pub mod proposal_ext;

--- a/consensus/consensus-types/src/pipeline_execution_result.rs
+++ b/consensus/consensus-types/src/pipeline_execution_result.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_executor_types::{ExecutorResult, StateComputeResult};
+use aptos_types::transaction::SignedTransaction;
+use std::time::Duration;
+use tokio::sync::oneshot;
+
+#[derive(Debug)]
+pub struct PipelineExecutionResult {
+    pub input_txns: Vec<SignedTransaction>,
+    pub result: StateComputeResult,
+    pub execution_time: Duration,
+    pub pre_commit_result_rx: oneshot::Receiver<ExecutorResult<()>>,
+}
+
+impl PipelineExecutionResult {
+    pub fn new(
+        input_txns: Vec<SignedTransaction>,
+        result: StateComputeResult,
+        execution_time: Duration,
+        pre_commit_result_rx: oneshot::Receiver<ExecutorResult<()>>,
+    ) -> Self {
+        Self {
+            input_txns,
+            result,
+            execution_time,
+            pre_commit_result_rx,
+        }
+    }
+}

--- a/consensus/src/execution_pipeline.rs
+++ b/consensus/src/execution_pipeline.rs
@@ -7,16 +7,17 @@ use crate::{
     block_preparer::BlockPreparer,
     counters::{self, log_executor_error_occurred},
     monitor,
-    state_computer::{PipelineExecutionResult, StateComputeResultFut},
+    pipeline::pipeline_phase::CountedRequest,
+    state_computer::StateComputeResultFut,
 };
-use aptos_consensus_types::block::Block;
+use aptos_consensus_types::{block::Block, pipeline_execution_result::PipelineExecutionResult};
 use aptos_crypto::HashValue;
 use aptos_executor_types::{
     state_checkpoint_output::StateCheckpointOutput, BlockExecutorTrait, ExecutorError,
     ExecutorResult,
 };
 use aptos_experimental_runtimes::thread_manager::optimal_min_len;
-use aptos_logger::{debug, error};
+use aptos_logger::{debug, warn};
 use aptos_types::{
     block_executor::{config::BlockExecutorConfigFromOnchain, partitioner::ExecutableBlock},
     block_metadata_ext::BlockMetadataExt,
@@ -53,7 +54,7 @@ impl ExecutionPipeline {
         let (prepare_block_tx, prepare_block_rx) = mpsc::unbounded_channel();
         let (execute_block_tx, execute_block_rx) = mpsc::unbounded_channel();
         let (ledger_apply_tx, ledger_apply_rx) = mpsc::unbounded_channel();
-        let (prec_commit_tx, pre_commit_rx) = mpsc::unbounded_channel();
+        let (pre_commit_tx, pre_commit_rx) = mpsc::unbounded_channel();
 
         runtime.spawn(Self::prepare_block_stage(
             prepare_block_rx,
@@ -66,7 +67,7 @@ impl ExecutionPipeline {
         ));
         runtime.spawn(Self::ledger_apply_stage(
             ledger_apply_rx,
-            prec_commit_tx,
+            pre_commit_tx,
             executor.clone(),
         ));
         runtime.spawn(Self::pre_commit_stage(pre_commit_rx, executor));
@@ -81,6 +82,7 @@ impl ExecutionPipeline {
         parent_block_id: HashValue,
         txn_generator: BlockPreparer,
         block_executor_onchain_config: BlockExecutorConfigFromOnchain,
+        lifetime_guard: CountedRequest<()>,
     ) -> StateComputeResultFut {
         let (result_tx, result_rx) = oneshot::channel();
         let block_id = block.id();
@@ -92,6 +94,7 @@ impl ExecutionPipeline {
                 parent_block_id,
                 block_preparer: txn_generator,
                 result_tx,
+                lifetime_guard,
             })
             .expect("Failed to send block to execution pipeline.");
 
@@ -118,14 +121,15 @@ impl ExecutionPipeline {
             parent_block_id,
             block_preparer,
             result_tx,
+            lifetime_guard,
         } = command;
 
         debug!("prepare_block received block {}.", block.id());
         let input_txns = block_preparer.prepare_block(&block).await;
         if let Err(e) = input_txns {
-            result_tx.send(Err(e)).unwrap_or_else(|value| {
-                process_failed_to_send_result(value, block.id(), "prepare")
-            });
+            result_tx
+                .send(Err(e))
+                .unwrap_or_else(log_failed_to_send_result("prepare_block", block.id()));
             return;
         }
         let validator_txns = block.validator_txns().cloned().unwrap_or_default();
@@ -149,6 +153,7 @@ impl ExecutionPipeline {
                     parent_block_id,
                     block_executor_onchain_config,
                     result_tx,
+                    lifetime_guard,
                 })
                 .expect("Failed to send block to execution pipeline.");
         })
@@ -180,6 +185,7 @@ impl ExecutionPipeline {
             parent_block_id,
             block_executor_onchain_config,
             result_tx,
+            lifetime_guard,
         }) = block_rx.recv().await
         {
             let block_id = block.block_id;
@@ -213,6 +219,7 @@ impl ExecutionPipeline {
                     parent_block_id,
                     state_checkpoint_output,
                     result_tx,
+                    lifetime_guard,
                 })
                 .expect("Failed to send block to ledger_apply stage.");
         }
@@ -230,6 +237,7 @@ impl ExecutionPipeline {
             parent_block_id,
             state_checkpoint_output: execution_result,
             result_tx,
+            lifetime_guard,
         }) = block_rx.recv().await
         {
             debug!("ledger_apply stage received block {}.", block_id);
@@ -247,22 +255,27 @@ impl ExecutionPipeline {
                 .map(|output| (output, execution_duration))
             }
             .await;
-            let (commit_tx, commit_rx) = oneshot::channel();
-            let pipe_line_res = res.map(|(output, execution_duration)| {
-                PipelineExecutionResult::new(input_txns, output, execution_duration, commit_rx)
+            let pipeline_res = res.map(|(output, execution_duration)| {
+                let (pre_commit_result_tx, pre_commit_result_rx) = oneshot::channel();
+                // schedule pre-commit
+                pre_commit_tx
+                    .send(PreCommitCommand {
+                        block_id,
+                        parent_block_id,
+                        result_tx: pre_commit_result_tx,
+                        lifetime_guard,
+                    })
+                    .expect("Failed to send block to pre_commit stage.");
+                PipelineExecutionResult::new(
+                    input_txns,
+                    output,
+                    execution_duration,
+                    pre_commit_result_rx,
+                )
             });
-            pre_commit_tx
-                .send(PreCommitCommand {
-                    block_id,
-                    parent_block_id,
-                    result_tx: commit_tx,
-                })
-                .unwrap_or_else(|_| {
-                    // FIXME(aldenhu): fix error processing
-                });
-            result_tx.send(pipe_line_res).unwrap_or_else(|value| {
-                process_failed_to_send_result(value, block_id, "ledger_apply")
-            });
+            result_tx
+                .send(pipeline_res)
+                .unwrap_or_else(log_failed_to_send_result("ledger_apply", block_id));
         }
         debug!("ledger_apply stage quitting.");
     }
@@ -275,6 +288,7 @@ impl ExecutionPipeline {
             block_id,
             parent_block_id,
             result_tx,
+            lifetime_guard,
         }) = block_rx.recv().await
         {
             debug!("pre_commit stage received block {}.", block_id);
@@ -283,19 +297,17 @@ impl ExecutionPipeline {
                 monitor!(
                     "pre_commit",
                     tokio::task::spawn_blocking(move || {
-                        executor.pre_commit(block_id, parent_block_id)
+                        executor.pre_commit_block(block_id, parent_block_id)
                     })
                 )
                 .await
                 .expect("Failed to spawn_blocking().")
             }
             .await;
-            result_tx.send(res).unwrap_or_else(|err| {
-                error!(
-                    block_id = block_id,
-                    "Failed to send back execution result for block {}: {:?}", block_id, err,
-                );
-            });
+            result_tx
+                .send(res)
+                .unwrap_or_else(log_failed_to_send_result("pre_commit", block_id));
+            drop(lifetime_guard);
         }
         debug!("pre_commit stage quitting.");
     }
@@ -309,6 +321,7 @@ struct PrepareBlockCommand {
     parent_block_id: HashValue,
     block_preparer: BlockPreparer,
     result_tx: oneshot::Sender<ExecutorResult<PipelineExecutionResult>>,
+    lifetime_guard: CountedRequest<()>,
 }
 
 struct ExecuteBlockCommand {
@@ -317,6 +330,7 @@ struct ExecuteBlockCommand {
     parent_block_id: HashValue,
     block_executor_onchain_config: BlockExecutorConfigFromOnchain,
     result_tx: oneshot::Sender<ExecutorResult<PipelineExecutionResult>>,
+    lifetime_guard: CountedRequest<()>,
 }
 
 struct LedgerApplyCommand {
@@ -325,30 +339,34 @@ struct LedgerApplyCommand {
     parent_block_id: HashValue,
     state_checkpoint_output: ExecutorResult<(StateCheckpointOutput, Duration)>,
     result_tx: oneshot::Sender<ExecutorResult<PipelineExecutionResult>>,
+    lifetime_guard: CountedRequest<()>,
 }
 
 struct PreCommitCommand {
     block_id: HashValue,
     parent_block_id: HashValue,
     result_tx: oneshot::Sender<ExecutorResult<()>>,
+    lifetime_guard: CountedRequest<()>,
 }
 
-fn process_failed_to_send_result(
-    value: Result<PipelineExecutionResult, ExecutorError>,
+fn log_failed_to_send_result<T>(
+    from_stage: &'static str,
     block_id: HashValue,
-    from_stage: &str,
-) {
-    error!(
-        block_id = block_id,
-        is_err = value.is_err(),
-        "Failed to send back execution result from {from_stage} stage",
-    );
-    if let Err(e) = value {
-        // receive channel discarding error, log for debugging.
-        log_executor_error_occurred(
-            e,
-            &counters::PIPELINE_DISCARDED_EXECUTOR_ERROR_COUNT,
-            block_id,
+) -> impl FnOnce(ExecutorResult<T>) {
+    move |value| {
+        warn!(
+            from_stage = from_stage,
+            block_id = block_id,
+            is_err = value.is_err(),
+            "Failed to send back execution/pre_commit result. (rx dropped)",
         );
+        if let Err(e) = value {
+            // receive channel discarding error, log for debugging.
+            log_executor_error_occurred(
+                e,
+                &counters::PIPELINE_DISCARDED_EXECUTOR_ERROR_COUNT,
+                block_id,
+            );
+        }
     }
 }

--- a/consensus/src/execution_pipeline.rs
+++ b/consensus/src/execution_pipeline.rs
@@ -53,6 +53,7 @@ impl ExecutionPipeline {
         let (prepare_block_tx, prepare_block_rx) = mpsc::unbounded_channel();
         let (execute_block_tx, execute_block_rx) = mpsc::unbounded_channel();
         let (ledger_apply_tx, ledger_apply_rx) = mpsc::unbounded_channel();
+        let (prec_commit_tx, pre_commit_rx) = mpsc::unbounded_channel();
 
         runtime.spawn(Self::prepare_block_stage(
             prepare_block_rx,
@@ -63,7 +64,13 @@ impl ExecutionPipeline {
             ledger_apply_tx,
             executor.clone(),
         ));
-        runtime.spawn(Self::ledger_apply_stage(ledger_apply_rx, executor));
+        runtime.spawn(Self::ledger_apply_stage(
+            ledger_apply_rx,
+            prec_commit_tx,
+            executor.clone(),
+        ));
+        runtime.spawn(Self::pre_commit_stage(pre_commit_rx, executor));
+
         Self { prepare_block_tx }
     }
 
@@ -214,6 +221,7 @@ impl ExecutionPipeline {
 
     async fn ledger_apply_stage(
         mut block_rx: mpsc::UnboundedReceiver<LedgerApplyCommand>,
+        pre_commit_tx: mpsc::UnboundedSender<PreCommitCommand>,
         executor: Arc<dyn BlockExecutorTrait>,
     ) {
         while let Some(LedgerApplyCommand {
@@ -239,14 +247,57 @@ impl ExecutionPipeline {
                 .map(|output| (output, execution_duration))
             }
             .await;
+            let (commit_tx, commit_rx) = oneshot::channel();
             let pipe_line_res = res.map(|(output, execution_duration)| {
-                PipelineExecutionResult::new(input_txns, output, execution_duration)
+                PipelineExecutionResult::new(input_txns, output, execution_duration, commit_rx)
             });
+            pre_commit_tx
+                .send(PreCommitCommand {
+                    block_id,
+                    parent_block_id,
+                    result_tx: commit_tx,
+                })
+                .unwrap_or_else(|_| {
+                    // FIXME(aldenhu): fix error processing
+                });
             result_tx.send(pipe_line_res).unwrap_or_else(|value| {
                 process_failed_to_send_result(value, block_id, "ledger_apply")
             });
         }
         debug!("ledger_apply stage quitting.");
+    }
+
+    async fn pre_commit_stage(
+        mut block_rx: mpsc::UnboundedReceiver<PreCommitCommand>,
+        executor: Arc<dyn BlockExecutorTrait>,
+    ) {
+        while let Some(PreCommitCommand {
+            block_id,
+            parent_block_id,
+            result_tx,
+        }) = block_rx.recv().await
+        {
+            debug!("pre_commit stage received block {}.", block_id);
+            let res = async {
+                let executor = executor.clone();
+                monitor!(
+                    "pre_commit",
+                    tokio::task::spawn_blocking(move || {
+                        executor.pre_commit(block_id, parent_block_id)
+                    })
+                )
+                .await
+                .expect("Failed to spawn_blocking().")
+            }
+            .await;
+            result_tx.send(res).unwrap_or_else(|err| {
+                error!(
+                    block_id = block_id,
+                    "Failed to send back execution result for block {}: {:?}", block_id, err,
+                );
+            });
+        }
+        debug!("pre_commit stage quitting.");
     }
 }
 
@@ -274,6 +325,12 @@ struct LedgerApplyCommand {
     parent_block_id: HashValue,
     state_checkpoint_output: ExecutorResult<(StateCheckpointOutput, Duration)>,
     result_tx: oneshot::Sender<ExecutorResult<PipelineExecutionResult>>,
+}
+
+struct PreCommitCommand {
+    block_id: HashValue,
+    parent_block_id: HashValue,
+    result_tx: oneshot::Sender<ExecutorResult<()>>,
 }
 
 fn process_failed_to_send_result(

--- a/consensus/src/pipeline/execution_schedule_phase.rs
+++ b/consensus/src/pipeline/execution_schedule_phase.rs
@@ -6,12 +6,11 @@ use crate::{
         execution_wait_phase::ExecutionWaitRequest,
         pipeline_phase::{CountedRequest, StatelessPipeline},
     },
-    state_computer::PipelineExecutionResult,
     state_replication::StateComputer,
 };
 use aptos_consensus_types::pipelined_block::PipelinedBlock;
 use aptos_crypto::HashValue;
-use aptos_executor_types::{ExecutorError, ExecutorResult};
+use aptos_executor_types::ExecutorError;
 use aptos_logger::debug;
 use async_trait::async_trait;
 use futures::TryFutureExt;
@@ -26,8 +25,8 @@ use std::{
 
 pub struct ExecutionRequest {
     pub ordered_blocks: Vec<PipelinedBlock>,
-    // Hold a CountedRequest to guarantee the executor doesn't get reset with pending tasks
-    // stuck in the ExecutinoPipeline.
+    // Pass down a CountedRequest to the ExecutionPipeline stages in order to guarantee the executor
+    // doesn't get reset with pending tasks stuck in the pipeline.
     pub lifetime_guard: CountedRequest<()>,
 }
 
@@ -82,34 +81,23 @@ impl StatelessPipeline for ExecutionSchedulePhase {
         for b in &ordered_blocks {
             let fut = self
                 .execution_proxy
-                .schedule_compute(b.block(), b.parent_id(), b.randomness().cloned())
+                .schedule_compute(
+                    b.block(),
+                    b.parent_id(),
+                    b.randomness().cloned(),
+                    lifetime_guard.spawn(()),
+                )
                 .await;
             futs.push(fut)
         }
 
         // In the future being returned, wait for the compute results in order.
-        // n.b. Must `spawn()` here to make sure lifetime_guard will be released even if
-        //      ExecutionWait phase is never kicked off.
         let fut = tokio::task::spawn(async move {
             let mut results = vec![];
-            // wait for all futs so that lifetime_guard is guaranteed to be dropped only
-            // after all executor calls are over
-            for (block, fut) in itertools::zip_eq(&ordered_blocks, futs) {
+            for (block, fut) in itertools::zip_eq(ordered_blocks, futs) {
                 debug!("try to receive compute result for block {}", block.id());
-                results.push(fut.await)
+                results.push(block.set_execution_result(fut.await?));
             }
-            let results = itertools::zip_eq(ordered_blocks, results)
-                .map(|(block, res)| {
-                    let PipelineExecutionResult {
-                        input_txns,
-                        result,
-                        execution_time,
-                        commit_rx,
-                    } = res?;
-                    Ok(block.set_execution_result(input_txns, result, execution_time, commit_rx))
-                })
-                .collect::<ExecutorResult<Vec<_>>>()?;
-            drop(lifetime_guard);
             Ok(results)
         })
         .map_err(ExecutorError::internal_err)

--- a/consensus/src/pipeline/execution_schedule_phase.rs
+++ b/consensus/src/pipeline/execution_schedule_phase.rs
@@ -104,8 +104,9 @@ impl StatelessPipeline for ExecutionSchedulePhase {
                         input_txns,
                         result,
                         execution_time,
+                        commit_rx,
                     } = res?;
-                    Ok(block.set_execution_result(input_txns, result, execution_time))
+                    Ok(block.set_execution_result(input_txns, result, execution_time, commit_rx))
                 })
                 .collect::<ExecutorResult<Vec<_>>>()?;
             drop(lifetime_guard);

--- a/consensus/src/pipeline/pipeline_phase.rs
+++ b/consensus/src/pipeline/pipeline_phase.rs
@@ -33,6 +33,10 @@ impl TaskGuard {
         counter.fetch_add(1, Ordering::SeqCst);
         Self { counter }
     }
+
+    fn spawn(&self) -> Self {
+        Self::new(self.counter.clone())
+    }
 }
 
 impl Drop for TaskGuard {
@@ -50,6 +54,13 @@ impl<Request> CountedRequest<Request> {
     pub fn new(req: Request, counter: Arc<AtomicU64>) -> Self {
         let guard = TaskGuard::new(counter);
         Self { req, guard }
+    }
+
+    pub fn spawn<OtherRequest>(&self, other_req: OtherRequest) -> CountedRequest<OtherRequest> {
+        CountedRequest {
+            req: other_req,
+            guard: self.guard.spawn(),
+        }
     }
 }
 

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -10,6 +10,7 @@ use crate::{
     execution_pipeline::ExecutionPipeline,
     monitor,
     payload_manager::TPayloadManager,
+    pipeline::pipeline_phase::CountedRequest,
     state_replication::{StateComputer, StateComputerCommitCallBackType},
     transaction_deduper::TransactionDeduper,
     transaction_filter::TransactionFilter,
@@ -18,50 +19,25 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_consensus_notifications::ConsensusNotificationSender;
-use aptos_consensus_types::{block::Block, common::Round, pipelined_block::PipelinedBlock};
+use aptos_consensus_types::{
+    block::Block, common::Round, pipeline_execution_result::PipelineExecutionResult,
+    pipelined_block::PipelinedBlock,
+};
 use aptos_crypto::HashValue;
-use aptos_executor_types::{BlockExecutorTrait, ExecutorResult, StateComputeResult};
+use aptos_executor_types::{BlockExecutorTrait, ExecutorError, ExecutorResult};
 use aptos_infallible::RwLock;
 use aptos_logger::prelude::*;
 use aptos_types::{
-    account_address::AccountAddress,
-    block_executor::config::BlockExecutorConfigFromOnchain,
-    contract_event::ContractEvent,
-    epoch_state::EpochState,
-    ledger_info::LedgerInfoWithSignatures,
-    randomness::Randomness,
-    transaction::{SignedTransaction, Transaction},
+    account_address::AccountAddress, block_executor::config::BlockExecutorConfigFromOnchain,
+    contract_event::ContractEvent, epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
+    randomness::Randomness, transaction::Transaction,
 };
 use fail::fail_point;
 use futures::{future::BoxFuture, SinkExt, StreamExt};
-use std::{boxed::Box, sync::Arc, time::Duration};
-use tokio::sync::{oneshot, Mutex as AsyncMutex};
+use std::{boxed::Box, sync::Arc};
+use tokio::sync::Mutex as AsyncMutex;
 
 pub type StateComputeResultFut = BoxFuture<'static, ExecutorResult<PipelineExecutionResult>>;
-
-#[derive(Debug)]
-pub struct PipelineExecutionResult {
-    pub input_txns: Vec<SignedTransaction>,
-    pub result: StateComputeResult,
-    pub execution_time: Duration,
-    pub commit_rx: oneshot::Receiver<ExecutorResult<()>>,
-}
-
-impl PipelineExecutionResult {
-    pub fn new(
-        input_txns: Vec<SignedTransaction>,
-        result: StateComputeResult,
-        execution_time: Duration,
-        commit_rx: oneshot::Receiver<ExecutorResult<()>>,
-    ) -> Self {
-        Self {
-            input_txns,
-            result,
-            execution_time,
-            commit_rx,
-        }
-    }
-}
 
 type NotificationType = (
     Box<dyn FnOnce() + Send + Sync>,
@@ -179,6 +155,7 @@ impl StateComputer for ExecutionProxy {
         // The parent block id.
         parent_block_id: HashValue,
         randomness: Option<Randomness>,
+        lifetime_guard: CountedRequest<()>,
     ) -> StateComputeResultFut {
         let block_id = block.id();
         debug!(
@@ -225,6 +202,7 @@ impl StateComputer for ExecutionProxy {
                 parent_block_id,
                 transaction_generator,
                 block_executor_onchain_config,
+                lifetime_guard,
             )
             .await;
 
@@ -278,7 +256,6 @@ impl StateComputer for ExecutionProxy {
         callback: StateComputerCommitCallBackType,
     ) -> ExecutorResult<()> {
         let mut latest_logical_time = self.write_mutex.lock().await;
-        let mut block_ids = Vec::new();
         let mut txns = Vec::new();
         let mut subscribable_txn_events = Vec::new();
         let mut payloads = Vec::new();
@@ -301,20 +278,18 @@ impl StateComputer for ExecutionProxy {
             .expect("must be set within an epoch");
         let mut pre_commit_rxs = Vec::with_capacity(blocks.len());
         for block in blocks {
-            block_ids.push(block.id());
-
             if let Some(payload) = block.block().payload() {
                 payloads.push(payload.clone());
             }
 
             txns.extend(self.transactions_to_commit(block, &validators, is_randomness_enabled));
             subscribable_txn_events.extend(block.subscribable_events());
-            pre_commit_rxs.push(block.take_commit_rx());
+            pre_commit_rxs.push(block.take_pre_commit_result_rx());
         }
 
         // wait until all blocks are committed
         for pre_commit_rx in pre_commit_rxs {
-            pre_commit_rx.await??;
+            pre_commit_rx.await.map_err(ExecutorError::internal_err)??;
         }
 
         let executor = self.executor.clone();
@@ -323,7 +298,7 @@ impl StateComputer for ExecutionProxy {
             "commit_block",
             tokio::task::spawn_blocking(move || {
                 executor
-                    .commit_blocks(block_ids, proof)
+                    .commit_ledger(proof)
                     .expect("Failed to commit blocks");
             })
             .await
@@ -352,17 +327,6 @@ impl StateComputer for ExecutionProxy {
             LogicalTime::new(target.ledger_info().epoch(), target.ledger_info().round());
         let block_timestamp = target.commit_info().timestamp_usecs();
 
-        if self.executor.committed_block_id() == target.commit_info().id() {
-            return Ok(());
-        }
-        if self.executor.latest_synced_version() == target.commit_info().version() {
-            // write the ledger down directly if it's already pre-commit (for epoch ending)
-            info!("Write the ledger info directly as it's already pre-committed.");
-            self.executor
-                .commit_blocks_ext(vec![target.commit_info().id()], target, false)
-                .unwrap();
-            return Ok(());
-        }
         // Before the state synchronization, we have to call finish() to free the in-memory SMT
         // held by BlockExecutor to prevent memory leak.
         self.executor.finish();
@@ -448,7 +412,9 @@ async fn test_commit_sync_race() {
     };
     use aptos_config::config::transaction_filter_type::Filter;
     use aptos_consensus_notifications::Error;
-    use aptos_executor_types::state_checkpoint_output::StateCheckpointOutput;
+    use aptos_executor_types::{
+        state_checkpoint_output::StateCheckpointOutput, StateComputeResult,
+    };
     use aptos_infallible::Mutex;
     use aptos_types::{
         aggregate_signature::AggregateSignature,
@@ -499,9 +465,16 @@ async fn test_commit_sync_race() {
             todo!()
         }
 
-        fn commit_blocks(
+        fn pre_commit_block(
             &self,
-            _block_ids: Vec<HashValue>,
+            _block_id: HashValue,
+            _parent_block_id: HashValue,
+        ) -> ExecutorResult<()> {
+            todo!()
+        }
+
+        fn commit_ledger(
+            &self,
             ledger_info_with_sigs: LedgerInfoWithSignatures,
         ) -> ExecutorResult<()> {
             *self.time.lock() = LogicalTime::new(

--- a/consensus/src/state_computer_tests.rs
+++ b/consensus/src/state_computer_tests.rs
@@ -3,9 +3,10 @@
 
 use crate::{
     error::MempoolError, payload_manager::DirectMempoolPayloadManager,
-    state_computer::ExecutionProxy, state_replication::StateComputer,
-    transaction_deduper::NoOpDeduper, transaction_filter::TransactionFilter,
-    transaction_shuffler::NoOpShuffler, txn_notifier::TxnNotifier,
+    pipeline::pipeline_phase::CountedRequest, state_computer::ExecutionProxy,
+    state_replication::StateComputer, transaction_deduper::NoOpDeduper,
+    transaction_filter::TransactionFilter, transaction_shuffler::NoOpShuffler,
+    txn_notifier::TxnNotifier,
 };
 use aptos_config::config::transaction_filter_type::Filter;
 use aptos_consensus_notifications::{ConsensusNotificationSender, Error};
@@ -26,7 +27,7 @@ use aptos_types::{
     validator_txn::ValidatorTransaction,
 };
 use futures_channel::oneshot;
-use std::sync::Arc;
+use std::sync::{atomic::AtomicU64, Arc};
 use tokio::runtime::Handle;
 
 struct DummyStateSyncNotifier {
@@ -121,9 +122,16 @@ impl BlockExecutorTrait for DummyBlockExecutor {
         Ok(StateComputeResult::new_dummy())
     }
 
-    fn commit_blocks(
+    fn pre_commit_block(
         &self,
-        _block_ids: Vec<HashValue>,
+        _block_id: HashValue,
+        _parent_block_id: HashValue,
+    ) -> ExecutorResult<()> {
+        Ok(())
+    }
+
+    fn commit_ledger(
+        &self,
         _ledger_info_with_sigs: LedgerInfoWithSignatures,
     ) -> ExecutorResult<()> {
         Ok(())
@@ -172,7 +180,7 @@ async fn schedule_compute_should_discover_validator_txns() {
 
     // Ensure the dummy executor has received the txns.
     let _ = execution_policy
-        .schedule_compute(&block, HashValue::zero(), None)
+        .schedule_compute(&block, HashValue::zero(), None, dummy_guard())
         .await
         .await;
 
@@ -196,7 +204,7 @@ async fn commit_should_discover_validator_txns() {
         Arc::new(DummyBlockExecutor::new()),
         Arc::new(DummyTxnNotifier {}),
         state_sync_notifier.clone(),
-        &tokio::runtime::Handle::current(),
+        &Handle::current(),
         TransactionFilter::new(Filter::empty()),
     );
 
@@ -225,6 +233,7 @@ async fn commit_should_discover_validator_txns() {
         vec![],
         state_compute_result,
     ))];
+    blocks[0].mark_successful_pre_commit_for_test();
     let epoch_state = EpochState::empty();
 
     execution_policy.new_epoch(
@@ -262,4 +271,8 @@ async fn commit_should_discover_validator_txns() {
     let supposed_validator_txn_1 = txns[2].try_as_validator_txn().unwrap();
     assert_eq!(&validator_txn_0, supposed_validator_txn_0);
     assert_eq!(&validator_txn_1, supposed_validator_txn_1);
+}
+
+fn dummy_guard() -> CountedRequest<()> {
+    CountedRequest::new((), Arc::new(AtomicU64::new(0)))
 }

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    error::StateSyncError, payload_manager::TPayloadManager, state_computer::StateComputeResultFut,
+    error::StateSyncError, payload_manager::TPayloadManager,
+    pipeline::pipeline_phase::CountedRequest, state_computer::StateComputeResultFut,
     transaction_deduper::TransactionDeduper, transaction_shuffler::TransactionShuffler,
 };
 use anyhow::Result;
@@ -31,8 +32,9 @@ pub trait StateComputer: Send + Sync {
         // The parent block root hash.
         _parent_block_id: HashValue,
         _randomness: Option<Randomness>,
+        _lifetime_guard: CountedRequest<()>,
     ) -> StateComputeResultFut {
-        unimplemented!("This state computer does not support scheduling");
+        unimplemented!();
     }
 
     /// Send a successful commit. A future is fulfilled when the state is finalized.

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -5,14 +5,17 @@
 use crate::{
     error::StateSyncError,
     payload_manager::TPayloadManager,
-    pipeline::buffer_manager::OrderedBlocks,
-    state_computer::{PipelineExecutionResult, StateComputeResultFut},
+    pipeline::{buffer_manager::OrderedBlocks, pipeline_phase::CountedRequest},
+    state_computer::StateComputeResultFut,
     state_replication::{StateComputer, StateComputerCommitCallBackType},
     transaction_deduper::TransactionDeduper,
     transaction_shuffler::TransactionShuffler,
 };
 use anyhow::Result;
-use aptos_consensus_types::{block::Block, pipelined_block::PipelinedBlock};
+use aptos_consensus_types::{
+    block::Block, pipeline_execution_result::PipelineExecutionResult,
+    pipelined_block::PipelinedBlock,
+};
 use aptos_crypto::HashValue;
 use aptos_executor_types::{ExecutorError, ExecutorResult, StateComputeResult};
 use aptos_logger::debug;
@@ -23,6 +26,7 @@ use aptos_types::{
 use futures::SinkExt;
 use futures_channel::mpsc::UnboundedSender;
 use std::{sync::Arc, time::Duration};
+use tokio::sync::oneshot;
 
 pub struct EmptyStateComputer {
     executor_channel: UnboundedSender<OrderedBlocks>,
@@ -108,6 +112,7 @@ impl StateComputer for RandomComputeResultStateComputer {
         _block: &Block,
         parent_block_id: HashValue,
         _randomness: Option<Randomness>,
+        _lifetime_guard: CountedRequest<()>,
     ) -> StateComputeResultFut {
         // trapdoor for Execution Error
         let res = if parent_block_id == self.random_compute_result_root_hash {
@@ -117,8 +122,10 @@ impl StateComputer for RandomComputeResultStateComputer {
                 self.random_compute_result_root_hash,
             ))
         };
+        let (tx, rx) = oneshot::channel();
+        tx.send(Ok(())).unwrap();
         let pipeline_execution_res =
-            res.map(|res| PipelineExecutionResult::new(vec![], res, Duration::from_secs(0)));
+            res.map(|res| PipelineExecutionResult::new(vec![], res, Duration::from_secs(0), rx));
         Box::pin(async move { pipeline_execution_res })
     }
 

--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/src/internal_indexer_db_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/src/internal_indexer_db_service.rs
@@ -82,12 +82,12 @@ impl InternalIndexerDBService {
             .state_sync_driver
             .bootstrapping_mode
             .is_fast_sync();
-        let mut main_db_synced_version = self.db_indexer.main_db_reader.get_synced_version()?;
+        let mut main_db_synced_version = self.db_indexer.main_db_reader.ensure_synced_version()?;
 
         // Wait till fast sync is done
         while fast_sync_enabled && main_db_synced_version == 0 {
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            main_db_synced_version = self.db_indexer.main_db_reader.get_synced_version()?;
+            main_db_synced_version = self.db_indexer.main_db_reader.ensure_synced_version()?;
         }
 
         let start_version = self

--- a/execution/executor-benchmark/src/ledger_update_stage.rs
+++ b/execution/executor-benchmark/src/ledger_update_stage.rs
@@ -75,9 +75,11 @@ where
                     output.root_hash(),
                     self.version,
                 );
+                let parent_block_id = self.executor.committed_block_id();
                 self.executor
-                    .commit_blocks(vec![block_id], ledger_info_with_sigs)
+                    .pre_commit_block(block_id, parent_block_id)
                     .unwrap();
+                self.executor.commit_ledger(ledger_info_with_sigs).unwrap();
             },
             CommitProcessing::Skip => {},
         }

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -166,7 +166,7 @@ pub fn run_benchmark<V>(
         ((0..pipeline_config.num_generator_workers).map(|_| transaction_generator_creator.create_transaction_generator()).collect::<Vec<_>>(), phase)
     });
 
-    let version = db.reader.get_synced_version().unwrap();
+    let version = db.reader.expect_synced_version();
 
     let (pipeline, block_sender) =
         Pipeline::new(executor, version, &pipeline_config, Some(num_blocks));
@@ -236,8 +236,7 @@ pub fn run_benchmark<V>(
     );
 
     if !pipeline_config.skip_commit {
-        let num_txns =
-            db.reader.get_synced_version().unwrap() - version - num_blocks_created as u64;
+        let num_txns = db.reader.expect_synced_version() - version - num_blocks_created as u64;
         overall_measuring.print_end("Overall", num_txns);
 
         if verify_sequence_numbers {
@@ -261,7 +260,7 @@ fn init_workload<V>(
 where
     V: TransactionBlockExecutor + 'static,
 {
-    let version = db.reader.get_synced_version().unwrap();
+    let version = db.reader.expect_synced_version();
     let (pipeline, block_sender) = Pipeline::<V>::new(
         BlockExecutor::new(db.clone()),
         version,

--- a/execution/executor-benchmark/src/transaction_committer.rs
+++ b/execution/executor-benchmark/src/transaction_committer.rs
@@ -90,9 +90,11 @@ where
             self.version += num_txns as u64;
             let commit_start = std::time::Instant::now();
             let ledger_info_with_sigs = gen_li_with_sigs(block_id, root_hash, self.version);
+            let parent_block_id = self.executor.committed_block_id();
             self.executor
-                .commit_blocks(vec![block_id], ledger_info_with_sigs)
+                .pre_commit_block(block_id, parent_block_id)
                 .unwrap();
+            self.executor.commit_ledger(ledger_info_with_sigs).unwrap();
 
             report_block(
                 start_version,

--- a/execution/executor-types/src/ledger_update_output.rs
+++ b/execution/executor-types/src/ledger_update_output.rs
@@ -216,4 +216,8 @@ impl LedgerUpdateOutput {
     pub fn first_version(&self) -> Version {
         self.transaction_accumulator.num_leaves() - self.to_commit.len() as Version
     }
+
+    pub fn num_txns(&self) -> usize {
+        self.to_commit.len()
+    }
 }

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -53,9 +53,7 @@ pub mod state_checkpoint_output;
 pub trait ChunkExecutorTrait: Send + Sync {
     /// Verifies the transactions based on the provided proofs and ledger info. If the transactions
     /// are valid, executes them and returns the executed result for commit.
-    ///
-    /// TODO: Remove after all callsites split the execute / apply stage into two separate stages
-    ///       and pipe them up.
+    #[cfg(any(test, feature = "fuzzing"))]
     fn execute_chunk(
         &self,
         txn_list_with_proof: TransactionListWithProof,
@@ -70,9 +68,7 @@ pub trait ChunkExecutorTrait: Send + Sync {
 
     /// Similar to `execute_chunk`, but instead of executing transactions, apply the transaction
     /// outputs directly to get the executed result.
-    ///
-    /// TODO: Remove after all callsites split the execute / apply stage into two separate stages
-    ///       and pipe them up.
+    #[cfg(any(test, feature = "fuzzing"))]
     fn apply_chunk(
         &self,
         txn_output_list_with_proof: TransactionOutputListWithProof,
@@ -139,6 +135,7 @@ pub trait BlockExecutorTrait: Send + Sync {
 
     /// Executes a block - TBD, this API will be removed in favor of `execute_and_state_checkpoint`, followed
     /// by `ledger_update` once we have ledger update as a separate pipeline phase.
+    #[cfg(any(test, feature = "fuzzing"))]
     fn execute_block(
         &self,
         block: ExecutableBlock,
@@ -166,24 +163,27 @@ pub trait BlockExecutorTrait: Send + Sync {
         state_checkpoint_output: StateCheckpointOutput,
     ) -> ExecutorResult<StateComputeResult>;
 
-    /// Saves eligible blocks to persistent storage.
-    /// If we have multiple blocks and not all of them have signatures, we may send them to storage
-    /// in a few batches. For example, if we have
-    /// ```text
-    /// A <- B <- C <- D <- E
-    /// ```
-    /// and only `C` and `E` have signatures, we will send `A`, `B` and `C` in the first batch,
-    /// then `D` and `E` later in the another batch.
-    /// Commits a block and all its ancestors in a batch manner.
+    #[cfg(any(test, feature = "fuzzing"))]
     fn commit_blocks(
         &self,
         block_ids: Vec<HashValue>,
         ledger_info_with_sigs: LedgerInfoWithSignatures,
+    ) -> ExecutorResult<()> {
+        let mut parent_block_id = self.committed_block_id();
+        for block_id in block_ids {
+            self.pre_commit_block(block_id, parent_block_id)?;
+            parent_block_id = block_id;
+        }
+        self.commit_ledger(ledger_info_with_sigs)
+    }
+
+    fn pre_commit_block(
+        &self,
+        block_id: HashValue,
+        parent_block_id: HashValue,
     ) -> ExecutorResult<()>;
 
-    fn pre_commit(&self, block_id: HashValue, parent_block_id: HashValue) -> ExecutorResult<()>;
-
-    fn latest_synced_version(&self) -> Version;
+    fn commit_ledger(&self, ledger_info_with_sigs: LedgerInfoWithSignatures) -> ExecutorResult<()>;
 
     /// Finishes the block executor by releasing memory held by inner data structures(SMT).
     fn finish(&self);

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -181,6 +181,10 @@ pub trait BlockExecutorTrait: Send + Sync {
         ledger_info_with_sigs: LedgerInfoWithSignatures,
     ) -> ExecutorResult<()>;
 
+    fn pre_commit(&self, block_id: HashValue, parent_block_id: HashValue) -> ExecutorResult<()>;
+
+    fn latest_synced_version(&self) -> Version;
+
     /// Finishes the block executor by releasing memory held by inner data structures(SMT).
     fn finish(&self);
 }

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -18,6 +18,7 @@ use crate::{
     },
 };
 use anyhow::{anyhow, ensure, Result};
+use aptos_crypto::HashValue;
 use aptos_drop_helper::DEFAULT_DROPPER;
 use aptos_executor_types::{
     ChunkCommitNotification, ChunkExecutorTrait, ExecutedChunk, ParsedTransactionOutput,
@@ -35,6 +36,7 @@ use aptos_types::{
     block_executor::config::BlockExecutorConfigFromOnchain,
     contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
+    proof::TransactionInfoListWithProof,
     state_store::StateViewId,
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, Transaction,
@@ -48,7 +50,14 @@ use fail::fail_point;
 use itertools::multizip;
 use once_cell::sync::Lazy;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
-use std::{iter::once, marker::PhantomData, sync::Arc};
+use std::{
+    iter::once,
+    marker::PhantomData,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 pub static SIG_VERIFY_POOL: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
     Arc::new(
@@ -79,6 +88,25 @@ impl<V: VMExecutor> ChunkExecutor<V> {
         }
         Ok(())
     }
+
+    fn with_inner<F, T>(&self, f: F) -> Result<T>
+    where
+        F: FnOnce(&ChunkExecutorInner<V>) -> Result<T>,
+    {
+        let locked = self.inner.read();
+        let inner = locked.as_ref().expect("not reset");
+
+        let has_pending_pre_commit = inner.has_pending_pre_commit.load(Ordering::Acquire);
+        f(inner).map_err(|error| {
+            if has_pending_pre_commit {
+                panic!(
+                    "Hit error with pending pre-committed ledger, panicking. {:?}",
+                    error,
+                );
+            }
+            error
+        })
+    }
 }
 
 impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
@@ -89,11 +117,13 @@ impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
         epoch_change_li: Option<&LedgerInfoWithSignatures>,
     ) -> Result<()> {
         self.maybe_initialize()?;
-        self.inner
-            .read()
-            .as_ref()
-            .expect("not reset")
-            .enqueue_chunk_by_execution(txn_list_with_proof, verified_target_li, epoch_change_li)
+        self.with_inner(|inner| {
+            inner.enqueue_chunk_by_execution(
+                txn_list_with_proof,
+                verified_target_li,
+                epoch_change_li,
+            )
+        })
     }
 
     fn enqueue_chunk_by_transaction_outputs(
@@ -102,31 +132,21 @@ impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
         verified_target_li: &LedgerInfoWithSignatures,
         epoch_change_li: Option<&LedgerInfoWithSignatures>,
     ) -> Result<()> {
-        self.inner
-            .read()
-            .as_ref()
-            .expect("not reset")
-            .enqueue_chunk_by_transaction_outputs(
+        self.with_inner(|inner| {
+            inner.enqueue_chunk_by_transaction_outputs(
                 txn_output_list_with_proof,
                 verified_target_li,
                 epoch_change_li,
             )
+        })
     }
 
     fn update_ledger(&self) -> Result<()> {
-        self.inner
-            .read()
-            .as_ref()
-            .expect("not reset")
-            .update_ledger()
+        self.with_inner(|inner| inner.update_ledger())
     }
 
     fn commit_chunk(&self) -> Result<ChunkCommitNotification> {
-        self.inner
-            .read()
-            .as_ref()
-            .expect("not reset")
-            .commit_chunk()
+        self.with_inner(|inner| inner.commit_chunk())
     }
 
     fn reset(&self) -> Result<()> {
@@ -142,15 +162,23 @@ impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
 struct ChunkExecutorInner<V> {
     db: DbReaderWriter,
     commit_queue: Mutex<ChunkCommitQueue>,
+    has_pending_pre_commit: AtomicBool,
     _phantom: PhantomData<V>,
 }
 
 impl<V: VMExecutor> ChunkExecutorInner<V> {
     pub fn new(db: DbReaderWriter) -> Result<Self> {
-        let commit_queue = Mutex::new(ChunkCommitQueue::new_from_db(&db.reader)?);
+        let commit_queue = ChunkCommitQueue::new_from_db(&db.reader)?;
+
+        let next_pre_committed_version = commit_queue.expecting_version();
+        let next_synced_version = db.reader.get_synced_version()?.map_or(0, |v| v + 1);
+        assert!(next_synced_version <= next_pre_committed_version);
+        let has_pending_pre_commit = next_synced_version < next_pre_committed_version;
+
         Ok(Self {
             db,
-            commit_queue,
+            commit_queue: Mutex::new(commit_queue),
+            has_pending_pre_commit: AtomicBool::new(has_pending_pre_commit),
             _phantom: PhantomData,
         })
     }
@@ -164,6 +192,25 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
             latest_state.current.clone(),
             Arc::new(AsyncProofFetcher::new(self.db.reader.clone())),
         )?)
+    }
+
+    fn verify_extends_ledger(
+        &self,
+        proof: &TransactionInfoListWithProof,
+        first_version: Version,
+        my_root_hash: HashValue,
+    ) -> Result<()> {
+        // In consensus-only mode, we cannot verify the proof against the executed output,
+        // because the proof returned by the remote peer is an empty one.
+        if cfg!(feature = "consensus-only-perf-test") {
+            return Ok(());
+        }
+
+        let num_overlap =
+            proof.verify_extends_ledger(first_version, my_root_hash, Some(first_version))?;
+        assert_eq!(num_overlap, 0, "overlapped chunks");
+
+        Ok(())
     }
 
     fn commit_chunk_impl(&self) -> Result<ExecutedChunk> {
@@ -418,18 +465,11 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
         } = chunk;
 
         let first_version = parent_accumulator.num_leaves();
-
-        // In consensus-only mode, we cannot verify the proof against the executed output,
-        // because the proof returned by the remote peer is an empty one.
-        #[cfg(not(feature = "consensus-only-perf-test"))]
-        {
-            let num_overlap = txn_infos_with_proof.verify_extends_ledger(
-                first_version,
-                parent_accumulator.root_hash(),
-                Some(first_version),
-            )?;
-            assert_eq!(num_overlap, 0, "overlapped chunks");
-        }
+        self.verify_extends_ledger(
+            &txn_infos_with_proof,
+            first_version,
+            parent_accumulator.root_hash(),
+        )?;
 
         let (ledger_update_output, to_discard, to_retry) = {
             let _timer =
@@ -470,6 +510,7 @@ impl<V: VMExecutor> ChunkExecutorInner<V> {
     fn commit_chunk(&self) -> Result<ChunkCommitNotification> {
         let _timer = APTOS_EXECUTOR_COMMIT_CHUNK_SECONDS.start_timer();
         let executed_chunk = self.commit_chunk_impl()?;
+        self.has_pending_pre_commit.store(false, Ordering::Release);
 
         let commit_notification = {
             let _timer = APTOS_CHUNK_EXECUTOR_OTHER_SECONDS

--- a/execution/executor/src/components/chunk_commit_queue.rs
+++ b/execution/executor/src/components/chunk_commit_queue.rs
@@ -11,6 +11,7 @@ use aptos_types::{
     epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
     proof::{accumulator::InMemoryTransactionAccumulator, TransactionInfoListWithProof},
+    transaction::Version,
 };
 use std::{collections::VecDeque, sync::Arc};
 
@@ -62,6 +63,10 @@ impl ChunkCommitQueue {
 
     pub(crate) fn latest_state(&self) -> StateDelta {
         self.latest_state.clone()
+    }
+
+    pub(crate) fn expecting_version(&self) -> Version {
+        self.latest_txn_accumulator.num_leaves()
     }
 
     pub(crate) fn expect_latest_view(&self) -> Result<ExecutedTrees> {

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -113,16 +113,24 @@ impl DbReader for FakeDb {
 }
 
 impl DbWriter for FakeDb {
-    fn save_transactions(
+    fn pre_commit_ledger(
         &self,
         _txns_to_commit: &[TransactionToCommit],
         _first_version: Version,
         _base_state_version: Option<Version>,
-        _ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
         _sync_commit: bool,
-        _in_memory_state: StateDelta,
-        _block_state_updates: Option<ShardedStateUpdates>,
+        _latest_in_memory_state: StateDelta,
+        _state_updates_until_last_checkpoint: Option<ShardedStateUpdates>,
         _sharded_state_cache: Option<&ShardedStateCache>,
+    ) -> aptos_storage_interface::Result<()> {
+        Ok(())
+    }
+
+    fn commit_ledger(
+        &self,
+        _version: Version,
+        _ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        _txns_to_commit: Option<&[TransactionToCommit]>,
     ) -> aptos_storage_interface::Result<()> {
         Ok(())
     }

--- a/execution/executor/src/tests/chunk_executor_tests.rs
+++ b/execution/executor/src/tests/chunk_executor_tests.rs
@@ -106,7 +106,7 @@ fn test_executor_execute_or_apply_and_commit_chunk() {
         } = TestExecutor::new();
         execute_and_commit_chunks(chunks, ledger_info.clone(), &db, &executor);
 
-        let ledger_version = db.reader.get_synced_version().unwrap();
+        let ledger_version = db.reader.expect_synced_version();
         let output1 = db
             .reader
             .get_transaction_outputs(first_batch_start, first_batch_size, ledger_version)

--- a/execution/executor/src/tests/chunk_executor_tests.rs
+++ b/execution/executor/src/tests/chunk_executor_tests.rs
@@ -9,7 +9,7 @@ use crate::{
     chunk_executor::ChunkExecutor,
     db_bootstrapper::{generate_waypoint, maybe_bootstrap},
     mock_vm::{encode_mint_transaction, MockVM},
-    tests,
+    tests::{self, create_blocks_and_chunks, create_transaction_chunks},
 };
 use aptos_crypto::HashValue;
 use aptos_db::AptosDB;
@@ -18,7 +18,7 @@ use aptos_storage_interface::DbReaderWriter;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     test_helpers::transaction_test_helpers::{block, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG},
-    transaction::TransactionListWithProof,
+    transaction::{TransactionListWithProof, Version},
 };
 use rand::Rng;
 
@@ -47,7 +47,7 @@ impl TestExecutor {
 }
 
 fn execute_and_commit_chunks(
-    chunks: Vec<TransactionListWithProof>,
+    chunks: [TransactionListWithProof; 3],
     ledger_info: LedgerInfoWithSignatures,
     db: &DbReaderWriter,
     executor: &ChunkExecutor<MockVM>,
@@ -91,10 +91,10 @@ fn test_executor_execute_or_apply_and_commit_chunk() {
     let third_batch_start = second_batch_start + second_batch_size;
 
     let (chunks, ledger_info) = {
-        tests::create_transaction_chunks(vec![
-            first_batch_start..first_batch_start + first_batch_size,
-            second_batch_start..second_batch_start + second_batch_size,
-            third_batch_start..third_batch_start + third_batch_size,
+        create_transaction_chunks(vec![
+            first_batch_start..=first_batch_start + first_batch_size - 1,
+            second_batch_start..=second_batch_start + second_batch_size - 1,
+            third_batch_start..=third_batch_start + third_batch_size - 1,
         ])
     };
     // First test with transactions only and reset chunks to be `Vec<TransactionOutputListWithProof>`.
@@ -104,7 +104,12 @@ fn test_executor_execute_or_apply_and_commit_chunk() {
             db,
             executor,
         } = TestExecutor::new();
-        execute_and_commit_chunks(chunks, ledger_info.clone(), &db, &executor);
+        execute_and_commit_chunks(
+            chunks.try_into().unwrap(),
+            ledger_info.clone(),
+            &db,
+            &executor,
+        );
 
         let ledger_version = db.reader.expect_synced_version();
         let output1 = db
@@ -119,7 +124,7 @@ fn test_executor_execute_or_apply_and_commit_chunk() {
             .reader
             .get_transaction_outputs(third_batch_start, third_batch_size, ledger_version)
             .unwrap();
-        vec![output1, output2, output3]
+        [output1, output2, output3]
     };
 
     // Test with transaction outputs.
@@ -165,8 +170,8 @@ fn test_executor_execute_and_commit_chunk_restart() {
         let first_batch_start = 1;
         let second_batch_start = first_batch_start + first_batch_size;
         tests::create_transaction_chunks(vec![
-            first_batch_start..first_batch_start + first_batch_size,
-            second_batch_start..second_batch_start + second_batch_size,
+            first_batch_start..=first_batch_start + first_batch_size - 1,
+            second_batch_start..=second_batch_start + second_batch_size - 1,
         ])
     };
 
@@ -189,13 +194,11 @@ fn test_executor_execute_and_commit_chunk_restart() {
 
     // Then we restart executor and resume to the next chunk.
     {
-        println!("------------------------------------ CCC");
         let executor = ChunkExecutor::<MockVM>::new(db.clone());
 
         executor
             .execute_chunk(chunks[1].clone(), &ledger_info, None)
             .unwrap();
-        println!("------------------------------------ DDD");
         executor.commit_chunk().unwrap();
         let li = db.reader.get_latest_ledger_info().unwrap();
         assert_eq!(li, ledger_info);
@@ -211,9 +214,9 @@ fn test_executor_execute_and_commit_chunk_local_result_mismatch() {
     let (chunks, ledger_info) = {
         let first_batch_start = 1;
         let second_batch_start = first_batch_start + first_batch_size;
-        tests::create_transaction_chunks(vec![
-            first_batch_start..first_batch_start + first_batch_size,
-            second_batch_start..second_batch_start + second_batch_size,
+        create_transaction_chunks(vec![
+            first_batch_start..=first_batch_start + first_batch_size - 1,
+            second_batch_start..=second_batch_start + second_batch_size - 1,
         ])
     };
 
@@ -304,4 +307,95 @@ fn test_executor_execute_and_commit_chunk_without_verify() {
     assert!(chunk_manager
         .execute_chunk(chunks[1].clone(), &ledger_info, None)
         .is_ok());
+}
+
+const PRE_COMMIT_TESTS_LATEST_VERSION: Version = 10;
+
+/// commits txn 1-3, pre-commits txn 4-7, returns txn 8-10 and ledger infos at 7 and 10
+fn commit_1_pre_commit_2_return_3() -> (
+    DbReaderWriter,
+    TransactionListWithProof,
+    LedgerInfoWithSignatures,
+    LedgerInfoWithSignatures,
+) {
+    let (blocks, chunks) =
+        create_blocks_and_chunks(vec![1..=3, 4..=7, 8..=10], vec![1..=3, 4..=7, 8..=10]);
+
+    let TestExecutor {
+        _path,
+        db,
+        executor: chunk_executor,
+    } = TestExecutor::new();
+    drop(chunk_executor);
+
+    let block_executor = BlockExecutor::<MockVM>::new(db.clone());
+    let mut parent_block_id = block_executor.committed_block_id();
+    // execute and pre-commit block 1 & 2
+    for (txns, ledger_info) in &blocks[0..=1] {
+        let block_id = ledger_info.commit_info().id();
+        let output = block_executor
+            .execute_block(
+                (block_id, block(txns.clone())).into(),
+                parent_block_id,
+                TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
+            )
+            .unwrap();
+        assert_eq!(
+            output.root_hash(),
+            ledger_info.ledger_info().transaction_accumulator_hash()
+        );
+        block_executor
+            .pre_commit_block(block_id, parent_block_id)
+            .unwrap();
+        parent_block_id = block_id;
+    }
+    // commit till block 1
+    let ledger_info1 = blocks[0].1.clone();
+    let ledger_info2 = blocks[1].1.clone();
+    let ledger_info3 = blocks[2].1.clone();
+    block_executor.commit_ledger(ledger_info1).unwrap();
+    assert_eq!(
+        ledger_info3.ledger_info().version(),
+        PRE_COMMIT_TESTS_LATEST_VERSION
+    );
+
+    (db, chunks[2].clone(), ledger_info2, ledger_info3)
+}
+
+#[test]
+#[should_panic(expected = "Hit error with pending pre-committed ledger, panicking.")]
+fn test_panic_on_mismatch_with_pre_committed() {
+    // See comments on `commit_1_pre_commit_2_return_3()`
+    let (db, _chunk3, _ledger_info2, _ledger_info3) = commit_1_pre_commit_2_return_3();
+
+    let (bad_chunks, bad_ledger_info) = create_transaction_chunks(vec![1..=7, 8..=12]);
+    // bad chunk has txn 8-12
+    let bad_chunk = bad_chunks[1].clone();
+
+    let chunk_executor = ChunkExecutor::<MockVM>::new(db);
+    // chunk executor knows there's pre-committed txns in the DB and when a verified chunk
+    // doesn't match the pre-committed root hash it panics in hope that pre-committed versions
+    // get truncated on reboot
+    let _res = chunk_executor.execute_chunk(bad_chunk, &bad_ledger_info, None);
+}
+
+#[test]
+fn test_continue_from_pre_committed() {
+    // See comments on `commit_1_pre_commit_2_return_3()`
+    let (db, chunk3, _ledger_info2, ledger_info3) = commit_1_pre_commit_2_return_3();
+
+    let (bad_chunks, bad_ledger_info) = create_transaction_chunks(vec![1..=10, 11..=15]);
+    // bad chunk has txn 11-15
+    let bad_chunk = bad_chunks[1].clone();
+
+    // continue from pre-committed version
+    let chunk_executor = ChunkExecutor::<MockVM>::new(db);
+    chunk_executor
+        .execute_chunk(chunk3, &ledger_info3, None)
+        .unwrap();
+    chunk_executor.commit_chunk().unwrap();
+    // once pre-committed range is committed, don't panic on errors
+    assert!(chunk_executor
+        .execute_chunk(bad_chunk, &bad_ledger_info, None)
+        .is_err());
 }

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -783,7 +783,7 @@ proptest! {
 
             // get txn_infos from db
             let db = executor.db.reader.clone();
-            prop_assert_eq!(db.get_synced_version().unwrap(), ledger_version);
+            prop_assert_eq!(db.expect_synced_version(), ledger_version);
             let txn_list = db.get_transactions(1 /* start version */, ledger_version, ledger_version /* ledger version */, false /* fetch events */).unwrap();
             prop_assert_eq!(&block.inner_txns(), &txn_list.transactions[..num_input_txns as usize]);
             let txn_infos = txn_list.proof.transaction_infos;

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -292,12 +292,10 @@ fn test_executor_commit_twice() {
         .unwrap();
     let ledger_info = gen_ledger_info(6, output1.root_hash(), block1_id, 1);
     executor
-        .commit_blocks(vec![block1_id], ledger_info.clone())
+        .pre_commit_block(block1_id, executor.committed_block_id())
         .unwrap();
-    // commit with the same ledger info again.
-    executor
-        .commit_blocks(vec![block1_id], ledger_info)
-        .unwrap();
+    executor.commit_ledger(ledger_info.clone()).unwrap();
+    executor.commit_ledger(ledger_info).unwrap();
 }
 
 #[test]
@@ -326,56 +324,82 @@ fn test_executor_execute_same_block_multiple_times() {
     assert_eq!(responses.len(), 1);
 }
 
-/// Generates a list of `TransactionListWithProof`s according to the given ranges.
-fn create_transaction_chunks(
-    chunk_ranges: Vec<std::ops::Range<Version>>,
-) -> (Vec<TransactionListWithProof>, LedgerInfoWithSignatures) {
-    assert_eq!(chunk_ranges.first().unwrap().start, 1);
+fn create_blocks_and_chunks(
+    block_ranges: Vec<std::ops::RangeInclusive<Version>>,
+    chunk_ranges: Vec<std::ops::RangeInclusive<Version>>,
+) -> (
+    Vec<(Vec<Transaction>, LedgerInfoWithSignatures)>,
+    Vec<TransactionListWithProof>,
+) {
+    assert_eq!(*block_ranges.first().unwrap().start(), 1);
+    assert_eq!(*chunk_ranges.first().unwrap().start(), 1);
+    assert_eq!(
+        chunk_ranges.last().unwrap().end(),
+        block_ranges.last().unwrap().end(),
+    );
+    for i in 1..block_ranges.len() {
+        let previous_range = &block_ranges[i - 1];
+        let range = &block_ranges[i];
+        assert!(previous_range.start() <= previous_range.end());
+        assert!(range.start() <= range.end());
+        assert_eq!(*range.start(), *previous_range.end() + 1);
+    }
     for i in 1..chunk_ranges.len() {
         let previous_range = &chunk_ranges[i - 1];
         let range = &chunk_ranges[i];
-        assert!(previous_range.start <= previous_range.end);
-        assert!(range.start <= range.end);
-        assert!(range.start <= previous_range.end);
-        assert!(previous_range.end <= range.end);
+        assert!(previous_range.start() <= previous_range.end());
+        assert!(range.start() <= range.end());
+        assert!(*range.start() <= *previous_range.end() + 1);
+        assert!(previous_range.end() < range.end());
     }
+
+    let mut out_blocks = Vec::new();
 
     // To obtain the batches of transactions, we first execute and save all these transactions in a
     // separate DB. Then we call get_transactions to retrieve them.
-    let TestExecutor { executor, .. } = TestExecutor::new();
+    let TestExecutor {
+        executor: block_executor,
+        db,
+        ..
+    } = TestExecutor::new();
 
-    let mut txns: Vec<SignatureVerifiedTransaction> = vec![];
-    for i in 1..(chunk_ranges.last().unwrap().end - 1) {
-        let txn = encode_mint_transaction(gen_address(i), 100);
-        txns.push(txn.into());
+    let mut parent_block_id = block_executor.committed_block_id();
+    for block_range in block_ranges {
+        let version = *block_range.end();
+        // range_size - 1 for the block prologue
+        let num_txns = *block_range.end() - *block_range.start();
+        let txns: Vec<_> = block_range
+            .into_iter()
+            .take(num_txns as usize)
+            .map(|v| encode_mint_transaction(gen_address(v), 10))
+            .collect();
+        let block_id = gen_block_id(version);
+        let output = block_executor
+            .execute_block(
+                (block_id, txns.clone()).into(),
+                parent_block_id,
+                TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
+            )
+            .unwrap();
+        assert_eq!(output.version(), version);
+        block_executor
+            .pre_commit_block(block_id, parent_block_id)
+            .unwrap();
+        let ledger_info = gen_ledger_info(version, output.root_hash(), block_id, version);
+        out_blocks.push((txns, ledger_info));
+        parent_block_id = block_id;
     }
+    let ledger_info = out_blocks.last().unwrap().1.clone();
+    let ledger_version = ledger_info.ledger_info().version();
+    block_executor.commit_ledger(ledger_info).unwrap();
 
-    let id = gen_block_id(1);
-
-    let output = executor
-        .execute_block(
-            (id, txns.clone()).into(),
-            executor.committed_block_id(),
-            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
-        )
-        .unwrap();
-
-    let ledger_version = txns.len() as u64 + 1;
-    assert_eq!(ledger_version, output.transactions_to_commit_len() as u64);
-    let ledger_info = gen_ledger_info(ledger_version, output.root_hash(), id, 1);
-    executor
-        .commit_blocks(vec![id], ledger_info.clone())
-        .unwrap();
-
-    let batches: Vec<_> = chunk_ranges
+    let out_chunks: Vec<_> = chunk_ranges
         .into_iter()
         .map(|range| {
-            executor
-                .db
-                .reader
+            db.reader
                 .get_transactions(
-                    range.start,
-                    range.end - range.start,
+                    *range.start(),
+                    *range.end() - *range.start() + 1,
                     ledger_version,
                     false, /* fetch_events */
                 )
@@ -383,33 +407,18 @@ fn create_transaction_chunks(
         })
         .collect();
 
-    (batches, ledger_info)
+    (out_blocks, out_chunks)
 }
 
-#[test]
-#[cfg_attr(feature = "consensus-only-perf-test", ignore)]
-fn test_noop_block_after_reconfiguration() {
-    let executor = TestExecutor::new();
-    let mut parent_block_id = executor.committed_block_id();
-    let first_txn = encode_reconfiguration_transaction();
-    let first_block_id = gen_block_id(1);
-    let output1 = executor
-        .execute_block(
-            (first_block_id, vec![first_txn]).into(),
-            parent_block_id,
-            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
-        )
-        .unwrap();
-    parent_block_id = first_block_id;
-    let second_block = TestBlock::new(10, 10, gen_block_id(2));
-    let output2 = executor
-        .execute_block(
-            (second_block.id, second_block.txns).into(),
-            parent_block_id,
-            TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
-        )
-        .unwrap();
-    assert_eq!(output1.root_hash(), output2.root_hash());
+fn create_transaction_chunks(
+    chunks: Vec<std::ops::RangeInclusive<Version>>,
+) -> (Vec<TransactionListWithProof>, LedgerInfoWithSignatures) {
+    let num_txns = *chunks.last().unwrap().end();
+    // last txn is a block epilogue
+    let all_txns = 1..=num_txns;
+    let (mut blocks, chunks) = create_blocks_and_chunks(vec![all_txns], chunks);
+
+    (chunks, blocks.pop().unwrap().1)
 }
 
 fn create_test_transaction(sequence_number: u64) -> Transaction {
@@ -600,11 +609,11 @@ fn test_reconfig_suffix_empty_blocks() {
         db: _,
         executor,
     } = TestExecutor::new();
-    let block_a = TestBlock::new(10000, 1, gen_block_id(1));
+    let block_a = TestBlock::new(100, 1, gen_block_id(1));
     // add block gas limit to be consistent with block executor that will add state checkpoint txn
-    let mut block_b = TestBlock::new(10000, 1, gen_block_id(2));
-    let block_c = TestBlock::new(1, 1, gen_block_id(3));
-    let block_d = TestBlock::new(1, 1, gen_block_id(4));
+    let mut block_b = TestBlock::new(100, 1, gen_block_id(2));
+    let block_c = TestBlock::new(10, 1, gen_block_id(3));
+    let block_d = TestBlock::new(10, 1, gen_block_id(4));
     block_b
         .txns
         .push(encode_reconfiguration_transaction().into());
@@ -616,21 +625,21 @@ fn test_reconfig_suffix_empty_blocks() {
             TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
-    let output = executor
+    let output2 = executor
         .execute_block(
             (block_b.id, block_b.txns).into(),
             block_a.id,
             TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
-    executor
+    let output3 = executor
         .execute_block(
             (block_c.id, block_c.txns).into(),
             block_b.id,
             TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
         )
         .unwrap();
-    executor
+    let output4 = executor
         .execute_block(
             (block_d.id, block_d.txns).into(),
             block_c.id,
@@ -638,7 +647,9 @@ fn test_reconfig_suffix_empty_blocks() {
         )
         .unwrap();
 
-    let ledger_info = gen_ledger_info(20002, output.root_hash(), block_d.id, 1);
+    assert_eq!(output2.root_hash(), output3.root_hash());
+    assert_eq!(output2.root_hash(), output4.root_hash());
+    let ledger_info = gen_ledger_info(202, output2.root_hash(), block_d.id, 1);
 
     executor
         .commit_blocks(
@@ -731,80 +742,84 @@ fn run_transactions_naive(
 }
 
 proptest! {
+#![proptest_config(ProptestConfig::with_cases(5))]
+
+#[test]
+#[cfg_attr(feature = "consensus-only-perf-test", ignore)]
+fn test_reconfiguration_with_retry_transaction_status(
+    (num_user_txns, reconfig_txn_index) in (2..5u64).prop_flat_map(|num_user_txns| {
+        (
+            Just(num_user_txns),
+            0..num_user_txns - 1 // avoid state checkpoint right after reconfig
+        )
+    }).no_shrink()) {
+        let executor = TestExecutor::new();
+
+        let block_id = gen_block_id(1);
+        let mut block = TestBlock::new(num_user_txns, 10, block_id);
+        let num_input_txns = block.txns.len() as LeafCount;
+        block.txns[reconfig_txn_index as usize] = encode_reconfiguration_transaction().into();
+
+        let parent_block_id = executor.committed_block_id();
+        let output = executor.execute_block(
+            (block_id, block.txns.clone()).into(), parent_block_id, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG
+        ).unwrap();
+
+        // assert: txns after the reconfiguration are with status "Retry"
+        let retry_iter = output.compute_status_for_input_txns().iter()
+        .skip_while(|status| matches!(*status, TransactionStatus::Keep(_)));
+        prop_assert_eq!(
+            retry_iter.take_while(|status| matches!(*status,TransactionStatus::Retry)).count() as u64,
+            num_input_txns - reconfig_txn_index - 1
+        );
+
+        // commit
+        let ledger_info = gen_ledger_info(reconfig_txn_index + 1 /* version */, output.root_hash(), block_id, 1 /* timestamp */);
+        executor.commit_blocks(vec![block_id], ledger_info).unwrap();
+        let parent_block_id = executor.committed_block_id();
+
+        // retry txns after reconfiguration
+        let retry_block_id = gen_block_id(2);
+        let retry_output = executor.execute_block(
+            (retry_block_id, block.txns.iter().skip(reconfig_txn_index as usize + 1).cloned().collect::<Vec<SignatureVerifiedTransaction>>()).into(), parent_block_id, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG
+        ).unwrap();
+        prop_assert!(retry_output.compute_status_for_input_txns().iter().all(|s| matches!(*s, TransactionStatus::Keep(_))));
+
+        // Second block has StateCheckpoint/BlockPrologue transaction added.
+        let ledger_version = num_input_txns + 1;
+
+        // commit
+        let ledger_info = gen_ledger_info(ledger_version, retry_output.root_hash(), retry_block_id, 12345 /* timestamp */);
+        executor.commit_blocks(vec![retry_block_id], ledger_info).unwrap();
+
+        // get txn_infos from db
+        let db = executor.db.reader.clone();
+        prop_assert_eq!(db.expect_synced_version(), ledger_version);
+        let txn_list = db.get_transactions(1 /* start version */, ledger_version, ledger_version /* ledger version */, false /* fetch events */).unwrap();
+        prop_assert_eq!(&block.inner_txns(), &txn_list.transactions[..num_input_txns as usize]);
+        let txn_infos = txn_list.proof.transaction_infos;
+        let write_sets = db.get_write_set_iterator(1, ledger_version).unwrap().collect::<Result<_>>().unwrap();
+        let event_vecs = db.get_events_iterator(1, ledger_version).unwrap().collect::<Result<_>>().unwrap();
+
+        // replay txns in one batch across epoch boundary,
+        // and the replayer should deal with `Retry`s automatically
+        let replayer = chunk_executor_tests::TestExecutor::new();
+        replayer.executor.replay(txn_list.transactions, txn_infos, write_sets, event_vecs, &VerifyExecutionMode::verify_all()).unwrap();
+        replayer.executor.commit().unwrap();
+        let replayed_db = replayer.db.reader.clone();
+        prop_assert_eq!(
+            replayed_db.get_accumulator_root_hash(ledger_version).unwrap(),
+            db.get_accumulator_root_hash(ledger_version).unwrap()
+        );
+    }
+}
+
+proptest! {
     #![proptest_config(ProptestConfig::with_cases(1))]
 
     #[test]
     #[cfg_attr(feature = "consensus-only-perf-test", ignore)]
-    fn test_reconfiguration_with_retry_transaction_status(
-        (num_user_txns, reconfig_txn_index) in (10..100u64).prop_flat_map(|num_user_txns| {
-            (
-                Just(num_user_txns),
-                0..num_user_txns - 1 // avoid state checkpoint right after reconfig
-            )
-        }).no_shrink()) {
-            let executor = TestExecutor::new();
-
-            let block_id = gen_block_id(1);
-            let mut block = TestBlock::new(num_user_txns, 10, block_id);
-            let num_input_txns = block.txns.len() as LeafCount;
-            block.txns[reconfig_txn_index as usize] = encode_reconfiguration_transaction().into();
-
-            let parent_block_id = executor.committed_block_id();
-            let output = executor.execute_block(
-                (block_id, block.txns.clone()).into(), parent_block_id, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG
-            ).unwrap();
-
-            // assert: txns after the reconfiguration are with status "Retry"
-            let retry_iter = output.compute_status_for_input_txns().iter()
-            .skip_while(|status| matches!(*status, TransactionStatus::Keep(_)));
-            prop_assert_eq!(
-                retry_iter.take_while(|status| matches!(*status,TransactionStatus::Retry)).count() as u64,
-                num_input_txns - reconfig_txn_index - 1
-            );
-
-            // commit
-            let ledger_info = gen_ledger_info(reconfig_txn_index + 1 /* version */, output.root_hash(), block_id, 1 /* timestamp */);
-            executor.commit_blocks(vec![block_id], ledger_info).unwrap();
-            let parent_block_id = executor.committed_block_id();
-
-            // retry txns after reconfiguration
-            let retry_block_id = gen_block_id(2);
-            let retry_output = executor.execute_block(
-                (retry_block_id, block.txns.iter().skip(reconfig_txn_index as usize + 1).cloned().collect::<Vec<SignatureVerifiedTransaction>>()).into(), parent_block_id, TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG
-            ).unwrap();
-            prop_assert!(retry_output.compute_status_for_input_txns().iter().all(|s| matches!(*s, TransactionStatus::Keep(_))));
-
-            // Second block has StateCheckpoint/BlockPrologue transaction added.
-            let ledger_version = num_input_txns + 1;
-
-            // commit
-            let ledger_info = gen_ledger_info(ledger_version, retry_output.root_hash(), retry_block_id, 12345 /* timestamp */);
-            executor.commit_blocks(vec![retry_block_id], ledger_info).unwrap();
-
-            // get txn_infos from db
-            let db = executor.db.reader.clone();
-            prop_assert_eq!(db.expect_synced_version(), ledger_version);
-            let txn_list = db.get_transactions(1 /* start version */, ledger_version, ledger_version /* ledger version */, false /* fetch events */).unwrap();
-            prop_assert_eq!(&block.inner_txns(), &txn_list.transactions[..num_input_txns as usize]);
-            let txn_infos = txn_list.proof.transaction_infos;
-            let write_sets = db.get_write_set_iterator(1, ledger_version).unwrap().collect::<Result<_>>().unwrap();
-            let event_vecs = db.get_events_iterator(1, ledger_version).unwrap().collect::<Result<_>>().unwrap();
-
-            // replay txns in one batch across epoch boundary,
-            // and the replayer should deal with `Retry`s automatically
-            let replayer = chunk_executor_tests::TestExecutor::new();
-            replayer.executor.replay(txn_list.transactions, txn_infos, write_sets, event_vecs, &VerifyExecutionMode::verify_all()).unwrap();
-            replayer.executor.commit().unwrap();
-            let replayed_db = replayer.db.reader.clone();
-            prop_assert_eq!(
-                replayed_db.get_accumulator_root_hash(ledger_version).unwrap(),
-                db.get_accumulator_root_hash(ledger_version).unwrap()
-            );
-        }
-
-    #[test]
-    #[cfg_attr(feature = "consensus-only-perf-test", ignore)]
-    fn test_executor_restart(a_size in 1..30u64, b_size in 1..30u64, amount in any::<u32>()) {
+    fn test_executor_restart(a_size in 1..5u64, b_size in 1..5u64, amount in any::<u32>()) {
         let TestExecutor { _path, db, executor } = TestExecutor::new();
 
         let block_a = TestBlock::new(a_size, amount, gen_block_id(1));

--- a/execution/executor/tests/internal_indexer_test.rs
+++ b/execution/executor/tests/internal_indexer_test.rs
@@ -136,7 +136,7 @@ fn test_db_indexer_data() {
     use std::{thread, time::Duration};
     // create test db
     let (aptos_db, core_account) = create_test_db();
-    let total_version = aptos_db.get_synced_version().unwrap();
+    let total_version = aptos_db.expect_synced_version();
     assert_eq!(total_version, 11);
     let temp_path = TempPath::new();
     let mut node_config = aptos_config::config::NodeConfig::default();

--- a/peer-monitoring-service/server/src/tests.rs
+++ b/peer-monitoring-service/server/src/tests.rs
@@ -681,7 +681,7 @@ mod database_mock {
 
             fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures>;
 
-            fn get_synced_version(&self) -> Result<Version>;
+            fn get_synced_version(&self) -> Result<Option<Version>>;
 
             fn get_latest_ledger_info_version(&self) -> Result<Version>;
 

--- a/state-sync/aptos-data-client/src/latency_monitor.rs
+++ b/state-sync/aptos-data-client/src/latency_monitor.rs
@@ -67,7 +67,7 @@ impl LatencyMonitor {
             // Wait for the next round
             loop_ticker.next().await;
 
-            let highest_synced_version = match self.storage.get_synced_version() {
+            let highest_synced_version = match self.storage.ensure_synced_version() {
                 Ok(version) => version,
                 Err(error) => {
                     sample!(

--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -466,7 +466,7 @@ impl<
         }
 
         // Get the highest synced and known ledger info versions
-        let highest_synced_version = utils::fetch_latest_synced_version(self.storage.clone())?;
+        let highest_synced_version = utils::fetch_pre_committed_version(self.storage.clone())?;
         let highest_known_ledger_info = self.get_highest_known_ledger_info()?;
         let highest_known_ledger_version = highest_known_ledger_info.ledger_info().version();
 

--- a/state-sync/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-driver/src/continuous_syncer.rs
@@ -265,7 +265,7 @@ impl<
 
     /// Returns the highest synced version and epoch in storage
     fn get_highest_synced_version_and_epoch(&self) -> Result<(Version, Epoch), Error> {
-        let highest_synced_version = utils::fetch_latest_synced_version(self.storage.clone())?;
+        let highest_synced_version = utils::fetch_pre_committed_version(self.storage.clone())?;
         let highest_synced_epoch = utils::fetch_latest_epoch_state(self.storage.clone())?.epoch;
 
         Ok((highest_synced_version, highest_synced_epoch))

--- a/state-sync/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-driver/src/driver.rs
@@ -378,7 +378,7 @@ impl<
         &mut self,
         sync_notification: ConsensusSyncNotification,
     ) -> Result<(), Error> {
-        let latest_synced_version = utils::fetch_latest_synced_version(self.storage.clone())?;
+        let latest_synced_version = utils::fetch_pre_committed_version(self.storage.clone())?;
         info!(
             LogSchema::new(LogEntry::ConsensusNotification).message(&format!(
             "Received a consensus sync notification! Target version: {:?}. Latest synced version: {:?}",

--- a/state-sync/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/tests/bootstrapper.rs
@@ -1614,6 +1614,9 @@ fn create_bootstrapper(
     mock_database_reader
         .expect_get_synced_version()
         .returning(|| Ok(Some(0)));
+    mock_database_reader
+        .expect_get_pre_committed_version()
+        .returning(|| Ok(Some(0)));
 
     // Create the output fallback handler
     let time_service = time_service.unwrap_or_else(TimeService::mock);
@@ -1670,6 +1673,9 @@ fn create_bootstrapper_with_storage(
         .returning(move || Ok(epoch_ending_ledger_info.clone()));
     mock_database_reader
         .expect_get_synced_version()
+        .returning(move || Ok(Some(latest_synced_version)));
+    mock_database_reader
+        .expect_get_pre_committed_version()
         .returning(move || Ok(Some(latest_synced_version)));
 
     // Create the output fallback handler

--- a/state-sync/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/tests/bootstrapper.rs
@@ -1613,7 +1613,7 @@ fn create_bootstrapper(
         .returning(|| Ok(create_epoch_ending_ledger_info()));
     mock_database_reader
         .expect_get_synced_version()
-        .returning(|| Ok(0));
+        .returning(|| Ok(Some(0)));
 
     // Create the output fallback handler
     let time_service = time_service.unwrap_or_else(TimeService::mock);
@@ -1670,7 +1670,7 @@ fn create_bootstrapper_with_storage(
         .returning(move || Ok(epoch_ending_ledger_info.clone()));
     mock_database_reader
         .expect_get_synced_version()
-        .returning(move || Ok(latest_synced_version));
+        .returning(move || Ok(Some(latest_synced_version)));
 
     // Create the output fallback handler
     let output_fallback_handler =

--- a/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
+++ b/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
@@ -503,7 +503,7 @@ fn create_continuous_syncer(
     let mut mock_database_reader = create_mock_db_reader();
     mock_database_reader
         .expect_get_synced_version()
-        .returning(move || Ok(synced_version));
+        .returning(move || Ok(Some(synced_version)));
     mock_database_reader
         .expect_get_latest_epoch_state()
         .returning(move || Ok(create_epoch_state(current_epoch)));

--- a/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
+++ b/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
@@ -505,6 +505,9 @@ fn create_continuous_syncer(
         .expect_get_synced_version()
         .returning(move || Ok(Some(synced_version)));
     mock_database_reader
+        .expect_get_pre_committed_version()
+        .returning(move || Ok(Some(synced_version)));
+    mock_database_reader
         .expect_get_latest_epoch_state()
         .returning(move || Ok(create_epoch_state(current_epoch)));
 

--- a/state-sync/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-driver/src/tests/mocks.rs
@@ -82,7 +82,7 @@ pub fn create_mock_reader_writer_with_version(
     let mut reader = reader.unwrap_or_else(create_mock_db_reader);
     reader
         .expect_get_synced_version()
-        .returning(move || Ok(highest_synced_version));
+        .returning(move || Ok(Some(highest_synced_version)));
     reader
         .expect_get_latest_epoch_state()
         .returning(|| Ok(create_empty_epoch_state()));
@@ -235,7 +235,7 @@ mock! {
 
         fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures>;
 
-        fn get_synced_version(&self) -> Result<Version>;
+        fn get_synced_version(&self) -> Result<Option<Version>>;
 
         fn get_latest_ledger_info_version(&self) -> Result<Version>;
 

--- a/state-sync/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-driver/src/tests/mocks.rs
@@ -84,6 +84,9 @@ pub fn create_mock_reader_writer_with_version(
         .expect_get_synced_version()
         .returning(move || Ok(Some(highest_synced_version)));
     reader
+        .expect_get_pre_committed_version()
+        .returning(move || Ok(Some(highest_synced_version)));
+    reader
         .expect_get_latest_epoch_state()
         .returning(|| Ok(create_empty_epoch_state()));
     reader
@@ -236,6 +239,8 @@ mock! {
         fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures>;
 
         fn get_synced_version(&self) -> Result<Option<Version>>;
+
+        fn get_pre_committed_version(&self) -> Result<Option<Version>>;
 
         fn get_latest_ledger_info_version(&self) -> Result<Version>;
 

--- a/state-sync/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-driver/src/utils.rs
@@ -279,7 +279,7 @@ pub fn fetch_latest_synced_ledger_info(
 
 /// Fetches the latest synced version from the specified storage
 pub fn fetch_latest_synced_version(storage: Arc<dyn DbReader>) -> Result<Version, Error> {
-    storage.get_synced_version().map_err(|e| {
+    storage.ensure_synced_version().map_err(|e| {
         Error::StorageError(format!("Failed to get latest version from storage: {e:?}"))
     })
 }

--- a/state-sync/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-driver/src/utils.rs
@@ -278,8 +278,8 @@ pub fn fetch_latest_synced_ledger_info(
 }
 
 /// Fetches the latest synced version from the specified storage
-pub fn fetch_latest_synced_version(storage: Arc<dyn DbReader>) -> Result<Version, Error> {
-    storage.ensure_synced_version().map_err(|e| {
+pub fn fetch_pre_committed_version(storage: Arc<dyn DbReader>) -> Result<Version, Error> {
+    storage.ensure_pre_committed_version().map_err(|e| {
         Error::StorageError(format!("Failed to get latest version from storage: {e:?}"))
     })
 }
@@ -288,7 +288,7 @@ pub fn fetch_latest_synced_version(storage: Arc<dyn DbReader>) -> Result<Version
 /// or after a state snapshot has been restored).
 pub fn initialize_sync_gauges(storage: Arc<dyn DbReader>) -> Result<(), Error> {
     // Update the latest synced versions
-    let highest_synced_version = fetch_latest_synced_version(storage.clone())?;
+    let highest_synced_version = fetch_pre_committed_version(storage.clone())?;
     let metrics = [
         metrics::StorageSynchronizerOperations::AppliedTransactionOutputs,
         metrics::StorageSynchronizerOperations::ExecutedTransactions,
@@ -328,7 +328,7 @@ pub async fn handle_committed_transactions<
 ) {
     // Fetch the latest synced version and ledger info from storage
     let (latest_synced_version, latest_synced_ledger_info) =
-        match fetch_latest_synced_version(storage.clone()) {
+        match fetch_pre_committed_version(storage.clone()) {
             Ok(latest_synced_version) => match fetch_latest_synced_ledger_info(storage.clone()) {
                 Ok(latest_synced_ledger_info) => (latest_synced_version, latest_synced_ledger_info),
                 Err(error) => {

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -288,7 +288,7 @@ mock! {
 
         fn get_latest_ledger_info(&self) -> aptos_storage_interface::Result<LedgerInfoWithSignatures>;
 
-        fn get_synced_version(&self) -> aptos_storage_interface::Result<Version>;
+        fn get_synced_version(&self) -> aptos_storage_interface::Result<Option<Version>>;
 
         fn get_latest_ledger_info_version(&self) -> aptos_storage_interface::Result<Version>;
 

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -119,7 +119,7 @@ impl RestoreHandler {
     }
 
     pub fn get_next_expected_transaction_version(&self) -> Result<Version> {
-        Ok(self.aptosdb.get_synced_version().map_or(0, |ver| ver + 1))
+        Ok(self.aptosdb.get_synced_version()?.map_or(0, |ver| ver + 1))
     }
 
     pub fn get_state_snapshot_before(

--- a/storage/aptosdb/src/backup/restore_utils.rs
+++ b/storage/aptosdb/src/backup/restore_utils.rs
@@ -161,6 +161,9 @@ pub(crate) fn save_transactions(
         )?;
 
         ledger_db.write_schemas(ledger_db_batch)?;
+        ledger_db
+            .metadata_db()
+            .set_pre_committed_version(last_version);
     }
 
     Ok(())

--- a/storage/aptosdb/src/db/fake_aptosdb.rs
+++ b/storage/aptosdb/src/db/fake_aptosdb.rs
@@ -236,7 +236,7 @@ impl FakeAptosDB {
             .current_version
             .map(|version| version + 1)
             .unwrap_or(0);
-        let num_transactions_in_db = self.get_synced_version().map_or(0, |v| v + 1);
+        let num_transactions_in_db = self.get_synced_version()?.map_or(0, |v| v + 1);
         ensure!(num_transactions_in_db == first_version && num_transactions_in_db == next_version_in_buffered_state,
             "The first version {} passed in, the next version in buffered state {} and the next version in db {} are inconsistent.",
             first_version,
@@ -667,7 +667,7 @@ impl DbReader for FakeAptosDB {
     fn get_block_timestamp(&self, version: Version) -> Result<u64> {
         gauged_api("get_block_timestamp", || {
             ensure!(
-                version <= self.get_synced_version()?,
+                version <= self.ensure_synced_version()?,
                 "version older than latest version"
             );
 
@@ -835,7 +835,7 @@ impl DbReader for FakeAptosDB {
         // This is because when we call save_transactions for the genesis block, we call [AptosDB::save_transactions]
         // where there is an expectation that the root of the SMTs are the same pointers. Here,
         // we get from the inner AptosDB which ensures that the pointers match when save_transactions is called.
-        if self.get_synced_version().unwrap_or_default() == 0 {
+        if self.ensure_synced_version().unwrap_or_default() == 0 {
             return self.inner.get_latest_executed_trees();
         }
 

--- a/storage/aptosdb/src/db/include/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_internal.rs
@@ -57,7 +57,8 @@ impl AptosDB {
                 state_merkle_db,
                 state_kv_db,
             ),
-            ledger_commit_lock: std::sync::Mutex::new(()),
+            pre_commit_lock: std::sync::Mutex::new(()),
+            commit_lock: std::sync::Mutex::new(()),
             indexer: None,
             skip_index_and_usage,
         }

--- a/storage/aptosdb/src/db/include/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_internal.rs
@@ -115,7 +115,7 @@ impl AptosDB {
         rocksdb_config: RocksdbConfig,
     ) -> Result<()> {
         let indexer = Indexer::open(&db_root_path, rocksdb_config)?;
-        let ledger_next_version = self.get_synced_version().map_or(0, |v| v + 1);
+        let ledger_next_version = self.get_synced_version()?.map_or(0, |v| v + 1);
         info!(
             indexer_next_version = indexer.next_version(),
             ledger_next_version = ledger_next_version,
@@ -232,7 +232,7 @@ impl AptosDB {
             let (first_version, new_block_event) = self.event_store.get_event_by_key(
                 &new_block_event_key(),
                 block_height,
-                self.get_synced_version()?,
+                self.ensure_synced_version()?,
             )?;
             let new_block_event = bcs::from_bytes(new_block_event.event_data())?;
             Ok(BlockInfo::from_new_block_event(
@@ -254,7 +254,7 @@ impl AptosDB {
         &self,
         version: Version,
     ) -> Result<(u64 /* block_height */, BlockInfo)> {
-        let synced_version = self.get_synced_version()?;
+        let synced_version = self.ensure_synced_version()?;
         ensure!(
             version <= synced_version,
             "Requested version {version} > synced version {synced_version}",

--- a/storage/aptosdb/src/db/include/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_reader.rs
@@ -61,6 +61,12 @@ impl DbReader for AptosDB {
         })
     }
 
+    fn get_pre_committed_version(&self) -> Result<Option<Version>> {
+        gauged_api("get_pre_committed_version", || {
+            Ok(self.ledger_db.metadata_db().get_pre_committed_version())
+        })
+    }
+
     fn get_account_transaction(
         &self,
         address: AccountAddress,

--- a/storage/aptosdb/src/db/include/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_reader.rs
@@ -55,7 +55,7 @@ impl DbReader for AptosDB {
         })
     }
 
-    fn get_synced_version(&self) -> Result<Version> {
+    fn get_synced_version(&self) -> Result<Option<Version>> {
         gauged_api("get_synced_version", || {
             self.ledger_db.metadata_db().get_synced_version()
         })
@@ -562,7 +562,7 @@ impl DbReader for AptosDB {
     // TODO(grao): Remove after DAG.
     fn get_latest_block_events(&self, num_events: usize) -> Result<Vec<EventWithVersion>> {
         gauged_api("get_latest_block_events", || {
-            let latest_version = self.get_synced_version();
+            let latest_version = self.get_synced_version()?;
             if !self.skip_index_and_usage {
                 return self.get_events(
                     &new_block_event_key(),

--- a/storage/aptosdb/src/db/include/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_writer.rs
@@ -1,48 +1,41 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use itertools::Itertools;
+
 impl DbWriter for AptosDB {
-    /// `first_version` is the version of the first transaction in `txns_to_commit`.
-    /// When `ledger_info_with_sigs` is provided, verify that the transaction accumulator root hash
-    /// it carries is generated after the `txns_to_commit` are applied.
-    /// Note that even if `txns_to_commit` is empty, `first_version` is checked to be
-    /// `ledger_info_with_sigs.ledger_info.version + 1` if `ledger_info_with_sigs` is not `None`.
-    fn save_transactions(
+    fn pre_commit_ledger(
         &self,
         txns_to_commit: &[TransactionToCommit],
         first_version: Version,
         base_state_version: Option<Version>,
-        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
         sync_commit: bool,
         latest_in_memory_state: StateDelta,
         state_updates_until_last_checkpoint: Option<ShardedStateUpdates>,
         sharded_state_cache: Option<&ShardedStateCache>,
     ) -> Result<()> {
-        gauged_api("save_transactions", || {
-            // Executing and committing from more than one threads not allowed -- consensus and
-            // state sync must hand over to each other after all pending execution and committing
-            // complete.
+        gauged_api("pre_commit_ledger", || {
+            // Pre-committing and committing in concurrency is allowed but not pre-committing at the
+            // same time from multiple threads, the same for committing.
+            // Consensus and state sync must hand over to each other after all pending execution and
+            // committing complete.
             let _lock = self
-                .ledger_commit_lock
+                .pre_commit_lock
                 .try_lock()
                 .expect("Concurrent committing detected.");
+            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["pre_commit_ledger"]);
 
             latest_in_memory_state.current.log_generation("db_save");
 
-            // For reconfig suffix.
-            if ledger_info_with_sigs.is_none() && txns_to_commit.is_empty() {
-                return Ok(());
-            }
-
-            self.save_transactions_validation(
+            self.pre_commit_validation(
                 txns_to_commit,
                 first_version,
                 base_state_version,
-                ledger_info_with_sigs,
                 &latest_in_memory_state,
             )?;
+            let last_version = first_version + txns_to_commit.len() as u64 - 1;
 
-            let new_root_hash = self.calculate_and_commit_ledger_and_state_kv(
+            let _new_root_hash = self.calculate_and_commit_ledger_and_state_kv(
                 txns_to_commit,
                 first_version,
                 latest_in_memory_state.current.usage(),
@@ -53,9 +46,6 @@ impl DbWriter for AptosDB {
             let _timer = OTHER_TIMERS_SECONDS.timer_with(&["save_transactions__others"]);
             {
                 let mut buffered_state = self.state_store.buffered_state().lock();
-                let last_version = first_version + txns_to_commit.len() as u64 - 1;
-
-                self.commit_ledger_info(last_version, new_root_hash, ledger_info_with_sigs)?;
 
                 if !txns_to_commit.is_empty() {
                     let _timer = OTHER_TIMERS_SECONDS.timer_with(&["buffered_state___update"]);
@@ -66,10 +56,52 @@ impl DbWriter for AptosDB {
                     )?;
                 }
             }
-
-            self.post_commit(txns_to_commit, first_version, ledger_info_with_sigs)
+            self.ledger_db.metadata_db().set_pre_committed_version(last_version);
+            Ok(())
         })
     }
+
+    fn commit_ledger(
+        &self,
+        version: Version,
+        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        txns_to_commit: Option<&[TransactionToCommit]>,
+    ) -> Result<()> {
+        gauged_api("commit_ledger", || {
+            // Pre-committing and committing in concurrency is allowed but not pre-committing at the
+            // same time from multiple threads, the same for committing.
+            // Consensus and state sync must hand over to each other after all pending execution and
+            // committing complete.
+            let _lock = self
+                .commit_lock
+                .try_lock()
+                .expect("Concurrent committing detected.");
+            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["commit_ledger"]);
+
+            let old_committed_ver = self.get_and_check_commit_range(version, txns_to_commit)?;
+
+            let ledger_batch = SchemaBatch::new();
+            // Write down LedgerInfo if provided.
+            if let Some(li) = ledger_info_with_sigs {
+                self.check_and_put_ledger_info(version, li, &ledger_batch)?;
+            }
+            // Write down commit progress
+            ledger_batch.put::<DbMetadataSchema>(
+                &DbMetadataKey::OverallCommitProgress,
+                &DbMetadataValue::Version(version),
+            )?;
+            self.ledger_db.metadata_db().write_schemas(ledger_batch)?;
+
+            // Notify the pruners, invoke the indexer, and update in-memory ledger info.
+            self.post_commit(
+                old_committed_ver,
+                version,
+                ledger_info_with_sigs,
+                txns_to_commit,
+            )
+        })
+    }
+
 
     fn get_state_snapshot_receiver(
         &self,
@@ -200,68 +232,55 @@ impl DbWriter for AptosDB {
 }
 
 impl AptosDB {
-    fn save_transactions_validation(
+    fn pre_commit_validation(
         &self,
         txns_to_commit: &[TransactionToCommit],
         first_version: Version,
         base_state_version: Option<Version>,
-        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
         latest_in_memory_state: &StateDelta,
     ) -> Result<()> {
         let _timer = OTHER_TIMERS_SECONDS
             .with_label_values(&["save_transactions_validation"])
             .start_timer();
-        let buffered_state = self.state_store.buffered_state().lock();
-        ensure!(
-            base_state_version == buffered_state.current_state().base_version,
-            "base_state_version {:?} does not equal to the base_version {:?} in buffered state with current version {:?}",
-            base_state_version,
-            buffered_state.current_state().base_version,
-            buffered_state.current_state().current_version,
-        );
-
-        // Ensure the incoming committing requests are always consecutive and the version in
-        // buffered state is consistent with that in db.
-        let next_version_in_buffered_state = buffered_state
-            .current_state()
-            .current_version
-            .map(|version| version + 1)
-            .unwrap_or(0);
-        let num_transactions_in_db = self.get_synced_version().map_or(0, |v| v + 1);
-        ensure!(num_transactions_in_db == first_version && num_transactions_in_db == next_version_in_buffered_state,
-            "The first version {} passed in, the next version in buffered state {} and the next version in db {} are inconsistent.",
-            first_version,
-            next_version_in_buffered_state,
-            num_transactions_in_db,
-        );
 
         let num_txns = txns_to_commit.len() as u64;
-        // ledger_info_with_sigs could be None if we are doing state synchronization. In this case
-        // txns_to_commit should not be empty. Otherwise it is okay to commit empty blocks.
         ensure!(
-            ledger_info_with_sigs.is_some() || num_txns > 0,
-            "txns_to_commit is empty while ledger_info_with_sigs is None.",
+            num_txns > 0,
+            "txns_to_commit is empty, nothing to save.",
         );
-
         let last_version = first_version + num_txns - 1;
-
-        if let Some(x) = ledger_info_with_sigs {
-            let claimed_last_version = x.ledger_info().version();
-            ensure!(
-                claimed_last_version  == last_version,
-                "Transaction batch not applicable: first_version {}, num_txns {}, last_version_in_ledger_info {}",
-                first_version,
-                num_txns,
-                claimed_last_version,
-            );
-        }
-
         ensure!(
             Some(last_version) == latest_in_memory_state.current_version,
             "the last_version {:?} to commit doesn't match the current_version {:?} in latest_in_memory_state",
             last_version,
             latest_in_memory_state.current_version.expect("Must exist"),
         );
+
+        let num_transactions_in_db = self.get_synced_version().map_or(0, |v| v + 1);
+        {
+            let buffered_state = self.state_store.buffered_state().lock();
+            ensure!(
+                base_state_version == buffered_state.current_state().base_version,
+                "base_state_version {:?} does not equal to the base_version {:?} in buffered state with current version {:?}",
+                base_state_version,
+                buffered_state.current_state().base_version,
+                buffered_state.current_state().current_version,
+            );
+
+            // Ensure the incoming committing requests are always consecutive and the version in
+            // buffered state is consistent with that in db.
+            let next_version_in_buffered_state = buffered_state
+                .current_state()
+                .current_version
+                .map(|version| version + 1)
+                .unwrap_or(0);
+            ensure!(num_transactions_in_db == first_version && num_transactions_in_db == next_version_in_buffered_state,
+                "The first version {} passed in, the next version in buffered state {} and the next version in db {} are inconsistent.",
+                first_version,
+                next_version_in_buffered_state,
+                num_transactions_in_db,
+            );
+        }
 
         Ok(())
     }
@@ -566,82 +585,121 @@ impl AptosDB {
         self.ledger_db.transaction_info_db().write_schemas(batch)
     }
 
-    fn commit_ledger_info(
+    fn get_and_check_commit_range(
         &self,
-        last_version: Version,
-        new_root_hash: HashValue,
-        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
-    ) -> Result<()> {
-        let _timer = OTHER_TIMERS_SECONDS
-            .with_label_values(&["commit_ledger_info"])
-            .start_timer();
-
-        let ledger_batch = SchemaBatch::new();
-
-        // If expected ledger info is provided, verify result root hash and save the ledger info.
-        if let Some(x) = ledger_info_with_sigs {
-            let expected_root_hash = x.ledger_info().transaction_accumulator_hash();
+        version_to_commit: Version,
+        txns_to_commit: Option<&[TransactionToCommit]>
+    ) -> Result<Option<Version>> {
+        let old_committed_ver = self.ledger_db.metadata_db().get_synced_version_opt()?;
+        let pre_committed_ver = self.ledger_db.metadata_db().get_pre_committed_version();
+        ensure!(
+            old_committed_ver.is_none() || version_to_commit >= old_committed_ver.unwrap(),
+            "Version too old to commit. Committed: {:?}; Trying to commit with LI: {}",
+            old_committed_ver,
+            version_to_commit,
+        );
+        ensure!(
+            pre_committed_ver.is_some() && version_to_commit <= pre_committed_ver.unwrap(),
+            "Version too new to commit. Pre-committed: {:?}, Trying to commit with LI: {}",
+            pre_committed_ver,
+            version_to_commit,
+        );
+        if let Some(txns_to_commit) = txns_to_commit {
+            let expected_next_to_commit = old_committed_ver.map_or(0, |v| v + 1);
             ensure!(
-                new_root_hash == expected_root_hash,
-                "Root hash calculated doesn't match expected. {:?} vs {:?}",
-                new_root_hash,
-                expected_root_hash,
+                txns_to_commit.len() as u64 == version_to_commit + 1 - expected_next_to_commit,
+                "Bad commit range. to-commit: {}, committed: {:?}, Num txns: {}",
+                version_to_commit,
+                old_committed_ver,
+                txns_to_commit.len(),
             );
-            let current_epoch = self
-                .ledger_db
-                .metadata_db()
-                .get_latest_ledger_info_option()
-                .map_or(0, |li| li.ledger_info().next_block_epoch());
-            ensure!(
-                x.ledger_info().epoch() == current_epoch,
-                "Gap in epoch history. Trying to put in LedgerInfo in epoch: {}, current epoch: {}",
-                x.ledger_info().epoch(),
-                current_epoch,
-            );
-
-            self.ledger_db
-                .metadata_db()
-                .put_ledger_info(x, &ledger_batch)?;
         }
+        Ok(old_committed_ver)
+    }
 
-        ledger_batch.put::<DbMetadataSchema>(
-            &DbMetadataKey::OverallCommitProgress,
-            &DbMetadataValue::Version(last_version),
-        )?;
-        self.ledger_db.metadata_db().write_schemas(ledger_batch)
+    fn check_and_put_ledger_info(
+        &self,
+        version: Version,
+        ledger_info_with_sig: &LedgerInfoWithSignatures,
+        ledger_batch: &SchemaBatch
+    ) -> Result<(), AptosDbError> {
+        let ledger_info = ledger_info_with_sig.ledger_info();
+
+        // Verify the version.
+        ensure!(
+            ledger_info.version() == version,
+            "Version in LedgerInfo doesn't match last version. {:?} vs {:?}",
+            ledger_info.version(),
+            version,
+        );
+
+        // Verify the root hash.
+        let db_root_hash = self.ledger_db.transaction_accumulator_db().get_root_hash(version)?;
+        let li_root_hash = ledger_info_with_sig.ledger_info().transaction_accumulator_hash();
+        ensure!(
+            db_root_hash == li_root_hash,
+            "Root hash pre-committed doesn't match LedgerInfo. pre-commited: {:?} vs in LedgerInfo: {:?}",
+            db_root_hash,
+            li_root_hash,
+        );
+
+        // Verify epoch continuity.
+        let current_epoch = self
+            .ledger_db
+            .metadata_db()
+            .get_latest_ledger_info_option()
+            .map_or(0, |li| li.ledger_info().next_block_epoch());
+        ensure!(
+            ledger_info_with_sig.ledger_info().epoch() == current_epoch,
+            "Gap in epoch history. Trying to put in LedgerInfo in epoch: {}, current epoch: {}",
+            ledger_info_with_sig.ledger_info().epoch(),
+            current_epoch,
+        );
+
+        // Put write to batch.
+        self.ledger_db
+            .metadata_db()
+            .put_ledger_info(ledger_info_with_sig, ledger_batch)?;
+        Ok(())
     }
 
     fn post_commit(
         &self,
-        txns_to_commit: &[TransactionToCommit],
-        first_version: Version,
+        old_committed_version: Option<Version>,
+        version: Version,
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        txns_to_commit: Option<&[TransactionToCommit]>,
     ) -> Result<()> {
         // If commit succeeds and there are at least one transaction written to the storage, we
         // will inform the pruner thread to work.
-        let num_txns = txns_to_commit.len() as u64;
-        if num_txns > 0 {
-            let last_version = first_version + num_txns - 1;
+        if old_committed_version.is_none() || version > old_committed_version.unwrap() {
+            let first_version = old_committed_version.map_or(0, |v| v + 1);
+            let num_txns = version + 1 - first_version;
+
             COMMITTED_TXNS.inc_by(num_txns);
-            LATEST_TXN_VERSION.set(last_version as i64);
+            LATEST_TXN_VERSION.set(version as i64);
             // Activate the ledger pruner and state kv pruner.
             // Note the state merkle pruner is activated when state snapshots are persisted
             // in their async thread.
             self.ledger_pruner
-                .maybe_set_pruner_target_db_version(last_version);
+                .maybe_set_pruner_target_db_version(version);
             self.state_store
                 .state_kv_pruner
-                .maybe_set_pruner_target_db_version(last_version);
-        }
+                .maybe_set_pruner_target_db_version(version);
 
-        // Note: this must happen after txns have been saved to db because types can be newly
-        // created in this same chunk of transactions.
-        if let Some(indexer) = &self.indexer {
-            let _timer = OTHER_TIMERS_SECONDS
-                .with_label_values(&["indexer_index"])
-                .start_timer();
-            let write_sets: Vec<_> = txns_to_commit.iter().map(|txn| txn.write_set()).collect();
-            indexer.index(self.state_store.clone(), first_version, &write_sets)?;
+            // Note: this must happen after txns have been saved to db because types can be newly
+            // created in this same chunk of transactions.
+            if let Some(indexer) = &self.indexer {
+                let _timer = OTHER_TIMERS_SECONDS.timer_with(&["indexer_index"]);
+                if let Some(txns_to_commit) = txns_to_commit {
+                    let write_sets = txns_to_commit.iter().map(|txn| txn.write_set()).collect_vec();
+                    indexer.index(self.state_store.clone(), first_version, &write_sets)?;
+                } else {
+                    let write_sets: Vec<_> = self.ledger_db.write_set_db().get_write_set_iter(first_version, num_txns as usize)?.try_collect()?;
+                    let write_set_refs = write_sets.iter().collect_vec();
+                    indexer.index(self.state_store.clone(), first_version, &write_set_refs)?;
+                };
+            }
         }
 
         // Once everything is successfully persisted, update the latest in-memory ledger info.

--- a/storage/aptosdb/src/db/include/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_writer.rs
@@ -256,7 +256,7 @@ impl AptosDB {
             latest_in_memory_state.current_version.expect("Must exist"),
         );
 
-        let num_transactions_in_db = self.get_synced_version().map_or(0, |v| v + 1);
+        let num_transactions_in_db = self.get_synced_version()?.map_or(0, |v| v + 1);
         {
             let buffered_state = self.state_store.buffered_state().lock();
             ensure!(
@@ -590,7 +590,7 @@ impl AptosDB {
         version_to_commit: Version,
         txns_to_commit: Option<&[TransactionToCommit]>
     ) -> Result<Option<Version>> {
-        let old_committed_ver = self.ledger_db.metadata_db().get_synced_version_opt()?;
+        let old_committed_ver = self.ledger_db.metadata_db().get_synced_version()?;
         let pre_committed_ver = self.ledger_db.metadata_db().get_pre_committed_version();
         ensure!(
             old_committed_ver.is_none() || version_to_commit >= old_committed_ver.unwrap(),

--- a/storage/aptosdb/src/db/include/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_writer.rs
@@ -354,6 +354,9 @@ impl AptosDB {
         sharded_state_cache: Option<&ShardedStateCache>,
         skip_index_and_usage: bool,
     ) -> Result<()> {
+        if txns_to_commit.is_empty() {
+            return Ok(());
+        }
         let _timer = OTHER_TIMERS_SECONDS
             .with_label_values(&["commit_state_kv_and_ledger_metadata"])
             .start_timer();

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -97,7 +97,8 @@ pub struct AptosDB {
     pub(crate) transaction_store: Arc<TransactionStore>,
     ledger_pruner: LedgerPrunerManager,
     _rocksdb_property_reporter: RocksdbPropertyReporter,
-    ledger_commit_lock: std::sync::Mutex<()>,
+    pre_commit_lock: std::sync::Mutex<()>,
+    commit_lock: std::sync::Mutex<()>,
     indexer: Option<Indexer>,
     skip_index_and_usage: bool,
 }

--- a/storage/aptosdb/src/db_debugger/state_kv/get_value.rs
+++ b/storage/aptosdb/src/db_debugger/state_kv/get_value.rs
@@ -35,7 +35,10 @@ impl Cmd {
 
         let ledger_db = self.db_dir.open_ledger_db()?;
         let db = self.db_dir.open_state_kv_db()?;
-        let latest_version = ledger_db.metadata_db().get_synced_version()?;
+        let latest_version = ledger_db
+            .metadata_db()
+            .get_synced_version()?
+            .expect("DB is empty.");
         println!("latest version: {latest_version}");
         if self.version != Version::MAX && self.version > latest_version {
             println!(

--- a/storage/aptosdb/src/db_debugger/truncate/mod.rs
+++ b/storage/aptosdb/src/db_debugger/truncate/mod.rs
@@ -89,6 +89,7 @@ impl Cmd {
         let overall_version = ledger_db
             .metadata_db()
             .get_synced_version()
+            .expect("DB read failed.")
             .expect("Overall commit progress must exist.");
         let ledger_db_version = ledger_db
             .metadata_db()
@@ -274,7 +275,7 @@ mod test {
                 version += txns_to_commit.len() as u64;
             }
 
-            let db_version = db.get_synced_version().unwrap();
+            let db_version = db.expect_synced_version();
             prop_assert_eq!(db_version, version - 1);
 
             drop(db);
@@ -293,7 +294,7 @@ mod test {
             cmd.run().unwrap();
 
             let db = if input.1 { AptosDB::new_for_test_with_sharding(&tmp_dir, DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD) } else { AptosDB::new_for_test(&tmp_dir) };
-            let db_version = db.get_synced_version().unwrap();
+            let db_version = db.expect_synced_version();
             prop_assert!(db_version <= target_version);
             target_version = db_version;
 

--- a/storage/aptosdb/src/fast_sync_storage_wrapper.rs
+++ b/storage/aptosdb/src/fast_sync_storage_wrapper.rs
@@ -67,7 +67,7 @@ impl FastSyncStorageWrapper {
             && (db_main
                 .ledger_db
                 .metadata_db()
-                .get_synced_version()
+                .get_synced_version()?
                 .map_or(0, |v| v)
                 == 0)
         {

--- a/storage/aptosdb/src/fast_sync_storage_wrapper.rs
+++ b/storage/aptosdb/src/fast_sync_storage_wrapper.rs
@@ -164,27 +164,35 @@ impl DbWriter for FastSyncStorageWrapper {
         Ok(())
     }
 
-    fn save_transactions(
+    fn pre_commit_ledger(
         &self,
         txns_to_commit: &[TransactionToCommit],
         first_version: Version,
         base_state_version: Option<Version>,
-        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
         sync_commit: bool,
         latest_in_memory_state: StateDelta,
         state_updates_until_last_checkpoint: Option<ShardedStateUpdates>,
         sharded_state_cache: Option<&ShardedStateCache>,
     ) -> Result<()> {
-        self.get_aptos_db_write_ref().save_transactions(
+        self.get_aptos_db_write_ref().pre_commit_ledger(
             txns_to_commit,
             first_version,
             base_state_version,
-            ledger_info_with_sigs,
             sync_commit,
             latest_in_memory_state,
             state_updates_until_last_checkpoint,
             sharded_state_cache,
         )
+    }
+
+    fn commit_ledger(
+        &self,
+        version: Version,
+        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        txns_to_commit: Option<&[TransactionToCommit]>,
+    ) -> Result<()> {
+        self.get_aptos_db_write_ref()
+            .commit_ledger(version, ledger_info_with_sigs, txns_to_commit)
     }
 }
 

--- a/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
+++ b/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
@@ -88,13 +88,7 @@ impl LedgerMetadataDb {
         self.db.write_schemas(batch)
     }
 
-    pub(crate) fn get_synced_version(&self) -> Result<Version> {
-        get_progress(&self.db, &DbMetadataKey::OverallCommitProgress)?.ok_or(
-            AptosDbError::NotFound("No OverallCommitProgress in db.".to_string()),
-        )
-    }
-
-    pub(crate) fn get_synced_version_opt(&self) -> Result<Option<Version>> {
+    pub(crate) fn get_synced_version(&self) -> Result<Option<Version>> {
         get_progress(&self.db, &DbMetadataKey::OverallCommitProgress)
     }
 

--- a/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
+++ b/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
@@ -16,12 +16,20 @@ use anyhow::anyhow;
 use aptos_schemadb::{SchemaBatch, DB};
 use aptos_storage_interface::{block_info::BlockInfo, db_ensure as ensure, AptosDbError, Result};
 use aptos_types::{
-    account_config::NewBlockEvent, block_info::BlockHeight, contract_event::ContractEvent,
-    epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
-    state_store::state_storage_usage::StateStorageUsage, transaction::Version,
+    account_config::NewBlockEvent,
+    block_info::BlockHeight,
+    contract_event::ContractEvent,
+    epoch_state::EpochState,
+    ledger_info::LedgerInfoWithSignatures,
+    state_store::state_storage_usage::StateStorageUsage,
+    transaction::{AtomicVersion, Version},
 };
 use arc_swap::ArcSwap;
-use std::{ops::Deref, path::Path, sync::Arc};
+use std::{
+    ops::Deref,
+    path::Path,
+    sync::{atomic::Ordering, Arc},
+};
 
 fn get_latest_ledger_info_in_db_impl(db: &DB) -> Result<Option<LedgerInfoWithSignatures>> {
     let mut iter = db.iter::<LedgerInfoSchema>()?;
@@ -37,16 +45,23 @@ pub(crate) struct LedgerMetadataDb {
     /// cache it in memory in order to avoid reading DB and deserializing the object frequently. It
     /// should be updated every time new ledger info and signatures are persisted.
     latest_ledger_info: ArcSwap<Option<LedgerInfoWithSignatures>>,
+
+    next_pre_commit_version: AtomicVersion,
 }
 
 impl LedgerMetadataDb {
     pub(super) fn new(db: Arc<DB>) -> Self {
-        let ledger_info = get_latest_ledger_info_in_db_impl(&db)
-            .expect("Reading latest ledger info from DB should work.");
+        let latest_ledger_info = get_latest_ledger_info_in_db_impl(&db).expect("DB read failed.");
+        let latest_ledger_info = ArcSwap::from(Arc::new(latest_ledger_info));
+
+        let synced_version =
+            get_progress(&db, &DbMetadataKey::OverallCommitProgress).expect("DB read failed.");
+        let next_pre_commit_version = AtomicVersion::new(synced_version.map_or(0, |v| v + 1));
 
         Self {
             db,
-            latest_ledger_info: ArcSwap::from(Arc::new(ledger_info)),
+            latest_ledger_info,
+            next_pre_commit_version,
         }
     }
 
@@ -79,6 +94,24 @@ impl LedgerMetadataDb {
         )
     }
 
+    pub(crate) fn get_synced_version_opt(&self) -> Result<Option<Version>> {
+        get_progress(&self.db, &DbMetadataKey::OverallCommitProgress)
+    }
+
+    pub(crate) fn get_pre_committed_version(&self) -> Option<Version> {
+        let next_version = self.next_pre_commit_version.load(Ordering::Acquire);
+        if next_version == 0 {
+            None
+        } else {
+            Some(next_version - 1)
+        }
+    }
+
+    pub(crate) fn set_pre_committed_version(&self, version: Version) {
+        self.next_pre_commit_version
+            .store(version + 1, Ordering::Release);
+    }
+
     pub(crate) fn get_ledger_commit_progress(&self) -> Result<Version> {
         get_progress(&self.db, &DbMetadataKey::LedgerCommitProgress)?.ok_or(AptosDbError::NotFound(
             "No LedgerCommitProgress in db.".to_string(),
@@ -99,6 +132,12 @@ impl LedgerMetadataDb {
         let ledger_info_ptr = self.latest_ledger_info.load();
         let ledger_info: &Option<_> = ledger_info_ptr.deref();
         ledger_info.clone()
+    }
+
+    pub(crate) fn get_committed_version(&self) -> Option<Version> {
+        let ledger_info_ptr = self.latest_ledger_info.load();
+        let ledger_info: &Option<_> = ledger_info_ptr.deref();
+        ledger_info.as_ref().map(|li| li.ledger_info().version())
     }
 
     /// Returns the latest ledger info, or NOT_FOUND if it doesn't exist.

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -342,7 +342,10 @@ impl StateStore {
         crash_if_difference_is_too_large: bool,
     ) {
         let ledger_metadata_db = ledger_db.metadata_db();
-        if let Ok(overall_commit_progress) = ledger_metadata_db.get_synced_version() {
+        if let Some(overall_commit_progress) = ledger_metadata_db
+            .get_synced_version()
+            .expect("DB read failed.")
+        {
             info!(
                 overall_commit_progress = overall_commit_progress,
                 "Start syncing databases..."
@@ -440,7 +443,7 @@ impl StateStore {
         let num_transactions = state_db
             .ledger_db
             .metadata_db()
-            .get_synced_version()
+            .get_synced_version()?
             .map_or(0, |v| v + 1);
 
         let latest_snapshot_version = state_db

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -87,7 +87,7 @@ const MAX_WRITE_SETS_AFTER_SNAPSHOT: LeafCount = buffered_state::TARGET_SNAPSHOT
     * (buffered_state::ASYNC_COMMIT_CHANNEL_BUFFER_SIZE + 2 + 1/*  Rendezvous channel */)
     * 2;
 
-pub const MAX_COMMIT_PROGRESS_DIFFERENCE: u64 = 100000;
+pub const MAX_COMMIT_PROGRESS_DIFFERENCE: u64 = 1_000_000;
 
 pub(crate) struct StateDb {
     pub ledger_db: Arc<LedgerDb>,

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -41,7 +41,7 @@ struct TestData {
 
 fn test_data_strategy() -> impl Strategy<Value = TestData> {
     let db = test_execution_with_storage_impl();
-    let latest_ver = db.get_synced_version().unwrap();
+    let latest_ver = db.expect_synced_version();
 
     let latest_epoch_state = db.get_latest_epoch_state().unwrap();
     let epoch_ending_lis = db

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -144,7 +144,7 @@ fn end_to_end() {
         assert_eq!(restore_ws, org_ws);
     }
 
-    assert_eq!(tgt_db.get_synced_version().unwrap(), target_version);
+    assert_eq!(tgt_db.expect_synced_version(), target_version);
     let recovered_transactions = tgt_db
         .get_transactions(
             0,

--- a/storage/indexer/src/db_indexer.rs
+++ b/storage/indexer/src/db_indexer.rs
@@ -347,7 +347,7 @@ impl DBIndexer {
     }
 
     fn get_num_of_transactions(&self, version: Version) -> Result<u64> {
-        let highest_version = self.main_db_reader.get_synced_version()?;
+        let highest_version = self.main_db_reader.ensure_synced_version()?;
         if version > highest_version {
             // In case main db is not synced yet or recreated
             return Ok(0);

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -284,6 +284,11 @@ pub trait DbReader: Send + Sync {
         /// Returns the latest "synced" transaction version, potentially not "committed" yet.
         fn get_synced_version(&self) -> Result<Option<Version>>;
 
+        /// Returns the latest "pre-committed" transaction version, which includes those written to
+        /// the DB but yet to be certified by consensus or a verified LedgerInfo from a state sync
+        /// peer.
+        fn get_pre_committed_version(&self) -> Result<Option<Version>>;
+
         /// Returns the latest state checkpoint version if any.
         fn get_latest_state_checkpoint_version(&self) -> Result<Option<Version>>;
 
@@ -496,6 +501,11 @@ pub trait DbReader: Send + Sync {
     fn expect_synced_version(&self) -> Version {
         self.ensure_synced_version()
             .expect("Failed to get synced version.")
+    }
+
+    fn ensure_pre_committed_version(&self) -> Result<Version> {
+        self.get_pre_committed_version()?
+            .ok_or_else(|| AptosDbError::NotFound("Pre-committed version not found.".to_string()))
     }
 }
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -519,11 +519,7 @@ pub trait DbWriter: Send + Sync {
         unimplemented!()
     }
 
-    /// Persist transactions. Called by the executor module when either syncing nodes or committing
-    /// blocks during normal operation.
-    /// See [`AptosDB::save_transactions`].
-    ///
-    /// [`AptosDB::save_transactions`]: ../aptosdb/struct.AptosDB.html#method.save_transactions
+    /// Persist transactions. Called by state sync to save verified transactions to the DB.
     fn save_transactions(
         &self,
         txns_to_commit: &[TransactionToCommit],
@@ -534,6 +530,67 @@ pub trait DbWriter: Send + Sync {
         latest_in_memory_state: StateDelta,
         state_updates_until_last_checkpoint: Option<ShardedStateUpdates>,
         sharded_state_cache: Option<&ShardedStateCache>,
+    ) -> Result<()> {
+        // For reconfig suffix.
+        if ledger_info_with_sigs.is_none() && txns_to_commit.is_empty() {
+            return Ok(());
+        }
+
+        if !txns_to_commit.is_empty() {
+            self.pre_commit_ledger(
+                txns_to_commit,
+                first_version,
+                base_state_version,
+                sync_commit,
+                latest_in_memory_state,
+                state_updates_until_last_checkpoint,
+                sharded_state_cache,
+            )?;
+        }
+        let version_to_commit = if let Some(ledger_info_with_sigs) = ledger_info_with_sigs {
+            ledger_info_with_sigs.ledger_info().version()
+        } else {
+            // here txns_to_commit is known to be non-empty
+            first_version + txns_to_commit.len() as u64 - 1
+        };
+        self.commit_ledger(
+            version_to_commit,
+            ledger_info_with_sigs,
+            Some(txns_to_commit),
+        )
+    }
+
+    /// Optimistically persist transactions to the ledger.
+    ///
+    /// Called by consensus to pre-commit blocks before execution result is agreed on by the
+    /// validators.
+    ///
+    ///   If these blocks are later confirmed to be included in the ledger, commit_ledger should be
+    ///       called with a `LedgerInfoWithSignatures`.
+    ///   If not, the consensus needs to panic, resulting in a reboot of the node where the DB will
+    ///       truncate the unconfirmed data.
+    fn pre_commit_ledger(
+        &self,
+        txns_to_commit: &[TransactionToCommit],
+        first_version: Version,
+        base_state_version: Option<Version>,
+        sync_commit: bool,
+        latest_in_memory_state: StateDelta,
+        state_updates_until_last_checkpoint: Option<ShardedStateUpdates>,
+        sharded_state_cache: Option<&ShardedStateCache>,
+    ) -> Result<()> {
+        unimplemented!()
+    }
+
+    /// Commit pre-committed transactions to the ledger.
+    ///
+    /// If a LedgerInfoWithSigs is provided, both the "synced version" and "committed version" will
+    /// advance, otherwise only the synced version will advance.
+    fn commit_ledger(
+        &self,
+        version: Version,
+        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        txns_to_commit: Option<&[TransactionToCommit]>,
     ) -> Result<()> {
         unimplemented!()
     }

--- a/storage/storage-interface/src/state_delta.rs
+++ b/storage/storage-interface/src/state_delta.rs
@@ -46,6 +46,17 @@ impl StateDelta {
         }
     }
 
+    pub fn new_with_version(base: Version, current: Version) -> Self {
+        let smt = SparseMerkleTree::new_empty();
+        Self::new(
+            smt.clone(),
+            Some(base),
+            smt,
+            Some(current),
+            create_empty_sharded_state_updates(),
+        )
+    }
+
     pub fn new_empty() -> Self {
         let smt = SparseMerkleTree::new_empty();
         Self::new(

--- a/storage/storage-interface/src/state_delta.rs
+++ b/storage/storage-interface/src/state_delta.rs
@@ -46,17 +46,6 @@ impl StateDelta {
         }
     }
 
-    pub fn new_with_version(base: Version, current: Version) -> Self {
-        let smt = SparseMerkleTree::new_empty();
-        Self::new(
-            smt.clone(),
-            Some(base),
-            smt,
-            Some(current),
-            create_empty_sharded_state_updates(),
-        )
-    }
-
     pub fn new_empty() -> Self {
         let smt = SparseMerkleTree::new_empty();
         Self::new(


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

From DB side, split `save_transactions` to `pre_commit_ledger()` and `commit_ledger()`;
From consensus side, kick off pre_commit when `ledger_update()` is done, and wait on the result in commit stage, before calling the final commit. 

In theory, this improves latency on the critical path by `qc_collection_time - ledger_update_time`, and in the land blocking forge test we see 200ms -ish reduction in latency:

[https://aptoslabs.grafana.net/d/ae591b2c-8a2f-445d-9122-ee53f99400df/end-to-end-txn-lat[…]ace=forge-e2e-pr-14110&var-kubernetes_pod_name=All&orgId=1](https://aptoslabs.grafana.net/d/ae591b2c-8a2f-445d-9122-ee53f99400df/end-to-end-txn-latency?from=1722483649000&to=1722484344000&var-Datasource=fHo-R604z&var-BigQuery=axNEitxVz&var-metrics_source=All&var-chain_name=forge-0&var-cluster=All&var-namespace=forge-e2e-pr-14110&var-kubernetes_pod_name=All&orgId=1)
vs
[https://aptoslabs.grafana.net/d/ae591b2c-8a2f-445d-9122-ee53f99400df/end-to-end-txn-lat[…]ace=forge-e2e-pr-13604&var-kubernetes_pod_name=All&orgId=1](https://aptoslabs.grafana.net/d/ae591b2c-8a2f-445d-9122-ee53f99400df/end-to-end-txn-latency?from=1722963747623&to=1722964179238&var-Datasource=fHo-R604z&var-BigQuery=axNEitxVz&var-metrics_source=All&var-chain_name=forge-0&var-cluster=All&var-namespace=forge-e2e-pr-13604&var-kubernetes_pod_name=All&orgId=1)

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Validator Node

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

unit tests