### PR TITLE
[gha][docker] migrate to runs-on runners

### DIFF
--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -73,11 +73,26 @@ permissions:
 
 jobs:
   rust-all:
-    runs-on: experimental-docker
+    runs-on: runs-on,cpu=64,family=c7,hdd=1024,image=aptos-ubuntu-x64,run-id=${{ github.run_id }} 
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ env.GIT_SHA }}
+
+      - name: Setup Runs On Cache for Docker
+        uses: runs-on/cache@v4
+        with:
+          path: |
+            /home/runner/docker-cache.tzst
+          key: docker-buildkit-cache-${{ env.PROFILE }}-${{ env.FEATURES }}${{ hashFiles('Cargo.lock') }}
+
+      - name: Untar cache if present
+        run: |
+          if [ -f /home/runner/docker-cache.tzst ]; then
+            sudo systemctl stop docker
+            sudo tar --posix -xf /home/runner/docker-cache.tzst -P -C /var/lib/docker --use-compress-program zstdmt .
+            sudo systemctl start docker
+          fi          
 
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
@@ -96,3 +111,11 @@ jobs:
           BUILD_ADDL_TESTING_IMAGES: ${{ env.BUILD_ADDL_TESTING_IMAGES }}
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
           TARGET_REGISTRY: ${{ env.TARGET_REGISTRY }}
+      
+      - name: Prepare Docker for Caching
+        run: |
+          if [ ! -f /home/runner/docker-cache.tzst ]; then
+            sudo systemctl stop docker
+            sudo tar --posix -cf /home/runner/docker-cache.tzst -P -C /var/lib/docker --use-compress-program zstdmt .
+          fi
+

--- a/docker/builder/builder.Dockerfile
+++ b/docker/builder/builder.Dockerfile
@@ -53,7 +53,6 @@ FROM builder-base as aptos-node-builder
 RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
     --mount=type=cache,target=/usr/local/cargo/git,id=node-builder-cargo-git-cache \
     --mount=type=cache,target=/usr/local/cargo/registry,id=node-builder-cargo-registry-cache \
-    --mount=type=cache,target=/aptos/target,id=node-builder-target-cache \
     docker/builder/build-node.sh
 
 FROM builder-base as tools-builder
@@ -61,7 +60,6 @@ FROM builder-base as tools-builder
 RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
     --mount=type=cache,target=/usr/local/cargo/git,id=tools-builder-cargo-git-cache \
     --mount=type=cache,target=/usr/local/cargo/registry,id=tools-builder-cargo-registry-cache \
-    --mount=type=cache,target=/aptos/target,id=tools-builder-target-cache \
     docker/builder/build-tools.sh
 
 FROM builder-base as indexer-builder
@@ -69,5 +67,4 @@ FROM builder-base as indexer-builder
 RUN --mount=type=secret,id=GIT_CREDENTIALS,target=/root/.git-credentials \
     --mount=type=cache,target=/usr/local/cargo/git,id=indexer-builder-cargo-git-cache \
     --mount=type=cache,target=/usr/local/cargo/registry,id=indexer-builder-cargo-registry-cache \
-    --mount=type=cache,target=/aptos/target,id=indexer-builder-target-cache \
     docker/builder/build-indexer.sh


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR migrates the docker build workflow to use runs-on runners. This setup is quite different from our experimental-docker setup in that it uses S3 caches instead of attached volumes. Essentially, there is a step that archives the `/var/lib/docker` folder and caches it. To workaround using the `cache` action on a privileged directory, a step first tars the directory with `sudo` privileges and then invokes the cache action. Similar, on download, it downloads the tar and untars it.
