### PR TITLE
add metrics and logs for in-memory cache, cache workers, and data service

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/metrics.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/metrics.rs
@@ -116,3 +116,30 @@ pub static BYTES_READY_TO_TRANSFER_FROM_SERVER: Lazy<IntCounterVec> = Lazy::new(
     )
     .unwrap()
 });
+
+/// Size of the data service grpc stream sender channel.
+pub static GRPC_STREAM_RESPONSE_CHANNEL_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "data_service_grpc_stream_thread_channel_size",
+        "Size of the data service grpc stream sender thread channel",
+        &[
+            "start_version",
+            "connection_id",
+        ],
+    )
+    .unwrap()
+});
+
+
+/// byte size for transactions fetched from data store: in-memory, redis, or file store.
+pub static GRPC_STREAM_DATA_BYTES_PER_SOURCE: Lazy<GaugeVec> = Lazy::new(|| {
+    register_gauge_vec!(
+        "data_service_grpc_stream_data_bytes_per_source",
+        "size of the bytes for the transactions fetched from the data source",
+        &[
+            "connection_id",
+            "data_source",
+        ],
+    )
+    .unwrap()
+});

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
@@ -5,7 +5,7 @@ use crate::{constants::IndexerGrpcRequestMetadata, timestamp_to_iso, timestamp_t
 use aptos_metrics_core::{register_gauge_vec, register_int_gauge_vec, GaugeVec, IntGaugeVec};
 use aptos_protos::util::timestamp::Timestamp;
 use once_cell::sync::Lazy;
-use prometheus::{register_int_counter_vec, IntCounterVec};
+use prometheus::{register_int_counter_vec, IntCounterVec, IntGauge, register_int_gauge};
 
 pub enum IndexerGrpcStep {
     // [Data Service] New request received.
@@ -206,6 +206,30 @@ pub static TRANSACTION_UNIX_TIMESTAMP: Lazy<GaugeVec> = Lazy::new(|| {
         "indexer_grpc_transaction_unix_timestamp",
         "Transaction timestamp in unixtime",
         &["service_type", "step", "message"]
+    )
+    .unwrap()
+});
+
+pub static IN_MEMORY_CACHE_LATEST_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "indexer_grpc_in_memory_cache_latest_version",
+        "Latest version in in-memory cache",
+    )
+    .unwrap()
+});
+
+pub static IN_MEMORY_CURRENT_CACHE_ENTRY_COUNT: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "in_memory_cache_current_total_entry_count",
+        "Current total entry count in in-memory cache",
+    )
+    .unwrap()
+});
+
+pub static REDIS_START_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "indexer_grpc_file_store_redis_start_version",
+        "Start version of the transactions that are being stored in redis"
     )
     .unwrap()
 });


### PR DESCRIPTION


## Description
this is a follow-up from the sev we received last weekend to add missing metrics and logs to help us debugging/rootcausing. 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests
- [X] Metrics/Logs

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [X] Full Node (API, **Indexer**, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Yes, this has been tested locally

## Key Areas to Review
These metrics and logs should provide an idea why issues related to the cache system in indexer occurs.

<img width="1372" alt="Screenshot 2024-06-11 at 10 23 08 PM" src="https://github.com/aptos-labs/aptos-core/assets/38443641/467d254c-b067-4505-87e9-f7630529768a">

![Screenshot 2024-06-11 at 10 22 01 PM](https://github.com/aptos-labs/aptos-core/assets/38443641/64f50aa6-1c00-43d9-8a9c-b455beddbecb)
![Screenshot 2024-06-11 at 10 21 56 PM](https://github.com/aptos-labs/aptos-core/assets/38443641/8470f16b-2409-4adb-999a-4c3990b9f25e)

![Screenshot 2024-06-11 at 10 21 44 PM](https://github.com/aptos-labs/aptos-core/assets/38443641/f30953fb-300d-43da-89d7-2879dd130aba)
