### PR TITLE
[CI/CD] Run all unit tests on release branch PRs.

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -108,6 +108,10 @@ jobs:
 
   # Run only the targeted rust unit tests. This is a PR required job.
   rust-targeted-unit-tests:
+    if: | # Don't run on release branches. Instead, all unit tests will be triggered.
+      (
+        !contains(github.event.pull_request.base.ref, '-release-')
+      )
     needs: file_change_determinator
     runs-on: high-perf-docker
     steps:
@@ -126,7 +130,8 @@ jobs:
       (
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'push' ||
-        contains(github.event.pull_request.labels.*.name, 'CICD:run-all-unit-tests')
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-all-unit-tests') ||
+        contains(github.event.pull_request.base.ref, '-release-')
       )
     runs-on: high-perf-docker
     steps:


### PR DESCRIPTION
## Description
This PR is a cherry-pick of https://github.com/aptos-labs/aptos-core/pull/13943 (into the 1.16 release branch).

## Testing Plan
Manual verification.
