### PR TITLE
[aptos-vm] Remove charging gas for module bundle from loader

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -856,6 +856,7 @@ impl AptosVM {
 
         let user_session_change_set = self.resolve_pending_code_publish_and_finish_user_session(
             session,
+            resolver,
             gas_meter,
             traversal_context,
             new_published_modules_loaded,
@@ -1241,6 +1242,7 @@ impl AptosVM {
         // modules.
         self.resolve_pending_code_publish_and_finish_user_session(
             session,
+            resolver,
             gas_meter,
             traversal_context,
             new_published_modules_loaded,
@@ -1359,6 +1361,7 @@ impl AptosVM {
     fn resolve_pending_code_publish_and_finish_user_session(
         &self,
         mut session: UserSession<'_, '_>,
+        resolver: &impl AptosMoveResolver,
         gas_meter: &mut impl AptosGasMeter,
         traversal_context: &mut TraversalContext,
         new_published_modules_loaded: &mut bool,
@@ -1374,10 +1377,6 @@ impl AptosVM {
                     check_compat: _,
                 } = publish_request;
 
-                // TODO: unfortunately we need to deserialize the entire bundle here to handle
-                // `init_module` and verify some deployment conditions, while the VM need to do
-                // the deserialization again. Consider adding an API to MoveVM which allows to
-                // directly pass CompiledModule.
                 let modules = self.deserialize_module_bundle(&bundle)?;
                 let modules: &Vec<CompiledModule> =
                     traversal_context.referenced_module_bundles.alloc(modules);
@@ -1386,14 +1385,31 @@ impl AptosVM {
                 //       result in shallow-loading of the modules and therefore subtle changes in
                 //       the error semantics.
                 if self.gas_feature_version >= 15 {
-                    // Charge old versions of the modules, in case of upgrades.
-                    session.check_dependencies_and_charge_gas_non_recursive_optional(
-                        gas_meter,
-                        traversal_context,
-                        modules
-                            .iter()
-                            .map(|module| (module.self_addr(), module.self_name())),
-                    )?;
+                    // Charge old versions of existing modules, in case of upgrades.
+                    for module in modules.iter() {
+                        let addr = module.self_addr();
+                        let name = module.self_name();
+                        let state_key = StateKey::module(addr, name);
+
+                        if let Some(size) = resolver
+                            .as_executor_view()
+                            .get_module_state_value_size(&state_key)
+                            .map_err(|e| e.finish(Location::Undefined))?
+                        {
+                            if !addr.is_special()
+                                && traversal_context.visited.insert((addr, name), ()).is_none()
+                            {
+                                gas_meter
+                                    .charge_dependency(false, addr, name, NumBytes::new(size))
+                                    .map_err(|err| {
+                                        err.finish(Location::Module(ModuleId::new(
+                                            *addr,
+                                            name.to_owned(),
+                                        )))
+                                    })?;
+                            }
+                        }
+                    }
 
                     // Charge all modules in the bundle that is about to be published.
                     for (module, blob) in modules.iter().zip(bundle.iter()) {

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -57,7 +57,7 @@ use aptos_types::{
         OnChainConfig, TimedFeatureFlag, TimedFeatures,
     },
     randomness::Randomness,
-    state_store::{StateView, TStateView},
+    state_store::{state_key::StateKey, StateView, TStateView},
     transaction::{
         authenticator::AnySignature, signature_verified_transaction::SignatureVerifiedTransaction,
         BlockOutput, EntryFunction, ExecutionError, ExecutionStatus, ModuleBundle, Multisig,

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -471,27 +471,6 @@ impl<'r, 'l> Session<'r, 'l> {
             )
     }
 
-    pub fn check_dependencies_and_charge_gas_non_recursive_optional<'a, I>(
-        &mut self,
-        gas_meter: &mut impl GasMeter,
-        traversal_context: &mut TraversalContext<'a>,
-        ids: I,
-    ) -> VMResult<()>
-    where
-        I: IntoIterator<Item = (&'a AccountAddress, &'a IdentStr)>,
-    {
-        self.move_vm
-            .runtime
-            .loader()
-            .check_dependencies_and_charge_gas_non_recursive_optional(
-                &self.module_store,
-                &mut self.data_cache,
-                gas_meter,
-                &mut traversal_context.visited,
-                ids,
-            )
-    }
-
     pub fn check_script_dependencies_and_check_gas(
         &mut self,
         gas_meter: &mut impl GasMeter,


### PR DESCRIPTION
## Description

Previously, we used `check_dependencies_and_charge_gas_non_recursive_optional` which lived inside loader/MoveVM. This is not great for the new code cache because:
1. Newly published modules (not yet verified!) were deserialized and cached inside the session (transaction data cache), which is clearly not the place for it.
2. The main goal was to charge for existent modules, but this was done via `allow_loading_to_fail` flags, and was not really needed: AptosVM has full information about which modules exist and which do not.

In this PR, `check_dependencies_and_charge_gas_non_recursive_optional` is removed, and the gas charging is moved to AptosVM. There is no caching of deserialization because we can fetch size from the state view directly. This also aligns with new code cache design where instead of going to "loader", we can fetch size of modules in bytes directly.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
