### PR TITLE
[Compiler-v2] Fix native struct

### DIFF
--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -218,6 +218,8 @@ impl ModuleGenerator {
         let struct_handle = self.struct_index(ctx, loc, struct_env);
         let fields = struct_env.get_fields();
         let field_information = if struct_env.get_field_count() == 0 {
+            // If a struct has no field, we can be sure that it is native
+            // because a user-defined empty struct will be attached with the `dummy_field` in the previous step
             FF::StructFieldInformation::Native
         } else {
             FF::StructFieldInformation::Declared(

--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -217,20 +217,24 @@ impl ModuleGenerator {
         }
         let struct_handle = self.struct_index(ctx, loc, struct_env);
         let fields = struct_env.get_fields();
-        let field_information = FF::StructFieldInformation::Declared(
-            fields
-                .map(|f| {
-                    let field_loc = f.get_loc();
-                    self.source_map
-                        .add_struct_field_mapping(def_idx, ctx.env.to_ir_loc(field_loc))
-                        .expect(SOURCE_MAP_OK);
-                    let name = self.name_index(ctx, field_loc, f.get_name());
-                    let signature =
-                        FF::TypeSignature(self.signature_token(ctx, loc, &f.get_type()));
-                    FF::FieldDefinition { name, signature }
-                })
-                .collect(),
-        );
+        let field_information = if struct_env.get_field_count() == 0 {
+            FF::StructFieldInformation::Native
+        } else {
+            FF::StructFieldInformation::Declared(
+                fields
+                    .map(|f| {
+                        let field_loc = f.get_loc();
+                        self.source_map
+                            .add_struct_field_mapping(def_idx, ctx.env.to_ir_loc(field_loc))
+                            .expect(SOURCE_MAP_OK);
+                        let name = self.name_index(ctx, field_loc, f.get_name());
+                        let signature =
+                            FF::TypeSignature(self.signature_token(ctx, loc, &f.get_type()));
+                        FF::FieldDefinition { name, signature }
+                    })
+                    .collect(),
+            )
+        };
         let def = FF::StructDefinition {
             struct_handle,
             field_information,

--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -217,9 +217,7 @@ impl ModuleGenerator {
         }
         let struct_handle = self.struct_index(ctx, loc, struct_env);
         let fields = struct_env.get_fields();
-        let field_information = if struct_env.get_field_count() == 0 {
-            // If a struct has no field, we can be sure that it is native
-            // because a user-defined empty struct will be attached with the `dummy_field` in the previous step
+        let field_information = if struct_env.is_native() {
             FF::StructFieldInformation::Native
         } else {
             FF::StructFieldInformation::Declared(

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/multi_pool_money_market_token.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/multi_pool_money_market_token.exp
@@ -1,0 +1,300 @@
+
+Diagnostics:
+warning: unused type parameter
+  ┌─ tests/checking/typing/v1-examples/multi_pool_money_market_token.move:5:21
+  │
+5 │     native struct T<K, V> has copy, drop, store;
+  │                     ^
+  │                     │
+  │                     Unused type parameter `K`. Consider declaring it as phantom
+
+warning: unused type parameter
+  ┌─ tests/checking/typing/v1-examples/multi_pool_money_market_token.move:5:24
+  │
+5 │     native struct T<K, V> has copy, drop, store;
+  │                        ^
+  │                        │
+  │                        Unused type parameter `V`. Consider declaring it as phantom
+
+// -- Model dump before bytecode pipeline
+module 0x2::Token {
+    struct Coin {
+        type: #0,
+        value: u64,
+    }
+    public fun create<ATy>(type: #0,value: u64): Token::Coin<#0> {
+        pack Token::Coin<ATy>(type, value)
+    }
+    public fun value<ATy>(coin: &Token::Coin<#0>): u64 {
+        select Token::Coin.value<&Token::Coin<ATy>>(coin)
+    }
+    public fun deposit<ATy>(coin: &mut Token::Coin<#0>,check: Token::Coin<#0>) {
+        {
+          let Token::Coin<ATy>{ type, value } = check;
+          if Eq<ATy>(Borrow(Immutable)(select Token::Coin.type<&mut Token::Coin<ATy>>(coin)), Borrow(Immutable)(type)) {
+            Tuple()
+          } else {
+            Abort(42)
+          };
+          select Token::Coin.value<&mut Token::Coin<ATy>>(coin) = Add<u64>(select Token::Coin.value<&mut Token::Coin<ATy>>(coin), value);
+          Tuple()
+        }
+    }
+    public fun destroy_zero<ATy>(coin: Token::Coin<#0>) {
+        {
+          let Token::Coin<ATy>{ type: _, value } = coin;
+          if Eq<u64>(value, 0) {
+            Tuple()
+          } else {
+            Abort(11)
+          }
+        }
+    }
+    public fun join<ATy>(xus: Token::Coin<#0>,coin2: Token::Coin<#0>): Token::Coin<#0> {
+        Token::deposit<ATy>(Borrow(Mutable)(xus), coin2);
+        xus
+    }
+    public fun split<ATy>(coin: Token::Coin<#0>,amount: u64): (Token::Coin<#0>, Token::Coin<#0>) {
+        {
+          let other: Token::Coin<ATy> = Token::withdraw<ATy>(Borrow(Mutable)(coin), amount);
+          Tuple(coin, other)
+        }
+    }
+    public fun withdraw<ATy>(coin: &mut Token::Coin<#0>,amount: u64): Token::Coin<#0> {
+        if Ge<u64>(select Token::Coin.value<&mut Token::Coin<ATy>>(coin), amount) {
+          Tuple()
+        } else {
+          Abort(10)
+        };
+        select Token::Coin.value<&mut Token::Coin<ATy>>(coin) = Sub<u64>(select Token::Coin.value<&mut Token::Coin<ATy>>(coin), amount);
+        pack Token::Coin<ATy>(Deref(Borrow(Immutable)(select Token::Coin.type<&mut Token::Coin<ATy>>(coin))), amount)
+    }
+} // end 0x2::Token
+module 0x2::Map {
+    struct T {
+    }
+    public native fun empty<K,V>(): Map::T<#0, #1>;
+    public native fun remove<K,V>(m: &Map::T<#0, #1>,k: &#0): #1;
+    public native fun contains_key<K,V>(m: &Map::T<#0, #1>,k: &#0): bool;
+    public native fun get<K,V>(m: &Map::T<#0, #1>,k: &#0): &#1;
+    public native fun get_mut<K,V>(m: &mut Map::T<#0, #1>,k: &#0): &mut #1;
+    public native fun insert<K,V>(m: &Map::T<#0, #1>,k: #0,v: #1);
+} // end 0x2::Map
+module 0x3::OneToOneMarket {
+    use std::signer;
+    use 0x2::Map; // resolved as: 0x2::Map
+    use 0x2::Token; // resolved as: 0x2::Token
+    struct BorrowRecord {
+        record: Map::T<address, u64>,
+    }
+    struct DepositRecord {
+        record: Map::T<address, u64>,
+    }
+    struct Pool {
+        coin: Token::Coin<#0>,
+    }
+    struct Price {
+        price: u64,
+    }
+    public fun borrow<In,Out>(account: &signer,pool_owner: address,amount: u64): Token::Coin<#1>
+        acquires OneToOneMarket::Price(*)
+        acquires OneToOneMarket::Pool(*)
+        acquires OneToOneMarket::DepositRecord(*)
+        acquires OneToOneMarket::BorrowRecord(*)
+     {
+        if Le<u64>(amount, OneToOneMarket::max_borrow_amount<In, Out>(account, pool_owner)) {
+          Tuple()
+        } else {
+          Abort(1025)
+        };
+        OneToOneMarket::update_borrow_record<In, Out>(account, pool_owner, amount);
+        {
+          let pool: &mut OneToOneMarket::Pool<Out> = BorrowGlobal(Mutable)<OneToOneMarket::Pool<Out>>(pool_owner);
+          Token::withdraw<Out>(Borrow(Mutable)(select OneToOneMarket::Pool.coin<&mut OneToOneMarket::Pool<Out>>(pool)), amount)
+        }
+    }
+    public fun deposit<In,Out>(account: &signer,pool_owner: address,coin: Token::Coin<#0>)
+        acquires OneToOneMarket::Pool(*)
+        acquires OneToOneMarket::DepositRecord(*)
+     {
+        {
+          let amount: u64 = Token::value<In>(Borrow(Immutable)(coin));
+          OneToOneMarket::update_deposit_record<In, Out>(account, pool_owner, amount);
+          {
+            let pool: &mut OneToOneMarket::Pool<In> = BorrowGlobal(Mutable)<OneToOneMarket::Pool<In>>(pool_owner);
+            Token::deposit<In>(Borrow(Mutable)(select OneToOneMarket::Pool.coin<&mut OneToOneMarket::Pool<In>>(pool)), coin)
+          }
+        }
+    }
+    private fun accept<AssetType>(account: &signer,init: Token::Coin<#0>) {
+        {
+          let sender: address = signer::address_of(account);
+          if Not(exists<OneToOneMarket::Pool<AssetType>>(sender)) {
+            Tuple()
+          } else {
+            Abort(42)
+          };
+          MoveTo<OneToOneMarket::Pool<AssetType>>(account, pack OneToOneMarket::Pool<AssetType>(init))
+        }
+    }
+    private fun borrowed_amount<In,Out>(account: &signer,pool_owner: address): u64
+        acquires OneToOneMarket::BorrowRecord(*)
+     {
+        {
+          let sender: address = signer::address_of(account);
+          if Not(exists<OneToOneMarket::BorrowRecord<In, Out>>(sender)) {
+            return 0
+          } else {
+            Tuple()
+          };
+          {
+            let record: &Map::T<address, u64> = Borrow(Immutable)(select OneToOneMarket::BorrowRecord.record<&OneToOneMarket::BorrowRecord<In, Out>>(BorrowGlobal(Immutable)<OneToOneMarket::BorrowRecord<In, Out>>(sender)));
+            if Map::contains_key<address, u64>(record, Borrow(Immutable)(pool_owner)) {
+              Deref(Map::get<address, u64>(record, Borrow(Immutable)(pool_owner)))
+            } else {
+              0
+            }
+          }
+        }
+    }
+    private fun deposited_amount<In,Out>(account: &signer,pool_owner: address): u64
+        acquires OneToOneMarket::DepositRecord(*)
+     {
+        {
+          let sender: address = signer::address_of(account);
+          if Not(exists<OneToOneMarket::DepositRecord<In, Out>>(sender)) {
+            return 0
+          } else {
+            Tuple()
+          };
+          {
+            let record: &Map::T<address, u64> = Borrow(Immutable)(select OneToOneMarket::DepositRecord.record<&OneToOneMarket::DepositRecord<In, Out>>(BorrowGlobal(Immutable)<OneToOneMarket::DepositRecord<In, Out>>(sender)));
+            if Map::contains_key<address, u64>(record, Borrow(Immutable)(pool_owner)) {
+              Deref(Map::get<address, u64>(record, Borrow(Immutable)(pool_owner)))
+            } else {
+              0
+            }
+          }
+        }
+    }
+    private fun max_borrow_amount<In,Out>(account: &signer,pool_owner: address): u64
+        acquires OneToOneMarket::Price(*)
+        acquires OneToOneMarket::Pool(*)
+        acquires OneToOneMarket::DepositRecord(*)
+        acquires OneToOneMarket::BorrowRecord(*)
+     {
+        {
+          let input_deposited: u64 = OneToOneMarket::deposited_amount<In, Out>(account, pool_owner);
+          {
+            let output_deposited: u64 = OneToOneMarket::borrowed_amount<In, Out>(account, pool_owner);
+            {
+              let input_into_output: u64 = Mul<u64>(input_deposited, select OneToOneMarket::Price.price<&OneToOneMarket::Price<In, Out>>(BorrowGlobal(Immutable)<OneToOneMarket::Price<In, Out>>(pool_owner)));
+              {
+                let max_output: u64 = if Lt<u64>(input_into_output, output_deposited) {
+                  0
+                } else {
+                  Sub<u64>(input_into_output, output_deposited)
+                };
+                {
+                  let available_output: u64 = {
+                    let pool: &OneToOneMarket::Pool<Out> = BorrowGlobal(Immutable)<OneToOneMarket::Pool<Out>>(pool_owner);
+                    Token::value<Out>(Borrow(Immutable)(select OneToOneMarket::Pool.coin<&OneToOneMarket::Pool<Out>>(pool)))
+                  };
+                  if Lt<u64>(max_output, available_output) {
+                    max_output
+                  } else {
+                    available_output
+                  }
+                }
+              }
+            }
+          }
+        }
+    }
+    public fun register_price<In,Out>(account: &signer,initial_in: Token::Coin<#0>,initial_out: Token::Coin<#1>,price: u64) {
+        OneToOneMarket::accept<In>(account, initial_in);
+        OneToOneMarket::accept<Out>(account, initial_out);
+        MoveTo<OneToOneMarket::Price<In, Out>>(account, pack OneToOneMarket::Price<In, Out>(price))
+    }
+    private fun update_borrow_record<In,Out>(account: &signer,pool_owner: address,amount: u64)
+        acquires OneToOneMarket::BorrowRecord(*)
+     {
+        {
+          let sender: address = signer::address_of(account);
+          if Not(exists<OneToOneMarket::BorrowRecord<In, Out>>(sender)) {
+            MoveTo<OneToOneMarket::BorrowRecord<In, Out>>(account, pack OneToOneMarket::BorrowRecord<In, Out>(Map::empty<address, u64>()))
+          } else {
+            Tuple()
+          };
+          {
+            let record: &mut Map::T<address, u64> = Borrow(Mutable)(select OneToOneMarket::BorrowRecord.record<&mut OneToOneMarket::BorrowRecord<In, Out>>(BorrowGlobal(Mutable)<OneToOneMarket::BorrowRecord<In, Out>>(sender)));
+            if Map::contains_key<address, u64>(Freeze(false)(record), Borrow(Immutable)(pool_owner)) {
+              {
+                let old_amount: u64 = Map::remove<address, u64>(Freeze(false)(record), Borrow(Immutable)(pool_owner));
+                amount: u64 = Add<u64>(amount, old_amount);
+                Tuple()
+              }
+            } else {
+              Tuple()
+            };
+            Map::insert<address, u64>(Freeze(false)(record), pool_owner, amount)
+          }
+        }
+    }
+    private fun update_deposit_record<In,Out>(account: &signer,pool_owner: address,amount: u64)
+        acquires OneToOneMarket::DepositRecord(*)
+     {
+        {
+          let sender: address = signer::address_of(account);
+          if Not(exists<OneToOneMarket::DepositRecord<In, Out>>(sender)) {
+            MoveTo<OneToOneMarket::DepositRecord<In, Out>>(account, pack OneToOneMarket::DepositRecord<In, Out>(Map::empty<address, u64>()))
+          } else {
+            Tuple()
+          };
+          {
+            let record: &mut Map::T<address, u64> = Borrow(Mutable)(select OneToOneMarket::DepositRecord.record<&mut OneToOneMarket::DepositRecord<In, Out>>(BorrowGlobal(Mutable)<OneToOneMarket::DepositRecord<In, Out>>(sender)));
+            if Map::contains_key<address, u64>(Freeze(false)(record), Borrow(Immutable)(pool_owner)) {
+              {
+                let old_amount: u64 = Map::remove<address, u64>(Freeze(false)(record), Borrow(Immutable)(pool_owner));
+                amount: u64 = Add<u64>(amount, old_amount);
+                Tuple()
+              }
+            } else {
+              Tuple()
+            };
+            Map::insert<address, u64>(Freeze(false)(record), pool_owner, amount)
+          }
+        }
+    }
+} // end 0x3::OneToOneMarket
+module 0x70dd::ToddNickels {
+    use 0x2::Token; // resolved as: 0x2::Token
+    use std::signer;
+    struct T {
+        dummy_field: bool,
+    }
+    struct Wallet {
+        nickels: Token::Coin<ToddNickels::T>,
+    }
+    public fun init(account: &signer) {
+        if Eq<address>(signer::address_of(account), 0x70dd) {
+          Tuple()
+        } else {
+          Abort(42)
+        };
+        MoveTo<ToddNickels::Wallet>(account, pack ToddNickels::Wallet(Token::create<ToddNickels::T>(pack ToddNickels::T(false), 0)))
+    }
+    public fun destroy(c: Token::Coin<ToddNickels::T>)
+        acquires ToddNickels::Wallet(*)
+     {
+        Token::deposit<ToddNickels::T>(Borrow(Mutable)(select ToddNickels::Wallet.nickels<&mut ToddNickels::Wallet>(BorrowGlobal(Mutable)<ToddNickels::Wallet>(0x70dd))), c)
+    }
+    public fun mint(account: &signer): Token::Coin<ToddNickels::T> {
+        if Eq<address>(signer::address_of(account), 0x70dd) {
+          Tuple()
+        } else {
+          Abort(42)
+        };
+        Token::create<ToddNickels::T>(pack ToddNickels::T(false), 5)
+    }
+} // end 0x70dd::ToddNickels

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/multi_pool_money_market_token.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/multi_pool_money_market_token.move
@@ -1,0 +1,240 @@
+
+address 0x2 {
+
+module Map {
+    native struct T<K, V> has copy, drop, store;
+
+    native public fun empty<K, V>(): T<K, V>;
+
+    native public fun get<K, V>(m: &T<K, V>, k: &K): &V;
+    native public fun get_mut<K, V>(m: &mut T<K, V>, k: &K): &mut V;
+
+    native public fun contains_key<K, V>(m: &T<K, V>, k: &K): bool;
+    // throws on duplicate as I don't feel like mocking up Option
+    native public fun insert<K, V>(m: &T<K, V>, k: K, v: V);
+    // throws on miss as I don't feel like mocking up Option
+    native public fun remove<K, V>(m: &T<K, V>, k: &K): V;
+}
+
+}
+
+address 0x2 {
+
+module Token {
+
+    struct Coin<AssetType: copy + drop> has store {
+        type: AssetType,
+        value: u64,
+    }
+
+    // control the minting/creation in the defining module of `ATy`
+    public fun create<ATy: copy + drop>(type: ATy, value: u64): Coin<ATy> {
+        Coin { type, value }
+    }
+
+    public fun value<ATy: copy + drop>(coin: &Coin<ATy>): u64 {
+        coin.value
+    }
+
+    public fun split<ATy: copy + drop>(coin: Coin<ATy>, amount: u64): (Coin<ATy>, Coin<ATy>) {
+        let other = withdraw(&mut coin, amount);
+        (coin, other)
+    }
+
+    public fun withdraw<ATy: copy + drop>(coin: &mut Coin<ATy>, amount: u64): Coin<ATy> {
+        assert!(coin.value >= amount, 10);
+        coin.value = coin.value - amount;
+        Coin { type: *&coin.type, value: amount }
+    }
+
+    public fun join<ATy: copy + drop>(xus: Coin<ATy>, coin2: Coin<ATy>): Coin<ATy> {
+        deposit(&mut xus, coin2);
+        xus
+    }
+
+    public fun deposit<ATy: copy + drop>(coin: &mut Coin<ATy>, check: Coin<ATy>) {
+        let Coin { value, type } = check;
+        assert!(&coin.type == &type, 42);
+        coin.value = coin.value + value;
+    }
+
+    public fun destroy_zero<ATy: copy + drop>(coin: Coin<ATy>) {
+        let Coin { value, type: _ } = coin;
+        assert!(value == 0, 11)
+    }
+
+}
+
+}
+
+address 0x3 {
+
+module OneToOneMarket {
+    use std::signer;
+    use 0x2::Map;
+    use 0x2::Token;
+
+    struct Pool<AssetType: copy + drop> has key {
+        coin: Token::Coin<AssetType>,
+    }
+
+    struct DepositRecord<phantom InputAsset: copy + drop, phantom OutputAsset: copy + drop> has key {
+        // pool owner => amount
+        record: Map::T<address, u64>
+    }
+
+    struct BorrowRecord<phantom InputAsset: copy + drop, phantom OutputAsset: copy + drop> has key {
+        // pool owner => amount
+        record: Map::T<address, u64>
+    }
+
+    struct Price<phantom InputAsset: copy + drop, phantom OutputAsset: copy + drop> has key {
+        price: u64,
+    }
+
+    fun accept<AssetType: copy + drop + store>(account: &signer, init: Token::Coin<AssetType>) {
+        let sender = signer::address_of(account);
+        assert!(!exists<Pool<AssetType>>(sender), 42);
+        move_to(account, Pool<AssetType> { coin: init })
+    }
+
+    public fun register_price<In: copy + drop + store, Out: copy + drop + store>(
+        account: &signer,
+        initial_in: Token::Coin<In>,
+        initial_out: Token::Coin<Out>,
+        price: u64
+    ) {
+        accept<In>(account, initial_in);
+        accept<Out>(account, initial_out);
+        move_to(account, Price<In, Out> { price })
+    }
+
+    public fun deposit<In: copy + drop + store, Out: copy + drop + store>(account: &signer, pool_owner: address, coin: Token::Coin<In>)
+        acquires Pool, DepositRecord
+    {
+        let amount = Token::value(&coin);
+
+        update_deposit_record<In, Out>(account, pool_owner, amount);
+
+        let pool = borrow_global_mut<Pool<In>>(pool_owner);
+        Token::deposit(&mut pool.coin, coin)
+    }
+
+    public fun borrow<In: copy + drop + store, Out: copy + drop + store>(
+        account: &signer,
+        pool_owner: address,
+        amount: u64,
+    ): Token::Coin<Out>
+        acquires Price, Pool, DepositRecord, BorrowRecord
+    {
+        assert!(amount <= max_borrow_amount<In, Out>(account, pool_owner), 1025);
+
+        update_borrow_record<In, Out>(account, pool_owner, amount);
+
+        let pool = borrow_global_mut<Pool<Out>>(pool_owner);
+        Token::withdraw(&mut pool.coin, amount)
+    }
+
+    fun max_borrow_amount<In: copy + drop + store, Out: copy + drop + store>(account: &signer, pool_owner: address): u64
+        acquires Price, Pool, DepositRecord, BorrowRecord
+    {
+        let input_deposited = deposited_amount<In, Out>(account, pool_owner);
+        let output_deposited = borrowed_amount<In, Out>(account, pool_owner);
+
+        let input_into_output =
+            input_deposited * borrow_global<Price<In, Out>>(pool_owner).price;
+        let max_output =
+            if (input_into_output < output_deposited) 0
+            else (input_into_output - output_deposited);
+        let available_output = {
+            let pool = borrow_global<Pool<Out>>(pool_owner);
+            Token::value(&pool.coin)
+        };
+        if (max_output < available_output) max_output else available_output
+
+    }
+
+    fun update_deposit_record<In: copy + drop + store, Out: copy + drop + store>(account: &signer, pool_owner: address, amount: u64)
+        acquires DepositRecord
+    {
+        let sender = signer::address_of(account);
+        if (!exists<DepositRecord<In, Out>>(sender)) {
+            move_to(account, DepositRecord<In, Out> { record: Map::empty() })
+        };
+        let record = &mut borrow_global_mut<DepositRecord<In, Out>>(sender).record;
+        if (Map::contains_key(record, &pool_owner)) {
+            let old_amount = Map::remove(record, &pool_owner);
+            amount = amount + old_amount;
+        };
+        Map::insert(record, pool_owner, amount)
+    }
+
+    fun update_borrow_record<In: copy + drop + store, Out: copy + drop + store>(account: &signer, pool_owner: address, amount: u64)
+        acquires BorrowRecord
+    {
+        let sender = signer::address_of(account);
+        if (!exists<BorrowRecord<In, Out>>(sender)) {
+            move_to(account, BorrowRecord<In, Out> { record: Map::empty() })
+        };
+        let record = &mut borrow_global_mut<BorrowRecord<In, Out>>(sender).record;
+        if (Map::contains_key(record, &pool_owner)) {
+            let old_amount = Map::remove(record, &pool_owner);
+            amount = amount + old_amount;
+        };
+        Map::insert(record, pool_owner, amount)
+    }
+
+    fun deposited_amount<In: copy + drop + store, Out: copy + drop + store>(account: &signer, pool_owner: address): u64
+        acquires DepositRecord
+    {
+        let sender = signer::address_of(account);
+        if (!exists<DepositRecord<In, Out>>(sender)) return 0;
+
+        let record = &borrow_global<DepositRecord<In, Out>>(sender).record;
+        if (Map::contains_key(record, &pool_owner)) *Map::get(record, &pool_owner)
+        else 0
+    }
+
+    fun borrowed_amount<In: copy + drop + store, Out: copy + drop + store>(account: &signer, pool_owner: address): u64
+        acquires BorrowRecord
+    {
+        let sender = signer::address_of(account);
+        if (!exists<BorrowRecord<In, Out>>(sender)) return 0;
+
+        let record = &borrow_global<BorrowRecord<In, Out>>(sender).record;
+        if (Map::contains_key(record, &pool_owner)) *Map::get(record, &pool_owner)
+        else 0
+    }
+}
+
+}
+
+address 0x70DD {
+
+module ToddNickels {
+    use 0x2::Token;
+    use std::signer;
+
+    struct T has copy, drop, store {}
+
+    struct Wallet has key {
+        nickels: Token::Coin<T>,
+    }
+
+    public fun init(account: &signer) {
+        assert!(signer::address_of(account) == @0x70DD, 42);
+        move_to(account, Wallet { nickels: Token::create(T{}, 0) })
+    }
+
+    public fun mint(account: &signer): Token::Coin<T> {
+        assert!(signer::address_of(account) == @0x70DD, 42);
+        Token::create(T{}, 5)
+    }
+
+    public fun destroy(c: Token::Coin<T>) acquires Wallet {
+        Token::deposit(&mut borrow_global_mut<Wallet>(@0x70DD).nickels, c)
+    }
+
+}
+
+}

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/simple_money_market_token.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/simple_money_market_token.exp
@@ -1,0 +1,247 @@
+// -- Model dump before bytecode pipeline
+module 0x2::Token {
+    struct Coin {
+        type: #0,
+        value: u64,
+    }
+    public fun create<ATy>(type: #0,value: u64): Token::Coin<#0> {
+        pack Token::Coin<ATy>(type, value)
+    }
+    public fun value<ATy>(coin: &Token::Coin<#0>): u64 {
+        select Token::Coin.value<&Token::Coin<ATy>>(coin)
+    }
+    public fun deposit<ATy>(coin: &mut Token::Coin<#0>,check: Token::Coin<#0>) {
+        {
+          let Token::Coin<ATy>{ type, value } = check;
+          if Eq<ATy>(Borrow(Immutable)(select Token::Coin.type<&mut Token::Coin<ATy>>(coin)), Borrow(Immutable)(type)) {
+            Tuple()
+          } else {
+            Abort(42)
+          };
+          select Token::Coin.value<&mut Token::Coin<ATy>>(coin) = Add<u64>(select Token::Coin.value<&mut Token::Coin<ATy>>(coin), value);
+          Tuple()
+        }
+    }
+    public fun destroy_zero<ATy>(coin: Token::Coin<#0>) {
+        {
+          let Token::Coin<ATy>{ type: _, value } = coin;
+          if Eq<u64>(value, 0) {
+            Tuple()
+          } else {
+            Abort(11)
+          }
+        }
+    }
+    public fun join<ATy>(xus: Token::Coin<#0>,coin2: Token::Coin<#0>): Token::Coin<#0> {
+        Token::deposit<ATy>(Borrow(Mutable)(xus), coin2);
+        xus
+    }
+    public fun split<ATy>(coin: Token::Coin<#0>,amount: u64): (Token::Coin<#0>, Token::Coin<#0>) {
+        {
+          let other: Token::Coin<ATy> = Token::withdraw<ATy>(Borrow(Mutable)(coin), amount);
+          Tuple(coin, other)
+        }
+    }
+    public fun withdraw<ATy>(coin: &mut Token::Coin<#0>,amount: u64): Token::Coin<#0> {
+        if Ge<u64>(select Token::Coin.value<&mut Token::Coin<ATy>>(coin), amount) {
+          Tuple()
+        } else {
+          Abort(10)
+        };
+        select Token::Coin.value<&mut Token::Coin<ATy>>(coin) = Sub<u64>(select Token::Coin.value<&mut Token::Coin<ATy>>(coin), amount);
+        pack Token::Coin<ATy>(Deref(Borrow(Immutable)(select Token::Coin.type<&mut Token::Coin<ATy>>(coin))), amount)
+    }
+} // end 0x2::Token
+module 0x70dd::ToddNickels {
+    use 0x2::Token; // resolved as: 0x2::Token
+    use std::signer;
+    struct T {
+        dummy_field: bool,
+    }
+    struct Wallet {
+        nickels: Token::Coin<ToddNickels::T>,
+    }
+    public fun init(account: &signer) {
+        if Eq<address>(signer::address_of(account), 0x70dd) {
+          Tuple()
+        } else {
+          Abort(42)
+        };
+        MoveTo<ToddNickels::Wallet>(account, pack ToddNickels::Wallet(Token::create<ToddNickels::T>(pack ToddNickels::T(false), 0)))
+    }
+    public fun destroy(c: Token::Coin<ToddNickels::T>)
+        acquires ToddNickels::Wallet(*)
+     {
+        Token::deposit<ToddNickels::T>(Borrow(Mutable)(select ToddNickels::Wallet.nickels<&mut ToddNickels::Wallet>(BorrowGlobal(Mutable)<ToddNickels::Wallet>(0x70dd))), c)
+    }
+    public fun mint(account: &signer): Token::Coin<ToddNickels::T> {
+        if Eq<address>(signer::address_of(account), 0x70dd) {
+          Tuple()
+        } else {
+          Abort(42)
+        };
+        Token::create<ToddNickels::T>(pack ToddNickels::T(false), 5)
+    }
+} // end 0x70dd::ToddNickels
+module 0xb055::OneToOneMarket {
+    use std::signer;
+    use 0x2::Token; // resolved as: 0x2::Token
+    struct BorrowRecord {
+        record: u64,
+    }
+    struct DepositRecord {
+        record: u64,
+    }
+    struct Pool {
+        coin: Token::Coin<#0>,
+    }
+    struct Price {
+        price: u64,
+    }
+    public fun borrow<In,Out>(account: &signer,amount: u64): Token::Coin<#1>
+        acquires OneToOneMarket::Price(*)
+        acquires OneToOneMarket::Pool(*)
+        acquires OneToOneMarket::DepositRecord(*)
+        acquires OneToOneMarket::BorrowRecord(*)
+     {
+        if Le<u64>(amount, OneToOneMarket::max_borrow_amount<In, Out>(account)) {
+          Tuple()
+        } else {
+          Abort(1025)
+        };
+        OneToOneMarket::update_borrow_record<In, Out>(account, amount);
+        {
+          let pool: &mut OneToOneMarket::Pool<Out> = BorrowGlobal(Mutable)<OneToOneMarket::Pool<Out>>(0xb055);
+          Token::withdraw<Out>(Borrow(Mutable)(select OneToOneMarket::Pool.coin<&mut OneToOneMarket::Pool<Out>>(pool)), amount)
+        }
+    }
+    public fun deposit<In,Out>(account: &signer,coin: Token::Coin<#0>)
+        acquires OneToOneMarket::Pool(*)
+        acquires OneToOneMarket::DepositRecord(*)
+     {
+        {
+          let amount: u64 = Token::value<In>(Borrow(Immutable)(coin));
+          OneToOneMarket::update_deposit_record<In, Out>(account, amount);
+          {
+            let pool: &mut OneToOneMarket::Pool<In> = BorrowGlobal(Mutable)<OneToOneMarket::Pool<In>>(0xb055);
+            Token::deposit<In>(Borrow(Mutable)(select OneToOneMarket::Pool.coin<&mut OneToOneMarket::Pool<In>>(pool)), coin)
+          }
+        }
+    }
+    private fun accept<AssetType>(account: &signer,init: Token::Coin<#0>) {
+        {
+          let sender: address = signer::address_of(account);
+          if Not(exists<OneToOneMarket::Pool<AssetType>>(sender)) {
+            Tuple()
+          } else {
+            Abort(42)
+          };
+          MoveTo<OneToOneMarket::Pool<AssetType>>(account, pack OneToOneMarket::Pool<AssetType>(init))
+        }
+    }
+    private fun borrowed_amount<In,Out>(account: &signer): u64
+        acquires OneToOneMarket::BorrowRecord(*)
+     {
+        {
+          let sender: address = signer::address_of(account);
+          if Not(exists<OneToOneMarket::BorrowRecord<In, Out>>(sender)) {
+            return 0
+          } else {
+            Tuple()
+          };
+          select OneToOneMarket::BorrowRecord.record<&OneToOneMarket::BorrowRecord<In, Out>>(BorrowGlobal(Immutable)<OneToOneMarket::BorrowRecord<In, Out>>(sender))
+        }
+    }
+    private fun deposited_amount<In,Out>(account: &signer): u64
+        acquires OneToOneMarket::DepositRecord(*)
+     {
+        {
+          let sender: address = signer::address_of(account);
+          if Not(exists<OneToOneMarket::DepositRecord<In, Out>>(sender)) {
+            return 0
+          } else {
+            Tuple()
+          };
+          select OneToOneMarket::DepositRecord.record<&OneToOneMarket::DepositRecord<In, Out>>(BorrowGlobal(Immutable)<OneToOneMarket::DepositRecord<In, Out>>(sender))
+        }
+    }
+    private fun max_borrow_amount<In,Out>(account: &signer): u64
+        acquires OneToOneMarket::Price(*)
+        acquires OneToOneMarket::Pool(*)
+        acquires OneToOneMarket::DepositRecord(*)
+        acquires OneToOneMarket::BorrowRecord(*)
+     {
+        {
+          let input_deposited: u64 = OneToOneMarket::deposited_amount<In, Out>(account);
+          {
+            let output_deposited: u64 = OneToOneMarket::borrowed_amount<In, Out>(account);
+            {
+              let input_into_output: u64 = Mul<u64>(input_deposited, select OneToOneMarket::Price.price<&OneToOneMarket::Price<In, Out>>(BorrowGlobal(Immutable)<OneToOneMarket::Price<In, Out>>(0xb055)));
+              {
+                let max_output: u64 = if Lt<u64>(input_into_output, output_deposited) {
+                  0
+                } else {
+                  Sub<u64>(input_into_output, output_deposited)
+                };
+                {
+                  let available_output: u64 = {
+                    let pool: &OneToOneMarket::Pool<Out> = BorrowGlobal(Immutable)<OneToOneMarket::Pool<Out>>(0xb055);
+                    Token::value<Out>(Borrow(Immutable)(select OneToOneMarket::Pool.coin<&OneToOneMarket::Pool<Out>>(pool)))
+                  };
+                  if Lt<u64>(max_output, available_output) {
+                    max_output
+                  } else {
+                    available_output
+                  }
+                }
+              }
+            }
+          }
+        }
+    }
+    public fun register_price<In,Out>(account: &signer,initial_in: Token::Coin<#0>,initial_out: Token::Coin<#1>,price: u64) {
+        {
+          let sender: address = signer::address_of(account);
+          if Eq<address>(sender, 0xb055) {
+            Tuple()
+          } else {
+            Abort(42)
+          };
+          OneToOneMarket::accept<In>(account, initial_in);
+          OneToOneMarket::accept<Out>(account, initial_out);
+          MoveTo<OneToOneMarket::Price<In, Out>>(account, pack OneToOneMarket::Price<In, Out>(price))
+        }
+    }
+    private fun update_borrow_record<In,Out>(account: &signer,amount: u64)
+        acquires OneToOneMarket::BorrowRecord(*)
+     {
+        {
+          let sender: address = signer::address_of(account);
+          if Not(exists<OneToOneMarket::BorrowRecord<In, Out>>(sender)) {
+            MoveTo<OneToOneMarket::BorrowRecord<In, Out>>(account, pack OneToOneMarket::BorrowRecord<In, Out>(0))
+          } else {
+            Tuple()
+          };
+          {
+            let record: &mut u64 = Borrow(Mutable)(select OneToOneMarket::BorrowRecord.record<&mut OneToOneMarket::BorrowRecord<In, Out>>(BorrowGlobal(Mutable)<OneToOneMarket::BorrowRecord<In, Out>>(sender)));
+            record = Add<u64>(Deref(record), amount)
+          }
+        }
+    }
+    private fun update_deposit_record<In,Out>(account: &signer,amount: u64)
+        acquires OneToOneMarket::DepositRecord(*)
+     {
+        {
+          let sender: address = signer::address_of(account);
+          if Not(exists<OneToOneMarket::DepositRecord<In, Out>>(sender)) {
+            MoveTo<OneToOneMarket::DepositRecord<In, Out>>(account, pack OneToOneMarket::DepositRecord<In, Out>(0))
+          } else {
+            Tuple()
+          };
+          {
+            let record: &mut u64 = Borrow(Mutable)(select OneToOneMarket::DepositRecord.record<&mut OneToOneMarket::DepositRecord<In, Out>>(BorrowGlobal(Mutable)<OneToOneMarket::DepositRecord<In, Out>>(sender)));
+            record = Add<u64>(Deref(record), amount)
+          }
+        }
+    }
+} // end 0xb055::OneToOneMarket

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/simple_money_market_token.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/simple_money_market_token.move
@@ -1,0 +1,204 @@
+address 0x2 {
+
+module Token {
+
+    struct Coin<AssetType: copy + drop> has store {
+        type: AssetType,
+        value: u64,
+    }
+
+    // control the minting/creation in the defining module of `ATy`
+    public fun create<ATy: copy + drop + store>(type: ATy, value: u64): Coin<ATy> {
+        Coin { type, value }
+    }
+
+    public fun value<ATy: copy + drop + store>(coin: &Coin<ATy>): u64 {
+        coin.value
+    }
+
+    public fun split<ATy: copy + drop + store>(coin: Coin<ATy>, amount: u64): (Coin<ATy>, Coin<ATy>) {
+        let other = withdraw(&mut coin, amount);
+        (coin, other)
+    }
+
+    public fun withdraw<ATy: copy + drop + store>(coin: &mut Coin<ATy>, amount: u64): Coin<ATy> {
+        assert!(coin.value >= amount, 10);
+        coin.value = coin.value - amount;
+        Coin { type: *&coin.type, value: amount }
+    }
+
+    public fun join<ATy: copy + drop + store>(xus: Coin<ATy>, coin2: Coin<ATy>): Coin<ATy> {
+        deposit(&mut xus, coin2);
+        xus
+    }
+
+    public fun deposit<ATy: copy + drop + store>(coin: &mut Coin<ATy>, check: Coin<ATy>) {
+        let Coin { value, type } = check;
+        assert!(&coin.type == &type, 42);
+        coin.value = coin.value + value;
+    }
+
+    public fun destroy_zero<ATy: copy + drop + store>(coin: Coin<ATy>) {
+        let Coin { value, type: _ } = coin;
+        assert!(value == 0, 11)
+    }
+
+}
+
+}
+
+address 0xB055 {
+
+module OneToOneMarket {
+    use std::signer;
+    use 0x2::Token;
+
+    struct Pool<AssetType: copy + drop> has key {
+        coin: Token::Coin<AssetType>,
+    }
+
+    struct DepositRecord<phantom InputAsset: copy + drop, phantom OutputAsset: copy + drop> has key {
+        record: u64,
+    }
+
+    struct BorrowRecord<phantom InputAsset: copy + drop, phantom OutputAsset: copy + drop> has key {
+        record: u64,
+    }
+
+    struct Price<phantom InputAsset: copy + drop, phantom OutputAsset: copy + drop> has key {
+        price: u64,
+    }
+
+    fun accept<AssetType: copy + drop + store>(account: &signer, init: Token::Coin<AssetType>) {
+        let sender = signer::address_of(account);
+        assert!(!exists<Pool<AssetType>>(sender), 42);
+        move_to(account, Pool<AssetType> { coin: init })
+    }
+
+    public fun register_price<In: copy + drop + store, Out: copy + drop + store>(
+        account: &signer,
+        initial_in: Token::Coin<In>,
+        initial_out: Token::Coin<Out>,
+        price: u64
+    ) {
+        let sender = signer::address_of(account);
+        assert!(sender == @0xB055, 42); // assert sender is module writer
+        accept<In>(account, initial_in);
+        accept<Out>(account, initial_out);
+        move_to(account, Price<In, Out> { price })
+    }
+
+    public fun deposit<In: copy + drop + store, Out: copy + drop + store>(account: &signer, coin: Token::Coin<In>)
+        acquires Pool, DepositRecord
+    {
+        let amount = Token::value(&coin);
+
+        update_deposit_record<In, Out>(account, amount);
+
+        let pool = borrow_global_mut<Pool<In>>(@0xB055);
+        Token::deposit(&mut pool.coin, coin)
+    }
+
+    public fun borrow<In: copy + drop + store, Out: copy + drop + store>(
+        account: &signer,
+        amount: u64,
+    ): Token::Coin<Out>
+        acquires Price, Pool, DepositRecord, BorrowRecord
+    {
+        assert!(amount <= max_borrow_amount<In, Out>(account), 1025);
+
+        update_borrow_record<In, Out>(account, amount);
+
+        let pool = borrow_global_mut<Pool<Out>>(@0xB055);
+        Token::withdraw(&mut pool.coin, amount)
+    }
+
+    fun max_borrow_amount<In: copy + drop + store, Out: copy + drop + store>(account: &signer): u64
+        acquires Price, Pool, DepositRecord, BorrowRecord
+    {
+        let input_deposited = deposited_amount<In, Out>(account);
+        let output_deposited = borrowed_amount<In, Out>(account);
+
+        let input_into_output =
+            input_deposited * borrow_global<Price<In, Out>>(@0xB055).price;
+        let max_output =
+            if (input_into_output < output_deposited) 0
+            else (input_into_output - output_deposited);
+        let available_output = {
+            let pool = borrow_global<Pool<Out>>(@0xB055);
+            Token::value(&pool.coin)
+        };
+        if (max_output < available_output) max_output else available_output
+
+    }
+
+    fun update_deposit_record<In: copy + drop + store, Out: copy + drop + store>(account: &signer, amount: u64)
+        acquires DepositRecord
+    {
+        let sender = signer::address_of(account);
+        if (!exists<DepositRecord<In, Out>>(sender)) {
+            move_to(account, DepositRecord<In, Out> { record: 0 })
+        };
+        let record = &mut borrow_global_mut<DepositRecord<In, Out>>(sender).record;
+        *record = *record + amount
+    }
+
+    fun update_borrow_record<In: copy + drop + store, Out: copy + drop + store>(account: &signer, amount: u64)
+        acquires BorrowRecord
+    {
+        let sender = signer::address_of(account);
+        if (!exists<BorrowRecord<In, Out>>(sender)) {
+            move_to(account, BorrowRecord<In, Out> { record: 0 })
+        };
+        let record = &mut borrow_global_mut<BorrowRecord<In, Out>>(sender).record;
+        *record = *record + amount
+    }
+
+    fun deposited_amount<In: copy + drop + store, Out: copy + drop + store>(account: &signer): u64
+        acquires DepositRecord
+    {
+        let sender = signer::address_of(account);
+        if (!exists<DepositRecord<In, Out>>(sender)) return 0;
+        borrow_global<DepositRecord<In, Out>>(sender).record
+    }
+
+    fun borrowed_amount<In: copy + drop + store, Out: copy + drop + store>(account: &signer): u64
+        acquires BorrowRecord
+    {
+        let sender = signer::address_of(account);
+        if (!exists<BorrowRecord<In, Out>>(sender)) return 0;
+        borrow_global<BorrowRecord<In, Out>>(sender).record
+    }
+}
+
+}
+
+address 0x70DD {
+
+module ToddNickels {
+    use 0x2::Token;
+    use std::signer;
+
+    struct T has copy, drop, store {}
+
+    struct Wallet has key {
+        nickels: Token::Coin<T>,
+    }
+
+    public fun init(account: &signer) {
+        assert!(signer::address_of(account) == @0x70DD, 42);
+        move_to(account, Wallet { nickels: Token::create(T{}, 0) })
+    }
+
+    public fun mint(account: &signer): Token::Coin<T> {
+        assert!(signer::address_of(account) == @0x70DD, 42);
+        Token::create(T{}, 5)
+    }
+
+    public fun destroy(c: Token::Coin<T>) acquires Wallet {
+        Token::deposit(&mut borrow_global_mut<Wallet>(@0x70DD).nickels, c)
+    }
+
+}
+
+}

--- a/third_party/move/move-compiler-v2/tests/v1.matched
+++ b/third_party/move/move-compiler-v2/tests/v1.matched
@@ -1,6 +1,6 @@
-WARNING: test `move-compiler-v2/tests/more-v1/verification/cross_module_valid.verification.move` and `move-compiler-v2/tests/more-v1/verification/verify/cross_module_valid.move` share common key `verification/cross_module_valid.verification.move`, discarding former one
-WARNING: test `move-compiler-v2/tests/more-v1/verification/double_annotation.verification.move` and `move-compiler-v2/tests/more-v1/verification/verify/double_annotation.move` share common key `verification/double_annotation.verification.move`, discarding former one
-WARNING: test `move-compiler-v2/tests/more-v1/verification/single_module_valid.verification.move` and `move-compiler-v2/tests/more-v1/verification/verify/single_module_valid.move` share common key `verification/single_module_valid.verification.move`, discarding former one
+WARNING: test `move-compiler-v2/tests/verification/cross_module_valid.verification.move` and `move-compiler-v2/tests/verification/verify/cross_module_valid.move` share common key `verification/cross_module_valid.verification.move`, discarding former one
+WARNING: test `move-compiler-v2/tests/verification/double_annotation.verification.move` and `move-compiler-v2/tests/verification/verify/double_annotation.move` share common key `verification/double_annotation.verification.move`, discarding former one
+WARNING: test `move-compiler-v2/tests/verification/single_module_valid.verification.move` and `move-compiler-v2/tests/verification/verify/single_module_valid.move` share common key `verification/single_module_valid.verification.move`, discarding former one
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_1.exp   move-compiler-v2/tests/acquires-checker/v1-borrow-tests/borrow_global_acquires_1.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_2.exp   move-compiler-v2/tests/acquires-checker/v1-borrow-tests/borrow_global_acquires_2.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/borrow_global_acquires_3.exp   move-compiler-v2/tests/acquires-checker/v1-borrow-tests/borrow_global_acquires_3.exp
@@ -155,17 +155,19 @@ move-compiler/tests/move_check/translated_ir_tests/move/commands/use_before_assi
 move-compiler/tests/move_check/control_flow/for_loop_empty_novar.exp   move-compiler-v2/tests/checking/control_flow/for_loop_empty_novar.exp
 move-compiler/tests/move_check/control_flow/for_type_mismatch.exp   move-compiler-v2/tests/checking/control_flow/for_type_mismatch.exp
 move-compiler/tests/move_check/control_flow/loop_after_loop.exp   move-compiler-v2/tests/checking/control_flow/loop_after_loop.exp
-move-compiler/tests/move_check/deprecated/deprecated_constant_duplicated_struct.exp   move-compiler-v2/tests/more-v1/deprecated/deprecated_constant_duplicated_struct.exp
-move-compiler/tests/move_check/deprecated/deprecated_constant_duplicated_struct2.exp   move-compiler-v2/tests/more-v1/deprecated/deprecated_constant_duplicated_struct2.exp
-move-compiler/tests/move_check/deprecated/deprecated_field_type.exp   move-compiler-v2/tests/more-v1/deprecated/deprecated_field_type.exp
-move-compiler/tests/move_check/deprecated/deprecated_field_type2.exp   move-compiler-v2/tests/more-v1/deprecated/deprecated_field_type2.exp
-move-compiler/tests/move_check/deprecated/deprecated_placement_address.exp   move-compiler-v2/tests/more-v1/deprecated/deprecated_placement_address.exp
-move-compiler/tests/move_check/deprecated/deprecated_placement_address_module_members.exp   move-compiler-v2/tests/more-v1/deprecated/deprecated_placement_address_module_members.exp
-move-compiler/tests/move_check/deprecated/deprecated_placement_members.exp   move-compiler-v2/tests/more-v1/deprecated/deprecated_placement_members.exp
-move-compiler/tests/move_check/deprecated/deprecated_placement_module.exp   move-compiler-v2/tests/more-v1/deprecated/deprecated_placement_module.exp
-move-compiler/tests/move_check/deprecated/deprecated_placement_module2.exp   move-compiler-v2/tests/more-v1/deprecated/deprecated_placement_module2.exp
-move-compiler/tests/move_check/deprecated/deprecated_placement_module_members.exp   move-compiler-v2/tests/more-v1/deprecated/deprecated_placement_module_members.exp
-move-compiler/tests/move_check/deprecated/public_script.exp   move-compiler-v2/tests/more-v1/deprecated/public_script.exp
+move-compiler/tests/move_check/deprecated/deprecated_constant_duplicated_struct.exp   move-compiler-v2/tests/deprecated/deprecated_constant_duplicated_struct.exp
+move-compiler/tests/move_check/deprecated/deprecated_constant_duplicated_struct2.exp   move-compiler-v2/tests/deprecated/deprecated_constant_duplicated_struct2.exp
+move-compiler/tests/move_check/deprecated/deprecated_field_type.exp   move-compiler-v2/tests/deprecated/deprecated_field_type.exp
+move-compiler/tests/move_check/deprecated/deprecated_field_type2.exp   move-compiler-v2/tests/deprecated/deprecated_field_type2.exp
+move-compiler/tests/move_check/deprecated/deprecated_placement_address.exp   move-compiler-v2/tests/deprecated/deprecated_placement_address.exp
+move-compiler/tests/move_check/deprecated/deprecated_placement_address_module_members.exp   move-compiler-v2/tests/deprecated/deprecated_placement_address_module_members.exp
+move-compiler/tests/move_check/deprecated/deprecated_placement_members.exp   move-compiler-v2/tests/deprecated/deprecated_placement_members.exp
+move-compiler/tests/move_check/deprecated/deprecated_placement_module.exp   move-compiler-v2/tests/deprecated/deprecated_placement_module.exp
+move-compiler/tests/move_check/deprecated/deprecated_placement_module2.exp   move-compiler-v2/tests/deprecated/deprecated_placement_module2.exp
+move-compiler/tests/move_check/deprecated/deprecated_placement_module_members.exp   move-compiler-v2/tests/deprecated/deprecated_placement_module_members.exp
+move-compiler/tests/move_check/deprecated/public_script.exp   move-compiler-v2/tests/deprecated/public_script.exp
+move-compiler/tests/move_check/examples/multi_pool_money_market_token.exp   move-compiler-v2/tests/checking/typing/v1-examples/multi_pool_money_market_token.exp
+move-compiler/tests/move_check/examples/simple_money_market_token.exp   move-compiler-v2/tests/checking/typing/v1-examples/simple_money_market_token.exp
 move-compiler/tests/move_check/folding/empty_vectors.exp   move-compiler-v2/tests/folding/empty_vectors.exp
 move-compiler/tests/move_check/folding/empty_vectors2.exp   move-compiler-v2/tests/folding/empty_vectors2.exp
 move-compiler/tests/move_check/folding/non_constant_empty_vec.exp   move-compiler-v2/tests/folding/non_constant_empty_vec.exp
@@ -637,12 +639,12 @@ move-compiler/tests/move_check/unit_test/test_filter_function.exp   move-compile
 move-compiler/tests/move_check/unit_test/test_filter_struct.exp   move-compiler-v2/tests/unit_test/notest/test_filter_struct.exp
 move-compiler/tests/move_check/unit_test/valid_test_module.exp   move-compiler-v2/tests/unit_test/notest/valid_test_module.exp
 move-compiler/tests/move_check/unit_test/valid_test_module.unit_test.exp   move-compiler-v2/tests/unit_test/test/valid_test_module.exp
-move-compiler/tests/move_check/verification/cross_module_invalid.exp   move-compiler-v2/tests/more-v1/verification/noverify/cross_module_invalid.exp
-move-compiler/tests/move_check/verification/cross_module_valid.exp   move-compiler-v2/tests/more-v1/verification/noverify/cross_module_valid.exp
-move-compiler/tests/move_check/verification/cross_module_valid.verification.exp   move-compiler-v2/tests/more-v1/verification/verify/cross_module_valid.exp
-move-compiler/tests/move_check/verification/double_annotation.exp   move-compiler-v2/tests/more-v1/verification/noverify/double_annotation.exp
-move-compiler/tests/move_check/verification/double_annotation.verification.exp   move-compiler-v2/tests/more-v1/verification/verify/double_annotation.exp
-move-compiler/tests/move_check/verification/single_module_invalid.exp   move-compiler-v2/tests/more-v1/verification/noverify/single_module_invalid.exp
-move-compiler/tests/move_check/verification/single_module_invalid.verification.exp   move-compiler-v2/tests/more-v1/verification/single_module_invalid.verification.exp
-move-compiler/tests/move_check/verification/single_module_valid.exp   move-compiler-v2/tests/more-v1/verification/noverify/single_module_valid.exp
-move-compiler/tests/move_check/verification/single_module_valid.verification.exp   move-compiler-v2/tests/more-v1/verification/verify/single_module_valid.exp
+move-compiler/tests/move_check/verification/cross_module_invalid.exp   move-compiler-v2/tests/verification/noverify/cross_module_invalid.exp
+move-compiler/tests/move_check/verification/cross_module_valid.exp   move-compiler-v2/tests/verification/noverify/cross_module_valid.exp
+move-compiler/tests/move_check/verification/cross_module_valid.verification.exp   move-compiler-v2/tests/verification/verify/cross_module_valid.exp
+move-compiler/tests/move_check/verification/double_annotation.exp   move-compiler-v2/tests/verification/noverify/double_annotation.exp
+move-compiler/tests/move_check/verification/double_annotation.verification.exp   move-compiler-v2/tests/verification/verify/double_annotation.exp
+move-compiler/tests/move_check/verification/single_module_invalid.exp   move-compiler-v2/tests/verification/noverify/single_module_invalid.exp
+move-compiler/tests/move_check/verification/single_module_invalid.verification.exp   move-compiler-v2/tests/verification/single_module_invalid.verification.exp
+move-compiler/tests/move_check/verification/single_module_valid.exp   move-compiler-v2/tests/verification/noverify/single_module_valid.exp
+move-compiler/tests/move_check/verification/single_module_valid.verification.exp   move-compiler-v2/tests/verification/verify/single_module_valid.exp

--- a/third_party/move/move-compiler-v2/tests/v1.unmatched
+++ b/third_party/move/move-compiler-v2/tests/v1.unmatched
@@ -1,6 +1,6 @@
-WARNING: test `move-compiler-v2/tests/more-v1/verification/cross_module_valid.verification.move` and `move-compiler-v2/tests/more-v1/verification/verify/cross_module_valid.move` share common key `verification/cross_module_valid.verification.move`, discarding former one
-WARNING: test `move-compiler-v2/tests/more-v1/verification/double_annotation.verification.move` and `move-compiler-v2/tests/more-v1/verification/verify/double_annotation.move` share common key `verification/double_annotation.verification.move`, discarding former one
-WARNING: test `move-compiler-v2/tests/more-v1/verification/single_module_valid.verification.move` and `move-compiler-v2/tests/more-v1/verification/verify/single_module_valid.move` share common key `verification/single_module_valid.verification.move`, discarding former one
+WARNING: test `move-compiler-v2/tests/verification/cross_module_valid.verification.move` and `move-compiler-v2/tests/verification/verify/cross_module_valid.move` share common key `verification/cross_module_valid.verification.move`, discarding former one
+WARNING: test `move-compiler-v2/tests/verification/double_annotation.verification.move` and `move-compiler-v2/tests/verification/verify/double_annotation.move` share common key `verification/double_annotation.verification.move`, discarding former one
+WARNING: test `move-compiler-v2/tests/verification/single_module_valid.verification.move` and `move-compiler-v2/tests/verification/verify/single_module_valid.move` share common key `verification/single_module_valid.verification.move`, discarding former one
 move-compiler/tests/move_check/borrow_tests/{
   borrow_global_acquires_duplicate_annotation.move,
   eq_bad.move,
@@ -35,10 +35,6 @@ move-compiler/tests/move_check/control_flow/{
 move-compiler/tests/move_check/deprecated/{
   assert_function.move,
   deprecated_placement_basecase.move,
-}
-move-compiler/tests/move_check/examples/{
-  multi_pool_money_market_token.move,
-  simple_money_market_token.move,
 }
 move-compiler/tests/move_check/liveness/{
   copy_after_move.move,

--- a/third_party/move/move-compiler-v2/tools/testdiff/src/main.rs
+++ b/third_party/move/move-compiler-v2/tools/testdiff/src/main.rs
@@ -83,6 +83,7 @@ static UNIT_PATH_REMAP: Lazy<Vec<(&'static str, &'static str)>> = Lazy::new(|| {
         ("typing/v1-naming", "naming"),
         ("typing/v1-operators", "operators"),
         ("typing/v1-signer", "signer"),
+        ("typing/v1-examples", "examples"),
         ("live-var/v1-commands", "commands"),
         ("live-var", "liveness"),
         ("visibility-checker/v1-typing", "typing"),

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -127,6 +127,7 @@ pub(crate) struct StructEntry {
     /// Whether the struct is originally empty
     /// always false when it is enum
     pub is_empty_struct: bool,
+    pub is_native: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -354,6 +355,7 @@ impl<'env> ModelBuilder<'env> {
         abilities: AbilitySet,
         type_params: Vec<TypeParameter>,
         layout: StructLayout,
+        is_native: bool,
     ) {
         let entry = StructEntry {
             loc,
@@ -365,6 +367,7 @@ impl<'env> ModelBuilder<'env> {
             layout,
             receiver_functions: BTreeMap::new(),
             is_empty_struct: false,
+            is_native,
         };
         self.struct_table.insert(name.clone(), entry);
         self.reverse_struct_table

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -491,7 +491,8 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             struct_id,
             abilities,
             type_params,
-            StructLayout::None, // will be filled in during definition analysis
+            StructLayout::None, // will be filled in during definition analysis,
+            matches!(def.layout, EA::StructLayout::Native(_)),
         );
     }
 
@@ -3447,6 +3448,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                     Some(variants)
                 },
                 spec: RefCell::new(spec),
+                is_native: entry.is_native,
             };
             struct_data.insert(StructId::new(name.symbol), data);
         }

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -1641,6 +1641,7 @@ impl GlobalEnv {
             field_data,
             variants: None,
             spec: RefCell::new(Spec::default()),
+            is_native: false,
         }
     }
 
@@ -3256,6 +3257,9 @@ pub struct StructData {
 
     /// Associated specification.
     pub(crate) spec: RefCell<Spec>,
+
+    /// Whether this struct is native
+    pub is_native: bool,
 }
 
 #[derive(Debug)]
@@ -3472,6 +3476,11 @@ impl<'env> StructEnv<'env> {
                 struct_env: self.clone(),
                 data,
             })
+    }
+
+    /// Return true if it is a native struct
+    pub fn is_native(&self) -> bool {
+        self.data.is_native
     }
 
     /// Return the number of fields in the struct. Notice of the struct has variants, this


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR closes #13758 by setting field_information as Native instead of Declared when the field count is 0 (which means it is a native struct).

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

1) existing tests pass;
2) migrate two tests from V1.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

Since `dummy_field` is inserted for user defined empty structs during compilation, if the field count is 0, the struct is native. Need to guarantee that this reasoning is correct.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
