### PR TITLE
Fix the VerifyError in forge tests

### DIFF
--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -1232,11 +1232,13 @@ impl RoundManager {
             )
             .await
             .context("RoundManager] Failed to process QC in order Cert")?;
-        self.process_certificates().await?;
-        self.block_store
+        let result = self
+            .block_store
             .insert_ordered_cert(&ordered_cert)
             .await
-            .context("[RoundManager] Failed to process a new OrderCert formed by order votes")
+            .context("[RoundManager] Failed to process a new OrderCert formed by order votes");
+        self.process_certificates().await?;
+        result
     }
 
     async fn new_2chain_tc_aggregated(

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -1232,6 +1232,7 @@ impl RoundManager {
             )
             .await
             .context("RoundManager] Failed to process QC in order Cert")?;
+        self.process_certificates().await?;
         self.block_store
             .insert_ordered_cert(&ordered_cert)
             .await


### PR DESCRIPTION
## Description
We've seen `VerifyError { inner: Vote Round should be higher than SyncInfo }` in forge tests. This happens when a validator receives votes and order votes for a round before getting proposal for the round. In this case, the validator has processed the ordered cert before receiving proposal for the round. 

In a regular case, QC for round r is inserted before inserting Ordered cert for round r. But in the above case, it's possible that we call `RoundManager::new_ordered_cert` on round r even before the QC for round r is inserted. In such a case, the `RoundManager::new_ordered_cert` will first insert the QC for round r. But we are not calling the `process_certificates` to increment the round number after this operation. When the validator later gets proposal for round r, the validator will broadcast the vote on round r, and other validators will raise `VerifyError` due to receiving an old vote.

In this PR, we call the `process_certificates` function in `RoundManager::new_ordered_cert` to fix the issue.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
