### PR TITLE
[Consensus Observer] Add block payload verification.

### DIFF
--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -9,9 +9,9 @@ use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 
 // Useful constants for enabling consensus observer on different node types
-const ENABLE_ON_VALIDATORS: bool = false;
-const ENABLE_ON_VALIDATOR_FULLNODES: bool = false;
-const ENABLE_ON_PUBLIC_FULLNODES: bool = false;
+const ENABLE_ON_VALIDATORS: bool = true;
+const ENABLE_ON_VALIDATOR_FULLNODES: bool = true;
+const ENABLE_ON_PUBLIC_FULLNODES: bool = true;
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]

--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -30,7 +30,7 @@ pub struct ConsensusObserverConfig {
 
     /// Interval (in milliseconds) to garbage collect peer state
     pub garbage_collection_interval_ms: u64,
-    /// Maximum number of pending blocks to keep in memory
+    /// Maximum number of pending blocks to keep in memory (including payloads, ordered blocks, etc.)
     pub max_num_pending_blocks: u64,
     /// Maximum timeout (in milliseconds) for active subscriptions
     pub max_subscription_timeout_ms: u64,

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -165,6 +165,10 @@ impl ProofWithData {
         }
     }
 
+    pub fn empty() -> Self {
+        Self::new(vec![])
+    }
+
     pub fn extend(&mut self, other: ProofWithData) {
         let other_data_status = other.status.lock().as_mut().unwrap().take();
         self.proofs.extend(other.proofs);

--- a/consensus/src/consensus_observer/metrics.rs
+++ b/consensus/src/consensus_observer/metrics.rs
@@ -9,7 +9,13 @@ use aptos_metrics_core::{
 use once_cell::sync::Lazy;
 
 // Useful metric labels
+pub const BLOCK_PAYLOAD_LABEL: &str = "block_payload";
+pub const COMMIT_DECISION_LABEL: &str = "commit_decision";
 pub const CREATED_SUBSCRIPTION_LABEL: &str = "created_subscription";
+pub const MISSING_BLOCKS_LABEL: &str = "missing_blocks";
+pub const ORDERED_MESSAGE_LABEL: &str = "ordered_message";
+pub const PENDING_ORDERED_BLOCKS_LABEL: &str = "pending_ordered_blocks";
+pub const STORED_PAYLOADS_LABEL: &str = "stored_payloads";
 
 /// Counter for tracking created subscriptions for the consensus observer
 pub static OBSERVER_CREATED_SUBSCRIPTIONS: Lazy<IntCounterVec> = Lazy::new(|| {
@@ -21,12 +27,32 @@ pub static OBSERVER_CREATED_SUBSCRIPTIONS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Counter for tracking the number of active subscriptions for the consensus observer
+/// Gauge for tracking the number of active subscriptions for the consensus observer
 pub static OBSERVER_NUM_ACTIVE_SUBSCRIPTIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "consensus_observer_num_active_subscriptions",
         "Gauge related to active subscriptions for the consensus observer",
         &["network_id"]
+    )
+    .unwrap()
+});
+
+/// Gauge for tracking the number of processed blocks by the consensus observer
+pub static OBSERVER_NUM_PROCESSED_BLOCKS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "consensus_observer_num_processed_blocks",
+        "Gauge for tracking the number of processed blocks by the consensus observer",
+        &["processed_type"]
+    )
+    .unwrap()
+});
+
+/// Gauge for tracking the processed block rounds by the consensus observer
+pub static OBSERVER_PROCESSED_BLOCK_ROUNDS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "consensus_observer_processed_block_rounds",
+        "Gauge for tracking the processed block rounds by the consensus observer",
+        &["processed_type"]
     )
     .unwrap()
 });
@@ -47,6 +73,16 @@ pub static OBSERVER_RECEIVED_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
         "consensus_observer_received_messages",
         "Counters related to received (direct send) messages by the consensus observer",
         &["message_type", "network_id"]
+    )
+    .unwrap()
+});
+
+/// Gauge for tracking the rounds of received messages by the consensus observer
+pub static OBSERVER_RECEIVED_MESSAGE_ROUNDS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "consensus_observer_received_message_rounds",
+        "Gauge for tracking the rounds of received messages by the consensus observer",
+        &["message_type"]
     )
     .unwrap()
 });
@@ -101,7 +137,7 @@ pub static PENDING_CONSENSUS_OBSERVER_NETWORK_EVENTS: Lazy<IntCounterVec> = Lazy
     .unwrap()
 });
 
-/// Counter for tracking the number of active subscribers for the consensus publisher
+/// Gauge for tracking the number of active subscribers for the consensus publisher
 pub static PUBLISHER_NUM_ACTIVE_SUBSCRIBERS: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         "consensus_publisher_num_active_subscribers",
@@ -166,7 +202,12 @@ pub fn observe_value_with_label(
         .observe(value)
 }
 
-/// Sets the gauge with the specific label and value
+/// Sets the gauge with the specific network ID and value
 pub fn set_gauge(counter: &Lazy<IntGaugeVec>, network_id: &NetworkId, value: i64) {
     counter.with_label_values(&[network_id.as_str()]).set(value);
+}
+
+/// Sets the gauge with the specific label and value
+pub fn set_gauge_with_label(counter: &Lazy<IntGaugeVec>, label: &str, value: u64) {
+    counter.with_label_values(&[label]).set(value as i64);
 }

--- a/consensus/src/consensus_observer/missing_blocks.rs
+++ b/consensus/src/consensus_observer/missing_blocks.rs
@@ -159,6 +159,7 @@ impl MissingBlockStore {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::consensus_observer::network_message::{BlockPayload, BlockTransactionPayload};
     use aptos_consensus_types::{
         block::Block,
         block_data::{BlockData, BlockType},
@@ -378,7 +379,7 @@ mod test {
         );
 
         // Create a new block payload store and insert payloads for the second block
-        let mut block_payload_store = BlockPayloadStore::new();
+        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
         let second_block = missing_blocks[1].clone();
         insert_payloads_for_ordered_block(&mut block_payload_store, &second_block);
 
@@ -439,13 +440,15 @@ mod test {
         );
 
         // Create an empty block payload store
-        let mut block_payload_store = BlockPayloadStore::new();
+        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
         // Incrementally insert and process each payload for the first block
         let first_block = missing_blocks.first().unwrap().clone();
         for block in first_block.blocks().clone() {
             // Insert the block
-            block_payload_store.insert_block_payload(block.block_info(), vec![], None);
+            let block_payload =
+                BlockPayload::new(block.block_info(), BlockTransactionPayload::empty());
+            block_payload_store.insert_block_payload(block_payload, true);
 
             // Attempt to remove the block (which might not be ready)
             let payload_round = block.round();
@@ -486,7 +489,9 @@ mod test {
             // Insert the block only if this is not the first block
             let payload_round = block.round();
             if payload_round != last_block.first_block().round() {
-                block_payload_store.insert_block_payload(block.block_info(), vec![], None);
+                let block_payload =
+                    BlockPayload::new(block.block_info(), BlockTransactionPayload::empty());
+                block_payload_store.insert_block_payload(block_payload, true);
             }
 
             // Attempt to remove the block (which might not be ready)
@@ -533,7 +538,7 @@ mod test {
         );
 
         // Create a new block payload store and insert payloads for the first block
-        let mut block_payload_store = BlockPayloadStore::new();
+        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
         let first_block = missing_blocks.first().unwrap().clone();
         insert_payloads_for_ordered_block(&mut block_payload_store, &first_block);
 
@@ -614,7 +619,7 @@ mod test {
         );
 
         // Create an empty block payload store
-        let block_payload_store = BlockPayloadStore::new();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
         // Remove the third block (which is not ready)
         let third_block = missing_blocks[2].clone();
@@ -716,7 +721,9 @@ mod test {
         ordered_block: &OrderedBlock,
     ) {
         for block in ordered_block.blocks() {
-            block_payload_store.insert_block_payload(block.block_info(), vec![], None);
+            let block_payload =
+                BlockPayload::new(block.block_info(), BlockTransactionPayload::empty());
+            block_payload_store.insert_block_payload(block_payload, true);
         }
     }
 

--- a/consensus/src/consensus_observer/missing_blocks.rs
+++ b/consensus/src/consensus_observer/missing_blocks.rs
@@ -3,6 +3,7 @@
 
 use crate::consensus_observer::{
     logging::{LogEntry, LogSchema},
+    metrics,
     network_message::OrderedBlock,
     payload_store::BlockPayloadStore,
 };
@@ -124,6 +125,29 @@ impl MissingBlockStore {
 
         // Return the ready block (if one exists)
         ready_block
+    }
+
+    /// Updates the metrics for the missing blocks
+    pub fn update_missing_blocks_metrics(&self) {
+        // Update the number of missing blocks
+        let blocks_missing_payloads = self.blocks_missing_payloads.lock();
+        let num_missing_blocks = blocks_missing_payloads.len() as u64;
+        metrics::set_gauge_with_label(
+            &metrics::OBSERVER_NUM_PROCESSED_BLOCKS,
+            metrics::MISSING_BLOCKS_LABEL,
+            num_missing_blocks,
+        );
+
+        // Update the highest round for the missing blocks
+        let highest_missing_round = blocks_missing_payloads
+            .last_key_value()
+            .map(|(_, missing_block)| missing_block.last_block().round())
+            .unwrap_or(0);
+        metrics::set_gauge_with_label(
+            &metrics::OBSERVER_PROCESSED_BLOCK_ROUNDS,
+            metrics::MISSING_BLOCKS_LABEL,
+            highest_missing_round,
+        );
     }
 }
 

--- a/consensus/src/consensus_observer/missing_blocks.rs
+++ b/consensus/src/consensus_observer/missing_blocks.rs
@@ -1,0 +1,679 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::consensus_observer::{
+    logging::{LogEntry, LogSchema},
+    network_message::OrderedBlock,
+    payload_store::BlockPayloadStore,
+};
+use aptos_config::config::ConsensusObserverConfig;
+use aptos_infallible::Mutex;
+use aptos_logger::warn;
+use aptos_types::block_info::Round;
+use std::{
+    collections::{btree_map::Entry, BTreeMap},
+    sync::Arc,
+};
+
+/// A simple struct to hold blocks that are missing payloads. This is useful to
+/// handle out-of-order messages, where payloads are received after ordered blocks.
+#[derive(Clone)]
+pub struct MissingBlockStore {
+    // The configuration of the consensus observer
+    consensus_observer_config: ConsensusObserverConfig,
+
+    // A map of ordered blocks that are missing payloads. The key is the
+    // (epoch, round) of the first block in the ordered block.
+    blocks_missing_payloads: Arc<Mutex<BTreeMap<(u64, Round), OrderedBlock>>>,
+}
+
+impl MissingBlockStore {
+    pub fn new(consensus_observer_config: ConsensusObserverConfig) -> Self {
+        Self {
+            consensus_observer_config,
+            blocks_missing_payloads: Arc::new(Mutex::new(BTreeMap::new())),
+        }
+    }
+
+    /// Inserts a block (with missing payloads) into the store
+    pub fn insert_missing_block(&self, ordered_block: OrderedBlock) {
+        // Get the epoch and round of the first block
+        let first_block = ordered_block.first_block();
+        let first_block_epoch_round = (first_block.epoch(), first_block.round());
+
+        // Insert the block into the store using the round of the first block
+        match self
+            .blocks_missing_payloads
+            .lock()
+            .entry(first_block_epoch_round)
+        {
+            Entry::Occupied(_) => {
+                // The block is already in the store
+                warn!(
+                    LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                        "A missing block was already found for the given epoch and round: {:?}",
+                        first_block_epoch_round
+                    ))
+                );
+            },
+            Entry::Vacant(entry) => {
+                // Insert the block into the store
+                entry.insert(ordered_block);
+            },
+        }
+
+        // Perform garbage collection if the store is too large
+        self.garbage_collect_missing_blocks();
+    }
+
+    /// Garbage collects the missing blocks store by removing
+    /// the oldest blocks if the store is too large.
+    fn garbage_collect_missing_blocks(&self) {
+        // Calculate the number of blocks to remove
+        let mut blocks_missing_payloads = self.blocks_missing_payloads.lock();
+        let num_missing_blocks = blocks_missing_payloads.len() as u64;
+        let max_pending_blocks = self.consensus_observer_config.max_num_pending_blocks;
+        let num_blocks_to_remove = num_missing_blocks.saturating_sub(max_pending_blocks);
+
+        // Remove the oldest blocks if the store is too large
+        for _ in 0..num_blocks_to_remove {
+            if let Some((oldest_epoch_round, _)) = blocks_missing_payloads.pop_first() {
+                warn!(
+                    LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                        "The missing block store is too large: {:?} blocks. Removing the block for the oldest epoch and round: {:?}",
+                        num_missing_blocks, oldest_epoch_round
+                    ))
+                );
+            }
+        }
+    }
+
+    /// Removes and returns the block from the store that is now ready
+    /// to be processed (after the new payload has been received).
+    pub fn remove_ready_block(
+        &self,
+        received_payload_epoch: u64,
+        received_payload_round: Round,
+        block_payload_store: &BlockPayloadStore,
+    ) -> Option<OrderedBlock> {
+        // Calculate the round at which to split the blocks
+        let split_round = received_payload_round.saturating_add(1);
+
+        // Split the missing blocks at the epoch and round
+        let mut blocks_missing_payloads = self.blocks_missing_payloads.lock();
+        let mut blocks_at_higher_rounds =
+            blocks_missing_payloads.split_off(&(received_payload_epoch, split_round));
+
+        // Check if the last block is ready (this should be the only ready block).
+        // Any earlier blocks are considered out-of-date and will be dropped.
+        let mut ready_block = None;
+        if let Some((epoch_and_round, ordered_block)) = blocks_missing_payloads.pop_last() {
+            // If all payloads exist for the block, then the block is ready
+            if block_payload_store.all_payloads_exist(ordered_block.blocks()) {
+                ready_block = Some(ordered_block);
+            } else {
+                // Otherwise, check if we're still waiting for higher payloads for the block
+                if ordered_block.last_block().round() > received_payload_round {
+                    blocks_at_higher_rounds.insert(epoch_and_round, ordered_block);
+                }
+            }
+        }
+
+        // Update the missing blocks to only include the blocks at higher rounds
+        *blocks_missing_payloads = blocks_at_higher_rounds;
+
+        // Return the ready block (if one exists)
+        ready_block
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use aptos_consensus_types::{
+        block::Block,
+        block_data::{BlockData, BlockType},
+        pipelined_block::PipelinedBlock,
+        quorum_cert::QuorumCert,
+    };
+    use aptos_crypto::HashValue;
+    use aptos_types::{
+        aggregate_signature::AggregateSignature,
+        block_info::BlockInfo,
+        ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    };
+    use rand::Rng;
+
+    #[test]
+    fn test_insert_missing_block() {
+        // Create a new missing block store
+        let max_num_pending_blocks = 10;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks: max_num_pending_blocks as u64,
+            ..ConsensusObserverConfig::default()
+        };
+        let missing_block_store = MissingBlockStore::new(consensus_observer_config);
+
+        // Insert the maximum number of blocks into the store
+        let current_epoch = 0;
+        let starting_round = 0;
+        let missing_blocks = create_and_add_missing_blocks(
+            &missing_block_store,
+            max_num_pending_blocks,
+            current_epoch,
+            starting_round,
+            5,
+        );
+
+        // Verify that all blocks were inserted correctly
+        verify_missing_blocks(
+            &missing_block_store,
+            max_num_pending_blocks,
+            &missing_blocks,
+        );
+
+        // Insert the maximum number of blocks into the store again
+        let starting_round = (max_num_pending_blocks * 100) as Round;
+        let missing_blocks = create_and_add_missing_blocks(
+            &missing_block_store,
+            max_num_pending_blocks,
+            current_epoch,
+            starting_round,
+            5,
+        );
+
+        // Verify that all blocks were inserted correctly
+        verify_missing_blocks(
+            &missing_block_store,
+            max_num_pending_blocks,
+            &missing_blocks,
+        );
+
+        // Insert one more block into the store (for the next epoch)
+        let next_epoch = 1;
+        let starting_round = 0;
+        let new_missing_block =
+            create_and_add_missing_blocks(&missing_block_store, 1, next_epoch, starting_round, 5);
+
+        // Verify the new block was inserted correctly
+        verify_missing_blocks(
+            &missing_block_store,
+            max_num_pending_blocks,
+            &new_missing_block,
+        );
+    }
+
+    #[test]
+    fn test_garbage_collect_missing_blocks() {
+        // Create a new missing block store
+        let max_num_pending_blocks = 100;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks: max_num_pending_blocks as u64,
+            ..ConsensusObserverConfig::default()
+        };
+        let missing_block_store = MissingBlockStore::new(consensus_observer_config);
+
+        // Insert the maximum number of blocks into the store
+        let current_epoch = 0;
+        let starting_round = 200;
+        let mut missing_blocks = create_and_add_missing_blocks(
+            &missing_block_store,
+            max_num_pending_blocks,
+            current_epoch,
+            starting_round,
+            5,
+        );
+
+        // Verify that all blocks were inserted correctly
+        verify_missing_blocks(
+            &missing_block_store,
+            max_num_pending_blocks,
+            &missing_blocks,
+        );
+
+        // Insert multiple blocks into the store (one at a time) and
+        // verify that the oldest block is garbage collected each time.
+        for i in 0..20 {
+            // Insert one more block into the store
+            let starting_round = ((max_num_pending_blocks * 10) + (i * 100)) as Round;
+            let new_missing_block = create_and_add_missing_blocks(
+                &missing_block_store,
+                1,
+                current_epoch,
+                starting_round,
+                5,
+            );
+
+            // Verify the new block was inserted correctly
+            verify_missing_blocks(
+                &missing_block_store,
+                max_num_pending_blocks,
+                &new_missing_block,
+            );
+
+            // Get the round of the oldest block (that was garbage collected)
+            let oldest_block = missing_blocks.remove(0);
+            let oldest_block_round = oldest_block.first_block().round();
+
+            // Verify that the oldest block was garbage collected
+            let blocks_missing_payloads = missing_block_store.blocks_missing_payloads.lock();
+            assert!(!blocks_missing_payloads.contains_key(&(current_epoch, oldest_block_round)));
+        }
+
+        // Insert multiple blocks into the store (for the next epoch) and
+        // verify that the oldest block is garbage collected each time.
+        let next_epoch = 1;
+        for i in 0..20 {
+            // Insert one more block into the store
+            let starting_round = i;
+            let new_missing_block = create_and_add_missing_blocks(
+                &missing_block_store,
+                1,
+                next_epoch,
+                starting_round,
+                5,
+            );
+
+            // Verify the new block was inserted correctly
+            verify_missing_blocks(
+                &missing_block_store,
+                max_num_pending_blocks,
+                &new_missing_block,
+            );
+
+            // Get the round of the oldest block (that was garbage collected)
+            let oldest_block = missing_blocks.remove(0);
+            let oldest_block_round = oldest_block.first_block().round();
+
+            // Verify that the oldest block was garbage collected
+            let blocks_missing_payloads = missing_block_store.blocks_missing_payloads.lock();
+            assert!(!blocks_missing_payloads.contains_key(&(current_epoch, oldest_block_round)));
+        }
+    }
+
+    #[test]
+    fn test_remove_ready_block_multiple_blocks() {
+        // Create a new missing block store
+        let max_num_pending_blocks = 40;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks: max_num_pending_blocks as u64,
+            ..ConsensusObserverConfig::default()
+        };
+        let missing_block_store = MissingBlockStore::new(consensus_observer_config);
+
+        // Insert the maximum number of blocks into the store
+        let current_epoch = 0;
+        let starting_round = 0;
+        let missing_blocks = create_and_add_missing_blocks(
+            &missing_block_store,
+            max_num_pending_blocks,
+            current_epoch,
+            starting_round,
+            5,
+        );
+
+        // Create a new block payload store and insert payloads for the second block
+        let mut block_payload_store = BlockPayloadStore::new();
+        let second_block = missing_blocks[1].clone();
+        insert_payloads_for_ordered_block(&mut block_payload_store, &second_block);
+
+        // Remove the second block (which is now ready)
+        let payload_round = second_block.first_block().round();
+        let ready_block = missing_block_store.remove_ready_block(
+            current_epoch,
+            payload_round,
+            &block_payload_store,
+        );
+        assert_eq!(ready_block, Some(second_block));
+
+        // Verify that the first and second blocks were removed
+        verify_missing_blocks(
+            &missing_block_store,
+            max_num_pending_blocks - 2,
+            &missing_blocks[2..].to_vec(),
+        );
+
+        // Insert payloads for the last block
+        let last_block = missing_blocks.last().unwrap().clone();
+        insert_payloads_for_ordered_block(&mut block_payload_store, &last_block);
+
+        // Remove the last block (which is now ready)
+        let payload_round = last_block.first_block().round();
+        let ready_block = missing_block_store.remove_ready_block(
+            current_epoch,
+            payload_round,
+            &block_payload_store,
+        );
+
+        // Verify that the last block was removed
+        assert_eq!(ready_block, Some(last_block));
+
+        // Verify that the store is empty
+        verify_missing_blocks(&missing_block_store, 0, &vec![]);
+    }
+
+    #[test]
+    fn test_remove_ready_block_multiple_blocks_missing() {
+        // Create a new missing block store
+        let max_num_pending_blocks = 4;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks: max_num_pending_blocks as u64,
+            ..ConsensusObserverConfig::default()
+        };
+        let missing_block_store = MissingBlockStore::new(consensus_observer_config);
+
+        // Insert the maximum number of blocks into the store
+        let current_epoch = 10;
+        let starting_round = 100;
+        let missing_blocks = create_and_add_missing_blocks(
+            &missing_block_store,
+            max_num_pending_blocks,
+            current_epoch,
+            starting_round,
+            5,
+        );
+
+        // Create an empty block payload store
+        let mut block_payload_store = BlockPayloadStore::new();
+
+        // Incrementally insert and process each payload for the first block
+        let first_block = missing_blocks.first().unwrap().clone();
+        for block in first_block.blocks().clone() {
+            // Insert the block
+            block_payload_store.insert_block_payload(block.block_info(), vec![], None);
+
+            // Attempt to remove the block (which might not be ready)
+            let payload_round = block.round();
+            let ready_block = missing_block_store.remove_ready_block(
+                current_epoch,
+                payload_round,
+                &block_payload_store,
+            );
+
+            // If the block is ready, verify that it was removed.
+            // Otherwise, verify that the block still remains.
+            if payload_round == first_block.last_block().round() {
+                // The block should be ready
+                assert_eq!(ready_block, Some(first_block.clone()));
+
+                // Verify that the block was removed
+                verify_missing_blocks(
+                    &missing_block_store,
+                    max_num_pending_blocks - 1,
+                    &missing_blocks[1..].to_vec(),
+                );
+            } else {
+                // The block should not be ready
+                assert!(ready_block.is_none());
+
+                // Verify that the block still remains
+                verify_missing_blocks(
+                    &missing_block_store,
+                    max_num_pending_blocks,
+                    &missing_blocks,
+                );
+            }
+        }
+
+        // Incrementally insert and process payloads for the last block (except one)
+        let last_block = missing_blocks.last().unwrap().clone();
+        for block in last_block.blocks().clone() {
+            // Insert the block only if this is not the first block
+            let payload_round = block.round();
+            if payload_round != last_block.first_block().round() {
+                block_payload_store.insert_block_payload(block.block_info(), vec![], None);
+            }
+
+            // Attempt to remove the block (which might not be ready)
+            let ready_block = missing_block_store.remove_ready_block(
+                current_epoch,
+                payload_round,
+                &block_payload_store,
+            );
+
+            // The block should not be ready
+            assert!(ready_block.is_none());
+
+            // Verify that the block still remains or has been removed on the last insert
+            if payload_round == last_block.last_block().round() {
+                verify_missing_blocks(&missing_block_store, 0, &vec![]);
+            } else {
+                verify_missing_blocks(&missing_block_store, 1, &vec![last_block.clone()]);
+            }
+        }
+
+        // Verify that the store is now empty
+        verify_missing_blocks(&missing_block_store, 0, &vec![]);
+    }
+
+    #[test]
+    fn test_remove_ready_block_singular_blocks() {
+        // Create a new missing block store
+        let max_num_pending_blocks = 10;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks: max_num_pending_blocks as u64,
+            ..ConsensusObserverConfig::default()
+        };
+        let missing_block_store = MissingBlockStore::new(consensus_observer_config);
+
+        // Insert the maximum number of blocks into the store
+        let current_epoch = 0;
+        let starting_round = 0;
+        let missing_blocks = create_and_add_missing_blocks(
+            &missing_block_store,
+            max_num_pending_blocks,
+            current_epoch,
+            starting_round,
+            1,
+        );
+
+        // Create a new block payload store and insert payloads for the first block
+        let mut block_payload_store = BlockPayloadStore::new();
+        let first_block = missing_blocks.first().unwrap().clone();
+        insert_payloads_for_ordered_block(&mut block_payload_store, &first_block);
+
+        // Remove the first block (which is now ready)
+        let payload_round = first_block.first_block().round();
+        let ready_block = missing_block_store.remove_ready_block(
+            current_epoch,
+            payload_round,
+            &block_payload_store,
+        );
+        assert_eq!(ready_block, Some(first_block));
+
+        // Verify that the first block was removed
+        verify_missing_blocks(
+            &missing_block_store,
+            max_num_pending_blocks - 1,
+            &missing_blocks[1..].to_vec(),
+        );
+
+        // Insert payloads for the second block
+        let second_block = missing_blocks[1].clone();
+        insert_payloads_for_ordered_block(&mut block_payload_store, &second_block);
+
+        // Remove the second block (which is now ready)
+        let payload_round = second_block.first_block().round();
+        let ready_block = missing_block_store.remove_ready_block(
+            current_epoch,
+            payload_round,
+            &block_payload_store,
+        );
+        assert_eq!(ready_block, Some(second_block));
+
+        // Verify that the first and second blocks were removed
+        verify_missing_blocks(
+            &missing_block_store,
+            max_num_pending_blocks - 2,
+            &missing_blocks[2..].to_vec(),
+        );
+
+        // Insert payloads for the last block
+        let last_block = missing_blocks.last().unwrap().clone();
+        insert_payloads_for_ordered_block(&mut block_payload_store, &last_block);
+
+        // Remove the last block (which is now ready)
+        let payload_round = last_block.first_block().round();
+        let ready_block = missing_block_store.remove_ready_block(
+            current_epoch,
+            payload_round,
+            &block_payload_store,
+        );
+
+        // Verify that the last block was removed
+        assert_eq!(ready_block, Some(last_block));
+
+        // Verify that the store is empty
+        verify_missing_blocks(&missing_block_store, 0, &vec![]);
+    }
+
+    #[test]
+    fn test_remove_ready_block_singular_blocks_missing() {
+        // Create a new missing block store
+        let max_num_pending_blocks = 100;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks: max_num_pending_blocks as u64,
+            ..ConsensusObserverConfig::default()
+        };
+        let missing_block_store = MissingBlockStore::new(consensus_observer_config);
+
+        // Insert the maximum number of blocks into the store
+        let current_epoch = 10;
+        let starting_round = 100;
+        let missing_blocks = create_and_add_missing_blocks(
+            &missing_block_store,
+            max_num_pending_blocks,
+            current_epoch,
+            starting_round,
+            1,
+        );
+
+        // Create an empty block payload store
+        let block_payload_store = BlockPayloadStore::new();
+
+        // Remove the third block (which is not ready)
+        let third_block = missing_blocks[2].clone();
+        let third_block_round = third_block.first_block().round();
+        let ready_block = missing_block_store.remove_ready_block(
+            current_epoch,
+            third_block_round,
+            &block_payload_store,
+        );
+        assert!(ready_block.is_none());
+
+        // Verify that the first three blocks were removed
+        verify_missing_blocks(
+            &missing_block_store,
+            max_num_pending_blocks - 3,
+            &missing_blocks[3..].to_vec(),
+        );
+
+        // Remove the last block (which is not ready)
+        let last_block = missing_blocks.last().unwrap().clone();
+        let last_block_round = last_block.first_block().round();
+        let ready_block = missing_block_store.remove_ready_block(
+            current_epoch,
+            last_block_round,
+            &block_payload_store,
+        );
+        assert!(ready_block.is_none());
+
+        // Verify that the store is now empty
+        verify_missing_blocks(&missing_block_store, 0, &vec![]);
+    }
+
+    /// Creates and adds the specified number of blocks to the missing block store
+    fn create_and_add_missing_blocks(
+        missing_block_store: &MissingBlockStore,
+        num_missing_blocks: usize,
+        epoch: u64,
+        starting_round: Round,
+        max_pipelined_blocks: u64,
+    ) -> Vec<OrderedBlock> {
+        let mut missing_blocks = vec![];
+        for i in 0..num_missing_blocks {
+            // Create the pipelined blocks
+            let num_pipelined_blocks = rand::thread_rng().gen_range(1, max_pipelined_blocks + 1);
+            let mut pipelined_blocks = vec![];
+            for j in 0..num_pipelined_blocks {
+                // Calculate the block round
+                let round = starting_round + ((i as Round) * max_pipelined_blocks) + j; // Ensure gaps between blocks
+
+                // Create a new block info
+                let block_info = BlockInfo::new(
+                    epoch,
+                    round,
+                    HashValue::random(),
+                    HashValue::random(),
+                    round,
+                    i as u64,
+                    None,
+                );
+
+                // Create the pipelined block
+                let block_data = BlockData::new_for_testing(
+                    block_info.epoch(),
+                    block_info.round(),
+                    block_info.timestamp_usecs(),
+                    QuorumCert::dummy(),
+                    BlockType::Genesis,
+                );
+                let block = Block::new_for_testing(block_info.id(), block_data, None);
+                let pipelined_block = Arc::new(PipelinedBlock::new_ordered(block));
+
+                // Add the pipelined block to the list
+                pipelined_blocks.push(pipelined_block);
+            }
+
+            // Create an ordered block
+            let ordered_proof = LedgerInfoWithSignatures::new(
+                LedgerInfo::new(
+                    BlockInfo::random_with_epoch(epoch, starting_round),
+                    HashValue::random(),
+                ),
+                AggregateSignature::empty(),
+            );
+            let ordered_block = OrderedBlock::new(pipelined_blocks, ordered_proof.clone());
+
+            // Insert the ordered block into the missing block store
+            missing_block_store.insert_missing_block(ordered_block.clone());
+
+            // Add the ordered block to the missing blocks
+            missing_blocks.push(ordered_block);
+        }
+
+        missing_blocks
+    }
+
+    /// Inserts payloads into the payload store for the ordered block
+    fn insert_payloads_for_ordered_block(
+        block_payload_store: &mut BlockPayloadStore,
+        ordered_block: &OrderedBlock,
+    ) {
+        for block in ordered_block.blocks() {
+            block_payload_store.insert_block_payload(block.block_info(), vec![], None);
+        }
+    }
+
+    /// Verifies that the missing block store contains the expected blocks
+    fn verify_missing_blocks(
+        missing_block_store: &MissingBlockStore,
+        num_expected_blocks: usize,
+        missing_blocks: &Vec<OrderedBlock>,
+    ) {
+        // Check the number of missing blocks
+        let blocks_missing_payloads = missing_block_store.blocks_missing_payloads.lock();
+        assert_eq!(blocks_missing_payloads.len(), num_expected_blocks);
+
+        // Check that all missing blocks are in the store
+        for missing_block in missing_blocks {
+            let first_block = missing_block.first_block();
+            assert_eq!(
+                blocks_missing_payloads
+                    .get(&(first_block.epoch(), first_block.round()))
+                    .unwrap(),
+                missing_block
+            );
+        }
+    }
+}

--- a/consensus/src/consensus_observer/mod.rs
+++ b/consensus/src/consensus_observer/mod.rs
@@ -4,6 +4,7 @@
 pub mod error;
 pub mod logging;
 pub mod metrics;
+pub mod missing_blocks;
 pub mod network_client;
 pub mod network_events;
 pub mod network_message;

--- a/consensus/src/consensus_observer/network_message.rs
+++ b/consensus/src/consensus_observer/network_message.rs
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::consensus_observer::error::Error;
-use aptos_consensus_types::pipelined_block::PipelinedBlock;
+use aptos_consensus_types::{
+    common::{BatchPayload, ProofWithData},
+    pipelined_block::PipelinedBlock,
+    proof_of_store::{BatchInfo, ProofCache},
+};
+use aptos_crypto::hash::CryptoHash;
 use aptos_types::{
     block_info::{BlockInfo, Round},
     epoch_change::Verifier,
@@ -12,6 +17,7 @@ use aptos_types::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::VecDeque,
     fmt::{Display, Formatter},
     sync::Arc,
 };
@@ -46,13 +52,11 @@ impl ConsensusObserverMessage {
     /// Creates and returns a new block payload message using the given block, transactions and limit
     pub fn new_block_payload_message(
         block: BlockInfo,
-        transactions: Vec<SignedTransaction>,
-        limit: Option<u64>,
+        transaction_payload: BlockTransactionPayload,
     ) -> ConsensusObserverDirectSend {
         ConsensusObserverDirectSend::BlockPayload(BlockPayload {
             block,
-            transactions,
-            limit,
+            transaction_payload,
         })
     }
 }
@@ -150,10 +154,11 @@ impl ConsensusObserverDirectSend {
             },
             ConsensusObserverDirectSend::BlockPayload(block_payload) => {
                 format!(
-                    "BlockPayload: {} {} {:?}",
-                    block_payload.block.id(),
-                    block_payload.transactions.len(),
-                    block_payload.limit
+                    "BlockPayload: {}. Number of transactions: {}, limit: {:?}, proofs: {:?}",
+                    block_payload.block,
+                    block_payload.transaction_payload.transactions.len(),
+                    block_payload.transaction_payload.limit,
+                    block_payload.transaction_payload.proof_with_data.proofs,
                 )
             },
         }
@@ -304,10 +309,142 @@ impl CommitDecision {
     }
 }
 
-/// Payload message contains the block, transactions and the limit of the block
+/// The transaction payload of each block
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BlockTransactionPayload {
+    pub transactions: Vec<SignedTransaction>,
+    pub limit: Option<u64>,
+    pub proof_with_data: ProofWithData,
+    pub inline_batches: Vec<BatchInfo>,
+}
+
+impl BlockTransactionPayload {
+    pub fn new(
+        transactions: Vec<SignedTransaction>,
+        limit: Option<u64>,
+        proof_with_data: ProofWithData,
+        inline_batches: Vec<BatchInfo>,
+    ) -> Self {
+        Self {
+            transactions,
+            limit,
+            proof_with_data,
+            inline_batches,
+        }
+    }
+
+    #[cfg(test)]
+    /// Returns an empty transaction payload (for testing)
+    pub fn empty() -> Self {
+        Self {
+            transactions: vec![],
+            limit: None,
+            proof_with_data: ProofWithData::empty(),
+            inline_batches: vec![],
+        }
+    }
+}
+
+/// Payload message contains the block and transaction payload
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BlockPayload {
     pub block: BlockInfo,
-    pub transactions: Vec<SignedTransaction>,
-    pub limit: Option<u64>,
+    pub transaction_payload: BlockTransactionPayload,
+}
+
+impl BlockPayload {
+    pub fn new(block: BlockInfo, transaction_payload: BlockTransactionPayload) -> Self {
+        Self {
+            block,
+            transaction_payload,
+        }
+    }
+
+    /// Verifies the block payload digests and returns an error if the data is invalid
+    pub fn verify_payload_digests(&self) -> Result<(), Error> {
+        // Verify the proof of store digests against the transactions
+        let mut transactions = self
+            .transaction_payload
+            .transactions
+            .iter()
+            .cloned()
+            .collect::<VecDeque<_>>();
+        for proof_of_store in &self.transaction_payload.proof_with_data.proofs {
+            reconstruct_and_verify_batch(&mut transactions, proof_of_store.info())?;
+        }
+
+        // Verify the inline batch digests against the inline batches
+        for batch_info in &self.transaction_payload.inline_batches {
+            reconstruct_and_verify_batch(&mut transactions, batch_info)?;
+        }
+
+        // Verify that there are no transactions remaining
+        if !transactions.is_empty() {
+            return Err(Error::InvalidMessageError(format!(
+                "Failed to verify payload transactions! Transactions remaining: {:?}. Expected: 0",
+                transactions.len()
+            )));
+        }
+
+        Ok(()) // All digests match
+    }
+
+    /// Verifies that the block payload proofs are correctly signed according
+    /// to the current epoch state. Returns an error if the data is invalid.
+    pub fn verify_payload_signatures(&self, epoch_state: &EpochState) -> Result<(), Error> {
+        // Create a dummy proof cache to verify the proofs
+        let proof_cache = ProofCache::new(1);
+
+        // Verify each of the proof signatures
+        let validator_verifier = &epoch_state.verifier;
+        for proof_of_store in &self.transaction_payload.proof_with_data.proofs {
+            if let Err(error) = proof_of_store.verify(validator_verifier, &proof_cache) {
+                return Err(Error::InvalidMessageError(format!(
+                    "Failed to verify the proof of store for batch: {:?}, Error: {:?}",
+                    proof_of_store.info(),
+                    error
+                )));
+            }
+        }
+
+        Ok(()) // All proofs are correctly signed
+    }
+}
+
+/// Reconstructs and verifies the batch using the
+/// given transactions and the expected batch info.
+fn reconstruct_and_verify_batch(
+    transactions: &mut VecDeque<SignedTransaction>,
+    expected_batch_info: &BatchInfo,
+) -> Result<(), Error> {
+    // Gather the transactions for the batch
+    let mut batch_transactions = vec![];
+    for i in 0..expected_batch_info.num_txns() {
+        let batch_transaction = match transactions.pop_front() {
+            Some(transaction) => transaction,
+            None => {
+                return Err(Error::InvalidMessageError(format!(
+                    "Failed to extract transaction during batch reconstruction! Batch: {:?}, transaction index: {:?}",
+                    expected_batch_info, i
+                )));
+            },
+        };
+        batch_transactions.push(batch_transaction);
+    }
+
+    // Calculate the batch digest
+    let batch_payload = BatchPayload::new(expected_batch_info.author(), batch_transactions);
+    let batch_digest = batch_payload.hash();
+
+    // Verify the reconstructed digest against the expected digest
+    let expected_digest = expected_batch_info.digest();
+    if batch_digest != *expected_digest {
+        return Err(Error::InvalidMessageError(format!(
+            "The reconstructed inline batch digest does not match the expected digest!\
+             Batch: {:?}, Expected digest: {:?}, Reconstructed digest: {:?}",
+            expected_batch_info, expected_digest, batch_digest
+        )));
+    }
+
+    Ok(())
 }

--- a/consensus/src/consensus_observer/observer.rs
+++ b/consensus/src/consensus_observer/observer.rs
@@ -158,6 +158,17 @@ impl ConsensusObserver {
         debug!(LogSchema::new(LogEntry::ConsensusObserver)
             .message("Checking consensus observer progress!"));
 
+        // If we're in state sync mode, we should wait for state sync to complete
+        if self.in_state_sync_mode() {
+            info!(
+                LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                    "Waiting for state sync to reach target: {:?}!",
+                    self.root.lock().commit_info()
+                ))
+            );
+            return;
+        }
+
         // Get the peer ID of the currently active subscription (if any)
         let active_subscription_peer = self
             .active_observer_subscription
@@ -192,8 +203,12 @@ impl ConsensusObserver {
             self.create_new_observer_subscription(active_subscription_peer)
                 .await;
 
-            // If we successfully created a new subscription, update the subscription creation metrics
+            // If we successfully created a new subscription, clear the state and update the metrics
             if let Some(active_subscription) = &self.active_observer_subscription {
+                // Clear the block state
+                self.clear_pending_block_state().await;
+
+                // Update the subscription creation metrics
                 self.update_subscription_creation_metrics(
                     active_subscription.get_peer_network_id(),
                 );
@@ -223,8 +238,7 @@ impl ConsensusObserver {
             // Verify the subscription has not timed out
             active_subscription.check_subscription_timeout()?;
 
-            // Verify that the DB is continuing to sync and commit new data.
-            // Note: we should only do this if we're not waiting for state sync.
+            // Verify that the DB is continuing to sync and commit new data
             active_subscription.check_syncing_progress()?;
 
             // Verify that the subscription peer is optimal
@@ -237,6 +251,30 @@ impl ConsensusObserver {
         }
 
         Ok(())
+    }
+
+    /// Clears the pending block state (this is useful for changing
+    /// subscriptions, where we want to wipe all state and restart).
+    async fn clear_pending_block_state(&self) {
+        // Clear the missing blocks
+        self.missing_block_store.clear_missing_blocks();
+
+        // Clear the payload store
+        self.block_payload_store.clear_all_payloads();
+
+        // Clear the pending blocks
+        self.pending_ordered_blocks.clear_all_pending_blocks();
+
+        // Reset the execution pipeline for the root
+        let root = self.root.lock().clone();
+        if let Err(error) = self.execution_client.reset(&root).await {
+            error!(
+                LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                    "Failed to reset the execution pipeline for the root! Error: {:?}",
+                    error
+                ))
+            );
+        }
     }
 
     /// Creates and returns a commit callback (to be called after the execution pipeline)
@@ -457,6 +495,11 @@ impl ConsensusObserver {
         }
     }
 
+    /// Returns true iff we are waiting for state sync to complete
+    fn in_state_sync_mode(&self) -> bool {
+        self.sync_handle.is_some()
+    }
+
     /// Processes the block payload message
     async fn process_block_payload_message(&mut self, block_payload: BlockPayload) {
         // Get the block round and epoch
@@ -580,7 +623,7 @@ impl ConsensusObserver {
                     .update_commit_decision(commit_decision);
 
                 // If we are not in sync mode, forward the commit decision to the execution pipeline
-                if self.sync_handle.is_none() {
+                if !self.in_state_sync_mode() {
                     debug!(
                         LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                             "Forwarding commit decision to the execution pipeline: {}",
@@ -734,7 +777,7 @@ impl ConsensusObserver {
                 .insert_ordered_block(ordered_block.clone(), verified_ordered_proof);
 
             // If we verified the proof, and we're not in sync mode, finalize the ordered blocks
-            if verified_ordered_proof && self.sync_handle.is_none() {
+            if verified_ordered_proof && !self.in_state_sync_mode() {
                 debug!(
                     LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                         "Forwarding blocks to the execution pipeline: {}",

--- a/consensus/src/consensus_observer/observer.rs
+++ b/consensus/src/consensus_observer/observer.rs
@@ -6,6 +6,7 @@ use crate::{
         error::Error,
         logging::{LogEntry, LogSchema},
         metrics,
+        missing_blocks::MissingBlockStore,
         network_client::ConsensusObserverClient,
         network_events::{ConsensusObserverNetworkEvents, NetworkMessage, ResponseSender},
         network_message::{
@@ -74,7 +75,9 @@ pub struct ConsensusObserver {
 
     // The payload store holds block transaction payloads
     block_payload_store: BlockPayloadStore,
-    // The pending ordered blocks (these are also buffered when in state sync mode)
+    // The missing block store holds pending ordered blocks that are missing payloads
+    missing_block_store: MissingBlockStore,
+    // The pending ordered blocks (these are also ordered when in state sync mode)
     pending_ordered_blocks: PendingOrderedBlocks,
     // The execution client to the buffer manager
     execution_client: Arc<dyn TExecutionClient>,
@@ -119,9 +122,10 @@ impl ConsensusObserver {
             consensus_observer_client,
             epoch_state: None,
             root: Arc::new(Mutex::new(root)),
+            block_payload_store: BlockPayloadStore::new(),
+            missing_block_store: MissingBlockStore::new(consensus_observer_config),
             pending_ordered_blocks: PendingOrderedBlocks::new(consensus_observer_config),
             execution_client,
-            block_payload_store: BlockPayloadStore::new(),
             sync_handle: None,
             sync_notification_sender,
             reconfig_events,
@@ -436,10 +440,14 @@ impl ConsensusObserver {
         }
     }
 
-    /// Processes the block payload
-    fn process_block_payload(&mut self, block_payload: BlockPayload) {
-        // Unpack the block payload
+    /// Processes the block payload message
+    async fn process_block_payload_message(&mut self, block_payload: BlockPayload) {
+        // Unpack the block round and epoch
         let block = block_payload.block;
+        let block_round = block.round();
+        let block_epoch = block.epoch();
+
+        // Unpack the block payload
         let transactions = block_payload.transactions;
         let limit = block_payload.limit;
 
@@ -448,10 +456,21 @@ impl ConsensusObserver {
         // Update the payload store with the payload
         self.block_payload_store
             .insert_block_payload(block, transactions, limit);
+
+        // Check if there are blocks that were missing payloads
+        // but are now ready because of the new payload.
+        if let Some(ordered_block) = self.missing_block_store.remove_ready_block(
+            block_epoch,
+            block_round,
+            &self.block_payload_store,
+        ) {
+            // Process the ordered block
+            self.process_ordered_block(ordered_block).await;
+        }
     }
 
-    /// Processes the commit decision
-    fn process_commit_decision(&mut self, commit_decision: CommitDecision) {
+    /// Processes the commit decision message
+    fn process_commit_decision_message(&mut self, commit_decision: CommitDecision) {
         // If the commit decision is for the current epoch, verify it
         let epoch_state = self.get_epoch_state();
         let commit_decision_epoch = commit_decision.epoch();
@@ -600,7 +619,7 @@ impl ConsensusObserver {
                         peer_network_id
                     ))
                 );
-                self.process_ordered_block(ordered_block).await;
+                self.process_ordered_block_message(ordered_block).await;
             },
             ConsensusObserverDirectSend::CommitDecision(commit_decision) => {
                 debug!(
@@ -610,7 +629,7 @@ impl ConsensusObserver {
                         peer_network_id
                     ))
                 );
-                self.process_commit_decision(commit_decision);
+                self.process_commit_decision_message(commit_decision);
             },
             ConsensusObserverDirectSend::BlockPayload(block_payload) => {
                 debug!(
@@ -619,13 +638,13 @@ impl ConsensusObserver {
                         block_payload.block, peer_network_id
                     ))
                 );
-                self.process_block_payload(block_payload);
+                self.process_block_payload_message(block_payload).await;
             },
         }
     }
 
     /// Processes the ordered block
-    async fn process_ordered_block(&mut self, ordered_block: OrderedBlock) {
+    async fn process_ordered_block_message(&mut self, ordered_block: OrderedBlock) {
         // Verify the ordered blocks before processing
         if let Err(error) = ordered_block.verify_ordered_blocks() {
             error!(
@@ -638,6 +657,21 @@ impl ConsensusObserver {
             return;
         };
 
+        // If all the payloads exist, process the ordered block.
+        // Otherwise, store the block in the missing block store.
+        if self
+            .block_payload_store
+            .all_payloads_exist(ordered_block.blocks())
+        {
+            self.process_ordered_block(ordered_block).await;
+        } else {
+            self.missing_block_store.insert_missing_block(ordered_block);
+        }
+    }
+
+    /// Processes the ordered block. This assumes the ordered block
+    /// has been sanity checked and that all payloads exist.
+    async fn process_ordered_block(&mut self, ordered_block: OrderedBlock) {
         // If the ordered block is for the current epoch, verify the proof
         let epoch_state = self.get_epoch_state();
         let verified_ordered_proof =

--- a/consensus/src/consensus_observer/observer.rs
+++ b/consensus/src/consensus_observer/observer.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::{config::ConsensusObserverConfig, network_id::PeerNetworkId};
-use aptos_consensus_types::pipeline;
+use aptos_consensus_types::{pipeline, pipelined_block::PipelinedBlock};
 use aptos_crypto::{bls12381, Genesis};
 use aptos_event_notifications::{DbBackedOnChainConfig, ReconfigNotificationListener};
 use aptos_infallible::Mutex;
@@ -60,6 +60,9 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::{sync::mpsc::UnboundedSender, time::interval};
 use tokio_stream::wrappers::IntervalStream;
 
+// Whether to log messages at the info level (useful for debugging)
+const LOG_MESSAGES_AT_INFO_LEVEL: bool = false;
+
 /// The consensus observer receives consensus updates and propagates them to the execution pipeline
 pub struct ConsensusObserver {
     // The configuration of the consensus observer
@@ -70,6 +73,8 @@ pub struct ConsensusObserver {
 
     // The current epoch state
     epoch_state: Option<Arc<EpochState>>,
+    // Whether quorum store is enabled (updated on epoch changes)
+    quorum_store_enabled: bool,
     // The latest ledger info (updated via a callback)
     root: Arc<Mutex<LedgerInfoWithSignatures>>,
 
@@ -121,6 +126,7 @@ impl ConsensusObserver {
             consensus_observer_config,
             consensus_observer_client,
             epoch_state: None,
+            quorum_store_enabled: false, // Updated on epoch changes
             root: Arc::new(Mutex::new(root)),
             block_payload_store: BlockPayloadStore::new(),
             missing_block_store: MissingBlockStore::new(consensus_observer_config),
@@ -134,6 +140,17 @@ impl ConsensusObserver {
             db_reader,
             time_service,
         }
+    }
+
+    /// Returns true iff all payloads exist for the given blocks
+    fn all_payloads_exist(&self, blocks: &[Arc<PipelinedBlock>]) -> bool {
+        // If quorum store is disabled, all payloads exist (they're already in the blocks)
+        if !self.quorum_store_enabled {
+            return true;
+        }
+
+        // Otherwise, check if all the payloads exist in the payload store
+        self.block_payload_store.all_payloads_exist(blocks)
     }
 
     /// Checks the progress of the consensus observer
@@ -442,14 +459,21 @@ impl ConsensusObserver {
 
     /// Processes the block payload message
     async fn process_block_payload_message(&mut self, block_payload: BlockPayload) {
-        // Unpack the block round and epoch
+        // Get the block round and epoch
         let block = block_payload.block;
         let block_round = block.round();
         let block_epoch = block.epoch();
 
-        // Unpack the block payload
+        // Get the block transactions and limit
         let transactions = block_payload.transactions;
         let limit = block_payload.limit;
+
+        // Update the metrics for the received block payload
+        metrics::set_gauge_with_label(
+            &metrics::OBSERVER_RECEIVED_MESSAGE_ROUNDS,
+            metrics::BLOCK_PAYLOAD_LABEL,
+            block_round,
+        );
 
         // TODO: verify the block payload!
 
@@ -471,6 +495,13 @@ impl ConsensusObserver {
 
     /// Processes the commit decision message
     fn process_commit_decision_message(&mut self, commit_decision: CommitDecision) {
+        // Update the metrics for the received commit decision
+        metrics::set_gauge_with_label(
+            &metrics::OBSERVER_RECEIVED_MESSAGE_ROUNDS,
+            metrics::COMMIT_DECISION_LABEL,
+            commit_decision.round(),
+        );
+
         // If the commit decision is for the current epoch, verify it
         let epoch_state = self.get_epoch_state();
         let commit_decision_epoch = commit_decision.epoch();
@@ -537,11 +568,8 @@ impl ConsensusObserver {
 
         // Process the pending block
         if let Some(pending_block) = pending_block {
-            // If the payload exists, add the commit decision to the pending blocks
-            if self
-                .block_payload_store
-                .all_payloads_exist(pending_block.blocks())
-            {
+            // If all payloads exist, add the commit decision to the pending blocks
+            if self.all_payloads_exist(pending_block.blocks()) {
                 debug!(
                     LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                         "Adding decision to pending block: {}",
@@ -612,35 +640,44 @@ impl ConsensusObserver {
         // Process the message based on the type
         match message {
             ConsensusObserverDirectSend::OrderedBlock(ordered_block) => {
-                debug!(
-                    LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                        "Received ordered block: {}, from peer: {}!",
-                        ordered_block.proof_block_info(),
-                        peer_network_id
-                    ))
+                // Log the received ordered block message
+                let log_message = format!(
+                    "Received ordered block: {}, from peer: {}!",
+                    ordered_block.proof_block_info(),
+                    peer_network_id
                 );
+                log_received_message(log_message);
+
+                // Process the ordered block message
                 self.process_ordered_block_message(ordered_block).await;
             },
             ConsensusObserverDirectSend::CommitDecision(commit_decision) => {
-                debug!(
-                    LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                        "Received commit decision: {}, from peer: {}!",
-                        commit_decision.proof_block_info(),
-                        peer_network_id
-                    ))
+                // Log the received commit decision message
+                let log_message = format!(
+                    "Received commit decision: {}, from peer: {}!",
+                    commit_decision.proof_block_info(),
+                    peer_network_id
                 );
+                log_received_message(log_message);
+
+                // Process the commit decision message
                 self.process_commit_decision_message(commit_decision);
             },
             ConsensusObserverDirectSend::BlockPayload(block_payload) => {
-                debug!(
-                    LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                        "Received block payload: {}, from peer: {}!",
-                        block_payload.block, peer_network_id
-                    ))
+                // Log the received block payload message
+                let log_message = format!(
+                    "Received block payload: {}, from peer: {}!",
+                    block_payload.block, peer_network_id
                 );
+                log_received_message(log_message);
+
+                // Process the block payload message
                 self.process_block_payload_message(block_payload).await;
             },
         }
+
+        // Update the metrics for the processed blocks
+        self.update_processed_blocks_metrics();
     }
 
     /// Processes the ordered block
@@ -657,12 +694,9 @@ impl ConsensusObserver {
             return;
         };
 
-        // If all the payloads exist, process the ordered block.
-        // Otherwise, store the block in the missing block store.
-        if self
-            .block_payload_store
-            .all_payloads_exist(ordered_block.blocks())
-        {
+        // If all payloads exist, process the block. Otherwise, store it
+        // in the missing block store and wait for the payloads to arrive.
+        if self.all_payloads_exist(ordered_block.blocks()) {
             self.process_ordered_block(ordered_block).await;
         } else {
             self.missing_block_store.insert_missing_block(ordered_block);
@@ -884,6 +918,18 @@ impl ConsensusObserver {
         });
     }
 
+    /// Updates the metrics for the processed blocks
+    fn update_processed_blocks_metrics(&self) {
+        // Update the missing block metrics
+        self.missing_block_store.update_missing_blocks_metrics();
+
+        // Update the payload store metrics
+        self.block_payload_store.update_payload_store_metrics();
+
+        // Update the pending block metrics
+        self.pending_ordered_blocks.update_pending_blocks_metrics();
+    }
+
     /// Updates the subscription creation metrics for the given peer
     fn update_subscription_creation_metrics(&self, peer_network_id: PeerNetworkId) {
         // Set the number of active subscriptions
@@ -935,17 +981,18 @@ impl ConsensusObserver {
             panic!("Reconfig events are required to wait for a new epoch to start! Something has gone wrong!")
         };
 
-        // Update the local epoch state
+        // Update the local epoch state and quorum store config
         self.epoch_state = Some(epoch_state.clone());
+        self.quorum_store_enabled = consensus_config.quorum_store_enabled();
         info!(
             LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                "New epoch started: {}. Updated the epoch state!",
-                epoch_state.epoch
+                "New epoch started: {:?}. Updated the epoch state! Quorum store enabled: {:?}",
+                epoch_state.epoch, self.quorum_store_enabled,
             ))
         );
 
         // Create the payload manager
-        let payload_manager = if consensus_config.quorum_store_enabled() {
+        let payload_manager = if self.quorum_store_enabled {
             PayloadManager::ConsensusObserver(
                 self.block_payload_store.get_block_payloads(),
                 self.consensus_publisher.clone(),
@@ -1173,6 +1220,17 @@ async fn extract_on_chain_configs(
         execution_config,
         onchain_randomness_config,
     )
+}
+
+/// Logs the received message using an appropriate log level
+fn log_received_message(message: String) {
+    // Log the message at the appropriate level
+    let log_schema = LogSchema::new(LogEntry::ConsensusObserver).message(&message);
+    if LOG_MESSAGES_AT_INFO_LEVEL {
+        info!(log_schema);
+    } else {
+        debug!(log_schema);
+    }
 }
 
 /// Spawns a task to sync to the given commit decision and notifies

--- a/consensus/src/consensus_observer/payload_store.rs
+++ b/consensus/src/consensus_observer/payload_store.rs
@@ -4,132 +4,243 @@
 use crate::consensus_observer::{
     logging::{LogEntry, LogSchema},
     metrics,
+    network_message::{BlockPayload, BlockTransactionPayload},
 };
-use aptos_consensus_types::pipelined_block::PipelinedBlock;
-use aptos_crypto::HashValue;
+use aptos_config::config::ConsensusObserverConfig;
+use aptos_consensus_types::{common::Round, pipelined_block::PipelinedBlock};
 use aptos_infallible::Mutex;
-use aptos_logger::error;
-use aptos_types::{block_info::BlockInfo, transaction::SignedTransaction};
+use aptos_logger::{error, warn};
+use aptos_types::epoch_state::EpochState;
 use std::{
-    collections::{hash_map::Entry, HashMap},
-    mem,
+    collections::{btree_map::Entry, BTreeMap},
     sync::Arc,
 };
 use tokio::sync::oneshot;
 
-/// The transaction payload of each block
-#[derive(Debug, Clone)]
-pub struct BlockTransactionPayload {
-    pub transactions: Vec<SignedTransaction>,
-    pub limit: Option<u64>,
-}
-
-impl BlockTransactionPayload {
-    pub fn new(transactions: Vec<SignedTransaction>, limit: Option<u64>) -> Self {
-        Self {
-            transactions,
-            limit,
-        }
-    }
-}
-
-/// The status of the block payload (requested or available)
+/// The status of the block payload
 pub enum BlockPayloadStatus {
+    AvailableAndVerified(BlockPayload),
+    AvailableAndUnverified(
+        BlockPayload,
+        Option<oneshot::Sender<BlockTransactionPayload>>,
+    ),
     Requested(oneshot::Sender<BlockTransactionPayload>),
-    Available(BlockTransactionPayload),
 }
 
 /// A simple struct to store the block payloads of ordered and committed blocks
 #[derive(Clone)]
 pub struct BlockPayloadStore {
-    // Block transaction payloads map the block ID to the transaction payloads
-    // (the same payloads that the payload manager returns).
-    block_transaction_payloads: Arc<Mutex<HashMap<HashValue, BlockPayloadStatus>>>,
+    // The configuration of the consensus observer
+    consensus_observer_config: ConsensusObserverConfig,
+
+    // Block transaction payloads (indexed by epoch and round)
+    block_payloads: Arc<Mutex<BTreeMap<(u64, Round), BlockPayloadStatus>>>,
 }
 
 impl BlockPayloadStore {
-    pub fn new() -> Self {
+    pub fn new(consensus_observer_config: ConsensusObserverConfig) -> Self {
         Self {
-            block_transaction_payloads: Arc::new(Mutex::new(HashMap::new())),
+            consensus_observer_config,
+            block_payloads: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
 
-    /// Returns true iff all the payloads for the given blocks are available
+    /// Returns true iff all the payloads for the given blocks
+    /// are available and have been verified.
     pub fn all_payloads_exist(&self, blocks: &[Arc<PipelinedBlock>]) -> bool {
-        let block_transaction_payloads = self.block_transaction_payloads.lock();
+        let block_payloads = self.block_payloads.lock();
         blocks.iter().all(|block| {
+            let epoch_and_round = (block.epoch(), block.round());
             matches!(
-                block_transaction_payloads.get(&block.id()),
-                Some(BlockPayloadStatus::Available(_))
+                block_payloads.get(&epoch_and_round),
+                Some(BlockPayloadStatus::AvailableAndVerified(_))
             )
         })
     }
 
     /// Clears all the payloads from the block payload store
     pub fn clear_all_payloads(&self) {
-        self.block_transaction_payloads.lock().clear();
+        self.block_payloads.lock().clear();
     }
 
-    /// Returns a reference to the block transaction payloads
-    pub fn get_block_payloads(&self) -> Arc<Mutex<HashMap<HashValue, BlockPayloadStatus>>> {
-        self.block_transaction_payloads.clone()
+    /// Returns a reference to the block payloads
+    pub fn get_block_payloads(&self) -> Arc<Mutex<BTreeMap<(u64, Round), BlockPayloadStatus>>> {
+        self.block_payloads.clone()
     }
 
     /// Inserts the given block payload data into the payload store
     pub fn insert_block_payload(
         &mut self,
-        block: BlockInfo,
-        transactions: Vec<SignedTransaction>,
-        limit: Option<u64>,
+        block_payload: BlockPayload,
+        verified_payload_signatures: bool,
     ) {
-        let mut block_transaction_payloads = self.block_transaction_payloads.lock();
-        let block_transaction_payload = BlockTransactionPayload::new(transactions, limit);
+        // Verify that the number of payloads doesn't exceed the maximum
+        let max_num_pending_blocks = self.consensus_observer_config.max_num_pending_blocks as usize;
+        if self.block_payloads.lock().len() >= max_num_pending_blocks {
+            warn!(
+                LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                    "Exceeded the maximum number of payloads: {:?}. Dropping block: {:?}!",
+                    max_num_pending_blocks, block_payload.block,
+                ))
+            );
+            return; // Drop the block if we've exceeded the maximum
+        }
 
-        match block_transaction_payloads.entry(block.id()) {
-            Entry::Occupied(mut entry) => {
-                // Replace the data status with the new block payload
-                let mut status = BlockPayloadStatus::Available(block_transaction_payload.clone());
-                mem::swap(entry.get_mut(), &mut status);
+        // Get the current block payload status (if one exists)
+        let epoch_and_round = (block_payload.block.epoch(), block_payload.block.round());
+        let previous_payload_status = self.block_payloads.lock().remove_entry(&epoch_and_round);
 
-                // If the status was originally requested, send the payload to the listener
-                if let BlockPayloadStatus::Requested(payload_sender) = status {
-                    if payload_sender.send(block_transaction_payload).is_err() {
-                        error!(LogSchema::new(LogEntry::ConsensusObserver)
-                            .message("Failed to send block payload to listener!",));
+        // Insert the new block payload status entry
+        match previous_payload_status {
+            Some((_, BlockPayloadStatus::Requested(payload_sender)))
+            | Some((_, BlockPayloadStatus::AvailableAndUnverified(_, Some(payload_sender)))) => {
+                // The payload was requested. Send it to the listener if it has already verified.
+                if verified_payload_signatures {
+                    if let Err(error) =
+                        payload_sender.send(block_payload.transaction_payload.clone())
+                    {
+                        error!(
+                            LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                                "Failed to send block payload to listener! Error: {:?}",
+                                error
+                            ))
+                        );
                     }
+                    self.block_payloads.lock().insert(
+                        epoch_and_round,
+                        BlockPayloadStatus::AvailableAndVerified(block_payload),
+                    );
+                } else {
+                    // Otherwise, save the payload and listener for verification later
+                    self.block_payloads.lock().insert(
+                        epoch_and_round,
+                        BlockPayloadStatus::AvailableAndUnverified(
+                            block_payload,
+                            Some(payload_sender),
+                        ),
+                    );
                 }
             },
-            Entry::Vacant(entry) => {
-                // Insert the block payload directly into the payload store
-                entry.insert(BlockPayloadStatus::Available(block_transaction_payload));
+            _ => {
+                // Insert the new payload status
+                self.block_payloads.lock().insert(
+                    epoch_and_round,
+                    create_available_payload_status(block_payload, verified_payload_signatures),
+                );
             },
         }
     }
 
-    /// Removes the given pipelined blocks from the payload store
-    pub fn remove_blocks(&self, blocks: &[Arc<PipelinedBlock>]) {
-        let mut block_transaction_payloads = self.block_transaction_payloads.lock();
-        for block in blocks.iter() {
-            block_transaction_payloads.remove(&block.id());
-        }
+    /// Removes all blocks up to the specified epoch and round (inclusive)
+    pub fn remove_blocks_for_epoch_round(&self, epoch: u64, round: Round) {
+        // Determine the round to split off
+        let split_off_round = round.saturating_add(1);
+
+        // Remove the blocks from the payload store
+        let mut block_payloads = self.block_payloads.lock();
+        *block_payloads = block_payloads.split_off(&(epoch, split_off_round));
+    }
+
+    /// Removes the committed blocks from the payload store
+    pub fn remove_committed_blocks(&self, committed_blocks: &[Arc<PipelinedBlock>]) {
+        // Identify the highest epoch and round for the committed blocks
+        let (highest_epoch, highest_round) = committed_blocks
+            .iter()
+            .map(|block| (block.epoch(), block.round()))
+            .max()
+            .unwrap_or((0, 0));
+
+        // Remove the blocks
+        self.remove_blocks_for_epoch_round(highest_epoch, highest_round);
     }
 
     /// Updates the metrics for the payload store
     pub fn update_payload_store_metrics(&self) {
-        // Update the number of block transaction payloads
-        let block_transaction_payloads = self.block_transaction_payloads.lock();
-        let num_payloads = block_transaction_payloads.len() as u64;
+        // Update the number of block payloads
+        let num_payloads = self.block_payloads.lock().len() as u64;
         metrics::set_gauge_with_label(
             &metrics::OBSERVER_NUM_PROCESSED_BLOCKS,
             metrics::STORED_PAYLOADS_LABEL,
             num_payloads,
         );
+
+        // Update the highest round for the block payloads
+        let highest_round = self
+            .block_payloads
+            .lock()
+            .last_key_value()
+            .map(|((_, round), _)| *round)
+            .unwrap_or(0);
+        metrics::set_gauge_with_label(
+            &metrics::OBSERVER_PROCESSED_BLOCK_ROUNDS,
+            metrics::STORED_PAYLOADS_LABEL,
+            highest_round,
+        );
+    }
+
+    /// Verifies the block payload signatures against the given epoch state.
+    /// If verification is successful, blocks are marked as verified.
+    pub fn verify_payload_signatures(&mut self, epoch_state: &EpochState) {
+        // Get the current epoch
+        let current_epoch = epoch_state.epoch;
+
+        // Gather the keys for the block payloads
+        let payload_epochs_and_rounds: Vec<(u64, Round)> =
+            self.block_payloads.lock().keys().cloned().collect();
+
+        // Go through all unverified blocks and attempt to verify the signatures
+        let mut verified_payloads_to_update = vec![];
+        for (epoch, round) in payload_epochs_and_rounds {
+            // Check if we can break early (BtreeMaps are sorted by key)
+            if epoch > current_epoch {
+                break;
+            }
+
+            // Otherwise, attempt to verify the payload signatures
+            if epoch == current_epoch {
+                if let Entry::Occupied(mut entry) = self.block_payloads.lock().entry((epoch, round))
+                {
+                    if let BlockPayloadStatus::AvailableAndUnverified(block_payload, _) =
+                        entry.get_mut()
+                    {
+                        if let Err(error) = block_payload.verify_payload_signatures(epoch_state) {
+                            // Log the verification failure
+                            error!(
+                                LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                                    "Failed to verify the block payload signatures for epoch: {:?} and round: {:?}. Error: {:?}",
+                                    epoch, round, error
+                                ))
+                            );
+
+                            // Remove the block payload from the store
+                            entry.remove();
+                        } else {
+                            // Save the block payload for reinsertion
+                            verified_payloads_to_update.push(block_payload.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Update the verified block payloads. Note: this will cause
+        // notifications to be sent to any listeners that are waiting.
+        for verified_payload in verified_payloads_to_update {
+            self.insert_block_payload(verified_payload, true);
+        }
     }
 }
 
-impl Default for BlockPayloadStore {
-    fn default() -> Self {
-        Self::new()
+/// Creates and returns a new block payload status based on the
+/// given payload and whether the signatures have been verified.
+fn create_available_payload_status(
+    block_payload: BlockPayload,
+    verified_payload_signatures: bool,
+) -> BlockPayloadStatus {
+    if verified_payload_signatures {
+        BlockPayloadStatus::AvailableAndVerified(block_payload)
+    } else {
+        BlockPayloadStatus::AvailableAndUnverified(block_payload, None)
     }
 }
 
@@ -139,147 +250,675 @@ mod test {
     use aptos_consensus_types::{
         block::Block,
         block_data::{BlockData, BlockType},
+        common::ProofWithData,
+        proof_of_store::{BatchId, BatchInfo, ProofOfStore},
         quorum_cert::QuorumCert,
     };
-    use aptos_types::{block_info::Round, transaction::Version};
+    use aptos_crypto::HashValue;
+    use aptos_types::{
+        aggregate_signature::AggregateSignature,
+        block_info::{BlockInfo, Round},
+        transaction::Version,
+        validator_signer::ValidatorSigner,
+        validator_verifier::{ValidatorConsensusInfo, ValidatorVerifier},
+        PeerId,
+    };
+    use rand::{rngs::OsRng, Rng};
 
     #[test]
     fn test_all_payloads_exist() {
-        // Create a new block payload store
-        let block_payload_store = BlockPayloadStore::new();
+        // Create the consensus observer config
+        let max_num_pending_blocks = 1000;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
 
-        // Add some blocks to the payload store
+        // Create a new block payload store
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some unverified blocks to the payload store
         let num_blocks_in_store = 100;
-        let pipelined_blocks =
-            create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store);
+        let unverified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            1,
+            false,
+        );
+
+        // Verify the payloads don't exist in the block payload store
+        assert!(!block_payload_store.all_payloads_exist(&unverified_blocks));
+        assert_eq!(get_num_verified_payloads(&block_payload_store), 0);
+        assert_eq!(
+            get_num_unverified_payloads(&block_payload_store),
+            num_blocks_in_store
+        );
+
+        // Add some verified blocks to the payload store
+        let num_blocks_in_store = 100;
+        let verified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            0,
+            true,
+        );
 
         // Check that all the payloads exist in the block payload store
-        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks));
+        assert!(block_payload_store.all_payloads_exist(&verified_blocks));
 
         // Check that a subset of the payloads exist in the block payload store
-        let subset_pipelined_blocks = &pipelined_blocks[0..50];
-        assert!(block_payload_store.all_payloads_exist(subset_pipelined_blocks));
+        let subset_verified_blocks = &verified_blocks[0..50];
+        assert!(block_payload_store.all_payloads_exist(subset_verified_blocks));
 
         // Remove some of the payloads from the block payload store
-        block_payload_store.remove_blocks(subset_pipelined_blocks);
+        block_payload_store.remove_committed_blocks(subset_verified_blocks);
 
         // Check that the payloads no longer exist in the block payload store
-        assert!(!block_payload_store.all_payloads_exist(subset_pipelined_blocks));
+        assert!(!block_payload_store.all_payloads_exist(subset_verified_blocks));
 
         // Check that the remaining payloads still exist in the block payload store
-        let subset_pipelined_blocks = &pipelined_blocks[50..100];
-        assert!(block_payload_store.all_payloads_exist(subset_pipelined_blocks));
+        let subset_verified_blocks = &verified_blocks[50..100];
+        assert!(block_payload_store.all_payloads_exist(subset_verified_blocks));
 
         // Remove the remaining payloads from the block payload store
-        block_payload_store.remove_blocks(subset_pipelined_blocks);
+        block_payload_store.remove_committed_blocks(subset_verified_blocks);
 
         // Check that the payloads no longer exist in the block payload store
-        assert!(!block_payload_store.all_payloads_exist(subset_pipelined_blocks));
+        assert!(!block_payload_store.all_payloads_exist(subset_verified_blocks));
     }
 
     #[test]
     fn test_all_payloads_exist_requested() {
         // Create a new block payload store
-        let block_payload_store = BlockPayloadStore::new();
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
-        // Add several blocks to the payload store
+        // Add several verified blocks to the payload store
         let num_blocks_in_store = 10;
-        let pipelined_blocks =
-            create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store);
+        let verified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            0,
+            true,
+        );
 
         // Check that the payloads exists in the block payload store
-        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks));
+        assert!(block_payload_store.all_payloads_exist(&verified_blocks));
 
         // Mark the payload of the first block as requested
-        mark_payload_as_requested(block_payload_store.clone(), pipelined_blocks[0].id());
+        mark_payload_as_requested(block_payload_store.clone(), &verified_blocks[0]);
 
         // Check that the payload no longer exists in the block payload store
-        assert!(!block_payload_store.all_payloads_exist(&pipelined_blocks));
+        assert!(!block_payload_store.all_payloads_exist(&verified_blocks));
 
         // Check that the remaining payloads still exist in the block payload store
-        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks[1..10]));
+        assert!(block_payload_store.all_payloads_exist(&verified_blocks[1..10]));
+    }
+
+    #[test]
+    fn test_clear_all_payloads() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some unverified blocks to the payload store
+        let num_blocks_in_store = 30;
+        create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store, 1, false);
+
+        // Add some verified blocks to the payload store
+        let verified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            0,
+            true,
+        );
+
+        // Check that the payloads exist in the block payload store
+        assert!(block_payload_store.all_payloads_exist(&verified_blocks));
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, num_blocks_in_store);
+        check_num_verified_payloads(&block_payload_store, num_blocks_in_store);
+
+        // Clear all the payloads from the block payload store
+        block_payload_store.clear_all_payloads();
+
+        // Check that the payloads no longer exist in the block payload store
+        assert!(!block_payload_store.all_payloads_exist(&verified_blocks));
+
+        // Check that the block payload store is empty
+        check_num_unverified_payloads(&block_payload_store, 0);
+        check_num_verified_payloads(&block_payload_store, 0);
     }
 
     #[test]
     fn test_insert_block_payload() {
         // Create a new block payload store
-        let mut block_payload_store = BlockPayloadStore::new();
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
-        // Add some blocks to the payload store
-        let num_blocks_in_store = 10;
-        let pipelined_blocks =
-            create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store);
+        // Add some verified blocks to the payload store
+        let num_blocks_in_store = 20;
+        let verified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            0,
+            true,
+        );
 
         // Check that the block payload store contains the new block payloads
-        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks));
+        assert!(block_payload_store.all_payloads_exist(&verified_blocks));
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, 0);
+        check_num_verified_payloads(&block_payload_store, num_blocks_in_store);
 
         // Mark the payload of the first block as requested
         let payload_receiver =
-            mark_payload_as_requested(block_payload_store.clone(), pipelined_blocks[0].id());
+            mark_payload_as_requested(block_payload_store.clone(), &verified_blocks[0]);
 
         // Check that the payload no longer exists in the block payload store
-        assert!(!block_payload_store.all_payloads_exist(&pipelined_blocks));
+        assert!(!block_payload_store.all_payloads_exist(&verified_blocks));
+
+        // Verify the number of verified blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, num_blocks_in_store - 1);
 
         // Insert the same block payload into the block payload store
-        block_payload_store.insert_block_payload(pipelined_blocks[0].block_info(), vec![], Some(0));
+        let transaction_payload =
+            BlockTransactionPayload::new(vec![], Some(0), ProofWithData::empty(), vec![]);
+        let block_payload = BlockPayload::new(verified_blocks[0].block_info(), transaction_payload);
+        block_payload_store.insert_block_payload(block_payload, true);
 
         // Check that the block payload store now contains the requested block payload
-        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks));
+        assert!(block_payload_store.all_payloads_exist(&verified_blocks));
 
         // Check that the payload receiver receives the requested block payload message
-        let block_transaction_payload = payload_receiver.blocking_recv().unwrap();
-        assert!(block_transaction_payload.transactions.is_empty());
-        assert_eq!(block_transaction_payload.limit, Some(0));
+        let block_payload = payload_receiver.blocking_recv().unwrap();
+        assert!(block_payload.transactions.is_empty());
+        assert_eq!(block_payload.limit, Some(0));
     }
 
     #[test]
-    fn test_remove_blocks() {
+    fn test_insert_block_payload_limit_verified() {
+        // Create a new config observer config
+        let max_num_pending_blocks = 10;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
         // Create a new block payload store
-        let block_payload_store = BlockPayloadStore::new();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
-        // Add some blocks to the payload store
-        let num_blocks_in_store = 10;
-        let pipelined_blocks =
-            create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store);
+        // Add the maximum number of verified blocks to the payload store
+        let num_blocks_in_store = max_num_pending_blocks as usize;
+        create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store, 0, true);
 
-        // Remove the first block from the block payload store
-        block_payload_store.remove_blocks(&pipelined_blocks[0..1]);
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, num_blocks_in_store);
+        check_num_unverified_payloads(&block_payload_store, 0);
 
-        // Check that the block payload store no longer contains the removed block
-        let block_transaction_payloads = block_payload_store.get_block_payloads();
-        assert!(!block_transaction_payloads
-            .lock()
-            .contains_key(&pipelined_blocks[0].id()));
+        // Add more blocks to the payload store
+        let num_blocks_to_add = 5;
+        create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_to_add, 0, true);
 
-        // Remove the last 5 blocks from the block payload store
-        block_payload_store.remove_blocks(&pipelined_blocks[5..10]);
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, max_num_pending_blocks as usize);
+        check_num_unverified_payloads(&block_payload_store, 0);
+
+        // Add a large number of blocks to the payload store
+        let num_blocks_to_add = 100;
+        create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_to_add, 0, true);
+
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, max_num_pending_blocks as usize);
+        check_num_unverified_payloads(&block_payload_store, 0);
+    }
+
+    #[test]
+    fn test_insert_block_payload_limit_unverified() {
+        // Create a new config observer config
+        let max_num_pending_blocks = 10;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
+        // Create a new block payload store
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add the maximum number of unverified blocks to the payload store
+        let num_blocks_in_store = max_num_pending_blocks as usize;
+        create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store, 0, false);
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, num_blocks_in_store);
+        check_num_verified_payloads(&block_payload_store, 0);
+
+        // Add more blocks to the payload store
+        let num_blocks_to_add = 5;
+        create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_to_add, 0, false);
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, max_num_pending_blocks as usize);
+        check_num_verified_payloads(&block_payload_store, 0);
+
+        // Add a large number of blocks to the payload store
+        let num_blocks_to_add = 100;
+        create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_to_add, 0, false);
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, max_num_pending_blocks as usize);
+        check_num_verified_payloads(&block_payload_store, 0);
+    }
+
+    #[test]
+    fn test_remove_blocks_for_epoch_round_verified() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some verified blocks to the payload store for the current epoch
+        let current_epoch = 0;
+        let num_blocks_in_store = 100;
+        let verified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            current_epoch,
+            true,
+        );
+
+        // Remove all the blocks for the given epoch and round
+        block_payload_store.remove_blocks_for_epoch_round(current_epoch, 49);
 
         // Check that the block payload store no longer contains the removed blocks
-        let block_transaction_payloads = block_payload_store.get_block_payloads();
-        for pipelined_block in pipelined_blocks.iter().take(10).skip(5) {
-            assert!(!block_transaction_payloads
+        let block_payloads = block_payload_store.get_block_payloads();
+        for verified_block in verified_blocks.iter().take(50) {
+            assert!(!block_payloads
                 .lock()
-                .contains_key(&pipelined_block.id()));
+                .contains_key(&(verified_block.epoch(), verified_block.round())));
         }
 
-        // Remove all the blocks from the block payload store (including some that don't exist)
-        block_payload_store.remove_blocks(&pipelined_blocks[0..10]);
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, num_blocks_in_store - 50);
+
+        // Remove all the blocks for the given epoch and round
+        block_payload_store
+            .remove_blocks_for_epoch_round(current_epoch, num_blocks_in_store as Round);
 
         // Check that the block payload store no longer contains any blocks
-        let block_transaction_payloads = block_payload_store.get_block_payloads();
-        assert!(block_transaction_payloads.lock().is_empty());
+        let block_payloads = block_payload_store.get_block_payloads();
+        assert!(block_payloads.lock().is_empty());
+
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, 0);
+
+        // Add some verified blocks to the payload store for the next epoch
+        let next_epoch = current_epoch + 1;
+        create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            next_epoch,
+            true,
+        );
+
+        // Remove all the blocks for the future epoch and round
+        let future_epoch = next_epoch + 1;
+        block_payload_store.remove_blocks_for_epoch_round(future_epoch, 0);
+
+        // Verify the store is now empty
+        check_num_verified_payloads(&block_payload_store, 0);
+    }
+
+    #[test]
+    fn test_remove_blocks_for_epoch_round_unverified() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some unverified blocks to the payload store for the current epoch
+        let current_epoch = 10;
+        let num_blocks_in_store = 100;
+        let unverified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            current_epoch,
+            false,
+        );
+
+        // Remove all the blocks for the given epoch and round
+        block_payload_store.remove_blocks_for_epoch_round(current_epoch, 49);
+
+        // Check that the block payload store no longer contains the removed blocks
+        for unverified_block in unverified_blocks.iter().take(50) {
+            assert!(!block_payload_store
+                .block_payloads
+                .lock()
+                .contains_key(&(unverified_block.epoch(), unverified_block.round())));
+        }
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, num_blocks_in_store - 50);
+
+        // Remove all the blocks for the given epoch and round
+        block_payload_store
+            .remove_blocks_for_epoch_round(current_epoch, num_blocks_in_store as Round);
+
+        // Check that the block payload store no longer contains any blocks
+        assert!(block_payload_store.block_payloads.lock().is_empty());
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, 0);
+
+        // Add some unverified blocks to the payload store for the next epoch
+        let next_epoch = current_epoch + 1;
+        create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            next_epoch,
+            false,
+        );
+
+        // Remove all the blocks for the future epoch and round
+        let future_epoch = next_epoch + 10;
+        block_payload_store.remove_blocks_for_epoch_round(future_epoch, 0);
+
+        // Verify the store is now empty
+        check_num_unverified_payloads(&block_payload_store, 0);
+    }
+
+    #[test]
+    fn test_remove_committed_blocks_verified() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some blocks to the payload store for the current epoch
+        let current_epoch = 0;
+        let num_blocks_in_store = 100;
+        let verified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            current_epoch,
+            true,
+        );
+
+        // Remove the first block from the block payload store
+        block_payload_store.remove_committed_blocks(&verified_blocks[0..1]);
+
+        // Check that the block payload store no longer contains the removed block
+        let block_payloads = block_payload_store.get_block_payloads();
+        let removed_block = &verified_blocks[0];
+        assert!(!block_payloads
+            .lock()
+            .contains_key(&(removed_block.epoch(), removed_block.round())));
+
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, num_blocks_in_store - 1);
+
+        // Remove the last 5 blocks from the block payload store
+        block_payload_store.remove_committed_blocks(&verified_blocks[5..10]);
+
+        // Check that the block payload store no longer contains the removed blocks
+        let block_payloads = block_payload_store.get_block_payloads();
+        for verified_block in verified_blocks.iter().take(10).skip(5) {
+            assert!(!block_payloads
+                .lock()
+                .contains_key(&(verified_block.epoch(), verified_block.round())));
+        }
+
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, num_blocks_in_store - 10);
+
+        // Remove all the blocks from the block payload store (including some that don't exist)
+        block_payload_store.remove_committed_blocks(&verified_blocks[0..num_blocks_in_store]);
+
+        // Check that the block payload store no longer contains any blocks
+        let block_payloads = block_payload_store.get_block_payloads();
+        assert!(block_payloads.lock().is_empty());
+
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, 0);
+
+        // Add some blocks to the payload store for the next epoch
+        let next_epoch = 1;
+        let verified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            next_epoch,
+            true,
+        );
+
+        // Remove the last committed block from the future epoch
+        block_payload_store.remove_committed_blocks(&verified_blocks[99..100]);
+
+        // Check that the block payload store is now empty
+        check_num_verified_payloads(&block_payload_store, 0);
+    }
+
+    #[test]
+    fn test_remove_committed_blocks_unverified() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some blocks to the payload store for the current epoch
+        let current_epoch = 10;
+        let num_blocks_in_store = 100;
+        let unverified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            current_epoch,
+            false,
+        );
+
+        // Remove the first block from the block payload store
+        block_payload_store.remove_committed_blocks(&unverified_blocks[0..1]);
+
+        // Check that the block payload store no longer contains the removed block
+        let removed_block = &unverified_blocks[0];
+        assert!(!block_payload_store
+            .block_payloads
+            .lock()
+            .contains_key(&(removed_block.epoch(), removed_block.round())));
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, num_blocks_in_store - 1);
+
+        // Remove the last 5 blocks from the block payload store
+        block_payload_store.remove_committed_blocks(&unverified_blocks[5..10]);
+
+        // Check that the block payload store no longer contains the removed blocks
+        for verified_block in unverified_blocks.iter().take(10).skip(5) {
+            assert!(!block_payload_store
+                .block_payloads
+                .lock()
+                .contains_key(&(verified_block.epoch(), verified_block.round())));
+        }
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, num_blocks_in_store - 10);
+
+        // Remove all the blocks from the block payload store (including some that don't exist)
+        block_payload_store.remove_committed_blocks(&unverified_blocks[0..num_blocks_in_store]);
+
+        // Check that the block payload store no longer contains any blocks
+        assert!(block_payload_store.block_payloads.lock().is_empty());
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, 0);
+
+        // Add some blocks to the payload store for the next epoch
+        let next_epoch = 11;
+        let unverified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            next_epoch,
+            false,
+        );
+
+        // Remove the last committed block from the future epoch
+        block_payload_store.remove_committed_blocks(&unverified_blocks[99..100]);
+
+        // Check that the block payload store is now empty
+        check_num_unverified_payloads(&block_payload_store, 0);
+    }
+
+    #[test]
+    fn test_verify_payload_signatures() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some verified blocks for the current epoch
+        let current_epoch = 0;
+        let num_verified_blocks = 10;
+        create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_verified_blocks,
+            current_epoch,
+            true,
+        );
+
+        // Add some unverified blocks for the next epoch
+        let next_epoch = current_epoch + 1;
+        let num_unverified_blocks = 20;
+        let unverified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_unverified_blocks,
+            next_epoch,
+            false,
+        );
+
+        // Add some unverified blocks for a future epoch
+        let future_epoch = current_epoch + 30;
+        let num_future_blocks = 30;
+        let future_unverified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_future_blocks,
+            future_epoch,
+            false,
+        );
+
+        // Create an epoch state for the next epoch (with an empty verifier)
+        let epoch_state = EpochState::new(next_epoch, ValidatorVerifier::new(vec![]));
+
+        // Verify the block payload signatures
+        block_payload_store.verify_payload_signatures(&epoch_state);
+
+        // Verify the unverified payloads were moved to the verified store
+        assert!(block_payload_store.all_payloads_exist(&unverified_blocks));
+        assert_eq!(
+            get_num_verified_payloads(&block_payload_store),
+            num_verified_blocks + num_unverified_blocks
+        );
+        assert_eq!(
+            get_num_unverified_payloads(&block_payload_store),
+            num_future_blocks
+        );
+
+        // Clear the verified blocks and check the verified blocks are empty
+        block_payload_store.remove_committed_blocks(&unverified_blocks);
+        assert_eq!(get_num_verified_payloads(&block_payload_store), 0);
+
+        // Create an epoch state for the future epoch (with an empty verifier)
+        let epoch_state = EpochState::new(future_epoch, ValidatorVerifier::new(vec![]));
+
+        // Verify the block payload signatures for a future epoch
+        block_payload_store.verify_payload_signatures(&epoch_state);
+
+        // Verify the future unverified payloads were moved to the verified store
+        assert!(block_payload_store.all_payloads_exist(&future_unverified_blocks));
+        assert_eq!(
+            get_num_verified_payloads(&block_payload_store),
+            num_future_blocks
+        );
+        assert_eq!(get_num_unverified_payloads(&block_payload_store), 0);
+    }
+
+    #[test]
+    fn test_verify_payload_signatures_failure() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some verified blocks for the current epoch
+        let current_epoch = 10;
+        let num_verified_blocks = 6;
+        create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_verified_blocks,
+            current_epoch,
+            true,
+        );
+
+        // Add some unverified blocks for the next epoch
+        let next_epoch = current_epoch + 1;
+        let num_unverified_blocks = 15;
+        let unverified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_unverified_blocks,
+            next_epoch,
+            false,
+        );
+
+        // Add some unverified blocks for a future epoch
+        let future_epoch = next_epoch + 1;
+        let num_future_blocks = 10;
+        let unverified_future_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_future_blocks,
+            future_epoch,
+            false,
+        );
+
+        // Create an epoch state for the next epoch (with a non-empty verifier)
+        let validator_signer = ValidatorSigner::random(None);
+        let validator_consensus_info = ValidatorConsensusInfo::new(
+            validator_signer.author(),
+            validator_signer.public_key(),
+            100,
+        );
+        let validator_verifier = ValidatorVerifier::new(vec![validator_consensus_info]);
+        let epoch_state = EpochState::new(next_epoch, validator_verifier.clone());
+
+        // Verify the block payload signatures (for this epoch)
+        block_payload_store.verify_payload_signatures(&epoch_state);
+
+        // Ensure the unverified payloads were not verified
+        assert!(!block_payload_store.all_payloads_exist(&unverified_blocks));
+
+        // Ensure the unverified payloads were all removed (for this epoch)
+        assert_eq!(
+            get_num_unverified_payloads(&block_payload_store),
+            num_future_blocks
+        );
+
+        // Create an epoch state for the future epoch (with a non-empty verifier)
+        let epoch_state = EpochState::new(future_epoch, validator_verifier);
+
+        // Verify the block payload signatures (for the future epoch)
+        block_payload_store.verify_payload_signatures(&epoch_state);
+
+        // Ensure the future unverified payloads were not verified
+        assert!(!block_payload_store.all_payloads_exist(&unverified_future_blocks));
+
+        // Ensure the future unverified payloads were all removed (for the future epoch)
+        assert_eq!(get_num_unverified_payloads(&block_payload_store), 0);
     }
 
     /// Creates and adds the given number of blocks to the block payload store
     fn create_and_add_blocks_to_store(
         mut block_payload_store: BlockPayloadStore,
         num_blocks: usize,
+        epoch: u64,
+        verified_payload_signatures: bool,
     ) -> Vec<Arc<PipelinedBlock>> {
         let mut pipelined_blocks = vec![];
         for i in 0..num_blocks {
             // Create the block info
             let block_info = BlockInfo::new(
-                i as u64,
+                epoch,
                 i as Round,
                 HashValue::random(),
                 HashValue::random(),
@@ -288,8 +927,31 @@ mod test {
                 None,
             );
 
+            // Create the block transaction payload with proofs of store
+            let mut proofs_of_store = vec![];
+            for _ in 0..10 {
+                let batch_info = BatchInfo::new(
+                    PeerId::random(),
+                    BatchId::new(0),
+                    epoch,
+                    0,
+                    HashValue::random(),
+                    0,
+                    0,
+                    0,
+                );
+                proofs_of_store.push(ProofOfStore::new(batch_info, AggregateSignature::empty()));
+            }
+            let block_transaction_payload = BlockTransactionPayload::new(
+                vec![],
+                None,
+                ProofWithData::new(proofs_of_store),
+                vec![],
+            );
+
             // Insert the block payload into the store
-            block_payload_store.insert_block_payload(block_info.clone(), vec![], Some(i as u64));
+            let block_payload = BlockPayload::new(block_info.clone(), block_transaction_payload);
+            block_payload_store.insert_block_payload(block_payload, verified_payload_signatures);
 
             // Create the equivalent pipelined block
             let block_data = BlockData::new_for_testing(
@@ -309,19 +971,77 @@ mod test {
         pipelined_blocks
     }
 
-    /// Marks the payload of the given block ID as requested and returns the receiver
+    /// Checks the number of unverified payloads in the block payload store
+    fn check_num_unverified_payloads(
+        block_payload_store: &BlockPayloadStore,
+        expected_num_payloads: usize,
+    ) {
+        let num_payloads = get_num_unverified_payloads(block_payload_store);
+        assert_eq!(num_payloads, expected_num_payloads);
+    }
+
+    /// Checks the number of verified payloads in the block payload store
+    fn check_num_verified_payloads(
+        block_payload_store: &BlockPayloadStore,
+        expected_num_payloads: usize,
+    ) {
+        let num_payloads = get_num_verified_payloads(block_payload_store);
+        assert_eq!(num_payloads, expected_num_payloads);
+    }
+
+    /// Generates and returns a random number (u64)
+    pub fn get_random_u64() -> u64 {
+        OsRng.gen()
+    }
+
+    /// Returns the number of unverified payloads in the block payload store
+    fn get_num_unverified_payloads(block_payload_store: &BlockPayloadStore) -> usize {
+        let mut num_unverified_payloads = 0;
+        for (_, block_payload_status) in block_payload_store.block_payloads.lock().iter() {
+            if let BlockPayloadStatus::AvailableAndUnverified(_, _) = block_payload_status {
+                num_unverified_payloads += 1;
+            }
+        }
+        num_unverified_payloads
+    }
+
+    /// Returns the number of verified payloads in the block payload store
+    fn get_num_verified_payloads(block_payload_store: &BlockPayloadStore) -> usize {
+        let mut num_verified_payloads = 0;
+        for (_, block_payload_status) in block_payload_store.block_payloads.lock().iter() {
+            if let BlockPayloadStatus::AvailableAndVerified(_) = block_payload_status {
+                num_verified_payloads += 1;
+            }
+        }
+        num_verified_payloads
+    }
+
+    /// Marks the payload of the given block as requested and returns the receiver
     fn mark_payload_as_requested(
         block_payload_store: BlockPayloadStore,
-        block_id: HashValue,
+        block: &Arc<PipelinedBlock>,
     ) -> oneshot::Receiver<BlockTransactionPayload> {
-        // Get the block payload entry for the given block ID
+        // Get the payload entry for the given block
         let block_payloads = block_payload_store.get_block_payloads();
         let mut block_payloads = block_payloads.lock();
-        let block_payload = block_payloads.get_mut(&block_id).unwrap();
+        let block_payload = block_payloads
+            .get_mut(&(block.epoch(), block.round()))
+            .unwrap();
 
-        // Mark the block payload as requested
+        // Create a new payload sender and receiver
         let (payload_sender, payload_receiver) = oneshot::channel();
-        *block_payload = BlockPayloadStatus::Requested(payload_sender);
+
+        // Mark the block payload as requested (either requested or unverified)
+        if get_random_u64() % 2 == 0 {
+            // Mark the payload as requested
+            *block_payload = BlockPayloadStatus::Requested(payload_sender);
+        } else {
+            // Mark the payload as unverified and requested
+            *block_payload = BlockPayloadStatus::AvailableAndUnverified(
+                BlockPayload::new(block.block_info(), BlockTransactionPayload::empty()),
+                Some(payload_sender),
+            );
+        };
 
         // Return the payload receiver
         payload_receiver

--- a/consensus/src/consensus_observer/payload_store.rs
+++ b/consensus/src/consensus_observer/payload_store.rs
@@ -65,6 +65,11 @@ impl BlockPayloadStore {
         })
     }
 
+    /// Clears all the payloads from the block payload store
+    pub fn clear_all_payloads(&self) {
+        self.block_transaction_payloads.lock().clear();
+    }
+
     /// Returns a reference to the block transaction payloads
     pub fn get_block_payloads(&self) -> Arc<Mutex<HashMap<HashValue, BlockPayloadStatus>>> {
         self.block_transaction_payloads.clone()

--- a/consensus/src/consensus_observer/payload_store.rs
+++ b/consensus/src/consensus_observer/payload_store.rs
@@ -1,7 +1,10 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::consensus_observer::logging::{LogEntry, LogSchema};
+use crate::consensus_observer::{
+    logging::{LogEntry, LogSchema},
+    metrics,
+};
 use aptos_consensus_types::pipelined_block::PipelinedBlock;
 use aptos_crypto::HashValue;
 use aptos_infallible::Mutex;
@@ -104,6 +107,18 @@ impl BlockPayloadStore {
         for block in blocks.iter() {
             block_transaction_payloads.remove(&block.id());
         }
+    }
+
+    /// Updates the metrics for the payload store
+    pub fn update_payload_store_metrics(&self) {
+        // Update the number of block transaction payloads
+        let block_transaction_payloads = self.block_transaction_payloads.lock();
+        let num_payloads = block_transaction_payloads.len() as u64;
+        metrics::set_gauge_with_label(
+            &metrics::OBSERVER_NUM_PROCESSED_BLOCKS,
+            metrics::STORED_PAYLOADS_LABEL,
+            num_payloads,
+        );
     }
 }
 

--- a/consensus/src/consensus_observer/pending_blocks.rs
+++ b/consensus/src/consensus_observer/pending_blocks.rs
@@ -757,8 +757,8 @@ mod test {
             validator_signer.public_key(),
             100,
         );
-        let validator_verified = ValidatorVerifier::new(vec![validator_consensus_info]);
-        let epoch_state = EpochState::new(next_epoch, validator_verified);
+        let validator_verifier = ValidatorVerifier::new(vec![validator_consensus_info]);
+        let epoch_state = EpochState::new(next_epoch, validator_verifier);
 
         // Verify the pending blocks for the next epoch
         pending_ordered_blocks.verify_pending_blocks(&epoch_state);

--- a/consensus/src/consensus_observer/publisher.rs
+++ b/consensus/src/consensus_observer/publisher.rs
@@ -314,7 +314,9 @@ fn spawn_message_serializer_and_sender(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::consensus_observer::network_message::BlockTransactionPayload;
     use aptos_config::network_id::NetworkId;
+    use aptos_consensus_types::common::ProofWithData;
     use aptos_crypto::HashValue;
     use aptos_network::{
         application::{metadata::ConnectionState, storage::PeersAndMetadata},
@@ -491,10 +493,11 @@ mod test {
         }
 
         // Publish a message to the active subscribers
+        let transaction_payload =
+            BlockTransactionPayload::new(vec![], Some(10), ProofWithData::empty(), vec![]);
         let block_payload_message = ConsensusObserverMessage::new_block_payload_message(
             BlockInfo::empty(),
-            vec![],
-            Some(10),
+            transaction_payload,
         );
         consensus_publisher
             .publish_message(block_payload_message.clone())
@@ -537,8 +540,10 @@ mod test {
         }
 
         // Publish another message to the active subscribers
-        let block_payload_message =
-            ConsensusObserverMessage::new_block_payload_message(BlockInfo::empty(), vec![], None);
+        let block_payload_message = ConsensusObserverMessage::new_block_payload_message(
+            BlockInfo::empty(),
+            BlockTransactionPayload::empty(),
+        );
         consensus_publisher
             .publish_message(block_payload_message.clone())
             .await;

--- a/consensus/src/payload_manager.rs
+++ b/consensus/src/payload_manager.rs
@@ -3,7 +3,8 @@
 
 use crate::{
     consensus_observer::{
-        network_message::ConsensusObserverMessage, payload_store::BlockPayloadStatus,
+        network_message::{BlockTransactionPayload, ConsensusObserverMessage},
+        payload_store::BlockPayloadStatus,
         publisher::ConsensusPublisher,
     },
     counters,
@@ -11,8 +12,8 @@ use crate::{
 };
 use aptos_consensus_types::{
     block::Block,
-    common::{DataStatus, Payload, ProofWithData},
-    proof_of_store::ProofOfStore,
+    common::{DataStatus, Payload, ProofWithData, Round},
+    proof_of_store::{BatchInfo, ProofOfStore},
 };
 use aptos_crypto::HashValue;
 use aptos_executor_types::{ExecutorError::DataNotFound, *};
@@ -22,7 +23,7 @@ use aptos_types::transaction::SignedTransaction;
 use futures::channel::mpsc::Sender;
 use itertools::Either;
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{btree_map::Entry, BTreeMap},
     sync::Arc,
     time::Duration,
 };
@@ -42,7 +43,7 @@ pub enum PayloadManager {
         Option<Arc<ConsensusPublisher>>,
     ),
     ConsensusObserver(
-        Arc<Mutex<HashMap<HashValue, BlockPayloadStatus>>>,
+        Arc<Mutex<BTreeMap<(u64, Round), BlockPayloadStatus>>>,
         Option<Arc<ConsensusPublisher>>,
     ),
 }
@@ -185,42 +186,8 @@ impl PayloadManager {
         };
 
         if let PayloadManager::ConsensusObserver(txns_pool, consensus_publisher) = self {
-            // If the data is already available, return it, otherwise put the tx in the pool and wait for it.
-            // It's important to make sure this doesn't race with the payload insertion part.
-            let result = match txns_pool.lock().entry(block.id()) {
-                Entry::Occupied(mut value) => match value.get_mut() {
-                    BlockPayloadStatus::Available(data) => Either::Left(data.clone()),
-                    BlockPayloadStatus::Requested(tx) => {
-                        let (new_tx, rx) = oneshot::channel();
-                        *tx = new_tx;
-                        Either::Right(rx)
-                    },
-                },
-                Entry::Vacant(entry) => {
-                    let (tx, rx) = oneshot::channel();
-                    entry.insert(BlockPayloadStatus::Requested(tx));
-                    Either::Right(rx)
-                },
-            };
-            let block_transaction_payload = match result {
-                Either::Left(data) => data,
-                Either::Right(rx) => timeout(Duration::from_millis(300), rx)
-                    .await
-                    .map_err(|_| ExecutorError::CouldNotGetData)?
-                    .map_err(|_| ExecutorError::CouldNotGetData)?,
-            };
-            if let Some(consensus_publisher) = consensus_publisher {
-                let message = ConsensusObserverMessage::new_block_payload_message(
-                    block.gen_block_info(HashValue::zero(), 0, None),
-                    block_transaction_payload.transactions.clone(),
-                    block_transaction_payload.limit,
-                );
-                consensus_publisher.publish_message(message).await;
-            }
-            return Ok((
-                block_transaction_payload.transactions,
-                block_transaction_payload.limit,
-            ));
+            return get_transactions_for_observer(block, payload, txns_pool, consensus_publisher)
+                .await;
         }
 
         async fn process_payload(
@@ -297,14 +264,18 @@ impl PayloadManager {
             }
         }
 
-        let result = match (self, payload) {
-            (PayloadManager::DirectMempool, Payload::DirectMempool(txns)) => (txns.clone(), None),
+        let (transactions, limit, proof_with_data, inline_batches) = match (self, payload) {
+            (PayloadManager::DirectMempool, Payload::DirectMempool(txns)) => {
+                return Ok((txns.clone(), None))
+            },
             (
                 PayloadManager::InQuorumStore(batch_reader, _, _),
                 Payload::InQuorumStore(proof_with_data),
             ) => (
                 process_payload(proof_with_data, batch_reader.clone(), block).await?,
                 None,
+                proof_with_data.clone(),
+                vec![],
             ),
             (
                 PayloadManager::InQuorumStore(batch_reader, _, _),
@@ -317,6 +288,8 @@ impl PayloadManager {
                 )
                 .await?,
                 proof_with_data.max_txns_to_execute,
+                proof_with_data.proof_with_data.clone(),
+                vec![],
             ),
             (
                 PayloadManager::InQuorumStore(batch_reader, _, _),
@@ -339,6 +312,11 @@ impl PayloadManager {
                     all_txns
                 },
                 *max_txns_to_execute,
+                proof_with_data.clone(),
+                inline_batches
+                    .iter()
+                    .map(|(batch_info, _)| batch_info.clone())
+                    .collect(),
             ),
             (_, _) => unreachable!(
                 "Wrong payload {} epoch {}, round {}, id {}",
@@ -348,14 +326,174 @@ impl PayloadManager {
                 block.id()
             ),
         };
+
         if let PayloadManager::InQuorumStore(_, _, Some(consensus_publisher)) = self {
+            let transaction_payload = BlockTransactionPayload::new(
+                transactions.clone(),
+                limit,
+                proof_with_data,
+                inline_batches,
+            );
             let message = ConsensusObserverMessage::new_block_payload_message(
                 block.gen_block_info(HashValue::zero(), 0, None),
-                result.0.clone(),
-                result.1,
+                transaction_payload,
             );
             consensus_publisher.publish_message(message).await;
         }
-        Ok(result)
+
+        Ok((transactions, limit))
+    }
+}
+
+async fn get_transactions_for_observer(
+    block: &Block,
+    payload: &Payload,
+    txns_pool: &Arc<Mutex<BTreeMap<(u64, Round), BlockPayloadStatus>>>,
+    consensus_publisher: &Option<Arc<ConsensusPublisher>>,
+) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>)> {
+    // If the data is already available, return it, otherwise wait for it.
+    // It's important to make sure this doesn't race with the payload insertion part.
+    let result = match txns_pool.lock().entry((block.epoch(), block.round())) {
+        Entry::Occupied(mut value) => match value.get_mut() {
+            BlockPayloadStatus::AvailableAndVerified(data) => Either::Left(data.clone()),
+            BlockPayloadStatus::AvailableAndUnverified(_, payload_sender) => {
+                let (new_payload_sender, new_payload_receiver) = oneshot::channel();
+                *payload_sender = Some(new_payload_sender);
+                Either::Right(new_payload_receiver)
+            },
+            BlockPayloadStatus::Requested(payload_sender) => {
+                let (new_payload_sender, new_payload_receiver) = oneshot::channel();
+                *payload_sender = new_payload_sender;
+                Either::Right(new_payload_receiver)
+            },
+        },
+        Entry::Vacant(entry) => {
+            let (payload_sender, payload_receiver) = oneshot::channel();
+            entry.insert(BlockPayloadStatus::Requested(payload_sender));
+            Either::Right(payload_receiver)
+        },
+    };
+
+    let block_transaction_payload = match result {
+        Either::Left(data) => data.transaction_payload,
+        Either::Right(rx) => timeout(Duration::from_millis(300), rx)
+            .await
+            .map_err(|_| ExecutorError::CouldNotGetData)?
+            .map_err(|_| ExecutorError::CouldNotGetData)?,
+    };
+
+    // Verify the payload and inline batches before returning the data. The
+    // batch digests and transactions will have already been verified by the
+    // consensus observer on message receipt.
+    match payload {
+        Payload::DirectMempool(_) => {
+            return Err(ExecutorError::InternalError {
+                error: "DirectMempool payloads should not be sent to the consensus observer!"
+                    .to_string(),
+            });
+        },
+        Payload::InQuorumStore(proof_with_data) => {
+            // Verify the batches in the requested block
+            verify_batches_in_block(&proof_with_data.proofs, &block_transaction_payload)?;
+        },
+        Payload::InQuorumStoreWithLimit(proof_with_data) => {
+            // Verify the batches in the requested block
+            verify_batches_in_block(
+                &proof_with_data.proof_with_data.proofs,
+                &block_transaction_payload,
+            )?;
+
+            // Verify the transaction limit
+            verify_transaction_limit(
+                proof_with_data.max_txns_to_execute,
+                &block_transaction_payload,
+            )?;
+        },
+        Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, max_txns_to_execute) => {
+            // Verify the batches in the requested block
+            verify_batches_in_block(&proof_with_data.proofs, &block_transaction_payload)?;
+
+            // Verify the inline batches
+            verify_inline_batches_in_block(inline_batches, &block_transaction_payload)?;
+
+            // Verify the transaction limit
+            verify_transaction_limit(*max_txns_to_execute, &block_transaction_payload)?;
+        },
+    }
+
+    if let Some(consensus_publisher) = consensus_publisher {
+        let message = ConsensusObserverMessage::new_block_payload_message(
+            block.gen_block_info(HashValue::zero(), 0, None),
+            block_transaction_payload.clone(),
+        );
+        consensus_publisher.publish_message(message).await;
+    }
+
+    Ok((
+        block_transaction_payload.transactions,
+        block_transaction_payload.limit,
+    ))
+}
+
+fn verify_batches_in_block(
+    verified_proofs: &[ProofOfStore],
+    block_transaction_payload: &BlockTransactionPayload,
+) -> ExecutorResult<()> {
+    let verified_batches: Vec<&BatchInfo> =
+        verified_proofs.iter().map(|proof| proof.info()).collect();
+    let found_batches: Vec<&BatchInfo> = block_transaction_payload
+        .proof_with_data
+        .proofs
+        .iter()
+        .map(|proof| proof.info())
+        .collect();
+
+    if verified_batches != found_batches {
+        Err(ExecutorError::InternalError {
+            error: format!(
+                "Expected batches {:?} but found {:?}!",
+                verified_batches, found_batches
+            ),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn verify_inline_batches_in_block(
+    verified_inline_batches: &[(BatchInfo, Vec<SignedTransaction>)],
+    block_transaction_payload: &BlockTransactionPayload,
+) -> ExecutorResult<()> {
+    let verified_batches: Vec<BatchInfo> = verified_inline_batches
+        .iter()
+        .map(|(batch_info, _)| batch_info.clone())
+        .collect();
+    let found_inline_batches = &block_transaction_payload.inline_batches;
+
+    if verified_batches != *found_inline_batches {
+        Err(ExecutorError::InternalError {
+            error: format!(
+                "Expected inline batches {:?} but found {:?}",
+                verified_batches, found_inline_batches
+            ),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+fn verify_transaction_limit(
+    max_txns_to_execute: Option<u64>,
+    block_transaction_payload: &BlockTransactionPayload,
+) -> ExecutorResult<()> {
+    if max_txns_to_execute != block_transaction_payload.limit {
+        Err(ExecutorError::InternalError {
+            error: format!(
+                "Expected transaction limit {:?} but found {:?}",
+                max_txns_to_execute, block_transaction_payload.limit
+            ),
+        })
+    } else {
+        Ok(())
     }
 }

--- a/consensus/src/test_utils/mock_execution_client.rs
+++ b/consensus/src/test_utils/mock_execution_client.rs
@@ -171,5 +171,9 @@ impl TExecutionClient for MockExecutionClient {
         Ok(())
     }
 
+    async fn reset(&self, _target: &LedgerInfoWithSignatures) -> Result<()> {
+        Ok(())
+    }
+
     async fn end_epoch(&self) {}
 }


### PR DESCRIPTION
Note:
- This PR builds on https://github.com/aptos-labs/aptos-core/pull/13886
- Most of this code is new unit tests.

## Description
This PR makes several improvements to consensus observer. Specifically, it offers the following commits:
1. Add a `reset()` method to the execution client trait. This method is already provided internally by `sync_to` and we want to expose it so that we can call it directly whenever consensus observer needs to reset execution state (e.g., on subscription changes).
1. Add methods to the missing and pending block stores to clear all data. This will also be used to reset internal state (e.g., on subscription changes).
1. Update consensus observer to perform message verification for block payloads. Specifically, we: (i) verify the payload batch digests (i.e., to make sure all transactions are valid and in the correct order); (ii) verify the payload signatures over the batches (if the payload is for the current epoch); (iii) if the payload signatures can't be verified in the current epoch, we store them and verify them once we transition epochs; (iv) when the payloads are retrieved (for an ordered block), we make sure the batches and transactions match the expected values in the block (this ties the payload to a verified block); and (v) add a configurable maximum number of pending payloads (to avoid OOM attacks).

## Testing Plan
New and existing test infrastructure.