### PR TITLE
Fix the InvalidOrderedLedgerInfo error

### DIFF
--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -378,6 +378,14 @@ impl SafetyRules {
         let old_ledger_info = ledger_info.ledger_info();
 
         if !old_ledger_info.commit_info().is_ordered_only()
+            // When doing fast forward sync, we pull the latest blocks and quorum certs from peers
+            // and store them in storage. We then compute the root ordered cert and root commit cert
+            // from storage and start the consensus from there. But given that we are not storing the
+            // ordered cert obtained from order votes in storage, instead of obtaining the root ordered cert
+            // from storage, we set root ordered cert to commit certificate.
+            // This means, the root ordered cert will not have a dummy executed_state_id in this case.
+            // To handle this, we do not raise error if the old_ledger_info.commit_info() matches with
+            // new_ledger_info.commit_info().
             && old_ledger_info.commit_info() != new_ledger_info.commit_info()
         {
             return Err(Error::InvalidOrderedLedgerInfo(old_ledger_info.to_string()));

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -377,7 +377,9 @@ impl SafetyRules {
 
         let old_ledger_info = ledger_info.ledger_info();
 
-        if !old_ledger_info.commit_info().is_ordered_only() {
+        if !old_ledger_info.commit_info().is_ordered_only()
+            && old_ledger_info.commit_info() != new_ledger_info.commit_info()
+        {
             return Err(Error::InvalidOrderedLedgerInfo(old_ledger_info.to_string()));
         }
 

--- a/consensus/src/pipeline/tests/signing_phase_tests.rs
+++ b/consensus/src/pipeline/tests/signing_phase_tests.rs
@@ -73,6 +73,7 @@ fn add_signing_phase_test_cases(
     );
 
     let (_, executed_ledger_info) = prepare_executed_blocks_with_executed_ledger_info(&signers[0]);
+    let executed_commit_ledger_info = executed_ledger_info.ledger_info().clone();
     let inconsistent_commit_ledger_info =
         LedgerInfo::new(BlockInfo::random(1), HashValue::from_u64(0xBEEF));
 
@@ -90,17 +91,15 @@ fn add_signing_phase_test_cases(
         }),
     );
 
-    // not ordered-only
+    // ordered ledger info same as commit ledger info
     phase_tester.add_test_case(
         SigningRequest {
             ordered_ledger_info: executed_ledger_info.clone(),
             commit_ledger_info: executed_ledger_info.ledger_info().clone(),
         },
         Box::new(move |resp| {
-            assert!(matches!(
-                resp.signature_result,
-                Err(Error::InvalidOrderedLedgerInfo(_))
-            ));
+            assert!(resp.signature_result.is_ok());
+            assert_eq!(resp.commit_ledger_info, executed_commit_ledger_info);
         }),
     );
 


### PR DESCRIPTION
## Description
Fix the InvalidOrderedLedgerInfo error that we observed in testnet. 
When doing fast forward sync, we pull the latest blocks and quorum certs from peers and store them in storage. 
We then compute the root ordered cert and root commit cert from storage and start the consensus from there.
But given that we are not storing the ordered cert obtained from order votes in storage, as a hack, we set root ordered cert to commit certificate. This means, the root ordered cert will not have a dummy execution_state_id in this case. When a block is being executed with this ordered cert, the safety rule for signing commit vote fails, which checks that the ordered cert should have dummy execution_state_id. This PR fixes the issue by bypassing the check when the ordered cert matches with commit vote's ledger info.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
