### PR TITLE
[smoke-test] further enhance progress metrics

### DIFF
--- a/testsuite/forge/src/test_utils/consensus_utils.rs
+++ b/testsuite/forge/src/test_utils/consensus_utils.rs
@@ -99,14 +99,11 @@ pub async fn test_consensus_fault_tolerance(
 
         let cur = get_all_states(&validator_clients).await;
 
-        let epochs = cur.iter().map(|s| s.epoch).max().unwrap()
-            - previous.iter().map(|s| s.epoch).max().unwrap();
-        let rounds = cur
-            .iter()
-            .map(|s| s.round)
-            .max()
-            .unwrap()
-            .saturating_sub(previous.iter().map(|s| s.round).max().unwrap());
+        let (cur_epoch, cur_round) = cur.iter().map(|s| (s.epoch, s.round)).max().unwrap();
+        let (prev_epoch, prev_round) = previous.iter().map(|s| (s.epoch, s.round)).max().unwrap();
+        let epochs = cur_epoch.saturating_sub(prev_epoch);
+        let rounds = cur_round.saturating_sub(prev_round);
+
         let transactions = cur.iter().map(|s| s.version).max().unwrap()
             - previous.iter().map(|s| s.version).max().unwrap();
 


### PR DESCRIPTION
Right now if we have
All at epochs: [3, 3, 3, 3], from [3, 2, 3, 2]
All at rounds: [9, 9, 9, 9], from [1, 10, 1, 10]

it'll report 0 epochs and 0 round, because it uses current max epoch/round - previous max epoch/round, which is 3 - 3, 9 - 10.

this commit updates it to look at maximum of (epoch, round) and compare, in this case (3, 9) - (3, 1) = (0, 8)