### PR TITLE
Add chain gap/pause analysis from onchain data to CLI 

### DIFF
--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -1215,7 +1215,7 @@ impl CliCommand<()> for AnalyzeValidatorPerformance {
             || self.analyze_mode == AnalyzeMode::All;
         let print_max_tps =
             self.analyze_mode == AnalyzeMode::MaxTps || self.analyze_mode == AnalyzeMode::All;
-        for epoch_info in epochs {
+        for epoch_info in &epochs {
             let mut epoch_stats =
                 AnalyzeValidators::analyze(&epoch_info.blocks, &epoch_info.validators);
             if !self.pool_addresses.is_empty() {
@@ -1313,6 +1313,8 @@ impl CliCommand<()> for AnalyzeValidatorPerformance {
                 stats.keys().max().unwrap()
             );
             AnalyzeValidators::print_network_health_over_time(&stats, &all_validators);
+
+            AnalyzeValidators::print_gap(epochs.iter().flat_map(|epoch| epoch.blocks.iter()));
         }
         Ok(())
     }

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -263,6 +263,30 @@ static SYSTEM_12_CORES_10GB_THRESHOLD: Lazy<SystemMetricsThreshold> = Lazy::new(
     )
 });
 
+static RELIABLE_PROGRESS_THRESHOLD: Lazy<StateProgressThreshold> =
+    Lazy::new(|| StateProgressThreshold {
+        max_non_epoch_no_progress_secs: 10.0,
+        max_epoch_no_progress_secs: 10.0,
+        max_non_epoch_round_gap: 4,
+        max_epoch_round_gap: 4,
+    });
+
+static PROGRESS_THRESHOLD_20_6: Lazy<StateProgressThreshold> =
+    Lazy::new(|| StateProgressThreshold {
+        max_non_epoch_no_progress_secs: 20.0,
+        max_epoch_no_progress_secs: 20.0,
+        max_non_epoch_round_gap: 6,
+        max_epoch_round_gap: 6,
+    });
+
+static RELIABLE_REAL_ENV_PROGRESS_THRESHOLD: Lazy<StateProgressThreshold> =
+    Lazy::new(|| StateProgressThreshold {
+        max_non_epoch_no_progress_secs: 30.0,
+        max_epoch_no_progress_secs: 30.0,
+        max_non_epoch_round_gap: 10,
+        max_epoch_round_gap: 10,
+    });
+
 /// Make an easy to remember random namespace for your testnet
 fn random_namespace<R: Rng>(dictionary: Vec<String>, rng: &mut R) -> Result<String> {
     // Pick four random words
@@ -797,10 +821,7 @@ fn run_consensus_only_realistic_env_max_tps() -> ForgeConfig {
             SuccessCriteria::new(10000)
                 .add_no_restarts()
                 .add_wait_for_catchup_s(240)
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 20.0,
-                    max_round_gap: 6,
-                }),
+                .add_chain_progress(PROGRESS_THRESHOLD_20_6.clone()),
         )
 }
 
@@ -876,10 +897,7 @@ fn twin_validator_test() -> ForgeConfig {
                 .add_no_restarts()
                 .add_wait_for_catchup_s(60)
                 .add_system_metrics_threshold(SYSTEM_12_CORES_5GB_THRESHOLD.clone())
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 10.0,
-                    max_round_gap: 4,
-                }),
+                .add_chain_progress(RELIABLE_PROGRESS_THRESHOLD.clone()),
         )
 }
 
@@ -1051,10 +1069,7 @@ fn realistic_env_sweep_wrap(
             SuccessCriteria::new(0)
                 .add_no_restarts()
                 .add_wait_for_catchup_s(60)
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 30.0,
-                    max_round_gap: 10,
-                }),
+                .add_chain_progress(RELIABLE_REAL_ENV_PROGRESS_THRESHOLD.clone()),
         )
 }
 
@@ -1263,10 +1278,7 @@ fn load_vs_perf_benchmark() -> ForgeConfig {
             SuccessCriteria::new(0)
                 .add_no_restarts()
                 .add_wait_for_catchup_s(60)
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 30.0,
-                    max_round_gap: 10,
-                }),
+                .add_chain_progress(RELIABLE_REAL_ENV_PROGRESS_THRESHOLD.clone()),
         )
 }
 
@@ -1305,10 +1317,7 @@ fn workload_vs_perf_benchmark() -> ForgeConfig {
             SuccessCriteria::new(0)
                 .add_no_restarts()
                 .add_wait_for_catchup_s(60)
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 30.0,
-                    max_round_gap: 10,
-                }),
+                .add_chain_progress(RELIABLE_REAL_ENV_PROGRESS_THRESHOLD.clone()),
         )
 }
 
@@ -1347,10 +1356,7 @@ fn realistic_env_graceful_overload() -> ForgeConfig {
                 ))
                 .add_latency_threshold(10.0, LatencyType::P50)
                 .add_latency_threshold(30.0, LatencyType::P90)
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 30.0,
-                    max_round_gap: 10,
-                }),
+                .add_chain_progress(RELIABLE_REAL_ENV_PROGRESS_THRESHOLD.clone()),
         )
 }
 
@@ -1440,10 +1446,7 @@ fn workload_mix_test() -> ForgeConfig {
             SuccessCriteria::new(3000)
                 .add_no_restarts()
                 .add_wait_for_catchup_s(240)
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 20.0,
-                    max_round_gap: 6,
-                }),
+                .add_chain_progress(PROGRESS_THRESHOLD_20_6.clone()),
         )
 }
 
@@ -1508,10 +1511,7 @@ fn individual_workload_tests(test_name: String) -> ForgeConfig {
             })
             .add_no_restarts()
             .add_wait_for_catchup_s(240)
-            .add_chain_progress(StateProgressThreshold {
-                max_no_progress_secs: 20.0,
-                max_round_gap: 6,
-            }),
+            .add_chain_progress(PROGRESS_THRESHOLD_20_6.clone()),
         )
 }
 
@@ -1661,10 +1661,7 @@ fn three_region_simulation_with_different_node_speed() -> ForgeConfig {
             SuccessCriteria::new(1000)
                 .add_no_restarts()
                 .add_wait_for_catchup_s(240)
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 20.0,
-                    max_round_gap: 6,
-                }),
+                .add_chain_progress(PROGRESS_THRESHOLD_20_6.clone()),
         )
 }
 
@@ -1679,10 +1676,7 @@ fn three_region_simulation() -> ForgeConfig {
             SuccessCriteria::new(3000)
                 .add_no_restarts()
                 .add_wait_for_catchup_s(240)
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 20.0,
-                    max_round_gap: 6,
-                }),
+                .add_chain_progress(PROGRESS_THRESHOLD_20_6.clone()),
         )
 }
 
@@ -1817,10 +1811,7 @@ fn validators_join_and_leave() -> ForgeConfig {
                 .add_no_restarts()
                 .add_wait_for_catchup_s(240)
                 .add_system_metrics_threshold(SYSTEM_12_CORES_10GB_THRESHOLD.clone())
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 10.0,
-                    max_round_gap: 4,
-                }),
+                .add_chain_progress(RELIABLE_PROGRESS_THRESHOLD.clone()),
         )
 }
 
@@ -1867,8 +1858,10 @@ fn realistic_env_max_load_test(
         .add_latency_threshold(3.4, LatencyType::P50)
         .add_latency_threshold(4.5, LatencyType::P90)
         .add_chain_progress(StateProgressThreshold {
-            max_no_progress_secs: 15.0,
-            max_round_gap: 4,
+            max_non_epoch_no_progress_secs: 15.0,
+            max_epoch_no_progress_secs: 15.0,
+            max_non_epoch_round_gap: 4,
+            max_epoch_round_gap: 4,
         });
     if !ha_proxy {
         success_criteria = success_criteria.add_latency_breakdown_threshold(
@@ -2028,10 +2021,7 @@ fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
                     /* This test runs at high load, so we need more catchup time */
                     .add_wait_for_catchup_s(120),
                 /* Doesn't work without event indices
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 10.0,
-                    max_round_gap: 4,
-                }),
+                .add_chain_progress(RELIABLE_PROGRESS_THRESHOLD.clone()),
                  */
             );
     } else {
@@ -2041,10 +2031,7 @@ fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
                 /* This test runs at high load, so we need more catchup time */
                 .add_wait_for_catchup_s(120),
             /* Doesn't work without event indices
-                .add_chain_progress(StateProgressThreshold {
-                     max_no_progress_secs: 10.0,
-                     max_round_gap: 4,
-                 }),
+                .add_chain_progress(RELIABLE_PROGRESS_THRESHOLD.clone()),
             */
         );
     }
@@ -2184,21 +2171,26 @@ pub fn changing_working_quorum_test_helper(
             let success_criteria = SuccessCriteria::new(min_avg_tps)
                 .add_no_restarts()
                 .add_wait_for_catchup_s(30)
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: if max_down_nodes == 0 {
+                .add_chain_progress({
+                    let max_no_progress_secs = if max_down_nodes == 0 {
                         // very aggressive if no nodes are expected to be down
                         3.0
                     } else if max_down_nodes * 3 + 1 + 2 < num_validators {
                         // number of down nodes is at least 2 below the quorum limit, so
-                        // we can still be reasonably aggressive
+                        // we can still be reasonably aggqressive
                         15.0
                     } else {
                         // number of down nodes is close to the quorum limit, so
                         // make a check a bit looser, as state sync might be required
                         // to get the quorum back.
                         40.0
-                    },
-                    max_round_gap: 60,
+                    };
+                    StateProgressThreshold {
+                        max_non_epoch_no_progress_secs: max_no_progress_secs,
+                        max_epoch_no_progress_secs: max_no_progress_secs,
+                        max_non_epoch_round_gap: 60,
+                        max_epoch_round_gap: 60,
+                    }
                 });
 
             // If errors are allowed, overwrite the success criteria
@@ -2248,10 +2240,7 @@ fn large_db_test(
             SuccessCriteria::new(min_avg_tps)
                 .add_no_restarts()
                 .add_wait_for_catchup_s(30)
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 20.0,
-                    max_round_gap: 6,
-                }),
+                .add_chain_progress(PROGRESS_THRESHOLD_20_6.clone()),
         )
 }
 
@@ -2265,10 +2254,7 @@ fn quorum_store_reconfig_enable_test() -> ForgeConfig {
                 .add_no_restarts()
                 .add_wait_for_catchup_s(240)
                 .add_system_metrics_threshold(SYSTEM_12_CORES_10GB_THRESHOLD.clone())
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 10.0,
-                    max_round_gap: 4,
-                }),
+                .add_chain_progress(RELIABLE_PROGRESS_THRESHOLD.clone()),
         )
 }
 
@@ -2295,10 +2281,7 @@ fn mainnet_like_simulation_test() -> ForgeConfig {
             SuccessCriteria::new(10000)
                 .add_no_restarts()
                 .add_wait_for_catchup_s(240)
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 20.0,
-                    max_round_gap: 6,
-                }),
+                .add_chain_progress(PROGRESS_THRESHOLD_20_6.clone()),
         )
 }
 
@@ -2324,10 +2307,7 @@ fn multiregion_benchmark_test() -> ForgeConfig {
                     180,
                 )
                 .add_system_metrics_threshold(SYSTEM_12_CORES_10GB_THRESHOLD.clone())
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 10.0,
-                    max_round_gap: 4,
-                }),
+                .add_chain_progress(RELIABLE_PROGRESS_THRESHOLD.clone()),
         )
 }
 
@@ -2375,10 +2355,7 @@ fn pfn_const_tps(
                     // Give at least 60s for catchup and at most 10% of the run
                     (duration.as_secs() / 10).max(60),
                 )
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 10.0,
-                    max_round_gap: 4,
-                }),
+                .add_chain_progress(RELIABLE_PROGRESS_THRESHOLD.clone()),
         )
 }
 
@@ -2437,10 +2414,7 @@ fn pfn_performance(
                     // Give at least 60s for catchup and at most 10% of the run
                     (duration.as_secs() / 10).max(60),
                 )
-                .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 10.0,
-                    max_round_gap: 4,
-                }),
+                .add_chain_progress(RELIABLE_PROGRESS_THRESHOLD.clone()),
         )
 }
 

--- a/testsuite/forge-cli/src/suites/dag.rs
+++ b/testsuite/forge-cli/src/suites/dag.rs
@@ -130,8 +130,10 @@ fn dag_realistic_env_max_load_test(
                 )
                 .add_latency_threshold(4.0, LatencyType::P50)
                 .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 15.0,
-                    max_round_gap: 8,
+                    max_non_epoch_no_progress_secs: 15.0,
+                    max_epoch_no_progress_secs: 15.0,
+                    max_non_epoch_round_gap: 8,
+                    max_epoch_round_gap: 8,
                 }),
         )
 }
@@ -217,8 +219,10 @@ fn dag_reconfig_enable_test() -> ForgeConfig {
                 .add_no_restarts()
                 .add_wait_for_catchup_s(240)
                 .add_chain_progress(StateProgressThreshold {
-                    max_no_progress_secs: 20.0,
-                    max_round_gap: 20,
+                    max_non_epoch_no_progress_secs: 20.0,
+                    max_epoch_no_progress_secs: 20.0,
+                    max_non_epoch_round_gap: 20,
+                    max_epoch_round_gap: 20,
                 }),
         )
 }

--- a/testsuite/forge/src/success_criteria.rs
+++ b/testsuite/forge/src/success_criteria.rs
@@ -9,16 +9,18 @@ use crate::{
     Swarm, SwarmExt, TestReport,
 };
 use anyhow::{bail, Context};
-use aptos::node::analyze::fetch_metadata::FetchMetadata;
-use aptos_sdk::types::PeerId;
+use aptos::node::analyze::{analyze_validators::AnalyzeValidators, fetch_metadata::FetchMetadata};
+use aptos_logger::info;
 use aptos_transaction_emitter_lib::{TxnStats, TxnStatsRate};
 use prometheus_http_query::response::Sample;
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 #[derive(Clone, Debug)]
 pub struct StateProgressThreshold {
-    pub max_no_progress_secs: f32,
-    pub max_round_gap: u64,
+    pub max_non_epoch_no_progress_secs: f32,
+    pub max_epoch_no_progress_secs: f32,
+    pub max_non_epoch_round_gap: u64,
+    pub max_epoch_round_gap: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -283,7 +285,7 @@ impl SuccessCriteriaChecker {
         start_version: u64,
         end_version: u64,
     ) -> anyhow::Result<()> {
-        println!(
+        info!(
             "End to end duration: {}s, performance measured for: {}s",
             window.as_secs(),
             stats.lasted.as_secs()
@@ -381,82 +383,62 @@ impl SuccessCriteriaChecker {
             .await
             .unwrap();
 
-        let mut max_round_gap = 0;
-        let mut max_round_gap_version = 0;
-        let mut max_time_gap = 0;
-        let mut max_time_gap_version = 0;
-
-        let mut prev_block = None;
-        let mut prev_ts = 0;
-        let mut failed_from_nil = 0;
-        let mut previous_epooch = 0;
-        let mut previous_round = 0;
-        for block in epochs
-            .iter()
-            .flat_map(|epoch| epoch.blocks.iter())
-            .filter(|b| b.version > start_version && b.version < end_version)
-        {
-            let is_nil = block.event.proposer() == PeerId::ZERO;
-
-            let current_gap = if previous_epooch == block.event.epoch() {
-                block.event.round() - previous_round - 1
-            } else {
-                u64::from(!is_nil) + block.event.failed_proposer_indices().len() as u64
-            };
-
-            if is_nil {
-                failed_from_nil += current_gap;
-            } else {
-                if prev_ts > 0 {
-                    let round_gap = current_gap + failed_from_nil;
-                    let time_gap = block.event.proposed_time() as i64 - prev_ts as i64;
-
-                    if time_gap < 0 {
-                        println!(
-                            "Clock went backwards? {}, {:?}, {:?}",
-                            time_gap, block, prev_block
-                        );
-                    }
-
-                    if round_gap > max_round_gap {
-                        max_round_gap = round_gap;
-                        max_round_gap_version = block.version;
-                    }
-                    if time_gap > max_time_gap as i64 {
-                        max_time_gap = time_gap as u64;
-                        max_time_gap_version = block.version;
-                    }
-                }
-
-                failed_from_nil = 0;
-                prev_ts = block.event.proposed_time();
-                prev_block = Some(block);
-            }
-
-            previous_epooch = block.event.epoch();
-            previous_round = block.event.round();
-        }
-
-        let max_time_gap_secs = Duration::from_micros(max_time_gap).as_secs_f32();
-
-        let gap_text = format!(
-            "Max round gap was {} [limit {}] at version {}. Max no progress secs was {} [limit {}] at version {}.",
-            max_round_gap,
-            chain_progress_threshold.max_round_gap,
-            max_round_gap_version,
-            max_time_gap_secs,
-            chain_progress_threshold.max_no_progress_secs,
-            max_time_gap_version,
+        let gap_info = AnalyzeValidators::analyze_gap(
+            epochs
+                .iter()
+                .flat_map(|epoch| epoch.blocks.iter())
+                .filter(|b| b.version > start_version && b.version < end_version),
         );
 
-        if max_round_gap > chain_progress_threshold.max_round_gap
-            || max_time_gap_secs > chain_progress_threshold.max_no_progress_secs
+        let gap_text = format!(
+            "Max non-epoch-change gap was: {} [limit {}], {} [limit {}].",
+            gap_info.non_epoch_round_gap.to_string_as_round(),
+            chain_progress_threshold.max_non_epoch_round_gap,
+            gap_info.non_epoch_time_gap.to_string_as_time(),
+            chain_progress_threshold.max_non_epoch_no_progress_secs,
+        );
+
+        let epoch_gap_text = format!(
+            "Max epoch-change gap was: {} [limit {}], {} [limit {}].",
+            gap_info.epoch_round_gap.to_string_as_round(),
+            chain_progress_threshold.max_epoch_round_gap,
+            gap_info.epoch_time_gap.to_string_as_time(),
+            chain_progress_threshold.max_epoch_no_progress_secs,
+        );
+
+        info!(
+            max_non_epoch_round_gap = gap_info.non_epoch_round_gap.max_gap,
+            max_epoch_round_gap = gap_info.epoch_round_gap.max_gap,
+            max_non_epoch_time_gap = gap_info.non_epoch_time_gap.max_gap,
+            max_epoch_time_gap = gap_info.epoch_time_gap.max_gap,
+            "Max gap values",
+        );
+
+        report.report_text(gap_text.clone());
+        report.report_text(epoch_gap_text.clone());
+
+        if gap_info.non_epoch_round_gap.max_gap.round() as u64
+            > chain_progress_threshold.max_non_epoch_round_gap
+            || gap_info.non_epoch_time_gap.max_gap
+                > chain_progress_threshold.max_non_epoch_no_progress_secs
         {
-            bail!("Failed chain progress check. {}", gap_text);
-        } else {
-            println!("Passed progress check. {}", gap_text);
-            report.report_text(gap_text);
+            bail!(
+                "Failed non-epoch-change chain progress check. {}",
+                &gap_text
+            );
         }
+        info!("Passed non-epoch-change progress check. {}", gap_text);
+
+        if gap_info.epoch_round_gap.max_gap.round() as u64
+            > chain_progress_threshold.max_epoch_round_gap
+            || gap_info.epoch_time_gap.max_gap > chain_progress_threshold.max_epoch_no_progress_secs
+        {
+            bail!(
+                "Failed epoch-change chain progress check. {}",
+                &epoch_gap_text
+            );
+        }
+        info!("Passed epoch-change progress check. {}", epoch_gap_text);
 
         Ok(())
     }
@@ -476,7 +458,7 @@ impl SuccessCriteriaChecker {
                 stats_rate,
             )
         } else {
-            println!(
+            info!(
                 "TPS is {} and is within limit of {}",
                 stats_rate.committed, min_avg_tps
             );
@@ -503,7 +485,7 @@ impl SuccessCriteriaChecker {
                     stats_rate,
                 )
             } else {
-                println!(
+                info!(
                     "{} TPS is {} and is below max limit of {}",
                     value_desc, value, max
                 );
@@ -565,7 +547,7 @@ impl SuccessCriteriaChecker {
                     .to_string(),
                 );
             } else {
-                println!(
+                info!(
                     "{:?} latency{} is {}s and is within limit of {}s",
                     latency_type,
                     traffic_name_addition,
@@ -591,7 +573,7 @@ impl SuccessCriteriaChecker {
                 error_count
             );
         } else {
-            println!("No error!() found in validator logs");
+            info!("No error!() found in validator logs");
             Ok(())
         }
     }

--- a/testsuite/testcases/tests/forge-local-performance.rs
+++ b/testsuite/testcases/tests/forge-local-performance.rs
@@ -24,8 +24,10 @@ fn main() -> Result<()> {
         )
         .with_success_criteria(SuccessCriteria::new(20).add_chain_progress(
             StateProgressThreshold {
-                max_no_progress_secs: 0.0,
-                max_round_gap: 0,
+                max_non_epoch_no_progress_secs: 0.0,
+                max_epoch_no_progress_secs: 0.0,
+                max_non_epoch_round_gap: 0,
+                max_epoch_round_gap: 0,
             },
         ));
 


### PR DESCRIPTION
## Description

`analyze-validator-performance --analyze-mode network-health-over-time` cli command gives health statistics of the network over time. Adding gap analysis to it as well, as an useful metric if there are any issues or not

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Aptos CLI/SDK

## How Has This Been Tested?
`cargo run -p aptos -- node analyze-validator-performance --analyze-mode network-health-over-time --url https://fullnode.mainnet.aptoslabs.com/ --start-epoch=-12`

returns

```
Max non-epoch-change gaps: 2 rounds at version 1039252739 (avg 0.00), 3.44s no progress at version 1039252739 (avg 0.22s).
Max epoch-change gaps: 0 rounds at version 0 (avg 0.00), 3.92s no progress at version 1038729529 (avg 2.76s).

```

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
