### PR TITLE
Upgrade to poem 3.x.x and poem-openapi 5.x.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,8 +389,8 @@ dependencies = [
  "aptos-system-utils 0.1.0",
  "aptos-types",
  "bcs 0.1.4",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "sha256",
  "tokio",
  "url",
@@ -437,13 +437,11 @@ dependencies = [
  "aptos-storage-interface",
  "aptos-types",
  "aptos-vm",
- "async-trait",
  "bcs 0.1.4",
  "bytes",
  "fail",
  "futures",
  "hex",
- "hyper",
  "itertools 0.12.1",
  "mime",
  "mini-moka",
@@ -493,7 +491,7 @@ dependencies = [
  "bcs 0.1.4",
  "bytes",
  "goldenfile",
- "hyper",
+ "hyper 0.14.28",
  "rand 0.7.3",
  "regex",
  "serde_json",
@@ -619,7 +617,7 @@ dependencies = [
  "aptos-types",
  "bcs 0.1.4",
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "once_cell",
  "reqwest",
  "serde",
@@ -1713,7 +1711,7 @@ dependencies = [
  "either",
  "futures",
  "hex",
- "hyper",
+ "hyper 0.14.28",
  "itertools 0.12.1",
  "json-patch",
  "k8s-openapi",
@@ -2114,7 +2112,7 @@ dependencies = [
  "futures",
  "goldenfile",
  "hex",
- "hyper",
+ "hyper 0.14.28",
  "itertools 0.12.1",
  "move-binary-format",
  "move-core-types",
@@ -2210,7 +2208,7 @@ dependencies = [
  "flate2",
  "futures",
  "google-cloud-storage",
- "hyper",
+ "hyper 0.14.28",
  "rocksdb",
  "serde",
  "serde_json",
@@ -2275,7 +2273,7 @@ dependencies = [
  "aptos-time-service",
  "assert_approx_eq",
  "futures",
- "hyper",
+ "hyper 0.14.28",
  "once_cell",
  "prometheus",
  "reqwest",
@@ -2354,7 +2352,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-types",
- "http",
+ "http 0.2.11",
  "move-core-types",
  "reqwest",
  "serde",
@@ -2477,7 +2475,7 @@ dependencies = [
  "bcs 0.1.4",
  "dashmap",
  "hex",
- "hyper",
+ "hyper 0.14.28",
  "jsonwebtoken 8.3.0",
  "jwt",
  "once_cell",
@@ -3118,7 +3116,6 @@ dependencies = [
 name = "aptos-openapi"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "percent-encoding",
  "poem",
  "poem-openapi",
@@ -3816,8 +3813,8 @@ dependencies = [
  "anyhow",
  "aptos-profiler 0.1.0",
  "async-mutex",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "lazy_static",
  "mime",
  "pprof",
@@ -3836,8 +3833,8 @@ dependencies = [
  "anyhow",
  "aptos-profiler 0.1.0 (git+https://github.com/aptos-labs/aptos-core.git?rev=4541add3fd29826ec57f22658ca286d2d6134b93)",
  "async-mutex",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "lazy_static",
  "mime",
  "pprof",
@@ -4442,7 +4439,7 @@ dependencies = [
  "aptos-config",
  "aptos-logger",
  "bcs 0.1.4",
- "hyper",
+ "hyper 0.14.28",
  "serde",
  "serde_json",
  "warp",
@@ -5026,9 +5023,9 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "itoa",
  "matchit",
  "memchr",
@@ -5037,7 +5034,7 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower",
  "tower-layer",
  "tower-service",
@@ -5052,8 +5049,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "mime",
  "rustversion",
  "tower-layer",
@@ -5479,8 +5476,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "hyperlocal",
  "log",
  "pin-project-lite",
@@ -5780,6 +5777,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
@@ -6246,12 +6249,12 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.17.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "aes-gcm",
- "base64 0.21.6",
+ "base64 0.22.1",
  "hkdf 0.12.4",
  "hmac 0.12.1",
  "percent-encoding",
@@ -6693,16 +6696,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
-dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
@@ -6716,20 +6709,6 @@ name = "darling_core"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
@@ -6760,17 +6739,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
-dependencies = [
- "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
 ]
@@ -8173,7 +8141,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "dyn-clone",
- "hyper",
+ "hyper 0.14.28",
  "hyper-rustls 0.24.2",
  "log",
  "reqwest",
@@ -8413,7 +8381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bdaaa4bc036e8318274d1b25f0f2265b3e95418b765fd1ea1c7ef938fd69bd"
 dependencies = [
  "google-cloud-token",
- "http",
+ "http 0.2.11",
  "thiserror",
  "tokio",
  "tokio-retry",
@@ -8577,7 +8545,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
+ "indexmap 2.2.5",
+ "slab",
+ "tokio",
+ "tokio-util 0.7.10",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
  "indexmap 2.2.5",
  "slab",
  "tokio",
@@ -8679,8 +8666,23 @@ checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
  "base64 0.21.6",
  "bytes",
- "headers-core",
- "http",
+ "headers-core 0.2.0",
+ "http 0.2.11",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64 0.21.6",
+ "bytes",
+ "headers-core 0.3.0",
+ "http 1.1.0",
  "httpdate",
  "mime",
  "sha1",
@@ -8692,7 +8694,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
- "http",
+ "http 0.2.11",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -8855,13 +8866,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -8897,7 +8942,7 @@ dependencies = [
  "crossbeam-utils",
  "form_urlencoded",
  "futures-util",
- "hyper",
+ "hyper 0.14.28",
  "isahc",
  "lazy_static",
  "levenshtein",
@@ -8936,9 +8981,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.26",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -8951,13 +8996,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.5",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "log",
  "rustls 0.20.9",
  "rustls-native-certs 0.6.3",
@@ -8972,8 +9037,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "log",
  "rustls 0.21.10",
  "rustls-native-certs 0.6.3",
@@ -8987,7 +9052,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
@@ -9000,10 +9065,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.28",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "hyper 1.4.1",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -9014,7 +9094,7 @@ checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
 dependencies = [
  "futures-util",
  "hex",
- "hyper",
+ "hyper 0.14.28",
  "pin-project",
  "tokio",
 ]
@@ -9390,7 +9470,7 @@ dependencies = [
  "encoding_rs",
  "event-listener 2.5.3",
  "futures-lite 1.13.0",
- "http",
+ "http 0.2.11",
  "log",
  "mime",
  "once_cell",
@@ -9605,9 +9685,9 @@ dependencies = [
  "dirs-next",
  "either",
  "futures",
- "http",
- "http-body",
- "hyper",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls 0.23.2",
  "hyper-timeout",
  "jsonpath_lib",
@@ -9636,7 +9716,7 @@ checksum = "c52b6ab05d160691083430f6f431707a4e05b64903f2ffa0095ee5efde759117"
 dependencies = [
  "chrono",
  "form_urlencoded",
- "http",
+ "http 0.2.11",
  "json-patch",
  "k8s-openapi",
  "once_cell",
@@ -9786,9 +9866,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -11196,9 +11276,26 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 0.2.11",
  "httparse",
  "log",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.1.0",
+ "httparse",
  "memchr",
  "mime",
  "spin 0.9.8",
@@ -11315,6 +11412,18 @@ checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -11840,7 +11949,7 @@ version = "3.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be30eaf4b0a9fba5336683b38de57bb86d179a35862ba6bfcf57625d006bde5b"
 dependencies = [
- "proc-macro-crate 2.0.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -12353,39 +12462,41 @@ dependencies = [
 
 [[package]]
 name = "poem"
-version = "1.3.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504774c97b0744c1ee108a37e5a65a9745a4725c4c06277521dabc28eb53a904"
+version = "3.0.1"
+source = "git+https://github.com/poem-web/poem.git?rev=809b2816d3504beeba140fef3fdfe9432d654c5b#809b2816d3504beeba140fef3fdfe9432d654c5b"
 dependencies = [
  "anyhow",
- "async-trait",
  "bytes",
  "chrono",
- "cookie 0.17.0",
+ "cookie 0.18.1",
  "futures-util",
- "headers",
- "http",
- "hyper",
+ "headers 0.4.0",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
  "mime",
- "multer",
- "nix 0.27.1",
+ "multer 3.1.0",
+ "nix 0.28.0",
  "parking_lot 0.12.1",
  "percent-encoding",
  "pin-project-lite",
  "poem-derive",
- "quick-xml 0.30.0",
+ "quick-xml 0.32.0",
  "regex",
  "rfc7239",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile 2.1.1",
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "serde_yaml 0.9.30",
  "smallvec",
+ "sync_wrapper 1.0.1",
  "tempfile",
  "thiserror",
  "time",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls 0.25.0",
  "tokio-stream",
  "tokio-util 0.7.10",
  "tracing",
@@ -12394,11 +12505,10 @@ dependencies = [
 
 [[package]]
 name = "poem-derive"
-version = "1.3.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ddcf4680d8d867e1e375116203846acb088483fa2070244f90589f458bbb31"
+version = "3.0.0"
+source = "git+https://github.com/poem-web/poem.git?rev=809b2816d3504beeba140fef3fdfe9432d654c5b#809b2816d3504beeba140fef3fdfe9432d654c5b"
 dependencies = [
- "proc-macro-crate 2.0.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -12406,19 +12516,19 @@ dependencies = [
 
 [[package]]
 name = "poem-openapi"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69c569eb0671cc85e65cfb6bd960d0168d24732ff58825227b4d2a10167ba91"
+version = "5.0.2"
+source = "git+https://github.com/poem-web/poem.git?rev=809b2816d3504beeba140fef3fdfe9432d654c5b#809b2816d3504beeba140fef3fdfe9432d654c5b"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "bytes",
  "derive_more",
  "futures-util",
+ "indexmap 2.2.5",
  "mime",
  "num-traits",
  "poem",
  "poem-openapi-derive",
- "quick-xml 0.23.1",
+ "quick-xml 0.32.0",
  "regex",
  "serde",
  "serde_json",
@@ -12431,19 +12541,18 @@ dependencies = [
 
 [[package]]
 name = "poem-openapi-derive"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "274cf13f710999977a3c1e396c2a5000d104075a7127ce6470fbdae4706be621"
+version = "5.0.2"
+source = "git+https://github.com/poem-web/poem.git?rev=809b2816d3504beeba140fef3fdfe9432d654c5b#809b2816d3504beeba140fef3fdfe9432d654c5b"
 dependencies = [
- "darling 0.14.4",
- "http",
- "indexmap 1.9.3",
+ "darling 0.20.9",
+ "http 1.1.0",
+ "indexmap 2.2.5",
  "mime",
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "regex",
- "syn 1.0.109",
+ "syn 2.0.48",
  "thiserror",
 ]
 
@@ -12741,12 +12850,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97dc5fea232fc28d2f597b37c4876b348a40e33f3b02cc975c8d006d78d94b1a"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_datetime",
  "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -12823,7 +12940,7 @@ dependencies = [
  "google-cloud-pubsub",
  "google-cloud-storage",
  "hex",
- "hyper",
+ "hyper 0.14.28",
  "itertools 0.12.1",
  "jemallocator",
  "kanal",
@@ -13117,7 +13234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
 dependencies = [
  "memchr",
- "serde",
 ]
 
 [[package]]
@@ -13131,9 +13247,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
 dependencies = [
  "memchr",
  "serde",
@@ -13456,10 +13572,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls 0.24.2",
  "hyper-tls",
  "ipnet",
@@ -13499,7 +13615,7 @@ checksum = "88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690"
 dependencies = [
  "anyhow",
  "async-trait",
- "http",
+ "http 0.2.11",
  "reqwest",
  "serde",
  "task-local-extensions",
@@ -13517,8 +13633,8 @@ dependencies = [
  "chrono",
  "futures",
  "getrandom 0.2.11",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "parking_lot 0.11.2",
  "reqwest",
  "reqwest-middleware",
@@ -14125,7 +14241,7 @@ name = "self_update"
 version = "0.39.0"
 source = "git+https://github.com/banool/self_update.git?rev=8306158ad0fd5b9d4766a3c6bf967e7ef0ea5c4b#8306158ad0fd5b9d4766a3c6bf967e7ef0ea5c4b"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "indicatif 0.17.7",
  "log",
  "quick-xml 0.23.1",
@@ -14780,7 +14896,7 @@ dependencies = [
  "digest 0.9.0",
  "futures",
  "hex",
- "hyper",
+ "hyper 0.14.28",
  "move-core-types",
  "num_cpus",
  "once_cell",
@@ -15104,6 +15220,15 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "sysinfo"
@@ -15614,6 +15739,17 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
@@ -15722,9 +15858,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
@@ -15754,6 +15890,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap 2.2.5",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tonic"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15767,10 +15914,10 @@ dependencies = [
  "flate2",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -15797,10 +15944,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "flate2",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.26",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
@@ -15863,8 +16010,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "http-range-header",
  "pin-project-lite",
  "tower-layer",
@@ -16061,7 +16208,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 0.2.11",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -16479,13 +16626,13 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "headers",
- "http",
- "hyper",
+ "headers 0.3.9",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "log",
  "mime",
  "mime_guess",
- "multer",
+ "multer 2.1.0",
  "percent-encoding",
  "pin-project",
  "rustls-pemfile 1.0.4",
@@ -16508,7 +16655,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "948552bbb7a5fb4ba3169fd09b6c1ab53c1b2fdd82603295df550f7a1ec644c0"
 dependencies = [
- "hyper",
+ "hyper 0.14.28",
  "once_cell",
  "reqwest",
  "thiserror",
@@ -17044,8 +17191,8 @@ dependencies = [
  "async-trait",
  "base64 0.21.6",
  "futures",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "hyper-rustls 0.24.2",
  "itertools 0.12.1",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -661,9 +661,10 @@ percent-encoding = "2.1.0"
 petgraph = "0.5.1"
 pin-project = "1.0.10"
 plotters = { version = "0.3.5", default-features = false }
-poem = { version = "=1.3.59", features = ["anyhow", "rustls"] }
-poem-openapi = { version = "=2.0.11", features = ["swagger-ui", "url"] }
-poem-openapi-derive = "=2.0.11"
+# We're using git deps until https://github.com/poem-web/poem/pull/829 gets formally released.
+poem = { git = "https://github.com/poem-web/poem.git", rev = "809b2816d3504beeba140fef3fdfe9432d654c5b", features = ["anyhow", "rustls"] }
+poem-openapi = { git = "https://github.com/poem-web/poem.git", rev = "809b2816d3504beeba140fef3fdfe9432d654c5b", features = ["swagger-ui", "url"] }
+poem-openapi-derive = { git = "https://github.com/poem-web/poem.git", rev = "809b2816d3504beeba140fef3fdfe9432d654c5b" }
 poseidon-ark = { git = "https://github.com/arnaucube/poseidon-ark.git", rev = "6d2487aa1308d9d3860a2b724c485d73095c1c68" }
 pprof = { version = "0.11", features = ["flamegraph", "protobuf-codec"] }
 pretty = "0.10.0"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -28,13 +28,11 @@ aptos-runtimes = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
-async-trait = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true }
 fail = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
-hyper = { workspace = true }
 itertools = { workspace = true }
 mime = { workspace = true }
 mini-moka = { workspace = true }

--- a/api/doc/CHANGELOG.md
+++ b/api/doc/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Aptos Node API will be captured in this file. This ch
 **Note**: The Aptos Node API does not follow semantic version while we are in active development. Instead, breaking changes will be announced with each devnet cut. Once we launch our mainnet, the API will follow semantic versioning closely.
 
 ## Unreleased
-N/A
+- OpenAPI layout changed slightly in some enum cases, see [#13929](https://github.com/aptos-labs/aptos-core/pull/13929) for more information.
 
 ## 1.2.0 (2022-09-29)
 - **[Breaking Changes]** Following the deprecation notice from the previous release, the following breaking changes have landed in this release. Please see the notes from last release for information on the new endpoints you must migrate to:

--- a/api/doc/spec.html
+++ b/api/doc/spec.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta http-equiv="cache-control" content="no-cache">
-    <title>Aptos REST API</title>
+    <title>Aptos Node API</title>
     <!-- Embed elements Elements via Web Component -->
     <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">

--- a/api/doc/spec.json
+++ b/api/doc/spec.json
@@ -13990,6 +13990,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "ed25519_signature"
+                ],
                 "example": "ed25519_signature"
               }
             }
@@ -14009,6 +14012,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "multi_ed25519_signature"
+                ],
                 "example": "multi_ed25519_signature"
               }
             }
@@ -14028,6 +14034,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "multi_key_signature"
+                ],
                 "example": "multi_key_signature"
               }
             }
@@ -14047,6 +14056,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "single_key_signature"
+                ],
                 "example": "single_key_signature"
               }
             }
@@ -14842,6 +14854,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "write_set_payload"
+                ],
                 "example": "write_set_payload"
               }
             }
@@ -15539,6 +15554,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "entry_function_payload"
+                ],
                 "example": "entry_function_payload"
               }
             }
@@ -15623,6 +15641,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "ed25519"
+                ],
                 "example": "ed25519"
               }
             }
@@ -15642,6 +15663,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "keyless"
+                ],
                 "example": "keyless"
               }
             }
@@ -15661,6 +15685,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "secp256k1_ecdsa"
+                ],
                 "example": "secp256k1_ecdsa"
               }
             }
@@ -15680,6 +15707,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "secp256r1_ecdsa"
+                ],
                 "example": "secp256r1_ecdsa"
               }
             }
@@ -15835,6 +15865,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "ed25519"
+                ],
                 "example": "ed25519"
               }
             }
@@ -15854,6 +15887,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "keyless"
+                ],
                 "example": "keyless"
               }
             }
@@ -15873,6 +15909,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "secp256k1_ecdsa"
+                ],
                 "example": "secp256k1_ecdsa"
               }
             }
@@ -15892,6 +15931,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "web_authn"
+                ],
                 "example": "web_authn"
               }
             }
@@ -16111,6 +16153,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "module_bundle_payload"
+                ],
                 "example": "module_bundle_payload"
               }
             }
@@ -16130,6 +16175,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "entry_function_payload"
+                ],
                 "example": "entry_function_payload"
               }
             }
@@ -16149,6 +16197,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "multisig_payload"
+                ],
                 "example": "multisig_payload"
               }
             }
@@ -16168,6 +16219,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "script_payload"
+                ],
                 "example": "script_payload"
               }
             }
@@ -16218,6 +16272,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "single_sender"
+                ],
                 "example": "single_sender"
               }
             }
@@ -16237,6 +16294,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "ed25519_signature"
+                ],
                 "example": "ed25519_signature"
               }
             }
@@ -16256,6 +16316,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "fee_payer_signature"
+                ],
                 "example": "fee_payer_signature"
               }
             }
@@ -16275,6 +16338,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "multi_agent_signature"
+                ],
                 "example": "multi_agent_signature"
               }
             }
@@ -16294,6 +16360,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "multi_ed25519_signature"
+                ],
                 "example": "multi_ed25519_signature"
               }
             }
@@ -16313,6 +16382,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "block_epilogue_transaction"
+                ],
                 "example": "block_epilogue_transaction"
               }
             }
@@ -16332,6 +16404,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "block_metadata_transaction"
+                ],
                 "example": "block_metadata_transaction"
               }
             }
@@ -16351,6 +16426,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "genesis_transaction"
+                ],
                 "example": "genesis_transaction"
               }
             }
@@ -16370,6 +16448,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "pending_transaction"
+                ],
                 "example": "pending_transaction"
               }
             }
@@ -16389,6 +16470,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "state_checkpoint_transaction"
+                ],
                 "example": "state_checkpoint_transaction"
               }
             }
@@ -16408,6 +16492,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "user_transaction"
+                ],
                 "example": "user_transaction"
               }
             }
@@ -16427,6 +16514,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "validator_transaction"
+                ],
                 "example": "validator_transaction"
               }
             }
@@ -16632,6 +16722,9 @@
             "properties": {
               "validator_transaction_type": {
                 "type": "string",
+                "enum": [
+                  "dkg_result"
+                ],
                 "example": "dkg_result"
               }
             }
@@ -16651,6 +16744,9 @@
             "properties": {
               "validator_transaction_type": {
                 "type": "string",
+                "enum": [
+                  "observed_jwk_update"
+                ],
                 "example": "observed_jwk_update"
               }
             }
@@ -16831,6 +16927,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "delete_module"
+                ],
                 "example": "delete_module"
               }
             }
@@ -16850,6 +16949,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "delete_resource"
+                ],
                 "example": "delete_resource"
               }
             }
@@ -16869,6 +16971,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "delete_table_item"
+                ],
                 "example": "delete_table_item"
               }
             }
@@ -16888,6 +16993,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "write_module"
+                ],
                 "example": "write_module"
               }
             }
@@ -16907,6 +17015,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "write_resource"
+                ],
                 "example": "write_resource"
               }
             }
@@ -16926,6 +17037,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "write_table_item"
+                ],
                 "example": "write_table_item"
               }
             }
@@ -16957,6 +17071,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "direct_write_set"
+                ],
                 "example": "direct_write_set"
               }
             }
@@ -16976,6 +17093,9 @@
             "properties": {
               "type": {
                 "type": "string",
+                "enum": [
+                  "script_write_set"
+                ],
                 "example": "script_write_set"
               }
             }

--- a/api/doc/spec.yaml
+++ b/api/doc/spec.yaml
@@ -10468,6 +10468,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - ed25519_signature
             example: ed25519_signature
       - $ref: '#/components/schemas/Ed25519Signature'
     AccountSignature_MultiEd25519Signature:
@@ -10478,6 +10480,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - multi_ed25519_signature
             example: multi_ed25519_signature
       - $ref: '#/components/schemas/MultiEd25519Signature'
     AccountSignature_MultiKeySignature:
@@ -10488,6 +10492,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - multi_key_signature
             example: multi_key_signature
       - $ref: '#/components/schemas/MultiKeySignature'
     AccountSignature_SingleKeySignature:
@@ -10498,6 +10504,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - single_key_signature
             example: single_key_signature
       - $ref: '#/components/schemas/SingleKeySignature'
     Address:
@@ -11090,6 +11098,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - write_set_payload
             example: write_set_payload
       - $ref: '#/components/schemas/WriteSetPayload'
     GenesisTransaction:
@@ -11677,6 +11687,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - entry_function_payload
             example: entry_function_payload
       - $ref: '#/components/schemas/EntryFunctionPayload'
     PendingTransaction:
@@ -11729,6 +11741,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - ed25519
             example: ed25519
       - $ref: '#/components/schemas/Ed25519'
     PublicKey_Keyless:
@@ -11739,6 +11753,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - keyless
             example: keyless
       - $ref: '#/components/schemas/Keyless'
     PublicKey_Secp256k1Ecdsa:
@@ -11749,6 +11765,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - secp256k1_ecdsa
             example: secp256k1_ecdsa
       - $ref: '#/components/schemas/Secp256k1Ecdsa'
     PublicKey_Secp256r1Ecdsa:
@@ -11759,6 +11777,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - secp256r1_ecdsa
             example: secp256r1_ecdsa
       - $ref: '#/components/schemas/Secp256r1Ecdsa'
     RSA_JWK:
@@ -11861,6 +11881,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - ed25519
             example: ed25519
       - $ref: '#/components/schemas/Ed25519'
     Signature_Keyless:
@@ -11871,6 +11893,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - keyless
             example: keyless
       - $ref: '#/components/schemas/Keyless'
     Signature_Secp256k1Ecdsa:
@@ -11881,6 +11905,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - secp256k1_ecdsa
             example: secp256k1_ecdsa
       - $ref: '#/components/schemas/Secp256k1Ecdsa'
     Signature_WebAuthn:
@@ -11891,6 +11917,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - web_authn
             example: web_authn
       - $ref: '#/components/schemas/WebAuthn'
     SingleKeySignature:
@@ -12038,6 +12066,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - module_bundle_payload
             example: module_bundle_payload
       - $ref: '#/components/schemas/DeprecatedModuleBundlePayload'
     TransactionPayload_EntryFunctionPayload:
@@ -12048,6 +12078,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - entry_function_payload
             example: entry_function_payload
       - $ref: '#/components/schemas/EntryFunctionPayload'
     TransactionPayload_MultisigPayload:
@@ -12058,6 +12090,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - multisig_payload
             example: multisig_payload
       - $ref: '#/components/schemas/MultisigPayload'
     TransactionPayload_ScriptPayload:
@@ -12068,6 +12102,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - script_payload
             example: script_payload
       - $ref: '#/components/schemas/ScriptPayload'
     TransactionSignature:
@@ -12095,6 +12131,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - single_sender
             example: single_sender
       - $ref: '#/components/schemas/AccountSignature'
     TransactionSignature_Ed25519Signature:
@@ -12105,6 +12143,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - ed25519_signature
             example: ed25519_signature
       - $ref: '#/components/schemas/Ed25519Signature'
     TransactionSignature_FeePayerSignature:
@@ -12115,6 +12155,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - fee_payer_signature
             example: fee_payer_signature
       - $ref: '#/components/schemas/FeePayerSignature'
     TransactionSignature_MultiAgentSignature:
@@ -12125,6 +12167,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - multi_agent_signature
             example: multi_agent_signature
       - $ref: '#/components/schemas/MultiAgentSignature'
     TransactionSignature_MultiEd25519Signature:
@@ -12135,6 +12179,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - multi_ed25519_signature
             example: multi_ed25519_signature
       - $ref: '#/components/schemas/MultiEd25519Signature'
     Transaction_BlockEpilogueTransaction:
@@ -12145,6 +12191,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - block_epilogue_transaction
             example: block_epilogue_transaction
       - $ref: '#/components/schemas/BlockEpilogueTransaction'
     Transaction_BlockMetadataTransaction:
@@ -12155,6 +12203,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - block_metadata_transaction
             example: block_metadata_transaction
       - $ref: '#/components/schemas/BlockMetadataTransaction'
     Transaction_GenesisTransaction:
@@ -12165,6 +12215,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - genesis_transaction
             example: genesis_transaction
       - $ref: '#/components/schemas/GenesisTransaction'
     Transaction_PendingTransaction:
@@ -12175,6 +12227,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - pending_transaction
             example: pending_transaction
       - $ref: '#/components/schemas/PendingTransaction'
     Transaction_StateCheckpointTransaction:
@@ -12185,6 +12239,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - state_checkpoint_transaction
             example: state_checkpoint_transaction
       - $ref: '#/components/schemas/StateCheckpointTransaction'
     Transaction_UserTransaction:
@@ -12195,6 +12251,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - user_transaction
             example: user_transaction
       - $ref: '#/components/schemas/UserTransaction'
     Transaction_ValidatorTransaction:
@@ -12205,6 +12263,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - validator_transaction
             example: validator_transaction
       - $ref: '#/components/schemas/ValidatorTransaction'
     TransactionsBatchSingleSubmissionFailure:
@@ -12366,6 +12426,8 @@ components:
         properties:
           validator_transaction_type:
             type: string
+            enum:
+            - dkg_result
             example: dkg_result
       - $ref: '#/components/schemas/DKGResultTransaction'
     ValidatorTransaction_JWKUpdateTransaction:
@@ -12376,6 +12438,8 @@ components:
         properties:
           validator_transaction_type:
             type: string
+            enum:
+            - observed_jwk_update
             example: observed_jwk_update
       - $ref: '#/components/schemas/JWKUpdateTransaction'
     VersionedEvent:
@@ -12492,6 +12556,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - delete_module
             example: delete_module
       - $ref: '#/components/schemas/DeleteModule'
     WriteSetChange_DeleteResource:
@@ -12502,6 +12568,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - delete_resource
             example: delete_resource
       - $ref: '#/components/schemas/DeleteResource'
     WriteSetChange_DeleteTableItem:
@@ -12512,6 +12580,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - delete_table_item
             example: delete_table_item
       - $ref: '#/components/schemas/DeleteTableItem'
     WriteSetChange_WriteModule:
@@ -12522,6 +12592,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - write_module
             example: write_module
       - $ref: '#/components/schemas/WriteModule'
     WriteSetChange_WriteResource:
@@ -12532,6 +12604,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - write_resource
             example: write_resource
       - $ref: '#/components/schemas/WriteResource'
     WriteSetChange_WriteTableItem:
@@ -12542,6 +12616,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - write_table_item
             example: write_table_item
       - $ref: '#/components/schemas/WriteTableItem'
     WriteSetPayload:
@@ -12560,6 +12636,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - direct_write_set
             example: direct_write_set
       - $ref: '#/components/schemas/DirectWriteSet'
     WriteSet_ScriptWriteSet:
@@ -12570,6 +12648,8 @@ components:
         properties:
           type:
             type: string
+            enum:
+            - script_write_set
             example: script_write_set
       - $ref: '#/components/schemas/ScriptWriteSet'
     WriteTableItem:

--- a/api/openapi-spec-generator/src/main.rs
+++ b/api/openapi-spec-generator/src/main.rs
@@ -4,7 +4,7 @@
 mod fake_context;
 
 use anyhow::Result;
-use aptos_api::get_api_service;
+use aptos_api::{get_api_service, spec::get_spec};
 use clap::{Parser, ValueEnum};
 use fake_context::get_fake_context;
 use std::{path::PathBuf, sync::Arc};
@@ -49,9 +49,10 @@ pub fn main() -> Result<()> {
     let api_service = get_api_service(Arc::new(get_fake_context()));
 
     let spec = match args.output_args.format {
-        OutputFormat::Json => api_service.spec(),
-        OutputFormat::Yaml => api_service.spec_yaml(),
+        OutputFormat::Json => get_spec(&api_service, false),
+        OutputFormat::Yaml => get_spec(&api_service, true),
     };
+
     args.output_args.write(&spec)
 }
 

--- a/api/src/accept_type.rs
+++ b/api/src/accept_type.rs
@@ -17,7 +17,6 @@ pub enum AcceptType {
 
 /// This impl allows us to get the data straight from the arguments to the
 /// endpoint handler.
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for AcceptType {
     async fn from_request(request: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         let accept = Accept::from_request_without_body(request).await?;

--- a/api/src/bcs_payload.rs
+++ b/api/src/bcs_payload.rs
@@ -49,12 +49,11 @@ impl Payload for Bcs {
     }
 }
 
-#[poem::async_trait]
 impl ParsePayload for Bcs {
     const IS_REQUIRED: bool = true;
 
     async fn from_request(request: &Request, body: &mut RequestBody) -> Result<Self> {
-        let data: Vec<u8> = FromRequest::from_request(request, body).await?;
+        let data = Vec::<u8>::from_request(request, body).await?;
         Ok(Self(data))
     }
 }

--- a/api/src/check_size.rs
+++ b/api/src/check_size.rs
@@ -1,9 +1,9 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use hyper::Method;
 use poem::{
     error::SizedLimitError,
+    http::Method,
     web::headers::{self, HeaderMapExt},
     Endpoint, Middleware, Request, Result,
 };
@@ -37,7 +37,6 @@ pub struct PostSizeLimitEndpoint<E> {
     max_size: u64,
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for PostSizeLimitEndpoint<E> {
     type Output = E::Output;
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -21,6 +21,7 @@ mod page;
 mod response;
 mod runtime;
 mod set_failpoints;
+pub mod spec;
 mod state;
 #[cfg(test)]
 pub mod tests;

--- a/api/src/log.rs
+++ b/api/src/log.rs
@@ -9,9 +9,11 @@ use aptos_logger::{
     prelude::{sample, SampleRate},
     warn, Schema,
 };
-use hyper::Method;
 use once_cell::sync::Lazy;
-use poem::{http::header, Endpoint, Request, Response, Result};
+use poem::{
+    http::{header, Method},
+    Endpoint, Request, Response, Result,
+};
 use poem_openapi::OperationId;
 use regex::Regex;
 use std::time::Duration;

--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -3,9 +3,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    accounts::AccountsApi, basic::BasicApi, blocks::BlocksApi, check_size::PostSizeLimit,
-    context::Context, error_converter::convert_error, events::EventsApi, index::IndexApi,
-    log::middleware_log, set_failpoints, state::StateApi, transactions::TransactionsApi,
+    accounts::AccountsApi,
+    basic::BasicApi,
+    blocks::BlocksApi,
+    check_size::PostSizeLimit,
+    context::Context,
+    error_converter::convert_error,
+    events::EventsApi,
+    index::IndexApi,
+    log::middleware_log,
+    set_failpoints,
+    spec::{spec_endpoint_json, spec_endpoint_yaml},
+    state::StateApi,
+    transactions::TransactionsApi,
     view_function::ViewFunctionApi,
 };
 use anyhow::Context as AnyhowContext;
@@ -164,8 +174,8 @@ pub fn attach_poem_to_runtime(
 
     let api_service = get_api_service(context.clone());
 
-    let spec_json = api_service.spec_endpoint();
-    let spec_yaml = api_service.spec_endpoint_yaml();
+    let spec_json = spec_endpoint_json(&api_service);
+    let spec_yaml = spec_endpoint_yaml(&api_service);
 
     let mut address = config.api.address;
 

--- a/api/src/spec.rs
+++ b/api/src/spec.rs
@@ -1,0 +1,58 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use poem::{
+    endpoint::{make_sync, Endpoint},
+    Response,
+};
+use poem_openapi::{OpenApi, OpenApiService, Webhook};
+
+/// Get the spec as JSON. We implement our own function because poem-openapi versions
+/// greater than 2.0.11 add this charset thing to the content type. This causes issues
+/// with our current Accept logic and messes up some code generators and our spec page,
+/// so we remove it.
+pub fn get_spec<T, W>(service: &OpenApiService<T, W>, yaml: bool) -> String
+where
+    T: OpenApi,
+    W: Webhook,
+{
+    let spec = if yaml {
+        service.spec_yaml()
+    } else {
+        service.spec()
+    };
+    spec.replace("; charset=utf-8", "")
+}
+
+/// Create an endpoint to serve the OpenAPI specification as json. We define this
+/// ourselves because we need to use our custom `get_spec` function that changes the
+/// spec to remove charset from the content type.
+pub fn spec_endpoint_json<T, W>(service: &OpenApiService<T, W>) -> impl Endpoint
+where
+    T: OpenApi,
+    W: Webhook,
+{
+    let spec = get_spec(service, false);
+    make_sync(move |_| {
+        Response::builder()
+            .content_type("application/json")
+            .body(spec.clone())
+    })
+}
+
+/// Create an endpoint to serve the OpenAPI specification as yaml. We define this
+/// ourselves because we need to use our custom `get_spec` function that changes the
+/// spec to remove charset from the content type.
+pub fn spec_endpoint_yaml<T, W>(service: &OpenApiService<T, W>) -> impl Endpoint
+where
+    T: OpenApi,
+    W: Webhook,
+{
+    let spec = get_spec(service, true);
+    make_sync(move |_| {
+        Response::builder()
+            .content_type("application/x-yaml")
+            .header("Content-Disposition", "inline; filename=\"spec.yaml\"")
+            .body(spec.clone())
+    })
+}

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -1435,8 +1435,7 @@ impl TransactionsApi {
                 let mut user_transactions = Vec::new();
                 for transaction in transactions.into_iter() {
                     match transaction {
-                        Transaction::UserTransaction(user_txn) => {
-                            let mut txn = *user_txn;
+                        Transaction::UserTransaction(mut user_txn) => {
                             match &vm_status {
                                 VMStatus::Error {
                                     message: Some(msg), ..
@@ -1444,13 +1443,13 @@ impl TransactionsApi {
                                 | VMStatus::ExecutionFailure {
                                     message: Some(msg), ..
                                 } => {
-                                    txn.info.vm_status +=
+                                    user_txn.info.vm_status +=
                                         format!("\nExecution failed with message: {}", msg)
                                             .as_str();
                                 },
                                 _ => (),
                             }
-                            user_transactions.push(txn);
+                            user_transactions.push(user_txn);
                         },
                         _ => {
                             return Err(SubmitTransactionError::internal_with_code(

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -176,7 +176,7 @@ impl
 #[oai(one_of, discriminator_name = "type", rename_all = "snake_case")]
 pub enum Transaction {
     PendingTransaction(PendingTransaction),
-    UserTransaction(Box<UserTransaction>),
+    UserTransaction(UserTransaction),
     GenesisTransaction(GenesisTransaction),
     BlockMetadataTransaction(BlockMetadataTransaction),
     StateCheckpointTransaction(StateCheckpointTransaction),
@@ -292,12 +292,12 @@ impl
             u64,
         ),
     ) -> Self {
-        Transaction::UserTransaction(Box::new(UserTransaction {
+        Transaction::UserTransaction(UserTransaction {
             info,
             request: (txn, payload).into(),
             events,
             timestamp: timestamp.into(),
-        }))
+        })
     }
 }
 

--- a/crates/aptos-faucet/core/src/endpoints/captcha.rs
+++ b/crates/aptos-faucet/core/src/endpoints/captcha.rs
@@ -34,7 +34,7 @@ impl CaptchaApi {
         path = "/request_captcha",
         method = "get",
         operation_id = "request_captcha",
-        response_header(name = "CAPTCHA_KEY", type = "u32", description = "Captcha key"),
+        response_header(name = "CAPTCHA_KEY", ty = "u32", description = "Captcha key"),
         tag = "ApiTags::Captcha"
     )]
     async fn request_captcha(&self) -> Result<Response<Binary<Vec<u8>>>, AptosTapErrorResponse> {

--- a/crates/aptos-openapi/Cargo.toml
+++ b/crates/aptos-openapi/Cargo.toml
@@ -13,7 +13,6 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-async-trait = { workspace = true }
 percent-encoding = { workspace = true }
 poem = { workspace = true }
 poem-openapi = { workspace = true }

--- a/crates/aptos-openapi/src/helpers.rs
+++ b/crates/aptos-openapi/src/helpers.rs
@@ -12,7 +12,7 @@
 //!     too unrelated, or even worse, in a totally different crate (the move
 //!     types are a great example of this).
 //!   - The type is not expressible via OpenAPI. For example, an enum that
-//!     has some enum variants with values and others without values.This is
+//!     has some enum variants with values and others without values. This is
 //!     not allowed in OpenAPI, types must be either unions (variants with
 //!     values) or enums (variants without values).
 //!   - We would prefer to serialize the data differently than its standard
@@ -136,6 +136,8 @@ macro_rules! impl_poem_type {
                 ::poem::http::HeaderValue::from_str(&string).ok()
             }
         }
+
+        impl ::poem_openapi::types::IsObjectType for $ty {}
     };
 }
 
@@ -156,7 +158,6 @@ macro_rules! impl_poem_parameter {
             }
         }
 
-        #[async_trait::async_trait]
         impl ::poem_openapi::types::ParseFromMultipartField for $ty {
             async fn parse_from_multipart(field: Option<::poem::web::Field>) -> ::poem_openapi::types::ParseResult<Self> {
                 match field {

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -2092,7 +2092,7 @@ async fn create_account_and_wait(
     sequence_number: Option<u64>,
     max_gas: Option<u64>,
     gas_unit_price: Option<u64>,
-) -> Result<Box<UserTransaction>, ErrorWrapper> {
+) -> Result<UserTransaction, ErrorWrapper> {
     submit_transaction(
         node_clients.rest_client,
         txn_expiry_duration.unwrap_or(DEFAULT_MAX_WAIT_DURATION),
@@ -2116,7 +2116,7 @@ async fn simple_transfer_and_wait(
     sender_key: &Ed25519PrivateKey,
     receiver: AccountAddress,
     amount: u64,
-) -> Result<Box<UserTransaction>, ErrorWrapper> {
+) -> Result<UserTransaction, ErrorWrapper> {
     transfer_and_wait(
         node_clients,
         sender_key,
@@ -2139,7 +2139,7 @@ async fn transfer_and_wait(
     sequence_number: Option<u64>,
     max_gas: Option<u64>,
     gas_unit_price: Option<u64>,
-) -> Result<Box<UserTransaction>, ErrorWrapper> {
+) -> Result<UserTransaction, ErrorWrapper> {
     submit_transaction(
         node_clients.rest_client,
         txn_expiry_duration.unwrap_or(DEFAULT_MAX_WAIT_DURATION),
@@ -2164,7 +2164,7 @@ async fn set_operator_and_wait(
     sender_key: &Ed25519PrivateKey,
     old_operator: Option<AccountAddress>,
     new_operator: AccountAddress,
-) -> Result<Box<UserTransaction>, ErrorWrapper> {
+) -> Result<UserTransaction, ErrorWrapper> {
     submit_transaction(
         node_clients.rest_client,
         DEFAULT_MAX_WAIT_DURATION,
@@ -2189,7 +2189,7 @@ async fn set_voter_and_wait(
     sender_key: &Ed25519PrivateKey,
     operator: Option<AccountAddress>,
     new_voter: AccountAddress,
-) -> Result<Box<UserTransaction>, ErrorWrapper> {
+) -> Result<UserTransaction, ErrorWrapper> {
     submit_transaction(
         node_clients.rest_client,
         DEFAULT_MAX_WAIT_DURATION,
@@ -2216,7 +2216,7 @@ async fn create_stake_pool_and_wait(
     voter: Option<AccountAddress>,
     stake_amount: Option<u64>,
     commission_percentage: Option<u64>,
-) -> Result<Box<UserTransaction>, ErrorWrapper> {
+) -> Result<UserTransaction, ErrorWrapper> {
     submit_transaction(
         node_clients.rest_client,
         DEFAULT_MAX_WAIT_DURATION,
@@ -2242,7 +2242,7 @@ async fn reset_lockup_and_wait(
     node_clients: &NodeClients<'_>,
     sender_key: &Ed25519PrivateKey,
     operator: Option<AccountAddress>,
-) -> Result<Box<UserTransaction>, ErrorWrapper> {
+) -> Result<UserTransaction, ErrorWrapper> {
     submit_transaction(
         node_clients.rest_client,
         DEFAULT_MAX_WAIT_DURATION,
@@ -2266,7 +2266,7 @@ async fn update_commission_and_wait(
     sender_key: &Ed25519PrivateKey,
     operator: Option<AccountAddress>,
     new_commission_percentage: Option<u64>,
-) -> Result<Box<UserTransaction>, ErrorWrapper> {
+) -> Result<UserTransaction, ErrorWrapper> {
     submit_transaction(
         node_clients.rest_client,
         DEFAULT_MAX_WAIT_DURATION,
@@ -2291,7 +2291,7 @@ async fn unlock_stake_and_wait(
     sender_key: &Ed25519PrivateKey,
     operator: Option<AccountAddress>,
     amount: Option<u64>,
-) -> Result<Box<UserTransaction>, ErrorWrapper> {
+) -> Result<UserTransaction, ErrorWrapper> {
     submit_transaction(
         node_clients.rest_client,
         DEFAULT_MAX_WAIT_DURATION,
@@ -2316,7 +2316,7 @@ async fn distribute_staking_rewards_and_wait(
     sender_key: &Ed25519PrivateKey,
     operator: AccountAddress,
     staker: AccountAddress,
-) -> Result<Box<UserTransaction>, ErrorWrapper> {
+) -> Result<UserTransaction, ErrorWrapper> {
     submit_transaction(
         node_clients.rest_client,
         DEFAULT_MAX_WAIT_DURATION,
@@ -2343,7 +2343,7 @@ async fn submit_transaction<
     rest_client: &aptos_rest_client::Client,
     txn_expiry_duration: Duration,
     transaction_builder: F,
-) -> Result<Box<UserTransaction>, ErrorWrapper> {
+) -> Result<UserTransaction, ErrorWrapper> {
     let expiry_time = expiry_time(txn_expiry_duration);
 
     let txn_hash = transaction_builder(expiry_time.as_secs())
@@ -2359,7 +2359,7 @@ async fn wait_for_transaction(
     rest_client: &aptos_rest_client::Client,
     expiry_time: Duration,
     txn_hash: String,
-) -> Result<Box<UserTransaction>, Box<UserTransaction>> {
+) -> Result<UserTransaction, UserTransaction> {
     let hash_value = HashValue::from_str(&txn_hash).unwrap();
     let response = rest_client
         .wait_for_transaction_by_hash(
@@ -2410,7 +2410,7 @@ async fn add_delegated_stake_and_wait(
     sequence_number: Option<u64>,
     max_gas: Option<u64>,
     gas_unit_price: Option<u64>,
-) -> Result<Box<UserTransaction>, ErrorWrapper> {
+) -> Result<UserTransaction, ErrorWrapper> {
     let expiry_time = expiry_time(txn_expiry_duration);
     let txn_hash = rosetta_client
         .add_delegated_stake(
@@ -2443,7 +2443,7 @@ async fn unlock_delegated_stake_and_wait(
     sequence_number: Option<u64>,
     max_gas: Option<u64>,
     gas_unit_price: Option<u64>,
-) -> Result<Box<UserTransaction>, ErrorWrapper> {
+) -> Result<UserTransaction, ErrorWrapper> {
     let expiry_time = expiry_time(txn_expiry_duration);
     let txn_hash = rosetta_client
         .unlock_delegated_stake(
@@ -2475,7 +2475,7 @@ async fn withdraw_undelegated_stake_and_wait(
     sequence_number: Option<u64>,
     max_gas: Option<u64>,
     gas_unit_price: Option<u64>,
-) -> Result<Box<UserTransaction>, ErrorWrapper> {
+) -> Result<UserTransaction, ErrorWrapper> {
     let expiry_time = expiry_time(txn_expiry_duration);
     let txn_hash = rosetta_client
         .withdraw_undelegated_stake(
@@ -2710,5 +2710,5 @@ async fn test_delegation_pool_operations() {
 #[derive(Debug)]
 pub enum ErrorWrapper {
     BeforeSubmission(anyhow::Error),
-    AfterSubmission(Box<UserTransaction>),
+    AfterSubmission(UserTransaction),
 }


### PR DESCRIPTION
## Description
In this PR I upgrade us from poem 1.x.x and poem-openapi 2.x.x to poem 3.x.x and poem-openapi 5.x.x. Besides it being good in general to stay up to date, we want to upgrade specifically to get the latest opentelemetry features so we can benefit from distributed tracing throughout the API stack. There have been other instances where being pinned to a specific version caused us issues.

The new Poem traits had issues with `Box<UserTransaction>` in transaction, so I just unboxed it. I can't see why it needs to be in a Box and the original commit (https://github.com/aptos-labs/aptos-core/commit/3ecd8e927a35ead89f528f035c0c6397ffb8d80b) doesn't explain it. Perhaps there used to be some recursive type that we had to break.

Besides that, fortunately there wasn't much to change with our types or our custom derive macros.

By default this changes the spec slightly, primarily the inclusion of `charset=utf-8` in the content type. I recall this caused issues for code generators, and it'd require changes to our Accept logic, so I remove that again. It also seems to change some of the enum variants. I don't believe we make use of the OpenAPI spec anywhere anymore so it shouldn't affect us, but we should reach out to anyone who might be affected (perhaps an old Go SDK, if it's still in development).

I will wait for https://github.com/poem-web/poem/pull/829 to be released and then upgrade the poem deps again before releasing this PR.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [x] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
For now just CI, let's see how that goes first.

I run a localnet and connected the explorer to it and clicked around and everything seemed to work fine, no errors from the network tab. The spec explorer (at /v1/spec) works as before.

## Key Areas to Review
- Ensure `Box<UserTransaction>` -> `UserTransaction` is valid.
- Make sure the modified OpenAPI spec is okay.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
