### PR TITLE
[move] Fix paranoid tests with missing substatus

### DIFF
--- a/third_party/move/move-vm/paranoid-tests/tests/ability/drop/eq_3.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/ability/drop/eq_3.exp
@@ -3,7 +3,7 @@ processed 2 tasks
 task 1 'run'. lines 17-27:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 6)],

--- a/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/address.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/address.exp
@@ -3,7 +3,7 @@ processed 7 tasks
 task 2 'run'. lines 33-41:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: 0x2::A,
     indices: [],
     offsets: [(FunctionDefinitionIndex(2), 3)],
@@ -30,7 +30,7 @@ Error: Script execution failed with VMError: {
 task 6 'run'. lines 78-87:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 6)],

--- a/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/bool.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/bool.exp
@@ -3,7 +3,7 @@ processed 7 tasks
 task 2 'run'. lines 33-41:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: 0x2::A,
     indices: [],
     offsets: [(FunctionDefinitionIndex(2), 3)],
@@ -21,7 +21,7 @@ Error: Script execution failed with VMError: {
 task 6 'run'. lines 78-87:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 6)],

--- a/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/u128.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/u128.exp
@@ -3,7 +3,7 @@ processed 7 tasks
 task 2 'run'. lines 33-41:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: 0x2::A,
     indices: [],
     offsets: [(FunctionDefinitionIndex(2), 3)],
@@ -21,7 +21,7 @@ Error: Script execution failed with VMError: {
 task 6 'run'. lines 78-87:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 6)],

--- a/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/u16.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/u16.exp
@@ -3,7 +3,7 @@ processed 7 tasks
 task 2 'run'. lines 33-41:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: 0x2::A,
     indices: [],
     offsets: [(FunctionDefinitionIndex(2), 3)],
@@ -21,7 +21,7 @@ Error: Script execution failed with VMError: {
 task 6 'run'. lines 78-87:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 6)],

--- a/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/u256.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/u256.exp
@@ -3,7 +3,7 @@ processed 7 tasks
 task 2 'run'. lines 33-41:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: 0x2::A,
     indices: [],
     offsets: [(FunctionDefinitionIndex(2), 3)],
@@ -21,7 +21,7 @@ Error: Script execution failed with VMError: {
 task 6 'run'. lines 78-87:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 6)],

--- a/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/u32.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/u32.exp
@@ -3,7 +3,7 @@ processed 7 tasks
 task 2 'run'. lines 33-41:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: 0x2::A,
     indices: [],
     offsets: [(FunctionDefinitionIndex(2), 3)],
@@ -21,7 +21,7 @@ Error: Script execution failed with VMError: {
 task 6 'run'. lines 78-87:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 6)],

--- a/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/u64.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/u64.exp
@@ -3,7 +3,7 @@ processed 7 tasks
 task 2 'run'. lines 33-41:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: 0x2::A,
     indices: [],
     offsets: [(FunctionDefinitionIndex(2), 3)],
@@ -21,7 +21,7 @@ Error: Script execution failed with VMError: {
 task 6 'run'. lines 78-87:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 6)],

--- a/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/u8.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/type_safety/primitives/u8.exp
@@ -3,7 +3,7 @@ processed 7 tasks
 task 2 'run'. lines 33-41:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: 0x2::A,
     indices: [],
     offsets: [(FunctionDefinitionIndex(2), 3)],
@@ -21,7 +21,7 @@ Error: Script execution failed with VMError: {
 task 6 'run'. lines 78-87:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 6)],

--- a/third_party/move/move-vm/paranoid-tests/tests/type_safety/references/borrow_field.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/type_safety/references/borrow_field.exp
@@ -3,7 +3,7 @@ processed 5 tasks
 task 2 'run'. lines 34-45:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 7)],

--- a/third_party/move/move-vm/paranoid-tests/tests/type_safety/references/borrow_field_generic.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/type_safety/references/borrow_field_generic.exp
@@ -3,7 +3,7 @@ processed 5 tasks
 task 2 'run'. lines 34-45:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 7)],

--- a/third_party/move/move-vm/paranoid-tests/tests/type_safety/references/borrow_global.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/type_safety/references/borrow_global.exp
@@ -12,7 +12,7 @@ Error: Script execution failed with VMError: {
 task 3 'run'. lines 73-86:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 10)],
@@ -21,7 +21,7 @@ Error: Script execution failed with VMError: {
 task 6 'run'. lines 116-127:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 8)],

--- a/third_party/move/move-vm/paranoid-tests/tests/type_safety/references/borrow_global_generic.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/type_safety/references/borrow_global_generic.exp
@@ -12,7 +12,7 @@ Error: Script execution failed with VMError: {
 task 3 'run'. lines 73-86:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 10)],
@@ -21,7 +21,7 @@ Error: Script execution failed with VMError: {
 task 6 'run'. lines 116-127:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 8)],

--- a/third_party/move/move-vm/paranoid-tests/tests/type_safety/references/freeze_ref.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/type_safety/references/freeze_ref.exp
@@ -3,7 +3,7 @@ processed 3 tasks
 task 1 'run'. lines 13-22:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 3)],
@@ -12,7 +12,7 @@ Error: Script execution failed with VMError: {
 task 2 'run'. lines 24-31:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 3)],

--- a/third_party/move/move-vm/paranoid-tests/tests/type_safety/references/write_ref_with_struct.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/type_safety/references/write_ref_with_struct.exp
@@ -3,7 +3,7 @@ processed 3 tasks
 task 2 'run'. lines 47-53:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: 0x2::A,
     indices: [],
     offsets: [(FunctionDefinitionIndex(3), 10)],

--- a/third_party/move/move-vm/paranoid-tests/tests/type_safety/references/write_ref_with_vector.exp
+++ b/third_party/move/move-vm/paranoid-tests/tests/type_safety/references/write_ref_with_vector.exp
@@ -3,7 +3,7 @@ processed 3 tasks
 task 2 'run'. lines 35-50:
 Error: Script execution failed with VMError: {
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 13)],


### PR DESCRIPTION
## Description

Previously, some paranoid checks were missing substatus. Recently landed type builder PR #13028 fixed that, but the tests were not updated and even caught by CI.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
