### PR TITLE
[dev_setup] retry flaky dotnet install

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -543,7 +543,7 @@ function install_dotnet {
     # Below we need to (a) set TERM variable because the .net installer expects it and it is not set
     # in some environments (b) use bash not sh because the installer uses bash features.
     # NOTE: use wget to better follow the redirect
-    wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
+    wget --tries 10 --retry-connrefused --waitretry=5 https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
     chmod +x dotnet-install.sh
     ./dotnet-install.sh --channel $DOTNET_VERSION --install-dir "${DOTNET_INSTALL_DIR}" --version latest
     rm dotnet-install.sh


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Dotnet install step in `dev_setup.sh` will occasionally fail due to server returning 500 when fetching the install script: https://learn.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual#scripted-install

```
+ wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
--2024-07-01 15:49:39--  https://dot.net/v1/dotnet-install.sh
Resolving dot.net (dot.net)... 20.76.201.171, 20.112.250.133, 20.236.44.162, ...
Connecting to dot.net (dot.net)|20.76.201.171|:443... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh [following]
--2024-07-01 15:49:39--  https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.sh
Resolving dotnet.microsoft.com (dotnet.microsoft.com)... 13.107.246.40, 2620:1ec:bdf::40
Connecting to dotnet.microsoft.com (dotnet.microsoft.com)|13.107.246.40|:443... connected.
HTTP request sent, awaiting response... 500 Internal Server Error
Cookie coming from dotnet.microsoft.com attempted to set domain to dotnetwebsite.azurewebsites.net
Cookie coming from dotnet.microsoft.com attempted to set domain to dotnetwebsite.azurewebsites.net
2024-07-01 15:49:40 ERROR 500: Internal Server Error.
```

Throw some retires onto wget. 

This started happening earlier today ~5:00 PST, searching by error logs on GH runners
<img width="1269" alt="image" src="https://github.com/aptos-labs/aptos-core/assets/12578616/6b1d9116-eac4-4dd6-8ed2-d88ab106514a">

(We had issues with this install path 14 months ago too :p https://github.com/aptos-labs/aptos-core/pull/8252)


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Run it locally. Also try to repro the flakiness

```
for i in {1..100000}; do
  wget --tries=10 --retry-connrefused --waitretry=5 https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh
  if [ $? -ne 0 ]; then
    echo "wget command failed, exiting."
    break
  fi
done
```

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

Roll out plan: PRs that are affected by this should either manually attempt retry on the job level, or they can rebase once this PR lands



## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
