### PR TITLE
[move cli] prevent publishing empty package

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -697,6 +697,13 @@ impl TryInto<PackagePublicationData> for &PublishPackage {
             );
         let package = BuiltPackage::build(package_path, options)
             .map_err(|e| CliError::MoveCompilationError(format!("{:#}", e)))?;
+
+        if package.package.root_compiled_units.is_empty() {
+            return Err(CliError::MoveCompilationError(
+                "prevent publishing the package with no modules".to_string(),
+            ));
+        }
+
         let compiled_units = package.extract_code();
         let metadata_serialized =
             bcs::to_bytes(&package.extract_metadata()?).expect("PackageMetadata has BCS");


### PR DESCRIPTION
## Description
prevent user from publishing empty package
issue link:https://github.com/aptos-labs/aptos-core/issues/12743

impl detail and error message fomat:
- check `compiled units` when publishing package, reject to build `PublishPackage`  if  `compiled units` is empty.
- return Error message as below:
```shell
Compiling, may take a little while to download git dependencies...
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING xxxx<br>
{
  "Error": "Move compilation failed: prevent publishing the package with no modules"
}
````

<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [X] Bug fix

## Which Components or Systems Does This Change Impact?
- [X] Aptos CLI/SDK

## How Has This Been Tested?
- create sample move module dir
  -  add Move.toml
  - mkdir sources, but without move file in the directory
- run cli command: `aptos move pulish ....`
- check if cli return error with message to indicate prohibit publishing empty package

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

<!-- Thank you for your contribution! -->
