### PR TITLE
[consensus][qs] Introduce OptQuorumStorePayload Payload

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -116,6 +116,9 @@ impl Block {
                 Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _) => {
                     inline_batches.len() + proof_with_data.proofs.len()
                 },
+                Payload::OptQuorumStore(opt_quorum_store_payload) => {
+                    opt_quorum_store_payload.num_txns()
+                },
             },
         }
     }

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -249,25 +249,6 @@ fn sum_max_txns_to_execute(m1: Option<u64>, m2: Option<u64>) -> Option<u64> {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub enum PayloadExecutionLimit {
-    None,
-    MaxTransactionToExecute(u64),
-}
-
-impl PayloadExecutionLimit {
-    pub(crate) fn extend(&mut self, other: PayloadExecutionLimit) {
-        *self = match (&self, &other) {
-            (PayloadExecutionLimit::None, _) => other,
-            (_, PayloadExecutionLimit::None) => return,
-            (
-                PayloadExecutionLimit::MaxTransactionToExecute(limit1),
-                PayloadExecutionLimit::MaxTransactionToExecute(limit2),
-            ) => PayloadExecutionLimit::MaxTransactionToExecute(*limit1 + *limit2),
-        };
-    }
-}
-
 /// The payload in block.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub enum Payload {

--- a/consensus/consensus-types/src/lib.rs
+++ b/consensus/consensus-types/src/lib.rs
@@ -13,6 +13,7 @@ pub mod epoch_retrieval;
 pub mod order_vote;
 pub mod order_vote_msg;
 pub mod order_vote_proposal;
+pub mod payload;
 pub mod pipeline;
 pub mod pipelined_block;
 pub mod proof_of_store;

--- a/consensus/consensus-types/src/payload.rs
+++ b/consensus/consensus-types/src/payload.rs
@@ -1,0 +1,175 @@
+use crate::{
+    common::{DataStatus, PayloadExecutionLimit},
+    proof_of_store::{BatchInfo, ProofOfStore},
+};
+use aptos_infallible::Mutex;
+use aptos_types::PeerId;
+use core::fmt;
+use serde::{Deserialize, Serialize};
+use std::{
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
+
+pub trait TDataInfo {
+    fn num_txns(&self) -> u64;
+
+    fn num_bytes(&self) -> u64;
+
+    fn info(&self) -> &BatchInfo;
+
+    fn signers(&self, ordered_authors: &Vec<PeerId>) -> Vec<PeerId>;
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct CachedDataPointer<T> {
+    pub pointer: Vec<T>,
+    #[serde(skip)]
+    pub status: Arc<Mutex<Option<DataStatus>>>,
+}
+
+impl<T> CachedDataPointer<T>
+where
+    T: TDataInfo,
+{
+    pub fn new(metadata: Vec<T>) -> Self {
+        Self {
+            pointer: metadata,
+            status: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub fn extend(&mut self, other: CachedDataPointer<T>) {
+        let other_data_status = other.status.lock().as_mut().unwrap().take();
+        self.pointer.extend(other.pointer);
+        let mut status = self.status.lock();
+        if status.is_none() {
+            *status = Some(other_data_status);
+        } else {
+            status.as_mut().unwrap().extend(other_data_status);
+        }
+    }
+
+    pub fn num_txns(&self) -> usize {
+        self.pointer
+            .iter()
+            .map(|info| info.num_txns() as usize)
+            .sum()
+    }
+
+    pub fn num_bytes(&self) -> usize {
+        self.pointer
+            .iter()
+            .map(|info| info.num_bytes() as usize)
+            .sum()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.pointer.is_empty()
+    }
+}
+
+impl<T: PartialEq> PartialEq for CachedDataPointer<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.pointer == other.pointer && Arc::as_ptr(&self.status) == Arc::as_ptr(&other.status)
+    }
+}
+
+impl<T: Eq> Eq for CachedDataPointer<T> {}
+
+impl<T> Deref for CachedDataPointer<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.pointer
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct OptQuorumStorePayloadV1 {
+    opt_batches: CachedDataPointer<BatchInfo>,
+    proofs: CachedDataPointer<ProofOfStore>,
+    execution_limits: PayloadExecutionLimit,
+}
+
+impl OptQuorumStorePayloadV1 {
+    pub fn get_all_batch_infos(&self) -> Vec<BatchInfo> {
+        self.opt_batches
+            .deref()
+            .iter()
+            .chain(self.proofs.iter().map(|proof| proof.info()))
+            .cloned()
+            .collect()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum OptQuorumStorePayload {
+    V1(OptQuorumStorePayloadV1),
+}
+
+impl OptQuorumStorePayload {
+    pub(crate) fn num_txns(&self) -> usize {
+        self.opt_batches.num_txns() + self.proofs.num_txns()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.opt_batches.is_empty() && self.proofs.is_empty()
+    }
+
+    pub(crate) fn extend(mut self, other: Self) -> Self {
+        let other: OptQuorumStorePayloadV1 = other.into_inner();
+        self.opt_batches.extend(other.opt_batches);
+        self.proofs.extend(other.proofs);
+        self.execution_limits.extend(other.execution_limits);
+        self
+    }
+
+    pub(crate) fn num_bytes(&self) -> usize {
+        self.opt_batches.num_bytes() + self.proofs.num_bytes()
+    }
+
+    fn into_inner(self) -> OptQuorumStorePayloadV1 {
+        match self {
+            OptQuorumStorePayload::V1(opt_qs_payload) => opt_qs_payload,
+        }
+    }
+
+    pub fn proof_with_data(&self) -> &CachedDataPointer<ProofOfStore> {
+        &self.proofs
+    }
+
+    pub fn opt_batches(&self) -> &CachedDataPointer<BatchInfo> {
+        &self.opt_batches
+    }
+}
+
+impl Deref for OptQuorumStorePayload {
+    type Target = OptQuorumStorePayloadV1;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            OptQuorumStorePayload::V1(opt_qs_payload) => opt_qs_payload,
+        }
+    }
+}
+
+impl DerefMut for OptQuorumStorePayload {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            OptQuorumStorePayload::V1(opt_qs_payload) => opt_qs_payload,
+        }
+    }
+}
+
+impl fmt::Display for OptQuorumStorePayload {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "OptQuorumStorePayload(opt_batches: {}, proofs: {}, limits: {:?})",
+            self.opt_batches.num_txns(),
+            self.proofs.num_txns(),
+            self.execution_limits,
+        )
+    }
+}

--- a/consensus/consensus-types/src/payload.rs
+++ b/consensus/consensus-types/src/payload.rs
@@ -1,9 +1,9 @@
 use crate::{
-    common::{DataStatus, PayloadExecutionLimit},
+    common::DataStatus,
     proof_of_store::{BatchInfo, ProofOfStore},
 };
 use aptos_infallible::Mutex;
-use aptos_types::PeerId;
+use aptos_types::{transaction::SignedTransaction, PeerId};
 use core::fmt;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -85,21 +85,121 @@ impl<T> Deref for CachedDataPointer<T> {
     }
 }
 
+impl<T> IntoIterator for CachedDataPointer<T> {
+    type IntoIter = std::vec::IntoIter<T>;
+    type Item = T;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.pointer.into_iter()
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum PayloadExecutionLimit {
+    None,
+    MaxTransactionsToExecute(u64),
+}
+
+impl PayloadExecutionLimit {
+    pub(crate) fn extend(&mut self, other: PayloadExecutionLimit) {
+        *self = match (&self, &other) {
+            (PayloadExecutionLimit::None, _) => other,
+            (_, PayloadExecutionLimit::None) => return,
+            (
+                PayloadExecutionLimit::MaxTransactionsToExecute(limit1),
+                PayloadExecutionLimit::MaxTransactionsToExecute(limit2),
+            ) => PayloadExecutionLimit::MaxTransactionsToExecute(*limit1 + *limit2),
+        };
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct InlineBatch {
+    batch_info: BatchInfo,
+    transactions: Vec<SignedTransaction>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct InlineBatches(Vec<InlineBatch>);
+
+impl InlineBatches {
+    fn num_txns(&self) -> usize {
+        self.0
+            .iter()
+            .map(|batch| batch.batch_info.num_txns() as usize)
+            .sum()
+    }
+
+    fn num_bytes(&self) -> usize {
+        self.0
+            .iter()
+            .map(|batch| batch.batch_info.num_bytes() as usize)
+            .sum()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn transactions(&self) -> Vec<SignedTransaction> {
+        self.0
+            .iter()
+            .flat_map(|inline_batch| inline_batch.transactions.clone())
+            .collect()
+    }
+
+    pub fn batch_infos(&self) -> Vec<BatchInfo> {
+        self.0
+            .iter()
+            .map(|inline_batch| inline_batch.batch_info.clone())
+            .collect()
+    }
+}
+
+impl Deref for InlineBatches {
+    type Target = Vec<InlineBatch>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for InlineBatches {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct OptQuorumStorePayloadV1 {
+    inline_batches: InlineBatches,
     opt_batches: CachedDataPointer<BatchInfo>,
     proofs: CachedDataPointer<ProofOfStore>,
     execution_limits: PayloadExecutionLimit,
 }
 
 impl OptQuorumStorePayloadV1 {
-    pub fn get_all_batch_infos(&self) -> Vec<BatchInfo> {
-        self.opt_batches
-            .deref()
-            .iter()
-            .chain(self.proofs.iter().map(|proof| proof.info()))
-            .cloned()
+    pub fn get_all_batch_infos(self) -> Vec<BatchInfo> {
+        let Self {
+            inline_batches,
+            opt_batches,
+            proofs,
+            execution_limits: _,
+        } = self;
+        inline_batches
+            .0
+            .into_iter()
+            .map(|batch| batch.batch_info)
+            .chain(opt_batches.into_iter())
+            .chain(proofs.into_iter().map(|proof| proof.info().clone()))
             .collect()
+    }
+
+    pub fn max_txns_to_execute(&self) -> Option<u64> {
+        match self.execution_limits {
+            PayloadExecutionLimit::None => None,
+            PayloadExecutionLimit::MaxTransactionsToExecute(max) => Some(max),
+        }
     }
 }
 
@@ -110,15 +210,16 @@ pub enum OptQuorumStorePayload {
 
 impl OptQuorumStorePayload {
     pub(crate) fn num_txns(&self) -> usize {
-        self.opt_batches.num_txns() + self.proofs.num_txns()
+        self.opt_batches.num_txns() + self.proofs.num_txns() + self.inline_batches.num_txns()
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.opt_batches.is_empty() && self.proofs.is_empty()
+        self.opt_batches.is_empty() && self.proofs.is_empty() && self.inline_batches.is_empty()
     }
 
     pub(crate) fn extend(mut self, other: Self) -> Self {
         let other: OptQuorumStorePayloadV1 = other.into_inner();
+        self.inline_batches.extend(other.inline_batches.0);
         self.opt_batches.extend(other.opt_batches);
         self.proofs.extend(other.proofs);
         self.execution_limits.extend(other.execution_limits);
@@ -126,13 +227,17 @@ impl OptQuorumStorePayload {
     }
 
     pub(crate) fn num_bytes(&self) -> usize {
-        self.opt_batches.num_bytes() + self.proofs.num_bytes()
+        self.opt_batches.num_bytes() + self.proofs.num_bytes() + self.inline_batches.num_bytes()
     }
 
-    fn into_inner(self) -> OptQuorumStorePayloadV1 {
+    pub fn into_inner(self) -> OptQuorumStorePayloadV1 {
         match self {
             OptQuorumStorePayload::V1(opt_qs_payload) => opt_qs_payload,
         }
+    }
+
+    pub fn inline_batches(&self) -> &InlineBatches {
+        &self.inline_batches
     }
 
     pub fn proof_with_data(&self) -> &CachedDataPointer<ProofOfStore> {

--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::payload::TDataInfo;
 use anyhow::{bail, ensure, Context};
 use aptos_crypto::{bls12381, CryptoMaterialError, HashValue};
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
@@ -142,6 +143,24 @@ impl BatchInfo {
 impl Display for BatchInfo {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(f, "({}:{}:{})", self.author, self.batch_id, self.digest)
+    }
+}
+
+impl TDataInfo for BatchInfo {
+    fn num_txns(&self) -> u64 {
+        self.num_txns()
+    }
+
+    fn num_bytes(&self) -> u64 {
+        self.num_bytes()
+    }
+
+    fn info(&self) -> &BatchInfo {
+        &self
+    }
+
+    fn signers(&self, _ordered_authors: &Vec<PeerId>) -> Vec<PeerId> {
+        vec![self.author()]
     }
 }
 
@@ -351,10 +370,8 @@ impl ProofOfStore {
         result
     }
 
-    pub fn shuffled_signers(&self, validator: &ValidatorVerifier) -> Vec<PeerId> {
-        let mut ret: Vec<PeerId> = self
-            .multi_signature
-            .get_signers_addresses(&validator.get_ordered_account_addresses());
+    pub fn shuffled_signers(&self, ordered_authors: &[PeerId]) -> Vec<PeerId> {
+        let mut ret: Vec<PeerId> = self.multi_signature.get_signers_addresses(ordered_authors);
         ret.shuffle(&mut thread_rng());
         ret
     }
@@ -373,5 +390,23 @@ impl Deref for ProofOfStore {
 
     fn deref(&self) -> &Self::Target {
         &self.info
+    }
+}
+
+impl TDataInfo for ProofOfStore {
+    fn num_txns(&self) -> u64 {
+        self.num_txns
+    }
+
+    fn num_bytes(&self) -> u64 {
+        self.num_bytes
+    }
+
+    fn info(&self) -> &BatchInfo {
+        self.info()
+    }
+
+    fn signers(&self, ordered_authors: &Vec<PeerId>) -> Vec<PeerId> {
+        self.shuffled_signers(ordered_authors)
     }
 }

--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -156,10 +156,10 @@ impl TDataInfo for BatchInfo {
     }
 
     fn info(&self) -> &BatchInfo {
-        &self
+        self
     }
 
-    fn signers(&self, _ordered_authors: &Vec<PeerId>) -> Vec<PeerId> {
+    fn signers(&self, _ordered_authors: &[PeerId]) -> Vec<PeerId> {
         vec![self.author()]
     }
 }
@@ -406,7 +406,7 @@ impl TDataInfo for ProofOfStore {
         self.info()
     }
 
-    fn signers(&self, ordered_authors: &Vec<PeerId>) -> Vec<PeerId> {
+    fn signers(&self, ordered_authors: &[PeerId]) -> Vec<PeerId> {
         self.shuffled_signers(ordered_authors)
     }
 }

--- a/consensus/src/consensus_observer/network_message.rs
+++ b/consensus/src/consensus_observer/network_message.rs
@@ -489,6 +489,7 @@ impl BlockTransactionPayload {
                 // Verify the transaction limit
                 self.verify_transaction_limit(*max_txns_to_execute)?;
             },
+            Payload::OptQuorumStore(_) => todo!(),
         }
 
         Ok(())

--- a/consensus/src/consensus_observer/network_message.rs
+++ b/consensus/src/consensus_observer/network_message.rs
@@ -365,6 +365,7 @@ pub enum BlockTransactionPayload {
     InQuorumStore(PayloadWithProof),
     InQuorumStoreWithLimit(PayloadWithProofAndLimit),
     QuorumStoreInlineHybrid(PayloadWithProofAndLimit, Vec<BatchInfo>),
+    OptQuorumStore(PayloadWithProofAndLimit, Vec<BatchInfo>),
 }
 
 impl BlockTransactionPayload {
@@ -400,6 +401,17 @@ impl BlockTransactionPayload {
         Self::QuorumStoreInlineHybrid(proof_with_limit, inline_batches)
     }
 
+    pub fn new_opt_quorum_store(
+        transactions: Vec<SignedTransaction>,
+        proofs: Vec<ProofOfStore>,
+        limit: Option<u64>,
+        batch_infos: Vec<BatchInfo>,
+    ) -> Self {
+        let payload_with_proof = PayloadWithProof::new(transactions, proofs);
+        let proof_with_limit = PayloadWithProofAndLimit::new(payload_with_proof, limit);
+        Self::OptQuorumStore(proof_with_limit, batch_infos)
+    }
+
     #[cfg(test)]
     /// Returns an empty transaction payload (for testing)
     pub fn empty() -> Self {
@@ -424,6 +436,7 @@ impl BlockTransactionPayload {
             BlockTransactionPayload::QuorumStoreInlineHybrid(payload, _) => {
                 payload.transaction_limit
             },
+            BlockTransactionPayload::OptQuorumStore(payload, _) => payload.transaction_limit,
         }
     }
 
@@ -437,6 +450,9 @@ impl BlockTransactionPayload {
             BlockTransactionPayload::QuorumStoreInlineHybrid(payload, _) => {
                 payload.payload_with_proof.proofs.clone()
             },
+            BlockTransactionPayload::OptQuorumStore(payload, _) => {
+                payload.payload_with_proof.proofs.clone()
+            },
         }
     }
 
@@ -448,6 +464,9 @@ impl BlockTransactionPayload {
                 payload.payload_with_proof.transactions.clone()
             },
             BlockTransactionPayload::QuorumStoreInlineHybrid(payload, _) => {
+                payload.payload_with_proof.transactions.clone()
+            },
+            BlockTransactionPayload::OptQuorumStore(payload, _) => {
                 payload.payload_with_proof.transactions.clone()
             },
         }
@@ -489,7 +508,16 @@ impl BlockTransactionPayload {
                 // Verify the transaction limit
                 self.verify_transaction_limit(*max_txns_to_execute)?;
             },
-            Payload::OptQuorumStore(_) => todo!(),
+            Payload::OptQuorumStore(opt_qs_payload) => {
+                // Verify the batches in the requested block
+                self.verify_batches(&opt_qs_payload.proof_with_data())?;
+
+                // Verify the inline batches
+                self.verify_opt_batches(opt_qs_payload.opt_batches())?;
+
+                // Verify the transaction limit
+                self.verify_transaction_limit(opt_qs_payload.max_txns_to_execute())?;
+            },
         }
 
         Ok(())
@@ -546,6 +574,25 @@ impl BlockTransactionPayload {
             )));
         }
 
+        Ok(())
+    }
+
+    fn verify_opt_batches(&self, expected_opt_batches: &Vec<BatchInfo>) -> Result<(), Error> {
+        let opt_batches: &Vec<BatchInfo> = match self {
+            BlockTransactionPayload::OptQuorumStore(_, opt_batches) => opt_batches,
+            _ => {
+                return Err(Error::InvalidMessageError(
+                    "Transaction payload is not an OptQS Payload".to_string(),
+                ))
+            },
+        };
+
+        if expected_opt_batches != opt_batches {
+            return Err(Error::InvalidMessageError(format!(
+                "Transaction payload failed optimistic batch verification! Expected optimistic batches {:?} but found {:?}",
+                expected_opt_batches, opt_batches
+            )));
+        }
         Ok(())
     }
 

--- a/consensus/src/consensus_observer/network_message.rs
+++ b/consensus/src/consensus_observer/network_message.rs
@@ -510,7 +510,7 @@ impl BlockTransactionPayload {
             },
             Payload::OptQuorumStore(opt_qs_payload) => {
                 // Verify the batches in the requested block
-                self.verify_batches(&opt_qs_payload.proof_with_data())?;
+                self.verify_batches(opt_qs_payload.proof_with_data())?;
 
                 // Verify the inline batches
                 self.verify_opt_batches(opt_qs_payload.opt_batches())?;

--- a/consensus/src/payload_manager.rs
+++ b/consensus/src/payload_manager.rs
@@ -13,7 +13,8 @@ use crate::{
 use aptos_consensus_types::{
     block::Block,
     common::{DataStatus, Payload, ProofWithData, Round},
-    proof_of_store::ProofOfStore,
+    payload::{CachedDataPointer, TDataInfo},
+    proof_of_store::BatchInfo,
 };
 use aptos_crypto::HashValue;
 use aptos_executor_types::{
@@ -22,7 +23,7 @@ use aptos_executor_types::{
 };
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
-use aptos_types::transaction::SignedTransaction;
+use aptos_types::{transaction::SignedTransaction, PeerId};
 use async_trait::async_trait;
 use futures::channel::mpsc::Sender;
 use std::{
@@ -91,6 +92,7 @@ pub struct QuorumStorePayloadManager {
     batch_reader: Arc<dyn BatchReader>,
     coordinator_tx: Sender<CoordinatorCommand>,
     maybe_consensus_publisher: Option<Arc<ConsensusPublisher>>,
+    ordered_authors: Vec<PeerId>,
 }
 
 impl QuorumStorePayloadManager {
@@ -98,16 +100,18 @@ impl QuorumStorePayloadManager {
         batch_reader: Arc<dyn BatchReader>,
         coordinator_tx: Sender<CoordinatorCommand>,
         maybe_consensus_publisher: Option<Arc<ConsensusPublisher>>,
+        ordered_authors: Vec<PeerId>,
     ) -> Self {
         Self {
             batch_reader,
             coordinator_tx,
             maybe_consensus_publisher,
+            ordered_authors,
         }
     }
 
-    fn request_transactions(
-        proofs: Vec<ProofOfStore>,
+    fn request_transactions<'a>(
+        batches: impl Iterator<Item = (&'a BatchInfo, Vec<PeerId>)>,
         block_timestamp: u64,
         batch_reader: Arc<dyn BatchReader>,
     ) -> Vec<(
@@ -115,17 +119,23 @@ impl QuorumStorePayloadManager {
         oneshot::Receiver<ExecutorResult<Vec<SignedTransaction>>>,
     )> {
         let mut receivers = Vec::new();
-        for pos in proofs {
+        for (batch_info, responders) in batches {
             trace!(
-                "QSE: requesting pos {:?}, digest {}, time = {}",
-                pos,
-                pos.digest(),
+                "QSE: requesting batch {:?}, time = {}",
+                batch_info,
                 block_timestamp
             );
-            if block_timestamp <= pos.expiration() {
-                receivers.push((*pos.digest(), batch_reader.get_batch(pos)));
+            if block_timestamp <= batch_info.expiration() {
+                receivers.push((
+                    *batch_info.digest(),
+                    batch_reader.get_batch(
+                        *batch_info.digest(),
+                        batch_info.expiration(),
+                        responders,
+                    ),
+                ));
             } else {
-                debug!("QSE: skipped expired pos {}", pos.digest());
+                debug!("QSE: skipped expired batch {}", batch_info.digest());
             }
         }
         receivers
@@ -167,6 +177,9 @@ impl TPayloadManager for QuorumStorePayloadManager {
                         )
                         .collect::<Vec<_>>()
                 },
+                Payload::OptQuorumStore(opt_quorum_store_payload) => {
+                    opt_quorum_store_payload.get_all_batch_infos()
+                },
             })
             .collect();
 
@@ -184,13 +197,18 @@ impl TPayloadManager for QuorumStorePayloadManager {
     }
 
     fn prefetch_payload_data(&self, payload: &Payload, timestamp: u64) {
+        // This is deprecated.
+        // TODO(ibalajiarun): Remove this after migrating to OptQuorumStore type
         let request_txns_and_update_status =
             move |proof_with_status: &ProofWithData, batch_reader: Arc<dyn BatchReader>| {
                 if proof_with_status.status.lock().is_some() {
                     return;
                 }
                 let receivers = Self::request_transactions(
-                    proof_with_status.proofs.clone(),
+                    proof_with_status
+                        .proofs
+                        .iter()
+                        .map(|proof| (proof.info(), proof.shuffled_signers(&self.ordered_authors))),
                     timestamp,
                     batch_reader,
                 );
@@ -199,6 +217,29 @@ impl TPayloadManager for QuorumStorePayloadManager {
                     .lock()
                     .replace(DataStatus::Requested(receivers));
             };
+
+        fn prefetch_helper<T: TDataInfo>(
+            data_pointer: &CachedDataPointer<T>,
+            batch_reader: Arc<dyn BatchReader>,
+            timestamp: u64,
+            ordered_authors: &Vec<PeerId>,
+        ) {
+            if data_pointer.status.lock().is_some() {
+                return;
+            }
+            let receivers = QuorumStorePayloadManager::request_transactions(
+                data_pointer
+                    .pointer
+                    .iter()
+                    .map(|proof| (proof.info(), proof.signers(ordered_authors))),
+                timestamp,
+                batch_reader,
+            );
+            data_pointer
+                .status
+                .lock()
+                .replace(DataStatus::Requested(receivers));
+        }
 
         match payload {
             Payload::InQuorumStore(proof_with_status) => {
@@ -216,6 +257,20 @@ impl TPayloadManager for QuorumStorePayloadManager {
             Payload::DirectMempool(_) => {
                 unreachable!()
             },
+            Payload::OptQuorumStore(opt_qs_payload) => {
+                prefetch_helper(
+                    opt_qs_payload.opt_batches(),
+                    self.batch_reader.clone(),
+                    timestamp,
+                    &self.ordered_authors,
+                );
+                prefetch_helper(
+                    opt_qs_payload.proof_with_data(),
+                    self.batch_reader.clone(),
+                    timestamp,
+                    &self.ordered_authors,
+                )
+            },
         };
     }
 
@@ -229,8 +284,13 @@ impl TPayloadManager for QuorumStorePayloadManager {
 
         let transaction_payload = match payload {
             Payload::InQuorumStore(proof_with_data) => {
-                let transactions =
-                    process_payload(proof_with_data, self.batch_reader.clone(), block).await?;
+                let transactions = process_payload(
+                    proof_with_data,
+                    self.batch_reader.clone(),
+                    block,
+                    &self.ordered_authors,
+                )
+                .await?;
                 BlockTransactionPayload::new_in_quorum_store(
                     transactions,
                     proof_with_data.proofs.clone(),
@@ -241,6 +301,7 @@ impl TPayloadManager for QuorumStorePayloadManager {
                     &proof_with_data.proof_with_data,
                     self.batch_reader.clone(),
                     block,
+                    &self.ordered_authors,
                 )
                 .await?;
                 BlockTransactionPayload::new_in_quorum_store_with_limit(
@@ -255,8 +316,13 @@ impl TPayloadManager for QuorumStorePayloadManager {
                 max_txns_to_execute,
             ) => {
                 let all_transactions = {
-                    let mut all_txns =
-                        process_payload(proof_with_data, self.batch_reader.clone(), block).await?;
+                    let mut all_txns = process_payload(
+                        proof_with_data,
+                        self.batch_reader.clone(),
+                        block,
+                        &self.ordered_authors,
+                    )
+                    .await?;
                     all_txns.append(
                         &mut inline_batches
                             .iter()
@@ -350,10 +416,94 @@ async fn get_transactions_for_observer(
     ))
 }
 
+async fn process_payload_helper<T: TDataInfo>(
+    data_ptr: &CachedDataPointer<T>,
+    batch_reader: Arc<dyn BatchReader>,
+    block: &Block,
+    ordered_authors: &Vec<PeerId>,
+) -> ExecutorResult<Vec<SignedTransaction>> {
+    let status = data_ptr.status.lock().take();
+    match status.expect("Should have been updated before.") {
+        DataStatus::Cached(data) => {
+            counters::QUORUM_BATCH_READY_COUNT.inc();
+            data_ptr
+                .status
+                .lock()
+                .replace(DataStatus::Cached(data.clone()));
+            Ok(data)
+        },
+        DataStatus::Requested(receivers) => {
+            let _timer = counters::BATCH_WAIT_DURATION.start_timer();
+            let mut vec_ret = Vec::new();
+            if !receivers.is_empty() {
+                debug!(
+                    "QSE: waiting for data on {} receivers, block_round {}",
+                    receivers.len(),
+                    block.round()
+                );
+            }
+            for (digest, rx) in receivers {
+                match rx.await {
+                    Err(e) => {
+                        // We probably advanced epoch already.
+                        warn!(
+                            "Oneshot channel to get a batch was dropped with error {:?}",
+                            e
+                        );
+                        let new_receivers = QuorumStorePayloadManager::request_transactions(
+                            data_ptr
+                                .pointer
+                                .iter()
+                                .map(|proof| (proof.info(), proof.signers(ordered_authors))),
+                            block.timestamp_usecs(),
+                            batch_reader.clone(),
+                        );
+                        // Could not get all data so requested again
+                        data_ptr
+                            .status
+                            .lock()
+                            .replace(DataStatus::Requested(new_receivers));
+                        return Err(DataNotFound(digest));
+                    },
+                    Ok(Ok(data)) => {
+                        vec_ret.push(data);
+                    },
+                    Ok(Err(e)) => {
+                        let new_receivers = QuorumStorePayloadManager::request_transactions(
+                            data_ptr
+                                .pointer
+                                .iter()
+                                .map(|proof| (proof.info(), proof.signers(ordered_authors))),
+                            block.timestamp_usecs(),
+                            batch_reader.clone(),
+                        );
+                        // Could not get all data so requested again
+                        data_ptr
+                            .status
+                            .lock()
+                            .replace(DataStatus::Requested(new_receivers));
+                        return Err(e);
+                    },
+                }
+            }
+            let ret: Vec<SignedTransaction> = vec_ret.into_iter().flatten().collect();
+            // execution asks for the data twice, so data is cached here for the second time.
+            data_ptr
+                .status
+                .lock()
+                .replace(DataStatus::Cached(ret.clone()));
+            Ok(ret)
+        },
+    }
+}
+
+/// This is deprecated. Use `process_payload_helper` instead after migrating to
+/// OptQuorumStore payload
 async fn process_payload(
     proof_with_data: &ProofWithData,
     batch_reader: Arc<dyn BatchReader>,
     block: &Block,
+    ordered_authors: &Vec<PeerId>,
 ) -> ExecutorResult<Vec<SignedTransaction>> {
     let status = proof_with_data.status.lock().take();
     match status.expect("Should have been updated before.") {
@@ -384,7 +534,9 @@ async fn process_payload(
                             e
                         );
                         let new_receivers = QuorumStorePayloadManager::request_transactions(
-                            proof_with_data.proofs.clone(),
+                            proof_with_data.proofs.iter().map(|proof| {
+                                (proof.info(), proof.shuffled_signers(&ordered_authors))
+                            }),
                             block.timestamp_usecs(),
                             batch_reader.clone(),
                         );
@@ -400,7 +552,9 @@ async fn process_payload(
                     },
                     Ok(Err(e)) => {
                         let new_receivers = QuorumStorePayloadManager::request_transactions(
-                            proof_with_data.proofs.clone(),
+                            proof_with_data.proofs.iter().map(|proof| {
+                                (proof.info(), proof.shuffled_signers(&ordered_authors))
+                            }),
                             block.timestamp_usecs(),
                             batch_reader.clone(),
                         );

--- a/consensus/src/payload_manager.rs
+++ b/consensus/src/payload_manager.rs
@@ -178,7 +178,7 @@ impl TPayloadManager for QuorumStorePayloadManager {
                         .collect::<Vec<_>>()
                 },
                 Payload::OptQuorumStore(opt_quorum_store_payload) => {
-                    opt_quorum_store_payload.get_all_batch_infos()
+                    opt_quorum_store_payload.into_inner().get_all_batch_infos()
                 },
             })
             .collect();

--- a/consensus/src/quorum_store/batch_requester.rs
+++ b/consensus/src/quorum_store/batch_requester.rs
@@ -9,7 +9,7 @@ use crate::{
         types::{BatchRequest, BatchResponse, PersistedValue},
     },
 };
-use aptos_consensus_types::proof_of_store::{BatchInfo, ProofOfStore};
+use aptos_consensus_types::proof_of_store::BatchInfo;
 use aptos_crypto::HashValue;
 use aptos_executor_types::*;
 use aptos_logger::prelude::*;

--- a/consensus/src/quorum_store/batch_requester.rs
+++ b/consensus/src/quorum_store/batch_requester.rs
@@ -130,13 +130,12 @@ impl<T: QuorumStoreSender + Sync + 'static> BatchRequester<T> {
 
     pub(crate) async fn request_batch(
         &self,
-        proof: ProofOfStore,
+        digest: HashValue,
+        expiration: u64,
+        signers: Vec<PeerId>,
         ret_tx: oneshot::Sender<ExecutorResult<Vec<SignedTransaction>>>,
         mut subscriber_rx: oneshot::Receiver<PersistedValue>,
     ) -> Option<(BatchInfo, Vec<SignedTransaction>)> {
-        let digest = *proof.digest();
-        let expiration = proof.expiration();
-        let signers = proof.shuffled_signers(&self.validator_verifier);
         let validator_verifier = self.validator_verifier.clone();
         let mut request_state = BatchRequesterState::new(signers, ret_tx, self.retry_limit);
         let network_sender = self.network_sender.clone();

--- a/consensus/src/quorum_store/batch_store.rs
+++ b/consensus/src/quorum_store/batch_store.rs
@@ -12,19 +12,18 @@ use crate::{
     },
 };
 use anyhow::bail;
-use aptos_consensus_types::proof_of_store::{BatchInfo, ProofOfStore, SignedBatchInfo};
+use aptos_consensus_types::proof_of_store::SignedBatchInfo;
 use aptos_crypto::HashValue;
 use aptos_executor_types::{ExecutorError, ExecutorResult};
 use aptos_logger::prelude::*;
 use aptos_types::{transaction::SignedTransaction, validator_signer::ValidatorSigner, PeerId};
 use dashmap::{
-    mapref::entry::Entry::{self, Occupied, Vacant},
+    mapref::entry::Entry::{Occupied, Vacant},
     DashMap,
 };
 use fail::fail_point;
 use once_cell::sync::OnceCell;
 use std::{
-    hash::Hash,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc, Mutex,

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -444,6 +444,7 @@ impl InnerBuilder {
                 // TODO: remove after splitting out clean requests
                 self.coordinator_tx.clone(),
                 consensus_publisher,
+                self.verifier.get_ordered_account_addresses(),
             )),
             Some(self.quorum_store_msg_tx.clone()),
         )

--- a/consensus/src/quorum_store/tests/batch_requester_test.rs
+++ b/consensus/src/quorum_store/tests/batch_requester_test.rs
@@ -14,7 +14,7 @@ use aptos_consensus_types::{
 };
 use aptos_crypto::HashValue;
 use aptos_types::{
-    aggregate_signature::{self, AggregateSignature, PartialSignatures},
+    aggregate_signature::PartialSignatures,
     block_info::BlockInfo,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     validator_signer::ValidatorSigner,
@@ -105,7 +105,7 @@ async fn test_batch_request_exists() {
         .request_batch(
             *batch.digest(),
             batch.expiration(),
-            Vec::new(),
+            vec![AccountAddress::random()],
             tx,
             subscriber_rx,
         )
@@ -201,7 +201,7 @@ async fn test_batch_request_not_exists_not_expired() {
         .request_batch(
             *batch.digest(),
             batch.expiration(),
-            Vec::new(),
+            vec![AccountAddress::random()],
             tx,
             subscriber_rx,
         )
@@ -246,11 +246,10 @@ async fn test_batch_request_not_exists_expired() {
     let request_start = Instant::now();
     let (_, subscriber_rx) = oneshot::channel();
     let result = batch_requester
-        .request_batch_for_proof(
-            ProofOfStore::new(
-                batch.batch_info().clone(),
-                AggregateSignature::new(vec![u8::MAX].into(), None),
-            ),
+        .request_batch(
+            *batch.digest(),
+            batch.expiration(),
+            vec![AccountAddress::random()],
             tx,
             subscriber_rx,
         )

--- a/consensus/src/quorum_store/tests/batch_requester_test.rs
+++ b/consensus/src/quorum_store/tests/batch_requester_test.rs
@@ -14,7 +14,7 @@ use aptos_consensus_types::{
 };
 use aptos_crypto::HashValue;
 use aptos_types::{
-    aggregate_signature::{AggregateSignature, PartialSignatures},
+    aggregate_signature::{self, AggregateSignature, PartialSignatures},
     block_info::BlockInfo,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     validator_signer::ValidatorSigner,
@@ -102,11 +102,10 @@ async fn test_batch_request_exists() {
 
     let (_, subscriber_rx) = oneshot::channel();
     let result = batch_requester
-        .request_batch_for_proof(
-            ProofOfStore::new(
-                batch.batch_info().clone(),
-                AggregateSignature::new(vec![u8::MAX].into(), None),
-            ),
+        .request_batch(
+            *batch.digest(),
+            batch.expiration(),
+            Vec::new(),
             tx,
             subscriber_rx,
         )
@@ -199,11 +198,10 @@ async fn test_batch_request_not_exists_not_expired() {
     let request_start = Instant::now();
     let (_, subscriber_rx) = oneshot::channel();
     let result = batch_requester
-        .request_batch_for_proof(
-            ProofOfStore::new(
-                batch.batch_info().clone(),
-                AggregateSignature::new(vec![u8::MAX].into(), None),
-            ),
+        .request_batch(
+            *batch.digest(),
+            batch.expiration(),
+            Vec::new(),
             tx,
             subscriber_rx,
         )

--- a/consensus/src/quorum_store/tests/batch_requester_test.rs
+++ b/consensus/src/quorum_store/tests/batch_requester_test.rs
@@ -102,7 +102,7 @@ async fn test_batch_request_exists() {
 
     let (_, subscriber_rx) = oneshot::channel();
     let result = batch_requester
-        .request_batch(
+        .request_batch_for_proof(
             ProofOfStore::new(
                 batch.batch_info().clone(),
                 AggregateSignature::new(vec![u8::MAX].into(), None),
@@ -199,7 +199,7 @@ async fn test_batch_request_not_exists_not_expired() {
     let request_start = Instant::now();
     let (_, subscriber_rx) = oneshot::channel();
     let result = batch_requester
-        .request_batch(
+        .request_batch_for_proof(
             ProofOfStore::new(
                 batch.batch_info().clone(),
                 AggregateSignature::new(vec![u8::MAX].into(), None),
@@ -248,7 +248,7 @@ async fn test_batch_request_not_exists_expired() {
     let request_start = Instant::now();
     let (_, subscriber_rx) = oneshot::channel();
     let result = batch_requester
-        .request_batch(
+        .request_batch_for_proof(
             ProofOfStore::new(
                 batch.batch_info().clone(),
                 AggregateSignature::new(vec![u8::MAX].into(), None),

--- a/consensus/src/quorum_store/tests/proof_coordinator_test.rs
+++ b/consensus/src/quorum_store/tests/proof_coordinator_test.rs
@@ -10,9 +10,7 @@ use crate::{
     },
     test_utils::{create_vec_signed_transactions, mock_quorum_store_sender::MockQuorumStoreSender},
 };
-use aptos_consensus_types::proof_of_store::{
-    BatchId, ProofOfStore, SignedBatchInfo, SignedBatchInfoMsg,
-};
+use aptos_consensus_types::proof_of_store::{BatchId, SignedBatchInfo, SignedBatchInfoMsg};
 use aptos_crypto::HashValue;
 use aptos_executor_types::ExecutorResult;
 use aptos_types::{
@@ -20,7 +18,7 @@ use aptos_types::{
 };
 use mini_moka::sync::Cache;
 use std::sync::Arc;
-use tokio::sync::{mpsc::channel, oneshot::Receiver};
+use tokio::sync::mpsc::channel;
 
 pub struct MockBatchReader {
     peer: PeerId,
@@ -31,7 +29,12 @@ impl BatchReader for MockBatchReader {
         Some(self.peer)
     }
 
-    fn get_batch(&self, _proof: ProofOfStore) -> Receiver<ExecutorResult<Vec<SignedTransaction>>> {
+    fn get_batch(
+        &self,
+        _digest: HashValue,
+        _expiration: u64,
+        _signers: Vec<PeerId>,
+    ) -> tokio::sync::oneshot::Receiver<ExecutorResult<Vec<SignedTransaction>>> {
         unimplemented!()
     }
 

--- a/consensus/src/util/db_tool.rs
+++ b/consensus/src/util/db_tool.rs
@@ -11,11 +11,7 @@ use crate::{
     },
 };
 use anyhow::{bail, Result};
-use aptos_consensus_types::{
-    block::Block,
-    common::Payload,
-    proof_of_store::{BatchInfo, ProofOfStore},
-};
+use aptos_consensus_types::{block::Block, common::Payload};
 use aptos_crypto::HashValue;
 use aptos_types::transaction::{SignedTransaction, Transaction};
 use clap::Parser;
@@ -65,9 +61,9 @@ impl Command {
     }
 }
 
-fn extract_txns_from_quorum_store<'a>(
+fn extract_txns_from_quorum_store(
     digests: impl Iterator<Item = HashValue>,
-    all_batches: &'a HashMap<HashValue, PersistedValue>,
+    all_batches: &HashMap<HashValue, PersistedValue>,
 ) -> anyhow::Result<Vec<&SignedTransaction>> {
     let mut block_txns = Vec::new();
     for digest in digests {

--- a/consensus/src/util/db_tool.rs
+++ b/consensus/src/util/db_tool.rs
@@ -11,7 +11,11 @@ use crate::{
     },
 };
 use anyhow::{bail, Result};
-use aptos_consensus_types::{block::Block, common::Payload, proof_of_store::ProofOfStore};
+use aptos_consensus_types::{
+    block::Block,
+    common::Payload,
+    proof_of_store::{BatchInfo, ProofOfStore},
+};
 use aptos_crypto::HashValue;
 use aptos_types::transaction::{SignedTransaction, Transaction};
 use clap::Parser;
@@ -61,49 +65,78 @@ impl Command {
     }
 }
 
+fn extract_txns_from_quorum_store<'a>(
+    digests: impl Iterator<Item = HashValue>,
+    all_batches: &'a HashMap<HashValue, PersistedValue>,
+) -> anyhow::Result<Vec<&SignedTransaction>> {
+    let mut block_txns = Vec::new();
+    for digest in digests {
+        if let Some(batch) = all_batches.get(&digest) {
+            if let Some(txns) = batch.payload() {
+                block_txns.extend(txns);
+            } else {
+                bail!("Payload is not found for batch ({digest}).");
+            }
+        } else {
+            bail!("Batch ({digest}) is not found.");
+        }
+    }
+    Ok(block_txns)
+}
+
 pub fn extract_txns_from_block<'a>(
     block: &'a Block,
     all_batches: &'a HashMap<HashValue, PersistedValue>,
 ) -> anyhow::Result<Vec<&'a SignedTransaction>> {
     match block.payload().as_ref() {
-        Some(payload) => {
-            let mut block_txns = Vec::new();
-
-            let extract_txns_from_proof_stores = move |proofs: &Vec<ProofOfStore>| {
-                for proof in proofs {
-                    let digest = proof.digest();
-                    if let Some(batch) = all_batches.get(digest) {
-                        if let Some(txns) = batch.payload() {
-                            block_txns.extend(txns);
-                        } else {
-                            bail!("Payload is not found for batch ({digest}).");
-                        }
-                    } else {
-                        bail!("Batch ({digest}) is not found.");
-                    }
+        Some(payload) => match payload {
+            Payload::DirectMempool(_) => {
+                bail!("DirectMempool is not supported.");
+            },
+            Payload::InQuorumStore(proof_with_data) => extract_txns_from_quorum_store(
+                proof_with_data.proofs.iter().map(|proof| *proof.digest()),
+                all_batches,
+            ),
+            Payload::InQuorumStoreWithLimit(proof_with_data) => extract_txns_from_quorum_store(
+                proof_with_data
+                    .proof_with_data
+                    .proofs
+                    .iter()
+                    .map(|proof| *proof.digest()),
+                all_batches,
+            ),
+            Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _) => {
+                let mut all_txns = extract_txns_from_quorum_store(
+                    proof_with_data.proofs.iter().map(|proof| *proof.digest()),
+                    all_batches,
+                )
+                .unwrap();
+                for (_, txns) in inline_batches {
+                    all_txns.extend(txns);
                 }
-                Ok(block_txns)
-            };
-
-            match payload {
-                Payload::DirectMempool(_) => {
-                    bail!("DirectMempool is not supported.");
-                },
-                Payload::InQuorumStore(proof_with_data) => {
-                    extract_txns_from_proof_stores(&proof_with_data.proofs)
-                },
-                Payload::InQuorumStoreWithLimit(proof_with_data) => {
-                    extract_txns_from_proof_stores(&proof_with_data.proof_with_data.proofs)
-                },
-                Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _) => {
-                    let mut all_txns =
-                        extract_txns_from_proof_stores(&proof_with_data.proofs).unwrap();
-                    for (_, txns) in inline_batches {
-                        all_txns.extend(txns);
-                    }
-                    Ok(all_txns)
-                },
-            }
+                Ok(all_txns)
+            },
+            Payload::OptQuorumStore(opt_qs_payload) => {
+                let mut all_txns = extract_txns_from_quorum_store(
+                    opt_qs_payload
+                        .proof_with_data()
+                        .iter()
+                        .map(|proof| *proof.digest()),
+                    all_batches,
+                )
+                .unwrap();
+                all_txns.extend(
+                    extract_txns_from_quorum_store(
+                        opt_qs_payload
+                            .opt_batches()
+                            .iter()
+                            .map(|info| *info.digest()),
+                        all_batches,
+                    )
+                    .unwrap(),
+                );
+                Ok(all_txns)
+            },
         },
         None => Ok(vec![]),
     }

--- a/testsuite/generate-format/src/consensus.rs
+++ b/testsuite/generate-format/src/consensus.rs
@@ -119,6 +119,7 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<aptos_consensus::network_interface::CommitMessage>(&samples)?;
     tracer.trace_type::<aptos_consensus_types::block_data::BlockType>(&samples)?;
     tracer.trace_type::<aptos_consensus_types::block_retrieval::BlockRetrievalStatus>(&samples)?;
+    tracer.trace_type::<aptos_consensus_types::payload::PayloadExecutionLimit>(&samples)?;
     tracer.trace_type::<aptos_consensus_types::common::Payload>(&samples)?;
 
     // aliases within StructTag

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -138,6 +138,11 @@ BatchPayload:
     - txns:
         SEQ:
           TYPENAME: SignedTransaction
+BatchPointer:
+  STRUCT:
+    - batch_summary:
+        SEQ:
+          TYPENAME: BatchInfo
 BatchRequest:
   STRUCT:
     - epoch: U64
@@ -546,6 +551,17 @@ IdCommitment:
   NEWTYPESTRUCT: BYTES
 Identifier:
   NEWTYPESTRUCT: STR
+InlineBatch:
+  STRUCT:
+    - batch_info:
+        TYPENAME: BatchInfo
+    - transactions:
+        SEQ:
+          TYPENAME: SignedTransaction
+InlineBatches:
+  NEWTYPESTRUCT:
+    SEQ:
+      TYPENAME: InlineBatch
 JWKMoveStruct:
   STRUCT:
     - variant:
@@ -631,6 +647,22 @@ OpenIdSig:
         TYPENAME: Pepper
     - idc_aud_val:
         OPTION: STR
+OptQuorumStorePayload:
+  ENUM:
+    0:
+      V1:
+        NEWTYPE:
+          TYPENAME: OptQuorumStorePayloadV1
+OptQuorumStorePayloadV1:
+  STRUCT:
+    - inline_batches:
+        TYPENAME: InlineBatches
+    - opt_batches:
+        TYPENAME: BatchPointer
+    - proofs:
+        TYPENAME: BatchPointer
+    - execution_limits:
+        TYPENAME: PayloadExecutionLimit
 OrderVote:
   STRUCT:
     - author:
@@ -676,6 +708,17 @@ Payload:
                     TYPENAME: SignedTransaction
           - TYPENAME: ProofWithData
           - OPTION: U64
+    4:
+      OptQuorumStore:
+        NEWTYPE:
+          TYPENAME: OptQuorumStorePayload
+PayloadExecutionLimit:
+  ENUM:
+    0:
+      None: UNIT
+    1:
+      MaxTransactionsToExecute:
+        NEWTYPE: U64
 Pepper:
   NEWTYPESTRUCT:
     TUPLEARRAY:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

- Introduces `OptQuorumStore` variant to `Payload` enum to support Optimistic QS batches in consensus. 
- Introduces `OptQuorumStorePayload` enum as value for the `Payload::OptQuorumStore` variant. The enum helps in future extensibility.
- Introduces a generic `CachedDataPointer<T: TDataInfo>` struct as a replacement to `ProofWithData`. The generic struct can hold both Proofs and BatchInfos for Optimistic batches. `TDataInfo` is a trait to support common operations across proofs and batches.
- Introduces `PayloadExecutionLimit` enum to support extensible way to specify execution limits for QuorumStore batches.
- Adds support for the new Payload variant to PayloadManager.

