### PR TITLE
[Compiler-v2] Check `dummy_field` in a struct

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/typing/dummy_field.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/dummy_field.exp
@@ -1,0 +1,38 @@
+// -- Model dump before bytecode pipeline
+module 0x42::test {
+    struct T {
+        dummy_field: bool,
+    }
+    struct R {
+        dummy_field: bool,
+    }
+    public entry fun test(addr: address)
+        acquires test::R(*)
+     {
+        {
+          let test::R{ dummy_field: _dummy_field } = MoveFrom<test::R>(addr);
+          Tuple()
+        }
+    }
+    private fun test2(): bool {
+        {
+          let r: test::R = pack test::R(true);
+          select test::R.dummy_field<test::R>(r)
+        }
+    }
+    public entry fun test3(addr: address)
+        acquires test::T(*)
+     {
+        {
+          let test::T{ dummy_field: _ } = MoveFrom<test::T>(addr);
+          Tuple()
+        }
+    }
+    public entry fun test4(s: &signer) {
+        {
+          let r: test::T = pack test::T(false);
+          MoveTo<test::T>(s, r);
+          Tuple()
+        }
+    }
+} // end 0x42::test

--- a/third_party/move/move-compiler-v2/tests/checking/typing/dummy_field.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/dummy_field.move
@@ -1,0 +1,30 @@
+module 0x42::test {
+
+    struct R has store, key, drop {
+        dummy_field: bool,
+    }
+
+    public entry fun test(addr: address) acquires R {
+        let R { dummy_field: _dummy_field  } = move_from<R>(addr);
+    }
+
+    fun test2(): bool {
+        let r = R {
+            dummy_field: true
+        };
+        r.dummy_field
+    }
+
+    struct T has store, key, drop {
+    }
+
+    public entry fun test3(addr: address) acquires T {
+        let T {  } = move_from<T>(addr);
+    }
+
+    public entry fun test4(s: &signer) {
+        let r = T {};
+        move_to<T>(s, r);
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/checking/typing/dummy_field_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/dummy_field_err.exp
@@ -1,0 +1,43 @@
+
+Diagnostics:
+error: missing field `dummy_field`
+  ┌─ tests/checking/typing/dummy_field_err.move:8:13
+  │
+8 │         let R {  } = move_from<R>(addr);
+  │             ^^^^^^
+
+error: missing field `dummy_field`
+   ┌─ tests/checking/typing/dummy_field_err.move:12:17
+   │
+12 │         let r = R {};
+   │                 ^^^^
+
+error: field `dummy_field` not declared in `test::T`
+   ┌─ tests/checking/typing/dummy_field_err.move:20:17
+   │
+20 │         let T { dummy_field } = move_from<T>(addr);
+   │                 ^^^^^^^^^^^
+
+error: empty struct `test::T` cannot access the field `dummy_field`
+   ┌─ tests/checking/typing/dummy_field_err.move:26:9
+   │
+26 │         t.dummy_field
+   │         ^^^^^^^^^^^^^
+
+error: missing field `dummy_field_1`
+   ┌─ tests/checking/typing/dummy_field_err.move:34:13
+   │
+34 │         let G {  } = move_from<G>(addr);
+   │             ^^^^^^
+
+error: missing field `dummy_field_1`
+   ┌─ tests/checking/typing/dummy_field_err.move:38:17
+   │
+38 │         let r = G {};
+   │                 ^^^^
+
+error: empty struct `test::A` cannot access the field `dummy_field`
+   ┌─ tests/checking/typing/dummy_field_err.move:47:17
+   │
+47 │         let x = a.dummy_field;
+   │                 ^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/dummy_field_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/dummy_field_err.move
@@ -1,0 +1,52 @@
+module 0x42::test {
+
+    struct R has store, key, drop {
+        dummy_field: bool,
+    }
+
+    public entry fun test(addr: address) acquires R {
+        let R {  } = move_from<R>(addr);
+    }
+
+    public entry fun test2(s: &signer) {
+        let r = R {};
+        move_to<R>(s, r);
+    }
+
+    struct T has store, key, drop {
+    }
+
+    public entry fun test3(addr: address) acquires T {
+        let T { dummy_field } = move_from<T>(addr);
+    }
+
+    fun test4(): bool {
+        let t = T {
+        };
+        t.dummy_field
+    }
+
+    struct G has store, key, drop {
+        dummy_field_1: bool,
+    }
+
+    public entry fun test5(addr: address) acquires G {
+        let G {  } = move_from<G>(addr);
+    }
+
+    public entry fun test6(s: &signer) {
+        let r = G {};
+        move_to<G>(s, r);
+    }
+
+    struct A has key, drop {
+    }
+
+    public fun test7(input: address): bool acquires A {
+        let a = move_from(input);
+        let x = a.dummy_field;
+        let A {} = a;
+        x
+    }
+
+}

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -124,6 +124,9 @@ pub(crate) struct StructEntry {
     /// Maps simple function names to the qualified symbols of receiver functions. The
     /// symbol can be used to index the global function table.
     pub receiver_functions: BTreeMap<Symbol, QualifiedSymbol>,
+    /// Whether the struct is originally empty
+    /// always false when it is enum
+    pub is_empty_struct: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -361,6 +364,7 @@ impl<'env> ModelBuilder<'env> {
             type_params,
             layout,
             receiver_functions: BTreeMap::new(),
+            is_empty_struct: false,
         };
         self.struct_table.insert(name.clone(), entry);
         self.reverse_struct_table
@@ -547,6 +551,11 @@ impl<'env> ModelBuilder<'env> {
     /// Looks up the StructEntry for a qualified id.
     pub fn lookup_struct_entry(&self, id: QualifiedId<StructId>) -> &StructEntry {
         let struct_name = self.get_struct_name(id);
+        self.lookup_struct_entry_by_name(struct_name)
+    }
+
+    /// Looks up the StructEntry by `struct_name`
+    pub fn lookup_struct_entry_by_name(&self, struct_name: &QualifiedSymbol) -> &StructEntry {
         self.struct_table
             .get(struct_name)
             .expect("invalid Type::Struct")


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR adds a new bool field `is_empty_struct` to `StructEntry` to indicate whether the struct does not have any fields. With this field, 

- if a user defines a struct with the field `dummy_field`, packing and unpacking without any fields will raise an error;
- accessing `dummy_field` from an empty struct will raise an error.


close #13594 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

1) Existing tests pass;
2) Add a new test `dummy_field.move`. 

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

Whether the added logic will break how struct fields are generally checked.


## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
