### PR TITLE
chore: Disable unwrap in non-test components for consensus

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -6,3 +6,5 @@ type-complexity-threshold = 10000
 too-many-arguments-threshold = 14
 # Reasonably large enum variants are okay
 enum-variant-size-threshold = 1000
+# Allow unwrap in test
+allow-unwrap-in-tests = true

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -116,3 +116,6 @@ failpoints = ["fail/failpoints"]
 
 [package.metadata.cargo-machete]
 ignored = ["serde_bytes"]
+
+[lints.clippy]
+unwrap_used = "deny"

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -495,7 +495,7 @@ impl Block {
                         )
                     })
             })
-            .map(|index| u32::try_from(index).unwrap())
+            .map(|index| u32::try_from(index).expect("Index is out of bounds for u32"))
             .collect()
     }
 }

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -118,7 +118,7 @@ impl BlockRetrievalResponse {
         ensure!(
             self.status != BlockRetrievalStatus::SucceededWithTarget
                 || (!self.blocks.is_empty()
-                    && retrieval_request.match_target_id(self.blocks.last().unwrap().id())),
+                    && self.blocks.last().map_or(false, |block| retrieval_request.match_target_id(block.id()))),
             "target not found in blocks returned, expect {:?}",
             retrieval_request.target_block_id(),
         );

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -165,6 +165,7 @@ impl ProofWithData {
         }
     }
 
+    #[allow(clippy::unwrap_used)]
     pub fn extend(&mut self, other: ProofWithData) {
         let other_data_status = other.status.lock().as_mut().unwrap().take();
         self.proofs.extend(other.proofs);

--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -269,6 +269,7 @@ pub enum SignedBatchInfoError {
     InvalidAuthor,
     NotFound,
     AlreadyCommitted,
+    NoTimeStamps,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]

--- a/consensus/consensus-types/src/timeout_2chain.rs
+++ b/consensus/consensus-types/src/timeout_2chain.rs
@@ -167,7 +167,7 @@ impl TwoChainTimeoutCertificate {
             .rounds()
             .iter()
             .max()
-            .expect("Empty rounds");
+            .ok_or_else(|| anyhow::anyhow!("Empty rounds"))?;
         ensure!(
             hqc_round == *signed_hqc,
             "Inconsistent hqc round, qc has round {}, highest signed round {}",

--- a/consensus/safety-rules/benches/safety_rules.rs
+++ b/consensus/safety-rules/benches/safety_rules.rs
@@ -2,6 +2,8 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::unwrap_used)]
+
 use aptos_consensus_types::block::block_test_utils;
 use aptos_safety_rules::{test_utils, PersistentSafetyStorage, SafetyRulesManager, TSafetyRules};
 use aptos_secure_storage::{InMemoryStorage, KVStorage, OnDiskStorage, Storage, VaultStorage};

--- a/consensus/safety-rules/src/counters.rs
+++ b/consensus/safety-rules/src/counters.rs
@@ -2,6 +2,8 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::unwrap_used)]
+
 use aptos_metrics_core::{
     register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, HistogramTimer,
     HistogramVec, IntCounterVec, IntGaugeVec,

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -70,6 +70,7 @@ impl From<serde_json::Error> for Error {
 }
 
 impl From<aptos_secure_net::Error> for Error {
+    #[allow(clippy::fallible_impl_from)]
     fn from(error: aptos_secure_net::Error) -> Self {
         Self::InternalError(error.to_string())
     }

--- a/consensus/safety-rules/src/fuzzing_utils.rs
+++ b/consensus/safety-rules/src/fuzzing_utils.rs
@@ -2,7 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::arc_with_non_send_sync)]
+#![allow(clippy::arc_with_non_send_sync, clippy::unwrap_used)]
 
 use crate::serializer::SafetyRulesInput;
 #[cfg(any(test, feature = "fuzzing"))]

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -52,7 +52,7 @@ pub fn storage(config: &SafetyRulesConfig) -> PersistentSafetyStorage {
             config.initial_safety_rules_config,
             InitialSafetyRulesConfig::None
         ) {
-            let identity_blob = config.initial_safety_rules_config.identity_blob().unwrap();
+            let identity_blob = config.initial_safety_rules_config.identity_blob().expect("No identity blob in initial safety rules config");
             let waypoint = config.initial_safety_rules_config.waypoint();
 
             let backend = &config.backend;

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -512,7 +512,7 @@ impl BlockStore {
                 // latency not known without non-genesis blocks
                 Duration::ZERO
             } else {
-                proposal_timestamp.checked_sub(timestamp).unwrap()
+                proposal_timestamp.checked_sub(timestamp).expect("latency must not be negative")
             }
         }
 

--- a/consensus/src/block_storage/block_tree.rs
+++ b/consensus/src/block_storage/block_tree.rs
@@ -432,7 +432,7 @@ impl BlockTree {
             .create_merged_with_executed_state(commit_decision)
             .expect("Inconsistent commit proof and evaluation decision, cannot commit block");
 
-        let block_to_commit = blocks_to_commit.last().unwrap().clone();
+        let block_to_commit = blocks_to_commit.last().expect("pipeline is empty").clone();
         update_counters_for_committed_blocks(blocks_to_commit);
         let current_round = self.commit_root().round();
         let committed_round = block_to_commit.round();

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -692,7 +692,7 @@ impl BlockRetriever {
                     // extend the result blocks
                     let batch = result.blocks().clone();
                     progress += batch.len() as u64;
-                    last_block_id = batch.last().unwrap().parent_id();
+                    last_block_id = batch.last().expect("Batch should not be empty").parent_id();
                     result_blocks.extend(batch);
                 },
                 Ok(result)
@@ -712,7 +712,7 @@ impl BlockRetriever {
                 },
             }
         }
-        assert_eq!(result_blocks.last().unwrap().id(), target_block_id);
+        assert_eq!(result_blocks.last().expect("Expected at least a result_block").id(), target_block_id);
         Ok(result_blocks)
     }
 

--- a/consensus/src/consensus_observer/metrics.rs
+++ b/consensus/src/consensus_observer/metrics.rs
@@ -1,6 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::unwrap_used)]
+
 use aptos_config::network_id::{NetworkId, PeerNetworkId};
 use aptos_metrics_core::{
     register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, HistogramVec,

--- a/consensus/src/consensus_observer/observer.rs
+++ b/consensus/src/consensus_observer/observer.rs
@@ -637,24 +637,25 @@ impl ConsensusObserver {
 
         // TODO: verify the ordered block!
 
-        // If the block is a child of our last block, we can insert it
-        if self.get_last_block().id() == blocks.first().unwrap().parent_id() {
-            // Insert the ordered block into the pending blocks
-            self.pending_ordered_blocks
-                .insert_ordered_block(ordered_block);
+        if let Some(block) = blocks.first() {
+            // If the block is a child of our last block, we can insert it
+            if self.get_last_block().id() == block.parent_id() {
+                // Insert the ordered block into the pending blocks
+                self.pending_ordered_blocks
+                    .insert_ordered_block(ordered_block);
 
-                // If we are not in sync mode, forward the blocks to the execution pipeline
-                if self.sync_handle.is_none() {
-                    debug!(
-                        LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                            "Forwarding blocks to the execution pipeline: {}",
-                            ordered_proof.commit_info()
-                        ))
-                    );
+                    // If we are not in sync mode, forward the blocks to the execution pipeline
+                    if self.sync_handle.is_none() {
+                        debug!(
+                            LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                                "Forwarding blocks to the execution pipeline: {}",
+                                ordered_proof.commit_info()
+                            ))
+                        );
 
-                    // Finalize the ordered block
-                    self.finalize_ordered_block(&blocks, ordered_proof).await;
-                }
+                        // Finalize the ordered block
+                        self.finalize_ordered_block(&blocks, ordered_proof).await;
+                    }
             } else {
                 warn!(
                     LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
@@ -664,8 +665,12 @@ impl ConsensusObserver {
                 );
             }
         } else {
-            // Handle the case where first block is unexpectedly missing
-            warn!("Expected to find a first block but none was found.");
+            warn!(
+                LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                    "Expected to find a first block but none was found! Ignoring: {:?}",
+                    ordered_proof.commit_info()
+                ))
+            );
         }
     }
 

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -41,6 +41,7 @@ use std::{collections::HashMap, sync::Arc};
 use tokio::runtime::Runtime;
 
 /// Helper function to start consensus based on configuration and return the runtime
+#[allow(clippy::unwrap_used)]
 pub fn start_consensus(
     node_config: &NodeConfig,
     network_client: NetworkClient<ConsensusMsg>,

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -2,6 +2,8 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::unwrap_used)]
+
 use crate::{
     block_storage::tracing::{observe_block, BlockStage},
     quorum_store,

--- a/consensus/src/dag/adapter.rs
+++ b/consensus/src/dag/adapter.rs
@@ -141,7 +141,7 @@ impl OrderedNotifier for OrderedNotifierAdapter {
         ordered_nodes: Vec<Arc<CertifiedNode>>,
         failed_author: Vec<(Round, Author)>,
     ) {
-        let anchor = ordered_nodes.last().unwrap();
+        let anchor = ordered_nodes.last().expect("ordered_nodes shuld not be empty");
         let epoch = anchor.epoch();
         let round = anchor.round();
         let timestamp = anchor.metadata().timestamp();
@@ -385,15 +385,15 @@ impl DAGStorage for StorageAdapter {
         for i in 1..=std::cmp::min(k, resource.length()) {
             let idx = (resource.next_idx() + resource.max_capacity() - i as u32)
                 % resource.max_capacity();
-            let new_block_event = bcs::from_bytes::<NewBlockEvent>(
-                self.aptos_db
-                    .get_state_value_by_version(
-                        &StateKey::table_item(handle, &bcs::to_bytes(&idx).unwrap()),
-                        version,
-                    )?
-                    .ok_or_else(|| format_err!("Table item doesn't exist"))?
-                    .bytes(),
-            )?;
+            // idx is an u32, so it's not possible to fail to convert it to bytes
+            let idx_bytes = bcs::to_bytes(&idx)
+                .map_err(|e| anyhow::anyhow!("Failed to serialize index: {:?}", e))?;
+            let state_value = self
+                .aptos_db
+                .get_state_value_by_version(&StateKey::table_item(handle, &idx_bytes), version)?
+                .ok_or_else(|| anyhow::anyhow!("Table item doesn't exist"))?;
+            let new_block_event = bcs::from_bytes::<NewBlockEvent>(state_value.bytes())
+                .map_err(|e| anyhow::anyhow!("Failed to deserialize NewBlockEvent: {:?}", e))?;
             if self
                 .epoch_to_validators
                 .contains_key(&new_block_event.epoch())

--- a/consensus/src/dag/anchor_election/leader_reputation_adapter.rs
+++ b/consensus/src/dag/anchor_election/leader_reputation_adapter.rs
@@ -49,14 +49,14 @@ impl MetadataBackendAdapter {
 
     // TODO: we should change NewBlockEvent on LeaderReputation to take a trait
     fn convert(&self, event: CommitEvent) -> NewBlockEvent {
-        let validators = self.epoch_to_validators.get(&event.epoch()).unwrap();
+        let validators = self.epoch_to_validators.get(&event.epoch()).expect("Event epoch should map back to validators!");
         let mut bitvec = BitVec::with_num_bits(validators.len() as u16);
         for author in event.parents() {
-            bitvec.set(*validators.get(author).unwrap() as u16);
+            bitvec.set(*validators.get(author).expect("Author should be in validators set!") as u16);
         }
         let mut failed_authors = vec![];
         for author in event.failed_authors() {
-            failed_authors.push(*validators.get(author).unwrap() as u64);
+            failed_authors.push(*validators.get(author).expect("Author should be in validators set!") as u64);
         }
         NewBlockEvent::new(
             AccountAddress::ZERO,

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -432,7 +432,7 @@ impl DagBootstrapper {
             .epoch_state
             .verifier
             .get_ordered_account_addresses_iter()
-            .map(|p| self.epoch_state.verifier.get_voting_power(&p).unwrap())
+            .map(|p| self.epoch_state.verifier.get_voting_power(&p).expect("No voting power associated with AccountAddress!"))
             .collect();
 
         Arc::new(LeaderReputationAdapter::new(

--- a/consensus/src/dag/dag_network.rs
+++ b/consensus/src/dag/dag_network.rs
@@ -63,6 +63,9 @@ impl Responders {
     }
 
     fn next_to_request(&mut self) -> Option<Vec<Author>> {
+        // We want to immediately stop if the number generator is not returning any value.
+        // expect will panic if the generator is not returning any value.
+        #[allow(clippy::unwrap_in_result)]
         let count = self.generator.next().expect("should return a number");
 
         if self.peers.is_empty() {

--- a/consensus/src/dag/dag_state_sync.rs
+++ b/consensus/src/dag/dag_state_sync.rs
@@ -256,7 +256,10 @@ impl DagStateSynchronizer {
 
         self.execution_client.sync_to(commit_li).await?;
 
-        Ok(Arc::into_inner(sync_dag_store).unwrap())
+        match Arc::try_unwrap(sync_dag_store) {
+            Ok(inner) => Ok(inner),
+            Err(_) => bail!("Failed to unwrap Arc, more than one strong reference exists"),
+        }
     }
 }
 

--- a/consensus/src/dag/dag_store.rs
+++ b/consensus/src/dag/dag_store.rs
@@ -110,6 +110,8 @@ impl InMemDag {
         );
 
         let node = Arc::new(node);
+        // Invariant violation, we must get the node ref (COMMENT ME)
+        #[allow(clippy::unwrap_in_result)]
         let round_ref = self
             .get_node_ref_mut(node.round(), node.author())
             .expect("must be present");
@@ -323,7 +325,7 @@ impl InMemDag {
         filter: impl Fn(&NodeStatus) -> bool,
     ) -> impl Iterator<Item = &NodeStatus> {
         let until = until.unwrap_or(self.lowest_round());
-        let initial_round = targets.clone().map(|t| t.round()).max().unwrap();
+        let initial_round = targets.clone().map(|t| t.round()).max().expect("Round should be not empty!");
         let initial = targets.map(|t| *t.digest()).collect();
 
         let mut reachable_filter = Self::reachable_filter(initial);
@@ -397,6 +399,8 @@ impl InMemDag {
         DagSnapshotBitmask::new(from_round, bitmask)
     }
 
+    /// unwrap is only used in debug mode
+    #[allow(clippy::unwrap_used)]
     pub(super) fn prune(&mut self) -> BTreeMap<u64, Vec<Option<NodeStatus>>> {
         let to_keep = self.nodes_by_round.split_off(&self.start_round);
         let to_prune = std::mem::replace(&mut self.nodes_by_round, to_keep);

--- a/consensus/src/dag/observability/counters.rs
+++ b/consensus/src/dag/observability/counters.rs
@@ -1,6 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::unwrap_used)]
+
 use aptos_metrics_core::{
     register_histogram, register_histogram_vec, register_int_gauge, Histogram, HistogramVec,
     IntGauge,

--- a/consensus/src/dag/types.rs
+++ b/consensus/src/dag/types.rs
@@ -579,15 +579,15 @@ impl BroadcastStatus<DAGMessage, DAGRpcResult> for Arc<SignatureBuilder> {
                 .check_voting_power(partial_signatures.signatures().keys(), true)
                 .is_ok()
         {
-            let aggregated_signature = self
-                .epoch_state
-                .verifier
-                .aggregate_signatures(partial_signatures)
-                .expect("Signature aggregation should succeed");
+            let aggregated_signature = match self.epoch_state.verifier.aggregate_signatures(partial_signatures) {
+                Ok(signature) => signature,
+                Err(_) => return Err(anyhow::anyhow!("Signature aggregation failed")),
+            };
             observe_node(self.metadata.timestamp(), NodeStage::CertAggregated);
             let certificate = NodeCertificate::new(self.metadata.clone(), aggregated_signature);
 
-            _ = tx.take().expect("must exist").send(certificate);
+            // Invariant Violation: The one-shot channel sender must exist to send the NodeCertificate
+            _ = tx.take().expect("The one-shot channel sender must exist to send the NodeCertificate").send(certificate);
         }
 
         if partial_signatures.signatures().len() == self.epoch_state.verifier.len() {
@@ -885,7 +885,7 @@ impl TConsensusMsg for DAGMessage {
     fn into_network_message(self) -> ConsensusMsg {
         ConsensusMsg::DAGMessage(DAGNetworkMessage {
             epoch: self.epoch(),
-            data: bcs::to_bytes(&self).unwrap(),
+            data: bcs::to_bytes(&self).expect("ConsensusMsg should serialize to bytes"),
         })
     }
 }
@@ -927,7 +927,7 @@ impl TConsensusMsg for DAGRpcResult {
     fn into_network_message(self) -> ConsensusMsg {
         ConsensusMsg::DAGMessage(DAGNetworkMessage {
             epoch: self.epoch(),
-            data: bcs::to_bytes(&self).unwrap(),
+            data: bcs::to_bytes(&self).expect("ConsensusMsg should serialize to bytes!"),
         })
     }
 }

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -180,7 +180,7 @@ pub struct EpochManager<P: OnChainConfigProvider> {
 }
 
 impl<P: OnChainConfigProvider> EpochManager<P> {
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, clippy::unwrap_used)]
     pub(crate) fn new(
         node_config: &NodeConfig,
         time_service: Arc<dyn TimeService>,
@@ -344,7 +344,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 let voting_powers: Vec<_> = if weight_by_voting_power {
                     proposers
                         .iter()
-                        .map(|p| epoch_state.verifier.get_voting_power(p).unwrap())
+                        .map(|p| epoch_state.verifier.get_voting_power(p).expect("INVARIANT VIOLATION: proposer not in verifier set"))
                         .collect()
                 } else {
                     vec![1; proposers.len()]
@@ -387,7 +387,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             },
             ProposerElectionType::RoundProposer(round_proposers) => {
                 // Hardcoded to the first proposer
-                let default_proposer = proposers.first().unwrap();
+                let default_proposer = proposers.first().expect("INVARIANT VIOLATION: proposers is empty");
                 Arc::new(RoundProposer::new(
                     round_proposers.clone(),
                     *default_proposer,
@@ -1290,7 +1290,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             .storage
             .aptos_db()
             .get_latest_ledger_info()
-            .unwrap()
+            .expect("unable to get latest ledger info")
             .commit_info()
             .round();
 
@@ -1338,7 +1338,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             self.aptos_time_service.clone(),
             payload_manager,
             payload_client,
-            self.execution_client.get_execution_channel().unwrap(),
+            self.execution_client.get_execution_channel().expect("unable to get execution channel"),
             self.execution_client.clone(),
             onchain_consensus_config.quorum_store_enabled(),
             onchain_consensus_config.effective_validator_txn_config(),
@@ -1389,7 +1389,9 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 Err(err) => return Err(err),
             }
             // same epoch -> run well-formedness + signature check
-            let epoch_state = self.epoch_state.clone().unwrap();
+            let epoch_state = self.epoch_state.clone().ok_or_else(|| {
+                anyhow::anyhow!("Epoch state is not available")
+            })?;
             let proof_cache = self.proof_cache.clone();
             let quorum_store_enabled = self.quorum_store_enabled;
             let quorum_store_msg_tx = self.quorum_store_msg_tx.clone();

--- a/consensus/src/execution_pipeline.rs
+++ b/consensus/src/execution_pipeline.rs
@@ -29,6 +29,7 @@ use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterato
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 
+#[allow(clippy::unwrap_used)]
 pub static SIG_VERIFY_POOL: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
     Arc::new(
         rayon::ThreadPoolBuilder::new()
@@ -121,7 +122,7 @@ impl ExecutionPipeline {
             return;
         }
         let validator_txns = block.validator_txns().cloned().unwrap_or_default();
-        let input_txns = input_txns.unwrap();
+        let input_txns = input_txns.expect("input_txns must be Some.");
         tokio::task::spawn_blocking(move || {
             let txns_to_execute =
                 Block::combine_to_input_transactions(validator_txns, input_txns.clone(), metadata);

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -296,16 +296,8 @@ impl NewBlockEventAggregation {
 
             &history[start..]
         } else {
-            if !history.is_empty() {
-                assert!(
-                    (
-                        history.first().unwrap().epoch(),
-                        history.first().unwrap().round()
-                    ) >= (
-                        history.last().unwrap().epoch(),
-                        history.last().unwrap().round()
-                    )
-                );
+            if let (Some(first), Some(last)) = (history.first(), history.last()) {
+                assert!((first.epoch(), first.round()) >= (last.epoch(), last.round()));
             }
             let end = if history.len() > window_size {
                 window_size
@@ -594,7 +586,7 @@ impl LeaderReputation {
         history: &[NewBlockEvent],
         round: Round,
     ) -> VotingPowerRatio {
-        let candidates = self.epoch_to_proposers.get(&self.epoch).unwrap();
+        let candidates = self.epoch_to_proposers.get(&self.epoch).expect("Epoch should always map to proposers");
         // use f64 counter, as total voting power is u128
         let total_voting_power = self.voting_powers.iter().map(|v| *v as f64).sum();
         CHAIN_HEALTH_TOTAL_VOTING_POWER.set(total_voting_power);

--- a/consensus/src/liveness/proposal_generator.rs
+++ b/consensus/src/liveness/proposal_generator.rs
@@ -383,7 +383,7 @@ impl ProposalGenerator {
 
             if !payload.is_direct()
                 && max_txns_from_block_to_execute.is_some()
-                && payload.len() as u64 > max_txns_from_block_to_execute.unwrap()
+                && payload.len() as u64 > max_txns_from_block_to_execute.unwrap_or(0)
             {
                 payload = payload.transform_to_quorum_store_v2(max_txns_from_block_to_execute);
             }
@@ -422,6 +422,7 @@ impl ProposalGenerator {
         Ok(block)
     }
 
+    #[allow(clippy::unwrap_used)]
     async fn calculate_max_block_sizes(
         &mut self,
         voting_power_ratio: f64,
@@ -462,7 +463,7 @@ impl ProposalGenerator {
         } else {
             PIPELINE_BACKPRESSURE_ON_PROPOSAL_TRIGGERED.observe(0.0);
         };
-
+        // the unwrap are safe because we always have at least one value in the vectors, see initialization.
         let max_block_txns = values_max_block_txns.into_iter().min().unwrap();
         let max_block_bytes = values_max_block_bytes.into_iter().min().unwrap();
         let proposal_delay = values_proposal_delay.into_iter().max().unwrap();

--- a/consensus/src/liveness/proposer_election.rs
+++ b/consensus/src/liveness/proposer_election.rs
@@ -66,7 +66,7 @@ pub(crate) fn choose_index(mut weights: Vec<u128>, state: Vec<u8>) -> usize {
                 Ordering::Greater
             }
         })
-        .unwrap_err()
+        .expect_err("Comparison never returns equals, so it's always guaranteed to be error")
 }
 
 #[test]

--- a/consensus/src/pending_order_votes.rs
+++ b/consensus/src/pending_order_votes.rs
@@ -85,7 +85,7 @@ impl PendingOrderVotes {
                     );
                     return OrderVoteReceptionResult::UnknownAuthor(order_vote.author());
                 }
-                let validator_voting_power = validator_voting_power.unwrap();
+                let validator_voting_power = validator_voting_power.expect("Author must exist in the validator set.");
 
                 if validator_voting_power == 0 {
                     warn!(

--- a/consensus/src/pending_votes.rs
+++ b/consensus/src/pending_votes.rs
@@ -291,23 +291,30 @@ impl PendingVotes {
         vote: Vote,
     ) -> VoteReceptionResult {
         let li_digest = vote.ledger_info().hash();
-        let (_, li_with_sig) = self.li_digest_to_votes.get_mut(&li_digest).unwrap();
-        match validator_verifier.check_voting_power(li_with_sig.signatures().keys(), true) {
-            // a quorum of signature was reached, a new QC is formed
-            Ok(_) => Self::aggregate_qc_now(validator_verifier, li_with_sig, vote.vote_data()),
+        match self.li_digest_to_votes.get_mut(&li_digest) {
+            Some((_, li_with_sig)) => {
+                match validator_verifier.check_voting_power(li_with_sig.signatures().keys(), true) {
+                    // a quorum of signature was reached, a new QC is formed
+                    Ok(_) => Self::aggregate_qc_now(validator_verifier, li_with_sig, vote.vote_data()),
 
-            // not enough votes
-            Err(VerifyError::TooLittleVotingPower { .. }) => {
-                panic!("Delayed QC aggregation should not be triggered if we don't have enough votes to form a QC");
+                    // not enough votes
+                    Err(VerifyError::TooLittleVotingPower { .. }) => {
+                        panic!("Delayed QC aggregation should not be triggered if we don't have enough votes to form a QC");
+                    },
+
+                    // error
+                    Err(error) => {
+                        error!(
+                            "MUST_FIX: vote received could not be added: {}, vote: {}",
+                            error, vote
+                        );
+                        VoteReceptionResult::ErrorAddingVote(error)
+                    },
+                }
             },
-
-            // error
-            Err(error) => {
-                error!(
-                    "MUST_FIX: vote received could not be added: {}, vote: {}",
-                    error, vote
-                );
-                VoteReceptionResult::ErrorAddingVote(error)
+            None => {
+                error!("No LedgerInfoWithSignatures found for the given digest: {}", li_digest);
+                VoteReceptionResult::ErrorAddingVote(VerifyError::EmptySignature)
             },
         }
     }

--- a/consensus/src/pipeline/buffer.rs
+++ b/consensus/src/pipeline/buffer.rs
@@ -48,6 +48,7 @@ impl<T: Hashable> Buffer<T> {
         &self.tail
     }
 
+    #[allow(clippy::unwrap_used)]
     pub fn push_back(&mut self, elem: T) {
         self.count = self.count.checked_add(1).unwrap();
         let t_hash = elem.hash();
@@ -63,6 +64,7 @@ impl<T: Hashable> Buffer<T> {
         self.head.get_or_insert(t_hash);
     }
 
+    #[allow(clippy::unwrap_used)]
     pub fn pop_front(&mut self) -> Option<T> {
         self.head.take().map(|head| {
             let mut item = self.map.remove(&head).unwrap();
@@ -77,10 +79,12 @@ impl<T: Hashable> Buffer<T> {
     }
 
     // utils - assuming item is not None
+    #[allow(clippy::unwrap_used)]
     pub fn get_next(&self, cursor: &Cursor) -> Cursor {
         self.map.get(cursor.as_ref().unwrap()).unwrap().next
     }
 
+    #[allow(clippy::unwrap_used)]
     pub fn get(&self, cursor: &Cursor) -> &T {
         self.map
             .get(cursor.as_ref().unwrap())
@@ -90,6 +94,7 @@ impl<T: Hashable> Buffer<T> {
             .unwrap()
     }
 
+    #[allow(clippy::unwrap_used)]
     pub fn set(&mut self, cursor: &Cursor, new_val: T) {
         self.map
             .get_mut(cursor.as_ref().unwrap())
@@ -98,6 +103,7 @@ impl<T: Hashable> Buffer<T> {
             .replace(new_val);
     }
 
+    #[allow(clippy::unwrap_used)]
     pub fn take(&mut self, cursor: &Cursor) -> T {
         self.map
             .get_mut(cursor.as_ref().unwrap())
@@ -130,7 +136,7 @@ impl<T: Hashable> Buffer<T> {
     /// we make sure that the element found by the key is after `cursor`
     /// if `cursor` is None, this function returns None (same as find_elem)
     pub fn find_elem_by_key(&self, cursor: Cursor, key: HashValue) -> Cursor {
-        let cursor_order = self.map.get(cursor.as_ref()?).unwrap().index;
+        let cursor_order = self.map.get(cursor.as_ref()?)?.index;
         let item = self.map.get(&key)?;
         if item.index >= cursor_order {
             Some(key)

--- a/consensus/src/pipeline/buffer_item.rs
+++ b/consensus/src/pipeline/buffer_item.rs
@@ -174,10 +174,10 @@ impl BufferItem {
                 for (b1, b2) in zip_eq(ordered_blocks.iter(), executed_blocks.iter()) {
                     assert_eq!(b1.id(), b2.id());
                 }
-                let mut commit_info = executed_blocks.last().unwrap().block_info();
+                let mut commit_info = executed_blocks.last().expect("execute_blocks should not be empty!").block_info();
                 match epoch_end_timestamp {
                     Some(timestamp) if commit_info.timestamp_usecs() != timestamp => {
-                        assert!(executed_blocks.last().unwrap().is_reconfiguration_suffix());
+                        assert!(executed_blocks.last().expect("").is_reconfiguration_suffix());
                         commit_info.change_timestamp(timestamp);
                     },
                     _ => (),
@@ -392,7 +392,7 @@ impl BufferItem {
     }
 
     pub fn block_id(&self) -> HashValue {
-        self.get_blocks().last().unwrap().id()
+        self.get_blocks().last().expect("Vec<PipelinedBlock> should not be empty").id()
     }
 
     pub fn add_signature_if_matched(&mut self, vote: CommitVote) -> anyhow::Result<()> {

--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -382,7 +382,7 @@ impl BufferManager {
             }
             if item.block_id() == target_block_id {
                 let aggregated_item = item.unwrap_aggregated();
-                let block = aggregated_item.executed_blocks.last().unwrap().block();
+                let block = aggregated_item.executed_blocks.last().expect("executed_blocks should be not empty").block();
                 observe_block(block.timestamp_usecs(), BlockStage::COMMIT_CERTIFIED);
                 // As all the validators broadcast commit votes directly to all other validators,
                 // the proposer do not have to broadcast commit decision again.
@@ -488,6 +488,7 @@ impl BufferManager {
     }
 
     /// If the response is successful, advance the item to Executed, otherwise panic (TODO fix).
+    #[allow(clippy::unwrap_used)]
     async fn process_execution_response(&mut self, response: ExecutionResponse) {
         let ExecutionResponse { block_id, inner } = response;
         // find the corresponding item, may not exist if a reset or aggregated happened

--- a/consensus/src/pipeline/execution_client.rs
+++ b/consensus/src/pipeline/execution_client.rs
@@ -343,19 +343,19 @@ impl TExecutionClient for ExecutionProxyClient {
         callback: StateComputerCommitCallBackType,
     ) -> ExecutorResult<()> {
         assert!(!blocks.is_empty());
-        let execute_tx = self.handle.read().execute_tx.clone();
-
-        if execute_tx.is_none() {
-            debug!("Failed to send to buffer manager, maybe epoch ends");
-            return Ok(());
-        }
+        let mut execute_tx = match self.handle.read().execute_tx.clone() {
+            Some(tx) => tx,
+            None => {
+                debug!("Failed to send to buffer manager, maybe epoch ends");
+                return Ok(());
+            }
+        };
 
         for block in blocks {
             block.set_insertion_time();
         }
 
         if execute_tx
-            .unwrap()
             .send(OrderedBlocks {
                 ordered_blocks: blocks
                     .iter()

--- a/consensus/src/pipeline/execution_schedule_phase.rs
+++ b/consensus/src/pipeline/execution_schedule_phase.rs
@@ -60,20 +60,20 @@ impl StatelessPipeline for ExecutionSchedulePhase {
 
     const NAME: &'static str = "execution_schedule";
 
+
     async fn process(&self, req: ExecutionRequest) -> ExecutionWaitRequest {
         let ExecutionRequest {
             ordered_blocks,
             lifetime_guard,
         } = req;
 
-        if ordered_blocks.is_empty() {
-            return ExecutionWaitRequest {
+        let block_id = match ordered_blocks.last() {
+            Some(block) => block.id(),
+            None => return ExecutionWaitRequest {
                 block_id: HashValue::zero(),
                 fut: Box::pin(async { Err(aptos_executor_types::ExecutorError::EmptyBlocks) }),
-            };
-        }
-
-        let block_id = ordered_blocks.last().unwrap().id();
+            },
+        };
 
         // Call schedule_compute() for each block here (not in the fut being returned) to
         // make sure they are scheduled in order.

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -1,6 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::unwrap_used)]
+
 use aptos_metrics_core::{
     exponential_buckets, op_counters::DurationHistogram, register_avg_counter, register_histogram,
     register_histogram_vec, register_int_counter, register_int_counter_vec, Histogram,

--- a/consensus/src/quorum_store/proof_coordinator.rs
+++ b/consensus/src/quorum_store/proof_coordinator.rs
@@ -232,9 +232,11 @@ impl ProofCoordinator {
                 #[allow(deprecated)]
                 let duration = chrono::Utc::now().naive_utc().timestamp_micros() as u64
                     - self
-                        .batch_info_to_time
-                        .remove(signed_batch_info.batch_info())
-                        .expect("Batch created without recording the time!");
+                    .batch_info_to_time
+                    .remove(signed_batch_info.batch_info())
+                    .ok_or(
+                        // Batch created without recording the time!
+                        SignedBatchInfoError::NoTimeStamps)?;
                 counters::BATCH_TO_POS_DURATION.observe_duration(Duration::from_micros(duration));
                 return Ok(Some(proof));
             }

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -268,6 +268,7 @@ impl InnerBuilder {
         batch_reader
     }
 
+    #[allow(clippy::unwrap_used)]
     fn spawn_quorum_store(
         mut self,
     ) -> (

--- a/consensus/src/quorum_store/quorum_store_db.rs
+++ b/consensus/src/quorum_store/quorum_store_db.rs
@@ -109,8 +109,7 @@ impl QuorumStoreStorage for QuorumStoreDB {
         for (epoch, batch_id) in epoch_batch_id {
             assert!(current_epoch >= epoch);
             if epoch < current_epoch {
-                self.delete_batch_id(epoch)
-                    .expect("Could not delete from db");
+                self.delete_batch_id(epoch)?;
             } else {
                 ret = Some(batch_id);
             }

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -75,6 +75,8 @@ impl<I: Ord + Hash> TimeExpirations<I> {
     }
 
     /// Expire and return items corresponding to expiration <= given certified time.
+    /// Unwrap is safe because peek() is called in loop condition.
+    #[allow(clippy::unwrap_used)]
     pub(crate) fn expire(&mut self, certified_time: u64) -> HashSet<I> {
         let mut ret = HashSet::new();
         while let Some((Reverse(t), _)) = self.expiries.peek() {

--- a/consensus/src/rand/rand_gen/block_queue.rs
+++ b/consensus/src/rand/rand_gen/block_queue.rs
@@ -40,12 +40,13 @@ impl QueueItem {
         self.blocks().len()
     }
 
+    #[allow(clippy::unwrap_used)]
     pub fn first_round(&self) -> u64 {
         self.blocks().first().unwrap().block().round()
     }
 
     pub fn offset(&self, round: Round) -> usize {
-        *self.offsets_by_round.get(&round).unwrap()
+        *self.offsets_by_round.get(&round).expect("Round should be in the queue")
     }
 
     pub fn num_undecided(&self) -> usize {
@@ -106,6 +107,8 @@ impl BlockQueue {
     }
 
     /// Dequeue all ordered blocks prefix that have randomness
+    /// Unwrap is safe because the queue is not empty
+    #[allow(clippy::unwrap_used)]
     pub fn dequeue_rand_ready_prefix(&mut self) -> Vec<OrderedBlocks> {
         let mut rand_ready_prefix = vec![];
         while let Some((_starting_round, item)) = self.queue.first_key_value() {

--- a/consensus/src/rand/rand_gen/network_messages.rs
+++ b/consensus/src/rand/rand_gen/network_messages.rs
@@ -82,6 +82,7 @@ impl<S: TShare, D: TAugmentedData> TConsensusMsg for RandMessage<S, D> {
         }
     }
 
+    #[allow(clippy::unwrap_used)]
     fn into_network_message(self) -> ConsensusMsg {
         ConsensusMsg::RandGenMessage(RandGenMessage {
             epoch: self.epoch(),

--- a/consensus/src/rand/rand_gen/rand_manager.rs
+++ b/consensus/src/rand/rand_gen/rand_manager.rs
@@ -212,7 +212,7 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
         message: RandMessage<S, D>,
     ) {
         let msg = message.into_network_message();
-        let _ = sender.send(Ok(protocol.to_bytes(&msg).unwrap().into()));
+        let _ = sender.send(Ok(protocol.to_bytes(&msg).expect("Message should be serializable into protocol").into()));
     }
 
     async fn verification_task(

--- a/consensus/src/rand/rand_gen/types.rs
+++ b/consensus/src/rand/rand_gen/types.rs
@@ -65,7 +65,7 @@ impl TShare for Share {
             WVUF::verify_share(
                 &rand_config.vuf_pp,
                 apk,
-                bcs::to_bytes(&rand_metadata).unwrap().as_slice(),
+                bcs::to_bytes(&rand_metadata).map_err(|e| anyhow!("Serialization failed: {}", e))?.as_slice(),
                 &self.share,
             )?;
         } else {
@@ -78,6 +78,7 @@ impl TShare for Share {
         Ok(())
     }
 
+    #[allow(clippy::unwrap_used)]
     fn generate(rand_config: &RandConfig, rand_metadata: RandMetadata) -> RandShare<Self>
     where
         Self: Sized,
@@ -629,7 +630,7 @@ impl RandConfig {
             .validator
             .address_to_validator_index()
             .get(peer)
-            .unwrap()
+            .expect("Peer should be in the index!")
     }
 
     pub fn get_certified_apk(&self, peer: &Author) -> Option<&APK> {

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -1293,6 +1293,7 @@ impl RoundManager {
     }
 
     /// Mainloop of processing messages.
+    #[allow(clippy::unwrap_used)]
     pub async fn start(
         mut self,
         mut event_rx: aptos_channel::Receiver<

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -2,6 +2,8 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::unwrap_used)]
+
 use crate::{
     block_storage::{pending_blocks::PendingBlocks, BlockStore},
     liveness::{

--- a/consensus/src/test_utils/mock_quorum_store_sender.rs
+++ b/consensus/src/test_utils/mock_quorum_store_sender.rs
@@ -76,7 +76,7 @@ impl QuorumStoreSender for MockQuorumStoreSender {
                 vec![],
             ))
             .await
-            .unwrap();
+            .expect("We should be able to send the proof of store message");
     }
 
     async fn send_proof_of_store_msg_to_self(&mut self, _proof_of_stores: Vec<ProofOfStore>) {

--- a/consensus/src/test_utils/mod.rs
+++ b/consensus/src/test_utils/mod.rs
@@ -2,6 +2,8 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::unwrap_used)]
+
 use crate::block_storage::{BlockReader, BlockStore};
 use aptos_consensus_types::{
     block::{block_test_utils::certificate_for_genesis, Block},
@@ -179,6 +181,7 @@ impl TreeInserter {
             .insert_single_quorum_cert(self.create_qc_for_block(block, committed_block))
             .unwrap()
     }
+
 
     pub fn create_block_with_qc(
         &self,

--- a/consensus/src/transaction_shuffler/deprecated_fairness/conflict_zone.rs
+++ b/consensus/src/transaction_shuffler/deprecated_fairness/conflict_zone.rs
@@ -57,11 +57,12 @@ impl<'a> ConflictZone<'a> {
         *self.counts_by_id.get_mut(key_id) += 1;
         self.sliding_window.push_back(key_id);
         if self.sliding_window.len() > self.sliding_window_size {
-            let removed_key_id = self.sliding_window.pop_front().unwrap();
-            let count = self.counts_by_id.get_mut(removed_key_id);
-            *count -= 1;
-            if *count == 0 && !self.key_registry.is_conflict_exempt(removed_key_id) {
-                return Some(removed_key_id);
+            if let Some(removed_key_id) = self.sliding_window.pop_front() {
+                let count = self.counts_by_id.get_mut(removed_key_id);
+                *count -= 1;
+                if *count == 0 && !self.key_registry.is_conflict_exempt(removed_key_id) {
+                    return Some(removed_key_id);
+                }
             }
         }
         None

--- a/consensus/src/transaction_shuffler/sender_aware.rs
+++ b/consensus/src/transaction_shuffler/sender_aware.rs
@@ -70,7 +70,7 @@ impl TransactionShuffler for SenderAwareShuffler {
 
             // If we can't find any candidate in above steps, then lastly
             // add pending transactions in the order if we can't find any other candidate
-            pending_txns.remove_first_pending().unwrap()
+            pending_txns.remove_first_pending().expect("Pending should return a transaction")
         };
         while sliding_window.num_txns() < num_transactions {
             let txn = next_to_add(&mut sliding_window);
@@ -131,11 +131,10 @@ impl PendingTransactions {
     pub fn remove_first_pending(&mut self) -> Option<SignedTransaction> {
         while let Some(txn) = self.ordered_txns.pop_front() {
             let sender = txn.sender();
-            // We don't remove the txns from ordered_txns when remove_pending_from_sender is called.
-            // So it is possible that the ordered_txns has some transactions that are not pending
-            // anymore.
-            if Some(txn).as_ref() == self.txns_by_senders.get(&sender).unwrap().front() {
-                return self.remove_pending_from_sender(sender);
+            if let Some(sender_queue) = self.txns_by_senders.get(&sender) {
+                if Some(txn).as_ref() == sender_queue.front() {
+                    return self.remove_pending_from_sender(sender);
+                }
             }
         }
         None
@@ -197,11 +196,14 @@ impl SlidingWindowState {
 
     /// Returns the sender which was dropped off of the conflict window in previous iteration.
     pub fn last_dropped_sender(&self) -> Option<AccountAddress> {
-        let prev_start_index = self.start_index - 1;
-        if prev_start_index >= 0 {
-            let last_sender = self.txns.get(prev_start_index as usize).unwrap().sender();
-            if *self.senders_in_window.get(&last_sender).unwrap() == 0 {
-                return Some(last_sender);
+        if self.start_index > 0 {
+            let prev_start_index = self.start_index - 1;
+            if let Some(last_sender) = self.txns.get(prev_start_index as usize).map(|txn| txn.sender()) {
+                if let Some(&count) = self.senders_in_window.get(&last_sender) {
+                    if count == 0 {
+                        return Some(last_sender);
+                    }
+                }
             }
         }
         None

--- a/consensus/src/util/db_tool.rs
+++ b/consensus/src/util/db_tool.rs
@@ -1,6 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::unwrap_used)]
+
 use crate::{
     consensusdb::ConsensusDB,
     quorum_store::{
@@ -44,6 +46,7 @@ impl Command {
         let mut txns = Vec::new();
         for block in blocks {
             let id = block.id();
+            #[allow(clippy::unwrap_in_result)]
             if self.block_id.is_none() || id == self.block_id.unwrap() {
                 txns.extend(
                     extract_txns_from_block(&block, &all_batches)?

--- a/consensus/src/util/time_service.rs
+++ b/consensus/src/util/time_service.rs
@@ -80,8 +80,8 @@ where
     T: Send + 'static,
 {
     fn run(&mut self) -> Pin<Box<dyn Future<Output = ()> + Send>> {
-        let mut sender = self.sender.take().unwrap();
-        let message = self.message.take().unwrap();
+        let mut sender = self.sender.take().expect("Expect to be able to take sender");
+        let message = self.message.take().expect("Expect to be able to take message");
         let r = async move {
             if let Err(e) = sender.send(message).await {
                 error!("Error on send: {:?}", e);


### PR DESCRIPTION
Replaced unwrap with tentative alternatives or temporarily with except statements pending further discussion in this PR.

## Description
After reviewing several parts of the code where an error triggers a panic, I have realized it is incredibly difficult to determine whether this behavior is intentional or accidental. Therefore, I propose reducing the use of unwrap (and later expect) to the bare minimum. To initiate this discussion, I have proposed some changes and request the cooperation of stakeholders in identifying other areas of concern or potential solutions.

I have configured Clippy to prohibit the use of unwrap except for testing purposes. This may seem drastic, but we need to start somewhere. The current solutions include rewriting the code without `unwrap`, using `match` and `let Some()`, or employing `expect`. Although `expect` is a loophole, it at least forces developers to consider the implications of a potential panic and what they expect from the code. Exceptions should be documented, and you can see examples of acceptable exceptions in the code files or functions I reviewed `#[allow(clippy::unwrap_used)]`.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [X] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
TBD

## Key Areas to Review
- We have `unwrap` simply replaced with `except` where I found no alternative solutions. Here you have to figure out whether you still want to throw a panic or not, and secondly whether the message is correct.
- `#[allow(clippy::unwrap_used)]` where it didn't seem to make sense to me to force this requirement
- Equivalent code without the use of unwrap

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
