### PR TITLE
Fix downloads in Windows setup script

### DIFF
--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -29,14 +29,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all git history for accurate target determination
 
+      - name: Set up WinGet
+        run: Set-Variable ProgressPreference SilentlyContinue ; PowerShell -ExecutionPolicy Bypass -File scripts/windows_dev_setup.ps1
+
       # This action will cache ~/.cargo and ./target (or the equivalent on Windows in
       # this case). See more here:
       # https://github.com/Swatinem/rust-cache#cache-details
       - name: Run cargo cache
         uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # pin@v2.2.0
-
-      - name: Set up WinGet
-        run: Set-Variable ProgressPreference SilentlyContinue ; PowerShell -ExecutionPolicy Bypass -File scripts/windows_dev_setup.ps1
 
       - name: Install the Developer Tools
         run: Set-Variable ProgressPreference SilentlyContinue ; PowerShell -ExecutionPolicy Bypass -File scripts/windows_dev_setup.ps1 -t


### PR DESCRIPTION
## Description
I was seeing that downloading the WinGet installer was just hanging. For whatever reason, Invoke-WebRequest struggled with the large WinGet installer package. Using Start-BitsTransfer fixes it. It doesn't know how to follow redirects so I resolve those myself, it seems like the actual URLs are sensible (like not ephemeral).

I also fixed some broken flags, e.g. typos for `--accept-source-agreements`.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
See Windows CLI build run. Note that the actual CLI build will fail until this lands: https://github.com/aptos-labs/aptos-core/pull/14067. The point of this PR is just to fix the setup phase.

## Key Areas to Review
N/A

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation