### PR TITLE
Revert "fix:Correct ECDSA signature malleability handling (#13544)"

### DIFF
--- a/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_sigs.rs
+++ b/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_sigs.rs
@@ -65,14 +65,14 @@ impl Signature {
         if bytes.len() != SIGNATURE_LENGTH {
             return Err(CryptoMaterialError::WrongLengthError);
         }
-        if !Signature::check_s_le_order_half(&bytes[32..]) {
+        if !Signature::check_s_lt_order_half(&bytes[32..]) {
             return Err(CryptoMaterialError::CanonicalRepresentationError);
         }
         Ok(())
     }
 
-    /// Check if S <= ORDER_HALF to capture invalid signatures.
-    fn check_s_le_order_half(s: &[u8]) -> bool {
+    /// Check if S < ORDER_HALF to capture invalid signatures.
+    fn check_s_lt_order_half(s: &[u8]) -> bool {
         for i in 0..32 {
             match s[i].cmp(&ORDER_HALF[i]) {
                 Ordering::Less => return true,
@@ -80,8 +80,8 @@ impl Signature {
                 _ => {},
             }
         }
-        // At this stage S == ORDER_HALF , it is still considered a canonical value.
-        true
+        // At this stage S == ORDER_HALF which implies a non canonical S.
+        false
     }
 
     /// If the signature {R,S} does not have S < n/2 where n is the Ristretto255 order, return

--- a/crates/aptos-crypto/src/unit_tests/secp256r1_ecdsa_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/secp256r1_ecdsa_test.rs
@@ -208,11 +208,13 @@ proptest! {
         let sig_unchecked = Signature::from_bytes_unchecked(&serialized);
         prop_assert!(sig_unchecked.is_ok());
 
-        // S = ORDER_HALF should be a canonical signature.
+        // Update the signature by setting S = L to make it invalid.
         serialized[32..].copy_from_slice(&ORDER_HALF);
-        let canonical: &[u8] = &serialized;
-        prop_assert!(
-            Signature::try_from(canonical).is_ok()
+        let serialized_malleable_l: &[u8] = &serialized;
+        // try_from will fail with CanonicalRepresentationError.
+        prop_assert_eq!(
+            Signature::try_from(serialized_malleable_l),
+            Err(CryptoMaterialError::CanonicalRepresentationError)
         );
     }
 }


### PR DESCRIPTION
## Description

Reverting this change due to lack of feature gating, for now.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

N/A.

## Key Areas to Review

N/A.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
