### PR TITLE
[Consensus Observer] Feature improvements, bug fixes and new metrics/logs.

### DIFF
--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -52,7 +52,7 @@ impl Default for ConsensusObserverConfig {
             garbage_collection_interval_ms: 60_000,            // 60 seconds
             max_subscription_timeout_ms: 30_000,               // 30 seconds
             max_synced_version_timeout_ms: 60_000,             // 60 seconds
-            peer_optimality_check_interval_ms: 300_000,        // 5 minutes
+            peer_optimality_check_interval_ms: 60_000,         // 60 seconds
             progress_check_interval_ms: 5_000,                 // 5 seconds
         }
     }

--- a/consensus/src/consensus_observer/error.rs
+++ b/consensus/src/consensus_observer/error.rs
@@ -12,8 +12,17 @@ pub enum Error {
     #[error("Aptos network rpc error: {0}")]
     RpcError(#[from] RpcError),
 
-    #[error("Subscription termination: {0}")]
-    SubscriptionTermination(String),
+    #[error("Subscription disconnected: {0}")]
+    SubscriptionDisconnected(String),
+
+    #[error("Subscription progress stopped: {0}")]
+    SubscriptionProgressStopped(String),
+
+    #[error("Subscription suboptimal: {0}")]
+    SubscriptionSuboptimal(String),
+
+    #[error("Subscription timeout: {0}")]
+    SubscriptionTimeout(String),
 
     #[error("Unexpected error encountered: {0}")]
     UnexpectedError(String),
@@ -25,7 +34,10 @@ impl Error {
         match self {
             Self::NetworkError(_) => "network_error",
             Self::RpcError(_) => "rpc_error",
-            Self::SubscriptionTermination(_) => "subscription_termination",
+            Self::SubscriptionDisconnected(_) => "subscription_disconnected",
+            Self::SubscriptionProgressStopped(_) => "subscription_progress_stopped",
+            Self::SubscriptionSuboptimal(_) => "subscription_suboptimal",
+            Self::SubscriptionTimeout(_) => "subscription_timeout",
             Self::UnexpectedError(_) => "unexpected_error",
         }
     }

--- a/consensus/src/consensus_observer/metrics.rs
+++ b/consensus/src/consensus_observer/metrics.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_config::network_id::PeerNetworkId;
+use aptos_config::network_id::{NetworkId, PeerNetworkId};
 use aptos_metrics_core::{
     register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, HistogramVec,
     IntCounterVec, IntGaugeVec,
@@ -11,98 +11,8 @@ use once_cell::sync::Lazy;
 // Useful metric labels
 pub const CREATED_SUBSCRIPTION_LABEL: &str = "created_subscription";
 
-/// Counter for tracking sent direct send messages by the network client
-pub static DIRECT_SEND_SENT_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "consensus_observer_network_client_direct_send_sent_messages",
-        "Counters related to sent direct send messages for the network client",
-        &["message_type", "network_id"]
-    )
-    .unwrap()
-});
-
-/// Counter for tracking received direct send messages by the network client
-pub static DIRECT_SEND_RECEIVED_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "consensus_observer_network_client_direct_send_received_messages",
-        "Counters related to received direct send messages for the network client",
-        &["message_type", "network_id"]
-    )
-    .unwrap()
-});
-
-/// Counter for tracking direct send message errors by the network client
-pub static DIRECT_SEND_ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "consensus_observer_network_client_direct_send_errors",
-        "Counters related to direct send message errors for the network client",
-        &["error_type", "network_id"]
-    )
-    .unwrap()
-});
-
-/// Counter for tracking the number of active subscriptions for the consensus observer
-pub static NUM_ACTIVE_SUBSCRIPTIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
-    register_int_gauge_vec!(
-        "consensus_observer_active_subscriptions",
-        "Guage related to active subscriptions for the consensus observer",
-        &["network_id"]
-    )
-    .unwrap()
-});
-
-/// Counter for pending network events to the consensus observer
-pub static PENDING_CONSENSUS_OBSERVER_NETWORK_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "consensus_observer_pending_network_events",
-        "Counters for pending network events for consensus observer",
-        &["state"]
-    )
-    .unwrap()
-});
-
-/// Counter for tracking RPC error responses received by the network client
-pub static RPC_ERROR_RESPONSES: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "consensus_observer_network_client_rpc_error_responses",
-        "Counters related to RPC error responses from the network client",
-        &["response_type", "network_id"]
-    )
-    .unwrap()
-});
-
-/// Counter for tracking sent RPC requests by the network client
-pub static RPC_SENT_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "consensus_observer_network_client_rpc_sent_requests",
-        "Counters related to sent RPC requests for the network client",
-        &["request_type", "network_id"]
-    )
-    .unwrap()
-});
-
-/// Counter for tracking successful RPC responses received by the network client
-pub static RPC_SUCCESS_RESPONSES: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "consensus_observer_network_client_rpc_success_responses",
-        "Counters related to RPC success responses received by the network client",
-        &["response_type", "network_id"]
-    )
-    .unwrap()
-});
-
-/// Counter for tracking RPC request latencies sent by the network client
-pub static RPC_REQUEST_LATENCIES: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        "consensus_observer_network_client_rpc_request_latencies",
-        "Counters related to RPC request latencies sent by the network client",
-        &["request_type", "network_id"]
-    )
-    .unwrap()
-});
-
 /// Counter for tracking created subscriptions for the consensus observer
-pub static CREATED_SUBSCRIPTIONS: Lazy<IntCounterVec> = Lazy::new(|| {
+pub static OBSERVER_CREATED_SUBSCRIPTIONS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "consensus_observer_created_subscriptions",
         "Counters for created subscriptions for consensus observer",
@@ -111,12 +21,122 @@ pub static CREATED_SUBSCRIPTIONS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Counter for tracking the number of active subscriptions for the consensus observer
+pub static OBSERVER_NUM_ACTIVE_SUBSCRIPTIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "consensus_observer_num_active_subscriptions",
+        "Gauge related to active subscriptions for the consensus observer",
+        &["network_id"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking successful RPC responses received by the consensus observer
+pub static OBSERVER_RECEIVED_MESSAGE_RESPONSES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "consensus_observer_received_message_responses",
+        "Counters related to successful RPC responses received by the consensus observer",
+        &["response_type", "network_id"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking received (direct send) messages by the consensus observer
+pub static OBSERVER_RECEIVED_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "consensus_observer_received_messages",
+        "Counters related to received (direct send) messages by the consensus observer",
+        &["message_type", "network_id"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking RPC request latencies sent by the consensus observer
+pub static OBSERVER_REQUEST_LATENCIES: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "consensus_observer_request_latencies",
+        "Counters related to RPC request latencies sent by the consensus observer",
+        &["request_type", "network_id"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking RPC error responses received by the consensus observer
+pub static OBSERVER_SENT_MESSAGE_ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "consensus_observer_sent_message_errors",
+        "Counters related to RPC error responses received by the consensus observer",
+        &["response_type", "network_id"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking sent RPC requests by the consensus observer
+pub static OBSERVER_SENT_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "consensus_observer_sent_requests",
+        "Counters related to sent RPC requests by the consensus observer",
+        &["request_type", "network_id"]
+    )
+    .unwrap()
+});
+
 /// Counter for tracking terminated subscriptions for the consensus observer
-pub static TERMINATED_SUBSCRIPTIONS: Lazy<IntCounterVec> = Lazy::new(|| {
+pub static OBSERVER_TERMINATED_SUBSCRIPTIONS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "consensus_observer_terminated_subscriptions",
         "Counters for terminated subscriptions for consensus observer",
         &["termination_label", "network_id"]
+    )
+    .unwrap()
+});
+
+/// Counter for pending network events for consensus observer and publisher
+pub static PENDING_CONSENSUS_OBSERVER_NETWORK_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "consensus_observer_pending_network_events",
+        "Counters for pending network events for consensus observer and publisher",
+        &["state"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking the number of active subscribers for the consensus publisher
+pub static PUBLISHER_NUM_ACTIVE_SUBSCRIBERS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "consensus_publisher_num_active_subscribers",
+        "Gauge related to active subscribers for the consensus publisher",
+        &["network_id"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking received RPC requests by the consensus publisher
+pub static PUBLISHER_RECEIVED_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "consensus_publisher_received_requests",
+        "Counters related to received RPC requests by the consensus publisher",
+        &["request_type", "network_id"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking sent (direct send) message errors for the consensus publisher
+pub static PUBLISHER_SENT_MESSAGE_ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "consensus_publisher_sent_message_errors",
+        "Counters related to sent (direct send) message errors for the consensus publisher",
+        &["error_type", "network_id"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking sent (direct send) messages by the consensus publisher
+pub static PUBLISHER_SENT_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "consensus_publisher_sent_messages",
+        "Counters related to sent (direct send) messages by the consensus publisher",
+        &["message_type", "network_id"]
     )
     .unwrap()
 });
@@ -147,7 +167,6 @@ pub fn observe_value_with_label(
 }
 
 /// Sets the gauge with the specific label and value
-pub fn set_gauge(counter: &Lazy<IntGaugeVec>, peer_network_id: &PeerNetworkId, value: i64) {
-    let network_id = peer_network_id.network_id();
+pub fn set_gauge(counter: &Lazy<IntGaugeVec>, network_id: &NetworkId, value: i64) {
     counter.with_label_values(&[network_id.as_str()]).set(value);
 }

--- a/consensus/src/consensus_observer/network_client.rs
+++ b/consensus/src/consensus_observer/network_client.rs
@@ -45,7 +45,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusObserverMessage>>
     ) -> Result<(), Error> {
         // Increment the message counter
         metrics::increment_request_counter(
-            &metrics::DIRECT_SEND_SENT_MESSAGES,
+            &metrics::PUBLISHER_SENT_MESSAGES,
             message_label,
             peer_network_id,
         );
@@ -73,7 +73,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusObserverMessage>>
 
             // Update the direct send error metrics
             metrics::increment_request_counter(
-                &metrics::DIRECT_SEND_ERRORS,
+                &metrics::PUBLISHER_SENT_MESSAGE_ERRORS,
                 error.get_label(),
                 peer_network_id,
             );
@@ -124,7 +124,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusObserverMessage>>
 
                 // Update the direct send error metrics
                 metrics::increment_request_counter(
-                    &metrics::DIRECT_SEND_ERRORS,
+                    &metrics::PUBLISHER_SENT_MESSAGE_ERRORS,
                     error.get_label(),
                     peer_network_id,
                 );
@@ -146,7 +146,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusObserverMessage>>
 
         // Increment the request counter
         metrics::increment_request_counter(
-            &metrics::RPC_SENT_REQUESTS,
+            &metrics::OBSERVER_SENT_REQUESTS,
             request.get_label(),
             peer_network_id,
         );
@@ -173,7 +173,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusObserverMessage>>
             Ok(consensus_observer_response) => {
                 // Update the RPC success metrics
                 metrics::increment_request_counter(
-                    &metrics::RPC_SUCCESS_RESPONSES,
+                    &metrics::OBSERVER_RECEIVED_MESSAGE_RESPONSES,
                     request_label,
                     peer_network_id,
                 );
@@ -191,7 +191,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusObserverMessage>>
 
                 // Update the RPC error metrics
                 metrics::increment_request_counter(
-                    &metrics::RPC_ERROR_RESPONSES,
+                    &metrics::OBSERVER_SENT_MESSAGE_ERRORS,
                     error.get_label(),
                     peer_network_id,
                 );
@@ -228,7 +228,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusObserverMessage>>
 
         // Update the RPC request metrics
         metrics::observe_value_with_label(
-            &metrics::RPC_REQUEST_LATENCIES,
+            &metrics::OBSERVER_REQUEST_LATENCIES,
             request_label,
             &peer_network_id,
             request_duration_secs,

--- a/consensus/src/consensus_observer/network_events.rs
+++ b/consensus/src/consensus_observer/network_events.rs
@@ -111,6 +111,14 @@ impl ResponseSender {
         Self { response_tx }
     }
 
+    #[cfg(test)]
+    /// Creates a new response sender for testing purposes.
+    pub fn new_for_test() -> Self {
+        Self {
+            response_tx: oneshot::channel().0,
+        }
+    }
+
     /// Send the response to the pending RPC request
     pub fn send(self, response: ConsensusObserverResponse) {
         // Create and serialize the response message

--- a/consensus/src/consensus_observer/network_message.rs
+++ b/consensus/src/consensus_observer/network_message.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 /// Types of messages that can be sent between the consensus publisher and observer
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum ConsensusObserverMessage {
     Request(ConsensusObserverRequest),
     Response(ConsensusObserverResponse),
@@ -75,7 +75,7 @@ impl Display for ConsensusObserverMessage {
 }
 
 /// Types of requests that can be sent between the consensus publisher and observer
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum ConsensusObserverRequest {
     Subscribe,
     Unsubscribe,
@@ -97,7 +97,7 @@ impl ConsensusObserverRequest {
 }
 
 /// Types of responses that can be sent between the consensus publisher and observer
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum ConsensusObserverResponse {
     SubscribeAck,
     UnsubscribeAck,
@@ -119,7 +119,7 @@ impl ConsensusObserverResponse {
 }
 
 /// Types of direct sends that can be sent between the consensus publisher and observer
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum ConsensusObserverDirectSend {
     OrderedBlock(OrderedBlock),
     CommitDecision(CommitDecision),
@@ -164,14 +164,14 @@ impl ConsensusObserverDirectSend {
 }
 
 /// OrderedBlock message contains the ordered blocks and the proof of the ordering
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct OrderedBlock {
     pub blocks: Vec<Arc<PipelinedBlock>>,
     pub ordered_proof: LedgerInfoWithSignatures,
 }
 
 /// Payload message contains the block, transactions and the limit of the block
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BlockPayload {
     pub block: BlockInfo,
     pub transactions: Vec<SignedTransaction>,

--- a/consensus/src/consensus_observer/observer.rs
+++ b/consensus/src/consensus_observer/observer.rs
@@ -519,7 +519,7 @@ impl ConsensusObserver {
 
             // If the payload exists, add the commit decision to the pending blocks
             if payload_exists {
-                info!(
+                debug!(
                     LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                         "Adding decision to pending block: {}",
                         commit_decision.ledger_info().commit_info()
@@ -529,7 +529,7 @@ impl ConsensusObserver {
 
                 // If we are not in sync mode, forward the commit decision to the execution pipeline
                 if self.sync_handle.is_none() {
-                    info!(
+                    debug!(
                         LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                             "Forwarding commit decision to the execution pipeline: {}",
                             commit_decision.ledger_info().commit_info()
@@ -574,7 +574,7 @@ impl ConsensusObserver {
         // Process the message based on the type
         match message {
             ConsensusObserverDirectSend::OrderedBlock(ordered_block) => {
-                info!(
+                debug!(
                     LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                         "Received ordered block: {}, from peer: {}!",
                         ordered_block.ordered_proof.commit_info(),
@@ -584,7 +584,7 @@ impl ConsensusObserver {
                 self.process_ordered_block(ordered_block).await;
             },
             ConsensusObserverDirectSend::CommitDecision(commit_decision) => {
-                info!(
+                debug!(
                     LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                         "Received commit decision: {}, from peer: {}!",
                         commit_decision.ledger_info().commit_info(),
@@ -594,7 +594,7 @@ impl ConsensusObserver {
                 self.process_commit_decision(commit_decision);
             },
             ConsensusObserverDirectSend::BlockPayload(block_payload) => {
-                info!(
+                debug!(
                     LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                         "Received block payload: {}, from peer: {}!",
                         block_payload.block, peer_network_id
@@ -615,7 +615,7 @@ impl ConsensusObserver {
 
         // If the block is a child of our last block, we can insert it
         if self.get_last_block().id() == blocks.first().unwrap().parent_id() {
-            info!(
+            debug!(
                 LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                     "Adding ordered block to the pending blocks: {}",
                     ordered_proof.commit_info()
@@ -629,7 +629,7 @@ impl ConsensusObserver {
 
             // If we are not in sync mode, forward the blocks to the execution pipeline
             if self.sync_handle.is_none() {
-                info!(
+                debug!(
                     LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                         "Forwarding blocks to the execution pipeline: {}",
                         ordered_proof.commit_info()

--- a/consensus/src/consensus_observer/observer.rs
+++ b/consensus/src/consensus_observer/observer.rs
@@ -3,7 +3,9 @@
 
 use crate::{
     consensus_observer::{
+        error::Error,
         logging::{LogEntry, LogSchema},
+        metrics,
         network_client::ConsensusObserverClient,
         network_events::{ConsensusObserverNetworkEvents, NetworkMessage, ResponseSender},
         network_message::{
@@ -166,28 +168,51 @@ impl ConsensusObserver {
         debug!(LogSchema::new(LogEntry::ConsensusObserver)
             .message("Checking consensus observer progress!"));
 
-        // Get the peer ID of the currently active subscription
+        // Get the peer ID of the currently active subscription (if any)
         let active_subscription_peer = self
             .active_observer_subscription
             .as_ref()
             .map(|subscription| subscription.get_peer_network_id());
 
         // If we have an active subscription, verify that the subscription
-        // is still healthy. If not, the subscription will be terminated.
-        if active_subscription_peer.is_some() {
-            self.check_active_subscription().await;
+        // is still healthy. If not, the subscription should be terminated.
+        if let Some(active_subscription_peer) = active_subscription_peer {
+            if let Err(error) = self.check_active_subscription() {
+                // Log the subscription termination
+                warn!(
+                    LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                        "Terminating subscription to peer: {:?}! Error: {:?}",
+                        active_subscription_peer, error
+                    ))
+                );
+
+                // Unsubscribe from the peer
+                self.unsubscribe_from_peer(active_subscription_peer);
+
+                // Update the subscription termination metrics
+                self.update_subscription_termination_metrics(active_subscription_peer, error);
+            }
         }
 
-        // If we no longer have an active subscription, select a new peer to subscribe to
+        // If we don't have a subscription, we should select a new peer to
+        // subscribe to. If we had a previous subscription, it should be
+        // excluded from the selection process.
         if self.active_observer_subscription.is_none() {
+            // Create a new observer subscription
             self.create_new_observer_subscription(active_subscription_peer)
                 .await;
+
+            // If we successfully created a new subscription, update the subscription creation metrics
+            if let Some(active_subscription) = &self.active_observer_subscription {
+                self.update_subscription_creation_metrics(
+                    active_subscription.get_peer_network_id(),
+                );
+            }
         }
     }
 
-    /// Checks if the active subscription is still healthy. If not,
-    /// the subscription is removed and the peer is notified.
-    async fn check_active_subscription(&mut self) {
+    /// Checks if the active subscription is still healthy. If not, an error is returned.
+    fn check_active_subscription(&mut self) -> Result<(), Error> {
         let active_observer_subscription = self.active_observer_subscription.take();
         if let Some(mut active_subscription) = active_observer_subscription {
             // Check if the peer for the subscription is still connected
@@ -200,66 +225,28 @@ impl ConsensusObserver {
 
             // Verify the peer is still connected
             if !peer_still_connected {
-                // Log the disconnection and terminate the subscription
-                warn!(
-                    LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                        "The peer is no longer connected! Terminating subscription: {:?}!",
-                        peer_network_id
-                    ))
-                );
-                self.unsubscribe_from_peer(peer_network_id);
-                return;
+                return Err(Error::SubscriptionDisconnected(
+                    "The peer is no longer connected!".to_string(),
+                ));
             }
 
             // Verify the subscription has not timed out
-            if let Err(error) = active_subscription.check_subscription_timeout() {
-                // Log the timeout and terminate the subscription
-                warn!(
-                    LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                        "The subscription has timed out with peer: {:?}! Error: {:?}",
-                        peer_network_id, error
-                    ))
-                );
-                self.unsubscribe_from_peer(peer_network_id);
-                return;
-            }
+            active_subscription.check_subscription_timeout()?;
 
             // Verify that the DB is continuing to sync and commit new data.
             // Note: we should only do this if we're not waiting for state sync.
-            if self.sync_handle.is_none() {
-                if let Err(error) = active_subscription.check_syncing_progress() {
-                    // Log the error and terminate the subscription
-                    warn!(
-                        LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                            "The observer is not making syncing progress with peer: {:?}! Error: {:?}",
-                            peer_network_id, error
-                        ))
-                    );
-                    self.unsubscribe_from_peer(peer_network_id);
-                    return;
-                }
-            }
+            active_subscription.check_syncing_progress()?;
 
             // Verify that the subscription peer is optimal
             if let Some(peers_and_metadata) = self.get_connected_peers_and_metadata() {
-                if let Err(error) =
-                    active_subscription.check_subscription_peer_optimality(peers_and_metadata)
-                {
-                    // Log the error and terminate the subscription
-                    warn!(
-                        LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                            "The subscription peer is no longer optimal: {:?}! Error: {:?}",
-                            peer_network_id, error
-                        ))
-                    );
-                    self.unsubscribe_from_peer(peer_network_id);
-                    return;
-                }
+                active_subscription.check_subscription_peer_optimality(peers_and_metadata)?;
             }
 
             // The subscription seems healthy, we can keep it
             self.active_observer_subscription = Some(active_subscription);
         }
+
+        Ok(())
     }
 
     /// Creates and returns a commit callback (to be called after the execution pipeline)
@@ -571,6 +558,13 @@ impl ConsensusObserver {
             );
         };
 
+        // Increment the received message counter
+        metrics::increment_request_counter(
+            &metrics::DIRECT_SEND_RECEIVED_MESSAGES,
+            message.get_label(),
+            &peer_network_id,
+        );
+
         // Process the message based on the type
         match message {
             ConsensusObserverDirectSend::OrderedBlock(ordered_block) => {
@@ -807,6 +801,36 @@ impl ConsensusObserver {
                 },
             }
         });
+    }
+
+    /// Updates the subscription creation metrics for the given peer
+    fn update_subscription_creation_metrics(&self, peer_network_id: PeerNetworkId) {
+        // Set the number of active subscriptions
+        metrics::set_gauge(&metrics::NUM_ACTIVE_SUBSCRIPTIONS, &peer_network_id, 1);
+
+        // Update the number of created subscriptions
+        metrics::increment_request_counter(
+            &metrics::CREATED_SUBSCRIPTIONS,
+            metrics::CREATED_SUBSCRIPTION_LABEL,
+            &peer_network_id,
+        );
+    }
+
+    /// Updates the subscription termination metrics for the given peer
+    fn update_subscription_termination_metrics(
+        &self,
+        peer_network_id: PeerNetworkId,
+        error: Error,
+    ) {
+        // Reset the number of active subscriptions
+        metrics::set_gauge(&metrics::NUM_ACTIVE_SUBSCRIPTIONS, &peer_network_id, 0);
+
+        // Update the number of terminated subscriptions
+        metrics::increment_request_counter(
+            &metrics::TERMINATED_SUBSCRIPTIONS,
+            error.get_label(),
+            &peer_network_id,
+        );
     }
 
     /// Waits for a new epoch to start

--- a/consensus/src/consensus_observer/observer.rs
+++ b/consensus/src/consensus_observer/observer.rs
@@ -603,7 +603,7 @@ impl ConsensusObserver {
 
         // Increment the received message counter
         metrics::increment_request_counter(
-            &metrics::DIRECT_SEND_RECEIVED_MESSAGES,
+            &metrics::OBSERVER_RECEIVED_MESSAGES,
             message.get_label(),
             &peer_network_id,
         );
@@ -852,11 +852,15 @@ impl ConsensusObserver {
     /// Updates the subscription creation metrics for the given peer
     fn update_subscription_creation_metrics(&self, peer_network_id: PeerNetworkId) {
         // Set the number of active subscriptions
-        metrics::set_gauge(&metrics::NUM_ACTIVE_SUBSCRIPTIONS, &peer_network_id, 1);
+        metrics::set_gauge(
+            &metrics::OBSERVER_NUM_ACTIVE_SUBSCRIPTIONS,
+            &peer_network_id.network_id(),
+            1,
+        );
 
         // Update the number of created subscriptions
         metrics::increment_request_counter(
-            &metrics::CREATED_SUBSCRIPTIONS,
+            &metrics::OBSERVER_CREATED_SUBSCRIPTIONS,
             metrics::CREATED_SUBSCRIPTION_LABEL,
             &peer_network_id,
         );
@@ -869,11 +873,15 @@ impl ConsensusObserver {
         error: Error,
     ) {
         // Reset the number of active subscriptions
-        metrics::set_gauge(&metrics::NUM_ACTIVE_SUBSCRIPTIONS, &peer_network_id, 0);
+        metrics::set_gauge(
+            &metrics::OBSERVER_NUM_ACTIVE_SUBSCRIPTIONS,
+            &peer_network_id.network_id(),
+            0,
+        );
 
         // Update the number of terminated subscriptions
         metrics::increment_request_counter(
-            &metrics::TERMINATED_SUBSCRIPTIONS,
+            &metrics::OBSERVER_TERMINATED_SUBSCRIPTIONS,
             error.get_label(),
             &peer_network_id,
         );

--- a/consensus/src/consensus_observer/publisher.rs
+++ b/consensus/src/consensus_observer/publisher.rs
@@ -122,6 +122,11 @@ impl ConsensusPublisher {
         }
     }
 
+    /// Returns a clone of the currently active subscribers
+    pub fn get_active_subscribers(&self) -> HashSet<PeerNetworkId> {
+        self.active_subscribers.read().clone()
+    }
+
     /// Returns a copy of the consensus observer client
     pub fn get_consensus_observer_client(
         &self,

--- a/consensus/src/consensus_observer/subscription.rs
+++ b/consensus/src/consensus_observer/subscription.rs
@@ -89,7 +89,7 @@ impl ConsensusObserverSubscription {
         // Verify that we're subscribed to the most optimal peer
         if let Some(optimal_peer) = sort_peers_by_distance_and_latency(peers_and_metadata).first() {
             if *optimal_peer != self.peer_network_id {
-                return Err(Error::SubscriptionTermination(format!(
+                return Err(Error::SubscriptionSuboptimal(format!(
                     "Subscription to peer: {} is no longer optimal! New optimal peer: {}",
                     self.peer_network_id, optimal_peer
                 )));
@@ -110,7 +110,7 @@ impl ConsensusObserverSubscription {
         if duration_since_last_message
             > Duration::from_millis(self.consensus_observer_config.max_subscription_timeout_ms)
         {
-            return Err(Error::SubscriptionTermination(format!(
+            return Err(Error::SubscriptionTimeout(format!(
                 "Subscription to peer: {} has timed out! No message received for: {:?}",
                 self.peer_network_id, duration_since_last_message
             )));
@@ -145,7 +145,7 @@ impl ConsensusObserverSubscription {
                     self.consensus_observer_config.max_synced_version_timeout_ms,
                 )
             {
-                return Err(Error::SubscriptionTermination(format!(
+                return Err(Error::SubscriptionProgressStopped(format!(
                     "The DB is not making sync progress! Highest synced version: {}, elapsed: {:?}",
                     highest_synced_version, duration_since_highest_seen
                 )));


### PR DESCRIPTION
## Description
This PR makes several small improvements to the consensus observer. Specifically, it offers the following commits:
1. Downgrade non-critical `info` logs to `debug`.
1. Add more metrics for subscription logic and errors.
1. Fix a race condition between the commit callback and the state sync process.
1. Remove several unnecessary `unwrap` calls.
1. Add more publisher metrics and clean up metric names.
1. Exclude the active subscribers from the potential peers list. This should help reduce the likelihood of subscription cycles (i.e., A subscribes to B, and B subscribes to A). Note, however, that even if a cycle occurs, the nodes will select new peers after being unable to make progress for a while.
1. Add simple tests for the consensus publisher.

## Testing Plan
Existing test infrastructure.