### PR TITLE
update move-ir-compiler examples

### DIFF
--- a/third_party/move/move-ir-compiler/README.md
+++ b/third_party/move/move-ir-compiler/README.md
@@ -57,10 +57,10 @@ ARGS:
 * Alternatively, the binary can be run directly with `cargo run -p compiler`.
 
 To compile and verify `foo.mvir`, which contains a Move IR module:
-> `compiler --address 0x42 --no-stdlib -m foo.mvir`
+> `compiler -m foo.mvir`
 
 To compile and verify `bar.mvir`, which contains a transaction script:
-> `compiler --address 0xca --no-stdlib bar.mvir`
+> `compiler bar.mvir`
 
 ## Folder Structure
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
The Move IR compiler does not require `--address` and `--no-stdlib`. Thus, remove them from examples.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [x] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)
