### PR TITLE
[quorum-store] subscribe to batches from DirectSend flow in batch requester

### DIFF
--- a/consensus/src/quorum_store/batch_store.rs
+++ b/consensus/src/quorum_store/batch_store.rs
@@ -116,6 +116,7 @@ pub struct BatchStore {
     db_quota: usize,
     batch_quota: usize,
     validator_signer: ValidatorSigner,
+    persist_subscribers: DashMap<HashValue, Vec<oneshot::Sender<PersistedValue>>>,
 }
 
 impl BatchStore {
@@ -140,6 +141,7 @@ impl BatchStore {
             db_quota,
             batch_quota,
             validator_signer,
+            persist_subscribers: DashMap::new(),
         };
         let db_content = db_clone
             .get_all_batches()
@@ -284,6 +286,7 @@ impl BatchStore {
                     // digest with a higher expiration would update the persisted value and
                     // effectively extend the expiration.
                     if entry.get().expiration() <= certified_time {
+                        self.persist_subscribers.remove(entry.get().digest());
                         Some(entry.remove())
                     } else {
                         None
@@ -371,13 +374,39 @@ impl BatchStore {
             Err(ExecutorError::CouldNotGetData)
         }
     }
+
+    /// This calls lets the caller subscribe to a batch being added to the batch store.
+    /// This can be useful in cases where there are multiple flows to add a batch (like
+    /// direct from author batch / batch requester fetch) to the batch store and either
+    /// flow needs to subscribe to the other.
+    fn subscribe(&self, digest: HashValue) -> oneshot::Receiver<PersistedValue> {
+        let (tx, rx) = oneshot::channel();
+        self.persist_subscribers.entry(digest).or_default().push(tx);
+
+        // This is to account for the race where this subscribe call happens after the
+        // persist call.
+        if let Ok(value) = self.get_batch_from_local(&digest) {
+            self.notify_subscribers(value)
+        }
+
+        rx
+    }
+
+    fn notify_subscribers(&self, value: PersistedValue) {
+        if let Some((_, subscribers)) = self.persist_subscribers.remove(value.digest()) {
+            for subscriber in subscribers {
+                subscriber.send(value.clone()).ok();
+            }
+        }
+    }
 }
 
 impl BatchWriter for BatchStore {
     fn persist(&self, persist_requests: Vec<PersistedValue>) -> Vec<SignedBatchInfo> {
         let mut signed_infos = vec![];
         for persist_request in persist_requests.into_iter() {
-            if let Some(signed_info) = self.persist_inner(persist_request) {
+            if let Some(signed_info) = self.persist_inner(persist_request.clone()) {
+                self.notify_subscribers(persist_request);
                 signed_infos.push(signed_info);
             }
         }
@@ -440,7 +469,10 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchReader for Batch
             } else {
                 // Quorum store metrics
                 counters::MISSED_BATCHES_COUNT.inc();
-                if let Some((batch_info, payload)) = batch_requester.request_batch(proof, tx).await
+                let subscriber_rx = batch_store.subscribe(*proof.digest());
+                if let Some((batch_info, payload)) = batch_requester
+                    .request_batch(proof, tx, subscriber_rx)
+                    .await
                 {
                     batch_store.persist(vec![PersistedValue::new(batch_info, Some(payload))]);
                 }

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -745,6 +745,14 @@ pub static RECEIVED_BATCH_RESPONSE_ERROR_COUNT: Lazy<IntCounter> = Lazy::new(|| 
     .unwrap()
 });
 
+pub static RECEIVED_BATCH_FROM_SUBSCRIPTION_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "quorum_store_batch_from_subscription_count",
+        "Count of the number of batches received via batch store subscription."
+    )
+    .unwrap()
+});
+
 pub static QS_BACKPRESSURE_TXN_COUNT: Lazy<Histogram> = Lazy::new(|| {
     register_avg_counter(
         "quorum_store_backpressure_txn_count",

--- a/consensus/src/quorum_store/tests/batch_requester_test.rs
+++ b/consensus/src/quorum_store/tests/batch_requester_test.rs
@@ -22,6 +22,7 @@ use aptos_types::{
 };
 use move_core_types::account_address::AccountAddress;
 use std::time::{Duration, Instant};
+use tokio::sync::oneshot;
 
 #[derive(Clone)]
 struct MockBatchRequester {
@@ -99,6 +100,7 @@ async fn test_batch_request_exists() {
         ValidatorVerifier::new_single(validator_signer.author(), validator_signer.public_key()),
     );
 
+    let (_, subscriber_rx) = oneshot::channel();
     let result = batch_requester
         .request_batch(
             ProofOfStore::new(
@@ -106,6 +108,7 @@ async fn test_batch_request_exists() {
                 AggregateSignature::new(vec![u8::MAX].into(), None),
             ),
             tx,
+            subscriber_rx,
         )
         .await;
     assert!(result.is_some());
@@ -194,6 +197,7 @@ async fn test_batch_request_not_exists_not_expired() {
     );
 
     let request_start = Instant::now();
+    let (_, subscriber_rx) = oneshot::channel();
     let result = batch_requester
         .request_batch(
             ProofOfStore::new(
@@ -201,6 +205,7 @@ async fn test_batch_request_not_exists_not_expired() {
                 AggregateSignature::new(vec![u8::MAX].into(), None),
             ),
             tx,
+            subscriber_rx,
         )
         .await;
     let request_duration = request_start.elapsed();
@@ -241,6 +246,7 @@ async fn test_batch_request_not_exists_expired() {
     );
 
     let request_start = Instant::now();
+    let (_, subscriber_rx) = oneshot::channel();
     let result = batch_requester
         .request_batch(
             ProofOfStore::new(
@@ -248,6 +254,7 @@ async fn test_batch_request_not_exists_expired() {
                 AggregateSignature::new(vec![u8::MAX].into(), None),
             ),
             tx,
+            subscriber_rx,
         )
         .await;
     let request_duration = request_start.elapsed();

--- a/consensus/src/quorum_store/types.rs
+++ b/consensus/src/quorum_store/types.rs
@@ -74,6 +74,10 @@ impl PersistedValue {
         }
         vec![]
     }
+
+    pub fn unpack(self) -> (BatchInfo, Option<Vec<SignedTransaction>>) {
+        (self.info, self.maybe_payload)
+    }
 }
 
 impl Deref for PersistedValue {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

In an event when the `PayloadManager::prefetch_payload_data` is invoked before a batch is received locally, the batch requester starts sending RPCs to retrieve the batch from remote peers. However, it is very possible the batch arrives from the author as soon as the prefetch happens, but the payload manager still waits for the batch requester to fetch. 

To prevent this, this PR proposes a subscription mechanism where the batch requester will subscribe to the batch store persist flow and listen to the batch being added from the Direct Send message. This will short circuit the batch requester and use this value to satisfy the PayloadManager. 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [X] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
