### PR TITLE
Update serde_yaml to 0.9.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ dependencies = [
  "self_update",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "server-framework",
  "shadow-rs",
  "tempfile",
@@ -572,7 +572,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "thiserror",
  "tokio",
  "tokio-io-timeout",
@@ -824,7 +824,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_merge",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "tempfile",
  "thiserror",
  "url",
@@ -901,7 +901,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "sha3 0.9.1",
  "strum_macros 0.24.3",
  "tempfile",
@@ -1608,7 +1608,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "tokio",
  "url",
 ]
@@ -1698,7 +1698,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "tempfile",
  "termcolor",
  "thiserror",
@@ -1728,7 +1728,7 @@ dependencies = [
  "rand 0.7.3",
  "random_word",
  "reqwest",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "tokio",
  "url",
 ]
@@ -1916,7 +1916,7 @@ dependencies = [
  "bcs 0.1.4",
  "rand 0.7.3",
  "serde",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
 ]
 
 [[package]]
@@ -2153,7 +2153,7 @@ dependencies = [
  "clap 4.4.14",
  "prometheus",
  "serde",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "tempfile",
  "tokio",
  "toml 0.7.8",
@@ -2910,7 +2910,7 @@ dependencies = [
  "futures",
  "once_cell",
  "rand 0.7.3",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "tokio",
  "url",
 ]
@@ -3013,7 +3013,7 @@ dependencies = [
  "rstack-self",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "tokio",
  "url",
 ]
@@ -3040,7 +3040,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "thiserror",
  "tokio",
  "url",
@@ -3306,7 +3306,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "sha3 0.9.1",
  "strum 0.24.1",
  "strum_macros 0.24.3",
@@ -3413,7 +3413,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "tokio",
  "url",
  "warp",
@@ -3550,7 +3550,7 @@ dependencies = [
  "once_cell",
  "serde-generate",
  "serde-reflection",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "tempfile",
  "textwrap 0.15.2",
  "which",
@@ -3900,7 +3900,7 @@ dependencies = [
  "reqwest-retry",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "thiserror",
  "tokio",
  "tracing",
@@ -4141,7 +4141,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_with",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "strum 0.24.1",
  "strum_macros 0.24.3",
  "thiserror",
@@ -8223,7 +8223,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde-reflection",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
 ]
 
 [[package]]
@@ -10808,7 +10808,7 @@ dependencies = [
  "petgraph 0.5.1",
  "regex",
  "serde",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "sha2 0.9.9",
  "tempfile",
  "termcolor",
@@ -12436,7 +12436,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "serde_yaml 0.9.30",
+ "serde_yaml 0.9.34+deprecated",
  "thiserror",
  "tokio",
  "url",
@@ -14382,9 +14382,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.30"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap 2.2.5",
  "itoa",
@@ -14810,7 +14810,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.34+deprecated",
  "tokio",
  "url",
  "walkdir",
@@ -16315,9 +16315,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -731,7 +731,7 @@ serde-name = "0.1.1"
 serde-generate = { git = "https://github.com/aptos-labs/serde-reflection", rev = "73b6bbf748334b71ff6d7d09d06a29e3062ca075" }
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "73b6bbf748334b71ff6d7d09d06a29e3062ca075" }
 serde_with = "3.4.0"
-serde_yaml = "0.8.24"
+serde_yaml = "0.9.34"
 shadow-rs = "0.16.2"
 simplelog = "0.9.0"
 smallbitvec = "2.5.1"

--- a/aptos-move/aptos-release-builder/src/components/mod.rs
+++ b/aptos-move/aptos-release-builder/src/components/mod.rs
@@ -683,8 +683,9 @@ impl ReleaseConfig {
     }
 
     pub fn save_config<P: AsRef<Path>>(&self, output_file: P) -> Result<()> {
-        let contents =
-            serde_yaml::to_vec(&self).map_err(|e| anyhow!("failed to generate config: {:?}", e))?;
+        let contents = serde_yaml::to_string(&self)
+            .map_err(|e| anyhow!("failed to generate config: {:?}", e))?
+            .into_bytes();
         let mut file = File::create(output_file.as_ref())
             .map_err(|e| anyhow!("failed to create file: {:?}", e))?;
         file.write_all(&contents)

--- a/config/src/config/persistable_config.rs
+++ b/config/src/config/persistable_config.rs
@@ -22,8 +22,9 @@ pub trait PersistableConfig: Serialize + DeserializeOwned {
     /// Save the config to disk at the given output path
     fn save_config<P: AsRef<Path>>(&self, output_file: P) -> Result<(), Error> {
         // Serialize the config to a string
-        let serialized_config = serde_yaml::to_vec(&self)
-            .map_err(|e| Error::Yaml(output_file.as_ref().to_str().unwrap().to_string(), e))?;
+        let serialized_config = serde_yaml::to_string(&self)
+            .map_err(|e| Error::Yaml(output_file.as_ref().to_str().unwrap().to_string(), e))?
+            .into_bytes();
 
         Self::write_file(serialized_config, output_file)
     }

--- a/network/discovery/src/file.rs
+++ b/network/discovery/src/file.rs
@@ -67,7 +67,7 @@ mod tests {
     use aptos_temppath::TempPath;
     use aptos_types::{network_address::NetworkAddress, PeerId};
     use futures::StreamExt;
-    use std::{collections::HashSet, str::FromStr, sync::Arc};
+    use std::{collections::HashSet, fs::File, str::FromStr, sync::Arc};
     use tokio::time::sleep;
 
     fn create_listener(path: Arc<TempPath>) -> Receiver<ConnectivityRequest> {
@@ -94,8 +94,7 @@ mod tests {
     }
 
     fn write_peer_set(peers: &PeerSet, path: &Path) {
-        let file_contents = serde_yaml::to_vec(peers).unwrap();
-        std::fs::write(path, file_contents).unwrap();
+        serde_yaml::to_writer(File::create(path).unwrap(), &peers).unwrap();
     }
 
     #[tokio::test]
@@ -131,8 +130,7 @@ mod tests {
             PeerId::random(),
             Peer::new(addrs, keys, PeerRole::Downstream),
         );
-        let file_contents = serde_yaml::to_vec(&peers).unwrap();
-        std::fs::write(path.as_ref(), file_contents).unwrap();
+        serde_yaml::to_writer(File::create(path.as_ref()).unwrap(), &peers).unwrap();
         // Clear old items
         while conn_mgr_reqs_rx.next().await.is_none() {}
 

--- a/testsuite/smoke-test/src/network.rs
+++ b/testsuite/smoke-test/src/network.rs
@@ -22,6 +22,7 @@ use aptos_sdk::move_types::account_address::AccountAddress;
 use aptos_temppath::TempPath;
 use std::{
     collections::HashMap,
+    fs::File,
     path::Path,
     sync::Arc,
     time::{Duration, Instant},
@@ -308,6 +309,5 @@ fn add_identity_to_config(
 }
 
 pub fn write_peerset_to_file(path: &Path, peers: PeerSet) {
-    let file_contents = serde_yaml::to_vec(&peers).unwrap();
-    std::fs::write(path, file_contents).unwrap();
+    serde_yaml::to_writer(File::create(path).unwrap(), &peers).unwrap();
 }


### PR DESCRIPTION
## Description
This PR upgrades serde_yaml to 0.9.x. This required only minimal changes and as far as I can tell relevant tools work the same as before. For example, this continues to work as before, with no change in the output:
```
cargo run -p aptos-openapi-spec-generator -- -f yaml -o api/doc/spec.yaml
```

This facilitates using work from another PR where we update to 0.9.x. It is also generally good to stay up to date.

This should be the last time we have to do this until / if we decide to use a different crate, since serde_yaml is now archived.

We use `serde_yaml::to_string` and `into_bytes` or `to_writer` instead of `to_vec` as per the advice from the changelog:
> The serde_yaml::to_vec function has been removed. Use serde_yaml::to_writer for doing I/O, or use serde_yaml::to_string + .into_bytes() on the resulting String.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [x] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify) 

## How Has This Been Tested?
See CI, see that yaml output is not meaningfully different.

## Key Areas to Review
Ensure I haven't missed anything that might change.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
