### PR TITLE
Use cargo deny to prevent onboarding certain crates

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -83,6 +83,19 @@ jobs:
       - run: echo "Skipping rust lints! Unrelated changes detected."
         if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
 
+  # Run cargo deny. This is a PR required job.
+  rust-cargo-deny:
+    needs: file_change_determinator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+      - uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          command: check licenses
+      - run: echo "Skipping cargo deny! Unrelated changes detected."
+        if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
+
   # Run all rust smoke tests. This is a PR required job.
   rust-smoke-tests:
     needs: file_change_determinator

--- a/aptos-move/aptos-abstract-gas-usage/Cargo.toml
+++ b/aptos-move/aptos-abstract-gas-usage/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aptos-abstract-gas-usage"
 version = "0.1.0"
 edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/aptos-move/aptos-gas-calibration/Cargo.toml
+++ b/aptos-move/aptos-gas-calibration/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aptos-gas-calibration"
 version = "0.1.0"
 edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/aptos-move/aptos-vm-benchmarks/Cargo.toml
+++ b/aptos-move/aptos-vm-benchmarks/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aptos-vm-benchmarks"
 version = "0.1.0"
 edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license = { workspace = true }
 
 [dependencies]
 aptos-cached-packages = { workspace = true }

--- a/crates/aptos-dkg/Cargo.toml
+++ b/crates/aptos-dkg/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aptos-dkg"
 version = "0.1.0"
 edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,40 @@
+# This is a configuration file for cargo deny, the tool we use to prevent accidentally
+# onboarding dependencies with licenses we don't want to use. To test this config, try
+# running a command like this:
+#
+# cargo deny check licenses --hide-inclusion-graph
+
+[licenses]
+version = 2
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    "CDDL-1.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "OpenSSL",
+    "Unicode-DFS-2016",
+    "Unlicense",
+    "Zlib",
+]
+
+# Since the tool cannot determine the license of this crate, we need to clarify it.
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]
+
+[licenses.private]
+ignore = true
+ignore-sources = [
+    # This is for the macros crate from diesel_async_migrations. It is MIT licensed, but
+    # uses an irregular license file name.
+    "https://github.com/niroco/diesel_async_migrations"
+]

--- a/ecosystem/indexer-grpc/indexer-grpc-integration-tests/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-integration-tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aptos-indexer-grpc-integration-tests"
 version = "0.1.0"
 edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/testsuite/fuzzer/Cargo.toml
+++ b/testsuite/fuzzer/Cargo.toml
@@ -2,6 +2,6 @@
 name = "fuzzer"
 version = "0.1.0"
 edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license = { workspace = true }
 
 [dependencies]

--- a/third_party/move/move-model/bytecode/abstract_domain_derive/Cargo.toml
+++ b/third_party/move/move-model/bytecode/abstract_domain_derive/Cargo.toml
@@ -2,6 +2,7 @@
 name = "abstract-domain-derive"
 version = "0.1.0"
 edition = "2021"
+license = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
## Description
Internal context: https://aptos-org.slack.com/archives/C03K45JU90C/p1720451868050819.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
CI is expected to fail until @grao1991 lands his PR. See thread in summary for more context. Once that is done, see that the new CI passes.

Update: CI passes now that that PR has been landed. Let's land.

## Key Areas to Review
Confirm that deny.toml is configured appropriately.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
