### PR TITLE
[CI/CD] Run all unit tests on release branch PRs.

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -108,6 +108,10 @@ jobs:
 
   # Run only the targeted rust unit tests. This is a PR required job.
   rust-targeted-unit-tests:
+    if: | # Don't run on release branches. Instead, all unit tests will be triggered.
+      (
+        !contains(github.event.pull_request.base.ref, '-release-')
+      )
     needs: file_change_determinator
     runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
@@ -126,7 +130,8 @@ jobs:
       (
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'push' ||
-        contains(github.event.pull_request.labels.*.name, 'CICD:run-all-unit-tests')
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-all-unit-tests') ||
+        contains(github.event.pull_request.base.ref, '-release-')
       )
     runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:


### PR DESCRIPTION
## Description
This PR updates CI/CD to force all unit tests to run whenever a pull request is made to a release branch. This is safer than doing targeted unit tests e.g., it will help to ensure all tests are passing on release branches after updates.

## Testing Plan
Manual verification.