### PR TITLE
[easy][cli] fix sorting bug in benchmarking code

### DIFF
--- a/crates/aptos/src/common/local_simulation.rs
+++ b/crates/aptos/src/common/local_simulation.rs
@@ -83,6 +83,7 @@ pub fn benchmark_transaction_using_debugger(
 
             times.push(t2 - t1);
         }
+        times.sort();
 
         times[n / 2]
     };


### PR DESCRIPTION
## Description
This fixes a small bug in the banchmarking code. I forgot to sort the list of measurements taken.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Manual testing

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
