### PR TITLE
[api] print SingleSender signature / key variants

### DIFF
--- a/api/goldens/aptos_api__tests__secp256k1_ecdsa__test_multi_secp256k1_ecdsa.json
+++ b/api/goldens/aptos_api__tests__secp256k1_ecdsa__test_multi_secp256k1_ecdsa.json
@@ -1,0 +1,19 @@
+{
+  "public_keys": [
+    {
+      "value": "0x049b8327d929a0e45285c04d19c9fffbee065c266b701972922d807228120e43f34ad68ac77f6ec0205fe39f7c5b6055dad973a03464a3a743302de0feaf6ec6d9",
+      "type": "secp256k1_ecdsa"
+    }
+  ],
+  "signatures": [
+    {
+      "index": 0,
+      "signature": {
+        "value": "0xd1c84463d33b27977431b60664b36c6c1717569b1fbe2f9808c1e78f36958ae71a2b59a7c062e9491c12e69e25e3d3f82253a4efd1c1857b3695ff1b9050c5e4",
+        "type": "secp256k1_ecdsa"
+      }
+    }
+  ],
+  "signatures_required": 1,
+  "type": "single_sender"
+}

--- a/api/goldens/aptos_api__tests__secp256k1_ecdsa__test_secp256k1_ecdsa.json
+++ b/api/goldens/aptos_api__tests__secp256k1_ecdsa__test_secp256k1_ecdsa.json
@@ -1,0 +1,11 @@
+{
+  "public_key": {
+    "value": "0x049b8327d929a0e45285c04d19c9fffbee065c266b701972922d807228120e43f34ad68ac77f6ec0205fe39f7c5b6055dad973a03464a3a743302de0feaf6ec6d9",
+    "type": "secp256k1_ecdsa"
+  },
+  "signature": {
+    "value": "0x357a77abdb3ef4a01aea1e8d0cb932606655bcf66e6726d2cefbfd904d57703b0bf38eb19bc3da1e3e9f6929db0d4806f83fa5370f6981d704efa42cdba56fb9",
+    "type": "secp256k1_ecdsa"
+  },
+  "type": "single_sender"
+}

--- a/api/src/tests/secp256k1_ecdsa.rs
+++ b/api/src/tests/secp256k1_ecdsa.rs
@@ -4,13 +4,72 @@
 
 use super::new_test_context;
 use aptos_api_test_context::current_function_name;
-use aptos_crypto::{ed25519::Ed25519PrivateKey, secp256k1_ecdsa};
+use aptos_crypto::{ed25519::Ed25519PrivateKey, secp256k1_ecdsa, SigningKey};
 use aptos_sdk::types::{
-    transaction::authenticator::{AnyPublicKey, AuthenticationKey},
+    transaction::{
+        authenticator::{
+            AccountAuthenticator, AnyPublicKey, AnySignature, AuthenticationKey, MultiKey,
+            MultiKeyAuthenticator,
+        },
+        SignedTransaction,
+    },
     LocalAccount,
 };
 use rand::{rngs::StdRng, SeedableRng};
 use std::convert::TryInto;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_multi_secp256k1_ecdsa() {
+    let mut context = new_test_context(current_function_name!());
+    let other = context.create_account().await;
+
+    let mut rng: StdRng = SeedableRng::from_seed([0; 32]);
+    let private_key: secp256k1_ecdsa::PrivateKey = aptos_crypto::Uniform::generate(&mut rng);
+    let public_key = aptos_crypto::PrivateKey::public_key(&private_key);
+    let address = AuthenticationKey::multi_key(
+        MultiKey::new(vec![AnyPublicKey::secp256k1_ecdsa(public_key.clone())], 1).unwrap(),
+    )
+    .account_address();
+
+    // Set a dummy key
+    let key_bytes =
+        hex::decode("a38ba78b1a0fbfc55e2c5dfdedf48d1172283d0f7c59fd64c02d811130a2f4b2").unwrap();
+    let ed25519_private_key: Ed25519PrivateKey = (&key_bytes[..]).try_into().unwrap();
+    let mut account = LocalAccount::new(address, ed25519_private_key, 0);
+
+    let txn0 = context.create_user_account(&account).await;
+    context.commit_block(&vec![txn0]).await;
+    let txn1 = context.mint_user_account(&account).await;
+    context.commit_block(&vec![txn1]).await;
+    let txn2 = context.create_user_account(&other).await;
+    context.commit_block(&vec![txn2]).await;
+
+    let ed22519_txn = context.account_transfer(&mut account, &other, 5);
+    let raw_txn = ed22519_txn.into_raw_transaction();
+
+    let signature = private_key.sign(&raw_txn).unwrap();
+    let authenticator = AccountAuthenticator::multi_key(
+        MultiKeyAuthenticator::new(
+            MultiKey::new(vec![AnyPublicKey::secp256k1_ecdsa(public_key)], 1).unwrap(),
+            vec![(0, AnySignature::secp256k1_ecdsa(signature))],
+        )
+        .unwrap(),
+    );
+    let secp256k1_ecdsa_txn = SignedTransaction::new_single_sender(raw_txn, authenticator);
+    let balance_start = context.get_apt_balance(other.address()).await;
+    let bcs_txn = bcs::to_bytes(&secp256k1_ecdsa_txn).unwrap();
+    context
+        .expect_status_code(202)
+        .post_bcs_txn("/transactions", bcs_txn)
+        .await;
+    context.commit_mempool_txns(1).await;
+    assert_eq!(
+        balance_start + 5,
+        context.get_apt_balance(other.address()).await
+    );
+    let txns = context.get("/transactions?start=14&limit=1").await;
+    context.check_golden_output(txns[0]["signature"].clone());
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_secp256k1_ecdsa() {
@@ -52,4 +111,6 @@ async fn test_secp256k1_ecdsa() {
         balance_start + 5,
         context.get_apt_balance(other.address()).await
     );
+    let txns = context.get("/transactions?start=14&limit=1").await;
+    context.check_golden_output(txns[0]["signature"].clone());
 }

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -1557,7 +1557,7 @@ fn override_gas_parameters(
     );
 
     // TODO: Check that signature is null, this would just be helpful for downstream use
-    SignedTransaction::new_with_authenticator(raw_txn, signed_txn.authenticator())
+    SignedTransaction::new_signed_transaction(raw_txn, signed_txn.authenticator())
 }
 
 enum GetByVersionResponse {

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -547,7 +547,7 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
             .signature
             .clone()
             .ok_or_else(|| format_err!("missing signature"))?;
-        Ok(SignedTransaction::new_with_authenticator(
+        Ok(SignedTransaction::new_signed_transaction(
             self.try_into_raw_transaction(txn, chain_id)?,
             signature.try_into()?,
         ))
@@ -558,7 +558,7 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
         submit_transaction_request: SubmitTransactionRequest,
         chain_id: ChainId,
     ) -> Result<SignedTransaction> {
-        Ok(SignedTransaction::new_with_authenticator(
+        Ok(SignedTransaction::new_signed_transaction(
             self.try_into_raw_transaction_poem(
                 submit_transaction_request.user_transaction_request,
                 chain_id,

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -1231,10 +1231,64 @@ impl VerifyInput for KeylessSignature {
 #[serde(tag = "type", rename_all = "snake_case")]
 #[oai(one_of, discriminator_name = "type", rename_all = "snake_case")]
 pub enum Signature {
-    Ed25519(HexEncodedBytes),
-    Secp256k1Ecdsa(HexEncodedBytes),
-    WebAuthn(HexEncodedBytes),
-    Keyless(HexEncodedBytes),
+    Ed25519(Ed25519),
+    Secp256k1Ecdsa(Secp256k1Ecdsa),
+    WebAuthn(WebAuthn),
+    Keyless(Keyless),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Object)]
+pub struct Ed25519 {
+    pub value: HexEncodedBytes,
+}
+
+impl Ed25519 {
+    pub fn new(value: HexEncodedBytes) -> Self {
+        Self { value }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Object)]
+pub struct Secp256k1Ecdsa {
+    pub value: HexEncodedBytes,
+}
+
+impl Secp256k1Ecdsa {
+    pub fn new(value: HexEncodedBytes) -> Self {
+        Self { value }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Object)]
+pub struct Secp256r1Ecdsa {
+    pub value: HexEncodedBytes,
+}
+
+impl Secp256r1Ecdsa {
+    pub fn new(value: HexEncodedBytes) -> Self {
+        Self { value }
+    }
+}
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Object)]
+pub struct WebAuthn {
+    pub value: HexEncodedBytes,
+}
+
+impl WebAuthn {
+    pub fn new(value: HexEncodedBytes) -> Self {
+        Self { value }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Object)]
+pub struct Keyless {
+    pub value: HexEncodedBytes,
+}
+
+impl Keyless {
+    pub fn new(value: HexEncodedBytes) -> Self {
+        Self { value }
+    }
 }
 
 impl TryFrom<Signature> for AnySignature {
@@ -1242,10 +1296,12 @@ impl TryFrom<Signature> for AnySignature {
 
     fn try_from(signature: Signature) -> Result<Self, Self::Error> {
         Ok(match signature {
-            Signature::Ed25519(s) => AnySignature::ed25519(s.inner().try_into()?),
-            Signature::Secp256k1Ecdsa(s) => AnySignature::secp256k1_ecdsa(s.inner().try_into()?),
-            Signature::WebAuthn(s) => AnySignature::webauthn(s.inner().try_into()?),
-            Signature::Keyless(s) => AnySignature::keyless(s.inner().try_into()?),
+            Signature::Ed25519(s) => AnySignature::ed25519(s.value.inner().try_into()?),
+            Signature::Secp256k1Ecdsa(s) => {
+                AnySignature::secp256k1_ecdsa(s.value.inner().try_into()?)
+            },
+            Signature::WebAuthn(s) => AnySignature::webauthn(s.value.inner().try_into()?),
+            Signature::Keyless(s) => AnySignature::keyless(s.value.inner().try_into()?),
         })
     }
 }
@@ -1254,15 +1310,17 @@ impl From<AnySignature> for Signature {
     fn from(signature: AnySignature) -> Self {
         match signature {
             AnySignature::Ed25519 { signature } => {
-                Signature::Ed25519(signature.to_bytes().to_vec().into())
+                Signature::Ed25519(Ed25519::new(signature.to_bytes().to_vec().into()))
             },
             AnySignature::Secp256k1Ecdsa { signature } => {
-                Signature::Secp256k1Ecdsa(signature.to_bytes().to_vec().into())
+                Signature::Secp256k1Ecdsa(Secp256k1Ecdsa::new(signature.to_bytes().to_vec().into()))
             },
             AnySignature::WebAuthn { signature } => {
-                Signature::WebAuthn(signature.to_bytes().to_vec().into())
+                Signature::WebAuthn(WebAuthn::new(signature.to_bytes().to_vec().into()))
             },
-            AnySignature::Keyless { signature } => Signature::Keyless(signature.to_bytes().into()),
+            AnySignature::Keyless { signature } => {
+                Signature::Keyless(Keyless::new(signature.to_bytes().into()))
+            },
         }
     }
 }
@@ -1271,10 +1329,10 @@ impl From<AnySignature> for Signature {
 #[serde(tag = "type", rename_all = "snake_case")]
 #[oai(one_of, discriminator_name = "type", rename_all = "snake_case")]
 pub enum PublicKey {
-    Ed25519(HexEncodedBytes),
-    Secp256k1Ecdsa(HexEncodedBytes),
-    Secp256r1Ecdsa(HexEncodedBytes),
-    Keyless(HexEncodedBytes),
+    Ed25519(Ed25519),
+    Secp256k1Ecdsa(Secp256k1Ecdsa),
+    Secp256r1Ecdsa(Secp256r1Ecdsa),
+    Keyless(Keyless),
 }
 
 impl TryFrom<PublicKey> for AnyPublicKey {
@@ -1282,10 +1340,14 @@ impl TryFrom<PublicKey> for AnyPublicKey {
 
     fn try_from(public_key: PublicKey) -> Result<Self, Self::Error> {
         Ok(match public_key {
-            PublicKey::Ed25519(p) => AnyPublicKey::ed25519(p.inner().try_into()?),
-            PublicKey::Secp256k1Ecdsa(p) => AnyPublicKey::secp256k1_ecdsa(p.inner().try_into()?),
-            PublicKey::Secp256r1Ecdsa(p) => AnyPublicKey::secp256r1_ecdsa(p.inner().try_into()?),
-            PublicKey::Keyless(p) => AnyPublicKey::keyless(p.inner().try_into()?),
+            PublicKey::Ed25519(p) => AnyPublicKey::ed25519(p.value.inner().try_into()?),
+            PublicKey::Secp256k1Ecdsa(p) => {
+                AnyPublicKey::secp256k1_ecdsa(p.value.inner().try_into()?)
+            },
+            PublicKey::Secp256r1Ecdsa(p) => {
+                AnyPublicKey::secp256r1_ecdsa(p.value.inner().try_into()?)
+            },
+            PublicKey::Keyless(p) => AnyPublicKey::keyless(p.value.inner().try_into()?),
         })
     }
 }
@@ -1294,16 +1356,16 @@ impl From<AnyPublicKey> for PublicKey {
     fn from(key: AnyPublicKey) -> Self {
         match key {
             AnyPublicKey::Ed25519 { public_key } => {
-                PublicKey::Ed25519(public_key.to_bytes().to_vec().into())
+                PublicKey::Ed25519(Ed25519::new(public_key.to_bytes().to_vec().into()))
             },
-            AnyPublicKey::Secp256k1Ecdsa { public_key } => {
-                PublicKey::Secp256k1Ecdsa(public_key.to_bytes().to_vec().into())
-            },
-            AnyPublicKey::Secp256r1Ecdsa { public_key } => {
-                PublicKey::Secp256r1Ecdsa(public_key.to_bytes().to_vec().into())
-            },
+            AnyPublicKey::Secp256k1Ecdsa { public_key } => PublicKey::Secp256k1Ecdsa(
+                Secp256k1Ecdsa::new(public_key.to_bytes().to_vec().into()),
+            ),
+            AnyPublicKey::Secp256r1Ecdsa { public_key } => PublicKey::Secp256r1Ecdsa(
+                Secp256r1Ecdsa::new(public_key.to_bytes().to_vec().into()),
+            ),
             AnyPublicKey::Keyless { public_key } => {
-                PublicKey::Keyless(public_key.to_bytes().into())
+                PublicKey::Keyless(Keyless::new(public_key.to_bytes().into()))
             },
         }
     }
@@ -1320,25 +1382,25 @@ impl VerifyInput for SingleKeySignature {
     fn verify(&self) -> anyhow::Result<()> {
         match (&self.public_key, &self.signature) {
             (PublicKey::Ed25519(p), Signature::Ed25519(s)) => Ed25519Signature {
-                public_key: p.clone(),
-                signature: s.clone(),
+                public_key: p.value.clone(),
+                signature: s.value.clone(),
             }
             .verify(),
             (PublicKey::Secp256k1Ecdsa(p), Signature::Secp256k1Ecdsa(s)) => {
                 Secp256k1EcdsaSignature {
-                    public_key: p.clone(),
-                    signature: s.clone(),
+                    public_key: p.value.clone(),
+                    signature: s.value.clone(),
                 }
                 .verify()
             },
             (PublicKey::Secp256r1Ecdsa(p), Signature::WebAuthn(s)) => WebAuthnSignature {
-                public_key: p.clone(),
-                signature: s.clone(),
+                public_key: p.value.clone(),
+                signature: s.value.clone(),
             }
             .verify(),
             (PublicKey::Keyless(p), Signature::Keyless(s)) => KeylessSignature {
-                public_key: p.clone(),
-                signature: s.clone(),
+                public_key: p.value.clone(),
+                signature: s.value.clone(),
             }
             .verify(),
             _ => bail!("Invalid public key, signature match."),
@@ -1362,26 +1424,26 @@ impl TryFrom<SingleKeySignature> for AccountAuthenticator {
         let key =
             match value.public_key {
                 PublicKey::Ed25519(p) => {
-                    let key = p
-                        .inner()
-                        .try_into()
-                        .context("Failed to parse given public_key bytes as Ed25519PublicKey")?;
+                    let key =
+                        p.value.inner().try_into().context(
+                            "Failed to parse given public_key bytes as Ed25519PublicKey",
+                        )?;
                     AnyPublicKey::ed25519(key)
                 },
                 PublicKey::Secp256k1Ecdsa(p) => {
-                    let key = p.inner().try_into().context(
+                    let key = p.value.inner().try_into().context(
                         "Failed to parse given public_key bytes as Secp256k1EcdsaPublicKey",
                     )?;
                     AnyPublicKey::secp256k1_ecdsa(key)
                 },
                 PublicKey::Secp256r1Ecdsa(p) => {
-                    let key = p.inner().try_into().context(
+                    let key = p.value.inner().try_into().context(
                         "Failed to parse given public_key bytes as Secp256r1EcdsaPublicKey",
                     )?;
                     AnyPublicKey::secp256r1_ecdsa(key)
                 },
                 PublicKey::Keyless(p) => {
-                    let key = p.inner().try_into().context(
+                    let key = p.value.inner().try_into().context(
                         "Failed to parse given public_key bytes as AnyPublicKey::Keyless",
                     )?;
                     AnyPublicKey::keyless(key)
@@ -1391,30 +1453,32 @@ impl TryFrom<SingleKeySignature> for AccountAuthenticator {
         let signature = match value.signature {
             Signature::Ed25519(s) => {
                 let signature = s
+                    .value
                     .inner()
                     .try_into()
                     .context("Failed to parse given signature bytes as Ed25519Signature")?;
                 AnySignature::ed25519(signature)
             },
             Signature::Secp256k1Ecdsa(s) => {
-                let signature = s
-                    .inner()
-                    .try_into()
-                    .context("Failed to parse given signature bytes as Secp256k1EcdsaSignature")?;
+                let signature =
+                    s.value.inner().try_into().context(
+                        "Failed to parse given signature bytes as Secp256k1EcdsaSignature",
+                    )?;
                 AnySignature::secp256k1_ecdsa(signature)
             },
             Signature::WebAuthn(s) => {
                 let signature = s
+                    .value
                     .inner()
                     .try_into()
                     .context( "Failed to parse given signature bytes as PartialAuthenticatorAssertionResponse")?;
                 AnySignature::webauthn(signature)
             },
             Signature::Keyless(s) => {
-                let signature = s
-                    .inner()
-                    .try_into()
-                    .context("Failed to parse given signature bytes as AnySignature::Keyless")?;
+                let signature =
+                    s.value.inner().try_into().context(
+                        "Failed to parse given signature bytes as AnySignature::Keyless",
+                    )?;
                 AnySignature::keyless(signature)
             },
         };
@@ -1462,26 +1526,26 @@ impl TryFrom<MultiKeySignature> for AccountAuthenticator {
         for public_key in value.public_keys {
             let key = match public_key {
                 PublicKey::Ed25519(p) => {
-                    let key = p
-                        .inner()
-                        .try_into()
-                        .context("Failed to parse given public_key bytes as Ed25519PublicKey")?;
+                    let key =
+                        p.value.inner().try_into().context(
+                            "Failed to parse given public_key bytes as Ed25519PublicKey",
+                        )?;
                     AnyPublicKey::ed25519(key)
                 },
                 PublicKey::Secp256k1Ecdsa(p) => {
-                    let key = p.inner().try_into().context(
+                    let key = p.value.inner().try_into().context(
                         "Failed to parse given public_key bytes as Secp256k1EcdsaPublicKey",
                     )?;
                     AnyPublicKey::secp256k1_ecdsa(key)
                 },
                 PublicKey::Secp256r1Ecdsa(p) => {
-                    let key = p.inner().try_into().context(
+                    let key = p.value.inner().try_into().context(
                         "Failed to parse given public_key bytes as Secp256r1EcdsaPublicKey",
                     )?;
                     AnyPublicKey::secp256r1_ecdsa(key)
                 },
                 PublicKey::Keyless(p) => {
-                    let key = p.inner().try_into().context(
+                    let key = p.value.inner().try_into().context(
                         "Failed to parse given public_key bytes as AnyPublicKey::Keyless",
                     )?;
                     AnyPublicKey::keyless(key)
@@ -1495,28 +1559,28 @@ impl TryFrom<MultiKeySignature> for AccountAuthenticator {
             let signature =
                 match indexed_signature.signature {
                     Signature::Ed25519(s) => {
-                        let signature = s.inner().try_into().context(
+                        let signature = s.value.inner().try_into().context(
                             "Failed to parse given public_key bytes as Ed25519Signature",
                         )?;
                         AnySignature::ed25519(signature)
                     },
                     Signature::Secp256k1Ecdsa(s) => {
-                        let signature = s.inner().try_into().context(
+                        let signature = s.value.inner().try_into().context(
                             "Failed to parse given signature as Secp256k1EcdsaSignature",
                         )?;
                         AnySignature::secp256k1_ecdsa(signature)
                     },
                     Signature::WebAuthn(s) => {
-                        let paar = s.inner().try_into().context(
+                        let paar = s.value.inner().try_into().context(
                         "Failed to parse given signature as PartialAuthenticatorAssertionResponse",
                     )?;
                         AnySignature::webauthn(paar)
                     },
                     Signature::Keyless(s) => {
-                        let signature = s
-                            .inner()
-                            .try_into()
-                            .context("Failed to parse given signature as AnySignature::Keyless")?;
+                        let signature =
+                            s.value.inner().try_into().context(
+                                "Failed to parse given signature as AnySignature::Keyless",
+                            )?;
                         AnySignature::keyless(signature)
                     },
                 };

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/convert.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/convert.rs
@@ -581,32 +581,32 @@ fn convert_signature(signature: &Signature) -> transaction::AnySignature {
     match signature {
         Signature::Ed25519(s) => transaction::AnySignature {
             r#type: transaction::any_signature::Type::Ed25519 as i32,
-            signature: s.0.clone(),
+            signature: s.value.clone().into(),
             signature_variant: Some(any_signature::SignatureVariant::Ed25519(Ed25519 {
-                signature: s.0.clone(),
+                signature: s.value.clone().into(),
             })),
         },
         Signature::Secp256k1Ecdsa(s) => transaction::AnySignature {
             r#type: transaction::any_signature::Type::Secp256k1Ecdsa as i32,
-            signature: s.0.clone(),
+            signature: s.value.clone().into(),
             signature_variant: Some(any_signature::SignatureVariant::Secp256k1Ecdsa(
                 Secp256k1Ecdsa {
-                    signature: s.0.clone(),
+                    signature: s.value.clone().into(),
                 },
             )),
         },
         Signature::WebAuthn(s) => transaction::AnySignature {
             r#type: transaction::any_signature::Type::Webauthn as i32,
-            signature: s.0.clone(),
+            signature: s.value.clone().into(),
             signature_variant: Some(any_signature::SignatureVariant::Webauthn(WebAuthn {
-                signature: s.0.clone(),
+                signature: s.value.clone().into(),
             })),
         },
         Signature::Keyless(s) => transaction::AnySignature {
             r#type: transaction::any_signature::Type::Keyless as i32,
-            signature: s.0.clone(),
+            signature: s.value.clone().into(),
             signature_variant: Some(any_signature::SignatureVariant::Keyless(Keyless {
-                signature: s.0.clone(),
+                signature: s.value.clone().into(),
             })),
         },
     }
@@ -616,19 +616,19 @@ fn convert_public_key(public_key: &PublicKey) -> transaction::AnyPublicKey {
     match public_key {
         PublicKey::Ed25519(p) => transaction::AnyPublicKey {
             r#type: transaction::any_public_key::Type::Ed25519 as i32,
-            public_key: p.0.clone(),
+            public_key: p.value.clone().into(),
         },
         PublicKey::Secp256k1Ecdsa(p) => transaction::AnyPublicKey {
             r#type: transaction::any_public_key::Type::Secp256k1Ecdsa as i32,
-            public_key: p.0.clone(),
+            public_key: p.value.clone().into(),
         },
         PublicKey::Secp256r1Ecdsa(p) => transaction::AnyPublicKey {
             r#type: transaction::any_public_key::Type::Secp256r1Ecdsa as i32,
-            public_key: p.0.clone(),
+            public_key: p.value.clone().into(),
         },
         PublicKey::Keyless(p) => transaction::AnyPublicKey {
             r#type: transaction::any_public_key::Type::Keyless as i32,
-            public_key: p.0.clone(),
+            public_key: p.value.clone().into(),
         },
     }
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -567,19 +567,14 @@ impl SignedTransaction {
         fee_payer_address: AccountAddress,
         fee_payer_signer: AccountAuthenticator,
     ) -> Self {
-        SignedTransaction {
-            raw_txn,
-            authenticator: TransactionAuthenticator::fee_payer(
-                sender,
-                secondary_signer_addresses,
-                secondary_signers,
-                fee_payer_address,
-                fee_payer_signer,
-            ),
-            raw_txn_size: OnceCell::new(),
-            authenticator_size: OnceCell::new(),
-            committed_hash: OnceCell::new(),
-        }
+        let authenticator = TransactionAuthenticator::fee_payer(
+            sender,
+            secondary_signer_addresses,
+            secondary_signers,
+            fee_payer_address,
+            fee_payer_signer,
+        );
+        Self::new_signed_transaction(raw_txn, authenticator)
     }
 
     pub fn new_multisig(
@@ -588,13 +583,7 @@ impl SignedTransaction {
         signature: MultiEd25519Signature,
     ) -> SignedTransaction {
         let authenticator = TransactionAuthenticator::multi_ed25519(public_key, signature);
-        SignedTransaction {
-            raw_txn,
-            authenticator,
-            raw_txn_size: OnceCell::new(),
-            authenticator_size: OnceCell::new(),
-            committed_hash: OnceCell::new(),
-        }
+        Self::new_signed_transaction(raw_txn, authenticator)
     }
 
     pub fn new_multi_agent(
@@ -603,17 +592,12 @@ impl SignedTransaction {
         secondary_signer_addresses: Vec<AccountAddress>,
         secondary_signers: Vec<AccountAuthenticator>,
     ) -> Self {
-        SignedTransaction {
-            raw_txn,
-            authenticator: TransactionAuthenticator::multi_agent(
-                sender,
-                secondary_signer_addresses,
-                secondary_signers,
-            ),
-            raw_txn_size: OnceCell::new(),
-            authenticator_size: OnceCell::new(),
-            committed_hash: OnceCell::new(),
-        }
+        let authenticator = TransactionAuthenticator::multi_agent(
+            sender,
+            secondary_signer_addresses,
+            secondary_signers,
+        );
+        Self::new_signed_transaction(raw_txn, authenticator)
     }
 
     pub fn new_secp256k1_ecdsa(
@@ -621,19 +605,11 @@ impl SignedTransaction {
         public_key: secp256k1_ecdsa::PublicKey,
         signature: secp256k1_ecdsa::Signature,
     ) -> SignedTransaction {
-        let authenticator = TransactionAuthenticator::single_sender(
-            AccountAuthenticator::single_key(SingleKeyAuthenticator::new(
-                AnyPublicKey::secp256k1_ecdsa(public_key),
-                AnySignature::secp256k1_ecdsa(signature),
-            )),
-        );
-        SignedTransaction {
-            raw_txn,
-            authenticator,
-            raw_txn_size: OnceCell::new(),
-            authenticator_size: OnceCell::new(),
-            committed_hash: OnceCell::new(),
-        }
+        let authenticator = AccountAuthenticator::single_key(SingleKeyAuthenticator::new(
+            AnyPublicKey::secp256k1_ecdsa(public_key),
+            AnySignature::secp256k1_ecdsa(signature),
+        ));
+        Self::new_single_sender(raw_txn, authenticator)
     }
 
     pub fn new_keyless(
@@ -641,45 +617,21 @@ impl SignedTransaction {
         public_key: KeylessPublicKey,
         signature: KeylessSignature,
     ) -> SignedTransaction {
-        let authenticator = TransactionAuthenticator::single_sender(
-            AccountAuthenticator::single_key(SingleKeyAuthenticator::new(
-                AnyPublicKey::keyless(public_key),
-                AnySignature::keyless(signature),
-            )),
-        );
-        SignedTransaction {
-            raw_txn,
-            authenticator,
-            raw_txn_size: OnceCell::new(),
-            authenticator_size: OnceCell::new(),
-            committed_hash: OnceCell::new(),
-        }
+        let authenticator = AccountAuthenticator::single_key(SingleKeyAuthenticator::new(
+            AnyPublicKey::keyless(public_key),
+            AnySignature::keyless(signature),
+        ));
+        Self::new_single_sender(raw_txn, authenticator)
     }
 
     pub fn new_single_sender(
         raw_txn: RawTransaction,
         authenticator: AccountAuthenticator,
     ) -> SignedTransaction {
-        SignedTransaction {
+        Self::new_signed_transaction(
             raw_txn,
-            authenticator: TransactionAuthenticator::single_sender(authenticator),
-            raw_txn_size: OnceCell::new(),
-            authenticator_size: OnceCell::new(),
-            committed_hash: OnceCell::new(),
-        }
-    }
-
-    pub fn new_with_authenticator(
-        raw_txn: RawTransaction,
-        authenticator: TransactionAuthenticator,
-    ) -> Self {
-        Self {
-            raw_txn,
-            authenticator,
-            raw_txn_size: OnceCell::new(),
-            authenticator_size: OnceCell::new(),
-            committed_hash: OnceCell::new(),
-        }
+            TransactionAuthenticator::single_sender(authenticator),
+        )
     }
 
     pub fn authenticator(&self) -> TransactionAuthenticator {


### PR DESCRIPTION
Poem's display functionality is a bit limiting and doesn't seem to handle printing enums effectively, so one needs to leverage a wrapping struct to effectively display a type and value field.

This PR introduces just that.

This means that anyone parsing single or multi key sender json output will be broken, of course, the data was largely useless to begin with.

Other aspects remain untouched so this is a minimally breaking changes PR.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [x] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Check the embedded golden files.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
Singlekey:
```
{
  "public_key": {
    "value": "0x049b8327d929a0e45285c04d19c9fffbee065c266b701972922d807228120e43f34ad68ac77f6ec0205fe39f7c5b6055dad973a03464a3a743302de0feaf6ec6d9",
    "type": "secp256k1_ecdsa"
  },
  "signature": {
    "value": "0x357a77abdb3ef4a01aea1e8d0cb932606655bcf66e6726d2cefbfd904d57703b0bf38eb19bc3da1e3e9f6929db0d4806f83fa5370f6981d704efa42cdba56fb9",
    "type": "secp256k1_ecdsa"
  },
  "type": "single_sender"
}
```

Multikey:
```
{
  "public_keys": [
    {
      "value": "0x049b8327d929a0e45285c04d19c9fffbee065c266b701972922d807228120e43f34ad68ac77f6ec0205fe39f7c5b6055dad973a03464a3a743302de0feaf6ec6d9",
      "type": "secp256k1_ecdsa"
    }
  ],
  "signatures": [
    {
      "index": 0,
      "signature": {
        "value": "0xd1c84463d33b27977431b60664b36c6c1717569b1fbe2f9808c1e78f36958ae71a2b59a7c062e9491c12e69e25e3d3f82253a4efd1c1857b3695ff1b9050c5e4",
        "type": "secp256k1_ecdsa"
      }
    }
  ],
  "signatures_required": 1,
  "type": "single_sender"
}
```