### PR TITLE
fix flag to compare concurrency levels in single node performance benchmark

### DIFF
--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -233,17 +233,19 @@ pub fn run_benchmark<V>(
         }
     );
 
-    let num_txns = db.reader.get_synced_version().unwrap() - version - num_blocks_created as u64;
-    overall_measuring.print_end("Overall", num_txns);
+    if !pipeline_config.skip_commit {
+        let num_txns =
+            db.reader.get_synced_version().unwrap() - version - num_blocks_created as u64;
+        overall_measuring.print_end("Overall", num_txns);
 
-    if verify_sequence_numbers {
-        generator.verify_sequence_numbers(db.reader.clone());
+        if verify_sequence_numbers {
+            generator.verify_sequence_numbers(db.reader.clone());
+        }
+        log_total_supply(&db.reader);
     }
 
     // Assert there were no error log lines in the run.
     assert_eq!(0, aptos_logger::ERROR_LOG_COUNT.get());
-
-    log_total_supply(&db.reader);
 }
 
 fn init_workload<V>(

--- a/execution/executor-benchmark/src/pipeline.rs
+++ b/execution/executor-benchmark/src/pipeline.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    block_preparation::BlockPreparationStage, ledger_update_stage::LedgerUpdateStage,
-    metrics::NUM_TXNS, OverallMeasuring, TransactionCommitter, TransactionExecutor,
+    block_preparation::BlockPreparationStage,
+    ledger_update_stage::{CommitProcessing, LedgerUpdateStage},
+    metrics::NUM_TXNS,
+    OverallMeasuring, TransactionCommitter, TransactionExecutor,
 };
 use aptos_block_partitioner::v2::config::PartitionerV2Config;
 use aptos_crypto::HashValue;
@@ -85,7 +87,7 @@ where
             );
 
         let (commit_sender, commit_receiver) = mpsc::sync_channel::<CommitBlockMessage>(
-            if config.split_stages || config.skip_commit {
+            if config.split_stages {
                 (num_blocks.unwrap() + 1).max(3)
             } else {
                 3
@@ -99,7 +101,7 @@ where
             (None, None)
         };
 
-        let (start_commit_tx, start_commit_rx) = if config.split_stages || config.skip_commit {
+        let (start_commit_tx, start_commit_rx) = if config.split_stages {
             let (start_commit_tx, start_commit_rx) = mpsc::sync_channel::<()>(1);
             (Some(start_commit_tx), Some(start_commit_rx))
         } else {
@@ -120,8 +122,13 @@ where
             config.allow_retries,
         );
 
+        let commit_processing = if config.skip_commit {
+            CommitProcessing::Skip
+        } else {
+            CommitProcessing::SendToQueue(commit_sender)
+        };
         let mut ledger_update_stage =
-            LedgerUpdateStage::new(executor_2, Some(commit_sender), version);
+            LedgerUpdateStage::new(executor_2, commit_processing, version);
 
         let (executable_block_sender, executable_block_receiver) =
             mpsc::sync_channel::<ExecuteBlockMessage>(3);
@@ -191,7 +198,9 @@ where
                     );
                 }
 
-                overall_measuring.print_end("Overall execution", executed);
+                if num_blocks.is_some() {
+                    overall_measuring.print_end("Overall execution", executed);
+                }
                 start_commit_tx.map(|tx| tx.send(()));
             })
             .expect("Failed to spawn transaction executor thread.");
@@ -212,21 +221,19 @@ where
             .expect("Failed to spawn ledger update thread.");
         join_handles.push(ledger_update_thread);
 
-        let skip_commit = config.skip_commit;
-
-        let commit_thread = std::thread::Builder::new()
-            .name("txn_committer".to_string())
-            .spawn(move || {
-                start_commit_rx.map(|rx| rx.recv());
-                info!("Starting commit thread");
-                if !skip_commit {
+        if !config.skip_commit {
+            let commit_thread = std::thread::Builder::new()
+                .name("txn_committer".to_string())
+                .spawn(move || {
+                    start_commit_rx.map(|rx| rx.recv());
+                    info!("Starting commit thread");
                     let mut committer =
                         TransactionCommitter::new(executor_3, version, commit_receiver);
                     committer.run();
-                }
-            })
-            .expect("Failed to spawn transaction committer thread.");
-        join_handles.push(commit_thread);
+                })
+                .expect("Failed to spawn transaction committer thread.");
+            join_handles.push(commit_thread);
+        }
 
         (
             Self {

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -193,7 +193,7 @@ NUMBER_OF_EXECUTION_THREADS = int(
 )
 
 if os.environ.get("DETAILED"):
-    EXECUTION_ONLY_NUMBER_OF_THREADS = [1, 2, 4, 8, 16, 32, 60]
+    EXECUTION_ONLY_NUMBER_OF_THREADS = [1, 2, 4, 8, 16, 32, 48, 60]
 else:
     EXECUTION_ONLY_NUMBER_OF_THREADS = []
 
@@ -407,9 +407,12 @@ def print_table(
             if single_field is not None:
                 _, field_getter = single_field
                 for num_threads in number_of_execution_threads:
-                    row.append(
-                        field_getter(result.number_of_threads_results[num_threads])
-                    )
+                    if num_threads in result.number_of_threads_results:
+                        row.append(
+                            field_getter(result.number_of_threads_results[num_threads])
+                        )
+                    else:
+                        row.append("-")
 
         if single_field is not None:
             _, field_getter = single_field
@@ -504,7 +507,7 @@ with tempfile.TemporaryDirectory() as tmpdirname:
         number_of_threads_results = {}
 
         for execution_threads in EXECUTION_ONLY_NUMBER_OF_THREADS:
-            test_db_command = f"RUST_BACKTRACE=1 {BUILD_FOLDER}/aptos-executor-benchmark --execution-threads {execution_threads} {common_command_suffix} --skip-commit --blocks {NUM_BLOCKS_DETAILED}"
+            test_db_command = f"RUST_BACKTRACE=1 {BUILD_FOLDER}/aptos-executor-benchmark --execution-threads {execution_threads} --skip-commit {common_command_suffix} --blocks {NUM_BLOCKS_DETAILED}"
             output = execute_command(test_db_command)
 
             number_of_threads_results[execution_threads] = extract_run_results(


### PR DESCRIPTION
## Description

fix DETAILED=1 flag in single_node_performance.py (which runs across different concurrency levels)

and for that fix --skip-commit flag in the executor benchmark

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Other (specify) - benchmarking

## How Has This Been Tested?
run 
NUMBER_OF_EXECUTION_THREADS=32 DETAILED=1 FLOW=CONTINUOUS SKIP_MOVE_E2E=1 NUM_INIT_ACCOUNTS=10000 ./testsuite/single_node_performance.py

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
