### PR TITLE
[aptos-framework] disallow dispatching on custom native

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -13,3 +13,7 @@ proposals:
           git_hash: ~
       - Gas:
           new: current
+      - FeatureFlag:
+          enabled:
+            - disallow_native_dispatch
+

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -121,6 +121,7 @@ pub enum FeatureFlag {
     DefaultToConcurrentFungibleBalance,
     LimitVMTypeSize,
     AbortIfMultisigPayloadMismatch,
+    DisallowNativeDispatch,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -316,6 +317,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::AbortIfMultisigPayloadMismatch => {
                 AptosFeatureFlag::ABORT_IF_MULTISIG_PAYLOAD_MISMATCH
             },
+            FeatureFlag::DisallowNativeDispatch => AptosFeatureFlag::DISALLOW_NATIVE_DISPATCH,
         }
     }
 }
@@ -440,6 +442,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::ABORT_IF_MULTISIG_PAYLOAD_MISMATCH => {
                 FeatureFlag::AbortIfMultisigPayloadMismatch
             },
+            AptosFeatureFlag::DISALLOW_NATIVE_DISPATCH => FeatureFlag::DisallowNativeDispatch,
         }
     }
 }

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -145,6 +145,9 @@ impl MoveVmExt {
         vm_config.pseudo_meter_vector_ty_to_ty_tag_construction =
             gas_feature_version >= RELEASE_V1_16;
         vm_config.ty_builder = ty_builder;
+        vm_config.disallow_dispatch_for_native = env
+            .features()
+            .is_enabled(FeatureFlag::DISALLOW_NATIVE_DISPATCH);
 
         Self {
             inner: WarmVmCache::get_warm_vm(

--- a/aptos-move/framework/aptos-framework/tests/native_disaptch_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/native_disaptch_token_tests.move
@@ -1,0 +1,16 @@
+#[test_only]
+module aptos_framework::native_dispatch_token_tests {
+    use aptos_framework::fungible_asset;
+    use 0xcafe::native_dispatch_token;
+
+    #[test(creator = @0xcafe)]
+    #[expected_failure(abort_code=0x10019, location=aptos_framework::fungible_asset)]
+    fun test_native_dispatch_token(
+        creator: &signer,
+    ) {
+        let (creator_ref, _) = fungible_asset::create_test_token(creator);
+        fungible_asset::init_test_metadata(&creator_ref);
+
+        native_dispatch_token::initialize(creator, &creator_ref);
+    }
+}

--- a/aptos-move/framework/aptos-framework/tests/native_dispatch_token.move
+++ b/aptos-move/framework/aptos-framework/tests/native_dispatch_token.move
@@ -1,0 +1,33 @@
+#[test_only]
+module 0xcafe::native_dispatch_token {
+    use aptos_framework::fungible_asset::{FungibleAsset, TransferRef};
+    use aptos_framework::dispatchable_fungible_asset;
+    use aptos_framework::object::{ConstructorRef, Object};
+    use aptos_framework::function_info;
+
+    use std::option;
+    use std::signer;
+    use std::string;
+
+    public fun initialize(account: &signer, constructor_ref: &ConstructorRef) {
+        assert!(signer::address_of(account) == @0xcafe, 1);
+        let withdraw = function_info::new_function_info(
+            account,
+            string::utf8(b"native_dispatch_token"),
+            string::utf8(b"withdraw"),
+        );
+
+        dispatchable_fungible_asset::register_dispatch_functions(
+            constructor_ref,
+            option::some(withdraw),
+            option::none(),
+            option::none(),
+        );
+    }
+
+    public native fun withdraw<T: key>(
+        store: Object<T>,
+        _amount: u64,
+        transfer_ref: &TransferRef,
+    ): FungibleAsset;
+}

--- a/aptos-move/framework/src/natives/function_info.rs
+++ b/aptos-move/framework/src/natives/function_info.rs
@@ -116,6 +116,10 @@ fn native_check_dispatch_type_compatibility_impl(
             && rhs.return_tys() == lhs.return_tys()
             && &lhs.param_tys()[0..lhs.param_count() - 1] == rhs.param_tys()
             && !rhs.is_friend_or_private()
+            && (!context
+                .get_feature_flags()
+                .is_enabled(aptos_types::on_chain_config::FeatureFlag::DISALLOW_NATIVE_DISPATCH)
+                || !rhs.is_native())
             && lhs_id != rhs_id
     )])
 }

--- a/third_party/move/move-vm/runtime/src/config.rs
+++ b/third_party/move/move-vm/runtime/src/config.rs
@@ -25,6 +25,7 @@ pub struct VMConfig {
     pub pseudo_meter_vector_ty_to_ty_tag_construction: bool,
     pub delayed_field_optimization_enabled: bool,
     pub ty_builder: TypeBuilder,
+    pub disallow_dispatch_for_native: bool,
 }
 
 impl Default for VMConfig {
@@ -41,6 +42,7 @@ impl Default for VMConfig {
             pseudo_meter_vector_ty_to_ty_tag_construction: true,
             delayed_field_optimization_enabled: false,
             ty_builder: TypeBuilder::Legacy,
+            disallow_dispatch_for_native: true,
         }
     }
 }

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -604,6 +604,13 @@ impl Interpreter {
                         ));
                 }
 
+                if resolver.loader().vm_config().disallow_dispatch_for_native
+                    && target_func.is_native()
+                {
+                    return Err(PartialVMError::new(StatusCode::RUNTIME_DISPATCH_ERROR)
+                        .with_message("Invoking native function during dispatch".to_string()));
+                }
+
                 // Checking type of the dispatch target function
                 //
                 // MoveVM will check that the native function that performs the dispatch will have the same

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -244,7 +244,7 @@ impl Function {
         }
     }
 
-    pub(crate) fn is_native(&self) -> bool {
+    pub fn is_native(&self) -> bool {
         self.is_native
     }
 

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -86,6 +86,7 @@ pub enum FeatureFlag {
     DEFAULT_TO_CONCURRENT_FUNGIBLE_BALANCE = 68,
     LIMIT_VM_TYPE_SIZE = 69,
     ABORT_IF_MULTISIG_PAYLOAD_MISMATCH = 70,
+    DISALLOW_NATIVE_DISPATCH = 71,
 }
 
 impl FeatureFlag {
@@ -152,6 +153,7 @@ impl FeatureFlag {
             FeatureFlag::CONCURRENT_FUNGIBLE_BALANCE,
             FeatureFlag::LIMIT_VM_TYPE_SIZE,
             FeatureFlag::ABORT_IF_MULTISIG_PAYLOAD_MISMATCH,
+            FeatureFlag::DISALLOW_NATIVE_DISPATCH,
         ]
     }
 }

--- a/types/src/vm/configs.rs
+++ b/types/src/vm/configs.rs
@@ -103,6 +103,7 @@ pub fn aptos_prod_vm_config(
         // manually where applicable.
         delayed_field_optimization_enabled: false,
         ty_builder,
+        disallow_dispatch_for_native: false,
     }
 }
 


### PR DESCRIPTION
## Description
Disallowing dispatching on custom native function. This wouldn't raist a correctness issue but it's just not user friendly when user attempted so for now as the VM will raise error at an unexpected location.


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Added a test to make sure such function gets rejected properly.

## Key Areas to Review

Make sure the gas version is set properly.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
