### PR TITLE
[smoke-test] better success criteria

### DIFF
--- a/testsuite/smoke-test/src/consensus/consensus_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/consensus_fault_tolerance.rs
@@ -159,6 +159,20 @@ async fn run_fail_point_test(
     .unwrap();
 }
 
+fn successful_criteria(executed_epochs: u64, executed_rounds: u64, executed_transactions: u64) {
+    assert!(
+        executed_transactions >= 4,
+        "no progress with active consensus, only {} transactions",
+        executed_transactions
+    );
+    assert!(
+        executed_epochs >= 1 || executed_rounds >= 2,
+        "no progress with active consensus, only {} epochs, {} rounds",
+        executed_epochs,
+        executed_rounds
+    );
+}
+
 #[tokio::test]
 async fn test_no_failures() {
     let num_validators = 3;
@@ -171,19 +185,12 @@ async fn test_no_failures() {
         5.0,
         1,
         no_failure_injection(),
-        Box::new(move |_, _, executed_rounds, executed_transactions, _, _| {
-            assert!(
-                executed_transactions >= 4,
-                "no progress with active consensus, only {} transactions",
-                executed_transactions
-            );
-            assert!(
-                executed_rounds >= 2,
-                "no progress with active consensus, only {} rounds",
-                executed_rounds
-            );
-            Ok(())
-        }),
+        Box::new(
+            move |_, executed_epochs, executed_rounds, executed_transactions, _, _| {
+                successful_criteria(executed_epochs, executed_rounds, executed_transactions);
+                Ok(())
+            },
+        ),
         true,
         false,
     )
@@ -212,19 +219,12 @@ async fn test_ordered_only_cert() {
                 true,
             )
         }))),
-        Box::new(move |_, _, executed_rounds, executed_transactions, _, _| {
-            assert!(
-                executed_transactions >= 4,
-                "no progress with active consensus, only {} transactions",
-                executed_transactions
-            );
-            assert!(
-                executed_rounds >= 2,
-                "no progress with active consensus, only {} rounds",
-                executed_rounds
-            );
-            Ok(())
-        }),
+        Box::new(
+            move |_, executed_epochs, executed_rounds, executed_transactions, _, _| {
+                successful_criteria(executed_epochs, executed_rounds, executed_transactions);
+                Ok(())
+            },
+        ),
         true,
         false,
     )
@@ -253,19 +253,12 @@ async fn test_execution_retry() {
                 true,
             )
         }))),
-        Box::new(move |_, _, executed_rounds, executed_transactions, _, _| {
-            assert!(
-                executed_transactions >= 4,
-                "no progress with active consensus, only {} transactions",
-                executed_transactions
-            );
-            assert!(
-                executed_rounds >= 1,
-                "no progress with active consensus, only {} rounds",
-                executed_rounds
-            );
-            Ok(())
-        }),
+        Box::new(
+            move |_, executed_epochs, executed_rounds, executed_transactions, _, _| {
+                successful_criteria(executed_epochs, executed_rounds, executed_transactions);
+                Ok(())
+            },
+        ),
         true,
         false,
     )
@@ -385,19 +378,12 @@ async fn test_changing_working_consensus() {
                 (vec![], false)
             }
         }),
-        Box::new(|_, _, executed_rounds, executed_transactions, _, _| {
-            assert!(
-                executed_transactions >= 5,
-                "no progress with active consensus, only {} transactions",
-                executed_transactions
-            );
-            assert!(
-                executed_rounds >= 2,
-                "no progress with active consensus, only {} rounds",
-                executed_rounds
-            );
-            Ok(())
-        }),
+        Box::new(
+            move |_, executed_epochs, executed_rounds, executed_transactions, _, _| {
+                successful_criteria(executed_epochs, executed_rounds, executed_transactions);
+                Ok(())
+            },
+        ),
     )
     .await;
 }
@@ -446,19 +432,12 @@ async fn test_changing_working_consensus_fast() {
                 true,
             )
         }),
-        Box::new(|_, _, executed_rounds, executed_transactions, _, _| {
-            assert!(
-                executed_transactions >= 4,
-                "no progress with active consensus, only {} transactions",
-                executed_transactions
-            );
-            assert!(
-                executed_rounds >= 2,
-                "no progress with active consensus, only {} rounds",
-                executed_rounds
-            );
-            Ok(())
-        }),
+        Box::new(
+            move |_, executed_epochs, executed_rounds, executed_transactions, _, _| {
+                successful_criteria(executed_epochs, executed_rounds, executed_transactions);
+                Ok(())
+            },
+        ),
     )
     .await;
 }
@@ -510,33 +489,36 @@ async fn test_alternating_having_consensus() {
                 (vec![], false)
             }
         }),
-        Box::new(|cycle, _, executed_rounds, executed_transactions, _, _| {
-            if cycle % 2 == 1 {
-                // allow 1 round / 3 transactions, in case anything was leftover in the pipeline
-                assert!(
-                    executed_transactions <= 3,
-                    "progress with active consensus, {} transactions",
-                    executed_transactions
-                );
-                assert!(
-                    executed_rounds <= 1,
-                    "progress with active consensus, {} rounds",
-                    executed_rounds
-                );
-            } else {
-                assert!(
-                    executed_transactions >= 5,
-                    "no progress with active consensus, only {} transactions",
-                    executed_transactions
-                );
-                assert!(
-                    executed_rounds >= 2,
-                    "no progress with active consensus, only {} rounds",
-                    executed_rounds
-                );
-            }
-            Ok(())
-        }),
+        Box::new(
+            |cycle, executed_epochs, executed_rounds, executed_transactions, _, _| {
+                if cycle % 2 == 1 {
+                    // allow 1 round / 3 transactions, in case anything was leftover in the pipeline
+                    assert!(
+                        executed_transactions <= 3,
+                        "progress with active consensus, {} transactions",
+                        executed_transactions
+                    );
+                    assert!(
+                        executed_rounds <= 1,
+                        "progress with active consensus, {} rounds",
+                        executed_rounds
+                    );
+                } else {
+                    assert!(
+                        executed_transactions >= 5,
+                        "no progress with active consensus, only {} transactions",
+                        executed_transactions
+                    );
+                    assert!(
+                        executed_epochs >= 1 || executed_rounds >= 2,
+                        "no progress with active consensus, only {} epochs, {} rounds",
+                        executed_epochs,
+                        executed_rounds
+                    );
+                }
+                Ok(())
+            },
+        ),
     )
     .await;
 }


### PR DESCRIPTION
Previously we only take rounds into considerations and tests can become flaky when the epoch advances and we don't see rounds increase. for example if it advances from (1, 10) to (2, 8), it actually makes progress of at least 8 rounds but the check would fail with 0 rounds.