### PR TITLE
[Consensus Observer] Add block payload verification.

### DIFF
--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -30,7 +30,7 @@ pub struct ConsensusObserverConfig {
 
     /// Interval (in milliseconds) to garbage collect peer state
     pub garbage_collection_interval_ms: u64,
-    /// Maximum number of pending blocks to keep in memory
+    /// Maximum number of blocks to keep in memory (e.g., pending blocks, ordered blocks, etc.)
     pub max_num_pending_blocks: u64,
     /// Maximum timeout (in milliseconds) for active subscriptions
     pub max_subscription_timeout_ms: u64,

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -165,6 +165,10 @@ impl ProofWithData {
         }
     }
 
+    pub fn empty() -> Self {
+        Self::new(vec![])
+    }
+
     pub fn extend(&mut self, other: ProofWithData) {
         let other_data_status = other.status.lock().as_mut().unwrap().take();
         self.proofs.extend(other.proofs);

--- a/consensus/src/consensus_observer/ordered_blocks.rs
+++ b/consensus/src/consensus_observer/ordered_blocks.rs
@@ -36,6 +36,11 @@ impl PendingOrderedBlocks {
         }
     }
 
+    /// Clears all pending blocks
+    pub fn clear_all_pending_blocks(&self) {
+        self.pending_blocks.lock().clear();
+    }
+
     /// Returns a copy of the verified pending blocks
     pub fn get_all_verified_pending_blocks(
         &self,
@@ -256,7 +261,40 @@ mod test {
     };
 
     #[test]
-    pub fn test_get_last_pending_block() {
+    fn test_clear_all_pending_blocks() {
+        // Create new pending ordered blocks
+        let pending_ordered_blocks = PendingOrderedBlocks::new(ConsensusObserverConfig::default());
+
+        // Insert several verified blocks for the current epoch
+        let current_epoch = 0;
+        let num_verified_blocks = 10;
+        create_and_add_pending_blocks(
+            &pending_ordered_blocks,
+            num_verified_blocks,
+            current_epoch,
+            true,
+        );
+
+        // Insert several unverified blocks for the next epoch
+        let next_epoch = current_epoch + 1;
+        let num_unverified_blocks = 20;
+        create_and_add_pending_blocks(
+            &pending_ordered_blocks,
+            num_unverified_blocks,
+            next_epoch,
+            false,
+        );
+
+        // Clear all pending blocks
+        pending_ordered_blocks.clear_all_pending_blocks();
+
+        // Check all the pending blocks were removed
+        let num_pending_blocks = pending_ordered_blocks.pending_blocks.lock().len();
+        assert_eq!(num_pending_blocks, 0);
+    }
+
+    #[test]
+    fn test_get_last_pending_block() {
         // Create new pending ordered blocks
         let pending_ordered_blocks = PendingOrderedBlocks::new(ConsensusObserverConfig::default());
 
@@ -313,7 +351,7 @@ mod test {
     }
 
     #[test]
-    pub fn test_get_verified_pending_block() {
+    fn test_get_verified_pending_block() {
         // Create new pending ordered blocks
         let pending_ordered_blocks = PendingOrderedBlocks::new(ConsensusObserverConfig::default());
 
@@ -369,7 +407,7 @@ mod test {
     }
 
     #[test]
-    pub fn test_insert_ordered_block_limit() {
+    fn test_insert_ordered_block_limit() {
         // Create a consensus observer config with a maximum of 10 pending blocks
         let max_num_pending_blocks = 10;
         let consensus_observer_config = ConsensusObserverConfig {
@@ -418,7 +456,7 @@ mod test {
     }
 
     #[test]
-    pub fn test_remove_blocks_for_commit() {
+    fn test_remove_blocks_for_commit() {
         // Create new pending ordered blocks
         let pending_ordered_blocks = PendingOrderedBlocks::new(ConsensusObserverConfig::default());
 
@@ -517,7 +555,7 @@ mod test {
     }
 
     #[test]
-    pub fn test_update_commit_decision() {
+    fn test_update_commit_decision() {
         // Create new pending ordered blocks
         let pending_ordered_blocks = PendingOrderedBlocks::new(ConsensusObserverConfig::default());
 

--- a/consensus/src/consensus_observer/ordered_blocks.rs
+++ b/consensus/src/consensus_observer/ordered_blocks.rs
@@ -767,8 +767,8 @@ mod test {
             validator_signer.public_key(),
             100,
         );
-        let validator_verified = ValidatorVerifier::new(vec![validator_consensus_info]);
-        let epoch_state = EpochState::new(next_epoch, validator_verified);
+        let validator_verifier = ValidatorVerifier::new(vec![validator_consensus_info]);
+        let epoch_state = EpochState::new(next_epoch, validator_verifier);
 
         // Verify the pending blocks for the next epoch
         pending_ordered_blocks.verify_pending_blocks(&epoch_state);

--- a/consensus/src/consensus_observer/payload_store.rs
+++ b/consensus/src/consensus_observer/payload_store.rs
@@ -65,6 +65,11 @@ impl BlockPayloadStore {
         })
     }
 
+    /// Clears all the payloads from the block payload store
+    pub fn clear_all_payloads(&self) {
+        self.block_transaction_payloads.lock().clear();
+    }
+
     /// Returns a reference to the block transaction payloads
     pub fn get_block_payloads(&self) -> Arc<Mutex<HashMap<HashValue, BlockPayloadStatus>>> {
         self.block_transaction_payloads.clone()
@@ -170,6 +175,32 @@ mod test {
 
         // Check that the payloads no longer exist in the block payload store
         assert!(!block_payload_store.all_payloads_exist(subset_pipelined_blocks));
+    }
+
+    #[test]
+    fn test_clear_all_payloads() {
+        // Create a new block payload store
+        let block_payload_store = BlockPayloadStore::new();
+
+        // Add some blocks to the payload store
+        let num_blocks_in_store = 100;
+        let pipelined_blocks =
+            create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store);
+
+        // Check that all the payloads exist in the block payload store
+        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks));
+
+        // Clear all the payloads from the block payload store
+        block_payload_store.clear_all_payloads();
+
+        // Check that all the payloads exist in the block payload store
+        assert!(!block_payload_store.all_payloads_exist(&pipelined_blocks));
+
+        // Check that the block payload store is empty
+        assert!(block_payload_store
+            .block_transaction_payloads
+            .lock()
+            .is_empty());
     }
 
     #[test]

--- a/consensus/src/consensus_observer/payload_store.rs
+++ b/consensus/src/consensus_observer/payload_store.rs
@@ -4,308 +4,875 @@
 use crate::consensus_observer::{
     logging::{LogEntry, LogSchema},
     metrics,
+    network_message::BlockPayload,
 };
-use aptos_consensus_types::pipelined_block::PipelinedBlock;
-use aptos_crypto::HashValue;
+use aptos_config::config::ConsensusObserverConfig;
+use aptos_consensus_types::{common::Round, pipelined_block::PipelinedBlock};
 use aptos_infallible::Mutex;
-use aptos_logger::error;
-use aptos_types::{block_info::BlockInfo, transaction::SignedTransaction};
+use aptos_logger::{error, warn};
+use aptos_types::epoch_state::EpochState;
 use std::{
-    collections::{hash_map::Entry, HashMap},
-    mem,
+    collections::{btree_map::Entry, BTreeMap},
     sync::Arc,
 };
-use tokio::sync::oneshot;
 
-/// The transaction payload of each block
-#[derive(Debug, Clone)]
-pub struct BlockTransactionPayload {
-    pub transactions: Vec<SignedTransaction>,
-    pub limit: Option<u64>,
-}
-
-impl BlockTransactionPayload {
-    pub fn new(transactions: Vec<SignedTransaction>, limit: Option<u64>) -> Self {
-        Self {
-            transactions,
-            limit,
-        }
-    }
-}
-
-/// The status of the block payload (requested or available)
+/// The status of the block payload
 pub enum BlockPayloadStatus {
-    Requested(oneshot::Sender<BlockTransactionPayload>),
-    Available(BlockTransactionPayload),
+    AvailableAndVerified(BlockPayload),
+    AvailableAndUnverified(BlockPayload),
 }
 
 /// A simple struct to store the block payloads of ordered and committed blocks
 #[derive(Clone)]
 pub struct BlockPayloadStore {
-    // Block transaction payloads map the block ID to the transaction payloads
-    // (the same payloads that the payload manager returns).
-    block_transaction_payloads: Arc<Mutex<HashMap<HashValue, BlockPayloadStatus>>>,
+    // The configuration of the consensus observer
+    consensus_observer_config: ConsensusObserverConfig,
+
+    // Block transaction payloads (indexed by epoch and round)
+    block_payloads: Arc<Mutex<BTreeMap<(u64, Round), BlockPayloadStatus>>>,
 }
 
 impl BlockPayloadStore {
-    pub fn new() -> Self {
+    pub fn new(consensus_observer_config: ConsensusObserverConfig) -> Self {
         Self {
-            block_transaction_payloads: Arc::new(Mutex::new(HashMap::new())),
+            consensus_observer_config,
+            block_payloads: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
 
-    /// Returns true iff all the payloads for the given blocks are available
+    /// Returns true iff all the payloads for the given blocks
+    /// are available and have been verified.
     pub fn all_payloads_exist(&self, blocks: &[Arc<PipelinedBlock>]) -> bool {
-        let block_transaction_payloads = self.block_transaction_payloads.lock();
+        let block_payloads = self.block_payloads.lock();
         blocks.iter().all(|block| {
+            let epoch_and_round = (block.epoch(), block.round());
             matches!(
-                block_transaction_payloads.get(&block.id()),
-                Some(BlockPayloadStatus::Available(_))
+                block_payloads.get(&epoch_and_round),
+                Some(BlockPayloadStatus::AvailableAndVerified(_))
             )
         })
     }
 
     /// Clears all the payloads from the block payload store
     pub fn clear_all_payloads(&self) {
-        self.block_transaction_payloads.lock().clear();
+        self.block_payloads.lock().clear();
     }
 
-    /// Returns a reference to the block transaction payloads
-    pub fn get_block_payloads(&self) -> Arc<Mutex<HashMap<HashValue, BlockPayloadStatus>>> {
-        self.block_transaction_payloads.clone()
+    /// Returns a reference to the block payloads
+    pub fn get_block_payloads(&self) -> Arc<Mutex<BTreeMap<(u64, Round), BlockPayloadStatus>>> {
+        self.block_payloads.clone()
     }
 
     /// Inserts the given block payload data into the payload store
     pub fn insert_block_payload(
         &mut self,
-        block: BlockInfo,
-        transactions: Vec<SignedTransaction>,
-        limit: Option<u64>,
+        block_payload: BlockPayload,
+        verified_payload_signatures: bool,
     ) {
-        let mut block_transaction_payloads = self.block_transaction_payloads.lock();
-        let block_transaction_payload = BlockTransactionPayload::new(transactions, limit);
-
-        match block_transaction_payloads.entry(block.id()) {
-            Entry::Occupied(mut entry) => {
-                // Replace the data status with the new block payload
-                let mut status = BlockPayloadStatus::Available(block_transaction_payload.clone());
-                mem::swap(entry.get_mut(), &mut status);
-
-                // If the status was originally requested, send the payload to the listener
-                if let BlockPayloadStatus::Requested(payload_sender) = status {
-                    if payload_sender.send(block_transaction_payload).is_err() {
-                        error!(LogSchema::new(LogEntry::ConsensusObserver)
-                            .message("Failed to send block payload to listener!",));
-                    }
-                }
-            },
-            Entry::Vacant(entry) => {
-                // Insert the block payload directly into the payload store
-                entry.insert(BlockPayloadStatus::Available(block_transaction_payload));
-            },
+        // Verify that the number of payloads doesn't exceed the maximum
+        let max_num_pending_blocks = self.consensus_observer_config.max_num_pending_blocks as usize;
+        if self.block_payloads.lock().len() >= max_num_pending_blocks {
+            warn!(
+                LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                    "Exceeded the maximum number of payloads: {:?}. Dropping block: {:?}!",
+                    max_num_pending_blocks, block_payload.block,
+                ))
+            );
+            return; // Drop the block if we've exceeded the maximum
         }
+
+        // Create the new payload status
+        let epoch_and_round = (block_payload.block.epoch(), block_payload.block.round());
+        let payload_status = if verified_payload_signatures {
+            BlockPayloadStatus::AvailableAndVerified(block_payload)
+        } else {
+            BlockPayloadStatus::AvailableAndUnverified(block_payload)
+        };
+
+        // Insert the new payload status
+        self.block_payloads
+            .lock()
+            .insert(epoch_and_round, payload_status);
     }
 
-    /// Removes the given pipelined blocks from the payload store
-    pub fn remove_blocks(&self, blocks: &[Arc<PipelinedBlock>]) {
-        let mut block_transaction_payloads = self.block_transaction_payloads.lock();
-        for block in blocks.iter() {
-            block_transaction_payloads.remove(&block.id());
-        }
+    /// Removes all blocks up to the specified epoch and round (inclusive)
+    pub fn remove_blocks_for_epoch_round(&self, epoch: u64, round: Round) {
+        // Determine the round to split off
+        let split_off_round = round.saturating_add(1);
+
+        // Remove the blocks from the payload store
+        let mut block_payloads = self.block_payloads.lock();
+        *block_payloads = block_payloads.split_off(&(epoch, split_off_round));
+    }
+
+    /// Removes the committed blocks from the payload store
+    pub fn remove_committed_blocks(&self, committed_blocks: &[Arc<PipelinedBlock>]) {
+        // Get the highest epoch and round for the committed blocks
+        let (highest_epoch, highest_round) = committed_blocks
+            .last()
+            .map_or((0, 0), |block| (block.epoch(), block.round()));
+
+        // Remove the blocks
+        self.remove_blocks_for_epoch_round(highest_epoch, highest_round);
     }
 
     /// Updates the metrics for the payload store
     pub fn update_payload_store_metrics(&self) {
-        // Update the number of block transaction payloads
-        let block_transaction_payloads = self.block_transaction_payloads.lock();
-        let num_payloads = block_transaction_payloads.len() as u64;
+        // Update the number of block payloads
+        let num_payloads = self.block_payloads.lock().len() as u64;
         metrics::set_gauge_with_label(
             &metrics::OBSERVER_NUM_PROCESSED_BLOCKS,
             metrics::STORED_PAYLOADS_LABEL,
             num_payloads,
         );
-    }
-}
 
-impl Default for BlockPayloadStore {
-    fn default() -> Self {
-        Self::new()
+        // Update the highest round for the block payloads
+        let highest_round = self
+            .block_payloads
+            .lock()
+            .last_key_value()
+            .map(|((_, round), _)| *round)
+            .unwrap_or(0);
+        metrics::set_gauge_with_label(
+            &metrics::OBSERVER_PROCESSED_BLOCK_ROUNDS,
+            metrics::STORED_PAYLOADS_LABEL,
+            highest_round,
+        );
+    }
+
+    /// Verifies the block payload signatures against the given epoch state.
+    /// If verification is successful, blocks are marked as verified. Each
+    /// new verified block is
+    pub fn verify_payload_signatures(&mut self, epoch_state: &EpochState) -> Vec<Round> {
+        // Get the current epoch
+        let current_epoch = epoch_state.epoch;
+
+        // Gather the keys for the block payloads
+        let payload_epochs_and_rounds: Vec<(u64, Round)> =
+            self.block_payloads.lock().keys().cloned().collect();
+
+        // Go through all unverified blocks and attempt to verify the signatures
+        let mut verified_payloads_to_update = vec![];
+        for (epoch, round) in payload_epochs_and_rounds {
+            // Check if we can break early (BtreeMaps are sorted by key)
+            if epoch > current_epoch {
+                break;
+            }
+
+            // Otherwise, attempt to verify the payload signatures
+            if epoch == current_epoch {
+                if let Entry::Occupied(mut entry) = self.block_payloads.lock().entry((epoch, round))
+                {
+                    if let BlockPayloadStatus::AvailableAndUnverified(block_payload) =
+                        entry.get_mut()
+                    {
+                        if let Err(error) = block_payload.verify_payload_signatures(epoch_state) {
+                            // Log the verification failure
+                            error!(
+                                LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                                    "Failed to verify the block payload signatures for epoch: {:?} and round: {:?}. Error: {:?}",
+                                    epoch, round, error
+                                ))
+                            );
+
+                            // Remove the block payload from the store
+                            entry.remove();
+                        } else {
+                            // Save the block payload for reinsertion
+                            verified_payloads_to_update.push(block_payload.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        // Collect the rounds of all newly verified blocks
+        let verified_payload_rounds: Vec<Round> = verified_payloads_to_update
+            .iter()
+            .map(|block_payload| block_payload.block.round())
+            .collect();
+
+        // Update the verified block payloads. Note: this will cause
+        // notifications to be sent to any listeners that are waiting.
+        for verified_payload in verified_payloads_to_update {
+            self.insert_block_payload(verified_payload, true);
+        }
+
+        // Return the newly verified payload rounds
+        verified_payload_rounds
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::consensus_observer::network_message::BlockTransactionPayload;
     use aptos_consensus_types::{
         block::Block,
         block_data::{BlockData, BlockType},
+        common::ProofWithData,
+        proof_of_store::{BatchId, BatchInfo, ProofOfStore},
         quorum_cert::QuorumCert,
     };
-    use aptos_types::{block_info::Round, transaction::Version};
+    use aptos_crypto::HashValue;
+    use aptos_types::{
+        aggregate_signature::AggregateSignature,
+        block_info::{BlockInfo, Round},
+        transaction::Version,
+        validator_signer::ValidatorSigner,
+        validator_verifier::{ValidatorConsensusInfo, ValidatorVerifier},
+        PeerId,
+    };
+    use rand::{rngs::OsRng, Rng};
 
     #[test]
     fn test_all_payloads_exist() {
-        // Create a new block payload store
-        let block_payload_store = BlockPayloadStore::new();
+        // Create the consensus observer config
+        let max_num_pending_blocks = 1000;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
 
-        // Add some blocks to the payload store
+        // Create a new block payload store
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some unverified blocks to the payload store
         let num_blocks_in_store = 100;
-        let pipelined_blocks =
-            create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store);
+        let unverified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            1,
+            false,
+        );
+
+        // Verify the payloads don't exist in the block payload store
+        assert!(!block_payload_store.all_payloads_exist(&unverified_blocks));
+        assert_eq!(get_num_verified_payloads(&block_payload_store), 0);
+        assert_eq!(
+            get_num_unverified_payloads(&block_payload_store),
+            num_blocks_in_store
+        );
+
+        // Add some verified blocks to the payload store
+        let num_blocks_in_store = 100;
+        let verified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            0,
+            true,
+        );
 
         // Check that all the payloads exist in the block payload store
-        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks));
+        assert!(block_payload_store.all_payloads_exist(&verified_blocks));
 
         // Check that a subset of the payloads exist in the block payload store
-        let subset_pipelined_blocks = &pipelined_blocks[0..50];
-        assert!(block_payload_store.all_payloads_exist(subset_pipelined_blocks));
+        let subset_verified_blocks = &verified_blocks[0..50];
+        assert!(block_payload_store.all_payloads_exist(subset_verified_blocks));
 
         // Remove some of the payloads from the block payload store
-        block_payload_store.remove_blocks(subset_pipelined_blocks);
+        block_payload_store.remove_committed_blocks(subset_verified_blocks);
 
         // Check that the payloads no longer exist in the block payload store
-        assert!(!block_payload_store.all_payloads_exist(subset_pipelined_blocks));
+        assert!(!block_payload_store.all_payloads_exist(subset_verified_blocks));
 
         // Check that the remaining payloads still exist in the block payload store
-        let subset_pipelined_blocks = &pipelined_blocks[50..100];
-        assert!(block_payload_store.all_payloads_exist(subset_pipelined_blocks));
+        let subset_verified_blocks = &verified_blocks[50..100];
+        assert!(block_payload_store.all_payloads_exist(subset_verified_blocks));
 
         // Remove the remaining payloads from the block payload store
-        block_payload_store.remove_blocks(subset_pipelined_blocks);
+        block_payload_store.remove_committed_blocks(subset_verified_blocks);
 
         // Check that the payloads no longer exist in the block payload store
-        assert!(!block_payload_store.all_payloads_exist(subset_pipelined_blocks));
+        assert!(!block_payload_store.all_payloads_exist(subset_verified_blocks));
+    }
+
+    #[test]
+    fn test_all_payloads_exist_unverified() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add several verified blocks to the payload store
+        let num_blocks_in_store = 10;
+        let verified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            0,
+            true,
+        );
+
+        // Check that the payloads exists in the block payload store
+        assert!(block_payload_store.all_payloads_exist(&verified_blocks));
+
+        // Mark the payload of the first block as unverified
+        mark_payload_as_unverified(block_payload_store.clone(), &verified_blocks[0]);
+
+        // Check that the payload no longer exists in the block payload store
+        assert!(!block_payload_store.all_payloads_exist(&verified_blocks));
+
+        // Check that the remaining payloads still exist in the block payload store
+        assert!(block_payload_store.all_payloads_exist(&verified_blocks[1..10]));
     }
 
     #[test]
     fn test_clear_all_payloads() {
         // Create a new block payload store
-        let block_payload_store = BlockPayloadStore::new();
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
-        // Add some blocks to the payload store
-        let num_blocks_in_store = 100;
-        let pipelined_blocks =
-            create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store);
+        // Add some unverified blocks to the payload store
+        let num_blocks_in_store = 30;
+        create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store, 1, false);
 
-        // Check that all the payloads exist in the block payload store
-        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks));
+        // Add some verified blocks to the payload store
+        let verified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            0,
+            true,
+        );
+
+        // Check that the payloads exist in the block payload store
+        assert!(block_payload_store.all_payloads_exist(&verified_blocks));
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, num_blocks_in_store);
+        check_num_verified_payloads(&block_payload_store, num_blocks_in_store);
 
         // Clear all the payloads from the block payload store
         block_payload_store.clear_all_payloads();
 
-        // Check that all the payloads exist in the block payload store
-        assert!(!block_payload_store.all_payloads_exist(&pipelined_blocks));
+        // Check that the payloads no longer exist in the block payload store
+        assert!(!block_payload_store.all_payloads_exist(&verified_blocks));
 
         // Check that the block payload store is empty
-        assert!(block_payload_store
-            .block_transaction_payloads
-            .lock()
-            .is_empty());
-    }
-
-    #[test]
-    fn test_all_payloads_exist_requested() {
-        // Create a new block payload store
-        let block_payload_store = BlockPayloadStore::new();
-
-        // Add several blocks to the payload store
-        let num_blocks_in_store = 10;
-        let pipelined_blocks =
-            create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store);
-
-        // Check that the payloads exists in the block payload store
-        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks));
-
-        // Mark the payload of the first block as requested
-        mark_payload_as_requested(block_payload_store.clone(), pipelined_blocks[0].id());
-
-        // Check that the payload no longer exists in the block payload store
-        assert!(!block_payload_store.all_payloads_exist(&pipelined_blocks));
-
-        // Check that the remaining payloads still exist in the block payload store
-        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks[1..10]));
+        check_num_unverified_payloads(&block_payload_store, 0);
+        check_num_verified_payloads(&block_payload_store, 0);
     }
 
     #[test]
     fn test_insert_block_payload() {
         // Create a new block payload store
-        let mut block_payload_store = BlockPayloadStore::new();
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
-        // Add some blocks to the payload store
-        let num_blocks_in_store = 10;
-        let pipelined_blocks =
-            create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store);
+        // Add some verified blocks to the payload store
+        let num_blocks_in_store = 20;
+        let verified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            0,
+            true,
+        );
 
         // Check that the block payload store contains the new block payloads
-        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks));
+        assert!(block_payload_store.all_payloads_exist(&verified_blocks));
 
-        // Mark the payload of the first block as requested
-        let payload_receiver =
-            mark_payload_as_requested(block_payload_store.clone(), pipelined_blocks[0].id());
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, 0);
+        check_num_verified_payloads(&block_payload_store, num_blocks_in_store);
+
+        // Mark the payload of the first block as unverified
+        mark_payload_as_unverified(block_payload_store.clone(), &verified_blocks[0]);
 
         // Check that the payload no longer exists in the block payload store
-        assert!(!block_payload_store.all_payloads_exist(&pipelined_blocks));
+        assert!(!block_payload_store.all_payloads_exist(&verified_blocks));
 
-        // Insert the same block payload into the block payload store
-        block_payload_store.insert_block_payload(pipelined_blocks[0].block_info(), vec![], Some(0));
+        // Verify the number of verified blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, num_blocks_in_store - 1);
+
+        // Insert the same block payload into the block payload store (as verified)
+        let transaction_payload =
+            BlockTransactionPayload::new(vec![], Some(0), ProofWithData::empty(), vec![]);
+        let block_payload = BlockPayload::new(verified_blocks[0].block_info(), transaction_payload);
+        block_payload_store.insert_block_payload(block_payload, true);
 
         // Check that the block payload store now contains the requested block payload
-        assert!(block_payload_store.all_payloads_exist(&pipelined_blocks));
-
-        // Check that the payload receiver receives the requested block payload message
-        let block_transaction_payload = payload_receiver.blocking_recv().unwrap();
-        assert!(block_transaction_payload.transactions.is_empty());
-        assert_eq!(block_transaction_payload.limit, Some(0));
+        assert!(block_payload_store.all_payloads_exist(&verified_blocks));
     }
 
     #[test]
-    fn test_remove_blocks() {
+    fn test_insert_block_payload_limit_verified() {
+        // Create a new config observer config
+        let max_num_pending_blocks = 10;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
         // Create a new block payload store
-        let block_payload_store = BlockPayloadStore::new();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
-        // Add some blocks to the payload store
-        let num_blocks_in_store = 10;
-        let pipelined_blocks =
-            create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store);
+        // Add the maximum number of verified blocks to the payload store
+        let num_blocks_in_store = max_num_pending_blocks as usize;
+        create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store, 0, true);
 
-        // Remove the first block from the block payload store
-        block_payload_store.remove_blocks(&pipelined_blocks[0..1]);
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, num_blocks_in_store);
+        check_num_unverified_payloads(&block_payload_store, 0);
 
-        // Check that the block payload store no longer contains the removed block
-        let block_transaction_payloads = block_payload_store.get_block_payloads();
-        assert!(!block_transaction_payloads
-            .lock()
-            .contains_key(&pipelined_blocks[0].id()));
+        // Add more blocks to the payload store
+        let num_blocks_to_add = 5;
+        create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_to_add, 0, true);
 
-        // Remove the last 5 blocks from the block payload store
-        block_payload_store.remove_blocks(&pipelined_blocks[5..10]);
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, max_num_pending_blocks as usize);
+        check_num_unverified_payloads(&block_payload_store, 0);
+
+        // Add a large number of blocks to the payload store
+        let num_blocks_to_add = 100;
+        create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_to_add, 0, true);
+
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, max_num_pending_blocks as usize);
+        check_num_unverified_payloads(&block_payload_store, 0);
+    }
+
+    #[test]
+    fn test_insert_block_payload_limit_unverified() {
+        // Create a new config observer config
+        let max_num_pending_blocks = 10;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
+        // Create a new block payload store
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add the maximum number of unverified blocks to the payload store
+        let num_blocks_in_store = max_num_pending_blocks as usize;
+        create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_in_store, 0, false);
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, num_blocks_in_store);
+        check_num_verified_payloads(&block_payload_store, 0);
+
+        // Add more blocks to the payload store
+        let num_blocks_to_add = 5;
+        create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_to_add, 0, false);
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, max_num_pending_blocks as usize);
+        check_num_verified_payloads(&block_payload_store, 0);
+
+        // Add a large number of blocks to the payload store
+        let num_blocks_to_add = 100;
+        create_and_add_blocks_to_store(block_payload_store.clone(), num_blocks_to_add, 0, false);
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, max_num_pending_blocks as usize);
+        check_num_verified_payloads(&block_payload_store, 0);
+    }
+
+    #[test]
+    fn test_remove_blocks_for_epoch_round_verified() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some verified blocks to the payload store for the current epoch
+        let current_epoch = 0;
+        let num_blocks_in_store = 100;
+        let verified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            current_epoch,
+            true,
+        );
+
+        // Remove all the blocks for the given epoch and round
+        block_payload_store.remove_blocks_for_epoch_round(current_epoch, 49);
 
         // Check that the block payload store no longer contains the removed blocks
-        let block_transaction_payloads = block_payload_store.get_block_payloads();
-        for pipelined_block in pipelined_blocks.iter().take(10).skip(5) {
-            assert!(!block_transaction_payloads
+        let block_payloads = block_payload_store.get_block_payloads();
+        for verified_block in verified_blocks.iter().take(50) {
+            assert!(!block_payloads
                 .lock()
-                .contains_key(&pipelined_block.id()));
+                .contains_key(&(verified_block.epoch(), verified_block.round())));
         }
 
-        // Remove all the blocks from the block payload store (including some that don't exist)
-        block_payload_store.remove_blocks(&pipelined_blocks[0..10]);
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, num_blocks_in_store - 50);
+
+        // Remove all the blocks for the given epoch and round
+        block_payload_store
+            .remove_blocks_for_epoch_round(current_epoch, num_blocks_in_store as Round);
 
         // Check that the block payload store no longer contains any blocks
-        let block_transaction_payloads = block_payload_store.get_block_payloads();
-        assert!(block_transaction_payloads.lock().is_empty());
+        let block_payloads = block_payload_store.get_block_payloads();
+        assert!(block_payloads.lock().is_empty());
+
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, 0);
+
+        // Add some verified blocks to the payload store for the next epoch
+        let next_epoch = current_epoch + 1;
+        create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            next_epoch,
+            true,
+        );
+
+        // Remove all the blocks for the future epoch and round
+        let future_epoch = next_epoch + 1;
+        block_payload_store.remove_blocks_for_epoch_round(future_epoch, 0);
+
+        // Verify the store is now empty
+        check_num_verified_payloads(&block_payload_store, 0);
+    }
+
+    #[test]
+    fn test_remove_blocks_for_epoch_round_unverified() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some unverified blocks to the payload store for the current epoch
+        let current_epoch = 10;
+        let num_blocks_in_store = 100;
+        let unverified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            current_epoch,
+            false,
+        );
+
+        // Remove all the blocks for the given epoch and round
+        block_payload_store.remove_blocks_for_epoch_round(current_epoch, 49);
+
+        // Check that the block payload store no longer contains the removed blocks
+        for unverified_block in unverified_blocks.iter().take(50) {
+            assert!(!block_payload_store
+                .block_payloads
+                .lock()
+                .contains_key(&(unverified_block.epoch(), unverified_block.round())));
+        }
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, num_blocks_in_store - 50);
+
+        // Remove all the blocks for the given epoch and round
+        block_payload_store
+            .remove_blocks_for_epoch_round(current_epoch, num_blocks_in_store as Round);
+
+        // Check that the block payload store no longer contains any blocks
+        assert!(block_payload_store.block_payloads.lock().is_empty());
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, 0);
+
+        // Add some unverified blocks to the payload store for the next epoch
+        let next_epoch = current_epoch + 1;
+        create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            next_epoch,
+            false,
+        );
+
+        // Remove all the blocks for the future epoch and round
+        let future_epoch = next_epoch + 10;
+        block_payload_store.remove_blocks_for_epoch_round(future_epoch, 0);
+
+        // Verify the store is now empty
+        check_num_unverified_payloads(&block_payload_store, 0);
+    }
+
+    #[test]
+    fn test_remove_committed_blocks_verified() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some blocks to the payload store for the current epoch
+        let current_epoch = 0;
+        let num_blocks_in_store = 100;
+        let verified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            current_epoch,
+            true,
+        );
+
+        // Remove the first block from the block payload store
+        block_payload_store.remove_committed_blocks(&verified_blocks[0..1]);
+
+        // Check that the block payload store no longer contains the removed block
+        let block_payloads = block_payload_store.get_block_payloads();
+        let removed_block = &verified_blocks[0];
+        assert!(!block_payloads
+            .lock()
+            .contains_key(&(removed_block.epoch(), removed_block.round())));
+
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, num_blocks_in_store - 1);
+
+        // Remove the last 5 blocks from the block payload store
+        block_payload_store.remove_committed_blocks(&verified_blocks[5..10]);
+
+        // Check that the block payload store no longer contains the removed blocks
+        let block_payloads = block_payload_store.get_block_payloads();
+        for verified_block in verified_blocks.iter().take(10).skip(5) {
+            assert!(!block_payloads
+                .lock()
+                .contains_key(&(verified_block.epoch(), verified_block.round())));
+        }
+
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, num_blocks_in_store - 10);
+
+        // Remove all the blocks from the block payload store (including some that don't exist)
+        block_payload_store.remove_committed_blocks(&verified_blocks[0..num_blocks_in_store]);
+
+        // Check that the block payload store no longer contains any blocks
+        let block_payloads = block_payload_store.get_block_payloads();
+        assert!(block_payloads.lock().is_empty());
+
+        // Verify the number of blocks in the block payload store
+        check_num_verified_payloads(&block_payload_store, 0);
+
+        // Add some blocks to the payload store for the next epoch
+        let next_epoch = 1;
+        let verified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            next_epoch,
+            true,
+        );
+
+        // Remove the last committed block from the future epoch
+        block_payload_store.remove_committed_blocks(&verified_blocks[99..100]);
+
+        // Check that the block payload store is now empty
+        check_num_verified_payloads(&block_payload_store, 0);
+    }
+
+    #[test]
+    fn test_remove_committed_blocks_unverified() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some blocks to the payload store for the current epoch
+        let current_epoch = 10;
+        let num_blocks_in_store = 100;
+        let unverified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            current_epoch,
+            false,
+        );
+
+        // Remove the first block from the block payload store
+        block_payload_store.remove_committed_blocks(&unverified_blocks[0..1]);
+
+        // Check that the block payload store no longer contains the removed block
+        let removed_block = &unverified_blocks[0];
+        assert!(!block_payload_store
+            .block_payloads
+            .lock()
+            .contains_key(&(removed_block.epoch(), removed_block.round())));
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, num_blocks_in_store - 1);
+
+        // Remove the last 5 blocks from the block payload store
+        block_payload_store.remove_committed_blocks(&unverified_blocks[5..10]);
+
+        // Check that the block payload store no longer contains the removed blocks
+        for verified_block in unverified_blocks.iter().take(10).skip(5) {
+            assert!(!block_payload_store
+                .block_payloads
+                .lock()
+                .contains_key(&(verified_block.epoch(), verified_block.round())));
+        }
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, num_blocks_in_store - 10);
+
+        // Remove all the blocks from the block payload store (including some that don't exist)
+        block_payload_store.remove_committed_blocks(&unverified_blocks[0..num_blocks_in_store]);
+
+        // Check that the block payload store no longer contains any blocks
+        assert!(block_payload_store.block_payloads.lock().is_empty());
+
+        // Verify the number of blocks in the block payload store
+        check_num_unverified_payloads(&block_payload_store, 0);
+
+        // Add some blocks to the payload store for the next epoch
+        let next_epoch = 11;
+        let unverified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_blocks_in_store,
+            next_epoch,
+            false,
+        );
+
+        // Remove the last committed block from the future epoch
+        block_payload_store.remove_committed_blocks(&unverified_blocks[99..100]);
+
+        // Check that the block payload store is now empty
+        check_num_unverified_payloads(&block_payload_store, 0);
+    }
+
+    #[test]
+    fn test_verify_payload_signatures() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some verified blocks for the current epoch
+        let current_epoch = 0;
+        let num_verified_blocks = 10;
+        create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_verified_blocks,
+            current_epoch,
+            true,
+        );
+
+        // Add some unverified blocks for the next epoch
+        let next_epoch = current_epoch + 1;
+        let num_unverified_blocks = 20;
+        let unverified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_unverified_blocks,
+            next_epoch,
+            false,
+        );
+
+        // Add some unverified blocks for a future epoch
+        let future_epoch = current_epoch + 30;
+        let num_future_blocks = 30;
+        let future_unverified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_future_blocks,
+            future_epoch,
+            false,
+        );
+
+        // Create an epoch state for the next epoch (with an empty verifier)
+        let epoch_state = EpochState::new(next_epoch, ValidatorVerifier::new(vec![]));
+
+        // Verify the block payload signatures
+        block_payload_store.verify_payload_signatures(&epoch_state);
+
+        // Verify the unverified payloads were moved to the verified store
+        assert!(block_payload_store.all_payloads_exist(&unverified_blocks));
+        assert_eq!(
+            get_num_verified_payloads(&block_payload_store),
+            num_verified_blocks + num_unverified_blocks
+        );
+        assert_eq!(
+            get_num_unverified_payloads(&block_payload_store),
+            num_future_blocks
+        );
+
+        // Clear the verified blocks and check the verified blocks are empty
+        block_payload_store.remove_committed_blocks(&unverified_blocks);
+        assert_eq!(get_num_verified_payloads(&block_payload_store), 0);
+
+        // Create an epoch state for the future epoch (with an empty verifier)
+        let epoch_state = EpochState::new(future_epoch, ValidatorVerifier::new(vec![]));
+
+        // Verify the block payload signatures for a future epoch
+        block_payload_store.verify_payload_signatures(&epoch_state);
+
+        // Verify the future unverified payloads were moved to the verified store
+        assert!(block_payload_store.all_payloads_exist(&future_unverified_blocks));
+        assert_eq!(
+            get_num_verified_payloads(&block_payload_store),
+            num_future_blocks
+        );
+        assert_eq!(get_num_unverified_payloads(&block_payload_store), 0);
+    }
+
+    #[test]
+    fn test_verify_payload_signatures_failure() {
+        // Create a new block payload store
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+
+        // Add some verified blocks for the current epoch
+        let current_epoch = 10;
+        let num_verified_blocks = 6;
+        create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_verified_blocks,
+            current_epoch,
+            true,
+        );
+
+        // Add some unverified blocks for the next epoch
+        let next_epoch = current_epoch + 1;
+        let num_unverified_blocks = 15;
+        let unverified_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_unverified_blocks,
+            next_epoch,
+            false,
+        );
+
+        // Add some unverified blocks for a future epoch
+        let future_epoch = next_epoch + 1;
+        let num_future_blocks = 10;
+        let unverified_future_blocks = create_and_add_blocks_to_store(
+            block_payload_store.clone(),
+            num_future_blocks,
+            future_epoch,
+            false,
+        );
+
+        // Create an epoch state for the next epoch (with a non-empty verifier)
+        let validator_signer = ValidatorSigner::random(None);
+        let validator_consensus_info = ValidatorConsensusInfo::new(
+            validator_signer.author(),
+            validator_signer.public_key(),
+            100,
+        );
+        let validator_verifier = ValidatorVerifier::new(vec![validator_consensus_info]);
+        let epoch_state = EpochState::new(next_epoch, validator_verifier.clone());
+
+        // Verify the block payload signatures (for this epoch)
+        block_payload_store.verify_payload_signatures(&epoch_state);
+
+        // Ensure the unverified payloads were not verified
+        assert!(!block_payload_store.all_payloads_exist(&unverified_blocks));
+
+        // Ensure the unverified payloads were all removed (for this epoch)
+        assert_eq!(
+            get_num_unverified_payloads(&block_payload_store),
+            num_future_blocks
+        );
+
+        // Create an epoch state for the future epoch (with a non-empty verifier)
+        let epoch_state = EpochState::new(future_epoch, validator_verifier);
+
+        // Verify the block payload signatures (for the future epoch)
+        block_payload_store.verify_payload_signatures(&epoch_state);
+
+        // Ensure the future unverified payloads were not verified
+        assert!(!block_payload_store.all_payloads_exist(&unverified_future_blocks));
+
+        // Ensure the future unverified payloads were all removed (for the future epoch)
+        assert_eq!(get_num_unverified_payloads(&block_payload_store), 0);
     }
 
     /// Creates and adds the given number of blocks to the block payload store
     fn create_and_add_blocks_to_store(
         mut block_payload_store: BlockPayloadStore,
         num_blocks: usize,
+        epoch: u64,
+        verified_payload_signatures: bool,
     ) -> Vec<Arc<PipelinedBlock>> {
         let mut pipelined_blocks = vec![];
         for i in 0..num_blocks {
             // Create the block info
             let block_info = BlockInfo::new(
-                i as u64,
+                epoch,
                 i as Round,
                 HashValue::random(),
                 HashValue::random(),
@@ -314,8 +881,31 @@ mod test {
                 None,
             );
 
+            // Create the block transaction payload with proofs of store
+            let mut proofs_of_store = vec![];
+            for _ in 0..10 {
+                let batch_info = BatchInfo::new(
+                    PeerId::random(),
+                    BatchId::new(0),
+                    epoch,
+                    0,
+                    HashValue::random(),
+                    0,
+                    0,
+                    0,
+                );
+                proofs_of_store.push(ProofOfStore::new(batch_info, AggregateSignature::empty()));
+            }
+            let block_transaction_payload = BlockTransactionPayload::new(
+                vec![],
+                None,
+                ProofWithData::new(proofs_of_store),
+                vec![],
+            );
+
             // Insert the block payload into the store
-            block_payload_store.insert_block_payload(block_info.clone(), vec![], Some(i as u64));
+            let block_payload = BlockPayload::new(block_info.clone(), block_transaction_payload);
+            block_payload_store.insert_block_payload(block_payload, verified_payload_signatures);
 
             // Create the equivalent pipelined block
             let block_data = BlockData::new_for_testing(
@@ -335,21 +925,67 @@ mod test {
         pipelined_blocks
     }
 
-    /// Marks the payload of the given block ID as requested and returns the receiver
-    fn mark_payload_as_requested(
+    /// Checks the number of unverified payloads in the block payload store
+    fn check_num_unverified_payloads(
+        block_payload_store: &BlockPayloadStore,
+        expected_num_payloads: usize,
+    ) {
+        let num_payloads = get_num_unverified_payloads(block_payload_store);
+        assert_eq!(num_payloads, expected_num_payloads);
+    }
+
+    /// Checks the number of verified payloads in the block payload store
+    fn check_num_verified_payloads(
+        block_payload_store: &BlockPayloadStore,
+        expected_num_payloads: usize,
+    ) {
+        let num_payloads = get_num_verified_payloads(block_payload_store);
+        assert_eq!(num_payloads, expected_num_payloads);
+    }
+
+    /// Generates and returns a random number (u64)
+    pub fn get_random_u64() -> u64 {
+        OsRng.gen()
+    }
+
+    /// Returns the number of unverified payloads in the block payload store
+    fn get_num_unverified_payloads(block_payload_store: &BlockPayloadStore) -> usize {
+        let mut num_unverified_payloads = 0;
+        for (_, block_payload_status) in block_payload_store.block_payloads.lock().iter() {
+            if let BlockPayloadStatus::AvailableAndUnverified(_) = block_payload_status {
+                num_unverified_payloads += 1;
+            }
+        }
+        num_unverified_payloads
+    }
+
+    /// Returns the number of verified payloads in the block payload store
+    fn get_num_verified_payloads(block_payload_store: &BlockPayloadStore) -> usize {
+        let mut num_verified_payloads = 0;
+        for (_, block_payload_status) in block_payload_store.block_payloads.lock().iter() {
+            if let BlockPayloadStatus::AvailableAndVerified(_) = block_payload_status {
+                num_verified_payloads += 1;
+            }
+        }
+        num_verified_payloads
+    }
+
+    /// Marks the payload of the given block as unverified
+    fn mark_payload_as_unverified(
         block_payload_store: BlockPayloadStore,
-        block_id: HashValue,
-    ) -> oneshot::Receiver<BlockTransactionPayload> {
-        // Get the block payload entry for the given block ID
+        block: &Arc<PipelinedBlock>,
+    ) {
+        // Get the payload entry for the given block
         let block_payloads = block_payload_store.get_block_payloads();
         let mut block_payloads = block_payloads.lock();
-        let block_payload = block_payloads.get_mut(&block_id).unwrap();
+        let block_payload = block_payloads
+            .get_mut(&(block.epoch(), block.round()))
+            .unwrap();
 
-        // Mark the block payload as requested
-        let (payload_sender, payload_receiver) = oneshot::channel();
-        *block_payload = BlockPayloadStatus::Requested(payload_sender);
-
-        // Return the payload receiver
-        payload_receiver
+        // Mark the block payload as unverified
+        *block_payload = BlockPayloadStatus::AvailableAndUnverified(BlockPayload::new(
+            block.block_info(),
+            BlockTransactionPayload::empty(),
+        ));
     }
 }

--- a/consensus/src/consensus_observer/pending_blocks.rs
+++ b/consensus/src/consensus_observer/pending_blocks.rs
@@ -180,6 +180,7 @@ impl PendingBlockStore {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::consensus_observer::network_message::{BlockPayload, BlockTransactionPayload};
     use aptos_consensus_types::{
         block::Block,
         block_data::{BlockData, BlockType},
@@ -399,7 +400,7 @@ mod test {
         );
 
         // Create a new block payload store and insert payloads for the second block
-        let mut block_payload_store = BlockPayloadStore::new();
+        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
         let second_block = pending_blocks[1].clone();
         insert_payloads_for_ordered_block(&mut block_payload_store, &second_block);
 
@@ -460,13 +461,15 @@ mod test {
         );
 
         // Create an empty block payload store
-        let mut block_payload_store = BlockPayloadStore::new();
+        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
         // Incrementally insert and process each payload for the first block
         let first_block = pending_blocks.first().unwrap().clone();
         for block in first_block.blocks().clone() {
             // Insert the block
-            block_payload_store.insert_block_payload(block.block_info(), vec![], None);
+            let block_payload =
+                BlockPayload::new(block.block_info(), BlockTransactionPayload::empty());
+            block_payload_store.insert_block_payload(block_payload, true);
 
             // Attempt to remove the block (which might not be ready)
             let payload_round = block.round();
@@ -507,7 +510,9 @@ mod test {
             // Insert the block only if this is not the first block
             let payload_round = block.round();
             if payload_round != last_block.first_block().round() {
-                block_payload_store.insert_block_payload(block.block_info(), vec![], None);
+                let block_payload =
+                    BlockPayload::new(block.block_info(), BlockTransactionPayload::empty());
+                block_payload_store.insert_block_payload(block_payload, true);
             }
 
             // Attempt to remove the block (which might not be ready)
@@ -554,7 +559,7 @@ mod test {
         );
 
         // Create a new block payload store and insert payloads for the first block
-        let mut block_payload_store = BlockPayloadStore::new();
+        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
         let first_block = pending_blocks.first().unwrap().clone();
         insert_payloads_for_ordered_block(&mut block_payload_store, &first_block);
 
@@ -635,7 +640,7 @@ mod test {
         );
 
         // Create an empty block payload store
-        let block_payload_store = BlockPayloadStore::new();
+        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
         // Remove the third block (which is not ready)
         let third_block = pending_blocks[2].clone();
@@ -737,7 +742,9 @@ mod test {
         ordered_block: &OrderedBlock,
     ) {
         for block in ordered_block.blocks() {
-            block_payload_store.insert_block_payload(block.block_info(), vec![], None);
+            let block_payload =
+                BlockPayload::new(block.block_info(), BlockTransactionPayload::empty());
+            block_payload_store.insert_block_payload(block_payload, true);
         }
     }
 

--- a/consensus/src/consensus_observer/publisher.rs
+++ b/consensus/src/consensus_observer/publisher.rs
@@ -314,7 +314,9 @@ fn spawn_message_serializer_and_sender(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::consensus_observer::network_message::BlockTransactionPayload;
     use aptos_config::network_id::NetworkId;
+    use aptos_consensus_types::common::ProofWithData;
     use aptos_crypto::HashValue;
     use aptos_network::{
         application::{metadata::ConnectionState, storage::PeersAndMetadata},
@@ -491,10 +493,11 @@ mod test {
         }
 
         // Publish a message to the active subscribers
+        let transaction_payload =
+            BlockTransactionPayload::new(vec![], Some(10), ProofWithData::empty(), vec![]);
         let block_payload_message = ConsensusObserverMessage::new_block_payload_message(
             BlockInfo::empty(),
-            vec![],
-            Some(10),
+            transaction_payload,
         );
         consensus_publisher
             .publish_message(block_payload_message.clone())
@@ -537,8 +540,10 @@ mod test {
         }
 
         // Publish another message to the active subscribers
-        let block_payload_message =
-            ConsensusObserverMessage::new_block_payload_message(BlockInfo::empty(), vec![], None);
+        let block_payload_message = ConsensusObserverMessage::new_block_payload_message(
+            BlockInfo::empty(),
+            BlockTransactionPayload::empty(),
+        );
         consensus_publisher
             .publish_message(block_payload_message.clone())
             .await;

--- a/consensus/src/test_utils/mock_execution_client.rs
+++ b/consensus/src/test_utils/mock_execution_client.rs
@@ -171,5 +171,9 @@ impl TExecutionClient for MockExecutionClient {
         Ok(())
     }
 
+    async fn reset(&self, _target: &LedgerInfoWithSignatures) -> Result<()> {
+        Ok(())
+    }
+
     async fn end_epoch(&self) {}
 }


### PR DESCRIPTION
Note: most of this code is new unit tests.

## Description
This PR makes several improvements to consensus observer. Specifically, it offers the following commits:
1. Add a `reset()` method to the execution client trait. This method is already provided internally by `sync_to` and we want to expose it so that we can call it directly whenever consensus observer needs to reset execution state (e.g., on subscription changes).
1. Update consensus observer to reset the execution pipeline and all pending block state when switching subscriptions. This shouldn't be strictly necessary, but it seems like a safe fallback.
1. Update consensus observer to perform message verification for block payloads. Specifically, we: (i) verify the payload batch digests (i.e., to make sure all transactions are valid and in the correct order); (ii) verify the payload signatures over the batches (if the payload is for the current epoch); (iii) if the payload signatures can't be verified in the current epoch, we store them and verify them once we transition epochs; (iv) when the payloads are retrieved (for an ordered block), we make sure the batches and transactions match the expected values in the block (this ties the payload to a verified block); and (v) add a configurable maximum number of pending payloads (to avoid OOM attacks).

Once this lands, there's a few cleanups and simplifications to be done. I'll have those in the next PR.

## Testing Plan
New and existing test infrastructure.