### PR TITLE
[compiler-v2] Pattern matching for struct variants (aka enum types)

### DIFF
--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/bug_bbb75fa.v2_exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/bug_bbb75fa.v2_exp
@@ -1,0 +1,1 @@
+processed 4 tasks

--- a/third_party/move/evm/move-to-yul/src/functions.rs
+++ b/third_party/move/evm/move-to-yul/src/functions.rs
@@ -548,6 +548,12 @@ impl<'a> FunctionGenerator<'a> {
 
                     // Unimplemented
                     Vector => unimplemented!("vector"),
+                    TestVariant(..)
+                    | PackVariant(..)
+                    | UnpackVariant(..)
+                    | BorrowFieldVariant(..) => {
+                        unimplemented!("variants")
+                    },
 
                     // Specification or other operations which can be ignored here
                     Release

--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -4,8 +4,10 @@
 
 use codespan_reporting::diagnostic::Severity;
 use ethnum::U256;
+use itertools::Itertools;
+use move_binary_format::file_format::Ability;
 use move_model::{
-    ast::{Exp, ExpData, Operation, Pattern, SpecBlockTarget, TempIndex, Value},
+    ast::{Exp, ExpData, MatchArm, Operation, Pattern, SpecBlockTarget, TempIndex, Value},
     exp_rewriter::{ExpRewriter, ExpRewriterFunctions, RewriteTarget},
     model::{
         FieldId, FunId, FunctionEnv, GlobalEnv, Loc, NodeId, Parameter, QualifiedId,
@@ -13,6 +15,7 @@ use move_model::{
     },
     symbol::Symbol,
     ty::{PrimitiveType, ReferenceKind, Type},
+    well_known,
 };
 use move_stackless_bytecode::{
     function_target::FunctionData,
@@ -22,7 +25,10 @@ use move_stackless_bytecode::{
     stackless_bytecode_generator::BytecodeGeneratorContext,
 };
 use num::ToPrimitive;
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+};
 
 // ======================================================================================
 // Entry
@@ -327,7 +333,6 @@ impl<'env> Generator<'env> {
     fn gen(&mut self, targets: Vec<TempIndex>, exp: &Exp) {
         match exp.as_ref() {
             ExpData::Invalid(id) => self.internal_error(*id, "invalid expression"),
-            ExpData::Match(id, ..) => self.internal_error(*id, "match not yet implemented"),
             ExpData::Temporary(id, temp) => self.gen_temporary(targets, *id, *temp),
             ExpData::Value(id, val) => self.gen_value(targets, *id, val),
             ExpData::LocalVar(id, name) => self.gen_local(targets, *id, *name),
@@ -428,6 +433,7 @@ impl<'env> Generator<'env> {
                 self.gen(targets, else_exp);
                 self.emit_with(else_id, |attr| Bytecode::Label(attr, end_label));
             },
+            ExpData::Match(id, exp, arms) => self.gen_match(targets, *id, exp, arms),
             ExpData::Loop(id, body) => {
                 let continue_label = self.new_label(*id);
                 let break_label = self.new_label(*id);
@@ -597,12 +603,14 @@ impl<'env> Generator<'env> {
                     }
                 }
             },
-            Operation::Pack(_, _, Some(_)) => {
-                self.internal_error(id, "variants not yet implemented")
-            },
-            Operation::Pack(mid, sid, None) => {
+            Operation::Pack(mid, sid, variant) => {
                 let inst = self.env().get_node_instantiation(id);
-                self.gen_op_call(targets, id, BytecodeOperation::Pack(*mid, *sid, inst), args)
+                let oper = if let Some(variant) = variant {
+                    BytecodeOperation::PackVariant(*mid, *sid, *variant, inst)
+                } else {
+                    BytecodeOperation::Pack(*mid, *sid, inst)
+                };
+                self.gen_op_call(targets, id, oper, args)
             },
             Operation::Select(mid, sid, fid) => {
                 let target = self.require_unary_target(id, targets);
@@ -716,7 +724,7 @@ impl<'env> Generator<'env> {
                 let temp = self.gen_escape_auto_ref_arg(&arg, false);
                 self.emit_with(id, |attr| Bytecode::Abort(attr, temp))
             },
-            Operation::Deref => self.gen_op_call(targets, id, BytecodeOperation::ReadRef, args),
+            Operation::Deref => self.gen_deref(targets, id, args),
             Operation::MoveFunction(m, f) => {
                 self.gen_function_call(targets, id, m.qualified(*f), args)
             },
@@ -824,6 +832,18 @@ impl<'env> Generator<'env> {
         self.emit_with(id, |attr| {
             Bytecode::Call(attr, targets, op, arg_temps, None)
         })
+    }
+
+    fn gen_deref(&mut self, targets: Vec<TempIndex>, id: NodeId, args: &[Exp]) {
+        // Optimize case of `Deref(Borrow(x)) => x`.
+        // This is safe and supports generation for matches, where rewriting of code may result
+        // in such expressions.
+        match args[0].as_ref() {
+            ExpData::Call(_, Operation::Borrow(_), borrow_args) => {
+                self.gen(targets, &borrow_args[0])
+            },
+            _ => self.gen_op_call(targets, id, BytecodeOperation::ReadRef, args),
+        }
     }
 
     fn gen_logical_shortcut(
@@ -979,6 +999,31 @@ impl<'env> Generator<'env> {
         }
     }
 
+    // Generates code for an expression which can represent a tuple. This flattens
+    // the tuple if explicit or introduces temporaries to hold the tuple value. If
+    // the expression is not a tuple, a singleton vector will be returned. This
+    // reflects the current special semantics of tuples in Move which cannot be
+    // nested.
+    fn gen_tuple(&mut self, exp: &Exp, with_force_temp: bool) -> Vec<TempIndex> {
+        if let ExpData::Call(_, Operation::Tuple, args) = exp.as_ref() {
+            args.iter().map(|arg| self.gen_arg(arg, false)).collect()
+        } else {
+            let exp_ty = self.env().get_node_type(exp.node_id());
+            if exp_ty.is_tuple() {
+                // Need to allocate new temps to store the tuple elements.
+                let temps = exp_ty
+                    .flatten()
+                    .into_iter()
+                    .map(|ty| self.new_temp(ty))
+                    .collect::<Vec<_>>();
+                self.gen(temps.clone(), exp);
+                temps
+            } else {
+                vec![self.gen_arg(exp, with_force_temp)]
+            }
+        }
+    }
+
     /// Compile the expression in reference mode. This enables automatic creation of references
     /// (e.g. for locals) and disables automatic dereferencing. This is used for compilation
     /// of expressions in 'lvalue' mode.
@@ -1031,6 +1076,10 @@ impl<'env> Generator<'env> {
                     *fid,
                     &self.require_unary_arg(id, args),
                 )
+            },
+            ExpData::Call(_arg_id, Operation::Deref, args) => {
+                // Optimize `Borrow(Deref(x)) => x`
+                return self.gen(vec![target], &args[0]);
             },
             ExpData::LocalVar(_arg_id, sym) => return self.gen_borrow_local(target, id, *sym),
             ExpData::Temporary(_arg_id, temp) => return self.gen_borrow_temp(target, id, *temp),
@@ -1162,6 +1211,72 @@ impl<'env> Generator<'env> {
 // ======================================================================================
 // Pattern matching
 
+/// Translation of patterns, both for irrefutable matches as in `let p = e`, and
+/// refutable matches as in `match (e) { p1 => e1, p2 => e2, ..}`.
+///
+/// The challenge with refutable match translation is to deal with consuming matches.
+/// Consider `let s = S{x: C{y}}; match (s) { S{C{y}}} if p(&y) => y, t => t }`. In order
+/// to check whether the match is true, the value in `s` must not be moved until the match
+/// is decided, while still being able to look at sub-fields and evaluate predicates.
+/// Therefore, the match need to evaluated first using a reference to `s`. We call this
+/// _probing_ of a match.
+///
+/// The type `MatchMode` is used to describe in which mode matching is performed.
+/// In irrefutable mode, it is expected that the pattern succeeds to match. In
+/// refutable mode, on match failure an exit branch is taken. Refutable mode
+/// can be furthermore characterized to be probing.
+enum MatchMode {
+    /// A match which cannot be refuted
+    Irrefutable,
+    /// A refutable match as in the match arm of the `match` expression
+    Refutable {
+        /// A temporary where to store the result of variant tests
+        bool_temp: TempIndex,
+        /// A branch to the exit point of the match fails
+        exit_path: Label,
+        /// Set if this is a probing match, and if so, the set of vars which need to
+        /// be bound for the match condition. In probing mode, we only need to
+        /// bind certain variables. For example, in `S{x, y} if p(y)` we do not need
+        /// to bind `x`.
+        probing_vars: Option<BTreeSet<Symbol>>,
+    },
+}
+
+impl MatchMode {
+    /// Whether this match is in probing mode.
+    fn is_probing(&self) -> bool {
+        matches!(self, MatchMode::Refutable {
+            probing_vars: Some(_),
+            ..
+        })
+    }
+
+    /// Whether a variable appearing in the pattern should be bound to a temporary.
+    /// In probing mode, only selected variables which appear in the optional guard of
+    /// a match arm need to be bound.
+    fn shall_bind_var(&self, var: Symbol) -> bool {
+        if let MatchMode::Refutable {
+            probing_vars: Some(vars),
+            ..
+        } = self
+        {
+            vars.contains(&var)
+        } else {
+            true
+        }
+    }
+
+    /// Returns the effective type. In probing mode, all non-reference types
+    /// are lifted to references.
+    fn effective_var_type(&self, ty: Type) -> Type {
+        if self.is_probing() && !ty.is_reference() {
+            Type::Reference(ReferenceKind::Immutable, Box::new(ty))
+        } else {
+            ty
+        }
+    }
+}
+
 impl<'env> Generator<'env> {
     /// Generate code for assignment of an expression to a pattern. This involves
     /// flattening nested patterns as needed. The optional `next_scope` is a
@@ -1171,7 +1286,7 @@ impl<'env> Generator<'env> {
             self.gen_tuple_assign(id, pat_args, exp, next_scope)
         } else {
             let arg = self.gen_escape_auto_ref_arg(exp, false);
-            self.gen_assign_from_temp(id, pat, arg, next_scope)
+            self.gen_match_from_temp(id, pat, &[arg], &MatchMode::Irrefutable, next_scope)
         }
     }
 
@@ -1190,7 +1305,10 @@ impl<'env> Generator<'env> {
                 if args.len() != pats.len() {
                     // Type checker should have complained already
                     self.internal_error(id, "inconsistent tuple arity")
-                } else if args.len() != 1 && self.have_overlapping_vars(pats, exp) {
+                } else if next_scope.is_none() // assignment, not declaration
+                    && args.len() != 1
+                    && self.have_overlapping_vars(pats, exp)
+                {
                     // We want to simulate the semantics for "simultaneous" assignment with
                     // overlapping variables, eg., `(x, y) = (y, x)`.
                     // To do so, we save each tuple arg (from rhs) into a temporary.
@@ -1200,170 +1318,458 @@ impl<'env> Generator<'env> {
                         .map(|exp| self.gen_escape_auto_ref_arg(exp, true))
                         .collect::<Vec<_>>();
                     for (pat, temp) in pats.iter().zip(temps.into_iter()) {
-                        self.gen_assign_from_temp(id, pat, temp, next_scope)
+                        self.gen_match_from_temp(
+                            id,
+                            pat,
+                            &[temp],
+                            &MatchMode::Irrefutable,
+                            next_scope,
+                        )
                     }
                 } else {
-                    // No overlap, or a 1-tuple: just do point-wise assignment.
+                    // No overlap, a 1-tuple, or not an assignment: just do point-wise match.
                     for (pat, exp) in pats.iter().zip(args.iter()) {
                         self.gen_assign(id, pat, exp, next_scope)
                     }
                 }
             },
             _ => {
-                // The type checker has ensured that this expression represents  tuple
-                let (temps, cont_assigns) = self.flatten_patterns(pats, next_scope);
-                self.gen(temps, exp);
-                for (cont_id, cont_pat, cont_temp) in cont_assigns {
-                    self.gen_assign_from_temp(cont_id, &cont_pat, cont_temp, next_scope)
+                // The type checker has ensured that this expression represents a function call
+                // resulting in a tuple. Collect the sub-matches to determine the targets to which
+                // assign the call results.
+                let match_mode = &MatchMode::Irrefutable;
+                let sub_matches = self.collect_sub_matches(true, pats, match_mode, next_scope);
+                self.gen(sub_matches.values().map(|(temp, _)| *temp).collect(), exp);
+                for (_, (temp, cont_opt)) in sub_matches.into_iter() {
+                    if let Some(cont_pat) = cont_opt {
+                        self.gen_match_from_temp(
+                            cont_pat.node_id(),
+                            &cont_pat,
+                            &[temp],
+                            match_mode,
+                            next_scope,
+                        )
+                    }
                 }
             },
         }
     }
 
-    /// Generate borrow_field when unpacking a reference to a struct
-    // e.g. `let s = &S; let (a, b, c) = &s`, a, b, and c are references
-    fn gen_borrow_field_for_unpack_ref(
-        &mut self,
-        id: &NodeId,
-        str: &QualifiedInstId<StructId>,
-        arg: TempIndex,
-        temps: Vec<TempIndex>,
-        ref_kind: ReferenceKind,
-    ) {
-        let struct_env = self.env().get_struct(str.to_qualified_id());
-        let mut temp_to_field_offsets = BTreeMap::new();
-        for (field, input_temp) in struct_env.get_fields().zip(temps.clone()) {
-            temp_to_field_offsets.insert(input_temp, field.get_offset());
+    /// Generates code for a match expression.
+    fn gen_match(&mut self, targets: Vec<TempIndex>, id: NodeId, exp: &Exp, arms: &[MatchArm]) {
+        // Generate temps for the exp we are matching over. The exp can be a tuple, so
+        // we have a vector of temps.
+        let values: Vec<TempIndex> = self.gen_tuple(exp, false);
+        // For each temp not a reference, create one, so we can match it without consuming it.
+        // Also set `needs_probing` to true if there are any non-references. This indicates
+        // that we need to generate a specialized, non-consuming 'probing' match.
+        let mut needs_probing = false;
+        let value_refs: Vec<TempIndex> = values
+            .iter()
+            .cloned()
+            .map(|value| {
+                let value_ty = self.temp_type(value);
+                if value_ty.is_reference() {
+                    value
+                } else {
+                    let value_ref = self.new_temp(Type::Reference(
+                        ReferenceKind::Immutable,
+                        Box::new(value_ty.clone()),
+                    ));
+                    self.emit_call(id, vec![value_ref], BytecodeOperation::BorrowLoc, vec![
+                        value,
+                    ]);
+                    needs_probing = true;
+                    value_ref
+                }
+            })
+            .collect();
+        // Label to jump to on success of a match arm
+        let success_path = self.new_label(id);
+        // Boolean temporary to store match results.
+        let bool_temp = self.new_temp(Type::new_prim(PrimitiveType::Bool));
+        for arm in arms {
+            let pat_id = arm.pattern.node_id();
+            let exit_path = self.new_label(pat_id);
+            let match_mode = if needs_probing {
+                // If we needed to create a reference (i.e. we match against a value)
+                // we need to evaluate whether the pattern matches in
+                // probe mode, without consuming the matched value.
+                self.gen_match_probe(pat_id, &value_refs, bool_temp, exit_path, arm);
+                // On success of the probe, matching the pattern will be irrefutable
+                MatchMode::Irrefutable
+            } else {
+                // Otherwise we perform a directly refutable match.
+                MatchMode::Refutable {
+                    exit_path,
+                    bool_temp,
+                    probing_vars: None,
+                }
+            };
+            // Declare all variables bound by the pattern
+            let scope = self.create_scope(arm.pattern.vars().into_iter(), false);
+            // Match the pattern, potentially branching to exit_path
+            self.gen_match_from_temp(id, &arm.pattern, &values, &match_mode, Some(&scope));
+            // If we have not yet executed the condition during probing, execute it now.
+            self.scopes.push(scope);
+            if let Some(cond) = arm.condition.as_ref().filter(|_| !needs_probing) {
+                self.gen(vec![bool_temp], cond);
+                self.branch_to_exit_if_false(cond.node_id(), bool_temp, exit_path)
+            }
+            // Translate the body
+            self.gen(targets.clone(), &arm.body);
+            self.scopes.pop().expect("scope stack balanced");
+            // Exit match with success
+            self.emit_with(id, |attr| Bytecode::Jump(attr, success_path));
+            // Point to continue if match failed
+            self.emit_with(id, |attr| Bytecode::Label(attr, exit_path))
         }
-        for (temp, field_offset) in temp_to_field_offsets {
-            self.with_reference_mode(|s, entering| {
-                if entering {
-                    s.reference_mode_kind = ref_kind
+        // At last, emit an abort that no arm matched
+        let abort_code = self.new_temp(Type::new_prim(PrimitiveType::U64));
+        self.emit_with(id, |attr| {
+            Bytecode::Load(
+                attr,
+                abort_code,
+                Constant::U64(well_known::INCOMPLETE_MATCH_ABORT_CODE),
+            )
+        });
+        self.emit_with(id, |attr| Bytecode::Abort(attr, abort_code));
+        // Here we end if some path was successful
+        self.emit_with(id, |attr| Bytecode::Label(attr, success_path));
+        // Finally check exhaustiveness of match
+        ValueShape::analyze_match_coverage(
+            self.env(),
+            exp.node_id(),
+            arms.iter().filter_map(|arm| {
+                if arm.condition.is_none() {
+                    Some(&arm.pattern)
+                } else {
+                    None
                 }
-                if !s.temp_type(temp).is_reference() {
-                    s.env().diag(
-                        Severity::Bug,
-                        &s.env().get_node_loc(*id),
-                        "Unpacking a reference to a struct must return the references of fields",
-                    );
+            }),
+        );
+    }
+
+    // Generates a probing match for a given match arm. The probing match doesn't consume
+    // the value which is expected to be a reference.
+    fn gen_match_probe(
+        &mut self,
+        id: NodeId,
+        value_refs: &[TempIndex],
+        bool_temp: TempIndex,
+        exit_path: Label,
+        arm: &MatchArm,
+    ) {
+        // Compute the set of vars we need to bind during the match.
+        let probing_vars = if let Some(exp) = &arm.condition {
+            // Include all vars in the condition
+            exp.free_vars()
+        } else {
+            // No condition, probing does not need to bind anything
+            BTreeSet::new()
+        };
+        let mode = MatchMode::Refutable {
+            bool_temp,
+            exit_path,
+            probing_vars: Some(probing_vars.clone()),
+        };
+        // Create a scope with variables bound by the pattern and needed for probing. All
+        // vars are lifted to be references to the original type.
+        let needed_vars = arm
+            .pattern
+            .vars()
+            .into_iter()
+            .filter(|(_, var)| probing_vars.contains(var))
+            .collect_vec();
+        let probe_scope = self.create_scope(needed_vars.clone().into_iter(), true);
+        // Match the pattern, potentially branching to exit_path
+        self.gen_match_from_temp(id, &arm.pattern, value_refs, &mode, Some(&probe_scope));
+        if let Some(exp) = &arm.condition {
+            // Evaluate matching condition, by rewriting the expression, such that
+            // references to `x` are replaced by references to `*x`. This is needed
+            // because in the original pattern, `x` is bound to a value, not a reference.
+            let env = self.env();
+            let rewritten_exp = ExpRewriter::new(env, &mut |id, target| {
+                if let RewriteTarget::LocalVar(var) = target {
+                    if probe_scope.contains_key(&var) {
+                        let new_id = env.new_node(
+                            env.get_node_loc(id),
+                            Type::Reference(
+                                ReferenceKind::Immutable,
+                                Box::new(env.get_node_type(id)),
+                            ),
+                        );
+                        return Some(
+                            ExpData::Call(id, Operation::Deref, vec![ExpData::LocalVar(
+                                new_id, var,
+                            )
+                            .into_exp()])
+                            .into_exp(),
+                        );
+                    }
                 }
-                s.emit_call(
-                    *id,
-                    vec![temp],
-                    BytecodeOperation::BorrowField(
-                        str.module_id,
-                        str.id,
-                        str.inst.to_owned(),
-                        field_offset,
-                    ),
-                    vec![arg],
-                );
-            });
+                None
+            })
+            .rewrite_exp(exp.clone());
+            self.scopes.push(probe_scope);
+            self.gen(vec![bool_temp], &rewritten_exp);
+            self.branch_to_exit_if_false(id, bool_temp, exit_path);
+            self.scopes.pop();
         }
     }
 
-    fn gen_assign_from_temp(
+    /// Generate match of values against pattern.
+    fn gen_match_from_temp(
         &mut self,
         id: NodeId,
         pat: &Pattern,
-        arg: TempIndex,
+        values: &[TempIndex],
+        match_mode: &MatchMode,
         next_scope: Option<&Scope>,
     ) {
+        if !matches!(pat, Pattern::Tuple(..)) && values.len() != 1 {
+            self.internal_error(id, "inconsistent tuple value in match");
+            return;
+        }
         match pat {
-            Pattern::Wildcard(_) => {
-                let ty = self.temp_type(arg).to_owned();
-                let temp = self.new_temp(ty);
-                // Assign to a temporary to allow stackless bytecode checkers to report any errors
-                // due to the assignment.
-                self.emit_with(id, |attr| {
-                    Bytecode::Assign(attr, temp, arg, AssignKind::Inferred)
-                })
+            Pattern::Wildcard(id) => {
+                let pat_ty = self.env().get_node_type(*id);
+                if !match_mode.is_probing() {
+                    let temp = self.new_temp(pat_ty);
+                    self.emit_with(*id, |attr| {
+                        Bytecode::Assign(attr, temp, values[0], AssignKind::Inferred)
+                    })
+                }
             },
             Pattern::Var(var_id, sym) => {
-                let local = self.find_local_for_pattern(*var_id, *sym, next_scope);
-                self.emit_with(id, |attr| {
-                    Bytecode::Assign(attr, local, arg, AssignKind::Inferred)
-                })
+                if match_mode.shall_bind_var(*sym) {
+                    let local = self.find_local_for_pattern(*var_id, *sym, next_scope);
+                    self.emit_with(id, |attr| {
+                        Bytecode::Assign(attr, local, values[0], AssignKind::Inferred)
+                    })
+                }
             },
-            Pattern::Struct(id, _, Some(_), _) => {
-                self.internal_error(*id, "variants not yet implemented")
-            },
-            Pattern::Struct(id, str, None, args) => {
-                let (temps, cont_assigns) = self.flatten_patterns(args, next_scope);
-                let ty = self.temp_type(arg);
-                if ty.is_reference() {
-                    let ref_kind = if ty.is_immutable_reference() {
-                        ReferenceKind::Immutable
-                    } else {
-                        ReferenceKind::Mutable
-                    };
-                    self.gen_borrow_field_for_unpack_ref(id, str, arg, temps, ref_kind);
-                } else {
+            Pattern::Struct(id, str, variant, args) => {
+                // If this is a variant, and we are doing a refutable match,
+                // insert a test and exit if it fails.
+                let value = values[0];
+                if let (
+                    Some(variant),
+                    MatchMode::Refutable {
+                        bool_temp,
+                        exit_path,
+                        ..
+                    },
+                ) = (variant, match_mode)
+                {
                     self.emit_call(
                         *id,
-                        temps,
-                        BytecodeOperation::Unpack(str.module_id, str.id, str.inst.to_owned()),
-                        vec![arg],
+                        vec![*bool_temp],
+                        BytecodeOperation::TestVariant(
+                            str.module_id,
+                            str.id,
+                            *variant,
+                            str.inst.clone(),
+                        ),
+                        vec![value],
+                    );
+                    self.branch_to_exit_if_false(*id, *bool_temp, *exit_path);
+                }
+                let ref_kind = self.temp_type(value).ref_kind();
+                let uses_unpack = ref_kind.is_none();
+                let sub_matches = self.collect_sub_matches(
+                    uses_unpack, // need all sub-patterns if unpack is used
+                    args,
+                    match_mode,
+                    next_scope,
+                );
+                if !uses_unpack {
+                    self.gen_borrow_field_for_unpack_ref(
+                        id,
+                        str,
+                        *variant,
+                        value,
+                        &sub_matches,
+                        ref_kind.expect("type is reference"),
+                    )
+                } else {
+                    assert_eq!(
+                        args.len(),
+                        sub_matches.len(),
+                        "contiguous allocation of temps for unpack"
+                    );
+                    self.emit_call(
+                        *id,
+                        sub_matches.values().map(|(temp, ..)| *temp).collect(),
+                        if let Some(variant) = variant {
+                            BytecodeOperation::UnpackVariant(
+                                str.module_id,
+                                str.id,
+                                *variant,
+                                str.inst.to_owned(),
+                            )
+                        } else {
+                            BytecodeOperation::Unpack(str.module_id, str.id, str.inst.to_owned())
+                        },
+                        vec![values[0]],
                     );
                 }
-                for (cont_id, cont_pat, cont_temp) in cont_assigns {
-                    self.gen_assign_from_temp(cont_id, &cont_pat, cont_temp, next_scope)
+                for (_, (temp, cont_opt)) in sub_matches.into_iter() {
+                    if let Some(cont_pat) = cont_opt {
+                        self.gen_match_from_temp(
+                            cont_pat.node_id(),
+                            &cont_pat,
+                            &[temp],
+                            match_mode,
+                            next_scope,
+                        )
+                    }
                 }
             },
-            Pattern::Tuple(id, _) => self.error(*id, "tuple not allowed here"),
+            Pattern::Tuple(id, pats) => {
+                if values.len() != pats.len() {
+                    self.internal_error(*id, "inconsistent pattern tuple");
+                    return;
+                }
+                for (elem, sub_pat) in values.iter().zip(pats.iter()) {
+                    self.gen_match_from_temp(
+                        sub_pat.node_id(),
+                        sub_pat,
+                        &[*elem],
+                        match_mode,
+                        next_scope,
+                    )
+                }
+            },
             Pattern::Error(_) => self.internal_error(id, "unexpected error pattern"),
         }
     }
 
-    /// Flatten a pattern, returning a temporary to receive the value being matched against,
-    /// and an optional continuation assignment to match the sub-pattern. The optional
-    /// `next_scope` is used to lookup locals which are introduced by this binding
+    /// Generate borrow_field when unpacking a reference to a struct
+    /// e.g. `let s = &S; let S(a, b, c) = &s`, a, b, and c are references
+    fn gen_borrow_field_for_unpack_ref(
+        &mut self,
+        id: &NodeId,
+        str: &QualifiedInstId<StructId>,
+        variant: Option<Symbol>,
+        arg: TempIndex,
+        sub_matches: &BTreeMap<usize, (TempIndex, Option<Pattern>)>,
+        ref_kind: ReferenceKind,
+    ) {
+        let struct_env = self.env().get_struct(str.to_qualified_id());
+        let fields = struct_env
+            .get_fields_optional_variant(variant)
+            .map(|f| f.get_offset())
+            .collect_vec();
+        for (pos, (temp, _)) in sub_matches {
+            let field_offset = fields[*pos];
+            self.with_reference_mode(|gen, entering| {
+                if entering {
+                    gen.reference_mode_kind = ref_kind
+                }
+                if !gen.temp_type(*temp).is_reference() {
+                    gen.env().diag(
+                        Severity::Bug,
+                        &gen.env().get_node_loc(*id),
+                        "Unpacking a reference to a struct must return the references of fields",
+                    );
+                }
+                gen.emit_call(
+                    *id,
+                    vec![*temp],
+                    if let Some(var) = variant {
+                        BytecodeOperation::BorrowFieldVariant(
+                            str.module_id,
+                            str.id,
+                            var,
+                            str.inst.to_owned(),
+                            field_offset,
+                        )
+                    } else {
+                        BytecodeOperation::BorrowField(
+                            str.module_id,
+                            str.id,
+                            str.inst.to_owned(),
+                            field_offset,
+                        )
+                    },
+                    vec![arg],
+                );
+            })
+        }
+    }
+
+    /// Collect a sub-match for a given pattern `pat` at argument position `pos`.
+    /// This returns a temporary in which to store the matched argument at `pos`, and
+    /// an optional continuation pattern to match on that value. For example,
+    /// for `S{x}`, this will insert `(temp, Some(S{x})` at `pos` in the accumulated
+    /// `sub_matches` map. In turn, for a pattern `x`, this will insert `(x, None)`.
+    /// Depending on the mode, obsolete sub-matches will not be produced. (See code
+    /// comments.)
+    ///
+    /// The optional `next_scope` is used to lookup locals which are introduced by this binding
     /// but are not yet in scope; this is needed to deal with assignments of the form
     /// `let x = f(x)` where the 2nd x refers to a variable in the current scope, but the first
     /// to one which we introduce right now.
-    fn flatten_pattern(
+    fn collect_sub_match(
         &mut self,
+        include_all: bool,
+        sub_matches: &mut BTreeMap<usize, (TempIndex, Option<Pattern>)>,
+        pos: usize,
         pat: &Pattern,
+        match_mode: &MatchMode,
         next_scope: Option<&Scope>,
-    ) -> (TempIndex, Option<(NodeId, Pattern, TempIndex)>) {
+    ) {
         match pat {
             Pattern::Wildcard(id) => {
-                // Wildcard pattern: we need to create a temporary to receive the value, even
-                // if its dropped afterwards.
-                let temp = self.new_temp(self.get_node_type(*id));
-                (temp, None)
+                let pat_ty = self.env().get_node_type(*id);
+                // If inclusion is not required, we can skip wildcards if either
+                // we are probing or the type is a reference.
+                if include_all || !match_mode.is_probing() && self.ty_requires_binding(&pat_ty) {
+                    let temp = self.new_temp(self.get_node_type(*id));
+                    sub_matches.insert(pos, (temp, None));
+                }
             },
             Pattern::Var(id, sym) => {
-                // Variable pattern: no continuation assignment needed as it is already in
-                // the expected form.
-                (self.find_local_for_pattern(*id, *sym, next_scope), None)
+                // If inclusion is not required, we only include variables as determined
+                // by matching mode.
+                if include_all || match_mode.shall_bind_var(*sym) {
+                    sub_matches.insert(
+                        pos,
+                        (self.find_local_for_pattern(*id, *sym, next_scope), None),
+                    );
+                }
             },
             _ => {
-                // Pattern is not flat: create a new temporary and an Assignment of this
+                // Pattern is not flat: create a new temporary and an assignment of this
                 // temporary to the pattern.
                 let id = pat.node_id();
-                let ty = self.get_node_type(id);
+                let ty = match_mode.effective_var_type(self.get_node_type(id));
                 let temp = self.new_temp(ty);
-                (temp, Some((id, pat.clone(), temp)))
+                sub_matches.insert(pos, (temp, Some(pat.clone())));
             },
         }
     }
 
-    fn flatten_patterns(
+    fn collect_sub_matches(
         &mut self,
-        pats: &[Pattern],
+        include_all: bool,
+        args: &[Pattern],
+        match_mode: &MatchMode,
         next_scope: Option<&Scope>,
-    ) -> (Vec<TempIndex>, Vec<(NodeId, Pattern, TempIndex)>) {
-        let mut temps = vec![];
-        let mut cont_assigns = vec![];
-        for pat in pats {
-            let (temp, opt_cont) = self.flatten_pattern(pat, next_scope);
-            temps.push(temp);
-            if let Some(cont) = opt_cont {
-                cont_assigns.push(cont)
-            }
+    ) -> BTreeMap<usize, (TempIndex, Option<Pattern>)> {
+        let mut sub_matches = BTreeMap::new();
+        for (pos, pat) in args.iter().enumerate() {
+            self.collect_sub_match(
+                include_all,
+                &mut sub_matches,
+                pos,
+                pat,
+                match_mode,
+                next_scope,
+            )
         }
-        (temps, cont_assigns)
+        sub_matches
     }
 
     fn find_local_for_pattern(
@@ -1395,6 +1801,315 @@ impl<'env> Generator<'env> {
             .collect::<Vec<_>>();
         let rhs_vars = rhs.free_vars_and_used_params(&param_symbols);
         lhs_vars.intersection(&rhs_vars).next().is_some()
+    }
+
+    fn branch_to_exit_if_false(&mut self, id: NodeId, cond: TempIndex, exit_path: Label) {
+        let fall_through = self.new_label(id);
+        self.emit_with(id, |attr| {
+            Bytecode::Branch(attr, fall_through, exit_path, cond)
+        });
+        self.emit_with(id, |attr| Bytecode::Label(attr, fall_through))
+    }
+
+    fn create_scope(
+        &mut self,
+        vars: impl Iterator<Item = (NodeId, Symbol)>,
+        as_ref: bool,
+    ) -> BTreeMap<Symbol, TempIndex> {
+        let mut scope = BTreeMap::new();
+        for (id, sym) in vars {
+            let mut ty = self.get_node_type(id);
+            if as_ref {
+                ty = Type::Reference(ReferenceKind::Immutable, Box::new(ty))
+            }
+            let temp = self.new_temp(ty);
+            scope.insert(sym, temp);
+            self.local_names.insert(temp, sym);
+        }
+        scope
+    }
+
+    /// Returns true if a value of given type need to be bound to a temporary, even if unused,
+    /// so it can be properly processed. Types which are known to be droppable
+    /// return false here.
+    fn ty_requires_binding(&self, ty: &Type) -> bool {
+        !self
+            .env()
+            .type_abilities(ty, &[])
+            .has_ability(Ability::Drop)
+    }
+}
+
+// ======================================================================================
+// Pattern coverage analysis
+
+/// Pattern coverage analysis is complicated by that patterns are
+/// matched sequentially (in contrast to so-called 'best fit' pattern matching).
+/// Consider the sequence of patterns from a match, `S{R{p}, q1}` and `S{_, q2}`.
+/// `R{p}` is only matched under the condition that `q1` is also matched. On
+/// the other hand, any arbitrary other value for the first parameter of `S` depends
+/// on that `q2` matches as well. These dependencies between patterns make it
+/// hard to decompose the analysis of completeness into independent sub-problems,
+/// and to apply some kind of algebraic simplification on patterns (e.g. something
+/// like `S{_, q1 | q2}` is _not_ equivalent to the above two patterns).
+///
+/// Another challenge in pattern coverage analysis is to produce useful error messages
+/// which show the counterexamples of missed patterns, but only up to the shape as the user
+/// has inspected values via patterns. For example, if the user has written `R{S{_}, _}`
+/// the counter example should not contain irrelevant other parts of the value (as e.g.
+/// in `R{T{x:_}, S}`). Moreover, missing patterns which can never be matched should
+/// be reported, as dead code analysis will not determine this without flow dependent
+/// analysis.
+///
+/// The solution to those problems performs some kind of 'abstract interpretation'
+/// of what happens during matching at runtime.
+///
+/// 1. The type `ValueShape` represents both patterns, as partial,
+///    _abstract_ values to be matched against.
+/// 2. All patterns are translated to a list of pattern shapes.
+/// 3. The list of abstract values which are needed to explore coverage of the
+///    shapes in (2) is computed. Those values are only as detailed
+///    as needed to fully explore the pattern shapes.
+/// 4. For each abstract value, at least one matching pattern shape must exist,
+///    otherwise the value (its shape) is reported as missing. Also, a pattern must
+///    match at least one value to be reachable.
+///
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum ValueShape {
+    Any,
+    Tuple(Vec<ValueShape>),
+    Struct(QualifiedId<StructId>, Option<Symbol>, Vec<ValueShape>),
+}
+
+struct ValueShapeDisplay<'a> {
+    env: &'a GlobalEnv,
+    shape: &'a ValueShape,
+}
+
+impl ValueShape {
+    /// Main entrypoint for analyzing match coverage.
+    fn analyze_match_coverage<'a>(
+        env: &GlobalEnv,
+        value_exp_id: NodeId,
+        patterns: impl Iterator<Item = &'a Pattern>,
+    ) {
+        // Translate patterns into shapes
+        let pattern_shapes: Vec<(NodeId, ValueShape)> = patterns
+            .map(|p| (p.node_id(), ValueShape::for_pattern(p)))
+            .collect();
+        // Compute the set of abstract values which need to be matched.
+        let mut values = BTreeSet::new();
+        for (_, shape) in &pattern_shapes {
+            for partial_value in shape.possible_values(env) {
+                Self::join_value_shape(&mut values, partial_value)
+            }
+        }
+        // Now go over all patterns in sequence and incrementally remove matched
+        // values. If a pattern doesn't match any values, report it as unreachable.
+        for (pat_id, pattern_shape) in pattern_shapes {
+            let mut matched = false;
+            let mut remaining_values = BTreeSet::new();
+            while let Some(value) = values.pop_first() {
+                if value.instance_of(&pattern_shape) {
+                    matched = true;
+                } else {
+                    remaining_values.insert(value);
+                }
+            }
+            if !matched {
+                env.error(&env.get_node_loc(pat_id), "unreachable pattern");
+            }
+            values = remaining_values
+        }
+        // Finally, report any unmatched value shapes
+        if !values.is_empty() {
+            env.error_with_notes(
+                &env.get_node_loc(value_exp_id),
+                "match not exhaustive",
+                values
+                    .into_iter()
+                    .map(|s| format!("missing `{}`", s.display(env)))
+                    .collect(),
+            )
+        }
+    }
+
+    /// Creates a value shape from a pattern.
+    fn for_pattern(pat: &Pattern) -> ValueShape {
+        use Pattern::*;
+        match pat {
+            Var(_, _) | Wildcard(_) => ValueShape::Any,
+            Tuple(_, pats) => ValueShape::Tuple(pats.iter().map(Self::for_pattern).collect()),
+            Struct(_, sid, variant, pats) => ValueShape::Struct(
+                sid.to_qualified_id(),
+                *variant,
+                pats.iter().map(Self::for_pattern).collect(),
+            ),
+            Error(_) => ValueShape::Any,
+        }
+    }
+
+    /// Creates all value shapes needed to explore the given pattern shape's completeness.
+    fn possible_values(&self, env: &GlobalEnv) -> Vec<ValueShape> {
+        use ValueShape::*;
+        match self {
+            Any => vec![Any],
+            Tuple(args) => Self::possible_values_product(env, args)
+                .map(Tuple)
+                .collect(),
+            Struct(sid, variant, args) => {
+                let derived = Self::possible_values_product(env, args)
+                    .map(|new_args| Struct(*sid, *variant, new_args));
+                if let Some(v) = variant {
+                    // If this is a variant pattern, need to add all _other_ variants to
+                    // explore for completeness.
+                    let struct_env = env.get_struct(*sid);
+                    derived
+                        .chain(
+                            struct_env
+                                .get_variants()
+                                .filter(|other_variant| v != other_variant)
+                                .map(|other_variant| {
+                                    let field_count =
+                                        struct_env.get_fields_of_variant(other_variant).count();
+                                    Struct(
+                                        *sid,
+                                        Some(other_variant),
+                                        (0..field_count).map(|_| Any).collect(),
+                                    )
+                                }),
+                        )
+                        .collect()
+                } else {
+                    derived.collect()
+                }
+            },
+        }
+    }
+
+    /// From a slice of pattern shapes, construct all value shapes needed to explore completeness
+    /// of the slice. The cartesian product of all value shapes for each individual pattern is
+    /// returned. Note that this can lead to some computational complexity, but because of
+    /// the sequential character matching as discussed at the top of this section, this is
+    /// currently not known how to avoid.
+    fn possible_values_product(
+        env: &GlobalEnv,
+        shapes: &[ValueShape],
+    ) -> impl Iterator<Item = Vec<ValueShape>> {
+        shapes
+            .iter()
+            .map(|shape| shape.possible_values(env))
+            .multi_cartesian_product()
+    }
+
+    /// Attempt to join two shapes. If the join exists, it can be used in place of the others
+    /// to explore pattern completeness. For example, `join(R{v, _}, R{_, w}) == R{v,w}`.
+    fn try_join(&self, other: &ValueShape) -> Option<ValueShape> {
+        use ValueShape::*;
+        let unify_n = |shapes1: &[ValueShape], shapes2: &[ValueShape]| -> Option<Vec<ValueShape>> {
+            let mut result = vec![];
+            for (s1, s2) in shapes1.iter().zip(shapes2) {
+                if let Some(s) = s1.try_join(s2) {
+                    result.push(s);
+                    break;
+                }
+            }
+            if result.len() == shapes1.len() {
+                Some(result)
+            } else {
+                None
+            }
+        };
+        match (self, other) {
+            (Any, _) => Some(other.clone()),
+            (_, Any) => Some(self.clone()),
+            (Struct(sid1, var1, args1), Struct(sid2, var2, args2))
+                if sid1 == sid2 && var1 == var2 =>
+            {
+                unify_n(args1, args2).map(|args| Struct(*sid1, *var1, args))
+            },
+            (Tuple(args1), Tuple(args2)) => unify_n(args1, args2).map(Tuple),
+            _ => None,
+        }
+    }
+
+    /// Given a list of value shapes, join a new one. This attempts specializing existing shapes
+    /// via the join operator in order to keep the list minimal.
+    fn join_value_shape(set: &mut BTreeSet<ValueShape>, value: ValueShape) {
+        for v in set.iter() {
+            if let Some(unified) = v.try_join(&value) {
+                let v = v.clone(); // to free set
+                set.remove(&v);
+                set.insert(unified);
+                return;
+            }
+        }
+        set.insert(value);
+    }
+
+    /// Checks whether one shape is instance of another. It holds that
+    /// `s1.instance_of(s2) <==> s1.unify(s2) == Some(s1)`.
+    fn instance_of(&self, other: &ValueShape) -> bool {
+        use ValueShape::*;
+        match (self, other) {
+            (_, Any) => true,
+            (Tuple(args1), Tuple(args2)) => {
+                args1.iter().zip(args2).all(|(a1, a2)| a1.instance_of(a2))
+            },
+            (Struct(str1, variant1, args1), Struct(str2, variant2, args2))
+                if str1 == str2 && variant1 == variant2 =>
+            {
+                args1.iter().zip(args2).all(|(a1, a2)| a1.instance_of(a2))
+            },
+            _ => false,
+        }
+    }
+
+    fn display<'a>(&'a self, env: &'a GlobalEnv) -> ValueShapeDisplay<'a> {
+        ValueShapeDisplay { env, shape: self }
+    }
+}
+
+impl<'a> fmt::Display for ValueShapeDisplay<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use ValueShape::*;
+        let fmt_list = |list: &[ValueShape], sep: &str| {
+            list.iter()
+                .map(|s| s.display(self.env).to_string())
+                .join(sep)
+        };
+        match self.shape {
+            Any => write!(f, "_"),
+            Tuple(elems) => write!(f, "({})", fmt_list(elems, ",")),
+            Struct(sid, var, args) => {
+                let struct_env = self.env.get_struct(*sid);
+                write!(
+                    f,
+                    "{}",
+                    struct_env.get_name().display(self.env.symbol_pool())
+                )?;
+                if let Some(v) = var {
+                    write!(f, "::{}", v.display(self.env.symbol_pool()))?
+                }
+                if var.is_none() || !args.is_empty() {
+                    if args.iter().all(|a| matches!(a, Any)) {
+                        write!(f, "{{..}}")?
+                    } else {
+                        write!(
+                            f,
+                            "{{{}}}",
+                            struct_env
+                                .get_fields_optional_variant(*var)
+                                .map(|f| f.get_name().display(self.env.symbol_pool()).to_string())
+                                .zip(args.iter())
+                                .map(|(f, e)| format!("{}: {}", f, e.display(self.env)))
+                                .join(", ")
+                        )?
+                    }
+                }
+                Ok(())
+            },
+        }
     }
 }
 

--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -374,6 +374,12 @@ impl<'a> FunctionGenerator<'a> {
         self.flush_any_conflicts(ctx, dest, source);
         let fun_ctx = ctx.fun_ctx;
         match oper {
+            Operation::TestVariant(..)
+            | Operation::PackVariant(..)
+            | Operation::UnpackVariant(..)
+            | Operation::BorrowFieldVariant(..) => {
+                fun_ctx.internal_error("variants not yet implemented")
+            },
             Operation::Function(mid, fid, inst) => {
                 self.gen_call(ctx, dest, mid.qualified(*fid), inst, source);
             },
@@ -992,7 +998,10 @@ impl<'a> FunctionGenerator<'a> {
 impl<'env> FunctionContext<'env> {
     /// Emits an internal error for this function.
     pub fn internal_error(&self, msg: impl AsRef<str>) {
-        self.module.internal_error(&self.loc, msg)
+        self.module.internal_error(
+            &self.loc,
+            format!("file format generator: {}", msg.as_ref()),
+        )
     }
 
     /// Gets the type of the temporary.

--- a/third_party/move/move-compiler-v2/tests/ability-check/v1-signer/read_ref_transitive.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-check/v1-signer/read_ref_transitive.exp
@@ -1,11 +1,5 @@
 
 Diagnostics:
-error: value of type `M::S<signer>` does not have the `copy` ability
-  ┌─ tests/ability-check/v1-signer/read_ref_transitive.move:5:9
-  │
-5 │         *&x
-  │         ^^^ reference content copied here
-
 error: value of type `signer` does not have the `copy` ability
    ┌─ tests/ability-check/v1-signer/read_ref_transitive.move:15:9
    │

--- a/third_party/move/move-compiler-v2/tests/ability-check/v1-typing/assign_pop_resource.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-check/v1-typing/assign_pop_resource.exp
@@ -4,10 +4,16 @@ error: value of type `M::R` does not have the `drop` ability
   ┌─ tests/ability-check/v1-typing/assign_pop_resource.move:5:9
   │
 5 │         _ = R{};
-  │         ^^^^^^^ implicitly dropped here since it is no longer used
+  │         ^ implicitly dropped here since it is no longer used
 
 error: value of type `M::R` does not have the `drop` ability
-  ┌─ tests/ability-check/v1-typing/assign_pop_resource.move:6:9
+  ┌─ tests/ability-check/v1-typing/assign_pop_resource.move:6:10
   │
 6 │         (_, _) = (R{}, R{});
-  │         ^^^^^^^^^^^^^^^^^^^ implicitly dropped here since it is no longer used
+  │          ^ implicitly dropped here since it is no longer used
+
+error: value of type `M::R` does not have the `drop` ability
+  ┌─ tests/ability-check/v1-typing/assign_pop_resource.move:6:13
+  │
+6 │         (_, _) = (R{}, R{});
+  │             ^ implicitly dropped here since it is no longer used

--- a/third_party/move/move-compiler-v2/tests/ability-check/v1-typing/bind_pop_resource.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-check/v1-typing/bind_pop_resource.exp
@@ -13,7 +13,13 @@ error: local `_r` of type `M::R` does not have the `drop` ability
   │                     ^^^ implicitly dropped here since it is no longer used
 
 error: value of type `M::R` does not have the `drop` ability
-  ┌─ tests/ability-check/v1-typing/bind_pop_resource.move:9:13
+  ┌─ tests/ability-check/v1-typing/bind_pop_resource.move:9:14
   │
 9 │         let (_, _):(R, R) = (R{}, R{});
-  │             ^^^^^^ implicitly dropped here since it is no longer used
+  │              ^ implicitly dropped here since it is no longer used
+
+error: value of type `M::R` does not have the `drop` ability
+  ┌─ tests/ability-check/v1-typing/bind_pop_resource.move:9:17
+  │
+9 │         let (_, _):(R, R) = (R{}, R{});
+  │                 ^ implicitly dropped here since it is no longer used

--- a/third_party/move/move-compiler-v2/tests/ability-transform/by_reference.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/by_reference.exp
@@ -8,34 +8,30 @@ fun <SELF>_0::check() {
      var $t3: u64
      var $t4: bool
      var $t5: u64
-     var $t6: &u64
+     var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
-     var $t10: bool
-     var $t11: vector<u8>
-     var $t12: &vector<u8>
-     var $t13: vector<u8>
-     var $t14: vector<u8>
-     var $t15: u64
-     var $t16: &mut u64
-     var $t17: u64
-     var $t18: u64
-     var $t19: &mut vector<u8>
-     var $t20: vector<u8>
-     var $t21: vector<u8>
+     var $t8: bool
+     var $t9: vector<u8>
+     var $t10: vector<u8>
+     var $t11: u64
+     var $t12: &mut u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: &mut vector<u8>
+     var $t16: vector<u8>
+     var $t17: vector<u8>
+     var $t18: bool
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
      var $t22: bool
-     var $t23: u64
-     var $t24: u64
+     var $t23: vector<u8>
+     var $t24: vector<u8>
      var $t25: u64
      var $t26: bool
-     var $t27: vector<u8>
-     var $t28: vector<u8>
+     var $t27: u64
+     var $t28: bool
      var $t29: u64
-     var $t30: bool
-     var $t31: u64
-     var $t32: bool
-     var $t33: u64
   0: $t0 := true
   1: if ($t0) goto 2 else goto 4
   2: label L0
@@ -52,75 +48,71 @@ fun <SELF>_0::check() {
  13: $t3 := 42
  14: abort($t3)
  15: label L5
- 16: $t7 := 0
- 17: $t6 := borrow_local($t7)
- 18: $t5 := read_ref($t6)
- 19: $t8 := 0
- 20: $t4 := ==($t5, $t8)
- 21: if ($t4) goto 22 else goto 24
- 22: label L6
- 23: goto 27
- 24: label L7
- 25: $t9 := 42
- 26: abort($t9)
- 27: label L8
- 28: $t13 := [104, 101, 108, 108, 111]
- 29: $t12 := borrow_local($t13)
- 30: $t11 := read_ref($t12)
- 31: $t14 := [104, 101, 108, 108, 111]
- 32: $t10 := ==($t11, $t14)
- 33: if ($t10) goto 34 else goto 36
- 34: label L9
- 35: goto 39
- 36: label L10
- 37: $t15 := 42
- 38: abort($t15)
- 39: label L11
- 40: $t17 := 0
- 41: $t16 := borrow_local($t17)
- 42: $t18 := 1
- 43: write_ref($t16, $t18)
- 44: $t20 := [104, 101, 108, 108, 111]
- 45: $t19 := borrow_local($t20)
- 46: $t21 := [98, 121, 101]
- 47: write_ref($t19, $t21)
- 48: $t23 := read_ref($t16)
- 49: $t24 := 1
- 50: $t22 := ==($t23, $t24)
- 51: if ($t22) goto 52 else goto 54
- 52: label L12
- 53: goto 57
- 54: label L13
- 55: $t25 := 42
- 56: abort($t25)
- 57: label L14
- 58: $t27 := read_ref($t19)
- 59: $t28 := [98, 121, 101]
- 60: $t26 := ==($t27, $t28)
- 61: if ($t26) goto 62 else goto 64
- 62: label L15
- 63: goto 67
- 64: label L16
- 65: $t29 := 42
- 66: abort($t29)
- 67: label L17
- 68: $t30 := true
- 69: if ($t30) goto 70 else goto 72
- 70: label L18
- 71: goto 75
- 72: label L19
- 73: $t31 := 42
- 74: abort($t31)
- 75: label L20
- 76: $t32 := true
- 77: if ($t32) goto 78 else goto 80
- 78: label L21
- 79: goto 83
- 80: label L22
- 81: $t33 := 42
- 82: abort($t33)
- 83: label L23
- 84: return ()
+ 16: $t5 := 0
+ 17: $t6 := 0
+ 18: $t4 := ==($t5, $t6)
+ 19: if ($t4) goto 20 else goto 22
+ 20: label L6
+ 21: goto 25
+ 22: label L7
+ 23: $t7 := 42
+ 24: abort($t7)
+ 25: label L8
+ 26: $t9 := [104, 101, 108, 108, 111]
+ 27: $t10 := [104, 101, 108, 108, 111]
+ 28: $t8 := ==($t9, $t10)
+ 29: if ($t8) goto 30 else goto 32
+ 30: label L9
+ 31: goto 35
+ 32: label L10
+ 33: $t11 := 42
+ 34: abort($t11)
+ 35: label L11
+ 36: $t13 := 0
+ 37: $t12 := borrow_local($t13)
+ 38: $t14 := 1
+ 39: write_ref($t12, $t14)
+ 40: $t16 := [104, 101, 108, 108, 111]
+ 41: $t15 := borrow_local($t16)
+ 42: $t17 := [98, 121, 101]
+ 43: write_ref($t15, $t17)
+ 44: $t19 := read_ref($t12)
+ 45: $t20 := 1
+ 46: $t18 := ==($t19, $t20)
+ 47: if ($t18) goto 48 else goto 50
+ 48: label L12
+ 49: goto 53
+ 50: label L13
+ 51: $t21 := 42
+ 52: abort($t21)
+ 53: label L14
+ 54: $t23 := read_ref($t15)
+ 55: $t24 := [98, 121, 101]
+ 56: $t22 := ==($t23, $t24)
+ 57: if ($t22) goto 58 else goto 60
+ 58: label L15
+ 59: goto 63
+ 60: label L16
+ 61: $t25 := 42
+ 62: abort($t25)
+ 63: label L17
+ 64: $t26 := true
+ 65: if ($t26) goto 66 else goto 68
+ 66: label L18
+ 67: goto 71
+ 68: label L19
+ 69: $t27 := 42
+ 70: abort($t27)
+ 71: label L20
+ 72: $t28 := true
+ 73: if ($t28) goto 74 else goto 76
+ 74: label L21
+ 75: goto 79
+ 76: label L22
+ 77: $t29 := 42
+ 78: abort($t29)
+ 79: label L23
+ 80: return ()
 }
 
 ============ after LiveVarAnalysisProcessor: ================
@@ -133,34 +125,30 @@ fun <SELF>_0::check() {
      var $t3: u64
      var $t4: bool
      var $t5: u64
-     var $t6: &u64
+     var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
-     var $t10: bool
-     var $t11: vector<u8>
-     var $t12: &vector<u8>
-     var $t13: vector<u8>
-     var $t14: vector<u8>
-     var $t15: u64
-     var $t16: &mut u64
-     var $t17: u64
-     var $t18: u64
-     var $t19: &mut vector<u8>
-     var $t20: vector<u8>
-     var $t21: vector<u8>
+     var $t8: bool
+     var $t9: vector<u8>
+     var $t10: vector<u8>
+     var $t11: u64
+     var $t12: &mut u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: &mut vector<u8>
+     var $t16: vector<u8>
+     var $t17: vector<u8>
+     var $t18: bool
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
      var $t22: bool
-     var $t23: u64
-     var $t24: u64
+     var $t23: vector<u8>
+     var $t24: vector<u8>
      var $t25: u64
      var $t26: bool
-     var $t27: vector<u8>
-     var $t28: vector<u8>
+     var $t27: u64
+     var $t28: bool
      var $t29: u64
-     var $t30: bool
-     var $t31: u64
-     var $t32: bool
-     var $t33: u64
      # live vars:
   0: $t0 := true
      # live vars: $t0
@@ -194,143 +182,135 @@ fun <SELF>_0::check() {
      # live vars:
  15: label L5
      # live vars:
- 16: $t7 := 0
-     # live vars: $t7
- 17: $t6 := borrow_local($t7)
-     # live vars: $t6
- 18: $t5 := read_ref($t6)
+ 16: $t5 := 0
      # live vars: $t5
- 19: $t8 := 0
-     # live vars: $t5, $t8
- 20: $t4 := ==($t5, $t8)
+ 17: $t6 := 0
+     # live vars: $t5, $t6
+ 18: $t4 := ==($t5, $t6)
      # live vars: $t4
- 21: if ($t4) goto 22 else goto 24
+ 19: if ($t4) goto 20 else goto 22
      # live vars:
- 22: label L6
+ 20: label L6
      # live vars:
- 23: goto 27
+ 21: goto 25
      # live vars:
- 24: label L7
+ 22: label L7
      # live vars:
- 25: $t9 := 42
+ 23: $t7 := 42
+     # live vars: $t7
+ 24: abort($t7)
+     # live vars:
+ 25: label L8
+     # live vars:
+ 26: $t9 := [104, 101, 108, 108, 111]
      # live vars: $t9
- 26: abort($t9)
+ 27: $t10 := [104, 101, 108, 108, 111]
+     # live vars: $t9, $t10
+ 28: $t8 := ==($t9, $t10)
+     # live vars: $t8
+ 29: if ($t8) goto 30 else goto 32
      # live vars:
- 27: label L8
+ 30: label L9
      # live vars:
- 28: $t13 := [104, 101, 108, 108, 111]
-     # live vars: $t13
- 29: $t12 := borrow_local($t13)
-     # live vars: $t12
- 30: $t11 := read_ref($t12)
+ 31: goto 35
+     # live vars:
+ 32: label L10
+     # live vars:
+ 33: $t11 := 42
      # live vars: $t11
- 31: $t14 := [104, 101, 108, 108, 111]
-     # live vars: $t11, $t14
- 32: $t10 := ==($t11, $t14)
-     # live vars: $t10
- 33: if ($t10) goto 34 else goto 36
+ 34: abort($t11)
      # live vars:
- 34: label L9
+ 35: label L11
      # live vars:
- 35: goto 39
-     # live vars:
- 36: label L10
-     # live vars:
- 37: $t15 := 42
+ 36: $t13 := 0
+     # live vars: $t13
+ 37: $t12 := borrow_local($t13)
+     # live vars: $t12
+ 38: $t14 := 1
+     # live vars: $t12, $t14
+ 39: write_ref($t12, $t14)
+     # live vars: $t12
+ 40: $t16 := [104, 101, 108, 108, 111]
+     # live vars: $t12, $t16
+ 41: $t15 := borrow_local($t16)
+     # live vars: $t12, $t15
+ 42: $t17 := [98, 121, 101]
+     # live vars: $t12, $t15, $t17
+ 43: write_ref($t15, $t17)
+     # live vars: $t12, $t15
+ 44: $t19 := read_ref($t12)
+     # live vars: $t15, $t19
+ 45: $t20 := 1
+     # live vars: $t15, $t19, $t20
+ 46: $t18 := ==($t19, $t20)
+     # live vars: $t15, $t18
+ 47: if ($t18) goto 48 else goto 50
      # live vars: $t15
- 38: abort($t15)
+ 48: label L12
+     # live vars: $t15
+ 49: goto 53
+     # live vars: $t15
+ 50: label L13
      # live vars:
- 39: label L11
+ 51: $t21 := 42
+     # live vars: $t21
+ 52: abort($t21)
+     # live vars: $t15
+ 53: label L14
+     # live vars: $t15
+ 54: $t23 := read_ref($t15)
+     # live vars: $t23
+ 55: $t24 := [98, 121, 101]
+     # live vars: $t23, $t24
+ 56: $t22 := ==($t23, $t24)
+     # live vars: $t22
+ 57: if ($t22) goto 58 else goto 60
      # live vars:
- 40: $t17 := 0
-     # live vars: $t17
- 41: $t16 := borrow_local($t17)
-     # live vars: $t16
- 42: $t18 := 1
-     # live vars: $t16, $t18
- 43: write_ref($t16, $t18)
-     # live vars: $t16
- 44: $t20 := [104, 101, 108, 108, 111]
-     # live vars: $t16, $t20
- 45: $t19 := borrow_local($t20)
-     # live vars: $t16, $t19
- 46: $t21 := [98, 121, 101]
-     # live vars: $t16, $t19, $t21
- 47: write_ref($t19, $t21)
-     # live vars: $t16, $t19
- 48: $t23 := read_ref($t16)
-     # live vars: $t19, $t23
- 49: $t24 := 1
-     # live vars: $t19, $t23, $t24
- 50: $t22 := ==($t23, $t24)
-     # live vars: $t19, $t22
- 51: if ($t22) goto 52 else goto 54
-     # live vars: $t19
- 52: label L12
-     # live vars: $t19
- 53: goto 57
-     # live vars: $t19
- 54: label L13
+ 58: label L15
      # live vars:
- 55: $t25 := 42
+ 59: goto 63
+     # live vars:
+ 60: label L16
+     # live vars:
+ 61: $t25 := 42
      # live vars: $t25
- 56: abort($t25)
-     # live vars: $t19
- 57: label L14
-     # live vars: $t19
- 58: $t27 := read_ref($t19)
-     # live vars: $t27
- 59: $t28 := [98, 121, 101]
-     # live vars: $t27, $t28
- 60: $t26 := ==($t27, $t28)
+ 62: abort($t25)
+     # live vars:
+ 63: label L17
+     # live vars:
+ 64: $t26 := true
      # live vars: $t26
- 61: if ($t26) goto 62 else goto 64
+ 65: if ($t26) goto 66 else goto 68
      # live vars:
- 62: label L15
+ 66: label L18
      # live vars:
- 63: goto 67
+ 67: goto 71
      # live vars:
- 64: label L16
+ 68: label L19
      # live vars:
- 65: $t29 := 42
+ 69: $t27 := 42
+     # live vars: $t27
+ 70: abort($t27)
+     # live vars:
+ 71: label L20
+     # live vars:
+ 72: $t28 := true
+     # live vars: $t28
+ 73: if ($t28) goto 74 else goto 76
+     # live vars:
+ 74: label L21
+     # live vars:
+ 75: goto 79
+     # live vars:
+ 76: label L22
+     # live vars:
+ 77: $t29 := 42
      # live vars: $t29
- 66: abort($t29)
+ 78: abort($t29)
      # live vars:
- 67: label L17
+ 79: label L23
      # live vars:
- 68: $t30 := true
-     # live vars: $t30
- 69: if ($t30) goto 70 else goto 72
-     # live vars:
- 70: label L18
-     # live vars:
- 71: goto 75
-     # live vars:
- 72: label L19
-     # live vars:
- 73: $t31 := 42
-     # live vars: $t31
- 74: abort($t31)
-     # live vars:
- 75: label L20
-     # live vars:
- 76: $t32 := true
-     # live vars: $t32
- 77: if ($t32) goto 78 else goto 80
-     # live vars:
- 78: label L21
-     # live vars:
- 79: goto 83
-     # live vars:
- 80: label L22
-     # live vars:
- 81: $t33 := 42
-     # live vars: $t33
- 82: abort($t33)
-     # live vars:
- 83: label L23
-     # live vars:
- 84: return ()
+ 80: return ()
 }
 
 ============ after ReferenceSafetyProcessor: ================
@@ -343,34 +323,30 @@ fun <SELF>_0::check() {
      var $t3: u64
      var $t4: bool
      var $t5: u64
-     var $t6: &u64
+     var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
-     var $t10: bool
-     var $t11: vector<u8>
-     var $t12: &vector<u8>
-     var $t13: vector<u8>
-     var $t14: vector<u8>
-     var $t15: u64
-     var $t16: &mut u64
-     var $t17: u64
-     var $t18: u64
-     var $t19: &mut vector<u8>
-     var $t20: vector<u8>
-     var $t21: vector<u8>
+     var $t8: bool
+     var $t9: vector<u8>
+     var $t10: vector<u8>
+     var $t11: u64
+     var $t12: &mut u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: &mut vector<u8>
+     var $t16: vector<u8>
+     var $t17: vector<u8>
+     var $t18: bool
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
      var $t22: bool
-     var $t23: u64
-     var $t24: u64
+     var $t23: vector<u8>
+     var $t24: vector<u8>
      var $t25: u64
      var $t26: bool
-     var $t27: vector<u8>
-     var $t28: vector<u8>
+     var $t27: u64
+     var $t28: bool
      var $t29: u64
-     var $t30: bool
-     var $t31: u64
-     var $t32: bool
-     var $t33: u64
      # live vars:
      # graph: {}
      # locals: {}
@@ -472,415 +448,391 @@ fun <SELF>_0::check() {
      # locals: {}
      # globals: {}
      #
- 16: $t7 := 0
+ 16: $t5 := 0
+     # live vars: $t5
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 17: $t6 := 0
+     # live vars: $t5, $t6
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 18: $t4 := ==($t5, $t6)
+     # live vars: $t4
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 19: if ($t4) goto 20 else goto 22
+     # live vars:
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 20: label L6
+     # live vars:
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 21: goto 25
+     # live vars:
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 22: label L7
+     # live vars:
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 23: $t7 := 42
      # live vars: $t7
      # graph: {}
      # locals: {}
      # globals: {}
      #
- 17: $t6 := borrow_local($t7)
-     # live vars: $t6
-     # graph: {@1100=local($t7)[borrow_imm -> @1101],@1101=derived[]}
-     # locals: {$t6=@1101,$t7=@1100}
-     # globals: {}
-     #
- 18: $t5 := read_ref($t6)
-     # live vars: $t5
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
-     # globals: {}
-     #
- 19: $t8 := 0
-     # live vars: $t5, $t8
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
-     # globals: {}
-     #
- 20: $t4 := ==($t5, $t8)
-     # live vars: $t4
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
-     # globals: {}
-     #
- 21: if ($t4) goto 22 else goto 24
+ 24: abort($t7)
      # live vars:
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 22: label L6
+ 25: label L8
      # live vars:
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 23: goto 27
-     # live vars:
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
-     # globals: {}
-     #
- 24: label L7
-     # live vars:
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
-     # globals: {}
-     #
- 25: $t9 := 42
+ 26: $t9 := [104, 101, 108, 108, 111]
      # live vars: $t9
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 26: abort($t9)
+ 27: $t10 := [104, 101, 108, 108, 111]
+     # live vars: $t9, $t10
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 28: $t8 := ==($t9, $t10)
+     # live vars: $t8
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 29: if ($t8) goto 30 else goto 32
      # live vars:
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 27: label L8
+ 30: label L9
      # live vars:
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 28: $t13 := [104, 101, 108, 108, 111]
-     # live vars: $t13
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
+ 31: goto 35
+     # live vars:
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 29: $t12 := borrow_local($t13)
-     # live vars: $t12
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[borrow_imm -> @1D01],@1D01=derived[]}
-     # locals: {$t7=@1100,$t12=@1D01,$t13=@1D00}
+ 32: label L10
+     # live vars:
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 30: $t11 := read_ref($t12)
+ 33: $t11 := 42
      # live vars: $t11
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 31: $t14 := [104, 101, 108, 108, 111]
-     # live vars: $t11, $t14
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
-     # globals: {}
-     #
- 32: $t10 := ==($t11, $t14)
-     # live vars: $t10
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
-     # globals: {}
-     #
- 33: if ($t10) goto 34 else goto 36
+ 34: abort($t11)
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 34: label L9
+ 35: label L11
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 35: goto 39
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+ 36: $t13 := 0
+     # live vars: $t13
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 36: label L10
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+ 37: $t12 := borrow_local($t13)
+     # live vars: $t12
+     # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[]}
+     # locals: {$t12=@2501,$t13=@2500}
      # globals: {}
      #
- 37: $t15 := 42
+ 38: $t14 := 1
+     # live vars: $t12, $t14
+     # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[]}
+     # locals: {$t12=@2501,$t13=@2500}
+     # globals: {}
+     #
+ 39: write_ref($t12, $t14)
+     # live vars: $t12
+     # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[]}
+     # locals: {$t12=@2501,$t13=@2500}
+     # globals: {}
+     #
+ 40: $t16 := [104, 101, 108, 108, 111]
+     # live vars: $t12, $t16
+     # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[]}
+     # locals: {$t12=@2501,$t13=@2500}
+     # globals: {}
+     #
+ 41: $t15 := borrow_local($t16)
+     # live vars: $t12, $t15
+     # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t12=@2501,$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 42: $t17 := [98, 121, 101]
+     # live vars: $t12, $t15, $t17
+     # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t12=@2501,$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 43: write_ref($t15, $t17)
+     # live vars: $t12, $t15
+     # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t12=@2501,$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 44: $t19 := read_ref($t12)
+     # live vars: $t15, $t19
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 45: $t20 := 1
+     # live vars: $t15, $t19, $t20
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 46: $t18 := ==($t19, $t20)
+     # live vars: $t15, $t18
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 47: if ($t18) goto 48 else goto 50
      # live vars: $t15
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
      # globals: {}
      #
- 38: abort($t15)
+ 48: label L12
+     # live vars: $t15
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 49: goto 53
+     # live vars: $t15
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 50: label L13
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 39: label L11
+ 51: $t21 := 42
+     # live vars: $t21
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 52: abort($t21)
+     # live vars: $t15
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 53: label L14
+     # live vars: $t15
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 54: $t23 := read_ref($t15)
+     # live vars: $t23
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 55: $t24 := [98, 121, 101]
+     # live vars: $t23, $t24
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 56: $t22 := ==($t23, $t24)
+     # live vars: $t22
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 57: if ($t22) goto 58 else goto 60
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 40: $t17 := 0
-     # live vars: $t17
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
-     # globals: {}
-     #
- 41: $t16 := borrow_local($t17)
-     # live vars: $t16
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow_mut -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
-     # globals: {}
-     #
- 42: $t18 := 1
-     # live vars: $t16, $t18
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow_mut -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
-     # globals: {}
-     #
- 43: write_ref($t16, $t18)
-     # live vars: $t16
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow_mut -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
-     # globals: {}
-     #
- 44: $t20 := [104, 101, 108, 108, 111]
-     # live vars: $t16, $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow_mut -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
-     # globals: {}
-     #
- 45: $t19 := borrow_local($t20)
-     # live vars: $t16, $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow_mut -> @2901],@2901=derived[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 46: $t21 := [98, 121, 101]
-     # live vars: $t16, $t19, $t21
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow_mut -> @2901],@2901=derived[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 47: write_ref($t19, $t21)
-     # live vars: $t16, $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow_mut -> @2901],@2901=derived[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 48: $t23 := read_ref($t16)
-     # live vars: $t19, $t23
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 49: $t24 := 1
-     # live vars: $t19, $t23, $t24
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 50: $t22 := ==($t23, $t24)
-     # live vars: $t19, $t22
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 51: if ($t22) goto 52 else goto 54
-     # live vars: $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 52: label L12
-     # live vars: $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 53: goto 57
-     # live vars: $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 54: label L13
+ 58: label L15
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 55: $t25 := 42
+ 59: goto 63
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 60: label L16
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 61: $t25 := 42
      # live vars: $t25
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 56: abort($t25)
-     # live vars: $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
+ 62: abort($t25)
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 57: label L14
-     # live vars: $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
+ 63: label L17
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 58: $t27 := read_ref($t19)
-     # live vars: $t27
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 59: $t28 := [98, 121, 101]
-     # live vars: $t27, $t28
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 60: $t26 := ==($t27, $t28)
+ 64: $t26 := true
      # live vars: $t26
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 61: if ($t26) goto 62 else goto 64
+ 65: if ($t26) goto 66 else goto 68
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 62: label L15
+ 66: label L18
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 63: goto 67
+ 67: goto 71
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 64: label L16
+ 68: label L19
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 65: $t29 := 42
+ 69: $t27 := 42
+     # live vars: $t27
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 70: abort($t27)
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 71: label L20
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 72: $t28 := true
+     # live vars: $t28
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 73: if ($t28) goto 74 else goto 76
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 74: label L21
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 75: goto 79
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 76: label L22
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 77: $t29 := 42
      # live vars: $t29
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 66: abort($t29)
+ 78: abort($t29)
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 67: label L17
+ 79: label L23
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 68: $t30 := true
-     # live vars: $t30
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 69: if ($t30) goto 70 else goto 72
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 70: label L18
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 71: goto 75
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 72: label L19
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 73: $t31 := 42
-     # live vars: $t31
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 74: abort($t31)
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 75: label L20
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 76: $t32 := true
-     # live vars: $t32
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 77: if ($t32) goto 78 else goto 80
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 78: label L21
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 79: goto 83
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 80: label L22
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 81: $t33 := 42
-     # live vars: $t33
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 82: abort($t33)
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 83: label L23
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 84: return ()
+ 80: return ()
 }
 
 ============ after AbortAnalysisProcessor: ================
@@ -893,34 +845,30 @@ fun <SELF>_0::check() {
      var $t3: u64
      var $t4: bool
      var $t5: u64
-     var $t6: &u64
+     var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
-     var $t10: bool
-     var $t11: vector<u8>
-     var $t12: &vector<u8>
-     var $t13: vector<u8>
-     var $t14: vector<u8>
-     var $t15: u64
-     var $t16: &mut u64
-     var $t17: u64
-     var $t18: u64
-     var $t19: &mut vector<u8>
-     var $t20: vector<u8>
-     var $t21: vector<u8>
+     var $t8: bool
+     var $t9: vector<u8>
+     var $t10: vector<u8>
+     var $t11: u64
+     var $t12: &mut u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: &mut vector<u8>
+     var $t16: vector<u8>
+     var $t17: vector<u8>
+     var $t18: bool
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
      var $t22: bool
-     var $t23: u64
-     var $t24: u64
+     var $t23: vector<u8>
+     var $t24: vector<u8>
      var $t25: u64
      var $t26: bool
-     var $t27: vector<u8>
-     var $t28: vector<u8>
+     var $t27: u64
+     var $t28: bool
      var $t29: u64
-     var $t30: bool
-     var $t31: u64
-     var $t32: bool
-     var $t33: u64
      # abort state: {returns,aborts}
      # live vars:
      # graph: {}
@@ -1039,483 +987,455 @@ fun <SELF>_0::check() {
      # locals: {}
      # globals: {}
      #
- 16: $t7 := 0
+ 16: $t5 := 0
      # abort state: {returns,aborts}
+     # live vars: $t5
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 17: $t6 := 0
+     # abort state: {returns,aborts}
+     # live vars: $t5, $t6
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 18: $t4 := ==($t5, $t6)
+     # abort state: {returns,aborts}
+     # live vars: $t4
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 19: if ($t4) goto 20 else goto 22
+     # abort state: {returns,aborts}
+     # live vars:
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 20: label L6
+     # abort state: {returns,aborts}
+     # live vars:
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 21: goto 25
+     # abort state: {aborts}
+     # live vars:
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 22: label L7
+     # abort state: {aborts}
+     # live vars:
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 23: $t7 := 42
+     # abort state: {aborts}
      # live vars: $t7
      # graph: {}
      # locals: {}
      # globals: {}
      #
- 17: $t6 := borrow_local($t7)
-     # abort state: {returns,aborts}
-     # live vars: $t6
-     # graph: {@1100=local($t7)[borrow_imm -> @1101],@1101=derived[]}
-     # locals: {$t6=@1101,$t7=@1100}
-     # globals: {}
-     #
- 18: $t5 := read_ref($t6)
-     # abort state: {returns,aborts}
-     # live vars: $t5
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
-     # globals: {}
-     #
- 19: $t8 := 0
-     # abort state: {returns,aborts}
-     # live vars: $t5, $t8
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
-     # globals: {}
-     #
- 20: $t4 := ==($t5, $t8)
-     # abort state: {returns,aborts}
-     # live vars: $t4
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
-     # globals: {}
-     #
- 21: if ($t4) goto 22 else goto 24
+ 24: abort($t7)
      # abort state: {returns,aborts}
      # live vars:
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 22: label L6
+ 25: label L8
      # abort state: {returns,aborts}
      # live vars:
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 23: goto 27
-     # abort state: {aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
-     # globals: {}
-     #
- 24: label L7
-     # abort state: {aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
-     # globals: {}
-     #
- 25: $t9 := 42
-     # abort state: {aborts}
+ 26: $t9 := [104, 101, 108, 108, 111]
+     # abort state: {returns,aborts}
      # live vars: $t9
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 26: abort($t9)
+ 27: $t10 := [104, 101, 108, 108, 111]
+     # abort state: {returns,aborts}
+     # live vars: $t9, $t10
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 28: $t8 := ==($t9, $t10)
+     # abort state: {returns,aborts}
+     # live vars: $t8
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 29: if ($t8) goto 30 else goto 32
      # abort state: {returns,aborts}
      # live vars:
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 27: label L8
+ 30: label L9
      # abort state: {returns,aborts}
      # live vars:
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 28: $t13 := [104, 101, 108, 108, 111]
+ 31: goto 35
+     # abort state: {aborts}
+     # live vars:
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 32: label L10
+     # abort state: {aborts}
+     # live vars:
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 33: $t11 := 42
+     # abort state: {aborts}
+     # live vars: $t11
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 34: abort($t11)
+     # abort state: {returns,aborts}
+     # live vars:
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 35: label L11
+     # abort state: {returns,aborts}
+     # live vars:
+     # graph: {}
+     # locals: {}
+     # globals: {}
+     #
+ 36: $t13 := 0
      # abort state: {returns,aborts}
      # live vars: $t13
-     # graph: {@1100=local($t7)[]}
-     # locals: {$t7=@1100}
+     # graph: {}
+     # locals: {}
      # globals: {}
      #
- 29: $t12 := borrow_local($t13)
+ 37: $t12 := borrow_local($t13)
      # abort state: {returns,aborts}
      # live vars: $t12
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[borrow_imm -> @1D01],@1D01=derived[]}
-     # locals: {$t7=@1100,$t12=@1D01,$t13=@1D00}
+     # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[]}
+     # locals: {$t12=@2501,$t13=@2500}
      # globals: {}
      #
- 30: $t11 := read_ref($t12)
+ 38: $t14 := 1
      # abort state: {returns,aborts}
-     # live vars: $t11
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+     # live vars: $t12, $t14
+     # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[]}
+     # locals: {$t12=@2501,$t13=@2500}
      # globals: {}
      #
- 31: $t14 := [104, 101, 108, 108, 111]
+ 39: write_ref($t12, $t14)
      # abort state: {returns,aborts}
-     # live vars: $t11, $t14
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+     # live vars: $t12
+     # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[]}
+     # locals: {$t12=@2501,$t13=@2500}
      # globals: {}
      #
- 32: $t10 := ==($t11, $t14)
+ 40: $t16 := [104, 101, 108, 108, 111]
      # abort state: {returns,aborts}
-     # live vars: $t10
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+     # live vars: $t12, $t16
+     # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[]}
+     # locals: {$t12=@2501,$t13=@2500}
      # globals: {}
      #
- 33: if ($t10) goto 34 else goto 36
+ 41: $t15 := borrow_local($t16)
      # abort state: {returns,aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+     # live vars: $t12, $t15
+     # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t12=@2501,$t13=@2500,$t15=@2901,$t16=@2900}
      # globals: {}
      #
- 34: label L9
+ 42: $t17 := [98, 121, 101]
      # abort state: {returns,aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+     # live vars: $t12, $t15, $t17
+     # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t12=@2501,$t13=@2500,$t15=@2901,$t16=@2900}
      # globals: {}
      #
- 35: goto 39
-     # abort state: {aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+ 43: write_ref($t15, $t17)
+     # abort state: {returns,aborts}
+     # live vars: $t12, $t15
+     # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t12=@2501,$t13=@2500,$t15=@2901,$t16=@2900}
      # globals: {}
      #
- 36: label L10
-     # abort state: {aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+ 44: $t19 := read_ref($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t15, $t19
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
      # globals: {}
      #
- 37: $t15 := 42
+ 45: $t20 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t15, $t19, $t20
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 46: $t18 := ==($t19, $t20)
+     # abort state: {returns,aborts}
+     # live vars: $t15, $t18
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 47: if ($t18) goto 48 else goto 50
+     # abort state: {returns,aborts}
+     # live vars: $t15
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 48: label L12
+     # abort state: {returns,aborts}
+     # live vars: $t15
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 49: goto 53
      # abort state: {aborts}
      # live vars: $t15
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
      # globals: {}
      #
- 38: abort($t15)
-     # abort state: {returns,aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
-     # globals: {}
-     #
- 39: label L11
-     # abort state: {returns,aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
-     # globals: {}
-     #
- 40: $t17 := 0
-     # abort state: {returns,aborts}
-     # live vars: $t17
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[]}
-     # locals: {$t7=@1100,$t13=@1D00}
-     # globals: {}
-     #
- 41: $t16 := borrow_local($t17)
-     # abort state: {returns,aborts}
-     # live vars: $t16
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow_mut -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
-     # globals: {}
-     #
- 42: $t18 := 1
-     # abort state: {returns,aborts}
-     # live vars: $t16, $t18
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow_mut -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
-     # globals: {}
-     #
- 43: write_ref($t16, $t18)
-     # abort state: {returns,aborts}
-     # live vars: $t16
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow_mut -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
-     # globals: {}
-     #
- 44: $t20 := [104, 101, 108, 108, 111]
-     # abort state: {returns,aborts}
-     # live vars: $t16, $t20
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow_mut -> @2901],@2901=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900}
-     # globals: {}
-     #
- 45: $t19 := borrow_local($t20)
-     # abort state: {returns,aborts}
-     # live vars: $t16, $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow_mut -> @2901],@2901=derived[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 46: $t21 := [98, 121, 101]
-     # abort state: {returns,aborts}
-     # live vars: $t16, $t19, $t21
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow_mut -> @2901],@2901=derived[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 47: write_ref($t19, $t21)
-     # abort state: {returns,aborts}
-     # live vars: $t16, $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[borrow_mut -> @2901],@2901=derived[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t16=@2901,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 48: $t23 := read_ref($t16)
-     # abort state: {returns,aborts}
-     # live vars: $t19, $t23
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 49: $t24 := 1
-     # abort state: {returns,aborts}
-     # live vars: $t19, $t23, $t24
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 50: $t22 := ==($t23, $t24)
-     # abort state: {returns,aborts}
-     # live vars: $t19, $t22
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 51: if ($t22) goto 52 else goto 54
-     # abort state: {returns,aborts}
-     # live vars: $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 52: label L12
-     # abort state: {returns,aborts}
-     # live vars: $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 53: goto 57
-     # abort state: {aborts}
-     # live vars: $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
-     # globals: {}
-     #
- 54: label L13
+ 50: label L13
      # abort state: {aborts}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 55: $t25 := 42
+ 51: $t21 := 42
+     # abort state: {aborts}
+     # live vars: $t21
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 52: abort($t21)
+     # abort state: {returns,aborts}
+     # live vars: $t15
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 53: label L14
+     # abort state: {returns,aborts}
+     # live vars: $t15
+     # graph: {@2500=local($t13)[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
+     # locals: {$t13=@2500,$t15=@2901,$t16=@2900}
+     # globals: {}
+     #
+ 54: $t23 := read_ref($t15)
+     # abort state: {returns,aborts}
+     # live vars: $t23
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 55: $t24 := [98, 121, 101]
+     # abort state: {returns,aborts}
+     # live vars: $t23, $t24
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 56: $t22 := ==($t23, $t24)
+     # abort state: {returns,aborts}
+     # live vars: $t22
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 57: if ($t22) goto 58 else goto 60
+     # abort state: {returns,aborts}
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 58: label L15
+     # abort state: {returns,aborts}
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 59: goto 63
+     # abort state: {aborts}
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 60: label L16
+     # abort state: {aborts}
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 61: $t25 := 42
      # abort state: {aborts}
      # live vars: $t25
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 56: abort($t25)
+ 62: abort($t25)
      # abort state: {returns,aborts}
-     # live vars: $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 57: label L14
+ 63: label L17
      # abort state: {returns,aborts}
-     # live vars: $t19
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[borrow_mut -> @2D01],@2D01=derived[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t19=@2D01,$t20=@2D00}
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 58: $t27 := read_ref($t19)
-     # abort state: {returns,aborts}
-     # live vars: $t27
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 59: $t28 := [98, 121, 101]
-     # abort state: {returns,aborts}
-     # live vars: $t27, $t28
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 60: $t26 := ==($t27, $t28)
+ 64: $t26 := true
      # abort state: {returns,aborts}
      # live vars: $t26
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 61: if ($t26) goto 62 else goto 64
+ 65: if ($t26) goto 66 else goto 68
      # abort state: {returns,aborts}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 62: label L15
+ 66: label L18
      # abort state: {returns,aborts}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 63: goto 67
+ 67: goto 71
      # abort state: {aborts}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 64: label L16
+ 68: label L19
      # abort state: {aborts}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 65: $t29 := 42
+ 69: $t27 := 42
+     # abort state: {aborts}
+     # live vars: $t27
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 70: abort($t27)
+     # abort state: {returns,aborts}
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 71: label L20
+     # abort state: {returns,aborts}
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 72: $t28 := true
+     # abort state: {returns,aborts}
+     # live vars: $t28
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 73: if ($t28) goto 74 else goto 76
+     # abort state: {returns}
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 74: label L21
+     # abort state: {returns}
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 75: goto 79
+     # abort state: {aborts}
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 76: label L22
+     # abort state: {aborts}
+     # live vars:
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
+     # globals: {}
+     #
+ 77: $t29 := 42
      # abort state: {aborts}
      # live vars: $t29
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 66: abort($t29)
-     # abort state: {returns,aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 67: label L17
-     # abort state: {returns,aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 68: $t30 := true
-     # abort state: {returns,aborts}
-     # live vars: $t30
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 69: if ($t30) goto 70 else goto 72
-     # abort state: {returns,aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 70: label L18
-     # abort state: {returns,aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 71: goto 75
-     # abort state: {aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 72: label L19
-     # abort state: {aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 73: $t31 := 42
-     # abort state: {aborts}
-     # live vars: $t31
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 74: abort($t31)
-     # abort state: {returns,aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 75: label L20
-     # abort state: {returns,aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 76: $t32 := true
-     # abort state: {returns,aborts}
-     # live vars: $t32
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 77: if ($t32) goto 78 else goto 80
+ 78: abort($t29)
      # abort state: {returns}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 78: label L21
+ 79: label L23
      # abort state: {returns}
      # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
+     # graph: {@2500=local($t13)[],@2900=local($t16)[]}
+     # locals: {$t13=@2500,$t16=@2900}
      # globals: {}
      #
- 79: goto 83
-     # abort state: {aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 80: label L22
-     # abort state: {aborts}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 81: $t33 := 42
-     # abort state: {aborts}
-     # live vars: $t33
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 82: abort($t33)
-     # abort state: {returns}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 83: label L23
-     # abort state: {returns}
-     # live vars:
-     # graph: {@1100=local($t7)[],@1D00=local($t13)[],@2900=local($t17)[],@2D00=local($t20)[]}
-     # locals: {$t7=@1100,$t13=@1D00,$t17=@2900,$t20=@2D00}
-     # globals: {}
-     #
- 84: return ()
+ 80: return ()
 }
 
 ============ after AbilityProcessor: ================
@@ -1528,34 +1448,30 @@ fun <SELF>_0::check() {
      var $t3: u64
      var $t4: bool
      var $t5: u64
-     var $t6: &u64
+     var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: u64
-     var $t10: bool
-     var $t11: vector<u8>
-     var $t12: &vector<u8>
-     var $t13: vector<u8>
-     var $t14: vector<u8>
-     var $t15: u64
-     var $t16: &mut u64
-     var $t17: u64
-     var $t18: u64
-     var $t19: &mut vector<u8>
-     var $t20: vector<u8>
-     var $t21: vector<u8>
+     var $t8: bool
+     var $t9: vector<u8>
+     var $t10: vector<u8>
+     var $t11: u64
+     var $t12: &mut u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: &mut vector<u8>
+     var $t16: vector<u8>
+     var $t17: vector<u8>
+     var $t18: bool
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
      var $t22: bool
-     var $t23: u64
-     var $t24: u64
+     var $t23: vector<u8>
+     var $t24: vector<u8>
      var $t25: u64
      var $t26: bool
-     var $t27: vector<u8>
-     var $t28: vector<u8>
+     var $t27: u64
+     var $t28: bool
      var $t29: u64
-     var $t30: bool
-     var $t31: u64
-     var $t32: bool
-     var $t33: u64
   0: $t0 := true
   1: if ($t0) goto 2 else goto 4
   2: label L0
@@ -1572,74 +1488,70 @@ fun <SELF>_0::check() {
  13: $t3 := 42
  14: abort($t3)
  15: label L5
- 16: $t7 := 0
- 17: $t6 := borrow_local($t7)
- 18: $t5 := read_ref($t6)
- 19: $t8 := 0
- 20: $t4 := ==($t5, $t8)
- 21: if ($t4) goto 22 else goto 24
- 22: label L6
- 23: goto 27
- 24: label L7
- 25: $t9 := 42
- 26: abort($t9)
- 27: label L8
- 28: $t13 := [104, 101, 108, 108, 111]
- 29: $t12 := borrow_local($t13)
- 30: $t11 := read_ref($t12)
- 31: $t14 := [104, 101, 108, 108, 111]
- 32: $t10 := ==($t11, $t14)
- 33: if ($t10) goto 34 else goto 36
- 34: label L9
- 35: goto 39
- 36: label L10
- 37: $t15 := 42
- 38: abort($t15)
- 39: label L11
- 40: $t17 := 0
- 41: $t16 := borrow_local($t17)
- 42: $t18 := 1
- 43: write_ref($t16, $t18)
- 44: $t20 := [104, 101, 108, 108, 111]
- 45: $t19 := borrow_local($t20)
- 46: $t21 := [98, 121, 101]
- 47: write_ref($t19, $t21)
- 48: $t23 := read_ref($t16)
- 49: $t24 := 1
- 50: $t22 := ==($t23, $t24)
- 51: if ($t22) goto 52 else goto 54
- 52: label L12
- 53: goto 58
- 54: label L13
- 55: drop($t19)
- 56: $t25 := 42
- 57: abort($t25)
- 58: label L14
- 59: $t27 := read_ref($t19)
- 60: $t28 := [98, 121, 101]
- 61: $t26 := ==($t27, $t28)
- 62: if ($t26) goto 63 else goto 65
- 63: label L15
- 64: goto 68
- 65: label L16
- 66: $t29 := 42
- 67: abort($t29)
- 68: label L17
- 69: $t30 := true
- 70: if ($t30) goto 71 else goto 73
- 71: label L18
- 72: goto 76
- 73: label L19
- 74: $t31 := 42
- 75: abort($t31)
- 76: label L20
- 77: $t32 := true
- 78: if ($t32) goto 79 else goto 81
- 79: label L21
- 80: goto 84
- 81: label L22
- 82: $t33 := 42
- 83: abort($t33)
- 84: label L23
- 85: return ()
+ 16: $t5 := 0
+ 17: $t6 := 0
+ 18: $t4 := ==($t5, $t6)
+ 19: if ($t4) goto 20 else goto 22
+ 20: label L6
+ 21: goto 25
+ 22: label L7
+ 23: $t7 := 42
+ 24: abort($t7)
+ 25: label L8
+ 26: $t9 := [104, 101, 108, 108, 111]
+ 27: $t10 := [104, 101, 108, 108, 111]
+ 28: $t8 := ==($t9, $t10)
+ 29: if ($t8) goto 30 else goto 32
+ 30: label L9
+ 31: goto 35
+ 32: label L10
+ 33: $t11 := 42
+ 34: abort($t11)
+ 35: label L11
+ 36: $t13 := 0
+ 37: $t12 := borrow_local($t13)
+ 38: $t14 := 1
+ 39: write_ref($t12, $t14)
+ 40: $t16 := [104, 101, 108, 108, 111]
+ 41: $t15 := borrow_local($t16)
+ 42: $t17 := [98, 121, 101]
+ 43: write_ref($t15, $t17)
+ 44: $t19 := read_ref($t12)
+ 45: $t20 := 1
+ 46: $t18 := ==($t19, $t20)
+ 47: if ($t18) goto 48 else goto 50
+ 48: label L12
+ 49: goto 54
+ 50: label L13
+ 51: drop($t15)
+ 52: $t21 := 42
+ 53: abort($t21)
+ 54: label L14
+ 55: $t23 := read_ref($t15)
+ 56: $t24 := [98, 121, 101]
+ 57: $t22 := ==($t23, $t24)
+ 58: if ($t22) goto 59 else goto 61
+ 59: label L15
+ 60: goto 64
+ 61: label L16
+ 62: $t25 := 42
+ 63: abort($t25)
+ 64: label L17
+ 65: $t26 := true
+ 66: if ($t26) goto 67 else goto 69
+ 67: label L18
+ 68: goto 72
+ 69: label L19
+ 70: $t27 := 42
+ 71: abort($t27)
+ 72: label L20
+ 73: $t28 := true
+ 74: if ($t28) goto 75 else goto 77
+ 75: label L21
+ 76: goto 80
+ 77: label L22
+ 78: $t29 := 42
+ 79: abort($t29)
+ 80: label L23
+ 81: return ()
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ability_err.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ability_err.exp
@@ -1,0 +1,168 @@
+// -- Model dump before bytecode pipeline
+module 0xc0ffee::m {
+    struct Box {
+        x: u64,
+    }
+    enum Inner {
+        Inner1 {
+            x: u64,
+        }
+        Inner2 {
+            x: u64,
+            y: u64,
+        }
+    }
+    enum Outer {
+        None,
+        One {
+            i: m::Inner,
+        }
+        Two {
+            i: m::Inner,
+            b: m::Box,
+        }
+    }
+    public fun condition_requires_copy(o: m::Outer): m::Outer {
+        match (o) {
+          m::Outer::One{ i } if m::consume(i) => {
+            pack m::Outer::One(i)
+          }
+          o: m::Outer => {
+            o
+          }
+        }
+
+    }
+    private fun consume(self: m::Inner): bool {
+        match (self) {
+          m::Inner::Inner1{ x: _ } => {
+            Tuple()
+          }
+          m::Inner::Inner2{ x: _, y: _ } => {
+            Tuple()
+          }
+        }
+        ;
+        true
+    }
+    public fun matched_value_not_consumed(o: m::Outer) {
+        match (o) {
+          m::Outer::One{ i: _ } => {
+            Tuple()
+          }
+          _: m::Outer => {
+            Tuple()
+          }
+        }
+
+    }
+} // end 0xc0ffee::m
+
+============ initial bytecode ================
+
+[variant baseline]
+public fun m::condition_requires_copy($t0: m::Outer): m::Outer {
+     var $t1: m::Outer
+     var $t2: &m::Outer
+     var $t3: bool
+     var $t4: &m::Inner
+     var $t5: m::Inner
+     var $t6: m::Inner
+     var $t7: m::Outer
+     var $t8: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := test_variant m::Outer::One($t2)
+  2: if ($t3) goto 3 else goto 12
+  3: label L2
+  4: $t4 := borrow_field_variant<m::Outer::One>.i($t2)
+  5: $t5 := read_ref($t4)
+  6: $t3 := m::consume($t5)
+  7: if ($t3) goto 8 else goto 12
+  8: label L3
+  9: $t6 := unpack_variant m::Outer::One($t0)
+ 10: $t1 := pack_variant m::Outer::One($t6)
+ 11: goto 19
+ 12: label L1
+ 13: $t7 := infer($t0)
+ 14: $t1 := infer($t7)
+ 15: goto 19
+ 16: label L4
+ 17: $t8 := 15621340914461310977
+ 18: abort($t8)
+ 19: label L0
+ 20: return $t1
+}
+
+
+[variant baseline]
+fun m::consume($t0: m::Inner): bool {
+     var $t1: bool
+     var $t2: &m::Inner
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := test_variant m::Inner::Inner1($t2)
+  2: if ($t3) goto 3 else goto 6
+  3: label L2
+  4: $t4 := unpack_variant m::Inner::Inner1($t0)
+  5: goto 15
+  6: label L1
+  7: $t3 := test_variant m::Inner::Inner2($t2)
+  8: if ($t3) goto 9 else goto 12
+  9: label L4
+ 10: ($t5, $t6) := unpack_variant m::Inner::Inner2($t0)
+ 11: goto 15
+ 12: label L3
+ 13: $t7 := 15621340914461310977
+ 14: abort($t7)
+ 15: label L0
+ 16: $t1 := true
+ 17: return $t1
+}
+
+
+[variant baseline]
+public fun m::matched_value_not_consumed($t0: m::Outer) {
+     var $t1: &m::Outer
+     var $t2: bool
+     var $t3: m::Inner
+     var $t4: m::Outer
+     var $t5: u64
+  0: $t1 := borrow_local($t0)
+  1: $t2 := test_variant m::Outer::One($t1)
+  2: if ($t2) goto 3 else goto 6
+  3: label L2
+  4: $t3 := unpack_variant m::Outer::One($t0)
+  5: goto 12
+  6: label L1
+  7: $t4 := infer($t0)
+  8: goto 12
+  9: label L3
+ 10: $t5 := 15621340914461310977
+ 11: abort($t5)
+ 12: label L0
+ 13: return ()
+}
+
+
+Diagnostics:
+error: value of type `m::Inner` does not have the `drop` ability
+   ┌─ tests/bytecode-generator/matching_ability_err.move:28:13
+   │
+28 │             One{i: _} => {}
+   │             ^^^^^^^^^ implicitly dropped here since it is no longer used
+
+error: value of type `m::Outer` does not have the `drop` ability
+   ┌─ tests/bytecode-generator/matching_ability_err.move:29:13
+   │
+29 │             _ => {}
+   │             ^ implicitly dropped here since it is no longer used
+
+error: local `i` of type `m::Inner` does not have the `copy` ability
+   ┌─ tests/bytecode-generator/matching_ability_err.move:35:31
+   │
+35 │             One{i} if consume(i) => Outer::One{i},
+   │                               ^ reference content copied here

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ability_err.move
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ability_err.move
@@ -1,0 +1,39 @@
+module 0xc0ffee::m {
+
+    enum Inner {
+        Inner1{ x: u64 }
+        Inner2{ x: u64, y: u64 }
+    }
+
+    fun consume(self: Inner): bool {
+        match (self) {
+            Inner1{x: _} => {}
+            Inner2{x: _, y:_ } => {}
+        };
+        true
+    }
+
+    struct Box has drop {
+        x: u64
+    }
+
+    enum Outer {
+        None,
+        One{i: Inner},
+        Two{i: Inner, b: Box},
+    }
+
+    public fun matched_value_not_consumed(o: Outer) {
+        match (o) {
+            One{i: _} => {}
+            _ => {}
+        }
+    }
+
+    public fun condition_requires_copy(o: Outer): Outer {
+        match (o) {
+            One{i} if consume(i) => Outer::One{i},
+            o => o
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_coverage_err.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_coverage_err.exp
@@ -1,0 +1,226 @@
+// -- Model dump before bytecode pipeline
+module 0xc0ffee::m {
+    struct Box {
+        x: u64,
+    }
+    enum Inner {
+        Inner1 {
+            x: u64,
+        }
+        Inner2 {
+            x: u64,
+            y: u64,
+        }
+    }
+    enum Outer {
+        None,
+        One {
+            i: m::Inner,
+        }
+        Two {
+            i: m::Inner,
+            b: m::Box,
+        }
+    }
+    public fun exhaustive_tuple(i: &m::Inner) {
+        match (Tuple(i, i)) {
+          (m::Inner::Inner1{ x: _ }, _: &m::Inner): (&m::Inner, &m::Inner) => {
+            Tuple()
+          }
+          (m::Inner::Inner2{ x: _, y: _ }, _: &m::Inner): (&m::Inner, &m::Inner) => {
+            Tuple()
+          }
+        }
+
+    }
+    public fun exhaustive_via_merge(o: &m::Outer) {
+        match (o) {
+          m::Outer::None => {
+            Tuple()
+          }
+          m::Outer::One{ i: m::Inner::Inner1{ x: _ } } => {
+            Tuple()
+          }
+          m::Outer::One{ i: m::Inner::Inner2{ x: _, y: _ } } => {
+            Tuple()
+          }
+          m::Outer::Two{ i: _, b: _ } => {
+            Tuple()
+          }
+        }
+
+    }
+    public fun non_exhaustive(o: &m::Outer) {
+        match (o) {
+          m::Outer::None => {
+            Tuple()
+          }
+          m::Outer::One{ i: _ } => {
+            Tuple()
+          }
+        }
+
+    }
+    public fun non_exhaustive_because_of_cond(o: &m::Outer) {
+        match (o) {
+          m::Outer::None => {
+            Tuple()
+          }
+          m::Outer::One{ i: _ } => {
+            Tuple()
+          }
+          m::Outer::Two{ i: _, b } if Gt<u64>(select m::Box.x<&m::Box>(b), 0) => {
+            Tuple()
+          }
+        }
+
+    }
+    public fun non_exhaustive_because_of_nested(o: &m::Outer) {
+        match (o) {
+          m::Outer::None => {
+            Tuple()
+          }
+          m::Outer::One{ i: m::Inner::Inner1{ x: _ } } => {
+            Tuple()
+          }
+          m::Outer::Two{ i: _, b: _ } => {
+            Tuple()
+          }
+        }
+
+    }
+    public fun non_exhaustive_tuple(i: &m::Inner) {
+        match (Tuple(i, i)) {
+          (m::Inner::Inner1{ x: _ }, _: &m::Inner): (&m::Inner, &m::Inner) => {
+            Tuple()
+          }
+        }
+
+    }
+    public fun non_exhaustive_tuple2(i: &m::Inner) {
+        match (Tuple(i, i)) {
+          (m::Inner::Inner1{ x: _ }, _: &m::Inner): (&m::Inner, &m::Inner) => {
+            Tuple()
+          }
+          (_: &m::Inner, m::Inner::Inner2{ x: _, y: _ }): (&m::Inner, &m::Inner) => {
+            Tuple()
+          }
+        }
+
+    }
+    public fun unreachable(o: &m::Outer) {
+        match (o) {
+          m::Outer::None => {
+            Tuple()
+          }
+          m::Outer::One{ i: _ } => {
+            Tuple()
+          }
+          m::Outer::Two{ i: _, b: _ } => {
+            Tuple()
+          }
+          _: &m::Outer => {
+            Tuple()
+          }
+        }
+
+    }
+    public fun unreachable_via_overlaying_pattern(o: &m::Outer) {
+        match (o) {
+          m::Outer::None => {
+            Tuple()
+          }
+          m::Outer::One{ i: m::Inner::Inner1{ x: _ } } => {
+            Tuple()
+          }
+          m::Outer::One{ i: _ } => {
+            Tuple()
+          }
+          m::Outer::One{ i: m::Inner::Inner1{ x: _ } } => {
+            Tuple()
+          }
+          _: &m::Outer => {
+            Tuple()
+          }
+        }
+
+    }
+    public fun unreachable_via_repeated_pattern(o: &m::Outer) {
+        match (o) {
+          m::Outer::None => {
+            Tuple()
+          }
+          m::Outer::One{ i: _ } => {
+            Tuple()
+          }
+          m::Outer::One{ i: _ } => {
+            Tuple()
+          }
+          _: &m::Outer => {
+            Tuple()
+          }
+        }
+
+    }
+} // end 0xc0ffee::m
+
+
+Diagnostics:
+error: match not exhaustive
+   ┌─ tests/bytecode-generator/matching_coverage_err.move:21:16
+   │
+21 │         match (o) {
+   │                ^
+   │
+   = missing `Outer::Two{..}`
+
+error: match not exhaustive
+   ┌─ tests/bytecode-generator/matching_coverage_err.move:28:16
+   │
+28 │         match (o) {
+   │                ^
+   │
+   = missing `Outer::Two{..}`
+
+error: match not exhaustive
+   ┌─ tests/bytecode-generator/matching_coverage_err.move:36:16
+   │
+36 │         match (o) {
+   │                ^
+   │
+   = missing `Outer::One{i: Inner::Inner2{..}}`
+
+error: match not exhaustive
+   ┌─ tests/bytecode-generator/matching_coverage_err.move:52:16
+   │
+52 │         match ((i, i)) {
+   │                ^^^^^^
+   │
+   = missing `(Inner::Inner2{..},_)`
+
+error: match not exhaustive
+   ┌─ tests/bytecode-generator/matching_coverage_err.move:65:16
+   │
+65 │         match ((i, i)) {
+   │                ^^^^^^
+   │
+   = missing `(_,Inner::Inner1{..})`
+   = missing `(Inner::Inner2{..},_)`
+
+error: unreachable pattern
+   ┌─ tests/bytecode-generator/matching_coverage_err.move:78:14
+   │
+78 │              _ => {}
+   │              ^
+
+error: unreachable pattern
+   ┌─ tests/bytecode-generator/matching_coverage_err.move:86:14
+   │
+86 │              One{i: _} => {}
+   │              ^^^^^^^^^
+
+error: unreachable pattern
+   ┌─ tests/bytecode-generator/matching_coverage_err.move:96:14
+   │
+96 │              One{i: Inner1{x:_}} => {}
+   │              ^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_coverage_err.move
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_coverage_err.move
@@ -1,0 +1,100 @@
+module 0xc0ffee::m {
+
+    enum Inner {
+        Inner1{ x: u64 }
+        Inner2{ x: u64, y: u64 }
+    }
+
+    struct Box has drop {
+        x: u64
+    }
+
+    enum Outer {
+        None,
+        One{i: Inner},
+        Two{i: Inner, b: Box},
+    }
+
+    // Exhaustiveness
+
+    public fun non_exhaustive(o: &Outer) {
+        match (o) {
+            None => {}
+            One{i: _} => {}
+        }
+    }
+
+    public fun non_exhaustive_because_of_cond(o: &Outer) {
+        match (o) {
+            None => {}
+            One{i: _} => {}
+            Two{i: _, b} if b.x > 0 => {}
+        }
+    }
+
+    public fun non_exhaustive_because_of_nested(o: &Outer) {
+        match (o) {
+            None => {}
+            One{i: Inner1{x: _}} => {}
+            Two{i: _, b: _} => {}
+        }
+    }
+
+    public fun exhaustive_via_merge(o: &Outer) {
+        match (o) {
+            None => {}
+            One{i: Inner1{x: _}} => {}
+            One{i: Inner2{x: _, y: _}} => {}
+            Two{i: _, b: _} => {}
+        }
+    }
+    public fun non_exhaustive_tuple(i: &Inner) {
+        match ((i, i)) {
+            (Inner1{x: _}, _) => {}
+        }
+    }
+
+    public fun exhaustive_tuple(i: &Inner) {
+        match ((i, i)) {
+            (Inner1{x: _}, _) => {}
+            (Inner2{x: _, y: _}, _) => {}
+        }
+    }
+
+    public fun non_exhaustive_tuple2(i: &Inner) {
+        match ((i, i)) {
+            (Inner1{x: _}, _) => {}
+            (_, Inner2{x: _, y: _}) => {}
+        }
+    }
+
+    // Reachability
+
+    public fun unreachable(o: &Outer) {
+         match (o) {
+             None => {}
+             One{i: _} => {}
+             Two{i: _, b: _} => {}
+             _ => {}
+         }
+    }
+
+    public fun unreachable_via_repeated_pattern(o: &Outer) {
+         match (o) {
+             None => {}
+             One{i: _} => {}
+             One{i: _} => {}
+             _ => {}
+         }
+    }
+
+    public fun unreachable_via_overlaying_pattern(o: &Outer) {
+         match (o) {
+             None => {}
+             One{i: Inner1{x:_}} => {}
+             One{i: _} => {}
+             One{i: Inner1{x:_}} => {}
+             _ => {}
+         }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.exp
@@ -12,6 +12,12 @@ module 0xc0ffee::m {
             y: u64,
         }
     }
+    enum Option {
+        None,
+        Some {
+            value: #0,
+        }
+    }
     enum Outer {
         None,
         One {
@@ -40,6 +46,42 @@ module 0xc0ffee::m {
           }
           _: &m::Inner => {
             false
+          }
+        }
+
+    }
+    public fun is_some<A>(x: &m::Option<#0>): bool {
+        match (x) {
+          m::Option::None<A> => {
+            false
+          }
+          m::Option::Some<A>{ value: _ } => {
+            true
+          }
+        }
+
+    }
+    public fun is_some_dropped<A>(x: m::Option<#0>): bool {
+        match (x) {
+          m::Option::None<A> => {
+            false
+          }
+          _: m::Option<A> => {
+            true
+          }
+        }
+
+    }
+    public fun is_some_specialized(x: &m::Option<m::Option<u64>>): bool {
+        match (x) {
+          m::Option::None<m::Option<u64>> => {
+            false
+          }
+          m::Option::Some<m::Option<u64>>{ value: m::Option::None<u64> } => {
+            false
+          }
+          m::Option::Some<m::Option<u64>>{ value: m::Option::Some<u64>{ value: _ } } => {
+            true
           }
         }
 
@@ -164,6 +206,96 @@ public fun m::is_inner1($t0: &m::Inner): bool {
  11: abort($t4)
  12: label L0
  13: return $t1
+}
+
+
+[variant baseline]
+public fun m::is_some<#0>($t0: &m::Option<#0>): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: u64
+  0: $t2 := test_variant m::Option<#0>::None($t0)
+  1: if ($t2) goto 2 else goto 5
+  2: label L2
+  3: $t1 := false
+  4: goto 14
+  5: label L1
+  6: $t2 := test_variant m::Option<#0>::Some($t0)
+  7: if ($t2) goto 8 else goto 11
+  8: label L4
+  9: $t1 := true
+ 10: goto 14
+ 11: label L3
+ 12: $t3 := 15621340914461310977
+ 13: abort($t3)
+ 14: label L0
+ 15: return $t1
+}
+
+
+[variant baseline]
+public fun m::is_some_dropped<#0>($t0: m::Option<#0>): bool {
+     var $t1: bool
+     var $t2: &m::Option<#0>
+     var $t3: bool
+     var $t4: m::Option<#0>
+     var $t5: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := test_variant m::Option<#0>::None($t2)
+  2: if ($t3) goto 3 else goto 7
+  3: label L2
+  4: unpack_variant m::Option<#0>::None($t0)
+  5: $t1 := false
+  6: goto 14
+  7: label L1
+  8: $t4 := infer($t0)
+  9: $t1 := true
+ 10: goto 14
+ 11: label L3
+ 12: $t5 := 15621340914461310977
+ 13: abort($t5)
+ 14: label L0
+ 15: return $t1
+}
+
+
+[variant baseline]
+public fun m::is_some_specialized($t0: &m::Option<m::Option<u64>>): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: &m::Option<u64>
+     var $t4: &m::Option<u64>
+     var $t5: u64
+  0: $t2 := test_variant m::Option<m::Option<u64>>::None($t0)
+  1: if ($t2) goto 2 else goto 5
+  2: label L2
+  3: $t1 := false
+  4: goto 28
+  5: label L1
+  6: $t2 := test_variant m::Option<m::Option<u64>>::Some($t0)
+  7: if ($t2) goto 8 else goto 15
+  8: label L4
+  9: $t3 := borrow_field_variant<m::Option<m::Option<u64>>::Some>.value($t0)
+ 10: $t2 := test_variant m::Option<u64>::None($t3)
+ 11: if ($t2) goto 12 else goto 15
+ 12: label L5
+ 13: $t1 := false
+ 14: goto 28
+ 15: label L3
+ 16: $t2 := test_variant m::Option<m::Option<u64>>::Some($t0)
+ 17: if ($t2) goto 18 else goto 25
+ 18: label L7
+ 19: $t4 := borrow_field_variant<m::Option<m::Option<u64>>::Some>.value($t0)
+ 20: $t2 := test_variant m::Option<u64>::Some($t4)
+ 21: if ($t2) goto 22 else goto 25
+ 22: label L8
+ 23: $t1 := true
+ 24: goto 28
+ 25: label L6
+ 26: $t5 := 15621340914461310977
+ 27: abort($t5)
+ 28: label L0
+ 29: return $t1
 }
 
 
@@ -420,3 +552,21 @@ bug: file format generator: variants not yet implemented
    │
 67 │     public fun outer_value_with_cond_ref(o: &Outer): bool {
    │                ^^^^^^^^^^^^^^^^^^^^^^^^^
+
+bug: file format generator: variants not yet implemented
+   ┌─ tests/bytecode-generator/matching_ok.move:82:16
+   │
+82 │     public fun is_some<A>(x: &Option<A>): bool {
+   │                ^^^^^^^
+
+bug: file format generator: variants not yet implemented
+   ┌─ tests/bytecode-generator/matching_ok.move:89:16
+   │
+89 │     public fun is_some_specialized(x: &Option<Option<u64>>): bool {
+   │                ^^^^^^^^^^^^^^^^^^^
+
+bug: file format generator: variants not yet implemented
+   ┌─ tests/bytecode-generator/matching_ok.move:97:16
+   │
+97 │     public fun is_some_dropped<A:drop>(x: Option<A>): bool {
+   │                ^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.exp
@@ -1,0 +1,422 @@
+// -- Model dump before bytecode pipeline
+module 0xc0ffee::m {
+    struct Box {
+        x: u64,
+    }
+    enum Inner {
+        Inner1 {
+            x: u64,
+        }
+        Inner2 {
+            x: u64,
+            y: u64,
+        }
+    }
+    enum Outer {
+        None,
+        One {
+            i: m::Inner,
+        }
+        Two {
+            i: m::Inner,
+            b: m::Box,
+        }
+    }
+    public fun inner_value(self: m::Inner): u64 {
+        match (self) {
+          m::Inner::Inner1{ x } => {
+            x
+          }
+          m::Inner::Inner2{ x, y } => {
+            Add<u64>(x, y)
+          }
+        }
+
+    }
+    public fun is_inner1(self: &m::Inner): bool {
+        match (self) {
+          m::Inner::Inner1{ x: _ } => {
+            true
+          }
+          _: &m::Inner => {
+            false
+          }
+        }
+
+    }
+    public fun outer_value(o: m::Outer): u64 {
+        match (o) {
+          m::Outer::None => {
+            0
+          }
+          m::Outer::One{ i } => {
+            m::inner_value(i)
+          }
+          m::Outer::Two{ i, b } => {
+            Add<u64>(m::inner_value(i), select m::Box.x<m::Box>(b))
+          }
+        }
+
+    }
+    public fun outer_value_nested(o: m::Outer): u64 {
+        match (o) {
+          m::Outer::None => {
+            0
+          }
+          m::Outer::One{ i: m::Inner::Inner1{ x } } => {
+            x
+          }
+          m::Outer::One{ i } => {
+            m::inner_value(i)
+          }
+          m::Outer::Two{ i, b } => {
+            Add<u64>(m::inner_value(i), select m::Box.x<m::Box>(b))
+          }
+        }
+
+    }
+    public fun outer_value_with_cond(o: m::Outer): u64 {
+        match (o) {
+          m::Outer::None => {
+            0
+          }
+          m::Outer::One{ i } if m::is_inner1(Borrow(Immutable)(i)) => {
+            Mod<u64>(m::inner_value(i), 2)
+          }
+          m::Outer::One{ i } => {
+            m::inner_value(i)
+          }
+          m::Outer::Two{ i, b } => {
+            Add<u64>(m::inner_value(i), select m::Box.x<m::Box>(b))
+          }
+        }
+
+    }
+    public fun outer_value_with_cond_ref(o: &m::Outer): bool {
+        match (o) {
+          m::Outer::None => {
+            false
+          }
+          m::Outer::One{ i } if m::is_inner1(i) => {
+            true
+          }
+          m::Outer::One{ i } => {
+            m::is_inner1(i)
+          }
+          m::Outer::Two{ i, b: _ } => {
+            m::is_inner1(i)
+          }
+        }
+
+    }
+} // end 0xc0ffee::m
+
+============ initial bytecode ================
+
+[variant baseline]
+public fun m::inner_value($t0: m::Inner): u64 {
+     var $t1: u64
+     var $t2: &m::Inner
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := test_variant m::Inner::Inner1($t2)
+  2: if ($t3) goto 3 else goto 7
+  3: label L2
+  4: $t4 := unpack_variant m::Inner::Inner1($t0)
+  5: $t1 := infer($t4)
+  6: goto 17
+  7: label L1
+  8: $t3 := test_variant m::Inner::Inner2($t2)
+  9: if ($t3) goto 10 else goto 14
+ 10: label L4
+ 11: ($t5, $t6) := unpack_variant m::Inner::Inner2($t0)
+ 12: $t1 := +($t5, $t6)
+ 13: goto 17
+ 14: label L3
+ 15: $t7 := 15621340914461310977
+ 16: abort($t7)
+ 17: label L0
+ 18: return $t1
+}
+
+
+[variant baseline]
+public fun m::is_inner1($t0: &m::Inner): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: &m::Inner
+     var $t4: u64
+  0: $t2 := test_variant m::Inner::Inner1($t0)
+  1: if ($t2) goto 2 else goto 5
+  2: label L2
+  3: $t1 := true
+  4: goto 12
+  5: label L1
+  6: $t3 := infer($t0)
+  7: $t1 := false
+  8: goto 12
+  9: label L3
+ 10: $t4 := 15621340914461310977
+ 11: abort($t4)
+ 12: label L0
+ 13: return $t1
+}
+
+
+[variant baseline]
+public fun m::outer_value($t0: m::Outer): u64 {
+     var $t1: u64
+     var $t2: &m::Outer
+     var $t3: bool
+     var $t4: m::Inner
+     var $t5: m::Inner
+     var $t6: m::Box
+     var $t7: u64
+     var $t8: u64
+     var $t9: &m::Box
+     var $t10: &u64
+     var $t11: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := test_variant m::Outer::None($t2)
+  2: if ($t3) goto 3 else goto 7
+  3: label L2
+  4: unpack_variant m::Outer::None($t0)
+  5: $t1 := 0
+  6: goto 28
+  7: label L1
+  8: $t3 := test_variant m::Outer::One($t2)
+  9: if ($t3) goto 10 else goto 14
+ 10: label L4
+ 11: $t4 := unpack_variant m::Outer::One($t0)
+ 12: $t1 := m::inner_value($t4)
+ 13: goto 28
+ 14: label L3
+ 15: $t3 := test_variant m::Outer::Two($t2)
+ 16: if ($t3) goto 17 else goto 25
+ 17: label L6
+ 18: ($t5, $t6) := unpack_variant m::Outer::Two($t0)
+ 19: $t7 := m::inner_value($t5)
+ 20: $t9 := borrow_local($t6)
+ 21: $t10 := borrow_field<m::Box>.x($t9)
+ 22: $t8 := read_ref($t10)
+ 23: $t1 := +($t7, $t8)
+ 24: goto 28
+ 25: label L5
+ 26: $t11 := 15621340914461310977
+ 27: abort($t11)
+ 28: label L0
+ 29: return $t1
+}
+
+
+[variant baseline]
+public fun m::outer_value_nested($t0: m::Outer): u64 {
+     var $t1: u64
+     var $t2: &m::Outer
+     var $t3: bool
+     var $t4: &m::Inner
+     var $t5: u64
+     var $t6: m::Inner
+     var $t7: m::Inner
+     var $t8: m::Inner
+     var $t9: m::Box
+     var $t10: u64
+     var $t11: u64
+     var $t12: &m::Box
+     var $t13: &u64
+     var $t14: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := test_variant m::Outer::None($t2)
+  2: if ($t3) goto 3 else goto 7
+  3: label L2
+  4: unpack_variant m::Outer::None($t0)
+  5: $t1 := 0
+  6: goto 40
+  7: label L1
+  8: $t3 := test_variant m::Outer::One($t2)
+  9: if ($t3) goto 10 else goto 19
+ 10: label L4
+ 11: $t4 := borrow_field_variant<m::Outer::One>.i($t2)
+ 12: $t3 := test_variant m::Inner::Inner1($t4)
+ 13: if ($t3) goto 14 else goto 19
+ 14: label L5
+ 15: $t6 := unpack_variant m::Outer::One($t0)
+ 16: $t5 := unpack_variant m::Inner::Inner1($t6)
+ 17: $t1 := infer($t5)
+ 18: goto 40
+ 19: label L3
+ 20: $t3 := test_variant m::Outer::One($t2)
+ 21: if ($t3) goto 22 else goto 26
+ 22: label L7
+ 23: $t7 := unpack_variant m::Outer::One($t0)
+ 24: $t1 := m::inner_value($t7)
+ 25: goto 40
+ 26: label L6
+ 27: $t3 := test_variant m::Outer::Two($t2)
+ 28: if ($t3) goto 29 else goto 37
+ 29: label L9
+ 30: ($t8, $t9) := unpack_variant m::Outer::Two($t0)
+ 31: $t10 := m::inner_value($t8)
+ 32: $t12 := borrow_local($t9)
+ 33: $t13 := borrow_field<m::Box>.x($t12)
+ 34: $t11 := read_ref($t13)
+ 35: $t1 := +($t10, $t11)
+ 36: goto 40
+ 37: label L8
+ 38: $t14 := 15621340914461310977
+ 39: abort($t14)
+ 40: label L0
+ 41: return $t1
+}
+
+
+[variant baseline]
+public fun m::outer_value_with_cond($t0: m::Outer): u64 {
+     var $t1: u64
+     var $t2: &m::Outer
+     var $t3: bool
+     var $t4: &m::Inner
+     var $t5: &m::Inner
+     var $t6: m::Inner
+     var $t7: u64
+     var $t8: u64
+     var $t9: m::Inner
+     var $t10: m::Inner
+     var $t11: m::Box
+     var $t12: u64
+     var $t13: u64
+     var $t14: &m::Box
+     var $t15: &u64
+     var $t16: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := test_variant m::Outer::None($t2)
+  2: if ($t3) goto 3 else goto 7
+  3: label L2
+  4: unpack_variant m::Outer::None($t0)
+  5: $t1 := 0
+  6: goto 42
+  7: label L1
+  8: $t3 := test_variant m::Outer::One($t2)
+  9: if ($t3) goto 10 else goto 21
+ 10: label L4
+ 11: $t4 := borrow_field_variant<m::Outer::One>.i($t2)
+ 12: $t5 := infer($t4)
+ 13: $t3 := m::is_inner1($t5)
+ 14: if ($t3) goto 15 else goto 21
+ 15: label L5
+ 16: $t6 := unpack_variant m::Outer::One($t0)
+ 17: $t7 := m::inner_value($t6)
+ 18: $t8 := 2
+ 19: $t1 := %($t7, $t8)
+ 20: goto 42
+ 21: label L3
+ 22: $t3 := test_variant m::Outer::One($t2)
+ 23: if ($t3) goto 24 else goto 28
+ 24: label L7
+ 25: $t9 := unpack_variant m::Outer::One($t0)
+ 26: $t1 := m::inner_value($t9)
+ 27: goto 42
+ 28: label L6
+ 29: $t3 := test_variant m::Outer::Two($t2)
+ 30: if ($t3) goto 31 else goto 39
+ 31: label L9
+ 32: ($t10, $t11) := unpack_variant m::Outer::Two($t0)
+ 33: $t12 := m::inner_value($t10)
+ 34: $t14 := borrow_local($t11)
+ 35: $t15 := borrow_field<m::Box>.x($t14)
+ 36: $t13 := read_ref($t15)
+ 37: $t1 := +($t12, $t13)
+ 38: goto 42
+ 39: label L8
+ 40: $t16 := 15621340914461310977
+ 41: abort($t16)
+ 42: label L0
+ 43: return $t1
+}
+
+
+[variant baseline]
+public fun m::outer_value_with_cond_ref($t0: &m::Outer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: &m::Inner
+     var $t4: &m::Inner
+     var $t5: &m::Inner
+     var $t6: u64
+  0: $t2 := test_variant m::Outer::None($t0)
+  1: if ($t2) goto 2 else goto 5
+  2: label L2
+  3: $t1 := false
+  4: goto 32
+  5: label L1
+  6: $t2 := test_variant m::Outer::One($t0)
+  7: if ($t2) goto 8 else goto 15
+  8: label L4
+  9: $t3 := borrow_field_variant<m::Outer::One>.i($t0)
+ 10: $t2 := m::is_inner1($t3)
+ 11: if ($t2) goto 12 else goto 15
+ 12: label L5
+ 13: $t1 := true
+ 14: goto 32
+ 15: label L3
+ 16: $t2 := test_variant m::Outer::One($t0)
+ 17: if ($t2) goto 18 else goto 22
+ 18: label L7
+ 19: $t4 := borrow_field_variant<m::Outer::One>.i($t0)
+ 20: $t1 := m::is_inner1($t4)
+ 21: goto 32
+ 22: label L6
+ 23: $t2 := test_variant m::Outer::Two($t0)
+ 24: if ($t2) goto 25 else goto 29
+ 25: label L9
+ 26: $t5 := borrow_field_variant<m::Outer::Two>.i($t0)
+ 27: $t1 := m::is_inner1($t5)
+ 28: goto 32
+ 29: label L8
+ 30: $t6 := 15621340914461310977
+ 31: abort($t6)
+ 32: label L0
+ 33: return $t1
+}
+
+
+Diagnostics:
+bug: file format generator: variants not yet implemented
+   ┌─ tests/bytecode-generator/matching_ok.move:19:16
+   │
+19 │     public fun inner_value(self: Inner): u64 {
+   │                ^^^^^^^^^^^
+
+bug: file format generator: variants not yet implemented
+   ┌─ tests/bytecode-generator/matching_ok.move:27:16
+   │
+27 │     public fun is_inner1(self: &Inner): bool {
+   │                ^^^^^^^^^
+
+bug: file format generator: variants not yet implemented
+   ┌─ tests/bytecode-generator/matching_ok.move:35:16
+   │
+35 │     public fun outer_value(o: Outer): u64 {
+   │                ^^^^^^^^^^^
+
+bug: file format generator: variants not yet implemented
+   ┌─ tests/bytecode-generator/matching_ok.move:45:16
+   │
+45 │     public fun outer_value_nested(o: Outer): u64 {
+   │                ^^^^^^^^^^^^^^^^^^
+
+bug: file format generator: variants not yet implemented
+   ┌─ tests/bytecode-generator/matching_ok.move:56:16
+   │
+56 │     public fun outer_value_with_cond(o: Outer): u64 {
+   │                ^^^^^^^^^^^^^^^^^^^^^
+
+bug: file format generator: variants not yet implemented
+   ┌─ tests/bytecode-generator/matching_ok.move:67:16
+   │
+67 │     public fun outer_value_with_cond_ref(o: &Outer): bool {
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.move
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.move
@@ -1,0 +1,75 @@
+module 0xc0ffee::m {
+
+    enum Inner {
+        Inner1{ x: u64 }
+        Inner2{ x: u64, y: u64 }
+    }
+
+    struct Box has drop {
+        x: u64
+    }
+
+    enum Outer {
+        None,
+        One{i: Inner},
+        Two{i: Inner, b: Box},
+    }
+
+    /// Simple matching
+    public fun inner_value(self: Inner): u64 {
+        match (self) {
+            Inner1{x} => x,
+            Inner2{x, y} => x + y
+        }
+    }
+
+    /// Matching with wildcard and reference
+    public fun is_inner1(self: &Inner): bool {
+        match (self) {
+            Inner1{x: _} => true,
+            _ => false
+        }
+    }
+
+    /// Matching which delegates ownership
+    public fun outer_value(o: Outer): u64 {
+        match (o) {
+            None => 0,
+            // `i` is moved and consumed by `inner_value`
+            One{i} => i.inner_value(),
+            Two{i, b} => i.inner_value() + b.x
+        }
+    }
+
+    /// Nested matching with delegation
+    public fun outer_value_nested(o: Outer): u64 {
+        match (o) {
+            None => 0,
+            // Nested match will require multiple probing steps
+            One{i: Inner::Inner1{x}} => x,
+            One{i} => i.inner_value(),
+            Two{i, b} => i.inner_value() + b.x
+        }
+    }
+
+    /// Matching with condition
+    public fun outer_value_with_cond(o: Outer): u64 {
+        match (o) {
+            None => 0,
+            // Match with condition requires probing and conversion from 'Deref(Borrow(x))` to `x`.
+            One{i} if i.is_inner1() => i.inner_value() % 2,
+            One{i} => i.inner_value(),
+            Two{i, b} => i.inner_value() + b.x
+        }
+    }
+
+    /// Matching with condition with references and wildcard
+    public fun outer_value_with_cond_ref(o: &Outer): bool {
+        match (o) {
+            None => false,
+            One{i} if i.is_inner1() => true,
+            One{i} => i.is_inner1(),
+            Two{i, b: _} => i.is_inner1()
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.move
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.move
@@ -72,4 +72,32 @@ module 0xc0ffee::m {
             Two{i, b: _} => i.is_inner1()
         }
     }
+
+    /// Matching with abilities and generics
+    enum Option<A> has drop {
+        None,
+        Some{value: A}
+    }
+
+    public fun is_some<A>(x: &Option<A>): bool {
+        match (x) {
+            None => false,
+            Some{value: _} => true
+        }
+    }
+
+    public fun is_some_specialized(x: &Option<Option<u64>>): bool {
+        match (x) {
+            None => false,
+            Some{value: Option::None} => false,
+            Some{value: Option::Some{value: _}} => true,
+        }
+    }
+
+    public fun is_some_dropped<A:drop>(x: Option<A>): bool {
+        match (x) {
+            None => false,
+            _ => true
+        }
+    }
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/wildcard6.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/wildcard6.exp
@@ -34,6 +34,6 @@ error: cannot move local `x` since it is still in use
   ┌─ tests/bytecode-generator/wildcard6.move:4:23
   │
 4 │         let (y, _) = (move x, x);
-  │             ------    ^^^^^^ attempted to move here
-  │             │
-  │             used here
+  │                 -     ^^^^^^ attempted to move here
+  │                 │
+  │                 used here

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/wildcard7.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/wildcard7.exp
@@ -49,4 +49,4 @@ error: cannot move local `x` since it is still in use
 5 │         let y = move x;
   │                 ^^^^^^ attempted to move here
 6 │         let (_, q) = (x, z);
-  │             ------ used here
+  │              - used here

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/wildcard8.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/wildcard8.exp
@@ -26,7 +26,13 @@ public fun m::test() {
 
 Diagnostics:
 error: use of unassigned local `x`
-  ┌─ tests/bytecode-generator/wildcard8.move:4:13
+  ┌─ tests/bytecode-generator/wildcard8.move:4:14
   │
 4 │         let (_, _) = (x, x);
-  │             ^^^^^^
+  │              ^
+
+error: use of unassigned local `x`
+  ┌─ tests/bytecode-generator/wildcard8.move:4:17
+  │
+4 │         let (_, _) = (x, x);
+  │                 ^

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_ok.exp
@@ -34,10 +34,10 @@ module 0x815::m {
           m::Color::RGB{ red, green, blue } => {
             Gt<u64>(Add<u64>(Add<u64>(red, green), blue), 0)
           }
-          m::Color::Red{  } => {
+          m::Color::Red => {
             true
           }
-          m::Color::Blue{  } => {
+          m::Color::Blue => {
             false
           }
         }
@@ -48,10 +48,10 @@ module 0x815::m {
           m::Color::RGB{ red, green, blue } => {
             Gt<u64>(Add<u64>(Add<u64>(red, green), blue), 0)
           }
-          m::Color::Red{  } => {
+          m::Color::Red => {
             true
           }
-          m::Color::Blue{  } => {
+          m::Color::Blue => {
             false
           }
         }
@@ -62,10 +62,10 @@ module 0x815::m {
           m::Color::RGB{ red: r, green: g, blue } => {
             Gt<u64>(Add<u64>(Add<u64>(r, g), blue), 0)
           }
-          m::Color::Red{  } => {
+          m::Color::Red => {
             true
           }
-          m::Color::Blue{  } => {
+          m::Color::Blue => {
             false
           }
         }
@@ -76,10 +76,10 @@ module 0x815::m {
           m::Color::RGB{ red, green, blue } => {
             Gt<u64>(Add<u64>(Add<u64>(red, green), blue), 0)
           }
-          m::Color::Red{  } => {
+          m::Color::Red => {
             true
           }
-          m::Color::Blue{  } => {
+          m::Color::Blue => {
             false
           }
         }
@@ -90,10 +90,10 @@ module 0x815::m {
           m::Color::RGB{ red, green, blue } => {
             Gt<u64>(Add<u64>(Add<u64>(red, green), blue), 0)
           }
-          m::Color::Red{  } => {
+          m::Color::Red => {
             true
           }
-          m::Color::Blue{  } => {
+          m::Color::Blue => {
             false
           }
         }
@@ -104,10 +104,10 @@ module 0x815::m {
           m::Color::RGB{ red, green, blue } => {
             Gt<u64>(Add<u64>(Add<u64>(red, green), blue), 0)
           }
-          m::Color::Red{  } => {
+          m::Color::Red => {
             true
           }
-          m::Color::Blue{  } => {
+          m::Color::Blue => {
             false
           }
         }
@@ -152,10 +152,10 @@ module 0x815::m {
           let x: u64 = 1;
           {
             let r: &u64 = match (Borrow(Mutable)(self)) {
-              m::Color::Red{  } => {
+              m::Color::Red => {
                 Borrow(Immutable)(x)
               }
-              m::Color::Blue{  } => {
+              m::Color::Blue => {
                 Freeze(false)(Borrow(Mutable)(x))
               }
               _: &mut m::Color => {
@@ -189,10 +189,10 @@ module 0x815::m {
           m::Color::RGB{ red, green, blue } => {
             And(Neq<u64>(red, green), Neq<u64>(green, blue))
           }
-          m::Color::Red{  } => {
+          m::Color::Red => {
             true
           }
-          m::Color::Blue{  } => {
+          m::Color::Blue => {
             false
           }
         }

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_on_mut_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_on_mut_invalid.exp
@@ -30,9 +30,9 @@ error: cannot immutably borrow since mutable references exist
 38 │         let field_ref = set_and_pick(account, copy point_ref);
    │                         ------------------------------------- previous mutable call result
 39 │         let x_val = *&freeze(point_ref).x;
-   │                     --^^^^^^^^^^^^^^^^^--
-   │                     │ │
-   │                     │ immutable borrow attempted here
-   │                     requirement enforced here
+   │                       ^^^^^^^^^^^^^^^^^--
+   │                       │
+   │                       requirement enforced here
+   │                       immutable borrow attempted here
 40 │         let returned_ref = bump_and_give(field_ref);
    │                            ------------------------ conflicting reference `field_ref` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_on_mut_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_on_mut_invalid.no-opt.exp
@@ -30,9 +30,9 @@ error: cannot immutably borrow since mutable references exist
 38 │         let field_ref = set_and_pick(account, copy point_ref);
    │                         ------------------------------------- previous mutable call result
 39 │         let x_val = *&freeze(point_ref).x;
-   │                     --^^^^^^^^^^^^^^^^^--
-   │                     │ │
-   │                     │ immutable borrow attempted here
-   │                     requirement enforced here
+   │                       ^^^^^^^^^^^^^^^^^--
+   │                       │
+   │                       requirement enforced here
+   │                       immutable borrow attempted here
 40 │         let returned_ref = bump_and_give(field_ref);
    │                            ------------------------ conflicting reference `field_ref` used here

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
@@ -161,6 +161,7 @@ pub enum Operation {
     Exists(ModuleId, StructId, Vec<Type>),
 
     // Variants
+    // Below the `Symbol` is the name of the variant.
     TestVariant(ModuleId, StructId, Symbol, Vec<Type>),
     PackVariant(ModuleId, StructId, Symbol, Vec<Type>),
     UnpackVariant(ModuleId, StructId, Symbol, Vec<Type>),

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
@@ -12,6 +12,7 @@ use move_model::{
     ast::{Address, Exp, ExpData, MemoryLabel, Spec, TempIndex, TraceKind},
     exp_rewriter::{ExpRewriter, ExpRewriterFunctions, RewriteTarget},
     model::{FunId, GlobalEnv, ModuleId, NodeId, QualifiedInstId, SpecVarId, StructId},
+    symbol::Symbol,
     ty::{Type, TypeDisplayContext},
 };
 use std::{
@@ -159,6 +160,12 @@ pub enum Operation {
     MoveFrom(ModuleId, StructId, Vec<Type>),
     Exists(ModuleId, StructId, Vec<Type>),
 
+    // Variants
+    TestVariant(ModuleId, StructId, Symbol, Vec<Type>),
+    PackVariant(ModuleId, StructId, Symbol, Vec<Type>),
+    UnpackVariant(ModuleId, StructId, Symbol, Vec<Type>),
+    BorrowFieldVariant(ModuleId, StructId, Symbol, Vec<Type>, usize),
+
     // Borrow
     BorrowLoc,
     BorrowField(ModuleId, StructId, Vec<Type>, usize),
@@ -252,6 +259,10 @@ impl Operation {
             Operation::OpaqueCallEnd(_, _, _) => false,
             Operation::Pack(_, _, _) => false,
             Operation::Unpack(_, _, _) => false,
+            Operation::TestVariant(_, _, _, _) => false,
+            Operation::PackVariant(_, _, _, _) => false,
+            Operation::UnpackVariant(_, _, _, _) => true, // aborts if not given variant
+            Operation::BorrowFieldVariant(_, _, _, _, _) => true, // aborts if not given variant
             Operation::MoveTo(_, _, _) => true,
             Operation::MoveFrom(_, _, _) => true,
             Operation::Exists(_, _, _) => false,
@@ -1100,12 +1111,57 @@ impl<'env> fmt::Display for OperationDisplay<'env> {
                 write!(f, "unpack {}", self.struct_str(*mid, *sid, targs))?;
             },
 
+            // Variants
+            TestVariant(mid, sid, variant, targs) => {
+                write!(
+                    f,
+                    "test_variant {}::{}",
+                    self.struct_str(*mid, *sid, targs),
+                    variant.display(self.func_target.symbol_pool())
+                )?;
+            },
+            PackVariant(mid, sid, variant, targs) => {
+                write!(
+                    f,
+                    "pack_variant {}::{}",
+                    self.struct_str(*mid, *sid, targs),
+                    variant.display(self.func_target.symbol_pool())
+                )?;
+            },
+            UnpackVariant(mid, sid, variant, targs) => {
+                write!(
+                    f,
+                    "unpack_variant {}::{}",
+                    self.struct_str(*mid, *sid, targs),
+                    variant.display(self.func_target.symbol_pool())
+                )?;
+            },
+
             // Borrow
             BorrowLoc => {
                 write!(f, "borrow_local")?;
             },
             BorrowField(mid, sid, targs, offset) => {
                 write!(f, "borrow_field<{}>", self.struct_str(*mid, *sid, targs))?;
+                let struct_env = self
+                    .func_target
+                    .global_env()
+                    .get_module(*mid)
+                    .into_struct(*sid);
+                let field_env = struct_env.get_field_by_offset(*offset);
+                write!(
+                    f,
+                    ".{}",
+                    field_env.get_name().display(struct_env.symbol_pool())
+                )?;
+            },
+            BorrowFieldVariant(mid, sid, variant, targs, offset) => {
+                write!(
+                    f,
+                    "borrow_field_variant<{}::{}>",
+                    self.struct_str(*mid, *sid, targs),
+                    variant.display(self.func_target.symbol_pool())
+                )?;
                 let struct_env = self
                     .func_target
                     .global_env()

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -3466,7 +3466,7 @@ impl<'env> StructEnv<'env> {
         self.data
             .field_data
             .values()
-            .filter(|data| data.common_for_variants || data.variant == variant)
+            .filter(|data| data.common_for_variants || variant.is_none() || data.variant == variant)
             .sorted_by_key(|data| data.offset)
             .map(move |data| FieldEnv {
                 struct_env: self.clone(),

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -3447,14 +3447,7 @@ impl<'env> StructEnv<'env> {
     /// Get an iterator for the fields, ordered by offset. Notice if the struct has
     /// variants, all fields of all variants are returned.
     pub fn get_fields(&'env self) -> impl Iterator<Item = FieldEnv<'env>> {
-        self.data
-            .field_data
-            .values()
-            .sorted_by_key(|data| data.offset)
-            .map(move |data| FieldEnv {
-                struct_env: self.clone(),
-                data,
-            })
+        self.get_fields_optional_variant(None)
     }
 
     /// Get fields of a particular variant.
@@ -3462,10 +3455,18 @@ impl<'env> StructEnv<'env> {
         &'env self,
         variant: Symbol,
     ) -> impl Iterator<Item = FieldEnv<'env>> {
+        self.get_fields_optional_variant(Some(variant))
+    }
+
+    /// Get fields of a particular variant.
+    pub fn get_fields_optional_variant(
+        &'env self,
+        variant: Option<Symbol>,
+    ) -> impl Iterator<Item = FieldEnv<'env>> {
         self.data
             .field_data
             .values()
-            .filter(|data| data.common_for_variants || data.variant == Some(variant))
+            .filter(|data| data.common_for_variants || data.variant == variant)
             .sorted_by_key(|data| data.offset)
             .map(move |data| FieldEnv {
                 struct_env: self.clone(),

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -806,6 +806,15 @@ impl Type {
         matches!(self, Type::Reference(_, _))
     }
 
+    /// If this is a reference, return the kind of the reference, otherwise None.
+    pub fn ref_kind(&self) -> Option<ReferenceKind> {
+        if let Type::Reference(kind, _) = self {
+            Some(*kind)
+        } else {
+            None
+        }
+    }
+
     /// Determines whether this is a mutable reference.
     pub fn is_mutable_reference(&self) -> bool {
         matches!(self, Type::Reference(ReferenceKind::Mutable, _))

--- a/third_party/move/move-model/src/well_known.rs
+++ b/third_party/move/move-model/src/well_known.rs
@@ -44,3 +44,9 @@ pub const TYPE_NAME_GET_SPEC: &str = "type_name::$get";
 
 /// The well-known name of the first parameter of a method.
 pub const RECEIVER_PARAM_NAME: &str = "self";
+
+/// The well-known abort codes used by the compiler. These are marked
+/// by lowest 6 bytes of a sha256 of the string "Move 2 Abort Code",
+/// appended with two bytes for the error type.
+pub const WELL_KNOWN_ABORT_CODE_BASE: u64 = 0xD8CA26CBD9BE << 16;
+pub const INCOMPLETE_MATCH_ABORT_CODE: u64 = WELL_KNOWN_ABORT_CODE_BASE | 0x1;

--- a/third_party/move/move-model/src/well_known.rs
+++ b/third_party/move/move-model/src/well_known.rs
@@ -48,5 +48,7 @@ pub const RECEIVER_PARAM_NAME: &str = "self";
 /// The well-known abort codes used by the compiler. These are marked
 /// by lowest 6 bytes of a sha256 of the string "Move 2 Abort Code",
 /// appended with two bytes for the error type.
+/// TODO: add a check at runtime that user is not clashing with reserved
+/// codes?
 pub const WELL_KNOWN_ABORT_CODE_BASE: u64 = 0xD8CA26CBD9BE << 16;
 pub const INCOMPLETE_MATCH_ABORT_CODE: u64 = WELL_KNOWN_ABORT_CODE_BASE | 0x1;

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -1119,6 +1119,13 @@ impl<'env> FunctionTranslator<'env> {
             Call(_, dests, oper, srcs, aa) => {
                 use Operation::*;
                 match oper {
+                    TestVariant(..)
+                    | PackVariant(..)
+                    | UnpackVariant(..)
+                    | BorrowFieldVariant(..) => {
+                        let loc = self.fun_target.get_bytecode_loc(attr_id);
+                        self.parent.env.error(&loc, "variants not yet implemented")
+                    },
                     FreezeRef(_) => unreachable!(),
                     UnpackRef | UnpackRefDeep | PackRef | PackRefDeep => {
                         // No effect


### PR DESCRIPTION
## Description

This implements the Move 2 `match` expression on stackless bytecode level. The PR consists of the following parts:

1. *Extending the Bytecode*

There are a few new bytecode operations:

```
dest := TestVariant(struct_id, variant, src)
dest := PackVariant(struct_id, variant, srcs)
dests := UnpackVariant(struct_id, variant, src)
dest := BorrowFieldVariant(struct_id, variant, field, src)
```

The `TestVariant` and `BorrowFieldVariant` operations  expect references to the variant struct. The `UnpackVariant` and `BorrowFieldVariant` operations abort if the `src` value is not a value of the given variant.

Notably, there are no new control flow operations, and the remaining part of the stackless bytecode framework should operate without changes. This may change in the future if we introduce a new branch instruction for switching over variants.

2. *Translating Matches*

Matches are translated into cascades of test & branch instructions. The translation is complicated by the need for 'probing' whether a value can be matched before it is consumed. See for discussion in the code how this problem is solved.

The current translation is manually reviewed via the baseline output, but it will not be fully tested before we are able to run e2e tests with VM execution. (Future PRs.)

3. *Checking Match Coverage*

Even though we generate robust match code which is resilient against addition of new match variants by explicit `abort` if there is no match, at compile time complete match coverage is required. Checking for this is non-trivial because of the sequential, imperative semantics of matching. See documentation in the code.

4. *Other*

There are some only indirectly related changes in this PR. To implement non-destructive matches with conditions, it appeared handy to have `*&x` to be equivalent to `x`. This seems to be general useful and is AFAICT also in Rust.

Also, the new pattern translation is a bit more efficient also in the `let` case, leading to some changes in baseline files.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

