### PR TITLE
[Consensus Observer] Small refactors and basic commit verification.

### DIFF
--- a/consensus/src/consensus_observer/error.rs
+++ b/consensus/src/consensus_observer/error.rs
@@ -6,6 +6,9 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("Invalid message error: {0}")]
+    InvalidMessageError(String),
+
     #[error("Network error: {0}")]
     NetworkError(String),
 
@@ -32,6 +35,7 @@ impl Error {
     /// Returns a summary label for the error
     pub fn get_label(&self) -> &'static str {
         match self {
+            Self::InvalidMessageError(_) => "invalid_message_error",
             Self::NetworkError(_) => "network_error",
             Self::RpcError(_) => "rpc_error",
             Self::SubscriptionDisconnected(_) => "subscription_disconnected",

--- a/consensus/src/consensus_observer/mod.rs
+++ b/consensus/src/consensus_observer/mod.rs
@@ -8,5 +8,6 @@ pub mod network_client;
 pub mod network_events;
 pub mod network_message;
 pub mod observer;
+pub mod payload_store;
 pub mod publisher;
 mod subscription;

--- a/consensus/src/consensus_observer/mod.rs
+++ b/consensus/src/consensus_observer/mod.rs
@@ -9,5 +9,6 @@ pub mod network_events;
 pub mod network_message;
 pub mod observer;
 pub mod payload_store;
+pub mod pending_blocks;
 pub mod publisher;
 mod subscription;

--- a/consensus/src/consensus_observer/observer.rs
+++ b/consensus/src/consensus_observer/observer.rs
@@ -13,6 +13,7 @@ use crate::{
             ConsensusObserverRequest, ConsensusObserverResponse, OrderedBlock,
         },
         payload_store::BlockPayloadStore,
+        pending_blocks::PendingOrderedBlocks,
         publisher::ConsensusPublisher,
         subscription,
         subscription::ConsensusObserverSubscription,
@@ -56,11 +57,7 @@ use futures::{
 };
 use futures_channel::oneshot;
 use move_core_types::account_address::AccountAddress;
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
-    time::Duration,
-};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::{sync::mpsc::UnboundedSender, time::interval};
 use tokio_stream::wrappers::IntervalStream;
 
@@ -79,8 +76,8 @@ pub struct ConsensusObserver {
 
     // The payload store holds block transaction payloads
     block_payload_store: BlockPayloadStore,
-    // The pending execute/commit blocks (also buffers when in sync mode)
-    pending_blocks: Arc<Mutex<BTreeMap<Round, (OrderedBlock, Option<CommitDecision>)>>>,
+    // The pending ordered blocks (these are also buffered when in state sync mode)
+    pending_ordered_blocks: PendingOrderedBlocks,
     // The execution client to the buffer manager
     execution_client: Arc<dyn TExecutionClient>,
 
@@ -124,7 +121,7 @@ impl ConsensusObserver {
             consensus_observer_client,
             epoch: root.commit_info().epoch(),
             root: Arc::new(Mutex::new(root)),
-            pending_blocks: Arc::new(Mutex::new(BTreeMap::new())),
+            pending_ordered_blocks: PendingOrderedBlocks::new(),
             execution_client,
             block_payload_store: BlockPayloadStore::new(),
             sync_handle: None,
@@ -227,7 +224,7 @@ impl ConsensusObserver {
     fn create_commit_callback(&self) -> StateComputerCommitCallBackType {
         // Clone the root, pending blocks and payload store
         let root = self.root.clone();
-        let pending_blocks = self.pending_blocks.clone();
+        let pending_ordered_blocks = self.pending_ordered_blocks.clone();
         let block_payload_store = self.block_payload_store.clone();
 
         // Create the commit callback
@@ -236,7 +233,7 @@ impl ConsensusObserver {
             block_payload_store.remove_blocks(blocks);
 
             // Remove the committed blocks from the pending blocks
-            remove_pending_blocks(pending_blocks, &ledger_info);
+            pending_ordered_blocks.remove_blocks_for_commit(&ledger_info);
 
             // Verify the ledger info is for the same epoch
             let mut root = root.lock();
@@ -403,9 +400,8 @@ impl ConsensusObserver {
 
     /// Returns the last known block
     fn get_last_block(&self) -> BlockInfo {
-        if let Some((_, (last_blocks, _))) = self.pending_blocks.lock().last_key_value() {
-            // Return the last block in the pending blocks
-            last_blocks.blocks.last().unwrap().block_info()
+        if let Some(last_pending_block) = self.pending_ordered_blocks.get_last_pending_block() {
+            last_pending_block
         } else {
             // Return the root ledger info
             self.root.lock().commit_info().clone()
@@ -449,6 +445,8 @@ impl ConsensusObserver {
 
     /// Processes the commit decision
     fn process_commit_decision(&mut self, commit_decision: CommitDecision) {
+        // TODO: verify the commit decision!
+
         // Update the pending blocks with the commit decision
         if self.process_commit_decision_for_pending_block(&commit_decision) {
             return; // The commit decision was successfully processed
@@ -469,7 +467,7 @@ impl ConsensusObserver {
 
             // Update the root and clear the pending blocks
             *self.root.lock() = commit_decision.ledger_info().clone();
-            self.pending_blocks.lock().clear();
+            self.pending_ordered_blocks.clear_all_pending_blocks();
 
             // Start the state sync process
             let abort_handle = sync_to_commit_decision(
@@ -486,24 +484,23 @@ impl ConsensusObserver {
     /// Processes the commit decision for the pending block and returns iff
     /// the commit decision was successfully processed.
     fn process_commit_decision_for_pending_block(&self, commit_decision: &CommitDecision) -> bool {
-        let mut pending_blocks = self.pending_blocks.lock();
-        if let Some((ordered_blocks, pending_commit_decision)) =
-            pending_blocks.get_mut(&commit_decision.round())
-        {
-            // Check if the payloads for the ordered blocks already exist
-            let payload_exists = self
-                .block_payload_store
-                .all_payloads_exist(&ordered_blocks.blocks);
-
+        let pending_block = self
+            .pending_ordered_blocks
+            .get_pending_block(commit_decision.round());
+        if let Some(pending_block) = pending_block {
             // If the payload exists, add the commit decision to the pending blocks
-            if payload_exists {
+            if self
+                .block_payload_store
+                .all_payloads_exist(&pending_block.blocks)
+            {
                 debug!(
                     LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                         "Adding decision to pending block: {}",
                         commit_decision.ledger_info().commit_info()
                     ))
                 );
-                *pending_commit_decision = Some(commit_decision.clone());
+                self.pending_ordered_blocks
+                    .update_commit_decision(commit_decision);
 
                 // If we are not in sync mode, forward the commit decision to the execution pipeline
                 if self.sync_handle.is_none() {
@@ -616,19 +613,13 @@ impl ConsensusObserver {
             return;
         }
 
+        // TODO: verify the ordered block!
+
         // If the block is a child of our last block, we can insert it
         if self.get_last_block().id() == blocks.first().unwrap().parent_id() {
-            debug!(
-                LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                    "Adding ordered block to the pending blocks: {}",
-                    ordered_proof.commit_info()
-                ))
-            );
-
             // Insert the ordered block into the pending blocks
-            self.pending_blocks
-                .lock()
-                .insert(blocks.last().unwrap().round(), (ordered_block, None));
+            self.pending_ordered_blocks
+                .insert_ordered_block(ordered_block);
 
             // If we are not in sync mode, forward the blocks to the execution pipeline
             if self.sync_handle.is_none() {
@@ -713,9 +704,10 @@ impl ConsensusObserver {
         // Reset and drop the sync handle
         self.sync_handle = None;
 
-        // Process the pending blocks
-        let pending_blocks = self.pending_blocks.lock().clone();
-        for (_, (ordered_block, commit_decision)) in pending_blocks.into_iter() {
+        // Process all the pending blocks. These were all buffered during the state sync process.
+        for (_, (ordered_block, commit_decision)) in
+            self.pending_ordered_blocks.get_all_pending_blocks()
+        {
             // Unpack the ordered block
             let OrderedBlock {
                 blocks,
@@ -1098,19 +1090,6 @@ async fn extract_on_chain_configs(
         execution_config,
         onchain_randomness_config,
     )
-}
-
-/// Removes the pending blocks before the given ledger info
-fn remove_pending_blocks(
-    pending_blocks: Arc<Mutex<BTreeMap<Round, (OrderedBlock, Option<CommitDecision>)>>>,
-    ledger_info: &LedgerInfoWithSignatures,
-) {
-    // Determine the round to split off
-    let split_off_round = ledger_info.commit_info().round() + 1;
-
-    // Remove the pending blocks before the split off round
-    let mut pending_blocks = pending_blocks.lock();
-    *pending_blocks = pending_blocks.split_off(&split_off_round);
 }
 
 /// Spawns a task to sync to the given commit decision and notifies

--- a/consensus/src/consensus_observer/observer.rs
+++ b/consensus/src/consensus_observer/observer.rs
@@ -12,6 +12,7 @@ use crate::{
             BlockPayload, ConsensusObserverDirectSend, ConsensusObserverMessage,
             ConsensusObserverRequest, ConsensusObserverResponse, OrderedBlock,
         },
+        payload_store::BlockPayloadStore,
         publisher::ConsensusPublisher,
         subscription,
         subscription::ConsensusObserverSubscription,
@@ -28,7 +29,7 @@ use aptos_config::{config::ConsensusObserverConfig, network_id::PeerNetworkId};
 use aptos_consensus_types::{
     pipeline::commit_decision::CommitDecision, pipelined_block::PipelinedBlock,
 };
-use aptos_crypto::{bls12381, Genesis, HashValue};
+use aptos_crypto::{bls12381, Genesis};
 use aptos_event_notifications::{DbBackedOnChainConfig, ReconfigNotificationListener};
 use aptos_infallible::Mutex;
 use aptos_logger::{debug, error, info, warn};
@@ -47,7 +48,6 @@ use aptos_types::{
         OnChainConsensusConfig, OnChainExecutionConfig, OnChainRandomnessConfig,
         RandomnessConfigMoveStruct, ValidatorSet,
     },
-    transaction::SignedTransaction,
     validator_signer::ValidatorSigner,
 };
 use futures::{
@@ -57,38 +57,12 @@ use futures::{
 use futures_channel::oneshot;
 use move_core_types::account_address::AccountAddress;
 use std::{
-    collections::{hash_map::Entry, BTreeMap, HashMap},
-    mem,
+    collections::{BTreeMap, HashMap},
     sync::Arc,
     time::Duration,
 };
-use tokio::{
-    sync::{mpsc::UnboundedSender, oneshot as tokio_oneshot},
-    time::interval,
-};
+use tokio::{sync::mpsc::UnboundedSender, time::interval};
 use tokio_stream::wrappers::IntervalStream;
-
-/// The transaction payload of each block
-#[derive(Debug, Clone)]
-pub struct BlockTransactionPayload {
-    pub transactions: Vec<SignedTransaction>,
-    pub limit: Option<u64>,
-}
-
-impl BlockTransactionPayload {
-    pub fn new(transactions: Vec<SignedTransaction>, limit: Option<u64>) -> Self {
-        Self {
-            transactions,
-            limit,
-        }
-    }
-}
-
-/// The status of consensus observer data
-pub enum ObserverDataStatus {
-    Requested(tokio_oneshot::Sender<BlockTransactionPayload>),
-    Available(BlockTransactionPayload),
-}
 
 /// The consensus observer receives consensus updates and propagates them to the execution pipeline
 pub struct ConsensusObserver {
@@ -103,12 +77,12 @@ pub struct ConsensusObserver {
     // The latest ledger info (updated via a callback)
     root: Arc<Mutex<LedgerInfoWithSignatures>>,
 
+    // The payload store holds block transaction payloads
+    block_payload_store: BlockPayloadStore,
     // The pending execute/commit blocks (also buffers when in sync mode)
     pending_blocks: Arc<Mutex<BTreeMap<Round, (OrderedBlock, Option<CommitDecision>)>>>,
     // The execution client to the buffer manager
     execution_client: Arc<dyn TExecutionClient>,
-    // The payload store maps block id's to transaction payloads (the same as payload manager returns)
-    payload_store: Arc<Mutex<HashMap<HashValue, ObserverDataStatus>>>,
 
     // If the sync handle is set it indicates that we're in state sync mode
     sync_handle: Option<DropGuard>,
@@ -152,7 +126,7 @@ impl ConsensusObserver {
             root: Arc::new(Mutex::new(root)),
             pending_blocks: Arc::new(Mutex::new(BTreeMap::new())),
             execution_client,
-            payload_store: Arc::new(Mutex::new(HashMap::new())),
+            block_payload_store: BlockPayloadStore::new(),
             sync_handle: None,
             sync_notification_sender,
             reconfig_events,
@@ -254,12 +228,12 @@ impl ConsensusObserver {
         // Clone the root, pending blocks and payload store
         let root = self.root.clone();
         let pending_blocks = self.pending_blocks.clone();
-        let payload_store = self.payload_store.clone();
+        let block_payload_store = self.block_payload_store.clone();
 
         // Create the commit callback
         Box::new(move |blocks, ledger_info: LedgerInfoWithSignatures| {
             // Remove the committed blocks from the payload store
-            remove_payload_blocks(payload_store, blocks);
+            block_payload_store.remove_blocks(blocks);
 
             // Remove the committed blocks from the pending blocks
             remove_pending_blocks(pending_blocks, &ledger_info);
@@ -466,31 +440,11 @@ impl ConsensusObserver {
         let transactions = block_payload.transactions;
         let limit = block_payload.limit;
 
-        // Update the payload store with the transaction payload
-        let transaction_payload = BlockTransactionPayload::new(transactions, limit);
-        match self.payload_store.lock().entry(block.id()) {
-            Entry::Occupied(mut entry) => {
-                // Replace the status with the new block payload
-                let mut status = ObserverDataStatus::Available(transaction_payload.clone());
-                mem::swap(entry.get_mut(), &mut status);
+        // TODO: verify the block payload!
 
-                // If the status was originally requested, send the payload to the listener
-                if let ObserverDataStatus::Requested(payload_sender) = status {
-                    if let Err(error) = payload_sender.send(transaction_payload) {
-                        error!(
-                            LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                                "Failed to send block payload to listener! Error: {:?}",
-                                error
-                            ))
-                        );
-                    }
-                }
-            },
-            Entry::Vacant(entry) => {
-                // Insert the block payload into the payload store
-                entry.insert(ObserverDataStatus::Available(transaction_payload));
-            },
-        }
+        // Update the payload store with the payload
+        self.block_payload_store
+            .insert_block_payload(block, transactions, limit);
     }
 
     /// Processes the commit decision
@@ -536,16 +490,10 @@ impl ConsensusObserver {
         if let Some((ordered_blocks, pending_commit_decision)) =
             pending_blocks.get_mut(&commit_decision.round())
         {
-            // Check if the payload already exists
-            let payload_exists = {
-                let payload_store = self.payload_store.lock();
-                ordered_blocks.blocks.iter().all(|block| {
-                    matches!(
-                        payload_store.get(&block.id()),
-                        Some(ObserverDataStatus::Available(_))
-                    )
-                })
-            };
+            // Check if the payloads for the ordered blocks already exist
+            let payload_exists = self
+                .block_payload_store
+                .all_payloads_exist(&ordered_blocks.blocks);
 
             // If the payload exists, add the commit decision to the pending blocks
             if payload_exists {
@@ -924,7 +872,7 @@ impl ConsensusObserver {
         // Create the payload manager
         let payload_manager = if consensus_config.quorum_store_enabled() {
             PayloadManager::ConsensusObserver(
-                self.payload_store.clone(),
+                self.block_payload_store.get_block_payloads(),
                 self.consensus_publisher.clone(),
             )
         } else {
@@ -1150,17 +1098,6 @@ async fn extract_on_chain_configs(
         execution_config,
         onchain_randomness_config,
     )
-}
-
-/// Removes the given payload blocks from the payload store
-fn remove_payload_blocks(
-    payload_store: Arc<Mutex<HashMap<HashValue, ObserverDataStatus>>>,
-    blocks: &[Arc<PipelinedBlock>],
-) {
-    let mut payload_store = payload_store.lock();
-    for block in blocks.iter() {
-        payload_store.remove(&block.id());
-    }
 }
 
 /// Removes the pending blocks before the given ledger info

--- a/consensus/src/consensus_observer/payload_store.rs
+++ b/consensus/src/consensus_observer/payload_store.rs
@@ -85,13 +85,9 @@ impl BlockPayloadStore {
 
                 // If the status was originally requested, send the payload to the listener
                 if let BlockPayloadStatus::Requested(payload_sender) = status {
-                    if let Err(error) = payload_sender.send(block_transaction_payload) {
-                        error!(
-                            LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                                "Failed to send block payload to listener! Error: {:?}",
-                                error
-                            ))
-                        );
+                    if payload_sender.send(block_transaction_payload).is_err() {
+                        error!(LogSchema::new(LogEntry::ConsensusObserver)
+                            .message("Failed to send block payload to listener!",));
                     }
                 }
             },

--- a/consensus/src/consensus_observer/payload_store.rs
+++ b/consensus/src/consensus_observer/payload_store.rs
@@ -1,0 +1,313 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::consensus_observer::logging::{LogEntry, LogSchema};
+use aptos_consensus_types::pipelined_block::PipelinedBlock;
+use aptos_crypto::HashValue;
+use aptos_infallible::Mutex;
+use aptos_logger::error;
+use aptos_types::{block_info::BlockInfo, transaction::SignedTransaction};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    mem,
+    sync::Arc,
+};
+use tokio::sync::oneshot;
+
+/// The transaction payload of each block
+#[derive(Debug, Clone)]
+pub struct BlockTransactionPayload {
+    pub transactions: Vec<SignedTransaction>,
+    pub limit: Option<u64>,
+}
+
+impl BlockTransactionPayload {
+    pub fn new(transactions: Vec<SignedTransaction>, limit: Option<u64>) -> Self {
+        Self {
+            transactions,
+            limit,
+        }
+    }
+}
+
+/// The status of the block payload (requested or available)
+pub enum BlockPayloadStatus {
+    Requested(oneshot::Sender<BlockTransactionPayload>),
+    Available(BlockTransactionPayload),
+}
+
+/// A simple struct to store the block payloads of ordered and committed blocks
+#[derive(Clone)]
+pub struct BlockPayloadStore {
+    // Block transaction payloads map the block ID to the transaction payloads
+    // (the same payloads that the payload manager returns).
+    block_transaction_payloads: Arc<Mutex<HashMap<HashValue, BlockPayloadStatus>>>,
+}
+
+impl BlockPayloadStore {
+    pub fn new() -> Self {
+        Self {
+            block_transaction_payloads: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Returns true iff all the payloads for the given blocks are available
+    pub fn all_payloads_exist(&self, blocks: &[Arc<PipelinedBlock>]) -> bool {
+        let block_transaction_payloads = self.block_transaction_payloads.lock();
+        blocks.iter().all(|block| {
+            matches!(
+                block_transaction_payloads.get(&block.id()),
+                Some(BlockPayloadStatus::Available(_))
+            )
+        })
+    }
+
+    /// Returns a reference to the block transaction payloads
+    pub fn get_block_payloads(&self) -> Arc<Mutex<HashMap<HashValue, BlockPayloadStatus>>> {
+        self.block_transaction_payloads.clone()
+    }
+
+    /// Inserts the given block payload data into the payload store
+    pub fn insert_block_payload(
+        &mut self,
+        block: BlockInfo,
+        transactions: Vec<SignedTransaction>,
+        limit: Option<u64>,
+    ) {
+        let mut block_transaction_payloads = self.block_transaction_payloads.lock();
+        let block_transaction_payload = BlockTransactionPayload::new(transactions, limit);
+
+        match block_transaction_payloads.entry(block.id()) {
+            Entry::Occupied(mut entry) => {
+                // Replace the data status with the new block payload
+                let mut status = BlockPayloadStatus::Available(block_transaction_payload.clone());
+                mem::swap(entry.get_mut(), &mut status);
+
+                // If the status was originally requested, send the payload to the listener
+                if let BlockPayloadStatus::Requested(payload_sender) = status {
+                    if let Err(error) = payload_sender.send(block_transaction_payload) {
+                        error!(
+                            LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                                "Failed to send block payload to listener! Error: {:?}",
+                                error
+                            ))
+                        );
+                    }
+                }
+            },
+            Entry::Vacant(entry) => {
+                // Insert the block payload directly into the payload store
+                entry.insert(BlockPayloadStatus::Available(block_transaction_payload));
+            },
+        }
+    }
+
+    /// Removes the given pipelined blocks from the payload store
+    pub fn remove_blocks(&self, blocks: &[Arc<PipelinedBlock>]) {
+        let mut block_transaction_payloads = self.block_transaction_payloads.lock();
+        for block in blocks.iter() {
+            block_transaction_payloads.remove(&block.id());
+        }
+    }
+}
+
+impl Default for BlockPayloadStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use aptos_consensus_types::{
+        block::Block,
+        block_data::{BlockData, BlockType},
+        quorum_cert::QuorumCert,
+    };
+    use aptos_types::{block_info::Round, transaction::Version};
+
+    #[test]
+    fn test_all_payloads_exist() {
+        // Create a new block payload store
+        let block_payload_store = BlockPayloadStore::new();
+
+        // Add some blocks to the payload store
+        let num_blocks_in_store = 100;
+        let pipelined_blocks =
+            create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store);
+
+        // Check that all the payloads exist in the block payload store
+        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks));
+
+        // Check that a subset of the payloads exist in the block payload store
+        let subset_pipelined_blocks = &pipelined_blocks[0..50];
+        assert!(block_payload_store.all_payloads_exist(subset_pipelined_blocks));
+
+        // Remove some of the payloads from the block payload store
+        block_payload_store.remove_blocks(subset_pipelined_blocks);
+
+        // Check that the payloads no longer exist in the block payload store
+        assert!(!block_payload_store.all_payloads_exist(subset_pipelined_blocks));
+
+        // Check that the remaining payloads still exist in the block payload store
+        let subset_pipelined_blocks = &pipelined_blocks[50..100];
+        assert!(block_payload_store.all_payloads_exist(subset_pipelined_blocks));
+
+        // Remove the remaining payloads from the block payload store
+        block_payload_store.remove_blocks(subset_pipelined_blocks);
+
+        // Check that the payloads no longer exist in the block payload store
+        assert!(!block_payload_store.all_payloads_exist(subset_pipelined_blocks));
+    }
+
+    #[test]
+    fn test_all_payloads_exist_requested() {
+        // Create a new block payload store
+        let block_payload_store = BlockPayloadStore::new();
+
+        // Add several blocks to the payload store
+        let num_blocks_in_store = 10;
+        let pipelined_blocks =
+            create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store);
+
+        // Check that the payloads exists in the block payload store
+        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks));
+
+        // Mark the payload of the first block as requested
+        mark_payload_as_requested(block_payload_store.clone(), pipelined_blocks[0].id());
+
+        // Check that the payload no longer exists in the block payload store
+        assert!(!block_payload_store.all_payloads_exist(&pipelined_blocks));
+
+        // Check that the remaining payloads still exist in the block payload store
+        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks[1..10]));
+    }
+
+    #[test]
+    fn test_insert_block_payload() {
+        // Create a new block payload store
+        let mut block_payload_store = BlockPayloadStore::new();
+
+        // Add some blocks to the payload store
+        let num_blocks_in_store = 10;
+        let pipelined_blocks =
+            create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store);
+
+        // Check that the block payload store contains the new block payloads
+        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks));
+
+        // Mark the payload of the first block as requested
+        let payload_receiver =
+            mark_payload_as_requested(block_payload_store.clone(), pipelined_blocks[0].id());
+
+        // Check that the payload no longer exists in the block payload store
+        assert!(!block_payload_store.all_payloads_exist(&pipelined_blocks));
+
+        // Insert the same block payload into the block payload store
+        block_payload_store.insert_block_payload(pipelined_blocks[0].block_info(), vec![], Some(0));
+
+        // Check that the block payload store now contains the requested block payload
+        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks));
+
+        // Check that the payload receiver receives the requested block payload message
+        let block_transaction_payload = payload_receiver.blocking_recv().unwrap();
+        assert!(block_transaction_payload.transactions.is_empty());
+        assert_eq!(block_transaction_payload.limit, Some(0));
+    }
+
+    #[test]
+    fn test_remove_blocks() {
+        // Create a new block payload store
+        let block_payload_store = BlockPayloadStore::new();
+
+        // Add some blocks to the payload store
+        let num_blocks_in_store = 10;
+        let pipelined_blocks =
+            create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store);
+
+        // Remove the first block from the block payload store
+        block_payload_store.remove_blocks(&pipelined_blocks[0..1]);
+
+        // Check that the block payload store no longer contains the removed block
+        let block_transaction_payloads = block_payload_store.get_block_payloads();
+        assert!(!block_transaction_payloads
+            .lock()
+            .contains_key(&pipelined_blocks[0].id()));
+
+        // Remove the last 5 blocks from the block payload store
+        block_payload_store.remove_blocks(&pipelined_blocks[5..10]);
+
+        // Check that the block payload store no longer contains the removed blocks
+        let block_transaction_payloads = block_payload_store.get_block_payloads();
+        for pipelined_block in pipelined_blocks.iter().take(10).skip(5) {
+            assert!(!block_transaction_payloads
+                .lock()
+                .contains_key(&pipelined_block.id()));
+        }
+
+        // Remove all the blocks from the block payload store (including some that don't exist)
+        block_payload_store.remove_blocks(&pipelined_blocks[0..10]);
+
+        // Check that the block payload store no longer contains any blocks
+        let block_transaction_payloads = block_payload_store.get_block_payloads();
+        assert!(block_transaction_payloads.lock().is_empty());
+    }
+
+    /// Creates and adds the given number of blocks to the block payload store
+    fn create_and_add_blocks_to_store(
+        mut block_payload_store: BlockPayloadStore,
+        num_blocks: usize,
+    ) -> Vec<Arc<PipelinedBlock>> {
+        let mut pipelined_blocks = vec![];
+        for i in 0..num_blocks {
+            // Create the block info
+            let block_info = BlockInfo::new(
+                i as u64,
+                i as Round,
+                HashValue::random(),
+                HashValue::random(),
+                i as Version,
+                i as u64,
+                None,
+            );
+
+            // Insert the block payload into the store
+            block_payload_store.insert_block_payload(block_info.clone(), vec![], Some(i as u64));
+
+            // Create the equivalent pipelined block
+            let block_data = BlockData::new_for_testing(
+                block_info.epoch(),
+                block_info.round(),
+                block_info.timestamp_usecs(),
+                QuorumCert::dummy(),
+                BlockType::Genesis,
+            );
+            let block = Block::new_for_testing(block_info.id(), block_data, None);
+            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(block));
+
+            // Add the pipelined block to the list
+            pipelined_blocks.push(pipelined_block.clone());
+        }
+
+        pipelined_blocks
+    }
+
+    /// Marks the payload of the given block ID as requested and returns the receiver
+    fn mark_payload_as_requested(
+        block_payload_store: BlockPayloadStore,
+        block_id: HashValue,
+    ) -> oneshot::Receiver<BlockTransactionPayload> {
+        // Get the block payload entry for the given block ID
+        let block_payloads = block_payload_store.get_block_payloads();
+        let mut block_payloads = block_payloads.lock();
+        let block_payload = block_payloads.get_mut(&block_id).unwrap();
+
+        // Mark the block payload as requested
+        let (payload_sender, payload_receiver) = oneshot::channel();
+        *block_payload = BlockPayloadStatus::Requested(payload_sender);
+
+        // Return the payload receiver
+        payload_receiver
+    }
+}

--- a/consensus/src/consensus_observer/pending_blocks.rs
+++ b/consensus/src/consensus_observer/pending_blocks.rs
@@ -1,0 +1,341 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::consensus_observer::{
+    logging::{LogEntry, LogSchema},
+    network_message::OrderedBlock,
+};
+use aptos_consensus_types::{common::Round, pipeline::commit_decision::CommitDecision};
+use aptos_infallible::Mutex;
+use aptos_logger::debug;
+use aptos_types::{block_info::BlockInfo, ledger_info::LedgerInfoWithSignatures};
+use std::{collections::BTreeMap, sync::Arc};
+
+/// A simple struct to store the block payloads of ordered and committed blocks
+#[derive(Clone)]
+pub struct PendingOrderedBlocks {
+    // Pending ordered blocks (indexed by consensus round)
+    pending_ordered_blocks: Arc<Mutex<BTreeMap<Round, (OrderedBlock, Option<CommitDecision>)>>>,
+}
+
+impl PendingOrderedBlocks {
+    pub fn new() -> Self {
+        Self {
+            pending_ordered_blocks: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    /// Clears all pending blocks
+    pub fn clear_all_pending_blocks(&self) {
+        self.pending_ordered_blocks.lock().clear();
+    }
+
+    /// Returns a copy of the pending ordered blocks map
+    pub fn get_all_pending_blocks(
+        &self,
+    ) -> BTreeMap<Round, (OrderedBlock, Option<CommitDecision>)> {
+        self.pending_ordered_blocks.lock().clone()
+    }
+
+    /// Returns the pending ordered block (if any)
+    pub fn get_last_pending_block(&self) -> Option<BlockInfo> {
+        let pending_ordered_blocks = self.pending_ordered_blocks.lock();
+        if let Some((_, (ordered_block, _))) = pending_ordered_blocks.last_key_value() {
+            Some(ordered_block.blocks.last().unwrap().block_info())
+        } else {
+            None // No pending blocks were found
+        }
+    }
+
+    /// Returns the pending ordered block (if any)
+    pub fn get_pending_block(&self, round: Round) -> Option<OrderedBlock> {
+        let pending_ordered_blocks = self.pending_ordered_blocks.lock();
+        pending_ordered_blocks
+            .get(&round)
+            .map(|(ordered_block, _)| ordered_block.clone())
+    }
+
+    /// Inserts the given ordered block into the pending blocks
+    pub fn insert_ordered_block(&self, ordered_block: OrderedBlock) {
+        debug!(
+            LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                "Adding ordered block to the pending blocks: {}",
+                ordered_block.ordered_proof.commit_info()
+            ))
+        );
+
+        // Insert the ordered block into the pending ordered blocks
+        let last_block_round = ordered_block.blocks.last().unwrap().round();
+        self.pending_ordered_blocks
+            .lock()
+            .insert(last_block_round, (ordered_block, None));
+    }
+
+    /// Removes the pending blocks for the given commit ledger info.
+    /// This will remove all blocks up to (and including) the commit
+    /// round of the committed ledger info.
+    pub fn remove_blocks_for_commit(&self, commit_ledger_info: &LedgerInfoWithSignatures) {
+        // Determine the round to split off
+        let split_off_round = commit_ledger_info.commit_info().round() + 1;
+
+        // Remove the pending blocks before the split off round
+        let mut pending_ordered_blocks = self.pending_ordered_blocks.lock();
+        *pending_ordered_blocks = pending_ordered_blocks.split_off(&split_off_round);
+    }
+
+    /// Updates the commit decision of the pending ordered block (if found)
+    pub fn update_commit_decision(&self, commit_decision: &CommitDecision) {
+        let mut pending_ordered_blocks = self.pending_ordered_blocks.lock();
+        if let Some((_, existing_commit_decision)) =
+            pending_ordered_blocks.get_mut(&commit_decision.round())
+        {
+            *existing_commit_decision = Some(commit_decision.clone());
+        }
+    }
+}
+
+impl Default for PendingOrderedBlocks {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use aptos_consensus_types::{
+        block::Block,
+        block_data::{BlockData, BlockType},
+        pipelined_block::PipelinedBlock,
+        quorum_cert::QuorumCert,
+    };
+    use aptos_crypto::HashValue;
+    use aptos_types::{
+        aggregate_signature::AggregateSignature, ledger_info::LedgerInfo, transaction::Version,
+    };
+
+    #[test]
+    pub fn test_clear_pending_blocks() {
+        // Create new pending ordered blocks
+        let pending_ordered_blocks = PendingOrderedBlocks::new();
+
+        // Insert several pending blocks
+        let num_pending_blocks = 10;
+        let pending_blocks =
+            create_and_add_pending_blocks(&pending_ordered_blocks, num_pending_blocks);
+
+        // Verify the pending blocks were all inserted
+        let all_pending_blocks = pending_ordered_blocks.get_all_pending_blocks();
+        assert_eq!(all_pending_blocks.len(), num_pending_blocks);
+
+        // Verify the pending blocks were inserted by round
+        for pending_block in pending_blocks {
+            // Get the round of the last block in the pending block
+            let round = pending_block.blocks.last().unwrap().round();
+
+            // Verify the pending block exists for the round
+            assert_eq!(
+                pending_block,
+                pending_ordered_blocks.get_pending_block(round).unwrap()
+            );
+        }
+
+        // Clear all pending blocks
+        pending_ordered_blocks.clear_all_pending_blocks();
+
+        // Verify all blocks were removed
+        let all_pending_blocks = pending_ordered_blocks.get_all_pending_blocks();
+        assert_eq!(all_pending_blocks.len(), 0);
+    }
+
+    #[test]
+    pub fn test_get_last_pending_block() {
+        // Create new pending ordered blocks
+        let pending_ordered_blocks = PendingOrderedBlocks::new();
+
+        // Insert several pending blocks
+        let num_pending_blocks = 100;
+        let pending_blocks =
+            create_and_add_pending_blocks(&pending_ordered_blocks, num_pending_blocks);
+
+        // Verify the last pending block is the one with the highest round
+        let last_pending_block = pending_blocks.last().unwrap();
+        let last_pending_block_info = last_pending_block.blocks.last().unwrap().block_info();
+        assert_eq!(
+            last_pending_block_info,
+            pending_ordered_blocks.get_last_pending_block().unwrap()
+        );
+    }
+
+    #[test]
+    pub fn test_remove_blocks_for_commit() {
+        // Create new pending ordered blocks
+        let pending_ordered_blocks = PendingOrderedBlocks::new();
+
+        // Insert several pending blocks
+        let num_pending_blocks = 10;
+        let pending_blocks =
+            create_and_add_pending_blocks(&pending_ordered_blocks, num_pending_blocks);
+
+        // Create a commit decision for the first pending block
+        let first_pending_block = pending_blocks.first().unwrap();
+        let first_pending_block_info = first_pending_block.blocks.last().unwrap().block_info();
+        let commit_decision = CommitDecision::new(LedgerInfoWithSignatures::new(
+            LedgerInfo::new(first_pending_block_info.clone(), HashValue::random()),
+            AggregateSignature::empty(),
+        ));
+
+        // Remove the pending blocks for the commit decision
+        pending_ordered_blocks.remove_blocks_for_commit(commit_decision.ledger_info());
+
+        // Verify the first pending block was removed
+        let all_pending_blocks = pending_ordered_blocks.get_all_pending_blocks();
+        assert_eq!(all_pending_blocks.len(), num_pending_blocks - 1);
+        assert!(!all_pending_blocks.contains_key(&first_pending_block_info.round()));
+
+        // Create a commit decision for the last pending block
+        let last_pending_block = pending_blocks.last().unwrap();
+        let last_pending_block_info = last_pending_block.blocks.last().unwrap().block_info();
+        let commit_decision = CommitDecision::new(LedgerInfoWithSignatures::new(
+            LedgerInfo::new(last_pending_block_info.clone(), HashValue::random()),
+            AggregateSignature::empty(),
+        ));
+
+        // Remove the pending blocks for the commit decision
+        pending_ordered_blocks.remove_blocks_for_commit(commit_decision.ledger_info());
+
+        // Verify all the pending blocks were removed
+        let all_pending_blocks = pending_ordered_blocks.get_all_pending_blocks();
+        assert!(all_pending_blocks.is_empty());
+    }
+
+    #[test]
+    pub fn test_update_commit_decision() {
+        // Create new pending ordered blocks
+        let pending_ordered_blocks = PendingOrderedBlocks::new();
+
+        // Insert several pending blocks
+        let num_pending_blocks = 10;
+        let pending_blocks =
+            create_and_add_pending_blocks(&pending_ordered_blocks, num_pending_blocks);
+
+        // Verify the pending blocks were all inserted
+        let all_pending_blocks = pending_ordered_blocks.get_all_pending_blocks();
+        assert_eq!(all_pending_blocks.len(), num_pending_blocks);
+
+        // Verify the pending blocks don't have any commit decisions
+        for (_, (_, commit_decision)) in all_pending_blocks.iter() {
+            assert!(commit_decision.is_none());
+        }
+
+        // Create a commit decision for the first pending block
+        let first_pending_block = pending_blocks.first().unwrap();
+        let first_pending_block_info = first_pending_block.blocks.last().unwrap().block_info();
+        let commit_decision = CommitDecision::new(LedgerInfoWithSignatures::new(
+            LedgerInfo::new(first_pending_block_info.clone(), HashValue::random()),
+            AggregateSignature::empty(),
+        ));
+
+        // Update the commit decision for the first pending block
+        pending_ordered_blocks.update_commit_decision(&commit_decision);
+
+        // Verify the commit decision was updated
+        verify_commit_decision(
+            &pending_ordered_blocks,
+            &first_pending_block_info,
+            commit_decision,
+        );
+
+        // Create a commit decision for the last pending block
+        let last_pending_block = pending_blocks.last().unwrap();
+        let last_pending_block_info = last_pending_block.blocks.last().unwrap().block_info();
+        let commit_decision = CommitDecision::new(LedgerInfoWithSignatures::new(
+            LedgerInfo::new(last_pending_block_info.clone(), HashValue::random()),
+            AggregateSignature::empty(),
+        ));
+
+        // Update the commit decision for the last pending block
+        pending_ordered_blocks.update_commit_decision(&commit_decision);
+
+        // Verify the commit decision was updated
+        verify_commit_decision(
+            &pending_ordered_blocks,
+            &last_pending_block_info,
+            commit_decision,
+        );
+
+        // Verify the commit decisions for the remaining blocks are still missing
+        let all_pending_blocks = pending_ordered_blocks.get_all_pending_blocks();
+        for i in 1..9 {
+            let (_, commit_decision) = all_pending_blocks.get(&(i as u64)).unwrap();
+            assert!(commit_decision.is_none());
+        }
+    }
+
+    /// Creates and adds the specified number of pending blocks to the pending ordered blocks
+    fn create_and_add_pending_blocks(
+        pending_ordered_blocks: &PendingOrderedBlocks,
+        num_pending_blocks: usize,
+    ) -> Vec<OrderedBlock> {
+        let mut pending_blocks = vec![];
+        for i in 0..num_pending_blocks {
+            // Create a new block info
+            let block_info = BlockInfo::new(
+                i as u64,
+                i as aptos_types::block_info::Round,
+                HashValue::random(),
+                HashValue::random(),
+                i as Version,
+                i as u64,
+                None,
+            );
+
+            // Create a pipelined block
+            let block_data = BlockData::new_for_testing(
+                block_info.epoch(),
+                block_info.round(),
+                block_info.timestamp_usecs(),
+                QuorumCert::dummy(),
+                BlockType::Genesis,
+            );
+            let block = Block::new_for_testing(block_info.id(), block_data, None);
+            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(block));
+
+            // Create an ordered block
+            let blocks = vec![pipelined_block];
+            let ordered_proof = LedgerInfoWithSignatures::new(
+                LedgerInfo::new(BlockInfo::empty(), HashValue::random()),
+                AggregateSignature::empty(),
+            );
+            let ordered_block = OrderedBlock {
+                blocks,
+                ordered_proof,
+            };
+
+            // Insert the ordered block into the pending ordered blocks
+            pending_ordered_blocks.insert_ordered_block(ordered_block.clone());
+
+            // Add the ordered block to the pending blocks
+            pending_blocks.push(ordered_block);
+        }
+
+        pending_blocks
+    }
+
+    /// Verifies the commit decision for the specified block info
+    fn verify_commit_decision(
+        pending_ordered_blocks: &PendingOrderedBlocks,
+        block_info: &BlockInfo,
+        commit_decision: CommitDecision,
+    ) {
+        // Get the commit decision for the block
+        let all_pending_blocks = pending_ordered_blocks.get_all_pending_blocks();
+        let (_, updated_commit_decision) = all_pending_blocks.get(&block_info.round()).unwrap();
+
+        // Verify the commit decision is expected
+        assert_eq!(
+            commit_decision,
+            updated_commit_decision.as_ref().unwrap().clone()
+        );
+    }
+}

--- a/state-sync/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-driver/src/driver.rs
@@ -317,8 +317,6 @@ impl<
         );
         self.update_consensus_commit_metrics(&consensus_commit_notification);
 
-        // TODO(joshlind): can we get consensus to forward the events?
-
         // Handle the commit notification
         let committed_transactions = CommittedTransactions {
             events: consensus_commit_notification.subscribable_events.clone(),


### PR DESCRIPTION
## Description
This PR makes several small refactors and improvements to consensus observer. Specifically, it offers the following commits:
1. Refactor the block payload store to a separate file, add a simple struct wrapper and several unit tests.
1. Refactor the pending ordered blocks to a separate file, add a simple struct wrapper and several unit tests.
1. Add simple message verification for commit messages. Here, we verify the commit ledger info using the current epoch state. If the ledger info is for a future epoch, we pass it to state sync and rely on state sync to verify the epoch change and syncing process.

## Testing Plan
New and existing test infrastructure.
