### PR TITLE
Make imports of rocksdb agnostic of features

### DIFF
--- a/aptos-move/aptos-e2e-comparison-testing/src/lib.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/lib.rs
@@ -11,7 +11,7 @@ use aptos_types::{
     transaction::Transaction,
     write_set::WriteSet,
 };
-use rocksdb::{DBWithThreadMode, SingleThreaded, DB};
+use rocksdb::{DBWithThreadMode, SingleThreaded};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
@@ -187,10 +187,11 @@ impl IndexReader {
     }
 }
 
+type DB = DBWithThreadMode<SingleThreaded>;
 struct DataManager {
     state_data_dir_path: PathBuf,
     write_set_dir_path: PathBuf,
-    db: DBWithThreadMode<SingleThreaded>,
+    db: DB,
 }
 
 impl DataManager {

--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/src/backup_restore/fs_ops.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/src/backup_restore/fs_ops.rs
@@ -89,13 +89,15 @@ pub fn unpack_tar_gz(temp_file_path: &PathBuf, target_db_path: &PathBuf) -> anyh
 mod tests {
     use super::*;
     use rocksdb::{
-        ColumnFamilyDescriptor, DBWithThreadMode, IteratorMode, Options, SingleThreaded, DB,
+        ColumnFamilyDescriptor, DBWithThreadMode, IteratorMode, Options, SingleThreaded,
     };
     use std::{
         fs::File,
         io::{Read, Write},
     };
     use tempfile::tempdir;
+
+    type DB = DBWithThreadMode<SingleThreaded>;
 
     #[test]
     fn test_rename_db_folders_and_cleanup() {

--- a/storage/schemadb/src/iterator.rs
+++ b/storage/schemadb/src/iterator.rs
@@ -12,6 +12,8 @@ pub enum ScanDirection {
     Backward,
 }
 
+type InnerDBIterator<'a> = rocksdb::DBRawIteratorWithThreadMode<'a, crate::InnerDB>;
+
 enum Status {
     Initialized,
     DoneSeek,
@@ -22,7 +24,7 @@ enum Status {
 /// DB Iterator parameterized on [`Schema`] that seeks with [`Schema::Key`] and yields
 /// [`Schema::Key`] and [`Schema::Value`]
 pub struct SchemaIterator<'a, S> {
-    db_iter: rocksdb::DBRawIterator<'a>,
+    db_iter: InnerDBIterator<'a>,
     direction: ScanDirection,
     status: Status,
     phantom: PhantomData<S>,
@@ -32,7 +34,7 @@ impl<'a, S> SchemaIterator<'a, S>
 where
     S: Schema,
 {
-    pub(crate) fn new(db_iter: rocksdb::DBRawIterator<'a>, direction: ScanDirection) -> Self {
+    pub(crate) fn new(db_iter: InnerDBIterator<'a>, direction: ScanDirection) -> Self {
         SchemaIterator {
             db_iter,
             direction,


### PR DESCRIPTION
## Description

In the `rocksdb` crate, `DB` is a typedef dependent on whether the "multi-threaded-cf" feature is enabled during compilation. The alternative types it aliases exhibit differing APIs as well.

When aptos crates are used as dependencies in an external project that also uses `rocksdb` and enables the "multi-threaded-cf" feature, some crates, most notably aptos-schemadb, fail to compile.

This is a footgun on the part of `rocksdb` crate developers, and the way to avoid it is to use the specific database types for the chosen threading mode.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
`cargo test -p aptos-schemadb`
All crates in the workspace should build successfully and all existing tests shall pass.

To test the breakage this avoids, add "multi-threaded-cf" to the list of features for the `rocksdb` dependency in the workspace `Cargo.toml`.

## Key Areas to Review

Nailing down the specific `rocksdb` type `DBWithThreadMode<SingleThreaded>` to be used throughout the code base corresponds to how the `DB` typedef happens to be defined with the features selected in the workspace for the `rocksdb` dependency. This brings no functional differences.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
