### PR TITLE
mention that a comma might be expected

### DIFF
--- a/third_party/move/move-compiler/src/parser/syntax.rs
+++ b/third_party/move/move-compiler/src/parser/syntax.rs
@@ -260,11 +260,20 @@ where
             let current_loc = context.tokens.start_loc();
             let loc = make_loc(context.tokens.file_hash(), current_loc, current_loc);
             let loc2 = make_loc(context.tokens.file_hash(), start_loc, start_loc);
-            return Err(Box::new(diag!(
-                Syntax::UnexpectedToken,
-                (loc, format!("Expected '{}'", end_token)),
-                (loc2, format!("To match this '{}'", start_token)),
-            )));
+            let missing_comma = parse_list_item(context).is_ok();
+            if missing_comma {
+                return Err(Box::new(diag!(
+                    Syntax::UnexpectedToken,
+                    (loc, format!("Expected either ',' or '{}'", end_token)),
+                    (loc2, format!("To match this '{}'", start_token)),
+                )));
+            } else {
+                return Err(Box::new(diag!(
+                    Syntax::UnexpectedToken,
+                    (loc, format!("Expected '{}'", end_token)),
+                    (loc2, format!("To match this '{}'", start_token)),
+                )));
+            }
         }
         adjust_token(context.tokens, end_token);
         if match_token(context.tokens, end_token)? {

--- a/third_party/move/move-compiler/tests/move_check/parser/missing_comma.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/missing_comma.exp
@@ -1,0 +1,9 @@
+error[E01002]: unexpected token
+  ┌─ tests/move_check/parser/missing_comma.move:4:5
+  │
+2 │   struct Bad {
+  │              - To match this '{'
+3 │     num: u8
+4 │     num2: u8
+  │     ^ Expected either ',' or '}'
+

--- a/third_party/move/move-compiler/tests/move_check/parser/missing_comma.move
+++ b/third_party/move/move-compiler/tests/move_check/parser/missing_comma.move
@@ -1,0 +1,6 @@
+module 0x42::example {
+  struct Bad {
+    num: u8
+    num2: u8
+  }
+}

--- a/third_party/move/move-compiler/tests/move_check/parser/phantom_param_invalid_keyword.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/phantom_param_invalid_keyword.exp
@@ -2,7 +2,7 @@ error[E01002]: unexpected token
   ┌─ tests/move_check/parser/phantom_param_invalid_keyword.move:2:25
   │
 2 │     struct S<T1, phatom T2> {
-  │             -           ^ Expected '>'
+  │             -           ^ Expected either ',' or '>'
   │             │            
   │             To match this '<'
 


### PR DESCRIPTION
## Description

In case of a missing comma, mention that as part of an error message.

Fixes #13632.

## How Has This Been Tested?

Added a test case based on the issue.  See an existing test case also is updated.

## Key Areas to Review

Is it really clearer?

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
