### PR TITLE
[aptos-framework] Dispatchable Fungible Asset - Derived Supply addition

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/dispatchable_fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/dispatchable_fungible_asset.md
@@ -28,14 +28,17 @@ See AIP-73 for further discussion
 -  [Function `transfer`](#0x1_dispatchable_fungible_asset_transfer)
 -  [Function `transfer_assert_minimum_deposit`](#0x1_dispatchable_fungible_asset_transfer_assert_minimum_deposit)
 -  [Function `derived_balance`](#0x1_dispatchable_fungible_asset_derived_balance)
+-  [Function `derived_supply`](#0x1_dispatchable_fungible_asset_derived_supply)
 -  [Function `borrow_transfer_ref`](#0x1_dispatchable_fungible_asset_borrow_transfer_ref)
 -  [Function `dispatchable_withdraw`](#0x1_dispatchable_fungible_asset_dispatchable_withdraw)
 -  [Function `dispatchable_deposit`](#0x1_dispatchable_fungible_asset_dispatchable_deposit)
 -  [Function `dispatchable_derived_balance`](#0x1_dispatchable_fungible_asset_dispatchable_derived_balance)
+-  [Function `dispatchable_derived_supply`](#0x1_dispatchable_fungible_asset_dispatchable_derived_supply)
 -  [Specification](#@Specification_1)
     -  [Function `dispatchable_withdraw`](#@Specification_1_dispatchable_withdraw)
     -  [Function `dispatchable_deposit`](#@Specification_1_dispatchable_deposit)
     -  [Function `dispatchable_derived_balance`](#@Specification_1_dispatchable_derived_balance)
+    -  [Function `dispatchable_derived_supply`](#@Specification_1_dispatchable_derived_supply)
 
 
 <pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
@@ -127,7 +130,7 @@ TransferRefStore doesn't exist on the fungible asset type.
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_register_dispatch_functions">register_dispatch_functions</a>(constructor_ref: &<a href="object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>, withdraw_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;, deposit_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;, derived_balance_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;)
+<pre><code><b>public</b> <b>fun</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_register_dispatch_functions">register_dispatch_functions</a>(constructor_ref: &<a href="object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>, withdraw_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;, deposit_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;, derived_balance_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;, derived_supply_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;)
 </code></pre>
 
 
@@ -141,12 +144,14 @@ TransferRefStore doesn't exist on the fungible asset type.
     withdraw_function: Option&lt;FunctionInfo&gt;,
     deposit_function: Option&lt;FunctionInfo&gt;,
     derived_balance_function: Option&lt;FunctionInfo&gt;,
+    derived_supply_function: Option&lt;FunctionInfo&gt;
 ) {
     <a href="fungible_asset.md#0x1_fungible_asset_register_dispatch_functions">fungible_asset::register_dispatch_functions</a>(
         constructor_ref,
         withdraw_function,
         deposit_function,
         derived_balance_function,
+        derived_supply_function
     );
     <b>let</b> store_obj = &<a href="object.md#0x1_object_generate_signer">object::generate_signer</a>(constructor_ref);
     <b>move_to</b>&lt;<a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_TransferRefStore">TransferRefStore</a>&gt;(
@@ -366,6 +371,45 @@ The semantics of value will be governed by the function specified in DispatchFun
 
 </details>
 
+<a id="0x1_dispatchable_fungible_asset_derived_supply"></a>
+
+## Function `derived_supply`
+
+Get the derived supply of the fungible asset using the overloaded hook.
+
+The semantics of supply will be governed by the function specified in DispatchFunctionStore.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_derived_supply">derived_supply</a>&lt;T: key&gt;(metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u128&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_derived_supply">derived_supply</a>&lt;T: key&gt;(metadata: Object&lt;T&gt;): Option&lt;u128&gt; {
+    <b>let</b> func_opt = <a href="fungible_asset.md#0x1_fungible_asset_derived_supply_dispatch_function">fungible_asset::derived_supply_dispatch_function</a>(metadata);
+    <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&func_opt)) {
+        <b>assert</b>!(
+            <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_dispatchable_fungible_asset_enabled">features::dispatchable_fungible_asset_enabled</a>(),
+            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_aborted">error::aborted</a>(<a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_ENOT_ACTIVATED">ENOT_ACTIVATED</a>)
+        );
+        <b>let</b> func = <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&func_opt);
+        <a href="function_info.md#0x1_function_info_load_module_from_function">function_info::load_module_from_function</a>(func);
+        <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_dispatchable_derived_supply">dispatchable_derived_supply</a>(metadata, func)
+    } <b>else</b> {
+        <a href="fungible_asset.md#0x1_fungible_asset_supply">fungible_asset::supply</a>(metadata)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_dispatchable_fungible_asset_borrow_transfer_ref"></a>
 
 ## Function `borrow_transfer_ref`
@@ -476,6 +520,31 @@ The semantics of value will be governed by the function specified in DispatchFun
 
 </details>
 
+<a id="0x1_dispatchable_fungible_asset_dispatchable_derived_supply"></a>
+
+## Function `dispatchable_derived_supply`
+
+
+
+<pre><code><b>fun</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_dispatchable_derived_supply">dispatchable_derived_supply</a>&lt;T: key&gt;(store: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;, function: &<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u128&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_dispatchable_derived_supply">dispatchable_derived_supply</a>&lt;T: key&gt;(
+    store: Object&lt;T&gt;,
+    function: &FunctionInfo,
+): Option&lt;u128&gt;;
+</code></pre>
+
+
+
+</details>
+
 <a id="@Specification_1"></a>
 
 ## Specification
@@ -525,6 +594,22 @@ The semantics of value will be governed by the function specified in DispatchFun
 
 
 <pre><code><b>fun</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_dispatchable_derived_balance">dispatchable_derived_balance</a>&lt;T: key&gt;(store: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;, function: &<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>): u64
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+<a id="@Specification_1_dispatchable_derived_supply"></a>
+
+### Function `dispatchable_derived_supply`
+
+
+<pre><code><b>fun</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_dispatchable_derived_supply">dispatchable_derived_supply</a>&lt;T: key&gt;(store: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;, function: &<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u128&gt;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/fungible_asset.md
@@ -59,6 +59,7 @@ metadata object can be any object that equipped with <code><a href="fungible_ass
 -  [Function `withdraw_dispatch_function`](#0x1_fungible_asset_withdraw_dispatch_function)
 -  [Function `has_withdraw_dispatch_function`](#0x1_fungible_asset_has_withdraw_dispatch_function)
 -  [Function `derived_balance_dispatch_function`](#0x1_fungible_asset_derived_balance_dispatch_function)
+-  [Function `derived_supply_dispatch_function`](#0x1_fungible_asset_derived_supply_dispatch_function)
 -  [Function `asset_metadata`](#0x1_fungible_asset_asset_metadata)
 -  [Function `mint_ref_metadata`](#0x1_fungible_asset_mint_ref_metadata)
 -  [Function `transfer_ref_metadata`](#0x1_fungible_asset_transfer_ref_metadata)
@@ -336,6 +337,12 @@ The store object that holds fungible assets of a specific type associated with a
 </dd>
 <dt>
 <code>derived_balance_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>derived_supply_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;</code>
 </dt>
 <dd>
 
@@ -744,7 +751,7 @@ Maximum possible coin supply.
 Trying to re-register dispatch hook on a fungible asset.
 
 
-<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_EALREADY_REGISTERED">EALREADY_REGISTERED</a>: u64 = 29;
+<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_EALREADY_REGISTERED">EALREADY_REGISTERED</a>: u64 = 30;
 </code></pre>
 
 
@@ -774,7 +781,7 @@ Cannot destroy non-empty fungible assets.
 Cannot register dispatch hook for APT.
 
 
-<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_EAPT_NOT_DISPATCHABLE">EAPT_NOT_DISPATCHABLE</a>: u64 = 31;
+<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_EAPT_NOT_DISPATCHABLE">EAPT_NOT_DISPATCHABLE</a>: u64 = 32;
 </code></pre>
 
 
@@ -814,7 +821,7 @@ Burn ref and store do not match.
 Flag for Concurrent Supply not enabled
 
 
-<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_ECONCURRENT_BALANCE_NOT_ENABLED">ECONCURRENT_BALANCE_NOT_ENABLED</a>: u64 = 32;
+<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_ECONCURRENT_BALANCE_NOT_ENABLED">ECONCURRENT_BALANCE_NOT_ENABLED</a>: u64 = 33;
 </code></pre>
 
 
@@ -859,6 +866,16 @@ Provided derived_balance function type doesn't meet the signature requirement.
 
 
 
+<a id="0x1_fungible_asset_EDERIVED_SUPPLY_FUNCTION_SIGNATURE_MISMATCH"></a>
+
+Provided derived_supply function type doesn't meet the signature requirement.
+
+
+<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_EDERIVED_SUPPLY_FUNCTION_SIGNATURE_MISMATCH">EDERIVED_SUPPLY_FUNCTION_SIGNATURE_MISMATCH</a>: u64 = 28;
+</code></pre>
+
+
+
 <a id="0x1_fungible_asset_EFUNGIBLE_ASSET_AND_STORE_MISMATCH"></a>
 
 Fungible asset and store do not match.
@@ -884,7 +901,7 @@ Fungible asset do not match when merging.
 Fungible metadata does not exist on this account.
 
 
-<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_EFUNGIBLE_METADATA_EXISTENCE">EFUNGIBLE_METADATA_EXISTENCE</a>: u64 = 30;
+<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_EFUNGIBLE_METADATA_EXISTENCE">EFUNGIBLE_METADATA_EXISTENCE</a>: u64 = 31;
 </code></pre>
 
 
@@ -915,7 +932,7 @@ Invalid withdraw/deposit on dispatchable token. The specified token has a dispat
 Need to invoke dispatchable_fungible_asset::withdraw/deposit to perform transfer.
 
 
-<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_EINVALID_DISPATCHABLE_OPERATIONS">EINVALID_DISPATCHABLE_OPERATIONS</a>: u64 = 28;
+<pre><code><b>const</b> <a href="fungible_asset.md#0x1_fungible_asset_EINVALID_DISPATCHABLE_OPERATIONS">EINVALID_DISPATCHABLE_OPERATIONS</a>: u64 = 29;
 </code></pre>
 
 
@@ -1301,7 +1318,7 @@ Returns true if the FA is untransferable.
 Create a fungible asset store whose transfer rule would be overloaded by the provided function.
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_register_dispatch_functions">register_dispatch_functions</a>(constructor_ref: &<a href="object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>, withdraw_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;, deposit_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;, derived_balance_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;)
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_register_dispatch_functions">register_dispatch_functions</a>(constructor_ref: &<a href="object.md#0x1_object_ConstructorRef">object::ConstructorRef</a>, withdraw_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;, deposit_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;, derived_balance_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;, derived_supply_function: <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;)
 </code></pre>
 
 
@@ -1315,6 +1332,7 @@ Create a fungible asset store whose transfer rule would be overloaded by the pro
     withdraw_function: Option&lt;FunctionInfo&gt;,
     deposit_function: Option&lt;FunctionInfo&gt;,
     derived_balance_function: Option&lt;FunctionInfo&gt;,
+    derived_supply_function: Option&lt;FunctionInfo&gt;
 ) {
     // Verify that caller type matches callee type so wrongly typed function cannot be registered.
     <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_for_each_ref">option::for_each_ref</a>(&withdraw_function, |withdraw_function| {
@@ -1371,6 +1389,24 @@ Create a fungible asset store whose transfer rule would be overloaded by the pro
         );
     });
 
+    <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_for_each_ref">option::for_each_ref</a>(&derived_supply_function, |supply_function| {
+        <b>let</b> dispatcher_derived_supply_function_info = <a href="function_info.md#0x1_function_info_new_function_info_from_address">function_info::new_function_info_from_address</a>(
+            @aptos_framework,
+            <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(b"<a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset">dispatchable_fungible_asset</a>"),
+            <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(b"dispatchable_derived_supply"),
+        );
+        // Verify that caller type matches callee type so wrongly typed function cannot be registered.
+        <b>assert</b>!(
+            <a href="function_info.md#0x1_function_info_check_dispatch_type_compatibility">function_info::check_dispatch_type_compatibility</a>(
+                &dispatcher_derived_supply_function_info,
+                supply_function
+            ),
+            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(
+                <a href="fungible_asset.md#0x1_fungible_asset_EDERIVED_SUPPLY_FUNCTION_SIGNATURE_MISMATCH">EDERIVED_SUPPLY_FUNCTION_SIGNATURE_MISMATCH</a>
+            )
+        );
+    });
+
     // Cannot register hook for APT.
     <b>assert</b>!(
         <a href="object.md#0x1_object_address_from_constructor_ref">object::address_from_constructor_ref</a>(constructor_ref) != @aptos_fungible_asset,
@@ -1402,6 +1438,7 @@ Create a fungible asset store whose transfer rule would be overloaded by the pro
             withdraw_function,
             deposit_function,
             derived_balance_function,
+            derived_supply_function
         }
     );
 }
@@ -2148,6 +2185,35 @@ Return whether a fungible asset type is dispatchable.
     <b>let</b> metadata_addr = <a href="object.md#0x1_object_object_address">object::object_address</a>(&fa_store.metadata);
     <b>if</b> (<b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a>&gt;(metadata_addr)) {
         <b>borrow_global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a>&gt;(metadata_addr).derived_balance_function
+    } <b>else</b> {
+        <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_fungible_asset_derived_supply_dispatch_function"></a>
+
+## Function `derived_supply_dispatch_function`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_derived_supply_dispatch_function">derived_supply_dispatch_function</a>&lt;T: key&gt;(metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_derived_supply_dispatch_function">derived_supply_dispatch_function</a>&lt;T: key&gt;(metadata: Object&lt;T&gt;): Option&lt;FunctionInfo&gt; <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a> {
+    <b>let</b> metadata_addr = <a href="object.md#0x1_object_object_address">object::object_address</a>(&metadata);
+    <b>if</b> (<b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a>&gt;(metadata_addr)) {
+        <b>borrow_global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a>&gt;(metadata_addr).derived_supply_function
     } <b>else</b> {
         <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
     }

--- a/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.move
@@ -42,12 +42,14 @@ module aptos_framework::dispatchable_fungible_asset {
         withdraw_function: Option<FunctionInfo>,
         deposit_function: Option<FunctionInfo>,
         derived_balance_function: Option<FunctionInfo>,
+        derived_supply_function: Option<FunctionInfo>
     ) {
         fungible_asset::register_dispatch_functions(
             constructor_ref,
             withdraw_function,
             deposit_function,
             derived_balance_function,
+            derived_supply_function
         );
         let store_obj = &object::generate_signer(constructor_ref);
         move_to<TransferRefStore>(
@@ -162,6 +164,25 @@ module aptos_framework::dispatchable_fungible_asset {
         }
     }
 
+    #[view]
+    /// Get the derived supply of the fungible asset using the overloaded hook.
+    ///
+    /// The semantics of supply will be governed by the function specified in DispatchFunctionStore.
+    public fun derived_supply<T: key>(metadata: Object<T>): Option<u128> {
+        let func_opt = fungible_asset::derived_supply_dispatch_function(metadata);
+        if (option::is_some(&func_opt)) {
+            assert!(
+                features::dispatchable_fungible_asset_enabled(),
+                error::aborted(ENOT_ACTIVATED)
+            );
+            let func = option::borrow(&func_opt);
+            function_info::load_module_from_function(func);
+            dispatchable_derived_supply(metadata, func)
+        } else {
+            fungible_asset::supply(metadata)
+        }
+    }
+
     inline fun borrow_transfer_ref<T: key>(metadata: Object<T>): &TransferRef acquires TransferRefStore {
         let metadata_addr = object::object_address(
             &fungible_asset::store_metadata(metadata)
@@ -191,4 +212,9 @@ module aptos_framework::dispatchable_fungible_asset {
         store: Object<T>,
         function: &FunctionInfo,
     ): u64;
+
+    native fun dispatchable_derived_supply<T: key>(
+        store: Object<T>,
+        function: &FunctionInfo,
+    ): Option<u128>;
 }

--- a/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.spec.move
@@ -14,4 +14,8 @@ spec aptos_framework::dispatchable_fungible_asset {
     spec dispatchable_derived_balance{
         pragma opaque;
     }
+
+    spec dispatchable_derived_supply{
+        pragma opaque;
+    }
 }

--- a/aptos-move/framework/aptos-framework/tests/deflation_token.move
+++ b/aptos-move/framework/aptos-framework/tests/deflation_token.move
@@ -30,6 +30,7 @@ module 0xcafe::deflation_token {
             option::some(withdraw),
             option::none(),
             option::none(),
+            option::none()
         );
     }
 

--- a/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
@@ -82,7 +82,7 @@ module 0xcafe::deflation_token_tests {
     }
 
     #[test(creator = @0xcafe)]
-    #[expected_failure(abort_code = 0x1001C, location = aptos_framework::fungible_asset)]
+    #[expected_failure(abort_code = 0x1001D, location = aptos_framework::fungible_asset)]
     fun test_deflation_fa_deposit(
         creator: &signer,
     ) {
@@ -106,7 +106,7 @@ module 0xcafe::deflation_token_tests {
     }
 
     #[test(creator = @0xcafe, aaron = @0xface)]
-    #[expected_failure(abort_code = 0x1001C, location = aptos_framework::fungible_asset)]
+    #[expected_failure(abort_code = 0x1001D, location = aptos_framework::fungible_asset)]
     fun test_deflation_fa_withdraw(
         creator: &signer,
         aaron: &signer,
@@ -133,7 +133,7 @@ module 0xcafe::deflation_token_tests {
     }
 
     #[test(creator = @0xcafe, aaron = @0xface)]
-    #[expected_failure(abort_code = 0x8001D, location = aptos_framework::fungible_asset)]
+    #[expected_failure(abort_code = 0x8001E, location = aptos_framework::fungible_asset)]
     fun test_double_init(
         creator: &signer,
     ) {
@@ -292,7 +292,7 @@ module 0xcafe::deflation_token_tests {
     }
 
     #[test(creator = @0xcafe)]
-    #[expected_failure(abort_code=0x6001E, location = aptos_framework::fungible_asset)]
+    #[expected_failure(abort_code=0x6001F, location = aptos_framework::fungible_asset)]
     fun test_register_on_non_metadata_object(
         creator: &signer,
     ) {

--- a/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
@@ -153,6 +153,7 @@ module 0xcafe::deflation_token_tests {
             option::some(withdraw),
             option::none(),
             option::none(),
+            option::none()
         );
     }
 
@@ -173,6 +174,7 @@ module 0xcafe::deflation_token_tests {
         dispatchable_fungible_asset::register_dispatch_functions(
             &creator_ref,
             option::some(withdraw),
+            option::none(),
             option::none(),
             option::none()
         );
@@ -196,6 +198,7 @@ module 0xcafe::deflation_token_tests {
             &creator_ref,
             option::some(withdraw),
             option::some(withdraw),
+            option::none(),
             option::none()
         );
     }
@@ -219,6 +222,7 @@ module 0xcafe::deflation_token_tests {
             option::some(withdraw),
             option::none(),
             option::some(withdraw),
+            option::none()
         );
     }
 
@@ -242,6 +246,7 @@ module 0xcafe::deflation_token_tests {
             option::some(withdraw),
             option::none(),
             option::none(),
+            option::none()
         );
     }
 
@@ -264,6 +269,7 @@ module 0xcafe::deflation_token_tests {
             option::some(withdraw),
             option::none(),
             option::none(),
+            option::none()
         );
     }
 
@@ -304,6 +310,7 @@ module 0xcafe::deflation_token_tests {
             option::some(withdraw),
             option::none(),
             option::none(),
+            option::none()
         );
     }
 

--- a/aptos-move/framework/aptos-framework/tests/nil_op_token.move
+++ b/aptos-move/framework/aptos-framework/tests/nil_op_token.move
@@ -21,6 +21,7 @@ module 0xcafe::nil_op_token {
             constructor_ref,
             option::some(withdraw),
             option::none(),
+            option::none(),
             option::none()
         );
     }

--- a/aptos-move/framework/aptos-framework/tests/permissioned_token.move
+++ b/aptos-move/framework/aptos-framework/tests/permissioned_token.move
@@ -31,6 +31,7 @@ module 0xcafe::permissioned_token {
             constructor_ref,
             option::some(withdraw),
             option::none(),
+            option::none(),
             option::none()
         );
     }

--- a/aptos-move/framework/aptos-framework/tests/reentrant_token.move
+++ b/aptos-move/framework/aptos-framework/tests/reentrant_token.move
@@ -21,6 +21,7 @@ module 0xcafe::reentrant_token {
             constructor_ref,
             option::none(),
             option::some(deposit),
+            option::none(),
             option::none()
         );
     }

--- a/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token.move
+++ b/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token.move
@@ -29,6 +29,7 @@ module 0xcafe::simple_token {
             option::some(withdraw),
             option::some(deposit),
             option::none(),
+            option::none()
         );
     }
 

--- a/aptos-move/framework/aptos-framework/tests/ten_x_token.move
+++ b/aptos-move/framework/aptos-framework/tests/ten_x_token.move
@@ -6,26 +6,41 @@ module 0xcafe::ten_x_token {
     use aptos_framework::function_info;
 
     use std::option;
+    use std::option::Option;
     use std::signer;
     use std::string;
 
     public fun initialize(account: &signer, constructor_ref: &ConstructorRef) {
         assert!(signer::address_of(account) == @0xcafe, 1);
-        let value = function_info::new_function_info(
+        let balance_value = function_info::new_function_info(
             account,
             string::utf8(b"ten_x_token"),
             string::utf8(b"derived_balance"),
+        );
+        let supply_value = function_info::new_function_info(
+            account,
+            string::utf8(b"ten_x_token"),
+            string::utf8(b"derived_supply"),
         );
         dispatchable_fungible_asset::register_dispatch_functions(
             constructor_ref,
             option::none(),
             option::none(),
-            option::some(value)
+            option::some(balance_value),
+            option::some(supply_value)
         );
     }
 
     public fun derived_balance<T: key>(store: Object<T>): u64 {
         // Derived value is always 10x!
         fungible_asset::balance(store) * 10
+    }
+
+    public fun derived_supply<T: key>(metadata: Object<T>): Option<u128> {
+        // Derived supply is 10x.
+        if(option::is_some(&fungible_asset::supply(metadata))) {
+            return option::some(option::extract(&mut fungible_asset::supply(metadata)) * 10)
+        };
+        option::none()
     }
 }

--- a/aptos-move/framework/aptos-framework/tests/ten_x_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/ten_x_token_tests.move
@@ -19,13 +19,17 @@ module aptos_framework::ten_x_token_tests {
         ten_x_token::initialize(creator, &creator_ref);
 
         assert!(fungible_asset::supply(metadata) == option::some(0), 1);
+        assert!(dispatchable_fungible_asset::derived_supply(metadata) == option::some(0), 2);
         // Mint
         let fa = fungible_asset::mint(&mint, 100);
-        assert!(fungible_asset::supply(metadata) == option::some(100), 2);
+        assert!(fungible_asset::supply(metadata) == option::some(100), 3);
         // Deposit will cause an re-entrant call into dispatchable_fungible_asset
         dispatchable_fungible_asset::deposit(creator_store, fa);
 
         // The derived value is 10x
-        assert!(dispatchable_fungible_asset::derived_balance(creator_store) == 1000, 5);
+        assert!(dispatchable_fungible_asset::derived_balance(creator_store) == 1000, 4);
+
+        // The derived supply is 10x
+        assert!(dispatchable_fungible_asset::derived_supply(metadata) == option::some(1000), 5);
     }
 }

--- a/aptos-move/framework/src/natives/dispatchable_fungible_asset.rs
+++ b/aptos-move/framework/src/natives/dispatchable_fungible_asset.rs
@@ -11,7 +11,7 @@ use smallvec::SmallVec;
 use std::collections::VecDeque;
 
 /***************************************************************************************************
- * native fun dispatchable_withdraw / dispatchable_deposit / dispatchable_derived_balance
+ * native fun dispatchable_withdraw / dispatchable_deposit / dispatchable_derived_balance / dispatchable_derived_supply
  *
  *   Directs control flow based on the last argument. We use the same native function implementation
  *   for all dispatching native.
@@ -54,6 +54,7 @@ pub fn make_all(
         ("dispatchable_withdraw", native_dispatch as RawSafeNative),
         ("dispatchable_deposit", native_dispatch),
         ("dispatchable_derived_balance", native_dispatch),
+        ("dispatchable_derived_supply", native_dispatch)
     ];
 
     builder.make_named_natives(natives)


### PR DESCRIPTION
## Overview
Derived Supply overload added to dispatchable fungible assets. 
*similar to `derived_balance`*

Intended for easier DevX when integrating with fungible assets that support custom supply overloading. Rather than requiring an additional dependency to the fungible asset's user-made smart contract, integration efforts only need to rely on `dispatchable_fungible_asset`'s explicit `derived_supply` functionality.

## Updates 
Primary Updates:
* Fungible Asset
  * Updated Errors to include Supply-related features.
  * `register_dispatch_functions` includes supply override support.
* Dispatchable Fungible Asset
  * `derived_supply` created to retrieve supply (either through function or default fungible asset supply), and re-package into expected Option-wrapped u128 value.
  * Native function defined for derived supply, with associated spec. Included in pre-existing `make_all` of related `.rs` file.

Secondary Updates:
* `ten_x_token.move` updated to include tests for `derived_supply`.
* `deflation_token.move` and tests updated to include new parameter for `register_dispatch_functions`.
  * `simple_dispatchable_token.move`, `reentrant_token.move`, `permissioned_token.move`, and `nil_op_token.move` have same additions as above.


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Added testing in `ten_x_token` files for derived supply.

## Key Areas to Review
Additional sections that may need updates that weren't shown in tests, like:
* Cargo tests (gas, e2e)
* Indexer support

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
