### PR TITLE
[Consensus Observer] Improve message serialization ordering.

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -196,6 +196,7 @@ pub struct AptosHandle {
     _api_runtime: Option<Runtime>,
     _backup_runtime: Option<Runtime>,
     _consensus_observer_runtime: Option<Runtime>,
+    _consensus_publisher_runtime: Option<Runtime>,
     _consensus_runtime: Option<Runtime>,
     _dkg_runtime: Option<Runtime>,
     _indexer_grpc_runtime: Option<Runtime>,
@@ -733,7 +734,7 @@ pub fn setup_environment_and_start_node(
     debug!("State sync initialization complete.");
 
     // Create the consensus observer publisher (if enabled)
-    let consensus_observer_publisher =
+    let (consensus_publisher_runtime, consensus_publisher) =
         consensus::create_consensus_publisher(&node_config, &consensus_observer_network_interfaces);
 
     // Create the consensus runtime (if enabled)
@@ -745,7 +746,7 @@ pub fn setup_environment_and_start_node(
         consensus_notifier.clone(),
         consensus_to_mempool_sender.clone(),
         vtxn_pool,
-        consensus_observer_publisher.clone(),
+        consensus_publisher.clone(),
         &mut admin_service,
     );
 
@@ -753,7 +754,7 @@ pub fn setup_environment_and_start_node(
     let consensus_observer_runtime = consensus::create_consensus_observer_runtime(
         &node_config,
         consensus_observer_network_interfaces,
-        consensus_observer_publisher,
+        consensus_publisher,
         consensus_notifier,
         consensus_to_mempool_sender,
         db_rw,
@@ -765,6 +766,7 @@ pub fn setup_environment_and_start_node(
         _api_runtime: api_runtime,
         _backup_runtime: backup_service,
         _consensus_observer_runtime: consensus_observer_runtime,
+        _consensus_publisher_runtime: consensus_publisher_runtime,
         _consensus_runtime: consensus_runtime,
         _dkg_runtime: dkg_runtime,
         _indexer_grpc_runtime: indexer_grpc_runtime,

--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -23,6 +23,13 @@ pub struct ConsensusObserverConfig {
 
     /// Maximum number of pending network messages
     pub max_network_channel_size: u64,
+    /// Maximum number of parallel serialization tasks for message sends
+    pub max_parallel_serialization_tasks: usize,
+    /// Timeout (in milliseconds) for network RPC requests
+    pub network_request_timeout_ms: u64,
+
+    /// Interval (in milliseconds) to garbage collect peer state
+    pub garbage_collection_interval_ms: u64,
     /// Maximum timeout (in milliseconds) for active subscriptions
     pub max_subscription_timeout_ms: u64,
     /// Maximum timeout (in milliseconds) we'll wait for the synced version to
@@ -32,8 +39,6 @@ pub struct ConsensusObserverConfig {
     pub peer_optimality_check_interval_ms: u64,
     /// Interval (in milliseconds) to check progress of the consensus observer
     pub progress_check_interval_ms: u64,
-    /// Timeout (in milliseconds) for network RPC requests
-    pub request_timeout_ms: u64,
 }
 
 impl Default for ConsensusObserverConfig {
@@ -42,11 +47,13 @@ impl Default for ConsensusObserverConfig {
             observer_enabled: false,
             publisher_enabled: false,
             max_network_channel_size: 1000,
-            max_subscription_timeout_ms: 30_000,   // 30 seconds
-            max_synced_version_timeout_ms: 60_000, // 60 seconds
-            peer_optimality_check_interval_ms: 300_000, // 5 minutes
-            progress_check_interval_ms: 5_000,     // 5 seconds
-            request_timeout_ms: 10_000,            // 10 seconds
+            max_parallel_serialization_tasks: num_cpus::get(), // Default to the number of CPUs
+            network_request_timeout_ms: 10_000,                // 10 seconds
+            garbage_collection_interval_ms: 60_000,            // 60 seconds
+            max_subscription_timeout_ms: 30_000,               // 30 seconds
+            max_synced_version_timeout_ms: 60_000,             // 60 seconds
+            peer_optimality_check_interval_ms: 300_000,        // 5 minutes
+            progress_check_interval_ms: 5_000,                 // 5 seconds
         }
     }
 }

--- a/consensus/src/consensus_observer/logging.rs
+++ b/consensus/src/consensus_observer/logging.rs
@@ -13,7 +13,6 @@ pub struct LogSchema<'a> {
     error: Option<&'a Error>,
     event: Option<LogEvent>,
     message: Option<&'a str>,
-    message_content: Option<&'a str>,
     message_type: Option<&'a str>,
     #[schema(display)]
     peer: Option<&'a PeerNetworkId>,
@@ -28,7 +27,6 @@ impl<'a> LogSchema<'a> {
             error: None,
             event: None,
             message: None,
-            message_content: None,
             message_type: None,
             peer: None,
             request_id: None,
@@ -41,6 +39,7 @@ impl<'a> LogSchema<'a> {
 #[serde(rename_all = "snake_case")]
 pub enum LogEntry {
     ConsensusObserver,
+    ConsensusPublisher,
     GetDownstreamPeers,
     SendDirectSendMessage,
     SendRpcRequest,
@@ -53,5 +52,6 @@ pub enum LogEvent {
     NetworkError,
     SendDirectSendMessage,
     SendRpcRequest,
+    Subscription,
     UnexpectedError,
 }

--- a/consensus/src/consensus_observer/observer.rs
+++ b/consensus/src/consensus_observer/observer.rs
@@ -93,7 +93,8 @@ pub struct ConsensusObserver {
     // The configuration of the consensus observer
     consensus_observer_config: ConsensusObserverConfig,
     // The consensus observer client to send network messages
-    consensus_observer_client: ConsensusObserverClient<NetworkClient<ConsensusObserverMessage>>,
+    consensus_observer_client:
+        Arc<ConsensusObserverClient<NetworkClient<ConsensusObserverMessage>>>,
 
     // The current epoch
     epoch: u64,
@@ -127,7 +128,9 @@ pub struct ConsensusObserver {
 impl ConsensusObserver {
     pub fn new(
         consensus_observer_config: ConsensusObserverConfig,
-        consensus_observer_client: ConsensusObserverClient<NetworkClient<ConsensusObserverMessage>>,
+        consensus_observer_client: Arc<
+            ConsensusObserverClient<NetworkClient<ConsensusObserverMessage>>,
+        >,
         db_reader: Arc<dyn DbReader>,
         execution_client: Arc<dyn TExecutionClient>,
         sync_notification_sender: UnboundedSender<(u64, Round)>,
@@ -312,7 +315,7 @@ impl ConsensusObserver {
                 .send_rpc_request_to_peer(
                     selected_peer,
                     subscription_request,
-                    self.consensus_observer_config.request_timeout_ms,
+                    self.consensus_observer_config.network_request_timeout_ms,
                 )
                 .await;
 

--- a/consensus/src/consensus_observer/observer.rs
+++ b/consensus/src/consensus_observer/observer.rs
@@ -191,29 +191,36 @@ impl ConsensusObserver {
         let active_observer_subscription = self.active_observer_subscription.take();
         if let Some(mut active_subscription) = active_observer_subscription {
             // Check if the peer for the subscription is still connected
-            let peer_still_connected =
-                self.get_connected_peers_and_metadata()
-                    .map_or(false, |peers_and_metadata| {
-                        peers_and_metadata.contains_key(&active_subscription.get_peer_network_id())
-                    });
+            let peer_network_id = active_subscription.get_peer_network_id();
+            let peer_still_connected = self
+                .get_connected_peers_and_metadata()
+                .map_or(false, |peers_and_metadata| {
+                    peers_and_metadata.contains_key(&peer_network_id)
+                });
 
             // Verify the peer is still connected
             if !peer_still_connected {
                 // Log the disconnection and terminate the subscription
                 warn!(
                     LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                        "The peer is no longer connected! Terminating subscription: {}!",
-                        active_subscription.get_peer_network_id()
+                        "The peer is no longer connected! Terminating subscription: {:?}!",
+                        peer_network_id
                     ))
                 );
+                self.unsubscribe_from_peer(peer_network_id);
                 return;
             }
 
             // Verify the subscription has not timed out
             if let Err(error) = active_subscription.check_subscription_timeout() {
                 // Log the timeout and terminate the subscription
-                warn!(LogSchema::new(LogEntry::ConsensusObserver)
-                    .message(&format!("The subscription has timed out: {:?}", error)));
+                warn!(
+                    LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                        "The subscription has timed out with peer: {:?}! Error: {:?}",
+                        peer_network_id, error
+                    ))
+                );
+                self.unsubscribe_from_peer(peer_network_id);
                 return;
             }
 
@@ -224,10 +231,11 @@ impl ConsensusObserver {
                     // Log the error and terminate the subscription
                     warn!(
                         LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                            "The observer is not making syncing progress: {:?}",
-                            error
+                            "The observer is not making syncing progress with peer: {:?}! Error: {:?}",
+                            peer_network_id, error
                         ))
                     );
+                    self.unsubscribe_from_peer(peer_network_id);
                     return;
                 }
             }
@@ -240,10 +248,11 @@ impl ConsensusObserver {
                     // Log the error and terminate the subscription
                     warn!(
                         LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                            "The subscription peer is no longer optimal: {:?}",
-                            error
+                            "The subscription peer is no longer optimal: {:?}! Error: {:?}",
+                            peer_network_id, error
                         ))
                     );
+                    self.unsubscribe_from_peer(peer_network_id);
                     return;
                 }
             }
@@ -749,6 +758,55 @@ impl ConsensusObserver {
         } else {
             None // No connected peers were found
         }
+    }
+
+    /// Unsubscribes from the given peer by sending an unsubscribe request
+    fn unsubscribe_from_peer(&self, peer_network_id: PeerNetworkId) {
+        // Send an unsubscribe request to the peer and process the response.
+        // Note: we execute this asynchronously, as we don't need to wait for the response.
+        let consensus_observer_client = self.consensus_observer_client.clone();
+        let consensus_observer_config = self.consensus_observer_config;
+        tokio::spawn(async move {
+            // Send the unsubscribe request to the peer
+            let unsubscribe_request = ConsensusObserverRequest::Unsubscribe;
+            let response = consensus_observer_client
+                .send_rpc_request_to_peer(
+                    &peer_network_id,
+                    unsubscribe_request,
+                    consensus_observer_config.network_request_timeout_ms,
+                )
+                .await;
+
+            // Process the response
+            match response {
+                Ok(ConsensusObserverResponse::UnsubscribeAck) => {
+                    info!(
+                        LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                            "Successfully unsubscribed from peer: {}!",
+                            peer_network_id
+                        ))
+                    );
+                },
+                Ok(response) => {
+                    // We received an invalid response
+                    warn!(
+                        LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                            "Got unexpected response type: {:?}",
+                            response.get_label()
+                        ))
+                    );
+                },
+                Err(error) => {
+                    // We encountered an error while sending the request
+                    error!(
+                        LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                            "Failed to send unsubscribe request to peer: {}! Error: {:?}",
+                            peer_network_id, error
+                        ))
+                    );
+                },
+            }
+        });
     }
 
     /// Waits for a new epoch to start

--- a/consensus/src/consensus_observer/publisher.rs
+++ b/consensus/src/consensus_observer/publisher.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::consensus_observer::{
+    logging::{LogEntry, LogEvent, LogSchema},
     network_client::ConsensusObserverClient,
     network_events::ResponseSender,
     network_message::{
@@ -9,11 +10,15 @@ use crate::consensus_observer::{
         ConsensusObserverResponse,
     },
 };
-use aptos_config::network_id::PeerNetworkId;
+use aptos_config::{config::ConsensusObserverConfig, network_id::PeerNetworkId};
 use aptos_infallible::RwLock;
 use aptos_logger::{info, warn};
 use aptos_network::application::interface::NetworkClient;
-use std::{collections::HashSet, sync::Arc};
+use futures::{SinkExt, StreamExt};
+use futures_channel::mpsc;
+use std::{collections::HashSet, sync::Arc, time::Duration};
+use tokio::time::interval;
+use tokio_stream::wrappers::IntervalStream;
 
 /// The consensus publisher sends consensus updates to downstream observers
 #[derive(Clone)]
@@ -22,16 +27,88 @@ pub struct ConsensusPublisher {
     consensus_observer_client:
         Arc<ConsensusObserverClient<NetworkClient<ConsensusObserverMessage>>>,
 
+    // The configuration for the consensus observer
+    consensus_observer_config: ConsensusObserverConfig,
+
     // The set of active subscribers that have subscribed to consensus updates
     active_subscribers: Arc<RwLock<HashSet<PeerNetworkId>>>,
+
+    // The sender for outbound network messages
+    outbound_message_sender: mpsc::Sender<(PeerNetworkId, ConsensusObserverDirectSend)>,
 }
 
 impl ConsensusPublisher {
-    pub fn new(network_client: NetworkClient<ConsensusObserverMessage>) -> Self {
-        Self {
+    pub fn new(
+        network_client: NetworkClient<ConsensusObserverMessage>,
+        consensus_observer_config: ConsensusObserverConfig,
+    ) -> (
+        Self,
+        mpsc::Receiver<(PeerNetworkId, ConsensusObserverDirectSend)>,
+    ) {
+        // Create the outbound message sender and receiver
+        let max_network_channel_size = consensus_observer_config.max_network_channel_size as usize;
+        let (outbound_message_sender, outbound_message_receiver) =
+            mpsc::channel(max_network_channel_size);
+
+        // Create the consensus publisher
+        let consensus_publisher = Self {
             consensus_observer_client: Arc::new(ConsensusObserverClient::new(network_client)),
+            consensus_observer_config,
             active_subscribers: Arc::new(RwLock::new(HashSet::new())),
+            outbound_message_sender,
+        };
+
+        // Return the publisher and the outbound message receiver
+        (consensus_publisher, outbound_message_receiver)
+    }
+
+    /// Garbage collect inactive subscriptions by removing peers that are no longer connected
+    fn garbage_collect_subscriptions(&self) {
+        // Get the set of active subscribers
+        let active_subscribers = self.active_subscribers.read().clone();
+
+        // Get the connected peers and metadata
+        let peers_and_metadata = self.consensus_observer_client.get_peers_and_metadata();
+        let connected_peers_and_metadata =
+            match peers_and_metadata.get_connected_peers_and_metadata() {
+                Ok(connected_peers_and_metadata) => connected_peers_and_metadata,
+                Err(error) => {
+                    // We failed to get the connected peers and metadata
+                    warn!(LogSchema::new(LogEntry::ConsensusPublisher)
+                        .event(LogEvent::UnexpectedError)
+                        .message(&format!(
+                            "Failed to get connected peers and metadata! Error: {:?}",
+                            error
+                        )));
+                    return;
+                },
+            };
+
+        // Identify the active subscribers that are no longer connected
+        let connected_peers: HashSet<PeerNetworkId> =
+            connected_peers_and_metadata.keys().cloned().collect();
+        let disconnected_subscribers: HashSet<PeerNetworkId> = active_subscribers
+            .difference(&connected_peers)
+            .cloned()
+            .collect();
+
+        // Remove any subscriptions from peers that are no longer connected
+        for peer_network_id in &disconnected_subscribers {
+            self.active_subscribers.write().remove(peer_network_id);
+            info!(LogSchema::new(LogEntry::ConsensusPublisher)
+                .event(LogEvent::Subscription)
+                .message(&format!(
+                    "Removed peer subscription due to disconnection! Peer: {:?}",
+                    peer_network_id
+                )));
         }
+    }
+
+    /// Returns a copy of the consensus observer client
+    pub fn get_consensus_observer_client(
+        &self,
+    ) -> Arc<ConsensusObserverClient<NetworkClient<ConsensusObserverMessage>>> {
+        self.consensus_observer_client.clone()
     }
 
     /// Handles a subscription message from a peer
@@ -45,10 +122,12 @@ impl ConsensusPublisher {
             ConsensusObserverRequest::Subscribe => {
                 // Add the peer to the set of active subscribers
                 self.active_subscribers.write().insert(*peer_network_id);
-                info!(
-                    "New peer subscribed to consensus updates! Peer: {}",
-                    peer_network_id
-                );
+                info!(LogSchema::new(LogEntry::ConsensusPublisher)
+                    .event(LogEvent::Subscription)
+                    .message(&format!(
+                        "New peer subscribed to consensus updates! Peer: {:?}",
+                        peer_network_id
+                    )));
 
                 // Send a simple subscription ACK
                 response_sender.send(ConsensusObserverResponse::SubscribeAck);
@@ -56,10 +135,12 @@ impl ConsensusPublisher {
             ConsensusObserverRequest::Unsubscribe => {
                 // Remove the peer from the set of active subscribers
                 self.active_subscribers.write().remove(peer_network_id);
-                info!(
-                    "Peer unsubscribed from consensus updates! Peer: {}",
-                    peer_network_id
-                );
+                info!(LogSchema::new(LogEntry::ConsensusPublisher)
+                    .event(LogEvent::Subscription)
+                    .message(&format!(
+                        "Peer unsubscribed from consensus updates! Peer: {:?}",
+                        peer_network_id
+                    )));
 
                 // Send a simple unsubscription ACK
                 response_sender.send(ConsensusObserverResponse::UnsubscribeAck);
@@ -68,26 +149,133 @@ impl ConsensusPublisher {
     }
 
     /// Publishes a direct send message to all active subscribers
-    pub fn publish_message(&self, message: ConsensusObserverDirectSend) {
-        // TODO: we should probably compress these messages before sending them.
-        // But, this requires us to ensure FIFO ordering across direct sends.
-
+    pub async fn publish_message(&self, message: ConsensusObserverDirectSend) {
         // Get the set of active subscribers
         let active_subscribers = self.active_subscribers.read().clone();
 
         // Send the message to all active subscribers
         for peer_network_id in &active_subscribers {
-            if let Err(error) = self
-                .consensus_observer_client
-                .send_message_to_peer(peer_network_id, message.clone())
+            // Send the message to the outbound receiver for publishing
+            let mut outbound_message_sender = self.outbound_message_sender.clone();
+            if let Err(error) = outbound_message_sender
+                .send((*peer_network_id, message.clone()))
+                .await
             {
-                // The message send failed. Log the error and remove the subscriber.
-                warn!(
-                    "Failed to send message to peer {}: {:?}",
-                    peer_network_id, error
-                );
-                self.active_subscribers.write().remove(peer_network_id);
+                // The message send failed
+                warn!(LogSchema::new(LogEntry::ConsensusPublisher)
+                    .event(LogEvent::SendDirectSendMessage)
+                    .message(&format!(
+                        "Failed to send outbound message to the receiver for peer {:?}! Error: {:?}",
+                        peer_network_id, error
+                    )));
             }
         }
     }
+
+    /// Starts the consensus publisher
+    pub async fn start(
+        self,
+        outbound_message_receiver: mpsc::Receiver<(PeerNetworkId, ConsensusObserverDirectSend)>,
+    ) {
+        // Spawn the message serializer and sender
+        spawn_message_serializer_and_sender(
+            self.consensus_observer_client.clone(),
+            self.consensus_observer_config,
+            outbound_message_receiver,
+        );
+
+        // Create a garbage collection ticker
+        let mut garbage_collection_interval = IntervalStream::new(interval(Duration::from_millis(
+            self.consensus_observer_config
+                .garbage_collection_interval_ms,
+        )))
+        .fuse();
+
+        // Start the publisher garbage collection loop
+        info!(LogSchema::new(LogEntry::ConsensusPublisher)
+            .message("Starting the consensus publisher garbage collection loop!"));
+        loop {
+            tokio::select! {
+                _ = garbage_collection_interval.select_next_some() => {
+                    // Perform garbage collection
+                    self.garbage_collect_subscriptions();
+                },
+            }
+        }
+    }
+}
+
+/// Spawns a message serialization task that serializes outbound publisher
+/// messages in parallel but guarantees in order sends to the receiver.
+fn spawn_message_serializer_and_sender(
+    consensus_observer_client: Arc<
+        ConsensusObserverClient<NetworkClient<ConsensusObserverMessage>>,
+    >,
+    consensus_observer_config: ConsensusObserverConfig,
+    outbound_message_receiver: mpsc::Receiver<(PeerNetworkId, ConsensusObserverDirectSend)>,
+) {
+    tokio::spawn(async move {
+        // Create the message serialization task
+        let consensus_observer_client_clone = consensus_observer_client.clone();
+        let serialization_task =
+            outbound_message_receiver.map(move |(peer_network_id, message)| {
+                // Spawn a new blocking task to serialize the message
+                let consensus_observer_client_clone = consensus_observer_client_clone.clone();
+                tokio::task::spawn_blocking(move || {
+                    let message_label = message.get_label();
+                    let serialized_message = consensus_observer_client_clone
+                        .serialize_message_for_peer(&peer_network_id, message);
+                    (peer_network_id, serialized_message, message_label)
+                })
+            });
+
+        // Execute the serialization task with in-order buffering
+        let consensus_observer_client_clone = consensus_observer_client.clone();
+        serialization_task
+            .buffered(consensus_observer_config.max_parallel_serialization_tasks)
+            .map(|serialization_result| {
+                // Attempt to send the serialized message to the peer
+                match serialization_result {
+                    Ok((peer_network_id, serialized_message, message_label)) => {
+                        match serialized_message {
+                            Ok(serialized_message) => {
+                                // Send the serialized message to the peer
+                                if let Err(error) = consensus_observer_client_clone
+                                    .send_serialized_message_to_peer(
+                                        &peer_network_id,
+                                        serialized_message,
+                                        message_label,
+                                    )
+                                {
+                                    // We failed to send the message
+                                    warn!(LogSchema::new(LogEntry::ConsensusPublisher)
+                                        .event(LogEvent::SendDirectSendMessage)
+                                        .message(&format!(
+                                            "Failed to send message to peer: {:?}. Error: {:?}",
+                                            peer_network_id, error
+                                        )));
+                                }
+                            },
+                            Err(error) => {
+                                // We failed to serialize the message
+                                warn!(LogSchema::new(LogEntry::ConsensusPublisher)
+                                    .event(LogEvent::SendDirectSendMessage)
+                                    .message(&format!(
+                                        "Failed to serialize message for peer: {:?}. Error: {:?}",
+                                        peer_network_id, error
+                                    )));
+                            },
+                        }
+                    },
+                    Err(error) => {
+                        // We failed to spawn the serialization task
+                        warn!(LogSchema::new(LogEntry::ConsensusPublisher)
+                            .event(LogEvent::SendDirectSendMessage)
+                            .message(&format!("Failed to spawn the serializer task: {:?}", error)));
+                    },
+                }
+            })
+            .collect::<()>()
+            .await;
+    });
 }

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -133,7 +133,15 @@ pub fn start_consensus_observer(
     let runtime = aptos_runtimes::spawn_named_runtime("observer".into(), None);
 
     // Create the consensus observer client
-    let consensus_observer_client = ConsensusObserverClient::new(observer_network_client.clone());
+    let consensus_observer_client = if let Some(consensus_publisher) = &consensus_publisher {
+        // Get the consensus observer client from the consensus publisher
+        consensus_publisher.get_consensus_observer_client()
+    } else {
+        // Otherwise, create a new client (the publisher is not enabled)
+        Arc::new(ConsensusObserverClient::new(
+            observer_network_client.clone(),
+        ))
+    };
 
     // Create the consensus observer network events
     let observer_network_events =

--- a/consensus/src/payload_manager.rs
+++ b/consensus/src/payload_manager.rs
@@ -215,7 +215,7 @@ impl PayloadManager {
                     block_transaction_payload.transactions.clone(),
                     block_transaction_payload.limit,
                 );
-                consensus_publisher.publish_message(message);
+                consensus_publisher.publish_message(message).await;
             }
             return Ok((
                 block_transaction_payload.transactions,
@@ -354,7 +354,7 @@ impl PayloadManager {
                 result.0.clone(),
                 result.1,
             );
-            consensus_publisher.publish_message(message);
+            consensus_publisher.publish_message(message).await;
         }
         Ok(result)
     }

--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -294,7 +294,7 @@ impl BufferManager {
                 ordered_blocks.clone().into_iter().map(Arc::new).collect(),
                 ordered_proof.clone(),
             );
-            consensus_publisher.publish_message(message);
+            consensus_publisher.publish_message(message).await;
         }
         self.execution_schedule_phase_tx
             .send(request)
@@ -396,7 +396,7 @@ impl BufferManager {
                     let message = ConsensusObserverMessage::new_commit_decision_message(
                         CommitDecision::new(commit_proof.clone()),
                     );
-                    consensus_publisher.publish_message(message);
+                    consensus_publisher.publish_message(message).await;
                 }
                 self.persisting_phase_tx
                     .send(self.create_new_request(PersistingRequest {

--- a/network/framework/src/application/interface.rs
+++ b/network/framework/src/application/interface.rs
@@ -53,6 +53,10 @@ pub trait NetworkClientInterface<Message: NetworkMessageTrait>: Clone + Send + S
     /// method does not guarantee message delivery or handle responses.
     fn send_to_peer(&self, _message: Message, _peer: PeerNetworkId) -> Result<(), Error>;
 
+    /// Sends the given message bytes to the specified peer. Note: this
+    /// method does not guarantee message delivery or handle responses.
+    fn send_to_peer_raw(&self, _message: Bytes, _peer: PeerNetworkId) -> Result<(), Error>;
+
     /// Sends the given message to each peer in the specified peer list.
     /// Note: this method does not guarantee message delivery or handle responses.
     fn send_to_peers(&self, _message: Message, _peers: Vec<PeerNetworkId>) -> Result<(), Error>;
@@ -217,6 +221,13 @@ impl<Message: NetworkMessageTrait> NetworkClientInterface<Message> for NetworkCl
         let direct_send_protocol_id = self
             .get_preferred_protocol_for_peer(&peer, &self.direct_send_protocols_and_preferences)?;
         Ok(network_sender.send_to(peer.peer_id(), direct_send_protocol_id, message)?)
+    }
+
+    fn send_to_peer_raw(&self, message: Bytes, peer: PeerNetworkId) -> Result<(), Error> {
+        let network_sender = self.get_sender_for_network_id(&peer.network_id())?;
+        let direct_send_protocol_id = self
+            .get_preferred_protocol_for_peer(&peer, &self.direct_send_protocols_and_preferences)?;
+        Ok(network_sender.send_to_raw(peer.peer_id(), direct_send_protocol_id, message)?)
     }
 
     fn send_to_peers(&self, message: Message, peers: Vec<PeerNetworkId>) -> Result<(), Error> {

--- a/network/framework/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/framework/src/protocols/wire/handshake/v1/mod.rs
@@ -160,6 +160,7 @@ impl ProtocolId {
             ProtocolId::ConsensusDirectSendCompressed | ProtocolId::ConsensusRpcCompressed => {
                 Encoding::CompressedBcs(RECURSION_LIMIT)
             },
+            ProtocolId::ConsensusObserver => Encoding::CompressedBcs(RECURSION_LIMIT),
             ProtocolId::DKGDirectSendCompressed | ProtocolId::DKGRpcCompressed => {
                 Encoding::CompressedBcs(RECURSION_LIMIT)
             },
@@ -177,6 +178,7 @@ impl ProtocolId {
             ProtocolId::ConsensusDirectSendCompressed | ProtocolId::ConsensusRpcCompressed => {
                 CompressionClient::Consensus
             },
+            ProtocolId::ConsensusObserver => CompressionClient::ConsensusObserver,
             ProtocolId::MempoolDirectSend => CompressionClient::Mempool,
             ProtocolId::DKGDirectSendCompressed | ProtocolId::DKGRpcCompressed => {
                 CompressionClient::DKG


### PR DESCRIPTION
## Description

This PR makes several changes to the network message flow for consensus observer. Specifically, it offers the following commits:
1. Add network compression to the direct send CO messages.
2. Add support for in-order message serialization for CO publisher. This helps to ensure that messages are not sent out-of-order (even if some take longer to serialize/compress than others).
3. Add support for explicitly unsubscribing from peers. We now send an unsubscribe request asynchronously when terminating a subscription.

## Testing Plan
Existing test infrastructure.



