### PR TITLE
e2e counters split out by top usecases

### DIFF
--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -60,6 +60,9 @@ pub struct MempoolConfig {
     pub broadcast_buckets: Vec<u64>,
     pub eager_expire_threshold_ms: Option<u64>,
     pub eager_expire_time_ms: u64,
+
+    pub usecase_stats_num_blocks_to_track: usize,
+    pub usecase_stats_num_top_to_track: usize,
 }
 
 impl Default for MempoolConfig {
@@ -87,6 +90,8 @@ impl Default for MempoolConfig {
             broadcast_buckets: DEFAULT_BUCKETS.to_vec(),
             eager_expire_threshold_ms: Some(15_000),
             eager_expire_time_ms: 6_000,
+            usecase_stats_num_blocks_to_track: 40,
+            usecase_stats_num_top_to_track: 5,
         }
     }
 }

--- a/consensus/src/transaction_shuffler/use_case_aware/delayed_queue.rs
+++ b/consensus/src/transaction_shuffler/use_case_aware/delayed_queue.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::transaction_shuffler::use_case_aware::{
-    types::{InputIdx, OutputIdx, UseCaseAwareTransaction, UseCaseKey},
+    types::{InputIdx, OutputIdx},
     utils::StrictMap,
     Config,
 };
+use aptos_types::transaction::use_case::{UseCaseAwareTransaction, UseCaseKey};
 use move_core_types::account_address::AccountAddress;
 use std::{
     collections::{hash_map, BTreeMap, HashMap, VecDeque},

--- a/consensus/src/transaction_shuffler/use_case_aware/iterator.rs
+++ b/consensus/src/transaction_shuffler/use_case_aware/iterator.rs
@@ -3,9 +3,10 @@
 
 use crate::transaction_shuffler::use_case_aware::{
     delayed_queue::DelayedQueue,
-    types::{InputIdx, OutputIdx, UseCaseAwareTransaction},
+    types::{InputIdx, OutputIdx},
     Config,
 };
+use aptos_types::transaction::use_case::UseCaseAwareTransaction;
 use std::{collections::VecDeque, fmt::Debug};
 
 #[derive(Debug)]

--- a/consensus/src/transaction_shuffler/use_case_aware/mod.rs
+++ b/consensus/src/transaction_shuffler/use_case_aware/mod.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::transaction_shuffler::{use_case_aware::types::UseCaseKey, TransactionShuffler};
-use aptos_types::transaction::SignedTransaction;
+use crate::transaction_shuffler::TransactionShuffler;
+use aptos_types::transaction::{use_case::UseCaseKey, SignedTransaction};
 use iterator::ShuffledTransactionIterator;
 
 pub(crate) mod iterator;

--- a/consensus/src/transaction_shuffler/use_case_aware/tests/mod.rs
+++ b/consensus/src/transaction_shuffler/use_case_aware/tests/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::transaction_shuffler::use_case_aware::types::{UseCaseAwareTransaction, UseCaseKey};
+use aptos_types::transaction::use_case::{UseCaseAwareTransaction, UseCaseKey};
 use move_core_types::account_address::AccountAddress;
 use proptest_derive::Arbitrary;
 use std::fmt::Debug;

--- a/consensus/src/transaction_shuffler/use_case_aware/types.rs
+++ b/consensus/src/transaction_shuffler/use_case_aware/types.rs
@@ -1,58 +1,5 @@
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_types::transaction::SignedTransaction;
-use move_core_types::account_address::AccountAddress;
-
 pub(crate) type InputIdx = usize;
 pub(crate) type OutputIdx = usize;
-
-#[derive(Clone, Eq, Hash, PartialEq)]
-pub(crate) enum UseCaseKey {
-    Platform,
-    ContractAddress(AccountAddress),
-    // ModuleBundle (deprecated anyway), scripts, Multisig.
-    Others,
-}
-
-impl std::fmt::Debug for UseCaseKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use UseCaseKey::*;
-
-        match self {
-            Platform => write!(f, "PP"),
-            ContractAddress(addr) => write!(f, "c{}", hex::encode_upper(&addr[31..])),
-            Others => write!(f, "OO"),
-        }
-    }
-}
-
-pub(crate) trait UseCaseAwareTransaction {
-    fn parse_sender(&self) -> AccountAddress;
-
-    fn parse_use_case(&self) -> UseCaseKey;
-}
-
-impl UseCaseAwareTransaction for SignedTransaction {
-    fn parse_sender(&self) -> AccountAddress {
-        self.sender()
-    }
-
-    fn parse_use_case(&self) -> UseCaseKey {
-        use aptos_types::transaction::TransactionPayload::*;
-        use UseCaseKey::*;
-
-        match self.payload() {
-            Script(_) | ModuleBundle(_) | Multisig(_) => Others,
-            EntryFunction(entry_fun) => {
-                let module_id = entry_fun.module();
-                if module_id.address().is_special() {
-                    Platform
-                } else {
-                    // n.b. Generics ignored.
-                    ContractAddress(*module_id.address())
-                }
-            },
-        }
-    }
-}

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -21,7 +21,7 @@ use aptos_logger::prelude::*;
 use aptos_types::{
     account_address::AccountAddress,
     mempool_status::{MempoolStatus, MempoolStatusCode},
-    transaction::SignedTransaction,
+    transaction::{use_case::UseCaseKey, SignedTransaction},
     vm_status::DiscardedVMStatus,
 };
 use std::{
@@ -57,13 +57,14 @@ impl Mempool {
         &self,
         sender: &AccountAddress,
         sequence_number: u64,
+        tracked_use_case: Option<UseCaseKey>,
         block_timestamp: Duration,
     ) {
         trace!(
             LogSchema::new(LogEntry::RemoveTxn).txns(TxnsLog::new_txn(*sender, sequence_number)),
             is_rejected = false
         );
-        self.log_commit_latency(*sender, sequence_number, block_timestamp);
+        self.log_commit_latency(*sender, sequence_number, tracked_use_case, block_timestamp);
         if let Some(ranking_score) = self.transactions.get_ranking_score(sender, sequence_number) {
             counters::core_mempool_txn_ranking_score(
                 counters::REMOVE_LABEL,
@@ -196,6 +197,7 @@ impl Mempool {
         &self,
         account: AccountAddress,
         sequence_number: u64,
+        tracked_use_case: Option<UseCaseKey>,
         block_timestamp: Duration,
     ) {
         if let Some((insertion_info, bucket)) = self
@@ -214,6 +216,21 @@ impl Mempool {
                     bucket,
                     insertion_to_block,
                 );
+
+                let use_case_label = match tracked_use_case {
+                    Some(UseCaseKey::Platform) => "platform".to_string(),
+                    Some(UseCaseKey::ContractAddress(addr)) => format!("contract_{:?}", addr),
+                    Some(UseCaseKey::Others) => "other".to_string(),
+                    None => "contract_other".to_string(),
+                };
+
+                counters::TXN_E2E_USE_CASE_COMMIT_LATENCY
+                    .with_label_values(&[
+                        &use_case_label,
+                        insertion_info.submitted_by_label(),
+                        bucket,
+                    ])
+                    .observe(insertion_to_block.as_secs_f64());
             }
         }
     }

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -57,7 +57,7 @@ impl Mempool {
         &self,
         sender: &AccountAddress,
         sequence_number: u64,
-        tracked_use_case: Option<UseCaseKey>,
+        tracked_use_case: Option<(UseCaseKey, &String)>,
         block_timestamp: Duration,
     ) {
         trace!(
@@ -197,7 +197,7 @@ impl Mempool {
         &self,
         account: AccountAddress,
         sequence_number: u64,
-        tracked_use_case: Option<UseCaseKey>,
+        tracked_use_case: Option<(UseCaseKey, &String)>,
         block_timestamp: Duration,
     ) {
         if let Some((insertion_info, bucket)) = self
@@ -217,16 +217,15 @@ impl Mempool {
                     insertion_to_block,
                 );
 
-                let use_case_label = match tracked_use_case {
-                    Some(UseCaseKey::Platform) => "platform".to_string(),
-                    Some(UseCaseKey::ContractAddress(addr)) => format!("contract_{:?}", addr),
-                    Some(UseCaseKey::Others) => "other".to_string(),
-                    None => "contract_other".to_string(),
-                };
+                let use_case_label = tracked_use_case
+                    .as_ref()
+                    .map_or("entry_user_other", |(_, use_case_name)| {
+                        use_case_name.as_str()
+                    });
 
                 counters::TXN_E2E_USE_CASE_COMMIT_LATENCY
                     .with_label_values(&[
-                        &use_case_label,
+                        use_case_label,
                         insertion_info.submitted_by_label(),
                         bucket,
                     ])

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -208,6 +208,16 @@ static CORE_MEMPOOL_TXN_COMMIT_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static TXN_E2E_USE_CASE_COMMIT_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "aptos_txn_e2e_use_case_commit_latency",
+        "Latency of txn commit_accept, by use_case",
+        &["use_case", "submitted_by", "bucket"],
+        MEMPOOL_LATENCY_BUCKETS.to_vec()
+    )
+    .unwrap()
+});
+
 pub fn core_mempool_txn_ranking_score(
     stage: &'static str,
     status: &str,

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -13,6 +13,7 @@ use crate::{
         tasks,
         tasks::process_committed_transactions,
         types::{notify_subscribers, ScheduledBroadcast, SharedMempool, SharedMempoolNotification},
+        use_case_history::UseCaseHistory,
     },
     MempoolEventsReceiver, QuorumStoreRequest,
 };
@@ -134,10 +135,16 @@ fn spawn_commit_notification_handler<NetworkClient, TransactionValidator>(
 {
     let mempool = smp.mempool.clone();
     let mempool_validator = smp.validator.clone();
+    let use_case_history = smp.use_case_history.clone();
 
     tokio::spawn(async move {
         while let Some(commit_notification) = mempool_listener.next().await {
-            handle_commit_notification(&mempool, &mempool_validator, commit_notification);
+            handle_commit_notification(
+                &mempool,
+                &mempool_validator,
+                &use_case_history,
+                commit_notification,
+            );
         }
     });
 }
@@ -202,6 +209,7 @@ async fn handle_client_request<NetworkClient, TransactionValidator>(
 fn handle_commit_notification<TransactionValidator>(
     mempool: &Arc<Mutex<CoreMempool>>,
     mempool_validator: &Arc<RwLock<TransactionValidator>>,
+    use_case_history: &Arc<Mutex<UseCaseHistory>>,
     msg: MempoolCommitNotification,
 ) where
     TransactionValidator: TransactionValidation,
@@ -218,7 +226,12 @@ fn handle_commit_notification<TransactionValidator>(
         counters::COMMIT_STATE_SYNC_LABEL,
         msg.transactions.len(),
     );
-    process_committed_transactions(mempool, msg.transactions, msg.block_timestamp_usecs);
+    process_committed_transactions(
+        mempool,
+        use_case_history,
+        msg.transactions,
+        msg.block_timestamp_usecs,
+    );
     mempool_validator.write().notify_commit();
     let latency = start_time.elapsed();
     counters::mempool_service_latency(

--- a/mempool/src/shared_mempool/mod.rs
+++ b/mempool/src/shared_mempool/mod.rs
@@ -11,3 +11,4 @@ pub use runtime::bootstrap;
 pub(crate) use runtime::start_shared_mempool;
 mod coordinator;
 pub(crate) mod tasks;
+pub(crate) mod use_case_history;

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -6,6 +6,7 @@
 use crate::{
     core_mempool::CoreMempool,
     network::{MempoolNetworkInterface, MempoolSyncMsg},
+    shared_mempool::use_case_history::UseCaseHistory,
 };
 use anyhow::Result;
 use aptos_config::{
@@ -50,6 +51,7 @@ pub(crate) struct SharedMempool<NetworkClient, TransactionValidator> {
     pub validator: Arc<RwLock<TransactionValidator>>,
     pub subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
     pub broadcast_within_validator_network: Arc<RwLock<bool>>,
+    pub use_case_history: Arc<Mutex<UseCaseHistory>>,
 }
 
 impl<
@@ -67,6 +69,10 @@ impl<
         role: RoleType,
     ) -> Self {
         let network_interface = MempoolNetworkInterface::new(network_client, role, config.clone());
+        let use_case_history = UseCaseHistory::new(
+            config.usecase_stats_num_blocks_to_track,
+            config.usecase_stats_num_top_to_track,
+        );
         SharedMempool {
             mempool,
             config,
@@ -75,6 +81,7 @@ impl<
             validator,
             subscribers,
             broadcast_within_validator_network: Arc::new(RwLock::new(true)),
+            use_case_history: Arc::new(Mutex::new(use_case_history)),
         }
     }
 

--- a/mempool/src/shared_mempool/use_case_history.rs
+++ b/mempool/src/shared_mempool/use_case_history.rs
@@ -1,14 +1,19 @@
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_logger::info;
 use aptos_mempool_notifications::CommittedTransaction;
 use aptos_types::transaction::use_case::UseCaseKey;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::{
+    cmp::Ordering,
+    collections::{BinaryHeap, HashMap, VecDeque},
+};
 
 pub(crate) struct UseCaseHistory {
     window_size: usize,
     num_top_to_track: usize,
     recent: VecDeque<HashMap<UseCaseKey, usize>>,
+    total: HashMap<UseCaseKey, usize>,
 }
 
 impl UseCaseHistory {
@@ -17,13 +22,72 @@ impl UseCaseHistory {
             window_size,
             num_top_to_track,
             recent: VecDeque::with_capacity(window_size + 1),
+            total: HashMap::new(),
         }
     }
 
-    pub(crate) fn update_usecases_and_get_tracking_set(
-        &mut self,
-        transactions: &[CommittedTransaction],
-    ) -> HashSet<UseCaseKey> {
+    fn add_to_recent(&mut self, count_by_usecase: HashMap<UseCaseKey, usize>) {
+        for (use_case, count) in &count_by_usecase {
+            assert!(*count > 0);
+            *self.total.entry(use_case.clone()).or_insert(0) += *count;
+        }
+        self.recent.push_back(count_by_usecase);
+
+        while self.recent.len() > self.window_size {
+            let to_remove = self.recent.pop_front().expect("non-empty after size check");
+            for (use_case, count) in to_remove {
+                assert!(count > 0);
+
+                use std::collections::hash_map::Entry;
+                match self.total.entry(use_case) {
+                    Entry::Occupied(mut o) => {
+                        assert!(*o.get() >= count);
+                        *o.get_mut() -= count;
+                        if *o.get() == 0 {
+                            o.remove_entry();
+                        }
+                    },
+                    Entry::Vacant(e) => {
+                        panic!("Entry present in recent cannot be missing in total {:?}", e)
+                    },
+                }
+            }
+        }
+    }
+
+    pub fn compute_tracking_set(&self) -> HashMap<UseCaseKey, String> {
+        let mut result = HashMap::new();
+        result.insert(UseCaseKey::Platform, "entry_platform".to_string());
+        result.insert(UseCaseKey::Others, "non_entry".to_string());
+
+        let mut max_heap: BinaryHeap<UseCaseByCount> = self
+            .total
+            .iter()
+            .filter(|(use_case, _)| {
+                *use_case != &UseCaseKey::Platform && *use_case != &UseCaseKey::Others
+            })
+            .map(|(use_case, count)| UseCaseByCount {
+                use_case: use_case.clone(),
+                count: *count,
+            })
+            .collect::<BinaryHeap<_>>();
+
+        let mut list_to_print = Vec::new();
+
+        for i in 0..self.num_top_to_track {
+            if let Some(UseCaseByCount { use_case, count }) = max_heap.pop() {
+                let name = format!("entry_user_top_{}", i + 1);
+
+                list_to_print.push((use_case.clone(), name.clone(), count));
+                result.insert(use_case, name);
+            }
+        }
+        info!("Computed new use case tracking set: {:?}", list_to_print);
+
+        result
+    }
+
+    pub(crate) fn update_usecases(&mut self, transactions: &[CommittedTransaction]) {
         let mut count_by_usecase = HashMap::new();
         for transaction in transactions {
             *count_by_usecase
@@ -31,33 +95,119 @@ impl UseCaseHistory {
                 .or_insert(0) += 1;
         }
 
-        self.recent.push_back(count_by_usecase);
-        while self.recent.len() > self.window_size {
-            self.recent.pop_front();
-        }
-
-        let mut total = HashMap::new();
-        for group in &self.recent {
-            for (use_case, count) in group {
-                if use_case != &UseCaseKey::Platform && use_case != &UseCaseKey::Others {
-                    *total.entry(use_case.clone()).or_insert(0) += count;
-                }
-            }
-        }
-
-        let mut result = HashSet::new();
-        result.insert(UseCaseKey::Platform);
-        result.insert(UseCaseKey::Others);
-
-        let mut sorted = total.into_iter().collect::<Vec<_>>();
-        sorted.sort_by_key(|(_, count)| *count);
-
-        for _ in 0..self.num_top_to_track {
-            if let Some((use_case, _)) = sorted.pop() {
-                result.insert(use_case);
-            }
-        }
-
-        result
+        self.add_to_recent(count_by_usecase);
     }
+}
+
+#[derive(Eq, PartialEq)]
+struct UseCaseByCount {
+    use_case: UseCaseKey,
+    count: usize,
+}
+
+impl Ord for UseCaseByCount {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.count.cmp(&other.count)
+    }
+}
+
+impl PartialOrd for UseCaseByCount {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[test]
+fn test_use_case_history() {
+    use aptos_types::account_address::AccountAddress;
+    let ct = |use_case: UseCaseKey| -> CommittedTransaction {
+        CommittedTransaction {
+            sender: AccountAddress::ONE,
+            sequence_number: 0,
+            use_case,
+        }
+    };
+
+    let expected_from_top2 =
+        |top_1: UseCaseKey, top_2: UseCaseKey| -> HashMap<UseCaseKey, String> {
+            HashMap::from([
+                (Platform, "entry_platform".into()),
+                (Others, "non_entry".into()),
+                (top_1, "entry_user_top_1".into()),
+                (top_2, "entry_user_top_2".into()),
+            ])
+        };
+
+    let usecase1 = ContractAddress(AccountAddress::random());
+    let usecase2 = ContractAddress(AccountAddress::random());
+    let usecase3 = ContractAddress(AccountAddress::random());
+
+    use UseCaseKey::*;
+
+    let mut history = UseCaseHistory::new(2, 2);
+
+    history.update_usecases(&[ct(Platform)]);
+    assert_eq!(
+        history.compute_tracking_set(),
+        HashMap::from([
+            (Platform, "entry_platform".into()),
+            (Others, "non_entry".into())
+        ])
+    );
+
+    history.update_usecases(&[
+        ct(Platform),
+        ct(Platform),
+        ct(usecase1.clone()),
+        ct(usecase1.clone()),
+        ct(usecase2.clone()),
+    ]);
+    assert_eq!(
+        history.compute_tracking_set(),
+        expected_from_top2(usecase1.clone(), usecase2.clone()),
+    );
+
+    history.update_usecases(&[
+        ct(usecase1.clone()),
+        ct(usecase2.clone()),
+        ct(usecase3.clone()),
+    ]);
+    assert_eq!(
+        history.compute_tracking_set(),
+        expected_from_top2(usecase1.clone(), usecase2.clone()),
+    );
+
+    history.update_usecases(&[
+        ct(usecase2.clone()),
+        ct(usecase2.clone()),
+        ct(usecase3.clone()),
+    ]);
+    assert_eq!(
+        history.compute_tracking_set(),
+        expected_from_top2(usecase2.clone(), usecase3.clone()),
+    );
+
+    history.update_usecases(&[
+        ct(usecase2.clone()),
+        ct(usecase2.clone()),
+        ct(usecase3.clone()),
+        ct(usecase3.clone()),
+        ct(usecase3.clone()),
+    ]);
+    assert_eq!(
+        history.compute_tracking_set(),
+        expected_from_top2(usecase2.clone(), usecase3.clone()),
+    );
+
+    history.update_usecases(&[
+        ct(ContractAddress(AccountAddress::random())),
+        ct(ContractAddress(AccountAddress::random())),
+        ct(ContractAddress(AccountAddress::random())),
+        ct(ContractAddress(AccountAddress::random())),
+        ct(ContractAddress(AccountAddress::random())),
+    ]);
+    assert_eq!(
+        history.compute_tracking_set(),
+        expected_from_top2(usecase3.clone(), usecase2.clone()),
+    );
 }

--- a/mempool/src/shared_mempool/use_case_history.rs
+++ b/mempool/src/shared_mempool/use_case_history.rs
@@ -1,0 +1,63 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_mempool_notifications::CommittedTransaction;
+use aptos_types::transaction::use_case::UseCaseKey;
+use std::collections::{HashMap, HashSet, VecDeque};
+
+pub(crate) struct UseCaseHistory {
+    window_size: usize,
+    num_top_to_track: usize,
+    recent: VecDeque<HashMap<UseCaseKey, usize>>,
+}
+
+impl UseCaseHistory {
+    pub(crate) fn new(window_size: usize, num_top_to_track: usize) -> Self {
+        Self {
+            window_size,
+            num_top_to_track,
+            recent: VecDeque::with_capacity(window_size + 1),
+        }
+    }
+
+    pub(crate) fn update_usecases_and_get_tracking_set(
+        &mut self,
+        transactions: &[CommittedTransaction],
+    ) -> HashSet<UseCaseKey> {
+        let mut count_by_usecase = HashMap::new();
+        for transaction in transactions {
+            *count_by_usecase
+                .entry(transaction.use_case.clone())
+                .or_insert(0) += 1;
+        }
+
+        self.recent.push_back(count_by_usecase);
+        while self.recent.len() > self.window_size {
+            self.recent.pop_front();
+        }
+
+        let mut total = HashMap::new();
+        for group in &self.recent {
+            for (use_case, count) in group {
+                if use_case != &UseCaseKey::Platform && use_case != &UseCaseKey::Others {
+                    *total.entry(use_case.clone()).or_insert(0) += count;
+                }
+            }
+        }
+
+        let mut result = HashSet::new();
+        result.insert(UseCaseKey::Platform);
+        result.insert(UseCaseKey::Others);
+
+        let mut sorted = total.into_iter().collect::<Vec<_>>();
+        sorted.sort_by_key(|(_, count)| *count);
+
+        for _ in 0..self.num_top_to_track {
+            if let Some((use_case, _)) = sorted.pop() {
+                result.insert(use_case);
+            }
+        }
+
+        result
+    }
+}

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -49,6 +49,7 @@ mod module;
 mod multisig;
 mod script;
 pub mod signature_verified_transaction;
+pub mod use_case;
 pub mod user_transaction_context;
 pub mod webauthn;
 

--- a/types/src/transaction/use_case.rs
+++ b/types/src/transaction/use_case.rs
@@ -1,0 +1,55 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transaction::SignedTransaction;
+use move_core_types::account_address::AccountAddress;
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+pub enum UseCaseKey {
+    Platform,
+    ContractAddress(AccountAddress),
+    // ModuleBundle (deprecated anyway), scripts, Multisig.
+    Others,
+}
+
+impl std::fmt::Debug for UseCaseKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use UseCaseKey::*;
+
+        match self {
+            Platform => write!(f, "PP"),
+            ContractAddress(addr) => write!(f, "c{}", hex::encode_upper(&addr[31..])),
+            Others => write!(f, "OO"),
+        }
+    }
+}
+
+pub trait UseCaseAwareTransaction {
+    fn parse_sender(&self) -> AccountAddress;
+
+    fn parse_use_case(&self) -> UseCaseKey;
+}
+
+impl UseCaseAwareTransaction for SignedTransaction {
+    fn parse_sender(&self) -> AccountAddress {
+        self.sender()
+    }
+
+    fn parse_use_case(&self) -> UseCaseKey {
+        use crate::transaction::TransactionPayload::*;
+        use UseCaseKey::*;
+
+        match self.payload() {
+            Script(_) | ModuleBundle(_) | Multisig(_) => Others,
+            EntryFunction(entry_fun) => {
+                let module_id = entry_fun.module();
+                if module_id.address().is_special() {
+                    Platform
+                } else {
+                    // n.b. Generics ignored.
+                    ContractAddress(*module_id.address())
+                }
+            },
+        }
+    }
+}

--- a/types/src/transaction/use_case.rs
+++ b/types/src/transaction/use_case.rs
@@ -46,7 +46,6 @@ impl UseCaseAwareTransaction for SignedTransaction {
                 if module_id.address().is_special() {
                     Platform
                 } else {
-                    // n.b. Generics ignored.
                     ContractAddress(*module_id.address())
                 }
             },


### PR DESCRIPTION
## Description
Track frequency of usecases in recent blocks (or during state sync - recent batches), and then report latency counters separately for top usecases, as well as framework and others (i.e. scripts)

We can then use this for monitoring, and gas estimation and more

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
