### PR TITLE
account recovery db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,7 +333,7 @@ dependencies = [
  "poem",
  "processor",
  "rand 0.7.3",
- "reqwest",
+ "reqwest 0.11.23",
  "self_update",
  "serde",
  "serde_json",
@@ -457,7 +457,7 @@ dependencies = [
  "proptest",
  "rand 0.7.3",
  "regex",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "tokio",
@@ -590,7 +590,7 @@ dependencies = [
  "proptest",
  "rand 0.7.3",
  "regex",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -619,7 +619,7 @@ dependencies = [
  "bytes",
  "hyper 0.14.28",
  "once_cell",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "tokio",
  "tokio-stream",
@@ -750,7 +750,7 @@ dependencies = [
  "env_logger",
  "guppy",
  "log",
- "reqwest",
+ "reqwest 0.11.23",
  "url",
 ]
 
@@ -1636,7 +1636,7 @@ dependencies = [
  "poem-openapi",
  "rand 0.7.3",
  "redis",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -1680,7 +1680,7 @@ dependencies = [
  "env_logger",
  "futures",
  "gcp-bigquery-client",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "tokio",
@@ -1727,7 +1727,7 @@ dependencies = [
  "prometheus-http-query",
  "rand 0.7.3",
  "regex",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -1759,7 +1759,7 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "random_word",
- "reqwest",
+ "reqwest 0.11.23",
  "serde_yaml 0.8.26",
  "tokio",
  "url",
@@ -2022,7 +2022,7 @@ dependencies = [
  "once_cell",
  "prost 0.12.3",
  "redis",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "tempfile",
  "tokio",
@@ -2167,7 +2167,7 @@ dependencies = [
  "once_cell",
  "redis",
  "regex",
- "reqwest",
+ "reqwest 0.11.23",
  "tempfile",
  "tokio",
  "tracing",
@@ -2282,7 +2282,7 @@ dependencies = [
  "hyper 0.14.28",
  "once_cell",
  "prometheus",
- "reqwest",
+ "reqwest 0.11.23",
  "rusty-fork",
  "serde_json",
  "tokio",
@@ -2360,7 +2360,7 @@ dependencies = [
  "aptos-types",
  "http 0.2.11",
  "move-core-types",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "tokio",
@@ -2444,7 +2444,6 @@ dependencies = [
  "serde",
  "serde-big-array",
  "sha2 0.10.8",
- "sha3 0.9.1",
 ]
 
 [[package]]
@@ -2452,6 +2451,7 @@ name = "aptos-keyless-pepper-example-client-rust"
 version = "0.1.0"
 dependencies = [
  "aptos-crypto",
+ "aptos-infallible",
  "aptos-keyless-pepper-common",
  "aptos-types",
  "ark-bls12-381",
@@ -2459,7 +2459,7 @@ dependencies = [
  "bcs 0.1.4",
  "firestore",
  "hex",
- "reqwest",
+ "reqwest 0.11.23",
  "serde_json",
  "tokio",
 ]
@@ -2484,7 +2484,6 @@ dependencies = [
  "bcs 0.1.4",
  "dashmap",
  "firestore",
- "google-cloud-auth 0.13.2",
  "hex",
  "hyper 0.14.28",
  "jsonwebtoken 8.3.0",
@@ -2492,7 +2491,7 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "regex",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "sha3 0.9.1",
@@ -2698,7 +2697,7 @@ dependencies = [
  "clap 4.4.14",
  "itertools 0.13.0",
  "regex",
- "reqwest",
+ "reqwest 0.11.23",
  "tokio",
  "url",
 ]
@@ -2979,7 +2978,7 @@ dependencies = [
  "image",
  "once_cell",
  "regex",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "sha256",
@@ -3081,7 +3080,7 @@ dependencies = [
  "poem",
  "poem-openapi",
  "prometheus-parse",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -3354,7 +3353,7 @@ dependencies = [
  "move-vm-types",
  "once_cell",
  "parking_lot 0.12.1",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -3415,7 +3414,7 @@ dependencies = [
  "clap 4.4.14",
  "hex",
  "move-core-types",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "thiserror",
@@ -3462,7 +3461,7 @@ dependencies = [
  "itertools 0.13.0",
  "move-core-types",
  "once_cell",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -3910,7 +3909,7 @@ dependencies = [
  "prometheus",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "reqwest",
+ "reqwest 0.11.23",
  "reqwest-middleware",
  "reqwest-retry",
  "serde",
@@ -3949,7 +3948,7 @@ dependencies = [
  "prometheus",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "reqwest",
+ "reqwest 0.11.23",
  "reqwest-middleware",
  "reqwest-retry",
  "serde",
@@ -3996,7 +3995,7 @@ dependencies = [
  "hex",
  "itertools 0.13.0",
  "rand 0.7.3",
- "reqwest",
+ "reqwest 0.11.23",
  "tokio",
  "tokio-scoped",
 ]
@@ -4074,7 +4073,7 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "tokio",
  "url",
@@ -4204,7 +4203,7 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "regex",
- "reqwest",
+ "reqwest 0.11.23",
  "ring 0.16.20",
  "rsa 0.9.6",
  "serde",
@@ -6112,7 +6111,7 @@ dependencies = [
  "lazy_static",
  "pem 0.8.3",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.11.23",
  "ring 0.16.20",
  "serde",
  "serde_json",
@@ -7897,9 +7896,9 @@ checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
 name = "firestore"
-version = "0.42.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bd798d0f3ed4d311c032374fbed2010f99eea98c49efff12252653a73eef23"
+checksum = "11f7f676812c6a51d8584aa52252e2d3a02417ee0b27966c7059fe4ef80945d5"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7907,7 +7906,7 @@ dependencies = [
  "futures",
  "gcloud-sdk",
  "hex",
- "hyper 0.14.28",
+ "hyper 1.4.1",
  "rand 0.8.5",
  "rsb_derive",
  "rvstruct",
@@ -8254,41 +8253,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
-name = "gcemeta"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d460327b24cc34c86d53d60a90e9e6044817f7906ebd9baa5c3d0ee13e1ecf"
-dependencies = [
- "bytes",
- "hyper 0.14.28",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "gcloud-sdk"
-version = "0.24.7"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa57d45d9a9778e0bf38deb6a4c9dbe293fa021d0b70b126b5dc593979b08569"
+checksum = "898e349fb0fabc16892de7858e5650b70a8044edeee13469cb2f7649040bf3c2"
 dependencies = [
  "async-trait",
+ "bytes",
  "chrono",
  "futures",
- "gcemeta",
- "hyper 0.14.28",
+ "hyper 1.4.1",
  "jsonwebtoken 9.3.0",
  "once_cell",
- "prost 0.12.3",
- "prost-types 0.12.3",
- "reqwest",
+ "prost 0.13.1",
+ "prost-types 0.13.1",
+ "reqwest 0.12.5",
  "secret-vault-value",
  "serde",
  "serde_json",
  "tokio",
- "tonic 0.11.0",
+ "tonic 0.12.1",
  "tower",
  "tower-layer",
  "tower-util",
@@ -8308,7 +8292,7 @@ dependencies = [
  "hyper 0.14.28",
  "hyper-rustls 0.24.2",
  "log",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "thiserror",
@@ -8524,33 +8508,11 @@ checksum = "931bedb2264cb00f914b0a6a5c304e34865c34306632d3932e0951a073e4a67d"
 dependencies = [
  "async-trait",
  "base64 0.21.6",
- "google-cloud-metadata 0.3.2",
+ "google-cloud-metadata",
  "google-cloud-token",
  "home",
  "jsonwebtoken 8.3.0",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "time",
- "tokio",
- "tracing",
- "urlencoding",
-]
-
-[[package]]
-name = "google-cloud-auth"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf7cb7864f08a92e77c26bb230d021ea57691788fb5dd51793f96965d19e7f9"
-dependencies = [
- "async-trait",
- "base64 0.21.6",
- "google-cloud-metadata 0.4.0",
- "google-cloud-token",
- "home",
- "jsonwebtoken 9.3.0",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "thiserror",
@@ -8593,18 +8555,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96e4ad0802d3f416f62e7ce01ac1460898ee0efc98f8b45cd4aab7611607012f"
 dependencies = [
- "reqwest",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "google-cloud-metadata"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc279bfb50487d7bcd900e8688406475fc750fe474a835b2ab9ade9eb1fc90e2"
-dependencies = [
- "reqwest",
+ "reqwest 0.11.23",
  "thiserror",
  "tokio",
 ]
@@ -8617,7 +8568,7 @@ checksum = "095b104502b6e1abbad9b9768af944b9202e032dbc7f0947d3c30d4191761071"
 dependencies = [
  "async-channel 1.9.0",
  "async-stream",
- "google-cloud-auth 0.12.0",
+ "google-cloud-auth",
  "google-cloud-gax",
  "google-cloud-googleapis",
  "google-cloud-token",
@@ -8638,14 +8589,14 @@ dependencies = [
  "base64 0.21.6",
  "bytes",
  "futures-util",
- "google-cloud-auth 0.12.0",
- "google-cloud-metadata 0.3.2",
+ "google-cloud-auth",
+ "google-cloud-metadata",
  "google-cloud-token",
  "hex",
  "once_cell",
  "percent-encoding",
  "regex",
- "reqwest",
+ "reqwest 0.11.23",
  "ring 0.16.20",
  "rsa 0.6.1",
  "serde",
@@ -9210,6 +9161,7 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -9244,6 +9196,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-util",
+ "rustls 0.23.7",
+ "rustls-native-certs 0.7.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9253,6 +9223,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -9275,12 +9258,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
+ "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "hyper 1.4.1",
  "pin-project-lite",
+ "socket2 0.5.5",
  "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -9910,7 +9898,7 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-rustls 0.23.2",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "jsonpath_lib",
  "k8s-openapi",
  "kube-core",
@@ -13263,7 +13251,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ae2f6a3f14ff35c16b51ac796d1dc73c15ad6472c48836c6c467f6d52266648"
 dependencies = [
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "time",
@@ -13334,6 +13322,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.1",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13360,6 +13358,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13375,6 +13386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
 dependencies = [
  "prost 0.12.3",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee5168b05f49d4b0ca581206eb14a7b22fafd963efe729ac48eb03266e25cc2"
+dependencies = [
+ "prost 0.13.1",
 ]
 
 [[package]]
@@ -13516,6 +13536,52 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
  "parking_lot 0.12.1",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.7",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand 0.8.5",
+ "ring 0.17.7",
+ "rustc-hash",
+ "rustls 0.23.7",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2 0.5.5",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13816,7 +13882,6 @@ version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
- "async-compression",
  "base64 0.21.6",
  "bytes",
  "cookie 0.16.2",
@@ -13840,7 +13905,6 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.10",
- "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -13854,10 +13918,56 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.3.0",
  "web-sys",
  "webpki-roots 0.25.3",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+dependencies = [
+ "async-compression",
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.2",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.7",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tokio-util 0.7.10",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.0",
+ "web-sys",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -13869,7 +13979,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 0.2.11",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "task-local-extensions",
  "thiserror",
@@ -13889,7 +13999,7 @@ dependencies = [
  "http 0.2.11",
  "hyper 0.14.28",
  "parking_lot 0.11.2",
- "reqwest",
+ "reqwest 0.11.23",
  "reqwest-middleware",
  "retry-policies",
  "task-local-extensions",
@@ -14543,7 +14653,7 @@ dependencies = [
  "log",
  "quick-xml 0.23.1",
  "regex",
- "reqwest",
+ "reqwest 0.11.23",
  "self-replace",
  "semver",
  "serde_json",
@@ -15209,7 +15319,7 @@ dependencies = [
  "once_cell",
  "rand 0.7.3",
  "regex",
- "reqwest",
+ "reqwest 0.11.23",
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -16233,7 +16343,7 @@ dependencies = [
  "http 0.2.11",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project 1.1.3",
  "prost 0.11.9",
@@ -16263,7 +16373,7 @@ dependencies = [
  "http 0.2.11",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project 1.1.3",
  "prost 0.12.3",
@@ -16279,6 +16389,39 @@ dependencies = [
  "tower-service",
  "tracing",
  "zstd",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38659f4a91aba8598d27821589f5db7dddd94601e7a01b1e485a50e5484c7401"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.5",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-timeout 0.5.1",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project 1.1.3",
+ "prost 0.13.1",
+ "rustls-native-certs 0.7.0",
+ "rustls-pemfile 2.1.1",
+ "socket2 0.5.5",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -16984,7 +17127,7 @@ checksum = "948552bbb7a5fb4ba3169fd09b6c1ab53c1b2fdd82603295df550f7a1ec644c0"
 dependencies = [
  "hyper 0.14.28",
  "once_cell",
- "reqwest",
+ "reqwest 0.11.23",
  "thiserror",
  "unicase",
  "warp",
@@ -17079,6 +17222,19 @@ name = "wasm-streams"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -17446,6 +17602,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
  "move-bytecode-verifier",
  "num_cpus",
  "once_cell",
- "pin-project",
+ "pin-project 1.1.3",
  "proptest",
  "rand 0.7.3",
  "regex",
@@ -2444,6 +2444,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "sha2 0.10.8",
+ "sha3 0.9.1",
 ]
 
 [[package]]
@@ -2456,6 +2457,7 @@ dependencies = [
  "ark-bls12-381",
  "ark-serialize",
  "bcs 0.1.4",
+ "firestore",
  "hex",
  "reqwest",
  "serde_json",
@@ -2469,6 +2471,7 @@ dependencies = [
  "aes-gcm",
  "anyhow",
  "aptos-crypto",
+ "aptos-infallible",
  "aptos-inspection-service",
  "aptos-keyless-pepper-common",
  "aptos-logger",
@@ -2480,6 +2483,8 @@ dependencies = [
  "ark-serialize",
  "bcs 0.1.4",
  "dashmap",
+ "firestore",
+ "google-cloud-auth 0.13.2",
  "hex",
  "hyper 0.14.28",
  "jsonwebtoken 8.3.0",
@@ -2812,7 +2817,7 @@ dependencies = [
  "aptos-types",
  "bytes",
  "futures",
- "pin-project",
+ "pin-project 1.1.3",
  "serde",
  "tokio",
  "tokio-util 0.7.10",
@@ -2852,7 +2857,7 @@ dependencies = [
  "maplit",
  "once_cell",
  "ordered-float 3.9.2",
- "pin-project",
+ "pin-project 1.1.3",
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
@@ -3309,7 +3314,7 @@ dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
  "futures",
- "pin-project",
+ "pin-project 1.1.3",
  "tokio",
  "tokio-util 0.7.10",
 ]
@@ -4003,7 +4008,7 @@ dependencies = [
  "aptos-infallible",
  "enum_dispatch",
  "futures",
- "pin-project",
+ "pin-project 1.1.3",
  "thiserror",
  "tokio",
  "tokio-test",
@@ -4773,6 +4778,19 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd066d0b4ef8ecb03a55319dc13aa6910616d0f44008a045bb1835af830abff5"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -6308,6 +6326,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7002,7 +7029,7 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -7869,6 +7896,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
 
 [[package]]
+name = "firestore"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bd798d0f3ed4d311c032374fbed2010f99eea98c49efff12252653a73eef23"
+dependencies = [
+ "async-trait",
+ "backoff",
+ "chrono",
+ "futures",
+ "gcloud-sdk",
+ "hex",
+ "hyper 0.14.28",
+ "rand 0.8.5",
+ "rsb_derive",
+ "rvstruct",
+ "serde",
+ "struct-path",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "fixed"
 version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8204,6 +8254,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
+name = "gcemeta"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d460327b24cc34c86d53d60a90e9e6044817f7906ebd9baa5c3d0ee13e1ecf"
+dependencies = [
+ "bytes",
+ "hyper 0.14.28",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "gcloud-sdk"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa57d45d9a9778e0bf38deb6a4c9dbe293fa021d0b70b126b5dc593979b08569"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "gcemeta",
+ "hyper 0.14.28",
+ "jsonwebtoken 9.3.0",
+ "once_cell",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
+ "reqwest",
+ "secret-vault-value",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tonic 0.11.0",
+ "tower",
+ "tower-layer",
+ "tower-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "gcp-bigquery-client"
 version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8431,10 +8524,32 @@ checksum = "931bedb2264cb00f914b0a6a5c304e34865c34306632d3932e0951a073e4a67d"
 dependencies = [
  "async-trait",
  "base64 0.21.6",
- "google-cloud-metadata",
+ "google-cloud-metadata 0.3.2",
  "google-cloud-token",
  "home",
  "jsonwebtoken 8.3.0",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "tokio",
+ "tracing",
+ "urlencoding",
+]
+
+[[package]]
+name = "google-cloud-auth"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf7cb7864f08a92e77c26bb230d021ea57691788fb5dd51793f96965d19e7f9"
+dependencies = [
+ "async-trait",
+ "base64 0.21.6",
+ "google-cloud-metadata 0.4.0",
+ "google-cloud-token",
+ "home",
+ "jsonwebtoken 9.3.0",
  "reqwest",
  "serde",
  "serde_json",
@@ -8484,6 +8599,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "google-cloud-metadata"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc279bfb50487d7bcd900e8688406475fc750fe474a835b2ab9ade9eb1fc90e2"
+dependencies = [
+ "reqwest",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "google-cloud-pubsub"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8491,7 +8617,7 @@ checksum = "095b104502b6e1abbad9b9768af944b9202e032dbc7f0947d3c30d4191761071"
 dependencies = [
  "async-channel 1.9.0",
  "async-stream",
- "google-cloud-auth",
+ "google-cloud-auth 0.12.0",
  "google-cloud-gax",
  "google-cloud-googleapis",
  "google-cloud-token",
@@ -8512,8 +8638,8 @@ dependencies = [
  "base64 0.21.6",
  "bytes",
  "futures-util",
- "google-cloud-auth",
- "google-cloud-metadata",
+ "google-cloud-auth 0.12.0",
+ "google-cloud-metadata 0.3.2",
  "google-cloud-token",
  "hex",
  "once_cell",
@@ -9166,7 +9292,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hyper 0.14.28",
- "pin-project",
+ "pin-project 1.1.3",
  "tokio",
 ]
 
@@ -9694,6 +9820,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+dependencies = [
+ "base64 0.21.6",
+ "js-sys",
+ "pem 3.0.4",
+ "ring 0.17.7",
+ "serde",
+ "serde_json",
+ "simple_asn1 0.6.2",
+]
+
+[[package]]
 name = "jwt"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9774,7 +9915,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem 1.1.1",
- "pin-project",
+ "pin-project 1.1.3",
  "rustls 0.20.9",
  "rustls-pemfile 0.2.1",
  "serde",
@@ -12267,6 +12408,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12404,11 +12555,31 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
+dependencies = [
+ "pin-project-internal 0.4.30",
+]
+
+[[package]]
+name = "pin-project"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 1.1.3",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -13645,6 +13816,7 @@ version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
+ "async-compression",
  "base64 0.21.6",
  "bytes",
  "cookie 0.16.2",
@@ -13668,6 +13840,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.10",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -13878,6 +14051,17 @@ dependencies = [
  "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rsb_derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2c53e42fccdc5f1172e099785fe78f89bc0c1e657d0c2ef591efbfac427e9a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -14163,6 +14347,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rvs_derive"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1fa12378eb54f3d4f2db8dcdbe33af610b7e7d001961c1055858282ecef2a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rvstruct"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5107860ec34506b64cf3680458074eac5c2c564f7ccc140918bbcd1714fd8d5d"
+dependencies = [
+ "rvs_derive",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14279,6 +14483,19 @@ dependencies = [
  "pkcs8 0.10.2",
  "serdect",
  "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secret-vault-value"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5f8cfb86d2019f64a4cfb49e499f401f406fbec946c1ffeea9d0504284347de"
+dependencies = [
+ "prost 0.12.3",
+ "prost-types 0.12.3",
+ "serde",
+ "serde_json",
  "zeroize",
 ]
 
@@ -15162,6 +15379,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "struct-path"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899edf28cf7320503eda593b4bbce1bc5e9533501a11d45537e2c5be90128fc7"
+dependencies = [
+ "convert_case 0.6.0",
+]
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15800,7 +16026,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
- "pin-project",
+ "pin-project 1.1.3",
  "rand 0.8.5",
  "tokio",
 ]
@@ -16009,7 +16235,7 @@ dependencies = [
  "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
- "pin-project",
+ "pin-project 1.1.3",
  "prost 0.11.9",
  "rustls-pemfile 1.0.4",
  "tokio",
@@ -16039,7 +16265,7 @@ dependencies = [
  "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
- "pin-project",
+ "pin-project 1.1.3",
  "prost 0.12.3",
  "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.1",
@@ -16077,7 +16303,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap 1.9.3",
- "pin-project",
+ "pin-project 1.1.3",
  "pin-project-lite",
  "rand 0.8.5",
  "slab",
@@ -16121,6 +16347,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
+name = "tower-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1093c19826d33807c72511e68f73b4a0469a3f22c2bd5f7d5212178b4b89674"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project 0.4.30",
+ "tower-service",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16159,7 +16397,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project",
+ "pin-project 1.1.3",
  "tracing",
 ]
 
@@ -16723,7 +16961,7 @@ dependencies = [
  "mime_guess",
  "multer 2.1.0",
  "percent-encoding",
- "pin-project",
+ "pin-project 1.1.3",
  "rustls-pemfile 1.0.4",
  "scoped-tls",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -569,7 +569,7 @@ fail = "0.5.0"
 ff = { version = "0.13", features = ["derive"] }
 field_count = "0.1.1"
 file_diff = "1.0.0"
-firestore = "0.42.0"
+firestore = "0.43.0"
 fixed = "1.25.1"
 flate2 = "1.0.24"
 flexi_logger = "0.27.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -569,6 +569,7 @@ fail = "0.5.0"
 ff = { version = "0.13", features = ["derive"] }
 field_count = "0.1.1"
 file_diff = "1.0.0"
+firestore = "0.42.0"
 fixed = "1.25.1"
 flate2 = "1.0.24"
 flexi_logger = "0.27.4"

--- a/keyless/pepper/common/Cargo.toml
+++ b/keyless/pepper/common/Cargo.toml
@@ -36,6 +36,7 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde-big-array = { workspace = true }
 sha2_0_10_6 = { workspace = true }
+sha3 = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["bcs"]

--- a/keyless/pepper/common/Cargo.toml
+++ b/keyless/pepper/common/Cargo.toml
@@ -36,7 +36,6 @@ regex = { workspace = true }
 serde = { workspace = true }
 serde-big-array = { workspace = true }
 sha2_0_10_6 = { workspace = true }
-sha3 = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["bcs"]

--- a/keyless/pepper/common/src/account_recovery_db.rs
+++ b/keyless/pepper/common/src/account_recovery_db.rs
@@ -16,6 +16,7 @@ pub struct AccountRecoveryDbEntry {
 }
 
 impl AccountRecoveryDbEntry {
+    /// Derive a unique ID for a document/data entry.
     pub fn document_id(&self) -> String {
         let mut hasher = Sha3_256::new();
         hasher.update((self.iss.len() as u64).to_be_bytes());

--- a/keyless/pepper/common/src/aud_db.rs
+++ b/keyless/pepper/common/src/aud_db.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Deserialize, Serialize};
+use aptos_crypto::compat::Sha3_256;
+use ed25519_dalek::Digest;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AudDbEntry {
+    pub iss: String,
+    pub aud: String,
+    pub uid_key: String,
+    pub uid_val: String,
+    pub last_request_unix_ms: u64,
+}
+
+impl AudDbEntry {
+    pub fn document_id(&self) -> String {
+        let mut hasher = Sha3_256::new();
+        hasher.update((self.iss.len() as u64).to_be_bytes());
+        hasher.update(&self.iss);
+        hasher.update((self.aud.len() as u64).to_be_bytes());
+        hasher.update(&self.aud);
+        hasher.update((self.uid_key.len() as u64).to_be_bytes());
+        hasher.update(&self.uid_key);
+        hasher.update((self.uid_val.len() as u64).to_be_bytes());
+        hasher.update(&self.uid_val);
+        let digest = hasher.finalize();
+        hex::encode(digest.as_slice())
+    }
+}

--- a/keyless/pepper/common/src/aud_db.rs
+++ b/keyless/pepper/common/src/aud_db.rs
@@ -5,8 +5,9 @@ use crate::{Deserialize, Serialize};
 use aptos_crypto::compat::Sha3_256;
 use ed25519_dalek::Digest;
 
+/// The schema used in the account recovery DB.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct AudDbEntry {
+pub struct AccountRecoveryDbEntry {
     pub iss: String,
     pub aud: String,
     pub uid_key: String,
@@ -14,7 +15,7 @@ pub struct AudDbEntry {
     pub last_request_unix_ms: u64,
 }
 
-impl AudDbEntry {
+impl AccountRecoveryDbEntry {
     pub fn document_id(&self) -> String {
         let mut hasher = Sha3_256::new();
         hasher.update((self.iss.len() as u64).to_be_bytes());

--- a/keyless/pepper/common/src/lib.rs
+++ b/keyless/pepper/common/src/lib.rs
@@ -4,9 +4,10 @@
 use aptos_types::transaction::authenticator::EphemeralPublicKey;
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
-pub mod aud_db;
+pub mod account_recovery_db;
 pub mod jwt;
 pub mod vuf;
+
 /// Custom serialization function to convert Vec<u8> into a hex string.
 fn serialize_bytes_to_hex<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
 where

--- a/keyless/pepper/common/src/lib.rs
+++ b/keyless/pepper/common/src/lib.rs
@@ -4,9 +4,9 @@
 use aptos_types::transaction::authenticator::EphemeralPublicKey;
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
+pub mod aud_db;
 pub mod jwt;
 pub mod vuf;
-
 /// Custom serialization function to convert Vec<u8> into a hex string.
 fn serialize_bytes_to_hex<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
 where

--- a/keyless/pepper/example-client-rust/Cargo.toml
+++ b/keyless/pepper/example-client-rust/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 aptos-crypto = { workspace = true }
+aptos-infallible = { workspace = true }
 aptos-keyless-pepper-common = { workspace = true }
 aptos-types = { workspace = true }
 ark-bls12-381 = { workspace = true }

--- a/keyless/pepper/example-client-rust/Cargo.toml
+++ b/keyless/pepper/example-client-rust/Cargo.toml
@@ -19,6 +19,7 @@ aptos-types = { workspace = true }
 ark-bls12-381 = { workspace = true }
 ark-serialize = { workspace = true }
 bcs = { workspace = true }
+firestore = { workspace = true }
 hex = { workspace = true }
 reqwest = { workspace = true }
 serde_json = { workspace = true }

--- a/keyless/pepper/example-client-rust/src/main.rs
+++ b/keyless/pepper/example-client-rust/src/main.rs
@@ -4,7 +4,7 @@
 use aptos_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use aptos_infallible::duration_since_epoch;
 use aptos_keyless_pepper_common::{
-    aud_db::AccountRecoveryDbEntry,
+    account_recovery_db::AccountRecoveryDbEntry,
     jwt,
     vuf::{self, VUF},
     PepperInput, PepperRequest, PepperResponse, PepperV0VufPubKey, SignatureResponse,

--- a/keyless/pepper/readme.md
+++ b/keyless/pepper/readme.md
@@ -1,17 +1,44 @@
-## Quickstart
+## Dev guide
 
-Start the pepper service in terminal 1.
+### Prepare dependency: a firestore instance.
+
+Pepper service now depends on firestore on GCP.
+You must have a GCP project in order to run firestore emulator locally
+You also need to create a service account, and grant firestore access to it, and download its credential file.
+Below we assume the credential file has been saved as `credential.json`.
+
+In terminal 0, start a local firestore emulator.
 ```bash
-ACCOUNT_MANAGER_0_ISSUER=https://accounts.google.com \
+gcloud emulators firestore start --host-port=localhost:8081
+```
+
+In terminal 1, start the pepper service.
+```bash
+FIRESTORE_EMULATOR_HOST=localhost:8081 \
+  GOOGLE_APPLICATION_CREDENTIALS=credential.json \
+  KEYLESS_PROJECT_ID=$(gcloud config get-value project) \
+  DATABASE_ID=account-db-devnet \
+  ACCOUNT_MANAGER_0_ISSUER=https://accounts.google.com \
   ACCOUNT_MANAGER_0_AUD=407408718192.apps.googleusercontent.com \
   VUF_KEY_SEED_HEX=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff \
   cargo run -p aptos-keyless-pepper-service
 ```
-NOTE: `ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00` is a dummy VUF private key seed.
+
+Remarks.
+- `ACCOUNT_MANAGER_0_ISSUER` and `ACCOUNT_MANAGER_0_AUD` together determines an account manager app which allows [account recovery/discovery](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-61.md#recovery-service).
+  - To specify more account managers, give each a short ID `X` and specify envvars `ACCOUNT_MANAGER_X_ISSUER` and `ACCOUNT_MANAGER_X_AUD`.
+- `VUF_KEY_SEED_HEX=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00` is a dummy VUF private key seed.
+- `GOOGLE_APPLICATION_CREDENTIALS` and `KEYLESS_PROJECT_ID` are required to connect to firestore.
+- If `FIRESTORE_EMULATOR_HOST` is specified, pepper service will connect to to specified emulator;
+  otherwise (probably the case in production), it connects to the default firestore instance in the GCP project as specified by `KEYLESS_PROJECT_ID`.
 
 Run the example client in terminal 2.
 ```bash
-cargo run -p aptos-keyless-pepper-example-client-rust
+FIRESTORE_EMULATOR_HOST=localhost:8081 \
+  GOOGLE_APPLICATION_CREDENTIALS=credential.json \
+  KEYLESS_PROJECT_ID=$(gcloud config get-value project) \
+  DATABASE_ID=account-db-devnet \
+  cargo run -p aptos-keyless-pepper-example-client-rust
 ```
 This is an interactive console program.
 Follow the instruction to manually complete a session with the pepper service.

--- a/keyless/pepper/service/Cargo.toml
+++ b/keyless/pepper/service/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = { workspace = true }
 aes-gcm = { workspace = true }
 anyhow = { workspace = true }
 aptos-crypto = { workspace = true }
+aptos-infallible = { workspace = true }
 aptos-inspection-service = { workspace = true }
 aptos-keyless-pepper-common = { workspace = true }
 aptos-logger = { workspace = true }
@@ -27,6 +28,7 @@ ark-ff = { workspace = true }
 ark-serialize = { workspace = true }
 bcs = { workspace = true }
 dashmap = { workspace = true }
+firestore = { workspace = true }
 hex = { workspace = true }
 hyper = { workspace = true }
 jsonwebtoken = { workspace = true }
@@ -40,3 +42,4 @@ serde_json = { workspace = true }
 sha3 = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
+google-cloud-auth = "0.13.0"

--- a/keyless/pepper/service/Cargo.toml
+++ b/keyless/pepper/service/Cargo.toml
@@ -42,4 +42,3 @@ serde_json = { workspace = true }
 sha3 = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
-google-cloud-auth = "0.13.0"

--- a/keyless/pepper/service/src/account_db.rs
+++ b/keyless/pepper/service/src/account_db.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use std::env::VarError;
+use firestore::{FirestoreDb, FirestoreDbOptions};
+use google_cloud_auth::project::Config;
+use once_cell::sync::Lazy;
+use tokio::sync::OnceCell;
+use aptos_logger::{info, warn};
+
+pub static AUD_DB: Lazy<OnceCell<FirestoreDb>> = Lazy::new(OnceCell::new);
+
+pub async fn init_account_db() -> FirestoreDb {
+    let google_project_id = match std::env::var("KEYLESS_PROJECT_ID") {
+        Ok(id) => id,
+        Err(e) => {
+            warn!("Could not load envvar `KEYLESS_PROJECT_ID`: {e}");
+            "unknown_project".to_string()
+        }
+    };
+
+    let database_id = match std::env::var("DATABASE_ID") {
+        Ok(id) => id,
+        Err(e) => {
+            warn!("Could not load envvar `DATABASE_ID`: {e}");
+            "unknown_database".to_string()
+        }
+    };
+
+    let option = FirestoreDbOptions {
+        google_project_id,
+        database_id,
+        max_retries: 1,
+        firebase_api_url: None,
+    };
+    FirestoreDb::with_options(option).await.unwrap()
+}

--- a/keyless/pepper/service/src/lib.rs
+++ b/keyless/pepper/service/src/lib.rs
@@ -12,7 +12,7 @@ use aptos_crypto::asymmetric_encryption::{
 };
 use aptos_infallible::duration_since_epoch;
 use aptos_keyless_pepper_common::{
-    aud_db::AccountRecoveryDbEntry,
+    account_recovery_db::AccountRecoveryDbEntry,
     jwt::Claims,
     vuf::{
         self,

--- a/keyless/pepper/service/src/main.rs
+++ b/keyless/pepper/service/src/main.rs
@@ -7,9 +7,10 @@ use aptos_keyless_pepper_service::{
     account_managers::ACCOUNT_MANAGERS,
     jwk::{self, parse_jwks, DECODING_KEY_CACHE},
     metrics::start_metric_server,
-    process_signature_v0, process_v0,
     vuf_keys::{PEPPER_VUF_VERIFICATION_KEY_JSON, VUF_SK},
-    ProcessingFailure::{self, BadRequest, InternalError},
+    HandlerTrait,
+    ProcessingFailure::{BadRequest, InternalError},
+    V0FetchHandler, V0SignatureHandler,
 };
 use aptos_logger::info;
 use aptos_types::keyless::test_utils::get_sample_iss;
@@ -23,6 +24,7 @@ use hyper::{
 };
 use serde::{de::DeserializeOwned, Serialize};
 use std::{convert::Infallible, fmt::Debug, net::SocketAddr, ops::Deref, time::Duration};
+use aptos_keyless_pepper_service::account_db::{AUD_DB, init_account_db};
 
 async fn handle_request(req: Request<Body>) -> Result<Response<Body>, Infallible> {
     let origin = req
@@ -41,9 +43,9 @@ async fn handle_request(req: Request<Body>) -> Result<Response<Body>, Infallible
             PEPPER_VUF_VERIFICATION_KEY_JSON.deref().clone(),
         ),
         (&Method::POST, "/v0/signature") => {
-            handle_fetch_common(origin, req, process_signature_v0).await
+            generate_response(origin, req, &V0SignatureHandler).await
         },
-        (&Method::POST, "/v0/fetch") => handle_fetch_common(origin, req, process_v0).await,
+        (&Method::POST, "/v0/fetch") => generate_response(origin, req, &V0FetchHandler).await,
         (&Method::OPTIONS, _) => hyper::Response::builder()
             .status(StatusCode::OK)
             .header(ACCESS_CONTROL_ALLOW_ORIGIN, origin)
@@ -66,7 +68,9 @@ async fn main() {
     // Trigger private key loading.
     let _ = VUF_SK.deref();
     let _ = ACCOUNT_MANAGERS.deref();
-
+    {
+        let _db = AUD_DB.get_or_init(init_account_db).await;
+    }
     aptos_logger::Logger::new().init();
     start_metric_server();
 
@@ -100,34 +104,40 @@ async fn main() {
     }
 }
 
-async fn handle_fetch_common<PREQ, PRES>(
+/// Feed a request into a handler and wrap the output as an HTTP response.
+async fn generate_response<PREQ, PRES, HDLR>(
     origin: String,
     req: Request<Body>,
-    process_func: fn(PREQ) -> Result<PRES, ProcessingFailure>,
+    handler: &HDLR,
 ) -> Response<Body>
 where
     PREQ: Debug + Serialize + DeserializeOwned,
     PRES: Debug + Serialize,
+    HDLR: HandlerTrait<PREQ, PRES> + Send + Sync,
 {
     let body = req.into_body();
     let body_bytes = hyper::body::to_bytes(body).await.unwrap_or_default();
     let pepper_request = serde_json::from_slice::<PREQ>(&body_bytes);
     info!("pepper_request={:?}", pepper_request);
-    let pepper_response = pepper_request.map(process_func);
-    info!("pepper_response={:?}", pepper_response);
-    let (status_code, body_json) = match pepper_response {
-        Ok(Ok(pepper_response)) => (
-            StatusCode::OK,
-            serde_json::to_string_pretty(&pepper_response).unwrap(),
-        ),
-        Ok(Err(BadRequest(err))) => (
-            StatusCode::BAD_REQUEST,
-            serde_json::to_string_pretty(&BadPepperRequestError {
-                message: err.to_string(),
-            })
-            .unwrap(),
-        ),
-        Ok(Err(InternalError(_))) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
+    let (status_code, body_json) = match pepper_request {
+        Ok(request) => {
+            let pepper_response = handler.handle(request).await;
+            info!("pepper_response={:?}", pepper_response);
+            match pepper_response {
+                Ok(pepper_response) => (
+                    StatusCode::OK,
+                    serde_json::to_string_pretty(&pepper_response).unwrap(),
+                ),
+                Err(BadRequest(err)) => (
+                    StatusCode::BAD_REQUEST,
+                    serde_json::to_string_pretty(&BadPepperRequestError {
+                        message: err.to_string(),
+                    })
+                    .unwrap(),
+                ),
+                Err(InternalError(_)) => (StatusCode::INTERNAL_SERVER_ERROR, String::new()),
+            }
+        },
         Err(err) => (
             StatusCode::BAD_REQUEST,
             serde_json::to_string_pretty(&BadPepperRequestError {


### PR DESCRIPTION
## Description

- Pepper service will save the account derivation preimages into an "account recovery DB", which is later to be used by the keyless account recovery service.
- Make HTTP request handling functions async (in order to adopt firestore async rust APIs).


## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [ ] Keyless Pepper Service

## How Has This Been Tested?
Local manual test suite as specified in `keyless/pepper/readme.md`.

## Key Areas to Review
The DB schema `AccountRecoveryDbEntry`.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
