### PR TITLE
[move-2] Fix CI breaking change in variant names in prover

### DIFF
--- a/third_party/move/move-compiler/src/expansion/translate.rs
+++ b/third_party/move/move-compiler/src/expansion/translate.rs
@@ -2301,7 +2301,8 @@ fn name_access_chain(
         },
         (_, PN::Two(sp!(_, LN::Name(n1)), n2)) => {
             if let Some((mident, mem)) = context.aliases.member_alias_get(&n1).filter(|_| {
-                is_valid_struct_constant_or_schema_name(n1.value.as_str())
+                context.env.flags().lang_v2()
+                    && is_valid_struct_constant_or_schema_name(n1.value.as_str())
                     && is_valid_struct_constant_or_schema_name(n2.value.as_str())
             }) {
                 // n1 is interpreted as a type and n2 as a variant in the type

--- a/third_party/move/move-compiler/tests/move_check/expansion/assign_non_simple_name.exp
+++ b/third_party/move/move-compiler/tests/move_check/expansion/assign_non_simple_name.exp
@@ -1,9 +1,3 @@
-warning[W09001]: unused alias
-  ┌─ tests/move_check/expansion/assign_non_simple_name.move:6:15
-  │
-6 │     use 0x42::X;
-  │               ^ Unused 'use' of alias 'X'. Consider removing it
-
 error[E01010]: syntax item restricted to spec contexts
    ┌─ tests/move_check/expansion/assign_non_simple_name.move:16:9
    │

--- a/third_party/move/move-compiler/tests/move_check/expansion/use_nested_self_as_invalid.exp
+++ b/third_party/move/move-compiler/tests/move_check/expansion/use_nested_self_as_invalid.exp
@@ -4,14 +4,11 @@ warning[W09001]: unused alias
 8 │     use 0x2::X::{Self as B, foo, S};
   │                          ^ Unused 'use' of alias 'B'. Consider removing it
 
-error[E04018]: cyclic data
+error[E03002]: unbound module
    ┌─ tests/move_check/expansion/use_nested_self_as_invalid.move:10:19
    │
 10 │     struct X { f: X::S, f2: S }
-   │                   ^^^^
-   │                   │
-   │                   Invalid field containing 'X' in struct 'X'.
-   │                   Using this struct creates a cycle: 'X' contains 'X'
+   │                   ^ Unbound module or type alias 'X'
 
 error[E03002]: unbound module
    ┌─ tests/move_check/expansion/use_nested_self_as_invalid.move:12:9

--- a/third_party/move/move-compiler/tests/move_check/expansion/use_struct_overlap_with_module.exp
+++ b/third_party/move/move-compiler/tests/move_check/expansion/use_struct_overlap_with_module.exp
@@ -1,6 +1,0 @@
-warning[W09001]: unused alias
-  ┌─ tests/move_check/expansion/use_struct_overlap_with_module.move:7:14
-  │
-7 │     use 0x2::X::{Self, S as X};
-  │              ^ Unused 'use' of alias 'X'. Consider removing it
-


### PR DESCRIPTION

## Description

This makes the interpretation of `Foo::Bar` as enum variant dependent on that Move 2 is enabled, allowing older legacy code which uses captilized module names to succeed as long as used for the v1 language only.

<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Against Diem prover tests