### PR TITLE
[consensus] leader election: lazy init cached db results

### DIFF
--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -701,13 +701,6 @@ impl ProposerElection for LeaderReputation {
     ) -> (Author, VotingPowerRatio) {
         let target_round = round.saturating_sub(self.exclude_round);
         let (sliding_window, root_hash) = self.backend.get_block_metadata(self.epoch, target_round);
-        info!(
-            "round: {}, target_round: {}, root_hash: {}, sliding_window.len(): {}",
-            round,
-            target_round,
-            root_hash,
-            sliding_window.len()
-        );
         let voting_power_participation_ratio =
             self.compute_chain_health_and_add_metrics(&sliding_window, round);
         let mut weights =

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -4,7 +4,6 @@
 
 use crate::cached_state_view::ShardedStateCache;
 use aptos_crypto::{hash::CryptoHash, HashValue};
-use aptos_logger::info;
 pub use aptos_types::indexer::indexer_db_reader::Order;
 use aptos_types::{
     account_address::AccountAddress,
@@ -469,14 +468,8 @@ pub trait DbReader: Send + Sync {
     /// Returns the latest committed version, error on on non-bootstrapped/empty DB.
     /// N.b. different from `get_synced_version()`.
     fn get_latest_ledger_info_version(&self) -> Result<Version> {
-        self.get_latest_ledger_info().map(|li| {
-            info!(
-                "latest ledger info version: {}, round: {}",
-                li.ledger_info().version(),
-                li.ledger_info().round()
-            );
-            li.ledger_info().version()
-        })
+        self.get_latest_ledger_info()
+            .map(|li| li.ledger_info().version())
     }
 
     /// Returns the latest version and committed block timestamp

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -4,6 +4,7 @@
 
 use crate::cached_state_view::ShardedStateCache;
 use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_logger::info;
 pub use aptos_types::indexer::indexer_db_reader::Order;
 use aptos_types::{
     account_address::AccountAddress,
@@ -468,8 +469,14 @@ pub trait DbReader: Send + Sync {
     /// Returns the latest committed version, error on on non-bootstrapped/empty DB.
     /// N.b. different from `get_synced_version()`.
     fn get_latest_ledger_info_version(&self) -> Result<Version> {
-        self.get_latest_ledger_info()
-            .map(|li| li.ledger_info().version())
+        self.get_latest_ledger_info().map(|li| {
+            info!(
+                "latest ledger info version: {}, round: {}",
+                li.ledger_info().version(),
+                li.ledger_info().round()
+            );
+            li.ledger_info().version()
+        })
     }
 
     /// Returns the latest version and committed block timestamp


### PR DESCRIPTION
## Description
Lazy init db result on first call to leader reputation. Otherwise there was a corner case where it would not start updating until one block after genesis. (This is the reason smoke test `client::test_basic_fault_tolerance` was flaky.)

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Ran `client::test_basic_fault_tolerance` multiple times
* Haven't seen it fail.
* Added verbose logs (since removed) to confirm that the block event sliding window now starts at length 1 (genesis) instead of length 0 (which is a bug, since genesis should be there)

## Key Areas to Review
This should only affect the corner case of a fresh chain. Experts should double check.

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
