### PR TITLE
fix aptos-vm dependence in third-party/.../transactional-tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10538,7 +10538,6 @@ dependencies = [
 name = "move-compiler-v2-transactional-tests"
 version = "0.1.0"
 dependencies = [
- "aptos-vm",
  "datatest-stable",
  "itertools 0.12.1",
  "move-command-line-common",

--- a/third_party/move/move-compiler-v2/transactional-tests/Cargo.toml
+++ b/third_party/move/move-compiler-v2/transactional-tests/Cargo.toml
@@ -11,7 +11,6 @@ move-command-line-common = { path = "../../move-command-line-common" }
 once_cell = { workspace = true }
 
 [dev-dependencies]
-aptos-vm = { workspace = true, features = ["testing"] }
 datatest-stable = { workspace = true }
 itertools = { workspace = true }
 move-compiler-v2 = { path = ".." }

--- a/third_party/move/testing-infra/transactional-test-runner/Cargo.toml
+++ b/third_party/move/testing-infra/transactional-test-runner/Cargo.toml
@@ -31,7 +31,7 @@ termcolor = { workspace = true }
 
 move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
 move-symbol-pool = { path = "../../move-symbol-pool" }
-move-vm-runtime = { path = "../../move-vm/runtime" }
+move-vm-runtime = { path = "../../move-vm/runtime", features = ["testing"] }
 move-vm-test-utils = { path = "../../move-vm/test-utils" }
 move-vm-types = { path = "../../move-vm/types" }
 


### PR DESCRIPTION
## Description

Previously, to fix the case of testing VM output sometimes appearing
in `move-compiler-v2-transactional-tests` and sometimes not, PR #13492
added a dependence on `aptos-vm` with `debugging` feature.  This
introduced unnecessary dependency builds when working in third-party.
This PR fixes that.

## How Has This Been Tested?

CI tests should do it.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## Key Areas to Review

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
