### PR TITLE
Attempt #2: switch high-perf-docker to runs-on.com runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,4 @@
 self-hosted-runner:
   # Labels of self-hosted runners in array of string
   labels:
-    - high-perf-docker
+    - runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}

--- a/.github/workflows/cli-e2e-tests.yaml
+++ b/.github/workflows/cli-e2e-tests.yaml
@@ -25,7 +25,7 @@ jobs:
   # we ensure that the Aptos CLI works with all 3 prod networks, at least
   # based on the tests in the test suite.
   run-cli-tests:
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/coverage-move-only.yaml
+++ b/.github/workflows/coverage-move-only.yaml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   rust-move-unit-coverage:
     timeout-minutes: 60
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -27,7 +27,7 @@ jobs:
       (github.event_name == 'schedule' && github.ref_name == 'main')
     # Note the tests run slowly due to instrutmentation. It takes CI 10 hrs
     timeout-minutes: 720
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -58,7 +58,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'CICD:run-coverage') ||
       (github.event_name == 'schedule' && github.ref_name == 'main')
     timeout-minutes: 720 # incremented from 240 due to execution time limit hit in cron
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/docker-build-rosetta.yaml
+++ b/.github/workflows/docker-build-rosetta.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/faucet-tests-main.yaml
+++ b/.github/workflows/faucet-tests-main.yaml
@@ -49,7 +49,7 @@ jobs:
   # be compatible in production.
   run-tests-main:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v3
         if: ${{ !inputs.SKIP_JOB }}

--- a/.github/workflows/faucet-tests-prod.yaml
+++ b/.github/workflows/faucet-tests-prod.yaml
@@ -37,7 +37,7 @@ jobs:
   run-tests-devnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
@@ -57,7 +57,7 @@ jobs:
   run-tests-testnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
+++ b/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   find-packages-with-undeclared-feature-dependencies:
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main

--- a/.github/workflows/indexer-grpc-integration-tests.yaml
+++ b/.github/workflows/indexer-grpc-integration-tests.yaml
@@ -30,7 +30,7 @@ jobs:
   run-tests-local-testnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     env:
       # spin up the local testnet using the latest devnet image
       VALIDATOR_IMAGE_REPO: ${{ vars.GCP_DOCKER_ARTIFACT_REPO }}/validator

--- a/.github/workflows/keyless-circuit-daily-test.yaml
+++ b/.github/workflows/keyless-circuit-daily-test.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   run-all-circuit-tests:
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -56,7 +56,7 @@ jobs:
   # Run the crypto hasher domain separation checks
   rust-cryptohasher-domain-separation-check:
     needs: file_change_determinator
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
   # Run all rust lints. This is a PR required job.
   rust-lints:
     needs: file_change_determinator
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -94,7 +94,7 @@ jobs:
         github.event.pull_request.auto_merge != null) ||
         contains(github.event.pull_request.body, '#e2e'
       )
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -109,7 +109,7 @@ jobs:
   # Run only the targeted rust unit tests. This is a PR required job.
   rust-targeted-unit-tests:
     needs: file_change_determinator
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -128,7 +128,7 @@ jobs:
         github.event_name == 'push' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-all-unit-tests')
       )
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - name: Run rust unit tests
@@ -147,7 +147,7 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
         github.event.pull_request.auto_merge != null
       )
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -162,7 +162,7 @@ jobs:
 
   # Run the consensus only unit tests
   rust-consensus-only-unit-test:
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
       - uses: actions/checkout@v4
@@ -178,7 +178,7 @@ jobs:
 
   # Run the consensus only smoke test
   rust-consensus-only-smoke-test:
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/move-test-compiler-v2.yaml
+++ b/.github/workflows/move-test-compiler-v2.yaml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   # Run Aptos Move Compiler v2 tests. This is a PR required job.
   rust-move-tests:
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v3
       - name: Run Aptos Move tests with compiler V2

--- a/.github/workflows/node-api-compatibility-tests.yaml
+++ b/.github/workflows/node-api-compatibility-tests.yaml
@@ -43,7 +43,7 @@ jobs:
   # if there are any changes that would affect it within the PR / commit. If
   # everything is checked in, run tests, build the SDK, and upload it to npmjs.
   node-api-compatibility-tests:
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/prover-daily-test.yaml
+++ b/.github/workflows/prover-daily-test.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   prover-inconsistency-test:
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     timeout-minutes: ${{ github.event_name == 'pull_request' && 10 || 480}}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run-gas-calibration.yaml
+++ b/.github/workflows/run-gas-calibration.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   run-gas-calibration:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/rust-client-tests.yaml
+++ b/.github/workflows/rust-client-tests.yaml
@@ -31,7 +31,7 @@ jobs:
   run-tests-devnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
@@ -50,7 +50,7 @@ jobs:
   run-tests-testnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
@@ -69,7 +69,7 @@ jobs:
   run-tests-mainnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v3
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main

--- a/.github/workflows/ts-sdk-e2e-tests.yaml
+++ b/.github/workflows/ts-sdk-e2e-tests.yaml
@@ -53,7 +53,7 @@ jobs:
   # Now that the latter runs against the local testnet too we make these land blocking.
   run-tests-main-branch:
     needs: [permission-check, file_change_determinator]
-    runs-on: high-perf-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v3
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'


### PR DESCRIPTION
Reintroducing runs-on runners as high-perf-docker replacement again. This is after flakyness issues that were observed last time have been resolved.
This time using AWS custom AMI build by @ibalajiarun .