### PR TITLE
[Data Service] Implement simple upstream transaction filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,6 +2013,7 @@ dependencies = [
  "aptos-metrics-core",
  "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=4801acae7aea30d7e96bbfbe5ec5b04056dfa4cf)",
  "aptos-protos 1.3.0",
+ "aptos-transaction-filter",
  "async-trait",
  "clap 4.4.14",
  "futures",
@@ -10189,9 +10190,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
@@ -15431,18 +15432,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/Cargo.toml
@@ -19,6 +19,7 @@ aptos-indexer-grpc-utils = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-moving-average = { workspace = true }
 aptos-protos = { workspace = true }
+aptos-transaction-filter = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true }
 futures = { workspace = true }

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/metrics.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/metrics.rs
@@ -100,12 +100,58 @@ pub static SHORT_CONNECTION_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Count of bytes transfered to the client. This only represents the bytes prepared and ready
-/// to send to the client. It does not represent the bytes actually sent to the client.
+/// Count of bytes transfered to the client. This only represents the bytes prepared and
+/// ready to send to the client. This only t It does not represent the bytes actually
+/// sent to the client.
+///
+/// This is pre stripping, so it may include bytes for transactions that were later
+/// stripped. See BYTES_READY_TO_TRANSFER_FROM_SERVER_AFTER_STRIPPING for post
+/// stirpping.
 pub static BYTES_READY_TO_TRANSFER_FROM_SERVER: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "indexer_grpc_data_service_bytes_ready_to_transfer_from_server",
-        "Count of bytes ready to transfer to the client",
+        "Count of bytes ready to transfer to the client (pre stripping)",
+        &[
+            "identifier_type",
+            "identifier",
+            "email",
+            "application_name",
+            "processor"
+        ],
+    )
+    .unwrap()
+});
+
+/// Count of bytes transfered to the client. This only represents the bytes prepared and
+/// ready to send to the client. This only t It does not represent the bytes actually
+/// sent to the client.
+///
+/// This is post stripping, meaning some transactions may have been stripped (removing
+/// things such as events, writesets, payload, signature). Compare this with
+/// BYTES_READY_TO_TRANSFER_FROM_SERVER to see how many bytes were stripped.
+pub static BYTES_READY_TO_TRANSFER_FROM_SERVER_AFTER_STRIPPING: Lazy<IntCounterVec> =
+    Lazy::new(|| {
+        register_int_counter_vec!(
+            "indexer_grpc_data_service_bytes_ready_to_transfer_from_server_after_stripping",
+            "Count of bytes ready to transfer to the client (post stripping)",
+            &[
+                "identifier_type",
+                "identifier",
+                "email",
+                "application_name",
+                "processor"
+            ],
+        )
+        .unwrap()
+    });
+
+/// The number of transactions that had data (such as events, writesets, payload,
+/// signature) stripped from them due to the `txns_to_strip_filter`. See
+/// `strip_transactions` for more.
+pub static NUM_TRANSACTIONS_STRIPPED: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "indexer_grpc_data_service_num_transactions_stripped",
+        "Number of transactions that had data (such as events, writesets, payload, signature) stripped from them",
         &[
             "identifier_type",
             "identifier",


### PR DESCRIPTION
## Description
There are two types of transaction filtering we will support in the future:
1. Per stream configuration: The downstream declares what txns they want to receive.
2. Global configuration: At the data service level we refuse to include full txns for all streams.

This PR implements the second of these, using @CapCap's work here:
~https://github.com/aptos-labs/aptos-indexer-processors/pull/398~ https://github.com/aptos-labs/aptos-core/pull/13715.

Rather than not sending txns at all if they match the blocklist filters, we just omit the writesets and events (and payload + signature, like we did with `sender_addresses_to_ignore`). Not sending the txns entirely would cause issues with processors, which today assume that they will receive all txns.

The txn filtering stuff is a superset of the existing `sender_addresses_to_ignore` functionality, so I remove that in this PR. I will include how to express `sender_addresses_to_ignore` using the txn filter stuff in the [runbook](https://www.notion.so/aptoslabs/Runbook-c006a37259394ac2ba904d6b54d180fa).

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
See updated unit test. We'll try this out in devnet first and release as per the release strategy.

## Key Areas to Review
Make sure the configuration approach seems ergonomic.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
