### PR TITLE
[RFC] Update gas schedule with new diff for 1.16

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -1,15 +1,16 @@
 ---
 remote_endpoint: ~
-name: "v1.14"
+name: "v1.16"
 proposals:
   - name: step_1_upgrade_framework
     metadata:
-      title: "Multi-step proposal to upgrade mainnet framework to v1.14"
-      description: "This includes changes in https://github.com/aptos-labs/aptos-core/commits/aptos-release-v1.13"
+      title: "Multi-step proposal to upgrade mainnet framework to v1.16"
+      description: "This includes changes in https://github.com/aptos-labs/aptos-core/commits/aptos-release-v1.16"
     execution_mode: MultiStep
     update_sequence:
+      - Gas:
+          old: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/v1.15.2.json
+          new: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/v1.16.1-rc.json
       - Framework:
           bytecode_version: 6
           git_hash: ~
-      - Gas:
-          new: current


### PR DESCRIPTION
This uses the newly introduced new / old gas option to ensure that the gas schedule is upgrading explicitly from the prior version to the new version

Test Plan: framework upgrade forge test runs in the PR triggered by the label