### PR TITLE
[bug/security] Bonding Curve Launchpad - Object creation seed collision fix

### DIFF
--- a/aptos-move/move-examples/bonding_curve_launchpad/sources/tests/test_bonding_curve_launchpad.move
+++ b/aptos-move/move-examples/bonding_curve_launchpad/sources/tests/test_bonding_curve_launchpad.move
@@ -45,7 +45,7 @@ module bonding_curve_launchpad::test_bonding_curve_launchpad {
 
     //---------------------------Unit Tests---------------------------
     #[test(deployer = @bonding_curve_launchpad)]
-    #[expected_failure(abort_code = liquidity_pairs::ELIQUIDITY_PAIR_DOES_NOT_EXIST, location = liquidity_pairs)]
+    #[expected_failure(abort_code = 393218, location = aptos_framework::object)]
     public fun test_nonexistant_is_frozen(deployer: &signer) {
         account::create_account_for_test(@0x1);
         liquidity_pairs::initialize_for_test(deployer);


### PR DESCRIPTION
## Description
Former/original object creation uses less secure method of generating a seed, which can lead to collisions.

* The generation of the `LiquidityPairs` FA pair is updated to rely on the collision-less solution described in the [Move Security Guidelines](https://aptos.dev/move/move-on-aptos/move-security-guidelines/#token-identifier-collision).
* The generation of the FA still relies on `name` and `symbol`, since there isn't a pre-existing `Object<Metadata>` to derive the object address for. 

Additionally, a few comments were updated to the doc comments style.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Other (specify): `move-examples`

## How Has This Been Tested?
Ran through already-crafted test suite.

## Key Areas to Review

Specifically the changes required for review are:
* Object creation
  * `LiquidityPairs` - 
    * `fun get_pair_obj_address` 
    * `pair_seed` assignment during `fun register_liquidity_pair`

Other functions/changes are for readability (comments, var names).


We *can* still restrict `bonding_curve_launchpad::swap` to only accept `Object<Metadata>`, rather than `name` and `symbol`. But, this doesn't solve the issue. It only pushes the problem to when the swapper is gathering the address, rather than during the swap.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
