### PR TITLE
Secp256k1 malleability fix

### DIFF
--- a/crates/aptos-crypto/src/secp256k1_ecdsa.rs
+++ b/crates/aptos-crypto/src/secp256k1_ecdsa.rs
@@ -217,7 +217,9 @@ impl Signature {
     // secp256k1
     fn s_equal_half_order_floor(&self) -> bool {
         let s_bytes = self.0.s.b32();
+        println!("in s_equal_half_order_floor");
         let s_limb_0 = as_u32_be(&s_bytes[0..3].try_into().unwrap());
+        println!("did first as_u32_be");
         let s_limb_1 = as_u32_be(&s_bytes[0..3].try_into().unwrap());
         let s_limb_2 = as_u32_be(&s_bytes[0..3].try_into().unwrap());
         let s_limb_3 = as_u32_be(&s_bytes[0..3].try_into().unwrap());
@@ -267,6 +269,7 @@ impl TryFrom<&[u8]> for Signature {
     type Error = CryptoMaterialError;
 
     fn try_from(bytes: &[u8]) -> std::result::Result<Signature, CryptoMaterialError> {
+        println!("in try from");
         match libsecp256k1::Signature::parse_standard_slice(bytes) {
             Ok(signature) => Ok(Signature(signature)),
             Err(_) => Err(CryptoMaterialError::DeserializationError),

--- a/crates/aptos-crypto/src/secp256k1_ecdsa.rs
+++ b/crates/aptos-crypto/src/secp256k1_ecdsa.rs
@@ -199,15 +199,6 @@ pub struct Signature(pub(crate) libsecp256k1::Signature);
 // floor(n/2) where n is the secp256k1 scalar field order
 const SECP256K1_HALF_ORDER_FLOOR: [u32; 8] = [0x681B20A0, 0xDFE92F46, 0x57A4501D, 0x5D576E73, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x7FFFFFFF];
 
-     /*const SECP256K1_N_H_0: u32 = 0x681B20A0;
-     3 const SECP256K1_N_H_1: u32 = 0xDFE92F46;
-     4 const SECP256K1_N_H_2: u32 = 0x57A4501D;
-     5 const SECP256K1_N_H_3: u32 = 0x5D576E73;
-     6 const SECP256K1_N_H_4: u32 = 0xFFFFFFFF;
-     7 const SECP256K1_N_H_5: u32 = 0xFFFFFFFF;
-     8 const SECP256K1_N_H_6: u32 = 0xFFFFFFFF;
-     9 const SECP256K1_N_H_7: u32 = 0x7FFFFFFF;*/
-
     fn as_u32_be(array: &[u8; 4]) -> u32 {
         ((array[0] as u32) << 24) +
         ((array[1] as u32) << 16) +
@@ -250,7 +241,10 @@ impl Signature {
     ) -> Result<()> {
         // Prevent malleability attacks, low order only. The library only signs in low
         // order, so this was done intentionally.
-        if self.0.s.is_high() && self.s_equal_half_order_floor() {
+        // The underlying secp256k1 library has a bug - `is_high` should check whether s > n/2.
+        // However, it incorrectly returns true when s = floor(n/2), despite the fact that
+        // floor(n/2) < n/2. We special case this.
+        if self.0.s.is_high() && !self.s_equal_half_order_floor() {
             Err(anyhow!(CryptoMaterialError::CanonicalRepresentationError))
         } else if libsecp256k1::verify(message, &self.0, public_key) {
             Ok(())
@@ -331,9 +325,4 @@ impl ValidCryptoMaterial for Signature {
 fn bytes_to_message(message: &[u8]) -> Result<libsecp256k1::Message> {
     let message_digest = HashValue::sha3_256_of(message).to_vec();
     libsecp256k1::Message::parse_slice(&message_digest).map_err(|e| anyhow!("{}", e))
-}
-
-#[test]
-fn mal_check() {
-    assert!(true);
 }

--- a/crates/aptos-crypto/src/secp256k1_ecdsa.rs
+++ b/crates/aptos-crypto/src/secp256k1_ecdsa.rs
@@ -200,17 +200,10 @@ pub struct Signature(pub(crate) libsecp256k1::Signature);
 const SECP256K1_HALF_ORDER_FLOOR: [u32; 8] = [0x681B20A0, 0xDFE92F46, 0x57A4501D, 0x5D576E73, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x7FFFFFFF];
 
 fn as_u32_be(vec: &[u8; 4]) -> u32 {
-    println!("vec: {:?}", vec);
-    //assert!(vec.len() == 4);
     let i1 = (vec[0] as u32) << 24;
     let i2 = (vec[1] as u32) << 16;
     let i3 = (vec[2] as u32) << 8;
     let i4 = (vec[3] as u32) << 0;
-    /*((array[0] as u32) << 24) +
-    ((array[1] as u32) << 16) +
-    ((array[2] as u32) <<  8) +
-    ((array[3] as u32) <<  0)*/
-    println!("as_u32_be: {}, {}, {}, {}", i1, i2, i3, i4);
     i1 + i2 + i3 + i4
 }
 
@@ -225,9 +218,7 @@ impl Signature {
     // secp256k1
     fn s_equal_half_order_floor(&self) -> bool {
         let s_bytes = self.0.s.b32();
-        println!("in s_equal_half_order_floor: {:?}", s_bytes);
         let s_limb_0 = as_u32_be(&s_bytes[0..4].try_into().unwrap());
-        println!("did first as_u32_be");
         let s_limb_1 = as_u32_be(&s_bytes[4..8].try_into().unwrap());
         let s_limb_2 = as_u32_be(&s_bytes[8..12].try_into().unwrap());
         let s_limb_3 = as_u32_be(&s_bytes[12..16].try_into().unwrap());
@@ -235,8 +226,6 @@ impl Signature {
         let s_limb_5 = as_u32_be(&s_bytes[20..24].try_into().unwrap());
         let s_limb_6 = as_u32_be(&s_bytes[24..28].try_into().unwrap());
         let s_limb_7 = as_u32_be(&s_bytes[28..32].try_into().unwrap());
-        println!("s_limb_0: {}", s_limb_0);
-        println!("SECP256K1_HALF_ORDER_FLOOR: {:?}", SECP256K1_HALF_ORDER_FLOOR);
         s_limb_0 == SECP256K1_HALF_ORDER_FLOOR[0]
             && s_limb_1 == SECP256K1_HALF_ORDER_FLOOR[1]
             && s_limb_2 == SECP256K1_HALF_ORDER_FLOOR[2]
@@ -252,8 +241,6 @@ impl Signature {
         message: &libsecp256k1::Message,
         public_key: &libsecp256k1::PublicKey,
     ) -> Result<()> {
-        println!("s: {:?}", self.0.clone());
-        println!("is equal to half order floor: {}", self.s_equal_half_order_floor());
         // Prevent malleability attacks, low order only. The library only signs in low
         // order, so this was done intentionally.
         // The underlying secp256k1 library has a bug - `is_high` should check whether s > n/2.
@@ -264,10 +251,6 @@ impl Signature {
         } else if libsecp256k1::verify(message, &self.0, public_key) {
             Ok(())
         } else {
-            /*if self.s_equal_half_order_floor() {
-                return Err(anyhow!(CryptoMaterialError::CanonicalRepresentationError));
-            }*/
-            //Err(CryptoMaterialError::ValidationError)
             Err(anyhow!("Unable to verify signature."))
         }
     }
@@ -285,7 +268,6 @@ impl TryFrom<&[u8]> for Signature {
     type Error = CryptoMaterialError;
 
     fn try_from(bytes: &[u8]) -> std::result::Result<Signature, CryptoMaterialError> {
-        println!("in try from");
         match libsecp256k1::Signature::parse_standard_slice(bytes) {
             Ok(signature) => Ok(Signature(signature)),
             Err(_) => Err(CryptoMaterialError::DeserializationError),

--- a/crates/aptos-crypto/src/secp256k1_ecdsa.rs
+++ b/crates/aptos-crypto/src/secp256k1_ecdsa.rs
@@ -122,7 +122,7 @@ impl ValidCryptoMaterial for PrivateKey {
     }
 }
 
-/// Secp256k1 ecds public key
+/// Secp256k1 ecdsa public key
 #[derive(DeserializeKey, Clone, Eq, PartialEq, SerializeKey)]
 #[key_name("Secp256k1EcdsaPublicKey")]
 pub struct PublicKey(pub(crate) libsecp256k1::PublicKey);

--- a/crates/aptos-crypto/src/secp256k1_ecdsa.rs
+++ b/crates/aptos-crypto/src/secp256k1_ecdsa.rs
@@ -251,7 +251,7 @@ impl Signature {
         &self,
         message: &libsecp256k1::Message,
         public_key: &libsecp256k1::PublicKey,
-    ) -> Result<(), CryptoMaterialError> {
+    ) -> Result<()> {
         println!("s: {:?}", self.0.clone());
         println!("is equal to half order floor: {}", self.s_equal_half_order_floor());
         // Prevent malleability attacks, low order only. The library only signs in low
@@ -260,15 +260,15 @@ impl Signature {
         // However, it incorrectly returns true when s = floor(n/2), despite the fact that
         // floor(n/2) < n/2. We special case this.
         if self.0.s.is_high() && !self.s_equal_half_order_floor() {
-            Err(CryptoMaterialError::CanonicalRepresentationError)
+            Err(anyhow!(CryptoMaterialError::CanonicalRepresentationError))
         } else if libsecp256k1::verify(message, &self.0, public_key) {
             Ok(())
         } else {
             /*if self.s_equal_half_order_floor() {
                 return Err(anyhow!(CryptoMaterialError::CanonicalRepresentationError));
             }*/
-            Err(CryptoMaterialError::ValidationError)
-            //Err(anyhow!("Unable to verify signature."))
+            //Err(CryptoMaterialError::ValidationError)
+            Err(anyhow!("Unable to verify signature."))
         }
     }
 }
@@ -315,12 +315,12 @@ impl traits::Signature for Signature {
     type SigningKeyMaterial = PrivateKey;
     type VerifyingKeyMaterial = PublicKey;
 
-    fn verify<T: CryptoHash + Serialize>(&self, message: &T, public_key: &PublicKey) -> Result<(), CryptoMaterialError> {
+    fn verify<T: CryptoHash + Serialize>(&self, message: &T, public_key: &PublicKey) -> Result<()> {
         let message = bytes_to_message(&traits::signing_message(message)?)?;
         self.verify(&message, &public_key.0)
     }
 
-    fn verify_arbitrary_msg(&self, message: &[u8], public_key: &PublicKey) -> Result<(), CryptoMaterialError> {
+    fn verify_arbitrary_msg(&self, message: &[u8], public_key: &PublicKey) -> Result<()> {
         let message = bytes_to_message(message)?;
         self.verify(&message, &public_key.0)
     }

--- a/crates/aptos-crypto/src/secp256k1_ecdsa.rs
+++ b/crates/aptos-crypto/src/secp256k1_ecdsa.rs
@@ -199,11 +199,19 @@ pub struct Signature(pub(crate) libsecp256k1::Signature);
 // floor(n/2) where n is the secp256k1 scalar field order
 const SECP256K1_HALF_ORDER_FLOOR: [u32; 8] = [0x681B20A0, 0xDFE92F46, 0x57A4501D, 0x5D576E73, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x7FFFFFFF];
 
-fn as_u32_be(array: &[u8; 4]) -> u32 {
-    ((array[0] as u32) << 24) +
+fn as_u32_be(vec: &[u8; 4]) -> u32 {
+    println!("vec: {:?}", vec);
+    //assert!(vec.len() == 4);
+    let i1 = (vec[0] as u32) << 24;
+    let i2 = (vec[1] as u32) << 16;
+    let i3 = (vec[2] as u32) << 8;
+    let i4 = (vec[3] as u32) << 0;
+    /*((array[0] as u32) << 24) +
     ((array[1] as u32) << 16) +
     ((array[2] as u32) <<  8) +
-    ((array[3] as u32) <<  0)
+    ((array[3] as u32) <<  0)*/
+    println!("as_u32_be: {}, {}, {}, {}", i1, i2, i3, i4);
+    i1 + i2 + i3 + i4
 }
 
 
@@ -217,16 +225,18 @@ impl Signature {
     // secp256k1
     fn s_equal_half_order_floor(&self) -> bool {
         let s_bytes = self.0.s.b32();
-        println!("in s_equal_half_order_floor");
-        let s_limb_0 = as_u32_be(&s_bytes[0..3].try_into().unwrap());
+        println!("in s_equal_half_order_floor: {:?}", s_bytes);
+        let s_limb_0 = as_u32_be(&s_bytes[0..4].try_into().unwrap());
         println!("did first as_u32_be");
-        let s_limb_1 = as_u32_be(&s_bytes[0..3].try_into().unwrap());
-        let s_limb_2 = as_u32_be(&s_bytes[0..3].try_into().unwrap());
-        let s_limb_3 = as_u32_be(&s_bytes[0..3].try_into().unwrap());
-        let s_limb_4 = as_u32_be(&s_bytes[0..3].try_into().unwrap());
-        let s_limb_5 = as_u32_be(&s_bytes[0..3].try_into().unwrap());
-        let s_limb_6 = as_u32_be(&s_bytes[0..3].try_into().unwrap());
-        let s_limb_7 = as_u32_be(&s_bytes[0..3].try_into().unwrap());
+        let s_limb_1 = as_u32_be(&s_bytes[4..8].try_into().unwrap());
+        let s_limb_2 = as_u32_be(&s_bytes[8..12].try_into().unwrap());
+        let s_limb_3 = as_u32_be(&s_bytes[12..16].try_into().unwrap());
+        let s_limb_4 = as_u32_be(&s_bytes[16..20].try_into().unwrap());
+        let s_limb_5 = as_u32_be(&s_bytes[20..24].try_into().unwrap());
+        let s_limb_6 = as_u32_be(&s_bytes[24..28].try_into().unwrap());
+        let s_limb_7 = as_u32_be(&s_bytes[28..32].try_into().unwrap());
+        println!("s_limb_0: {}", s_limb_0);
+        println!("SECP256K1_HALF_ORDER_FLOOR: {:?}", SECP256K1_HALF_ORDER_FLOOR);
         s_limb_0 == SECP256K1_HALF_ORDER_FLOOR[0]
             && s_limb_1 == SECP256K1_HALF_ORDER_FLOOR[1]
             && s_limb_2 == SECP256K1_HALF_ORDER_FLOOR[2]
@@ -242,6 +252,8 @@ impl Signature {
         message: &libsecp256k1::Message,
         public_key: &libsecp256k1::PublicKey,
     ) -> Result<()> {
+        println!("s: {:?}", self.0.clone());
+        println!("is equal to half order floor: {}", self.s_equal_half_order_floor());
         // Prevent malleability attacks, low order only. The library only signs in low
         // order, so this was done intentionally.
         // The underlying secp256k1 library has a bug - `is_high` should check whether s > n/2.
@@ -252,6 +264,9 @@ impl Signature {
         } else if libsecp256k1::verify(message, &self.0, public_key) {
             Ok(())
         } else {
+            /*if self.s_equal_half_order_floor() {
+                return Err(anyhow!(CryptoMaterialError::CanonicalRepresentationError));
+            }*/
             Err(anyhow!("Unable to verify signature."))
         }
     }

--- a/crates/aptos-crypto/src/secp256k1_ecdsa.rs
+++ b/crates/aptos-crypto/src/secp256k1_ecdsa.rs
@@ -199,12 +199,13 @@ pub struct Signature(pub(crate) libsecp256k1::Signature);
 // floor(n/2) where n is the secp256k1 scalar field order
 const SECP256K1_HALF_ORDER_FLOOR: [u32; 8] = [0x681B20A0, 0xDFE92F46, 0x57A4501D, 0x5D576E73, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x7FFFFFFF];
 
-    fn as_u32_be(array: &[u8; 4]) -> u32 {
-        ((array[0] as u32) << 24) +
-        ((array[1] as u32) << 16) +
-        ((array[2] as u32) <<  8) +
-        ((array[3] as u32) <<  0)
-    }
+fn as_u32_be(array: &[u8; 4]) -> u32 {
+    ((array[0] as u32) << 24) +
+    ((array[1] as u32) << 16) +
+    ((array[2] as u32) <<  8) +
+    ((array[3] as u32) <<  0)
+}
+
 
 impl Signature {
     /// Serialize the signature into a byte vector

--- a/crates/aptos-crypto/src/unit_tests/secp256k1_ecdsa_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/secp256k1_ecdsa_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    secp256k1_ecdsa::{self, PrivateKey, PublicKey},
+    secp256k1_ecdsa::{self, PrivateKey, PublicKey, Signature as ECDSASignature},
     test_utils::KeyPair,
     Signature, SigningKey, Uniform,
 };
@@ -78,12 +78,12 @@ fn serialization() {
     assert_eq!(key_pair.public_key, public_key_deserialized);
 }
 
-fn from_u32_be(val: u32) -> [u8; 4] {
+fn from_u32_be(val: u32) -> Vec<u8> {
     let res_0 = (val >> 24) as u8;
     let res_1 = (val >> 16) as u8;
     let res_2 = (val >> 8) as u8;
     let res_3 = val as u8; 
-    [res_0, res_1, res_2, res_3]
+    vec![res_0, res_1, res_2, res_3]
 }
 
 /// Tests malleability
@@ -119,19 +119,28 @@ fn malleability() {
         .unwrap_err();
 
     const SECP256K1_HALF_ORDER_FLOOR: [u32; 8] = [0x681B20A0, 0xDFE92F46, 0x57A4501D, 0x5D576E73, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x7FFFFFFF];
-    let arr_0 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[0]);
-    let arr_1 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[1]); 
-    let arr_2 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[2]); 
-    let arr_3 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[3]); 
-    let arr_4 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[4]); 
-    let arr_5 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[5]); 
-    let arr_6 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[6]); 
-    let arr_7 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[7]); 
-    let arr_list = [arr_0, arr_1, arr_2, arr_3, arr_4, arr_5, arr_6, arr_7];
-    //let bytes = arr_list.iter().flat_map(|s| s.iter()).collect();
-    let vector = vec!();
-    
+    let mut vec_0 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[0]);
+    let mut vec_1 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[1]); 
+    let mut vec_2 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[2]); 
+    let mut vec_3 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[3]); 
+    let mut vec_4 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[4]); 
+    let mut vec_5 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[5]); 
+    let mut vec_6 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[6]); 
+    let mut vec_7 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[7]); 
+    let mut vector = vec!();
+    vector.append(&mut vec_0);
+    vector.append(&mut vec_1); 
+    vector.append(&mut vec_2);
+    vector.append(&mut vec_3);
+    vector.append(&mut vec_4);
+    vector.append(&mut vec_5);
+    vector.append(&mut vec_6);
+    vector.append(&mut vec_7);
+    let mut dummy_vec: Vec<u8> = vec![0; 32];
+    vector.append(&mut dummy_vec);
 
+    //let sig: Signature = vector[..].try_from().unwrap();
+    let sig = ECDSASignature::try_from(&vector[..]);
 }
 
 /// Test deserialization_failures

--- a/crates/aptos-crypto/src/unit_tests/secp256k1_ecdsa_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/secp256k1_ecdsa_test.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    secp256k1_ecdsa::{self, PrivateKey, PublicKey, Signature as ECDSASignature},
-    test_utils::KeyPair,
-    Signature, SigningKey, Uniform,
+    secp256k1_ecdsa::{self, PrivateKey, PublicKey, Signature as ECDSASignature}, test_utils::KeyPair, CryptoMaterialError, Signature, SigningKey, Uniform
 };
 use rand_core::OsRng;
 use anyhow::anyhow;
@@ -151,8 +149,13 @@ fn malleability() {
         Ok(_v) => panic!(),
         Err(v) => v, //assert_eq!(v.downcast().unwrap(), Err("Unable to verify signature.")),
     };
+    //let downcast_err : Option<String> = err.downcast_ref();
     println!("err: {:?}", err);
-    let downcast_err: Error = (err as anyhow::Error).downcast_ref().unwrap();
+    /*match err.downcast() {
+        CryptoMaterialError(_) => panic!(),
+        _ => panic!(),
+    };*/
+    //let downcast_err: dyn Error = (err as anyhow::Error).downcast::<dyn Error>().unwrap();
     //assert_eq!(res, anyhow!(Err("Unable to verify signature.")));
     assert!(false);
 }

--- a/crates/aptos-crypto/src/unit_tests/secp256k1_ecdsa_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/secp256k1_ecdsa_test.rs
@@ -147,7 +147,7 @@ fn malleability() {
     println!("res: {:?}", res);
     let err = match res {
         Ok(_v) => panic!(),
-        Err(v) => v, //assert_eq!(v.downcast().unwrap(), Err("Unable to verify signature.")),
+        Err(v) => v.to_string(), //assert_eq!(v.downcast().unwrap(), Err("Unable to verify signature.")),
     };
     //let downcast_err : Option<String> = err.downcast_ref();
     println!("err: {:?}", err);
@@ -157,7 +157,8 @@ fn malleability() {
     };*/
     //let downcast_err: dyn Error = (err as anyhow::Error).downcast::<dyn Error>().unwrap();
     //assert_eq!(res, anyhow!(Err("Unable to verify signature.")));
-    assert!(false);
+    //assert!(false);
+    assert_eq!(err, "Unable to verify signature.");
 }
 
 /// Test deserialization_failures

--- a/crates/aptos-crypto/src/unit_tests/secp256k1_ecdsa_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/secp256k1_ecdsa_test.rs
@@ -78,6 +78,14 @@ fn serialization() {
     assert_eq!(key_pair.public_key, public_key_deserialized);
 }
 
+fn from_u32_be(val: u32) -> [u8; 4] {
+    let res_0 = (val >> 24) as u8;
+    let res_1 = (val >> 16) as u8;
+    let res_2 = (val >> 8) as u8;
+    let res_3 = val as u8; 
+    [res_0, res_1, res_2, res_3]
+}
+
 /// Tests malleability
 #[test]
 fn malleability() {
@@ -109,6 +117,21 @@ fn malleability() {
     high_signature
         .verify_arbitrary_msg(message, &key_pair.public_key)
         .unwrap_err();
+
+    const SECP256K1_HALF_ORDER_FLOOR: [u32; 8] = [0x681B20A0, 0xDFE92F46, 0x57A4501D, 0x5D576E73, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0x7FFFFFFF];
+    let arr_0 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[0]);
+    let arr_1 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[1]); 
+    let arr_2 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[2]); 
+    let arr_3 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[3]); 
+    let arr_4 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[4]); 
+    let arr_5 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[5]); 
+    let arr_6 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[6]); 
+    let arr_7 = from_u32_be(SECP256K1_HALF_ORDER_FLOOR[7]); 
+    let arr_list = [arr_0, arr_1, arr_2, arr_3, arr_4, arr_5, arr_6, arr_7];
+    //let bytes = arr_list.iter().flat_map(|s| s.iter()).collect();
+    let vector = vec!();
+    
+
 }
 
 /// Test deserialization_failures

--- a/crates/aptos-crypto/src/unit_tests/secp256k1_ecdsa_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/secp256k1_ecdsa_test.rs
@@ -89,6 +89,7 @@ fn from_u32_be(val: u32) -> Vec<u8> {
 /// Tests malleability
 #[test]
 fn malleability() {
+    println!("running mal test");
     let mut rng = OsRng;
     let message = b"Hello world";
     let key_pair = KeyPair::<PrivateKey, PublicKey>::generate(&mut rng);


### PR DESCRIPTION
## Description

See also [this PR](https://github.com/aptos-labs/aptos-core/pull/13544).

Previously, floor(n/2) where n is the scalar field order for secp256k1 would be incorrectly rejected as an invalid signature point due to our underlying `secp256k1` library that we use. This is incorrect, as preventing malleability while preserving completeness requires that all points less than n/2 be accepted, and floor(n/2) < n/2. This PR patches this issue by special casing the signature equal to floor(n/2) for secp256k1. 

## Type of Change
- [ ] New feature
- [ x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
A test has been modified to confirm that secp256k1 signatures equal to floor(n/2) are not rejected for being malleable. 

## Key Areas to Review
Make sure any significant test cases aren't missing. 

Confirm that the value for floor(n/2) being used is correct. 

## Checklist
- [ x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x ] I tested both happy and unhappy path of the functionality
- [x ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
