### PR TITLE
[move-2] Allow variables and functions be called `match` in Move-2

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_empty_block.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_empty_block.exp
@@ -1,0 +1,6 @@
+// -- Model dump before bytecode pipeline
+module 0x815::m {
+    private fun match() {
+        Tuple()
+    }
+} // end 0x815::m

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_empty_block.move
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_empty_block.move
@@ -1,0 +1,3 @@
+module 0x815::m {
+    fun match() {}
+}

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_fun_1.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_fun_1.exp
@@ -1,0 +1,27 @@
+// -- Model dump before bytecode pipeline
+module 0x815::m {
+    enum CommonFields {
+        Foo {
+            x: u64,
+            y: u8,
+        }
+        Bar {
+            x: u64,
+            z: u32,
+        }
+    }
+    private fun caller(c: m::CommonFields): bool {
+        m::match(c)
+    }
+    private fun match(c: m::CommonFields): bool {
+        match (c) {
+          m::CommonFields::Foo{ x, y: _ } => {
+            Gt<u64>(x, 0)
+          }
+          _: m::CommonFields => {
+            false
+          }
+        }
+
+    }
+} // end 0x815::m

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_fun_1.move
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_fun_1.move
@@ -1,0 +1,17 @@
+module 0x815::m {
+    enum CommonFields {
+        Foo{x: u64, y: u8},
+        Bar{x: u64, z: u32}
+    }
+
+    fun match(c: CommonFields): bool {
+        match (c) {
+            Foo{x, y: _} => x > 0,
+            _ => false
+        }
+    }
+
+    fun caller(c: CommonFields): bool {
+        match(c)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_fun_2.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_fun_2.exp
@@ -1,0 +1,30 @@
+// -- Model dump before bytecode pipeline
+module 0x815::m {
+    enum CommonFields {
+        Foo {
+            x: u64,
+            y: u8,
+        }
+        Bar {
+            x: u64,
+            z: u32,
+        }
+    }
+    private fun caller(): bool {
+        m::match()
+    }
+    private fun match(): bool {
+        {
+          let c: m::CommonFields = pack m::CommonFields::Foo(0, 0);
+          match (c) {
+            m::CommonFields::Foo{ x, y: _ } => {
+              Gt<u64>(x, 0)
+            }
+            _: m::CommonFields => {
+              false
+            }
+          }
+
+        }
+    }
+} // end 0x815::m

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_fun_2.move
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_fun_2.move
@@ -1,0 +1,18 @@
+module 0x815::m {
+    enum CommonFields {
+        Foo{x: u64, y: u8},
+        Bar{x: u64, z: u32}
+    }
+
+    fun match(): bool {
+        let c = CommonFields::Foo{x: 0, y: 0};
+        match (c) {
+            Foo{x, y: _} => x > 0,
+            _ => false
+        }
+    }
+
+    fun caller(): bool {
+        match()
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_fun_3.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_fun_3.exp
@@ -1,0 +1,27 @@
+// -- Model dump before bytecode pipeline
+module 0x815::m {
+    enum CommonFields {
+        Foo {
+            x: u64,
+            y: u8,
+        }
+        Bar {
+            x: u64,
+            z: u32,
+        }
+    }
+    private fun caller(c: m::CommonFields): bool {
+        And(m::match(c, 22), true)
+    }
+    private fun match(c: m::CommonFields,t: u64): bool {
+        match (c) {
+          m::CommonFields::Foo{ x, y: _ } => {
+            Gt<u64>(x, t)
+          }
+          _: m::CommonFields => {
+            false
+          }
+        }
+
+    }
+} // end 0x815::m

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_fun_3.move
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_fun_3.move
@@ -1,0 +1,17 @@
+module 0x815::m {
+    enum CommonFields {
+        Foo{x: u64, y: u8},
+        Bar{x: u64, z: u32}
+    }
+
+    fun match(c: CommonFields, t: u64): bool {
+        match (c) {
+            Foo{x, y: _} => x > t,
+            _ => false
+        }
+    }
+
+    fun caller(c: CommonFields): bool {
+        match(c, 22) && true
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_var.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_var.exp
@@ -1,0 +1,27 @@
+// -- Model dump before bytecode pipeline
+module 0x815::m {
+    enum CommonFields {
+        Foo {
+            x: u64,
+            y: u8,
+        }
+        Bar {
+            x: u64,
+            z: u32,
+        }
+    }
+    private fun match(c: m::CommonFields,t: u64): bool {
+        match (c) {
+          m::CommonFields::Foo{ x, y: _ } => {
+            {
+              let match: bool = Gt<u64>(x, t);
+              match
+            }
+          }
+          _: m::CommonFields => {
+            false
+          }
+        }
+
+    }
+} // end 0x815::m

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_var.move
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_allow_match_var.move
@@ -1,0 +1,16 @@
+module 0x815::m {
+    enum CommonFields {
+        Foo{x: u64, y: u8},
+        Bar{x: u64, z: u32}
+    }
+
+    fun match(c: CommonFields, t: u64): bool {
+        match (c) {
+            Foo{x, y: _} => {
+                let match = x > t;
+                match
+            }
+            _ => false
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_parse_err4.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_parse_err4.exp
@@ -7,4 +7,4 @@ error: unexpected token
    │               ^^^^
    │               │
    │               Unexpected 'self'
-   │               Expected '('
+   │               Expected ';'

--- a/third_party/move/move-compiler/src/parser/syntax.rs
+++ b/third_party/move/move-compiler/src/parser/syntax.rs
@@ -994,7 +994,10 @@ fn parse_term(context: &mut Context) -> Result<Exp, Box<Diagnostic>> {
             }
             return parse_binop_exp(context, control_exp, /* min_prec */ 1);
         },
-        Tok::Identifier if context.tokens.content() == "match" => {
+        Tok::Identifier
+            if context.tokens.content() == "match"
+                && context.tokens.lookahead()? == Tok::LParen =>
+        {
             // Match always ends in block (see above case for comparison)
             let match_exp = parse_match_exp(context)?;
             if at_end_of_exp(context) {
@@ -1464,21 +1467,80 @@ fn parse_for_loop(context: &mut Context) -> Result<(Exp, bool), Box<Diagnostic>>
 
 // Match = "match" "(" <Exp> ")" "{" ( <MatchArm> ","? )* "}"
 // MatchArm = <Bind> ( "if" <Exp> )? "=>" <Exp>
+// If called, we know we are looking at `match (`.
 fn parse_match_exp(context: &mut Context) -> Result<Exp, Box<Diagnostic>> {
+    // We cannot uniquely determine this is actually a match expression
+    // until we have seen the `match (exp) {` prefix. We parse the parts and
+    // decide on the go whether to interpret this as a call to a function `match`.
     let start_loc = context.tokens.start_loc();
-    require_move_2_and_advance(context, "match expression")?;
-    consume_token(context.tokens, Tok::LParen)?;
-    let exp = parse_exp(context)?;
-    consume_token(context.tokens, Tok::RParen)?;
-    consume_token(context.tokens, Tok::LBrace)?;
-    let arms = parse_match_arms(context)?;
-    consume_token(context.tokens, Tok::RBrace)?;
-    Ok(spanned(
-        context.tokens.file_hash(),
-        start_loc,
-        context.tokens.previous_end_loc(),
-        Exp_::Match(Box::new(exp), arms),
-    ))
+    let match_ident = parse_identifier(context)?;
+    debug_assert!(match_ident.value.as_str() == "match");
+    let start_lparen_loc = context.tokens.start_loc();
+    assert!(consume_token(context.tokens, Tok::LParen).is_ok());
+    if match_token(context.tokens, Tok::RParen)? {
+        // Interpret as function call `match()`
+        let end_loc = context.tokens.previous_end_loc();
+        Ok(spanned(
+            context.tokens.file_hash(),
+            start_loc,
+            end_loc,
+            Exp_::Call(
+                sp(match_ident.loc, NameAccessChain_::One(match_ident)),
+                CallKind::Regular,
+                None,
+                spanned(
+                    match_ident.loc.file_hash(),
+                    start_lparen_loc,
+                    end_loc,
+                    vec![],
+                ),
+            ),
+        ))
+    } else {
+        let exp = parse_exp(context)?;
+        // As we have seen `match (exp`, now check whether we are looking at `match (exp) {`
+        // to confirm match expression
+        if (context.tokens.peek(), context.tokens.lookahead()?) == (Tok::RParen, Tok::LBrace) {
+            require_move_2(context, match_ident.loc, "match expression");
+            consume_token(context.tokens, Tok::RParen)?;
+            consume_token(context.tokens, Tok::LBrace)?;
+            let arms = parse_match_arms(context)?;
+            consume_token(context.tokens, Tok::RBrace)?;
+            Ok(spanned(
+                context.tokens.file_hash(),
+                start_loc,
+                context.tokens.previous_end_loc(),
+                Exp_::Match(Box::new(exp), arms),
+            ))
+        } else {
+            // Interpret as a function call `match(arg1, .., argn)`
+            let mut args = vec![exp];
+            if context.tokens.peek() == Tok::Comma {
+                // parse remaining `, arg2, arg3, ..)`
+                args.append(&mut parse_comma_list(
+                    context,
+                    Tok::Comma,
+                    Tok::RParen,
+                    parse_exp,
+                    "a call argument expression",
+                )?);
+            } else {
+                consume_token(context.tokens, Tok::RParen)?;
+            }
+            let end_loc = context.tokens.previous_end_loc();
+            Ok(spanned(
+                match_ident.loc.file_hash(),
+                start_loc,
+                end_loc,
+                Exp_::Call(
+                    sp(match_ident.loc, NameAccessChain_::One(match_ident)),
+                    CallKind::Regular,
+                    None,
+                    spanned(match_ident.loc.file_hash(), start_lparen_loc, end_loc, args),
+                ),
+            ))
+        }
+    }
 }
 
 fn parse_match_arms(


### PR DESCRIPTION
## Description

Fixes #14038.

The introduction of the `match (exp) { .. }` expression accidentally disabled the `match` name to be used for functions or variables. This PR adds context sensitivity to the parser to distinguish, for example, `match(x, y)` (a function call) from `match (e) { .. }`. As we are using a LL(2) parser, this is achieved by factoring out the common prefix. There is no function call `match(e) {` possible, so we know it is a match expression once we see `{`.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Added a number of test cases to the Move 2 testsuite. The parsers for language v1 and v2 are the same, so this also covers use cases for compiler v1 and compiler v2/language version v1.
