### PR TITLE
[Target Determinator] Small improvements to determinator logic.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "camino",
+ "chrono",
  "clap 4.4.14",
  "clap-verbosity-flag",
  "determinator",

--- a/devtools/aptos-cargo-cli/Cargo.toml
+++ b/devtools/aptos-cargo-cli/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 camino = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true }
 clap-verbosity-flag = { workspace = true }
 determinator = { workspace = true }

--- a/devtools/aptos-cargo-cli/src/lib.rs
+++ b/devtools/aptos-cargo-cli/src/lib.rs
@@ -475,7 +475,7 @@ fn output_affected_packages(packages: Vec<String>) -> anyhow::Result<()> {
     if packages.is_empty() {
         println!("No packages were affected!");
     } else {
-        println!("Affected packages detected:");
+        println!("Affected packages detected ({:?} total):", packages.len());
         for package in packages {
             println!("\t{:?}", package)
         }


### PR DESCRIPTION
## Description
This PR makes several small improvements to the target determinator logic in CI/CD. Specifically:
1. It improves the error message returned when metadata for an old commit (i.e., an old merge-base) cannot be fetched. In these cases, folks should simply rebase.
1. It adds a simple check to ensure that the merge-base is no greater than 7 days old. If so, the determinator will return an error telling folks to rebase.
1. It updates the target-determinator cargo options to include dev-dependencies. This helps to ensure that test-only crates are correctly handled (i.e., test-only crates will be marked as tainted if any of their dev-dependencies change). This should help to address a few edge-cases we've seen.

## Testing Plan
Existing test infrastructure and manual verification.
