### PR TITLE
Add speed comparison flags to remote debugger 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3990,9 +3990,7 @@ dependencies = [
  "criterion",
  "criterion-cpu-time",
  "num_cpus",
- "once_cell",
  "proptest",
- "rayon",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2650,6 +2650,7 @@ name = "aptos-move-debugger"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-block-executor",
  "aptos-consensus",
  "aptos-crypto",
  "aptos-gas-profiling",
@@ -2662,6 +2663,7 @@ dependencies = [
  "aptos-vm-types",
  "bcs 0.1.4",
  "clap 4.4.14",
+ "itertools 0.12.1",
  "regex",
  "reqwest",
  "tokio",

--- a/aptos-move/aptos-debugger/Cargo.toml
+++ b/aptos-move/aptos-debugger/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-block-executor = { workspace = true }
 aptos-consensus = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-gas-profiling = { workspace = true }
@@ -26,6 +27,7 @@ aptos-vm-logging = { workspace = true }
 aptos-vm-types = { workspace = true }
 bcs = { workspace = true }
 clap = { workspace = true }
+itertools = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }

--- a/aptos-move/aptos-debugger/src/aptos_debugger.rs
+++ b/aptos-move/aptos-debugger/src/aptos_debugger.rs
@@ -5,21 +5,22 @@ use anyhow::{bail, format_err, Result};
 use aptos_gas_profiling::{GasProfiler, TransactionGasLog};
 use aptos_rest_client::Client;
 use aptos_types::{
-    account_address::AccountAddress,
-    state_store::TStateView,
-    transaction::{
+    account_address::AccountAddress, block_executor::config::{BlockExecutorConfig, BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig}, state_store::TStateView, transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, SignedTransaction,
         Transaction, TransactionInfo, TransactionOutput, TransactionPayload, Version,
-    },
-    vm_status::VMStatus,
+    }, vm_status::VMStatus
 };
 use aptos_validator_interface::{
     AptosValidatorInterface, DBDebuggerInterface, DebuggerStateView, RestDebuggerInterface,
 };
-use aptos_vm::{data_cache::AsMoveResolver, AptosVM, VMExecutor};
+use aptos_vm::{aptos_vm::RAYON_EXEC_POOL, block_executor::{AptosTransactionOutput, BlockAptosVM}, data_cache::AsMoveResolver, AptosVM};
 use aptos_vm_logging::log_schema::AdapterLogSchema;
 use aptos_vm_types::output::VMOutput;
-use std::{path::Path, sync::Arc};
+use std::{path::Path, sync::Arc, time::Instant};
+use itertools::Itertools;
+use aptos_block_executor::txn_commit_hook::NoOpTransactionCommitHook;
+use aptos_types::transaction::BlockOutput;
+
 
 pub struct AptosDebugger {
     debugger: Arc<dyn AptosValidatorInterface + Send>,
@@ -45,32 +46,80 @@ impl AptosDebugger {
         version: Version,
         txns: Vec<Transaction>,
         repeat_execution_times: u64,
+        concurrency_levels: &[usize]
     ) -> Result<Vec<TransactionOutput>> {
         let sig_verified_txns: Vec<SignatureVerifiedTransaction> =
             txns.into_iter().map(|x| x.into()).collect::<Vec<_>>();
         let state_view = DebuggerStateView::new(self.debugger.clone(), version);
 
-        let result = AptosVM::execute_block_no_limit(&sig_verified_txns, &state_view)
-            .map_err(|err| format_err!("Unexpected VM Error: {:?}", err))?;
+        let transaction_types = sig_verified_txns
+            .iter()
+            .map(|txn| txn.expect_valid().type_name().to_string())
+            // conflate same consecutive elements into one with count
+            .group_by(|k| k.clone())
+            .into_iter()
+            .map(|(k, r)| {
+                let num = r.count();
+                if num > 1 { format!("{} {}s", num, k) } else { k }
+            })
+            .collect::<Vec<_>>();
+        let entry_functions = sig_verified_txns
+            .iter()
+            .filter_map(|txn|
+                txn.expect_valid().try_as_signed_user_txn()
+                    .map(|txn| match &txn.payload() {
+                        TransactionPayload::EntryFunction(txn) => format!("entry: {:?}::{:?}", txn.module().name.as_str(), txn.function().as_str()),
+                        TransactionPayload::Script(_) => "script".to_string(),
+                        TransactionPayload::ModuleBundle(_) => panic!("deprecated module bundle"),
+                        TransactionPayload::Multisig(_) => "multisig".to_string(),
+                    })
+            )
+            // Count number of instances for each (irrsepsecitve of order)
+            .sorted()
+            .group_by(|k| k.clone())
+            .into_iter()
+            .map(|(k, r)| (r.count(), k))
+            .sorted_by_key(|(num, _k)| *num)
+            .rev()
+            .map(|(num, k)| if num > 1 { format!("{} {}s", num, k) } else { k })
+            .collect::<Vec<_>>();
+        println!("[{} txns from {}] Transaction types: {:?}", sig_verified_txns.len(), version, transaction_types);
+        println!("[{} txns from {}] Entry Functions {:?}", sig_verified_txns.len(), version, entry_functions);
 
-        for i in 1..repeat_execution_times {
-            let repeat_result = AptosVM::execute_block_no_limit(&sig_verified_txns, &state_view)
-                .map_err(|err| format_err!("Unexpected VM Error: {:?}", err))?;
-            println!(
-                "Finished execution round {}/{} with {} transactions",
-                i,
-                repeat_execution_times,
-                sig_verified_txns.len()
-            );
-            if !Self::ensure_output_matches(&repeat_result, &result, version) {
-                bail!(
-                    "Execution result mismatched in round {}/{}",
-                    i,
-                    repeat_execution_times
+        let mut result = None;
+
+        for concurrency_level in concurrency_levels {
+            for i in 0..repeat_execution_times {
+                let start_time = Instant::now();
+                let cur_result = execute_block_no_limit(&sig_verified_txns, &state_view, *concurrency_level)
+                    .map_err(|err| format_err!("Unexpected VM Error: {:?}", err))?;
+
+                println!(
+                    "[{} txns from {}] Finished execution round {}/{} with concurrency_level={} in {}ms",
+                    sig_verified_txns.len(),
+                    version,
+                    i + 1,
+                    repeat_execution_times,
+                    concurrency_level,
+                    start_time.elapsed().as_millis(),
                 );
+
+                match &result {
+                    None => result = Some(cur_result),
+                    Some(prev_result) => {
+                        if !Self::ensure_output_matches(&cur_result, prev_result, version) {
+                            bail!(
+                                "Execution result mismatched in round {}/{}",
+                                i,
+                                repeat_execution_times
+                            );
+                        }
+                    }
+                }
             }
         }
-        Ok(result)
+
+        Ok(result.unwrap())
     }
 
     pub fn execute_transaction_at_version_with_gas_profiler(
@@ -123,31 +172,43 @@ impl AptosDebugger {
         &self,
         mut begin: Version,
         mut limit: u64,
+        use_same_block_boundaries: bool,
         repeat_execution_times: u64,
+        concurrency_levels: &[usize],
     ) -> Result<Vec<TransactionOutput>> {
         let (mut txns, mut txn_infos) = self
             .debugger
             .get_committed_transactions(begin, limit)
             .await?;
 
-        let mut ret = vec![];
-        while limit != 0 {
-            println!(
-                "Starting epoch execution at {:?}, {:?} transactions remaining",
-                begin, limit
-            );
-            let mut epoch_result = self
-                .execute_transactions_by_epoch(begin, txns.clone(), repeat_execution_times)
-                .await?;
-            begin += epoch_result.len() as u64;
-            limit -= epoch_result.len() as u64;
-            txns = txns.split_off(epoch_result.len());
-            let epoch_txn_infos = txn_infos.drain(0..epoch_result.len()).collect::<Vec<_>>();
-            Self::print_mismatches(&epoch_result, &epoch_txn_infos, begin);
+        if use_same_block_boundaries {
+            // when going block by block, no need to worry about epoch boundaries
+            // as new epoch is always a new block.
+            Ok(self
+                .execute_transactions_by_block(begin, txns.clone(), repeat_execution_times, concurrency_levels)
+                .await?)
+        } else {
+            let mut ret = vec![];
+            while limit != 0 {
+                println!(
+                    "Starting epoch execution at {:?}, {:?} transactions remaining",
+                    begin, limit
+                );
 
-            ret.append(&mut epoch_result);
+                let mut epoch_result =
+                     self
+                        .execute_transactions_by_epoch(begin, txns.clone(), repeat_execution_times, concurrency_levels)
+                        .await?;
+                begin += epoch_result.len() as u64;
+                limit -= epoch_result.len() as u64;
+                txns = txns.split_off(epoch_result.len());
+                let epoch_txn_infos = txn_infos.drain(0..epoch_result.len()).collect::<Vec<_>>();
+                Self::print_mismatches(&epoch_result, &epoch_txn_infos, begin);
+
+                ret.append(&mut epoch_result);
+            }
+            Ok(ret)
         }
-        Ok(ret)
     }
 
     fn print_mismatches(
@@ -191,8 +252,9 @@ impl AptosDebugger {
         begin: Version,
         txns: Vec<Transaction>,
         repeat_execution_times: u64,
+        concurrency_levels: &[usize]
     ) -> Result<Vec<TransactionOutput>> {
-        let results = self.execute_transactions_at_version(begin, txns, repeat_execution_times)?;
+        let results = self.execute_transactions_at_version(begin, txns, repeat_execution_times, concurrency_levels)?;
         let mut ret = vec![];
         let mut is_reconfig = false;
 
@@ -205,6 +267,34 @@ impl AptosDebugger {
             }
             ret.push(result)
         }
+        Ok(ret)
+    }
+
+    pub async fn execute_transactions_by_block(
+        &self,
+        begin: Version,
+        txns: Vec<Transaction>,
+        repeat_execution_times: u64,
+        concurrency_levels: &[usize],
+    ) -> Result<Vec<TransactionOutput>> {
+        let mut ret = vec![];
+        let mut cur = vec![];
+        let mut cur_version = begin;
+        for txn in txns {
+            if txn.try_as_block_metadata().is_some() || txn.try_as_block_metadata_ext().is_some() {
+                if !cur.is_empty() {
+                    let results = self.execute_transactions_at_version(cur_version, cur.clone(), repeat_execution_times, concurrency_levels)?;
+                    assert_eq!(cur.len(), results.len());
+                    cur_version += results.len() as u64;
+                    ret.extend(results);
+                    cur.clear();
+                }
+            }
+            cur.push(txn);
+        }
+        let results = self.execute_transactions_at_version(cur_version, cur, repeat_execution_times, concurrency_levels)?;
+        ret.extend(results);
+
         Ok(ret)
     }
 
@@ -243,4 +333,22 @@ fn is_reconfiguration(vm_output: &TransactionOutput) -> bool {
         .events()
         .iter()
         .any(|event| event.event_key() == Some(&new_epoch_event_key))
+}
+
+fn execute_block_no_limit(sig_verified_txns: &[SignatureVerifiedTransaction], state_view: &DebuggerStateView, concurrency_level: usize) -> Result<Vec<TransactionOutput>, VMStatus> {
+    BlockAptosVM::execute_block::<_, NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>>(
+        Arc::clone(&RAYON_EXEC_POOL),
+        sig_verified_txns,
+        state_view,
+        BlockExecutorConfig {
+            local: BlockExecutorLocalConfig {
+                concurrency_level,
+                allow_fallback: true,
+                discard_failed_blocks: false,
+            },
+            onchain: BlockExecutorConfigFromOnchain::new_no_block_limit(),
+        },
+        None,
+    )
+    .map(BlockOutput::into_transaction_outputs_forced)
 }

--- a/aptos-move/aptos-debugger/src/bcs_txn_decoder.rs
+++ b/aptos-move/aptos-debugger/src/bcs_txn_decoder.rs
@@ -70,7 +70,9 @@ impl Command {
             println!("===============================");
             println!(
                 "{:#?}",
-                debugger.execute_past_transactions(version, 1, false, 1, &[self.concurrency_level]).await?
+                debugger
+                    .execute_past_transactions(version, 1, false, 1, &[self.concurrency_level])
+                    .await?
             );
         }
 

--- a/aptos-move/aptos-debugger/src/bcs_txn_decoder.rs
+++ b/aptos-move/aptos-debugger/src/bcs_txn_decoder.rs
@@ -5,7 +5,6 @@ use crate::aptos_debugger::AptosDebugger;
 use anyhow::Result;
 use aptos_rest_client::Client;
 use aptos_types::transaction::SignedTransaction;
-use aptos_vm::AptosVM;
 use clap::Parser;
 use regex::Regex;
 use std::io;
@@ -65,14 +64,13 @@ impl Command {
         );
 
         if self.execute {
-            AptosVM::set_concurrency_level_once(self.concurrency_level);
             println!();
             println!("===============================");
             println!("Transaction re-execution result");
             println!("===============================");
             println!(
                 "{:#?}",
-                debugger.execute_past_transactions(version, 1, 1).await?
+                debugger.execute_past_transactions(version, 1, false, 1, &[self.concurrency_level]).await?
             );
         }
 

--- a/aptos-move/aptos-debugger/src/common.rs
+++ b/aptos-move/aptos-debugger/src/common.rs
@@ -27,8 +27,8 @@ pub struct Opts {
     #[clap(flatten)]
     pub(crate) target: Target,
 
-    #[clap(long, default_value_t = 1)]
-    pub(crate) concurrency_level: usize,
+    #[clap(long, num_args = 0..)]
+    pub(crate) concurrency_level: Vec<usize>,
 }
 
 #[derive(Parser)]

--- a/aptos-move/aptos-debugger/src/execute_past_transactions.rs
+++ b/aptos-move/aptos-debugger/src/execute_past_transactions.rs
@@ -4,7 +4,6 @@
 use crate::{aptos_debugger::AptosDebugger, common::Opts};
 use anyhow::Result;
 use aptos_rest_client::Client;
-use aptos_vm::AptosVM;
 use clap::Parser;
 use url::Url;
 
@@ -24,12 +23,13 @@ pub struct Command {
 
     #[clap(long)]
     repeat_execution_times: Option<u64>,
+
+    #[clap(long)]
+    use_same_block_boundaries: bool,
 }
 
 impl Command {
     pub async fn run(self) -> Result<()> {
-        AptosVM::set_concurrency_level_once(self.opts.concurrency_level);
-
         let debugger = if let Some(rest_endpoint) = self.opts.target.rest_endpoint {
             AptosDebugger::rest_client(Client::new(Url::parse(&rest_endpoint)?))?
         } else if let Some(db_path) = self.opts.target.db_path {
@@ -42,7 +42,9 @@ impl Command {
             .execute_past_transactions(
                 self.begin_version,
                 self.limit,
+                self.use_same_block_boundaries,
                 self.repeat_execution_times.unwrap_or(1),
+                &self.opts.concurrency_level,
             )
             .await?;
 

--- a/aptos-move/aptos-debugger/src/execute_pending_block.rs
+++ b/aptos-move/aptos-debugger/src/execute_pending_block.rs
@@ -6,7 +6,6 @@ use anyhow::Result;
 use aptos_crypto::HashValue;
 use aptos_logger::info;
 use aptos_rest_client::Client;
-use aptos_vm::AptosVM;
 use clap::Parser;
 use std::path::PathBuf;
 use url::Url;
@@ -42,8 +41,6 @@ pub struct Command {
 
 impl Command {
     pub async fn run(self) -> Result<()> {
-        AptosVM::set_concurrency_level_once(self.opts.concurrency_level);
-
         let debugger = if let Some(rest_endpoint) = self.opts.target.rest_endpoint {
             AptosDebugger::rest_client(Client::new(Url::parse(&rest_endpoint)?))?
         } else if let Some(db_path) = self.opts.target.db_path {
@@ -91,6 +88,7 @@ impl Command {
             self.begin_version,
             block,
             self.repeat_execution_times.unwrap_or(1),
+            &self.opts.concurrency_level,
         )?;
         println!("{txn_outputs:#?}");
 

--- a/aptos-move/aptos-transaction-benchmarks/Cargo.toml
+++ b/aptos-move/aptos-transaction-benchmarks/Cargo.toml
@@ -29,9 +29,7 @@ clap = { workspace = true }
 criterion = { workspace = true, features = ["html_reports"] }
 criterion-cpu-time = { workspace = true }
 num_cpus = { workspace = true }
-once_cell = { workspace = true }
 proptest = { workspace = true }
-rayon = { workspace = true }
 
 [[bench]]
 name = "transaction_benches"

--- a/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{transactions, transactions::RAYON_EXEC_POOL};
+use crate::transactions;
 use aptos_bitvec::BitVec;
 use aptos_block_executor::txn_commit_hook::NoOpTransactionCommitHook;
 use aptos_block_partitioner::{
@@ -216,7 +216,6 @@ where
             _,
             NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
         >(
-            Arc::clone(&RAYON_EXEC_POOL),
             transactions,
             self.state_view.as_ref(),
             BlockExecutorConfig::new_maybe_block_limit(1, maybe_block_gas_limit),
@@ -265,7 +264,6 @@ where
             _,
             NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
         >(
-            Arc::clone(&RAYON_EXEC_POOL),
             transactions,
             self.state_view.as_ref(),
             BlockExecutorConfig::new_maybe_block_limit(

--- a/aptos-move/aptos-transaction-benchmarks/src/transactions.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transactions.rs
@@ -13,19 +13,8 @@ use aptos_language_e2e_tests::{
     gas_costs::TXN_RESERVED,
 };
 use criterion::{measurement::Measurement, BatchSize, Bencher};
-use once_cell::sync::Lazy;
 use proptest::strategy::Strategy;
-use std::{net::SocketAddr, sync::Arc};
-
-pub static RAYON_EXEC_POOL: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .thread_name(|index| format!("par_exec_{}", index))
-            .build()
-            .unwrap(),
-    )
-});
+use std::net::SocketAddr;
 
 /// Benchmarking support for transactions.
 #[derive(Clone)]

--- a/aptos-move/aptos-validator-interface/src/lib.rs
+++ b/aptos-move/aptos-validator-interface/src/lib.rs
@@ -11,8 +11,7 @@ use aptos_framework::natives::code::PackageMetadata;
 use aptos_types::{
     account_address::AccountAddress,
     state_store::{
-        state_key::StateKey, state_storage_usage::StateStorageUsage, state_value::StateValue,
-        Result as StateViewResult, TStateView,
+        state_key::StateKey, state_storage_usage::StateStorageUsage, state_value::StateValue, Result as StateViewResult, StateViewId, TStateView
     },
     transaction::{Transaction, TransactionInfo, Version},
 };
@@ -159,6 +158,10 @@ impl DebuggerStateView {
 
 impl TStateView for DebuggerStateView {
     type Key = StateKey;
+
+    fn id(&self) -> StateViewId {
+        StateViewId::Replay
+    }
 
     fn get_state_value(&self, state_key: &StateKey) -> StateViewResult<Option<StateValue>> {
         self.get_state_value_internal(state_key, self.version)

--- a/aptos-move/aptos-validator-interface/src/lib.rs
+++ b/aptos-move/aptos-validator-interface/src/lib.rs
@@ -11,7 +11,8 @@ use aptos_framework::natives::code::PackageMetadata;
 use aptos_types::{
     account_address::AccountAddress,
     state_store::{
-        state_key::StateKey, state_storage_usage::StateStorageUsage, state_value::StateValue, Result as StateViewResult, StateViewId, TStateView
+        state_key::StateKey, state_storage_usage::StateStorageUsage, state_value::StateValue,
+        Result as StateViewResult, StateViewId, TStateView,
     },
     transaction::{Transaction, TransactionInfo, Version},
 };

--- a/aptos-move/aptos-vm-logging/src/log_schema.rs
+++ b/aptos-move/aptos-vm-logging/src/log_schema.rs
@@ -52,7 +52,14 @@ impl AdapterLogSchema {
                 base_version: Some(base_version),
                 txn_idx,
             },
-            StateViewId::Miscellaneous | StateViewId::Replay => Self {
+            StateViewId::Replay => Self {
+                name: LogEntry::Execution,
+                block_id: None,
+                first_version: None,
+                base_version: None,
+                txn_idx,
+            },
+            StateViewId::Miscellaneous => Self {
                 name: LogEntry::Miscellaneous,
                 block_id: None,
                 first_version: None,

--- a/aptos-move/aptos-vm-logging/src/log_schema.rs
+++ b/aptos-move/aptos-vm-logging/src/log_schema.rs
@@ -52,7 +52,7 @@ impl AdapterLogSchema {
                 base_version: Some(base_version),
                 txn_idx,
             },
-            StateViewId::Miscellaneous => Self {
+            StateViewId::Miscellaneous | StateViewId::Replay => Self {
                 name: LogEntry::Miscellaneous,
                 block_id: None,
                 first_version: None,

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -101,7 +101,7 @@ use move_vm_runtime::{
 };
 use move_vm_types::gas::{GasMeter, UnmeteredGasMeter};
 use num_cpus;
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::OnceCell;
 use std::{
     cmp::{max, min},
     collections::{BTreeMap, BTreeSet},
@@ -114,17 +114,6 @@ static NUM_EXECUTION_SHARD: OnceCell<usize> = OnceCell::new();
 static NUM_PROOF_READING_THREADS: OnceCell<usize> = OnceCell::new();
 static DISCARD_FAILED_BLOCKS: OnceCell<bool> = OnceCell::new();
 static PROCESSED_TRANSACTIONS_DETAILED_COUNTERS: OnceCell<bool> = OnceCell::new();
-
-// TODO: Don't expose this in AptosVM, and use only in BlockAptosVM!
-pub static RAYON_EXEC_POOL: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
-    Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .thread_name(|index| format!("par_exec-{}", index))
-            .build()
-            .unwrap(),
-    )
-});
 
 macro_rules! deprecated_module_bundle {
     () => {
@@ -2513,7 +2502,6 @@ impl VMExecutor for AptosVM {
             _,
             NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
         >(
-            Arc::clone(&RAYON_EXEC_POOL),
             transactions,
             state_view,
             BlockExecutorConfig {

--- a/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
+++ b/aptos-move/aptos-vm/src/sharded_block_executor/sharded_executor_service.rs
@@ -135,7 +135,7 @@ impl<S: StateView + Sync + Send + 'static> ShardedExecutorService<S> {
                 );
             });
             s.spawn(move |_| {
-                let ret = BlockAptosVM::execute_block(
+                let ret = BlockAptosVM::execute_block_on_thread_pool(
                     executor_thread_pool,
                     &signature_verified_transactions,
                     aggr_overridden_state_view.as_ref(),

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -464,6 +464,7 @@ where
         shared_counter: &AtomicU32,
         executor: &E,
         block: &[T],
+        num_workers: usize,
     ) -> Result<(), PanicOr<ParallelBlockExecutionError>> {
         let mut block_limit_processor = shared_commit_state.acquire();
 
@@ -592,6 +593,7 @@ where
                     block_limit_processor.finish_parallel_update_counters_and_log_info(
                         txn_idx + 1,
                         scheduler.num_txns(),
+                        num_workers,
                     );
 
                     // failpoint triggering error at the last committed transaction,
@@ -756,6 +758,7 @@ where
         shared_counter: &AtomicU32,
         shared_commit_state: &ExplicitSyncWrapper<BlockGasLimitProcessor<T>>,
         final_results: &ExplicitSyncWrapper<Vec<E::Output>>,
+        num_workers: usize,
     ) -> Result<(), PanicOr<ParallelBlockExecutionError>> {
         // Make executor for each task. TODO: fast concurrent executor.
         let init_timer = VM_INIT_SECONDS.start_timer();
@@ -795,6 +798,7 @@ where
                     shared_counter,
                     &executor,
                     block,
+                    num_workers,
                 )?;
                 scheduler.queueing_commits_mark_done();
             }
@@ -883,7 +887,7 @@ where
         }
 
         let num_txns = signature_verified_block.len();
-        let concurrency_level = self.config.local.concurrency_level.min(num_txns / 2).max(2);
+        let num_workers = self.config.local.concurrency_level.min(num_txns / 2).max(2);
 
         let shared_commit_state = ExplicitSyncWrapper::new(BlockGasLimitProcessor::new(
             self.config.onchain.block_gas_limit_type.clone(),
@@ -906,7 +910,7 @@ where
 
         let timer = RAYON_EXECUTION_SECONDS.start_timer();
         self.executor_thread_pool.scope(|s| {
-            for _ in 0..concurrency_level {
+            for _ in 0..num_workers {
                 s.spawn(|_| {
                     if let Err(err) = self.worker_loop(
                         env,
@@ -919,6 +923,7 @@ where
                         &shared_counter,
                         &shared_commit_state,
                         &final_results,
+                        num_workers,
                     ) {
                         // If there are multiple errors, they all get logged:
                         // ModulePathReadWriteError and FatalVMError variant is logged at construction,

--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -1,6 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Instant;
+
 use crate::{counters, types::ReadWriteSummary};
 use aptos_logger::info;
 use aptos_types::{
@@ -18,6 +20,7 @@ pub struct BlockGasLimitProcessor<T: Transaction> {
     txn_fee_statements: Vec<FeeStatement>,
     txn_read_write_summaries: Vec<ReadWriteSummary<T>>,
     module_rw_conflict: bool,
+    start_time: Instant,
 }
 
 impl<T: Transaction> BlockGasLimitProcessor<T> {
@@ -30,6 +33,7 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
             txn_fee_statements: Vec::with_capacity(init_size),
             txn_read_write_summaries: Vec::with_capacity(init_size),
             module_rw_conflict: false,
+            start_time: Instant::now(),
         }
     }
 
@@ -216,7 +220,7 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
                 .block_gas_limit_type
                 .block_output_limit()
                 .map_or(false, |limit| accumulated_approx_output_size >= limit),
-            "[BlockSTM]: {} execution completed. {} out of {} txns committed",
+            "[BlockSTM]: {} execution completed. {} out of {} txns committed, took {}ms",
             if is_parallel {
                 "Parallel"
             } else {
@@ -224,6 +228,7 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
             },
             num_committed,
             num_total,
+            self.start_time.elapsed().as_millis(),
         );
     }
 

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -533,7 +533,7 @@ impl FakeExecutor {
             },
             onchain: onchain_config,
         };
-        BlockAptosVM::execute_block::<
+        BlockAptosVM::execute_block_on_thread_pool::<
             _,
             NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
         >(

--- a/testsuite/smoke-test/src/aptos/mint_transfer.rs
+++ b/testsuite/smoke-test/src/aptos/mint_transfer.rs
@@ -81,7 +81,7 @@ async fn test_mint_transfer() {
         .unwrap();
 
     let output = debugger
-        .execute_past_transactions(txn_ver, 1, 1)
+        .execute_past_transactions(txn_ver, 1, false, 1, &[1])
         .await
         .unwrap()
         .pop()

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -67,6 +67,7 @@ pub enum StateViewId {
     TransactionValidation { base_version: Version },
     /// For test, db-bootstrapper, etc. Usually not aimed to pass to VM.
     Miscellaneous,
+    Replay,
 }
 
 impl<R, S, K> TStateView for R

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -60,11 +60,17 @@ impl<T: TStateView<Key = StateKey>> StateView for T {}
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum StateViewId {
     /// State-sync applying a chunk of transactions.
-    ChunkExecution { first_version: Version },
+    ChunkExecution {
+        first_version: Version,
+    },
     /// LEC applying a block.
-    BlockExecution { block_id: HashValue },
+    BlockExecution {
+        block_id: HashValue,
+    },
     /// VmValidator verifying incoming transaction.
-    TransactionValidation { base_version: Version },
+    TransactionValidation {
+        base_version: Version,
+    },
     /// For test, db-bootstrapper, etc. Usually not aimed to pass to VM.
     Miscellaneous,
     Replay,

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -2020,6 +2020,17 @@ impl Transaction {
             | Transaction::ValidatorTransaction(_) => false,
         }
     }
+
+    pub fn is_block_start(&self) -> bool {
+        match self {
+            Transaction::BlockMetadata(_) | Transaction::BlockMetadataExt(_) => true,
+            Transaction::StateCheckpoint(_)
+            | Transaction::BlockEpilogue(_)
+            | Transaction::UserTransaction(_)
+            | Transaction::GenesisTransaction(_)
+            | Transaction::ValidatorTransaction(_) => false,
+        }
+    }
 }
 
 impl TryFrom<Transaction> for SignedTransaction {


### PR DESCRIPTION
being able to use:
 --use-same-block-boundaries --concurrency-level=1 --concurrency-level=4 --concurrency-level=8 --concurrency-leve
l=16 --concurrency-level=32 --concurrency-level=48
and compare speeds as well.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
