### PR TITLE
[cli] Add balance command to make it easier to lookup balances

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Add balance command to easily get account balances for APT currently
 
 ## [3.4.1] - 2024/05/31
 - Upgraded indexer processors for localnet from ca60e51b53c3be6f9517de7c73d4711e9c1f7236 to 5244b84fa5ed872e5280dc8df032d744d62ad29d. Upgraded Hasura metadata accordingly.

--- a/crates/aptos/src/account/balance.rs
+++ b/crates/aptos/src/account/balance.rs
@@ -1,0 +1,97 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::types::{
+    CliCommand, CliConfig, CliError, CliTypedResult, ConfigSearchMode, ProfileOptions, RestOptions,
+};
+use aptos_api_types::ViewFunction;
+use aptos_types::{account_address::AccountAddress, APTOS_COIN_TYPE};
+use async_trait::async_trait;
+use clap::Parser;
+use move_core_types::{ident_str, language_storage::ModuleId, parser::parse_type_tag};
+use serde::Serialize;
+
+/// Show the account's balance of different coins
+///
+/// TODO: Fungible assets
+#[derive(Debug, Parser)]
+pub struct Balance {
+    /// Address of the account you want to list resources/modules/balance for
+    #[clap(long, value_parser = crate::common::types::load_account_arg)]
+    pub(crate) account: Option<AccountAddress>,
+
+    /// Coin type to lookup.  Defaults to 0x1::aptos_coin::AptosCoin
+    #[clap(long)]
+    pub(crate) coin_type: Option<String>,
+
+    #[clap(flatten)]
+    pub(crate) rest_options: RestOptions,
+    #[clap(flatten)]
+    pub(crate) profile_options: ProfileOptions,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AccountBalance {
+    asset_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    coin_type: Option<String>,
+    balance: u64,
+}
+
+#[async_trait]
+impl CliCommand<Vec<AccountBalance>> for Balance {
+    fn command_name(&self) -> &'static str {
+        "Balance"
+    }
+
+    async fn execute(self) -> CliTypedResult<Vec<AccountBalance>> {
+        let account = if let Some(account) = self.account {
+            account
+        } else if let Some(Some(account)) = CliConfig::load_profile(
+            self.profile_options.profile_name(),
+            ConfigSearchMode::CurrentDirAndParents,
+        )?
+        .map(|p| p.account)
+        {
+            account
+        } else {
+            return Err(CliError::CommandArgumentError(
+                "Please provide an account using --account or run aptos init".to_string(),
+            ));
+        };
+
+        let coin_type = if let Some(coin) = self.coin_type {
+            parse_type_tag(&coin).map_err(|err| {
+                CliError::CommandArgumentError(format!("Invalid coin type '{}': {:#?}", coin, err))
+            })?
+        } else {
+            // If nothing is given, use the default APT
+            APTOS_COIN_TYPE.to_owned()
+        };
+
+        let client = self.rest_options.client(&self.profile_options)?;
+        let response = client
+            .view_bcs_with_json_response(
+                &ViewFunction {
+                    module: ModuleId::new(AccountAddress::ONE, ident_str!("coin").to_owned()),
+                    function: ident_str!("balance").to_owned(),
+                    ty_args: vec![coin_type.clone()],
+                    args: vec![account.to_vec()],
+                },
+                None,
+            )
+            .await?;
+
+        let balance = response.inner()[0]
+            .as_str()
+            .unwrap()
+            .parse::<u64>()
+            .unwrap();
+
+        return Ok(vec![AccountBalance {
+            asset_type: "coin".to_string(),
+            coin_type: Some(coin_type.to_string()),
+            balance,
+        }]);
+    }
+}

--- a/crates/aptos/src/account/mod.rs
+++ b/crates/aptos/src/account/mod.rs
@@ -4,6 +4,7 @@
 use crate::common::types::{CliCommand, CliResult};
 use clap::Subcommand;
 
+pub mod balance;
 pub mod create;
 pub mod create_resource_account;
 pub mod derive_resource_account;
@@ -23,6 +24,7 @@ pub enum AccountTool {
     CreateResourceAccount(create_resource_account::CreateResourceAccount),
     DeriveResourceAccountAddress(derive_resource_account::DeriveResourceAccount),
     FundWithFaucet(fund::FundWithFaucet),
+    Balance(balance::Balance),
     List(list::ListAccount),
     LookupAddress(key_rotation::LookupAddress),
     RotateKey(key_rotation::RotateKey),
@@ -36,6 +38,7 @@ impl AccountTool {
             AccountTool::CreateResourceAccount(tool) => tool.execute_serialized().await,
             AccountTool::DeriveResourceAccountAddress(tool) => tool.execute_serialized().await,
             AccountTool::FundWithFaucet(tool) => tool.execute_serialized().await,
+            AccountTool::Balance(tool) => tool.execute_serialized().await,
             AccountTool::List(tool) => tool.execute_serialized().await,
             AccountTool::LookupAddress(tool) => tool.execute_serialized().await,
             AccountTool::RotateKey(tool) => tool.execute_serialized().await,


### PR DESCRIPTION
## Description
I did some user research, and realized `aptos account list --query balance` isn't exactly the easiest to find.  Instead it is now `aptos account balance`, with coin support.  Fungible asset can be added in the future.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
Tested on devnet
```bash
./target/debug/aptos account balance --account 0xa550c18
{
  "Result": [
    {
      "asset_type": "coin",
      "coin_type": "0x1::aptos_coin::AptosCoin",
      "balance": 18445820919974317715
    }
  ]
}

```

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
