### PR TITLE
[gha][docker] use capacity optimized spot runners

### DIFF
--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -73,7 +73,7 @@ permissions:
 
 jobs:
   rust-all:
-    runs-on: runs-on,cpu=64,family=c7,hdd=1024,image=aptos-ubuntu-x64,run-id=${{ github.run_id }} 
+    runs-on: runs-on,cpu=64,family=c7,hdd=1024,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=co
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Using `capacity-optimized` spot instances to limit preemptions.