### PR TITLE
LayeredMap: carries Value instead of Option<Value>

### DIFF
--- a/experimental/storage/layered-map/src/lib.rs
+++ b/experimental/storage/layered-map/src/lib.rs
@@ -196,7 +196,7 @@ where
                 NodeStrongRef::Empty => return None,
                 NodeStrongRef::Leaf(leaf) => {
                     return if &leaf.key == key {
-                        leaf.value.clone()
+                        Some(leaf.value.clone())
                     } else {
                         None
                     }
@@ -217,7 +217,7 @@ where
         } // end loop
     }
 
-    fn new_leaf(&self, item: &(K, Option<V>)) -> NodeRef<K, V> {
+    fn new_leaf(&self, item: &(K, V)) -> NodeRef<K, V> {
         let (key, value) = item.clone();
         NodeRef::new_leaf(key, value, self.top_layer() + 1)
     }
@@ -264,7 +264,7 @@ where
         &self,
         depth: usize,
         current_root: NodeStrongRef<K, V>,
-        items: &[(K, Option<V>)],
+        items: &[(K, V)],
     ) -> NodeRef<K, V> {
         if items.is_empty() {
             return current_root.weak_ref();
@@ -292,7 +292,7 @@ where
         )
     }
 
-    pub fn new_layer(&self, items: &[(K, Option<V>)]) -> MapLayer<K, V> {
+    pub fn new_layer(&self, items: &[(K, V)]) -> MapLayer<K, V> {
         let _timer = TIMER.timer_with(&[self.top_layer.inner.use_case, "new_layer"]);
         let root = self.create_tree(0, self.root(), items);
         MapLayer {

--- a/experimental/storage/layered-map/src/node.rs
+++ b/experimental/storage/layered-map/src/node.rs
@@ -14,7 +14,7 @@ pub(crate) struct InternalNode<K, V> {
 #[derive(Debug)]
 pub(crate) struct LeafNode<K, V> {
     pub key: K,
-    pub value: Option<V>,
+    pub value: V,
     pub layer: u64,
 }
 
@@ -26,7 +26,7 @@ pub(crate) enum NodeRef<K, V> {
 }
 
 impl<K, V> NodeRef<K, V> {
-    pub fn new_leaf(key: K, value: Option<V>, layer: u64) -> Self {
+    pub fn new_leaf(key: K, value: V, layer: u64) -> Self {
         Self::Leaf(Ref::Strong(Arc::new(LeafNode { key, value, layer })))
     }
 


### PR DESCRIPTION

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

The interface used to understand `None` as deletions (None as tombstones) and when trying to get a key, the result is the same if the key is not found or the value is None. The behavior confused the call site, I'd rather let the call site deal with the tombstones "manually.

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [ ] Other (specify) -- experimental

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

unit test
