### PR TITLE
remove dev_setup from lint-test workflow

### DIFF
--- a/.github/actions/move-tests-compiler-v2/action.yaml
+++ b/.github/actions/move-tests-compiler-v2/action.yaml
@@ -13,14 +13,6 @@ runs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0 # Fetch all git history for accurate target determination
-    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
-      with:
-        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
-
-    # Install nextest
-    - uses: taiki-e/install-action@v1.5.6
-      with:
-        tool: nextest
 
     # Output the changed files
     - name: Output the changed files

--- a/.github/actions/rust-doc-tests/action.yaml
+++ b/.github/actions/rust-doc-tests/action.yaml
@@ -9,9 +9,6 @@ runs:
   using: composite
   steps:
     # The source code must be checked out by the workflow that invokes this action.
-    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
-      with:
-        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
 
     # Run the rust doc tests
     - name: Run rust doc tests

--- a/.github/actions/rust-lints/action.yaml
+++ b/.github/actions/rust-lints/action.yaml
@@ -10,10 +10,6 @@ runs:
   steps:
     # The source code must be checkout out by the workflow that invokes this action.
 
-    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
-      with:
-        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
-
     # Run the pre-commit checks
     - uses: pre-commit/action@v3.0.0
 

--- a/.github/actions/rust-smoke-tests/action.yaml
+++ b/.github/actions/rust-smoke-tests/action.yaml
@@ -10,15 +10,6 @@ runs:
   steps:
     # The source code must be checkout out by the workflow that invokes this action.
 
-    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
-      with:
-        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
-
-    # Install nextest
-    - uses: taiki-e/install-action@v1.5.6
-      with:
-        tool: nextest
-
     # Run a postgres database
     - name: Run postgres database
       run: docker run --detach -p 5432:5432 cimg/postgres:14.2

--- a/.github/actions/rust-targeted-unit-tests/action.yaml
+++ b/.github/actions/rust-targeted-unit-tests/action.yaml
@@ -9,14 +9,6 @@ runs:
   using: composite
   steps:
     # The source code must be checked out by the workflow that invokes this action.
-    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
-      with:
-        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
-
-    # Install nextest
-    - uses: taiki-e/install-action@v1.5.6
-      with:
-        tool: nextest
 
     # Run a postgres database
     - name: Run postgres database

--- a/.github/actions/rust-unit-tests/action.yaml
+++ b/.github/actions/rust-unit-tests/action.yaml
@@ -9,9 +9,6 @@ runs:
   using: composite
   steps:
     # The source code must be checkout out by the workflow that invokes this action.
-    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
-      with:
-        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
 
     # Check the VM features
     - name: Check VM features
@@ -22,11 +19,6 @@ runs:
     - name: Run rust doc tests
       run: cargo test --profile ci --locked --doc --workspace --exclude aptos-node-checker
       shell: bash
-
-    # Install nextest
-    - uses: taiki-e/install-action@v1.5.6
-      with:
-        tool: nextest
 
     # Run a postgres database
     - name: Run postgres database

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -60,10 +60,6 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
-        with:
-          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - run: python3 scripts/check-cryptohasher-symbols.py
 
   # Run all rust lints. This is a PR required job.
@@ -185,9 +181,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
-      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
-        with:
-          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       - name: Run aptos cached packages build test
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         run: scripts/cargo_build_aptos_cached_packages.sh --check
@@ -200,12 +193,6 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
       - uses: actions/checkout@v4
-      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
-        with:
-          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
-      - uses: taiki-e/install-action@v1.5.6
-        with:
-          tool: nextest
       - run: cargo nextest run --locked --workspace --exclude smoke-test --exclude aptos-testcases --exclude aptos-api --exclude aptos-executor-benchmark --exclude aptos-backup-cli --retries 3 --no-fail-fast -F consensus-only-perf-test
         env:
           RUST_MIN_STACK: 4297152
@@ -216,12 +203,6 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
       - uses: actions/checkout@v4
-      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
-        with:
-          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
-      - uses: taiki-e/install-action@v1.5.6
-        with:
-          tool: nextest
       # prebuild aptos-node binary, so that tests don't start before node is built.
       # also prebuild aptos-node binary as a separate step to avoid feature unification issues
       - run: cargo build --locked --package=aptos-node -F consensus-only-perf-test --release && LOCAL_SWARM_NODE_RELEASE=1 CONSENSUS_ONLY_PERF_TEST=1 cargo nextest run --release --package smoke-test -E "test(test_consensus_only_with_txn_emitter)" --run-ignored all


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
Remove the rust-setup and `cargo install nextest` steps from the lint-test workflows. These are now included in the custom image used by the runs-on runners

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
See the workflow runs for this PR

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
