### PR TITLE
Update processor dep for localnet to fix Windows CLI build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2758,7 +2758,7 @@ dependencies = [
 [[package]]
 name = "aptos-moving-average"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d954cf4eef9ceabdd941b2e08923fff83984b591#d954cf4eef9ceabdd941b2e08923fff83984b591"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=fa1ce4947f4c2be57529f1c9732529e05a06cb7f#fa1ce4947f4c2be57529f1c9732529e05a06cb7f"
 dependencies = [
  "chrono",
 ]
@@ -3263,8 +3263,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-protos"
-version = "1.3.0"
-source = "git+https://github.com/aptos-labs/aptos-core.git?rev=d76b5bb423b78b2b9affc72d3853f0d973d3f11f#d76b5bb423b78b2b9affc72d3853f0d973d3f11f"
+version = "1.3.1"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -3276,6 +3275,7 @@ dependencies = [
 [[package]]
 name = "aptos-protos"
 version = "1.3.1"
+source = "git+https://github.com/aptos-labs/aptos-core.git?rev=5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb#5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb"
 dependencies = [
  "futures-core",
  "pbjson",
@@ -12977,14 +12977,14 @@ dependencies = [
 [[package]]
 name = "processor"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d954cf4eef9ceabdd941b2e08923fff83984b591#d954cf4eef9ceabdd941b2e08923fff83984b591"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=fa1ce4947f4c2be57529f1c9732529e05a06cb7f#fa1ce4947f4c2be57529f1c9732529e05a06cb7f"
 dependencies = [
  "ahash 0.8.11",
  "allocative",
  "allocative_derive",
  "anyhow",
- "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d954cf4eef9ceabdd941b2e08923fff83984b591)",
- "aptos-protos 1.3.0",
+ "aptos-moving-average 0.1.0 (git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=fa1ce4947f4c2be57529f1c9732529e05a06cb7f)",
+ "aptos-protos 1.3.1 (git+https://github.com/aptos-labs/aptos-core.git?rev=5c48aee129b5a141be2792ffa3d9bd0a1a61c9cb)",
  "async-trait",
  "bcs 0.1.4",
  "bigdecimal",
@@ -13031,7 +13031,6 @@ dependencies = [
  "tracing",
  "unescape",
  "url",
- "uuid",
 ]
 
 [[package]]
@@ -14582,7 +14581,7 @@ dependencies = [
 [[package]]
 name = "server-framework"
 version = "1.0.0"
-source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=d954cf4eef9ceabdd941b2e08923fff83984b591#d954cf4eef9ceabdd941b2e08923fff83984b591"
+source = "git+https://github.com/aptos-labs/aptos-indexer-processors.git?rev=fa1ce4947f4c2be57529f1c9732529e05a06cb7f#fa1ce4947f4c2be57529f1c9732529e05a06cb7f"
 dependencies = [
  "anyhow",
  "aptos-system-utils 0.1.0 (git+https://github.com/aptos-labs/aptos-core.git?rev=4541add3fd29826ec57f22658ca286d2d6134b93)",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 ## Unreleased
 
-## [3.5.1] - 2024/07/19
-- Upgraded indexer processors for localnet from 5244b84fa5ed872e5280dc8df032d744d62ad29d to d954cf4eef9ceabdd941b2e08923fff83984b591. Upgraded Hasura metadata accordingly.
+## [3.5.1] - 2024/07/21
+- Upgraded indexer processors for localnet from 5244b84fa5ed872e5280dc8df032d744d62ad29d to fa1ce4947f4c2be57529f1c9732529e05a06cb7f. Upgraded Hasura metadata accordingly.
 - Upgraded Hasura image from 2.36.1 to 2.40.2-ce. Note that we use the Community Edition, so the console won't ask users to upgrade to enterprise anymore / hint at any enterprise features.
 - Fixes a bug in the Move compiler (both v1 and v2) which disallowed `match` as a name for a function or for a variable.
 

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -83,14 +83,14 @@ pathsearch = { workspace = true }
 poem = { workspace = true }
 # We set default-features to false so we don't onboard the libpq dep. See more here:
 # https://github.com/aptos-labs/aptos-core/pull/12568
-processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "d954cf4eef9ceabdd941b2e08923fff83984b591", default-features = false }
+processor = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "fa1ce4947f4c2be57529f1c9732529e05a06cb7f", default-features = false }
 rand = { workspace = true }
 reqwest = { workspace = true }
 self_update = { git = "https://github.com/banool/self_update.git", rev = "8306158ad0fd5b9d4766a3c6bf967e7ef0ea5c4b", features = ["archive-zip", "compression-zip-deflate"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "d954cf4eef9ceabdd941b2e08923fff83984b591" }
+server-framework = { git = "https://github.com/aptos-labs/aptos-indexer-processors.git", rev = "fa1ce4947f4c2be57529f1c9732529e05a06cb7f" }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/crates/aptos/src/node/local_testnet/processors.rs
+++ b/crates/aptos/src/node/local_testnet/processors.rs
@@ -12,8 +12,7 @@ use processor::{
     gap_detectors::DEFAULT_GAP_DETECTION_BATCH_SIZE,
     processors::{
         objects_processor::ObjectsProcessorConfig, stake_processor::StakeProcessorConfig,
-        token_processor::TokenProcessorConfig, token_v2_processor::TokenV2ProcessorConfig,
-        ProcessorConfig, ProcessorName,
+        token_v2_processor::TokenV2ProcessorConfig, ProcessorConfig, ProcessorName,
     },
     utils::database::run_pending_migrations,
     IndexerGrpcProcessorConfig,
@@ -38,13 +37,11 @@ pub struct ProcessorArgs {
         value_enum,
         default_values_t = vec![
             ProcessorName::AccountTransactionsProcessor,
-            ProcessorName::CoinProcessor,
             ProcessorName::DefaultProcessor,
             ProcessorName::EventsProcessor,
             ProcessorName::FungibleAssetProcessor,
             ProcessorName::ObjectsProcessor,
             ProcessorName::StakeProcessor,
-            ProcessorName::TokenProcessor,
             ProcessorName::TokenV2Processor,
             ProcessorName::TransactionMetadataProcessor,
             ProcessorName::UserTransactionProcessor,
@@ -74,11 +71,7 @@ impl ProcessorManager {
             ProcessorName::AnsProcessor => {
                 bail!("ANS processor is not supported in the localnet")
             },
-            ProcessorName::CoinProcessor => ProcessorConfig::CoinProcessor,
             ProcessorName::DefaultProcessor => ProcessorConfig::DefaultProcessor,
-            ProcessorName::DefaultParquetProcessor => {
-                bail!("Default Parquet processor is not supported in the localnet")
-            },
             ProcessorName::EventsProcessor => ProcessorConfig::EventsProcessor,
             ProcessorName::FungibleAssetProcessor => ProcessorConfig::FungibleAssetProcessor,
             ProcessorName::MonitoringProcessor => {
@@ -93,16 +86,14 @@ impl ProcessorManager {
                     query_retry_delay_ms: Default::default(),
                 })
             },
+            ProcessorName::ParquetDefaultProcessor => {
+                bail!("ParquetDefaultProcessor is not supported in the localnet")
+            },
+            ProcessorName::ParquetFungibleAssetProcessor => {
+                bail!("ParquetFungibleAssetProcessor is not supported in the localnet")
+            },
             ProcessorName::StakeProcessor => {
                 ProcessorConfig::StakeProcessor(StakeProcessorConfig {
-                    query_retries: Default::default(),
-                    query_retry_delay_ms: Default::default(),
-                })
-            },
-            ProcessorName::TokenProcessor => {
-                ProcessorConfig::TokenProcessor(TokenProcessorConfig {
-                    // This NFT points contract doesn't exist on localnets.
-                    nft_points_contract: None,
                     query_retries: Default::default(),
                     query_retry_delay_ms: Default::default(),
                 })


### PR DESCRIPTION
## Stack
Previous: https://github.com/aptos-labs/aptos-core/pull/14068

## Description
The previous processor dependency broke the CLI build on Windows. This PR updates the dependency to fix that. This updates the dependency such that the v1 processors have been deleted. I update the CLI code accordingly.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
This time I applied the `CICD:run-windows-tests` label, see that the Windows build CI passes.

## Key Areas to Review
N/A

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
