### PR TITLE
fix randomness_stall_recovery flakiness

### DIFF
--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -421,7 +421,7 @@ async fn delete_storage_and_wait_for_catchup(env: &mut LocalSwarm, validator_ind
 }
 
 /// Enables sync_only mode for the specified validator and wait for it to become healthy
-async fn enable_sync_only_mode(num_nodes: usize, validator_node: &mut LocalNode) {
+pub(crate) async fn enable_sync_only_mode(num_nodes: usize, validator_node: &mut LocalNode) {
     // Update the validator's config to enable sync_only mode
     let mut validator_config = validator_node.config().clone();
     validator_config.consensus.sync_only = true;

--- a/testsuite/smoke-test/src/randomness/randomness_stall_recovery.rs
+++ b/testsuite/smoke-test/src/randomness/randomness_stall_recovery.rs
@@ -14,6 +14,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
+use crate::genesis::enable_sync_only_mode;
 
 /// Chain recovery using a local config from randomness stall should work.
 /// See `randomness_config_seqnum.move` for more details.
@@ -48,23 +49,10 @@ async fn randomness_stall_recovery() {
         .await
         .expect("Epoch 2 taking too long to arrive!");
 
-    info!("Inject RandManager fault to every node.");
-    let validator_clients: Vec<Client> =
-        swarm.validators().map(|node| node.rest_client()).collect();
-    let tasks = validator_clients
-        .iter()
-        .map(|client| {
-            client.set_failpoint(
-                "rand_manager::process_ready_blocks".to_string(),
-                "return".to_string(),
-            )
-        })
-        .collect::<Vec<_>>();
-    let aptos_results = join_all(tasks).await;
-    debug!("aptos_results={:?}", aptos_results);
-
-    // Bake the fault injection...
-    tokio::time::sleep(Duration::from_secs(10)).await;
+    info!("Halting the chain by putting every validator into sync_only mode.");
+    for validator in swarm.validators_mut() {
+        enable_sync_only_mode(4, validator).await;
+    }
 
     info!("Chain should have halted.");
     let liveness_check_result = swarm
@@ -73,6 +61,7 @@ async fn randomness_stall_recovery() {
     info!("liveness_check_result={:?}", liveness_check_result);
     assert!(liveness_check_result.is_err());
 
+    info!("Hot-fixing all validators.");
     for (idx, validator) in swarm.validators_mut().enumerate() {
         info!("Stopping validator {}.", idx);
         validator.stop();
@@ -82,6 +71,9 @@ async fn randomness_stall_recovery() {
         validator_override_config
             .override_config_mut()
             .randomness_override_seq_num = 1;
+        validator_override_config
+            .override_config_mut()
+            .consensus.sync_only = false;
         info!("Updating validator {} config.", idx);
         validator_override_config.save_config(config_path).unwrap();
         info!("Restarting validator {}.", idx);

--- a/testsuite/smoke-test/src/randomness/randomness_stall_recovery.rs
+++ b/testsuite/smoke-test/src/randomness/randomness_stall_recovery.rs
@@ -1,20 +1,20 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{randomness::get_on_chain_resource, smoke_test_environment::SwarmBuilder};
+use crate::{
+    genesis::enable_sync_only_mode, randomness::get_on_chain_resource,
+    smoke_test_environment::SwarmBuilder,
+};
 use aptos::common::types::GasOptions;
 use aptos_config::config::{OverrideNodeConfig, PersistableConfig};
 use aptos_forge::{NodeExt, Swarm, SwarmExt};
 use aptos_logger::{debug, info};
-use aptos_rest_client::Client;
 use aptos_types::{on_chain_config::OnChainRandomnessConfig, randomness::PerBlockRandomness};
-use futures::future::join_all;
 use std::{
     ops::Add,
     sync::Arc,
     time::{Duration, Instant},
 };
-use crate::genesis::enable_sync_only_mode;
 
 /// Chain recovery using a local config from randomness stall should work.
 /// See `randomness_config_seqnum.move` for more details.
@@ -73,7 +73,8 @@ async fn randomness_stall_recovery() {
             .randomness_override_seq_num = 1;
         validator_override_config
             .override_config_mut()
-            .consensus.sync_only = false;
+            .consensus
+            .sync_only = false;
         info!("Updating validator {} config.", idx);
         validator_override_config.save_config(config_path).unwrap();
         info!("Restarting validator {}.", idx);


### PR DESCRIPTION
## Description

Current fault in `process_ready_blocks()` sometimes won't work: it's possible that the 1st faulty validator gets stuck starting block `i` while the other 3 unaffected validators moved forward with seed in `B`, in which case the 1st validator will later not able to commit block `i`.

## Type of Change
- [x] Tests

## Which Components or Systems Does This Change Impact?
n/a

## How Has This Been Tested?
It's a test.

## Key Areas to Review
n/a

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
