### PR TITLE
[smoke-test][qs] add generate_traffic timeout to bad node

### DIFF
--- a/testsuite/smoke-test/src/consensus/quorum_store_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/quorum_store_fault_tolerance.rs
@@ -370,21 +370,24 @@ async fn test_swarm_with_bad_non_qs_node() {
         .unwrap();
 
     info!("generate traffic");
-    let tx_stat = generate_traffic(
-        &mut swarm,
-        &[dishonest_peer_id],
-        Duration::from_secs(20),
-        1,
-        vec![vec![
-            (TransactionTypeArg::CoinTransfer.materialize_default(), 70),
-            (
-                TransactionTypeArg::AccountGeneration.materialize_default(),
-                20,
-            ),
-        ]],
+    let tx_stat = tokio::time::timeout(
+        Duration::from_secs(60),
+        generate_traffic(
+            &mut swarm,
+            &[dishonest_peer_id],
+            Duration::from_secs(20),
+            1,
+            vec![vec![
+                (TransactionTypeArg::CoinTransfer.materialize_default(), 70),
+                (
+                    TransactionTypeArg::AccountGeneration.materialize_default(),
+                    20,
+                ),
+            ]],
+        ),
     )
     .await;
-    assert!(tx_stat.is_err());
+    assert!(tx_stat.is_err() || tx_stat.is_ok_and(|result| result.is_err()));
 
     generate_traffic_and_assert_committed(
         &mut swarm,


### PR DESCRIPTION
## Description

Adds a timeout to `generate_traffic` call to non quorum store node in the `test_swarm_with_bad_non_qs_node` smoke test. The test was flaky because the bad node crashes and dies but the transaction emitter keeps trying for 600 seconds before giving up.