### PR TITLE
[do-not-merge] apply the updated movefmt tool to framework code

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account.move
@@ -50,11 +50,17 @@ module aptos_framework::account {
         type_info: TypeInfo,
     }
 
-    struct CapabilityOffer<phantom T> has store { for: Option<address> }
+    struct CapabilityOffer<phantom T> has store {
+        for: Option<address>
+    }
 
-    struct RotationCapability has drop, store { account: address }
+    struct RotationCapability has drop, store {
+        account: address
+    }
 
-    struct SignerCapability has drop, store { account: address }
+    struct SignerCapability has drop, store {
+        account: address
+    }
 
     /// It is easy to fetch the authentication key of an address by simply reading it from the `Account` struct at that address.
     /// The table in this struct makes it possible to do a reverse lookup: it maps an authentication key, to the address of the account which has that authentication key set.
@@ -175,14 +181,14 @@ module aptos_framework::account {
 
     #[test_only]
     /// Create signer for testing, independently of an Aptos-style `Account`.
-    public fun create_signer_for_test(addr: address): signer { create_signer(addr) }
+    public fun create_signer_for_test(addr: address): signer {
+        create_signer(addr)
+    }
 
     /// Only called during genesis to initialize system resources for this module.
     public(friend) fun initialize(aptos_framework: &signer) {
         system_addresses::assert_aptos_framework(aptos_framework);
-        move_to(aptos_framework, OriginatingAddress {
-            address_map: table::new(),
-        });
+        move_to(aptos_framework, OriginatingAddress { address_map: table::new(), });
     }
 
     public fun create_account_if_does_not_exist(account_address: address) {
@@ -196,12 +202,16 @@ module aptos_framework::account {
     /// `new_address`.
     public(friend) fun create_account(new_address: address): signer {
         // there cannot be an Account resource under new_addr already.
-        assert!(!exists<Account>(new_address), error::already_exists(EACCOUNT_ALREADY_EXISTS));
+        assert!(
+            !exists<Account>(new_address), error::already_exists(EACCOUNT_ALREADY_EXISTS)
+        );
 
         // NOTE: @core_resources gets created via a `create_account` call, so we do not include it below.
         assert!(
-            new_address != @vm_reserved && new_address != @aptos_framework && new_address != @aptos_token,
-            error::invalid_argument(ECANNOT_RESERVED_ADDRESS)
+            new_address != @vm_reserved
+            && new_address != @aptos_framework
+            && new_address != @aptos_token,
+            error::invalid_argument(ECANNOT_RESERVED_ADDRESS),
         );
 
         create_account_unchecked(new_address)
@@ -212,16 +222,18 @@ module aptos_framework::account {
         let authentication_key = bcs::to_bytes(&new_address);
         assert!(
             vector::length(&authentication_key) == 32,
-            error::invalid_argument(EMALFORMED_AUTHENTICATION_KEY)
+            error::invalid_argument(EMALFORMED_AUTHENTICATION_KEY),
         );
 
         let guid_creation_num = 0;
 
         let guid_for_coin = guid::create(new_address, &mut guid_creation_num);
-        let coin_register_events = event::new_event_handle<CoinRegisterEvent>(guid_for_coin);
+        let coin_register_events =
+            event::new_event_handle<CoinRegisterEvent>(guid_for_coin);
 
         let guid_for_rotation = guid::create(new_address, &mut guid_creation_num);
-        let key_rotation_events = event::new_event_handle<KeyRotationEvent>(guid_for_rotation);
+        let key_rotation_events =
+            event::new_event_handle<KeyRotationEvent>(guid_for_rotation);
 
         move_to(
             &new_account,
@@ -233,7 +245,7 @@ module aptos_framework::account {
                 key_rotation_events,
                 rotation_capability_offer: CapabilityOffer { for: option::none() },
                 signer_capability_offer: CapabilityOffer { for: option::none() },
-            }
+            },
         );
 
         new_account
@@ -259,7 +271,7 @@ module aptos_framework::account {
 
         assert!(
             (*sequence_number as u128) < MAX_U64,
-            error::out_of_range(ESEQUENCE_NUMBER_TOO_BIG)
+            error::out_of_range(ESEQUENCE_NUMBER_TOO_BIG),
         );
 
         *sequence_number = *sequence_number + 1;
@@ -275,12 +287,14 @@ module aptos_framework::account {
     /// 1. During normal key rotation via `rotate_authentication_key` or `rotate_authentication_key_call`
     /// 2. During resource account initialization so that no private key can control the resource account
     /// 3. During multisig_v2 account creation
-    public(friend) fun rotate_authentication_key_internal(account: &signer, new_auth_key: vector<u8>) acquires Account {
+    public(friend) fun rotate_authentication_key_internal(
+        account: &signer, new_auth_key: vector<u8>
+    ) acquires Account {
         let addr = signer::address_of(account);
         assert!(exists_at(addr), error::not_found(EACCOUNT_DOES_NOT_EXIST));
         assert!(
             vector::length(&new_auth_key) == 32,
-            error::invalid_argument(EMALFORMED_AUTHENTICATION_KEY)
+            error::invalid_argument(EMALFORMED_AUTHENTICATION_KEY),
         );
         let account_resource = borrow_global_mut<Account>(addr);
         account_resource.authentication_key = new_auth_key;
@@ -291,7 +305,9 @@ module aptos_framework::account {
     /// does not come with a proof-of-knowledge of the underlying SK. Nonetheless, we need this functionality due to
     /// the introduction of non-standard key algorithms, such as passkeys, which cannot produce proofs-of-knowledge in
     /// the format expected in `rotate_authentication_key`.
-    entry fun rotate_authentication_key_call(account: &signer, new_auth_key: vector<u8>) acquires Account {
+    entry fun rotate_authentication_key_call(
+        account: &signer, new_auth_key: vector<u8>
+    ) acquires Account {
         rotate_authentication_key_internal(account, new_auth_key);
     }
 
@@ -338,25 +354,32 @@ module aptos_framework::account {
 
         // Verify the given `from_public_key_bytes` matches this account's current authentication key.
         if (from_scheme == ED25519_SCHEME) {
-            let from_pk = ed25519::new_unvalidated_public_key_from_bytes(from_public_key_bytes);
-            let from_auth_key = ed25519::unvalidated_public_key_to_authentication_key(&from_pk);
+            let from_pk =
+                ed25519::new_unvalidated_public_key_from_bytes(from_public_key_bytes);
+            let from_auth_key =
+                ed25519::unvalidated_public_key_to_authentication_key(&from_pk);
             assert!(
                 account_resource.authentication_key == from_auth_key,
-                error::unauthenticated(EWRONG_CURRENT_PUBLIC_KEY)
+                error::unauthenticated(EWRONG_CURRENT_PUBLIC_KEY),
             );
         } else if (from_scheme == MULTI_ED25519_SCHEME) {
-            let from_pk = multi_ed25519::new_unvalidated_public_key_from_bytes(from_public_key_bytes);
-            let from_auth_key = multi_ed25519::unvalidated_public_key_to_authentication_key(&from_pk);
+            let from_pk =
+                multi_ed25519::new_unvalidated_public_key_from_bytes(
+                    from_public_key_bytes
+                );
+            let from_auth_key =
+                multi_ed25519::unvalidated_public_key_to_authentication_key(&from_pk);
             assert!(
                 account_resource.authentication_key == from_auth_key,
-                error::unauthenticated(EWRONG_CURRENT_PUBLIC_KEY)
+                error::unauthenticated(EWRONG_CURRENT_PUBLIC_KEY),
             );
         } else {
             abort error::invalid_argument(EINVALID_SCHEME)
         };
 
         // Construct a valid `RotationProofChallenge` that `cap_rotate_key` and `cap_update_table` will validate against.
-        let curr_auth_key_as_address = from_bcs::to_address(account_resource.authentication_key);
+        let curr_auth_key_as_address =
+            from_bcs::to_address(account_resource.authentication_key);
         let challenge = RotationProofChallenge {
             sequence_number: account_resource.sequence_number,
             originator: addr,
@@ -369,17 +392,20 @@ module aptos_framework::account {
             from_scheme,
             from_public_key_bytes,
             cap_rotate_key,
-            &challenge
+            &challenge,
         );
-        let new_auth_key = assert_valid_rotation_proof_signature_and_get_auth_key(
-            to_scheme,
-            to_public_key_bytes,
-            cap_update_table,
-            &challenge
-        );
+        let new_auth_key =
+            assert_valid_rotation_proof_signature_and_get_auth_key(
+                to_scheme,
+                to_public_key_bytes,
+                cap_update_table,
+                &challenge,
+            );
 
         // Update the `OriginatingAddress` table.
-        update_auth_key_and_originating_address_table(addr, account_resource, new_auth_key);
+        update_auth_key_and_originating_address_table(
+            addr, account_resource, new_auth_key
+        );
     }
 
     public entry fun rotate_authentication_key_with_rotation_capability(
@@ -389,17 +415,24 @@ module aptos_framework::account {
         new_public_key_bytes: vector<u8>,
         cap_update_table: vector<u8>
     ) acquires Account, OriginatingAddress {
-        assert!(exists_at(rotation_cap_offerer_address), error::not_found(EOFFERER_ADDRESS_DOES_NOT_EXIST));
+        assert!(
+            exists_at(rotation_cap_offerer_address),
+            error::not_found(EOFFERER_ADDRESS_DOES_NOT_EXIST),
+        );
 
         // Check that there exists a rotation capability offer at the offerer's account resource for the delegate.
         let delegate_address = signer::address_of(delegate_signer);
-        let offerer_account_resource = borrow_global<Account>(rotation_cap_offerer_address);
+        let offerer_account_resource =
+            borrow_global<Account>(rotation_cap_offerer_address);
         assert!(
-            option::contains(&offerer_account_resource.rotation_capability_offer.for, &delegate_address),
-            error::not_found(ENO_SUCH_ROTATION_CAPABILITY_OFFER)
+            option::contains(
+                &offerer_account_resource.rotation_capability_offer.for, &delegate_address
+            ),
+            error::not_found(ENO_SUCH_ROTATION_CAPABILITY_OFFER),
         );
 
-        let curr_auth_key = from_bcs::to_address(offerer_account_resource.authentication_key);
+        let curr_auth_key =
+            from_bcs::to_address(offerer_account_resource.authentication_key);
         let challenge = RotationProofChallenge {
             sequence_number: get_sequence_number(delegate_address),
             originator: rotation_cap_offerer_address,
@@ -408,19 +441,21 @@ module aptos_framework::account {
         };
 
         // Verifies that the `RotationProofChallenge` from above is signed under the new public key that we are rotating to.        l
-        let new_auth_key = assert_valid_rotation_proof_signature_and_get_auth_key(
-            new_scheme,
-            new_public_key_bytes,
-            cap_update_table,
-            &challenge
-        );
+        let new_auth_key =
+            assert_valid_rotation_proof_signature_and_get_auth_key(
+                new_scheme,
+                new_public_key_bytes,
+                cap_update_table,
+                &challenge,
+            );
 
         // Update the `OriginatingAddress` table, so we can find the originating address using the new address.
-        let offerer_account_resource = borrow_global_mut<Account>(rotation_cap_offerer_address);
+        let offerer_account_resource =
+            borrow_global_mut<Account>(rotation_cap_offerer_address);
         update_auth_key_and_originating_address_table(
             rotation_cap_offerer_address,
             offerer_account_resource,
-            new_auth_key
+            new_auth_key,
         );
     }
 
@@ -462,37 +497,51 @@ module aptos_framework::account {
 
         // verify the signature on `RotationCapabilityOfferProofChallengeV2` by the account owner
         if (account_scheme == ED25519_SCHEME) {
-            let pubkey = ed25519::new_unvalidated_public_key_from_bytes(account_public_key_bytes);
-            let expected_auth_key = ed25519::unvalidated_public_key_to_authentication_key(&pubkey);
+            let pubkey =
+                ed25519::new_unvalidated_public_key_from_bytes(account_public_key_bytes);
+            let expected_auth_key =
+                ed25519::unvalidated_public_key_to_authentication_key(&pubkey);
             assert!(
                 account_resource.authentication_key == expected_auth_key,
-                error::invalid_argument(EWRONG_CURRENT_PUBLIC_KEY)
+                error::invalid_argument(EWRONG_CURRENT_PUBLIC_KEY),
             );
 
-            let rotation_capability_sig = ed25519::new_signature_from_bytes(rotation_capability_sig_bytes);
+            let rotation_capability_sig =
+                ed25519::new_signature_from_bytes(rotation_capability_sig_bytes);
             assert!(
-                ed25519::signature_verify_strict_t(&rotation_capability_sig, &pubkey, proof_challenge),
-                error::invalid_argument(EINVALID_PROOF_OF_KNOWLEDGE)
+                ed25519::signature_verify_strict_t(
+                    &rotation_capability_sig, &pubkey, proof_challenge
+                ),
+                error::invalid_argument(EINVALID_PROOF_OF_KNOWLEDGE),
             );
         } else if (account_scheme == MULTI_ED25519_SCHEME) {
-            let pubkey = multi_ed25519::new_unvalidated_public_key_from_bytes(account_public_key_bytes);
-            let expected_auth_key = multi_ed25519::unvalidated_public_key_to_authentication_key(&pubkey);
+            let pubkey =
+                multi_ed25519::new_unvalidated_public_key_from_bytes(
+                    account_public_key_bytes
+                );
+            let expected_auth_key =
+                multi_ed25519::unvalidated_public_key_to_authentication_key(&pubkey);
             assert!(
                 account_resource.authentication_key == expected_auth_key,
-                error::invalid_argument(EWRONG_CURRENT_PUBLIC_KEY)
+                error::invalid_argument(EWRONG_CURRENT_PUBLIC_KEY),
             );
 
-            let rotation_capability_sig = multi_ed25519::new_signature_from_bytes(rotation_capability_sig_bytes);
+            let rotation_capability_sig =
+                multi_ed25519::new_signature_from_bytes(rotation_capability_sig_bytes);
             assert!(
-                multi_ed25519::signature_verify_strict_t(&rotation_capability_sig, &pubkey, proof_challenge),
-                error::invalid_argument(EINVALID_PROOF_OF_KNOWLEDGE)
+                multi_ed25519::signature_verify_strict_t(
+                    &rotation_capability_sig, &pubkey, proof_challenge
+                ),
+                error::invalid_argument(EINVALID_PROOF_OF_KNOWLEDGE),
             );
         } else {
             abort error::invalid_argument(EINVALID_SCHEME)
         };
 
         // update the existing rotation capability offer or put in a new rotation capability offer for the current account
-        option::swap_or_fill(&mut account_resource.rotation_capability_offer.for, recipient_address);
+        option::swap_or_fill(
+            &mut account_resource.rotation_capability_offer.for, recipient_address
+        );
     }
 
     #[view]
@@ -514,13 +563,19 @@ module aptos_framework::account {
     }
 
     /// Revoke the rotation capability offer given to `to_be_revoked_recipient_address` from `account`
-    public entry fun revoke_rotation_capability(account: &signer, to_be_revoked_address: address) acquires Account {
-        assert!(exists_at(to_be_revoked_address), error::not_found(EACCOUNT_DOES_NOT_EXIST));
+    public entry fun revoke_rotation_capability(
+        account: &signer, to_be_revoked_address: address
+    ) acquires Account {
+        assert!(
+            exists_at(to_be_revoked_address), error::not_found(EACCOUNT_DOES_NOT_EXIST)
+        );
         let addr = signer::address_of(account);
         let account_resource = borrow_global_mut<Account>(addr);
         assert!(
-            option::contains(&account_resource.rotation_capability_offer.for, &to_be_revoked_address),
-            error::not_found(ENO_SUCH_ROTATION_CAPABILITY_OFFER)
+            option::contains(
+                &account_resource.rotation_capability_offer.for, &to_be_revoked_address
+            ),
+            error::not_found(ENO_SUCH_ROTATION_CAPABILITY_OFFER),
         );
         revoke_any_rotation_capability(account);
     }
@@ -557,11 +612,18 @@ module aptos_framework::account {
             recipient_address,
         };
         verify_signed_message(
-            source_address, account_scheme, account_public_key_bytes, signer_capability_sig_bytes, proof_challenge);
+            source_address,
+            account_scheme,
+            account_public_key_bytes,
+            signer_capability_sig_bytes,
+            proof_challenge,
+        );
 
         // Update the existing signer capability offer or put in a new signer capability offer for the recipient.
         let account_resource = borrow_global_mut<Account>(source_address);
-        option::swap_or_fill(&mut account_resource.signer_capability_offer.for, recipient_address);
+        option::swap_or_fill(
+            &mut account_resource.signer_capability_offer.for, recipient_address
+        );
     }
 
     #[view]
@@ -584,13 +646,19 @@ module aptos_framework::account {
 
     /// Revoke the account owner's signer capability offer for `to_be_revoked_address` (i.e., the address that
     /// has a signer capability offer from `account` but will be revoked in this function).
-    public entry fun revoke_signer_capability(account: &signer, to_be_revoked_address: address) acquires Account {
-        assert!(exists_at(to_be_revoked_address), error::not_found(EACCOUNT_DOES_NOT_EXIST));
+    public entry fun revoke_signer_capability(
+        account: &signer, to_be_revoked_address: address
+    ) acquires Account {
+        assert!(
+            exists_at(to_be_revoked_address), error::not_found(EACCOUNT_DOES_NOT_EXIST)
+        );
         let addr = signer::address_of(account);
         let account_resource = borrow_global_mut<Account>(addr);
         assert!(
-            option::contains(&account_resource.signer_capability_offer.for, &to_be_revoked_address),
-            error::not_found(ENO_SUCH_SIGNER_CAPABILITY)
+            option::contains(
+                &account_resource.signer_capability_offer.for, &to_be_revoked_address
+            ),
+            error::not_found(ENO_SUCH_SIGNER_CAPABILITY),
         );
         revoke_any_signer_capability(account);
     }
@@ -603,15 +671,19 @@ module aptos_framework::account {
 
     /// Return an authorized signer of the offerer, if there's an existing signer capability offer for `account`
     /// at the offerer's address.
-    public fun create_authorized_signer(account: &signer, offerer_address: address): signer acquires Account {
-        assert!(exists_at(offerer_address), error::not_found(EOFFERER_ADDRESS_DOES_NOT_EXIST));
+    public fun create_authorized_signer(
+        account: &signer, offerer_address: address
+    ): signer acquires Account {
+        assert!(
+            exists_at(offerer_address), error::not_found(EOFFERER_ADDRESS_DOES_NOT_EXIST)
+        );
 
         // Check if there's an existing signer capability offer from the offerer.
         let account_resource = borrow_global<Account>(offerer_address);
         let addr = signer::address_of(account);
         assert!(
             option::contains(&account_resource.signer_capability_offer.for, &addr),
-            error::not_found(ENO_SUCH_SIGNER_CAPABILITY)
+            error::not_found(ENO_SUCH_SIGNER_CAPABILITY),
         );
 
         create_signer(offerer_address)
@@ -631,15 +703,16 @@ module aptos_framework::account {
             let sig = ed25519::new_signature_from_bytes(signature);
             assert!(
                 ed25519::signature_verify_strict_t(&sig, &pk, *challenge),
-                std::error::invalid_argument(EINVALID_PROOF_OF_KNOWLEDGE)
+                std::error::invalid_argument(EINVALID_PROOF_OF_KNOWLEDGE),
             );
             ed25519::unvalidated_public_key_to_authentication_key(&pk)
         } else if (scheme == MULTI_ED25519_SCHEME) {
-            let pk = multi_ed25519::new_unvalidated_public_key_from_bytes(public_key_bytes);
+            let pk =
+                multi_ed25519::new_unvalidated_public_key_from_bytes(public_key_bytes);
             let sig = multi_ed25519::new_signature_from_bytes(signature);
             assert!(
                 multi_ed25519::signature_verify_strict_t(&sig, &pk, *challenge),
-                std::error::invalid_argument(EINVALID_PROOF_OF_KNOWLEDGE)
+                std::error::invalid_argument(EINVALID_PROOF_OF_KNOWLEDGE),
             );
             multi_ed25519::unvalidated_public_key_to_authentication_key(&pk)
         } else {
@@ -654,7 +727,8 @@ module aptos_framework::account {
         account_resource: &mut Account,
         new_auth_key_vector: vector<u8>,
     ) acquires OriginatingAddress {
-        let address_map = &mut borrow_global_mut<OriginatingAddress>(@aptos_framework).address_map;
+        let address_map =
+            &mut borrow_global_mut<OriginatingAddress>(@aptos_framework).address_map;
         let curr_auth_key = from_bcs::to_address(account_resource.authentication_key);
 
         // Checks `OriginatingAddress[curr_auth_key]` is either unmapped, or mapped to `originating_address`.
@@ -672,7 +746,7 @@ module aptos_framework::account {
             // because address b is not the account's originating address.
             assert!(
                 originating_addr == table::remove(address_map, curr_auth_key),
-                error::not_found(EINVALID_ORIGINATING_ADDRESS)
+                error::not_found(EINVALID_ORIGINATING_ADDRESS),
             );
         };
 
@@ -681,18 +755,20 @@ module aptos_framework::account {
         table::add(address_map, new_auth_key, originating_addr);
 
         if (std::features::module_event_migration_enabled()) {
-            event::emit(KeyRotation {
-                account: originating_addr,
-                old_authentication_key: account_resource.authentication_key,
-                new_authentication_key: new_auth_key_vector,
-            });
+            event::emit(
+                KeyRotation {
+                    account: originating_addr,
+                    old_authentication_key: account_resource.authentication_key,
+                    new_authentication_key: new_auth_key_vector,
+                },
+            );
         };
         event::emit_event<KeyRotationEvent>(
             &mut account_resource.key_rotation_events,
             KeyRotationEvent {
                 old_authentication_key: account_resource.authentication_key,
                 new_authentication_key: new_auth_key_vector,
-            }
+            },
         );
 
         // Update the account resource's authentication key.
@@ -721,22 +797,24 @@ module aptos_framework::account {
     /// yet to execute any transactions and that the `Account::signer_capability_offer::for` is none. The probability of a
     /// collision where someone has legitimately produced a private key that maps to a resource account address is less
     /// than `(1/2)^(256)`.
-    public fun create_resource_account(source: &signer, seed: vector<u8>): (signer, SignerCapability) acquires Account {
+    public fun create_resource_account(source: &signer, seed: vector<u8>)
+        : (signer, SignerCapability) acquires Account {
         let resource_addr = create_resource_address(&signer::address_of(source), seed);
-        let resource = if (exists_at(resource_addr)) {
-            let account = borrow_global<Account>(resource_addr);
-            assert!(
-                option::is_none(&account.signer_capability_offer.for),
-                error::already_exists(ERESOURCE_ACCCOUNT_EXISTS),
-            );
-            assert!(
-                account.sequence_number == 0,
-                error::invalid_state(EACCOUNT_ALREADY_USED),
-            );
-            create_signer(resource_addr)
-        } else {
-            create_account_unchecked(resource_addr)
-        };
+        let resource =
+            if (exists_at(resource_addr)) {
+                let account = borrow_global<Account>(resource_addr);
+                assert!(
+                    option::is_none(&account.signer_capability_offer.for),
+                    error::already_exists(ERESOURCE_ACCCOUNT_EXISTS),
+                );
+                assert!(
+                    account.sequence_number == 0,
+                    error::invalid_state(EACCOUNT_ALREADY_USED),
+                );
+                create_signer(resource_addr)
+            } else {
+                create_account_unchecked(resource_addr)
+            };
 
         // By default, only the SignerCapability should have control over the resource account and not the auth key.
         // If the source account wants direct control via auth key, they would need to explicitly rotate the auth key
@@ -750,18 +828,19 @@ module aptos_framework::account {
     }
 
     /// create the account for system reserved addresses
-    public(friend) fun create_framework_reserved_account(addr: address): (signer, SignerCapability) {
+    public(friend) fun create_framework_reserved_account(addr: address)
+        : (signer, SignerCapability) {
         assert!(
-            addr == @0x1 ||
-                addr == @0x2 ||
-                addr == @0x3 ||
-                addr == @0x4 ||
-                addr == @0x5 ||
-                addr == @0x6 ||
-                addr == @0x7 ||
-                addr == @0x8 ||
-                addr == @0x9 ||
-                addr == @0xa,
+            addr == @0x1
+            || addr == @0x2
+            || addr == @0x3
+            || addr == @0x4
+            || addr == @0x5
+            || addr == @0x6
+            || addr == @0x7
+            || addr == @0x8
+            || addr == @0x9
+            || addr == @0xa,
             error::permission_denied(ENO_VALID_FRAMEWORK_RESERVED_ADDRESS),
         );
         let signer = create_account_unchecked(addr);
@@ -800,9 +879,7 @@ module aptos_framework::account {
         let account = borrow_global_mut<Account>(account_addr);
         event::emit_event<CoinRegisterEvent>(
             &mut account.coin_register_events,
-            CoinRegisterEvent {
-                type_info: type_info::type_of<CoinType>(),
-            },
+            CoinRegisterEvent { type_info: type_info::type_of<CoinType>(), },
         );
     }
 
@@ -812,8 +889,7 @@ module aptos_framework::account {
 
     #[test_only]
     public fun get_signer_capability_offer_proof_challenge_v2(
-        source_address: address,
-        recipient_address: address,
+        source_address: address, recipient_address: address,
     ): SignerCapabilityOfferProofChallengeV2 acquires Account {
         SignerCapabilityOfferProofChallengeV2 {
             sequence_number: borrow_global_mut<Account>(source_address).sequence_number,
@@ -826,12 +902,16 @@ module aptos_framework::account {
     /// Capability based functions for efficient use.
     ///////////////////////////////////////////////////////////////////////////
 
-    public fun create_signer_with_capability(capability: &SignerCapability): signer {
+    public fun create_signer_with_capability(
+        capability: &SignerCapability
+    ): signer {
         let addr = &capability.account;
         create_signer(*addr)
     }
 
-    public fun get_signer_capability_address(capability: &SignerCapability): address {
+    public fun get_signer_capability_address(
+        capability: &SignerCapability
+    ): address {
         capability.account
     }
 
@@ -845,29 +925,39 @@ module aptos_framework::account {
         let account_resource = borrow_global_mut<Account>(account);
         // Verify that the `SignerCapabilityOfferProofChallengeV2` has the right information and is signed by the account owner's key
         if (account_scheme == ED25519_SCHEME) {
-            let pubkey = ed25519::new_unvalidated_public_key_from_bytes(account_public_key);
-            let expected_auth_key = ed25519::unvalidated_public_key_to_authentication_key(&pubkey);
+            let pubkey =
+                ed25519::new_unvalidated_public_key_from_bytes(account_public_key);
+            let expected_auth_key =
+                ed25519::unvalidated_public_key_to_authentication_key(&pubkey);
             assert!(
                 account_resource.authentication_key == expected_auth_key,
                 error::invalid_argument(EWRONG_CURRENT_PUBLIC_KEY),
             );
 
-            let signer_capability_sig = ed25519::new_signature_from_bytes(signed_message_bytes);
+            let signer_capability_sig =
+                ed25519::new_signature_from_bytes(signed_message_bytes);
             assert!(
-                ed25519::signature_verify_strict_t(&signer_capability_sig, &pubkey, message),
+                ed25519::signature_verify_strict_t(
+                    &signer_capability_sig, &pubkey, message
+                ),
                 error::invalid_argument(EINVALID_PROOF_OF_KNOWLEDGE),
             );
         } else if (account_scheme == MULTI_ED25519_SCHEME) {
-            let pubkey = multi_ed25519::new_unvalidated_public_key_from_bytes(account_public_key);
-            let expected_auth_key = multi_ed25519::unvalidated_public_key_to_authentication_key(&pubkey);
+            let pubkey =
+                multi_ed25519::new_unvalidated_public_key_from_bytes(account_public_key);
+            let expected_auth_key =
+                multi_ed25519::unvalidated_public_key_to_authentication_key(&pubkey);
             assert!(
                 account_resource.authentication_key == expected_auth_key,
                 error::invalid_argument(EWRONG_CURRENT_PUBLIC_KEY),
             );
 
-            let signer_capability_sig = multi_ed25519::new_signature_from_bytes(signed_message_bytes);
+            let signer_capability_sig =
+                multi_ed25519::new_signature_from_bytes(signed_message_bytes);
             assert!(
-                multi_ed25519::signature_verify_strict_t(&signer_capability_sig, &pubkey, message),
+                multi_ed25519::signature_verify_strict_t(
+                    &signer_capability_sig, &pubkey, message
+                ),
                 error::invalid_argument(EINVALID_PROOF_OF_KNOWLEDGE),
             );
         } else {
@@ -894,7 +984,8 @@ module aptos_framework::account {
 
     #[test(user = @0x1)]
     public entry fun test_create_resource_account(user: signer) acquires Account {
-        let (resource_account, resource_account_cap) = create_resource_account(&user, x"01");
+        let (resource_account, resource_account_cap) =
+            create_resource_account(&user, x"01");
         let resource_addr = signer::address_of(&resource_account);
         assert!(resource_addr != signer::address_of(&user), 0);
         assert!(resource_addr == get_signer_capability_address(&resource_account_cap), 1);
@@ -903,7 +994,8 @@ module aptos_framework::account {
     #[test]
     #[expected_failure(abort_code = 0x10007, location = Self)]
     public entry fun test_cannot_control_resource_account_via_auth_key() acquires Account {
-        let alice_pk = x"4141414141414141414141414141414141414141414141414141414141414145";
+        let alice_pk =
+            x"4141414141414141414141414141414141414141414141414141414141414145";
         let alice = create_account_from_ed25519_public_key(alice_pk);
         let alice_auth = get_authentication_key(signer::address_of(&alice)); // must look like a valid public key
 
@@ -930,25 +1022,29 @@ module aptos_framework::account {
         let account_public_key_bytes = alice_auth;
         vector::append(&mut account_public_key_bytes, eve_pk_bytes);
         vector::push_back(&mut account_public_key_bytes, 1); // Multisig verification threshold.
-        let fake_pk = multi_ed25519::new_unvalidated_public_key_from_bytes(account_public_key_bytes);
+        let fake_pk =
+            multi_ed25519::new_unvalidated_public_key_from_bytes(account_public_key_bytes);
 
         // Construct a multisig for `proof_challenge` as if it is signed by the signers behind `fake_pk`,
         // Eve being the only participant.
         let signer_capability_sig_bytes = x"";
-        vector::append(&mut signer_capability_sig_bytes, ed25519::signature_to_bytes(&eve_sig));
+        vector::append(
+            &mut signer_capability_sig_bytes, ed25519::signature_to_bytes(&eve_sig)
+        );
         vector::append(&mut signer_capability_sig_bytes, x"40000000"); // Signers bitmap.
-        let fake_sig = multi_ed25519::new_signature_from_bytes(signer_capability_sig_bytes);
+        let fake_sig =
+            multi_ed25519::new_signature_from_bytes(signer_capability_sig_bytes);
 
         assert!(
             multi_ed25519::signature_verify_strict_t(&fake_sig, &fake_pk, proof_challenge),
-            error::invalid_state(EINVALID_PROOF_OF_KNOWLEDGE)
+            error::invalid_state(EINVALID_PROOF_OF_KNOWLEDGE),
         );
         offer_signer_capability(
             &resource,
             signer_capability_sig_bytes,
             MULTI_ED25519_SCHEME,
             account_public_key_bytes,
-            recipient_address
+            recipient_address,
         );
     }
 
@@ -988,9 +1084,7 @@ module aptos_framework::account {
 
     #[test_only]
     /// Increment sequence number of account at address `addr`
-    public fun increment_sequence_number_for_test(
-        addr: address,
-    ) acquires Account {
+    public fun increment_sequence_number_for_test(addr: address,) acquires Account {
         let acct = borrow_global_mut<Account>(addr);
         acct.sequence_number = acct.sequence_number + 1;
     }
@@ -998,8 +1092,7 @@ module aptos_framework::account {
     #[test_only]
     /// Update address `addr` to have `s` as its sequence number
     public fun set_sequence_number(
-        addr: address,
-        s: u64
+        addr: address, s: u64
     ) acquires Account {
         borrow_global_mut<Account>(addr).sequence_number = s;
     }
@@ -1010,21 +1103,26 @@ module aptos_framework::account {
     }
 
     #[test_only]
-    public fun set_signer_capability_offer(offerer: address, receiver: address) acquires Account {
+    public fun set_signer_capability_offer(
+        offerer: address, receiver: address
+    ) acquires Account {
         let account_resource = borrow_global_mut<Account>(offerer);
         option::swap_or_fill(&mut account_resource.signer_capability_offer.for, receiver);
     }
 
     #[test_only]
-    public fun set_rotation_capability_offer(offerer: address, receiver: address) acquires Account {
+    public fun set_rotation_capability_offer(
+        offerer: address, receiver: address
+    ) acquires Account {
         let account_resource = borrow_global_mut<Account>(offerer);
-        option::swap_or_fill(&mut account_resource.rotation_capability_offer.for, receiver);
+        option::swap_or_fill(
+            &mut account_resource.rotation_capability_offer.for, receiver
+        );
     }
 
     #[test]
     /// Verify test-only sequence number mocking
-    public entry fun mock_sequence_numbers()
-    acquires Account {
+    public entry fun mock_sequence_numbers() acquires Account {
         let addr: address = @0x1234; // Define test address
         create_account(addr); // Initialize account resource
         // Assert sequence number intializes to 0
@@ -1046,8 +1144,11 @@ module aptos_framework::account {
     public entry fun test_empty_public_key(alice: signer) acquires Account, OriginatingAddress {
         create_account(signer::address_of(&alice));
         let pk = vector::empty<u8>();
-        let sig = x"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
-        rotate_authentication_key(&alice, ED25519_SCHEME, pk, ED25519_SCHEME, pk, sig, sig);
+        let sig =
+            x"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+        rotate_authentication_key(
+            &alice, ED25519_SCHEME, pk, ED25519_SCHEME, pk, sig, sig
+        );
     }
 
     #[test(alice = @0xa11ce)]
@@ -1056,11 +1157,21 @@ module aptos_framework::account {
         create_account(signer::address_of(&alice));
         let test_signature = vector::empty<u8>();
         let pk = x"0000000000000000000000000000000000000000000000000000000000000000";
-        rotate_authentication_key(&alice, ED25519_SCHEME, pk, ED25519_SCHEME, pk, test_signature, test_signature);
+        rotate_authentication_key(
+            &alice,
+            ED25519_SCHEME,
+            pk,
+            ED25519_SCHEME,
+            pk,
+            test_signature,
+            test_signature,
+        );
     }
 
     #[test_only]
-    public fun create_account_from_ed25519_public_key(pk_bytes: vector<u8>): signer {
+    public fun create_account_from_ed25519_public_key(
+        pk_bytes: vector<u8>
+    ): signer {
         let pk = ed25519::new_unvalidated_public_key_from_bytes(pk_bytes);
         let curr_auth_key = ed25519::unvalidated_public_key_to_authentication_key(&pk);
         let alice_address = from_bcs::to_address(curr_auth_key);
@@ -1100,7 +1211,9 @@ module aptos_framework::account {
     }
 
     #[test(bob = @0x345)]
-    public entry fun test_valid_check_signer_capability_and_create_authorized_signer(bob: signer) acquires Account {
+    public entry fun test_valid_check_signer_capability_and_create_authorized_signer(
+        bob: signer
+    ) acquires Account {
         let (alice_sk, alice_pk) = ed25519::generate_keys();
         let alice_pk_bytes = ed25519::validated_public_key_to_bytes(&alice_pk);
         let alice = create_account_from_ed25519_public_key(alice_pk_bytes);
@@ -1122,10 +1235,15 @@ module aptos_framework::account {
             ed25519::signature_to_bytes(&alice_signer_capability_offer_sig),
             0,
             alice_pk_bytes,
-            bob_addr
+            bob_addr,
         );
 
-        assert!(option::contains(&borrow_global<Account>(alice_addr).signer_capability_offer.for, &bob_addr), 0);
+        assert!(
+            option::contains(
+                &borrow_global<Account>(alice_addr).signer_capability_offer.for, &bob_addr
+            ),
+            0,
+        );
 
         let signer = create_authorized_signer(&bob, alice_addr);
         assert!(signer::address_of(&signer) == signer::address_of(&alice), 0);
@@ -1154,19 +1272,17 @@ module aptos_framework::account {
             ed25519::signature_to_bytes(&alice_signer_capability_offer_sig),
             0,
             alice_pk_bytes,
-            bob_addr
+            bob_addr,
         );
 
         assert!(is_signer_capability_offered(alice_addr), 0);
         assert!(get_signer_capability_offer_for(alice_addr) == bob_addr, 0);
     }
 
-
     #[test(bob = @0x345, charlie = @0x567)]
     #[expected_failure(abort_code = 393230, location = Self)]
     public entry fun test_invalid_check_signer_capability_and_create_authorized_signer(
-        bob: signer,
-        charlie: signer
+        bob: signer, charlie: signer
     ) acquires Account {
         let (alice_sk, alice_pk) = ed25519::generate_keys();
         let alice_pk_bytes = ed25519::validated_public_key_to_bytes(&alice_pk);
@@ -1189,11 +1305,16 @@ module aptos_framework::account {
             ed25519::signature_to_bytes(&alice_signer_capability_offer_sig),
             0,
             alice_pk_bytes,
-            bob_addr
+            bob_addr,
         );
 
         let alice_account_resource = borrow_global_mut<Account>(alice_addr);
-        assert!(option::contains(&alice_account_resource.signer_capability_offer.for, &bob_addr), 0);
+        assert!(
+            option::contains(
+                &alice_account_resource.signer_capability_offer.for, &bob_addr
+            ),
+            0,
+        );
 
         create_authorized_signer(&charlie, alice_addr);
     }
@@ -1221,14 +1342,16 @@ module aptos_framework::account {
             ed25519::signature_to_bytes(&alice_signer_capability_offer_sig),
             0,
             alice_pk_bytes,
-            bob_addr
+            bob_addr,
         );
         revoke_signer_capability(&alice, bob_addr);
     }
 
     #[test(bob = @0x345, charlie = @0x567)]
     #[expected_failure(abort_code = 393230, location = Self)]
-    public entry fun test_invalid_revoke_signer_capability(bob: signer, charlie: signer) acquires Account {
+    public entry fun test_invalid_revoke_signer_capability(
+        bob: signer, charlie: signer
+    ) acquires Account {
         let (alice_sk, alice_pk) = ed25519::generate_keys();
         let alice_pk_bytes = ed25519::validated_public_key_to_bytes(&alice_pk);
         let alice = create_account_from_ed25519_public_key(alice_pk_bytes);
@@ -1252,7 +1375,7 @@ module aptos_framework::account {
             ed25519::signature_to_bytes(&alice_signer_capability_offer_sig),
             0,
             alice_pk_bytes,
-            bob_addr
+            bob_addr,
         );
         revoke_signer_capability(&alice, charlie_addr);
     }
@@ -1261,7 +1384,9 @@ module aptos_framework::account {
     // Tests for offering rotation capabilities
     //
     #[test(bob = @0x345, framework = @aptos_framework)]
-    public entry fun test_valid_offer_rotation_capability(bob: signer, framework: signer) acquires Account {
+    public entry fun test_valid_offer_rotation_capability(
+        bob: signer, framework: signer
+    ) acquires Account {
         chain_id::initialize_for_test(&framework, 4);
         let (alice_sk, alice_pk) = ed25519::generate_keys();
         let alice_pk_bytes = ed25519::validated_public_key_to_bytes(&alice_pk);
@@ -1278,23 +1403,28 @@ module aptos_framework::account {
             recipient_address: bob_addr,
         };
 
-        let alice_rotation_capability_offer_sig = ed25519::sign_struct(&alice_sk, challenge);
+        let alice_rotation_capability_offer_sig =
+            ed25519::sign_struct(&alice_sk, challenge);
 
         offer_rotation_capability(
             &alice,
             ed25519::signature_to_bytes(&alice_rotation_capability_offer_sig),
             0,
             alice_pk_bytes,
-            bob_addr
+            bob_addr,
         );
 
         let alice_resource = borrow_global_mut<Account>(signer::address_of(&alice));
-        assert!(option::contains(&alice_resource.rotation_capability_offer.for, &bob_addr), 0);
+        assert!(
+            option::contains(&alice_resource.rotation_capability_offer.for, &bob_addr), 0
+        );
     }
 
     #[test(bob = @0x345, framework = @aptos_framework)]
     #[expected_failure(abort_code = 65544, location = Self)]
-    public entry fun test_invalid_offer_rotation_capability(bob: signer, framework: signer) acquires Account {
+    public entry fun test_invalid_offer_rotation_capability(
+        bob: signer, framework: signer
+    ) acquires Account {
         chain_id::initialize_for_test(&framework, 4);
         let (alice_sk, alice_pk) = ed25519::generate_keys();
         let alice_pk_bytes = ed25519::validated_public_key_to_bytes(&alice_pk);
@@ -1312,19 +1442,22 @@ module aptos_framework::account {
             recipient_address: bob_addr,
         };
 
-        let alice_rotation_capability_offer_sig = ed25519::sign_struct(&alice_sk, challenge);
+        let alice_rotation_capability_offer_sig =
+            ed25519::sign_struct(&alice_sk, challenge);
 
         offer_rotation_capability(
             &alice,
             ed25519::signature_to_bytes(&alice_rotation_capability_offer_sig),
             0,
             alice_pk_bytes,
-            signer::address_of(&bob)
+            signer::address_of(&bob),
         );
     }
 
     #[test(bob = @0x345, framework = @aptos_framework)]
-    public entry fun test_valid_revoke_rotation_capability(bob: signer, framework: signer) acquires Account {
+    public entry fun test_valid_revoke_rotation_capability(
+        bob: signer, framework: signer
+    ) acquires Account {
         chain_id::initialize_for_test(&framework, 4);
         let (alice_sk, alice_pk) = ed25519::generate_keys();
         let alice_pk_bytes = ed25519::validated_public_key_to_bytes(&alice_pk);
@@ -1341,14 +1474,15 @@ module aptos_framework::account {
             recipient_address: bob_addr,
         };
 
-        let alice_rotation_capability_offer_sig = ed25519::sign_struct(&alice_sk, challenge);
+        let alice_rotation_capability_offer_sig =
+            ed25519::sign_struct(&alice_sk, challenge);
 
         offer_rotation_capability(
             &alice,
             ed25519::signature_to_bytes(&alice_rotation_capability_offer_sig),
             0,
             alice_pk_bytes,
-            signer::address_of(&bob)
+            signer::address_of(&bob),
         );
         revoke_rotation_capability(&alice, signer::address_of(&bob));
     }
@@ -1356,9 +1490,7 @@ module aptos_framework::account {
     #[test(bob = @0x345, charlie = @0x567, framework = @aptos_framework)]
     #[expected_failure(abort_code = 393234, location = Self)]
     public entry fun test_invalid_revoke_rotation_capability(
-        bob: signer,
-        charlie: signer,
-        framework: signer
+        bob: signer, charlie: signer, framework: signer
     ) acquires Account {
         chain_id::initialize_for_test(&framework, 4);
         let (alice_sk, alice_pk) = ed25519::generate_keys();
@@ -1377,14 +1509,15 @@ module aptos_framework::account {
             recipient_address: bob_addr,
         };
 
-        let alice_rotation_capability_offer_sig = ed25519::sign_struct(&alice_sk, challenge);
+        let alice_rotation_capability_offer_sig =
+            ed25519::sign_struct(&alice_sk, challenge);
 
         offer_rotation_capability(
             &alice,
             ed25519::signature_to_bytes(&alice_rotation_capability_offer_sig),
             0,
             alice_pk_bytes,
-            signer::address_of(&bob)
+            signer::address_of(&bob),
         );
         revoke_rotation_capability(&alice, signer::address_of(&charlie));
     }
@@ -1400,20 +1533,28 @@ module aptos_framework::account {
         initialize(&account);
         let (curr_sk, curr_pk) = multi_ed25519::generate_keys(2, 3);
         let curr_pk_unvalidated = multi_ed25519::public_key_to_unvalidated(&curr_pk);
-        let curr_auth_key = multi_ed25519::unvalidated_public_key_to_authentication_key(&curr_pk_unvalidated);
+        let curr_auth_key =
+            multi_ed25519::unvalidated_public_key_to_authentication_key(
+                &curr_pk_unvalidated
+            );
         let alice_addr = from_bcs::to_address(curr_auth_key);
         let alice = create_account_unchecked(alice_addr);
 
         let (new_sk, new_pk) = multi_ed25519::generate_keys(4, 5);
         let new_pk_unvalidated = multi_ed25519::public_key_to_unvalidated(&new_pk);
-        let new_auth_key = multi_ed25519::unvalidated_public_key_to_authentication_key(&new_pk_unvalidated);
+        let new_auth_key =
+            multi_ed25519::unvalidated_public_key_to_authentication_key(
+                &new_pk_unvalidated
+            );
         let new_address = from_bcs::to_address(new_auth_key);
 
         let challenge = RotationProofChallenge {
             sequence_number: borrow_global<Account>(alice_addr).sequence_number,
             originator: alice_addr,
             current_auth_key: alice_addr,
-            new_public_key: multi_ed25519::unvalidated_public_key_to_bytes(&new_pk_unvalidated),
+            new_public_key: multi_ed25519::unvalidated_public_key_to_bytes(
+                &new_pk_unvalidated
+            ),
         };
 
         let from_sig = multi_ed25519::sign_struct(&curr_sk, challenge);
@@ -1428,7 +1569,8 @@ module aptos_framework::account {
             multi_ed25519::signature_to_bytes(&from_sig),
             multi_ed25519::signature_to_bytes(&to_sig),
         );
-        let address_map = &mut borrow_global_mut<OriginatingAddress>(@aptos_framework).address_map;
+        let address_map =
+            &mut borrow_global_mut<OriginatingAddress>(@aptos_framework).address_map;
         let expected_originating_address = table::borrow(address_map, new_address);
         assert!(*expected_originating_address == alice_addr, 0);
         assert!(borrow_global<Account>(alice_addr).authentication_key == new_auth_key, 0);
@@ -1442,7 +1584,10 @@ module aptos_framework::account {
 
         let (curr_sk, curr_pk) = multi_ed25519::generate_keys(2, 3);
         let curr_pk_unvalidated = multi_ed25519::public_key_to_unvalidated(&curr_pk);
-        let curr_auth_key = multi_ed25519::unvalidated_public_key_to_authentication_key(&curr_pk_unvalidated);
+        let curr_auth_key =
+            multi_ed25519::unvalidated_public_key_to_authentication_key(
+                &curr_pk_unvalidated
+            );
         let alice_addr = from_bcs::to_address(curr_auth_key);
         let alice = create_account_unchecked(alice_addr);
 
@@ -1450,7 +1595,8 @@ module aptos_framework::account {
 
         let (new_sk, new_pk) = ed25519::generate_keys();
         let new_pk_unvalidated = ed25519::public_key_to_unvalidated(&new_pk);
-        let new_auth_key = ed25519::unvalidated_public_key_to_authentication_key(&new_pk_unvalidated);
+        let new_auth_key =
+            ed25519::unvalidated_public_key_to_authentication_key(&new_pk_unvalidated);
         let new_addr = from_bcs::to_address(new_auth_key);
 
         let challenge = RotationProofChallenge {
@@ -1473,12 +1619,12 @@ module aptos_framework::account {
             ed25519::signature_to_bytes(&to_sig),
         );
 
-        let address_map = &mut borrow_global_mut<OriginatingAddress>(@aptos_framework).address_map;
+        let address_map =
+            &mut borrow_global_mut<OriginatingAddress>(@aptos_framework).address_map;
         let expected_originating_address = table::borrow(address_map, new_addr);
         assert!(*expected_originating_address == alice_addr, 0);
         assert!(borrow_global<Account>(alice_addr).authentication_key == new_auth_key, 0);
     }
-
 
     #[test(account = @aptos_framework)]
     public entry fun test_simple_rotation(account: &signer) acquires Account {
@@ -1489,13 +1635,13 @@ module aptos_framework::account {
 
         let (_new_sk, new_pk) = ed25519::generate_keys();
         let new_pk_unvalidated = ed25519::public_key_to_unvalidated(&new_pk);
-        let new_auth_key = ed25519::unvalidated_public_key_to_authentication_key(&new_pk_unvalidated);
+        let new_auth_key =
+            ed25519::unvalidated_public_key_to_authentication_key(&new_pk_unvalidated);
         let _new_addr = from_bcs::to_address(new_auth_key);
 
         rotate_authentication_key_call(&alice, new_auth_key);
         assert!(borrow_global<Account>(alice_addr).authentication_key == new_auth_key, 0);
     }
-
 
     #[test(account = @aptos_framework)]
     #[expected_failure(abort_code = 0x20014, location = Self)]

--- a/aptos-move/framework/aptos-framework/sources/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account.move
@@ -203,14 +203,15 @@ module aptos_framework::account {
     public(friend) fun create_account(new_address: address): signer {
         // there cannot be an Account resource under new_addr already.
         assert!(
-            !exists<Account>(new_address), error::already_exists(EACCOUNT_ALREADY_EXISTS)
+            !exists<Account>(new_address),
+            error::already_exists(EACCOUNT_ALREADY_EXISTS),
         );
 
         // NOTE: @core_resources gets created via a `create_account` call, so we do not include it below.
         assert!(
             new_address != @vm_reserved
-            && new_address != @aptos_framework
-            && new_address != @aptos_token,
+                && new_address != @aptos_framework
+                && new_address != @aptos_token,
             error::invalid_argument(ECANNOT_RESERVED_ADDRESS),
         );
 
@@ -426,7 +427,8 @@ module aptos_framework::account {
             borrow_global<Account>(rotation_cap_offerer_address);
         assert!(
             option::contains(
-                &offerer_account_resource.rotation_capability_offer.for, &delegate_address
+                &offerer_account_resource.rotation_capability_offer.for,
+                &delegate_address,
             ),
             error::not_found(ENO_SUCH_ROTATION_CAPABILITY_OFFER),
         );
@@ -675,7 +677,8 @@ module aptos_framework::account {
         account: &signer, offerer_address: address
     ): signer acquires Account {
         assert!(
-            exists_at(offerer_address), error::not_found(EOFFERER_ADDRESS_DOES_NOT_EXIST)
+            exists_at(offerer_address),
+            error::not_found(EOFFERER_ADDRESS_DOES_NOT_EXIST),
         );
 
         // Check if there's an existing signer capability offer from the offerer.
@@ -832,15 +835,15 @@ module aptos_framework::account {
         : (signer, SignerCapability) {
         assert!(
             addr == @0x1
-            || addr == @0x2
-            || addr == @0x3
-            || addr == @0x4
-            || addr == @0x5
-            || addr == @0x6
-            || addr == @0x7
-            || addr == @0x8
-            || addr == @0x9
-            || addr == @0xa,
+                || addr == @0x2
+                || addr == @0x3
+                || addr == @0x4
+                || addr == @0x5
+                || addr == @0x6
+                || addr == @0x7
+                || addr == @0x8
+                || addr == @0x9
+                || addr == @0xa,
             error::permission_denied(ENO_VALID_FRAMEWORK_RESERVED_ADDRESS),
         );
         let signer = create_account_unchecked(addr);
@@ -1091,9 +1094,7 @@ module aptos_framework::account {
 
     #[test_only]
     /// Update address `addr` to have `s` as its sequence number
-    public fun set_sequence_number(
-        addr: address, s: u64
-    ) acquires Account {
+    public fun set_sequence_number(addr: address, s: u64) acquires Account {
         borrow_global_mut<Account>(addr).sequence_number = s;
     }
 
@@ -1240,7 +1241,8 @@ module aptos_framework::account {
 
         assert!(
             option::contains(
-                &borrow_global<Account>(alice_addr).signer_capability_offer.for, &bob_addr
+                &borrow_global<Account>(alice_addr).signer_capability_offer.for,
+                &bob_addr,
             ),
             0,
         );

--- a/aptos-move/framework/aptos-framework/sources/account.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/account.spec.move
@@ -122,22 +122,24 @@ spec aptos_framework::account {
     spec create_account_if_does_not_exist(account_address: address) {
         let authentication_key = bcs::to_bytes(account_address);
 
-        aborts_if !exists<Account>(account_address) && (
-            account_address == @vm_reserved
-            || account_address == @aptos_framework
-            || account_address == @aptos_token
-            || !(len(authentication_key) == 32)
-        );
+        aborts_if !exists<Account>(account_address)
+            && (
+                account_address == @vm_reserved
+                || account_address == @aptos_framework
+                || account_address == @aptos_token
+                || !(len(authentication_key) == 32)
+            );
         ensures exists<Account>(account_address);
     }
-
 
     /// Check if the bytes of the new address is 32.
     /// The Account does not exist under the new address before creating the account.
     /// Limit the new account address is not @vm_reserved / @aptos_framework / @aptos_toke.
     spec create_account(new_address: address): signer {
-        include CreateAccountAbortsIf {addr: new_address};
-        aborts_if new_address == @vm_reserved || new_address == @aptos_framework || new_address == @aptos_token;
+        include CreateAccountAbortsIf { addr: new_address };
+        aborts_if new_address == @vm_reserved
+            || new_address == @aptos_framework
+            || new_address == @aptos_token;
         ensures signer::address_of(result) == new_address;
         /// [high-level-req-2]
         ensures exists<Account>(new_address);
@@ -146,7 +148,7 @@ spec aptos_framework::account {
     /// Check if the bytes of the new address is 32.
     /// The Account does not exist under the new address before creating the account.
     spec create_account_unchecked(new_address: address): signer {
-        include CreateAccountAbortsIf {addr: new_address};
+        include CreateAccountAbortsIf { addr: new_address };
         ensures signer::address_of(result) == new_address;
         ensures exists<Account>(new_address);
     }
@@ -213,34 +215,56 @@ spec aptos_framework::account {
         ensures account_resource.authentication_key == new_auth_key;
     }
 
-    spec fun spec_assert_valid_rotation_proof_signature_and_get_auth_key(scheme: u8, public_key_bytes: vector<u8>, signature: vector<u8>, challenge: RotationProofChallenge): vector<u8>;
+    spec fun spec_assert_valid_rotation_proof_signature_and_get_auth_key(
+        scheme: u8,
+        public_key_bytes: vector<u8>,
+        signature: vector<u8>,
+        challenge: RotationProofChallenge
+    ): vector<u8>;
 
-    spec assert_valid_rotation_proof_signature_and_get_auth_key(scheme: u8, public_key_bytes: vector<u8>, signature: vector<u8>, challenge: &RotationProofChallenge): vector<u8> {
+    spec assert_valid_rotation_proof_signature_and_get_auth_key(
+        scheme: u8,
+        public_key_bytes: vector<u8>,
+        signature: vector<u8>,
+        challenge: &RotationProofChallenge
+    ): vector<u8> {
         pragma opaque;
         include AssertValidRotationProofSignatureAndGetAuthKeyAbortsIf;
-        ensures [abstract] result == spec_assert_valid_rotation_proof_signature_and_get_auth_key(scheme, public_key_bytes, signature, challenge);
+        ensures [abstract] result
+            == spec_assert_valid_rotation_proof_signature_and_get_auth_key(
+                scheme, public_key_bytes, signature, challenge
+            );
     }
+
     spec schema AssertValidRotationProofSignatureAndGetAuthKeyAbortsIf {
         scheme: u8;
         public_key_bytes: vector<u8>;
         signature: vector<u8>;
         challenge: RotationProofChallenge;
 
-        include scheme == ED25519_SCHEME ==> ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: public_key_bytes };
-        include scheme == ED25519_SCHEME ==> ed25519::NewSignatureFromBytesAbortsIf { bytes: signature };
-        aborts_if scheme == ED25519_SCHEME && !ed25519::spec_signature_verify_strict_t(
-            ed25519::Signature { bytes: signature },
-            ed25519::UnvalidatedPublicKey { bytes: public_key_bytes },
-            challenge
-        );
+        include scheme == ED25519_SCHEME ==>
+            ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: public_key_bytes };
+        include scheme == ED25519_SCHEME ==>
+            ed25519::NewSignatureFromBytesAbortsIf { bytes: signature };
+        aborts_if scheme == ED25519_SCHEME
+            && !ed25519::spec_signature_verify_strict_t(
+                ed25519::Signature { bytes: signature },
+                ed25519::UnvalidatedPublicKey { bytes: public_key_bytes },
+                challenge,
+            );
 
-        include scheme == MULTI_ED25519_SCHEME ==> multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: public_key_bytes };
-        include scheme == MULTI_ED25519_SCHEME ==> multi_ed25519::NewSignatureFromBytesAbortsIf { bytes: signature };
-        aborts_if scheme == MULTI_ED25519_SCHEME && !multi_ed25519::spec_signature_verify_strict_t(
-            multi_ed25519::Signature { bytes: signature },
-            multi_ed25519::UnvalidatedPublicKey { bytes: public_key_bytes },
-            challenge
-        );
+        include scheme == MULTI_ED25519_SCHEME ==>
+            multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf {
+                bytes: public_key_bytes
+            };
+        include scheme == MULTI_ED25519_SCHEME ==>
+            multi_ed25519::NewSignatureFromBytesAbortsIf { bytes: signature };
+        aborts_if scheme == MULTI_ED25519_SCHEME
+            && !multi_ed25519::spec_signature_verify_strict_t(
+                multi_ed25519::Signature { bytes: signature },
+                multi_ed25519::UnvalidatedPublicKey { bytes: public_key_bytes },
+                challenge,
+            );
         aborts_if scheme != ED25519_SCHEME && scheme != MULTI_ED25519_SCHEME;
     }
 
@@ -260,21 +284,41 @@ spec aptos_framework::account {
         aborts_if !exists<Account>(addr);
 
         /// [high-level-req-6.1]
-        include from_scheme == ED25519_SCHEME ==> ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: from_public_key_bytes };
-        aborts_if from_scheme == ED25519_SCHEME && ({
-            let expected_auth_key = ed25519::spec_public_key_bytes_to_authentication_key(from_public_key_bytes);
-            account_resource.authentication_key != expected_auth_key
-        });
-        include from_scheme == MULTI_ED25519_SCHEME ==> multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: from_public_key_bytes };
-        aborts_if from_scheme == MULTI_ED25519_SCHEME && ({
-            let from_auth_key = multi_ed25519::spec_public_key_bytes_to_authentication_key(from_public_key_bytes);
-            account_resource.authentication_key != from_auth_key
-        });
+        include from_scheme == ED25519_SCHEME ==>
+            ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf {
+                bytes: from_public_key_bytes
+            };
+        aborts_if from_scheme == ED25519_SCHEME
+            && (
+                {
+                    let expected_auth_key =
+                        ed25519::spec_public_key_bytes_to_authentication_key(
+                            from_public_key_bytes
+                        );
+                    account_resource.authentication_key != expected_auth_key
+                }
+            );
+        include from_scheme == MULTI_ED25519_SCHEME ==>
+            multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf {
+                bytes: from_public_key_bytes
+            };
+        aborts_if from_scheme == MULTI_ED25519_SCHEME
+            && (
+                {
+                    let from_auth_key =
+                        multi_ed25519::spec_public_key_bytes_to_authentication_key(
+                            from_public_key_bytes
+                        );
+                    account_resource.authentication_key != from_auth_key
+                }
+            );
 
         /// [high-level-req-5.1]
         aborts_if from_scheme != ED25519_SCHEME && from_scheme != MULTI_ED25519_SCHEME;
 
-        let curr_auth_key = from_bcs::deserialize<address>(account_resource.authentication_key);
+        let curr_auth_key = from_bcs::deserialize<address>(
+            account_resource.authentication_key
+        );
         aborts_if !from_bcs::deserializable<address>(account_resource.authentication_key);
 
         let challenge = RotationProofChallenge {
@@ -301,23 +345,24 @@ spec aptos_framework::account {
 
         // Verify all properties in update_auth_key_and_originating_address_table
         let originating_addr = addr;
-        let new_auth_key_vector = spec_assert_valid_rotation_proof_signature_and_get_auth_key(to_scheme, to_public_key_bytes, cap_update_table, challenge);
+        let new_auth_key_vector = spec_assert_valid_rotation_proof_signature_and_get_auth_key(
+            to_scheme, to_public_key_bytes, cap_update_table, challenge
+        );
 
         let address_map = global<OriginatingAddress>(@aptos_framework).address_map;
         let new_auth_key = from_bcs::deserialize<address>(new_auth_key_vector);
 
         aborts_if !exists<OriginatingAddress>(@aptos_framework);
         aborts_if !from_bcs::deserializable<address>(account_resource.authentication_key);
-        aborts_if table::spec_contains(address_map, curr_auth_key) &&
-            table::spec_get(address_map, curr_auth_key) != originating_addr;
+        aborts_if table::spec_contains(address_map, curr_auth_key)
+            && table::spec_get(address_map, curr_auth_key) != originating_addr;
 
         aborts_if !from_bcs::deserializable<address>(new_auth_key_vector);
 
-        aborts_if curr_auth_key != new_auth_key && table::spec_contains(address_map, new_auth_key);
+        aborts_if curr_auth_key != new_auth_key
+            && table::spec_contains(address_map, new_auth_key);
 
-        include UpdateAuthKeyAndOriginatingAddressTableAbortsIf {
-            originating_addr: addr,
-        };
+        include UpdateAuthKeyAndOriginatingAddressTableAbortsIf { originating_addr: addr, };
 
         let post auth_key = global<Account>(addr).authentication_key;
         ensures auth_key == new_auth_key_vector;
@@ -334,8 +379,12 @@ spec aptos_framework::account {
         aborts_if !exists<Account>(rotation_cap_offerer_address);
         let delegate_address = signer::address_of(delegate_signer);
         let offerer_account_resource = global<Account>(rotation_cap_offerer_address);
-        aborts_if !from_bcs::deserializable<address>(offerer_account_resource.authentication_key);
-        let curr_auth_key = from_bcs::deserialize<address>(offerer_account_resource.authentication_key);
+        aborts_if !from_bcs::deserializable<address>(
+            offerer_account_resource.authentication_key
+        );
+        let curr_auth_key = from_bcs::deserialize<address>(
+            offerer_account_resource.authentication_key
+        );
         aborts_if !exists<Account>(delegate_address);
         let challenge = RotationProofChallenge {
             sequence_number: global<Account>(delegate_address).sequence_number,
@@ -344,7 +393,9 @@ spec aptos_framework::account {
             new_public_key: new_public_key_bytes,
         };
         /// [high-level-req-6.2]
-        aborts_if !option::spec_contains(offerer_account_resource.rotation_capability_offer.for, delegate_address);
+        aborts_if !option::spec_contains(
+            offerer_account_resource.rotation_capability_offer.for, delegate_address
+        );
         /// [high-level-req-9.1]
         include AssertValidRotationProofSignatureAndGetAuthKeyAbortsIf {
             scheme: new_scheme,
@@ -353,19 +404,24 @@ spec aptos_framework::account {
             challenge,
         };
 
-        let new_auth_key_vector = spec_assert_valid_rotation_proof_signature_and_get_auth_key(new_scheme, new_public_key_bytes, cap_update_table, challenge);
+        let new_auth_key_vector = spec_assert_valid_rotation_proof_signature_and_get_auth_key(
+            new_scheme, new_public_key_bytes, cap_update_table, challenge
+        );
         let address_map = global<OriginatingAddress>(@aptos_framework).address_map;
 
         // Verify all properties in update_auth_key_and_originating_address_table
         aborts_if !exists<OriginatingAddress>(@aptos_framework);
-        aborts_if !from_bcs::deserializable<address>(offerer_account_resource.authentication_key);
-        aborts_if table::spec_contains(address_map, curr_auth_key) &&
-            table::spec_get(address_map, curr_auth_key) != rotation_cap_offerer_address;
+        aborts_if !from_bcs::deserializable<address>(
+            offerer_account_resource.authentication_key
+        );
+        aborts_if table::spec_contains(address_map, curr_auth_key)
+            && table::spec_get(address_map, curr_auth_key) != rotation_cap_offerer_address;
 
         aborts_if !from_bcs::deserializable<address>(new_auth_key_vector);
         let new_auth_key = from_bcs::deserialize<address>(new_auth_key_vector);
 
-        aborts_if curr_auth_key != new_auth_key && table::spec_contains(address_map, new_auth_key);
+        aborts_if curr_auth_key != new_auth_key
+            && table::spec_contains(address_map, new_auth_key);
         include UpdateAuthKeyAndOriginatingAddressTableAbortsIf {
             originating_addr: rotation_cap_offerer_address,
             account_resource: offerer_account_resource,
@@ -395,29 +451,53 @@ spec aptos_framework::account {
         aborts_if !exists<Account>(recipient_address);
         aborts_if !exists<Account>(source_address);
 
-        include account_scheme == ED25519_SCHEME ==> ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: account_public_key_bytes };
-        aborts_if account_scheme == ED25519_SCHEME && ({
-            let expected_auth_key = ed25519::spec_public_key_bytes_to_authentication_key(account_public_key_bytes);
-            account_resource.authentication_key != expected_auth_key
-        });
-        include account_scheme == ED25519_SCHEME ==> ed25519::NewSignatureFromBytesAbortsIf { bytes: rotation_capability_sig_bytes };
-        aborts_if account_scheme == ED25519_SCHEME && !ed25519::spec_signature_verify_strict_t(
-            ed25519::Signature { bytes: rotation_capability_sig_bytes },
-            ed25519::UnvalidatedPublicKey { bytes: account_public_key_bytes },
-            proof_challenge
-        );
+        include account_scheme == ED25519_SCHEME ==>
+            ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf {
+                bytes: account_public_key_bytes
+            };
+        aborts_if account_scheme == ED25519_SCHEME
+            && (
+                {
+                    let expected_auth_key =
+                        ed25519::spec_public_key_bytes_to_authentication_key(
+                            account_public_key_bytes
+                        );
+                    account_resource.authentication_key != expected_auth_key
+                }
+            );
+        include account_scheme == ED25519_SCHEME ==>
+            ed25519::NewSignatureFromBytesAbortsIf { bytes: rotation_capability_sig_bytes };
+        aborts_if account_scheme == ED25519_SCHEME
+            && !ed25519::spec_signature_verify_strict_t(
+                ed25519::Signature { bytes: rotation_capability_sig_bytes },
+                ed25519::UnvalidatedPublicKey { bytes: account_public_key_bytes },
+                proof_challenge,
+            );
 
-        include account_scheme == MULTI_ED25519_SCHEME ==> multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: account_public_key_bytes };
-        aborts_if account_scheme == MULTI_ED25519_SCHEME && ({
-            let expected_auth_key = multi_ed25519::spec_public_key_bytes_to_authentication_key(account_public_key_bytes);
-            account_resource.authentication_key != expected_auth_key
-        });
-        include account_scheme == MULTI_ED25519_SCHEME ==> multi_ed25519::NewSignatureFromBytesAbortsIf { bytes: rotation_capability_sig_bytes };
-        aborts_if account_scheme == MULTI_ED25519_SCHEME && !multi_ed25519::spec_signature_verify_strict_t(
-            multi_ed25519::Signature { bytes: rotation_capability_sig_bytes },
-            multi_ed25519::UnvalidatedPublicKey { bytes: account_public_key_bytes },
-            proof_challenge
-        );
+        include account_scheme == MULTI_ED25519_SCHEME ==>
+            multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf {
+                bytes: account_public_key_bytes
+            };
+        aborts_if account_scheme == MULTI_ED25519_SCHEME
+            && (
+                {
+                    let expected_auth_key =
+                        multi_ed25519::spec_public_key_bytes_to_authentication_key(
+                            account_public_key_bytes
+                        );
+                    account_resource.authentication_key != expected_auth_key
+                }
+            );
+        include account_scheme == MULTI_ED25519_SCHEME ==>
+            multi_ed25519::NewSignatureFromBytesAbortsIf {
+                bytes: rotation_capability_sig_bytes
+            };
+        aborts_if account_scheme == MULTI_ED25519_SCHEME
+            && !multi_ed25519::spec_signature_verify_strict_t(
+                multi_ed25519::Signature { bytes: rotation_capability_sig_bytes },
+                multi_ed25519::UnvalidatedPublicKey { bytes: account_public_key_bytes },
+                proof_challenge,
+            );
 
         /// [high-level-req-5.2]
         aborts_if account_scheme != ED25519_SCHEME && account_scheme != MULTI_ED25519_SCHEME;
@@ -448,29 +528,53 @@ spec aptos_framework::account {
         aborts_if !exists<Account>(recipient_address);
         aborts_if !exists<Account>(source_address);
 
-        include account_scheme == ED25519_SCHEME ==> ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: account_public_key_bytes };
-        aborts_if account_scheme == ED25519_SCHEME && ({
-            let expected_auth_key = ed25519::spec_public_key_bytes_to_authentication_key(account_public_key_bytes);
-            account_resource.authentication_key != expected_auth_key
-        });
-        include account_scheme == ED25519_SCHEME ==> ed25519::NewSignatureFromBytesAbortsIf { bytes: signer_capability_sig_bytes };
-        aborts_if account_scheme == ED25519_SCHEME && !ed25519::spec_signature_verify_strict_t(
-            ed25519::Signature { bytes: signer_capability_sig_bytes },
-            ed25519::UnvalidatedPublicKey { bytes: account_public_key_bytes },
-            proof_challenge
-        );
+        include account_scheme == ED25519_SCHEME ==>
+            ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf {
+                bytes: account_public_key_bytes
+            };
+        aborts_if account_scheme == ED25519_SCHEME
+            && (
+                {
+                    let expected_auth_key =
+                        ed25519::spec_public_key_bytes_to_authentication_key(
+                            account_public_key_bytes
+                        );
+                    account_resource.authentication_key != expected_auth_key
+                }
+            );
+        include account_scheme == ED25519_SCHEME ==>
+            ed25519::NewSignatureFromBytesAbortsIf { bytes: signer_capability_sig_bytes };
+        aborts_if account_scheme == ED25519_SCHEME
+            && !ed25519::spec_signature_verify_strict_t(
+                ed25519::Signature { bytes: signer_capability_sig_bytes },
+                ed25519::UnvalidatedPublicKey { bytes: account_public_key_bytes },
+                proof_challenge,
+            );
 
-        include account_scheme == MULTI_ED25519_SCHEME ==> multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: account_public_key_bytes };
-        aborts_if account_scheme == MULTI_ED25519_SCHEME && ({
-            let expected_auth_key = multi_ed25519::spec_public_key_bytes_to_authentication_key(account_public_key_bytes);
-            account_resource.authentication_key != expected_auth_key
-        });
-        include account_scheme == MULTI_ED25519_SCHEME ==> multi_ed25519::NewSignatureFromBytesAbortsIf { bytes: signer_capability_sig_bytes };
-        aborts_if account_scheme == MULTI_ED25519_SCHEME && !multi_ed25519::spec_signature_verify_strict_t(
-            multi_ed25519::Signature { bytes: signer_capability_sig_bytes },
-            multi_ed25519::UnvalidatedPublicKey { bytes: account_public_key_bytes },
-            proof_challenge
-        );
+        include account_scheme == MULTI_ED25519_SCHEME ==>
+            multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf {
+                bytes: account_public_key_bytes
+            };
+        aborts_if account_scheme == MULTI_ED25519_SCHEME
+            && (
+                {
+                    let expected_auth_key =
+                        multi_ed25519::spec_public_key_bytes_to_authentication_key(
+                            account_public_key_bytes
+                        );
+                    account_resource.authentication_key != expected_auth_key
+                }
+            );
+        include account_scheme == MULTI_ED25519_SCHEME ==>
+            multi_ed25519::NewSignatureFromBytesAbortsIf {
+                bytes: signer_capability_sig_bytes
+            };
+        aborts_if account_scheme == MULTI_ED25519_SCHEME
+            && !multi_ed25519::spec_signature_verify_strict_t(
+                multi_ed25519::Signature { bytes: signer_capability_sig_bytes },
+                multi_ed25519::UnvalidatedPublicKey { bytes: account_public_key_bytes },
+                proof_challenge,
+            );
 
         /// [high-level-req-5.3]
         aborts_if account_scheme != ED25519_SCHEME && account_scheme != MULTI_ED25519_SCHEME;
@@ -508,7 +612,9 @@ spec aptos_framework::account {
         let addr = signer::address_of(account);
         let account_resource = global<Account>(addr);
         aborts_if !exists<Account>(addr);
-        aborts_if !option::spec_contains(account_resource.signer_capability_offer.for,to_be_revoked_address);
+        aborts_if !option::spec_contains(
+            account_resource.signer_capability_offer.for, to_be_revoked_address
+        );
         modifies global<Account>(addr);
         ensures exists<Account>(to_be_revoked_address);
     }
@@ -526,7 +632,9 @@ spec aptos_framework::account {
         let addr = signer::address_of(account);
         let account_resource = global<Account>(addr);
         aborts_if !exists<Account>(addr);
-        aborts_if !option::spec_contains(account_resource.rotation_capability_offer.for,to_be_revoked_address);
+        aborts_if !option::spec_contains(
+            account_resource.rotation_capability_offer.for, to_be_revoked_address
+        );
         modifies global<Account>(addr);
         ensures exists<Account>(to_be_revoked_address);
         let post offer_for = global<Account>(addr).rotation_capability_offer.for;
@@ -548,10 +656,7 @@ spec aptos_framework::account {
     /// The value of signer_capability_offer.for of Account resource under the signer is offerer_address.
     spec create_authorized_signer(account: &signer, offerer_address: address): signer {
         /// [high-level-req-8]
-        include AccountContainsAddr{
-            account,
-            address: offerer_address,
-        };
+        include AccountContainsAddr { account, address: offerer_address, };
         modifies global<Account>(offerer_address);
         ensures exists<Account>(offerer_address);
         ensures signer::address_of(result) == offerer_address;
@@ -564,7 +669,9 @@ spec aptos_framework::account {
         let account_resource = global<Account>(address);
         aborts_if !exists<Account>(address);
         /// [create_signer::high-level-spec-3]
-        aborts_if !option::spec_contains(account_resource.signer_capability_offer.for,addr);
+        aborts_if !option::spec_contains(
+            account_resource.signer_capability_offer.for, addr
+        );
     }
 
     /// The Account existed under the signer
@@ -584,8 +691,10 @@ spec aptos_framework::account {
         let resource_addr = spec_create_resource_address(source_addr, seed);
 
         aborts_if len(ZERO_AUTH_KEY) != 32;
-        include exists_at(resource_addr) ==> CreateResourceAccountAbortsIf;
-        include !exists_at(resource_addr) ==> CreateAccountAbortsIf {addr: resource_addr};
+        include exists_at(resource_addr) ==>
+            CreateResourceAccountAbortsIf;
+        include !exists_at(resource_addr) ==>
+            CreateAccountAbortsIf { addr: resource_addr };
 
         ensures signer::address_of(result_1) == resource_addr;
         let post offer_for = global<Account>(resource_addr).signer_capability_offer.for;
@@ -598,34 +707,33 @@ spec aptos_framework::account {
     /// The system reserved addresses is @0x1 / @0x2 / @0x3 / @0x4 / @0x5  / @0x6 / @0x7 / @0x8 / @0x9 / @0xa.
     spec create_framework_reserved_account(addr: address): (signer, SignerCapability) {
         aborts_if spec_is_framework_address(addr);
-        include CreateAccountAbortsIf {addr};
+        include CreateAccountAbortsIf { addr };
         ensures signer::address_of(result_1) == addr;
         ensures result_2 == SignerCapability { account: addr };
     }
 
-    spec fun spec_is_framework_address(addr: address): bool{
-        addr != @0x1 &&
-        addr != @0x2 &&
-        addr != @0x3 &&
-        addr != @0x4 &&
-        addr != @0x5 &&
-        addr != @0x6 &&
-        addr != @0x7 &&
-        addr != @0x8 &&
-        addr != @0x9 &&
-        addr != @0xa
+    spec fun spec_is_framework_address(addr: address): bool {
+        addr != @0x1
+            && addr != @0x2
+            && addr != @0x3
+            && addr != @0x4
+            && addr != @0x5
+            && addr != @0x6
+            && addr != @0x7
+            && addr != @0x8
+            && addr != @0x9
+            && addr != @0xa
     }
 
     /// The Account existed under the signer.
     /// The guid_creation_num of the ccount resource is up to MAX_U64.
     spec create_guid(account_signer: &signer): guid::GUID {
         let addr = signer::address_of(account_signer);
-        include NewEventHandleAbortsIf {
-            account: account_signer,
-        };
+        include NewEventHandleAbortsIf { account: account_signer, };
         modifies global<Account>(addr);
         /// [high-level-req-11]
-        ensures global<Account>(addr).guid_creation_num == old(global<Account>(addr).guid_creation_num) + 1;
+        ensures global<Account>(addr).guid_creation_num
+            == old(global<Account>(addr).guid_creation_num) + 1;
     }
 
     /// The Account existed under the signer.
@@ -633,6 +741,7 @@ spec aptos_framework::account {
     spec new_event_handle<T: drop + store>(account: &signer): EventHandle<T> {
         include NewEventHandleAbortsIf;
     }
+
     spec schema NewEventHandleAbortsIf {
         account: &signer;
         let addr = signer::address_of(account);
@@ -668,21 +777,28 @@ spec aptos_framework::account {
         modifies global<OriginatingAddress>(@aptos_framework);
         include UpdateAuthKeyAndOriginatingAddressTableAbortsIf;
     }
+
     spec schema UpdateAuthKeyAndOriginatingAddressTableAbortsIf {
         originating_addr: address;
         account_resource: Account;
         new_auth_key_vector: vector<u8>;
         let address_map = global<OriginatingAddress>(@aptos_framework).address_map;
-        let curr_auth_key = from_bcs::deserialize<address>(account_resource.authentication_key);
+        let curr_auth_key = from_bcs::deserialize<address>(
+            account_resource.authentication_key
+        );
         let new_auth_key = from_bcs::deserialize<address>(new_auth_key_vector);
         aborts_if !exists<OriginatingAddress>(@aptos_framework);
         aborts_if !from_bcs::deserializable<address>(account_resource.authentication_key);
-        aborts_if table::spec_contains(address_map, curr_auth_key) &&
-            table::spec_get(address_map, curr_auth_key) != originating_addr;
+        aborts_if table::spec_contains(address_map, curr_auth_key)
+            && table::spec_get(address_map, curr_auth_key) != originating_addr;
         aborts_if !from_bcs::deserializable<address>(new_auth_key_vector);
-        aborts_if curr_auth_key != new_auth_key && table::spec_contains(address_map, new_auth_key);
+        aborts_if curr_auth_key != new_auth_key
+            && table::spec_contains(address_map, new_auth_key);
 
-        ensures table::spec_contains(global<OriginatingAddress>(@aptos_framework).address_map, from_bcs::deserialize<address>(new_auth_key_vector));
+        ensures table::spec_contains(
+            global<OriginatingAddress>(@aptos_framework).address_map,
+            from_bcs::deserialize<address>(new_auth_key_vector),
+        );
     }
 
     spec verify_signed_message<T: drop>(
@@ -698,19 +814,36 @@ spec aptos_framework::account {
         let account_resource = global<Account>(account);
         aborts_if !exists<Account>(account);
 
-        include account_scheme == ED25519_SCHEME ==> ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: account_public_key };
-        aborts_if account_scheme == ED25519_SCHEME && ({
-            let expected_auth_key = ed25519::spec_public_key_bytes_to_authentication_key(account_public_key);
-            account_resource.authentication_key != expected_auth_key
-        });
+        include account_scheme == ED25519_SCHEME ==>
+            ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: account_public_key };
+        aborts_if account_scheme == ED25519_SCHEME
+            && (
+                {
+                    let expected_auth_key =
+                        ed25519::spec_public_key_bytes_to_authentication_key(
+                            account_public_key
+                        );
+                    account_resource.authentication_key != expected_auth_key
+                }
+            );
 
-        include account_scheme == MULTI_ED25519_SCHEME ==> multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: account_public_key };
-        aborts_if account_scheme == MULTI_ED25519_SCHEME && ({
-            let expected_auth_key = multi_ed25519::spec_public_key_bytes_to_authentication_key(account_public_key);
-            account_resource.authentication_key != expected_auth_key
-        });
+        include account_scheme == MULTI_ED25519_SCHEME ==>
+            multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf {
+                bytes: account_public_key
+            };
+        aborts_if account_scheme == MULTI_ED25519_SCHEME
+            && (
+                {
+                    let expected_auth_key =
+                        multi_ed25519::spec_public_key_bytes_to_authentication_key(
+                            account_public_key
+                        );
+                    account_resource.authentication_key != expected_auth_key
+                }
+            );
 
-        include account_scheme == ED25519_SCHEME ==> ed25519::NewSignatureFromBytesAbortsIf { bytes: signed_message_bytes };
+        include account_scheme == ED25519_SCHEME ==>
+            ed25519::NewSignatureFromBytesAbortsIf { bytes: signed_message_bytes };
         // TODO: compiler error with message T
         // aborts_if account_scheme == ED25519_SCHEME && !ed25519::spec_signature_verify_strict_t(
         //     ed25519::Signature { bytes: signed_message_bytes },
@@ -718,7 +851,8 @@ spec aptos_framework::account {
         //     message
         // );
 
-        include account_scheme == MULTI_ED25519_SCHEME ==> multi_ed25519::NewSignatureFromBytesAbortsIf { bytes: signed_message_bytes };
+        include account_scheme == MULTI_ED25519_SCHEME ==>
+            multi_ed25519::NewSignatureFromBytesAbortsIf { bytes: signed_message_bytes };
         // TODO: compiler error with message T
         // aborts_if account_scheme == MULTI_ED25519_SCHEME && !multi_ed25519::spec_signature_verify_strict_t(
         //     multi_ed25519::Signature { bytes: signed_message_bytes },

--- a/aptos-move/framework/aptos-framework/sources/account.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/account.spec.move
@@ -125,9 +125,9 @@ spec aptos_framework::account {
         aborts_if !exists<Account>(account_address)
             && (
                 account_address == @vm_reserved
-                || account_address == @aptos_framework
-                || account_address == @aptos_token
-                || !(len(authentication_key) == 32)
+                    || account_address == @aptos_framework
+                    || account_address == @aptos_token
+                    || !(len(authentication_key) == 32)
             );
         ensures exists<Account>(account_address);
     }
@@ -232,7 +232,10 @@ spec aptos_framework::account {
         include AssertValidRotationProofSignatureAndGetAuthKeyAbortsIf;
         ensures [abstract] result
             == spec_assert_valid_rotation_proof_signature_and_get_auth_key(
-                scheme, public_key_bytes, signature, challenge
+                scheme,
+                public_key_bytes,
+                signature,
+                challenge,
             );
     }
 
@@ -289,29 +292,25 @@ spec aptos_framework::account {
                 bytes: from_public_key_bytes
             };
         aborts_if from_scheme == ED25519_SCHEME
-            && (
-                {
-                    let expected_auth_key =
-                        ed25519::spec_public_key_bytes_to_authentication_key(
-                            from_public_key_bytes
-                        );
-                    account_resource.authentication_key != expected_auth_key
-                }
-            );
+            && ({
+                let expected_auth_key =
+                    ed25519::spec_public_key_bytes_to_authentication_key(
+                        from_public_key_bytes
+                    );
+                account_resource.authentication_key != expected_auth_key
+            });
         include from_scheme == MULTI_ED25519_SCHEME ==>
             multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf {
                 bytes: from_public_key_bytes
             };
         aborts_if from_scheme == MULTI_ED25519_SCHEME
-            && (
-                {
-                    let from_auth_key =
-                        multi_ed25519::spec_public_key_bytes_to_authentication_key(
-                            from_public_key_bytes
-                        );
-                    account_resource.authentication_key != from_auth_key
-                }
-            );
+            && ({
+                let from_auth_key =
+                    multi_ed25519::spec_public_key_bytes_to_authentication_key(
+                        from_public_key_bytes
+                    );
+                account_resource.authentication_key != from_auth_key
+            });
 
         /// [high-level-req-5.1]
         aborts_if from_scheme != ED25519_SCHEME && from_scheme != MULTI_ED25519_SCHEME;
@@ -456,15 +455,13 @@ spec aptos_framework::account {
                 bytes: account_public_key_bytes
             };
         aborts_if account_scheme == ED25519_SCHEME
-            && (
-                {
-                    let expected_auth_key =
-                        ed25519::spec_public_key_bytes_to_authentication_key(
-                            account_public_key_bytes
-                        );
-                    account_resource.authentication_key != expected_auth_key
-                }
-            );
+            && ({
+                let expected_auth_key =
+                    ed25519::spec_public_key_bytes_to_authentication_key(
+                        account_public_key_bytes
+                    );
+                account_resource.authentication_key != expected_auth_key
+            });
         include account_scheme == ED25519_SCHEME ==>
             ed25519::NewSignatureFromBytesAbortsIf { bytes: rotation_capability_sig_bytes };
         aborts_if account_scheme == ED25519_SCHEME
@@ -479,15 +476,13 @@ spec aptos_framework::account {
                 bytes: account_public_key_bytes
             };
         aborts_if account_scheme == MULTI_ED25519_SCHEME
-            && (
-                {
-                    let expected_auth_key =
-                        multi_ed25519::spec_public_key_bytes_to_authentication_key(
-                            account_public_key_bytes
-                        );
-                    account_resource.authentication_key != expected_auth_key
-                }
-            );
+            && ({
+                let expected_auth_key =
+                    multi_ed25519::spec_public_key_bytes_to_authentication_key(
+                        account_public_key_bytes
+                    );
+                account_resource.authentication_key != expected_auth_key
+            });
         include account_scheme == MULTI_ED25519_SCHEME ==>
             multi_ed25519::NewSignatureFromBytesAbortsIf {
                 bytes: rotation_capability_sig_bytes
@@ -533,15 +528,13 @@ spec aptos_framework::account {
                 bytes: account_public_key_bytes
             };
         aborts_if account_scheme == ED25519_SCHEME
-            && (
-                {
-                    let expected_auth_key =
-                        ed25519::spec_public_key_bytes_to_authentication_key(
-                            account_public_key_bytes
-                        );
-                    account_resource.authentication_key != expected_auth_key
-                }
-            );
+            && ({
+                let expected_auth_key =
+                    ed25519::spec_public_key_bytes_to_authentication_key(
+                        account_public_key_bytes
+                    );
+                account_resource.authentication_key != expected_auth_key
+            });
         include account_scheme == ED25519_SCHEME ==>
             ed25519::NewSignatureFromBytesAbortsIf { bytes: signer_capability_sig_bytes };
         aborts_if account_scheme == ED25519_SCHEME
@@ -556,15 +549,13 @@ spec aptos_framework::account {
                 bytes: account_public_key_bytes
             };
         aborts_if account_scheme == MULTI_ED25519_SCHEME
-            && (
-                {
-                    let expected_auth_key =
-                        multi_ed25519::spec_public_key_bytes_to_authentication_key(
-                            account_public_key_bytes
-                        );
-                    account_resource.authentication_key != expected_auth_key
-                }
-            );
+            && ({
+                let expected_auth_key =
+                    multi_ed25519::spec_public_key_bytes_to_authentication_key(
+                        account_public_key_bytes
+                    );
+                account_resource.authentication_key != expected_auth_key
+            });
         include account_scheme == MULTI_ED25519_SCHEME ==>
             multi_ed25519::NewSignatureFromBytesAbortsIf {
                 bytes: signer_capability_sig_bytes
@@ -817,30 +808,26 @@ spec aptos_framework::account {
         include account_scheme == ED25519_SCHEME ==>
             ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf { bytes: account_public_key };
         aborts_if account_scheme == ED25519_SCHEME
-            && (
-                {
-                    let expected_auth_key =
-                        ed25519::spec_public_key_bytes_to_authentication_key(
-                            account_public_key
-                        );
-                    account_resource.authentication_key != expected_auth_key
-                }
-            );
+            && ({
+                let expected_auth_key =
+                    ed25519::spec_public_key_bytes_to_authentication_key(
+                        account_public_key
+                    );
+                account_resource.authentication_key != expected_auth_key
+            });
 
         include account_scheme == MULTI_ED25519_SCHEME ==>
             multi_ed25519::NewUnvalidatedPublicKeyFromBytesAbortsIf {
                 bytes: account_public_key
             };
         aborts_if account_scheme == MULTI_ED25519_SCHEME
-            && (
-                {
-                    let expected_auth_key =
-                        multi_ed25519::spec_public_key_bytes_to_authentication_key(
-                            account_public_key
-                        );
-                    account_resource.authentication_key != expected_auth_key
-                }
-            );
+            && ({
+                let expected_auth_key =
+                    multi_ed25519::spec_public_key_bytes_to_authentication_key(
+                        account_public_key
+                    );
+                account_resource.authentication_key != expected_auth_key
+            });
 
         include account_scheme == ED25519_SCHEME ==>
             ed25519::NewSignatureFromBytesAbortsIf { bytes: signed_message_bytes };

--- a/aptos-move/framework/aptos-framework/sources/aggregator/aggregator.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/aggregator.spec.move
@@ -32,16 +32,22 @@ spec aptos_framework::aggregator {
         /// [high-level-req-2]
         aborts_if spec_aggregator_get_val(aggregator) + value > MAX_U128;
         ensures spec_get_limit(aggregator) == spec_get_limit(old(aggregator));
-        ensures aggregator == spec_aggregator_set_val(old(aggregator),
-            spec_aggregator_get_val(old(aggregator)) + value);
+        ensures aggregator
+            == spec_aggregator_set_val(
+                old(aggregator),
+                spec_aggregator_get_val(old(aggregator)) + value,
+            );
     }
 
     spec sub(aggregator: &mut Aggregator, value: u128) {
         pragma opaque;
         aborts_if spec_aggregator_get_val(aggregator) < value;
         ensures spec_get_limit(aggregator) == spec_get_limit(old(aggregator));
-        ensures aggregator == spec_aggregator_set_val(old(aggregator),
-            spec_aggregator_get_val(old(aggregator)) - value);
+        ensures aggregator
+            == spec_aggregator_set_val(
+                old(aggregator),
+                spec_aggregator_get_val(old(aggregator)) - value,
+            );
     }
 
     spec read(aggregator: &Aggregator): u128 {
@@ -66,9 +72,14 @@ spec aptos_framework::aggregator {
     }
 
     spec native fun spec_read(aggregator: Aggregator): u128;
+
     spec native fun spec_get_limit(a: Aggregator): u128;
+
     spec native fun spec_get_handle(a: Aggregator): u128;
+
     spec native fun spec_get_key(a: Aggregator): u128;
+
     spec native fun spec_aggregator_set_val(a: Aggregator, v: u128): Aggregator;
+
     spec native fun spec_aggregator_get_val(a: Aggregator): u128;
 }

--- a/aptos-move/framework/aptos-framework/sources/aggregator/aggregator_factory.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/aggregator_factory.move
@@ -24,11 +24,11 @@ module aptos_framework::aggregator_factory {
     }
 
     /// Creates a new factory for aggregators. Can only be called during genesis.
-    public(friend) fun initialize_aggregator_factory(aptos_framework: &signer) {
+    public(friend) fun initialize_aggregator_factory(
+        aptos_framework: &signer
+    ) {
         system_addresses::assert_aptos_framework(aptos_framework);
-        let aggregator_factory = AggregatorFactory {
-            phantom_table: table::new()
-        };
+        let aggregator_factory = AggregatorFactory { phantom_table: table::new() };
         move_to(aptos_framework, aggregator_factory);
     }
 
@@ -36,7 +36,7 @@ module aptos_framework::aggregator_factory {
     public(friend) fun create_aggregator_internal(limit: u128): Aggregator acquires AggregatorFactory {
         assert!(
             exists<AggregatorFactory>(@aptos_framework),
-            error::not_found(EAGGREGATOR_FACTORY_NOT_FOUND)
+            error::not_found(EAGGREGATOR_FACTORY_NOT_FOUND),
         );
 
         let aggregator_factory = borrow_global_mut<AggregatorFactory>(@aptos_framework);
@@ -55,7 +55,9 @@ module aptos_framework::aggregator_factory {
     native fun new_aggregator(aggregator_factory: &mut AggregatorFactory, limit: u128): Aggregator;
 
     #[test_only]
-    public fun initialize_aggregator_factory_for_test(aptos_framework: &signer) {
+    public fun initialize_aggregator_factory_for_test(
+        aptos_framework: &signer
+    ) {
         initialize_aggregator_factory(aptos_framework);
     }
 

--- a/aptos-move/framework/aptos-framework/sources/aggregator/aggregator_factory.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/aggregator_factory.spec.move
@@ -60,6 +60,7 @@ spec aptos_framework::aggregator_factory {
         ensures aggregator::spec_get_limit(result) == limit;
         ensures aggregator::spec_aggregator_get_val(result) == 0;
     }
+
     spec schema CreateAggregatorInternalAbortsIf {
         aborts_if !exists<AggregatorFactory>(@aptos_framework);
     }

--- a/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.move
@@ -24,17 +24,14 @@ module aptos_framework::optional_aggregator {
 
     /// Creates a new integer which overflows on exceeding a `limit`.
     fun new_integer(limit: u128): Integer {
-        Integer {
-            value: 0,
-            limit,
-        }
+        Integer { value: 0, limit, }
     }
 
     /// Adds `value` to integer. Aborts on overflowing the limit.
     fun add_integer(integer: &mut Integer, value: u128) {
         assert!(
             value <= (integer.limit - integer.value),
-            error::out_of_range(EAGGREGATOR_OVERFLOW)
+            error::out_of_range(EAGGREGATOR_OVERFLOW),
         );
         integer.value = integer.value + value;
     }
@@ -72,7 +69,9 @@ module aptos_framework::optional_aggregator {
     public(friend) fun new(limit: u128, parallelizable: bool): OptionalAggregator {
         if (parallelizable) {
             OptionalAggregator {
-                aggregator: option::some(aggregator_factory::create_aggregator_internal(limit)),
+                aggregator: option::some(
+                    aggregator_factory::create_aggregator_internal(limit)
+                ),
                 integer: option::none(),
             }
         } else {
@@ -136,7 +135,9 @@ module aptos_framework::optional_aggregator {
     }
 
     /// Destroys parallelizable optional aggregator and returns its limit.
-    fun destroy_optional_aggregator(optional_aggregator: OptionalAggregator): u128 {
+    fun destroy_optional_aggregator(
+        optional_aggregator: OptionalAggregator
+    ): u128 {
         let OptionalAggregator { aggregator, integer } = optional_aggregator;
         let limit = aggregator::limit(option::borrow(&aggregator));
         aggregator::destroy(option::destroy_some(aggregator));
@@ -154,7 +155,9 @@ module aptos_framework::optional_aggregator {
     }
 
     /// Adds `value` to optional aggregator, aborting on exceeding the `limit`.
-    public fun add(optional_aggregator: &mut OptionalAggregator, value: u128) {
+    public fun add(
+        optional_aggregator: &mut OptionalAggregator, value: u128
+    ) {
         if (option::is_some(&optional_aggregator.aggregator)) {
             let aggregator = option::borrow_mut(&mut optional_aggregator.aggregator);
             aggregator::add(aggregator, value);
@@ -165,7 +168,9 @@ module aptos_framework::optional_aggregator {
     }
 
     /// Subtracts `value` from optional aggregator, aborting on going below zero.
-    public fun sub(optional_aggregator: &mut OptionalAggregator, value: u128) {
+    public fun sub(
+        optional_aggregator: &mut OptionalAggregator, value: u128
+    ) {
         if (option::is_some(&optional_aggregator.aggregator)) {
             let aggregator = option::borrow_mut(&mut optional_aggregator.aggregator);
             aggregator::sub(aggregator, value);

--- a/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.spec.move
@@ -73,12 +73,10 @@ spec aptos_framework::optional_aggregator {
 
     spec sub(optional_aggregator: &mut OptionalAggregator, value: u128) {
         include SubAbortsIf;
-        ensures (
-            (
-                optional_aggregator_value(optional_aggregator)
-                    == optional_aggregator_value(old(optional_aggregator)) - value
-            )
-        );
+        ensures ((
+            optional_aggregator_value(optional_aggregator)
+                == optional_aggregator_value(old(optional_aggregator)) - value
+        ));
     }
 
     spec schema SubAbortsIf {
@@ -105,12 +103,10 @@ spec aptos_framework::optional_aggregator {
 
     spec add(optional_aggregator: &mut OptionalAggregator, value: u128) {
         include AddAbortsIf;
-        ensures (
-            (
-                optional_aggregator_value(optional_aggregator)
-                    == optional_aggregator_value(old(optional_aggregator)) + value
-            )
-        );
+        ensures ((
+            optional_aggregator_value(optional_aggregator)
+                == optional_aggregator_value(old(optional_aggregator)) + value
+        ));
     }
 
     spec schema AddAbortsIf {

--- a/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.spec.move
@@ -30,11 +30,15 @@ spec aptos_framework::optional_aggregator {
     }
 
     spec OptionalAggregator {
-        invariant option::is_some(aggregator) <==> option::is_none(integer);
-        invariant option::is_some(integer) <==> option::is_none(aggregator);
-        invariant option::is_some(integer) ==> option::borrow(integer).value <= option::borrow(integer).limit;
-        invariant option::is_some(aggregator) ==> aggregator::spec_aggregator_get_val(option::borrow(aggregator)) <=
-            aggregator::spec_get_limit(option::borrow(aggregator));
+        invariant option::is_some(aggregator) <==>
+            option::is_none(integer);
+        invariant option::is_some(integer) <==>
+            option::is_none(aggregator);
+        invariant option::is_some(integer) ==>
+            option::borrow(integer).value <= option::borrow(integer).limit;
+        invariant option::is_some(aggregator) ==>
+            aggregator::spec_aggregator_get_val(option::borrow(aggregator))
+                <= aggregator::spec_get_limit(option::borrow(aggregator));
     }
 
     spec new_integer(limit: u128): Integer {
@@ -69,48 +73,84 @@ spec aptos_framework::optional_aggregator {
 
     spec sub(optional_aggregator: &mut OptionalAggregator, value: u128) {
         include SubAbortsIf;
-        ensures ((optional_aggregator_value(optional_aggregator) == optional_aggregator_value(old(optional_aggregator)) - value));
+        ensures (
+            (
+                optional_aggregator_value(optional_aggregator)
+                    == optional_aggregator_value(old(optional_aggregator)) - value
+            )
+        );
     }
 
     spec schema SubAbortsIf {
         optional_aggregator: OptionalAggregator;
         value: u128;
-        aborts_if is_parallelizable(optional_aggregator) && (aggregator::spec_aggregator_get_val(option::borrow(optional_aggregator.aggregator))
-            < value);
-        aborts_if !is_parallelizable(optional_aggregator) &&
-            (option::borrow(optional_aggregator.integer).value < value);
+        aborts_if is_parallelizable(optional_aggregator)
+            && (
+                aggregator::spec_aggregator_get_val(
+                    option::borrow(optional_aggregator.aggregator)
+                ) < value
+            );
+        aborts_if !is_parallelizable(optional_aggregator)
+            && (option::borrow(optional_aggregator.integer).value < value);
     }
 
     spec read(optional_aggregator: &OptionalAggregator): u128 {
-        ensures !is_parallelizable(optional_aggregator) ==> result == option::borrow(optional_aggregator.integer).value;
+        ensures !is_parallelizable(optional_aggregator) ==>
+            result == option::borrow(optional_aggregator.integer).value;
         ensures is_parallelizable(optional_aggregator) ==>
-            result == aggregator::spec_read(option::borrow(optional_aggregator.aggregator));
+            result == aggregator::spec_read(
+                option::borrow(optional_aggregator.aggregator)
+            );
     }
 
     spec add(optional_aggregator: &mut OptionalAggregator, value: u128) {
         include AddAbortsIf;
-        ensures ((optional_aggregator_value(optional_aggregator) == optional_aggregator_value(old(optional_aggregator)) + value));
+        ensures (
+            (
+                optional_aggregator_value(optional_aggregator)
+                    == optional_aggregator_value(old(optional_aggregator)) + value
+            )
+        );
     }
 
     spec schema AddAbortsIf {
         optional_aggregator: OptionalAggregator;
         value: u128;
-        aborts_if is_parallelizable(optional_aggregator) && (aggregator::spec_aggregator_get_val(option::borrow(optional_aggregator.aggregator))
-            + value > aggregator::spec_get_limit(option::borrow(optional_aggregator.aggregator)));
-        aborts_if is_parallelizable(optional_aggregator) && (aggregator::spec_aggregator_get_val(option::borrow(optional_aggregator.aggregator))
-            + value > MAX_U128);
-        aborts_if !is_parallelizable(optional_aggregator) &&
-            (option::borrow(optional_aggregator.integer).value + value > MAX_U128);
-        aborts_if !is_parallelizable(optional_aggregator) &&
-            (value > (option::borrow(optional_aggregator.integer).limit - option::borrow(optional_aggregator.integer).value));
+        aborts_if is_parallelizable(optional_aggregator)
+            && (
+                aggregator::spec_aggregator_get_val(
+                    option::borrow(optional_aggregator.aggregator)
+                ) + value
+                    > aggregator::spec_get_limit(
+                        option::borrow(optional_aggregator.aggregator)
+                    )
+            );
+        aborts_if is_parallelizable(optional_aggregator)
+            && (
+                aggregator::spec_aggregator_get_val(
+                    option::borrow(optional_aggregator.aggregator)
+                ) + value > MAX_U128
+            );
+        aborts_if !is_parallelizable(optional_aggregator)
+            && (option::borrow(optional_aggregator.integer).value + value > MAX_U128);
+        aborts_if !is_parallelizable(optional_aggregator)
+            && (
+                value
+                    > (
+                        option::borrow(optional_aggregator.integer).limit
+                            - option::borrow(optional_aggregator.integer).value
+                    )
+            );
     }
 
     spec switch(optional_aggregator: &mut OptionalAggregator) {
         let vec_ref = optional_aggregator.integer.vec;
         aborts_if is_parallelizable(optional_aggregator) && len(vec_ref) != 0;
         aborts_if !is_parallelizable(optional_aggregator) && len(vec_ref) == 0;
-        aborts_if !is_parallelizable(optional_aggregator) && !exists<aggregator_factory::AggregatorFactory>(@aptos_framework);
-        ensures optional_aggregator_value(optional_aggregator) == optional_aggregator_value(old(optional_aggregator));
+        aborts_if !is_parallelizable(optional_aggregator)
+            && !exists<aggregator_factory::AggregatorFactory>(@aptos_framework);
+        ensures optional_aggregator_value(optional_aggregator)
+            == optional_aggregator_value(old(optional_aggregator));
     }
 
     spec sub_integer(integer: &mut Integer, value: u128) {
@@ -119,7 +159,8 @@ spec aptos_framework::optional_aggregator {
     }
 
     spec new(limit: u128, parallelizable: bool): OptionalAggregator {
-        aborts_if parallelizable && !exists<aggregator_factory::AggregatorFactory>(@aptos_framework);
+        aborts_if parallelizable
+            && !exists<aggregator_factory::AggregatorFactory>(@aptos_framework);
         ensures parallelizable ==> is_parallelizable(result);
         ensures !parallelizable ==> !is_parallelizable(result);
         ensures optional_aggregator_value(result) == 0;
@@ -133,18 +174,21 @@ spec aptos_framework::optional_aggregator {
         let vec_ref = optional_aggregator.integer.vec;
         aborts_if is_parallelizable(optional_aggregator) && len(vec_ref) != 0;
         aborts_if !is_parallelizable(optional_aggregator) && len(vec_ref) == 0;
-        aborts_if !is_parallelizable(optional_aggregator) && !exists<aggregator_factory::AggregatorFactory>(@aptos_framework);
+        aborts_if !is_parallelizable(optional_aggregator)
+            && !exists<aggregator_factory::AggregatorFactory>(@aptos_framework);
         /// [high-level-req-3]
-        ensures is_parallelizable(old(optional_aggregator)) ==> !is_parallelizable(optional_aggregator);
-        ensures !is_parallelizable(old(optional_aggregator)) ==> is_parallelizable(optional_aggregator);
+        ensures is_parallelizable(old(optional_aggregator)) ==>
+            !is_parallelizable(optional_aggregator);
+        ensures !is_parallelizable(old(optional_aggregator)) ==>
+            is_parallelizable(optional_aggregator);
         ensures optional_aggregator_value(optional_aggregator) == 0;
     }
 
     /// The aggregator exists and the integer dosex not exist when Switches from parallelizable to non-parallelizable implementation.
-    spec switch_to_integer_and_zero_out(
-        optional_aggregator: &mut OptionalAggregator
-    ): u128 {
-        let limit = aggregator::spec_get_limit(option::borrow(optional_aggregator.aggregator));
+    spec switch_to_integer_and_zero_out(optional_aggregator: &mut OptionalAggregator): u128 {
+        let limit = aggregator::spec_get_limit(
+            option::borrow(optional_aggregator.aggregator)
+        );
         aborts_if len(optional_aggregator.aggregator.vec) == 0;
         aborts_if len(optional_aggregator.integer.vec) != 0;
         ensures !is_parallelizable(optional_aggregator);
@@ -154,28 +198,32 @@ spec aptos_framework::optional_aggregator {
 
     /// The integer exists and the aggregator does not exist when Switches from non-parallelizable to parallelizable implementation.
     /// The AggregatorFactory is under the @aptos_framework.
-    spec switch_to_aggregator_and_zero_out(
-        optional_aggregator: &mut OptionalAggregator
-    ): u128 {
+    spec switch_to_aggregator_and_zero_out(optional_aggregator: &mut OptionalAggregator): u128 {
         let limit = option::borrow(optional_aggregator.integer).limit;
         aborts_if len(optional_aggregator.integer.vec) == 0;
         aborts_if !exists<aggregator_factory::AggregatorFactory>(@aptos_framework);
         aborts_if len(optional_aggregator.aggregator.vec) != 0;
         ensures is_parallelizable(optional_aggregator);
-        ensures aggregator::spec_get_limit(option::borrow(optional_aggregator.aggregator)) == limit;
-        ensures aggregator::spec_aggregator_get_val(option::borrow(optional_aggregator.aggregator)) == 0;
+        ensures aggregator::spec_get_limit(option::borrow(optional_aggregator.aggregator)) ==
+             limit;
+        ensures aggregator::spec_aggregator_get_val(
+            option::borrow(optional_aggregator.aggregator)
+        ) == 0;
     }
 
     spec destroy(optional_aggregator: OptionalAggregator) {
-        aborts_if is_parallelizable(optional_aggregator) && len(optional_aggregator.integer.vec) != 0;
-        aborts_if !is_parallelizable(optional_aggregator) && len(optional_aggregator.integer.vec) == 0;
+        aborts_if is_parallelizable(optional_aggregator)
+            && len(optional_aggregator.integer.vec) != 0;
+        aborts_if !is_parallelizable(optional_aggregator)
+            && len(optional_aggregator.integer.vec) == 0;
     }
 
     /// The aggregator exists and the integer does not exist when destroy the aggregator.
     spec destroy_optional_aggregator(optional_aggregator: OptionalAggregator): u128 {
         aborts_if len(optional_aggregator.aggregator.vec) == 0;
         aborts_if len(optional_aggregator.integer.vec) != 0;
-        ensures result == aggregator::spec_get_limit(option::borrow(optional_aggregator.aggregator));
+        ensures result
+            == aggregator::spec_get_limit(option::borrow(optional_aggregator.aggregator));
     }
 
     /// The integer exists and the aggregator does not exist when destroy the integer.
@@ -187,7 +235,9 @@ spec aptos_framework::optional_aggregator {
 
     spec fun optional_aggregator_value(optional_aggregator: OptionalAggregator): u128 {
         if (is_parallelizable(optional_aggregator)) {
-            aggregator::spec_aggregator_get_val(option::borrow(optional_aggregator.aggregator))
+            aggregator::spec_aggregator_get_val(
+                option::borrow(optional_aggregator.aggregator)
+            )
         } else {
             option::borrow(optional_aggregator.integer).value
         }
@@ -200,5 +250,4 @@ spec aptos_framework::optional_aggregator {
             option::borrow(optional_aggregator.integer).limit
         }
     }
-
 }

--- a/aptos-move/framework/aptos-framework/sources/aggregator_v2/aggregator_v2.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator_v2/aggregator_v2.move
@@ -67,7 +67,9 @@ module aptos_framework::aggregator_v2 {
     }
 
     /// Returns `max_value` exceeding which aggregator overflows.
-    public fun max_value<IntElement: copy + drop>(aggregator: &Aggregator<IntElement>): IntElement {
+    public fun max_value<IntElement: copy + drop>(
+        aggregator: &Aggregator<IntElement>
+    ): IntElement {
         aggregator.max_value
     }
 
@@ -75,9 +77,12 @@ module aptos_framework::aggregator_v2 {
     ///
     /// Currently supported types for IntElement are u64 and u128.
     /// EAGGREGATOR_ELEMENT_TYPE_NOT_SUPPORTED raised if called with a different type.
-    public native fun create_aggregator<IntElement: copy + drop>(max_value: IntElement): Aggregator<IntElement>;
+    public native fun create_aggregator<IntElement: copy + drop>(max_value: IntElement): Aggregator<
+        IntElement>;
 
-    public fun create_aggregator_with_value<IntElement: copy + drop>(start_value: IntElement, max_value: IntElement): Aggregator<IntElement> {
+    public fun create_aggregator_with_value<IntElement: copy + drop>(
+        start_value: IntElement, max_value: IntElement
+    ): Aggregator<IntElement> {
         let aggregator = create_aggregator(max_value);
         add(&mut aggregator, start_value);
         aggregator
@@ -90,7 +95,9 @@ module aptos_framework::aggregator_v2 {
     /// EAGGREGATOR_ELEMENT_TYPE_NOT_SUPPORTED raised if called with a different type.
     public native fun create_unbounded_aggregator<IntElement: copy + drop>(): Aggregator<IntElement>;
 
-    public fun create_unbounded_aggregator_with_value<IntElement: copy + drop>(start_value: IntElement): Aggregator<IntElement> {
+    public fun create_unbounded_aggregator_with_value<IntElement: copy + drop>(
+        start_value: IntElement
+    ): Aggregator<IntElement> {
         let aggregator = create_unbounded_aggregator();
         add(&mut aggregator, start_value);
         aggregator
@@ -100,13 +107,17 @@ module aptos_framework::aggregator_v2 {
     /// If addition would exceed the max_value, `false` is returned, and aggregator value is left unchanged.
     ///
     /// Parallelism info: This operation enables speculative parallelism.
-    public native fun try_add<IntElement>(aggregator: &mut Aggregator<IntElement>, value: IntElement): bool;
+    public native fun try_add<IntElement>(
+        aggregator: &mut Aggregator<IntElement>, value: IntElement
+    ): bool;
 
     /// Adds `value` to aggregator, unconditionally.
     /// If addition would exceed the max_value, EAGGREGATOR_OVERFLOW exception will be thrown.
     ///
     /// Parallelism info: This operation enables speculative parallelism.
-    public fun add<IntElement>(aggregator: &mut Aggregator<IntElement>, value: IntElement) {
+    public fun add<IntElement>(
+        aggregator: &mut Aggregator<IntElement>, value: IntElement
+    ) {
         assert!(try_add(aggregator, value), error::out_of_range(EAGGREGATOR_OVERFLOW));
     }
 
@@ -114,17 +125,23 @@ module aptos_framework::aggregator_v2 {
     /// If subtraction would result in a negative value, `false` is returned, and aggregator value is left unchanged.
     ///
     /// Parallelism info: This operation enables speculative parallelism.
-    public native fun try_sub<IntElement>(aggregator: &mut Aggregator<IntElement>, value: IntElement): bool;
+    public native fun try_sub<IntElement>(
+        aggregator: &mut Aggregator<IntElement>, value: IntElement
+    ): bool;
 
     // Subtracts `value` to aggregator, unconditionally.
     // If subtraction would result in a negative value, EAGGREGATOR_UNDERFLOW exception will be thrown.
     ///
     /// Parallelism info: This operation enables speculative parallelism.
-    public fun sub<IntElement>(aggregator: &mut Aggregator<IntElement>, value: IntElement) {
+    public fun sub<IntElement>(
+        aggregator: &mut Aggregator<IntElement>, value: IntElement
+    ) {
         assert!(try_sub(aggregator, value), error::out_of_range(EAGGREGATOR_UNDERFLOW));
     }
 
-    native fun is_at_least_impl<IntElement>(aggregator: &Aggregator<IntElement>, min_amount: IntElement): bool;
+    native fun is_at_least_impl<IntElement>(
+        aggregator: &Aggregator<IntElement>, min_amount: IntElement
+    ): bool;
 
     /// Returns true if aggregator value is larger than or equal to the given `min_amount`, false otherwise.
     ///
@@ -134,8 +151,13 @@ module aptos_framework::aggregator_v2 {
     /// - for `is_equal(agg, value)`, you can do `is_at_least(value) && !is_at_least(value + 1)`
     ///
     /// Parallelism info: This operation enables speculative parallelism.
-    public fun is_at_least<IntElement>(aggregator: &Aggregator<IntElement>, min_amount: IntElement): bool {
-        assert!(features::aggregator_v2_is_at_least_api_enabled(), EAGGREGATOR_API_V2_NOT_ENABLED);
+    public fun is_at_least<IntElement>(
+        aggregator: &Aggregator<IntElement>, min_amount: IntElement
+    ): bool {
+        assert!(
+            features::aggregator_v2_is_at_least_api_enabled(),
+            EAGGREGATOR_API_V2_NOT_ENABLED,
+        );
         is_at_least_impl(aggregator, min_amount)
     }
 
@@ -165,11 +187,13 @@ module aptos_framework::aggregator_v2 {
     /// Unlike read(), it is fast and avoids sequential dependencies.
     ///
     /// Parallelism info: This operation enables parallelism.
-    public native fun snapshot<IntElement>(aggregator: &Aggregator<IntElement>): AggregatorSnapshot<IntElement>;
+    public native fun snapshot<IntElement>(aggregator: &Aggregator<IntElement>): AggregatorSnapshot<
+        IntElement>;
 
     /// Creates a snapshot of a given value.
     /// Useful for when object is sometimes created via snapshot() or string_concat(), and sometimes directly.
-    public native fun create_snapshot<IntElement: copy + drop>(value: IntElement): AggregatorSnapshot<IntElement>;
+    public native fun create_snapshot<IntElement: copy + drop>(value: IntElement): AggregatorSnapshot<
+        IntElement>;
 
     /// Returns a value stored in this snapshot.
     /// Note: This operation is resource-intensive, and reduces parallelism.
@@ -197,17 +221,23 @@ module aptos_framework::aggregator_v2 {
     /// If length of prefix and suffix together exceed 256 bytes, ECONCAT_STRING_LENGTH_TOO_LARGE is raised.
     ///
     /// Parallelism info: This operation enables parallelism.
-    public native fun derive_string_concat<IntElement>(before: String, snapshot: &AggregatorSnapshot<IntElement>, after: String): DerivedStringSnapshot;
+    public native fun derive_string_concat<IntElement>(
+        before: String, snapshot: &AggregatorSnapshot<IntElement>, after: String
+    ): DerivedStringSnapshot;
 
     // ===== DEPRECATE/NOT YET IMPLEMENTED ====
 
     #[deprecated]
     /// NOT YET IMPLEMENTED, always raises EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED.
-    public native fun copy_snapshot<IntElement: copy + drop>(snapshot: &AggregatorSnapshot<IntElement>): AggregatorSnapshot<IntElement>;
+    public native fun copy_snapshot<IntElement: copy + drop>(
+        snapshot: &AggregatorSnapshot<IntElement>
+    ): AggregatorSnapshot<IntElement>;
 
     #[deprecated]
     /// DEPRECATED, use derive_string_concat() instead. always raises EAGGREGATOR_FUNCTION_NOT_YET_SUPPORTED.
-    public native fun string_concat<IntElement>(before: String, snapshot: &AggregatorSnapshot<IntElement>, after: String): AggregatorSnapshot<String>;
+    public native fun string_concat<IntElement>(
+        before: String, snapshot: &AggregatorSnapshot<IntElement>, after: String
+    ): AggregatorSnapshot<String>;
 
     // ========================================
 
@@ -247,7 +277,10 @@ module aptos_framework::aggregator_v2 {
     #[test]
     fun test_string_concat1() {
         let snapshot = create_snapshot(42);
-        let derived = derive_string_concat(std::string::utf8(b"before"), &snapshot, std::string::utf8(b"after"));
+        let derived =
+            derive_string_concat(
+                std::string::utf8(b"before"), &snapshot, std::string::utf8(b"after")
+            );
         assert!(read_derived_string(&derived) == std::string::utf8(b"before42after"), 0);
     }
 

--- a/aptos-move/framework/aptos-framework/sources/aptos_account.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_account.move
@@ -58,17 +58,22 @@ module aptos_framework::aptos_account {
     }
 
     /// Batch version of APT transfer.
-    public entry fun batch_transfer(source: &signer, recipients: vector<address>, amounts: vector<u64>) {
+    public entry fun batch_transfer(
+        source: &signer, recipients: vector<address>, amounts: vector<u64>
+    ) {
         let recipients_len = vector::length(&recipients);
         assert!(
             recipients_len == vector::length(&amounts),
             error::invalid_argument(EMISMATCHING_RECIPIENTS_AND_AMOUNTS_LENGTH),
         );
 
-        vector::enumerate_ref(&recipients, |i, to| {
-            let amount = *vector::borrow(&amounts, i);
-            transfer(source, *to, amount);
-        });
+        vector::enumerate_ref(
+            &recipients,
+            |i, to| {
+                let amount = *vector::borrow(&amounts, i);
+                transfer(source, *to, amount);
+            },
+        );
     }
 
     /// Convenient function to transfer APT to a recipient account that might not exist.
@@ -92,22 +97,28 @@ module aptos_framework::aptos_account {
 
     /// Batch version of transfer_coins.
     public entry fun batch_transfer_coins<CoinType>(
-        from: &signer, recipients: vector<address>, amounts: vector<u64>) acquires DirectTransferConfig {
+        from: &signer, recipients: vector<address>, amounts: vector<u64>
+    ) acquires DirectTransferConfig {
         let recipients_len = vector::length(&recipients);
         assert!(
             recipients_len == vector::length(&amounts),
             error::invalid_argument(EMISMATCHING_RECIPIENTS_AND_AMOUNTS_LENGTH),
         );
 
-        vector::enumerate_ref(&recipients, |i, to| {
-            let amount = *vector::borrow(&amounts, i);
-            transfer_coins<CoinType>(from, *to, amount);
-        });
+        vector::enumerate_ref(
+            &recipients,
+            |i, to| {
+                let amount = *vector::borrow(&amounts, i);
+                transfer_coins<CoinType>(from, *to, amount);
+            },
+        );
     }
 
     /// Convenient function to transfer a custom CoinType to a recipient account that might not exist.
     /// This would create the recipient account first and register it to receive the CoinType, before transferring.
-    public entry fun transfer_coins<CoinType>(from: &signer, to: address, amount: u64) acquires DirectTransferConfig {
+    public entry fun transfer_coins<CoinType>(
+        from: &signer, to: address, amount: u64
+    ) acquires DirectTransferConfig {
         deposit_coins(to, coin::withdraw<CoinType>(from, amount));
     }
 
@@ -118,7 +129,8 @@ module aptos_framework::aptos_account {
             create_account(to);
             spec {
                 assert coin::spec_is_account_registered<AptosCoin>(to);
-                assume aptos_std::type_info::type_of<CoinType>() == aptos_std::type_info::type_of<AptosCoin>() ==>
+                assume aptos_std::type_info::type_of<CoinType>()
+                    == aptos_std::type_info::type_of<AptosCoin>() ==>
                     coin::spec_is_account_registered<CoinType>(to);
             };
         };
@@ -138,38 +150,54 @@ module aptos_framework::aptos_account {
 
     public fun assert_account_is_registered_for_apt(addr: address) {
         assert_account_exists(addr);
-        assert!(coin::is_account_registered<AptosCoin>(addr), error::not_found(EACCOUNT_NOT_REGISTERED_FOR_APT));
+        assert!(
+            coin::is_account_registered<AptosCoin>(addr),
+            error::not_found(EACCOUNT_NOT_REGISTERED_FOR_APT),
+        );
     }
 
     /// Set whether `account` can receive direct transfers of coins that they have not explicitly registered to receive.
-    public entry fun set_allow_direct_coin_transfers(account: &signer, allow: bool) acquires DirectTransferConfig {
+    public entry fun set_allow_direct_coin_transfers(
+        account: &signer, allow: bool
+    ) acquires DirectTransferConfig {
         let addr = signer::address_of(account);
         if (exists<DirectTransferConfig>(addr)) {
             let direct_transfer_config = borrow_global_mut<DirectTransferConfig>(addr);
             // Short-circuit to avoid emitting an event if direct transfer config is not changing.
-            if (direct_transfer_config.allow_arbitrary_coin_transfers == allow) {
-                return
-            };
+            if (direct_transfer_config.allow_arbitrary_coin_transfers == allow) { return };
 
             direct_transfer_config.allow_arbitrary_coin_transfers = allow;
 
             if (std::features::module_event_migration_enabled()) {
-                emit(DirectCoinTransferConfigUpdated { account: addr, new_allow_direct_transfers: allow });
+                emit(
+                    DirectCoinTransferConfigUpdated {
+                        account: addr,
+                        new_allow_direct_transfers: allow
+                    },
+                );
             };
             emit_event(
                 &mut direct_transfer_config.update_coin_transfer_events,
-                DirectCoinTransferConfigUpdatedEvent { new_allow_direct_transfers: allow });
+                DirectCoinTransferConfigUpdatedEvent { new_allow_direct_transfers: allow },
+            );
         } else {
             let direct_transfer_config = DirectTransferConfig {
                 allow_arbitrary_coin_transfers: allow,
-                update_coin_transfer_events: new_event_handle<DirectCoinTransferConfigUpdatedEvent>(account),
+                update_coin_transfer_events: new_event_handle<
+                    DirectCoinTransferConfigUpdatedEvent>(account),
             };
             if (std::features::module_event_migration_enabled()) {
-                emit(DirectCoinTransferConfigUpdated { account: addr, new_allow_direct_transfers: allow });
+                emit(
+                    DirectCoinTransferConfigUpdated {
+                        account: addr,
+                        new_allow_direct_transfers: allow
+                    },
+                );
             };
             emit_event(
                 &mut direct_transfer_config.update_coin_transfer_events,
-                DirectCoinTransferConfigUpdatedEvent { new_allow_direct_transfers: allow });
+                DirectCoinTransferConfigUpdatedEvent { new_allow_direct_transfers: allow },
+            );
             move_to(account, direct_transfer_config);
         };
     }
@@ -180,8 +208,8 @@ module aptos_framework::aptos_account {
     ///
     /// By default, this returns true if an account has not explicitly set whether the can receive direct transfers.
     public fun can_receive_direct_coin_transfers(account: address): bool acquires DirectTransferConfig {
-        !exists<DirectTransferConfig>(account) ||
-            borrow_global<DirectTransferConfig>(account).allow_arbitrary_coin_transfers
+        !exists<DirectTransferConfig>(account)
+            || borrow_global<DirectTransferConfig>(account).allow_arbitrary_coin_transfers
     }
 
     public(friend) fun register_apt(account_signer: &signer) {
@@ -202,7 +230,8 @@ module aptos_framework::aptos_account {
     fun fungible_transfer_only(
         source: &signer, to: address, amount: u64
     ) {
-        let sender_store = ensure_primary_fungible_store_exists(signer::address_of(source));
+        let sender_store =
+            ensure_primary_fungible_store_exists(signer::address_of(source));
         let recipient_store = ensure_primary_fungible_store_exists(to);
 
         // use internal APIs, as they skip:
@@ -210,11 +239,15 @@ module aptos_framework::aptos_account {
         // as APT cannot be frozen or have dispatch, and PFS cannot be transfered
         // (PFS could potentially be burned. regular transfer would permanently unburn the store.
         // Ignoring the check here has the equivalent of unburning, transfers, and then burning again)
-        fungible_asset::deposit_internal(recipient_store, fungible_asset::withdraw_internal(sender_store, amount));
+        fungible_asset::deposit_internal(
+            recipient_store, fungible_asset::withdraw_internal(sender_store, amount)
+        );
     }
 
     /// Is balance from APT Primary FungibleStore at least the given amount
-    public(friend) fun is_fungible_balance_at_least(account: address, amount: u64): bool {
+    public(friend) fun is_fungible_balance_at_least(
+        account: address, amount: u64
+    ): bool {
         let store_addr = primary_fungible_store_address(account);
         fungible_asset::is_address_balance_at_least(store_addr, amount)
     }
@@ -238,7 +271,11 @@ module aptos_framework::aptos_account {
         if (fungible_asset::store_exists(store_addr)) {
             store_addr
         } else {
-            object::object_address(&primary_fungible_store::create_primary_store(owner, object::address_to_object<Metadata>(@aptos_fungible_asset)))
+            object::object_address(
+                &primary_fungible_store::create_primary_store(
+                    owner, object::address_to_object<Metadata>(@aptos_fungible_asset)
+                ),
+            )
         }
     }
 
@@ -261,8 +298,14 @@ module aptos_framework::aptos_account {
 
     #[test(alice = @0xa11ce, core = @0x1)]
     public fun test_transfer(alice: &signer, core: &signer) {
-        let bob = from_bcs::to_address(x"0000000000000000000000000000000000000000000000000000000000000b0b");
-        let carol = from_bcs::to_address(x"00000000000000000000000000000000000000000000000000000000000ca501");
+        let bob =
+            from_bcs::to_address(
+                x"0000000000000000000000000000000000000000000000000000000000000b0b"
+            );
+        let carol =
+            from_bcs::to_address(
+                x"00000000000000000000000000000000000000000000000000000000000ca501"
+            );
 
         let (burn_cap, mint_cap) = aptos_framework::aptos_coin::initialize_for_test(core);
         create_account(signer::address_of(alice));
@@ -279,7 +322,9 @@ module aptos_framework::aptos_account {
     }
 
     #[test(alice = @0xa11ce, core = @0x1)]
-    public fun test_transfer_to_resource_account(alice: &signer, core: &signer) {
+    public fun test_transfer_to_resource_account(
+        alice: &signer, core: &signer
+    ) {
         let (resource_account, _) = account::create_resource_account(alice, vector[]);
         let resource_acc_addr = signer::address_of(&resource_account);
         let (burn_cap, mint_cap) = aptos_framework::aptos_coin::initialize_for_test(core);
@@ -295,7 +340,9 @@ module aptos_framework::aptos_account {
     }
 
     #[test(from = @0x123, core = @0x1, recipient_1 = @0x124, recipient_2 = @0x125)]
-    public fun test_batch_transfer(from: &signer, core: &signer, recipient_1: &signer, recipient_2: &signer) {
+    public fun test_batch_transfer(
+        from: &signer, core: &signer, recipient_1: &signer, recipient_2: &signer
+    ) {
         let (burn_cap, mint_cap) = aptos_framework::aptos_coin::initialize_for_test(core);
         create_account(signer::address_of(from));
         let recipient_1_addr = signer::address_of(recipient_1);
@@ -316,13 +363,14 @@ module aptos_framework::aptos_account {
 
     #[test(from = @0x1, to = @0x12)]
     public fun test_direct_coin_transfers(from: &signer, to: &signer) acquires DirectTransferConfig {
-        let (burn_cap, freeze_cap, mint_cap) = coin::initialize<FakeCoin>(
-            from,
-            utf8(b"FC"),
-            utf8(b"FC"),
-            10,
-            true,
-        );
+        let (burn_cap, freeze_cap, mint_cap) =
+            coin::initialize<FakeCoin>(
+                from,
+                utf8(b"FC"),
+                utf8(b"FC"),
+                10,
+                true,
+            );
         create_account_for_test(signer::address_of(from));
         create_account_for_test(signer::address_of(to));
         deposit_coins(signer::address_of(from), coin::mint(1000, &mint_cap));
@@ -338,14 +386,16 @@ module aptos_framework::aptos_account {
 
     #[test(from = @0x1, recipient_1 = @0x124, recipient_2 = @0x125)]
     public fun test_batch_transfer_coins(
-        from: &signer, recipient_1: &signer, recipient_2: &signer) acquires DirectTransferConfig {
-        let (burn_cap, freeze_cap, mint_cap) = coin::initialize<FakeCoin>(
-            from,
-            utf8(b"FC"),
-            utf8(b"FC"),
-            10,
-            true,
-        );
+        from: &signer, recipient_1: &signer, recipient_2: &signer
+    ) acquires DirectTransferConfig {
+        let (burn_cap, freeze_cap, mint_cap) =
+            coin::initialize<FakeCoin>(
+                from,
+                utf8(b"FC"),
+                utf8(b"FC"),
+                10,
+                true,
+            );
         create_account_for_test(signer::address_of(from));
         let recipient_1_addr = signer::address_of(recipient_1);
         let recipient_2_addr = signer::address_of(recipient_2);
@@ -379,14 +429,16 @@ module aptos_framework::aptos_account {
 
     #[test(from = @0x1, to = @0x12)]
     public fun test_direct_coin_transfers_with_explicit_direct_coin_transfer_config(
-        from: &signer, to: &signer) acquires DirectTransferConfig {
-        let (burn_cap, freeze_cap, mint_cap) = coin::initialize<FakeCoin>(
-            from,
-            utf8(b"FC"),
-            utf8(b"FC"),
-            10,
-            true,
-        );
+        from: &signer, to: &signer
+    ) acquires DirectTransferConfig {
+        let (burn_cap, freeze_cap, mint_cap) =
+            coin::initialize<FakeCoin>(
+                from,
+                utf8(b"FC"),
+                utf8(b"FC"),
+                10,
+                true,
+            );
         create_account_for_test(signer::address_of(from));
         create_account_for_test(signer::address_of(to));
         set_allow_direct_coin_transfers(from, true);
@@ -404,14 +456,16 @@ module aptos_framework::aptos_account {
     #[test(from = @0x1, to = @0x12)]
     #[expected_failure(abort_code = 0x50003, location = Self)]
     public fun test_direct_coin_transfers_fail_if_recipient_opted_out(
-        from: &signer, to: &signer) acquires DirectTransferConfig {
-        let (burn_cap, freeze_cap, mint_cap) = coin::initialize<FakeCoin>(
-            from,
-            utf8(b"FC"),
-            utf8(b"FC"),
-            10,
-            true,
-        );
+        from: &signer, to: &signer
+    ) acquires DirectTransferConfig {
+        let (burn_cap, freeze_cap, mint_cap) =
+            coin::initialize<FakeCoin>(
+                from,
+                utf8(b"FC"),
+                utf8(b"FC"),
+                10,
+                true,
+            );
         create_account_for_test(signer::address_of(from));
         create_account_for_test(signer::address_of(to));
         set_allow_direct_coin_transfers(from, false);
@@ -425,9 +479,7 @@ module aptos_framework::aptos_account {
     }
 
     #[test(user = @0xcafe)]
-    fun test_primary_fungible_store_address(
-        user: &signer,
-    ) {
+    fun test_primary_fungible_store_address(user: &signer,) {
         use aptos_framework::fungible_asset::Metadata;
         use aptos_framework::aptos_coin;
 
@@ -435,7 +487,11 @@ module aptos_framework::aptos_account {
 
         let apt_metadata = object::address_to_object<Metadata>(@aptos_fungible_asset);
         let user_addr = signer::address_of(user);
-        assert!(primary_fungible_store_address(user_addr) == primary_fungible_store::primary_store_address(user_addr, apt_metadata), 1);
+        assert!(
+            primary_fungible_store_address(user_addr)
+                == primary_fungible_store::primary_store_address(user_addr, apt_metadata),
+            1,
+        );
 
         ensure_primary_fungible_store_exists(user_addr);
         assert!(primary_fungible_store::primary_store_exists(user_addr, apt_metadata), 2);

--- a/aptos-move/framework/aptos-framework/sources/aptos_account.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_account.spec.move
@@ -140,49 +140,49 @@ spec aptos_framework::aptos_account {
 
         // create account properties
         aborts_if len(recipients) != len(amounts);
-        aborts_if exists i in 0..len(recipients): !account::exists_at(recipients[i])
-            && length_judgment(recipients[i]);
-        aborts_if exists i in 0..len(recipients): !account::exists_at(recipients[i])
-            && (
-                recipients[i] == @vm_reserved
-                || recipients[i] == @aptos_framework
-                || recipients[i] == @aptos_token
-            );
-        ensures forall i in 0..len(recipients): (
-                !account::exists_at(recipients[i]) ==>
-                !length_judgment(recipients[i])
-            )
-            && (
-                !account::exists_at(recipients[i]) ==>
-                (
-                    recipients[i] != @vm_reserved
-                    && recipients[i] != @aptos_framework
-                    && recipients[i] != @aptos_token
-                )
-            );
+        aborts_if exists i in 0..len(recipients):
+            !account::exists_at(recipients[i]) && length_judgment(recipients[i]);
+        aborts_if exists i in 0..len(recipients):
+            !account::exists_at(recipients[i])
+                && (
+                    recipients[i] == @vm_reserved
+                        || recipients[i] == @aptos_framework
+                        || recipients[i] == @aptos_token
+                );
+        ensures forall i in 0..len(recipients):
+            (!account::exists_at(recipients[i]) ==>
+                !length_judgment(recipients[i]))
+                && (
+                    !account::exists_at(recipients[i]) ==>
+                        (
+                            recipients[i] != @vm_reserved
+                                && recipients[i] != @aptos_framework
+                                && recipients[i] != @aptos_token
+                        )
+                );
 
         // coin::withdraw properties
-        aborts_if exists i in 0..len(recipients): !exists<coin::CoinStore<AptosCoin>>(
-            account_addr_source
-        );
+        aborts_if exists i in 0..len(recipients):
+            !exists<coin::CoinStore<AptosCoin>>(account_addr_source);
         aborts_if exists i in 0..len(recipients): coin_store_source.frozen;
-        aborts_if exists i in 0..len(recipients): global<coin::CoinStore<AptosCoin>>(
-            account_addr_source
-        ).coin.value < amounts[i];
+        aborts_if exists i in 0..len(recipients):
+            global<coin::CoinStore<AptosCoin>>(account_addr_source).coin.value < amounts[i];
 
         // deposit properties
-        aborts_if exists i in 0..len(recipients): exists<coin::CoinStore<AptosCoin>>(
-            recipients[i]
-        ) && global<coin::CoinStore<AptosCoin>>(recipients[i]).frozen;
+        aborts_if exists i in 0..len(recipients):
+            exists<coin::CoinStore<AptosCoin>>(recipients[i])
+                && global<coin::CoinStore<AptosCoin>>(recipients[i]).frozen;
 
         // guid properties
-        aborts_if exists i in 0..len(recipients): account::exists_at(recipients[i])
-            && !exists<coin::CoinStore<AptosCoin>>(recipients[i])
-            && global<account::Account>(recipients[i]).guid_creation_num + 2
-                >= account::MAX_GUID_CREATION_NUM;
-        aborts_if exists i in 0..len(recipients): account::exists_at(recipients[i])
-            && !exists<coin::CoinStore<AptosCoin>>(recipients[i])
-            && global<account::Account>(recipients[i]).guid_creation_num + 2 > MAX_U64;
+        aborts_if exists i in 0..len(recipients):
+            account::exists_at(recipients[i])
+                && !exists<coin::CoinStore<AptosCoin>>(recipients[i])
+                && global<account::Account>(recipients[i]).guid_creation_num + 2
+                    >= account::MAX_GUID_CREATION_NUM;
+        aborts_if exists i in 0..len(recipients):
+            account::exists_at(recipients[i])
+                && !exists<coin::CoinStore<AptosCoin>>(recipients[i])
+                && global<account::Account>(recipients[i]).guid_creation_num + 2 > MAX_U64;
     }
 
     spec can_receive_direct_coin_transfers(account: address): bool {
@@ -213,54 +213,53 @@ spec aptos_framework::aptos_account {
         aborts_if len(recipients) != len(amounts);
 
         //create account properties
-        aborts_if exists i in 0..len(recipients): !account::exists_at(recipients[i])
-            && length_judgment(recipients[i]);
-        aborts_if exists i in 0..len(recipients): !account::exists_at(recipients[i])
-            && (
-                recipients[i] == @vm_reserved
-                || recipients[i] == @aptos_framework
-                || recipients[i] == @aptos_token
-            );
-        ensures forall i in 0..len(recipients): (
-                !account::exists_at(recipients[i]) ==>
-                !length_judgment(recipients[i])
-            )
-            && (
-                !account::exists_at(recipients[i]) ==>
-                (
-                    recipients[i] != @vm_reserved
-                    && recipients[i] != @aptos_framework
-                    && recipients[i] != @aptos_token
-                )
-            );
+        aborts_if exists i in 0..len(recipients):
+            !account::exists_at(recipients[i]) && length_judgment(recipients[i]);
+        aborts_if exists i in 0..len(recipients):
+            !account::exists_at(recipients[i])
+                && (
+                    recipients[i] == @vm_reserved
+                        || recipients[i] == @aptos_framework
+                        || recipients[i] == @aptos_token
+                );
+        ensures forall i in 0..len(recipients):
+            (!account::exists_at(recipients[i]) ==>
+                !length_judgment(recipients[i]))
+                && (
+                    !account::exists_at(recipients[i]) ==>
+                        (
+                            recipients[i] != @vm_reserved
+                                && recipients[i] != @aptos_framework
+                                && recipients[i] != @aptos_token
+                        )
+                );
 
         // coin::withdraw properties
-        aborts_if exists i in 0..len(recipients): !exists<coin::CoinStore<CoinType>>(
-            account_addr_source
-        );
+        aborts_if exists i in 0..len(recipients):
+            !exists<coin::CoinStore<CoinType>>(account_addr_source);
         aborts_if exists i in 0..len(recipients): coin_store_source.frozen;
-        aborts_if exists i in 0..len(recipients): global<coin::CoinStore<CoinType>>(
-            account_addr_source
-        ).coin.value < amounts[i];
+        aborts_if exists i in 0..len(recipients):
+            global<coin::CoinStore<CoinType>>(account_addr_source).coin.value < amounts[i];
 
         // deposit properties
-        aborts_if exists i in 0..len(recipients): exists<coin::CoinStore<CoinType>>(
-            recipients[i]
-        ) && global<coin::CoinStore<CoinType>>(recipients[i]).frozen;
+        aborts_if exists i in 0..len(recipients):
+            exists<coin::CoinStore<CoinType>>(recipients[i])
+                && global<coin::CoinStore<CoinType>>(recipients[i]).frozen;
 
         // guid properties
-        aborts_if exists i in 0..len(recipients): account::exists_at(recipients[i])
-            && !exists<coin::CoinStore<CoinType>>(recipients[i])
-            && global<account::Account>(recipients[i]).guid_creation_num + 2
-                >= account::MAX_GUID_CREATION_NUM;
-        aborts_if exists i in 0..len(recipients): account::exists_at(recipients[i])
-            && !exists<coin::CoinStore<CoinType>>(recipients[i])
-            && global<account::Account>(recipients[i]).guid_creation_num + 2 > MAX_U64;
+        aborts_if exists i in 0..len(recipients):
+            account::exists_at(recipients[i])
+                && !exists<coin::CoinStore<CoinType>>(recipients[i])
+                && global<account::Account>(recipients[i]).guid_creation_num + 2
+                    >= account::MAX_GUID_CREATION_NUM;
+        aborts_if exists i in 0..len(recipients):
+            account::exists_at(recipients[i])
+                && !exists<coin::CoinStore<CoinType>>(recipients[i])
+                && global<account::Account>(recipients[i]).guid_creation_num + 2 > MAX_U64;
 
         // register_coin properties
-        aborts_if exists i in 0..len(recipients): !coin::spec_is_account_registered<CoinType>(
-            recipients[i]
-        ) && !type_info::spec_is_struct<CoinType>();
+        aborts_if exists i in 0..len(recipients):
+            !coin::spec_is_account_registered<CoinType>(recipients[i]) && !type_info::spec_is_struct<CoinType>();
     }
 
     spec deposit_coins<CoinType>(to: address, coins: Coin<CoinType>) {

--- a/aptos-move/framework/aptos-framework/sources/aptos_account.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_account.spec.move
@@ -71,11 +71,14 @@ spec aptos_framework::aptos_account {
         include CreateAccountAbortsIf;
         ensures exists<account::Account>(auth_key);
     }
+
     spec schema CreateAccountAbortsIf {
         auth_key: address;
         aborts_if exists<account::Account>(auth_key);
         aborts_if length_judgment(auth_key);
-        aborts_if auth_key == @vm_reserved || auth_key == @aptos_framework || auth_key == @aptos_token;
+        aborts_if auth_key == @vm_reserved
+            || auth_key == @aptos_framework
+            || auth_key == @aptos_token;
     }
 
     spec fun length_judgment(auth_key: address): bool {
@@ -95,10 +98,11 @@ spec aptos_framework::aptos_account {
 
         include CreateAccountTransferAbortsIf;
         include GuidAbortsIf<AptosCoin>;
-        include WithdrawAbortsIf<AptosCoin>{from: source};
+        include WithdrawAbortsIf<AptosCoin> { from: source };
         include TransferEnsures<AptosCoin>;
 
-        aborts_if exists<coin::CoinStore<AptosCoin>>(to) && global<coin::CoinStore<AptosCoin>>(to).frozen;
+        aborts_if exists<coin::CoinStore<AptosCoin>>(to)
+            && global<coin::CoinStore<AptosCoin>>(to).frozen;
         /// [high-level-req-5]
         ensures exists<aptos_framework::account::Account>(to);
         ensures exists<coin::CoinStore<AptosCoin>>(to);
@@ -131,50 +135,69 @@ spec aptos_framework::aptos_account {
         let coin_store_source = global<coin::CoinStore<AptosCoin>>(account_addr_source);
         let balance_source = coin_store_source.coin.value;
 
-        requires forall i in 0..len(recipients):
-            recipients[i] != account_addr_source;
-        requires exists i in 0..len(recipients):
-            amounts[i] > 0;
+        requires forall i in 0..len(recipients): recipients[i] != account_addr_source;
+        requires exists i in 0..len(recipients): amounts[i] > 0;
 
         // create account properties
         aborts_if len(recipients) != len(amounts);
-        aborts_if exists i in 0..len(recipients):
-                !account::exists_at(recipients[i]) && length_judgment(recipients[i]);
-        aborts_if exists i in 0..len(recipients):
-                !account::exists_at(recipients[i]) && (recipients[i] == @vm_reserved || recipients[i] == @aptos_framework || recipients[i] == @aptos_token);
-        ensures forall i in 0..len(recipients):
-                (!account::exists_at(recipients[i]) ==> !length_judgment(recipients[i])) &&
-                    (!account::exists_at(recipients[i]) ==> (recipients[i] != @vm_reserved && recipients[i] != @aptos_framework && recipients[i] != @aptos_token));
+        aborts_if exists i in 0..len(recipients): !account::exists_at(recipients[i])
+            && length_judgment(recipients[i]);
+        aborts_if exists i in 0..len(recipients): !account::exists_at(recipients[i])
+            && (
+                recipients[i] == @vm_reserved
+                || recipients[i] == @aptos_framework
+                || recipients[i] == @aptos_token
+            );
+        ensures forall i in 0..len(recipients): (
+                !account::exists_at(recipients[i]) ==>
+                !length_judgment(recipients[i])
+            )
+            && (
+                !account::exists_at(recipients[i]) ==>
+                (
+                    recipients[i] != @vm_reserved
+                    && recipients[i] != @aptos_framework
+                    && recipients[i] != @aptos_token
+                )
+            );
 
         // coin::withdraw properties
-        aborts_if exists i in 0..len(recipients):
-            !exists<coin::CoinStore<AptosCoin>>(account_addr_source);
-        aborts_if exists i in 0..len(recipients):
-            coin_store_source.frozen;
-        aborts_if exists i in 0..len(recipients):
-            global<coin::CoinStore<AptosCoin>>(account_addr_source).coin.value < amounts[i];
+        aborts_if exists i in 0..len(recipients): !exists<coin::CoinStore<AptosCoin>>(
+            account_addr_source
+        );
+        aborts_if exists i in 0..len(recipients): coin_store_source.frozen;
+        aborts_if exists i in 0..len(recipients): global<coin::CoinStore<AptosCoin>>(
+            account_addr_source
+        ).coin.value < amounts[i];
 
         // deposit properties
-        aborts_if exists i in 0..len(recipients):
-            exists<coin::CoinStore<AptosCoin>>(recipients[i]) && global<coin::CoinStore<AptosCoin>>(recipients[i]).frozen;
+        aborts_if exists i in 0..len(recipients): exists<coin::CoinStore<AptosCoin>>(
+            recipients[i]
+        ) && global<coin::CoinStore<AptosCoin>>(recipients[i]).frozen;
 
         // guid properties
-        aborts_if exists i in 0..len(recipients):
-            account::exists_at(recipients[i]) && !exists<coin::CoinStore<AptosCoin>>(recipients[i]) && global<account::Account>(recipients[i]).guid_creation_num + 2 >= account::MAX_GUID_CREATION_NUM;
-        aborts_if exists i in 0..len(recipients):
-            account::exists_at(recipients[i]) && !exists<coin::CoinStore<AptosCoin>>(recipients[i]) && global<account::Account>(recipients[i]).guid_creation_num + 2 > MAX_U64;
+        aborts_if exists i in 0..len(recipients): account::exists_at(recipients[i])
+            && !exists<coin::CoinStore<AptosCoin>>(recipients[i])
+            && global<account::Account>(recipients[i]).guid_creation_num + 2
+                >= account::MAX_GUID_CREATION_NUM;
+        aborts_if exists i in 0..len(recipients): account::exists_at(recipients[i])
+            && !exists<coin::CoinStore<AptosCoin>>(recipients[i])
+            && global<account::Account>(recipients[i]).guid_creation_num + 2 > MAX_U64;
     }
 
     spec can_receive_direct_coin_transfers(account: address): bool {
         aborts_if false;
         /// [high-level-req-3]
-        ensures result == (
-            !exists<DirectTransferConfig>(account) ||
-                global<DirectTransferConfig>(account).allow_arbitrary_coin_transfers
-        );
+        ensures result
+            == (
+                !exists<DirectTransferConfig>(account)
+                    || global<DirectTransferConfig>(account).allow_arbitrary_coin_transfers
+            );
     }
 
-    spec batch_transfer_coins<CoinType>(from: &signer, recipients: vector<address>, amounts: vector<u64>) {
+    spec batch_transfer_coins<CoinType>(
+        from: &signer, recipients: vector<address>, amounts: vector<u64>
+    ) {
         //TODO: Can't verify the loop invariant in enumerate
         use aptos_std::type_info;
         pragma verify = false;
@@ -182,45 +205,62 @@ spec aptos_framework::aptos_account {
         let coin_store_source = global<coin::CoinStore<CoinType>>(account_addr_source);
         let balance_source = coin_store_source.coin.value;
 
-        requires forall i in 0..len(recipients):
-            recipients[i] != account_addr_source;
+        requires forall i in 0..len(recipients): recipients[i] != account_addr_source;
 
-        requires exists i in 0..len(recipients):
-            amounts[i] > 0;
+        requires exists i in 0..len(recipients): amounts[i] > 0;
 
         /// [high-level-req-7]
         aborts_if len(recipients) != len(amounts);
 
         //create account properties
-        aborts_if exists i in 0..len(recipients):
-                !account::exists_at(recipients[i]) && length_judgment(recipients[i]);
-        aborts_if exists i in 0..len(recipients):
-                !account::exists_at(recipients[i]) && (recipients[i] == @vm_reserved || recipients[i] == @aptos_framework || recipients[i] == @aptos_token);
-        ensures forall i in 0..len(recipients):
-                (!account::exists_at(recipients[i]) ==> !length_judgment(recipients[i])) &&
-                    (!account::exists_at(recipients[i]) ==> (recipients[i] != @vm_reserved && recipients[i] != @aptos_framework && recipients[i] != @aptos_token));
+        aborts_if exists i in 0..len(recipients): !account::exists_at(recipients[i])
+            && length_judgment(recipients[i]);
+        aborts_if exists i in 0..len(recipients): !account::exists_at(recipients[i])
+            && (
+                recipients[i] == @vm_reserved
+                || recipients[i] == @aptos_framework
+                || recipients[i] == @aptos_token
+            );
+        ensures forall i in 0..len(recipients): (
+                !account::exists_at(recipients[i]) ==>
+                !length_judgment(recipients[i])
+            )
+            && (
+                !account::exists_at(recipients[i]) ==>
+                (
+                    recipients[i] != @vm_reserved
+                    && recipients[i] != @aptos_framework
+                    && recipients[i] != @aptos_token
+                )
+            );
 
         // coin::withdraw properties
-        aborts_if exists i in 0..len(recipients):
-            !exists<coin::CoinStore<CoinType>>(account_addr_source);
-        aborts_if exists i in 0..len(recipients):
-            coin_store_source.frozen;
-        aborts_if exists i in 0..len(recipients):
-            global<coin::CoinStore<CoinType>>(account_addr_source).coin.value < amounts[i];
+        aborts_if exists i in 0..len(recipients): !exists<coin::CoinStore<CoinType>>(
+            account_addr_source
+        );
+        aborts_if exists i in 0..len(recipients): coin_store_source.frozen;
+        aborts_if exists i in 0..len(recipients): global<coin::CoinStore<CoinType>>(
+            account_addr_source
+        ).coin.value < amounts[i];
 
         // deposit properties
-        aborts_if exists i in 0..len(recipients):
-            exists<coin::CoinStore<CoinType>>(recipients[i]) && global<coin::CoinStore<CoinType>>(recipients[i]).frozen;
+        aborts_if exists i in 0..len(recipients): exists<coin::CoinStore<CoinType>>(
+            recipients[i]
+        ) && global<coin::CoinStore<CoinType>>(recipients[i]).frozen;
 
         // guid properties
-        aborts_if exists i in 0..len(recipients):
-            account::exists_at(recipients[i]) && !exists<coin::CoinStore<CoinType>>(recipients[i]) && global<account::Account>(recipients[i]).guid_creation_num + 2 >= account::MAX_GUID_CREATION_NUM;
-        aborts_if exists i in 0..len(recipients):
-            account::exists_at(recipients[i]) && !exists<coin::CoinStore<CoinType>>(recipients[i]) && global<account::Account>(recipients[i]).guid_creation_num + 2 > MAX_U64;
+        aborts_if exists i in 0..len(recipients): account::exists_at(recipients[i])
+            && !exists<coin::CoinStore<CoinType>>(recipients[i])
+            && global<account::Account>(recipients[i]).guid_creation_num + 2
+                >= account::MAX_GUID_CREATION_NUM;
+        aborts_if exists i in 0..len(recipients): account::exists_at(recipients[i])
+            && !exists<coin::CoinStore<CoinType>>(recipients[i])
+            && global<account::Account>(recipients[i]).guid_creation_num + 2 > MAX_U64;
 
         // register_coin properties
-        aborts_if exists i in 0..len(recipients):
-            !coin::spec_is_account_registered<CoinType>(recipients[i]) && !type_info::spec_is_struct<CoinType>();
+        aborts_if exists i in 0..len(recipients): !coin::spec_is_account_registered<CoinType>(
+            recipients[i]
+        ) && !type_info::spec_is_struct<CoinType>();
     }
 
     spec deposit_coins<CoinType>(to: address, coins: Coin<CoinType>) {
@@ -238,7 +278,8 @@ spec aptos_framework::aptos_account {
 
         let coin_store_to = global<coin::CoinStore<CoinType>>(to).coin.value;
         let post post_coin_store_to = global<coin::CoinStore<CoinType>>(to).coin.value;
-        ensures if_exist_coin ==> post_coin_store_to == coin_store_to + coins.value;
+        ensures if_exist_coin ==>
+            post_coin_store_to == coin_store_to + coins.value;
     }
 
     spec transfer_coins<CoinType>(from: &signer, to: address, amount: u64) {
@@ -255,7 +296,8 @@ spec aptos_framework::aptos_account {
         include RegistCoinAbortsIf<CoinType>;
         include TransferEnsures<CoinType>;
 
-        aborts_if exists<coin::CoinStore<CoinType>>(to) && global<coin::CoinStore<CoinType>>(to).frozen;
+        aborts_if exists<coin::CoinStore<CoinType>>(to)
+            && global<coin::CoinStore<CoinType>>(to).frozen;
         ensures exists<aptos_framework::account::Account>(to);
         ensures exists<aptos_framework::coin::CoinStore<CoinType>>(to);
     }
@@ -275,11 +317,7 @@ spec aptos_framework::aptos_account {
         pragma verify = false;
     }
 
-    spec burn_from_fungible_store(
-        ref: &BurnRef,
-        account: address,
-        amount: u64,
-    ) {
+    spec burn_from_fungible_store(ref: &BurnRef, account: address, amount: u64,) {
         // TODO: temporary mockup.
         pragma verify = false;
     }
@@ -287,7 +325,10 @@ spec aptos_framework::aptos_account {
     spec schema CreateAccountTransferAbortsIf {
         to: address;
         aborts_if !account::exists_at(to) && length_judgment(to);
-        aborts_if !account::exists_at(to) && (to == @vm_reserved || to == @aptos_framework || to == @aptos_token);
+        aborts_if !account::exists_at(to)
+            && (to == @vm_reserved
+                || to == @aptos_framework
+                || to == @aptos_token);
     }
 
     spec schema WithdrawAbortsIf<CoinType> {
@@ -304,14 +345,19 @@ spec aptos_framework::aptos_account {
     spec schema GuidAbortsIf<CoinType> {
         to: address;
         let acc = global<account::Account>(to);
-        aborts_if account::exists_at(to) && !exists<coin::CoinStore<CoinType>>(to) && acc.guid_creation_num + 2 >= account::MAX_GUID_CREATION_NUM;
-        aborts_if account::exists_at(to) && !exists<coin::CoinStore<CoinType>>(to) && acc.guid_creation_num + 2 > MAX_U64;
+        aborts_if account::exists_at(to)
+            && !exists<coin::CoinStore<CoinType>>(to)
+            && acc.guid_creation_num + 2 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if account::exists_at(to)
+            && !exists<coin::CoinStore<CoinType>>(to)
+            && acc.guid_creation_num + 2 > MAX_U64;
     }
 
     spec schema RegistCoinAbortsIf<CoinType> {
         use aptos_std::type_info;
         to: address;
-        aborts_if !coin::spec_is_account_registered<CoinType>(to) && !type_info::spec_is_struct<CoinType>();
+        aborts_if !coin::spec_is_account_registered<CoinType>(to)
+            && !type_info::spec_is_struct<CoinType>();
         aborts_if exists<aptos_framework::account::Account>(to);
         aborts_if type_info::type_of<CoinType>() != type_info::type_of<AptosCoin>();
     }
@@ -326,8 +372,11 @@ spec aptos_framework::aptos_account {
         let coin_store_to = global<coin::CoinStore<CoinType>>(to);
         let coin_store_source = global<coin::CoinStore<CoinType>>(account_addr_source);
         let post p_coin_store_to = global<coin::CoinStore<CoinType>>(to);
-        let post p_coin_store_source = global<coin::CoinStore<CoinType>>(account_addr_source);
+        let post p_coin_store_source = global<coin::CoinStore<CoinType>>(
+            account_addr_source
+        );
         ensures coin_store_source.coin.value - amount == p_coin_store_source.coin.value;
-        ensures if_exist_account && if_exist_coin ==> coin_store_to.coin.value + amount == p_coin_store_to.coin.value;
+        ensures if_exist_account && if_exist_coin ==>
+            coin_store_to.coin.value + amount == p_coin_store_to.coin.value;
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/aptos_coin.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_coin.move
@@ -36,16 +36,20 @@ module aptos_framework::aptos_coin {
     }
 
     /// Can only called during genesis to initialize the Aptos coin.
-    public(friend) fun initialize(aptos_framework: &signer): (BurnCapability<AptosCoin>, MintCapability<AptosCoin>) {
+    public(friend) fun initialize(aptos_framework: &signer)
+        : (
+        BurnCapability<AptosCoin>, MintCapability<AptosCoin>
+    ) {
         system_addresses::assert_aptos_framework(aptos_framework);
 
-        let (burn_cap, freeze_cap, mint_cap) = coin::initialize_with_parallelizable_supply<AptosCoin>(
-            aptos_framework,
-            string::utf8(b"Aptos Coin"),
-            string::utf8(b"APT"),
-            8, // decimals
-            true, // monitor_supply
-        );
+        let (burn_cap, freeze_cap, mint_cap) =
+            coin::initialize_with_parallelizable_supply<AptosCoin>(
+                aptos_framework,
+                string::utf8(b"Aptos Coin"),
+                string::utf8(b"APT"),
+                8, // decimals
+                true, // monitor_supply
+            );
 
         // Aptos framework needs mint cap to mint coins to initial validators. This will be revoked once the validators
         // have been initialized.
@@ -79,8 +83,7 @@ module aptos_framework::aptos_coin {
 
         // Mint the core resource account AptosCoin for gas so it can execute system transactions.
         let coins = coin::mint<AptosCoin>(
-            18446744073709551615,
-            &mint_cap,
+            18446744073709551615, &mint_cap
         );
         coin::deposit<AptosCoin>(signer::address_of(core_resources), coins);
 
@@ -112,10 +115,13 @@ module aptos_framework::aptos_coin {
     public entry fun delegate_mint_capability(account: signer, to: address) acquires Delegations {
         system_addresses::assert_core_resource(&account);
         let delegations = &mut borrow_global_mut<Delegations>(@core_resources).inner;
-        vector::for_each_ref(delegations, |element| {
-            let element: &DelegatedMintCapability = element;
-            assert!(element.to != to, error::invalid_argument(EALREADY_DELEGATED));
-        });
+        vector::for_each_ref(
+            delegations,
+            |element| {
+                let element: &DelegatedMintCapability = element;
+                assert!(element.to != to, error::invalid_argument(EALREADY_DELEGATED));
+            },
+        );
         vector::push_back(delegations, DelegatedMintCapability { to });
     }
 
@@ -162,8 +168,8 @@ module aptos_framework::aptos_coin {
         coin::coin_to_fungible_asset(
             coin::mint(
                 amount,
-                &borrow_global<MintCapStore>(@aptos_framework).mint_cap
-            )
+                &borrow_global<MintCapStore>(@aptos_framework).mint_cap,
+            ),
         )
     }
 
@@ -172,7 +178,9 @@ module aptos_framework::aptos_coin {
         let aptos_framework = account::create_signer_for_test(@aptos_framework);
         if (!exists<MintCapStore>(@aptos_framework)) {
             if (!aggregator_factory::aggregator_factory_exists_for_testing()) {
-                aggregator_factory::initialize_aggregator_factory_for_test(&aptos_framework);
+                aggregator_factory::initialize_aggregator_factory_for_test(
+                    &aptos_framework
+                );
             };
             let (burn_cap, mint_cap) = initialize(&aptos_framework);
             coin::destroy_burn_cap(burn_cap);
@@ -183,7 +191,10 @@ module aptos_framework::aptos_coin {
     }
 
     #[test_only]
-    public fun initialize_for_test(aptos_framework: &signer): (BurnCapability<AptosCoin>, MintCapability<AptosCoin>) {
+    public fun initialize_for_test(aptos_framework: &signer)
+        : (
+        BurnCapability<AptosCoin>, MintCapability<AptosCoin>
+    ) {
         aggregator_factory::initialize_aggregator_factory_for_test(aptos_framework);
         let (burn_cap, mint_cap) = initialize(aptos_framework);
         coin::create_coin_conversion_map(aptos_framework);

--- a/aptos-move/framework/aptos-framework/sources/aptos_coin.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_coin.move
@@ -82,9 +82,7 @@ module aptos_framework::aptos_coin {
         system_addresses::assert_aptos_framework(aptos_framework);
 
         // Mint the core resource account AptosCoin for gas so it can execute system transactions.
-        let coins = coin::mint<AptosCoin>(
-            18446744073709551615, &mint_cap
-        );
+        let coins = coin::mint<AptosCoin>(18446744073709551615, &mint_cap);
         coin::deposit<AptosCoin>(signer::address_of(core_resources), coins);
 
         move_to(core_resources, MintCapStore { mint_cap });

--- a/aptos-move/framework/aptos-framework/sources/aptos_coin.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_coin.spec.move
@@ -34,7 +34,9 @@ spec aptos_framework::aptos_coin {
         pragma aborts_if_is_strict;
     }
 
-    spec initialize(aptos_framework: &signer): (BurnCapability<AptosCoin>, MintCapability<AptosCoin>) {
+    spec initialize(aptos_framework: &signer): (
+        BurnCapability<AptosCoin>, MintCapability<AptosCoin>
+    ) {
         use aptos_framework::aggregator_factory;
 
         let addr = signer::address_of(aptos_framework);
@@ -48,7 +50,7 @@ spec aptos_framework::aptos_coin {
         ensures exists<MintCapStore>(addr);
         // property 3: The abilities to mint Aptos tokens should be transferable, duplicatable, and destroyable.
         /// [high-level-req-3]
-        ensures global<MintCapStore>(addr).mint_cap ==  MintCapability<AptosCoin> {};
+        ensures global<MintCapStore>(addr).mint_cap == MintCapability<AptosCoin> {};
         ensures exists<coin::CoinInfo<AptosCoin>>(addr);
         ensures result_1 == BurnCapability<AptosCoin> {};
         ensures result_2 == MintCapability<AptosCoin> {};
@@ -66,11 +68,7 @@ spec aptos_framework::aptos_coin {
     }
 
     // Only callable in tests and testnets. not needed verify.
-    spec mint(
-        account: &signer,
-        dst_addr: address,
-        amount: u64,
-    ) {
+    spec mint(account: &signer, dst_addr: address, amount: u64,) {
         pragma verify = false;
     }
 
@@ -91,5 +89,4 @@ spec aptos_framework::aptos_coin {
     spec schema ExistsAptosCoin {
         requires exists<coin::CoinInfo<AptosCoin>>(@aptos_framework);
     }
-
 }

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -313,7 +313,7 @@ module aptos_framework::aptos_governance {
         // The voter's stake needs to be locked up at least as long as the proposal's expiration.
         // Also no one can vote on a expired proposal.
         if (proposal_expiration > lockup_until
-                || timestamp::now_seconds() > proposal_expiration) {
+            || timestamp::now_seconds() > proposal_expiration) {
             return 0
         };
 
@@ -640,9 +640,7 @@ module aptos_framework::aptos_governance {
 
     /// Resolve a successful single-step proposal. This would fail if the proposal is not successful (not enough votes or more no
     /// than yes).
-    public fun resolve(
-        proposal_id: u64, signer_address: address
-    ): signer acquires ApprovedExecutionHashes, GovernanceResponsbility {
+    public fun resolve(proposal_id: u64, signer_address: address): signer acquires ApprovedExecutionHashes, GovernanceResponsbility {
         voting::resolve<GovernanceProposal>(@aptos_framework, proposal_id);
         remove_approved_hash(proposal_id);
         get_signer(signer_address)
@@ -899,7 +897,10 @@ module aptos_framework::aptos_governance {
         // Resolve the proposal.
         let account =
             resolve_proposal_for_test(
-                0, @aptos_framework, use_generic_resolve_function, true
+                0,
+                @aptos_framework,
+                use_generic_resolve_function,
+                true,
             );
         assert!(signer::address_of(&account) == @aptos_framework, 1);
         assert!(voting::is_resolved<GovernanceProposal>(@aptos_framework, 0), 2);
@@ -908,7 +909,14 @@ module aptos_framework::aptos_governance {
         assert!(!simple_map::contains_key(&approved_hashes, &0), 3);
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, yes_voter = @0x234, no_voter = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            yes_voter = @0x234,
+            no_voter = @345
+        )
+    ]
     public entry fun test_voting(
         aptos_framework: signer,
         proposer: signer,
@@ -918,7 +926,14 @@ module aptos_framework::aptos_governance {
         test_voting_generic(aptos_framework, proposer, yes_voter, no_voter, false, false);
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, yes_voter = @0x234, no_voter = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            yes_voter = @0x234,
+            no_voter = @345
+        )
+    ]
     public entry fun test_voting_multi_step(
         aptos_framework: signer,
         proposer: signer,
@@ -928,7 +943,14 @@ module aptos_framework::aptos_governance {
         test_voting_generic(aptos_framework, proposer, yes_voter, no_voter, true, true);
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, yes_voter = @0x234, no_voter = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            yes_voter = @0x234,
+            no_voter = @345
+        )
+    ]
     #[expected_failure(abort_code = 0x5000a, location = aptos_framework::voting)]
     public entry fun test_voting_multi_step_cannot_use_single_step_resolve(
         aptos_framework: signer,
@@ -939,7 +961,14 @@ module aptos_framework::aptos_governance {
         test_voting_generic(aptos_framework, proposer, yes_voter, no_voter, true, false);
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, yes_voter = @0x234, no_voter = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            yes_voter = @0x234,
+            no_voter = @345
+        )
+    ]
     public entry fun test_voting_single_step_can_use_generic_resolve_function(
         aptos_framework: signer,
         proposer: signer,
@@ -991,7 +1020,14 @@ module aptos_framework::aptos_governance {
         assert!(!simple_map::contains_key(&approved_hashes, &0), 1);
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, yes_voter = @0x234, no_voter = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            yes_voter = @0x234,
+            no_voter = @345
+        )
+    ]
     public entry fun test_can_remove_approved_hash_if_executed_directly_via_voting(
         aptos_framework: signer,
         proposer: signer,
@@ -1007,7 +1043,14 @@ module aptos_framework::aptos_governance {
         );
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, yes_voter = @0x234, no_voter = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            yes_voter = @0x234,
+            no_voter = @345
+        )
+    ]
     public entry fun test_can_remove_approved_hash_if_executed_directly_via_voting_multi_step(
         aptos_framework: signer,
         proposer: signer,
@@ -1023,7 +1066,14 @@ module aptos_framework::aptos_governance {
         );
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, voter_1 = @0x234, voter_2 = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            voter_1 = @0x234,
+            voter_2 = @345
+        )
+    ]
     #[expected_failure(abort_code = 0x10004, location = aptos_framework::voting)]
     public entry fun test_cannot_double_vote(
         aptos_framework: signer,
@@ -1046,7 +1096,14 @@ module aptos_framework::aptos_governance {
         vote(&voter_1, signer::address_of(&voter_1), 0, true);
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, voter_1 = @0x234, voter_2 = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            voter_1 = @0x234,
+            voter_2 = @345
+        )
+    ]
     #[expected_failure(abort_code = 0x10004, location = aptos_framework::voting)]
     public entry fun test_cannot_double_vote_with_different_voter_addresses(
         aptos_framework: signer,
@@ -1070,7 +1127,14 @@ module aptos_framework::aptos_governance {
         vote(&voter_2, signer::address_of(&voter_1), 0, true);
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, voter_1 = @0x234, voter_2 = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            voter_1 = @0x234,
+            voter_2 = @345
+        )
+    ]
     public entry fun test_stake_pool_can_vote_on_partial_voting_proposal_many_times(
         aptos_framework: signer,
         proposer: signer,
@@ -1097,7 +1161,14 @@ module aptos_framework::aptos_governance {
         test_resolving_proposal_generic(aptos_framework, true, execution_hash);
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, voter_1 = @0x234, voter_2 = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            voter_1 = @0x234,
+            voter_2 = @345
+        )
+    ]
     #[expected_failure(abort_code = 0x3, location = Self)]
     public entry fun test_stake_pool_can_vote_with_partial_voting_power(
         aptos_framework: signer,
@@ -1124,7 +1195,14 @@ module aptos_framework::aptos_governance {
         test_resolving_proposal_generic(aptos_framework, true, execution_hash);
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, voter_1 = @0x234, voter_2 = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            voter_1 = @0x234,
+            voter_2 = @345
+        )
+    ]
     public entry fun test_batch_vote(
         aptos_framework: signer,
         proposer: signer,
@@ -1147,7 +1225,14 @@ module aptos_framework::aptos_governance {
         test_resolving_proposal_generic(aptos_framework, true, execution_hash);
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, voter_1 = @0x234, voter_2 = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            voter_1 = @0x234,
+            voter_2 = @345
+        )
+    ]
     public entry fun test_batch_partial_vote(
         aptos_framework: signer,
         proposer: signer,
@@ -1170,7 +1255,14 @@ module aptos_framework::aptos_governance {
         test_resolving_proposal_generic(aptos_framework, true, execution_hash);
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, voter_1 = @0x234, voter_2 = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            voter_1 = @0x234,
+            voter_2 = @345
+        )
+    ]
     public entry fun test_stake_pool_can_vote_only_with_its_own_voting_power(
         aptos_framework: signer,
         proposer: signer,
@@ -1197,7 +1289,14 @@ module aptos_framework::aptos_governance {
         test_resolving_proposal_generic(aptos_framework, true, execution_hash);
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, voter_1 = @0x234, voter_2 = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            voter_1 = @0x234,
+            voter_2 = @345
+        )
+    ]
     public entry fun test_stake_pool_can_vote_before_and_after_partial_governance_voting_enabled(
         aptos_framework: signer,
         proposer: signer,
@@ -1219,7 +1318,9 @@ module aptos_framework::aptos_governance {
 
         initialize_partial_voting(&aptos_framework);
         features::change_feature_flags_for_testing(
-            &aptos_framework, vector[features::get_partial_governance_voting()], vector[]
+            &aptos_framework,
+            vector[features::get_partial_governance_voting()],
+            vector[],
         );
 
         coin::register<AptosCoin>(&voter_1);
@@ -1236,7 +1337,14 @@ module aptos_framework::aptos_governance {
         test_resolving_proposal_generic(aptos_framework, true, execution_hash);
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, voter_1 = @0x234, voter_2 = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            voter_1 = @0x234,
+            voter_2 = @345
+        )
+    ]
     public entry fun test_no_remaining_voting_power_about_proposal_expiration_time(
         aptos_framework: signer,
         proposer: signer,
@@ -1401,7 +1509,9 @@ module aptos_framework::aptos_governance {
     ) acquires GovernanceResponsbility {
         initialize_partial_voting(aptos_framework);
         features::change_feature_flags_for_testing(
-            aptos_framework, vector[features::get_partial_governance_voting()], vector[]
+            aptos_framework,
+            vector[features::get_partial_governance_voting()],
+            vector[],
         );
         setup_voting(aptos_framework, proposer, voter_1, voter_2);
     }
@@ -1429,7 +1539,14 @@ module aptos_framework::aptos_governance {
         update_governance_config(&account, 10, 20, 30);
     }
 
-    #[test(aptos_framework = @aptos_framework, proposer = @0x123, yes_voter = @0x234, no_voter = @345)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            proposer = @0x123,
+            yes_voter = @0x234,
+            no_voter = @345
+        )
+    ]
     public entry fun test_replace_execution_hash(
         aptos_framework: signer,
         proposer: signer,

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -179,11 +179,14 @@ module aptos_framework::aptos_governance {
         if (!exists<GovernanceResponsbility>(@aptos_framework)) {
             move_to(
                 aptos_framework,
-                GovernanceResponsbility { signer_caps: simple_map::create<address, SignerCapability>() }
+                GovernanceResponsbility {
+                    signer_caps: simple_map::create<address, SignerCapability>()
+                },
             );
         };
 
-        let signer_caps = &mut borrow_global_mut<GovernanceResponsbility>(@aptos_framework).signer_caps;
+        let signer_caps =
+            &mut borrow_global_mut<GovernanceResponsbility>(@aptos_framework).signer_caps;
         simple_map::add(signer_caps, signer_address, signer_cap);
     }
 
@@ -199,22 +202,31 @@ module aptos_framework::aptos_governance {
         system_addresses::assert_aptos_framework(aptos_framework);
 
         voting::register<GovernanceProposal>(aptos_framework);
-        move_to(aptos_framework, GovernanceConfig {
-            voting_duration_secs,
-            min_voting_threshold,
-            required_proposer_stake,
-        });
-        move_to(aptos_framework, GovernanceEvents {
-            create_proposal_events: account::new_event_handle<CreateProposalEvent>(aptos_framework),
-            update_config_events: account::new_event_handle<UpdateConfigEvent>(aptos_framework),
-            vote_events: account::new_event_handle<VoteEvent>(aptos_framework),
-        });
-        move_to(aptos_framework, VotingRecords {
-            votes: table::new(),
-        });
-        move_to(aptos_framework, ApprovedExecutionHashes {
-            hashes: simple_map::create<u64, vector<u8>>(),
-        })
+        move_to(
+            aptos_framework,
+            GovernanceConfig {
+                voting_duration_secs,
+                min_voting_threshold,
+                required_proposer_stake,
+            },
+        );
+        move_to(
+            aptos_framework,
+            GovernanceEvents {
+                create_proposal_events: account::new_event_handle<CreateProposalEvent>(
+                    aptos_framework
+                ),
+                update_config_events: account::new_event_handle<UpdateConfigEvent>(
+                    aptos_framework
+                ),
+                vote_events: account::new_event_handle<VoteEvent>(aptos_framework),
+            },
+        );
+        move_to(aptos_framework, VotingRecords { votes: table::new(), });
+        move_to(
+            aptos_framework,
+            ApprovedExecutionHashes { hashes: simple_map::create<u64, vector<u8>>(), },
+        )
     }
 
     /// Update the governance configurations. This can only be called as part of resolving a proposal in this same
@@ -254,14 +266,10 @@ module aptos_framework::aptos_governance {
 
     /// Initializes the state for Aptos Governance partial voting. Can only be called through Aptos governance
     /// proposals with a signer for the aptos_framework (0x1) account.
-    public fun initialize_partial_voting(
-        aptos_framework: &signer,
-    ) {
+    public fun initialize_partial_voting(aptos_framework: &signer,) {
         system_addresses::assert_aptos_framework(aptos_framework);
 
-        move_to(aptos_framework, VotingRecordsV2 {
-            votes: smart_table::new(),
-        });
+        move_to(aptos_framework, VotingRecordsV2 { votes: smart_table::new(), });
     }
 
     #[view]
@@ -282,10 +290,7 @@ module aptos_framework::aptos_governance {
     #[view]
     /// Return true if a stake pool has already voted on a proposal before partial governance voting is enabled.
     public fun has_entirely_voted(stake_pool: address, proposal_id: u64): bool acquires VotingRecords {
-        let record_key = RecordKey {
-            stake_pool,
-            proposal_id,
-        };
+        let record_key = RecordKey { stake_pool, proposal_id, };
         // If a stake pool has already voted on a proposal before partial governance voting is enabled,
         // there is a record in VotingRecords.
         let voting_records = borrow_global<VotingRecords>(@aptos_framework);
@@ -296,19 +301,19 @@ module aptos_framework::aptos_governance {
     /// Return remaining voting power of a stake pool on a proposal.
     /// Note: a stake pool's voting power on a proposal could increase over time(e.g. rewards/new stake).
     public fun get_remaining_voting_power(
-        stake_pool: address,
-        proposal_id: u64
+        stake_pool: address, proposal_id: u64
     ): u64 acquires VotingRecords, VotingRecordsV2 {
         assert_voting_initialization();
 
-        let proposal_expiration = voting::get_proposal_expiration_secs<GovernanceProposal>(
-            @aptos_framework,
-            proposal_id
-        );
+        let proposal_expiration =
+            voting::get_proposal_expiration_secs<GovernanceProposal>(
+                @aptos_framework, proposal_id
+            );
         let lockup_until = stake::get_lockup_secs(stake_pool);
         // The voter's stake needs to be locked up at least as long as the proposal's expiration.
         // Also no one can vote on a expired proposal.
-        if (proposal_expiration > lockup_until || timestamp::now_seconds() > proposal_expiration) {
+        if (proposal_expiration > lockup_until
+                || timestamp::now_seconds() > proposal_expiration) {
             return 0
         };
 
@@ -317,14 +322,13 @@ module aptos_framework::aptos_governance {
         if (has_entirely_voted(stake_pool, proposal_id)) {
             return 0
         };
-        let record_key = RecordKey {
-            stake_pool,
-            proposal_id,
-        };
+        let record_key = RecordKey { stake_pool, proposal_id, };
         let used_voting_power = 0u64;
         if (features::partial_governance_voting_enabled()) {
             let voting_records_v2 = borrow_global<VotingRecordsV2>(@aptos_framework);
-            used_voting_power = *smart_table::borrow_with_default(&voting_records_v2.votes, record_key, &0);
+            used_voting_power = *smart_table::borrow_with_default(
+                &voting_records_v2.votes, record_key, &0
+            );
         };
         get_voting_power(stake_pool) - used_voting_power
     }
@@ -339,7 +343,14 @@ module aptos_framework::aptos_governance {
         metadata_location: vector<u8>,
         metadata_hash: vector<u8>,
     ) acquires GovernanceConfig, GovernanceEvents {
-        create_proposal_v2(proposer, stake_pool, execution_hash, metadata_location, metadata_hash, false);
+        create_proposal_v2(
+            proposer,
+            stake_pool,
+            execution_hash,
+            metadata_location,
+            metadata_hash,
+            false,
+        );
     }
 
     /// Create a single-step or multi-step proposal with the backing `stake_pool`.
@@ -359,7 +370,7 @@ module aptos_framework::aptos_governance {
             execution_hash,
             metadata_location,
             metadata_hash,
-            is_multi_step_proposal
+            is_multi_step_proposal,
         );
     }
 
@@ -378,7 +389,7 @@ module aptos_framework::aptos_governance {
         let proposer_address = signer::address_of(proposer);
         assert!(
             stake::get_delegated_voter(stake_pool) == proposer_address,
-            error::invalid_argument(ENOT_DELEGATED_VOTER)
+            error::invalid_argument(ENOT_DELEGATED_VOTER),
         );
 
         // The proposer's stake needs to be at least the required bond amount.
@@ -412,17 +423,18 @@ module aptos_framework::aptos_governance {
             early_resolution_vote_threshold = option::some(total_supply / 2 + 1);
         };
 
-        let proposal_id = voting::create_proposal_v2(
-            proposer_address,
-            @aptos_framework,
-            governance_proposal::create_proposal(),
-            execution_hash,
-            governance_config.min_voting_threshold,
-            proposal_expiration,
-            early_resolution_vote_threshold,
-            proposal_metadata,
-            is_multi_step_proposal,
-        );
+        let proposal_id =
+            voting::create_proposal_v2(
+                proposer_address,
+                @aptos_framework,
+                governance_proposal::create_proposal(),
+                execution_hash,
+                governance_config.min_voting_threshold,
+                proposal_expiration,
+                early_resolution_vote_threshold,
+                proposal_metadata,
+                is_multi_step_proposal,
+            );
 
         if (std::features::module_event_migration_enabled()) {
             event::emit(
@@ -456,9 +468,12 @@ module aptos_framework::aptos_governance {
         proposal_id: u64,
         should_pass: bool,
     ) acquires ApprovedExecutionHashes, VotingRecords, VotingRecordsV2, GovernanceEvents {
-        vector::for_each(stake_pools, |stake_pool| {
-            vote_internal(voter, stake_pool, proposal_id, MAX_U64, should_pass);
-        });
+        vector::for_each(
+            stake_pools,
+            |stake_pool| {
+                vote_internal(voter, stake_pool, proposal_id, MAX_U64, should_pass);
+            },
+        );
     }
 
     /// Batch vote on proposal with proposal_id and specified voting power from multiple stake_pools.
@@ -469,9 +484,12 @@ module aptos_framework::aptos_governance {
         voting_power: u64,
         should_pass: bool,
     ) acquires ApprovedExecutionHashes, VotingRecords, VotingRecordsV2, GovernanceEvents {
-        vector::for_each(stake_pools, |stake_pool| {
-            vote_internal(voter, stake_pool, proposal_id, voting_power, should_pass);
-        });
+        vector::for_each(
+            stake_pools,
+            |stake_pool| {
+                vote_internal(voter, stake_pool, proposal_id, voting_power, should_pass);
+            },
+        );
     }
 
     /// Vote on proposal with `proposal_id` and all voting power from `stake_pool`.
@@ -507,13 +525,16 @@ module aptos_framework::aptos_governance {
         should_pass: bool,
     ) acquires ApprovedExecutionHashes, VotingRecords, VotingRecordsV2, GovernanceEvents {
         let voter_address = signer::address_of(voter);
-        assert!(stake::get_delegated_voter(stake_pool) == voter_address, error::invalid_argument(ENOT_DELEGATED_VOTER));
+        assert!(
+            stake::get_delegated_voter(stake_pool) == voter_address,
+            error::invalid_argument(ENOT_DELEGATED_VOTER),
+        );
 
         // The voter's stake needs to be locked up at least as long as the proposal's expiration.
-        let proposal_expiration = voting::get_proposal_expiration_secs<GovernanceProposal>(
-            @aptos_framework,
-            proposal_id
-        );
+        let proposal_expiration =
+            voting::get_proposal_expiration_secs<GovernanceProposal>(
+                @aptos_framework, proposal_id
+            );
         assert!(
             stake::get_lockup_secs(stake_pool) >= proposal_expiration,
             error::invalid_argument(EINSUFFICIENT_STAKE_LOCKUP),
@@ -521,7 +542,8 @@ module aptos_framework::aptos_governance {
 
         // If a stake pool has already voted on a proposal before partial governance voting is enabled,
         // `get_remaining_voting_power` returns 0.
-        let staking_pool_voting_power = get_remaining_voting_power(stake_pool, proposal_id);
+        let staking_pool_voting_power =
+            get_remaining_voting_power(stake_pool, proposal_id);
         voting_power = min(voting_power, staking_pool_voting_power);
 
         // Short-circuit if the voter has no voting power.
@@ -535,20 +557,21 @@ module aptos_framework::aptos_governance {
             should_pass,
         );
 
-        let record_key = RecordKey {
-            stake_pool,
-            proposal_id,
-        };
+        let record_key = RecordKey { stake_pool, proposal_id, };
         if (features::partial_governance_voting_enabled()) {
             let voting_records_v2 = borrow_global_mut<VotingRecordsV2>(@aptos_framework);
-            let used_voting_power = smart_table::borrow_mut_with_default(&mut voting_records_v2.votes, record_key, 0);
+            let used_voting_power =
+                smart_table::borrow_mut_with_default(
+                    &mut voting_records_v2.votes, record_key, 0
+                );
             // This calculation should never overflow because the used voting cannot exceed the total voting power of this stake pool.
             *used_voting_power = *used_voting_power + voting_power;
         } else {
             let voting_records = borrow_global_mut<VotingRecords>(@aptos_framework);
             assert!(
                 !table::contains(&voting_records.votes, record_key),
-                error::invalid_argument(EALREADY_VOTED));
+                error::invalid_argument(EALREADY_VOTED),
+            );
             table::add(&mut voting_records.votes, record_key, true);
         };
 
@@ -575,7 +598,8 @@ module aptos_framework::aptos_governance {
             },
         );
 
-        let proposal_state = voting::get_proposal_state<GovernanceProposal>(@aptos_framework, proposal_id);
+        let proposal_state =
+            voting::get_proposal_state<GovernanceProposal>(@aptos_framework, proposal_id);
         if (proposal_state == PROPOSAL_STATE_SUCCEEDED) {
             add_approved_script_hash(proposal_id);
         }
@@ -589,18 +613,25 @@ module aptos_framework::aptos_governance {
     /// This is needed to bypass the mempool transaction size limit for approved governance proposal transactions that
     /// are too large (e.g. module upgrades).
     public fun add_approved_script_hash(proposal_id: u64) acquires ApprovedExecutionHashes {
-        let approved_hashes = borrow_global_mut<ApprovedExecutionHashes>(@aptos_framework);
+        let approved_hashes =
+            borrow_global_mut<ApprovedExecutionHashes>(@aptos_framework);
 
         // Ensure the proposal can be resolved.
-        let proposal_state = voting::get_proposal_state<GovernanceProposal>(@aptos_framework, proposal_id);
-        assert!(proposal_state == PROPOSAL_STATE_SUCCEEDED, error::invalid_argument(EPROPOSAL_NOT_RESOLVABLE_YET));
+        let proposal_state =
+            voting::get_proposal_state<GovernanceProposal>(@aptos_framework, proposal_id);
+        assert!(
+            proposal_state == PROPOSAL_STATE_SUCCEEDED,
+            error::invalid_argument(EPROPOSAL_NOT_RESOLVABLE_YET),
+        );
 
-        let execution_hash = voting::get_execution_hash<GovernanceProposal>(@aptos_framework, proposal_id);
+        let execution_hash =
+            voting::get_execution_hash<GovernanceProposal>(@aptos_framework, proposal_id);
 
         // If this is a multi-step proposal, the proposal id will already exist in the ApprovedExecutionHashes map.
         // We will update execution hash in ApprovedExecutionHashes to be the next_execution_hash.
         if (simple_map::contains_key(&approved_hashes.hashes, &proposal_id)) {
-            let current_execution_hash = simple_map::borrow_mut(&mut approved_hashes.hashes, &proposal_id);
+            let current_execution_hash =
+                simple_map::borrow_mut(&mut approved_hashes.hashes, &proposal_id);
             *current_execution_hash = execution_hash;
         } else {
             simple_map::add(&mut approved_hashes.hashes, proposal_id, execution_hash);
@@ -610,8 +641,7 @@ module aptos_framework::aptos_governance {
     /// Resolve a successful single-step proposal. This would fail if the proposal is not successful (not enough votes or more no
     /// than yes).
     public fun resolve(
-        proposal_id: u64,
-        signer_address: address
+        proposal_id: u64, signer_address: address
     ): signer acquires ApprovedExecutionHashes, GovernanceResponsbility {
         voting::resolve<GovernanceProposal>(@aptos_framework, proposal_id);
         remove_approved_hash(proposal_id);
@@ -620,11 +650,11 @@ module aptos_framework::aptos_governance {
 
     /// Resolve a successful multi-step proposal. This would fail if the proposal is not successful.
     public fun resolve_multi_step_proposal(
-        proposal_id: u64,
-        signer_address: address,
-        next_execution_hash: vector<u8>
+        proposal_id: u64, signer_address: address, next_execution_hash: vector<u8>
     ): signer acquires GovernanceResponsbility, ApprovedExecutionHashes {
-        voting::resolve_proposal_v2<GovernanceProposal>(@aptos_framework, proposal_id, next_execution_hash);
+        voting::resolve_proposal_v2<GovernanceProposal>(
+            @aptos_framework, proposal_id, next_execution_hash
+        );
         // If the current step is the last step of this multi-step proposal,
         // we will remove the execution hash from the ApprovedExecutionHashes map.
         if (vector::length(&next_execution_hash) == 0) {
@@ -645,7 +675,8 @@ module aptos_framework::aptos_governance {
             error::invalid_argument(EPROPOSAL_NOT_RESOLVED_YET),
         );
 
-        let approved_hashes = &mut borrow_global_mut<ApprovedExecutionHashes>(@aptos_framework).hashes;
+        let approved_hashes =
+            &mut borrow_global_mut<ApprovedExecutionHashes>(@aptos_framework).hashes;
         if (simple_map::contains_key(approved_hashes, &proposal_id)) {
             simple_map::remove(approved_hashes, &proposal_id);
         };
@@ -689,7 +720,9 @@ module aptos_framework::aptos_governance {
     }
 
     /// Update feature flags and also trigger reconfiguration.
-    public fun toggle_features(aptos_framework: &signer, enable: vector<u64>, disable: vector<u64>) {
+    public fun toggle_features(
+        aptos_framework: &signer, enable: vector<u64>, disable: vector<u64>
+    ) {
         system_addresses::assert_aptos_framework(aptos_framework);
         features::change_feature_flags_for_next_epoch(aptos_framework, enable, disable);
         reconfigure(aptos_framework);
@@ -697,19 +730,25 @@ module aptos_framework::aptos_governance {
 
     /// Only called in testnet where the core resources account exists and has been granted power to mint Aptos coins.
     public fun get_signer_testnet_only(
-        core_resources: &signer, signer_address: address): signer acquires GovernanceResponsbility {
+        core_resources: &signer, signer_address: address
+    ): signer acquires GovernanceResponsbility {
         system_addresses::assert_core_resource(core_resources);
         // Core resources account only has mint capability in tests/testnets.
-        assert!(aptos_coin::has_mint_capability(core_resources), error::unauthenticated(EUNAUTHORIZED));
+        assert!(
+            aptos_coin::has_mint_capability(core_resources),
+            error::unauthenticated(EUNAUTHORIZED),
+        );
         get_signer(signer_address)
     }
 
     #[view]
     /// Return the voting power a stake pool has with respect to governance proposals.
     public fun get_voting_power(pool_address: address): u64 {
-        let allow_validator_set_change = staking_config::get_allow_validator_set_change(&staking_config::get());
+        let allow_validator_set_change =
+            staking_config::get_allow_validator_set_change(&staking_config::get());
         if (allow_validator_set_change) {
-            let (active, _, pending_active, pending_inactive) = stake::get_stake(pool_address);
+            let (active, _, pending_active, pending_inactive) =
+                stake::get_stake(pool_address);
             // We calculate the voting power as total non-inactive stakes of the pool. Even if the validator is not in the
             // active validator set, as long as they have a lockup (separately checked in create_proposal and voting), their
             // stake would still count in their voting power for governance proposals.
@@ -721,17 +760,24 @@ module aptos_framework::aptos_governance {
 
     /// Return a signer for making changes to 0x1 as part of on-chain governance proposal process.
     fun get_signer(signer_address: address): signer acquires GovernanceResponsbility {
-        let governance_responsibility = borrow_global<GovernanceResponsbility>(@aptos_framework);
-        let signer_cap = simple_map::borrow(&governance_responsibility.signer_caps, &signer_address);
+        let governance_responsibility =
+            borrow_global<GovernanceResponsbility>(@aptos_framework);
+        let signer_cap =
+            simple_map::borrow(&governance_responsibility.signer_caps, &signer_address);
         create_signer_with_capability(signer_cap)
     }
 
     fun create_proposal_metadata(
-        metadata_location: vector<u8>,
-        metadata_hash: vector<u8>
+        metadata_location: vector<u8>, metadata_hash: vector<u8>
     ): SimpleMap<String, vector<u8>> {
-        assert!(string::length(&utf8(metadata_location)) <= 256, error::invalid_argument(EMETADATA_LOCATION_TOO_LONG));
-        assert!(string::length(&utf8(metadata_hash)) <= 256, error::invalid_argument(EMETADATA_HASH_TOO_LONG));
+        assert!(
+            string::length(&utf8(metadata_location)) <= 256,
+            error::invalid_argument(EMETADATA_LOCATION_TOO_LONG),
+        );
+        assert!(
+            string::length(&utf8(metadata_hash)) <= 256,
+            error::invalid_argument(EMETADATA_HASH_TOO_LONG),
+        );
 
         let metadata = simple_map::create<String, vector<u8>>();
         simple_map::add(&mut metadata, utf8(METADATA_LOCATION_KEY), metadata_location);
@@ -741,14 +787,16 @@ module aptos_framework::aptos_governance {
 
     fun assert_voting_initialization() {
         if (features::partial_governance_voting_enabled()) {
-            assert!(exists<VotingRecordsV2>(@aptos_framework), error::invalid_state(EPARTIAL_VOTING_NOT_INITIALIZED));
+            assert!(
+                exists<VotingRecordsV2>(@aptos_framework),
+                error::invalid_state(EPARTIAL_VOTING_NOT_INITIALIZED),
+            );
         };
     }
 
     #[test_only]
     public entry fun create_proposal_for_test(
-        proposer: &signer,
-        multi_step: bool,
+        proposer: &signer, multi_step: bool,
     ) acquires GovernanceConfig, GovernanceEvents {
         let execution_hash = vector::empty<u8>();
         vector::push_back(&mut execution_hash, 1);
@@ -784,7 +832,9 @@ module aptos_framework::aptos_governance {
             vector::push_back(&mut execution_hash, 1);
 
             if (finish_multi_step_execution) {
-                resolve_multi_step_proposal(proposal_id, signer_address, vector::empty<u8>())
+                resolve_multi_step_proposal(
+                    proposal_id, signer_address, vector::empty<u8>()
+                )
             } else {
                 resolve_multi_step_proposal(proposal_id, signer_address, execution_hash)
             }
@@ -795,7 +845,9 @@ module aptos_framework::aptos_governance {
 
     #[test_only]
     /// Force reconfigure. To be called at the end of a proposal that alters on-chain configs.
-    public fun toggle_features_for_test(enable: vector<u64>, disable: vector<u64>) {
+    public fun toggle_features_for_test(
+        enable: vector<u64>, disable: vector<u64>
+    ) {
         toggle_features(&account::create_signer_for_test(@0x1), enable, disable);
     }
 
@@ -818,7 +870,9 @@ module aptos_framework::aptos_governance {
         vote(&yes_voter, signer::address_of(&yes_voter), 0, true);
         vote(&no_voter, signer::address_of(&no_voter), 0, false);
 
-        test_resolving_proposal_generic(aptos_framework, use_generic_resolve_function, execution_hash);
+        test_resolving_proposal_generic(
+            aptos_framework, use_generic_resolve_function, execution_hash
+        );
     }
 
     #[test_only]
@@ -830,19 +884,27 @@ module aptos_framework::aptos_governance {
         // Once expiration time has passed, the proposal should be considered resolve now as there are more yes votes
         // than no.
         timestamp::update_global_time_for_test(100001000000);
-        let proposal_state = voting::get_proposal_state<GovernanceProposal>(signer::address_of(&aptos_framework), 0);
+        let proposal_state =
+            voting::get_proposal_state<GovernanceProposal>(
+                signer::address_of(&aptos_framework), 0
+            );
         assert!(proposal_state == PROPOSAL_STATE_SUCCEEDED, proposal_state);
 
         // Add approved script hash.
         add_approved_script_hash(0);
-        let approved_hashes = borrow_global<ApprovedExecutionHashes>(@aptos_framework).hashes;
+        let approved_hashes =
+            borrow_global<ApprovedExecutionHashes>(@aptos_framework).hashes;
         assert!(*simple_map::borrow(&approved_hashes, &0) == execution_hash, 0);
 
         // Resolve the proposal.
-        let account = resolve_proposal_for_test(0, @aptos_framework, use_generic_resolve_function, true);
+        let account =
+            resolve_proposal_for_test(
+                0, @aptos_framework, use_generic_resolve_function, true
+            );
         assert!(signer::address_of(&account) == @aptos_framework, 1);
         assert!(voting::is_resolved<GovernanceProposal>(@aptos_framework, 0), 2);
-        let approved_hashes = borrow_global<ApprovedExecutionHashes>(@aptos_framework).hashes;
+        let approved_hashes =
+            borrow_global<ApprovedExecutionHashes>(@aptos_framework).hashes;
         assert!(!simple_map::contains_key(&approved_hashes, &0), 3);
     }
 
@@ -910,7 +972,9 @@ module aptos_framework::aptos_governance {
             let execution_hash = vector::empty<u8>();
             let next_execution_hash = vector::empty<u8>();
             vector::push_back(&mut execution_hash, 1);
-            voting::resolve_proposal_v2<GovernanceProposal>(@aptos_framework, 0, next_execution_hash);
+            voting::resolve_proposal_v2<GovernanceProposal>(
+                @aptos_framework, 0, next_execution_hash
+            );
             assert!(voting::is_resolved<GovernanceProposal>(@aptos_framework, 0), 0);
             if (vector::length(&next_execution_hash) == 0) {
                 remove_approved_hash(0);
@@ -922,7 +986,8 @@ module aptos_framework::aptos_governance {
             assert!(voting::is_resolved<GovernanceProposal>(@aptos_framework, 0), 0);
             remove_approved_hash(0);
         };
-        let approved_hashes = borrow_global<ApprovedExecutionHashes>(@aptos_framework).hashes;
+        let approved_hashes =
+            borrow_global<ApprovedExecutionHashes>(@aptos_framework).hashes;
         assert!(!simple_map::contains_key(&approved_hashes, &0), 1);
     }
 
@@ -938,7 +1003,7 @@ module aptos_framework::aptos_governance {
             proposer,
             yes_voter,
             no_voter,
-            false
+            false,
         );
     }
 
@@ -954,7 +1019,7 @@ module aptos_framework::aptos_governance {
             proposer,
             yes_voter,
             no_voter,
-            true
+            true,
         );
     }
 
@@ -1066,7 +1131,11 @@ module aptos_framework::aptos_governance {
         voter_1: signer,
         voter_2: signer,
     ) acquires ApprovedExecutionHashes, GovernanceConfig, GovernanceResponsbility, VotingRecords, VotingRecordsV2, GovernanceEvents {
-        features::change_feature_flags_for_testing(&aptos_framework, vector[features::get_coin_to_fungible_asset_migration_feature()], vector[]);
+        features::change_feature_flags_for_testing(
+            &aptos_framework,
+            vector[features::get_coin_to_fungible_asset_migration_feature()],
+            vector[],
+        );
         setup_partial_voting(&aptos_framework, &proposer, &voter_1, &voter_2);
         let execution_hash = vector::empty<u8>();
         vector::push_back(&mut execution_hash, 1);
@@ -1085,7 +1154,11 @@ module aptos_framework::aptos_governance {
         voter_1: signer,
         voter_2: signer,
     ) acquires ApprovedExecutionHashes, GovernanceConfig, GovernanceResponsbility, VotingRecords, VotingRecordsV2, GovernanceEvents {
-        features::change_feature_flags_for_testing(&aptos_framework, vector[features::get_coin_to_fungible_asset_migration_feature()], vector[]);
+        features::change_feature_flags_for_testing(
+            &aptos_framework,
+            vector[features::get_coin_to_fungible_asset_migration_feature()],
+            vector[],
+        );
         setup_partial_voting(&aptos_framework, &proposer, &voter_1, &voter_2);
         let execution_hash = vector::empty<u8>();
         vector::push_back(&mut execution_hash, 1);
@@ -1145,7 +1218,9 @@ module aptos_framework::aptos_governance {
         assert!(get_remaining_voting_power(voter_2_addr, 0) == 10, 2);
 
         initialize_partial_voting(&aptos_framework);
-        features::change_feature_flags_for_testing(&aptos_framework, vector[features::get_partial_governance_voting()], vector[]);
+        features::change_feature_flags_for_testing(
+            &aptos_framework, vector[features::get_partial_governance_voting()], vector[]
+        );
 
         coin::register<AptosCoin>(&voter_1);
         coin::register<AptosCoin>(&voter_2);
@@ -1168,7 +1243,9 @@ module aptos_framework::aptos_governance {
         voter_1: signer,
         voter_2: signer,
     ) acquires GovernanceConfig, GovernanceResponsbility, VotingRecords, VotingRecordsV2, GovernanceEvents {
-        setup_voting_with_initialized_stake(&aptos_framework, &proposer, &voter_1, &voter_2);
+        setup_voting_with_initialized_stake(
+            &aptos_framework, &proposer, &voter_1, &voter_2
+        );
         let execution_hash = vector::empty<u8>();
         vector::push_back(&mut execution_hash, 1);
         let proposer_addr = signer::address_of(&proposer);
@@ -1214,7 +1291,9 @@ module aptos_framework::aptos_governance {
         account::create_account_for_test(signer::address_of(no_voter));
 
         // Initialize the governance.
-        staking_config::initialize_for_test(aptos_framework, 0, 1000, 2000, true, 0, 1, 100);
+        staking_config::initialize_for_test(
+            aptos_framework, 0, 1000, 2000, true, 0, 1, 100
+        );
         initialize(aptos_framework, 10, 100, 1000);
         store_signer_cap(
             aptos_framework,
@@ -1242,9 +1321,24 @@ module aptos_framework::aptos_governance {
         coin::deposit(signer::address_of(yes_voter), coin::mint(20, &mint_cap));
         coin::register<AptosCoin>(no_voter);
         coin::deposit(signer::address_of(no_voter), coin::mint(10, &mint_cap));
-        stake::create_stake_pool(proposer, coin::mint(50, &mint_cap), coin::mint(50, &mint_cap), 10000);
-        stake::create_stake_pool(yes_voter, coin::mint(10, &mint_cap), coin::mint(10, &mint_cap), 10000);
-        stake::create_stake_pool(no_voter, coin::mint(5, &mint_cap), coin::mint(5, &mint_cap), 10000);
+        stake::create_stake_pool(
+            proposer,
+            coin::mint(50, &mint_cap),
+            coin::mint(50, &mint_cap),
+            10000,
+        );
+        stake::create_stake_pool(
+            yes_voter,
+            coin::mint(10, &mint_cap),
+            coin::mint(10, &mint_cap),
+            10000,
+        );
+        stake::create_stake_pool(
+            no_voter,
+            coin::mint(5, &mint_cap),
+            coin::mint(5, &mint_cap),
+            10000,
+        );
         coin::destroy_mint_cap<AptosCoin>(mint_cap);
         coin::destroy_burn_cap<AptosCoin>(burn_cap);
     }
@@ -1267,7 +1361,9 @@ module aptos_framework::aptos_governance {
         account::create_account_for_test(signer::address_of(no_voter));
 
         // Initialize the governance.
-        stake::initialize_for_test_custom(aptos_framework, 0, 1000, 2000, true, 0, 1, 1000);
+        stake::initialize_for_test_custom(
+            aptos_framework, 0, 1000, 2000, true, 0, 1, 1000
+        );
         initialize(aptos_framework, 10, 100, 1000);
         store_signer_cap(
             aptos_framework,
@@ -1304,7 +1400,9 @@ module aptos_framework::aptos_governance {
         voter_2: &signer,
     ) acquires GovernanceResponsbility {
         initialize_partial_voting(aptos_framework);
-        features::change_feature_flags_for_testing(aptos_framework, vector[features::get_partial_governance_voting()], vector[]);
+        features::change_feature_flags_for_testing(
+            aptos_framework, vector[features::get_partial_governance_voting()], vector[]
+        );
         setup_voting(aptos_framework, proposer, voter_1, voter_2);
     }
 
@@ -1325,7 +1423,8 @@ module aptos_framework::aptos_governance {
     #[test(account = @0x123)]
     #[expected_failure(abort_code = 0x50003, location = aptos_framework::system_addresses)]
     public entry fun test_update_governance_config_unauthorized_should_fail(
-        account: signer) acquires GovernanceConfig, GovernanceEvents {
+        account: signer
+    ) acquires GovernanceConfig, GovernanceEvents {
         initialize(&account, 1, 2, 3);
         update_governance_config(&account, 10, 20, 30);
     }
@@ -1353,7 +1452,9 @@ module aptos_framework::aptos_governance {
         vector::push_back(&mut execution_hash, 1);
         vector::push_back(&mut next_execution_hash, 10);
 
-        voting::resolve_proposal_v2<GovernanceProposal>(@aptos_framework, 0, next_execution_hash);
+        voting::resolve_proposal_v2<GovernanceProposal>(
+            @aptos_framework, 0, next_execution_hash
+        );
 
         if (vector::length(&next_execution_hash) == 0) {
             remove_approved_hash(0);
@@ -1361,8 +1462,9 @@ module aptos_framework::aptos_governance {
             add_approved_script_hash(0)
         };
 
-        let approved_hashes = borrow_global<ApprovedExecutionHashes>(@aptos_framework).hashes;
-        assert!(*simple_map::borrow(&approved_hashes, &0) == vector[10u8, ], 1);
+        let approved_hashes =
+            borrow_global<ApprovedExecutionHashes>(@aptos_framework).hashes;
+        assert!(*simple_map::borrow(&approved_hashes, &0) == vector[10u8,], 1);
     }
 
     #[test_only]
@@ -1372,7 +1474,12 @@ module aptos_framework::aptos_governance {
         required_proposer_stake: u64,
         voting_duration_secs: u64,
     ) {
-        initialize(aptos_framework, min_voting_threshold, required_proposer_stake, voting_duration_secs);
+        initialize(
+            aptos_framework,
+            min_voting_threshold,
+            required_proposer_stake,
+            voting_duration_secs,
+        );
     }
 
     #[verify_only]
@@ -1382,6 +1489,11 @@ module aptos_framework::aptos_governance {
         required_proposer_stake: u64,
         voting_duration_secs: u64,
     ) {
-        initialize(aptos_framework, min_voting_threshold, required_proposer_stake, voting_duration_secs);
+        initialize(
+            aptos_framework,
+            min_voting_threshold,
+            required_proposer_stake,
+            voting_duration_secs,
+        );
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.spec.move
@@ -377,8 +377,8 @@ spec aptos_framework::aptos_governance {
         let spec_voting_power = spec_get_voting_power(stake_pool, staking_config);
         let voting_records_v2 = borrow_global<VotingRecordsV2>(@aptos_framework);
         let used_voting_power = if (smart_table::spec_contains(
-                voting_records_v2.votes, record_key
-            )) {
+            voting_records_v2.votes, record_key
+        )) {
             smart_table::spec_get(voting_records_v2.votes, record_key)
         } else { 0 };
         aborts_if !remain_zero_1_cond
@@ -567,20 +567,20 @@ spec aptos_framework::aptos_governance {
         aborts_if timestamp::now_seconds() <= proposal.expiration_secs
             && (
                 option::spec_is_none(proposal.early_resolution_vote_threshold)
-                || proposal.yes_votes < early_resolution_threshold
-                && proposal.no_votes < early_resolution_threshold
+                    || proposal.yes_votes < early_resolution_threshold
+                        && proposal.no_votes < early_resolution_threshold
             );
         aborts_if (
-                timestamp::now_seconds() > proposal.expiration_secs
+            timestamp::now_seconds() > proposal.expiration_secs
                 || option::spec_is_some(proposal.early_resolution_vote_threshold)
-                && (
-                    proposal.yes_votes >= early_resolution_threshold
-                    || proposal.no_votes >= early_resolution_threshold
-                )
-            )
+                    && (
+                        proposal.yes_votes >= early_resolution_threshold
+                            || proposal.no_votes >= early_resolution_threshold
+                    )
+        )
             && (
                 proposal.yes_votes <= proposal.no_votes
-                || proposal.yes_votes + proposal.no_votes < proposal.min_vote_threshold
+                    || proposal.yes_votes + proposal.no_votes < proposal.min_vote_threshold
             );
 
         let post post_approved_hashes = global<ApprovedExecutionHashes>(@aptos_framework);
@@ -718,7 +718,7 @@ spec aptos_framework::aptos_governance {
             stake_pool_res.active.value + stake_pool_res.pending_active.value
                 + stake_pool_res.pending_inactive.value
         } else if (!allow_validator_set_change
-                && (stake::spec_is_current_epoch_validator(pool_address))) {
+            && (stake::spec_is_current_epoch_validator(pool_address))) {
             stake_pool_res.active.value + stake_pool_res.pending_inactive.value
         } else { 0 }
     }
@@ -749,8 +749,8 @@ spec aptos_framework::aptos_governance {
         let voting_power = spec_get_voting_power(stake_pool, staking_config);
         let voting_records_v2 = borrow_global<VotingRecordsV2>(@aptos_framework);
         let used_voting_power = if (smart_table::spec_contains(
-                voting_records_v2.votes, record_key
-            )) {
+            voting_records_v2.votes, record_key
+        )) {
             smart_table::spec_get(voting_records_v2.votes, record_key)
         } else { 0 };
         aborts_if !remain_zero_1_cond

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.spec.move
@@ -33,16 +33,16 @@ spec aptos_framework::aptos_governance {
     }
 
     spec store_signer_cap(
-        aptos_framework: &signer,
-        signer_address: address,
-        signer_cap: SignerCapability,
+        aptos_framework: &signer, signer_address: address, signer_cap: SignerCapability,
     ) {
-        aborts_if !system_addresses::is_aptos_framework_address(signer::address_of(aptos_framework));
+        aborts_if !system_addresses::is_aptos_framework_address(
+            signer::address_of(aptos_framework)
+        );
         aborts_if !system_addresses::is_framework_reserved_address(signer_address);
 
         let signer_caps = global<GovernanceResponsbility>(@aptos_framework).signer_caps;
-        aborts_if exists<GovernanceResponsbility>(@aptos_framework) &&
-            simple_map::spec_contains_key(signer_caps, signer_address);
+        aborts_if exists<GovernanceResponsbility>(@aptos_framework)
+            && simple_map::spec_contains_key(signer_caps, signer_address);
         ensures exists<GovernanceResponsbility>(@aptos_framework);
         let post post_signer_caps = global<GovernanceResponsbility>(@aptos_framework).signer_caps;
         ensures simple_map::spec_contains_key(post_signer_caps, signer_address);
@@ -80,9 +80,7 @@ spec aptos_framework::aptos_governance {
 
     /// Signer address must be @aptos_framework.
     /// Abort if structs have already been created.
-    spec initialize_partial_voting(
-        aptos_framework: &signer,
-    ) {
+    spec initialize_partial_voting(aptos_framework: &signer,) {
         let addr = signer::address_of(aptos_framework);
         aborts_if addr != @aptos_framework;
         aborts_if exists<VotingRecordsV2>(@aptos_framework);
@@ -98,7 +96,9 @@ spec aptos_framework::aptos_governance {
         let addr = signer::address_of(aptos_framework);
         let account = global<account::Account>(addr);
         aborts_if addr != @aptos_framework;
-        aborts_if exists<voting::VotingForum<governance_proposal::GovernanceProposal>>(addr);
+        aborts_if exists<voting::VotingForum<governance_proposal::GovernanceProposal>>(
+            addr
+        );
         aborts_if exists<GovernanceConfig>(addr);
         aborts_if exists<GovernanceEvents>(addr);
         aborts_if exists<VotingRecords>(addr);
@@ -130,11 +130,7 @@ spec aptos_framework::aptos_governance {
 
     /// Signer address must be @aptos_framework.
     /// Address @aptos_framework must exist GovernanceConfig and GovernanceEvents.
-    spec toggle_features(
-        aptos_framework: &signer,
-        enable: vector<u64>,
-        disable: vector<u64>,
-    ) {
+    spec toggle_features(aptos_framework: &signer, enable: vector<u64>, disable: vector<u64>,) {
         use aptos_framework::chain_status;
         use aptos_framework::coin::CoinInfo;
         use aptos_framework::aptos_coin::AptosCoin;
@@ -142,9 +138,7 @@ spec aptos_framework::aptos_governance {
         pragma verify = false; // TODO: set because of timeout (property proved).
         let addr = signer::address_of(aptos_framework);
         aborts_if addr != @aptos_framework;
-        include reconfiguration_with_dkg::FinishRequirement {
-            framework: aptos_framework
-        };
+        include reconfiguration_with_dkg::FinishRequirement { framework: aptos_framework };
         include stake::GetReconfigStartTimeRequirement;
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
         requires chain_status::is_operating();
@@ -202,7 +196,7 @@ spec aptos_framework::aptos_governance {
         include CreateProposalAbortsIf;
     }
 
-    spec create_proposal_v2_impl (
+    spec create_proposal_v2_impl(
         proposer: &signer,
         stake_pool: address,
         execution_hash: vector<u8>,
@@ -237,16 +231,22 @@ spec aptos_framework::aptos_governance {
         let allow_validator_set_change = staking_config.allow_validator_set_change;
         let stake_pool_res = global<stake::StakePool>(stake_pool);
         // Three results of get_voting_power(stake_pool)
-        let stake_balance_0 = stake_pool_res.active.value + stake_pool_res.pending_active.value + stake_pool_res.pending_inactive.value;
-        let stake_balance_1 = stake_pool_res.active.value + stake_pool_res.pending_inactive.value;
+        let stake_balance_0 = stake_pool_res.active.value
+            + stake_pool_res.pending_active.value + stake_pool_res.pending_inactive.value;
+        let stake_balance_1 = stake_pool_res.active.value
+            + stake_pool_res.pending_inactive.value;
         let stake_balance_2 = 0;
         let governance_config = global<GovernanceConfig>(@aptos_framework);
         let required_proposer_stake = governance_config.required_proposer_stake;
         /// [high-level-req-2]
         // Comparison of the three results of get_voting_power(stake_pool) and required_proposer_stake
         aborts_if allow_validator_set_change && stake_balance_0 < required_proposer_stake;
-        aborts_if !allow_validator_set_change && stake::spec_is_current_epoch_validator(stake_pool) && stake_balance_1 < required_proposer_stake;
-        aborts_if !allow_validator_set_change && !stake::spec_is_current_epoch_validator(stake_pool) && stake_balance_2 < required_proposer_stake;
+        aborts_if !allow_validator_set_change
+            && stake::spec_is_current_epoch_validator(stake_pool)
+            && stake_balance_1 < required_proposer_stake;
+        aborts_if !allow_validator_set_change
+            && !stake::spec_is_current_epoch_validator(stake_pool)
+            && stake_balance_2 < required_proposer_stake;
 
         aborts_if !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
         let current_time = timestamp::spec_now_seconds();
@@ -260,22 +260,32 @@ spec aptos_framework::aptos_governance {
         aborts_if !exists<coin::CoinInfo<AptosCoin>>(addr);
         let maybe_supply = global<coin::CoinInfo<AptosCoin>>(addr).supply;
         let supply = option::spec_borrow(maybe_supply);
-        let total_supply = aptos_framework::optional_aggregator::optional_aggregator_value(supply);
+        let total_supply = aptos_framework::optional_aggregator::optional_aggregator_value(
+            supply
+        );
         let early_resolution_vote_threshold_value = total_supply / 2 + 1;
 
         // verify voting::create_proposal_v2
-        aborts_if option::spec_is_some(maybe_supply) && governance_config.min_voting_threshold > early_resolution_vote_threshold_value;
+        aborts_if option::spec_is_some(maybe_supply)
+            && governance_config.min_voting_threshold
+                > early_resolution_vote_threshold_value;
         aborts_if len(execution_hash) == 0;
         aborts_if !exists<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
-        let voting_forum = global<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
+        let voting_forum = global<voting::VotingForum<GovernanceProposal>>(
+            @aptos_framework
+        );
         let proposal_id = voting_forum.next_proposal_id;
         aborts_if proposal_id + 1 > MAX_U64;
-        let post post_voting_forum = global<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
+        let post post_voting_forum = global<voting::VotingForum<GovernanceProposal>>(
+            @aptos_framework
+        );
         let post post_next_proposal_id = post_voting_forum.next_proposal_id;
         ensures post_next_proposal_id == proposal_id + 1;
         aborts_if !string::spec_internal_check_utf8(voting::IS_MULTI_STEP_PROPOSAL_KEY);
-        aborts_if !string::spec_internal_check_utf8(voting::IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
-        aborts_if table::spec_contains(voting_forum.proposals,proposal_id);
+        aborts_if !string::spec_internal_check_utf8(
+            voting::IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY
+        );
+        aborts_if table::spec_contains(voting_forum.proposals, proposal_id);
         ensures table::spec_contains(post_voting_forum.proposals, proposal_id);
         aborts_if !exists<GovernanceEvents>(@aptos_framework);
     }
@@ -293,26 +303,21 @@ spec aptos_framework::aptos_governance {
     /// stake_pool must exist StakePool.
     /// The delegated voter under the resource StakePool of the stake_pool must be the voter address.
     /// Address @aptos_framework must exist VotingRecords and GovernanceProposal.
-    spec vote (
-        voter: &signer,
-        stake_pool: address,
-        proposal_id: u64,
-        should_pass: bool,
+    spec vote(
+        voter: &signer, stake_pool: address, proposal_id: u64, should_pass: bool,
     ) {
         use aptos_framework::chain_status;
         pragma verify_duration_estimate = 60;
 
         requires chain_status::is_operating();
-        include VoteAbortIf  {
-            voting_power: MAX_U64
-        };
+        include VoteAbortIf { voting_power: MAX_U64 };
     }
 
     /// stake_pool must exist StakePool.
     /// The delegated voter under the resource StakePool of the stake_pool must be the voter address.
     /// Address @aptos_framework must exist VotingRecords and GovernanceProposal.
     /// Address @aptos_framework must exist VotingRecordsV2 if partial_governance_voting flag is enabled.
-    spec partial_vote (
+    spec partial_vote(
         voter: &signer,
         stake_pool: address,
         proposal_id: u64,
@@ -330,7 +335,7 @@ spec aptos_framework::aptos_governance {
     /// The delegated voter under the resource StakePool of the stake_pool must be the voter address.
     /// Address @aptos_framework must exist VotingRecords and GovernanceProposal.
     /// Address @aptos_framework must exist VotingRecordsV2 if partial_governance_voting flag is enabled.
-    spec vote_internal (
+    spec vote_internal(
         voter: &signer,
         stake_pool: address,
         proposal_id: u64,
@@ -353,46 +358,53 @@ spec aptos_framework::aptos_governance {
 
         include VotingGetDelegatedVoterAbortsIf { sign: voter };
 
-        aborts_if spec_proposal_expiration <= locked_until && !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
-        let spec_proposal_expiration = voting::spec_get_proposal_expiration_secs<GovernanceProposal>(@aptos_framework, proposal_id);
+        aborts_if spec_proposal_expiration <= locked_until
+            && !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
+        let spec_proposal_expiration = voting::spec_get_proposal_expiration_secs<
+            GovernanceProposal>(@aptos_framework, proposal_id);
         let locked_until = global<stake::StakePool>(stake_pool).locked_until_secs;
-        let remain_zero_1_cond = (spec_proposal_expiration > locked_until || timestamp::spec_now_seconds() > spec_proposal_expiration);
-        let record_key = RecordKey {
-            stake_pool,
-            proposal_id,
-        };
+        let remain_zero_1_cond = (
+            spec_proposal_expiration > locked_until
+                || timestamp::spec_now_seconds() > spec_proposal_expiration
+        );
+        let record_key = RecordKey { stake_pool, proposal_id, };
         let entirely_voted = spec_has_entirely_voted(stake_pool, proposal_id, record_key);
         aborts_if !remain_zero_1_cond && !exists<VotingRecords>(@aptos_framework);
-        include !remain_zero_1_cond && !entirely_voted ==> GetVotingPowerAbortsIf {
-            pool_address: stake_pool
-        };
+        include !remain_zero_1_cond && !entirely_voted ==>
+            GetVotingPowerAbortsIf { pool_address: stake_pool };
 
         let staking_config = global<staking_config::StakingConfig>(@aptos_framework);
         let spec_voting_power = spec_get_voting_power(stake_pool, staking_config);
         let voting_records_v2 = borrow_global<VotingRecordsV2>(@aptos_framework);
-        let used_voting_power = if (smart_table::spec_contains(voting_records_v2.votes, record_key)) {
+        let used_voting_power = if (smart_table::spec_contains(
+                voting_records_v2.votes, record_key
+            )) {
             smart_table::spec_get(voting_records_v2.votes, record_key)
-        } else {
-            0
-        };
-        aborts_if !remain_zero_1_cond && !entirely_voted && features::spec_partial_governance_voting_enabled() &&
-            used_voting_power > 0 && spec_voting_power < used_voting_power;
+        } else { 0 };
+        aborts_if !remain_zero_1_cond
+            && !entirely_voted
+            && features::spec_partial_governance_voting_enabled()
+            && used_voting_power > 0
+            && spec_voting_power < used_voting_power;
 
         let remaining_power = spec_get_remaining_voting_power(stake_pool, proposal_id);
-        let real_voting_power =  min(voting_power, remaining_power);
+        let real_voting_power = min(voting_power, remaining_power);
         aborts_if !(real_voting_power > 0);
 
         aborts_if !exists<VotingRecords>(@aptos_framework);
         let voting_records = global<VotingRecords>(@aptos_framework);
 
-
         // verify get_voting_power(stake_pool)
-        let allow_validator_set_change = global<staking_config::StakingConfig>(@aptos_framework).allow_validator_set_change;
+        let allow_validator_set_change = global<staking_config::StakingConfig>(
+            @aptos_framework
+        ).allow_validator_set_change;
         let stake_pool_res = global<stake::StakePool>(stake_pool);
         // Two results of get_voting_power(stake_pool) and the third one is zero.
 
         aborts_if !exists<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
-        let voting_forum = global<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
+        let voting_forum = global<voting::VotingForum<GovernanceProposal>>(
+            @aptos_framework
+        );
         let proposal = table::spec_get(voting_forum.proposals, proposal_id);
         aborts_if !table::spec_contains(voting_forum.proposals, proposal_id);
         let proposal_expiration = proposal.expiration_secs;
@@ -402,89 +414,127 @@ spec aptos_framework::aptos_governance {
         // verify voting::vote
         aborts_if timestamp::now_seconds() > proposal_expiration;
         aborts_if proposal.is_resolved;
-        aborts_if !string::spec_internal_check_utf8(voting::IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
+        aborts_if !string::spec_internal_check_utf8(
+            voting::IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY
+        );
         let execution_key = utf8(voting::IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
-        aborts_if simple_map::spec_contains_key(proposal.metadata, execution_key) &&
-                  simple_map::spec_get(proposal.metadata, execution_key) != std::bcs::to_bytes(false);
+        aborts_if simple_map::spec_contains_key(proposal.metadata, execution_key)
+            && simple_map::spec_get(proposal.metadata, execution_key)
+                != std::bcs::to_bytes(false);
         // Since there are two possibilities for voting_power, the result of the vote is not only related to should_pass,
         // but also to allow_validator_set_change which determines the voting_power
-        aborts_if
-            if (should_pass) { proposal.yes_votes + real_voting_power > MAX_U128 } else { proposal.no_votes + real_voting_power > MAX_U128 };
-        let post post_voting_forum = global<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
+        aborts_if if (should_pass) {
+            proposal.yes_votes + real_voting_power > MAX_U128
+        } else {
+            proposal.no_votes + real_voting_power > MAX_U128
+        };
+        let post post_voting_forum = global<voting::VotingForum<GovernanceProposal>>(
+            @aptos_framework
+        );
         let post post_proposal = table::spec_get(post_voting_forum.proposals, proposal_id);
 
         aborts_if !string::spec_internal_check_utf8(voting::RESOLVABLE_TIME_METADATA_KEY);
         let key = utf8(voting::RESOLVABLE_TIME_METADATA_KEY);
         ensures simple_map::spec_contains_key(post_proposal.metadata, key);
-        ensures simple_map::spec_get(post_proposal.metadata, key) == std::bcs::to_bytes(timestamp::now_seconds());
+        ensures simple_map::spec_get(post_proposal.metadata, key)
+            == std::bcs::to_bytes(timestamp::now_seconds());
 
-        aborts_if features::spec_partial_governance_voting_enabled() && used_voting_power + real_voting_power > MAX_U64;
-        aborts_if !features::spec_partial_governance_voting_enabled() && table::spec_contains(voting_records.votes, record_key);
-
+        aborts_if features::spec_partial_governance_voting_enabled()
+            && used_voting_power + real_voting_power > MAX_U64;
+        aborts_if !features::spec_partial_governance_voting_enabled()
+            && table::spec_contains(voting_records.votes, record_key);
 
         aborts_if !exists<GovernanceEvents>(@aptos_framework);
 
         // verify voting::get_proposal_state
-        let early_resolution_threshold = option::spec_borrow(proposal.early_resolution_vote_threshold);
+        let early_resolution_threshold = option::spec_borrow(
+            proposal.early_resolution_vote_threshold
+        );
         let is_voting_period_over = timestamp::spec_now_seconds() > proposal_expiration;
 
         let new_proposal_yes_votes_0 = proposal.yes_votes + real_voting_power;
-        let can_be_resolved_early_0 = option::spec_is_some(proposal.early_resolution_vote_threshold) &&
-                                    (new_proposal_yes_votes_0 >= early_resolution_threshold ||
-                                     proposal.no_votes >= early_resolution_threshold);
+        let can_be_resolved_early_0 = option::spec_is_some(
+            proposal.early_resolution_vote_threshold
+        ) && (
+            new_proposal_yes_votes_0 >= early_resolution_threshold
+                || proposal.no_votes >= early_resolution_threshold
+        );
         let is_voting_closed_0 = is_voting_period_over || can_be_resolved_early_0;
-        let proposal_state_successed_0 = is_voting_closed_0 && new_proposal_yes_votes_0 > proposal.no_votes &&
-                                         new_proposal_yes_votes_0 + proposal.no_votes >= proposal.min_vote_threshold;
+        let proposal_state_successed_0 = is_voting_closed_0
+            && new_proposal_yes_votes_0 > proposal.no_votes
+            && new_proposal_yes_votes_0 + proposal.no_votes >= proposal.min_vote_threshold;
         let new_proposal_no_votes_0 = proposal.no_votes + real_voting_power;
-        let can_be_resolved_early_1 = option::spec_is_some(proposal.early_resolution_vote_threshold) &&
-                                    (proposal.yes_votes >= early_resolution_threshold ||
-                                     new_proposal_no_votes_0 >= early_resolution_threshold);
+        let can_be_resolved_early_1 = option::spec_is_some(
+            proposal.early_resolution_vote_threshold
+        ) && (
+            proposal.yes_votes >= early_resolution_threshold
+                || new_proposal_no_votes_0 >= early_resolution_threshold
+        );
         let is_voting_closed_1 = is_voting_period_over || can_be_resolved_early_1;
-        let proposal_state_successed_1 = is_voting_closed_1 && proposal.yes_votes > new_proposal_no_votes_0 &&
-                                         proposal.yes_votes + new_proposal_no_votes_0 >= proposal.min_vote_threshold;
+        let proposal_state_successed_1 = is_voting_closed_1
+            && proposal.yes_votes > new_proposal_no_votes_0
+            && proposal.yes_votes + new_proposal_no_votes_0 >= proposal.min_vote_threshold;
         let new_proposal_yes_votes_1 = proposal.yes_votes + real_voting_power;
-        let can_be_resolved_early_2 = option::spec_is_some(proposal.early_resolution_vote_threshold) &&
-                                    (new_proposal_yes_votes_1 >= early_resolution_threshold ||
-                                     proposal.no_votes >= early_resolution_threshold);
+        let can_be_resolved_early_2 = option::spec_is_some(
+            proposal.early_resolution_vote_threshold
+        ) && (
+            new_proposal_yes_votes_1 >= early_resolution_threshold
+                || proposal.no_votes >= early_resolution_threshold
+        );
         let is_voting_closed_2 = is_voting_period_over || can_be_resolved_early_2;
-        let proposal_state_successed_2 = is_voting_closed_2 && new_proposal_yes_votes_1 > proposal.no_votes &&
-                                         new_proposal_yes_votes_1 + proposal.no_votes >= proposal.min_vote_threshold;
+        let proposal_state_successed_2 = is_voting_closed_2
+            && new_proposal_yes_votes_1 > proposal.no_votes
+            && new_proposal_yes_votes_1 + proposal.no_votes >= proposal.min_vote_threshold;
         let new_proposal_no_votes_1 = proposal.no_votes + real_voting_power;
-        let can_be_resolved_early_3 = option::spec_is_some(proposal.early_resolution_vote_threshold) &&
-                                    (proposal.yes_votes >= early_resolution_threshold ||
-                                     new_proposal_no_votes_1 >= early_resolution_threshold);
+        let can_be_resolved_early_3 = option::spec_is_some(
+            proposal.early_resolution_vote_threshold
+        ) && (
+            proposal.yes_votes >= early_resolution_threshold
+                || new_proposal_no_votes_1 >= early_resolution_threshold
+        );
         let is_voting_closed_3 = is_voting_period_over || can_be_resolved_early_3;
-        let proposal_state_successed_3 = is_voting_closed_3 && proposal.yes_votes > new_proposal_no_votes_1 &&
-                                         proposal.yes_votes + new_proposal_no_votes_1 >= proposal.min_vote_threshold;
+        let proposal_state_successed_3 = is_voting_closed_3
+            && proposal.yes_votes > new_proposal_no_votes_1
+            && proposal.yes_votes + new_proposal_no_votes_1 >= proposal.min_vote_threshold;
         // post state
-        let post can_be_resolved_early = option::spec_is_some(proposal.early_resolution_vote_threshold) &&
-                                    (post_proposal.yes_votes >= early_resolution_threshold ||
-                                     post_proposal.no_votes >= early_resolution_threshold);
+        let post can_be_resolved_early = option::spec_is_some(
+            proposal.early_resolution_vote_threshold
+        ) && (
+            post_proposal.yes_votes >= early_resolution_threshold
+                || post_proposal.no_votes >= early_resolution_threshold
+        );
         let post is_voting_closed = is_voting_period_over || can_be_resolved_early;
-        let post proposal_state_successed = is_voting_closed && post_proposal.yes_votes > post_proposal.no_votes &&
-                                         post_proposal.yes_votes + post_proposal.no_votes >= proposal.min_vote_threshold;
+        let post proposal_state_successed = is_voting_closed
+            && post_proposal.yes_votes > post_proposal.no_votes
+            && post_proposal.yes_votes + post_proposal.no_votes
+                >= proposal.min_vote_threshold;
         // verify add_approved_script_hash(proposal_id)
         let execution_hash = proposal.execution_hash;
         let post post_approved_hashes = global<ApprovedExecutionHashes>(@aptos_framework);
 
         // Due to the complexity of the success state, the validation of 'borrow_global_mut<ApprovedExecutionHashes>(@aptos_framework);' is discussed in four cases.
         /// [high-level-req-3]
-        aborts_if
-            if (should_pass) {
-                proposal_state_successed_0 && !exists<ApprovedExecutionHashes>(@aptos_framework)
-            } else {
-                proposal_state_successed_1 && !exists<ApprovedExecutionHashes>(@aptos_framework)
-            };
-        aborts_if
-            if (should_pass) {
-                proposal_state_successed_2 && !exists<ApprovedExecutionHashes>(@aptos_framework)
-            } else {
-                proposal_state_successed_3 && !exists<ApprovedExecutionHashes>(@aptos_framework)
-            };
-        ensures proposal_state_successed ==> simple_map::spec_contains_key(post_approved_hashes.hashes, proposal_id) &&
-                                             simple_map::spec_get(post_approved_hashes.hashes, proposal_id) == execution_hash;
+        aborts_if if (should_pass) {
+            proposal_state_successed_0
+                && !exists<ApprovedExecutionHashes>(@aptos_framework)
+        } else {
+            proposal_state_successed_1
+                && !exists<ApprovedExecutionHashes>(@aptos_framework)
+        };
+        aborts_if if (should_pass) {
+            proposal_state_successed_2
+                && !exists<ApprovedExecutionHashes>(@aptos_framework)
+        } else {
+            proposal_state_successed_3
+                && !exists<ApprovedExecutionHashes>(@aptos_framework)
+        };
+        ensures proposal_state_successed ==>
+            simple_map::spec_contains_key(post_approved_hashes.hashes, proposal_id)
+                && simple_map::spec_get(post_approved_hashes.hashes, proposal_id)
+                    == execution_hash;
 
-        aborts_if features::spec_partial_governance_voting_enabled() && !exists<VotingRecordsV2>(@aptos_framework);
+        aborts_if features::spec_partial_governance_voting_enabled()
+            && !exists<VotingRecordsV2>(@aptos_framework);
     }
 
     spec add_approved_script_hash(proposal_id: u64) {
@@ -506,22 +556,38 @@ spec aptos_framework::aptos_governance {
         aborts_if !exists<ApprovedExecutionHashes>(@aptos_framework);
 
         aborts_if !exists<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
-        let voting_forum = global<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
+        let voting_forum = global<voting::VotingForum<GovernanceProposal>>(
+            @aptos_framework
+        );
         let proposal = table::spec_get(voting_forum.proposals, proposal_id);
         aborts_if !table::spec_contains(voting_forum.proposals, proposal_id);
-        let early_resolution_threshold = option::spec_borrow(proposal.early_resolution_vote_threshold);
-        aborts_if timestamp::now_seconds() <= proposal.expiration_secs &&
-            (option::spec_is_none(proposal.early_resolution_vote_threshold) ||
-            proposal.yes_votes < early_resolution_threshold && proposal.no_votes < early_resolution_threshold);
-        aborts_if (timestamp::now_seconds() > proposal.expiration_secs ||
-            option::spec_is_some(proposal.early_resolution_vote_threshold) && (proposal.yes_votes >= early_resolution_threshold ||
-                                                                               proposal.no_votes >= early_resolution_threshold)) &&
-            (proposal.yes_votes <= proposal.no_votes || proposal.yes_votes + proposal.no_votes < proposal.min_vote_threshold);
+        let early_resolution_threshold = option::spec_borrow(
+            proposal.early_resolution_vote_threshold
+        );
+        aborts_if timestamp::now_seconds() <= proposal.expiration_secs
+            && (
+                option::spec_is_none(proposal.early_resolution_vote_threshold)
+                || proposal.yes_votes < early_resolution_threshold
+                && proposal.no_votes < early_resolution_threshold
+            );
+        aborts_if (
+                timestamp::now_seconds() > proposal.expiration_secs
+                || option::spec_is_some(proposal.early_resolution_vote_threshold)
+                && (
+                    proposal.yes_votes >= early_resolution_threshold
+                    || proposal.no_votes >= early_resolution_threshold
+                )
+            )
+            && (
+                proposal.yes_votes <= proposal.no_votes
+                || proposal.yes_votes + proposal.no_votes < proposal.min_vote_threshold
+            );
 
         let post post_approved_hashes = global<ApprovedExecutionHashes>(@aptos_framework);
         /// [high-level-req-4]
-        ensures simple_map::spec_contains_key(post_approved_hashes.hashes, proposal_id) &&
-            simple_map::spec_get(post_approved_hashes.hashes, proposal_id) == proposal.execution_hash;
+        ensures simple_map::spec_contains_key(post_approved_hashes.hashes, proposal_id)
+            && simple_map::spec_get(post_approved_hashes.hashes, proposal_id)
+                == proposal.execution_hash;
     }
 
     /// Address @aptos_framework must exist ApprovedExecutionHashes and GovernanceProposal and GovernanceResponsbility.
@@ -533,19 +599,31 @@ spec aptos_framework::aptos_governance {
         // verify voting::resolve
         include VotingIsProposalResolvableAbortsif;
 
-        let voting_forum = global<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
+        let voting_forum = global<voting::VotingForum<GovernanceProposal>>(
+            @aptos_framework
+        );
         let proposal = table::spec_get(voting_forum.proposals, proposal_id);
 
         let multi_step_key = utf8(voting::IS_MULTI_STEP_PROPOSAL_KEY);
-        let has_multi_step_key = simple_map::spec_contains_key(proposal.metadata, multi_step_key);
-        let is_multi_step_proposal = aptos_std::from_bcs::deserialize<bool>(simple_map::spec_get(proposal.metadata, multi_step_key));
-        aborts_if has_multi_step_key && !aptos_std::from_bcs::deserializable<bool>(simple_map::spec_get(proposal.metadata, multi_step_key));
+        let has_multi_step_key = simple_map::spec_contains_key(
+            proposal.metadata, multi_step_key
+        );
+        let is_multi_step_proposal = aptos_std::from_bcs::deserialize<bool>(
+            simple_map::spec_get(proposal.metadata, multi_step_key)
+        );
+        aborts_if has_multi_step_key
+            && !aptos_std::from_bcs::deserializable<bool>(
+                simple_map::spec_get(proposal.metadata, multi_step_key)
+            );
         aborts_if !string::spec_internal_check_utf8(voting::IS_MULTI_STEP_PROPOSAL_KEY);
         aborts_if has_multi_step_key && is_multi_step_proposal;
 
-        let post post_voting_forum = global<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
+        let post post_voting_forum = global<voting::VotingForum<GovernanceProposal>>(
+            @aptos_framework
+        );
         let post post_proposal = table::spec_get(post_voting_forum.proposals, proposal_id);
-        ensures post_proposal.is_resolved == true && post_proposal.resolution_time_secs == timestamp::now_seconds();
+        ensures post_proposal.is_resolved == true
+            && post_proposal.resolution_time_secs == timestamp::now_seconds();
         aborts_if option::spec_is_none(proposal.execution_content);
 
         // verify remove_approved_hash
@@ -556,7 +634,9 @@ spec aptos_framework::aptos_governance {
         // verify get_signer
         include GetSignerAbortsIf;
         let governance_responsibility = global<GovernanceResponsbility>(@aptos_framework);
-        let signer_cap = simple_map::spec_get(governance_responsibility.signer_caps, signer_address);
+        let signer_cap = simple_map::spec_get(
+            governance_responsibility.signer_caps, signer_address
+        );
         let addr = signer_cap.account;
         ensures signer::address_of(result) == addr;
     }
@@ -565,7 +645,9 @@ spec aptos_framework::aptos_governance {
     spec remove_approved_hash(proposal_id: u64) {
         aborts_if !exists<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
         aborts_if !exists<ApprovedExecutionHashes>(@aptos_framework);
-        let voting_forum = global<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
+        let voting_forum = global<voting::VotingForum<GovernanceProposal>>(
+            @aptos_framework
+        );
         aborts_if !table::spec_contains(voting_forum.proposals, proposal_id);
         aborts_if !exists<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
         let proposal = table::spec_get(voting_forum.proposals, proposal_id);
@@ -580,10 +662,10 @@ spec aptos_framework::aptos_governance {
         use aptos_framework::aptos_coin::AptosCoin;
         use aptos_framework::transaction_fee;
         pragma verify = false; // TODO: set because of timeout (property proved).
-        aborts_if !system_addresses::is_aptos_framework_address(signer::address_of(aptos_framework));
-        include reconfiguration_with_dkg::FinishRequirement {
-            framework: aptos_framework
-        };
+        aborts_if !system_addresses::is_aptos_framework_address(
+            signer::address_of(aptos_framework)
+        );
+        include reconfiguration_with_dkg::FinishRequirement { framework: aptos_framework };
         include stake::GetReconfigStartTimeRequirement;
 
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
@@ -613,90 +695,105 @@ spec aptos_framework::aptos_governance {
         let allow_validator_set_change = staking_config.allow_validator_set_change;
         let stake_pool_res = global<stake::StakePool>(pool_address);
 
-        ensures allow_validator_set_change ==> result == stake_pool_res.active.value + stake_pool_res.pending_active.value + stake_pool_res.pending_inactive.value;
-        ensures !allow_validator_set_change ==> if (stake::spec_is_current_epoch_validator(pool_address)) {
-            result == stake_pool_res.active.value + stake_pool_res.pending_inactive.value
-        } else {
-            result == 0
-        };
+        ensures allow_validator_set_change ==>
+            result
+                == stake_pool_res.active.value + stake_pool_res.pending_active.value
+                    + stake_pool_res.pending_inactive.value;
+        ensures !allow_validator_set_change ==>
+            if (stake::spec_is_current_epoch_validator(pool_address)) {
+                result
+                    == stake_pool_res.active.value + stake_pool_res.pending_inactive.value
+            } else {
+                result == 0
+            };
         ensures result == spec_get_voting_power(pool_address, staking_config);
     }
 
-    spec fun spec_get_voting_power(pool_address: address, staking_config: staking_config::StakingConfig): u64 {
+    spec fun spec_get_voting_power(
+        pool_address: address, staking_config: staking_config::StakingConfig
+    ): u64 {
         let allow_validator_set_change = staking_config.allow_validator_set_change;
         let stake_pool_res = global<stake::StakePool>(pool_address);
         if (allow_validator_set_change) {
-            stake_pool_res.active.value + stake_pool_res.pending_active.value + stake_pool_res.pending_inactive.value
-        } else if (!allow_validator_set_change && (stake::spec_is_current_epoch_validator(pool_address))) {
+            stake_pool_res.active.value + stake_pool_res.pending_active.value
+                + stake_pool_res.pending_inactive.value
+        } else if (!allow_validator_set_change
+                && (stake::spec_is_current_epoch_validator(pool_address))) {
             stake_pool_res.active.value + stake_pool_res.pending_inactive.value
-        } else {
-            0
-        }
+        } else { 0 }
     }
 
     spec get_remaining_voting_power(stake_pool: address, proposal_id: u64): u64 {
-        aborts_if features::spec_partial_governance_voting_enabled() && !exists<VotingRecordsV2>(@aptos_framework);
+        aborts_if features::spec_partial_governance_voting_enabled()
+            && !exists<VotingRecordsV2>(@aptos_framework);
         include voting::AbortsIfNotContainProposalID<GovernanceProposal> {
             voting_forum_address: @aptos_framework
         };
         aborts_if !exists<stake::StakePool>(stake_pool);
-        aborts_if spec_proposal_expiration <= locked_until && !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
-        let spec_proposal_expiration = voting::spec_get_proposal_expiration_secs<GovernanceProposal>(@aptos_framework, proposal_id);
+        aborts_if spec_proposal_expiration <= locked_until
+            && !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
+        let spec_proposal_expiration = voting::spec_get_proposal_expiration_secs<
+            GovernanceProposal>(@aptos_framework, proposal_id);
         let locked_until = global<stake::StakePool>(stake_pool).locked_until_secs;
-        let remain_zero_1_cond = (spec_proposal_expiration > locked_until || timestamp::spec_now_seconds() > spec_proposal_expiration);
+        let remain_zero_1_cond = (
+            spec_proposal_expiration > locked_until
+                || timestamp::spec_now_seconds() > spec_proposal_expiration
+        );
         ensures remain_zero_1_cond ==> result == 0;
-        let record_key = RecordKey {
-            stake_pool,
-            proposal_id,
-        };
+        let record_key = RecordKey { stake_pool, proposal_id, };
         let entirely_voted = spec_has_entirely_voted(stake_pool, proposal_id, record_key);
         aborts_if !remain_zero_1_cond && !exists<VotingRecords>(@aptos_framework);
-        include !remain_zero_1_cond && !entirely_voted ==> GetVotingPowerAbortsIf {
-            pool_address: stake_pool
-        };
+        include !remain_zero_1_cond && !entirely_voted ==>
+            GetVotingPowerAbortsIf { pool_address: stake_pool };
         let staking_config = global<staking_config::StakingConfig>(@aptos_framework);
         let voting_power = spec_get_voting_power(stake_pool, staking_config);
         let voting_records_v2 = borrow_global<VotingRecordsV2>(@aptos_framework);
-        let used_voting_power = if (smart_table::spec_contains(voting_records_v2.votes, record_key)) {
+        let used_voting_power = if (smart_table::spec_contains(
+                voting_records_v2.votes, record_key
+            )) {
             smart_table::spec_get(voting_records_v2.votes, record_key)
-        } else {
-            0
-        };
-        aborts_if !remain_zero_1_cond && !entirely_voted && features::spec_partial_governance_voting_enabled() &&
-            used_voting_power > 0 && voting_power < used_voting_power;
+        } else { 0 };
+        aborts_if !remain_zero_1_cond
+            && !entirely_voted
+            && features::spec_partial_governance_voting_enabled()
+            && used_voting_power > 0
+            && voting_power < used_voting_power;
 
         ensures result == spec_get_remaining_voting_power(stake_pool, proposal_id);
     }
 
     spec fun spec_get_remaining_voting_power(stake_pool: address, proposal_id: u64): u64 {
-        let spec_proposal_expiration = voting::spec_get_proposal_expiration_secs<GovernanceProposal>(@aptos_framework, proposal_id);
+        let spec_proposal_expiration =
+            voting::spec_get_proposal_expiration_secs<GovernanceProposal>(
+                @aptos_framework, proposal_id
+            );
         let locked_until = global<stake::StakePool>(stake_pool).locked_until_secs;
-        let remain_zero_1_cond = (spec_proposal_expiration > locked_until || timestamp::spec_now_seconds() > spec_proposal_expiration);
+        let remain_zero_1_cond =
+            (
+                spec_proposal_expiration > locked_until
+                    || timestamp::spec_now_seconds() > spec_proposal_expiration
+            );
         let staking_config = global<staking_config::StakingConfig>(@aptos_framework);
         let voting_records_v2 = borrow_global<VotingRecordsV2>(@aptos_framework);
-        let record_key = RecordKey {
-            stake_pool,
-            proposal_id,
-        };
+        let record_key = RecordKey { stake_pool, proposal_id, };
         let entirely_voted = spec_has_entirely_voted(stake_pool, proposal_id, record_key);
         let voting_power = spec_get_voting_power(stake_pool, staking_config);
-        let used_voting_power = if (smart_table::spec_contains(voting_records_v2.votes, record_key)) {
-            smart_table::spec_get(voting_records_v2.votes, record_key)
-        } else {
-            0
-        };
-        if (remain_zero_1_cond) {
-            0
-        } else if (entirely_voted) {
-            0
-        } else if (!features::spec_partial_governance_voting_enabled()) {
+        let used_voting_power =
+            if (smart_table::spec_contains(voting_records_v2.votes, record_key)) {
+                smart_table::spec_get(voting_records_v2.votes, record_key)
+            } else { 0 };
+        if (remain_zero_1_cond) { 0 }
+        else if (entirely_voted) { 0 }
+        else if (!features::spec_partial_governance_voting_enabled()) {
             voting_power
         } else {
             voting_power - used_voting_power
         }
     }
 
-    spec fun spec_has_entirely_voted(stake_pool: address, proposal_id: u64, record_key: RecordKey): bool {
+    spec fun spec_has_entirely_voted(
+        stake_pool: address, proposal_id: u64, record_key: RecordKey
+    ): bool {
         let voting_records = global<VotingRecords>(@aptos_framework);
         table::spec_contains(voting_records.votes, record_key)
     }
@@ -708,10 +805,18 @@ spec aptos_framework::aptos_governance {
         aborts_if !exists<staking_config::StakingConfig>(@aptos_framework);
         let allow_validator_set_change = staking_config.allow_validator_set_change;
         let stake_pool_res = global<stake::StakePool>(pool_address);
-        aborts_if allow_validator_set_change && (stake_pool_res.active.value + stake_pool_res.pending_active.value + stake_pool_res.pending_inactive.value) > MAX_U64;
+        aborts_if allow_validator_set_change
+            && (
+                stake_pool_res.active.value + stake_pool_res.pending_active.value
+                    + stake_pool_res.pending_inactive.value
+            ) > MAX_U64;
         aborts_if !exists<stake::StakePool>(pool_address);
-        aborts_if !allow_validator_set_change && !exists<stake::ValidatorSet>(@aptos_framework);
-        aborts_if !allow_validator_set_change && stake::spec_is_current_epoch_validator(pool_address) && stake_pool_res.active.value + stake_pool_res.pending_inactive.value > MAX_U64;
+        aborts_if !allow_validator_set_change
+            && !exists<stake::ValidatorSet>(@aptos_framework);
+        aborts_if !allow_validator_set_change
+            && stake::spec_is_current_epoch_validator(pool_address)
+            && stake_pool_res.active.value + stake_pool_res.pending_inactive.value
+                > MAX_U64;
     }
 
     spec get_signer(signer_address: address): signer {
@@ -752,7 +857,9 @@ spec aptos_framework::aptos_governance {
         pragma verify = false;
     }
 
-    spec resolve_multi_step_proposal(proposal_id: u64, signer_address: address, next_execution_hash: vector<u8>): signer {
+    spec resolve_multi_step_proposal(
+        proposal_id: u64, signer_address: address, next_execution_hash: vector<u8>
+    ): signer {
         use aptos_framework::chain_status;
         requires chain_status::is_operating();
 
@@ -761,44 +868,74 @@ spec aptos_framework::aptos_governance {
         // verify voting::resolve_proposal_v2
         include VotingIsProposalResolvableAbortsif;
 
-        let voting_forum = global<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
+        let voting_forum = global<voting::VotingForum<GovernanceProposal>>(
+            @aptos_framework
+        );
         let proposal = table::spec_get(voting_forum.proposals, proposal_id);
-        let post post_voting_forum = global<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
+        let post post_voting_forum = global<voting::VotingForum<GovernanceProposal>>(
+            @aptos_framework
+        );
         let post post_proposal = table::spec_get(post_voting_forum.proposals, proposal_id);
 
-        aborts_if !string::spec_internal_check_utf8(voting::IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
-        let multi_step_in_execution_key = utf8(voting::IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
-        let post is_multi_step_proposal_in_execution_value = simple_map::spec_get(post_proposal.metadata, multi_step_in_execution_key);
+        aborts_if !string::spec_internal_check_utf8(
+            voting::IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY
+        );
+        let multi_step_in_execution_key = utf8(
+            voting::IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY
+        );
+        let post is_multi_step_proposal_in_execution_value = simple_map::spec_get(
+            post_proposal.metadata, multi_step_in_execution_key
+        );
 
         aborts_if !string::spec_internal_check_utf8(voting::IS_MULTI_STEP_PROPOSAL_KEY);
         let multi_step_key = utf8(voting::IS_MULTI_STEP_PROPOSAL_KEY);
-        aborts_if simple_map::spec_contains_key(proposal.metadata, multi_step_key) &&
-            !aptos_std::from_bcs::deserializable<bool>(simple_map::spec_get(proposal.metadata, multi_step_key));
-        let is_multi_step = simple_map::spec_contains_key(proposal.metadata, multi_step_key) &&
-                            aptos_std::from_bcs::deserialize<bool>(simple_map::spec_get(proposal.metadata, multi_step_key));
+        aborts_if simple_map::spec_contains_key(proposal.metadata, multi_step_key)
+            && !aptos_std::from_bcs::deserializable<bool>(
+                simple_map::spec_get(proposal.metadata, multi_step_key)
+            );
+        let is_multi_step = simple_map::spec_contains_key(
+            proposal.metadata, multi_step_key
+        ) && aptos_std::from_bcs::deserialize<bool>(
+            simple_map::spec_get(proposal.metadata, multi_step_key)
+        );
         let next_execution_hash_is_empty = len(next_execution_hash) == 0;
         aborts_if !is_multi_step && !next_execution_hash_is_empty;
-        aborts_if next_execution_hash_is_empty && is_multi_step && !simple_map::spec_contains_key(proposal.metadata, multi_step_in_execution_key); // ?
-        ensures next_execution_hash_is_empty ==> post_proposal.is_resolved == true && post_proposal.resolution_time_secs == timestamp::spec_now_seconds() &&
-            if (is_multi_step) {
-                is_multi_step_proposal_in_execution_value == std::bcs::serialize(false)
-            } else {
-                simple_map::spec_contains_key(proposal.metadata, multi_step_in_execution_key) ==>
-                    is_multi_step_proposal_in_execution_value == std::bcs::serialize(true)
-            };
-        ensures !next_execution_hash_is_empty ==> post_proposal.execution_hash == next_execution_hash;
+        aborts_if next_execution_hash_is_empty
+            && is_multi_step
+            && !simple_map::spec_contains_key(
+                proposal.metadata, multi_step_in_execution_key
+            ); // ?
+        ensures next_execution_hash_is_empty ==>
+            post_proposal.is_resolved == true
+                && post_proposal.resolution_time_secs == timestamp::spec_now_seconds()
+                && if (is_multi_step) {
+                    is_multi_step_proposal_in_execution_value == std::bcs::serialize(
+                        false
+                    )
+                } else {
+                    simple_map::spec_contains_key(
+                        proposal.metadata, multi_step_in_execution_key
+                    ) ==>
+                        is_multi_step_proposal_in_execution_value
+                            == std::bcs::serialize(true)
+                };
+        ensures !next_execution_hash_is_empty ==>
+            post_proposal.execution_hash == next_execution_hash;
 
         // verify remove_approved_hash
         aborts_if !exists<ApprovedExecutionHashes>(@aptos_framework);
         let post post_approved_hashes = global<ApprovedExecutionHashes>(@aptos_framework).hashes;
-        ensures next_execution_hash_is_empty ==> !simple_map::spec_contains_key(post_approved_hashes, proposal_id);
+        ensures next_execution_hash_is_empty ==>
+            !simple_map::spec_contains_key(post_approved_hashes, proposal_id);
         ensures !next_execution_hash_is_empty ==>
             simple_map::spec_get(post_approved_hashes, proposal_id) == next_execution_hash;
 
         // verify get_signer
         include GetSignerAbortsIf;
         let governance_responsibility = global<GovernanceResponsbility>(@aptos_framework);
-        let signer_cap = simple_map::spec_get(governance_responsibility.signer_caps, signer_address);
+        let signer_cap = simple_map::spec_get(
+            governance_responsibility.signer_caps, signer_address
+        );
         let addr = signer_cap.account;
         ensures signer::address_of(result) == addr;
     }
@@ -807,27 +944,49 @@ spec aptos_framework::aptos_governance {
         proposal_id: u64;
 
         aborts_if !exists<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
-        let voting_forum = global<voting::VotingForum<GovernanceProposal>>(@aptos_framework);
+        let voting_forum = global<voting::VotingForum<GovernanceProposal>>(
+            @aptos_framework
+        );
         let proposal = table::spec_get(voting_forum.proposals, proposal_id);
         aborts_if !table::spec_contains(voting_forum.proposals, proposal_id);
-        let early_resolution_threshold = option::spec_borrow(proposal.early_resolution_vote_threshold);
+        let early_resolution_threshold = option::spec_borrow(
+            proposal.early_resolution_vote_threshold
+        );
         let voting_period_over = timestamp::now_seconds() > proposal.expiration_secs;
-        let be_resolved_early = option::spec_is_some(proposal.early_resolution_vote_threshold) &&
-                                    (proposal.yes_votes >= early_resolution_threshold ||
-                                     proposal.no_votes >= early_resolution_threshold);
+        let be_resolved_early = option::spec_is_some(
+            proposal.early_resolution_vote_threshold
+        ) && (
+            proposal.yes_votes >= early_resolution_threshold
+                || proposal.no_votes >= early_resolution_threshold
+        );
         let voting_closed = voting_period_over || be_resolved_early;
         // If Voting Failed
-        aborts_if voting_closed && (proposal.yes_votes <= proposal.no_votes || proposal.yes_votes + proposal.no_votes < proposal.min_vote_threshold);
+        aborts_if voting_closed
+            && (
+                proposal.yes_votes <= proposal.no_votes
+                    || proposal.yes_votes + proposal.no_votes < proposal.min_vote_threshold
+            );
         // If Voting Pending
         aborts_if !voting_closed;
 
         aborts_if proposal.is_resolved;
         aborts_if !string::spec_internal_check_utf8(voting::RESOLVABLE_TIME_METADATA_KEY);
-        aborts_if !simple_map::spec_contains_key(proposal.metadata, utf8(voting::RESOLVABLE_TIME_METADATA_KEY));
-        let resolvable_time = aptos_std::from_bcs::deserialize<u64>(simple_map::spec_get(proposal.metadata, utf8(voting::RESOLVABLE_TIME_METADATA_KEY)));
-        aborts_if !aptos_std::from_bcs::deserializable<u64>(simple_map::spec_get(proposal.metadata, utf8(voting::RESOLVABLE_TIME_METADATA_KEY)));
+        aborts_if !simple_map::spec_contains_key(
+            proposal.metadata, utf8(voting::RESOLVABLE_TIME_METADATA_KEY)
+        );
+        let resolvable_time = aptos_std::from_bcs::deserialize<u64>(
+            simple_map::spec_get(
+                proposal.metadata, utf8(voting::RESOLVABLE_TIME_METADATA_KEY)
+            ),
+        );
+        aborts_if !aptos_std::from_bcs::deserializable<u64>(
+            simple_map::spec_get(
+                proposal.metadata, utf8(voting::RESOLVABLE_TIME_METADATA_KEY)
+            ),
+        );
         aborts_if timestamp::now_seconds() <= resolvable_time;
-        aborts_if aptos_framework::transaction_context::spec_get_script_hash() != proposal.execution_hash;
+        aborts_if aptos_framework::transaction_context::spec_get_script_hash()
+            != proposal.execution_hash;
     }
 
     spec assert_voting_initialization() {
@@ -839,13 +998,12 @@ spec aptos_framework::aptos_governance {
         use std::signer;
         pragma verify = false; // TODO: set because of timeout (property proved).
         let address = signer::address_of(aptos_framework);
-        include reconfiguration_with_dkg::FinishRequirement {
-            framework: aptos_framework
-        };
+        include reconfiguration_with_dkg::FinishRequirement { framework: aptos_framework };
     }
 
     spec schema VotingInitializationAbortIfs {
-        aborts_if features::spec_partial_governance_voting_enabled() && !exists<VotingRecordsV2>(@aptos_framework);
+        aborts_if features::spec_partial_governance_voting_enabled()
+            && !exists<VotingRecordsV2>(@aptos_framework);
     }
 
     spec force_end_epoch_test_only {
@@ -853,10 +1011,7 @@ spec aptos_framework::aptos_governance {
     }
 
     spec batch_vote(
-        voter: &signer,
-        stake_pools: vector<address>,
-        proposal_id: u64,
-        should_pass: bool,
+        voter: &signer, stake_pools: vector<address>, proposal_id: u64, should_pass: bool,
     ) {
         // TODO: Temporary mockup. Specify the `for_each` statement.
         pragma verify = false;

--- a/aptos-move/framework/aptos-framework/sources/block.move
+++ b/aptos-move/framework/aptos-framework/sources/block.move
@@ -90,42 +90,50 @@ module aptos_framework::block {
     const EZERO_MAX_CAPACITY: u64 = 3;
 
     /// This can only be called during Genesis.
-    public(friend) fun initialize(aptos_framework: &signer, epoch_interval_microsecs: u64) {
+    public(friend) fun initialize(
+        aptos_framework: &signer, epoch_interval_microsecs: u64
+    ) {
         system_addresses::assert_aptos_framework(aptos_framework);
-        assert!(epoch_interval_microsecs > 0, error::invalid_argument(EZERO_EPOCH_INTERVAL));
+        assert!(
+            epoch_interval_microsecs > 0, error::invalid_argument(EZERO_EPOCH_INTERVAL)
+        );
 
-        move_to<CommitHistory>(aptos_framework, CommitHistory {
-            max_capacity: 2000,
-            next_idx: 0,
-            table: table_with_length::new(),
-        });
+        move_to<CommitHistory>(
+            aptos_framework,
+            CommitHistory {
+                max_capacity: 2000,
+                next_idx: 0,
+                table: table_with_length::new(),
+            },
+        );
 
         move_to<BlockResource>(
             aptos_framework,
             BlockResource {
                 height: 0,
                 epoch_interval: epoch_interval_microsecs,
-                new_block_events: account::new_event_handle<NewBlockEvent>(aptos_framework),
-                update_epoch_interval_events: account::new_event_handle<UpdateEpochIntervalEvent>(aptos_framework),
-            }
+                new_block_events: account::new_event_handle<NewBlockEvent>(
+                    aptos_framework
+                ),
+                update_epoch_interval_events: account::new_event_handle<
+                    UpdateEpochIntervalEvent>(aptos_framework),
+            },
         );
     }
 
     /// Initialize the commit history resource if it's not in genesis.
     public fun initialize_commit_history(fx: &signer, max_capacity: u32) {
         assert!(max_capacity > 0, error::invalid_argument(EZERO_MAX_CAPACITY));
-        move_to<CommitHistory>(fx, CommitHistory {
-            max_capacity,
-            next_idx: 0,
-            table: table_with_length::new(),
-        });
+        move_to<CommitHistory>(
+            fx,
+            CommitHistory { max_capacity, next_idx: 0, table: table_with_length::new(), },
+        );
     }
 
     /// Update the epoch interval.
     /// Can only be called as part of the Aptos governance proposal process established by the AptosGovernance module.
     public fun update_epoch_interval_microsecs(
-        aptos_framework: &signer,
-        new_epoch_interval: u64,
+        aptos_framework: &signer, new_epoch_interval: u64,
     ) acquires BlockResource {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert!(new_epoch_interval > 0, error::invalid_argument(EZERO_EPOCH_INTERVAL));
@@ -135,9 +143,7 @@ module aptos_framework::block {
         block_resource.epoch_interval = new_epoch_interval;
 
         if (std::features::module_event_migration_enabled()) {
-            event::emit(
-                UpdateEpochInterval { old_epoch_interval, new_epoch_interval },
-            );
+            event::emit(UpdateEpochInterval { old_epoch_interval, new_epoch_interval });
         };
         event::emit_event<UpdateEpochIntervalEvent>(
             &mut block_resource.update_epoch_interval_events,
@@ -150,7 +156,6 @@ module aptos_framework::block {
     public fun get_epoch_interval_secs(): u64 acquires BlockResource {
         borrow_global<BlockResource>(@aptos_framework).epoch_interval / 1000000
     }
-
 
     fun block_prologue_common(
         vm: &signer,
@@ -200,7 +205,12 @@ module aptos_framework::block {
             failed_proposer_indices,
             time_microseconds: timestamp,
         };
-        emit_new_block_event(vm, &mut block_metadata_ref.new_block_events, new_block_event, new_block_event_v2);
+        emit_new_block_event(
+            vm,
+            &mut block_metadata_ref.new_block_events,
+            new_block_event,
+            new_block_event_v2,
+        );
 
         if (features::collect_and_distribute_gas_fees()) {
             // Assign the fees collected from the previous block to the previous block proposer.
@@ -231,7 +241,17 @@ module aptos_framework::block {
         previous_block_votes_bitvec: vector<u8>,
         timestamp: u64
     ) acquires BlockResource, CommitHistory {
-        let epoch_interval = block_prologue_common(&vm, hash, epoch, round, proposer, failed_proposer_indices, previous_block_votes_bitvec, timestamp);
+        let epoch_interval =
+            block_prologue_common(
+                &vm,
+                hash,
+                epoch,
+                round,
+                proposer,
+                failed_proposer_indices,
+                previous_block_votes_bitvec,
+                timestamp,
+            );
         randomness::on_new_block(&vm, epoch, round, option::none());
         if (timestamp - reconfiguration::last_reconfiguration_time() >= epoch_interval) {
             reconfiguration::reconfigure();
@@ -250,16 +270,17 @@ module aptos_framework::block {
         timestamp: u64,
         randomness_seed: Option<vector<u8>>,
     ) acquires BlockResource, CommitHistory {
-        let epoch_interval = block_prologue_common(
-            &vm,
-            hash,
-            epoch,
-            round,
-            proposer,
-            failed_proposer_indices,
-            previous_block_votes_bitvec,
-            timestamp
-        );
+        let epoch_interval =
+            block_prologue_common(
+                &vm,
+                hash,
+                epoch,
+                round,
+                proposer,
+                failed_proposer_indices,
+                previous_block_votes_bitvec,
+                timestamp,
+            );
         randomness::on_new_block(&vm, epoch, round, randomness_seed);
 
         if (timestamp - reconfiguration::last_reconfiguration_time() >= epoch_interval) {
@@ -286,13 +307,17 @@ module aptos_framework::block {
             if (table_with_length::contains(&commit_history_ref.table, idx)) {
                 table_with_length::remove(&mut commit_history_ref.table, idx);
             };
-            table_with_length::add(&mut commit_history_ref.table, idx, copy new_block_event);
+            table_with_length::add(
+                &mut commit_history_ref.table, idx, copy new_block_event
+            );
             spec {
                 assume idx + 1 <= MAX_U32;
             };
             commit_history_ref.next_idx = (idx + 1) % commit_history_ref.max_capacity;
         };
-        timestamp::update_global_time(vm, new_block_event.proposer, new_block_event.time_microseconds);
+        timestamp::update_global_time(
+            vm, new_block_event.proposer, new_block_event.time_microseconds
+        );
         assert!(
             event::counter(event_handle) == new_block_event.height,
             error::invalid_argument(ENUM_NEW_BLOCK_EVENTS_DOES_NOT_MATCH_BLOCK_HEIGHT),
@@ -330,13 +355,15 @@ module aptos_framework::block {
                 proposer: @vm_reserved,
                 failed_proposer_indices: vector::empty(),
                 time_microseconds: 0,
-            }
+            },
         );
     }
 
     ///  Emit a `NewBlockEvent` event. This function will be invoked by write set script directly to generate the
     ///  new block event for WriteSetPayload.
-    public fun emit_writeset_block_event(vm_signer: &signer, fake_block_hash: address) acquires BlockResource, CommitHistory {
+    public fun emit_writeset_block_event(
+        vm_signer: &signer, fake_block_hash: address
+    ) acquires BlockResource, CommitHistory {
         system_addresses::assert_vm(vm_signer);
         let block_metadata_ref = borrow_global_mut<BlockResource>(@aptos_framework);
         block_metadata_ref.height = event::counter(&block_metadata_ref.new_block_events);
@@ -363,12 +390,14 @@ module aptos_framework::block {
                 proposer: @vm_reserved,
                 failed_proposer_indices: vector::empty(),
                 time_microseconds: timestamp::now_microseconds(),
-            }
+            },
         );
     }
 
     #[test_only]
-    public fun initialize_for_test(account: &signer, epoch_interval_microsecs: u64) {
+    public fun initialize_for_test(
+        account: &signer, epoch_interval_microsecs: u64
+    ) {
         initialize(account, epoch_interval_microsecs);
     }
 
@@ -384,8 +413,7 @@ module aptos_framework::block {
     #[test(aptos_framework = @aptos_framework, account = @0x123)]
     #[expected_failure(abort_code = 0x50003, location = aptos_framework::system_addresses)]
     public entry fun test_update_epoch_interval_unauthorized_should_fail(
-        aptos_framework: signer,
-        account: signer,
+        aptos_framework: signer, account: signer,
     ) acquires BlockResource {
         account::create_account_for_test(@aptos_framework);
         initialize(&aptos_framework, 1);

--- a/aptos-move/framework/aptos-framework/sources/block.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/block.spec.move
@@ -43,9 +43,11 @@ spec aptos_framework::block {
     spec module {
         use aptos_framework::chain_status;
         // After genesis, `BlockResource` exist.
-        invariant [suspendable] chain_status::is_operating() ==> exists<BlockResource>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<BlockResource>(@aptos_framework);
         // After genesis, `CommitHistory` exist.
-        invariant [suspendable] chain_status::is_operating() ==> exists<CommitHistory>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<CommitHistory>(@aptos_framework);
     }
 
     spec BlockResource {
@@ -64,7 +66,6 @@ spec aptos_framework::block {
     }
 
     spec block_prologue {
-
         pragma verify_duration_estimate = 1000; // TODO: set because of timeout (property proved)
         requires timestamp >= reconfiguration::last_reconfiguration_time();
         include BlockRequirement;
@@ -85,7 +86,8 @@ spec aptos_framework::block {
 
         requires chain_status::is_operating();
         requires system_addresses::is_vm(vm);
-        requires event::counter(global<BlockResource>(@aptos_framework).new_block_events) == 0;
+        requires event::counter(global<BlockResource>(@aptos_framework).new_block_events)
+            == 0;
         requires (timestamp::spec_now_microseconds() == 0);
 
         aborts_if false;
@@ -98,8 +100,10 @@ spec aptos_framework::block {
 
         requires chain_status::is_operating();
         requires system_addresses::is_vm(vm);
-        requires (proposer == @vm_reserved) ==> (timestamp::spec_now_microseconds() == timestamp);
-        requires (proposer != @vm_reserved) ==> (timestamp::spec_now_microseconds() < timestamp);
+        requires (proposer == @vm_reserved) ==>
+            (timestamp::spec_now_microseconds() == timestamp);
+        requires (proposer != @vm_reserved) ==>
+            (timestamp::spec_now_microseconds() < timestamp);
         /// [high-level-req-5]
         requires event::counter(event_handle) == new_block_event.height;
 
@@ -142,9 +146,12 @@ spec aptos_framework::block {
         requires chain_status::is_operating();
         requires system_addresses::is_vm(vm);
         /// [high-level-req-4]
-        requires proposer == @vm_reserved || stake::spec_is_current_epoch_validator(proposer);
-        requires (proposer == @vm_reserved) ==> (timestamp::spec_now_microseconds() == timestamp);
-        requires (proposer != @vm_reserved) ==> (timestamp::spec_now_microseconds() < timestamp);
+        requires proposer == @vm_reserved
+            || stake::spec_is_current_epoch_validator(proposer);
+        requires (proposer == @vm_reserved) ==>
+            (timestamp::spec_now_microseconds() == timestamp);
+        requires (proposer != @vm_reserved) ==>
+            (timestamp::spec_now_microseconds() < timestamp);
         requires exists<stake::ValidatorFees>(@aptos_framework);
         requires exists<CoinInfo<AptosCoin>>(@aptos_framework);
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
@@ -180,10 +187,7 @@ spec aptos_framework::block {
     /// The caller is @aptos_framework.
     /// The new_epoch_interval must be greater than 0.
     /// The BlockResource existed under the @aptos_framework.
-    spec update_epoch_interval_microsecs(
-        aptos_framework: &signer,
-        new_epoch_interval: u64,
-    ) {
+    spec update_epoch_interval_microsecs(aptos_framework: &signer, new_epoch_interval: u64,) {
         /// [high-level-req-3.1]
         include UpdateEpochIntervalMicrosecs;
     }

--- a/aptos-move/framework/aptos-framework/sources/code.move
+++ b/aptos-move/framework/aptos-framework/sources/code.move
@@ -201,13 +201,17 @@ module aptos_framework::code {
         };
 
         event::emit(
-            PublishPackage { code_address: addr, is_upgrade: upgrade_number > 0 },
+            PublishPackage { code_address: addr, is_upgrade: upgrade_number > 0 }
         );
 
         // Request publish
         if (features::code_dependency_check_enabled())
             request_publish_with_allowed_deps(
-                addr, module_names, allowed_deps, code, policy.policy
+                addr,
+                module_names,
+                allowed_deps,
+                code,
+                policy.policy,
             ) else
         // The new `request_publish_with_allowed_deps` has not yet rolled out, so call downwards
         // compatible code.

--- a/aptos-move/framework/aptos-framework/sources/code.move
+++ b/aptos-move/framework/aptos-framework/sources/code.move
@@ -126,25 +126,32 @@ module aptos_framework::code {
 
     /// Whether the upgrade policy can be changed. In general, the policy can be only
     /// strengthened but not weakened.
-    public fun can_change_upgrade_policy_to(from: UpgradePolicy, to: UpgradePolicy): bool {
+    public fun can_change_upgrade_policy_to(
+        from: UpgradePolicy, to: UpgradePolicy
+    ): bool {
         from.policy <= to.policy
     }
 
     /// Initialize package metadata for Genesis.
-    fun initialize(aptos_framework: &signer, package_owner: &signer, metadata: PackageMetadata)
-    acquires PackageRegistry {
+    fun initialize(
+        aptos_framework: &signer, package_owner: &signer, metadata: PackageMetadata
+    ) acquires PackageRegistry {
         system_addresses::assert_aptos_framework(aptos_framework);
         let addr = signer::address_of(package_owner);
         if (!exists<PackageRegistry>(addr)) {
             move_to(package_owner, PackageRegistry { packages: vector[metadata] })
         } else {
-            vector::push_back(&mut borrow_global_mut<PackageRegistry>(addr).packages, metadata)
+            vector::push_back(
+                &mut borrow_global_mut<PackageRegistry>(addr).packages, metadata
+            )
         }
     }
 
     /// Publishes a package at the given signer's address. The caller must provide package metadata describing the
     /// package.
-    public fun publish_package(owner: &signer, pack: PackageMetadata, code: vector<vector<u8>>) acquires PackageRegistry {
+    public fun publish_package(
+        owner: &signer, pack: PackageMetadata, code: vector<vector<u8>>
+    ) acquires PackageRegistry {
         // Disallow incompatible upgrade mode. Governance can decide later if this should be reconsidered.
         assert!(
             pack.upgrade_policy.policy > upgrade_policy_arbitrary().policy,
@@ -167,17 +174,19 @@ module aptos_framework::code {
         let len = vector::length(package_immutable);
         let index = len;
         let upgrade_number = 0;
-        vector::enumerate_ref(package_immutable
-        , |i, old| {
-            let old: &PackageMetadata = old;
-            if (old.name == pack.name) {
-                upgrade_number = old.upgrade_number + 1;
-                check_upgradability(old, &pack, &module_names);
-                index = i;
-            } else {
-                check_coexistence(old, &module_names)
-            };
-        });
+        vector::enumerate_ref(
+            package_immutable,
+            |i, old| {
+                let old: &PackageMetadata = old;
+                if (old.name == pack.name) {
+                    upgrade_number = old.upgrade_number + 1;
+                    check_upgradability(old, &pack, &module_names);
+                    index = i;
+                } else {
+                    check_coexistence(old, &module_names)
+                };
+            },
+        );
 
         // Assign the upgrade counter.
         pack.upgrade_number = upgrade_number;
@@ -191,40 +200,51 @@ module aptos_framework::code {
             vector::push_back(packages, pack)
         };
 
-        event::emit(PublishPackage {
-            code_address: addr,
-            is_upgrade: upgrade_number > 0
-        });
+        event::emit(
+            PublishPackage { code_address: addr, is_upgrade: upgrade_number > 0 },
+        );
 
         // Request publish
         if (features::code_dependency_check_enabled())
-            request_publish_with_allowed_deps(addr, module_names, allowed_deps, code, policy.policy)
-        else
+            request_publish_with_allowed_deps(
+                addr, module_names, allowed_deps, code, policy.policy
+            ) else
         // The new `request_publish_with_allowed_deps` has not yet rolled out, so call downwards
         // compatible code.
-            request_publish(addr, module_names, code, policy.policy)
+        request_publish(addr, module_names, code, policy.policy)
     }
 
-    public fun freeze_code_object(publisher: &signer, code_object: Object<PackageRegistry>) acquires PackageRegistry {
+    public fun freeze_code_object(
+        publisher: &signer, code_object: Object<PackageRegistry>
+    ) acquires PackageRegistry {
         let code_object_addr = object::object_address(&code_object);
-        assert!(exists<PackageRegistry>(code_object_addr), error::not_found(ECODE_OBJECT_DOES_NOT_EXIST));
+        assert!(
+            exists<PackageRegistry>(code_object_addr),
+            error::not_found(ECODE_OBJECT_DOES_NOT_EXIST),
+        );
         assert!(
             object::is_owner(code_object, signer::address_of(publisher)),
-            error::permission_denied(ENOT_PACKAGE_OWNER)
+            error::permission_denied(ENOT_PACKAGE_OWNER),
         );
 
         let registry = borrow_global_mut<PackageRegistry>(code_object_addr);
-        vector::for_each_mut<PackageMetadata>(&mut registry.packages, |pack| {
-            let package: &mut PackageMetadata = pack;
-            package.upgrade_policy = upgrade_policy_immutable();
-        });
+        vector::for_each_mut<PackageMetadata>(
+            &mut registry.packages,
+            |pack| {
+                let package: &mut PackageMetadata = pack;
+                package.upgrade_policy = upgrade_policy_immutable();
+            },
+        );
     }
 
     /// Same as `publish_package` but as an entry function which can be called as a transaction. Because
     /// of current restrictions for txn parameters, the metadata needs to be passed in serialized form.
-    public entry fun publish_package_txn(owner: &signer, metadata_serialized: vector<u8>, code: vector<vector<u8>>)
-    acquires PackageRegistry {
-        publish_package(owner, util::from_bytes<PackageMetadata>(metadata_serialized), code)
+    public entry fun publish_package_txn(
+        owner: &signer, metadata_serialized: vector<u8>, code: vector<vector<u8>>
+    ) acquires PackageRegistry {
+        publish_package(
+            owner, util::from_bytes<PackageMetadata>(metadata_serialized), code
+        )
     }
 
     // Helpers
@@ -232,83 +252,117 @@ module aptos_framework::code {
 
     /// Checks whether the given package is upgradable, and returns true if a compatibility check is needed.
     fun check_upgradability(
-        old_pack: &PackageMetadata, new_pack: &PackageMetadata, new_modules: &vector<String>) {
-        assert!(old_pack.upgrade_policy.policy < upgrade_policy_immutable().policy,
-            error::invalid_argument(EUPGRADE_IMMUTABLE));
-        assert!(can_change_upgrade_policy_to(old_pack.upgrade_policy, new_pack.upgrade_policy),
-            error::invalid_argument(EUPGRADE_WEAKER_POLICY));
+        old_pack: &PackageMetadata,
+        new_pack: &PackageMetadata,
+        new_modules: &vector<String>
+    ) {
+        assert!(
+            old_pack.upgrade_policy.policy < upgrade_policy_immutable().policy,
+            error::invalid_argument(EUPGRADE_IMMUTABLE),
+        );
+        assert!(
+            can_change_upgrade_policy_to(old_pack.upgrade_policy, new_pack.upgrade_policy),
+            error::invalid_argument(EUPGRADE_WEAKER_POLICY),
+        );
         let old_modules = get_module_names(old_pack);
 
-        vector::for_each_ref(&old_modules, |old_module| {
-            assert!(
-                vector::contains(new_modules, old_module),
-                EMODULE_MISSING
-            );
-        });
+        vector::for_each_ref(
+            &old_modules,
+            |old_module| {
+                assert!(
+                    vector::contains(new_modules, old_module),
+                    EMODULE_MISSING,
+                );
+            },
+        );
     }
 
     /// Checks whether a new package with given names can co-exist with old package.
-    fun check_coexistence(old_pack: &PackageMetadata, new_modules: &vector<String>) {
+    fun check_coexistence(
+        old_pack: &PackageMetadata, new_modules: &vector<String>
+    ) {
         // The modules introduced by each package must not overlap with `names`.
-        vector::for_each_ref(&old_pack.modules, |old_mod| {
-            let old_mod: &ModuleMetadata = old_mod;
-            let j = 0;
-            while (j < vector::length(new_modules)) {
-                let name = vector::borrow(new_modules, j);
-                assert!(&old_mod.name != name, error::already_exists(EMODULE_NAME_CLASH));
-                j = j + 1;
-            };
-        });
+        vector::for_each_ref(
+            &old_pack.modules,
+            |old_mod| {
+                let old_mod: &ModuleMetadata = old_mod;
+                let j = 0;
+                while (j < vector::length(new_modules)) {
+                    let name = vector::borrow(new_modules, j);
+                    assert!(
+                        &old_mod.name != name, error::already_exists(EMODULE_NAME_CLASH)
+                    );
+                    j = j + 1;
+                };
+            },
+        );
     }
 
     /// Check that the upgrade policies of all packages are equal or higher quality than this package. Also
     /// compute the list of module dependencies which are allowed by the package metadata. The later
     /// is passed on to the native layer to verify that bytecode dependencies are actually what is pretended here.
-    fun check_dependencies(publish_address: address, pack: &PackageMetadata): vector<AllowedDep>
-    acquires PackageRegistry {
+    fun check_dependencies(
+        publish_address: address, pack: &PackageMetadata
+    ): vector<AllowedDep> acquires PackageRegistry {
         let allowed_module_deps = vector::empty();
         let deps = &pack.deps;
-        vector::for_each_ref(deps, |dep| {
-            let dep: &PackageDep = dep;
-            assert!(exists<PackageRegistry>(dep.account), error::not_found(EPACKAGE_DEP_MISSING));
-            if (is_policy_exempted_address(dep.account)) {
-                // Allow all modules from this address, by using "" as a wildcard in the AllowedDep
-                let account: address = dep.account;
-                let module_name = string::utf8(b"");
-                vector::push_back(&mut allowed_module_deps, AllowedDep { account, module_name });
-            } else {
-                let registry = borrow_global<PackageRegistry>(dep.account);
-                let found = vector::any(&registry.packages, |dep_pack| {
-                    let dep_pack: &PackageMetadata = dep_pack;
-                    if (dep_pack.name == dep.package_name) {
-                        // Check policy
-                        assert!(
-                            dep_pack.upgrade_policy.policy >= pack.upgrade_policy.policy,
-                            error::invalid_argument(EDEP_WEAKER_POLICY)
-                        );
-                        if (dep_pack.upgrade_policy == upgrade_policy_arbitrary()) {
-                            assert!(
-                                dep.account == publish_address,
-                                error::invalid_argument(EDEP_ARBITRARY_NOT_SAME_ADDRESS)
-                            )
-                        };
-                        // Add allowed deps
-                        let account = dep.account;
-                        let k = 0;
-                        let r = vector::length(&dep_pack.modules);
-                        while (k < r) {
-                            let module_name = vector::borrow(&dep_pack.modules, k).name;
-                            vector::push_back(&mut allowed_module_deps, AllowedDep { account, module_name });
-                            k = k + 1;
-                        };
-                        true
-                    } else {
-                        false
-                    }
-                });
-                assert!(found, error::not_found(EPACKAGE_DEP_MISSING));
-            };
-        });
+        vector::for_each_ref(
+            deps,
+            |dep| {
+                let dep: &PackageDep = dep;
+                assert!(
+                    exists<PackageRegistry>(dep.account),
+                    error::not_found(EPACKAGE_DEP_MISSING),
+                );
+                if (is_policy_exempted_address(dep.account)) {
+                    // Allow all modules from this address, by using "" as a wildcard in the AllowedDep
+                    let account: address = dep.account;
+                    let module_name = string::utf8(b"");
+                    vector::push_back(
+                        &mut allowed_module_deps, AllowedDep { account, module_name }
+                    );
+                } else {
+                    let registry = borrow_global<PackageRegistry>(dep.account);
+                    let found = vector::any(
+                        &registry.packages,
+                        |dep_pack| {
+                            let dep_pack: &PackageMetadata = dep_pack;
+                            if (dep_pack.name == dep.package_name) {
+                                // Check policy
+                                assert!(
+                                    dep_pack.upgrade_policy.policy
+                                        >= pack.upgrade_policy.policy,
+                                    error::invalid_argument(EDEP_WEAKER_POLICY),
+                                );
+                                if (dep_pack.upgrade_policy == upgrade_policy_arbitrary()) {
+                                    assert!(
+                                        dep.account == publish_address,
+                                        error::invalid_argument(
+                                            EDEP_ARBITRARY_NOT_SAME_ADDRESS
+                                        ),
+                                    )
+                                };
+                                // Add allowed deps
+                                let account = dep.account;
+                                let k = 0;
+                                let r = vector::length(&dep_pack.modules);
+                                while (k < r) {
+                                    let module_name = vector::borrow(&dep_pack.modules, k)
+                                        .name;
+                                    vector::push_back(
+                                        &mut allowed_module_deps,
+                                        AllowedDep { account, module_name },
+                                    );
+                                    k = k + 1;
+                                };
+                                true
+                            } else { false }
+                        },
+                    );
+                    assert!(found, error::not_found(EPACKAGE_DEP_MISSING));
+                };
+            },
+        );
         allowed_module_deps
     }
 
@@ -316,17 +370,28 @@ module aptos_framework::code {
     /// this exemption, it would not be possible to define an immutable package based on the core system, which
     /// requires to be upgradable for maintenance and evolution, and is configured to be `compatible`.
     fun is_policy_exempted_address(addr: address): bool {
-        addr == @1 || addr == @2 || addr == @3 || addr == @4 || addr == @5 ||
-            addr == @6 || addr == @7 || addr == @8 || addr == @9 || addr == @10
+        addr == @1
+            || addr == @2
+            || addr == @3
+            || addr == @4
+            || addr == @5
+            || addr == @6
+            || addr == @7
+            || addr == @8
+            || addr == @9
+            || addr == @10
     }
 
     /// Get the names of the modules in a package.
     fun get_module_names(pack: &PackageMetadata): vector<String> {
         let module_names = vector::empty();
-        vector::for_each_ref(&pack.modules, |pack_module| {
-            let pack_module: &ModuleMetadata = pack_module;
-            vector::push_back(&mut module_names, pack_module.name);
-        });
+        vector::for_each_ref(
+            &pack.modules,
+            |pack_module| {
+                let pack_module: &ModuleMetadata = pack_module;
+                vector::push_back(&mut module_names, pack_module.name);
+            },
+        );
         module_names
     }
 

--- a/aptos-move/framework/aptos-framework/sources/code.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/code.spec.move
@@ -93,11 +93,15 @@ spec aptos_framework::code {
         pragma verify = false;
     }
 
-    spec check_upgradability(old_pack: &PackageMetadata, new_pack: &PackageMetadata, new_modules: &vector<String>) {
+    spec check_upgradability(
+        old_pack: &PackageMetadata, new_pack: &PackageMetadata, new_modules: &vector<String>
+    ) {
         // TODO: Can't verify 'vector::enumerate' loop.
         pragma aborts_if_is_partial;
         aborts_if old_pack.upgrade_policy.policy >= upgrade_policy_immutable().policy;
-        aborts_if !can_change_upgrade_policy_to(old_pack.upgrade_policy, new_pack.upgrade_policy);
+        aborts_if !can_change_upgrade_policy_to(
+            old_pack.upgrade_policy, new_pack.upgrade_policy
+        );
     }
 
     spec check_dependencies(publish_address: address, pack: &PackageMetadata): vector<AllowedDep> {

--- a/aptos-move/framework/aptos-framework/sources/code.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/code.spec.move
@@ -94,7 +94,9 @@ spec aptos_framework::code {
     }
 
     spec check_upgradability(
-        old_pack: &PackageMetadata, new_pack: &PackageMetadata, new_modules: &vector<String>
+        old_pack: &PackageMetadata,
+        new_pack: &PackageMetadata,
+        new_modules: &vector<String>
     ) {
         // TODO: Can't verify 'vector::enumerate' loop.
         pragma aborts_if_is_partial;

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -280,7 +280,7 @@ module aptos_framework::coin {
     /// Get the paired fungible asset metadata object of a coin type. If not exist, return option::none().
     public fun paired_metadata<CoinType>(): Option<Object<Metadata>> acquires CoinConversionMap {
         if (exists<CoinConversionMap>(@aptos_framework)
-                && features::coin_to_fungible_asset_migration_feature_enabled()) {
+            && features::coin_to_fungible_asset_migration_feature_enabled()) {
             let map =
                 &borrow_global<CoinConversionMap>(@aptos_framework).coin_to_fungible_asset_map;
             let type = type_info::type_of<CoinType>();
@@ -686,9 +686,7 @@ module aptos_framework::coin {
         if (amount == 0) { return };
 
         let (coin_amount_to_collect, fa_amount_to_collect) =
-            calculate_amount_to_withdraw<CoinType>(
-                account_addr, amount
-            );
+            calculate_amount_to_withdraw<CoinType>(account_addr, amount);
         let coin =
             if (coin_amount_to_collect > 0) {
                 let coin_store = borrow_global_mut<CoinStore<CoinType>>(account_addr);
@@ -715,10 +713,10 @@ module aptos_framework::coin {
         } else {
             let metadata = paired_metadata<CoinType>();
             if (option::is_some(&metadata)
-                    && primary_fungible_store::primary_store_exists(
-                        account_addr,
-                        option::destroy_some(metadata),
-                    ))
+                && primary_fungible_store::primary_store_exists(
+                    account_addr,
+                    option::destroy_some(metadata),
+                ))
             (coin_balance, amount - coin_balance)
             else abort error::invalid_argument(EINSUFFICIENT_BALANCE)
         }
@@ -939,9 +937,7 @@ module aptos_framework::coin {
         if (amount == 0) { return };
 
         let (coin_amount_to_burn, fa_amount_to_burn) =
-            calculate_amount_to_withdraw<CoinType>(
-                account_addr, amount
-            );
+            calculate_amount_to_withdraw<CoinType>(account_addr, amount);
         if (coin_amount_to_burn > 0) {
             let coin_store = borrow_global_mut<CoinStore<CoinType>>(account_addr);
             let coin_to_burn = extract(&mut coin_store.coin, coin_amount_to_burn);
@@ -951,7 +947,8 @@ module aptos_framework::coin {
             fungible_asset::burn_from(
                 borrow_paired_burn_ref(burn_cap),
                 primary_fungible_store::primary_store(
-                    account_addr, option::destroy_some(paired_metadata<CoinType>())
+                    account_addr,
+                    option::destroy_some(paired_metadata<CoinType>()),
                 ),
                 fa_amount_to_burn,
             );
@@ -985,10 +982,10 @@ module aptos_framework::coin {
         } else {
             let metadata = paired_metadata<CoinType>();
             if (option::is_some(&metadata)
-                    && migrated_primary_fungible_store_exists(
-                        account_addr,
-                        option::destroy_some(metadata),
-                    )) {
+                && migrated_primary_fungible_store_exists(
+                    account_addr,
+                    option::destroy_some(metadata),
+                )) {
                 primary_fungible_store::deposit(
                     account_addr, coin_to_fungible_asset(coin)
                 );
@@ -1024,10 +1021,10 @@ module aptos_framework::coin {
         } else {
             let metadata = paired_metadata<CoinType>();
             if (option::is_some(&metadata)
-                    && migrated_primary_fungible_store_exists(
-                        account_addr,
-                        option::destroy_some(metadata),
-                    )) {
+                && migrated_primary_fungible_store_exists(
+                    account_addr,
+                    option::destroy_some(metadata),
+                )) {
                 let fa = coin_to_fungible_asset(coin);
                 let metadata = fungible_asset::asset_metadata(&fa);
                 let store = primary_fungible_store::primary_store(account_addr, metadata);
@@ -1252,15 +1249,11 @@ module aptos_framework::coin {
     }
 
     /// Withdraw specified `amount` of coin `CoinType` from the signing account.
-    public fun withdraw<CoinType>(
-        account: &signer, amount: u64,
-    ): Coin<CoinType> acquires CoinStore, CoinConversionMap, CoinInfo, PairedCoinType {
+    public fun withdraw<CoinType>(account: &signer, amount: u64,): Coin<CoinType> acquires CoinStore, CoinConversionMap, CoinInfo, PairedCoinType {
         let account_addr = signer::address_of(account);
 
         let (coin_amount_to_withdraw, fa_amount_to_withdraw) =
-            calculate_amount_to_withdraw<CoinType>(
-                account_addr, amount
-            );
+            calculate_amount_to_withdraw<CoinType>(account_addr, amount);
         let withdrawn_coin =
             if (coin_amount_to_withdraw > 0) {
                 let coin_store = borrow_global_mut<CoinStore<CoinType>>(account_addr);
@@ -1464,9 +1457,7 @@ module aptos_framework::coin {
     }
 
     #[test(source = @0x1, destination = @0x2)]
-    public entry fun end_to_end(
-        source: signer, destination: signer,
-    ) acquires CoinInfo, CoinStore, CoinConversionMap, PairedCoinType {
+    public entry fun end_to_end(source: signer, destination: signer,) acquires CoinInfo, CoinStore, CoinConversionMap, PairedCoinType {
         let source_addr = signer::address_of(&source);
         account::create_account_for_test(source_addr);
         let destination_addr = signer::address_of(&destination);
@@ -1476,9 +1467,7 @@ module aptos_framework::coin {
         let symbol = string::utf8(b"FMD");
 
         let (burn_cap, freeze_cap, mint_cap) =
-            initialize_and_register_fake_money(
-                &source, 18, true
-            );
+            initialize_and_register_fake_money(&source, 18, true);
         register<FakeMoney>(&source);
         register<FakeMoney>(&destination);
         assert!(*option::borrow(&supply<FakeMoney>()) == 0, 0);
@@ -2104,9 +2093,7 @@ module aptos_framework::coin {
     }
 
     #[test(account = @aptos_framework, aaron = @0xcafe)]
-    fun test_balance_with_both_stores(
-        account: &signer, aaron: &signer
-    ) acquires CoinConversionMap, CoinInfo, CoinStore {
+    fun test_balance_with_both_stores(account: &signer, aaron: &signer) acquires CoinConversionMap, CoinInfo, CoinStore {
         let account_addr = signer::address_of(account);
         let aaron_addr = signer::address_of(aaron);
         account::create_account_for_test(account_addr);
@@ -2296,7 +2283,8 @@ module aptos_framework::coin {
         force_deposit(aaron_addr, mint<FakeMoney>(50, &mint_cap));
         assert!(
             primary_fungible_store::balance(
-                aaron_addr, option::extract(&mut paired_metadata<FakeMoney>())
+                aaron_addr,
+                option::extract(&mut paired_metadata<FakeMoney>()),
             ) == 51,
             0,
         );
@@ -2342,7 +2330,8 @@ module aptos_framework::coin {
 
         // Deposit FA to bob to created primary fungible store without `MigrationFlag`.
         primary_fungible_store::deposit(
-            bob_addr, coin_to_fungible_asset(mint<FakeMoney>(100, &mint_cap))
+            bob_addr,
+            coin_to_fungible_asset(mint<FakeMoney>(100, &mint_cap)),
         );
         assert!(!coin_store_exists<FakeMoney>(bob_addr), 0);
         register<FakeMoney>(bob);

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -15,7 +15,14 @@ module aptos_framework::coin {
     use aptos_framework::optional_aggregator::{Self, OptionalAggregator};
     use aptos_framework::system_addresses;
 
-    use aptos_framework::fungible_asset::{Self, FungibleAsset, Metadata, MintRef, TransferRef, BurnRef};
+    use aptos_framework::fungible_asset::{
+        Self,
+        FungibleAsset,
+        Metadata,
+        MintRef,
+        TransferRef,
+        BurnRef
+    };
     use aptos_framework::object::{Self, Object, object_address};
     use aptos_framework::primary_fungible_store;
     use aptos_std::type_info::{Self, TypeInfo, type_name};
@@ -165,7 +172,6 @@ module aptos_framework::coin {
         supply: Option<OptionalAggregator>,
     }
 
-
     #[event]
     /// Module event emitted when some amount of a coin is deposited into an account.
     struct CoinDeposit has drop, store {
@@ -207,7 +213,6 @@ module aptos_framework::coin {
     struct WithdrawEvent has drop, store {
         amount: u64,
     }
-
 
     #[event]
     /// Module event emitted when the event handles related to coin store is deleted.
@@ -274,9 +279,10 @@ module aptos_framework::coin {
     #[view]
     /// Get the paired fungible asset metadata object of a coin type. If not exist, return option::none().
     public fun paired_metadata<CoinType>(): Option<Object<Metadata>> acquires CoinConversionMap {
-        if (exists<CoinConversionMap>(@aptos_framework) && features::coin_to_fungible_asset_migration_feature_enabled(
-        )) {
-            let map = &borrow_global<CoinConversionMap>(@aptos_framework).coin_to_fungible_asset_map;
+        if (exists<CoinConversionMap>(@aptos_framework)
+                && features::coin_to_fungible_asset_migration_feature_enabled()) {
+            let map =
+                &borrow_global<CoinConversionMap>(@aptos_framework).coin_to_fungible_asset_map;
             let type = type_info::type_of<CoinType>();
             if (table::contains(map, type)) {
                 return option::some(*table::borrow(map, type))
@@ -288,16 +294,15 @@ module aptos_framework::coin {
     public entry fun create_coin_conversion_map(aptos_framework: &signer) {
         system_addresses::assert_aptos_framework(aptos_framework);
         if (!exists<CoinConversionMap>(@aptos_framework)) {
-            move_to(aptos_framework, CoinConversionMap {
-                coin_to_fungible_asset_map: table::new(),
-            })
+            move_to(
+                aptos_framework,
+                CoinConversionMap { coin_to_fungible_asset_map: table::new(), },
+            )
         };
     }
 
     /// Create APT pairing by passing `AptosCoin`.
-    public entry fun create_pairing<CoinType>(
-        aptos_framework: &signer
-    ) acquires CoinConversionMap, CoinInfo {
+    public entry fun create_pairing<CoinType>(aptos_framework: &signer) acquires CoinConversionMap, CoinInfo {
         system_addresses::assert_aptos_framework(aptos_framework);
         create_and_return_paired_metadata_if_not_exist<CoinType>(true);
     }
@@ -306,24 +311,34 @@ module aptos_framework::coin {
         type_info::type_name<CoinType>() == string::utf8(b"0x1::aptos_coin::AptosCoin")
     }
 
-    inline fun create_and_return_paired_metadata_if_not_exist<CoinType>(allow_apt_creation: bool): Object<Metadata> {
+    inline fun create_and_return_paired_metadata_if_not_exist<CoinType>(
+        allow_apt_creation: bool
+    ): Object<Metadata> {
         assert!(
             features::coin_to_fungible_asset_migration_feature_enabled(),
-            error::invalid_state(EMIGRATION_FRAMEWORK_NOT_ENABLED)
+            error::invalid_state(EMIGRATION_FRAMEWORK_NOT_ENABLED),
         );
-        assert!(exists<CoinConversionMap>(@aptos_framework), error::not_found(ECOIN_CONVERSION_MAP_NOT_FOUND));
+        assert!(
+            exists<CoinConversionMap>(@aptos_framework),
+            error::not_found(ECOIN_CONVERSION_MAP_NOT_FOUND),
+        );
         let map = borrow_global_mut<CoinConversionMap>(@aptos_framework);
         let type = type_info::type_of<CoinType>();
         if (!table::contains(&map.coin_to_fungible_asset_map, type)) {
             let is_apt = is_apt<CoinType>();
-            assert!(!is_apt || allow_apt_creation, error::invalid_state(EAPT_PAIRING_IS_NOT_ENABLED));
+            assert!(
+                !is_apt || allow_apt_creation,
+                error::invalid_state(EAPT_PAIRING_IS_NOT_ENABLED),
+            );
             let metadata_object_cref =
                 if (is_apt) {
-                    object::create_sticky_object_at_address(@aptos_framework, @aptos_fungible_asset)
+                    object::create_sticky_object_at_address(
+                        @aptos_framework, @aptos_fungible_asset
+                    )
                 } else {
                     object::create_named_object(
                         &create_signer::create_signer(@aptos_fungible_asset),
-                        *string::bytes(&type_info::type_name<CoinType>())
+                        *string::bytes(&type_info::type_name<CoinType>()),
                     )
                 };
             primary_fungible_store::create_primary_store_enabled_fungible_asset(
@@ -342,21 +357,25 @@ module aptos_framework::coin {
             let metadata_obj = object::object_from_constructor_ref(&metadata_object_cref);
 
             table::add(&mut map.coin_to_fungible_asset_map, type, metadata_obj);
-            event::emit(PairCreation {
-                coin_type: type,
-                fungible_asset_metadata_address: object_address(&metadata_obj)
-            });
+            event::emit(
+                PairCreation {
+                    coin_type: type,
+                    fungible_asset_metadata_address: object_address(&metadata_obj)
+                },
+            );
 
             // Generates all three refs
             let mint_ref = fungible_asset::generate_mint_ref(&metadata_object_cref);
-            let transfer_ref = fungible_asset::generate_transfer_ref(&metadata_object_cref);
+            let transfer_ref =
+                fungible_asset::generate_transfer_ref(&metadata_object_cref);
             let burn_ref = fungible_asset::generate_burn_ref(&metadata_object_cref);
-            move_to(metadata_object_signer,
+            move_to(
+                metadata_object_signer,
                 PairedFungibleAssetRefs {
                     mint_ref_opt: option::some(mint_ref),
                     transfer_ref_opt: option::some(transfer_ref),
                     burn_ref_opt: option::some(burn_ref),
-                }
+                },
             );
         };
         *table::borrow(&map.coin_to_fungible_asset_map, type)
@@ -379,25 +398,25 @@ module aptos_framework::coin {
     }
 
     /// Conversion from coin to fungible asset
-    public fun coin_to_fungible_asset<CoinType>(
-        coin: Coin<CoinType>
-    ): FungibleAsset acquires CoinConversionMap, CoinInfo {
+    public fun coin_to_fungible_asset<CoinType>(coin: Coin<CoinType>): FungibleAsset acquires CoinConversionMap, CoinInfo {
         let metadata = ensure_paired_metadata<CoinType>();
         let amount = burn_internal(coin);
         fungible_asset::mint_internal(metadata, amount)
     }
 
     /// Conversion from fungible asset to coin. Not public to push the migration to FA.
-    fun fungible_asset_to_coin<CoinType>(
-        fungible_asset: FungibleAsset
-    ): Coin<CoinType> acquires CoinInfo, PairedCoinType {
-        let metadata_addr = object::object_address(&fungible_asset::metadata_from_asset(&fungible_asset));
+    fun fungible_asset_to_coin<CoinType>(fungible_asset: FungibleAsset): Coin<CoinType> acquires CoinInfo, PairedCoinType {
+        let metadata_addr =
+            object::object_address(&fungible_asset::metadata_from_asset(&fungible_asset));
         assert!(
             object::object_exists<PairedCoinType>(metadata_addr),
-            error::not_found(EPAIRED_COIN)
+            error::not_found(EPAIRED_COIN),
         );
         let coin_type_info = borrow_global<PairedCoinType>(metadata_addr).type;
-        assert!(coin_type_info == type_info::type_of<CoinType>(), error::invalid_argument(ECOIN_TYPE_MISMATCH));
+        assert!(
+            coin_type_info == type_info::type_of<CoinType>(),
+            error::invalid_argument(ECOIN_TYPE_MISMATCH),
+        );
         let amount = fungible_asset::burn_internal(fungible_asset);
         mint_internal<CoinType>(amount)
     }
@@ -413,8 +432,13 @@ module aptos_framework::coin {
     public fun paired_mint_ref_exists<CoinType>(): bool acquires CoinConversionMap, PairedFungibleAssetRefs {
         let metadata = assert_paired_metadata_exists<CoinType>();
         let metadata_addr = object_address(&metadata);
-        assert!(exists<PairedFungibleAssetRefs>(metadata_addr), error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND));
-        option::is_some(&borrow_global<PairedFungibleAssetRefs>(metadata_addr).mint_ref_opt)
+        assert!(
+            exists<PairedFungibleAssetRefs>(metadata_addr),
+            error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND),
+        );
+        option::is_some(
+            &borrow_global<PairedFungibleAssetRefs>(metadata_addr).mint_ref_opt
+        )
     }
 
     /// Get the `MintRef` of paired fungible asset of a coin type from `MintCapability`.
@@ -423,21 +447,28 @@ module aptos_framework::coin {
     ): (MintRef, MintRefReceipt) acquires CoinConversionMap, PairedFungibleAssetRefs {
         let metadata = assert_paired_metadata_exists<CoinType>();
         let metadata_addr = object_address(&metadata);
-        assert!(exists<PairedFungibleAssetRefs>(metadata_addr), error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND));
-        let mint_ref_opt = &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).mint_ref_opt;
+        assert!(
+            exists<PairedFungibleAssetRefs>(metadata_addr),
+            error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND),
+        );
+        let mint_ref_opt =
+            &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).mint_ref_opt;
         assert!(option::is_some(mint_ref_opt), error::not_found(EMINT_REF_NOT_FOUND));
         (option::extract(mint_ref_opt), MintRefReceipt { metadata })
     }
 
     /// Return the `MintRef` with the hot potato receipt.
-    public fun return_paired_mint_ref(mint_ref: MintRef, receipt: MintRefReceipt) acquires PairedFungibleAssetRefs {
+    public fun return_paired_mint_ref(
+        mint_ref: MintRef, receipt: MintRefReceipt
+    ) acquires PairedFungibleAssetRefs {
         let MintRefReceipt { metadata } = receipt;
         assert!(
             fungible_asset::mint_ref_metadata(&mint_ref) == metadata,
-            error::invalid_argument(EMINT_REF_RECEIPT_MISMATCH)
+            error::invalid_argument(EMINT_REF_RECEIPT_MISMATCH),
         );
         let metadata_addr = object_address(&metadata);
-        let mint_ref_opt = &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).mint_ref_opt;
+        let mint_ref_opt =
+            &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).mint_ref_opt;
         option::fill(mint_ref_opt, mint_ref);
     }
 
@@ -446,8 +477,13 @@ module aptos_framework::coin {
     public fun paired_transfer_ref_exists<CoinType>(): bool acquires CoinConversionMap, PairedFungibleAssetRefs {
         let metadata = assert_paired_metadata_exists<CoinType>();
         let metadata_addr = object_address(&metadata);
-        assert!(exists<PairedFungibleAssetRefs>(metadata_addr), error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND));
-        option::is_some(&borrow_global<PairedFungibleAssetRefs>(metadata_addr).transfer_ref_opt)
+        assert!(
+            exists<PairedFungibleAssetRefs>(metadata_addr),
+            error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND),
+        );
+        option::is_some(
+            &borrow_global<PairedFungibleAssetRefs>(metadata_addr).transfer_ref_opt
+        )
     }
 
     /// Get the TransferRef of paired fungible asset of a coin type from `FreezeCapability`.
@@ -456,24 +492,30 @@ module aptos_framework::coin {
     ): (TransferRef, TransferRefReceipt) acquires CoinConversionMap, PairedFungibleAssetRefs {
         let metadata = assert_paired_metadata_exists<CoinType>();
         let metadata_addr = object_address(&metadata);
-        assert!(exists<PairedFungibleAssetRefs>(metadata_addr), error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND));
-        let transfer_ref_opt = &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).transfer_ref_opt;
-        assert!(option::is_some(transfer_ref_opt), error::not_found(ETRANSFER_REF_NOT_FOUND));
+        assert!(
+            exists<PairedFungibleAssetRefs>(metadata_addr),
+            error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND),
+        );
+        let transfer_ref_opt =
+            &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).transfer_ref_opt;
+        assert!(
+            option::is_some(transfer_ref_opt), error::not_found(ETRANSFER_REF_NOT_FOUND)
+        );
         (option::extract(transfer_ref_opt), TransferRefReceipt { metadata })
     }
 
     /// Return the `TransferRef` with the hot potato receipt.
     public fun return_paired_transfer_ref(
-        transfer_ref: TransferRef,
-        receipt: TransferRefReceipt
+        transfer_ref: TransferRef, receipt: TransferRefReceipt
     ) acquires PairedFungibleAssetRefs {
         let TransferRefReceipt { metadata } = receipt;
         assert!(
             fungible_asset::transfer_ref_metadata(&transfer_ref) == metadata,
-            error::invalid_argument(ETRANSFER_REF_RECEIPT_MISMATCH)
+            error::invalid_argument(ETRANSFER_REF_RECEIPT_MISMATCH),
         );
         let metadata_addr = object_address(&metadata);
-        let transfer_ref_opt = &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).transfer_ref_opt;
+        let transfer_ref_opt =
+            &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).transfer_ref_opt;
         option::fill(transfer_ref_opt, transfer_ref);
     }
 
@@ -482,8 +524,13 @@ module aptos_framework::coin {
     public fun paired_burn_ref_exists<CoinType>(): bool acquires CoinConversionMap, PairedFungibleAssetRefs {
         let metadata = assert_paired_metadata_exists<CoinType>();
         let metadata_addr = object_address(&metadata);
-        assert!(exists<PairedFungibleAssetRefs>(metadata_addr), error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND));
-        option::is_some(&borrow_global<PairedFungibleAssetRefs>(metadata_addr).burn_ref_opt)
+        assert!(
+            exists<PairedFungibleAssetRefs>(metadata_addr),
+            error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND),
+        );
+        option::is_some(
+            &borrow_global<PairedFungibleAssetRefs>(metadata_addr).burn_ref_opt
+        )
     }
 
     /// Get the `BurnRef` of paired fungible asset of a coin type from `BurnCapability`.
@@ -492,8 +539,12 @@ module aptos_framework::coin {
     ): (BurnRef, BurnRefReceipt) acquires CoinConversionMap, PairedFungibleAssetRefs {
         let metadata = assert_paired_metadata_exists<CoinType>();
         let metadata_addr = object_address(&metadata);
-        assert!(exists<PairedFungibleAssetRefs>(metadata_addr), error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND));
-        let burn_ref_opt = &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).burn_ref_opt;
+        assert!(
+            exists<PairedFungibleAssetRefs>(metadata_addr),
+            error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND),
+        );
+        let burn_ref_opt =
+            &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).burn_ref_opt;
         assert!(option::is_some(burn_ref_opt), error::not_found(EBURN_REF_NOT_FOUND));
         (option::extract(burn_ref_opt), BurnRefReceipt { metadata })
     }
@@ -506,24 +557,28 @@ module aptos_framework::coin {
         destroy_burn_cap(burn_cap);
         let metadata = assert_paired_metadata_exists<CoinType>();
         let metadata_addr = object_address(&metadata);
-        assert!(exists<PairedFungibleAssetRefs>(metadata_addr), error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND));
-        let burn_ref_opt = &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).burn_ref_opt;
+        assert!(
+            exists<PairedFungibleAssetRefs>(metadata_addr),
+            error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND),
+        );
+        let burn_ref_opt =
+            &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).burn_ref_opt;
         assert!(option::is_some(burn_ref_opt), error::not_found(EBURN_REF_NOT_FOUND));
         option::extract(burn_ref_opt)
     }
 
     /// Return the `BurnRef` with the hot potato receipt.
     public fun return_paired_burn_ref(
-        burn_ref: BurnRef,
-        receipt: BurnRefReceipt
+        burn_ref: BurnRef, receipt: BurnRefReceipt
     ) acquires PairedFungibleAssetRefs {
         let BurnRefReceipt { metadata } = receipt;
         assert!(
             fungible_asset::burn_ref_metadata(&burn_ref) == metadata,
-            error::invalid_argument(EBURN_REF_RECEIPT_MISMATCH)
+            error::invalid_argument(EBURN_REF_RECEIPT_MISMATCH),
         );
         let metadata_addr = object_address(&metadata);
-        let burn_ref_opt = &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).burn_ref_opt;
+        let burn_ref_opt =
+            &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).burn_ref_opt;
         option::fill(burn_ref_opt, burn_ref);
     }
 
@@ -532,8 +587,12 @@ module aptos_framework::coin {
     ): &BurnRef acquires CoinConversionMap, PairedFungibleAssetRefs {
         let metadata = assert_paired_metadata_exists<CoinType>();
         let metadata_addr = object_address(&metadata);
-        assert!(exists<PairedFungibleAssetRefs>(metadata_addr), error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND));
-        let burn_ref_opt = &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).burn_ref_opt;
+        assert!(
+            exists<PairedFungibleAssetRefs>(metadata_addr),
+            error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND),
+        );
+        let burn_ref_opt =
+            &mut borrow_global_mut<PairedFungibleAssetRefs>(metadata_addr).burn_ref_opt;
         assert!(option::is_some(burn_ref_opt), error::not_found(EBURN_REF_NOT_FOUND));
         option::borrow(burn_ref_opt)
     }
@@ -550,9 +609,12 @@ module aptos_framework::coin {
 
     /// This should be called by on-chain governance to update the config and allow
     /// or disallow upgradability of total supply.
-    public fun allow_supply_upgrades(aptos_framework: &signer, allowed: bool) acquires SupplyConfig {
+    public fun allow_supply_upgrades(
+        aptos_framework: &signer, allowed: bool
+    ) acquires SupplyConfig {
         system_addresses::assert_aptos_framework(aptos_framework);
-        let allow_upgrades = &mut borrow_global_mut<SupplyConfig>(@aptos_framework).allow_upgrades;
+        let allow_upgrades =
+            &mut borrow_global_mut<SupplyConfig>(@aptos_framework).allow_upgrades;
         *allow_upgrades = allowed;
     }
 
@@ -562,27 +624,33 @@ module aptos_framework::coin {
 
     /// Creates a new aggregatable coin with value overflowing on `limit`. Note that this function can
     /// only be called by Aptos Framework (0x1) account for now because of `create_aggregator`.
-    public(friend) fun initialize_aggregatable_coin<CoinType>(aptos_framework: &signer): AggregatableCoin<CoinType> {
+    public(friend) fun initialize_aggregatable_coin<CoinType>(
+        aptos_framework: &signer
+    ): AggregatableCoin<CoinType> {
         let aggregator = aggregator_factory::create_aggregator(aptos_framework, MAX_U64);
-        AggregatableCoin<CoinType> {
-            value: aggregator,
-        }
+        AggregatableCoin<CoinType> { value: aggregator, }
     }
 
     /// Returns true if the value of aggregatable coin is zero.
-    public(friend) fun is_aggregatable_coin_zero<CoinType>(coin: &AggregatableCoin<CoinType>): bool {
+    public(friend) fun is_aggregatable_coin_zero<CoinType>(
+        coin: &AggregatableCoin<CoinType>
+    ): bool {
         let amount = aggregator::read(&coin.value);
         amount == 0
     }
 
     /// Drains the aggregatable coin, setting it to zero and returning a standard coin.
-    public(friend) fun drain_aggregatable_coin<CoinType>(coin: &mut AggregatableCoin<CoinType>): Coin<CoinType> {
+    public(friend) fun drain_aggregatable_coin<CoinType>(
+        coin: &mut AggregatableCoin<CoinType>
+    ): Coin<CoinType> {
         spec {
             // TODO: The data invariant is not properly assumed from CollectedFeesPerBlock.
             assume aggregator::spec_get_limit(coin.value) == MAX_U64;
         };
         let amount = aggregator::read(&coin.value);
-        assert!(amount <= MAX_U64, error::out_of_range(EAGGREGATABLE_COIN_VALUE_TOO_LARGE));
+        assert!(
+            amount <= MAX_U64, error::out_of_range(EAGGREGATABLE_COIN_VALUE_TOO_LARGE)
+        );
         spec {
             update aggregate_supply<CoinType> = aggregate_supply<CoinType> - amount;
         };
@@ -590,15 +658,12 @@ module aptos_framework::coin {
         spec {
             update supply<CoinType> = supply<CoinType> + amount;
         };
-        Coin<CoinType> {
-            value: (amount as u64),
-        }
+        Coin<CoinType> { value: (amount as u64), }
     }
 
     /// Merges `coin` into aggregatable coin (`dst_coin`).
     public(friend) fun merge_aggregatable_coin<CoinType>(
-        dst_coin: &mut AggregatableCoin<CoinType>,
-        coin: Coin<CoinType>
+        dst_coin: &mut AggregatableCoin<CoinType>, coin: Coin<CoinType>
     ) {
         spec {
             update supply<CoinType> = supply<CoinType> - coin.value;
@@ -618,25 +683,23 @@ module aptos_framework::coin {
         dst_coin: &mut AggregatableCoin<CoinType>,
     ) acquires CoinStore, CoinConversionMap, CoinInfo, PairedCoinType {
         // Skip collecting if amount is zero.
-        if (amount == 0) {
-            return
-        };
+        if (amount == 0) { return };
 
-        let (coin_amount_to_collect, fa_amount_to_collect) = calculate_amount_to_withdraw<CoinType>(
-            account_addr,
-            amount
-        );
-        let coin = if (coin_amount_to_collect > 0) {
-            let coin_store = borrow_global_mut<CoinStore<CoinType>>(account_addr);
-            extract(&mut coin_store.coin, coin_amount_to_collect)
-        } else {
-            zero()
-        };
-        if (fa_amount_to_collect > 0) {
-            let store_addr = primary_fungible_store::primary_store_address(
-                account_addr,
-                option::destroy_some(paired_metadata<CoinType>())
+        let (coin_amount_to_collect, fa_amount_to_collect) =
+            calculate_amount_to_withdraw<CoinType>(
+                account_addr, amount
             );
+        let coin =
+            if (coin_amount_to_collect > 0) {
+                let coin_store = borrow_global_mut<CoinStore<CoinType>>(account_addr);
+                extract(&mut coin_store.coin, coin_amount_to_collect)
+            } else { zero() };
+        if (fa_amount_to_collect > 0) {
+            let store_addr =
+                primary_fungible_store::primary_store_address(
+                    account_addr,
+                    option::destroy_some(paired_metadata<CoinType>()),
+                );
             let fa = fungible_asset::withdraw_internal(store_addr, fa_amount_to_collect);
             merge(&mut coin, fungible_asset_to_coin<CoinType>(fa));
         };
@@ -644,21 +707,20 @@ module aptos_framework::coin {
     }
 
     inline fun calculate_amount_to_withdraw<CoinType>(
-        account_addr: address,
-        amount: u64
+        account_addr: address, amount: u64
     ): (u64, u64) {
         let coin_balance = coin_balance<CoinType>(account_addr);
         if (coin_balance >= amount) {
             (amount, 0)
         } else {
             let metadata = paired_metadata<CoinType>();
-            if (option::is_some(&metadata) && primary_fungible_store::primary_store_exists(
-                account_addr,
-                option::destroy_some(metadata)
-            ))
-                (coin_balance, amount - coin_balance)
-            else
-                abort error::invalid_argument(EINSUFFICIENT_BALANCE)
+            if (option::is_some(&metadata)
+                    && primary_fungible_store::primary_store_exists(
+                        account_addr,
+                        option::destroy_some(metadata),
+                    ))
+            (coin_balance, amount - coin_balance)
+            else abort error::invalid_argument(EINSUFFICIENT_BALANCE)
         }
     }
 
@@ -666,23 +728,29 @@ module aptos_framework::coin {
         if (!features::coin_to_fungible_asset_migration_feature_enabled()) {
             abort error::unavailable(ECOIN_TO_FUNGIBLE_ASSET_FEATURE_NOT_ENABLED)
         };
-        assert!(is_coin_initialized<CoinType>(), error::invalid_argument(ECOIN_INFO_NOT_PUBLISHED));
+        assert!(
+            is_coin_initialized<CoinType>(),
+            error::invalid_argument(ECOIN_INFO_NOT_PUBLISHED),
+        );
 
         let metadata = ensure_paired_metadata<CoinType>();
         let store = primary_fungible_store::ensure_primary_store_exists(account, metadata);
         let store_address = object::object_address(&store);
         if (exists<CoinStore<CoinType>>(account)) {
-            let CoinStore<CoinType> { coin, frozen, deposit_events, withdraw_events } = move_from<CoinStore<CoinType>>(
-                account
-            );
+            let CoinStore<CoinType> { coin, frozen, deposit_events, withdraw_events } =
+                move_from<CoinStore<CoinType>>(account);
             event::emit(
                 CoinEventHandleDeletion {
                     event_handle_creation_address: guid::creator_address(
                         event::guid(&deposit_events)
                     ),
-                    deleted_deposit_event_handle_creation_number: guid::creation_num(event::guid(&deposit_events)),
-                    deleted_withdraw_event_handle_creation_number: guid::creation_num(event::guid(&withdraw_events))
-                }
+                    deleted_deposit_event_handle_creation_number: guid::creation_num(
+                        event::guid(&deposit_events)
+                    ),
+                    deleted_withdraw_event_handle_creation_number: guid::creation_num(
+                        event::guid(&withdraw_events)
+                    )
+                },
             );
             event::destroy_handle(deposit_events);
             event::destroy_handle(withdraw_events);
@@ -706,9 +774,7 @@ module aptos_framework::coin {
     }
 
     /// Voluntarily migrate to fungible store for `CoinType` if not yet.
-    public entry fun migrate_to_fungible_store<CoinType>(
-        account: &signer
-    ) acquires CoinStore, CoinConversionMap, CoinInfo {
+    public entry fun migrate_to_fungible_store<CoinType>(account: &signer) acquires CoinStore, CoinConversionMap, CoinInfo {
         maybe_convert_to_fungible_store<CoinType>(signer::address_of(account));
     }
 
@@ -726,12 +792,13 @@ module aptos_framework::coin {
     /// Returns the balance of `owner` for provided `CoinType` and its paired FA if exists.
     public fun balance<CoinType>(owner: address): u64 acquires CoinConversionMap, CoinStore {
         let paired_metadata = paired_metadata<CoinType>();
-        coin_balance<CoinType>(owner) + if (option::is_some(&paired_metadata)) {
-            primary_fungible_store::balance(
-                owner,
-                option::extract(&mut paired_metadata)
-            )
-        } else { 0 }
+        coin_balance<CoinType>(owner)
+            + if (option::is_some(&paired_metadata)) {
+                primary_fungible_store::balance(
+                    owner,
+                    option::extract(&mut paired_metadata),
+                )
+            } else { 0 }
     }
 
     #[view]
@@ -748,7 +815,7 @@ module aptos_framework::coin {
             primary_fungible_store::is_balance_at_least(
                 owner,
                 option::extract(&mut paired_metadata),
-                left_amount
+                left_amount,
             )
         } else { false }
     }
@@ -756,9 +823,7 @@ module aptos_framework::coin {
     inline fun coin_balance<CoinType>(owner: address): u64 {
         if (exists<CoinStore<CoinType>>(owner)) {
             borrow_global<CoinStore<CoinType>>(owner).coin.value
-        } else {
-            0
-        }
+        } else { 0 }
     }
 
     #[view]
@@ -769,9 +834,7 @@ module aptos_framework::coin {
 
     #[view]
     /// Returns `true` is account_addr has frozen the CoinStore or if it's not registered at all
-    public fun is_coin_store_frozen<CoinType>(
-        account_addr: address
-    ): bool acquires CoinStore, CoinConversionMap {
+    public fun is_coin_store_frozen<CoinType>(account_addr: address): bool acquires CoinStore, CoinConversionMap {
         if (!is_account_registered<CoinType>(account_addr)) {
             return true
         };
@@ -783,14 +846,19 @@ module aptos_framework::coin {
     #[view]
     /// Returns `true` if `account_addr` is registered to receive `CoinType`.
     public fun is_account_registered<CoinType>(account_addr: address): bool acquires CoinConversionMap {
-        assert!(is_coin_initialized<CoinType>(), error::invalid_argument(ECOIN_INFO_NOT_PUBLISHED));
-        if (exists<CoinStore<CoinType>>(account_addr)) {
-            true
-        } else {
+        assert!(
+            is_coin_initialized<CoinType>(),
+            error::invalid_argument(ECOIN_INFO_NOT_PUBLISHED),
+        );
+        if (exists<CoinStore<CoinType>>(account_addr)) { true }
+        else {
             let paired_metadata_opt = paired_metadata<CoinType>();
-            (option::is_some(
-                &paired_metadata_opt
-            ) && migrated_primary_fungible_store_exists(account_addr, option::destroy_some(paired_metadata_opt)))
+            (
+                option::is_some(&paired_metadata_opt)
+                    && migrated_primary_fungible_store_exists(
+                        account_addr, option::destroy_some(paired_metadata_opt)
+                    )
+            )
         }
     }
 
@@ -820,7 +888,8 @@ module aptos_framework::coin {
         let coin_supply = coin_supply<CoinType>();
         let metadata = paired_metadata<CoinType>();
         if (option::is_some(&metadata)) {
-            let fungible_asset_supply = fungible_asset::supply(option::extract(&mut metadata));
+            let fungible_asset_supply =
+                fungible_asset::supply(option::extract(&mut metadata));
             if (option::is_some(&coin_supply)) {
                 let supply = option::borrow_mut(&mut coin_supply);
                 *supply = *supply + option::destroy_some(fungible_asset_supply);
@@ -832,7 +901,8 @@ module aptos_framework::coin {
     #[view]
     /// Returns the amount of coin in existence.
     public fun coin_supply<CoinType>(): Option<u128> acquires CoinInfo {
-        let maybe_supply = &borrow_global<CoinInfo<CoinType>>(coin_address<CoinType>()).supply;
+        let maybe_supply =
+            &borrow_global<CoinInfo<CoinType>>(coin_address<CoinType>()).supply;
         if (option::is_some(maybe_supply)) {
             // We do track supply, in this case read from optional aggregator.
             let supply = option::borrow(maybe_supply);
@@ -842,13 +912,16 @@ module aptos_framework::coin {
             option::none()
         }
     }
+
     //
     // Public functions
     //
 
     /// Burn `coin` with capability.
     /// The capability `_cap` should be passed as a reference to `BurnCapability<CoinType>`.
-    public fun burn<CoinType>(coin: Coin<CoinType>, _cap: &BurnCapability<CoinType>) acquires CoinInfo {
+    public fun burn<CoinType>(
+        coin: Coin<CoinType>, _cap: &BurnCapability<CoinType>
+    ) acquires CoinInfo {
         burn_internal(coin);
     }
 
@@ -863,14 +936,12 @@ module aptos_framework::coin {
         burn_cap: &BurnCapability<CoinType>,
     ) acquires CoinInfo, CoinStore, CoinConversionMap, PairedFungibleAssetRefs {
         // Skip burning if amount is zero. This shouldn't error out as it's called as part of transaction fee burning.
-        if (amount == 0) {
-            return
-        };
+        if (amount == 0) { return };
 
-        let (coin_amount_to_burn, fa_amount_to_burn) = calculate_amount_to_withdraw<CoinType>(
-            account_addr,
-            amount
-        );
+        let (coin_amount_to_burn, fa_amount_to_burn) =
+            calculate_amount_to_withdraw<CoinType>(
+                account_addr, amount
+            );
         if (coin_amount_to_burn > 0) {
             let coin_store = borrow_global_mut<CoinStore<CoinType>>(account_addr);
             let coin_to_burn = extract(&mut coin_store.coin, coin_amount_to_burn);
@@ -879,16 +950,17 @@ module aptos_framework::coin {
         if (fa_amount_to_burn > 0) {
             fungible_asset::burn_from(
                 borrow_paired_burn_ref(burn_cap),
-                primary_fungible_store::primary_store(account_addr, option::destroy_some(paired_metadata<CoinType>())),
-                fa_amount_to_burn
+                primary_fungible_store::primary_store(
+                    account_addr, option::destroy_some(paired_metadata<CoinType>())
+                ),
+                fa_amount_to_burn,
             );
         };
     }
 
     /// Deposit the coin balance into the recipient's account and emit an event.
     public fun deposit<CoinType>(
-        account_addr: address,
-        coin: Coin<CoinType>
+        account_addr: address, coin: Coin<CoinType>
     ) acquires CoinStore, CoinConversionMap, CoinInfo {
         if (exists<CoinStore<CoinType>>(account_addr)) {
             let coin_store = borrow_global_mut<CoinStore<CoinType>>(account_addr);
@@ -898,7 +970,11 @@ module aptos_framework::coin {
             );
             if (std::features::module_event_migration_enabled()) {
                 event::emit(
-                    CoinDeposit { coin_type: type_name<CoinType>(), account: account_addr, amount: coin.value }
+                    CoinDeposit {
+                        coin_type: type_name<CoinType>(),
+                        account: account_addr,
+                        amount: coin.value
+                    },
                 );
             };
             event::emit_event<DepositEvent>(
@@ -908,11 +984,14 @@ module aptos_framework::coin {
             merge(&mut coin_store.coin, coin);
         } else {
             let metadata = paired_metadata<CoinType>();
-            if (option::is_some(&metadata) && migrated_primary_fungible_store_exists(
-                account_addr,
-                option::destroy_some(metadata)
-            )) {
-                primary_fungible_store::deposit(account_addr, coin_to_fungible_asset(coin));
+            if (option::is_some(&metadata)
+                    && migrated_primary_fungible_store_exists(
+                        account_addr,
+                        option::destroy_some(metadata),
+                    )) {
+                primary_fungible_store::deposit(
+                    account_addr, coin_to_fungible_asset(coin)
+                );
             } else {
                 abort error::not_found(ECOIN_STORE_NOT_PUBLISHED)
             };
@@ -920,31 +999,35 @@ module aptos_framework::coin {
     }
 
     inline fun migrated_primary_fungible_store_exists(
-        account_address: address,
-        metadata: Object<Metadata>
+        account_address: address, metadata: Object<Metadata>
     ): bool {
-        let primary_store_address = primary_fungible_store::primary_store_address<Metadata>(account_address, metadata);
-        fungible_asset::store_exists(primary_store_address) && (
-            // migration flag is needed, until we start defaulting new accounts to APT PFS
-            features::new_accounts_default_to_fa_apt_store_enabled() || exists<MigrationFlag>(primary_store_address)
-        )
+        let primary_store_address =
+            primary_fungible_store::primary_store_address<Metadata>(
+                account_address, metadata
+            );
+        fungible_asset::store_exists(primary_store_address)
+            && (
+                // migration flag is needed, until we start defaulting new accounts to APT PFS
+                features::new_accounts_default_to_fa_apt_store_enabled()
+                    || exists<MigrationFlag>(primary_store_address)
+            )
     }
 
     /// Deposit the coin balance into the recipient's account without checking if the account is frozen.
     /// This is for internal use only and doesn't emit an DepositEvent.
     public(friend) fun force_deposit<CoinType>(
-        account_addr: address,
-        coin: Coin<CoinType>
+        account_addr: address, coin: Coin<CoinType>
     ) acquires CoinStore, CoinConversionMap, CoinInfo {
         if (exists<CoinStore<CoinType>>(account_addr)) {
             let coin_store = borrow_global_mut<CoinStore<CoinType>>(account_addr);
             merge(&mut coin_store.coin, coin);
         } else {
             let metadata = paired_metadata<CoinType>();
-            if (option::is_some(&metadata) && migrated_primary_fungible_store_exists(
-                account_addr,
-                option::destroy_some(metadata)
-            )) {
+            if (option::is_some(&metadata)
+                    && migrated_primary_fungible_store_exists(
+                        account_addr,
+                        option::destroy_some(metadata),
+                    )) {
                 let fa = coin_to_fungible_asset(coin);
                 let metadata = fungible_asset::asset_metadata(&fa);
                 let store = primary_fungible_store::primary_store(account_addr, metadata);
@@ -995,8 +1078,7 @@ module aptos_framework::coin {
     #[legacy_entry_fun]
     /// Freeze a CoinStore to prevent transfers
     public entry fun freeze_coin_store<CoinType>(
-        account_addr: address,
-        _freeze_cap: &FreezeCapability<CoinType>,
+        account_addr: address, _freeze_cap: &FreezeCapability<CoinType>,
     ) acquires CoinStore {
         let coin_store = borrow_global_mut<CoinStore<CoinType>>(account_addr);
         coin_store.frozen = true;
@@ -1005,8 +1087,7 @@ module aptos_framework::coin {
     #[legacy_entry_fun]
     /// Unfreeze a CoinStore to allow transfers
     public entry fun unfreeze_coin_store<CoinType>(
-        account_addr: address,
-        _freeze_cap: &FreezeCapability<CoinType>,
+        account_addr: address, _freeze_cap: &FreezeCapability<CoinType>,
     ) acquires CoinStore {
         let coin_store = borrow_global_mut<CoinStore<CoinType>>(account_addr);
         coin_store.frozen = false;
@@ -1026,7 +1107,7 @@ module aptos_framework::coin {
         // Can only succeed once on-chain governance agreed on the upgrade.
         assert!(
             borrow_global_mut<SupplyConfig>(@aptos_framework).allow_upgrades,
-            error::permission_denied(ECOIN_SUPPLY_UPGRADE_NOT_SUPPORTED)
+            error::permission_denied(ECOIN_SUPPLY_UPGRADE_NOT_SUPPORTED),
         );
 
         let maybe_supply = &mut borrow_global_mut<CoinInfo<CoinType>>(account_addr).supply;
@@ -1085,27 +1166,39 @@ module aptos_framework::coin {
             error::already_exists(ECOIN_INFO_ALREADY_PUBLISHED),
         );
 
-        assert!(string::length(&name) <= MAX_COIN_NAME_LENGTH, error::invalid_argument(ECOIN_NAME_TOO_LONG));
-        assert!(string::length(&symbol) <= MAX_COIN_SYMBOL_LENGTH, error::invalid_argument(ECOIN_SYMBOL_TOO_LONG));
+        assert!(
+            string::length(&name) <= MAX_COIN_NAME_LENGTH,
+            error::invalid_argument(ECOIN_NAME_TOO_LONG),
+        );
+        assert!(
+            string::length(&symbol) <= MAX_COIN_SYMBOL_LENGTH,
+            error::invalid_argument(ECOIN_SYMBOL_TOO_LONG),
+        );
 
         let coin_info = CoinInfo<CoinType> {
             name,
             symbol,
             decimals,
             supply: if (monitor_supply) {
-                option::some(
-                    optional_aggregator::new(MAX_U128, parallelizable)
-                )
-            } else { option::none() },
+                option::some(optional_aggregator::new(MAX_U128, parallelizable))
+            } else {
+                option::none()
+            },
         };
         move_to(account, coin_info);
 
-        (BurnCapability<CoinType> {}, FreezeCapability<CoinType> {}, MintCapability<CoinType> {})
+        (
+            BurnCapability<CoinType> {},
+            FreezeCapability<CoinType> {},
+            MintCapability<CoinType> {}
+        )
     }
 
     /// "Merges" the two given coins.  The coin passed in as `dst_coin` will have a value equal
     /// to the sum of the two tokens (`dst_coin` and `source_coin`).
-    public fun merge<CoinType>(dst_coin: &mut Coin<CoinType>, source_coin: Coin<CoinType>) {
+    public fun merge<CoinType>(
+        dst_coin: &mut Coin<CoinType>, source_coin: Coin<CoinType>
+    ) {
         spec {
             assume dst_coin.value + source_coin.value <= MAX_U64;
         };
@@ -1123,8 +1216,7 @@ module aptos_framework::coin {
     /// The capability `_cap` should be passed as reference to `MintCapability<CoinType>`.
     /// Returns minted `Coin`.
     public fun mint<CoinType>(
-        amount: u64,
-        _cap: &MintCapability<CoinType>,
+        amount: u64, _cap: &MintCapability<CoinType>,
     ): Coin<CoinType> acquires CoinInfo {
         mint_internal<CoinType>(amount)
     }
@@ -1132,9 +1224,7 @@ module aptos_framework::coin {
     public fun register<CoinType>(account: &signer) acquires CoinConversionMap {
         let account_addr = signer::address_of(account);
         // Short-circuit and do nothing if account is already registered for CoinType.
-        if (is_account_registered<CoinType>(account_addr)) {
-            return
-        };
+        if (is_account_registered<CoinType>(account_addr)) { return };
 
         account::register_coin<CoinType>(account_addr);
         let coin_store = CoinStore<CoinType> {
@@ -1163,42 +1253,43 @@ module aptos_framework::coin {
 
     /// Withdraw specified `amount` of coin `CoinType` from the signing account.
     public fun withdraw<CoinType>(
-        account: &signer,
-        amount: u64,
+        account: &signer, amount: u64,
     ): Coin<CoinType> acquires CoinStore, CoinConversionMap, CoinInfo, PairedCoinType {
         let account_addr = signer::address_of(account);
 
-        let (coin_amount_to_withdraw, fa_amount_to_withdraw) = calculate_amount_to_withdraw<CoinType>(
-            account_addr,
-            amount
-        );
-        let withdrawn_coin = if (coin_amount_to_withdraw > 0) {
-            let coin_store = borrow_global_mut<CoinStore<CoinType>>(account_addr);
-            assert!(
-                !coin_store.frozen,
-                error::permission_denied(EFROZEN),
+        let (coin_amount_to_withdraw, fa_amount_to_withdraw) =
+            calculate_amount_to_withdraw<CoinType>(
+                account_addr, amount
             );
-            if (std::features::module_event_migration_enabled()) {
-                event::emit(
-                    CoinWithdraw {
-                        coin_type: type_name<CoinType>(), account: account_addr, amount: coin_amount_to_withdraw
-                    }
+        let withdrawn_coin =
+            if (coin_amount_to_withdraw > 0) {
+                let coin_store = borrow_global_mut<CoinStore<CoinType>>(account_addr);
+                assert!(
+                    !coin_store.frozen,
+                    error::permission_denied(EFROZEN),
                 );
-            };
-            event::emit_event<WithdrawEvent>(
-                &mut coin_store.withdraw_events,
-                WithdrawEvent { amount: coin_amount_to_withdraw },
-            );
-            extract(&mut coin_store.coin, coin_amount_to_withdraw)
-        } else {
-            zero()
-        };
+                if (std::features::module_event_migration_enabled()) {
+                    event::emit(
+                        CoinWithdraw {
+                            coin_type: type_name<CoinType>(),
+                            account: account_addr,
+                            amount: coin_amount_to_withdraw
+                        },
+                    );
+                };
+                event::emit_event<WithdrawEvent>(
+                    &mut coin_store.withdraw_events,
+                    WithdrawEvent { amount: coin_amount_to_withdraw },
+                );
+                extract(&mut coin_store.coin, coin_amount_to_withdraw)
+            } else { zero() };
         if (fa_amount_to_withdraw > 0) {
-            let fa = primary_fungible_store::withdraw(
-                account,
-                option::destroy_some(paired_metadata<CoinType>()),
-                fa_amount_to_withdraw
-            );
+            let fa =
+                primary_fungible_store::withdraw(
+                    account,
+                    option::destroy_some(paired_metadata<CoinType>()),
+                    fa_amount_to_withdraw,
+                );
             merge(&mut withdrawn_coin, fungible_asset_to_coin(fa));
         };
         withdrawn_coin
@@ -1209,45 +1300,56 @@ module aptos_framework::coin {
         spec {
             update supply<CoinType> = supply<CoinType> + 0;
         };
-        Coin<CoinType> {
-            value: 0
-        }
+        Coin<CoinType> { value: 0 }
     }
 
     /// Destroy a freeze capability. Freeze capability is dangerous and therefore should be destroyed if not used.
-    public fun destroy_freeze_cap<CoinType>(freeze_cap: FreezeCapability<CoinType>) {
+    public fun destroy_freeze_cap<CoinType>(
+        freeze_cap: FreezeCapability<CoinType>
+    ) {
         let FreezeCapability<CoinType> {} = freeze_cap;
     }
 
     /// Destroy a mint capability.
-    public fun destroy_mint_cap<CoinType>(mint_cap: MintCapability<CoinType>) {
+    public fun destroy_mint_cap<CoinType>(
+        mint_cap: MintCapability<CoinType>
+    ) {
         let MintCapability<CoinType> {} = mint_cap;
     }
 
     /// Destroy a burn capability.
-    public fun destroy_burn_cap<CoinType>(burn_cap: BurnCapability<CoinType>) {
+    public fun destroy_burn_cap<CoinType>(
+        burn_cap: BurnCapability<CoinType>
+    ) {
         let BurnCapability<CoinType> {} = burn_cap;
     }
 
     fun mint_internal<CoinType>(amount: u64): Coin<CoinType> acquires CoinInfo {
         if (amount == 0) {
-            return Coin<CoinType> {
-                value: 0
-            }
+            return Coin<CoinType> { value: 0 }
         };
 
-        let maybe_supply = &mut borrow_global_mut<CoinInfo<CoinType>>(coin_address<CoinType>()).supply;
+        let maybe_supply =
+            &mut borrow_global_mut<CoinInfo<CoinType>>(coin_address<CoinType>()).supply;
         if (option::is_some(maybe_supply)) {
             let supply = option::borrow_mut(maybe_supply);
             spec {
                 use aptos_framework::optional_aggregator;
                 use aptos_framework::aggregator;
-                assume optional_aggregator::is_parallelizable(supply) ==> (aggregator::spec_aggregator_get_val(
-                    option::borrow(supply.aggregator)
-                )
-                    + amount <= aggregator::spec_get_limit(option::borrow(supply.aggregator)));
+                assume optional_aggregator::is_parallelizable(supply) ==>
+                    (
+                        aggregator::spec_aggregator_get_val(
+                            option::borrow(supply.aggregator)
+                        ) + amount
+                            <= aggregator::spec_get_limit(
+                                option::borrow(supply.aggregator)
+                            )
+                    );
                 assume !optional_aggregator::is_parallelizable(supply) ==>
-                    (option::borrow(supply.integer).value + amount <= option::borrow(supply.integer).limit);
+                    (
+                        option::borrow(supply.integer).value + amount
+                            <= option::borrow(supply.integer).limit
+                    );
             };
             optional_aggregator::add(supply, (amount as u128));
         };
@@ -1263,7 +1365,8 @@ module aptos_framework::coin {
         };
         let Coin { value: amount } = coin;
         if (amount != 0) {
-            let maybe_supply = &mut borrow_global_mut<CoinInfo<CoinType>>(coin_address<CoinType>()).supply;
+            let maybe_supply =
+                &mut borrow_global_mut<CoinInfo<CoinType>>(coin_address<CoinType>()).supply;
             if (option::is_some(maybe_supply)) {
                 let supply = option::borrow_mut(maybe_supply);
                 optional_aggregator::sub(supply, (amount as u128));
@@ -1291,7 +1394,10 @@ module aptos_framework::coin {
 
     #[test_only]
     fun create_coin_store<CoinType>(account: &signer) {
-        assert!(is_coin_initialized<CoinType>(), error::invalid_argument(ECOIN_INFO_NOT_PUBLISHED));
+        assert!(
+            is_coin_initialized<CoinType>(),
+            error::invalid_argument(ECOIN_INFO_NOT_PUBLISHED),
+        );
         if (!exists<CoinStore<CoinType>>(signer::address_of(account))) {
             let coin_store = CoinStore<CoinType> {
                 coin: Coin { value: 0 },
@@ -1320,7 +1426,7 @@ module aptos_framework::coin {
             string::utf8(b"Fake money"),
             string::utf8(b"FMD"),
             decimals,
-            monitor_supply
+            monitor_supply,
         )
     }
 
@@ -1330,11 +1436,12 @@ module aptos_framework::coin {
         decimals: u8,
         monitor_supply: bool,
     ): (BurnCapability<FakeMoney>, FreezeCapability<FakeMoney>, MintCapability<FakeMoney>) {
-        let (burn_cap, freeze_cap, mint_cap) = initialize_fake_money(
-            account,
-            decimals,
-            monitor_supply
-        );
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_fake_money(
+                account,
+                decimals,
+                monitor_supply,
+            );
         create_coin_store<FakeMoney>(account);
         create_coin_conversion_map(account);
         (burn_cap, freeze_cap, mint_cap)
@@ -1342,26 +1449,23 @@ module aptos_framework::coin {
 
     #[test_only]
     public entry fun create_fake_money(
-        source: &signer,
-        destination: &signer,
-        amount: u64
+        source: &signer, destination: &signer, amount: u64
     ) acquires CoinInfo, CoinStore, CoinConversionMap {
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(source, 18, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(source, 18, true);
 
         create_coin_store<FakeMoney>(destination);
         let coins_minted = mint<FakeMoney>(amount, &mint_cap);
         deposit(signer::address_of(source), coins_minted);
-        move_to(source, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            source,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(source = @0x1, destination = @0x2)]
     public entry fun end_to_end(
-        source: signer,
-        destination: signer,
+        source: signer, destination: signer,
     ) acquires CoinInfo, CoinStore, CoinConversionMap, PairedCoinType {
         let source_addr = signer::address_of(&source);
         account::create_account_for_test(source_addr);
@@ -1371,11 +1475,10 @@ module aptos_framework::coin {
         let name = string::utf8(b"Fake money");
         let symbol = string::utf8(b"FMD");
 
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(
-            &source,
-            18,
-            true
-        );
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(
+                &source, 18, true
+            );
         register<FakeMoney>(&source);
         register<FakeMoney>(&destination);
         assert!(*option::borrow(&supply<FakeMoney>()) == 0, 0);
@@ -1403,24 +1506,23 @@ module aptos_framework::coin {
         burn(coin, &burn_cap);
         assert!(*option::borrow(&supply<FakeMoney>()) == 90, 8);
 
-        move_to(&source, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            &source,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(source = @0x1, destination = @0x2)]
     public entry fun end_to_end_no_supply(
-        source: signer,
-        destination: signer,
+        source: signer, destination: signer,
     ) acquires CoinInfo, CoinStore, CoinConversionMap, PairedCoinType {
         let source_addr = signer::address_of(&source);
         account::create_account_for_test(source_addr);
         let destination_addr = signer::address_of(&destination);
         account::create_account_for_test(destination_addr);
 
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&source, 1, false);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(&source, 1, false);
 
         register<FakeMoney>(&destination);
         assert!(option::is_none(&supply<FakeMoney>()), 0);
@@ -1437,43 +1539,42 @@ module aptos_framework::coin {
         burn(coin, &burn_cap);
         assert!(option::is_none(&supply<FakeMoney>()), 4);
 
-        move_to(&source, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            &source,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(source = @0x2, framework = @aptos_framework)]
     #[expected_failure(abort_code = 0x10001, location = Self)]
     public fun fail_initialize(source: signer, framework: signer) {
         aggregator_factory::initialize_aggregator_factory_for_test(&framework);
-        let (burn_cap, freeze_cap, mint_cap) = initialize<FakeMoney>(
-            &source,
-            string::utf8(b"Fake money"),
-            string::utf8(b"FMD"),
-            1,
-            true,
-        );
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize<FakeMoney>(
+                &source,
+                string::utf8(b"Fake money"),
+                string::utf8(b"FMD"),
+                1,
+                true,
+            );
 
-        move_to(&source, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            &source,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(source = @0x1, destination = @0x2)]
     public entry fun transfer_to_migrated_destination(
-        source: signer,
-        destination: signer,
+        source: signer, destination: signer,
     ) acquires CoinInfo, CoinStore, CoinConversionMap, PairedCoinType {
         let source_addr = signer::address_of(&source);
         account::create_account_for_test(source_addr);
         let destination_addr = signer::address_of(&destination);
         account::create_account_for_test(destination_addr);
 
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&source, 1, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(&source, 1, true);
         assert!(*option::borrow(&supply<FakeMoney>()) == 0, 0);
 
         let coins_minted = mint<FakeMoney>(100, &mint_cap);
@@ -1485,20 +1586,18 @@ module aptos_framework::coin {
         assert!(balance<FakeMoney>(destination_addr) == 50, 2);
         assert!(!coin_store_exists<FakeMoney>(destination_addr), 0);
 
-        move_to(&source, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            &source,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(source = @0x1)]
-    public entry fun test_burn_from_with_capability(
-        source: signer,
-    ) acquires CoinInfo, CoinStore, CoinConversionMap, PairedFungibleAssetRefs {
+    public entry fun test_burn_from_with_capability(source: signer,) acquires CoinInfo, CoinStore, CoinConversionMap, PairedFungibleAssetRefs {
         let source_addr = signer::address_of(&source);
         account::create_account_for_test(source_addr);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&source, 1, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(&source, 1, true);
 
         let coins_minted = mint<FakeMoney>(100, &mint_cap);
         deposit(source_addr, coins_minted);
@@ -1513,12 +1612,22 @@ module aptos_framework::coin {
         // Burn coin and fa with both stores
         burn_from<FakeMoney>(source_addr, 100, &burn_cap);
         assert!(balance<FakeMoney>(source_addr) == 150, 0);
-        assert!(primary_fungible_store::balance(source_addr, ensure_paired_metadata<FakeMoney>()) == 150, 0);
+        assert!(
+            primary_fungible_store::balance(
+                source_addr, ensure_paired_metadata<FakeMoney>()
+            ) == 150,
+            0,
+        );
 
         // Burn fa only with both stores
         burn_from<FakeMoney>(source_addr, 100, &burn_cap);
         assert!(balance<FakeMoney>(source_addr) == 50, 0);
-        assert!(primary_fungible_store::balance(source_addr, ensure_paired_metadata<FakeMoney>()) == 50, 0);
+        assert!(
+            primary_fungible_store::balance(
+                source_addr, ensure_paired_metadata<FakeMoney>()
+            ) == 50,
+            0,
+        );
 
         // Burn fa only with only fungible store
         let coins_minted = mint<FakeMoney>(50, &mint_cap);
@@ -1532,37 +1641,33 @@ module aptos_framework::coin {
         assert!(balance<FakeMoney>(source_addr) == 90, 2);
         assert!(*option::borrow(&supply<FakeMoney>()) == 90, 3);
 
-        move_to(&source, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            &source,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(source = @0x1)]
     #[expected_failure(abort_code = 0x10007, location = Self)]
-    public fun test_destroy_non_zero(
-        source: signer,
-    ) acquires CoinInfo {
+    public fun test_destroy_non_zero(source: signer,) acquires CoinInfo {
         account::create_account_for_test(signer::address_of(&source));
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&source, 1, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(&source, 1, true);
         let coins_minted = mint<FakeMoney>(100, &mint_cap);
         destroy_zero(coins_minted);
 
-        move_to(&source, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            &source,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(source = @0x1)]
-    public entry fun test_extract(
-        source: signer,
-    ) acquires CoinInfo, CoinStore, CoinConversionMap {
+    public entry fun test_extract(source: signer,) acquires CoinInfo, CoinStore, CoinConversionMap {
         let source_addr = signer::address_of(&source);
         account::create_account_for_test(source_addr);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&source, 1, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(&source, 1, true);
 
         let coins_minted = mint<FakeMoney>(100, &mint_cap);
 
@@ -1575,11 +1680,10 @@ module aptos_framework::coin {
 
         assert!(balance<FakeMoney>(source_addr) == 100, 2);
 
-        move_to(&source, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            &source,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(source = @0x1)]
@@ -1589,28 +1693,27 @@ module aptos_framework::coin {
         let (burn_cap, freeze_cap, mint_cap) = initialize_fake_money(&source, 1, true);
         assert!(is_coin_initialized<FakeMoney>(), 1);
 
-        move_to(&source, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            &source,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(account = @0x1)]
     public fun test_is_coin_store_frozen(account: signer) acquires CoinStore, CoinConversionMap, CoinInfo {
         let account_addr = signer::address_of(&account);
         account::create_account_for_test(account_addr);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(&account, 18, true);
         assert!(coin_store_exists<FakeMoney>(account_addr), 1);
         assert!(!is_coin_store_frozen<FakeMoney>(account_addr), 1);
         maybe_convert_to_fungible_store<FakeMoney>(account_addr);
         assert!(!coin_store_exists<FakeMoney>(account_addr), 1);
 
-        move_to(&account, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            &account,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test]
@@ -1621,12 +1724,11 @@ module aptos_framework::coin {
     }
 
     #[test(account = @0x1)]
-    public entry fun burn_frozen(
-        account: signer
-    ) acquires CoinInfo, CoinStore, CoinConversionMap, PairedFungibleAssetRefs {
+    public entry fun burn_frozen(account: signer) acquires CoinInfo, CoinStore, CoinConversionMap, PairedFungibleAssetRefs {
         let account_addr = signer::address_of(&account);
         account::create_account_for_test(account_addr);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(&account, 18, true);
 
         let coins_minted = mint<FakeMoney>(100, &mint_cap);
         deposit(account_addr, coins_minted);
@@ -1634,14 +1736,23 @@ module aptos_framework::coin {
         freeze_coin_store(account_addr, &freeze_cap);
         burn_from(account_addr, 90, &burn_cap);
         maybe_convert_to_fungible_store<FakeMoney>(account_addr);
-        assert!(primary_fungible_store::is_frozen(account_addr, ensure_paired_metadata<FakeMoney>()), 1);
-        assert!(primary_fungible_store::balance(account_addr, ensure_paired_metadata<FakeMoney>()) == 10, 1);
+        assert!(
+            primary_fungible_store::is_frozen(
+                account_addr, ensure_paired_metadata<FakeMoney>()
+            ),
+            1,
+        );
+        assert!(
+            primary_fungible_store::balance(
+                account_addr, ensure_paired_metadata<FakeMoney>()
+            ) == 10,
+            1,
+        );
 
-        move_to(&account, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            &account,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(account = @0x1)]
@@ -1649,7 +1760,8 @@ module aptos_framework::coin {
     public entry fun withdraw_frozen(account: signer) acquires CoinInfo, CoinStore, CoinConversionMap, PairedCoinType {
         let account_addr = signer::address_of(&account);
         account::create_account_for_test(account_addr);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(&account, 18, true);
         let coins_minted = mint<FakeMoney>(100, &mint_cap);
         deposit(account_addr, coins_minted);
 
@@ -1658,11 +1770,10 @@ module aptos_framework::coin {
         let coin = withdraw<FakeMoney>(&account, 90);
         burn(coin, &burn_cap);
 
-        move_to(&account, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            &account,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(account = @0x1)]
@@ -1670,26 +1781,25 @@ module aptos_framework::coin {
     public entry fun deposit_frozen(account: signer) acquires CoinInfo, CoinStore, CoinConversionMap {
         let account_addr = signer::address_of(&account);
         account::create_account_for_test(account_addr);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(&account, 18, true);
 
         let coins_minted = mint<FakeMoney>(100, &mint_cap);
         freeze_coin_store(account_addr, &freeze_cap);
         deposit(account_addr, coins_minted);
 
-        move_to(&account, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            &account,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(account = @0x1)]
-    public entry fun deposit_withdraw_unfrozen(
-        account: signer
-    ) acquires CoinInfo, CoinStore, CoinConversionMap, PairedCoinType {
+    public entry fun deposit_withdraw_unfrozen(account: signer) acquires CoinInfo, CoinStore, CoinConversionMap, PairedCoinType {
         let account_addr = signer::address_of(&account);
         account::create_account_for_test(account_addr);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(&account, 18, true);
 
         let coins_minted = mint<FakeMoney>(100, &mint_cap);
         freeze_coin_store(account_addr, &freeze_cap);
@@ -1701,45 +1811,43 @@ module aptos_framework::coin {
         let coin = withdraw<FakeMoney>(&account, 10);
         burn(coin, &burn_cap);
 
-        move_to(&account, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            &account,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test_only]
     fun initialize_with_aggregator(account: &signer) {
-        let (burn_cap, freeze_cap, mint_cap) = initialize_with_parallelizable_supply<FakeMoney>(
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_with_parallelizable_supply<FakeMoney>(
+                account,
+                string::utf8(b"Fake money"),
+                string::utf8(b"FMD"),
+                1,
+                true,
+            );
+        move_to(
             account,
-            string::utf8(b"Fake money"),
-            string::utf8(b"FMD"),
-            1,
-            true
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
         );
-        move_to(account, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
     }
 
     #[test_only]
     fun initialize_with_integer(account: &signer) {
-        let (burn_cap, freeze_cap, mint_cap) = initialize<FakeMoney>(
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize<FakeMoney>(
+                account,
+                string::utf8(b"Fake money"),
+                string::utf8(b"FMD"),
+                1,
+                true,
+            );
+        move_to(
             account,
-            string::utf8(b"Fake money"),
-            string::utf8(b"FMD"),
-            1,
-            true
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
         );
-        move_to(account, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
     }
-
 
     #[test(framework = @aptos_framework, other = @0x123)]
     #[expected_failure(abort_code = 0x50003, location = aptos_framework::system_addresses)]
@@ -1765,7 +1873,8 @@ module aptos_framework::coin {
         aggregator_factory::initialize_aggregator_factory_for_test(&framework);
         initialize_with_aggregator(&framework);
 
-        let maybe_supply = &mut borrow_global_mut<CoinInfo<FakeMoney>>(coin_address<FakeMoney>()).supply;
+        let maybe_supply =
+            &mut borrow_global_mut<CoinInfo<FakeMoney>>(coin_address<FakeMoney>()).supply;
         let supply = option::borrow_mut(maybe_supply);
 
         // Supply should be parallelizable.
@@ -1783,7 +1892,8 @@ module aptos_framework::coin {
         aggregator_factory::initialize_aggregator_factory_for_test(&framework);
         initialize_with_aggregator(&framework);
 
-        let maybe_supply = &mut borrow_global_mut<CoinInfo<FakeMoney>>(coin_address<FakeMoney>()).supply;
+        let maybe_supply =
+            &mut borrow_global_mut<CoinInfo<FakeMoney>>(coin_address<FakeMoney>()).supply;
         let supply = option::borrow_mut(maybe_supply);
 
         optional_aggregator::add(supply, MAX_U128);
@@ -1798,7 +1908,8 @@ module aptos_framework::coin {
         aggregator_factory::initialize_aggregator_factory_for_test(&framework);
         initialize_with_integer(&framework);
 
-        let maybe_supply = &mut borrow_global_mut<CoinInfo<FakeMoney>>(coin_address<FakeMoney>()).supply;
+        let maybe_supply =
+            &mut borrow_global_mut<CoinInfo<FakeMoney>>(coin_address<FakeMoney>()).supply;
         let supply = option::borrow_mut(maybe_supply);
 
         // Supply should be non-parallelizable.
@@ -1819,7 +1930,8 @@ module aptos_framework::coin {
         initialize_with_integer(&framework);
 
         // Ensure we have a non-parellelizable non-zero supply.
-        let maybe_supply = &mut borrow_global_mut<CoinInfo<FakeMoney>>(coin_address<FakeMoney>()).supply;
+        let maybe_supply =
+            &mut borrow_global_mut<CoinInfo<FakeMoney>>(coin_address<FakeMoney>()).supply;
         let supply = option::borrow_mut(maybe_supply);
         assert!(!optional_aggregator::is_parallelizable(supply), 0);
         optional_aggregator::add(supply, 100);
@@ -1829,31 +1941,35 @@ module aptos_framework::coin {
         upgrade_supply<FakeMoney>(&framework);
 
         // Check supply again.
-        let maybe_supply = &mut borrow_global_mut<CoinInfo<FakeMoney>>(coin_address<FakeMoney>()).supply;
+        let maybe_supply =
+            &mut borrow_global_mut<CoinInfo<FakeMoney>>(coin_address<FakeMoney>()).supply;
         let supply = option::borrow_mut(maybe_supply);
         assert!(optional_aggregator::is_parallelizable(supply), 0);
         assert!(optional_aggregator::read(supply) == 100, 0);
     }
 
     #[test_only]
-    fun destroy_aggregatable_coin_for_test<CoinType>(aggregatable_coin: AggregatableCoin<CoinType>) {
+    fun destroy_aggregatable_coin_for_test<CoinType>(
+        aggregatable_coin: AggregatableCoin<CoinType>
+    ) {
         let AggregatableCoin { value } = aggregatable_coin;
         aggregator::destroy(value);
     }
 
     #[test(framework = @aptos_framework)]
-    public entry fun test_collect_from_and_drain(
-        framework: signer,
-    ) acquires CoinInfo, CoinStore, CoinConversionMap, PairedCoinType {
+    public entry fun test_collect_from_and_drain(framework: signer,) acquires CoinInfo, CoinStore, CoinConversionMap, PairedCoinType {
         let framework_addr = signer::address_of(&framework);
         account::create_account_for_test(framework_addr);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&framework, 1, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(&framework, 1, true);
 
         // Collect from coin store only.
         let coins_minted = mint<FakeMoney>(100, &mint_cap);
         deposit(framework_addr, coins_minted);
         let aggregatable_coin = initialize_aggregatable_coin<FakeMoney>(&framework);
-        collect_into_aggregatable_coin<FakeMoney>(framework_addr, 50, &mut aggregatable_coin);
+        collect_into_aggregatable_coin<FakeMoney>(
+            framework_addr, 50, &mut aggregatable_coin
+        );
 
         let fa_minted = coin_to_fungible_asset(mint<FakeMoney>(100, &mint_cap));
         primary_fungible_store::deposit(framework_addr, fa_minted);
@@ -1861,12 +1977,16 @@ module aptos_framework::coin {
         assert!(*option::borrow(&supply<FakeMoney>()) == 200, 0);
 
         // Collect from coin store and fungible store.
-        collect_into_aggregatable_coin<FakeMoney>(framework_addr, 100, &mut aggregatable_coin);
+        collect_into_aggregatable_coin<FakeMoney>(
+            framework_addr, 100, &mut aggregatable_coin
+        );
 
         assert!(balance<FakeMoney>(framework_addr) == 50, 0);
         maybe_convert_to_fungible_store<FakeMoney>(framework_addr);
         // Collect from fungible store only.
-        collect_into_aggregatable_coin<FakeMoney>(framework_addr, 30, &mut aggregatable_coin);
+        collect_into_aggregatable_coin<FakeMoney>(
+            framework_addr, 30, &mut aggregatable_coin
+        );
 
         // Check that aggregatable coin has the right amount.
         let collected_coin = drain_aggregatable_coin(&mut aggregatable_coin);
@@ -1879,15 +1999,16 @@ module aptos_framework::coin {
 
         burn(collected_coin, &burn_cap);
         destroy_aggregatable_coin_for_test(aggregatable_coin);
-        move_to(&framework, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            &framework,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test_only]
-    fun deposit_to_coin_store<CoinType>(account_addr: address, coin: Coin<CoinType>) acquires CoinStore {
+    fun deposit_to_coin_store<CoinType>(
+        account_addr: address, coin: Coin<CoinType>
+    ) acquires CoinStore {
         assert!(
             coin_store_exists<CoinType>(account_addr),
             error::not_found(ECOIN_STORE_NOT_PUBLISHED),
@@ -1908,16 +2029,26 @@ module aptos_framework::coin {
     }
 
     #[test(account = @aptos_framework)]
-    fun test_conversion_basic(
-        account: &signer
-    ) acquires CoinConversionMap, CoinInfo, CoinStore, PairedCoinType, PairedFungibleAssetRefs {
+    fun test_conversion_basic(account: &signer) acquires CoinConversionMap, CoinInfo, CoinStore, PairedCoinType, PairedFungibleAssetRefs {
         let account_addr = signer::address_of(account);
         account::create_account_for_test(account_addr);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(account, 1, true);
 
-        assert!(fungible_asset::name(ensure_paired_metadata<FakeMoney>()) == name<FakeMoney>(), 0);
-        assert!(fungible_asset::symbol(ensure_paired_metadata<FakeMoney>()) == symbol<FakeMoney>(), 0);
-        assert!(fungible_asset::decimals(ensure_paired_metadata<FakeMoney>()) == decimals<FakeMoney>(), 0);
+        assert!(
+            fungible_asset::name(ensure_paired_metadata<FakeMoney>()) == name<FakeMoney>(),
+            0,
+        );
+        assert!(
+            fungible_asset::symbol(ensure_paired_metadata<FakeMoney>())
+                == symbol<FakeMoney>(),
+            0,
+        );
+        assert!(
+            fungible_asset::decimals(ensure_paired_metadata<FakeMoney>())
+                == decimals<FakeMoney>(),
+            0,
+        );
 
         let minted_coin = mint(100, &mint_cap);
         let converted_fa = coin_to_fungible_asset(minted_coin);
@@ -1948,7 +2079,12 @@ module aptos_framework::coin {
         maybe_convert_to_fungible_store<FakeMoney>(account_addr);
         assert!(!coin_store_exists<FakeMoney>(account_addr), 0);
         assert!(balance<FakeMoney>(account_addr) == 199, 0);
-        assert!(primary_fungible_store::balance(account_addr, ensure_paired_metadata<FakeMoney>()) == 199, 0);
+        assert!(
+            primary_fungible_store::balance(
+                account_addr, ensure_paired_metadata<FakeMoney>()
+            ) == 199,
+            0,
+        );
 
         let fa = coin_to_fungible_asset(withdrawn_coin);
         fungible_asset::burn(&burn_ref, fa);
@@ -1961,23 +2097,22 @@ module aptos_framework::coin {
         assert!(paired_transfer_ref_exists<FakeMoney>(), 0);
         assert!(paired_burn_ref_exists<FakeMoney>(), 0);
 
-        move_to(account, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            account,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(account = @aptos_framework, aaron = @0xcafe)]
     fun test_balance_with_both_stores(
-        account: &signer,
-        aaron: &signer
+        account: &signer, aaron: &signer
     ) acquires CoinConversionMap, CoinInfo, CoinStore {
         let account_addr = signer::address_of(account);
         let aaron_addr = signer::address_of(aaron);
         account::create_account_for_test(account_addr);
         account::create_account_for_test(aaron_addr);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(account, 1, true);
         create_coin_store<FakeMoney>(aaron);
         let coin = mint(100, &mint_cap);
         let fa = coin_to_fungible_asset(mint(100, &mint_cap));
@@ -1989,24 +2124,27 @@ module aptos_framework::coin {
         assert!(balance<FakeMoney>(aaron_addr) == 200, 0);
         assert!(coin_balance<FakeMoney>(aaron_addr) == 0, 0);
 
-        move_to(account, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            account,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(account = @aptos_framework)]
-    fun test_deposit(
-        account: &signer,
-    ) acquires CoinConversionMap, CoinInfo, CoinStore {
+    fun test_deposit(account: &signer,) acquires CoinConversionMap, CoinInfo, CoinStore {
         let account_addr = signer::address_of(account);
         account::create_account_for_test(account_addr);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(account, 1, true);
         let coin = mint<FakeMoney>(100, &mint_cap);
         deposit(account_addr, coin);
         assert!(coin_store_exists<FakeMoney>(account_addr), 0);
-        assert!(primary_fungible_store::balance(account_addr, ensure_paired_metadata<FakeMoney>()) == 0, 0);
+        assert!(
+            primary_fungible_store::balance(
+                account_addr, ensure_paired_metadata<FakeMoney>()
+            ) == 0,
+            0,
+        );
         assert!(balance<FakeMoney>(account_addr) == 100, 0);
 
         maybe_convert_to_fungible_store<FakeMoney>(account_addr);
@@ -2014,22 +2152,25 @@ module aptos_framework::coin {
         deposit(account_addr, coin);
         assert!(!coin_store_exists<FakeMoney>(account_addr), 0);
         assert!(balance<FakeMoney>(account_addr) == 200, 0);
-        assert!(primary_fungible_store::balance(account_addr, ensure_paired_metadata<FakeMoney>()) == 200, 0);
+        assert!(
+            primary_fungible_store::balance(
+                account_addr, ensure_paired_metadata<FakeMoney>()
+            ) == 200,
+            0,
+        );
 
-        move_to(account, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            account,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(account = @aptos_framework)]
-    fun test_withdraw(
-        account: &signer,
-    ) acquires CoinConversionMap, CoinInfo, CoinStore, PairedCoinType {
+    fun test_withdraw(account: &signer,) acquires CoinConversionMap, CoinInfo, CoinStore, PairedCoinType {
         let account_addr = signer::address_of(account);
         account::create_account_for_test(account_addr);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(account, 1, true);
         let coin = mint<FakeMoney>(200, &mint_cap);
         deposit_to_coin_store(account_addr, coin);
         assert!(coin_balance<FakeMoney>(account_addr) == 200, 0);
@@ -2043,74 +2184,102 @@ module aptos_framework::coin {
         let fa = coin_to_fungible_asset(coin);
         primary_fungible_store::deposit(account_addr, fa);
         assert!(coin_store_exists<FakeMoney>(account_addr), 0);
-        assert!(primary_fungible_store::balance(account_addr, ensure_paired_metadata<FakeMoney>()) == 100, 0);
+        assert!(
+            primary_fungible_store::balance(
+                account_addr, ensure_paired_metadata<FakeMoney>()
+            ) == 100,
+            0,
+        );
         assert!(balance<FakeMoney>(account_addr) == 200, 0);
 
         // Withdraw from both coin store and fungible store.
         let coin = withdraw<FakeMoney>(account, 150);
         assert!(coin_balance<FakeMoney>(account_addr) == 0, 0);
-        assert!(primary_fungible_store::balance(account_addr, ensure_paired_metadata<FakeMoney>()) == 50, 0);
+        assert!(
+            primary_fungible_store::balance(
+                account_addr, ensure_paired_metadata<FakeMoney>()
+            ) == 50,
+            0,
+        );
 
         deposit_to_coin_store(account_addr, coin);
         maybe_convert_to_fungible_store<FakeMoney>(account_addr);
         assert!(!coin_store_exists<FakeMoney>(account_addr), 0);
         assert!(balance<FakeMoney>(account_addr) == 200, 0);
-        assert!(primary_fungible_store::balance(account_addr, ensure_paired_metadata<FakeMoney>()) == 200, 0);
+        assert!(
+            primary_fungible_store::balance(
+                account_addr, ensure_paired_metadata<FakeMoney>()
+            ) == 200,
+            0,
+        );
 
         // Withdraw from fungible store only.
         let coin = withdraw<FakeMoney>(account, 150);
         assert!(balance<FakeMoney>(account_addr) == 50, 0);
         burn(coin, &burn_cap);
 
-        move_to(account, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            account,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(account = @aptos_framework)]
-    fun test_supply(
-        account: &signer,
-    ) acquires CoinConversionMap, CoinInfo, PairedCoinType, PairedFungibleAssetRefs {
+    fun test_supply(account: &signer,) acquires CoinConversionMap, CoinInfo, PairedCoinType, PairedFungibleAssetRefs {
         account::create_account_for_test(signer::address_of(account));
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(account, 1, true);
         let coin = mint<FakeMoney>(100, &mint_cap);
         ensure_paired_metadata<FakeMoney>();
         let (mint_ref, mint_ref_receipt) = get_paired_mint_ref(&mint_cap);
         let (burn_ref, burn_ref_receipt) = get_paired_burn_ref(&burn_cap);
         let fungible_asset = fungible_asset::mint(&mint_ref, 50);
-        assert!(option::is_none(&fungible_asset::maximum(ensure_paired_metadata<FakeMoney>())), 0);
+        assert!(
+            option::is_none(&fungible_asset::maximum(ensure_paired_metadata<FakeMoney>())),
+            0,
+        );
         assert!(supply<FakeMoney>() == option::some(150), 0);
         assert!(coin_supply<FakeMoney>() == option::some(100), 0);
-        assert!(fungible_asset::supply(ensure_paired_metadata<FakeMoney>()) == option::some(50), 0);
+        assert!(
+            fungible_asset::supply(ensure_paired_metadata<FakeMoney>()) == option::some(
+                50
+            ),
+            0,
+        );
         let fa_from_coin = coin_to_fungible_asset(coin);
         assert!(supply<FakeMoney>() == option::some(150), 0);
         assert!(coin_supply<FakeMoney>() == option::some(0), 0);
-        assert!(fungible_asset::supply(ensure_paired_metadata<FakeMoney>()) == option::some(150), 0);
+        assert!(
+            fungible_asset::supply(ensure_paired_metadata<FakeMoney>()) == option::some(
+                150
+            ),
+            0,
+        );
 
         let coin_from_fa = fungible_asset_to_coin<FakeMoney>(fungible_asset);
         assert!(supply<FakeMoney>() == option::some(150), 0);
         assert!(coin_supply<FakeMoney>() == option::some(50), 0);
-        assert!(fungible_asset::supply(ensure_paired_metadata<FakeMoney>()) == option::some(100), 0);
+        assert!(
+            fungible_asset::supply(ensure_paired_metadata<FakeMoney>()) == option::some(
+                100
+            ),
+            0,
+        );
         burn(coin_from_fa, &burn_cap);
         fungible_asset::burn(&burn_ref, fa_from_coin);
         assert!(supply<FakeMoney>() == option::some(0), 0);
         return_paired_mint_ref(mint_ref, mint_ref_receipt);
         return_paired_burn_ref(burn_ref, burn_ref_receipt);
-        move_to(account, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            account,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(account = @aptos_framework, aaron = @0xaa10, bob = @0xb0b)]
     #[expected_failure(abort_code = 0x60005, location = Self)]
     fun test_force_deposit(
-        account: &signer,
-        aaron: &signer,
-        bob: &signer
+        account: &signer, aaron: &signer, bob: &signer
     ) acquires CoinConversionMap, CoinInfo, CoinStore {
         let account_addr = signer::address_of(account);
         let aaron_addr = signer::address_of(aaron);
@@ -2118,23 +2287,25 @@ module aptos_framework::coin {
         account::create_account_for_test(account_addr);
         account::create_account_for_test(aaron_addr);
         account::create_account_for_test(bob_addr);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(account, 1, true);
         maybe_convert_to_fungible_store<FakeMoney>(aaron_addr);
         deposit(aaron_addr, mint<FakeMoney>(1, &mint_cap));
 
         force_deposit(account_addr, mint<FakeMoney>(100, &mint_cap));
         force_deposit(aaron_addr, mint<FakeMoney>(50, &mint_cap));
         assert!(
-            primary_fungible_store::balance(aaron_addr, option::extract(&mut paired_metadata<FakeMoney>())) == 51,
-            0
+            primary_fungible_store::balance(
+                aaron_addr, option::extract(&mut paired_metadata<FakeMoney>())
+            ) == 51,
+            0,
         );
         assert!(coin_balance<FakeMoney>(account_addr) == 100, 0);
         force_deposit(bob_addr, mint<FakeMoney>(1, &mint_cap));
-        move_to(account, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            account,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(account = @aptos_framework, aaron = @0xaa10, bob = @0xb0b)]
@@ -2149,7 +2320,8 @@ module aptos_framework::coin {
         account::create_account_for_test(account_addr);
         account::create_account_for_test(aaron_addr);
         account::create_account_for_test(bob_addr);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(account, 1, true);
 
         assert!(coin_store_exists<FakeMoney>(account_addr), 0);
         assert!(is_account_registered<FakeMoney>(account_addr), 0);
@@ -2169,7 +2341,9 @@ module aptos_framework::coin {
         assert!(is_account_registered<FakeMoney>(account_addr), 0);
 
         // Deposit FA to bob to created primary fungible store without `MigrationFlag`.
-        primary_fungible_store::deposit(bob_addr, coin_to_fungible_asset(mint<FakeMoney>(100, &mint_cap)));
+        primary_fungible_store::deposit(
+            bob_addr, coin_to_fungible_asset(mint<FakeMoney>(100, &mint_cap))
+        );
         assert!(!coin_store_exists<FakeMoney>(bob_addr), 0);
         register<FakeMoney>(bob);
         assert!(coin_store_exists<FakeMoney>(bob_addr), 0);
@@ -2178,11 +2352,10 @@ module aptos_framework::coin {
         register<FakeMoney>(bob);
         assert!(!coin_store_exists<FakeMoney>(bob_addr), 0);
 
-        move_to(account, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            account,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     #[test(account = @aptos_framework, aaron = @0xaa10)]
@@ -2191,24 +2364,34 @@ module aptos_framework::coin {
     ) acquires CoinConversionMap, CoinInfo, CoinStore, PairedCoinType {
         account::create_account_for_test(signer::address_of(account));
         let account_addr = signer::address_of(account);
-        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
+        let (burn_cap, freeze_cap, mint_cap) =
+            initialize_and_register_fake_money(account, 1, true);
 
         let coin = mint<FakeMoney>(100, &mint_cap);
         primary_fungible_store::deposit(account_addr, coin_to_fungible_asset(coin));
         assert!(coin_balance<FakeMoney>(account_addr) == 0, 0);
         assert!(balance<FakeMoney>(account_addr) == 100, 0);
         let coin = withdraw<FakeMoney>(account, 50);
-        assert!(!migrated_primary_fungible_store_exists(account_addr, ensure_paired_metadata<FakeMoney>()), 0);
+        assert!(
+            !migrated_primary_fungible_store_exists(
+                account_addr, ensure_paired_metadata<FakeMoney>()
+            ),
+            0,
+        );
         maybe_convert_to_fungible_store<FakeMoney>(account_addr);
-        assert!(migrated_primary_fungible_store_exists(account_addr, ensure_paired_metadata<FakeMoney>()), 0);
+        assert!(
+            migrated_primary_fungible_store_exists(
+                account_addr, ensure_paired_metadata<FakeMoney>()
+            ),
+            0,
+        );
         deposit(account_addr, coin);
         assert!(coin_balance<FakeMoney>(account_addr) == 0, 0);
         assert!(balance<FakeMoney>(account_addr) == 100, 0);
 
-        move_to(account, FakeMoneyCapabilities {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            account,
+            FakeMoneyCapabilities { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/coin.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.spec.move
@@ -62,35 +62,53 @@ spec aptos_framework::coin {
         pragma verify = true;
         global supply<CoinType>: num;
         global aggregate_supply<CoinType>: num;
-        apply TotalSupplyTracked<CoinType> to *<CoinType> except
-        initialize, initialize_internal, initialize_with_parallelizable_supply;
+        apply TotalSupplyTracked<CoinType> to *<CoinType> except initialize, initialize_internal, initialize_with_parallelizable_supply;
         // TODO(fa_migration)
         // apply TotalSupplyNoChange<CoinType> to *<CoinType> except mint,
         //     burn, burn_from, initialize, initialize_internal, initialize_with_parallelizable_supply;
     }
 
     spec fun spec_fun_supply_tracked<CoinType>(val: u64, supply: Option<OptionalAggregator>): bool {
-        option::spec_is_some(supply) ==> val == optional_aggregator::optional_aggregator_value
-            (option::spec_borrow(supply))
+        option::spec_is_some(supply) ==>
+            val
+                == optional_aggregator::optional_aggregator_value(
+                    option::spec_borrow(supply)
+                )
     }
 
     spec schema TotalSupplyTracked<CoinType> {
-        ensures old(spec_fun_supply_tracked<CoinType>(supply<CoinType> + aggregate_supply<CoinType>,
-            global<CoinInfo<CoinType>>(type_info::type_of<CoinType>().account_address).supply)) ==>
-            spec_fun_supply_tracked<CoinType>(supply<CoinType> + aggregate_supply<CoinType>,
-                global<CoinInfo<CoinType>>(type_info::type_of<CoinType>().account_address).supply);
+        ensures old(
+            spec_fun_supply_tracked<CoinType>(
+                supply<CoinType> + aggregate_supply<CoinType>,
+                global<CoinInfo<CoinType>>(type_info::type_of<CoinType>().account_address)
+                .supply,
+            ),
+        ) ==>
+            spec_fun_supply_tracked<CoinType>(
+                supply<CoinType> + aggregate_supply<CoinType>,
+                global<CoinInfo<CoinType>>(type_info::type_of<CoinType>().account_address)
+                .supply,
+            );
     }
 
-    spec fun spec_fun_supply_no_change<CoinType>(old_supply: Option<OptionalAggregator>,
-                                                 supply: Option<OptionalAggregator>): bool {
-        option::spec_is_some(old_supply) ==> optional_aggregator::optional_aggregator_value
-            (option::spec_borrow(old_supply)) == optional_aggregator::optional_aggregator_value
-            (option::spec_borrow(supply))
+    spec fun spec_fun_supply_no_change<CoinType>(
+        old_supply: Option<OptionalAggregator>, supply: Option<OptionalAggregator>
+    ): bool {
+        option::spec_is_some(old_supply) ==>
+            optional_aggregator::optional_aggregator_value(
+                option::spec_borrow(old_supply)
+            ) == optional_aggregator::optional_aggregator_value(
+                option::spec_borrow(supply)
+            )
     }
 
     spec schema TotalSupplyNoChange<CoinType> {
-        let old_supply = global<CoinInfo<CoinType>>(type_info::type_of<CoinType>().account_address).supply;
-        let post supply = global<CoinInfo<CoinType>>(type_info::type_of<CoinType>().account_address).supply;
+        let old_supply = global<CoinInfo<CoinType>>(
+            type_info::type_of<CoinType>().account_address
+        ).supply;
+        let post supply = global<CoinInfo<CoinType>>(
+            type_info::type_of<CoinType>().account_address
+        ).supply;
         ensures spec_fun_supply_no_change<CoinType>(old_supply, supply);
     }
 
@@ -162,7 +180,8 @@ spec aptos_framework::coin {
 
     spec fun spec_paired_metadata<CoinType>(): Option<Object<Metadata>> {
         if (exists<CoinConversionMap>(@aptos_framework)) {
-            let map = global<CoinConversionMap>(@aptos_framework).coin_to_fungible_asset_map;
+            let map =
+                global<CoinConversionMap>(@aptos_framework).coin_to_fungible_asset_map;
             if (table::spec_contains(map, type_info::type_of<CoinType>())) {
                 let metadata = table::spec_get(map, type_info::type_of<CoinType>());
                 option::spec_some(metadata)
@@ -176,9 +195,13 @@ spec aptos_framework::coin {
 
     spec fun spec_is_account_registered<CoinType>(account_addr: address): bool {
         let paired_metadata_opt = spec_paired_metadata<CoinType>();
-        exists<CoinStore<CoinType>>(account_addr) || (option::spec_is_some(
-            paired_metadata_opt
-        ) && primary_fungible_store::spec_primary_store_exists(account_addr, option::spec_borrow(paired_metadata_opt)))
+        exists<CoinStore<CoinType>>(account_addr)
+            || (
+                option::spec_is_some(paired_metadata_opt)
+                    && primary_fungible_store::spec_primary_store_exists(
+                        account_addr, option::spec_borrow(paired_metadata_opt)
+                    )
+            )
     }
 
     spec schema CoinSubAbortsIf<CoinType> {
@@ -186,9 +209,11 @@ spec aptos_framework::coin {
         amount: u64;
         let addr = type_info::type_of<CoinType>().account_address;
         let maybe_supply = global<CoinInfo<CoinType>>(addr).supply;
-        include (option::is_some(
-            maybe_supply
-        )) ==> optional_aggregator::SubAbortsIf { optional_aggregator: option::borrow(maybe_supply), value: amount };
+        include (option::is_some(maybe_supply)) ==>
+            optional_aggregator::SubAbortsIf {
+                optional_aggregator: option::borrow(maybe_supply),
+                value: amount
+            };
     }
 
     spec schema CoinAddAbortsIf<CoinType> {
@@ -196,9 +221,11 @@ spec aptos_framework::coin {
         amount: u64;
         let addr = type_info::type_of<CoinType>().account_address;
         let maybe_supply = global<CoinInfo<CoinType>>(addr).supply;
-        include (option::is_some(
-            maybe_supply
-        )) ==> optional_aggregator::AddAbortsIf { optional_aggregator: option::borrow(maybe_supply), value: amount };
+        include (option::is_some(maybe_supply)) ==>
+            optional_aggregator::AddAbortsIf {
+                optional_aggregator: option::borrow(maybe_supply),
+                value: amount
+            };
     }
 
     spec schema AbortsIfNotExistCoinInfo<CoinType> {
@@ -240,10 +267,7 @@ spec aptos_framework::coin {
         };
     }
 
-    spec burn<CoinType>(
-    coin: Coin<CoinType>,
-    _cap: &BurnCapability<CoinType>,
-    ) {
+    spec burn<CoinType>(coin: Coin<CoinType>, _cap: &BurnCapability<CoinType>,) {
         // TODO(fa_migration)
         pragma verify = false;
         let addr = type_info::type_of<CoinType>().account_address;
@@ -262,9 +286,7 @@ spec aptos_framework::coin {
     }
 
     spec burn_from<CoinType>(
-    account_addr: address,
-    amount: u64,
-    burn_cap: &BurnCapability<CoinType>,
+        account_addr: address, amount: u64, burn_cap: &BurnCapability<CoinType>,
     ) {
         // TODO(fa_migration)
         pragma verify = false;
@@ -307,9 +329,8 @@ spec aptos_framework::coin {
         modifies global<CoinInfo<CoinType>>(account_addr);
         /// [high-level-req-8.3]
         include DepositAbortsIf<CoinType>;
-        ensures global<CoinStore<CoinType>>(account_addr).coin.value == old(
-            global<CoinStore<CoinType>>(account_addr)
-        ).coin.value + coin.value;
+        ensures global<CoinStore<CoinType>>(account_addr).coin.value
+            == old(global<CoinStore<CoinType>>(account_addr)).coin.value + coin.value;
     }
 
     spec coin_to_fungible_asset<CoinType>(coin: Coin<CoinType>): FungibleAsset {
@@ -343,9 +364,8 @@ spec aptos_framework::coin {
         pragma verify = false;
         modifies global<CoinStore<CoinType>>(account_addr);
         aborts_if !exists<CoinStore<CoinType>>(account_addr);
-        ensures global<CoinStore<CoinType>>(account_addr).coin.value == old(
-            global<CoinStore<CoinType>>(account_addr)
-        ).coin.value + coin.value;
+        ensures global<CoinStore<CoinType>>(account_addr).coin.value
+            == old(global<CoinStore<CoinType>>(account_addr)).coin.value + coin.value;
     }
 
     /// The value of `zero_coin` must be 0.
@@ -365,8 +385,7 @@ spec aptos_framework::coin {
     }
 
     spec freeze_coin_store<CoinType>(
-    account_addr: address,
-    _freeze_cap: &FreezeCapability<CoinType>,
+        account_addr: address, _freeze_cap: &FreezeCapability<CoinType>,
     ) {
         // TODO(fa_migration)
         pragma verify = false;
@@ -379,8 +398,7 @@ spec aptos_framework::coin {
     }
 
     spec unfreeze_coin_store<CoinType>(
-    account_addr: address,
-    _freeze_cap: &FreezeCapability<CoinType>,
+        account_addr: address, _freeze_cap: &FreezeCapability<CoinType>,
     ) {
         // TODO(fa_migration)
         pragma verify = false;
@@ -414,10 +432,11 @@ spec aptos_framework::coin {
         let post post_supply = option::spec_borrow(post_maybe_supply);
         let post post_value = optional_aggregator::optional_aggregator_value(post_supply);
 
-        let supply_no_parallel = option::spec_is_some(maybe_supply) &&
-            !optional_aggregator::is_parallelizable(supply);
+        let supply_no_parallel = option::spec_is_some(maybe_supply)
+            && !optional_aggregator::is_parallelizable(supply);
 
-        aborts_if supply_no_parallel && !exists<aggregator_factory::AggregatorFactory>(@aptos_framework);
+        aborts_if supply_no_parallel
+            && !exists<aggregator_factory::AggregatorFactory>(@aptos_framework);
         ensures supply_no_parallel ==>
             optional_aggregator::is_parallelizable(post_supply) && post_value == value;
     }
@@ -434,16 +453,17 @@ spec aptos_framework::coin {
 
     // `account` must be `@aptos_framework`.
     spec initialize_with_parallelizable_supply<CoinType>(
-    account: &signer,
-    name: string::String,
-    symbol: string::String,
-    decimals: u8,
-    monitor_supply: bool,
+        account: &signer,
+        name: string::String,
+        symbol: string::String,
+        decimals: u8,
+        monitor_supply: bool,
     ): (BurnCapability<CoinType>, FreezeCapability<CoinType>, MintCapability<CoinType>) {
         use aptos_framework::aggregator_factory;
         let addr = signer::address_of(account);
         aborts_if addr != @aptos_framework;
-        aborts_if monitor_supply && !exists<aggregator_factory::AggregatorFactory>(@aptos_framework);
+        aborts_if monitor_supply
+            && !exists<aggregator_factory::AggregatorFactory>(@aptos_framework);
         include InitializeInternalSchema<CoinType> {
             name: name.bytes,
             symbol: symbol.bytes
@@ -466,12 +486,12 @@ spec aptos_framework::coin {
     }
 
     spec initialize_internal<CoinType>(
-    account: &signer,
-    name: string::String,
-    symbol: string::String,
-    decimals: u8,
-    monitor_supply: bool,
-    parallelizable: bool,
+        account: &signer,
+        name: string::String,
+        symbol: string::String,
+        decimals: u8,
+        monitor_supply: bool,
+        parallelizable: bool,
     ): (BurnCapability<CoinType>, FreezeCapability<CoinType>, MintCapability<CoinType>) {
         include InitializeInternalSchema<CoinType> {
             name: name.bytes,
@@ -483,15 +503,16 @@ spec aptos_framework::coin {
         let post value = optional_aggregator::optional_aggregator_value(supply);
         let post limit = optional_aggregator::optional_aggregator_limit(supply);
         modifies global<CoinInfo<CoinType>>(account_addr);
-        aborts_if monitor_supply && parallelizable
+        aborts_if monitor_supply
+            && parallelizable
             && !exists<aggregator_factory::AggregatorFactory>(@aptos_framework);
         /// [managed_coin::high-level-req-2]
         ensures exists<CoinInfo<CoinType>>(account_addr)
             && coin_info.name == name
-            && coin_info.symbol == symbol
-            && coin_info.decimals == decimals;
+            && coin_info.symbol == symbol && coin_info.decimals == decimals;
         ensures if (monitor_supply) {
-            value == 0 && limit == MAX_U128
+            value == 0
+                && limit == MAX_U128
                 && (parallelizable == optional_aggregator::is_parallelizable(supply))
         } else {
             option::spec_is_none(coin_info.supply)
@@ -523,11 +544,7 @@ spec aptos_framework::coin {
     /// `from` and `to` account not frozen.
     /// `from` and `to` not the same address.
     /// `from` account sufficient balance.
-    spec transfer<CoinType>(
-    from: &signer,
-    to: address,
-    amount: u64,
-    ) {
+    spec transfer<CoinType>(from: &signer, to: address, amount: u64,) {
         // TODO(fa_migration)
         pragma verify = false;
         let account_addr_from = signer::address_of(from);
@@ -544,17 +561,16 @@ spec aptos_framework::coin {
         aborts_if coin_store_to.frozen;
         aborts_if coin_store_from.coin.value < amount;
 
-        ensures account_addr_from != to ==> coin_store_post_from.coin.value ==
-            coin_store_from.coin.value - amount;
-        ensures account_addr_from != to ==> coin_store_post_to.coin.value == coin_store_to.coin.value + amount;
-        ensures account_addr_from == to ==> coin_store_post_from.coin.value == coin_store_from.coin.value;
+        ensures account_addr_from != to ==>
+            coin_store_post_from.coin.value == coin_store_from.coin.value - amount;
+        ensures account_addr_from != to ==>
+            coin_store_post_to.coin.value == coin_store_to.coin.value + amount;
+        ensures account_addr_from == to ==>
+            coin_store_post_from.coin.value == coin_store_from.coin.value;
     }
 
     /// Account is not frozen and sufficient balance.
-    spec withdraw<CoinType>(
-    account: &signer,
-    amount: u64,
-    ): Coin<CoinType> {
+    spec withdraw<CoinType>(account: &signer, amount: u64,): Coin<CoinType> {
         // TODO(fa_migration)
         pragma verify = false;
         include WithdrawAbortsIf<CoinType>;
@@ -566,6 +582,7 @@ spec aptos_framework::coin {
         ensures coin_post == balance - amount;
         ensures result == Coin<CoinType> { value: amount };
     }
+
     spec schema WithdrawAbortsIf<CoinType> {
         account: &signer;
         amount: u64;
@@ -594,17 +611,21 @@ spec aptos_framework::coin {
         ensures result.value == aggregator::spec_aggregator_get_val(old(coin).value);
     }
 
-    spec merge_aggregatable_coin<CoinType>(dst_coin: &mut AggregatableCoin<CoinType>, coin: Coin<CoinType>) {
+    spec merge_aggregatable_coin<CoinType>(
+        dst_coin: &mut AggregatableCoin<CoinType>, coin: Coin<CoinType>
+    ) {
         let aggr = dst_coin.value;
         let post p_aggr = dst_coin.value;
-        aborts_if aggregator::spec_aggregator_get_val(aggr)
-            + coin.value > aggregator::spec_get_limit(aggr);
-        aborts_if aggregator::spec_aggregator_get_val(aggr)
-            + coin.value > MAX_U128;
-        ensures aggregator::spec_aggregator_get_val(aggr) + coin.value == aggregator::spec_aggregator_get_val(p_aggr);
+        aborts_if aggregator::spec_aggregator_get_val(aggr) + coin.value
+            > aggregator::spec_get_limit(aggr);
+        aborts_if aggregator::spec_aggregator_get_val(aggr) + coin.value > MAX_U128;
+        ensures aggregator::spec_aggregator_get_val(aggr) + coin.value
+            == aggregator::spec_aggregator_get_val(p_aggr);
     }
 
-    spec collect_into_aggregatable_coin<CoinType>(account_addr: address, amount: u64, dst_coin: &mut AggregatableCoin<CoinType>) {
+    spec collect_into_aggregatable_coin<CoinType>(
+        account_addr: address, amount: u64, dst_coin: &mut AggregatableCoin<CoinType>
+    ) {
         // TODO(fa_migration)
         pragma verify = false;
         let aggr = dst_coin.value;
@@ -613,11 +634,13 @@ spec aptos_framework::coin {
         let post p_coin_store = global<CoinStore<CoinType>>(account_addr);
         aborts_if amount > 0 && !exists<CoinStore<CoinType>>(account_addr);
         aborts_if amount > 0 && coin_store.coin.value < amount;
-        aborts_if amount > 0 && aggregator::spec_aggregator_get_val(aggr)
-            + amount > aggregator::spec_get_limit(aggr);
-        aborts_if amount > 0 && aggregator::spec_aggregator_get_val(aggr)
-            + amount > MAX_U128;
-        ensures aggregator::spec_aggregator_get_val(aggr) + amount == aggregator::spec_aggregator_get_val(p_aggr);
+        aborts_if amount > 0
+            && aggregator::spec_aggregator_get_val(aggr) + amount
+                > aggregator::spec_get_limit(aggr);
+        aborts_if amount > 0
+            && aggregator::spec_aggregator_get_val(aggr) + amount > MAX_U128;
+        ensures aggregator::spec_aggregator_get_val(aggr) + amount
+            == aggregator::spec_aggregator_get_val(p_aggr);
         ensures coin_store.coin.value - amount == p_coin_store.coin.value;
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/configs/config_buffer.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/config_buffer.move
@@ -39,9 +39,7 @@ module aptos_framework::config_buffer {
     public fun initialize(aptos_framework: &signer) {
         system_addresses::assert_aptos_framework(aptos_framework);
         if (!exists<PendingConfigs>(@aptos_framework)) {
-            move_to(aptos_framework, PendingConfigs {
-                configs: simple_map::new(),
-            })
+            move_to(aptos_framework, PendingConfigs { configs: simple_map::new(), })
         }
     }
 
@@ -50,9 +48,7 @@ module aptos_framework::config_buffer {
         if (exists<PendingConfigs>(@aptos_framework)) {
             let config = borrow_global<PendingConfigs>(@aptos_framework);
             simple_map::contains_key(&config.configs, &type_info::type_name<T>())
-        } else {
-            false
-        }
+        } else { false }
     }
 
     /// Upsert an on-chain config to the buffer for the next epoch.

--- a/aptos-move/framework/aptos-framework/sources/configs/config_buffer.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/config_buffer.spec.move
@@ -13,9 +13,7 @@ spec aptos_framework::config_buffer {
         if (exists<PendingConfigs>(@aptos_framework)) {
             let config = global<PendingConfigs>(@aptos_framework);
             simple_map::spec_contains_key(config.configs, type_name)
-        } else {
-            false
-        }
+        } else { false }
     }
 
     spec upsert<T: drop + store>(config: T) {
@@ -31,9 +29,7 @@ spec aptos_framework::config_buffer {
         let configs = global<PendingConfigs>(@aptos_framework);
         let key = type_info::type_name<T>();
         aborts_if !simple_map::spec_contains_key(configs.configs, key);
-        include any::UnpackAbortsIf<T> {
-            x: simple_map::spec_get(configs.configs, key)
-        };
+        include any::UnpackAbortsIf<T> { x: simple_map::spec_get(configs.configs, key) };
     }
 
     spec schema SetForNextEpochAbortsIf {
@@ -50,9 +46,8 @@ spec aptos_framework::config_buffer {
         let type_name = type_info::type_name<T>();
         let configs = global<PendingConfigs>(@aptos_framework);
         // TODO(#12015)
-        include spec_fun_does_exist<T>(type_name) ==> any::UnpackAbortsIf<T> {
-            x: simple_map::spec_get(configs.configs, type_name)
-        };
+        include spec_fun_does_exist<T>(type_name) ==>
+            any::UnpackAbortsIf<T> { x: simple_map::spec_get(configs.configs, type_name) };
     }
 
     spec schema OnNewEpochRequirement<T> {
@@ -60,9 +55,9 @@ spec aptos_framework::config_buffer {
         let type_name = type_info::type_name<T>();
         let configs = global<PendingConfigs>(@aptos_framework);
         // TODO(#12015)
-        include spec_fun_does_exist<T>(type_name) ==> any::UnpackRequirement<T> {
-            x: simple_map::spec_get(configs.configs, type_name)
-        };
+        include spec_fun_does_exist<T>(type_name) ==>
+            any::UnpackRequirement<T> {
+                x: simple_map::spec_get(configs.configs, type_name)
+            };
     }
-
 }

--- a/aptos-move/framework/aptos-framework/sources/configs/consensus_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/consensus_config.move
@@ -20,7 +20,9 @@ module aptos_framework::consensus_config {
     const EINVALID_CONFIG: u64 = 1;
 
     /// Publishes the ConsensusConfig config.
-    public(friend) fun initialize(aptos_framework: &signer, config: vector<u8>) {
+    public(friend) fun initialize(
+        aptos_framework: &signer, config: vector<u8>
+    ) {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert!(vector::length(&config) > 0, error::invalid_argument(EINVALID_CONFIG));
         move_to(aptos_framework, ConsensusConfig { config });
@@ -52,7 +54,7 @@ module aptos_framework::consensus_config {
     public fun set_for_next_epoch(account: &signer, config: vector<u8>) {
         system_addresses::assert_aptos_framework(account);
         assert!(vector::length(&config) > 0, error::invalid_argument(EINVALID_CONFIG));
-        std::config_buffer::upsert<ConsensusConfig>(ConsensusConfig {config});
+        std::config_buffer::upsert<ConsensusConfig>(ConsensusConfig { config });
     }
 
     /// Only used in reconfigurations to apply the pending `ConsensusConfig`, if there is any.

--- a/aptos-move/framework/aptos-framework/sources/configs/consensus_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/consensus_config.spec.move
@@ -25,7 +25,8 @@ spec aptos_framework::consensus_config {
         use aptos_framework::chain_status;
         pragma verify = true;
         pragma aborts_if_is_strict;
-        invariant [suspendable] chain_status::is_operating() ==> exists<ConsensusConfig>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<ConsensusConfig>(@aptos_framework);
     }
 
     /// Ensure caller is admin.
@@ -65,7 +66,8 @@ spec aptos_framework::consensus_config {
         aborts_if !(len(config) > 0);
 
         requires chain_status::is_genesis();
-        requires timestamp::spec_now_microseconds() >= reconfiguration::last_reconfiguration_time();
+        requires timestamp::spec_now_microseconds()
+            >= reconfiguration::last_reconfiguration_time();
         requires exists<stake::ValidatorFees>(@aptos_framework);
         requires exists<CoinInfo<AptosCoin>>(@aptos_framework);
         ensures global<ConsensusConfig>(@aptos_framework).config == config;
@@ -84,7 +86,10 @@ spec aptos_framework::consensus_config {
     spec validator_txn_enabled(): bool {
         pragma opaque;
         aborts_if !exists<ConsensusConfig>(@aptos_framework);
-        ensures [abstract] result == spec_validator_txn_enabled_internal(global<ConsensusConfig>(@aptos_framework).config);
+        ensures [abstract] result
+            == spec_validator_txn_enabled_internal(
+                global<ConsensusConfig>(@aptos_framework).config
+            );
     }
 
     spec validator_txn_enabled_internal(config_bytes: vector<u8>): bool {

--- a/aptos-move/framework/aptos-framework/sources/configs/execution_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/execution_config.move
@@ -30,7 +30,8 @@ module aptos_framework::execution_config {
         assert!(vector::length(&config) > 0, error::invalid_argument(EINVALID_CONFIG));
 
         if (exists<ExecutionConfig>(@aptos_framework)) {
-            let config_ref = &mut borrow_global_mut<ExecutionConfig>(@aptos_framework).config;
+            let config_ref =
+                &mut borrow_global_mut<ExecutionConfig>(@aptos_framework).config;
             *config_ref = config;
         } else {
             move_to(account, ExecutionConfig { config });

--- a/aptos-move/framework/aptos-framework/sources/configs/execution_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/execution_config.spec.move
@@ -24,10 +24,12 @@ spec aptos_framework::execution_config {
         requires exists<stake::ValidatorFees>(@aptos_framework);
         requires exists<staking_config::StakingRewardsConfig>(@aptos_framework);
         requires len(config) > 0;
-        include features::spec_periodical_reward_rate_decrease_enabled() ==> staking_config::StakingRewardsConfigEnabledRequirement;
+        include features::spec_periodical_reward_rate_decrease_enabled() ==>
+            staking_config::StakingRewardsConfigEnabledRequirement;
         include aptos_coin::ExistsAptosCoin;
         requires system_addresses::is_aptos_framework_address(addr);
-        requires timestamp::spec_now_microseconds() >= reconfiguration::last_reconfiguration_time();
+        requires timestamp::spec_now_microseconds()
+            >= reconfiguration::last_reconfiguration_time();
 
         ensures exists<ExecutionConfig>(@aptos_framework);
     }

--- a/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.move
@@ -40,9 +40,14 @@ module aptos_framework::gas_schedule {
     }
 
     /// Only called during genesis.
-    public(friend) fun initialize(aptos_framework: &signer, gas_schedule_blob: vector<u8>) {
+    public(friend) fun initialize(
+        aptos_framework: &signer, gas_schedule_blob: vector<u8>
+    ) {
         system_addresses::assert_aptos_framework(aptos_framework);
-        assert!(!vector::is_empty(&gas_schedule_blob), error::invalid_argument(EINVALID_GAS_SCHEDULE));
+        assert!(
+            !vector::is_empty(&gas_schedule_blob),
+            error::invalid_argument(EINVALID_GAS_SCHEDULE),
+        );
 
         // TODO(Gas): check if gas schedule is consistent
         let gas_schedule: GasScheduleV2 = from_bytes(gas_schedule_blob);
@@ -54,20 +59,26 @@ module aptos_framework::gas_schedule {
     /// WARNING: calling this while randomness is enabled will trigger a new epoch without randomness!
     ///
     /// TODO: update all the tests that reference this function, then disable this function.
-    public fun set_gas_schedule(aptos_framework: &signer, gas_schedule_blob: vector<u8>) acquires GasSchedule, GasScheduleV2 {
+    public fun set_gas_schedule(
+        aptos_framework: &signer, gas_schedule_blob: vector<u8>
+    ) acquires GasSchedule, GasScheduleV2 {
         system_addresses::assert_aptos_framework(aptos_framework);
-        assert!(!vector::is_empty(&gas_schedule_blob), error::invalid_argument(EINVALID_GAS_SCHEDULE));
+        assert!(
+            !vector::is_empty(&gas_schedule_blob),
+            error::invalid_argument(EINVALID_GAS_SCHEDULE),
+        );
         chain_status::assert_genesis();
 
         if (exists<GasScheduleV2>(@aptos_framework)) {
             let gas_schedule = borrow_global_mut<GasScheduleV2>(@aptos_framework);
             let new_gas_schedule: GasScheduleV2 = from_bytes(gas_schedule_blob);
-            assert!(new_gas_schedule.feature_version >= gas_schedule.feature_version,
-                error::invalid_argument(EINVALID_GAS_FEATURE_VERSION));
+            assert!(
+                new_gas_schedule.feature_version >= gas_schedule.feature_version,
+                error::invalid_argument(EINVALID_GAS_FEATURE_VERSION),
+            );
             // TODO(Gas): check if gas schedule is consistent
             *gas_schedule = new_gas_schedule;
-        }
-        else {
+        } else {
             if (exists<GasSchedule>(@aptos_framework)) {
                 _ = move_from<GasSchedule>(@aptos_framework);
             };
@@ -88,15 +99,20 @@ module aptos_framework::gas_schedule {
     /// aptos_framework::gas_schedule::set_for_next_epoch(&framework_signer, some_gas_schedule_blob);
     /// aptos_framework::aptos_governance::reconfigure(&framework_signer);
     /// ```
-    public fun set_for_next_epoch(aptos_framework: &signer, gas_schedule_blob: vector<u8>) acquires GasScheduleV2 {
+    public fun set_for_next_epoch(
+        aptos_framework: &signer, gas_schedule_blob: vector<u8>
+    ) acquires GasScheduleV2 {
         system_addresses::assert_aptos_framework(aptos_framework);
-        assert!(!vector::is_empty(&gas_schedule_blob), error::invalid_argument(EINVALID_GAS_SCHEDULE));
+        assert!(
+            !vector::is_empty(&gas_schedule_blob),
+            error::invalid_argument(EINVALID_GAS_SCHEDULE),
+        );
         let new_gas_schedule: GasScheduleV2 = from_bytes(gas_schedule_blob);
         if (exists<GasScheduleV2>(@aptos_framework)) {
             let cur_gas_schedule = borrow_global<GasScheduleV2>(@aptos_framework);
             assert!(
                 new_gas_schedule.feature_version >= cur_gas_schedule.feature_version,
-                error::invalid_argument(EINVALID_GAS_FEATURE_VERSION)
+                error::invalid_argument(EINVALID_GAS_FEATURE_VERSION),
             );
         };
         config_buffer::upsert(new_gas_schedule);
@@ -111,20 +127,23 @@ module aptos_framework::gas_schedule {
         new_gas_schedule_blob: vector<u8>
     ) acquires GasScheduleV2 {
         system_addresses::assert_aptos_framework(aptos_framework);
-        assert!(!vector::is_empty(&new_gas_schedule_blob), error::invalid_argument(EINVALID_GAS_SCHEDULE));
+        assert!(
+            !vector::is_empty(&new_gas_schedule_blob),
+            error::invalid_argument(EINVALID_GAS_SCHEDULE),
+        );
 
         let new_gas_schedule: GasScheduleV2 = from_bytes(new_gas_schedule_blob);
         if (exists<GasScheduleV2>(@aptos_framework)) {
             let cur_gas_schedule = borrow_global<GasScheduleV2>(@aptos_framework);
             assert!(
                 new_gas_schedule.feature_version >= cur_gas_schedule.feature_version,
-                error::invalid_argument(EINVALID_GAS_FEATURE_VERSION)
+                error::invalid_argument(EINVALID_GAS_FEATURE_VERSION),
             );
             let cur_gas_schedule_bytes = bcs::to_bytes(cur_gas_schedule);
             let cur_gas_schedule_hash = aptos_hash::sha3_512(cur_gas_schedule_bytes);
             assert!(
                 cur_gas_schedule_hash == old_gas_schedule_hash,
-                error::invalid_argument(EINVALID_GAS_SCHEDULE_HASH)
+                error::invalid_argument(EINVALID_GAS_SCHEDULE_HASH),
             );
         };
 
@@ -144,32 +163,32 @@ module aptos_framework::gas_schedule {
         }
     }
 
-    public fun set_storage_gas_config(aptos_framework: &signer, config: StorageGasConfig) {
+    public fun set_storage_gas_config(
+        aptos_framework: &signer, config: StorageGasConfig
+    ) {
         storage_gas::set_config(aptos_framework, config);
         // Need to trigger reconfiguration so the VM is guaranteed to load the new gas fee starting from the next
         // transaction.
         reconfiguration::reconfigure();
     }
 
-    public fun set_storage_gas_config_for_next_epoch(aptos_framework: &signer, config: StorageGasConfig) {
+    public fun set_storage_gas_config_for_next_epoch(
+        aptos_framework: &signer, config: StorageGasConfig
+    ) {
         storage_gas::set_config(aptos_framework, config);
     }
 
     #[test(fx = @0x1)]
-    #[expected_failure(abort_code=0x010002, location = Self)]
-    fun set_for_next_epoch_should_abort_if_gas_version_is_too_old(fx: signer) acquires GasScheduleV2 {
+    #[expected_failure(abort_code = 0x010002, location = Self)]
+    fun set_for_next_epoch_should_abort_if_gas_version_is_too_old(
+        fx: signer
+    ) acquires GasScheduleV2 {
         // Setup.
-        let old_gas_schedule = GasScheduleV2 {
-            feature_version: 1000,
-            entries: vector[],
-        };
+        let old_gas_schedule = GasScheduleV2 { feature_version: 1000, entries: vector[], };
         move_to(&fx, old_gas_schedule);
 
         // Setting an older version should not work.
-        let new_gas_schedule = GasScheduleV2 {
-            feature_version: 999,
-            entries: vector[],
-        };
+        let new_gas_schedule = GasScheduleV2 { feature_version: 999, entries: vector[], };
         let new_bytes = to_bytes(&new_gas_schedule);
         set_for_next_epoch(&fx, new_bytes);
     }

--- a/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.spec.move
@@ -39,7 +39,7 @@ spec aptos_framework::gas_schedule {
 
         let addr = signer::address_of(aptos_framework);
         /// [high-level-req-1]
-        include system_addresses::AbortsIfNotAptosFramework{ account: aptos_framework };
+        include system_addresses::AbortsIfNotAptosFramework { account: aptos_framework };
         /// [high-level-req-3.3]
         aborts_if len(gas_schedule_blob) == 0;
         aborts_if exists<GasScheduleV2>(addr);
@@ -65,13 +65,14 @@ spec aptos_framework::gas_schedule {
         include staking_config::StakingRewardsConfigRequirement;
 
         /// [high-level-req-2]
-        include system_addresses::AbortsIfNotAptosFramework{ account: aptos_framework };
+        include system_addresses::AbortsIfNotAptosFramework { account: aptos_framework };
         /// [high-level-req-3.2]
         aborts_if len(gas_schedule_blob) == 0;
         let new_gas_schedule = util::spec_from_bytes<GasScheduleV2>(gas_schedule_blob);
         let gas_schedule = global<GasScheduleV2>(@aptos_framework);
         /// [high-level-req-4]
-        aborts_if exists<GasScheduleV2>(@aptos_framework) && new_gas_schedule.feature_version < gas_schedule.feature_version;
+        aborts_if exists<GasScheduleV2>(@aptos_framework)
+            && new_gas_schedule.feature_version < gas_schedule.feature_version;
         ensures exists<GasScheduleV2>(signer::address_of(aptos_framework));
         ensures global<GasScheduleV2>(@aptos_framework) == new_gas_schedule;
     }
@@ -87,7 +88,7 @@ spec aptos_framework::gas_schedule {
         pragma verify_duration_estimate = 600;
         requires exists<stake::ValidatorFees>(@aptos_framework);
         requires exists<CoinInfo<AptosCoin>>(@aptos_framework);
-        include system_addresses::AbortsIfNotAptosFramework{ account: aptos_framework };
+        include system_addresses::AbortsIfNotAptosFramework { account: aptos_framework };
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
         include staking_config::StakingRewardsConfigRequirement;
         aborts_if !exists<StorageGasConfig>(@aptos_framework);
@@ -97,31 +98,43 @@ spec aptos_framework::gas_schedule {
     spec set_for_next_epoch(aptos_framework: &signer, gas_schedule_blob: vector<u8>) {
         use aptos_framework::util;
 
-        include system_addresses::AbortsIfNotAptosFramework{ account: aptos_framework };
+        include system_addresses::AbortsIfNotAptosFramework { account: aptos_framework };
         include config_buffer::SetForNextEpochAbortsIf {
             account: aptos_framework,
             config: gas_schedule_blob
         };
         let new_gas_schedule = util::spec_from_bytes<GasScheduleV2>(gas_schedule_blob);
         let cur_gas_schedule = global<GasScheduleV2>(@aptos_framework);
-        aborts_if exists<GasScheduleV2>(@aptos_framework) && new_gas_schedule.feature_version < cur_gas_schedule.feature_version;
+        aborts_if exists<GasScheduleV2>(@aptos_framework)
+            && new_gas_schedule.feature_version < cur_gas_schedule.feature_version;
     }
 
-    spec set_for_next_epoch_check_hash(aptos_framework: &signer, old_gas_schedule_hash: vector<u8>, new_gas_schedule_blob: vector<u8>) {
+    spec set_for_next_epoch_check_hash(
+        aptos_framework: &signer,
+        old_gas_schedule_hash: vector<u8>,
+        new_gas_schedule_blob: vector<u8>
+    ) {
         use aptos_std::aptos_hash;
         use std::bcs;
         use std::features;
         use aptos_framework::util;
 
-        include system_addresses::AbortsIfNotAptosFramework{ account: aptos_framework };
+        include system_addresses::AbortsIfNotAptosFramework { account: aptos_framework };
         include config_buffer::SetForNextEpochAbortsIf {
             account: aptos_framework,
             config: new_gas_schedule_blob
         };
         let new_gas_schedule = util::spec_from_bytes<GasScheduleV2>(new_gas_schedule_blob);
         let cur_gas_schedule = global<GasScheduleV2>(@aptos_framework);
-        aborts_if exists<GasScheduleV2>(@aptos_framework) && new_gas_schedule.feature_version < cur_gas_schedule.feature_version;
-        aborts_if exists<GasScheduleV2>(@aptos_framework) && (!features::spec_sha_512_and_ripemd_160_enabled() || aptos_hash::spec_sha3_512_internal(bcs::serialize(cur_gas_schedule)) != old_gas_schedule_hash);
+        aborts_if exists<GasScheduleV2>(@aptos_framework)
+            && new_gas_schedule.feature_version < cur_gas_schedule.feature_version;
+        aborts_if exists<GasScheduleV2>(@aptos_framework)
+            && (
+                !features::spec_sha_512_and_ripemd_160_enabled()
+                    || aptos_hash::spec_sha3_512_internal(
+                        bcs::serialize(cur_gas_schedule)
+                    ) != old_gas_schedule_hash
+            );
     }
 
     spec on_new_epoch(framework: &signer) {
@@ -131,12 +144,14 @@ spec aptos_framework::gas_schedule {
     }
 
     spec set_storage_gas_config(aptos_framework: &signer, config: storage_gas::StorageGasConfig) {
-        include system_addresses::AbortsIfNotAptosFramework{ account: aptos_framework };
+        include system_addresses::AbortsIfNotAptosFramework { account: aptos_framework };
         aborts_if !exists<storage_gas::StorageGasConfig>(@aptos_framework);
     }
 
-    spec set_storage_gas_config_for_next_epoch(aptos_framework: &signer, config: storage_gas::StorageGasConfig) {
-        include system_addresses::AbortsIfNotAptosFramework{ account: aptos_framework };
+    spec set_storage_gas_config_for_next_epoch(
+        aptos_framework: &signer, config: storage_gas::StorageGasConfig
+    ) {
+        include system_addresses::AbortsIfNotAptosFramework { account: aptos_framework };
         aborts_if !exists<storage_gas::StorageGasConfig>(@aptos_framework);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/configs/jwk_consensus_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/jwk_consensus_config.move
@@ -59,7 +59,9 @@ module aptos_framework::jwk_consensus_config {
     /// jwk_consensus_config::set_for_next_epoch(&framework_signer, config);
     /// aptos_governance::reconfigure(&framework_signer);
     /// ```
-    public fun set_for_next_epoch(framework: &signer, config: JWKConsensusConfig) {
+    public fun set_for_next_epoch(
+        framework: &signer, config: JWKConsensusConfig
+    ) {
         system_addresses::assert_aptos_framework(framework);
         config_buffer::upsert(config);
     }
@@ -79,9 +81,7 @@ module aptos_framework::jwk_consensus_config {
 
     /// Construct a `JWKConsensusConfig` of variant `ConfigOff`.
     public fun new_off(): JWKConsensusConfig {
-        JWKConsensusConfig {
-            variant: copyable_any::pack( ConfigOff {} )
-        }
+        JWKConsensusConfig { variant: copyable_any::pack(ConfigOff {}) }
     }
 
     /// Construct a `JWKConsensusConfig` of variant `ConfigV1`.
@@ -89,16 +89,17 @@ module aptos_framework::jwk_consensus_config {
     /// Abort if the given provider list contains duplicated provider names.
     public fun new_v1(oidc_providers: vector<OIDCProvider>): JWKConsensusConfig {
         let name_set = simple_map::new<String, u64>();
-        vector::for_each_ref(&oidc_providers, |provider| {
-            let provider: &OIDCProvider = provider;
-            let (_, old_value) = simple_map::upsert(&mut name_set, provider.name, 0);
-            if (option::is_some(&old_value)) {
-                abort(error::invalid_argument(EDUPLICATE_PROVIDERS))
-            }
-        });
-        JWKConsensusConfig {
-            variant: copyable_any::pack( ConfigV1 { oidc_providers } )
-        }
+        vector::for_each_ref(
+            &oidc_providers,
+            |provider| {
+                let provider: &OIDCProvider = provider;
+                let (_, old_value) = simple_map::upsert(&mut name_set, provider.name, 0);
+                if (option::is_some(&old_value)) {
+                    abort(error::invalid_argument(EDUPLICATE_PROVIDERS))
+                }
+            },
+        );
+        JWKConsensusConfig { variant: copyable_any::pack(ConfigV1 { oidc_providers }) }
     }
 
     /// Construct an `OIDCProvider` object.
@@ -108,7 +109,7 @@ module aptos_framework::jwk_consensus_config {
 
     #[test_only]
     fun enabled(): bool acquires JWKConsensusConfig {
-        let variant= borrow_global<JWKConsensusConfig>(@aptos_framework).variant;
+        let variant = borrow_global<JWKConsensusConfig>(@aptos_framework).variant;
         let variant_type_name = *string::bytes(copyable_any::type_name(&variant));
         variant_type_name != b"0x1::jwk_consensus_config::ConfigOff"
     }
@@ -122,10 +123,12 @@ module aptos_framework::jwk_consensus_config {
     #[test(framework = @0x1)]
     fun init_buffer_apply(framework: signer) acquires JWKConsensusConfig {
         initialize_for_testing(&framework);
-        let config = new_v1(vector[
-            new_oidc_provider(utf8(b"Bob"), utf8(b"https://bob.dev")),
-            new_oidc_provider(utf8(b"Alice"), utf8(b"https://alice.io")),
-        ]);
+        let config =
+            new_v1(
+                vector[
+                    new_oidc_provider(utf8(b"Bob"), utf8(b"https://bob.dev")),
+                    new_oidc_provider(utf8(b"Alice"), utf8(b"https://alice.io")),],
+            );
         set_for_next_epoch(&framework, config);
         on_new_epoch(&framework);
         assert!(enabled(), 1);
@@ -138,11 +141,12 @@ module aptos_framework::jwk_consensus_config {
     #[test]
     #[expected_failure(abort_code = 0x010001, location = Self)]
     fun name_uniqueness_in_config_v1() {
-        new_v1(vector[
-            new_oidc_provider(utf8(b"Alice"), utf8(b"https://alice.info")),
-            new_oidc_provider(utf8(b"Bob"), utf8(b"https://bob.dev")),
-            new_oidc_provider(utf8(b"Alice"), utf8(b"https://alice.io")),
-        ]);
+        new_v1(
+            vector[
+                new_oidc_provider(utf8(b"Alice"), utf8(b"https://alice.info")),
+                new_oidc_provider(utf8(b"Bob"), utf8(b"https://bob.dev")),
+                new_oidc_provider(utf8(b"Alice"), utf8(b"https://alice.io")),],
+        );
 
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/configs/jwk_consensus_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/jwk_consensus_config.move
@@ -127,7 +127,8 @@ module aptos_framework::jwk_consensus_config {
             new_v1(
                 vector[
                     new_oidc_provider(utf8(b"Bob"), utf8(b"https://bob.dev")),
-                    new_oidc_provider(utf8(b"Alice"), utf8(b"https://alice.io")),],
+                    new_oidc_provider(utf8(b"Alice"), utf8(b"https://alice.io")),
+                ],
             );
         set_for_next_epoch(&framework, config);
         on_new_epoch(&framework);
@@ -145,7 +146,8 @@ module aptos_framework::jwk_consensus_config {
             vector[
                 new_oidc_provider(utf8(b"Alice"), utf8(b"https://alice.info")),
                 new_oidc_provider(utf8(b"Bob"), utf8(b"https://bob.dev")),
-                new_oidc_provider(utf8(b"Alice"), utf8(b"https://alice.io")),],
+                new_oidc_provider(utf8(b"Alice"), utf8(b"https://alice.io")),
+            ],
         );
 
     }

--- a/aptos-move/framework/aptos-framework/sources/configs/randomness_api_v0_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/randomness_api_v0_config.move
@@ -15,7 +15,11 @@ module aptos_framework::randomness_api_v0_config {
     }
 
     /// Only used in genesis.
-    fun initialize(framework: &signer, required_amount: RequiredGasDeposit, allow_custom_max_gas_flag: AllowCustomMaxGasFlag) {
+    fun initialize(
+        framework: &signer,
+        required_amount: RequiredGasDeposit,
+        allow_custom_max_gas_flag: AllowCustomMaxGasFlag
+    ) {
         system_addresses::assert_aptos_framework(framework);
         chain_status::assert_genesis();
         move_to(framework, required_amount);
@@ -23,15 +27,19 @@ module aptos_framework::randomness_api_v0_config {
     }
 
     /// This can be called by on-chain governance to update `RequiredGasDeposit` for the next epoch.
-    public fun set_for_next_epoch(framework: &signer, gas_amount: Option<u64>) {
+    public fun set_for_next_epoch(
+        framework: &signer, gas_amount: Option<u64>
+    ) {
         system_addresses::assert_aptos_framework(framework);
         config_buffer::upsert(RequiredGasDeposit { gas_amount });
     }
 
     /// This can be called by on-chain governance to update `AllowCustomMaxGasFlag` for the next epoch.
-    public fun set_allow_max_gas_flag_for_next_epoch(framework: &signer, value: bool) {
+    public fun set_allow_max_gas_flag_for_next_epoch(
+        framework: &signer, value: bool
+    ) {
         system_addresses::assert_aptos_framework(framework);
-        config_buffer::upsert(AllowCustomMaxGasFlag { value } );
+        config_buffer::upsert(AllowCustomMaxGasFlag { value });
     }
 
     /// Only used in reconfigurations to apply the pending `RequiredGasDeposit`, if there is any.

--- a/aptos-move/framework/aptos-framework/sources/configs/randomness_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/randomness_config.move
@@ -50,7 +50,9 @@ module aptos_framework::randomness_config {
     }
 
     /// This can be called by on-chain governance to update on-chain consensus configs for the next epoch.
-    public fun set_for_next_epoch(framework: &signer, new_config: RandomnessConfig) {
+    public fun set_for_next_epoch(
+        framework: &signer, new_config: RandomnessConfig
+    ) {
         system_addresses::assert_aptos_framework(framework);
         config_buffer::upsert(new_config);
     }
@@ -75,27 +77,25 @@ module aptos_framework::randomness_config {
     public fun enabled(): bool acquires RandomnessConfig {
         if (exists<RandomnessConfig>(@aptos_framework)) {
             let config = borrow_global<RandomnessConfig>(@aptos_framework);
-            let variant_type_name = *string::bytes(copyable_any::type_name(&config.variant));
+            let variant_type_name =
+                *string::bytes(copyable_any::type_name(&config.variant));
             variant_type_name != b"0x1::randomness_config::ConfigOff"
-        } else {
-            false
-        }
+        } else { false }
     }
 
     /// Create a `ConfigOff` variant.
     public fun new_off(): RandomnessConfig {
-        RandomnessConfig {
-            variant: copyable_any::pack( ConfigOff {} )
-        }
+        RandomnessConfig { variant: copyable_any::pack(ConfigOff {}) }
     }
 
     /// Create a `ConfigV1` variant.
-    public fun new_v1(secrecy_threshold: FixedPoint64, reconstruction_threshold: FixedPoint64): RandomnessConfig {
+    public fun new_v1(
+        secrecy_threshold: FixedPoint64, reconstruction_threshold: FixedPoint64
+    ): RandomnessConfig {
         RandomnessConfig {
-            variant: copyable_any::pack( ConfigV1 {
-                secrecy_threshold,
-                reconstruction_threshold
-            } )
+            variant: copyable_any::pack(
+                ConfigV1 { secrecy_threshold, reconstruction_threshold },
+            )
         }
     }
 
@@ -106,11 +106,13 @@ module aptos_framework::randomness_config {
         fast_path_secrecy_threshold: FixedPoint64,
     ): RandomnessConfig {
         RandomnessConfig {
-            variant: copyable_any::pack( ConfigV2 {
-                secrecy_threshold,
-                reconstruction_threshold,
-                fast_path_secrecy_threshold,
-            } )
+            variant: copyable_any::pack(
+                ConfigV2 {
+                    secrecy_threshold,
+                    reconstruction_threshold,
+                    fast_path_secrecy_threshold,
+                },
+            )
         }
     }
 
@@ -137,10 +139,11 @@ module aptos_framework::randomness_config {
         initialize_for_testing(&framework);
 
         // Enabling.
-        let config = new_v1(
-            fixed_point64::create_from_rational(1, 2),
-            fixed_point64::create_from_rational(2, 3)
-        );
+        let config =
+            new_v1(
+                fixed_point64::create_from_rational(1, 2),
+                fixed_point64::create_from_rational(2, 3),
+            );
         set_for_next_epoch(&framework, config);
         on_new_epoch(&framework);
         assert!(enabled(), 1);

--- a/aptos-move/framework/aptos-framework/sources/configs/randomness_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/randomness_config.move
@@ -94,7 +94,7 @@ module aptos_framework::randomness_config {
     ): RandomnessConfig {
         RandomnessConfig {
             variant: copyable_any::pack(
-                ConfigV1 { secrecy_threshold, reconstruction_threshold },
+                ConfigV1 { secrecy_threshold, reconstruction_threshold }
             )
         }
     }

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
@@ -258,8 +258,8 @@ module aptos_framework::staking_config {
             error::invalid_argument(EINVALID_LAST_REWARDS_RATE_PERIOD_START),
         );
         if (current_time_in_secs
-                - staking_rewards_config.last_rewards_rate_period_start_in_secs
-                < staking_rewards_config.rewards_rate_period_in_secs) {
+            - staking_rewards_config.last_rewards_rate_period_start_in_secs
+            < staking_rewards_config.rewards_rate_period_in_secs) {
             return *staking_rewards_config
         };
         // Rewards rate decrease rate cannot be greater than 100%. Otherwise rewards rate will be negative.
@@ -534,7 +534,8 @@ module aptos_framework::staking_config {
         assert!(config.rewards_rate_period_in_secs == ONE_YEAR_IN_SECS, 4);
         assert!(config.last_rewards_rate_period_start_in_secs == start_time_in_secs, 4);
         assert!(
-            equal(config.rewards_rate_decrease_rate, create_from_rational(25, 100)), 5
+            equal(config.rewards_rate_decrease_rate, create_from_rational(25, 100)),
+            5,
         );
     }
 

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
@@ -44,7 +44,6 @@ module aptos_framework::staking_config {
 
     const MAX_U64: u128 = 18446744073709551615;
 
-
     /// Validator set configurations that will be stored with the @aptos_framework account.
     struct StakingConfig has copy, drop, key {
         // A validator needs to stake at least this amount to be able to join the validator set.
@@ -105,7 +104,10 @@ module aptos_framework::staking_config {
         // This can fail genesis but is necessary so that any misconfigurations can be corrected before genesis succeeds
         validate_required_stake(minimum_stake, maximum_stake);
 
-        assert!(recurring_lockup_duration_secs > 0, error::invalid_argument(EZERO_LOCKUP_DURATION));
+        assert!(
+            recurring_lockup_duration_secs > 0,
+            error::invalid_argument(EZERO_LOCKUP_DURATION),
+        );
         assert!(
             rewards_rate_denominator > 0,
             error::invalid_argument(EZERO_REWARDS_RATE_DENOMINATOR),
@@ -118,20 +120,29 @@ module aptos_framework::staking_config {
         // `rewards_rate` which is the numerator is limited to be `<= MAX_REWARDS_RATE` in order to avoid the arithmetic
         // overflow in the rewards calculation. `rewards_rate_denominator` can be adjusted to get the desired rewards
         // rate (i.e., rewards_rate / rewards_rate_denominator).
-        assert!(rewards_rate <= MAX_REWARDS_RATE, error::invalid_argument(EINVALID_REWARDS_RATE));
+        assert!(
+            rewards_rate <= MAX_REWARDS_RATE,
+            error::invalid_argument(EINVALID_REWARDS_RATE),
+        );
 
         // We assert that (rewards_rate / rewards_rate_denominator <= 1).
-        assert!(rewards_rate <= rewards_rate_denominator, error::invalid_argument(EINVALID_REWARDS_RATE));
+        assert!(
+            rewards_rate <= rewards_rate_denominator,
+            error::invalid_argument(EINVALID_REWARDS_RATE),
+        );
 
-        move_to(aptos_framework, StakingConfig {
-            minimum_stake,
-            maximum_stake,
-            recurring_lockup_duration_secs,
-            allow_validator_set_change,
-            rewards_rate,
-            rewards_rate_denominator,
-            voting_power_increase_limit,
-        });
+        move_to(
+            aptos_framework,
+            StakingConfig {
+                minimum_stake,
+                maximum_stake,
+                recurring_lockup_duration_secs,
+                allow_validator_set_change,
+                rewards_rate,
+                rewards_rate_denominator,
+                voting_power_increase_limit,
+            },
+        );
     }
 
     #[view]
@@ -160,16 +171,19 @@ module aptos_framework::staking_config {
         );
         assert!(
             timestamp::now_seconds() >= last_rewards_rate_period_start_in_secs,
-            error::invalid_argument(EINVALID_LAST_REWARDS_RATE_PERIOD_START)
+            error::invalid_argument(EINVALID_LAST_REWARDS_RATE_PERIOD_START),
         );
 
-        move_to(aptos_framework, StakingRewardsConfig {
-            rewards_rate,
-            min_rewards_rate,
-            rewards_rate_period_in_secs,
-            last_rewards_rate_period_start_in_secs,
-            rewards_rate_decrease_rate,
-        });
+        move_to(
+            aptos_framework,
+            StakingRewardsConfig {
+                rewards_rate,
+                min_rewards_rate,
+                rewards_rate_period_in_secs,
+                last_rewards_rate_period_start_in_secs,
+                rewards_rate_decrease_rate,
+            },
+        );
     }
 
     public fun get(): StakingConfig acquires StakingConfig {
@@ -195,17 +209,22 @@ module aptos_framework::staking_config {
     /// Return the reward rate of this epoch.
     public fun get_reward_rate(config: &StakingConfig): (u64, u64) acquires StakingRewardsConfig {
         if (features::periodical_reward_rate_decrease_enabled()) {
-            let epoch_rewards_rate = borrow_global<StakingRewardsConfig>(@aptos_framework).rewards_rate;
+            let epoch_rewards_rate =
+                borrow_global<StakingRewardsConfig>(@aptos_framework).rewards_rate;
             if (fixed_point64::is_zero(epoch_rewards_rate)) {
                 (0u64, 1u64)
             } else {
                 // Maximize denominator for higher precision.
                 // Restriction: nominator <= MAX_REWARDS_RATE && denominator <= MAX_U64
-                let denominator = fixed_point64::divide_u128((MAX_REWARDS_RATE as u128), epoch_rewards_rate);
+                let denominator =
+                    fixed_point64::divide_u128(
+                        (MAX_REWARDS_RATE as u128), epoch_rewards_rate
+                    );
                 if (denominator > MAX_U64) {
                     denominator = MAX_U64
                 };
-                let nominator = (fixed_point64::multiply_u128(denominator, epoch_rewards_rate) as u64);
+                let nominator =
+                    (fixed_point64::multiply_u128(denominator, epoch_rewards_rate) as u64);
                 (nominator, (denominator as u64))
             }
         } else {
@@ -220,41 +239,49 @@ module aptos_framework::staking_config {
 
     /// Calculate and save the latest rewards rate.
     public(friend) fun calculate_and_save_latest_epoch_rewards_rate(): FixedPoint64 acquires StakingRewardsConfig {
-        assert!(features::periodical_reward_rate_decrease_enabled(), error::invalid_state(EDISABLED_FUNCTION));
+        assert!(
+            features::periodical_reward_rate_decrease_enabled(),
+            error::invalid_state(EDISABLED_FUNCTION),
+        );
         let staking_rewards_config = calculate_and_save_latest_rewards_config();
         staking_rewards_config.rewards_rate
     }
 
     /// Calculate and return the up-to-date StakingRewardsConfig.
     fun calculate_and_save_latest_rewards_config(): StakingRewardsConfig acquires StakingRewardsConfig {
-        let staking_rewards_config = borrow_global_mut<StakingRewardsConfig>(@aptos_framework);
+        let staking_rewards_config =
+            borrow_global_mut<StakingRewardsConfig>(@aptos_framework);
         let current_time_in_secs = timestamp::now_seconds();
         assert!(
-            current_time_in_secs >= staking_rewards_config.last_rewards_rate_period_start_in_secs,
-            error::invalid_argument(EINVALID_LAST_REWARDS_RATE_PERIOD_START)
+            current_time_in_secs
+                >= staking_rewards_config.last_rewards_rate_period_start_in_secs,
+            error::invalid_argument(EINVALID_LAST_REWARDS_RATE_PERIOD_START),
         );
-        if (current_time_in_secs - staking_rewards_config.last_rewards_rate_period_start_in_secs < staking_rewards_config.rewards_rate_period_in_secs) {
+        if (current_time_in_secs
+                - staking_rewards_config.last_rewards_rate_period_start_in_secs
+                < staking_rewards_config.rewards_rate_period_in_secs) {
             return *staking_rewards_config
         };
         // Rewards rate decrease rate cannot be greater than 100%. Otherwise rewards rate will be negative.
         assert!(
             fixed_point64::ceil(staking_rewards_config.rewards_rate_decrease_rate) <= 1,
-            error::invalid_argument(EINVALID_REWARDS_RATE_DECREASE_RATE)
+            error::invalid_argument(EINVALID_REWARDS_RATE_DECREASE_RATE),
         );
-        let new_rate = math_fixed64::mul_div(
-            staking_rewards_config.rewards_rate,
-            fixed_point64::sub(
+        let new_rate =
+            math_fixed64::mul_div(
+                staking_rewards_config.rewards_rate,
+                fixed_point64::sub(
+                    fixed_point64::create_from_u128(1),
+                    staking_rewards_config.rewards_rate_decrease_rate,
+                ),
                 fixed_point64::create_from_u128(1),
-                staking_rewards_config.rewards_rate_decrease_rate,
-            ),
-            fixed_point64::create_from_u128(1),
-        );
+            );
         new_rate = fixed_point64::max(new_rate, staking_rewards_config.min_rewards_rate);
 
         staking_rewards_config.rewards_rate = new_rate;
-        staking_rewards_config.last_rewards_rate_period_start_in_secs =
-            staking_rewards_config.last_rewards_rate_period_start_in_secs +
-            staking_rewards_config.rewards_rate_period_in_secs;
+        staking_rewards_config.last_rewards_rate_period_start_in_secs = staking_rewards_config
+            .last_rewards_rate_period_start_in_secs
+            + staking_rewards_config.rewards_rate_period_in_secs;
         return *staking_rewards_config
     }
 
@@ -276,10 +303,12 @@ module aptos_framework::staking_config {
     /// Update the recurring lockup duration.
     /// Can only be called as part of the Aptos governance proposal process established by the AptosGovernance module.
     public fun update_recurring_lockup_duration_secs(
-        aptos_framework: &signer,
-        new_recurring_lockup_duration_secs: u64,
+        aptos_framework: &signer, new_recurring_lockup_duration_secs: u64,
     ) acquires StakingConfig {
-        assert!(new_recurring_lockup_duration_secs > 0, error::invalid_argument(EZERO_LOCKUP_DURATION));
+        assert!(
+            new_recurring_lockup_duration_secs > 0,
+            error::invalid_argument(EZERO_LOCKUP_DURATION),
+        );
         system_addresses::assert_aptos_framework(aptos_framework);
 
         let staking_config = borrow_global_mut<StakingConfig>(@aptos_framework);
@@ -294,7 +323,10 @@ module aptos_framework::staking_config {
         new_rewards_rate: u64,
         new_rewards_rate_denominator: u64,
     ) acquires StakingConfig {
-        assert!(!features::periodical_reward_rate_decrease_enabled(), error::invalid_state(EDEPRECATED_FUNCTION));
+        assert!(
+            !features::periodical_reward_rate_decrease_enabled(),
+            error::invalid_state(EDEPRECATED_FUNCTION),
+        );
         system_addresses::assert_aptos_framework(aptos_framework);
         assert!(
             new_rewards_rate_denominator > 0,
@@ -303,10 +335,16 @@ module aptos_framework::staking_config {
         // `rewards_rate` which is the numerator is limited to be `<= MAX_REWARDS_RATE` in order to avoid the arithmetic
         // overflow in the rewards calculation. `rewards_rate_denominator` can be adjusted to get the desired rewards
         // rate (i.e., rewards_rate / rewards_rate_denominator).
-        assert!(new_rewards_rate <= MAX_REWARDS_RATE, error::invalid_argument(EINVALID_REWARDS_RATE));
+        assert!(
+            new_rewards_rate <= MAX_REWARDS_RATE,
+            error::invalid_argument(EINVALID_REWARDS_RATE),
+        );
 
         // We assert that (rewards_rate / rewards_rate_denominator <= 1).
-        assert!(new_rewards_rate <= new_rewards_rate_denominator, error::invalid_argument(EINVALID_REWARDS_RATE));
+        assert!(
+            new_rewards_rate <= new_rewards_rate_denominator,
+            error::invalid_argument(EINVALID_REWARDS_RATE),
+        );
 
         let staking_config = borrow_global_mut<StakingConfig>(@aptos_framework);
         staking_config.rewards_rate = new_rewards_rate;
@@ -329,11 +367,13 @@ module aptos_framework::staking_config {
             rewards_rate_decrease_rate,
         );
 
-        let staking_rewards_config = borrow_global_mut<StakingRewardsConfig>(@aptos_framework);
+        let staking_rewards_config =
+            borrow_global_mut<StakingRewardsConfig>(@aptos_framework);
         // Currently rewards_rate_period_in_secs is not allowed to be changed because this could bring complicated
         // logics. At the moment the argument is just a placeholder for future use.
         assert!(
-            rewards_rate_period_in_secs == staking_rewards_config.rewards_rate_period_in_secs,
+            rewards_rate_period_in_secs
+                == staking_rewards_config.rewards_rate_period_in_secs,
             error::invalid_argument(EINVALID_REWARDS_RATE_PERIOD),
         );
         staking_rewards_config.rewards_rate = rewards_rate;
@@ -345,8 +385,7 @@ module aptos_framework::staking_config {
     /// Update the joining limit %.
     /// Can only be called as part of the Aptos governance proposal process established by the AptosGovernance module.
     public fun update_voting_power_increase_limit(
-        aptos_framework: &signer,
-        new_voting_power_increase_limit: u64,
+        aptos_framework: &signer, new_voting_power_increase_limit: u64,
     ) acquires StakingConfig {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert!(
@@ -359,7 +398,10 @@ module aptos_framework::staking_config {
     }
 
     fun validate_required_stake(minimum_stake: u64, maximum_stake: u64) {
-        assert!(minimum_stake <= maximum_stake && maximum_stake > 0, error::invalid_argument(EINVALID_STAKE_RANGE));
+        assert!(
+            minimum_stake <= maximum_stake && maximum_stake > 0,
+            error::invalid_argument(EINVALID_STAKE_RANGE),
+        );
     }
 
     fun validate_rewards_config(
@@ -371,16 +413,16 @@ module aptos_framework::staking_config {
         // Bound rewards rate to avoid arithmetic overflow.
         assert!(
             less_or_equal(rewards_rate, fixed_point64::create_from_u128((1u128))),
-            error::invalid_argument(EINVALID_REWARDS_RATE)
+            error::invalid_argument(EINVALID_REWARDS_RATE),
         );
         assert!(
             less_or_equal(min_rewards_rate, rewards_rate),
-            error::invalid_argument(EINVALID_MIN_REWARDS_RATE)
+            error::invalid_argument(EINVALID_MIN_REWARDS_RATE),
         );
         // Rewards rate decrease rate cannot be greater than 100%. Otherwise rewards rate will be negative.
         assert!(
             fixed_point64::ceil(rewards_rate_decrease_rate) <= 1,
-            error::invalid_argument(EINVALID_REWARDS_RATE_DECREASE_RATE)
+            error::invalid_argument(EINVALID_REWARDS_RATE_DECREASE_RATE),
         );
         // This field, rewards_rate_period_in_secs must be greater than 0.
         // TODO: rewards_rate_period_in_secs should be longer than the epoch duration but reading epoch duration causes a circular dependency.
@@ -412,7 +454,9 @@ module aptos_framework::staking_config {
     }
 
     #[test(aptos_framework = @aptos_framework)]
-    public entry fun test_staking_rewards_rate_decrease_over_time(aptos_framework: signer) acquires StakingRewardsConfig {
+    public entry fun test_staking_rewards_rate_decrease_over_time(
+        aptos_framework: signer
+    ) acquires StakingRewardsConfig {
         let start_time_in_secs: u64 = 100001000000;
         initialize_rewards_for_test(
             &aptos_framework,
@@ -420,7 +464,7 @@ module aptos_framework::staking_config {
             create_from_rational(3, 1000),
             ONE_YEAR_IN_SECS,
             start_time_in_secs,
-            create_from_rational(50, 100)
+            create_from_rational(50, 100),
         );
 
         let epoch_reward_rate = calculate_and_save_latest_epoch_rewards_rate();
@@ -456,13 +500,16 @@ module aptos_framework::staking_config {
             fixed_point64::almost_equal(
                 epoch_reward_rate,
                 create_from_rational(2955, 1000000),
-                create_from_rational(1, 100000000)
+                create_from_rational(1, 100000000),
             ),
-            4);
+            4,
+        );
     }
 
     #[test(aptos_framework = @aptos_framework)]
-    public entry fun test_change_staking_rewards_configs(aptos_framework: signer) acquires StakingRewardsConfig {
+    public entry fun test_change_staking_rewards_configs(
+        aptos_framework: signer
+    ) acquires StakingRewardsConfig {
         let start_time_in_secs: u64 = 100001000000;
         initialize_rewards_for_test(
             &aptos_framework,
@@ -486,37 +533,53 @@ module aptos_framework::staking_config {
         assert!(equal(config.min_rewards_rate, create_from_rational(6, 1000)), 1);
         assert!(config.rewards_rate_period_in_secs == ONE_YEAR_IN_SECS, 4);
         assert!(config.last_rewards_rate_period_start_in_secs == start_time_in_secs, 4);
-        assert!(equal(config.rewards_rate_decrease_rate, create_from_rational(25, 100)), 5);
+        assert!(
+            equal(config.rewards_rate_decrease_rate, create_from_rational(25, 100)), 5
+        );
     }
 
     #[test(account = @0x123)]
     #[expected_failure(abort_code = 0x50003, location = aptos_framework::system_addresses)]
-    public entry fun test_update_required_stake_unauthorized_should_fail(account: signer) acquires StakingConfig {
+    public entry fun test_update_required_stake_unauthorized_should_fail(
+        account: signer
+    ) acquires StakingConfig {
         update_required_stake(&account, 1, 2);
     }
 
     #[test(account = @0x123)]
     #[expected_failure(abort_code = 0x50003, location = aptos_framework::system_addresses)]
-    public entry fun test_update_required_lockup_unauthorized_should_fail(account: signer) acquires StakingConfig {
+    public entry fun test_update_required_lockup_unauthorized_should_fail(
+        account: signer
+    ) acquires StakingConfig {
         update_recurring_lockup_duration_secs(&account, 1);
     }
 
     #[test(account = @0x123)]
     #[expected_failure(abort_code = 0x50003, location = aptos_framework::system_addresses)]
-    public entry fun test_update_rewards_unauthorized_should_fail(account: signer) acquires StakingConfig {
+    public entry fun test_update_rewards_unauthorized_should_fail(
+        account: signer
+    ) acquires StakingConfig {
         update_rewards_rate(&account, 1, 10);
     }
 
     #[test(account = @0x123)]
     #[expected_failure(abort_code = 0x50003, location = aptos_framework::system_addresses)]
-    public entry fun test_update_voting_power_increase_limit_unauthorized_should_fail(account: signer) acquires StakingConfig {
+    public entry fun test_update_voting_power_increase_limit_unauthorized_should_fail(
+        account: signer
+    ) acquires StakingConfig {
         update_voting_power_increase_limit(&account, 10);
     }
 
     #[test(account = @0x123, aptos_framework = @aptos_framework)]
     #[expected_failure(abort_code = 0x50003, location = aptos_framework::system_addresses)]
-    public entry fun test_update_rewards_config_unauthorized_should_fail(account: signer, aptos_framework: signer) acquires StakingRewardsConfig {
-        features::change_feature_flags_for_testing(&aptos_framework, vector[features::get_periodical_reward_rate_decrease_feature()], vector[]);
+    public entry fun test_update_rewards_config_unauthorized_should_fail(
+        account: signer, aptos_framework: signer
+    ) acquires StakingRewardsConfig {
+        features::change_feature_flags_for_testing(
+            &aptos_framework,
+            vector[features::get_periodical_reward_rate_decrease_feature()],
+            vector[],
+        );
         update_rewards_config(
             &account,
             create_from_rational(1, 100),
@@ -528,31 +591,41 @@ module aptos_framework::staking_config {
 
     #[test(aptos_framework = @aptos_framework)]
     #[expected_failure(abort_code = 0x10003, location = Self)]
-    public entry fun test_update_required_stake_invalid_range_should_fail(aptos_framework: signer) acquires StakingConfig {
+    public entry fun test_update_required_stake_invalid_range_should_fail(
+        aptos_framework: signer
+    ) acquires StakingConfig {
         update_required_stake(&aptos_framework, 10, 5);
     }
 
     #[test(aptos_framework = @aptos_framework)]
     #[expected_failure(abort_code = 0x10003, location = Self)]
-    public entry fun test_update_required_stake_zero_max_stake_should_fail(aptos_framework: signer) acquires StakingConfig {
+    public entry fun test_update_required_stake_zero_max_stake_should_fail(
+        aptos_framework: signer
+    ) acquires StakingConfig {
         update_required_stake(&aptos_framework, 0, 0);
     }
 
     #[test(aptos_framework = @aptos_framework)]
     #[expected_failure(abort_code = 0x10001, location = Self)]
-    public entry fun test_update_required_lockup_to_zero_should_fail(aptos_framework: signer) acquires StakingConfig {
+    public entry fun test_update_required_lockup_to_zero_should_fail(
+        aptos_framework: signer
+    ) acquires StakingConfig {
         update_recurring_lockup_duration_secs(&aptos_framework, 0);
     }
 
     #[test(aptos_framework = @aptos_framework)]
     #[expected_failure(abort_code = 0x10002, location = Self)]
-    public entry fun test_update_rewards_invalid_denominator_should_fail(aptos_framework: signer) acquires StakingConfig {
+    public entry fun test_update_rewards_invalid_denominator_should_fail(
+        aptos_framework: signer
+    ) acquires StakingConfig {
         update_rewards_rate(&aptos_framework, 1, 0);
     }
 
     #[test(aptos_framework = @aptos_framework)]
     #[expected_failure(abort_code = 0x10005, location = Self)]
-    public entry fun test_update_rewards_config_rewards_rate_greater_than_1_should_fail(aptos_framework: signer) acquires StakingRewardsConfig {
+    public entry fun test_update_rewards_config_rewards_rate_greater_than_1_should_fail(
+        aptos_framework: signer
+    ) acquires StakingRewardsConfig {
         let start_time_in_secs: u64 = 100001000000;
         initialize_rewards_for_test(
             &aptos_framework,
@@ -573,7 +646,9 @@ module aptos_framework::staking_config {
 
     #[test(aptos_framework = @aptos_framework)]
     #[expected_failure(abort_code = 0x10008, location = Self)]
-    public entry fun test_update_rewards_config_invalid_rewards_rate_decrease_rate_should_fail(aptos_framework: signer) acquires StakingRewardsConfig {
+    public entry fun test_update_rewards_config_invalid_rewards_rate_decrease_rate_should_fail(
+        aptos_framework: signer
+    ) acquires StakingRewardsConfig {
         let start_time_in_secs: u64 = 100001000000;
         initialize_rewards_for_test(
             &aptos_framework,
@@ -594,7 +669,9 @@ module aptos_framework::staking_config {
 
     #[test(aptos_framework = @aptos_framework)]
     #[expected_failure(abort_code = 0x10009, location = Self)]
-    public entry fun test_update_rewards_config_cannot_change_rewards_rate_period(aptos_framework: signer) acquires StakingRewardsConfig {
+    public entry fun test_update_rewards_config_cannot_change_rewards_rate_period(
+        aptos_framework: signer
+    ) acquires StakingRewardsConfig {
         let start_time_in_secs: u64 = 100001000000;
         initialize_rewards_for_test(
             &aptos_framework,
@@ -615,8 +692,14 @@ module aptos_framework::staking_config {
 
     #[test(aptos_framework = @aptos_framework)]
     #[expected_failure(abort_code = 0x3000B, location = Self)]
-    public entry fun test_feature_flag_disabled_get_epoch_rewards_rate_should_fail(aptos_framework: signer) acquires StakingRewardsConfig {
-        features::change_feature_flags_for_testing(&aptos_framework, vector[], vector[features::get_periodical_reward_rate_decrease_feature()]);
+    public entry fun test_feature_flag_disabled_get_epoch_rewards_rate_should_fail(
+        aptos_framework: signer
+    ) acquires StakingRewardsConfig {
+        features::change_feature_flags_for_testing(
+            &aptos_framework,
+            vector[],
+            vector[features::get_periodical_reward_rate_decrease_feature()],
+        );
         calculate_and_save_latest_epoch_rewards_rate();
     }
 
@@ -649,15 +732,18 @@ module aptos_framework::staking_config {
         voting_power_increase_limit: u64,
     ) {
         if (!exists<StakingConfig>(@aptos_framework)) {
-            move_to(aptos_framework, StakingConfig {
-                minimum_stake,
-                maximum_stake,
-                recurring_lockup_duration_secs,
-                allow_validator_set_change,
-                rewards_rate,
-                rewards_rate_denominator,
-                voting_power_increase_limit,
-            });
+            move_to(
+                aptos_framework,
+                StakingConfig {
+                    minimum_stake,
+                    maximum_stake,
+                    recurring_lockup_duration_secs,
+                    allow_validator_set_change,
+                    rewards_rate,
+                    rewards_rate_denominator,
+                    voting_power_increase_limit,
+                },
+            );
         };
     }
 
@@ -671,9 +757,15 @@ module aptos_framework::staking_config {
         last_rewards_rate_period_start_in_secs: u64,
         rewards_rate_decrease_rate: FixedPoint64,
     ) {
-        features::change_feature_flags_for_testing(aptos_framework, vector[features::get_periodical_reward_rate_decrease_feature()], vector[]);
+        features::change_feature_flags_for_testing(
+            aptos_framework,
+            vector[features::get_periodical_reward_rate_decrease_feature()],
+            vector[],
+        );
         timestamp::set_time_has_started_for_testing(aptos_framework);
-        timestamp::update_global_time_for_test_secs(last_rewards_rate_period_start_in_secs);
+        timestamp::update_global_time_for_test_secs(
+            last_rewards_rate_period_start_in_secs
+        );
         initialize_rewards(
             aptos_framework,
             rewards_rate,

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
@@ -57,7 +57,8 @@ spec aptos_framework::staking_config {
     ///
     spec module {
         use aptos_framework::chain_status;
-        invariant [suspendable] chain_status::is_operating() ==> exists<StakingConfig>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<StakingConfig>(@aptos_framework);
         pragma verify = true;
         pragma aborts_if_is_strict;
     }
@@ -80,8 +81,8 @@ spec aptos_framework::staking_config {
 
     spec StakingRewardsConfig {
         invariant fixed_point64::spec_less_or_equal(
-            rewards_rate,
-            fixed_point64::spec_create_from_u128((1u128)));
+            rewards_rate, fixed_point64::spec_create_from_u128((1u128))
+        );
         invariant fixed_point64::spec_less_or_equal(min_rewards_rate, rewards_rate);
         invariant rewards_rate_period_in_secs > 0;
         invariant fixed_point64::spec_ceil(rewards_rate_decrease_rate) <= 1;
@@ -150,18 +151,26 @@ spec aptos_framework::staking_config {
 
     spec get_reward_rate(config: &StakingConfig): (u64, u64) {
         include StakingRewardsConfigRequirement;
-        ensures (features::spec_periodical_reward_rate_decrease_enabled() &&
-            (global<StakingRewardsConfig>(@aptos_framework).rewards_rate.value as u64) != 0) ==>
-                result_1 <= MAX_REWARDS_RATE && result_2 <= MAX_U64;
+        ensures (
+            features::spec_periodical_reward_rate_decrease_enabled()
+            && (global<StakingRewardsConfig>(@aptos_framework).rewards_rate.value as u64)
+                != 0
+        ) ==>
+            result_1 <= MAX_REWARDS_RATE
+                && result_2 <= MAX_U64;
     }
 
     spec reward_rate(): (u64, u64) {
         let config = global<StakingConfig>(@aptos_framework);
         aborts_if !exists<StakingConfig>(@aptos_framework);
         include StakingRewardsConfigRequirement;
-        ensures (features::spec_periodical_reward_rate_decrease_enabled() &&
-            (global<StakingRewardsConfig>(@aptos_framework).rewards_rate.value as u64) != 0) ==>
-            result_1 <= MAX_REWARDS_RATE && result_2 <= MAX_U64;
+        ensures (
+            features::spec_periodical_reward_rate_decrease_enabled()
+            && (global<StakingRewardsConfig>(@aptos_framework).rewards_rate.value as u64)
+                != 0
+        ) ==>
+            result_1 <= MAX_REWARDS_RATE
+                && result_2 <= MAX_U64;
     }
 
     spec calculate_and_save_latest_epoch_rewards_rate(): FixedPoint64 {
@@ -182,9 +191,7 @@ spec aptos_framework::staking_config {
     /// The maximum_stake must be greater than maximum_stake in the range of Specified stake and the maximum_stake greater than zero.
     /// The StakingConfig is under @aptos_framework.
     spec update_required_stake(
-        aptos_framework: &signer,
-        minimum_stake: u64,
-        maximum_stake: u64,
+        aptos_framework: &signer, minimum_stake: u64, maximum_stake: u64,
     ) {
         use std::signer;
         let addr = signer::address_of(aptos_framework);
@@ -192,16 +199,15 @@ spec aptos_framework::staking_config {
         aborts_if addr != @aptos_framework;
         aborts_if minimum_stake > maximum_stake || maximum_stake == 0;
         aborts_if !exists<StakingConfig>(@aptos_framework);
-        ensures global<StakingConfig>(@aptos_framework).minimum_stake == minimum_stake &&
-            global<StakingConfig>(@aptos_framework).maximum_stake == maximum_stake;
+        ensures global<StakingConfig>(@aptos_framework).minimum_stake == minimum_stake
+            && global<StakingConfig>(@aptos_framework).maximum_stake == maximum_stake;
     }
 
     /// Caller must be @aptos_framework.
     /// The new_recurring_lockup_duration_secs must greater than zero.
     /// The StakingConfig is under @aptos_framework.
     spec update_recurring_lockup_duration_secs(
-        aptos_framework: &signer,
-        new_recurring_lockup_duration_secs: u64,
+        aptos_framework: &signer, new_recurring_lockup_duration_secs: u64,
     ) {
         use std::signer;
         let addr = signer::address_of(aptos_framework);
@@ -210,7 +216,8 @@ spec aptos_framework::staking_config {
         /// [high-level-req-3.2]
         aborts_if new_recurring_lockup_duration_secs == 0;
         aborts_if !exists<StakingConfig>(@aptos_framework);
-        ensures global<StakingConfig>(@aptos_framework).recurring_lockup_duration_secs == new_recurring_lockup_duration_secs;
+        ensures global<StakingConfig>(@aptos_framework).recurring_lockup_duration_secs
+            == new_recurring_lockup_duration_secs;
     }
 
     /// Caller must be @aptos_framework.
@@ -219,9 +226,7 @@ spec aptos_framework::staking_config {
     /// The `rewards_rate` which is the numerator is limited to be `<= MAX_REWARDS_RATE` in order to avoid the arithmetic overflow in the rewards calculation.
     /// rewards_rate/rewards_rate_denominator <= 1.
     spec update_rewards_rate(
-        aptos_framework: &signer,
-        new_rewards_rate: u64,
-        new_rewards_rate_denominator: u64,
+        aptos_framework: &signer, new_rewards_rate: u64, new_rewards_rate_denominator: u64,
     ) {
         use std::signer;
         aborts_if features::spec_periodical_reward_rate_decrease_enabled();
@@ -252,31 +257,35 @@ spec aptos_framework::staking_config {
         let addr = signer::address_of(aptos_framework);
         /// [high-level-req-1.6]
         aborts_if addr != @aptos_framework;
-        aborts_if global<StakingRewardsConfig>(@aptos_framework).rewards_rate_period_in_secs != rewards_rate_period_in_secs;
+        aborts_if global<StakingRewardsConfig>(@aptos_framework).rewards_rate_period_in_secs
+            != rewards_rate_period_in_secs;
         include StakingRewardsConfigValidationAbortsIf;
         aborts_if !exists<StakingRewardsConfig>(addr);
         let post staking_rewards_config = global<StakingRewardsConfig>(@aptos_framework);
         ensures staking_rewards_config.rewards_rate == rewards_rate;
         ensures staking_rewards_config.min_rewards_rate == min_rewards_rate;
-        ensures staking_rewards_config.rewards_rate_period_in_secs == rewards_rate_period_in_secs;
-        ensures staking_rewards_config.rewards_rate_decrease_rate == rewards_rate_decrease_rate;
+        ensures staking_rewards_config.rewards_rate_period_in_secs
+            == rewards_rate_period_in_secs;
+        ensures staking_rewards_config.rewards_rate_decrease_rate
+            == rewards_rate_decrease_rate;
     }
 
     /// Caller must be @aptos_framework.
     /// Only this %0-%50 of current total voting power is allowed to join the validator set in each epoch.
     /// The StakingConfig is under @aptos_framework.
     spec update_voting_power_increase_limit(
-        aptos_framework: &signer,
-        new_voting_power_increase_limit: u64,
+        aptos_framework: &signer, new_voting_power_increase_limit: u64,
     ) {
         use std::signer;
         let addr = signer::address_of(aptos_framework);
         /// [high-level-req-1.7]
         aborts_if addr != @aptos_framework;
         /// [high-level-req-2.2]
-        aborts_if new_voting_power_increase_limit == 0 || new_voting_power_increase_limit > 50;
+        aborts_if new_voting_power_increase_limit == 0
+            || new_voting_power_increase_limit > 50;
         aborts_if !exists<StakingConfig>(@aptos_framework);
-        ensures global<StakingConfig>(@aptos_framework).voting_power_increase_limit == new_voting_power_increase_limit;
+        ensures global<StakingConfig>(@aptos_framework).voting_power_increase_limit
+            == new_voting_power_increase_limit;
     }
 
     /// The maximum_stake must be greater than maximum_stake in the range of Specified stake and the maximum_stake greater than zero.
@@ -305,8 +314,8 @@ spec aptos_framework::staking_config {
         rewards_rate_decrease_rate: FixedPoint64;
 
         aborts_if fixed_point64::spec_greater(
-            rewards_rate,
-            fixed_point64::spec_create_from_u128((1u128)));
+            rewards_rate, fixed_point64::spec_create_from_u128((1u128))
+        );
         aborts_if fixed_point64::spec_greater(min_rewards_rate, rewards_rate);
         aborts_if rewards_rate_period_in_secs == 0;
         aborts_if fixed_point64::spec_ceil(rewards_rate_decrease_rate) > 1;
@@ -314,7 +323,8 @@ spec aptos_framework::staking_config {
 
     spec schema StakingRewardsConfigRequirement {
         requires exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
-        include features::spec_periodical_reward_rate_decrease_enabled() ==> StakingRewardsConfigEnabledRequirement;
+        include features::spec_periodical_reward_rate_decrease_enabled() ==>
+            StakingRewardsConfigEnabledRequirement;
     }
 
     spec schema StakingRewardsConfigEnabledRequirement {
@@ -327,8 +337,8 @@ spec aptos_framework::staking_config {
         let rewards_rate_decrease_rate = staking_rewards_config.rewards_rate_decrease_rate;
 
         requires fixed_point64::spec_less_or_equal(
-            rewards_rate,
-            fixed_point64::spec_create_from_u128((1u128)));
+            rewards_rate, fixed_point64::spec_create_from_u128((1u128))
+        );
         requires fixed_point64::spec_less_or_equal(min_rewards_rate, rewards_rate);
         requires rewards_rate_period_in_secs > 0;
         /// [high-level-req-4]

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
@@ -153,8 +153,9 @@ spec aptos_framework::staking_config {
         include StakingRewardsConfigRequirement;
         ensures (
             features::spec_periodical_reward_rate_decrease_enabled()
-            && (global<StakingRewardsConfig>(@aptos_framework).rewards_rate.value as u64)
-                != 0
+                && (
+                    global<StakingRewardsConfig>(@aptos_framework).rewards_rate.value as u64
+                ) != 0
         ) ==>
             result_1 <= MAX_REWARDS_RATE
                 && result_2 <= MAX_U64;
@@ -166,8 +167,9 @@ spec aptos_framework::staking_config {
         include StakingRewardsConfigRequirement;
         ensures (
             features::spec_periodical_reward_rate_decrease_enabled()
-            && (global<StakingRewardsConfig>(@aptos_framework).rewards_rate.value as u64)
-                != 0
+                && (
+                    global<StakingRewardsConfig>(@aptos_framework).rewards_rate.value as u64
+                ) != 0
         ) ==>
             result_1 <= MAX_REWARDS_RATE
                 && result_2 <= MAX_U64;

--- a/aptos-move/framework/aptos-framework/sources/configs/version.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/version.move
@@ -24,7 +24,9 @@ module aptos_framework::version {
 
     /// Only called during genesis.
     /// Publishes the Version config.
-    public(friend) fun initialize(aptos_framework: &signer, initial_version: u64) {
+    public(friend) fun initialize(
+        aptos_framework: &signer, initial_version: u64
+    ) {
         system_addresses::assert_aptos_framework(aptos_framework);
 
         move_to(aptos_framework, Version { major: initial_version });
@@ -39,7 +41,10 @@ module aptos_framework::version {
     ///
     /// TODO: update all the tests that reference this function, then disable this function.
     public entry fun set_version(account: &signer, major: u64) acquires Version {
-        assert!(exists<SetVersionCapability>(signer::address_of(account)), error::permission_denied(ENOT_AUTHORIZED));
+        assert!(
+            exists<SetVersionCapability>(signer::address_of(account)),
+            error::permission_denied(ENOT_AUTHORIZED),
+        );
         chain_status::assert_genesis();
 
         let old_major = borrow_global<Version>(@aptos_framework).major;
@@ -57,10 +62,13 @@ module aptos_framework::version {
     /// - `aptos_framework::version::set_for_next_epoch(&framework_signer, new_version);`
     /// - `aptos_framework::aptos_governance::reconfigure(&framework_signer);`
     public entry fun set_for_next_epoch(account: &signer, major: u64) acquires Version {
-        assert!(exists<SetVersionCapability>(signer::address_of(account)), error::permission_denied(ENOT_AUTHORIZED));
+        assert!(
+            exists<SetVersionCapability>(signer::address_of(account)),
+            error::permission_denied(ENOT_AUTHORIZED),
+        );
         let old_major = borrow_global<Version>(@aptos_framework).major;
         assert!(old_major < major, error::invalid_argument(EINVALID_MAJOR_VERSION_NUMBER));
-        config_buffer::upsert(Version {major});
+        config_buffer::upsert(Version { major });
     }
 
     /// Only used in reconfigurations to apply the pending `Version`, if there is any.
@@ -93,8 +101,7 @@ module aptos_framework::version {
 
     #[test(aptos_framework = @aptos_framework, core_resources = @core_resources)]
     public entry fun test_set_version_core_resources(
-        aptos_framework: signer,
-        core_resources: signer,
+        aptos_framework: signer, core_resources: signer,
     ) acquires Version {
         initialize(&aptos_framework, 1);
         assert!(borrow_global<Version>(@aptos_framework).major == 1, 0);
@@ -106,8 +113,7 @@ module aptos_framework::version {
     #[test(aptos_framework = @aptos_framework, random_account = @0x123)]
     #[expected_failure(abort_code = 327682, location = Self)]
     public entry fun test_set_version_unauthorized_should_fail(
-        aptos_framework: signer,
-        random_account: signer,
+        aptos_framework: signer, random_account: signer,
     ) acquires Version {
         initialize(&aptos_framework, 1);
         set_version(&random_account, 2);

--- a/aptos-move/framework/aptos-framework/sources/configs/version.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/version.spec.move
@@ -38,7 +38,8 @@ spec aptos_framework::version {
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
         include staking_config::StakingRewardsConfigRequirement;
         requires chain_status::is_genesis();
-        requires timestamp::spec_now_microseconds() >= reconfiguration::last_reconfiguration_time();
+        requires timestamp::spec_now_microseconds()
+            >= reconfiguration::last_reconfiguration_time();
         requires exists<stake::ValidatorFees>(@aptos_framework);
         requires exists<CoinInfo<AptosCoin>>(@aptos_framework);
 

--- a/aptos-move/framework/aptos-framework/sources/delegation_pool.move
+++ b/aptos-move/framework/aptos-framework/sources/delegation_pool.move
@@ -524,7 +524,8 @@ module aptos_framework::delegation_pool {
     #[view]
     /// Return whether a delegation pool has already enabled partial governance voting.
     public fun partial_governance_voting_enabled(pool_address: address): bool {
-        exists<GovernanceRecords>(pool_address) && stake::get_delegated_voter(pool_address) == pool_address
+        exists<GovernanceRecords>(pool_address)
+            && stake::get_delegated_voter(pool_address) == pool_address
     }
 
     #[view]
@@ -536,16 +537,17 @@ module aptos_framework::delegation_pool {
 
     #[view]
     /// Return whether the commission percentage for the next lockup cycle is effective.
-    public fun is_next_commission_percentage_effective(pool_address: address): bool acquires NextCommissionPercentage {
-        exists<NextCommissionPercentage>(pool_address) &&
-            timestamp::now_seconds() >= borrow_global<NextCommissionPercentage>(pool_address).effective_after_secs
+    public fun is_next_commission_percentage_effective(
+        pool_address: address
+    ): bool acquires NextCommissionPercentage {
+        exists<NextCommissionPercentage>(pool_address)
+            && timestamp::now_seconds()
+                >= borrow_global<NextCommissionPercentage>(pool_address).effective_after_secs
     }
 
     #[view]
     /// Return the operator commission percentage set on the delegation pool `pool_address`.
-    public fun operator_commission_percentage(
-        pool_address: address
-    ): u64 acquires DelegationPool, NextCommissionPercentage {
+    public fun operator_commission_percentage(pool_address: address): u64 acquires DelegationPool, NextCommissionPercentage {
         assert_delegation_pool_exists(pool_address);
         if (is_next_commission_percentage_effective(pool_address)) {
             operator_commission_percentage_next_lockup_cycle(pool_address)
@@ -571,7 +573,9 @@ module aptos_framework::delegation_pool {
     /// Return the number of delegators owning active stake within `pool_address`.
     public fun shareholders_count_active_pool(pool_address: address): u64 acquires DelegationPool {
         assert_delegation_pool_exists(pool_address);
-        pool_u64::shareholders_count(&borrow_global<DelegationPool>(pool_address).active_shares)
+        pool_u64::shareholders_count(
+            &borrow_global<DelegationPool>(pool_address).active_shares
+        )
     }
 
     #[view]
@@ -586,20 +590,15 @@ module aptos_framework::delegation_pool {
     /// Return whether the given delegator has any withdrawable stake. If they recently requested to unlock
     /// some stake and the stake pool's lockup cycle has not ended, their coins are not withdrawable yet.
     public fun get_pending_withdrawal(
-        pool_address: address,
-        delegator_address: address
+        pool_address: address, delegator_address: address
     ): (bool, u64) acquires DelegationPool {
         assert_delegation_pool_exists(pool_address);
         let pool = borrow_global<DelegationPool>(pool_address);
-        let (
-            lockup_cycle_ended,
-            _,
-            pending_inactive,
-            _,
-            commission_pending_inactive
-        ) = calculate_stake_pool_drift(pool);
+        let (lockup_cycle_ended, _, pending_inactive, _, commission_pending_inactive) =
+            calculate_stake_pool_drift(pool);
 
-        let (withdrawal_exists, withdrawal_olc) = pending_withdrawal_exists(pool, delegator_address);
+        let (withdrawal_exists, withdrawal_olc) =
+            pending_withdrawal_exists(pool, delegator_address);
         if (!withdrawal_exists) {
             // if no pending withdrawal, there is neither inactive nor pending_inactive stake
             (false, 0)
@@ -614,7 +613,7 @@ module aptos_framework::delegation_pool {
                     inactive_shares,
                     pool_u64::shares(inactive_shares, delegator_address),
                     // exclude operator pending_inactive rewards not converted to shares yet
-                    pending_inactive - commission_pending_inactive
+                    pending_inactive - commission_pending_inactive,
                 );
                 // if withdrawal's lockup cycle ended ONLY on stake pool then it is also inactive
                 (lockup_cycle_ended, pending_inactive)
@@ -626,27 +625,24 @@ module aptos_framework::delegation_pool {
     /// Return total stake owned by `delegator_address` within delegation pool `pool_address`
     /// in each of its individual states: (`active`,`inactive`,`pending_inactive`)
     public fun get_stake(
-        pool_address: address,
-        delegator_address: address
+        pool_address: address, delegator_address: address
     ): (u64, u64, u64) acquires DelegationPool, BeneficiaryForOperator {
         assert_delegation_pool_exists(pool_address);
         let pool = borrow_global<DelegationPool>(pool_address);
         let (
-            lockup_cycle_ended,
-            active,
-            _,
-            commission_active,
-            commission_pending_inactive
+            lockup_cycle_ended, active, _, commission_active, commission_pending_inactive
         ) = calculate_stake_pool_drift(pool);
 
         let total_active_shares = pool_u64::total_shares(&pool.active_shares);
-        let delegator_active_shares = pool_u64::shares(&pool.active_shares, delegator_address);
+        let delegator_active_shares =
+            pool_u64::shares(&pool.active_shares, delegator_address);
 
         let (_, _, pending_active, _) = stake::get_stake(pool_address);
         if (pending_active == 0) {
             // zero `pending_active` stake indicates that either there are no `add_stake` fees or
             // previous epoch has ended and should identify shares owning these fees as released
-            total_active_shares = total_active_shares - pool_u64::shares(&pool.active_shares, NULL_SHAREHOLDER);
+            total_active_shares = total_active_shares
+                - pool_u64::shares(&pool.active_shares, NULL_SHAREHOLDER);
             if (delegator_address == NULL_SHAREHOLDER) {
                 delegator_active_shares = 0
             }
@@ -656,13 +652,15 @@ module aptos_framework::delegation_pool {
             delegator_active_shares,
             // exclude operator active rewards not converted to shares yet
             active - commission_active,
-            total_active_shares
+            total_active_shares,
         );
 
         // get state and stake (0 if there is none) of the pending withdrawal
-        let (withdrawal_inactive, withdrawal_stake) = get_pending_withdrawal(pool_address, delegator_address);
+        let (withdrawal_inactive, withdrawal_stake) =
+            get_pending_withdrawal(pool_address, delegator_address);
         // report non-active stakes accordingly to the state of the pending withdrawal
-        let (inactive, pending_inactive) = if (withdrawal_inactive) (withdrawal_stake, 0) else (0, withdrawal_stake);
+        let (inactive, pending_inactive) =
+            if (withdrawal_inactive) (withdrawal_stake, 0) else (0, withdrawal_stake);
 
         // should also include commission rewards in case of the operator account
         // operator rewards are actually used to buy shares which is introducing
@@ -691,17 +689,23 @@ module aptos_framework::delegation_pool {
     /// for the rewards the remaining stake would have earned if active:
     /// extracted-fee = (amount - extracted-fee) * reward-rate% * (100% - operator-commission%)
     public fun get_add_stake_fee(
-        pool_address: address,
-        amount: u64
+        pool_address: address, amount: u64
     ): u64 acquires DelegationPool, NextCommissionPercentage {
         if (stake::is_current_epoch_validator(pool_address)) {
-            let (rewards_rate, rewards_rate_denominator) = staking_config::get_reward_rate(&staking_config::get());
+            let (rewards_rate, rewards_rate_denominator) =
+                staking_config::get_reward_rate(&staking_config::get());
             if (rewards_rate_denominator > 0) {
                 assert_delegation_pool_exists(pool_address);
 
-                rewards_rate = rewards_rate * (MAX_FEE - operator_commission_percentage(pool_address));
+                rewards_rate = rewards_rate
+                    * (MAX_FEE - operator_commission_percentage(pool_address));
                 rewards_rate_denominator = rewards_rate_denominator * MAX_FEE;
-                ((((amount as u128) * (rewards_rate as u128)) / ((rewards_rate as u128) + (rewards_rate_denominator as u128))) as u64)
+                (
+                    (
+                        ((amount as u128) * (rewards_rate as u128))
+                            / ((rewards_rate as u128) + (rewards_rate_denominator as u128))
+                    ) as u64
+                )
             } else { 0 }
         } else { 0 }
     }
@@ -711,16 +715,15 @@ module aptos_framework::delegation_pool {
     /// the delegation pool, implicitly its stake pool, in the special case
     /// the validator had gone inactive before its lockup expired.
     public fun can_withdraw_pending_inactive(pool_address: address): bool {
-        stake::get_validator_state(pool_address) == VALIDATOR_STATUS_INACTIVE &&
-            timestamp::now_seconds() >= stake::get_lockup_secs(pool_address)
+        stake::get_validator_state(pool_address) == VALIDATOR_STATUS_INACTIVE
+            && timestamp::now_seconds() >= stake::get_lockup_secs(pool_address)
     }
 
     #[view]
     /// Return the total voting power of a delegator in a delegation pool. This function syncs DelegationPool to the
     /// latest state.
     public fun calculate_and_update_voter_total_voting_power(
-        pool_address: address,
-        voter: address
+        pool_address: address, voter: address
     ): u64 acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         assert_partial_governance_voting_enabled(pool_address);
         // Delegation pool need to be synced to explain rewards(which could change the coin amount) and
@@ -728,7 +731,8 @@ module aptos_framework::delegation_pool {
         synchronize_delegation_pool(pool_address);
         let pool = borrow_global<DelegationPool>(pool_address);
         let governance_records = borrow_global_mut<GovernanceRecords>(pool_address);
-        let latest_delegated_votes = update_and_borrow_mut_delegated_votes(pool, governance_records, voter);
+        let latest_delegated_votes =
+            update_and_borrow_mut_delegated_votes(pool, governance_records, voter);
         calculate_total_voting_power(pool, latest_delegated_votes)
     }
 
@@ -736,9 +740,7 @@ module aptos_framework::delegation_pool {
     /// Return the remaining voting power of a delegator in a delegation pool on a proposal. This function syncs DelegationPool to the
     /// latest state.
     public fun calculate_and_update_remaining_voting_power(
-        pool_address: address,
-        voter_address: address,
-        proposal_id: u64
+        pool_address: address, voter_address: address, proposal_id: u64
     ): u64 acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         assert_partial_governance_voting_enabled(pool_address);
         // If the whole stake pool has no voting power(e.g. it has already voted before partial
@@ -747,45 +749,51 @@ module aptos_framework::delegation_pool {
             return 0
         };
 
-        let total_voting_power = calculate_and_update_voter_total_voting_power(pool_address, voter_address);
+        let total_voting_power =
+            calculate_and_update_voter_total_voting_power(pool_address, voter_address);
         let governance_records = borrow_global<GovernanceRecords>(pool_address);
-        total_voting_power - get_used_voting_power(governance_records, voter_address, proposal_id)
+        total_voting_power
+            - get_used_voting_power(governance_records, voter_address, proposal_id)
     }
 
     #[view]
     /// Return the latest delegated voter of a delegator in a delegation pool. This function syncs DelegationPool to the
     /// latest state.
     public fun calculate_and_update_delegator_voter(
-        pool_address: address,
-        delegator_address: address
+        pool_address: address, delegator_address: address
     ): address acquires DelegationPool, GovernanceRecords {
         assert_partial_governance_voting_enabled(pool_address);
         calculate_and_update_delegator_voter_internal(
             borrow_global<DelegationPool>(pool_address),
             borrow_global_mut<GovernanceRecords>(pool_address),
-            delegator_address
+            delegator_address,
         )
     }
 
     #[view]
     /// Return the current state of a voting delegation of a delegator in a delegation pool.
     public fun calculate_and_update_voting_delegation(
-        pool_address: address,
-        delegator_address: address
+        pool_address: address, delegator_address: address
     ): (address, address, u64) acquires DelegationPool, GovernanceRecords {
         assert_partial_governance_voting_enabled(pool_address);
-        let vote_delegation = update_and_borrow_mut_delegator_vote_delegation(
-            borrow_global<DelegationPool>(pool_address),
-            borrow_global_mut<GovernanceRecords>(pool_address),
-            delegator_address
-        );
+        let vote_delegation =
+            update_and_borrow_mut_delegator_vote_delegation(
+                borrow_global<DelegationPool>(pool_address),
+                borrow_global_mut<GovernanceRecords>(pool_address),
+                delegator_address,
+            );
 
-        (vote_delegation.voter, vote_delegation.pending_voter, vote_delegation.last_locked_until_secs)
+        (
+            vote_delegation.voter,
+            vote_delegation.pending_voter,
+            vote_delegation.last_locked_until_secs
+        )
     }
 
     #[view]
     /// Return the address of the stake pool to be created with the provided owner, and seed.
-    public fun get_expected_stake_pool_address(owner: address, delegation_pool_creation_seed: vector<u8>
+    public fun get_expected_stake_pool_address(
+        owner: address, delegation_pool_creation_seed: vector<u8>
     ): address {
         let seed = create_resource_account_seed(delegation_pool_creation_seed);
         account::create_resource_address(&owner, seed)
@@ -811,24 +819,28 @@ module aptos_framework::delegation_pool {
     /// - allowlisting is disabled on the pool
     /// - delegator is part of the allowlist
     public fun delegator_allowlisted(
-        pool_address: address,
-        delegator_address: address,
+        pool_address: address, delegator_address: address,
     ): bool acquires DelegationPoolAllowlisting {
-        if (!allowlisting_enabled(pool_address)) { return true };
-        smart_table::contains(freeze(borrow_mut_delegators_allowlist(pool_address)), delegator_address)
+        if (!allowlisting_enabled(pool_address)) {
+            return true
+        };
+        smart_table::contains(
+            freeze(borrow_mut_delegators_allowlist(pool_address)), delegator_address
+        )
     }
 
     #[view]
     /// Return allowlist or revert if allowlisting is not enabled for the provided delegation pool.
-    public fun get_delegators_allowlist(
-        pool_address: address,
-    ): vector<address> acquires DelegationPoolAllowlisting {
+    public fun get_delegators_allowlist(pool_address: address,): vector<address> acquires DelegationPoolAllowlisting {
         assert_allowlisting_enabled(pool_address);
 
         let allowlist = vector[];
-        smart_table::for_each_ref(freeze(borrow_mut_delegators_allowlist(pool_address)), |delegator, _v| {
-            vector::push_back(&mut allowlist, *delegator);
-        });
+        smart_table::for_each_ref(
+            freeze(borrow_mut_delegators_allowlist(pool_address)),
+            |delegator, _v| {
+                vector::push_back(&mut allowlist, *delegator);
+            },
+        );
         allowlist
     }
 
@@ -841,15 +853,25 @@ module aptos_framework::delegation_pool {
         operator_commission_percentage: u64,
         delegation_pool_creation_seed: vector<u8>,
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
-        assert!(features::delegation_pools_enabled(), error::invalid_state(EDELEGATION_POOLS_DISABLED));
+        assert!(
+            features::delegation_pools_enabled(),
+            error::invalid_state(EDELEGATION_POOLS_DISABLED),
+        );
         let owner_address = signer::address_of(owner);
-        assert!(!owner_cap_exists(owner_address), error::already_exists(EOWNER_CAP_ALREADY_EXISTS));
-        assert!(operator_commission_percentage <= MAX_FEE, error::invalid_argument(EINVALID_COMMISSION_PERCENTAGE));
+        assert!(
+            !owner_cap_exists(owner_address),
+            error::already_exists(EOWNER_CAP_ALREADY_EXISTS),
+        );
+        assert!(
+            operator_commission_percentage <= MAX_FEE,
+            error::invalid_argument(EINVALID_COMMISSION_PERCENTAGE),
+        );
 
         // generate a seed to be used to create the resource account hosting the delegation pool
         let seed = create_resource_account_seed(delegation_pool_creation_seed);
 
-        let (stake_pool_signer, stake_pool_signer_cap) = account::create_resource_account(owner, seed);
+        let (stake_pool_signer, stake_pool_signer_cap) =
+            account::create_resource_account(owner, seed);
         coin::register<AptosCoin>(&stake_pool_signer);
 
         // stake_pool_signer will be owner of the stake pool and have its `stake::OwnerCapability`
@@ -860,30 +882,42 @@ module aptos_framework::delegation_pool {
         table::add(
             &mut inactive_shares,
             olc_with_index(0),
-            pool_u64::create_with_scaling_factor(SHARES_SCALING_FACTOR)
+            pool_u64::create_with_scaling_factor(SHARES_SCALING_FACTOR),
         );
 
-        move_to(&stake_pool_signer, DelegationPool {
-            active_shares: pool_u64::create_with_scaling_factor(SHARES_SCALING_FACTOR),
-            observed_lockup_cycle: olc_with_index(0),
-            inactive_shares,
-            pending_withdrawals: table::new<address, ObservedLockupCycle>(),
-            stake_pool_signer_cap,
-            total_coins_inactive: 0,
-            operator_commission_percentage,
-            add_stake_events: account::new_event_handle<AddStakeEvent>(&stake_pool_signer),
-            reactivate_stake_events: account::new_event_handle<ReactivateStakeEvent>(&stake_pool_signer),
-            unlock_stake_events: account::new_event_handle<UnlockStakeEvent>(&stake_pool_signer),
-            withdraw_stake_events: account::new_event_handle<WithdrawStakeEvent>(&stake_pool_signer),
-            distribute_commission_events: account::new_event_handle<DistributeCommissionEvent>(&stake_pool_signer),
-        });
+        move_to(
+            &stake_pool_signer,
+            DelegationPool {
+                active_shares: pool_u64::create_with_scaling_factor(SHARES_SCALING_FACTOR),
+                observed_lockup_cycle: olc_with_index(0),
+                inactive_shares,
+                pending_withdrawals: table::new<address, ObservedLockupCycle>(),
+                stake_pool_signer_cap,
+                total_coins_inactive: 0,
+                operator_commission_percentage,
+                add_stake_events: account::new_event_handle<AddStakeEvent>(
+                    &stake_pool_signer
+                ),
+                reactivate_stake_events: account::new_event_handle<ReactivateStakeEvent>(
+                    &stake_pool_signer
+                ),
+                unlock_stake_events: account::new_event_handle<UnlockStakeEvent>(
+                    &stake_pool_signer
+                ),
+                withdraw_stake_events: account::new_event_handle<WithdrawStakeEvent>(
+                    &stake_pool_signer
+                ),
+                distribute_commission_events: account::new_event_handle<
+                    DistributeCommissionEvent>(&stake_pool_signer),
+            },
+        );
 
         // save delegation pool ownership and resource account address (inner stake pool address) on `owner`
         move_to(owner, DelegationPoolOwnership { pool_address });
 
         // All delegation pool enable partial governance voting by default once the feature flag is enabled.
-        if (features::partial_governance_voting_enabled(
-        ) && features::delegation_pool_partial_governance_voting_enabled()) {
+        if (features::partial_governance_voting_enabled()
+                && features::delegation_pool_partial_governance_voting_enabled()) {
             enable_partial_governance_voting(pool_address);
         }
     }
@@ -903,10 +937,13 @@ module aptos_framework::delegation_pool {
     public entry fun enable_partial_governance_voting(
         pool_address: address,
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
-        assert!(features::partial_governance_voting_enabled(), error::invalid_state(EDISABLED_FUNCTION));
+        assert!(
+            features::partial_governance_voting_enabled(),
+            error::invalid_state(EDISABLED_FUNCTION),
+        );
         assert!(
             features::delegation_pool_partial_governance_voting_enabled(),
-            error::invalid_state(EDISABLED_FUNCTION)
+            error::invalid_state(EDISABLED_FUNCTION),
         );
         assert_delegation_pool_exists(pool_address);
         // synchronize delegation and stake pools before any user operation.
@@ -916,17 +953,25 @@ module aptos_framework::delegation_pool {
         let stake_pool_signer = retrieve_stake_pool_owner(delegation_pool);
         // delegated_voter is managed by the stake pool itself, which signer capability is managed by DelegationPool.
         // So voting power of this stake pool can only be used through this module.
-        stake::set_delegated_voter(&stake_pool_signer, signer::address_of(&stake_pool_signer));
+        stake::set_delegated_voter(
+            &stake_pool_signer, signer::address_of(&stake_pool_signer)
+        );
 
-        move_to(&stake_pool_signer, GovernanceRecords {
-            votes: smart_table::new(),
-            votes_per_proposal: smart_table::new(),
-            vote_delegation: smart_table::new(),
-            delegated_votes: smart_table::new(),
-            vote_events: account::new_event_handle<VoteEvent>(&stake_pool_signer),
-            create_proposal_events: account::new_event_handle<CreateProposalEvent>(&stake_pool_signer),
-            delegate_voting_power_events: account::new_event_handle<DelegateVotingPowerEvent>(&stake_pool_signer),
-        });
+        move_to(
+            &stake_pool_signer,
+            GovernanceRecords {
+                votes: smart_table::new(),
+                votes_per_proposal: smart_table::new(),
+                vote_delegation: smart_table::new(),
+                delegated_votes: smart_table::new(),
+                vote_events: account::new_event_handle<VoteEvent>(&stake_pool_signer),
+                create_proposal_events: account::new_event_handle<CreateProposalEvent>(
+                    &stake_pool_signer
+                ),
+                delegate_voting_power_events: account::new_event_handle<
+                    DelegateVotingPowerEvent>(&stake_pool_signer),
+            },
+        );
     }
 
     /// Vote on a proposal with a voter's voting power. To successfully vote, the following conditions must be met:
@@ -946,11 +991,12 @@ module aptos_framework::delegation_pool {
         synchronize_delegation_pool(pool_address);
 
         let voter_address = signer::address_of(voter);
-        let remaining_voting_power = calculate_and_update_remaining_voting_power(
-            pool_address,
-            voter_address,
-            proposal_id
-        );
+        let remaining_voting_power =
+            calculate_and_update_remaining_voting_power(
+                pool_address,
+                voter_address,
+                proposal_id,
+            );
         if (voting_power > remaining_voting_power) {
             voting_power = remaining_voting_power;
         };
@@ -958,12 +1004,18 @@ module aptos_framework::delegation_pool {
 
         let governance_records = borrow_global_mut<GovernanceRecords>(pool_address);
         // Check a edge case during the transient period of enabling partial governance voting.
-        assert_and_update_proposal_used_voting_power(governance_records, pool_address, proposal_id, voting_power);
-        let used_voting_power = borrow_mut_used_voting_power(governance_records, voter_address, proposal_id);
+        assert_and_update_proposal_used_voting_power(
+            governance_records, pool_address, proposal_id, voting_power
+        );
+        let used_voting_power =
+            borrow_mut_used_voting_power(governance_records, voter_address, proposal_id);
         *used_voting_power = *used_voting_power + voting_power;
 
-        let pool_signer = retrieve_stake_pool_owner(borrow_global<DelegationPool>(pool_address));
-        aptos_governance::partial_vote(&pool_signer, pool_address, proposal_id, voting_power, should_pass);
+        let pool_signer =
+            retrieve_stake_pool_owner(borrow_global<DelegationPool>(pool_address));
+        aptos_governance::partial_vote(
+            &pool_signer, pool_address, proposal_id, voting_power, should_pass
+        );
 
         if (features::module_event_migration_enabled()) {
             event::emit(
@@ -973,7 +1025,7 @@ module aptos_framework::delegation_pool {
                     delegation_pool: pool_address,
                     num_votes: voting_power,
                     should_pass,
-                }
+                },
             );
         };
 
@@ -985,7 +1037,7 @@ module aptos_framework::delegation_pool {
                 delegation_pool: pool_address,
                 num_votes: voting_power,
                 should_pass,
-            }
+            },
         );
     }
 
@@ -1008,19 +1060,23 @@ module aptos_framework::delegation_pool {
         let voter_addr = signer::address_of(voter);
         let pool = borrow_global<DelegationPool>(pool_address);
         let governance_records = borrow_global_mut<GovernanceRecords>(pool_address);
-        let total_voting_power = calculate_and_update_delegated_votes(pool, governance_records, voter_addr);
+        let total_voting_power =
+            calculate_and_update_delegated_votes(pool, governance_records, voter_addr);
         assert!(
             total_voting_power >= aptos_governance::get_required_proposer_stake(),
-            error::invalid_argument(EINSUFFICIENT_PROPOSER_STAKE));
-        let pool_signer = retrieve_stake_pool_owner(borrow_global<DelegationPool>(pool_address));
-        let proposal_id = aptos_governance::create_proposal_v2_impl(
-            &pool_signer,
-            pool_address,
-            execution_hash,
-            metadata_location,
-            metadata_hash,
-            is_multi_step_proposal,
+            error::invalid_argument(EINSUFFICIENT_PROPOSER_STAKE),
         );
+        let pool_signer =
+            retrieve_stake_pool_owner(borrow_global<DelegationPool>(pool_address));
+        let proposal_id =
+            aptos_governance::create_proposal_v2_impl(
+                &pool_signer,
+                pool_address,
+                execution_hash,
+                metadata_location,
+                metadata_hash,
+                is_multi_step_proposal,
+            );
 
         let governance_records = borrow_global_mut<GovernanceRecords>(pool_address);
 
@@ -1030,7 +1086,7 @@ module aptos_framework::delegation_pool {
                     proposal_id,
                     voter: voter_addr,
                     delegation_pool: pool_address,
-                }
+                },
             );
         };
 
@@ -1040,7 +1096,7 @@ module aptos_framework::delegation_pool {
                 proposal_id,
                 voter: voter_addr,
                 delegation_pool: pool_address,
-            }
+            },
         );
     }
 
@@ -1049,19 +1105,30 @@ module aptos_framework::delegation_pool {
     }
 
     fun assert_delegation_pool_exists(pool_address: address) {
-        assert!(delegation_pool_exists(pool_address), error::invalid_argument(EDELEGATION_POOL_DOES_NOT_EXIST));
+        assert!(
+            delegation_pool_exists(pool_address),
+            error::invalid_argument(EDELEGATION_POOL_DOES_NOT_EXIST),
+        );
     }
 
-    fun assert_min_active_balance(pool: &DelegationPool, delegator_address: address) {
+    fun assert_min_active_balance(
+        pool: &DelegationPool, delegator_address: address
+    ) {
         let balance = pool_u64::balance(&pool.active_shares, delegator_address);
-        assert!(balance >= MIN_COINS_ON_SHARES_POOL, error::invalid_argument(EDELEGATOR_ACTIVE_BALANCE_TOO_LOW));
-    }
-
-    fun assert_min_pending_inactive_balance(pool: &DelegationPool, delegator_address: address) {
-        let balance = pool_u64::balance(pending_inactive_shares_pool(pool), delegator_address);
         assert!(
             balance >= MIN_COINS_ON_SHARES_POOL,
-            error::invalid_argument(EDELEGATOR_PENDING_INACTIVE_BALANCE_TOO_LOW)
+            error::invalid_argument(EDELEGATOR_ACTIVE_BALANCE_TOO_LOW),
+        );
+    }
+
+    fun assert_min_pending_inactive_balance(
+        pool: &DelegationPool, delegator_address: address
+    ) {
+        let balance =
+            pool_u64::balance(pending_inactive_shares_pool(pool), delegator_address);
+        assert!(
+            balance >= MIN_COINS_ON_SHARES_POOL,
+            error::invalid_argument(EDELEGATOR_PENDING_INACTIVE_BALANCE_TOO_LOW),
         );
     }
 
@@ -1069,21 +1136,23 @@ module aptos_framework::delegation_pool {
         assert_delegation_pool_exists(pool_address);
         assert!(
             partial_governance_voting_enabled(pool_address),
-            error::invalid_state(EPARTIAL_GOVERNANCE_VOTING_NOT_ENABLED)
+            error::invalid_state(EPARTIAL_GOVERNANCE_VOTING_NOT_ENABLED),
         );
     }
 
     fun assert_allowlisting_enabled(pool_address: address) {
-        assert!(allowlisting_enabled(pool_address), error::invalid_state(EDELEGATORS_ALLOWLISTING_NOT_ENABLED));
+        assert!(
+            allowlisting_enabled(pool_address),
+            error::invalid_state(EDELEGATORS_ALLOWLISTING_NOT_ENABLED),
+        );
     }
 
     fun assert_delegator_allowlisted(
-        pool_address: address,
-        delegator_address: address,
+        pool_address: address, delegator_address: address,
     ) acquires DelegationPoolAllowlisting {
         assert!(
             delegator_allowlisted(pool_address, delegator_address),
-            error::permission_denied(EDELEGATOR_NOT_ALLOWLISTED)
+            error::permission_denied(EDELEGATOR_NOT_ALLOWLISTED),
         );
     }
 
@@ -1093,10 +1162,11 @@ module aptos_framework::delegation_pool {
         amount: u64,
     ): u64 {
         // find how many coins would be redeemed if supplying `amount`
-        let redeemed_coins = pool_u64::shares_to_amount(
-            src_shares_pool,
-            amount_to_shares_to_redeem(src_shares_pool, shareholder, amount)
-        );
+        let redeemed_coins =
+            pool_u64::shares_to_amount(
+                src_shares_pool,
+                amount_to_shares_to_redeem(src_shares_pool, shareholder, amount),
+            );
         // if balance drops under threshold then redeem it entirely
         let src_balance = pool_u64::balance(src_shares_pool, shareholder);
         if (src_balance - redeemed_coins < MIN_COINS_ON_SHARES_POOL) {
@@ -1112,10 +1182,11 @@ module aptos_framework::delegation_pool {
         amount: u64,
     ): u64 {
         // find how many coins would be redeemed from source if supplying `amount`
-        let redeemed_coins = pool_u64::shares_to_amount(
-            src_shares_pool,
-            amount_to_shares_to_redeem(src_shares_pool, shareholder, amount)
-        );
+        let redeemed_coins =
+            pool_u64::shares_to_amount(
+                src_shares_pool,
+                amount_to_shares_to_redeem(src_shares_pool, shareholder, amount),
+            );
         // if balance on destination would be less than threshold then redeem difference to threshold
         let dst_balance = pool_u64::balance(dst_shares_pool, shareholder);
         if (dst_balance + redeemed_coins < MIN_COINS_ON_SHARES_POOL) {
@@ -1138,22 +1209,25 @@ module aptos_framework::delegation_pool {
     }
 
     /// Get the active share amount of the delegator.
-    fun get_delegator_active_shares(pool: &DelegationPool, delegator: address): u128 {
+    fun get_delegator_active_shares(
+        pool: &DelegationPool, delegator: address
+    ): u128 {
         pool_u64::shares(&pool.active_shares, delegator)
     }
 
     /// Get the pending inactive share amount of the delegator.
-    fun get_delegator_pending_inactive_shares(pool: &DelegationPool, delegator: address): u128 {
+    fun get_delegator_pending_inactive_shares(
+        pool: &DelegationPool, delegator: address
+    ): u128 {
         pool_u64::shares(pending_inactive_shares_pool(pool), delegator)
     }
 
     /// Get the used voting power of a voter on a proposal.
-    fun get_used_voting_power(governance_records: &GovernanceRecords, voter: address, proposal_id: u64): u64 {
+    fun get_used_voting_power(
+        governance_records: &GovernanceRecords, voter: address, proposal_id: u64
+    ): u64 {
         let votes = &governance_records.votes;
-        let key = VotingRecordKey {
-            voter,
-            proposal_id,
-        };
+        let key = VotingRecordKey { voter, proposal_id, };
         *smart_table::borrow_with_default(votes, key, &0)
     }
 
@@ -1171,15 +1245,10 @@ module aptos_framework::delegation_pool {
 
     /// Borrow the mutable used voting power of a voter on a proposal.
     inline fun borrow_mut_used_voting_power(
-        governance_records: &mut GovernanceRecords,
-        voter: address,
-        proposal_id: u64
+        governance_records: &mut GovernanceRecords, voter: address, proposal_id: u64
     ): &mut u64 {
         let votes = &mut governance_records.votes;
-        let key = VotingRecordKey {
-            proposal_id,
-            voter,
-        };
+        let key = VotingRecordKey { proposal_id, voter, };
         smart_table::borrow_mut_with_default(votes, key, 0)
     }
 
@@ -1196,11 +1265,15 @@ module aptos_framework::delegation_pool {
         // By default, a delegator's delegated voter is itself.
         // TODO: recycle storage when VoteDelegation equals to default value.
         if (!smart_table::contains(vote_delegation_table, delegator)) {
-            return smart_table::borrow_mut_with_default(vote_delegation_table, delegator, VoteDelegation {
-                voter: delegator,
-                last_locked_until_secs: locked_until_secs,
-                pending_voter: delegator,
-            })
+            return smart_table::borrow_mut_with_default(
+                vote_delegation_table,
+                delegator,
+                VoteDelegation {
+                    voter: delegator,
+                    last_locked_until_secs: locked_until_secs,
+                    pending_voter: delegator,
+                },
+            )
         };
 
         let vote_delegation = smart_table::borrow_mut(vote_delegation_table, delegator);
@@ -1214,9 +1287,7 @@ module aptos_framework::delegation_pool {
 
     /// Update DelegatedVotes of a voter to up-to-date then borrow_mut it.
     fun update_and_borrow_mut_delegated_votes(
-        pool: &DelegationPool,
-        governance_records: &mut GovernanceRecords,
-        voter: address
+        pool: &DelegationPool, governance_records: &mut GovernanceRecords, voter: address
     ): &mut DelegatedVotes {
         let pool_address = get_pool_address(pool);
         let locked_until_secs = stake::get_lockup_secs(pool_address);
@@ -1227,12 +1298,16 @@ module aptos_framework::delegation_pool {
         if (!smart_table::contains(delegated_votes_per_voter, voter)) {
             let active_shares = get_delegator_active_shares(pool, voter);
             let inactive_shares = get_delegator_pending_inactive_shares(pool, voter);
-            return smart_table::borrow_mut_with_default(delegated_votes_per_voter, voter, DelegatedVotes {
-                active_shares,
-                pending_inactive_shares: inactive_shares,
-                active_shares_next_lockup: active_shares,
-                last_locked_until_secs: locked_until_secs,
-            })
+            return smart_table::borrow_mut_with_default(
+                delegated_votes_per_voter,
+                voter,
+                DelegatedVotes {
+                    active_shares,
+                    pending_inactive_shares: inactive_shares,
+                    active_shares_next_lockup: active_shares,
+                    last_locked_until_secs: locked_until_secs,
+                },
+            )
         };
 
         let delegated_votes = smart_table::borrow_mut(delegated_votes_per_voter, voter);
@@ -1251,13 +1326,18 @@ module aptos_framework::delegation_pool {
 
     /// Given the amounts of shares in `active_shares` pool and `inactive_shares` pool, calculate the total voting
     /// power, which equals to the sum of the coin amounts.
-    fun calculate_total_voting_power(delegation_pool: &DelegationPool, latest_delegated_votes: &DelegatedVotes): u64 {
-        let active_amount = pool_u64::shares_to_amount(
-            &delegation_pool.active_shares,
-            latest_delegated_votes.active_shares);
-        let pending_inactive_amount = pool_u64::shares_to_amount(
-            pending_inactive_shares_pool(delegation_pool),
-            latest_delegated_votes.pending_inactive_shares);
+    fun calculate_total_voting_power(
+        delegation_pool: &DelegationPool, latest_delegated_votes: &DelegatedVotes
+    ): u64 {
+        let active_amount =
+            pool_u64::shares_to_amount(
+                &delegation_pool.active_shares, latest_delegated_votes.active_shares
+            );
+        let pending_inactive_amount =
+            pool_u64::shares_to_amount(
+                pending_inactive_shares_pool(delegation_pool),
+                latest_delegated_votes.pending_inactive_shares,
+            );
         active_amount + pending_inactive_amount
     }
 
@@ -1267,36 +1347,39 @@ module aptos_framework::delegation_pool {
         governance_records: &mut GovernanceRecords,
         delegator: address
     ): address {
-        let vote_delegation = update_and_borrow_mut_delegator_vote_delegation(pool, governance_records, delegator);
+        let vote_delegation =
+            update_and_borrow_mut_delegator_vote_delegation(
+                pool, governance_records, delegator
+            );
         vote_delegation.voter
     }
 
     /// Update DelegatedVotes of a voter to up-to-date then return the total voting power of this voter.
     fun calculate_and_update_delegated_votes(
-        pool: &DelegationPool,
-        governance_records: &mut GovernanceRecords,
-        voter: address
+        pool: &DelegationPool, governance_records: &mut GovernanceRecords, voter: address
     ): u64 {
-        let delegated_votes = update_and_borrow_mut_delegated_votes(pool, governance_records, voter);
+        let delegated_votes =
+            update_and_borrow_mut_delegated_votes(pool, governance_records, voter);
         calculate_total_voting_power(pool, delegated_votes)
     }
 
-    inline fun borrow_mut_delegators_allowlist(
-        pool_address: address
-    ): &mut SmartTable<address, bool> acquires DelegationPoolAllowlisting {
+    inline fun borrow_mut_delegators_allowlist(pool_address: address)
+        : &mut SmartTable<address, bool> acquires DelegationPoolAllowlisting {
         &mut borrow_global_mut<DelegationPoolAllowlisting>(pool_address).allowlist
     }
 
     /// Allows an owner to change the operator of the underlying stake pool.
     public entry fun set_operator(
-        owner: &signer,
-        new_operator: address
+        owner: &signer, new_operator: address
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         let pool_address = get_owned_pool_address(signer::address_of(owner));
         // synchronize delegation and stake pools before any user operation
         // ensure the old operator is paid its uncommitted commission rewards
         synchronize_delegation_pool(pool_address);
-        stake::set_operator(&retrieve_stake_pool_owner(borrow_global<DelegationPool>(pool_address)), new_operator);
+        stake::set_operator(
+            &retrieve_stake_pool_owner(borrow_global<DelegationPool>(pool_address)),
+            new_operator,
+        );
     }
 
     /// Allows an operator to change its beneficiary. Any existing unpaid commission rewards will be paid to the new
@@ -1304,47 +1387,58 @@ module aptos_framework::delegation_pool {
     /// before switching the beneficiary. An operator can set one beneficiary for delegation pools, not a separate
     /// one for each pool.
     public entry fun set_beneficiary_for_operator(
-        operator: &signer,
-        new_beneficiary: address
+        operator: &signer, new_beneficiary: address
     ) acquires BeneficiaryForOperator {
-        assert!(features::operator_beneficiary_change_enabled(), std::error::invalid_state(
-            EOPERATOR_BENEFICIARY_CHANGE_NOT_SUPPORTED
-        ));
+        assert!(
+            features::operator_beneficiary_change_enabled(),
+            std::error::invalid_state(EOPERATOR_BENEFICIARY_CHANGE_NOT_SUPPORTED),
+        );
         // The beneficiay address of an operator is stored under the operator's address.
         // So, the operator does not need to be validated with respect to a staking pool.
         let operator_addr = signer::address_of(operator);
         let old_beneficiary = beneficiary_for_operator(operator_addr);
         if (exists<BeneficiaryForOperator>(operator_addr)) {
-            borrow_global_mut<BeneficiaryForOperator>(operator_addr).beneficiary_for_operator = new_beneficiary;
+            borrow_global_mut<BeneficiaryForOperator>(operator_addr).beneficiary_for_operator =
+                 new_beneficiary;
         } else {
-            move_to(operator, BeneficiaryForOperator { beneficiary_for_operator: new_beneficiary });
+            move_to(
+                operator,
+                BeneficiaryForOperator { beneficiary_for_operator: new_beneficiary },
+            );
         };
 
-        emit(SetBeneficiaryForOperator {
-            operator: operator_addr,
-            old_beneficiary,
-            new_beneficiary,
-        });
+        emit(
+            SetBeneficiaryForOperator {
+                operator: operator_addr,
+                old_beneficiary,
+                new_beneficiary,
+            },
+        );
     }
 
     /// Allows an owner to update the commission percentage for the operator of the underlying stake pool.
     public entry fun update_commission_percentage(
-        owner: &signer,
-        new_commission_percentage: u64
+        owner: &signer, new_commission_percentage: u64
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
-        assert!(features::commission_change_delegation_pool_enabled(), error::invalid_state(
-            ECOMMISSION_RATE_CHANGE_NOT_SUPPORTED
-        ));
-        assert!(new_commission_percentage <= MAX_FEE, error::invalid_argument(EINVALID_COMMISSION_PERCENTAGE));
+        assert!(
+            features::commission_change_delegation_pool_enabled(),
+            error::invalid_state(ECOMMISSION_RATE_CHANGE_NOT_SUPPORTED),
+        );
+        assert!(
+            new_commission_percentage <= MAX_FEE,
+            error::invalid_argument(EINVALID_COMMISSION_PERCENTAGE),
+        );
         let owner_address = signer::address_of(owner);
         let pool_address = get_owned_pool_address(owner_address);
         assert!(
-            operator_commission_percentage(pool_address) + MAX_COMMISSION_INCREASE >= new_commission_percentage,
-            error::invalid_argument(ETOO_LARGE_COMMISSION_INCREASE)
+            operator_commission_percentage(pool_address) + MAX_COMMISSION_INCREASE
+                >= new_commission_percentage,
+            error::invalid_argument(ETOO_LARGE_COMMISSION_INCREASE),
         );
         assert!(
-            stake::get_remaining_lockup_secs(pool_address) >= min_remaining_secs_for_commission_change(),
-            error::invalid_state(ETOO_LATE_COMMISSION_CHANGE)
+            stake::get_remaining_lockup_secs(pool_address)
+                >= min_remaining_secs_for_commission_change(),
+            error::invalid_state(ETOO_LATE_COMMISSION_CHANGE),
         );
 
         // synchronize delegation and stake pools before any user operation. this ensures:
@@ -1353,47 +1447,58 @@ module aptos_framework::delegation_pool {
         synchronize_delegation_pool(pool_address);
 
         if (exists<NextCommissionPercentage>(pool_address)) {
-            let commission_percentage = borrow_global_mut<NextCommissionPercentage>(pool_address);
+            let commission_percentage =
+                borrow_global_mut<NextCommissionPercentage>(pool_address);
             commission_percentage.commission_percentage_next_lockup_cycle = new_commission_percentage;
-            commission_percentage.effective_after_secs = stake::get_lockup_secs(pool_address);
+            commission_percentage.effective_after_secs = stake::get_lockup_secs(
+                pool_address
+            );
         } else {
             let delegation_pool = borrow_global<DelegationPool>(pool_address);
-            let pool_signer = account::create_signer_with_capability(&delegation_pool.stake_pool_signer_cap);
-            move_to(&pool_signer, NextCommissionPercentage {
-                commission_percentage_next_lockup_cycle: new_commission_percentage,
-                effective_after_secs: stake::get_lockup_secs(pool_address),
-            });
+            let pool_signer =
+                account::create_signer_with_capability(
+                    &delegation_pool.stake_pool_signer_cap
+                );
+            move_to(
+                &pool_signer,
+                NextCommissionPercentage {
+                    commission_percentage_next_lockup_cycle: new_commission_percentage,
+                    effective_after_secs: stake::get_lockup_secs(pool_address),
+                },
+            );
         };
 
-        event::emit(CommissionPercentageChange {
-            pool_address,
-            owner: owner_address,
-            commission_percentage_next_lockup_cycle: new_commission_percentage,
-        });
+        event::emit(
+            CommissionPercentageChange {
+                pool_address,
+                owner: owner_address,
+                commission_percentage_next_lockup_cycle: new_commission_percentage,
+            },
+        );
     }
 
     /// Allows an owner to change the delegated voter of the underlying stake pool.
     public entry fun set_delegated_voter(
-        owner: &signer,
-        new_voter: address
+        owner: &signer, new_voter: address
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         // No one can change delegated_voter once the partial governance voting feature is enabled.
         assert!(
             !features::delegation_pool_partial_governance_voting_enabled(),
-            error::invalid_state(EDEPRECATED_FUNCTION)
+            error::invalid_state(EDEPRECATED_FUNCTION),
         );
         let pool_address = get_owned_pool_address(signer::address_of(owner));
         // synchronize delegation and stake pools before any user operation
         synchronize_delegation_pool(pool_address);
-        stake::set_delegated_voter(&retrieve_stake_pool_owner(borrow_global<DelegationPool>(pool_address)), new_voter);
+        stake::set_delegated_voter(
+            &retrieve_stake_pool_owner(borrow_global<DelegationPool>(pool_address)),
+            new_voter,
+        );
     }
 
     /// Allows a delegator to delegate its voting power to a voter. If this delegator already has a delegated voter,
     /// this change won't take effects until the next lockup period.
     public entry fun delegate_voting_power(
-        delegator: &signer,
-        pool_address: address,
-        new_voter: address
+        delegator: &signer, pool_address: address, new_voter: address
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         assert_partial_governance_voting_enabled(pool_address);
 
@@ -1403,77 +1508,87 @@ module aptos_framework::delegation_pool {
         let delegator_address = signer::address_of(delegator);
         let delegation_pool = borrow_global<DelegationPool>(pool_address);
         let governance_records = borrow_global_mut<GovernanceRecords>(pool_address);
-        let delegator_vote_delegation = update_and_borrow_mut_delegator_vote_delegation(
-            delegation_pool,
-            governance_records,
-            delegator_address
-        );
+        let delegator_vote_delegation =
+            update_and_borrow_mut_delegator_vote_delegation(
+                delegation_pool,
+                governance_records,
+                delegator_address,
+            );
         let pending_voter: address = delegator_vote_delegation.pending_voter;
 
         // No need to update if the voter doesn't really change.
         if (pending_voter != new_voter) {
             delegator_vote_delegation.pending_voter = new_voter;
-            let active_shares = get_delegator_active_shares(delegation_pool, delegator_address);
+            let active_shares =
+                get_delegator_active_shares(delegation_pool, delegator_address);
             // <active shares> of <pending voter of shareholder> -= <active_shares>
             // <active shares> of <new voter of shareholder> += <active_shares>
-            let pending_delegated_votes = update_and_borrow_mut_delegated_votes(
-                delegation_pool,
-                governance_records,
-                pending_voter
-            );
-            pending_delegated_votes.active_shares_next_lockup =
-                pending_delegated_votes.active_shares_next_lockup - active_shares;
+            let pending_delegated_votes =
+                update_and_borrow_mut_delegated_votes(
+                    delegation_pool,
+                    governance_records,
+                    pending_voter,
+                );
+            pending_delegated_votes.active_shares_next_lockup = pending_delegated_votes.active_shares_next_lockup
+                - active_shares;
 
-            let new_delegated_votes = update_and_borrow_mut_delegated_votes(
-                delegation_pool,
-                governance_records,
-                new_voter
-            );
-            new_delegated_votes.active_shares_next_lockup =
-                new_delegated_votes.active_shares_next_lockup + active_shares;
+            let new_delegated_votes =
+                update_and_borrow_mut_delegated_votes(
+                    delegation_pool,
+                    governance_records,
+                    new_voter,
+                );
+            new_delegated_votes.active_shares_next_lockup = new_delegated_votes.active_shares_next_lockup
+                + active_shares;
         };
 
         if (features::module_event_migration_enabled()) {
-            event::emit(DelegateVotingPower {
+            event::emit(
+                DelegateVotingPower {
+                    pool_address,
+                    delegator: delegator_address,
+                    voter: new_voter,
+                },
+            )
+        };
+
+        event::emit_event(
+            &mut governance_records.delegate_voting_power_events,
+            DelegateVotingPowerEvent {
                 pool_address,
                 delegator: delegator_address,
                 voter: new_voter,
-            })
-        };
-
-        event::emit_event(&mut governance_records.delegate_voting_power_events, DelegateVotingPowerEvent {
-            pool_address,
-            delegator: delegator_address,
-            voter: new_voter,
-        });
+            },
+        );
     }
 
     /// Enable delegators allowlisting as the pool owner.
-    public entry fun enable_delegators_allowlisting(
-        owner: &signer,
-    ) acquires DelegationPoolOwnership, DelegationPool {
+    public entry fun enable_delegators_allowlisting(owner: &signer,) acquires DelegationPoolOwnership, DelegationPool {
         assert!(
             features::delegation_pool_allowlisting_enabled(),
-            error::invalid_state(EDELEGATORS_ALLOWLISTING_NOT_SUPPORTED)
+            error::invalid_state(EDELEGATORS_ALLOWLISTING_NOT_SUPPORTED),
         );
 
         let pool_address = get_owned_pool_address(signer::address_of(owner));
         if (allowlisting_enabled(pool_address)) { return };
 
-        let pool_signer = retrieve_stake_pool_owner(borrow_global<DelegationPool>(pool_address));
-        move_to(&pool_signer, DelegationPoolAllowlisting { allowlist: smart_table::new<address, bool>() });
+        let pool_signer =
+            retrieve_stake_pool_owner(borrow_global<DelegationPool>(pool_address));
+        move_to(
+            &pool_signer,
+            DelegationPoolAllowlisting { allowlist: smart_table::new<address, bool>() },
+        );
 
         event::emit(EnableDelegatorsAllowlisting { pool_address });
     }
 
     /// Disable delegators allowlisting as the pool owner. The existing allowlist will be emptied.
-    public entry fun disable_delegators_allowlisting(
-        owner: &signer,
-    ) acquires DelegationPoolOwnership, DelegationPoolAllowlisting {
+    public entry fun disable_delegators_allowlisting(owner: &signer,) acquires DelegationPoolOwnership, DelegationPoolAllowlisting {
         let pool_address = get_owned_pool_address(signer::address_of(owner));
         assert_allowlisting_enabled(pool_address);
 
-        let DelegationPoolAllowlisting { allowlist } = move_from<DelegationPoolAllowlisting>(pool_address);
+        let DelegationPoolAllowlisting { allowlist } =
+            move_from<DelegationPoolAllowlisting>(pool_address);
         // if the allowlist becomes too large, the owner can always remove some delegators
         smart_table::destroy(allowlist);
 
@@ -1482,44 +1597,45 @@ module aptos_framework::delegation_pool {
 
     /// Allowlist a delegator as the pool owner.
     public entry fun allowlist_delegator(
-        owner: &signer,
-        delegator_address: address,
+        owner: &signer, delegator_address: address,
     ) acquires DelegationPoolOwnership, DelegationPoolAllowlisting {
         let pool_address = get_owned_pool_address(signer::address_of(owner));
         assert_allowlisting_enabled(pool_address);
 
         if (delegator_allowlisted(pool_address, delegator_address)) { return };
 
-        smart_table::add(borrow_mut_delegators_allowlist(pool_address), delegator_address, true);
+        smart_table::add(
+            borrow_mut_delegators_allowlist(pool_address), delegator_address, true
+        );
 
         event::emit(AllowlistDelegator { pool_address, delegator_address });
     }
 
     /// Remove a delegator from the allowlist as the pool owner, but do not unlock their stake.
     public entry fun remove_delegator_from_allowlist(
-        owner: &signer,
-        delegator_address: address,
+        owner: &signer, delegator_address: address,
     ) acquires DelegationPoolOwnership, DelegationPoolAllowlisting {
         let pool_address = get_owned_pool_address(signer::address_of(owner));
         assert_allowlisting_enabled(pool_address);
 
         if (!delegator_allowlisted(pool_address, delegator_address)) { return };
 
-        smart_table::remove(borrow_mut_delegators_allowlist(pool_address), delegator_address);
+        smart_table::remove(
+            borrow_mut_delegators_allowlist(pool_address), delegator_address
+        );
 
         event::emit(RemoveDelegatorFromAllowlist { pool_address, delegator_address });
     }
 
     /// Evict a delegator that is not allowlisted by unlocking their entire stake.
     public entry fun evict_delegator(
-        owner: &signer,
-        delegator_address: address,
+        owner: &signer, delegator_address: address,
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage, DelegationPoolAllowlisting {
         let pool_address = get_owned_pool_address(signer::address_of(owner));
         assert_allowlisting_enabled(pool_address);
         assert!(
             !delegator_allowlisted(pool_address, delegator_address),
-            error::invalid_state(ECANNOT_EVICT_ALLOWLISTED_DELEGATOR)
+            error::invalid_state(ECANNOT_EVICT_ALLOWLISTED_DELEGATOR),
         );
 
         // synchronize pool in order to query latest balance of delegator
@@ -1528,16 +1644,18 @@ module aptos_framework::delegation_pool {
         let pool = borrow_global<DelegationPool>(pool_address);
         if (get_delegator_active_shares(pool, delegator_address) == 0) { return };
 
-        unlock_internal(delegator_address, pool_address, pool_u64::balance(&pool.active_shares, delegator_address));
+        unlock_internal(
+            delegator_address,
+            pool_address,
+            pool_u64::balance(&pool.active_shares, delegator_address),
+        );
 
         event::emit(EvictDelegator { pool_address, delegator_address });
     }
 
     /// Add `amount` of coins to the delegation pool `pool_address`.
     public entry fun add_stake(
-        delegator: &signer,
-        pool_address: address,
-        amount: u64
+        delegator: &signer, pool_address: address, amount: u64
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage, DelegationPoolAllowlisting {
         // short-circuit if amount to add is 0 so no event is emitted
         if (amount == 0) { return };
@@ -1592,9 +1710,7 @@ module aptos_framework::delegation_pool {
     /// Unlock `amount` from the active + pending_active stake of `delegator` or
     /// at most how much active stake there is on the stake pool.
     public entry fun unlock(
-        delegator: &signer,
-        pool_address: address,
-        amount: u64
+        delegator: &signer, pool_address: address, amount: u64
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         // short-circuit if amount to unlock is 0 so no event is emitted
         if (amount == 0) { return };
@@ -1607,15 +1723,18 @@ module aptos_framework::delegation_pool {
     }
 
     fun unlock_internal(
-        delegator_address: address,
-        pool_address: address,
-        amount: u64
+        delegator_address: address, pool_address: address, amount: u64
     ) acquires DelegationPool, GovernanceRecords {
-        assert!(delegator_address != NULL_SHAREHOLDER, error::invalid_argument(ECANNOT_UNLOCK_NULL_SHAREHOLDER));
+        assert!(
+            delegator_address != NULL_SHAREHOLDER,
+            error::invalid_argument(ECANNOT_UNLOCK_NULL_SHAREHOLDER),
+        );
 
         // fail unlock of more stake than `active` on the stake pool
         let (active, _, _, _) = stake::get_stake(pool_address);
-        assert!(amount <= active, error::invalid_argument(ENOT_ENOUGH_ACTIVE_STAKE_TO_UNLOCK));
+        assert!(
+            amount <= active, error::invalid_argument(ENOT_ENOUGH_ACTIVE_STAKE_TO_UNLOCK)
+        );
 
         let pool = borrow_global_mut<DelegationPool>(pool_address);
         amount = coins_to_transfer_to_ensure_min_stake(
@@ -1633,29 +1752,19 @@ module aptos_framework::delegation_pool {
 
         if (features::module_event_migration_enabled()) {
             event::emit(
-                UnlockStake {
-                    pool_address,
-                    delegator_address,
-                    amount_unlocked: amount,
-                },
+                UnlockStake { pool_address, delegator_address, amount_unlocked: amount, },
             );
         };
 
         event::emit_event(
             &mut pool.unlock_stake_events,
-            UnlockStakeEvent {
-                pool_address,
-                delegator_address,
-                amount_unlocked: amount,
-            },
+            UnlockStakeEvent { pool_address, delegator_address, amount_unlocked: amount, },
         );
     }
 
     /// Move `amount` of coins from pending_inactive to active.
     public entry fun reactivate_stake(
-        delegator: &signer,
-        pool_address: address,
-        amount: u64
+        delegator: &signer, pool_address: address, amount: u64
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage, DelegationPoolAllowlisting {
         // short-circuit if amount to reactivate is 0 so no event is emitted
         if (amount == 0) { return };
@@ -1674,7 +1783,9 @@ module aptos_framework::delegation_pool {
             amount,
         );
         let observed_lockup_cycle = pool.observed_lockup_cycle;
-        amount = redeem_inactive_shares(pool, delegator_address, amount, observed_lockup_cycle);
+        amount = redeem_inactive_shares(
+            pool, delegator_address, amount, observed_lockup_cycle
+        );
 
         stake::reactivate_stake(&retrieve_stake_pool_owner(pool), amount);
 
@@ -1703,32 +1814,36 @@ module aptos_framework::delegation_pool {
 
     /// Withdraw `amount` of owned inactive stake from the delegation pool at `pool_address`.
     public entry fun withdraw(
-        delegator: &signer,
-        pool_address: address,
-        amount: u64
+        delegator: &signer, pool_address: address, amount: u64
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         assert!(amount > 0, error::invalid_argument(EWITHDRAW_ZERO_STAKE));
         // synchronize delegation and stake pools before any user operation
         synchronize_delegation_pool(pool_address);
-        withdraw_internal(borrow_global_mut<DelegationPool>(pool_address), signer::address_of(delegator), amount);
+        withdraw_internal(
+            borrow_global_mut<DelegationPool>(pool_address),
+            signer::address_of(delegator),
+            amount,
+        );
     }
 
     fun withdraw_internal(
-        pool: &mut DelegationPool,
-        delegator_address: address,
-        amount: u64
+        pool: &mut DelegationPool, delegator_address: address, amount: u64
     ) acquires GovernanceRecords {
         // TODO: recycle storage when a delegator fully exits the delegation pool.
         // short-circuit if amount to withdraw is 0 so no event is emitted
         if (amount == 0) { return };
 
         let pool_address = get_pool_address(pool);
-        let (withdrawal_exists, withdrawal_olc) = pending_withdrawal_exists(pool, delegator_address);
+        let (withdrawal_exists, withdrawal_olc) =
+            pending_withdrawal_exists(pool, delegator_address);
         // exit if no withdrawal or (it is pending and cannot withdraw pending_inactive stake from stake pool)
         if (!(
-            withdrawal_exists &&
-                (withdrawal_olc.index < pool.observed_lockup_cycle.index || can_withdraw_pending_inactive(pool_address))
-        )) { return };
+                withdrawal_exists
+                && (
+                    withdrawal_olc.index < pool.observed_lockup_cycle.index
+                        || can_withdraw_pending_inactive(pool_address)
+                )
+            )) { return };
 
         if (withdrawal_olc.index == pool.observed_lockup_cycle.index) {
             amount = coins_to_redeem_to_ensure_min_stake(
@@ -1768,11 +1883,7 @@ module aptos_framework::delegation_pool {
 
         if (features::module_event_migration_enabled()) {
             event::emit(
-                WithdrawStake {
-                    pool_address,
-                    delegator_address,
-                    amount_withdrawn: amount,
-                },
+                WithdrawStake { pool_address, delegator_address, amount_withdrawn: amount, },
             );
         };
 
@@ -1789,7 +1900,9 @@ module aptos_framework::delegation_pool {
     /// Return the unique observed lockup cycle where delegator `delegator_address` may have
     /// unlocking (or already unlocked) stake to be withdrawn from delegation pool `pool`.
     /// A bool is returned to signal if a pending withdrawal exists at all.
-    fun pending_withdrawal_exists(pool: &DelegationPool, delegator_address: address): (bool, ObservedLockupCycle) {
+    fun pending_withdrawal_exists(
+        pool: &DelegationPool, delegator_address: address
+    ): (bool, ObservedLockupCycle) {
         if (table::contains(&pool.pending_withdrawals, delegator_address)) {
             (true, *table::borrow(&pool.pending_withdrawals, delegator_address))
         } else {
@@ -1812,8 +1925,11 @@ module aptos_framework::delegation_pool {
     /// if existing and already inactive to allow the creation of a new one.
     /// `pending_inactive` stake would be left untouched even if withdrawable and should
     /// be explicitly withdrawn by delegator
-    fun execute_pending_withdrawal(pool: &mut DelegationPool, delegator_address: address) acquires GovernanceRecords {
-        let (withdrawal_exists, withdrawal_olc) = pending_withdrawal_exists(pool, delegator_address);
+    fun execute_pending_withdrawal(
+        pool: &mut DelegationPool, delegator_address: address
+    ) acquires GovernanceRecords {
+        let (withdrawal_exists, withdrawal_olc) =
+            pending_withdrawal_exists(pool, delegator_address);
         if (withdrawal_exists && withdrawal_olc.index < pool.observed_lockup_cycle.index) {
             withdraw_internal(pool, delegator_address, MAX_U64);
         }
@@ -1828,12 +1944,16 @@ module aptos_framework::delegation_pool {
     ): u128 acquires GovernanceRecords {
         let new_shares = pool_u64::amount_to_shares(&pool.active_shares, coins_amount);
         // No need to buy 0 shares.
-        if (new_shares == 0) { return 0 };
+        if (new_shares == 0) {
+            return 0
+        };
 
         // Always update governance records before any change to the shares pool.
         let pool_address = get_pool_address(pool);
         if (partial_governance_voting_enabled(pool_address)) {
-            update_governance_records_for_buy_in_active_shares(pool, pool_address, new_shares, shareholder);
+            update_governance_records_for_buy_in_active_shares(
+                pool, pool_address, new_shares, shareholder
+            );
         };
 
         pool_u64::buy_in(&mut pool.active_shares, shareholder, coins_amount);
@@ -1849,30 +1969,38 @@ module aptos_framework::delegation_pool {
         shareholder: address,
         coins_amount: u64,
     ): u128 acquires GovernanceRecords {
-        let new_shares = pool_u64::amount_to_shares(pending_inactive_shares_pool(pool), coins_amount);
+        let new_shares =
+            pool_u64::amount_to_shares(pending_inactive_shares_pool(pool), coins_amount);
         // never create a new pending withdrawal unless delegator owns some pending_inactive shares
-        if (new_shares == 0) { return 0 };
+        if (new_shares == 0) {
+            return 0
+        };
 
         // Always update governance records before any change to the shares pool.
         let pool_address = get_pool_address(pool);
         if (partial_governance_voting_enabled(pool_address)) {
-            update_governance_records_for_buy_in_pending_inactive_shares(pool, pool_address, new_shares, shareholder);
+            update_governance_records_for_buy_in_pending_inactive_shares(
+                pool, pool_address, new_shares, shareholder
+            );
         };
 
         // cannot buy inactive shares, only pending_inactive at current lockup cycle
-        pool_u64::buy_in(pending_inactive_shares_pool_mut(pool), shareholder, coins_amount);
+        pool_u64::buy_in(
+            pending_inactive_shares_pool_mut(pool), shareholder, coins_amount
+        );
 
         // execute the pending withdrawal if exists and is inactive before creating a new one
         execute_pending_withdrawal(pool, shareholder);
 
         // save observed lockup cycle for the new pending withdrawal
         let observed_lockup_cycle = pool.observed_lockup_cycle;
-        assert!(*table::borrow_mut_with_default(
-            &mut pool.pending_withdrawals,
-            shareholder,
-            observed_lockup_cycle
-        ) == observed_lockup_cycle,
-            error::invalid_state(EPENDING_WITHDRAWAL_EXISTS)
+        assert!(
+            *table::borrow_mut_with_default(
+                &mut pool.pending_withdrawals,
+                shareholder,
+                observed_lockup_cycle,
+            ) == observed_lockup_cycle,
+            error::invalid_state(EPENDING_WITHDRAWAL_EXISTS),
         );
 
         new_shares
@@ -1902,14 +2030,17 @@ module aptos_framework::delegation_pool {
         shareholder: address,
         coins_amount: u64,
     ): u64 acquires GovernanceRecords {
-        let shares_to_redeem = amount_to_shares_to_redeem(&pool.active_shares, shareholder, coins_amount);
+        let shares_to_redeem =
+            amount_to_shares_to_redeem(&pool.active_shares, shareholder, coins_amount);
         // silently exit if not a shareholder otherwise redeem would fail with `ESHAREHOLDER_NOT_FOUND`
         if (shares_to_redeem == 0) return 0;
 
         // Always update governance records before any change to the shares pool.
         let pool_address = get_pool_address(pool);
         if (partial_governance_voting_enabled(pool_address)) {
-            update_governanace_records_for_redeem_active_shares(pool, pool_address, shares_to_redeem, shareholder);
+            update_governanace_records_for_redeem_active_shares(
+                pool, pool_address, shares_to_redeem, shareholder
+            );
         };
 
         pool_u64::redeem_shares(&mut pool.active_shares, shareholder, shares_to_redeem)
@@ -1927,28 +2058,32 @@ module aptos_framework::delegation_pool {
         coins_amount: u64,
         lockup_cycle: ObservedLockupCycle,
     ): u64 acquires GovernanceRecords {
-        let shares_to_redeem = amount_to_shares_to_redeem(
-            table::borrow(&pool.inactive_shares, lockup_cycle),
-            shareholder,
-            coins_amount);
+        let shares_to_redeem =
+            amount_to_shares_to_redeem(
+                table::borrow(&pool.inactive_shares, lockup_cycle),
+                shareholder,
+                coins_amount,
+            );
         // silently exit if not a shareholder otherwise redeem would fail with `ESHAREHOLDER_NOT_FOUND`
         if (shares_to_redeem == 0) return 0;
 
         // Always update governance records before any change to the shares pool.
         let pool_address = get_pool_address(pool);
         // Only redeem shares from the pending_inactive pool at `lockup_cycle` == current OLC.
-        if (partial_governance_voting_enabled(pool_address) && lockup_cycle.index == pool.observed_lockup_cycle.index) {
+        if (partial_governance_voting_enabled(pool_address)
+                && lockup_cycle.index == pool.observed_lockup_cycle.index) {
             update_governanace_records_for_redeem_pending_inactive_shares(
                 pool,
                 pool_address,
                 shares_to_redeem,
-                shareholder
+                shareholder,
             );
         };
 
         let inactive_shares = table::borrow_mut(&mut pool.inactive_shares, lockup_cycle);
         // 1. reaching here means delegator owns inactive/pending_inactive shares at OLC `lockup_cycle`
-        let redeemed_coins = pool_u64::redeem_shares(inactive_shares, shareholder, shares_to_redeem);
+        let redeemed_coins =
+            pool_u64::redeem_shares(inactive_shares, shareholder, shares_to_redeem);
 
         // if entirely reactivated pending_inactive stake or withdrawn inactive one,
         // re-enable unlocking for delegator by deleting this pending withdrawal
@@ -1958,8 +2093,11 @@ module aptos_framework::delegation_pool {
             table::remove(&mut pool.pending_withdrawals, shareholder);
         };
         // destroy inactive shares pool of past OLC if all its stake has been withdrawn
-        if (lockup_cycle.index < pool.observed_lockup_cycle.index && total_coins(inactive_shares) == 0) {
-            pool_u64::destroy_empty(table::remove(&mut pool.inactive_shares, lockup_cycle));
+        if (lockup_cycle.index < pool.observed_lockup_cycle.index
+                && total_coins(inactive_shares) == 0) {
+            pool_u64::destroy_empty(
+                table::remove(&mut pool.inactive_shares, lockup_cycle)
+            );
         };
 
         redeemed_coins
@@ -1969,10 +2107,11 @@ module aptos_framework::delegation_pool {
     /// capture the rewards earned in the meantime, resulted operator commission and
     /// whether the lockup expired on the stake pool.
     fun calculate_stake_pool_drift(pool: &DelegationPool): (bool, u64, u64, u64, u64) {
-        let (active, inactive, pending_active, pending_inactive) = stake::get_stake(get_pool_address(pool));
+        let (active, inactive, pending_active, pending_inactive) =
+            stake::get_stake(get_pool_address(pool));
         assert!(
             inactive >= pool.total_coins_inactive,
-            error::invalid_state(ESLASHED_INACTIVE_STAKE_ON_PAST_OLC)
+            error::invalid_state(ESLASHED_INACTIVE_STAKE_ON_PAST_OLC),
         );
         // determine whether a new lockup cycle has been ended on the stake pool and
         // inactivated SOME `pending_inactive` stake which should stop earning rewards now,
@@ -1996,33 +2135,41 @@ module aptos_framework::delegation_pool {
 
         // operator `active` rewards not persisted yet to the active shares pool
         let pool_active = total_coins(&pool.active_shares);
-        let commission_active = if (active > pool_active) {
-            math64::mul_div(active - pool_active, pool.operator_commission_percentage, MAX_FEE)
-        } else {
-            // handle any slashing applied to `active` stake
-            0
-        };
+        let commission_active =
+            if (active > pool_active) {
+                math64::mul_div(
+                    active - pool_active, pool.operator_commission_percentage, MAX_FEE
+                )
+            } else {
+                // handle any slashing applied to `active` stake
+                0
+            };
         // operator `pending_inactive` rewards not persisted yet to the pending_inactive shares pool
         let pool_pending_inactive = total_coins(pending_inactive_shares_pool(pool));
-        let commission_pending_inactive = if (pending_inactive > pool_pending_inactive) {
-            math64::mul_div(
-                pending_inactive - pool_pending_inactive,
-                pool.operator_commission_percentage,
-                MAX_FEE
-            )
-        } else {
-            // handle any slashing applied to `pending_inactive` stake
-            0
-        };
+        let commission_pending_inactive =
+            if (pending_inactive > pool_pending_inactive) {
+                math64::mul_div(
+                    pending_inactive - pool_pending_inactive,
+                    pool.operator_commission_percentage,
+                    MAX_FEE,
+                )
+            } else {
+                // handle any slashing applied to `pending_inactive` stake
+                0
+            };
 
-        (lockup_cycle_ended, active, pending_inactive, commission_active, commission_pending_inactive)
+        (
+            lockup_cycle_ended,
+            active,
+            pending_inactive,
+            commission_active,
+            commission_pending_inactive
+        )
     }
 
     /// Synchronize delegation and stake pools: distribute yet-undetected rewards to the corresponding internal
     /// shares pools, assign commission to operator and eventually prepare delegation pool for a new lockup cycle.
-    public entry fun synchronize_delegation_pool(
-        pool_address: address
-    ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
+    public entry fun synchronize_delegation_pool(pool_address: address) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         assert_delegation_pool_exists(pool_address);
         let pool = borrow_global_mut<DelegationPool>(pool_address);
         let (
@@ -2052,16 +2199,20 @@ module aptos_framework::delegation_pool {
         // update total coins accumulated by `pending_inactive` shares at current observed lockup cycle
         pool_u64::update_total_coins(
             pending_inactive_shares_pool_mut(pool),
-            pending_inactive - commission_pending_inactive
+            pending_inactive - commission_pending_inactive,
         );
 
         // reward operator its commission out of uncommitted active rewards (`add_stake` fees already excluded)
-        buy_in_active_shares(pool, beneficiary_for_operator(stake::get_operator(pool_address)), commission_active);
+        buy_in_active_shares(
+            pool,
+            beneficiary_for_operator(stake::get_operator(pool_address)),
+            commission_active,
+        );
         // reward operator its commission out of uncommitted pending_inactive rewards
         buy_in_pending_inactive_shares(
             pool,
             beneficiary_for_operator(stake::get_operator(pool_address)),
-            commission_pending_inactive
+            commission_pending_inactive,
         );
 
         event::emit_event(
@@ -2075,13 +2226,17 @@ module aptos_framework::delegation_pool {
         );
 
         if (features::operator_beneficiary_change_enabled()) {
-            emit(DistributeCommission {
-                pool_address,
-                operator: stake::get_operator(pool_address),
-                beneficiary: beneficiary_for_operator(stake::get_operator(pool_address)),
-                commission_active,
-                commission_pending_inactive,
-            })
+            emit(
+                DistributeCommission {
+                    pool_address,
+                    operator: stake::get_operator(pool_address),
+                    beneficiary: beneficiary_for_operator(
+                        stake::get_operator(pool_address)
+                    ),
+                    commission_active,
+                    commission_pending_inactive,
+                },
+            )
         };
 
         // advance lockup cycle on delegation pool if already ended on stake pool (AND stake explicitly inactivated)
@@ -2096,7 +2251,7 @@ module aptos_framework::delegation_pool {
             table::add(
                 &mut pool.inactive_shares,
                 pool.observed_lockup_cycle,
-                pool_u64::create_with_scaling_factor(SHARES_SCALING_FACTOR)
+                pool_u64::create_with_scaling_factor(SHARES_SCALING_FACTOR),
             );
         };
 
@@ -2108,17 +2263,22 @@ module aptos_framework::delegation_pool {
     }
 
     inline fun assert_and_update_proposal_used_voting_power(
-        governance_records: &mut GovernanceRecords, pool_address: address, proposal_id: u64, voting_power: u64
+        governance_records: &mut GovernanceRecords,
+        pool_address: address,
+        proposal_id: u64,
+        voting_power: u64
     ) {
-        let stake_pool_remaining_voting_power = aptos_governance::get_remaining_voting_power(pool_address, proposal_id);
-        let stake_pool_used_voting_power = aptos_governance::get_voting_power(
-            pool_address
-        ) - stake_pool_remaining_voting_power;
-        let proposal_used_voting_power = smart_table::borrow_mut_with_default(
-            &mut governance_records.votes_per_proposal,
-            proposal_id,
-            0
-        );
+        let stake_pool_remaining_voting_power =
+            aptos_governance::get_remaining_voting_power(pool_address, proposal_id);
+        let stake_pool_used_voting_power =
+            aptos_governance::get_voting_power(pool_address)
+                - stake_pool_remaining_voting_power;
+        let proposal_used_voting_power =
+            smart_table::borrow_mut_with_default(
+                &mut governance_records.votes_per_proposal,
+                proposal_id,
+                0,
+            );
         // A edge case: Before enabling partial governance voting on a delegation pool, the delegation pool has
         // a voter which can vote with all voting power of this delegation pool. If the voter votes on a proposal after
         // partial governance voting flag is enabled, the delegation pool doesn't have enough voting power on this
@@ -2126,84 +2286,117 @@ module aptos_framework::delegation_pool {
         // To detect this case, check if the stake pool had used voting power not through delegation_pool module.
         assert!(
             stake_pool_used_voting_power == *proposal_used_voting_power,
-            error::invalid_argument(EALREADY_VOTED_BEFORE_ENABLE_PARTIAL_VOTING)
+            error::invalid_argument(EALREADY_VOTED_BEFORE_ENABLE_PARTIAL_VOTING),
         );
         *proposal_used_voting_power = *proposal_used_voting_power + voting_power;
     }
 
     fun update_governance_records_for_buy_in_active_shares(
-        pool: &DelegationPool, pool_address: address, new_shares: u128, shareholder: address
+        pool: &DelegationPool,
+        pool_address: address,
+        new_shares: u128,
+        shareholder: address
     ) acquires GovernanceRecords {
         // <active shares> of <shareholder> += <new_shares> ---->
         // <active shares> of <current voter of shareholder> += <new_shares>
         // <active shares> of <next voter of shareholder> += <new_shares>
         let governance_records = borrow_global_mut<GovernanceRecords>(pool_address);
-        let vote_delegation = update_and_borrow_mut_delegator_vote_delegation(pool, governance_records, shareholder);
+        let vote_delegation =
+            update_and_borrow_mut_delegator_vote_delegation(
+                pool, governance_records, shareholder
+            );
         let current_voter = vote_delegation.voter;
         let pending_voter = vote_delegation.pending_voter;
         let current_delegated_votes =
             update_and_borrow_mut_delegated_votes(pool, governance_records, current_voter);
-        current_delegated_votes.active_shares = current_delegated_votes.active_shares + new_shares;
+        current_delegated_votes.active_shares = current_delegated_votes.active_shares
+            + new_shares;
         if (pending_voter == current_voter) {
-            current_delegated_votes.active_shares_next_lockup =
-                current_delegated_votes.active_shares_next_lockup + new_shares;
+            current_delegated_votes.active_shares_next_lockup = current_delegated_votes.active_shares_next_lockup
+                + new_shares;
         } else {
             let pending_delegated_votes =
-                update_and_borrow_mut_delegated_votes(pool, governance_records, pending_voter);
-            pending_delegated_votes.active_shares_next_lockup =
-                pending_delegated_votes.active_shares_next_lockup + new_shares;
+                update_and_borrow_mut_delegated_votes(
+                    pool, governance_records, pending_voter
+                );
+            pending_delegated_votes.active_shares_next_lockup = pending_delegated_votes.active_shares_next_lockup
+                + new_shares;
         };
     }
 
     fun update_governance_records_for_buy_in_pending_inactive_shares(
-        pool: &DelegationPool, pool_address: address, new_shares: u128, shareholder: address
+        pool: &DelegationPool,
+        pool_address: address,
+        new_shares: u128,
+        shareholder: address
     ) acquires GovernanceRecords {
         // <pending inactive shares> of <shareholder> += <new_shares>   ---->
         // <pending inactive shares> of <current voter of shareholder> += <new_shares>
         // no impact on <pending inactive shares> of <next voter of shareholder>
         let governance_records = borrow_global_mut<GovernanceRecords>(pool_address);
-        let current_voter = calculate_and_update_delegator_voter_internal(pool, governance_records, shareholder);
-        let current_delegated_votes = update_and_borrow_mut_delegated_votes(pool, governance_records, current_voter);
-        current_delegated_votes.pending_inactive_shares = current_delegated_votes.pending_inactive_shares + new_shares;
+        let current_voter =
+            calculate_and_update_delegator_voter_internal(
+                pool, governance_records, shareholder
+            );
+        let current_delegated_votes =
+            update_and_borrow_mut_delegated_votes(pool, governance_records, current_voter);
+        current_delegated_votes.pending_inactive_shares = current_delegated_votes.pending_inactive_shares
+            + new_shares;
     }
 
     fun update_governanace_records_for_redeem_active_shares(
-        pool: &DelegationPool, pool_address: address, shares_to_redeem: u128, shareholder: address
+        pool: &DelegationPool,
+        pool_address: address,
+        shares_to_redeem: u128,
+        shareholder: address
     ) acquires GovernanceRecords {
         // <active shares> of <shareholder> -= <shares_to_redeem> ---->
         // <active shares> of <current voter of shareholder> -= <shares_to_redeem>
         // <active shares> of <next voter of shareholder> -= <shares_to_redeem>
         let governance_records = borrow_global_mut<GovernanceRecords>(pool_address);
-        let vote_delegation = update_and_borrow_mut_delegator_vote_delegation(
-            pool,
-            governance_records,
-            shareholder
-        );
+        let vote_delegation =
+            update_and_borrow_mut_delegator_vote_delegation(
+                pool,
+                governance_records,
+                shareholder,
+            );
         let current_voter = vote_delegation.voter;
         let pending_voter = vote_delegation.pending_voter;
-        let current_delegated_votes = update_and_borrow_mut_delegated_votes(pool, governance_records, current_voter);
-        current_delegated_votes.active_shares = current_delegated_votes.active_shares - shares_to_redeem;
+        let current_delegated_votes =
+            update_and_borrow_mut_delegated_votes(pool, governance_records, current_voter);
+        current_delegated_votes.active_shares = current_delegated_votes.active_shares
+            - shares_to_redeem;
         if (current_voter == pending_voter) {
-            current_delegated_votes.active_shares_next_lockup =
-                current_delegated_votes.active_shares_next_lockup - shares_to_redeem;
+            current_delegated_votes.active_shares_next_lockup = current_delegated_votes.active_shares_next_lockup
+                - shares_to_redeem;
         } else {
             let pending_delegated_votes =
-                update_and_borrow_mut_delegated_votes(pool, governance_records, pending_voter);
-            pending_delegated_votes.active_shares_next_lockup =
-                pending_delegated_votes.active_shares_next_lockup - shares_to_redeem;
+                update_and_borrow_mut_delegated_votes(
+                    pool, governance_records, pending_voter
+                );
+            pending_delegated_votes.active_shares_next_lockup = pending_delegated_votes.active_shares_next_lockup
+                - shares_to_redeem;
         };
     }
 
     fun update_governanace_records_for_redeem_pending_inactive_shares(
-        pool: &DelegationPool, pool_address: address, shares_to_redeem: u128, shareholder: address
+        pool: &DelegationPool,
+        pool_address: address,
+        shares_to_redeem: u128,
+        shareholder: address
     ) acquires GovernanceRecords {
         // <pending inactive shares> of <shareholder> -= <shares_to_redeem>  ---->
         // <pending inactive shares> of <current voter of shareholder> -= <shares_to_redeem>
         // no impact on <pending inactive shares> of <next voter of shareholder>
         let governance_records = borrow_global_mut<GovernanceRecords>(pool_address);
-        let current_voter = calculate_and_update_delegator_voter_internal(pool, governance_records, shareholder);
-        let current_delegated_votes = update_and_borrow_mut_delegated_votes(pool, governance_records, current_voter);
-        current_delegated_votes.pending_inactive_shares = current_delegated_votes.pending_inactive_shares - shares_to_redeem;
+        let current_voter =
+            calculate_and_update_delegator_voter_internal(
+                pool, governance_records, shareholder
+            );
+        let current_delegated_votes =
+            update_and_borrow_mut_delegated_votes(pool, governance_records, current_voter);
+        current_delegated_votes.pending_inactive_shares = current_delegated_votes.pending_inactive_shares
+            - shares_to_redeem;
     }
 
     #[deprecated]
@@ -2269,7 +2462,7 @@ module aptos_framework::delegation_pool {
             true,
             1,
             100,
-            1000000
+            1000000,
         );
     }
 
@@ -2283,7 +2476,7 @@ module aptos_framework::delegation_pool {
             true,
             0,
             100,
-            1000000
+            1000000,
         );
     }
 
@@ -2312,8 +2505,12 @@ module aptos_framework::delegation_pool {
         reconfiguration::initialize_for_test(aptos_framework);
         features::change_feature_flags_for_testing(
             aptos_framework,
-            vector[DELEGATION_POOLS, MODULE_EVENT, OPERATOR_BENEFICIARY_CHANGE, COMMISSION_CHANGE_DELEGATION_POOL],
-            vector[]
+            vector[
+                DELEGATION_POOLS,
+                MODULE_EVENT,
+                OPERATOR_BENEFICIARY_CHANGE,
+                COMMISSION_CHANGE_DELEGATION_POOL],
+            vector[],
         );
     }
 
@@ -2324,7 +2521,9 @@ module aptos_framework::delegation_pool {
         should_join_validator_set: bool,
         should_end_epoch: bool,
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage, DelegationPoolAllowlisting {
-        initialize_test_validator_custom(validator, amount, should_join_validator_set, should_end_epoch, 0);
+        initialize_test_validator_custom(
+            validator, amount, should_join_validator_set, should_end_epoch, 0
+        );
     }
 
     #[test_only]
@@ -2343,7 +2542,9 @@ module aptos_framework::delegation_pool {
         initialize_delegation_pool(validator, commission_percentage, vector::empty<u8>());
         let pool_address = get_owned_pool_address(validator_address);
 
-        stake::rotate_consensus_key(validator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1);
+        stake::rotate_consensus_key(
+            validator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1
+        );
 
         if (amount > 0) {
             stake::mint(validator, amount);
@@ -2361,9 +2562,7 @@ module aptos_framework::delegation_pool {
 
     #[test_only]
     fun unlock_with_min_stake_disabled(
-        delegator: &signer,
-        pool_address: address,
-        amount: u64
+        delegator: &signer, pool_address: address, amount: u64
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         synchronize_delegation_pool(pool_address);
 
@@ -2376,30 +2575,32 @@ module aptos_framework::delegation_pool {
     }
 
     #[test_only]
-    public fun enable_delegation_pool_allowlisting_feature(aptos_framework: &signer) {
+    public fun enable_delegation_pool_allowlisting_feature(
+        aptos_framework: &signer
+    ) {
         features::change_feature_flags_for_testing(
             aptos_framework,
             vector[features::get_delegation_pool_allowlisting_feature()],
-            vector[]
+            vector[],
         );
     }
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x3000A, location = Self)]
     public entry fun test_delegation_pools_disabled(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         initialize_for_test(aptos_framework);
-        features::change_feature_flags_for_testing(aptos_framework, vector[], vector[DELEGATION_POOLS]);
+        features::change_feature_flags_for_testing(
+            aptos_framework, vector[], vector[DELEGATION_POOLS]
+        );
 
         initialize_delegation_pool(validator, 0, vector::empty<u8>());
     }
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_set_operator_and_delegated_voter(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         initialize_for_test(aptos_framework);
 
@@ -2420,8 +2621,7 @@ module aptos_framework::delegation_pool {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x60001, location = Self)]
     public entry fun test_cannot_set_operator(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         initialize_for_test(aptos_framework);
         // account does not own any delegation pool
@@ -2431,8 +2631,7 @@ module aptos_framework::delegation_pool {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x60001, location = Self)]
     public entry fun test_cannot_set_delegated_voter(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         initialize_for_test(aptos_framework);
         // account does not own any delegation pool
@@ -2442,8 +2641,7 @@ module aptos_framework::delegation_pool {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x80002, location = Self)]
     public entry fun test_already_owns_delegation_pool(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         initialize_for_test(aptos_framework);
         initialize_delegation_pool(validator, 0, x"00");
@@ -2453,8 +2651,7 @@ module aptos_framework::delegation_pool {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000B, location = Self)]
     public entry fun test_cannot_withdraw_zero_stake(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         initialize_for_test(aptos_framework);
         initialize_delegation_pool(validator, 0, x"00");
@@ -2463,8 +2660,7 @@ module aptos_framework::delegation_pool {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_initialize_delegation_pool(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage {
         initialize_for_test(aptos_framework);
 
@@ -2501,7 +2697,7 @@ module aptos_framework::delegation_pool {
             true,
             1,
             100,
-            1000000
+            1000000,
         );
 
         let validator_address = signer::address_of(validator);
@@ -2511,7 +2707,9 @@ module aptos_framework::delegation_pool {
         initialize_delegation_pool(validator, 3735, vector::empty<u8>());
         let pool_address = get_owned_pool_address(validator_address);
 
-        stake::rotate_consensus_key(validator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1);
+        stake::rotate_consensus_key(
+            validator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1
+        );
 
         // zero `add_stake` fee as validator is not producing rewards this epoch
         assert!(get_add_stake_fee(pool_address, 1000000 * ONE_APT) == 0, 0);
@@ -2549,7 +2747,13 @@ module aptos_framework::delegation_pool {
         add_stake(delegator1, pool_address, 10000 * ONE_APT);
 
         let fee = get_add_stake_fee(pool_address, 10000 * ONE_APT);
-        assert_delegation(delegator1_address, pool_address, delegator1_active + 10000 * ONE_APT - fee, 0, 0);
+        assert_delegation(
+            delegator1_address,
+            pool_address,
+            delegator1_active + 10000 * ONE_APT - fee,
+            0,
+            0,
+        );
 
         // delegator 2 should not benefit in any way from this new stake
         assert_delegation(delegator2_address, pool_address, 1000000000000, 0, 0);
@@ -2583,17 +2787,27 @@ module aptos_framework::delegation_pool {
         add_stake(delegator1, pool_address, 20000 * ONE_APT);
 
         fee = get_add_stake_fee(pool_address, 20000 * ONE_APT);
-        assert_delegation(delegator1_address, pool_address, delegator1_active + 20000 * ONE_APT - fee, 0, 0);
+        assert_delegation(
+            delegator1_address,
+            pool_address,
+            delegator1_active + 20000 * ONE_APT - fee,
+            0,
+            0,
+        );
 
         // delegator 1 unlocks his entire newly added stake
         unlock(delegator1, pool_address, 20000 * ONE_APT - fee);
         end_aptos_epoch();
         // delegator 1 should own previous 11131957502250 active * 1.006265 and 20000 coins pending_inactive
-        assert_delegation(delegator1_address, pool_address, 11201699216002, 0, 2000000000000);
+        assert_delegation(
+            delegator1_address, pool_address, 11201699216002, 0, 2000000000000
+        );
 
         // stakes should remain the same - `Self::get_stake` correctly calculates them
         synchronize_delegation_pool(pool_address);
-        assert_delegation(delegator1_address, pool_address, 11201699216002, 0, 2000000000000);
+        assert_delegation(
+            delegator1_address, pool_address, 11201699216002, 0, 2000000000000
+        );
 
         let reward_period_start_time_in_sec = timestamp::now_seconds();
         // Enable rewards rate decrease. Initially rewards rate is still 1% every epoch. Rewards rate halves every year.
@@ -2609,13 +2823,15 @@ module aptos_framework::delegation_pool {
         features::change_feature_flags_for_testing(
             aptos_framework,
             vector[features::get_periodical_reward_rate_decrease_feature()],
-            vector[]
+            vector[],
         );
 
         // add more stake from delegator 1
         stake::mint(delegator1, 20000 * ONE_APT);
         let delegator1_pending_inactive: u64;
-        (delegator1_active, _, delegator1_pending_inactive) = get_stake(pool_address, delegator1_address);
+        (delegator1_active, _, delegator1_pending_inactive) = get_stake(
+            pool_address, delegator1_address
+        );
         fee = get_add_stake_fee(pool_address, 20000 * ONE_APT);
         add_stake(delegator1, pool_address, 20000 * ONE_APT);
 
@@ -2624,18 +2840,22 @@ module aptos_framework::delegation_pool {
             pool_address,
             delegator1_active + 20000 * ONE_APT - fee,
             0,
-            delegator1_pending_inactive
+            delegator1_pending_inactive,
         );
 
         // delegator 1 unlocks his entire newly added stake
         unlock(delegator1, pool_address, 20000 * ONE_APT - fee);
         end_aptos_epoch();
         // delegator 1 should own previous 11201699216002 active * ~1.01253 and 20000 * ~1.01253 + 20000 coins pending_inactive
-        assert_delegation(delegator1_address, pool_address, 11342056366822, 0, 4025059974939);
+        assert_delegation(
+            delegator1_address, pool_address, 11342056366822, 0, 4025059974939
+        );
 
         // stakes should remain the same - `Self::get_stake` correctly calculates them
         synchronize_delegation_pool(pool_address);
-        assert_delegation(delegator1_address, pool_address, 11342056366822, 0, 4025059974939);
+        assert_delegation(
+            delegator1_address, pool_address, 11342056366822, 0, 4025059974939
+        );
 
         fast_forward_seconds(one_year_in_secs);
     }
@@ -2706,8 +2926,7 @@ module aptos_framework::delegation_pool {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x10008, location = Self)]
     public entry fun test_add_stake_min_amount(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage, DelegationPoolAllowlisting {
         initialize_for_test(aptos_framework);
         initialize_test_validator(validator, MIN_COINS_ON_SHARES_POOL - 1, false, false);
@@ -2715,8 +2934,7 @@ module aptos_framework::delegation_pool {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_add_stake_single(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage, DelegationPoolAllowlisting {
         initialize_for_test(aptos_framework);
         initialize_test_validator(validator, 1000 * ONE_APT, false, false);
@@ -2764,7 +2982,13 @@ module aptos_framework::delegation_pool {
         add_stake(validator, pool_address, 100 * ONE_APT);
 
         let fee2 = get_add_stake_fee(pool_address, 100 * ONE_APT);
-        assert_delegation(validator_address, pool_address, 1600 * ONE_APT - fee1 - fee2, 0, 0);
+        assert_delegation(
+            validator_address,
+            pool_address,
+            1600 * ONE_APT - fee1 - fee2,
+            0,
+            0,
+        );
         // check `add_stake` fee has been transferred to the null shareholder
         assert_delegation(NULL_SHAREHOLDER, pool_address, fee1 + fee2, 0, 0);
         stake::assert_stake_pool(pool_address, 1250 * ONE_APT, 0, 350 * ONE_APT, 0);
@@ -2777,7 +3001,13 @@ module aptos_framework::delegation_pool {
         // check that shares of null shareholder have been released
         assert_delegation(NULL_SHAREHOLDER, pool_address, 0, 0, 0);
         synchronize_delegation_pool(pool_address);
-        assert!(pool_u64::shares(&borrow_global<DelegationPool>(pool_address).active_shares, NULL_SHAREHOLDER) == 0, 0);
+        assert!(
+            pool_u64::shares(
+                &borrow_global<DelegationPool>(pool_address).active_shares,
+                NULL_SHAREHOLDER,
+            ) == 0,
+            0,
+        );
         assert_delegation(NULL_SHAREHOLDER, pool_address, 0, 0, 0);
 
         // add 200 coins being pending_active until next epoch
@@ -2798,7 +3028,13 @@ module aptos_framework::delegation_pool {
         // check that shares of null shareholder have been released
         assert_delegation(NULL_SHAREHOLDER, pool_address, 0, 0, 0);
         synchronize_delegation_pool(pool_address);
-        assert!(pool_u64::shares(&borrow_global<DelegationPool>(pool_address).active_shares, NULL_SHAREHOLDER) == 0, 0);
+        assert!(
+            pool_u64::shares(
+                &borrow_global<DelegationPool>(pool_address).active_shares,
+                NULL_SHAREHOLDER,
+            ) == 0,
+            0,
+        );
         assert_delegation(NULL_SHAREHOLDER, pool_address, 0, 0, 0);
     }
 
@@ -2889,17 +3125,35 @@ module aptos_framework::delegation_pool {
 
         // cannot unlock pending_active stake (only 100/300 stake can be displaced)
         unlock(validator, pool_address, 100 * ONE_APT);
-        assert_delegation(validator_address, pool_address, 200 * ONE_APT - fee, 0, 100 * ONE_APT);
-        assert_pending_withdrawal(validator_address, pool_address, true, 0, false, 100 * ONE_APT);
+        assert_delegation(
+            validator_address,
+            pool_address,
+            200 * ONE_APT - fee,
+            0,
+            100 * ONE_APT,
+        );
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 0, false, 100 * ONE_APT
+        );
         stake::assert_stake_pool(pool_address, 0, 0, 200 * ONE_APT, 100 * ONE_APT);
         assert_inactive_shares_pool(pool_address, 0, true, 100 * ONE_APT);
 
         // reactivate entire pending_inactive stake progressively
         reactivate_stake(validator, pool_address, 50 * ONE_APT);
 
-        assert_delegation(validator_address, pool_address, 250 * ONE_APT - fee, 0, 50 * ONE_APT);
-        assert_pending_withdrawal(validator_address, pool_address, true, 0, false, 50 * ONE_APT);
-        stake::assert_stake_pool(pool_address, 50 * ONE_APT, 0, 200 * ONE_APT, 50 * ONE_APT);
+        assert_delegation(
+            validator_address,
+            pool_address,
+            250 * ONE_APT - fee,
+            0,
+            50 * ONE_APT,
+        );
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 0, false, 50 * ONE_APT
+        );
+        stake::assert_stake_pool(
+            pool_address, 50 * ONE_APT, 0, 200 * ONE_APT, 50 * ONE_APT
+        );
 
         reactivate_stake(validator, pool_address, 50 * ONE_APT);
 
@@ -2918,15 +3172,23 @@ module aptos_framework::delegation_pool {
         unlock(validator, pool_address, 150 * ONE_APT);
         assert_delegation(validator_address, pool_address, 15100000001, 0, 14999999999);
         stake::assert_stake_pool(pool_address, 15100000001, 0, 0, 14999999999);
-        assert_pending_withdrawal(validator_address, pool_address, true, 0, false, 14999999999);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 0, false, 14999999999
+        );
 
-        assert!(stake::get_remaining_lockup_secs(pool_address) == LOCKUP_CYCLE_SECONDS - EPOCH_DURATION, 0);
+        assert!(
+            stake::get_remaining_lockup_secs(pool_address)
+                == LOCKUP_CYCLE_SECONDS - EPOCH_DURATION,
+            0,
+        );
         end_aptos_epoch(); // additionally forwards EPOCH_DURATION seconds
 
         // pending_inactive stake should have not been inactivated
         // 15100000001 * 1.01 active stake + 14999999999 pending_inactive * 1.01 stake
         assert_delegation(validator_address, pool_address, 15251000001, 0, 15149999998);
-        assert_pending_withdrawal(validator_address, pool_address, true, 0, false, 15149999998);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 0, false, 15149999998
+        );
         stake::assert_stake_pool(pool_address, 15251000001, 0, 0, 15149999998);
 
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS - 3 * EPOCH_DURATION);
@@ -2934,7 +3196,9 @@ module aptos_framework::delegation_pool {
 
         // 15251000001 * 1.01 active stake + 15149999998 * 1.01 pending_inactive(now inactive) stake
         assert_delegation(validator_address, pool_address, 15403510001, 15301499997, 0);
-        assert_pending_withdrawal(validator_address, pool_address, true, 0, true, 15301499997);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 0, true, 15301499997
+        );
         stake::assert_stake_pool(pool_address, 15403510001, 15301499997, 0, 0);
 
         // add 50 coins from another account
@@ -2965,7 +3229,9 @@ module aptos_framework::delegation_pool {
         // new pending withdrawal can be created on lockup cycle 1
         unlock(validator, pool_address, 5403510001);
         assert_delegation(validator_address, pool_address, 10000000000, 0, 5403510000);
-        assert_pending_withdrawal(validator_address, pool_address, true, 1, false, 5403510000);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 1, false, 5403510000
+        );
 
         // end lockup cycle 1
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
@@ -2973,7 +3239,9 @@ module aptos_framework::delegation_pool {
 
         // 10000000000 * 1.01 active stake + 5403510000 * 1.01 pending_inactive(now inactive) stake
         assert_delegation(validator_address, pool_address, 10100000000, 5457545100, 0);
-        assert_pending_withdrawal(validator_address, pool_address, true, 1, true, 5457545100);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 1, true, 5457545100
+        );
 
         // unlock when the pending withdrawal exists and gets automatically executed
         let balance = coin::balance<AptosCoin>(validator_address);
@@ -2981,7 +3249,9 @@ module aptos_framework::delegation_pool {
         assert!(coin::balance<AptosCoin>(validator_address) == balance + 5457545100, 0);
         assert_delegation(validator_address, pool_address, 0, 0, 10100000000);
         // this is the new pending withdrawal replacing the executed one
-        assert_pending_withdrawal(validator_address, pool_address, true, 2, false, 10100000000);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 2, false, 10100000000
+        );
 
         // create dummy validator to ensure the existing validator can leave the set
         initialize_test_validator(delegator, 100 * ONE_APT, true, true);
@@ -3003,7 +3273,9 @@ module aptos_framework::delegation_pool {
         // 10100000000 * 1.01 * 1.01 pending_inactive stake
         assert_delegation(validator_address, pool_address, 0, 0, 10303010000);
         // the pending withdrawal should be reported as still pending
-        assert_pending_withdrawal(validator_address, pool_address, true, 2, false, 10303010000);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 2, false, 10303010000
+        );
 
         // validator is inactive and lockup expired => pending_inactive stake is withdrawable
         balance = coin::balance<AptosCoin>(validator_address);
@@ -3014,7 +3286,9 @@ module aptos_framework::delegation_pool {
         assert_pending_withdrawal(validator_address, pool_address, false, 0, false, 0);
         stake::assert_stake_pool(pool_address, 5100500001, 0, 0, 0);
         // pending_inactive shares pool has not been deleted (as can still `unlock` this OLC)
-        assert_inactive_shares_pool(pool_address, observed_lockup_cycle(pool_address), true, 0);
+        assert_inactive_shares_pool(
+            pool_address, observed_lockup_cycle(pool_address), true, 0
+        );
 
         stake::mint(validator, 30 * ONE_APT);
         add_stake(validator, pool_address, 30 * ONE_APT);
@@ -3022,7 +3296,9 @@ module aptos_framework::delegation_pool {
 
         assert_delegation(validator_address, pool_address, 1999999999, 0, 1000000000);
         // the pending withdrawal should be reported as still pending
-        assert_pending_withdrawal(validator_address, pool_address, true, 2, false, 1000000000);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 2, false, 1000000000
+        );
 
         balance = coin::balance<AptosCoin>(validator_address);
         // pending_inactive balance would be under threshold => redeem entire balance
@@ -3098,12 +3374,18 @@ module aptos_framework::delegation_pool {
         assert!(total_coins_inactive(pool_address) == inactive, 0);
         synchronize_delegation_pool(pool_address);
         // total_coins_inactive == previous inactive stake + previous pending_inactive stake and its rewards
-        assert!(total_coins_inactive(pool_address) == inactive + pending_inactive + pending_inactive / 100, 0);
+        assert!(
+            total_coins_inactive(pool_address)
+                == inactive + pending_inactive + pending_inactive / 100,
+            0,
+        );
 
         // withdraw some of inactive stake of delegator 2
         let total_coins_inactive = total_coins_inactive(pool_address);
         withdraw(delegator2, pool_address, 3049999998);
-        assert!(total_coins_inactive(pool_address) == total_coins_inactive - 3049999997, 0);
+        assert!(
+            total_coins_inactive(pool_address) == total_coins_inactive - 3049999997, 0
+        );
 
         // unlock some stake from delegator `validator`
         unlock(validator, pool_address, 50 * ONE_APT);
@@ -3144,8 +3426,7 @@ module aptos_framework::delegation_pool {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_reactivate_stake_single(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage, DelegationPoolAllowlisting {
         initialize_for_test(aptos_framework);
         initialize_test_validator(validator, 200 * ONE_APT, true, true);
@@ -3155,17 +3436,29 @@ module aptos_framework::delegation_pool {
 
         // unlock some stake from the active one
         unlock(validator, pool_address, 100 * ONE_APT);
-        assert_delegation(validator_address, pool_address, 100 * ONE_APT, 0, 100 * ONE_APT);
+        assert_delegation(
+            validator_address, pool_address, 100 * ONE_APT, 0, 100 * ONE_APT
+        );
         stake::assert_stake_pool(pool_address, 100 * ONE_APT, 0, 0, 100 * ONE_APT);
-        assert_pending_withdrawal(validator_address, pool_address, true, 0, false, 100 * ONE_APT);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 0, false, 100 * ONE_APT
+        );
 
         // add some stake to pending_active state
         stake::mint(validator, 150 * ONE_APT);
         add_stake(validator, pool_address, 150 * ONE_APT);
 
         let fee = get_add_stake_fee(pool_address, 150 * ONE_APT);
-        assert_delegation(validator_address, pool_address, 250 * ONE_APT - fee, 0, 100 * ONE_APT);
-        stake::assert_stake_pool(pool_address, 100 * ONE_APT, 0, 150 * ONE_APT, 100 * ONE_APT);
+        assert_delegation(
+            validator_address,
+            pool_address,
+            250 * ONE_APT - fee,
+            0,
+            100 * ONE_APT,
+        );
+        stake::assert_stake_pool(
+            pool_address, 100 * ONE_APT, 0, 150 * ONE_APT, 100 * ONE_APT
+        );
 
         // can reactivate only pending_inactive stake
         reactivate_stake(validator, pool_address, 150 * ONE_APT);
@@ -3189,7 +3482,9 @@ module aptos_framework::delegation_pool {
 
         // 20200000001 active stake * 1.01 + 14999999999 pending_inactive stake * 1.01
         assert_delegation(validator_address, pool_address, 20402000001, 15149999998, 0);
-        assert_pending_withdrawal(validator_address, pool_address, true, 0, true, 15149999998);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 0, true, 15149999998
+        );
 
         // cannot reactivate inactive stake
         reactivate_stake(validator, pool_address, 15149999998);
@@ -3199,11 +3494,15 @@ module aptos_framework::delegation_pool {
         unlock(validator, pool_address, 100 * ONE_APT);
         assert!(coin::balance<AptosCoin>(validator_address) == 15149999998, 0);
         assert_delegation(validator_address, pool_address, 10402000002, 0, 9999999999);
-        assert_pending_withdrawal(validator_address, pool_address, true, 1, false, 9999999999);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 1, false, 9999999999
+        );
 
         // reactivate the new pending withdrawal almost entirely
         reactivate_stake(validator, pool_address, 8999999999);
-        assert_pending_withdrawal(validator_address, pool_address, true, 1, false, 1000000000);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 1, false, 1000000000
+        );
         // reactivate remaining stake of the new pending withdrawal
         reactivate_stake(validator, pool_address, 1000000000);
         assert_pending_withdrawal(validator_address, pool_address, false, 0, false, 0);
@@ -3228,14 +3527,18 @@ module aptos_framework::delegation_pool {
         add_stake(delegator, pool_address, 200 * ONE_APT);
 
         unlock(validator, pool_address, 100 * ONE_APT);
-        assert_pending_withdrawal(validator_address, pool_address, true, 0, false, 100 * ONE_APT);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 0, false, 100 * ONE_APT
+        );
 
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
         end_aptos_epoch();
 
         assert_delegation(delegator_address, pool_address, 200 * ONE_APT, 0, 0);
         assert_delegation(validator_address, pool_address, 90899999999, 10100000000, 0);
-        assert_pending_withdrawal(validator_address, pool_address, true, 0, true, 10100000000);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 0, true, 10100000000
+        );
         assert_inactive_shares_pool(pool_address, 0, true, 100 * ONE_APT);
 
         // check cannot withdraw inactive stake unlocked by others
@@ -3246,7 +3549,9 @@ module aptos_framework::delegation_pool {
         unlock(delegator, pool_address, 100 * ONE_APT);
         assert_delegation(delegator_address, pool_address, 10000000000, 0, 9999999999);
         assert_delegation(validator_address, pool_address, 90900000000, 10100000000, 0);
-        assert_pending_withdrawal(delegator_address, pool_address, true, 1, false, 9999999999);
+        assert_pending_withdrawal(
+            delegator_address, pool_address, true, 1, false, 9999999999
+        );
 
         // check cannot withdraw inactive stake unlocked by others even if owning pending_inactive
         withdraw(delegator, pool_address, MAX_U64);
@@ -3264,7 +3569,9 @@ module aptos_framework::delegation_pool {
         end_aptos_epoch();
 
         assert_delegation(delegator_address, pool_address, 10100000000, 10099999998, 0);
-        assert_pending_withdrawal(delegator_address, pool_address, true, 1, true, 10099999998);
+        assert_pending_withdrawal(
+            delegator_address, pool_address, true, 1, true, 10099999998
+        );
         assert_inactive_shares_pool(pool_address, 1, true, 9999999999);
 
         // use too small of an unlock amount to actually transfer shares to the pending_inactive pool
@@ -3273,7 +3580,9 @@ module aptos_framework::delegation_pool {
         unlock_with_min_stake_disabled(delegator, pool_address, 1);
         stake::assert_stake_pool(pool_address, 101909000001, 10099999998, 0, 0);
         assert_delegation(delegator_address, pool_address, 10100000000, 10099999998, 0);
-        assert_pending_withdrawal(delegator_address, pool_address, true, 1, true, 10099999998);
+        assert_pending_withdrawal(
+            delegator_address, pool_address, true, 1, true, 10099999998
+        );
 
         // implicitly execute the pending withdrawal by unlocking min stake to buy 1 share
         unlock_with_min_stake_disabled(delegator, pool_address, 2);
@@ -3357,13 +3666,19 @@ module aptos_framework::delegation_pool {
 
         assert_delegation(delegator_address, pool_address, 0, 0, 10000000002);
         assert_delegation(validator_address, pool_address, 103030100001, 20000000001, 0);
-        assert_pending_withdrawal(validator_address, pool_address, true, 0, true, 20000000001);
-        assert_pending_withdrawal(delegator_address, pool_address, true, 1, false, 10000000002);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 0, true, 20000000001
+        );
+        assert_pending_withdrawal(
+            delegator_address, pool_address, true, 1, false, 10000000002
+        );
         stake::assert_stake_pool(pool_address, 103030100001, 20000000001, 0, 10000000002);
 
         // reactivate validator
         stake::join_validator_set(validator, pool_address);
-        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 0);
+        assert!(
+            stake::get_validator_state(pool_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 0
+        );
         end_aptos_epoch();
 
         assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_ACTIVE, 0);
@@ -3371,13 +3686,19 @@ module aptos_framework::delegation_pool {
         stake::assert_stake_pool(pool_address, 103030100001, 20000000001, 0, 10000000002);
 
         synchronize_delegation_pool(pool_address);
-        assert_pending_withdrawal(validator_address, pool_address, true, 0, true, 20000000001);
-        assert_pending_withdrawal(delegator_address, pool_address, true, 1, false, 10000000002);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 0, true, 20000000001
+        );
+        assert_pending_withdrawal(
+            delegator_address, pool_address, true, 1, false, 10000000002
+        );
         assert!(observed_lockup_cycle(pool_address) == observed_lockup_cycle, 0);
 
         // cannot withdraw pending_inactive stake anymore
         withdraw(delegator, pool_address, 10000000002);
-        assert_pending_withdrawal(delegator_address, pool_address, true, 1, false, 10000000002);
+        assert_pending_withdrawal(
+            delegator_address, pool_address, true, 1, false, 10000000002
+        );
 
         // earning rewards is resumed from this epoch on
         end_aptos_epoch();
@@ -3385,17 +3706,24 @@ module aptos_framework::delegation_pool {
 
         // new pending_inactive stake earns rewards but so does the old one
         unlock(validator, pool_address, 104060401001);
-        assert_pending_withdrawal(validator_address, pool_address, true, 1, false, 104060401000);
-        assert_pending_withdrawal(delegator_address, pool_address, true, 1, false, 10100000002);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 1, false, 104060401000
+        );
+        assert_pending_withdrawal(
+            delegator_address, pool_address, true, 1, false, 10100000002
+        );
         end_aptos_epoch();
-        assert_pending_withdrawal(validator_address, pool_address, true, 1, false, 105101005010);
-        assert_pending_withdrawal(delegator_address, pool_address, true, 1, false, 10201000002);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 1, false, 105101005010
+        );
+        assert_pending_withdrawal(
+            delegator_address, pool_address, true, 1, false, 10201000002
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_stake_rewards(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage, DelegationPoolAllowlisting {
         initialize_for_test(aptos_framework);
         initialize_test_validator(validator, 1000 * ONE_APT, true, true);
@@ -3453,7 +3781,13 @@ module aptos_framework::delegation_pool {
         add_stake(validator, pool_address, 1000 * ONE_APT);
 
         fee = get_add_stake_fee(pool_address, 1000 * ONE_APT);
-        assert_delegation(validator_address, pool_address, 211717346653 - fee, 20199999998, 0);
+        assert_delegation(
+            validator_address,
+            pool_address,
+            211717346653 - fee,
+            20199999998,
+            0,
+        );
 
         end_aptos_epoch();
         // 111717346653 active stake * 1.01 + 100000000000 pending_active stake + 20199999998 inactive stake
@@ -3527,8 +3861,7 @@ module aptos_framework::delegation_pool {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_pending_inactive_stake_rewards(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage, DelegationPoolAllowlisting {
         initialize_for_test(aptos_framework);
         initialize_test_validator(validator, 1000 * ONE_APT, true, true);
@@ -3599,7 +3932,9 @@ module aptos_framework::delegation_pool {
 
         // create the pending withdrawal of delegator 1 in lockup cycle 0
         unlock(delegator1, pool_address, 150 * ONE_APT);
-        assert_pending_withdrawal(delegator1_address, pool_address, true, 0, false, 14999999999);
+        assert_pending_withdrawal(
+            delegator1_address, pool_address, true, 0, false, 14999999999
+        );
 
         // move to lockup cycle 1
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
@@ -3607,22 +3942,32 @@ module aptos_framework::delegation_pool {
 
         // create the pending withdrawal of delegator 2 in lockup cycle 1
         unlock(delegator2, pool_address, 150 * ONE_APT);
-        assert_pending_withdrawal(delegator2_address, pool_address, true, 1, false, 14999999999);
+        assert_pending_withdrawal(
+            delegator2_address, pool_address, true, 1, false, 14999999999
+        );
         // 14999999999 pending_inactive stake * 1.01
-        assert_pending_withdrawal(delegator1_address, pool_address, true, 0, true, 15149999998);
+        assert_pending_withdrawal(
+            delegator1_address, pool_address, true, 0, true, 15149999998
+        );
 
         // move to lockup cycle 2
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
         end_aptos_epoch();
 
-        assert_pending_withdrawal(delegator2_address, pool_address, true, 1, true, 15149999998);
-        assert_pending_withdrawal(delegator1_address, pool_address, true, 0, true, 15149999998);
+        assert_pending_withdrawal(
+            delegator2_address, pool_address, true, 1, true, 15149999998
+        );
+        assert_pending_withdrawal(
+            delegator1_address, pool_address, true, 0, true, 15149999998
+        );
 
         // both delegators who unlocked at different lockup cycles should be able to withdraw their stakes
         withdraw(delegator1, pool_address, 15149999998);
         withdraw(delegator2, pool_address, 5149999998);
 
-        assert_pending_withdrawal(delegator2_address, pool_address, true, 1, true, 10000000001);
+        assert_pending_withdrawal(
+            delegator2_address, pool_address, true, 1, true, 10000000001
+        );
         assert_pending_withdrawal(delegator1_address, pool_address, false, 0, false, 0);
         assert!(coin::balance<AptosCoin>(delegator1_address) == 15149999998, 0);
         assert!(coin::balance<AptosCoin>(delegator2_address) == 5149999997, 0);
@@ -3634,9 +3979,13 @@ module aptos_framework::delegation_pool {
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
         end_aptos_epoch();
 
-        assert_pending_withdrawal(delegator2_address, pool_address, true, 1, true, 10000000001);
+        assert_pending_withdrawal(
+            delegator2_address, pool_address, true, 1, true, 10000000001
+        );
         // 9999999999 pending_inactive stake * 1.01
-        assert_pending_withdrawal(delegator1_address, pool_address, true, 2, true, 10099999998);
+        assert_pending_withdrawal(
+            delegator1_address, pool_address, true, 2, true, 10099999998
+        );
 
         // withdraw inactive stake of delegator 2 left from lockup cycle 1 in cycle 3
         withdraw(delegator2, pool_address, 10000000001);
@@ -3645,7 +3994,9 @@ module aptos_framework::delegation_pool {
 
         // withdraw inactive stake of delegator 1 left from previous lockup cycle
         withdraw(delegator1, pool_address, 10099999998);
-        assert!(coin::balance<AptosCoin>(delegator1_address) == 15149999998 + 10099999998, 0);
+        assert!(
+            coin::balance<AptosCoin>(delegator1_address) == 15149999998 + 10099999998, 0
+        );
         assert_pending_withdrawal(delegator1_address, pool_address, false, 0, false, 0);
     }
 
@@ -3689,7 +4040,9 @@ module aptos_framework::delegation_pool {
         assert_delegation(validator_address, pool_address, 0, 0, 0);
 
         // activate validator
-        stake::rotate_consensus_key(validator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1);
+        stake::rotate_consensus_key(
+            validator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1
+        );
         stake::join_validator_set(validator, pool_address);
         end_aptos_epoch();
 
@@ -3740,7 +4093,9 @@ module aptos_framework::delegation_pool {
         // distribute operator pending_inactive commission rewards
         synchronize_delegation_pool(pool_address);
         // 99999999 pending_inactive rewards * 0.1265
-        assert_pending_withdrawal(validator_address, pool_address, true, 0, false, 12649998);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 0, false, 12649998
+        );
 
         // 209090300 active rewards * 0.1265 + 115658596 active stake * 1.008735
         // 99999999 pending_inactive rewards * 0.1265
@@ -3761,7 +4116,9 @@ module aptos_framework::delegation_pool {
         assert_delegation(validator_address, pool_address, 171083360, 25536995, 0);
         // distribute operator pending_inactive commission rewards
         synchronize_delegation_pool(pool_address);
-        assert_pending_withdrawal(validator_address, pool_address, true, 0, true, 25536995);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 0, true, 25536995
+        );
 
         // check operator is not rewarded by `add_stake` fees
         stake::mint(delegator1, 100 * ONE_APT);
@@ -3785,7 +4142,9 @@ module aptos_framework::delegation_pool {
 
         // in-flight pending_inactive commission can coexist with previous inactive commission
         assert_delegation(validator_address, pool_address, 227532711, 25536996, 13671160);
-        assert_pending_withdrawal(validator_address, pool_address, true, 0, true, 25536996);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 0, true, 25536996
+        );
 
         // distribute in-flight pending_inactive commission, implicitly executing the inactive withdrawal of operator
         coin::register<AptosCoin>(validator);
@@ -3795,7 +4154,9 @@ module aptos_framework::delegation_pool {
         // in-flight commission has been synced, implicitly used to buy shares for operator
         // expect operator stake to be slightly less than previously reported by `Self::get_stake`
         assert_delegation(validator_address, pool_address, 227532711, 0, 13671159);
-        assert_pending_withdrawal(validator_address, pool_address, true, 1, false, 13671159);
+        assert_pending_withdrawal(
+            validator_address, pool_address, true, 1, false, 13671159
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, old_operator = @0x123, delegator = @0x010, new_operator = @0x020)]
@@ -3826,7 +4187,9 @@ module aptos_framework::delegation_pool {
         unlock(delegator, pool_address, 100 * ONE_APT);
 
         // activate validator
-        stake::rotate_consensus_key(old_operator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1);
+        stake::rotate_consensus_key(
+            old_operator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1
+        );
         stake::join_validator_set(old_operator, pool_address);
         end_aptos_epoch();
 
@@ -3860,13 +4223,7 @@ module aptos_framework::delegation_pool {
         assert_delegation(new_operator_address, pool_address, 26050290, 0, 26050290);
     }
 
-    #[test(
-        aptos_framework = @aptos_framework,
-        operator1 = @0x123,
-        delegator = @0x010,
-        beneficiary = @0x020,
-        operator2 = @0x030
-    )]
+    #[test(aptos_framework = @aptos_framework, operator1 = @0x123, delegator = @0x010, beneficiary = @0x020, operator2 = @0x030)]
     public entry fun test_set_beneficiary_for_operator(
         aptos_framework: &signer,
         operator1: &signer,
@@ -3899,7 +4256,9 @@ module aptos_framework::delegation_pool {
         unlock(delegator, pool_address, 1000000 * ONE_APT);
 
         // activate validator
-        stake::rotate_consensus_key(operator1, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1);
+        stake::rotate_consensus_key(
+            operator1, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1
+        );
         stake::join_validator_set(operator1, pool_address);
         end_aptos_epoch();
 
@@ -3964,7 +4323,9 @@ module aptos_framework::delegation_pool {
         unlock(delegator, pool_address, 100 * ONE_APT);
 
         // activate validator
-        stake::rotate_consensus_key(operator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1);
+        stake::rotate_consensus_key(
+            operator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1
+        );
         stake::join_validator_set(operator, pool_address);
         end_aptos_epoch();
 
@@ -4026,7 +4387,9 @@ module aptos_framework::delegation_pool {
         unlock(delegator, pool_address, 100 * ONE_APT);
 
         // activate validator
-        stake::rotate_consensus_key(operator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1);
+        stake::rotate_consensus_key(
+            operator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1
+        );
         stake::join_validator_set(operator, pool_address);
         end_aptos_epoch();
 
@@ -4108,7 +4471,9 @@ module aptos_framework::delegation_pool {
         assert_delegation(delegator1_address, pool_address, 1000000000, 0, 4000000000);
 
         // pending_inactive balance would be under threshold => move entire balance
-        reactivate_stake(delegator1, pool_address, 4000000000 - (MIN_COINS_ON_SHARES_POOL - 1));
+        reactivate_stake(
+            delegator1, pool_address, 4000000000 - (MIN_COINS_ON_SHARES_POOL - 1)
+        );
         assert_delegation(delegator1_address, pool_address, 5000000000, 0, 0);
 
         // active + pending_inactive balance < 2 * MIN_COINS_ON_SHARES_POOL
@@ -4178,9 +4543,11 @@ module aptos_framework::delegation_pool {
         aptos_governance::initialize_partial_voting(aptos_framework);
         features::change_feature_flags_for_testing(
             aptos_framework,
-            vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting(
-            )],
-            vector[]);
+            vector[
+                features::get_partial_governance_voting(),
+                features::get_delegation_pool_partial_governance_voting()],
+            vector[],
+        );
         initialize_test_validator(validator, 100 * ONE_APT, true, false);
 
         let validator_address = signer::address_of(validator);
@@ -4224,9 +4591,11 @@ module aptos_framework::delegation_pool {
         aptos_governance::initialize_partial_voting(aptos_framework);
         features::change_feature_flags_for_testing(
             aptos_framework,
-            vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting(
-            )],
-            vector[]);
+            vector[
+                features::get_partial_governance_voting(),
+                features::get_delegation_pool_partial_governance_voting()],
+            vector[],
+        );
         initialize_test_validator(validator, 100 * ONE_APT, true, false);
 
         let validator_address = signer::address_of(validator);
@@ -4254,14 +4623,7 @@ module aptos_framework::delegation_pool {
         );
     }
 
-    #[test(
-        aptos_framework = @aptos_framework,
-        validator = @0x123,
-        delegator1 = @0x010,
-        delegator2 = @0x020,
-        voter1 = @0x030,
-        voter2 = @0x040
-    )]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator1 = @0x010, delegator2 = @0x020, voter1 = @0x030, voter2 = @0x040)]
     public entry fun test_voting_power_change(
         aptos_framework: &signer,
         validator: &signer,
@@ -4280,9 +4642,10 @@ module aptos_framework::delegation_pool {
         aptos_governance::initialize_partial_voting(aptos_framework);
         features::change_feature_flags_for_testing(
             aptos_framework,
-            vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting(
-            )],
-            vector[]
+            vector[
+                features::get_partial_governance_voting(),
+                features::get_delegation_pool_partial_governance_voting()],
+            vector[],
         );
 
         initialize_test_validator(validator, 100 * ONE_APT, true, false);
@@ -4308,110 +4671,356 @@ module aptos_framework::delegation_pool {
         stake::mint(delegator2, 110 * ONE_APT);
         add_stake(delegator2, pool_address, 90 * ONE_APT);
         // By default, the voter of a delegator is itself.
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 10 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 90 * ONE_APT, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 10 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 90 * ONE_APT,
+            1,
+        );
 
         end_aptos_epoch();
         // Reward rate is 0. No reward so no voting power change.
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 10 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 90 * ONE_APT, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 10 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 90 * ONE_APT,
+            1,
+        );
 
         // Delegator1 delegates its voting power to voter1 but it takes 1 lockup cycle to take effects. So no voting power
         // change now.
         delegate_voting_power(delegator1, pool_address, voter1_address);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 10 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 90 * ONE_APT, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 10 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 90 * ONE_APT,
+            1,
+        );
 
         // 1 epoch passed but the lockup cycle hasn't ended. No voting power change.
         end_aptos_epoch();
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 10 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 90 * ONE_APT, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 10 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 90 * ONE_APT,
+            1,
+        );
 
         // One cycle passed. The voter change takes effects.
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
         end_aptos_epoch();
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 10 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 90 * ONE_APT, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address)
+                == 10 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 90 * ONE_APT,
+            1,
+        );
 
         // Delegator2 delegates its voting power to voter1 but it takes 1 lockup cycle to take effects. So no voting power
         // change now.
         delegate_voting_power(delegator2, pool_address, voter1_address);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 10 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 90 * ONE_APT, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address)
+                == 10 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 90 * ONE_APT,
+            1,
+        );
 
         // One cycle passed. The voter change takes effects.
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
         end_aptos_epoch();
-        assert!(calculate_and_update_delegator_voter(pool_address, delegator2_address) == voter1_address, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 100 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 0, 1);
+        assert!(
+            calculate_and_update_delegator_voter(pool_address, delegator2_address)
+                == voter1_address,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address)
+                == 100 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 0,
+            1,
+        );
 
         // delegator1 changes to voter2 then change back. delegator2 changes to voter1.
         // No voting power change in this lockup cycle.
         delegate_voting_power(delegator1, pool_address, voter2_address);
         delegate_voting_power(delegator2, pool_address, voter2_address);
         delegate_voting_power(delegator1, pool_address, voter1_address);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 100 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 0, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address)
+                == 100 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 0,
+            1,
+        );
 
         // One cycle passed. The voter change takes effects.
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
         end_aptos_epoch();
-        assert!(calculate_and_update_delegator_voter(pool_address, delegator1_address) == voter1_address, 1);
-        assert!(calculate_and_update_delegator_voter(pool_address, delegator2_address) == voter2_address, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 10 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 90 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 0, 1);
+        assert!(
+            calculate_and_update_delegator_voter(pool_address, delegator1_address)
+                == voter1_address,
+            1,
+        );
+        assert!(
+            calculate_and_update_delegator_voter(pool_address, delegator2_address)
+                == voter2_address,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address)
+                == 10 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address)
+                == 90 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 0,
+            1,
+        );
 
         // delegator1 adds stake to the pool. Voting power changes immediately.
         add_stake(delegator1, pool_address, 90 * ONE_APT);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 100 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 90 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 0, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address)
+                == 100 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address)
+                == 90 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 0,
+            1,
+        );
 
         // delegator1 unlocks stake and changes its voter. No voting power change until next lockup cycle.
         unlock(delegator1, pool_address, 90 * ONE_APT);
         delegate_voting_power(delegator1, pool_address, voter2_address);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 100 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 90 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 0, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address)
+                == 100 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address)
+                == 90 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 0,
+            1,
+        );
 
         // One cycle passed. The voter change takes effects.
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
         end_aptos_epoch();
         // Withdrawl inactive shares will not change voting power.
         withdraw(delegator1, pool_address, 45 * ONE_APT);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 100 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 0, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address)
+                == 100 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 0,
+            1,
+        );
 
         // voter2 adds stake for itself. Voting power changes immediately.
         stake::mint(voter2, 110 * ONE_APT);
         add_stake(voter2, pool_address, 10 * ONE_APT);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 110 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 0, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address)
+                == 110 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 0,
+            1,
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator1 = @0x010, voter1 = @0x030)]
@@ -4450,9 +5059,10 @@ module aptos_framework::delegation_pool {
         // Enable partial governance voting feature flag.
         features::change_feature_flags_for_testing(
             aptos_framework,
-            vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting(
-            )],
-            vector[]
+            vector[
+                features::get_partial_governance_voting(),
+                features::get_delegation_pool_partial_governance_voting()],
+            vector[],
         );
         // Voter doens't change until enabling partial governance voting on this delegation pool.
         assert!(stake::get_delegated_voter(pool_address) == validator_address, 1);
@@ -4462,30 +5072,50 @@ module aptos_framework::delegation_pool {
         assert!(partial_governance_voting_enabled(pool_address), 1);
 
         // By default, the voter of a delegator is itself.
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 10 * ONE_APT, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 10 * ONE_APT,
+            1,
+        );
 
         // Delegator1 delegates its voting power to voter1.
         // It takes 1 cycle to take effect. No immediate change.
         delegate_voting_power(delegator1, pool_address, voter1_address);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 10 * ONE_APT, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 10 * ONE_APT,
+            1,
+        );
 
         // One cycle passed. The voter change takes effects.
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
         end_aptos_epoch();
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 10 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 0, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address)
+                == 10 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 0,
+            1,
+        );
     }
 
-    #[test(
-        aptos_framework = @aptos_framework,
-        validator = @0x123,
-        delegator1 = @0x010,
-        delegator2 = @0x020,
-        voter1 = @0x030,
-        voter2 = @0x040
-    )]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator1 = @0x010, delegator2 = @0x020, voter1 = @0x030, voter2 = @0x040)]
     public entry fun test_voting_power_change_for_rewards(
         aptos_framework: &signer,
         validator: &signer,
@@ -4502,7 +5132,7 @@ module aptos_framework::delegation_pool {
             true,
             100,
             100,
-            1000000
+            1000000,
         );
         aptos_governance::initialize_for_test(
             aptos_framework,
@@ -4513,9 +5143,10 @@ module aptos_framework::delegation_pool {
         aptos_governance::initialize_partial_voting(aptos_framework);
         features::change_feature_flags_for_testing(
             aptos_framework,
-            vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting(
-            )],
-            vector[]
+            vector[
+                features::get_partial_governance_voting(),
+                features::get_delegation_pool_partial_governance_voting()],
+            vector[],
         );
 
         // 50% commission rate
@@ -4542,48 +5173,121 @@ module aptos_framework::delegation_pool {
         stake::mint(delegator2, 110 * ONE_APT);
         add_stake(delegator2, pool_address, 90 * ONE_APT);
         // By default, the voter of a delegator is itself.
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, validator_address) == 100 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 10 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 90 * ONE_APT, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, validator_address) ==
+             100 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 10 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 90 * ONE_APT,
+            1,
+        );
 
         // One epoch is passed. Delegators earn no reward because their stake was inactive.
         end_aptos_epoch();
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, validator_address) == 100 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 10 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 90 * ONE_APT, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, validator_address) ==
+             100 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 10 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 90 * ONE_APT,
+            1,
+        );
 
         // 2 epoches are passed. Delegators earn reward and voting power increases. Operator earns reward and
         // commission. Because there is no operation during these 2 epoches. Operator's commission is not compounded.
         end_aptos_epoch();
         end_aptos_epoch();
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, validator_address) == 550 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 25 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 225 * ONE_APT, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, validator_address) ==
+             550 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 25 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 225 * ONE_APT,
+            1,
+        );
 
         // Another epoch is passed. Voting power chage due to reward is correct even if delegator1 and delegator2 change its voter.
         delegate_voting_power(delegator1, pool_address, voter1_address);
         delegate_voting_power(delegator2, pool_address, voter1_address);
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
         end_aptos_epoch();
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, validator_address) == 122499999999, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 375 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 0, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 0, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, validator_address) ==
+             122499999999,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address)
+                == 375 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address) ==
+            0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 0,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 0,
+            1,
+        );
     }
 
-    #[test(
-        aptos_framework = @aptos_framework,
-        validator = @0x123,
-        delegator1 = @0x010,
-        delegator2 = @0x020,
-        voter1 = @0x030,
-        voter2 = @0x040
-    )]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator1 = @0x010, delegator2 = @0x020, voter1 = @0x030, voter2 = @0x040)]
     public entry fun test_voting_power_change_already_voted_before_partial(
         aptos_framework: &signer,
         validator: &signer,
@@ -4615,22 +5319,24 @@ module aptos_framework::delegation_pool {
         // Create 2 proposals and vote for proposal1.
         let execution_hash = vector::empty<u8>();
         vector::push_back(&mut execution_hash, 1);
-        let proposal2_id = aptos_governance::create_proposal_v2_impl(
-            validator,
-            pool_address,
-            execution_hash,
-            b"",
-            b"",
-            true,
-        );
+        let proposal2_id =
+            aptos_governance::create_proposal_v2_impl(
+                validator,
+                pool_address,
+                execution_hash,
+                b"",
+                b"",
+                true,
+            );
         aptos_governance::vote(validator, pool_address, proposal1_id, true);
 
         // Enable partial governance voting feature flag.
         features::change_feature_flags_for_testing(
             aptos_framework,
-            vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting(
-            )],
-            vector[]
+            vector[
+                features::get_partial_governance_voting(),
+                features::get_delegation_pool_partial_governance_voting()],
+            vector[],
         );
         // Voter doens't change until enabling partial governance voting on this delegation pool.
         assert!(stake::get_delegated_voter(pool_address) == validator_address, 1);
@@ -4639,41 +5345,90 @@ module aptos_framework::delegation_pool {
         assert!(stake::get_delegated_voter(pool_address) == pool_address, 1);
         assert!(partial_governance_voting_enabled(pool_address), 1);
 
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, validator_address) == 100 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 10 * ONE_APT, 1);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator2_address) == 90 * ONE_APT, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(pool_address, validator_address) ==
+             100 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 10 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator2_address
+            ) == 90 * ONE_APT,
+            1,
+        );
         // No one can vote for proposal1 because it's already voted before enabling partial governance voting.
-        assert!(calculate_and_update_remaining_voting_power(pool_address, validator_address, proposal1_id) == 0, 1);
-        assert!(calculate_and_update_remaining_voting_power(pool_address, delegator1_address, proposal1_id) == 0, 1);
-        assert!(calculate_and_update_remaining_voting_power(pool_address, delegator2_address, proposal1_id) == 0, 1);
         assert!(
-            calculate_and_update_remaining_voting_power(pool_address, validator_address, proposal2_id) == 100 * ONE_APT,
-            1
+            calculate_and_update_remaining_voting_power(
+                pool_address, validator_address, proposal1_id
+            ) == 0,
+            1,
         );
         assert!(
-            calculate_and_update_remaining_voting_power(pool_address, delegator1_address, proposal2_id) == 10 * ONE_APT,
-            1
+            calculate_and_update_remaining_voting_power(
+                pool_address, delegator1_address, proposal1_id
+            ) == 0,
+            1,
         );
         assert!(
-            calculate_and_update_remaining_voting_power(pool_address, delegator2_address, proposal2_id) == 90 * ONE_APT,
-            1
+            calculate_and_update_remaining_voting_power(
+                pool_address, delegator2_address, proposal1_id
+            ) == 0,
+            1,
+        );
+        assert!(
+            calculate_and_update_remaining_voting_power(
+                pool_address, validator_address, proposal2_id
+            ) == 100 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_remaining_voting_power(
+                pool_address, delegator1_address, proposal2_id
+            ) == 10 * ONE_APT,
+            1,
+        );
+        assert!(
+            calculate_and_update_remaining_voting_power(
+                pool_address, delegator2_address, proposal2_id
+            ) == 90 * ONE_APT,
+            1,
         );
 
         // Delegator1 tries to use 50 APT to vote on proposal2, but it only has 10 APT. So only 10 APT voting power is used.
         vote(delegator1, pool_address, proposal2_id, 50 * ONE_APT, true);
-        assert!(calculate_and_update_remaining_voting_power(pool_address, delegator1_address, proposal2_id) == 0, 1);
+        assert!(
+            calculate_and_update_remaining_voting_power(
+                pool_address, delegator1_address, proposal2_id
+            ) == 0,
+            1,
+        );
 
         add_stake(delegator1, pool_address, 60 * ONE_APT);
-        assert!(calculate_and_update_voter_total_voting_power(pool_address, delegator1_address) == 70 * ONE_APT, 1);
+        assert!(
+            calculate_and_update_voter_total_voting_power(
+                pool_address, delegator1_address
+            ) == 70 * ONE_APT,
+            1,
+        );
         vote(delegator1, pool_address, proposal2_id, 25 * ONE_APT, true);
         assert!(
-            calculate_and_update_remaining_voting_power(pool_address, delegator1_address, proposal2_id) == 35 * ONE_APT,
-            1
+            calculate_and_update_remaining_voting_power(
+                pool_address, delegator1_address, proposal2_id
+            ) == 35 * ONE_APT,
+            1,
         );
         vote(delegator1, pool_address, proposal2_id, 30 * ONE_APT, false);
         assert!(
-            calculate_and_update_remaining_voting_power(pool_address, delegator1_address, proposal2_id) == 5 * ONE_APT,
-            1
+            calculate_and_update_remaining_voting_power(
+                pool_address, delegator1_address, proposal2_id
+            ) == 5 * ONE_APT,
+            1,
         );
     }
 
@@ -4704,9 +5459,10 @@ module aptos_framework::delegation_pool {
         // Enable partial governance voting feature flag.
         features::change_feature_flags_for_testing(
             aptos_framework,
-            vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting(
-            )],
-            vector[]
+            vector[
+                features::get_partial_governance_voting(),
+                features::get_delegation_pool_partial_governance_voting()],
+            vector[],
         );
         // Enable partial governance voting on this delegation pool.
         enable_partial_governance_voting(pool_address);
@@ -4739,9 +5495,10 @@ module aptos_framework::delegation_pool {
         // Enable partial governance voting feature flag.
         features::change_feature_flags_for_testing(
             aptos_framework,
-            vector[features::get_partial_governance_voting(), features::get_delegation_pool_partial_governance_voting(
-            )],
-            vector[]
+            vector[
+                features::get_partial_governance_voting(),
+                features::get_delegation_pool_partial_governance_voting()],
+            vector[],
         );
 
         // The operator voter votes on the proposal after partial governace voting flag is enabled but before partial voting is enabled on the pool.
@@ -4792,13 +5549,7 @@ module aptos_framework::delegation_pool {
         delegate_voting_power(delegator1, pool_address, signer::address_of(voter1));
     }
 
-    #[test(
-        aptos_framework = @aptos_framework,
-        validator = @0x123,
-        delegator = @0x010,
-        voter1 = @0x020,
-        voter2 = @0x030
-    )]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator = @0x010, voter1 = @0x020, voter2 = @0x030)]
     public entry fun test_delegate_voting_power_applies_next_lockup(
         aptos_framework: &signer,
         validator: &signer,
@@ -4812,9 +5563,8 @@ module aptos_framework::delegation_pool {
             aptos_framework,
             vector[
                 features::get_partial_governance_voting(),
-                features::get_delegation_pool_partial_governance_voting()
-            ],
-            vector[]
+                features::get_delegation_pool_partial_governance_voting()],
+            vector[],
         );
 
         initialize_test_validator(validator, 100 * ONE_APT, true, true);
@@ -4831,10 +5581,10 @@ module aptos_framework::delegation_pool {
 
         let first_lockup_end = stake::get_lockup_secs(pool_address);
         // default voter is the delegator
-        let (voter, pending_voter, last_locked_until_secs) = calculate_and_update_voting_delegation(
-            pool_address,
-            delegator_address
-        );
+        let (voter, pending_voter, last_locked_until_secs) =
+            calculate_and_update_voting_delegation(
+                pool_address, delegator_address
+            );
         assert!(voter == delegator_address, 0);
         assert!(pending_voter == delegator_address, 0);
         assert!(last_locked_until_secs == first_lockup_end, 0);
@@ -4842,8 +5592,7 @@ module aptos_framework::delegation_pool {
         // delegate to voter 1 which takes effect next lockup
         delegate_voting_power(delegator, pool_address, voter1_address);
         (voter, pending_voter, last_locked_until_secs) = calculate_and_update_voting_delegation(
-            pool_address,
-            delegator_address
+            pool_address, delegator_address
         );
         assert!(voter == delegator_address, 0);
         assert!(pending_voter == voter1_address, 0);
@@ -4851,9 +5600,9 @@ module aptos_framework::delegation_pool {
         assert!(
             calculate_and_update_voter_total_voting_power(
                 pool_address,
-                delegator_address
+                delegator_address,
             ) == 20 * ONE_APT - get_add_stake_fee(pool_address, 20 * ONE_APT),
-            0
+            0,
         );
 
         // end this lockup cycle
@@ -4862,61 +5611,64 @@ module aptos_framework::delegation_pool {
         assert!(second_lockup_end > first_lockup_end, 0);
 
         (voter, pending_voter, last_locked_until_secs) = calculate_and_update_voting_delegation(
-            pool_address,
-            delegator_address
+            pool_address, delegator_address
         );
         // voter 1 becomes current voter and owns all voting power of delegator
         assert!(voter == voter1_address, 0);
         assert!(pending_voter == voter1_address, 0);
         assert!(last_locked_until_secs == second_lockup_end, 0);
         assert!(
-            calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 20 * ONE_APT,
-            0
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address)
+                == 20 * ONE_APT,
+            0,
         );
 
         // delegate to voter 2, current voter should still be voter 1
         delegate_voting_power(delegator, pool_address, voter2_address);
         (voter, pending_voter, last_locked_until_secs) = calculate_and_update_voting_delegation(
-            pool_address,
-            delegator_address
+            pool_address, delegator_address
         );
         assert!(voter == voter1_address, 0);
         assert!(pending_voter == voter2_address, 0);
         assert!(last_locked_until_secs == second_lockup_end, 0);
         assert!(
-            calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 20 * ONE_APT,
-            0
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address)
+                == 20 * ONE_APT,
+            0,
         );
 
         // stake added by delegator counts as voting power for the current voter
         add_stake(delegator, pool_address, 30 * ONE_APT);
         assert!(
             calculate_and_update_voter_total_voting_power(
-                pool_address,
-                voter1_address
-            ) == 20 * ONE_APT + 30 * ONE_APT - get_add_stake_fee(pool_address, 30 * ONE_APT),
-            0
+                pool_address, voter1_address
+            ) == 20 * ONE_APT + 30 * ONE_APT
+                - get_add_stake_fee(pool_address, 30 * ONE_APT),
+            0,
         );
 
         // refunded `add_stake` fee is counted as voting power too
         end_aptos_epoch();
         assert!(
-            calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 5020000000,
-            0
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address)
+                == 5020000000,
+            0,
         );
 
         // delegator can unlock their entire stake (all voting shares are owned by voter 1)
         unlock(delegator, pool_address, 5020000000);
         assert!(
-            calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 5020000000,
-            0
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address)
+                == 5020000000,
+            0,
         );
 
         // delegator can reactivate their entire stake (all voting shares are owned by voter 1)
         reactivate_stake(delegator, pool_address, 5020000000);
         assert!(
-            calculate_and_update_voter_total_voting_power(pool_address, voter1_address) == 5019999999,
-            0
+            calculate_and_update_voter_total_voting_power(pool_address, voter1_address)
+                == 5019999999,
+            0,
         );
 
         // end this lockup cycle
@@ -4926,26 +5678,19 @@ module aptos_framework::delegation_pool {
 
         // voter 2 becomes current voter and owns all voting power of delegator
         (voter, pending_voter, last_locked_until_secs) = calculate_and_update_voting_delegation(
-            pool_address,
-            delegator_address
+            pool_address, delegator_address
         );
         assert!(voter == voter2_address, 0);
         assert!(pending_voter == voter2_address, 0);
         assert!(last_locked_until_secs == third_lockup_end, 0);
         assert!(
-            calculate_and_update_voter_total_voting_power(pool_address, voter2_address) == 5070199999,
-            0
+            calculate_and_update_voter_total_voting_power(pool_address, voter2_address)
+                == 5070199999,
+            0,
         );
     }
 
-    #[test(
-        aptos_framework = @aptos_framework,
-        validator = @0x123,
-        validator_min_consensus = @0x234,
-        delegator = @0x010,
-        voter1 = @0x020,
-        voter2 = @0x030
-    )]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, validator_min_consensus = @0x234, delegator = @0x010, voter1 = @0x020, voter2 = @0x030)]
     public entry fun test_delegate_voting_power_from_inactive_validator(
         aptos_framework: &signer,
         validator: &signer,
@@ -4960,9 +5705,8 @@ module aptos_framework::delegation_pool {
             aptos_framework,
             vector[
                 features::get_partial_governance_voting(),
-                features::get_delegation_pool_partial_governance_voting()
-            ],
-            vector[]
+                features::get_delegation_pool_partial_governance_voting()],
+            vector[],
         );
 
         // activate more validators in order to inactivate one later
@@ -4978,18 +5722,17 @@ module aptos_framework::delegation_pool {
         let voter2_address = signer::address_of(voter2);
 
         let first_lockup_end = stake::get_lockup_secs(pool_address);
-        let (voter, pending_voter, last_locked_until_secs) = calculate_and_update_voting_delegation(
-            pool_address,
-            delegator_address
-        );
+        let (voter, pending_voter, last_locked_until_secs) =
+            calculate_and_update_voting_delegation(
+                pool_address, delegator_address
+            );
         assert!(voter == delegator_address, 0);
         assert!(pending_voter == delegator_address, 0);
         assert!(last_locked_until_secs == first_lockup_end, 0);
 
         delegate_voting_power(delegator, pool_address, voter1_address);
         (voter, pending_voter, last_locked_until_secs) = calculate_and_update_voting_delegation(
-            pool_address,
-            delegator_address
+            pool_address, delegator_address
         );
         assert!(voter == delegator_address, 0);
         assert!(pending_voter == voter1_address, 0);
@@ -5002,8 +5745,7 @@ module aptos_framework::delegation_pool {
 
         // voter 1 becomes current voter
         (voter, pending_voter, last_locked_until_secs) = calculate_and_update_voting_delegation(
-            pool_address,
-            delegator_address
+            pool_address, delegator_address
         );
         assert!(voter == voter1_address, 0);
         assert!(pending_voter == voter1_address, 0);
@@ -5012,8 +5754,7 @@ module aptos_framework::delegation_pool {
         // delegate to voter 2 which should apply next lockup
         delegate_voting_power(delegator, pool_address, voter2_address);
         (voter, pending_voter, last_locked_until_secs) = calculate_and_update_voting_delegation(
-            pool_address,
-            delegator_address
+            pool_address, delegator_address
         );
         assert!(voter == voter1_address, 0);
         assert!(pending_voter == voter2_address, 0);
@@ -5031,8 +5772,7 @@ module aptos_framework::delegation_pool {
 
         // pending voter 2 is not applied
         (voter, pending_voter, last_locked_until_secs) = calculate_and_update_voting_delegation(
-            pool_address,
-            delegator_address
+            pool_address, delegator_address
         );
         assert!(voter == voter1_address, 0);
         assert!(pending_voter == voter2_address, 0);
@@ -5049,8 +5789,7 @@ module aptos_framework::delegation_pool {
 
         // voter 2 finally becomes current voter
         (voter, pending_voter, last_locked_until_secs) = calculate_and_update_voting_delegation(
-            pool_address,
-            delegator_address
+            pool_address, delegator_address
         );
         assert!(voter == voter2_address, 0);
         assert!(pending_voter == voter2_address, 0);
@@ -5060,14 +5799,17 @@ module aptos_framework::delegation_pool {
     #[test(staker = @0xe256f4f4e2986cada739e339895cf5585082ff247464cab8ec56eea726bd2263)]
     public entry fun test_get_expected_stake_pool_address(staker: address) {
         let pool_address = get_expected_stake_pool_address(staker, vector[0x42, 0x42]);
-        assert!(pool_address == @0xe9fc2fbb82b7e1cb7af3daef8c7a24e66780f9122d15e4f1d486ee7c7c36c48d, 0);
+        assert!(
+            pool_address
+                == @0xe9fc2fbb82b7e1cb7af3daef8c7a24e66780f9122d15e4f1d486ee7c7c36c48d,
+            0,
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x30017, location = Self)]
     public entry fun test_delegators_allowlisting_not_supported(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage, DelegationPoolAllowlisting {
         initialize_for_test(aptos_framework);
         initialize_test_validator(validator, 100 * ONE_APT, true, true);
@@ -5083,8 +5825,7 @@ module aptos_framework::delegation_pool {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x30018, location = Self)]
     public entry fun test_cannot_disable_allowlisting_if_already_off(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires DelegationPoolOwnership, DelegationPool, GovernanceRecords, BeneficiaryForOperator, NextCommissionPercentage, DelegationPoolAllowlisting {
         initialize_for_test(aptos_framework);
         initialize_test_validator(validator, 100 * ONE_APT, true, true);
@@ -5175,23 +5916,32 @@ module aptos_framework::delegation_pool {
         assert!(delegator_allowlisted(pool_address, delegator_1_address), 0);
         assert!(!delegator_allowlisted(pool_address, delegator_2_address), 0);
         allowlist = &get_delegators_allowlist(pool_address);
-        assert!(vector::length(allowlist) == 1 && vector::contains(allowlist, &delegator_1_address), 0);
+        assert!(
+            vector::length(allowlist) == 1
+                && vector::contains(allowlist, &delegator_1_address),
+            0,
+        );
 
         allowlist_delegator(validator, delegator_2_address);
         assert!(delegator_allowlisted(pool_address, delegator_1_address), 0);
         assert!(delegator_allowlisted(pool_address, delegator_2_address), 0);
         allowlist = &get_delegators_allowlist(pool_address);
-        assert!(vector::length(allowlist) == 2 &&
-            vector::contains(allowlist, &delegator_1_address) &&
-            vector::contains(allowlist, &delegator_2_address),
-            0
+        assert!(
+            vector::length(allowlist) == 2
+            && vector::contains(allowlist, &delegator_1_address)
+            && vector::contains(allowlist, &delegator_2_address),
+            0,
         );
 
         remove_delegator_from_allowlist(validator, delegator_2_address);
         assert!(delegator_allowlisted(pool_address, delegator_1_address), 0);
         assert!(!delegator_allowlisted(pool_address, delegator_2_address), 0);
         allowlist = &get_delegators_allowlist(pool_address);
-        assert!(vector::length(allowlist) == 1 && vector::contains(allowlist, &delegator_1_address), 0);
+        assert!(
+            vector::length(allowlist) == 1
+                && vector::contains(allowlist, &delegator_1_address),
+            0,
+        );
 
         // destroy the allowlist constructed so far
         disable_delegators_allowlisting(validator);
@@ -5207,22 +5957,38 @@ module aptos_framework::delegation_pool {
         assert!(!delegator_allowlisted(pool_address, delegator_1_address), 0);
         assert!(delegator_allowlisted(pool_address, delegator_2_address), 0);
         allowlist = &get_delegators_allowlist(pool_address);
-        assert!(vector::length(allowlist) == 1 && vector::contains(allowlist, &delegator_2_address), 0);
+        assert!(
+            vector::length(allowlist) == 1
+                && vector::contains(allowlist, &delegator_2_address),
+            0,
+        );
 
         // allowlist does not ever have duplicates
         allowlist_delegator(validator, delegator_2_address);
         allowlist = &get_delegators_allowlist(pool_address);
-        assert!(vector::length(allowlist) == 1 && vector::contains(allowlist, &delegator_2_address), 0);
+        assert!(
+            vector::length(allowlist) == 1
+                && vector::contains(allowlist, &delegator_2_address),
+            0,
+        );
 
         // no override of existing allowlist when enabling allowlisting again
         enable_delegators_allowlisting(validator);
         allowlist = &get_delegators_allowlist(pool_address);
-        assert!(vector::length(allowlist) == 1 && vector::contains(allowlist, &delegator_2_address), 0);
+        assert!(
+            vector::length(allowlist) == 1
+                && vector::contains(allowlist, &delegator_2_address),
+            0,
+        );
 
         // nothing changes when trying to remove an inexistent delegator
         remove_delegator_from_allowlist(validator, delegator_1_address);
         allowlist = &get_delegators_allowlist(pool_address);
-        assert!(vector::length(allowlist) == 1 && vector::contains(allowlist, &delegator_2_address), 0);
+        assert!(
+            vector::length(allowlist) == 1
+                && vector::contains(allowlist, &delegator_2_address),
+            0,
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123, delegator_1 = @0x010)]
@@ -5269,7 +6035,12 @@ module aptos_framework::delegation_pool {
         // add some active shares to NULL_SHAREHOLDER from `add_stake` fee
         stake::mint(delegator_1, 50 * ONE_APT);
         add_stake(delegator_1, pool_address, 50 * ONE_APT);
-        assert!(get_delegator_active_shares(borrow_global<DelegationPool>(pool_address), NULL_SHAREHOLDER) != 0, 0);
+        assert!(
+            get_delegator_active_shares(
+                borrow_global<DelegationPool>(pool_address), NULL_SHAREHOLDER
+            ) != 0,
+            0,
+        );
 
         enable_delegators_allowlisting(validator);
         evict_delegator(validator, NULL_SHAREHOLDER);
@@ -5426,19 +6197,21 @@ module aptos_framework::delegation_pool {
         assert!(!delegator_allowlisted(pool_address, delegator_1_address), 0);
 
         // check that in-flight active rewards are evicted too, which validates that `synchronize_delegation_pool` was called
-        let active = pool_u64::balance(
-            &borrow_global<DelegationPool>(pool_address).active_shares,
-            delegator_1_address
-        ) + get_add_stake_fee(pool_address, 10 * ONE_APT);
+        let active =
+            pool_u64::balance(
+                &borrow_global<DelegationPool>(pool_address).active_shares,
+                delegator_1_address,
+            ) + get_add_stake_fee(pool_address, 10 * ONE_APT);
         // 5050000000 + 1000000000 active at last `synchronize_delegation_pool`
         assert!(active == 6050000000, active);
 
         evict_delegator(validator, delegator_1_address);
         assert_delegation(delegator_1_address, pool_address, 0, 0, 6161504999);
-        let pending_inactive = pool_u64::balance(
-            pending_inactive_shares_pool(borrow_global<DelegationPool>(pool_address)),
-            delegator_1_address
-        );
+        let pending_inactive =
+            pool_u64::balance(
+                pending_inactive_shares_pool(borrow_global<DelegationPool>(pool_address)),
+                delegator_1_address,
+            );
         assert!(pending_inactive == 6161504999, pending_inactive);
 
         // allowlist delegator 1 back and check that they can add stake
@@ -5450,7 +6223,13 @@ module aptos_framework::delegation_pool {
 
         // can reactivate stake when allowlisted
         reactivate_stake(delegator_1, pool_address, 5223120050);
-        assert_delegation(delegator_1_address, pool_address, 20 * ONE_APT + 5223120049, 0, 10 * ONE_APT);
+        assert_delegation(
+            delegator_1_address,
+            pool_address,
+            20 * ONE_APT + 5223120049,
+            0,
+            10 * ONE_APT,
+        );
 
         // evict delegator 1 after they reactivated
         remove_delegator_from_allowlist(validator, delegator_1_address);
@@ -5471,10 +6250,13 @@ module aptos_framework::delegation_pool {
         inactive_stake: u64,
         pending_inactive_stake: u64,
     ) acquires DelegationPool, BeneficiaryForOperator {
-        let (actual_active, actual_inactive, actual_pending_inactive) = get_stake(pool_address, delegator_address);
+        let (actual_active, actual_inactive, actual_pending_inactive) =
+            get_stake(pool_address, delegator_address);
         assert!(actual_active == active_stake, actual_active);
         assert!(actual_inactive == inactive_stake, actual_inactive);
-        assert!(actual_pending_inactive == pending_inactive_stake, actual_pending_inactive);
+        assert!(
+            actual_pending_inactive == pending_inactive_stake, actual_pending_inactive
+        );
     }
 
     #[test_only]
@@ -5488,10 +6270,12 @@ module aptos_framework::delegation_pool {
     ) acquires DelegationPool {
         assert_delegation_pool_exists(pool_address);
         let pool = borrow_global<DelegationPool>(pool_address);
-        let (withdrawal_exists, withdrawal_olc) = pending_withdrawal_exists(pool, delegator_address);
+        let (withdrawal_exists, withdrawal_olc) =
+            pending_withdrawal_exists(pool, delegator_address);
         assert!(withdrawal_exists == exists, 0);
         assert!(withdrawal_olc.index == olc, withdrawal_olc.index);
-        let (withdrawal_inactive, withdrawal_stake) = get_pending_withdrawal(pool_address, delegator_address);
+        let (withdrawal_inactive, withdrawal_stake) =
+            get_pending_withdrawal(pool_address, delegator_address);
         assert!(withdrawal_inactive == inactive, 0);
         assert!(withdrawal_stake == stake, withdrawal_stake);
     }
@@ -5507,7 +6291,8 @@ module aptos_framework::delegation_pool {
         let pool = borrow_global<DelegationPool>(pool_address);
         assert!(table::contains(&pool.inactive_shares, olc_with_index(olc)) == exists, 0);
         if (exists) {
-            let actual_stake = total_coins(table::borrow(&pool.inactive_shares, olc_with_index(olc)));
+            let actual_stake =
+                total_coins(table::borrow(&pool.inactive_shares, olc_with_index(olc)));
             assert!(actual_stake == stake, actual_stake);
         } else {
             assert!(0 == stake, 0);
@@ -5542,20 +6327,23 @@ module aptos_framework::delegation_pool {
         // Create 1 proposals and vote for proposal1.
         let execution_hash = vector::empty<u8>();
         vector::push_back(&mut execution_hash, 1);
-        let proposal_id = aptos_governance::create_proposal_v2_impl(
-            validator,
-            pool_address,
-            execution_hash,
-            b"",
-            b"",
-            true,
-        );
+        let proposal_id =
+            aptos_governance::create_proposal_v2_impl(
+                validator,
+                pool_address,
+                execution_hash,
+                b"",
+                b"",
+                true,
+            );
         if (enable_partial_voting) {
             features::change_feature_flags_for_testing(
                 aptos_framework,
-                vector[features::get_partial_governance_voting(
-                ), features::get_delegation_pool_partial_governance_voting()],
-                vector[]);
+                vector[
+                    features::get_partial_governance_voting(),
+                    features::get_delegation_pool_partial_governance_voting()],
+                vector[],
+            );
             enable_partial_governance_voting(pool_address);
         };
         proposal_id

--- a/aptos-move/framework/aptos-framework/sources/delegation_pool.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/delegation_pool.spec.move
@@ -91,6 +91,6 @@ spec aptos_framework::delegation_pool {
     ///
     spec module {
         // TODO: verification disabled until this module is specified.
-        pragma verify=false;
+        pragma verify = false;
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.move
@@ -92,7 +92,8 @@ module aptos_framework::dispatchable_fungible_asset {
             );
             let end_balance = fungible_asset::balance(store);
             assert!(
-                amount <= start_balance - end_balance, error::aborted(EAMOUNT_MISMATCH)
+                amount <= start_balance - end_balance,
+                error::aborted(EAMOUNT_MISMATCH),
             );
             fa
         } else {

--- a/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.move
@@ -54,17 +54,15 @@ module aptos_framework::dispatchable_fungible_asset {
             store_obj,
             TransferRefStore {
                 transfer_ref: fungible_asset::generate_transfer_ref(constructor_ref),
-            }
+            },
         );
     }
 
     public fun register_derive_supply_dispatch_function(
-        constructor_ref: &ConstructorRef,
-        dispatch_function: Option<FunctionInfo>
+        constructor_ref: &ConstructorRef, dispatch_function: Option<FunctionInfo>
     ) {
         fungible_asset::register_derive_supply_dispatch_function(
-            constructor_ref,
-            dispatch_function
+            constructor_ref, dispatch_function
         );
     }
 
@@ -81,7 +79,7 @@ module aptos_framework::dispatchable_fungible_asset {
         if (option::is_some(&func_opt)) {
             assert!(
                 features::dispatchable_fungible_asset_enabled(),
-                error::aborted(ENOT_ACTIVATED)
+                error::aborted(ENOT_ACTIVATED),
             );
             let start_balance = fungible_asset::balance(store);
             let func = option::borrow(&func_opt);
@@ -93,7 +91,9 @@ module aptos_framework::dispatchable_fungible_asset {
                 func,
             );
             let end_balance = fungible_asset::balance(store);
-            assert!(amount <= start_balance - end_balance, error::aborted(EAMOUNT_MISMATCH));
+            assert!(
+                amount <= start_balance - end_balance, error::aborted(EAMOUNT_MISMATCH)
+            );
             fa
         } else {
             fungible_asset::withdraw_internal(object::object_address(&store), amount)
@@ -109,7 +109,7 @@ module aptos_framework::dispatchable_fungible_asset {
         if (option::is_some(&func_opt)) {
             assert!(
                 features::dispatchable_fungible_asset_enabled(),
-                error::aborted(ENOT_ACTIVATED)
+                error::aborted(ENOT_ACTIVATED),
             );
             let func = option::borrow(&func_opt);
             function_info::load_module_from_function(func);
@@ -117,7 +117,7 @@ module aptos_framework::dispatchable_fungible_asset {
                 store,
                 fa,
                 borrow_transfer_ref(store),
-                func
+                func,
             )
         } else {
             fungible_asset::deposit_internal(object::object_address(&store), fa)
@@ -162,7 +162,7 @@ module aptos_framework::dispatchable_fungible_asset {
         if (option::is_some(&func_opt)) {
             assert!(
                 features::dispatchable_fungible_asset_enabled(),
-                error::aborted(ENOT_ACTIVATED)
+                error::aborted(ENOT_ACTIVATED),
             );
             let func = option::borrow(&func_opt);
             function_info::load_module_from_function(func);
@@ -181,7 +181,7 @@ module aptos_framework::dispatchable_fungible_asset {
         if (option::is_some(&func_opt)) {
             assert!(
                 features::dispatchable_fungible_asset_enabled(),
-                error::aborted(ENOT_ACTIVATED)
+                error::aborted(ENOT_ACTIVATED),
             );
             let func = option::borrow(&func_opt);
             function_info::load_module_from_function(func);
@@ -192,21 +192,17 @@ module aptos_framework::dispatchable_fungible_asset {
     }
 
     inline fun borrow_transfer_ref<T: key>(metadata: Object<T>): &TransferRef acquires TransferRefStore {
-        let metadata_addr = object::object_address(
-            &fungible_asset::store_metadata(metadata)
-        );
+        let metadata_addr =
+            object::object_address(&fungible_asset::store_metadata(metadata));
         assert!(
             exists<TransferRefStore>(metadata_addr),
-            error::not_found(ESTORE_NOT_FOUND)
+            error::not_found(ESTORE_NOT_FOUND),
         );
         &borrow_global<TransferRefStore>(metadata_addr).transfer_ref
     }
 
     native fun dispatchable_withdraw<T: key>(
-        store: Object<T>,
-        amount: u64,
-        transfer_ref: &TransferRef,
-        function: &FunctionInfo,
+        store: Object<T>, amount: u64, transfer_ref: &TransferRef, function: &FunctionInfo,
     ): FungibleAsset;
 
     native fun dispatchable_deposit<T: key>(
@@ -216,13 +212,7 @@ module aptos_framework::dispatchable_fungible_asset {
         function: &FunctionInfo,
     );
 
-    native fun dispatchable_derived_balance<T: key>(
-        store: Object<T>,
-        function: &FunctionInfo,
-    ): u64;
+    native fun dispatchable_derived_balance<T: key>(store: Object<T>, function: &FunctionInfo,): u64;
 
-    native fun dispatchable_derived_supply<T: key>(
-        store: Object<T>,
-        function: &FunctionInfo,
-    ): Option<u128>;
+    native fun dispatchable_derived_supply<T: key>(store: Object<T>, function: &FunctionInfo,): Option<u128>;
 }

--- a/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.spec.move
@@ -11,11 +11,11 @@ spec aptos_framework::dispatchable_fungible_asset {
         pragma opaque;
     }
 
-    spec dispatchable_derived_balance{
+    spec dispatchable_derived_balance {
         pragma opaque;
     }
 
-    spec dispatchable_derived_supply{
+    spec dispatchable_derived_supply {
         pragma opaque;
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/dkg.move
+++ b/aptos-move/framework/aptos-framework/sources/dkg.move
@@ -51,7 +51,7 @@ module aptos_framework::dkg {
                 DKGState {
                     last_completed: std::option::none(),
                     in_progress: std::option::none(),
-                }
+                },
             );
         }
     }
@@ -72,16 +72,17 @@ module aptos_framework::dkg {
             target_validator_set,
         };
         let start_time_us = timestamp::now_microseconds();
-        dkg_state.in_progress = std::option::some(DKGSessionState {
-            metadata: new_session_metadata,
-            start_time_us,
-            transcript: vector[],
-        });
+        dkg_state.in_progress = std::option::some(
+            DKGSessionState {
+                metadata: new_session_metadata,
+                start_time_us,
+                transcript: vector[],
+            },
+        );
 
-        emit(DKGStartEvent {
-            start_time_us,
-            session_metadata: new_session_metadata,
-        });
+        emit(
+            DKGStartEvent { start_time_us, session_metadata: new_session_metadata, },
+        );
     }
 
     /// Put a transcript into the currently incomplete DKG session, then mark it completed.
@@ -89,7 +90,10 @@ module aptos_framework::dkg {
     /// Abort if DKG is not in progress.
     public(friend) fun finish(transcript: vector<u8>) acquires DKGState {
         let dkg_state = borrow_global_mut<DKGState>(@aptos_framework);
-        assert!(option::is_some(&dkg_state.in_progress), error::invalid_state(EDKG_NOT_IN_PROGRESS));
+        assert!(
+            option::is_some(&dkg_state.in_progress),
+            error::invalid_state(EDKG_NOT_IN_PROGRESS),
+        );
         let session = option::extract(&mut dkg_state.in_progress);
         session.transcript = transcript;
         dkg_state.last_completed = option::some(session);

--- a/aptos-move/framework/aptos-framework/sources/dkg.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/dkg.spec.move
@@ -2,7 +2,8 @@ spec aptos_framework::dkg {
 
     spec module {
         use aptos_framework::chain_status;
-        invariant [suspendable] chain_status::is_operating() ==> exists<DKGState>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<DKGState>(@aptos_framework);
     }
 
     spec initialize(aptos_framework: &signer) {
@@ -31,9 +32,7 @@ spec aptos_framework::dkg {
     spec fun has_incomplete_session(): bool {
         if (exists<DKGState>(@aptos_framework)) {
             option::spec_is_some(global<DKGState>(@aptos_framework).in_progress)
-        } else {
-            false
-        }
+        } else { false }
     }
 
     spec try_clear_incomplete_session(fx: &signer) {

--- a/aptos-move/framework/aptos-framework/sources/event.move
+++ b/aptos-move/framework/aptos-framework/sources/event.move
@@ -41,15 +41,14 @@ module aptos_framework::event {
     #[deprecated]
     /// Use EventHandleGenerator to generate a unique event handle for `sig`
     public(friend) fun new_event_handle<T: drop + store>(guid: GUID): EventHandle<T> {
-        EventHandle<T> {
-            counter: 0,
-            guid,
-        }
+        EventHandle<T> { counter: 0, guid, }
     }
 
     #[deprecated]
     /// Emit an event with payload `msg` by using `handle_ref`'s key and counter.
-    public fun emit_event<T: drop + store>(handle_ref: &mut EventHandle<T>, msg: T) {
+    public fun emit_event<T: drop + store>(
+        handle_ref: &mut EventHandle<T>, msg: T
+    ) {
         write_to_event_store<T>(bcs::to_bytes(&handle_ref.guid), handle_ref.counter, msg);
         spec {
             assume handle_ref.counter + 1 <= MAX_U64;
@@ -85,7 +84,9 @@ module aptos_framework::event {
 
     #[deprecated]
     #[test_only]
-    public fun was_event_emitted_by_handle<T: drop + store>(handle: &EventHandle<T>, msg: &T): bool {
+    public fun was_event_emitted_by_handle<T: drop + store>(
+        handle: &EventHandle<T>, msg: &T
+    ): bool {
         use std::vector;
         vector::contains(&emitted_events_by_handle(handle), msg)
     }

--- a/aptos-move/framework/aptos-framework/sources/function_info.move
+++ b/aptos-move/framework/aptos-framework/sources/function_info.move
@@ -42,17 +42,13 @@ module aptos_framework::function_info {
     ): FunctionInfo {
         assert!(
             is_identifier(string::bytes(&module_name)),
-            EINVALID_IDENTIFIER
+            EINVALID_IDENTIFIER,
         );
         assert!(
             is_identifier(string::bytes(&function_name)),
-            EINVALID_IDENTIFIER
+            EINVALID_IDENTIFIER,
         );
-        FunctionInfo {
-            module_address,
-            module_name,
-            function_name,
-        }
+        FunctionInfo { module_address, module_name, function_name, }
     }
 
     /// Check if the dispatch target function meets the type requirements of the disptach entry point.
@@ -66,12 +62,11 @@ module aptos_framework::function_info {
     ///
     /// dispatch_target also needs to be public so the type signature will remain unchanged.
     public(friend) fun check_dispatch_type_compatibility(
-        framework_function: &FunctionInfo,
-        dispatch_target: &FunctionInfo,
+        framework_function: &FunctionInfo, dispatch_target: &FunctionInfo,
     ): bool {
         assert!(
             features::dispatchable_fungible_asset_enabled(),
-            error::aborted(ENOT_ACTIVATED)
+            error::aborted(ENOT_ACTIVATED),
         );
         load_function_impl(dispatch_target);
         check_dispatch_type_compatibility_impl(framework_function, dispatch_target)

--- a/aptos-move/framework/aptos-framework/sources/function_info.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/function_info.spec.move
@@ -7,7 +7,7 @@ spec aptos_framework::function_info {
         pragma opaque;
     }
 
-    spec load_function_impl{
+    spec load_function_impl {
         pragma opaque;
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -149,8 +149,8 @@ module aptos_framework::fungible_asset {
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     struct DispatchFunctionStore has key {
-		withdraw_function: Option<FunctionInfo>,
-		deposit_function: Option<FunctionInfo>,
+        withdraw_function: Option<FunctionInfo>,
+        deposit_function: Option<FunctionInfo>,
         derived_balance_function: Option<FunctionInfo>,
     }
 
@@ -243,37 +243,52 @@ module aptos_framework::fungible_asset {
         icon_uri: String,
         project_uri: String,
     ): Object<Metadata> {
-        assert!(!object::can_generate_delete_ref(constructor_ref), error::invalid_argument(EOBJECT_IS_DELETABLE));
+        assert!(
+            !object::can_generate_delete_ref(constructor_ref),
+            error::invalid_argument(EOBJECT_IS_DELETABLE),
+        );
         let metadata_object_signer = &object::generate_signer(constructor_ref);
-        assert!(string::length(&name) <= MAX_NAME_LENGTH, error::out_of_range(ENAME_TOO_LONG));
-        assert!(string::length(&symbol) <= MAX_SYMBOL_LENGTH, error::out_of_range(ESYMBOL_TOO_LONG));
+        assert!(
+            string::length(&name) <= MAX_NAME_LENGTH, error::out_of_range(ENAME_TOO_LONG)
+        );
+        assert!(
+            string::length(&symbol) <= MAX_SYMBOL_LENGTH,
+            error::out_of_range(ESYMBOL_TOO_LONG),
+        );
         assert!(decimals <= MAX_DECIMALS, error::out_of_range(EDECIMALS_TOO_LARGE));
-        assert!(string::length(&icon_uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
-        assert!(string::length(&project_uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
-        move_to(metadata_object_signer,
-            Metadata {
-                name,
-                symbol,
-                decimals,
-                icon_uri,
-                project_uri,
-            }
+        assert!(
+            string::length(&icon_uri) <= MAX_URI_LENGTH, error::out_of_range(
+                EURI_TOO_LONG
+            )
+        );
+        assert!(
+            string::length(&project_uri) <= MAX_URI_LENGTH,
+            error::out_of_range(EURI_TOO_LONG),
+        );
+        move_to(
+            metadata_object_signer,
+            Metadata { name, symbol, decimals, icon_uri, project_uri, },
         );
 
         if (default_to_concurrent_fungible_supply()) {
             let unlimited = option::is_none(&maximum_supply);
-            move_to(metadata_object_signer, ConcurrentSupply {
-                current: if (unlimited) {
-                    aggregator_v2::create_unbounded_aggregator()
-                } else {
-                    aggregator_v2::create_aggregator(option::extract(&mut maximum_supply))
+            move_to(
+                metadata_object_signer,
+                ConcurrentSupply {
+                    current: if (unlimited) {
+                        aggregator_v2::create_unbounded_aggregator()
+                    } else {
+                        aggregator_v2::create_aggregator(
+                            option::extract(&mut maximum_supply)
+                        )
+                    },
                 },
-            });
+            );
         } else {
-            move_to(metadata_object_signer, Supply {
-                current: 0,
-                maximum: maximum_supply
-            });
+            move_to(
+                metadata_object_signer,
+                Supply { current: 0, maximum: maximum_supply },
+            );
         };
 
         object::object_from_constructor_ref<Metadata>(constructor_ref)
@@ -282,11 +297,14 @@ module aptos_framework::fungible_asset {
     /// Set that only untransferable stores can be created for this fungible asset.
     public fun set_untransferable(constructor_ref: &ConstructorRef) {
         let metadata_addr = object::address_from_constructor_ref(constructor_ref);
-        assert!(exists<Metadata>(metadata_addr), error::not_found(EFUNGIBLE_METADATA_EXISTENCE));
+        assert!(
+            exists<Metadata>(metadata_addr), error::not_found(
+                EFUNGIBLE_METADATA_EXISTENCE
+            )
+        );
         let metadata_signer = &object::generate_signer(constructor_ref);
         move_to(metadata_signer, Untransferable {});
     }
-
 
     #[view]
     /// Returns true if the FA is untransferable.
@@ -302,65 +320,73 @@ module aptos_framework::fungible_asset {
         derived_balance_function: Option<FunctionInfo>,
     ) {
         // Verify that caller type matches callee type so wrongly typed function cannot be registered.
-        option::for_each_ref(&withdraw_function, |withdraw_function| {
-            let dispatcher_withdraw_function_info = function_info::new_function_info_from_address(
-                @aptos_framework,
-                string::utf8(b"dispatchable_fungible_asset"),
-                string::utf8(b"dispatchable_withdraw"),
-            );
+        option::for_each_ref(
+            &withdraw_function,
+            |withdraw_function| {
+                let dispatcher_withdraw_function_info =
+                    function_info::new_function_info_from_address(
+                        @aptos_framework,
+                        string::utf8(b"dispatchable_fungible_asset"),
+                        string::utf8(b"dispatchable_withdraw"),
+                    );
 
-            assert!(
-                function_info::check_dispatch_type_compatibility(
-                    &dispatcher_withdraw_function_info,
-                    withdraw_function
-                ),
-                error::invalid_argument(
-                    EWITHDRAW_FUNCTION_SIGNATURE_MISMATCH
-                )
-            );
-        });
+                assert!(
+                    function_info::check_dispatch_type_compatibility(
+                        &dispatcher_withdraw_function_info,
+                        withdraw_function,
+                    ),
+                    error::invalid_argument(EWITHDRAW_FUNCTION_SIGNATURE_MISMATCH),
+                );
+            },
+        );
 
-        option::for_each_ref(&deposit_function, |deposit_function| {
-            let dispatcher_deposit_function_info = function_info::new_function_info_from_address(
-                @aptos_framework,
-                string::utf8(b"dispatchable_fungible_asset"),
-                string::utf8(b"dispatchable_deposit"),
-            );
-            // Verify that caller type matches callee type so wrongly typed function cannot be registered.
-            assert!(
-                function_info::check_dispatch_type_compatibility(
-                    &dispatcher_deposit_function_info,
-                    deposit_function
-                ),
-                error::invalid_argument(
-                    EDEPOSIT_FUNCTION_SIGNATURE_MISMATCH
-                )
-            );
-        });
+        option::for_each_ref(
+            &deposit_function,
+            |deposit_function| {
+                let dispatcher_deposit_function_info =
+                    function_info::new_function_info_from_address(
+                        @aptos_framework,
+                        string::utf8(b"dispatchable_fungible_asset"),
+                        string::utf8(b"dispatchable_deposit"),
+                    );
+                // Verify that caller type matches callee type so wrongly typed function cannot be registered.
+                assert!(
+                    function_info::check_dispatch_type_compatibility(
+                        &dispatcher_deposit_function_info,
+                        deposit_function,
+                    ),
+                    error::invalid_argument(EDEPOSIT_FUNCTION_SIGNATURE_MISMATCH),
+                );
+            },
+        );
 
-        option::for_each_ref(&derived_balance_function, |balance_function| {
-            let dispatcher_derived_balance_function_info = function_info::new_function_info_from_address(
-                @aptos_framework,
-                string::utf8(b"dispatchable_fungible_asset"),
-                string::utf8(b"dispatchable_derived_balance"),
-            );
-            // Verify that caller type matches callee type so wrongly typed function cannot be registered.
-            assert!(
-                function_info::check_dispatch_type_compatibility(
-                    &dispatcher_derived_balance_function_info,
-                    balance_function
-                ),
-                error::invalid_argument(
-                    EDERIVED_BALANCE_FUNCTION_SIGNATURE_MISMATCH
-                )
-            );
-        });
+        option::for_each_ref(
+            &derived_balance_function,
+            |balance_function| {
+                let dispatcher_derived_balance_function_info =
+                    function_info::new_function_info_from_address(
+                        @aptos_framework,
+                        string::utf8(b"dispatchable_fungible_asset"),
+                        string::utf8(b"dispatchable_derived_balance"),
+                    );
+                // Verify that caller type matches callee type so wrongly typed function cannot be registered.
+                assert!(
+                    function_info::check_dispatch_type_compatibility(
+                        &dispatcher_derived_balance_function_info,
+                        balance_function,
+                    ),
+                    error::invalid_argument(
+                        EDERIVED_BALANCE_FUNCTION_SIGNATURE_MISMATCH
+                    ),
+                );
+            },
+        );
         register_dispatch_function_sanity_check(constructor_ref);
         assert!(
             !exists<DispatchFunctionStore>(
                 object::address_from_constructor_ref(constructor_ref)
             ),
-            error::already_exists(EALREADY_REGISTERED)
+            error::already_exists(EALREADY_REGISTERED),
         );
 
         let store_obj = &object::generate_signer(constructor_ref);
@@ -372,70 +398,68 @@ module aptos_framework::fungible_asset {
                 withdraw_function,
                 deposit_function,
                 derived_balance_function,
-            }
+            },
         );
     }
 
     /// Define the derived supply dispatch with the provided function.
     public(friend) fun register_derive_supply_dispatch_function(
-        constructor_ref: &ConstructorRef,
-        dispatch_function: Option<FunctionInfo>
+        constructor_ref: &ConstructorRef, dispatch_function: Option<FunctionInfo>
     ) {
         // Verify that caller type matches callee type so wrongly typed function cannot be registered.
-        option::for_each_ref(&dispatch_function, |supply_function| {
-            let function_info = function_info::new_function_info_from_address(
-                @aptos_framework,
-                string::utf8(b"dispatchable_fungible_asset"),
-                string::utf8(b"dispatchable_derived_supply"),
-            );
-            // Verify that caller type matches callee type so wrongly typed function cannot be registered.
-            assert!(
-                function_info::check_dispatch_type_compatibility(
-                    &function_info,
-                    supply_function
-                ),
-                error::invalid_argument(
-                    EDERIVED_SUPPLY_FUNCTION_SIGNATURE_MISMATCH
-                )
-            );
-        });
+        option::for_each_ref(
+            &dispatch_function,
+            |supply_function| {
+                let function_info =
+                    function_info::new_function_info_from_address(
+                        @aptos_framework,
+                        string::utf8(b"dispatchable_fungible_asset"),
+                        string::utf8(b"dispatchable_derived_supply"),
+                    );
+                // Verify that caller type matches callee type so wrongly typed function cannot be registered.
+                assert!(
+                    function_info::check_dispatch_type_compatibility(
+                        &function_info,
+                        supply_function,
+                    ),
+                    error::invalid_argument(
+                        EDERIVED_SUPPLY_FUNCTION_SIGNATURE_MISMATCH
+                    ),
+                );
+            },
+        );
         register_dispatch_function_sanity_check(constructor_ref);
         assert!(
             !exists<DeriveSupply>(
                 object::address_from_constructor_ref(constructor_ref)
             ),
-            error::already_exists(EALREADY_REGISTERED)
+            error::already_exists(EALREADY_REGISTERED),
         );
-
 
         let store_obj = &object::generate_signer(constructor_ref);
 
         // Store the overload function hook.
         move_to<DeriveSupply>(
             store_obj,
-            DeriveSupply {
-                dispatch_function
-            }
+            DeriveSupply { dispatch_function },
         );
     }
 
     /// Check the requirements for registering a dispatchable function.
     inline fun register_dispatch_function_sanity_check(
         constructor_ref: &ConstructorRef,
-    )  {
+    ) {
         // Cannot register hook for APT.
         assert!(
             object::address_from_constructor_ref(constructor_ref) != @aptos_fungible_asset,
-            error::permission_denied(EAPT_NOT_DISPATCHABLE)
+            error::permission_denied(EAPT_NOT_DISPATCHABLE),
         );
         assert!(
             !object::can_generate_delete_ref(constructor_ref),
-            error::invalid_argument(EOBJECT_IS_DELETABLE)
+            error::invalid_argument(EOBJECT_IS_DELETABLE),
         );
         assert!(
-            exists<Metadata>(
-                object::address_from_constructor_ref(constructor_ref)
-            ),
+            exists<Metadata>(object::address_from_constructor_ref(constructor_ref)),
             error::not_found(EFUNGIBLE_METADATA_EXISTENCE),
         );
     }
@@ -465,7 +489,9 @@ module aptos_framework::fungible_asset {
     /// Creates a mutate metadata ref that can be used to change the metadata information of fungible assets from the
     /// given fungible object's constructor ref.
     /// This can only be called at object creation time as constructor_ref is only available then.
-    public fun generate_mutate_metadata_ref(constructor_ref: &ConstructorRef): MutateMetadataRef {
+    public fun generate_mutate_metadata_ref(
+        constructor_ref: &ConstructorRef
+    ): MutateMetadataRef {
         let metadata = object::object_from_constructor_ref<Metadata>(constructor_ref);
         MutateMetadataRef { metadata }
     }
@@ -581,15 +607,16 @@ module aptos_framework::fungible_asset {
         let store_addr = object::object_address(&store);
         if (store_exists_inline(store_addr)) {
             let store_balance = borrow_store_resource(&store).balance;
-            if (store_balance == 0 && concurrent_fungible_balance_exists_inline(store_addr)) {
-                let balance_resource = borrow_global<ConcurrentFungibleBalance>(store_addr);
+            if (store_balance == 0 && concurrent_fungible_balance_exists_inline(
+                    store_addr
+                )) {
+                let balance_resource =
+                    borrow_global<ConcurrentFungibleBalance>(store_addr);
                 aggregator_v2::read(&balance_resource.balance)
             } else {
                 store_balance
             }
-        } else {
-            0
-        }
+        } else { 0 }
     }
 
     #[view]
@@ -600,11 +627,16 @@ module aptos_framework::fungible_asset {
     }
 
     /// Check whether the balance of a given store is >= `amount`.
-    public(friend) fun is_address_balance_at_least(store_addr: address, amount: u64): bool acquires FungibleStore, ConcurrentFungibleBalance {
+    public(friend) fun is_address_balance_at_least(
+        store_addr: address, amount: u64
+    ): bool acquires FungibleStore, ConcurrentFungibleBalance {
         if (store_exists_inline(store_addr)) {
             let store_balance = borrow_global<FungibleStore>(store_addr).balance;
-            if (store_balance == 0 && concurrent_fungible_balance_exists_inline(store_addr)) {
-                let balance_resource = borrow_global<ConcurrentFungibleBalance>(store_addr);
+            if (store_balance == 0 && concurrent_fungible_balance_exists_inline(
+                    store_addr
+                )) {
+                let balance_resource =
+                    borrow_global<ConcurrentFungibleBalance>(store_addr);
                 aggregator_v2::is_at_least(&balance_resource.balance, amount)
             } else {
                 store_balance >= amount
@@ -634,7 +666,7 @@ module aptos_framework::fungible_asset {
     public fun deposit_dispatch_function<T: key>(store: Object<T>): Option<FunctionInfo> acquires FungibleStore, DispatchFunctionStore {
         let fa_store = borrow_store_resource(&store);
         let metadata_addr = object::object_address(&fa_store.metadata);
-        if(exists<DispatchFunctionStore>(metadata_addr)) {
+        if (exists<DispatchFunctionStore>(metadata_addr)) {
             borrow_global<DispatchFunctionStore>(metadata_addr).deposit_function
         } else {
             option::none()
@@ -644,17 +676,18 @@ module aptos_framework::fungible_asset {
     fun has_deposit_dispatch_function(metadata: Object<Metadata>): bool acquires DispatchFunctionStore {
         let metadata_addr = object::object_address(&metadata);
         // Short circuit on APT for better perf
-        if(metadata_addr != @aptos_fungible_asset && exists<DispatchFunctionStore>(metadata_addr)) {
-            option::is_some(&borrow_global<DispatchFunctionStore>(metadata_addr).deposit_function)
-        } else {
-            false
-        }
+        if (metadata_addr != @aptos_fungible_asset
+                && exists<DispatchFunctionStore>(metadata_addr)) {
+            option::is_some(
+                &borrow_global<DispatchFunctionStore>(metadata_addr).deposit_function
+            )
+        } else { false }
     }
 
     public fun withdraw_dispatch_function<T: key>(store: Object<T>): Option<FunctionInfo> acquires FungibleStore, DispatchFunctionStore {
         let fa_store = borrow_store_resource(&store);
         let metadata_addr = object::object_address(&fa_store.metadata);
-        if(exists<DispatchFunctionStore>(metadata_addr)) {
+        if (exists<DispatchFunctionStore>(metadata_addr)) {
             borrow_global<DispatchFunctionStore>(metadata_addr).withdraw_function
         } else {
             option::none()
@@ -664,14 +697,17 @@ module aptos_framework::fungible_asset {
     fun has_withdraw_dispatch_function(metadata: Object<Metadata>): bool acquires DispatchFunctionStore {
         let metadata_addr = object::object_address(&metadata);
         // Short circuit on APT for better perf
-        if (metadata_addr != @aptos_fungible_asset && exists<DispatchFunctionStore>(metadata_addr)) {
-            option::is_some(&borrow_global<DispatchFunctionStore>(metadata_addr).withdraw_function)
-        } else {
-            false
-        }
+        if (metadata_addr != @aptos_fungible_asset
+                && exists<DispatchFunctionStore>(metadata_addr)) {
+            option::is_some(
+                &borrow_global<DispatchFunctionStore>(metadata_addr).withdraw_function
+            )
+        } else { false }
     }
 
-    public(friend) fun derived_balance_dispatch_function<T: key>(store: Object<T>): Option<FunctionInfo> acquires FungibleStore, DispatchFunctionStore {
+    public(friend) fun derived_balance_dispatch_function<T: key>(
+        store: Object<T>
+    ): Option<FunctionInfo> acquires FungibleStore, DispatchFunctionStore {
         let fa_store = borrow_store_resource(&store);
         let metadata_addr = object::object_address(&fa_store.metadata);
         if (exists<DispatchFunctionStore>(metadata_addr)) {
@@ -681,7 +717,9 @@ module aptos_framework::fungible_asset {
         }
     }
 
-    public(friend) fun derived_supply_dispatch_function<T: key>(metadata: Object<T>): Option<FunctionInfo> acquires DeriveSupply {
+    public(friend) fun derived_supply_dispatch_function<T: key>(
+        metadata: Object<T>
+    ): Option<FunctionInfo> acquires DeriveSupply {
         let metadata_addr = object::object_address(&metadata);
         if (exists<DeriveSupply>(metadata_addr)) {
             borrow_global<DeriveSupply>(metadata_addr).dispatch_function
@@ -729,24 +767,29 @@ module aptos_framework::fungible_asset {
     /// Allow an object to hold a store for fungible assets.
     /// Applications can use this to create multiple stores for isolating fungible assets for different purposes.
     public fun create_store<T: key>(
-        constructor_ref: &ConstructorRef,
-        metadata: Object<T>,
+        constructor_ref: &ConstructorRef, metadata: Object<T>,
     ): Object<FungibleStore> {
         let store_obj = &object::generate_signer(constructor_ref);
-        move_to(store_obj, FungibleStore {
-            metadata: object::convert(metadata),
-            balance: 0,
-            frozen: false,
-        });
+        move_to(
+            store_obj,
+            FungibleStore {
+                metadata: object::convert(metadata),
+                balance: 0,
+                frozen: false,
+            },
+        );
 
         if (is_untransferable(metadata)) {
             object::set_untransferable(constructor_ref);
         };
 
         if (default_to_concurrent_fungible_balance()) {
-            move_to(store_obj, ConcurrentFungibleBalance {
-                balance: aggregator_v2::create_unbounded_aggregator(),
-            });
+            move_to(
+                store_obj,
+                ConcurrentFungibleBalance {
+                    balance: aggregator_v2::create_unbounded_aggregator(),
+                },
+            );
         };
 
         object::object_from_constructor_ref<FungibleStore>(constructor_ref)
@@ -756,22 +799,23 @@ module aptos_framework::fungible_asset {
     public fun remove_store(delete_ref: &DeleteRef) acquires FungibleStore, FungibleAssetEvents, ConcurrentFungibleBalance {
         let store = &object::object_from_delete_ref<FungibleStore>(delete_ref);
         let addr = object::object_address(store);
-        let FungibleStore { metadata: _, balance, frozen: _ }
-            = move_from<FungibleStore>(addr);
+        let FungibleStore { metadata: _, balance, frozen: _ } =
+            move_from<FungibleStore>(addr);
         assert!(balance == 0, error::permission_denied(EBALANCE_IS_NOT_ZERO));
 
         if (concurrent_fungible_balance_exists_inline(addr)) {
-            let ConcurrentFungibleBalance { balance } = move_from<ConcurrentFungibleBalance>(addr);
-            assert!(aggregator_v2::read(&balance) == 0, error::permission_denied(EBALANCE_IS_NOT_ZERO));
+            let ConcurrentFungibleBalance { balance } =
+                move_from<ConcurrentFungibleBalance>(addr);
+            assert!(
+                aggregator_v2::read(&balance) == 0,
+                error::permission_denied(EBALANCE_IS_NOT_ZERO),
+            );
         };
 
         // Cleanup deprecated event handles if exist.
         if (exists<FungibleAssetEvents>(addr)) {
-            let FungibleAssetEvents {
-                deposit_events,
-                withdraw_events,
-                frozen_events,
-            } = move_from<FungibleAssetEvents>(addr);
+            let FungibleAssetEvents { deposit_events, withdraw_events, frozen_events, } =
+                move_from<FungibleAssetEvents>(addr);
             event::destroy_handle(deposit_events);
             event::destroy_handle(withdraw_events);
             event::destroy_handle(frozen_events);
@@ -794,24 +838,26 @@ module aptos_framework::fungible_asset {
         store: Object<T>,
         abort_on_dispatch: bool,
     ) acquires FungibleStore, DispatchFunctionStore {
-        assert!(object::owns(store, signer::address_of(owner)), error::permission_denied(ENOT_STORE_OWNER));
+        assert!(
+            object::owns(store, signer::address_of(owner)),
+            error::permission_denied(ENOT_STORE_OWNER),
+        );
         let fa_store = borrow_store_resource(&store);
         assert!(
             !abort_on_dispatch || !has_withdraw_dispatch_function(fa_store.metadata),
-            error::invalid_argument(EINVALID_DISPATCHABLE_OPERATIONS)
+            error::invalid_argument(EINVALID_DISPATCHABLE_OPERATIONS),
         );
         assert!(!fa_store.frozen, error::permission_denied(ESTORE_IS_FROZEN));
     }
 
     /// Deposit `amount` of the fungible asset to `store`.
     public fun deposit_sanity_check<T: key>(
-        store: Object<T>,
-        abort_on_dispatch: bool
+        store: Object<T>, abort_on_dispatch: bool
     ) acquires FungibleStore, DispatchFunctionStore {
         let fa_store = borrow_store_resource(&store);
         assert!(
             !abort_on_dispatch || !has_deposit_dispatch_function(fa_store.metadata),
-            error::invalid_argument(EINVALID_DISPATCHABLE_OPERATIONS)
+            error::invalid_argument(EINVALID_DISPATCHABLE_OPERATIONS),
         );
         assert!(!fa_store.frozen, error::permission_denied(ESTORE_IS_FROZEN));
     }
@@ -830,19 +876,16 @@ module aptos_framework::fungible_asset {
 
     /// CAN ONLY BE CALLED BY coin.move for migration.
     public(friend) fun mint_internal(
-        metadata: Object<Metadata>,
-        amount: u64
+        metadata: Object<Metadata>, amount: u64
     ): FungibleAsset acquires Supply, ConcurrentSupply {
         increase_supply(&metadata, amount);
-        FungibleAsset {
-            metadata,
-            amount
-        }
+        FungibleAsset { metadata, amount }
     }
 
     /// Mint the specified `amount` of the fungible asset to a destination store.
-    public fun mint_to<T: key>(ref: &MintRef, store: Object<T>, amount: u64)
-    acquires FungibleStore, Supply, ConcurrentSupply, DispatchFunctionStore, ConcurrentFungibleBalance {
+    public fun mint_to<T: key>(
+        ref: &MintRef, store: Object<T>, amount: u64
+    ) acquires FungibleStore, Supply, ConcurrentSupply, DispatchFunctionStore, ConcurrentFungibleBalance {
         deposit_sanity_check(store, false);
         deposit_internal(object::object_address(&store), mint(ref, amount));
     }
@@ -861,8 +904,7 @@ module aptos_framework::fungible_asset {
     }
 
     public(friend) fun set_frozen_flag_internal<T: key>(
-        store: Object<T>,
-        frozen: bool
+        store: Object<T>, frozen: bool
     ) acquires FungibleStore {
         let store_addr = object::object_address(&store);
         borrow_global_mut<FungibleStore>(store_addr).frozen = frozen;
@@ -874,37 +916,28 @@ module aptos_framework::fungible_asset {
     public fun burn(ref: &BurnRef, fa: FungibleAsset) acquires Supply, ConcurrentSupply {
         assert!(
             ref.metadata == metadata_from_asset(&fa),
-            error::invalid_argument(EBURN_REF_AND_FUNGIBLE_ASSET_MISMATCH)
+            error::invalid_argument(EBURN_REF_AND_FUNGIBLE_ASSET_MISMATCH),
         );
         burn_internal(fa);
     }
 
     /// CAN ONLY BE CALLED BY coin.move for migration.
-    public(friend) fun burn_internal(
-        fa: FungibleAsset
-    ): u64 acquires Supply, ConcurrentSupply {
-        let FungibleAsset {
-            metadata,
-            amount
-        } = fa;
+    public(friend) fun burn_internal(fa: FungibleAsset): u64 acquires Supply, ConcurrentSupply {
+        let FungibleAsset { metadata, amount } = fa;
         decrease_supply(&metadata, amount);
         amount
     }
 
     /// Burn the `amount` of the fungible asset from the given store.
     public fun burn_from<T: key>(
-        ref: &BurnRef,
-        store: Object<T>,
-        amount: u64
+        ref: &BurnRef, store: Object<T>, amount: u64
     ) acquires FungibleStore, Supply, ConcurrentSupply, ConcurrentFungibleBalance {
         // ref metadata match is checked in burn() call
         burn(ref, withdraw_internal(object::object_address(&store), amount));
     }
 
     public(friend) fun address_burn_from(
-        ref: &BurnRef,
-        store_addr: address,
-        amount: u64
+        ref: &BurnRef, store_addr: address, amount: u64
     ) acquires FungibleStore, Supply, ConcurrentSupply, ConcurrentFungibleBalance {
         // ref metadata match is checked in burn() call
         burn(ref, withdraw_internal(store_addr, amount));
@@ -912,9 +945,7 @@ module aptos_framework::fungible_asset {
 
     /// Withdraw `amount` of the fungible asset from the `store` ignoring `frozen`.
     public fun withdraw_with_ref<T: key>(
-        ref: &TransferRef,
-        store: Object<T>,
-        amount: u64
+        ref: &TransferRef, store: Object<T>, amount: u64
     ): FungibleAsset acquires FungibleStore, ConcurrentFungibleBalance {
         assert!(
             ref.metadata == store_metadata(store),
@@ -925,13 +956,11 @@ module aptos_framework::fungible_asset {
 
     /// Deposit the fungible asset into the `store` ignoring `frozen`.
     public fun deposit_with_ref<T: key>(
-        ref: &TransferRef,
-        store: Object<T>,
-        fa: FungibleAsset
+        ref: &TransferRef, store: Object<T>, fa: FungibleAsset
     ) acquires FungibleStore, ConcurrentFungibleBalance {
         assert!(
             ref.metadata == fa.metadata,
-            error::invalid_argument(ETRANSFER_REF_AND_FUNGIBLE_ASSET_MISMATCH)
+            error::invalid_argument(ETRANSFER_REF_AND_FUNGIBLE_ASSET_MISMATCH),
         );
         deposit_internal(object::object_address(&store), fa);
     }
@@ -959,19 +988,19 @@ module aptos_framework::fungible_asset {
         let metadata_address = object::object_address(&metadata_ref.metadata);
         let mutable_metadata = borrow_global_mut<Metadata>(metadata_address);
 
-        if (option::is_some(&name)){
+        if (option::is_some(&name)) {
             mutable_metadata.name = option::extract(&mut name);
         };
-        if (option::is_some(&symbol)){
+        if (option::is_some(&symbol)) {
             mutable_metadata.symbol = option::extract(&mut symbol);
         };
-        if (option::is_some(&decimals)){
+        if (option::is_some(&decimals)) {
             mutable_metadata.decimals = option::extract(&mut decimals);
         };
-        if (option::is_some(&icon_uri)){
+        if (option::is_some(&icon_uri)) {
             mutable_metadata.icon_uri = option::extract(&mut icon_uri);
         };
-        if (option::is_some(&project_uri)){
+        if (option::is_some(&project_uri)) {
             mutable_metadata.project_uri = option::extract(&mut project_uri);
         };
     }
@@ -979,27 +1008,30 @@ module aptos_framework::fungible_asset {
     /// Create a fungible asset with zero amount.
     /// This can be useful when starting a series of computations where the initial value is 0.
     public fun zero<T: key>(metadata: Object<T>): FungibleAsset {
-        FungibleAsset {
-            metadata: object::convert(metadata),
-            amount: 0,
-        }
+        FungibleAsset { metadata: object::convert(metadata), amount: 0, }
     }
 
     /// Extract a given amount from the given fungible asset and return a new one.
     public fun extract(fungible_asset: &mut FungibleAsset, amount: u64): FungibleAsset {
-        assert!(fungible_asset.amount >= amount, error::invalid_argument(EINSUFFICIENT_BALANCE));
+        assert!(
+            fungible_asset.amount >= amount, error::invalid_argument(
+                EINSUFFICIENT_BALANCE
+            )
+        );
         fungible_asset.amount = fungible_asset.amount - amount;
-        FungibleAsset {
-            metadata: fungible_asset.metadata,
-            amount,
-        }
+        FungibleAsset { metadata: fungible_asset.metadata, amount, }
     }
 
     /// "Merges" the two given fungible assets. The fungible asset passed in as `dst_fungible_asset` will have a value
     /// equal to the sum of the two (`dst_fungible_asset` and `src_fungible_asset`).
-    public fun merge(dst_fungible_asset: &mut FungibleAsset, src_fungible_asset: FungibleAsset) {
+    public fun merge(
+        dst_fungible_asset: &mut FungibleAsset, src_fungible_asset: FungibleAsset
+    ) {
         let FungibleAsset { metadata, amount } = src_fungible_asset;
-        assert!(metadata == dst_fungible_asset.metadata, error::invalid_argument(EFUNGIBLE_ASSET_MISMATCH));
+        assert!(
+            metadata == dst_fungible_asset.metadata,
+            error::invalid_argument(EFUNGIBLE_ASSET_MISMATCH),
+        );
         dst_fungible_asset.amount = dst_fungible_asset.amount + amount;
     }
 
@@ -1009,16 +1041,24 @@ module aptos_framework::fungible_asset {
         assert!(amount == 0, error::invalid_argument(EAMOUNT_IS_NOT_ZERO));
     }
 
-    public(friend) fun deposit_internal(store_addr: address, fa: FungibleAsset) acquires FungibleStore, ConcurrentFungibleBalance {
+    public(friend) fun deposit_internal(
+        store_addr: address, fa: FungibleAsset
+    ) acquires FungibleStore, ConcurrentFungibleBalance {
         let FungibleAsset { metadata, amount } = fa;
-        assert!(exists<FungibleStore>(store_addr), error::not_found(EFUNGIBLE_STORE_EXISTENCE));
+        assert!(
+            exists<FungibleStore>(store_addr), error::not_found(EFUNGIBLE_STORE_EXISTENCE)
+        );
         let store = borrow_global_mut<FungibleStore>(store_addr);
-        assert!(metadata == store.metadata, error::invalid_argument(EFUNGIBLE_ASSET_AND_STORE_MISMATCH));
+        assert!(
+            metadata == store.metadata,
+            error::invalid_argument(EFUNGIBLE_ASSET_AND_STORE_MISMATCH),
+        );
 
         if (amount == 0) return;
 
         if (store.balance == 0 && concurrent_fungible_balance_exists_inline(store_addr)) {
-            let balance_resource = borrow_global_mut<ConcurrentFungibleBalance>(store_addr);
+            let balance_resource =
+                borrow_global_mut<ConcurrentFungibleBalance>(store_addr);
             aggregator_v2::add(&mut balance_resource.balance, amount);
         } else {
             store.balance = store.balance + amount;
@@ -1029,22 +1069,30 @@ module aptos_framework::fungible_asset {
 
     /// Extract `amount` of the fungible asset from `store`.
     public(friend) fun withdraw_internal(
-        store_addr: address,
-        amount: u64,
+        store_addr: address, amount: u64,
     ): FungibleAsset acquires FungibleStore, ConcurrentFungibleBalance {
-        assert!(exists<FungibleStore>(store_addr), error::not_found(EFUNGIBLE_STORE_EXISTENCE));
+        assert!(
+            exists<FungibleStore>(store_addr), error::not_found(EFUNGIBLE_STORE_EXISTENCE)
+        );
 
         let store = borrow_global_mut<FungibleStore>(store_addr);
         let metadata = store.metadata;
         if (amount != 0) {
-            if (store.balance == 0 && concurrent_fungible_balance_exists_inline(store_addr)) {
-                let balance_resource = borrow_global_mut<ConcurrentFungibleBalance>(store_addr);
+            if (store.balance == 0 && concurrent_fungible_balance_exists_inline(
+                    store_addr
+                )) {
+                let balance_resource =
+                    borrow_global_mut<ConcurrentFungibleBalance>(store_addr);
                 assert!(
                     aggregator_v2::try_sub(&mut balance_resource.balance, amount),
-                    error::invalid_argument(EINSUFFICIENT_BALANCE)
+                    error::invalid_argument(EINSUFFICIENT_BALANCE),
                 );
             } else {
-                assert!(store.balance >= amount, error::invalid_argument(EINSUFFICIENT_BALANCE));
+                assert!(
+                    store.balance >= amount, error::invalid_argument(
+                        EINSUFFICIENT_BALANCE
+                    )
+                );
                 store.balance = store.balance - amount;
             };
 
@@ -1055,16 +1103,14 @@ module aptos_framework::fungible_asset {
 
     /// Increase the supply of a fungible asset by minting.
     fun increase_supply<T: key>(metadata: &Object<T>, amount: u64) acquires Supply, ConcurrentSupply {
-        if (amount == 0) {
-            return
-        };
+        if (amount == 0) { return };
         let metadata_address = object::object_address(metadata);
 
         if (exists<ConcurrentSupply>(metadata_address)) {
             let supply = borrow_global_mut<ConcurrentSupply>(metadata_address);
             assert!(
                 aggregator_v2::try_add(&mut supply.current, (amount as u128)),
-                error::out_of_range(EMAX_SUPPLY_EXCEEDED)
+                error::out_of_range(EMAX_SUPPLY_EXCEEDED),
             );
         } else if (exists<Supply>(metadata_address)) {
             let supply = borrow_global_mut<Supply>(metadata_address);
@@ -1072,7 +1118,7 @@ module aptos_framework::fungible_asset {
                 let max = *option::borrow_mut(&mut supply.maximum);
                 assert!(
                     max - supply.current >= (amount as u128),
-                    error::out_of_range(EMAX_SUPPLY_EXCEEDED)
+                    error::out_of_range(EMAX_SUPPLY_EXCEEDED),
                 )
             };
             supply.current = supply.current + (amount as u128);
@@ -1083,9 +1129,7 @@ module aptos_framework::fungible_asset {
 
     /// Decrease the supply of a fungible asset by burning.
     fun decrease_supply<T: key>(metadata: &Object<T>, amount: u64) acquires Supply, ConcurrentSupply {
-        if (amount == 0) {
-            return
-        };
+        if (amount == 0) { return };
         let metadata_address = object::object_address(metadata);
 
         if (exists<ConcurrentSupply>(metadata_address)) {
@@ -1093,14 +1137,14 @@ module aptos_framework::fungible_asset {
 
             assert!(
                 aggregator_v2::try_sub(&mut supply.current, (amount as u128)),
-                error::out_of_range(ESUPPLY_UNDERFLOW)
+                error::out_of_range(ESUPPLY_UNDERFLOW),
             );
         } else if (exists<Supply>(metadata_address)) {
             assert!(exists<Supply>(metadata_address), error::not_found(ESUPPLY_NOT_FOUND));
             let supply = borrow_global_mut<Supply>(metadata_address);
             assert!(
                 supply.current >= (amount as u128),
-                error::invalid_state(ESUPPLY_UNDERFLOW)
+                error::invalid_state(ESUPPLY_UNDERFLOW),
             );
             supply.current = supply.current - (amount as u128);
         } else {
@@ -1108,60 +1152,61 @@ module aptos_framework::fungible_asset {
         }
     }
 
-    inline fun borrow_fungible_metadata<T: key>(
-        metadata: &Object<T>
-    ): &Metadata acquires Metadata {
+    inline fun borrow_fungible_metadata<T: key>(metadata: &Object<T>): &Metadata acquires Metadata {
         let addr = object::object_address(metadata);
         borrow_global<Metadata>(addr)
     }
 
-    inline fun borrow_fungible_metadata_mut<T: key>(
-        metadata: &Object<T>
-    ): &mut Metadata acquires Metadata {
+    inline fun borrow_fungible_metadata_mut<T: key>(metadata: &Object<T>): &mut Metadata acquires Metadata {
         let addr = object::object_address(metadata);
         borrow_global_mut<Metadata>(addr)
     }
 
     inline fun borrow_store_resource<T: key>(store: &Object<T>): &FungibleStore acquires FungibleStore {
         let store_addr = object::object_address(store);
-        assert!(exists<FungibleStore>(store_addr), error::not_found(EFUNGIBLE_STORE_EXISTENCE));
+        assert!(
+            exists<FungibleStore>(store_addr), error::not_found(EFUNGIBLE_STORE_EXISTENCE)
+        );
         borrow_global<FungibleStore>(store_addr)
     }
 
-    public fun upgrade_to_concurrent(
-        ref: &ExtendRef,
-    ) acquires Supply {
+    public fun upgrade_to_concurrent(ref: &ExtendRef,) acquires Supply {
         let metadata_object_address = object::address_from_extend_ref(ref);
         let metadata_object_signer = object::generate_signer_for_extending(ref);
         assert!(
             features::concurrent_fungible_assets_enabled(),
-            error::invalid_argument(ECONCURRENT_SUPPLY_NOT_ENABLED)
+            error::invalid_argument(ECONCURRENT_SUPPLY_NOT_ENABLED),
         );
-        assert!(exists<Supply>(metadata_object_address), error::not_found(ESUPPLY_NOT_FOUND));
-        let Supply {
-            current,
-            maximum,
-        } = move_from<Supply>(metadata_object_address);
+        assert!(
+            exists<Supply>(metadata_object_address), error::not_found(ESUPPLY_NOT_FOUND)
+        );
+        let Supply { current, maximum, } = move_from<Supply>(metadata_object_address);
 
         let unlimited = option::is_none(&maximum);
         let supply = ConcurrentSupply {
             current: if (unlimited) {
                 aggregator_v2::create_unbounded_aggregator_with_value(current)
-            }
-            else {
-                aggregator_v2::create_aggregator_with_value(current, option::extract(&mut maximum))
+            } else {
+                aggregator_v2::create_aggregator_with_value(
+                    current, option::extract(&mut maximum)
+                )
             },
         };
         move_to(&metadata_object_signer, supply);
     }
 
     public entry fun upgrade_store_to_concurrent<T: key>(
-        owner: &signer,
-        store: Object<T>,
+        owner: &signer, store: Object<T>,
     ) acquires FungibleStore {
-        assert!(object::owns(store, signer::address_of(owner)), error::permission_denied(ENOT_STORE_OWNER));
+        assert!(
+            object::owns(store, signer::address_of(owner)),
+            error::permission_denied(ENOT_STORE_OWNER),
+        );
         assert!(!is_frozen(store), error::invalid_argument(ESTORE_IS_FROZEN));
-        assert!(allow_upgrade_to_concurrent_fungible_balance(), error::invalid_argument(ECONCURRENT_BALANCE_NOT_ENABLED));
+        assert!(
+            allow_upgrade_to_concurrent_fungible_balance(),
+            error::invalid_argument(ECONCURRENT_BALANCE_NOT_ENABLED),
+        );
         ensure_store_upgraded_to_concurrent_internal(object::object_address(&store));
     }
 
@@ -1169,11 +1214,10 @@ module aptos_framework::fungible_asset {
     fun ensure_store_upgraded_to_concurrent_internal(
         fungible_store_address: address,
     ) acquires FungibleStore {
-        if (exists<ConcurrentFungibleBalance>(fungible_store_address)) {
-            return
-        };
+        if (exists<ConcurrentFungibleBalance>(fungible_store_address)) { return };
         let store = borrow_global_mut<FungibleStore>(fungible_store_address);
-        let balance = aggregator_v2::create_unbounded_aggregator_with_value(store.balance);
+        let balance =
+            aggregator_v2::create_unbounded_aggregator_with_value(store.balance);
         store.balance = 0;
         let object_signer = create_signer::create_signer(fungible_store_address);
         move_to(&object_signer, ConcurrentFungibleBalance { balance });
@@ -1184,7 +1228,6 @@ module aptos_framework::fungible_asset {
 
     #[test_only]
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
-
     struct TestToken has key {}
 
     #[test_only]
@@ -1199,7 +1242,10 @@ module aptos_framework::fungible_asset {
     }
 
     #[test_only]
-    public fun init_test_metadata(constructor_ref: &ConstructorRef): (MintRef, TransferRef, BurnRef, MutateMetadataRef) {
+    public fun init_test_metadata(constructor_ref: &ConstructorRef)
+        : (
+        MintRef, TransferRef, BurnRef, MutateMetadataRef
+    ) {
         add_fungibility(
             constructor_ref,
             option::some(100) /* max supply */,
@@ -1212,21 +1258,24 @@ module aptos_framework::fungible_asset {
         let mint_ref = generate_mint_ref(constructor_ref);
         let burn_ref = generate_burn_ref(constructor_ref);
         let transfer_ref = generate_transfer_ref(constructor_ref);
-        let mutate_metadata_ref= generate_mutate_metadata_ref(constructor_ref);
+        let mutate_metadata_ref = generate_mutate_metadata_ref(constructor_ref);
         (mint_ref, transfer_ref, burn_ref, mutate_metadata_ref)
     }
 
     #[test_only]
-    public fun create_fungible_asset(
-        creator: &signer
-    ): (MintRef, TransferRef, BurnRef, MutateMetadataRef, Object<Metadata>) {
+    public fun create_fungible_asset(creator: &signer)
+        : (
+        MintRef, TransferRef, BurnRef, MutateMetadataRef, Object<Metadata>
+    ) {
         let (creator_ref, token_object) = create_test_token(creator);
         let (mint, transfer, burn, mutate_metadata) = init_test_metadata(&creator_ref);
         (mint, transfer, burn, mutate_metadata, object::convert(token_object))
     }
 
     #[test_only]
-    public fun create_test_store<T: key>(owner: &signer, metadata: Object<T>): Object<FungibleStore> {
+    public fun create_test_store<T: key>(
+        owner: &signer, metadata: Object<T>
+    ): Object<FungibleStore> {
         let owner_addr = signer::address_of(owner);
         if (!account::exists_at(owner_addr)) {
             account::create_account_for_test(owner_addr);
@@ -1243,16 +1292,22 @@ module aptos_framework::fungible_asset {
         assert!(name(metadata) == string::utf8(b"TEST"), 3);
         assert!(symbol(metadata) == string::utf8(b"@@"), 4);
         assert!(decimals(metadata) == 0, 5);
-        assert!(icon_uri(metadata) == string::utf8(b"http://www.example.com/favicon.ico"), 6);
+        assert!(
+            icon_uri(metadata) == string::utf8(b"http://www.example.com/favicon.ico"), 6
+        );
         assert!(project_uri(metadata) == string::utf8(b"http://www.example.com"), 7);
 
-        assert!(metadata(metadata) == Metadata {
-            name: string::utf8(b"TEST"),
-            symbol: string::utf8(b"@@"),
-            decimals: 0,
-            icon_uri: string::utf8(b"http://www.example.com/favicon.ico"),
-            project_uri: string::utf8(b"http://www.example.com"),
-        }, 8);
+        assert!(
+            metadata(metadata)
+                == Metadata {
+                    name: string::utf8(b"TEST"),
+                    symbol: string::utf8(b"@@"),
+                    decimals: 0,
+                    icon_uri: string::utf8(b"http://www.example.com/favicon.ico"),
+                    project_uri: string::utf8(b"http://www.example.com"),
+                },
+            8,
+        );
 
         increase_supply(&metadata, 50);
         assert!(supply(metadata) == option::some(50), 9);
@@ -1279,10 +1334,10 @@ module aptos_framework::fungible_asset {
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     fun test_e2e_basic_flow(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) acquires FungibleStore, Supply, ConcurrentSupply, DispatchFunctionStore, ConcurrentFungibleBalance, Metadata {
-        let (mint_ref, transfer_ref, burn_ref, mutate_metadata_ref, test_token) = create_fungible_asset(creator);
+        let (mint_ref, transfer_ref, burn_ref, mutate_metadata_ref, test_token) =
+            create_fungible_asset(creator);
         let metadata = mint_ref.metadata;
         let creator_store = create_test_store(creator, metadata);
         let aaron_store = create_test_store(aaron, metadata);
@@ -1314,21 +1369,22 @@ module aptos_framework::fungible_asset {
             option::some(string::utf8(b"mutated_symbol")),
             option::none(),
             option::none(),
-            option::none()
+            option::none(),
         );
         assert!(name(metadata) == string::utf8(b"mutated_name"), 8);
         assert!(symbol(metadata) == string::utf8(b"mutated_symbol"), 9);
         assert!(decimals(metadata) == 0, 10);
-        assert!(icon_uri(metadata) == string::utf8(b"http://www.example.com/favicon.ico"), 11);
+        assert!(
+            icon_uri(metadata) == string::utf8(b"http://www.example.com/favicon.ico"), 11
+        );
         assert!(project_uri(metadata) == string::utf8(b"http://www.example.com"), 12);
     }
 
     #[test(creator = @0xcafe)]
     #[expected_failure(abort_code = 0x50003, location = Self)]
-    fun test_frozen(
-        creator: &signer
-    ) acquires FungibleStore, Supply, ConcurrentSupply, DispatchFunctionStore, ConcurrentFungibleBalance {
-        let (mint_ref, transfer_ref, _burn_ref, _mutate_metadata_ref,  _) = create_fungible_asset(creator);
+    fun test_frozen(creator: &signer) acquires FungibleStore, Supply, ConcurrentSupply, DispatchFunctionStore, ConcurrentFungibleBalance {
+        let (mint_ref, transfer_ref, _burn_ref, _mutate_metadata_ref, _) =
+            create_fungible_asset(creator);
 
         let creator_store = create_test_store(creator, mint_ref.metadata);
         let fa = mint(&mint_ref, 100);
@@ -1338,10 +1394,9 @@ module aptos_framework::fungible_asset {
 
     #[test(creator = @0xcafe)]
     #[expected_failure(abort_code = 0x50003, location = Self)]
-    fun test_mint_to_frozen(
-        creator: &signer
-    ) acquires FungibleStore, ConcurrentFungibleBalance, Supply, ConcurrentSupply, DispatchFunctionStore {
-        let (mint_ref, transfer_ref, _burn_ref, _mutate_metadata_ref, _) = create_fungible_asset(creator);
+    fun test_mint_to_frozen(creator: &signer) acquires FungibleStore, ConcurrentFungibleBalance, Supply, ConcurrentSupply, DispatchFunctionStore {
+        let (mint_ref, transfer_ref, _burn_ref, _mutate_metadata_ref, _) =
+            create_fungible_asset(creator);
 
         let creator_store = create_test_store(creator, mint_ref.metadata);
         set_frozen_flag(&transfer_ref, creator_store, true);
@@ -1350,9 +1405,7 @@ module aptos_framework::fungible_asset {
 
     #[test(creator = @0xcafe)]
     #[expected_failure(abort_code = 0x50003, location = aptos_framework::object)]
-    fun test_untransferable(
-        creator: &signer
-    ) {
+    fun test_untransferable(creator: &signer) {
         let (creator_ref, _) = create_test_token(creator);
         let (mint_ref, _, _, _) = init_test_metadata(&creator_ref);
         set_untransferable(&creator_ref);
@@ -1363,10 +1416,10 @@ module aptos_framework::fungible_asset {
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     fun test_transfer_with_ref(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) acquires FungibleStore, Supply, ConcurrentSupply, ConcurrentFungibleBalance {
-        let (mint_ref, transfer_ref, _burn_ref, _mutate_metadata_ref, _) = create_fungible_asset(creator);
+        let (mint_ref, transfer_ref, _burn_ref, _mutate_metadata_ref, _) =
+            create_fungible_asset(creator);
         let metadata = mint_ref.metadata;
         let creator_store = create_test_store(creator, metadata);
         let aaron_store = create_test_store(aaron, metadata);
@@ -1383,10 +1436,9 @@ module aptos_framework::fungible_asset {
     }
 
     #[test(creator = @0xcafe)]
-    fun test_mutate_metadata(
-        creator: &signer
-    ) acquires Metadata {
-        let (mint_ref, _transfer_ref, _burn_ref, mutate_metadata_ref, _) = create_fungible_asset(creator);
+    fun test_mutate_metadata(creator: &signer) acquires Metadata {
+        let (mint_ref, _transfer_ref, _burn_ref, mutate_metadata_ref, _) =
+            create_fungible_asset(creator);
         let metadata = mint_ref.metadata;
 
         mutate_metadata(
@@ -1395,20 +1447,26 @@ module aptos_framework::fungible_asset {
             option::some(string::utf8(b"mutated_symbol")),
             option::some(10),
             option::some(string::utf8(b"http://www.mutated-example.com/favicon.ico")),
-            option::some(string::utf8(b"http://www.mutated-example.com"))
+            option::some(string::utf8(b"http://www.mutated-example.com")),
         );
         assert!(name(metadata) == string::utf8(b"mutated_name"), 1);
         assert!(symbol(metadata) == string::utf8(b"mutated_symbol"), 2);
         assert!(decimals(metadata) == 10, 3);
-        assert!(icon_uri(metadata) == string::utf8(b"http://www.mutated-example.com/favicon.ico"), 4);
-        assert!(project_uri(metadata) == string::utf8(b"http://www.mutated-example.com"), 5);
+        assert!(
+            icon_uri(metadata) == string::utf8(
+                b"http://www.mutated-example.com/favicon.ico"
+            ),
+            4,
+        );
+        assert!(
+            project_uri(metadata) == string::utf8(b"http://www.mutated-example.com"), 5
+        );
     }
 
     #[test(creator = @0xcafe)]
-    fun test_partial_mutate_metadata(
-        creator: &signer
-    ) acquires Metadata {
-        let (mint_ref, _transfer_ref, _burn_ref, mutate_metadata_ref, _) = create_fungible_asset(creator);
+    fun test_partial_mutate_metadata(creator: &signer) acquires Metadata {
+        let (mint_ref, _transfer_ref, _burn_ref, mutate_metadata_ref, _) =
+            create_fungible_asset(creator);
         let metadata = mint_ref.metadata;
 
         mutate_metadata(
@@ -1417,18 +1475,21 @@ module aptos_framework::fungible_asset {
             option::some(string::utf8(b"mutated_symbol")),
             option::none(),
             option::none(),
-            option::none()
+            option::none(),
         );
         assert!(name(metadata) == string::utf8(b"mutated_name"), 8);
         assert!(symbol(metadata) == string::utf8(b"mutated_symbol"), 9);
         assert!(decimals(metadata) == 0, 10);
-        assert!(icon_uri(metadata) == string::utf8(b"http://www.example.com/favicon.ico"), 11);
+        assert!(
+            icon_uri(metadata) == string::utf8(b"http://www.example.com/favicon.ico"), 11
+        );
         assert!(project_uri(metadata) == string::utf8(b"http://www.example.com"), 12);
     }
 
     #[test(creator = @0xcafe)]
     fun test_merge_and_exact(creator: &signer) acquires Supply, ConcurrentSupply {
-        let (mint_ref, _transfer_ref, burn_ref, _mutate_metadata_ref, _) = create_fungible_asset(creator);
+        let (mint_ref, _transfer_ref, burn_ref, _mutate_metadata_ref, _) =
+            create_fungible_asset(creator);
         let fa = mint(&mint_ref, 100);
         let cash = extract(&mut fa, 80);
         assert!(fa.amount == 20, 1);
@@ -1450,40 +1511,41 @@ module aptos_framework::fungible_asset {
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     #[expected_failure(abort_code = 0x10006, location = Self)]
-    fun test_fungible_asset_mismatch_when_merge(creator: &signer, aaron: &signer) {
+    fun test_fungible_asset_mismatch_when_merge(
+        creator: &signer, aaron: &signer
+    ) {
         let (_, _, _, _, metadata1) = create_fungible_asset(creator);
         let (_, _, _, _, metadata2) = create_fungible_asset(aaron);
-        let base = FungibleAsset {
-            metadata: metadata1,
-            amount: 1,
-        };
-        let addon = FungibleAsset {
-            metadata: metadata2,
-            amount: 1
-        };
+        let base = FungibleAsset { metadata: metadata1, amount: 1, };
+        let addon = FungibleAsset { metadata: metadata2, amount: 1 };
         merge(&mut base, addon);
-        let FungibleAsset {
-            metadata: _,
-            amount: _
-        } = base;
+        let FungibleAsset { metadata: _, amount: _ } = base;
     }
 
     #[test(fx = @aptos_framework, creator = @0xcafe)]
     fun test_fungible_asset_upgrade(fx: &signer, creator: &signer) acquires Supply, ConcurrentSupply, FungibleStore, ConcurrentFungibleBalance {
         let supply_feature = features::get_concurrent_fungible_assets_feature();
         let balance_feature = features::get_concurrent_fungible_balance_feature();
-        let default_balance_feature = features::get_default_to_concurrent_fungible_balance_feature();
+        let default_balance_feature =
+            features::get_default_to_concurrent_fungible_balance_feature();
 
-        features::change_feature_flags_for_testing(fx, vector[], vector[supply_feature, balance_feature, default_balance_feature]);
+        features::change_feature_flags_for_testing(
+            fx,
+            vector[],
+            vector[supply_feature, balance_feature, default_balance_feature],
+        );
 
         let (creator_ref, token_object) = create_test_token(creator);
-        let (mint_ref, transfer_ref, _burn, _mutate_metadata_ref) = init_test_metadata(&creator_ref);
+        let (mint_ref, transfer_ref, _burn, _mutate_metadata_ref) =
+            init_test_metadata(&creator_ref);
         let test_token = object::convert<TestToken, Metadata>(token_object);
         assert!(exists<Supply>(object::object_address(&test_token)), 1);
         assert!(!exists<ConcurrentSupply>(object::object_address(&test_token)), 2);
         let creator_store = create_test_store(creator, test_token);
         assert!(exists<FungibleStore>(object::object_address(&creator_store)), 3);
-        assert!(!exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)), 4);
+        assert!(
+            !exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)), 4
+        );
 
         let fa = mint(&mint_ref, 30);
         assert!(supply(test_token) == option::some(30), 5);
@@ -1491,9 +1553,13 @@ module aptos_framework::fungible_asset {
         deposit_with_ref(&transfer_ref, creator_store, fa);
         assert!(exists<FungibleStore>(object::object_address(&creator_store)), 13);
         assert!(borrow_store_resource(&creator_store).balance == 30, 14);
-        assert!(!exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)), 15);
+        assert!(
+            !exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)), 15
+        );
 
-        features::change_feature_flags_for_testing(fx, vector[supply_feature, balance_feature], vector[default_balance_feature]);
+        features::change_feature_flags_for_testing(
+            fx, vector[supply_feature, balance_feature], vector[default_balance_feature]
+        );
 
         let extend_ref = object::generate_extend_ref(&creator_ref);
         // manual conversion of supply
@@ -1507,28 +1573,47 @@ module aptos_framework::fungible_asset {
         // both store and new balance need to exist. Old balance should be 0.
         assert!(exists<FungibleStore>(object::object_address(&creator_store)), 9);
         assert!(borrow_store_resource(&creator_store).balance == 0, 10);
-        assert!(exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)), 11);
-        assert!(aggregator_v2::read(&borrow_global<ConcurrentFungibleBalance>(object::object_address(&creator_store)).balance) == 10, 12);
+        assert!(
+            exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)), 11
+        );
+        assert!(
+            aggregator_v2::read(
+                &borrow_global<ConcurrentFungibleBalance>(
+                    object::object_address(&creator_store)
+                ).balance,
+            ) == 10,
+            12,
+        );
 
         deposit_with_ref(&transfer_ref, creator_store, fb);
     }
 
     #[test(fx = @aptos_framework, creator = @0xcafe)]
-    fun test_fungible_asset_default_concurrent(fx: &signer, creator: &signer) acquires Supply, ConcurrentSupply, FungibleStore, ConcurrentFungibleBalance {
+    fun test_fungible_asset_default_concurrent(
+        fx: &signer, creator: &signer
+    ) acquires Supply, ConcurrentSupply, FungibleStore, ConcurrentFungibleBalance {
         let supply_feature = features::get_concurrent_fungible_assets_feature();
         let balance_feature = features::get_concurrent_fungible_balance_feature();
-        let default_balance_feature = features::get_default_to_concurrent_fungible_balance_feature();
+        let default_balance_feature =
+            features::get_default_to_concurrent_fungible_balance_feature();
 
-        features::change_feature_flags_for_testing(fx, vector[supply_feature, balance_feature, default_balance_feature], vector[]);
+        features::change_feature_flags_for_testing(
+            fx,
+            vector[supply_feature, balance_feature, default_balance_feature],
+            vector[],
+        );
 
         let (creator_ref, token_object) = create_test_token(creator);
-        let (mint_ref, transfer_ref, _burn, _mutate_metadata_ref) = init_test_metadata(&creator_ref);
+        let (mint_ref, transfer_ref, _burn, _mutate_metadata_ref) =
+            init_test_metadata(&creator_ref);
         let test_token = object::convert<TestToken, Metadata>(token_object);
         assert!(!exists<Supply>(object::object_address(&test_token)), 1);
         assert!(exists<ConcurrentSupply>(object::object_address(&test_token)), 2);
         let creator_store = create_test_store(creator, test_token);
         assert!(exists<FungibleStore>(object::object_address(&creator_store)), 3);
-        assert!(exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)), 4);
+        assert!(
+            exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)), 4
+        );
 
         let fa = mint(&mint_ref, 30);
         assert!(supply(test_token) == option::some(30), 5);
@@ -1537,8 +1622,17 @@ module aptos_framework::fungible_asset {
 
         assert!(exists<FungibleStore>(object::object_address(&creator_store)), 9);
         assert!(borrow_store_resource(&creator_store).balance == 0, 10);
-        assert!(exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)), 11);
-        assert!(aggregator_v2::read(&borrow_global<ConcurrentFungibleBalance>(object::object_address(&creator_store)).balance) == 30, 12);
+        assert!(
+            exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)), 11
+        );
+        assert!(
+            aggregator_v2::read(
+                &borrow_global<ConcurrentFungibleBalance>(
+                    object::object_address(&creator_store)
+                ).balance,
+            ) == 30,
+            12,
+        );
     }
 
     #[deprecated]

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -257,9 +257,8 @@ module aptos_framework::fungible_asset {
         );
         assert!(decimals <= MAX_DECIMALS, error::out_of_range(EDECIMALS_TOO_LARGE));
         assert!(
-            string::length(&icon_uri) <= MAX_URI_LENGTH, error::out_of_range(
-                EURI_TOO_LONG
-            )
+            string::length(&icon_uri) <= MAX_URI_LENGTH,
+            error::out_of_range(EURI_TOO_LONG),
         );
         assert!(
             string::length(&project_uri) <= MAX_URI_LENGTH,
@@ -298,9 +297,8 @@ module aptos_framework::fungible_asset {
     public fun set_untransferable(constructor_ref: &ConstructorRef) {
         let metadata_addr = object::address_from_constructor_ref(constructor_ref);
         assert!(
-            exists<Metadata>(metadata_addr), error::not_found(
-                EFUNGIBLE_METADATA_EXISTENCE
-            )
+            exists<Metadata>(metadata_addr),
+            error::not_found(EFUNGIBLE_METADATA_EXISTENCE),
         );
         let metadata_signer = &object::generate_signer(constructor_ref);
         move_to(metadata_signer, Untransferable {});
@@ -608,8 +606,8 @@ module aptos_framework::fungible_asset {
         if (store_exists_inline(store_addr)) {
             let store_balance = borrow_store_resource(&store).balance;
             if (store_balance == 0 && concurrent_fungible_balance_exists_inline(
-                    store_addr
-                )) {
+                store_addr
+            )) {
                 let balance_resource =
                     borrow_global<ConcurrentFungibleBalance>(store_addr);
                 aggregator_v2::read(&balance_resource.balance)
@@ -633,8 +631,8 @@ module aptos_framework::fungible_asset {
         if (store_exists_inline(store_addr)) {
             let store_balance = borrow_global<FungibleStore>(store_addr).balance;
             if (store_balance == 0 && concurrent_fungible_balance_exists_inline(
-                    store_addr
-                )) {
+                store_addr
+            )) {
                 let balance_resource =
                     borrow_global<ConcurrentFungibleBalance>(store_addr);
                 aggregator_v2::is_at_least(&balance_resource.balance, amount)
@@ -677,7 +675,7 @@ module aptos_framework::fungible_asset {
         let metadata_addr = object::object_address(&metadata);
         // Short circuit on APT for better perf
         if (metadata_addr != @aptos_fungible_asset
-                && exists<DispatchFunctionStore>(metadata_addr)) {
+            && exists<DispatchFunctionStore>(metadata_addr)) {
             option::is_some(
                 &borrow_global<DispatchFunctionStore>(metadata_addr).deposit_function
             )
@@ -698,7 +696,7 @@ module aptos_framework::fungible_asset {
         let metadata_addr = object::object_address(&metadata);
         // Short circuit on APT for better perf
         if (metadata_addr != @aptos_fungible_asset
-                && exists<DispatchFunctionStore>(metadata_addr)) {
+            && exists<DispatchFunctionStore>(metadata_addr)) {
             option::is_some(
                 &borrow_global<DispatchFunctionStore>(metadata_addr).withdraw_function
             )
@@ -1014,9 +1012,8 @@ module aptos_framework::fungible_asset {
     /// Extract a given amount from the given fungible asset and return a new one.
     public fun extract(fungible_asset: &mut FungibleAsset, amount: u64): FungibleAsset {
         assert!(
-            fungible_asset.amount >= amount, error::invalid_argument(
-                EINSUFFICIENT_BALANCE
-            )
+            fungible_asset.amount >= amount,
+            error::invalid_argument(EINSUFFICIENT_BALANCE),
         );
         fungible_asset.amount = fungible_asset.amount - amount;
         FungibleAsset { metadata: fungible_asset.metadata, amount, }
@@ -1046,7 +1043,8 @@ module aptos_framework::fungible_asset {
     ) acquires FungibleStore, ConcurrentFungibleBalance {
         let FungibleAsset { metadata, amount } = fa;
         assert!(
-            exists<FungibleStore>(store_addr), error::not_found(EFUNGIBLE_STORE_EXISTENCE)
+            exists<FungibleStore>(store_addr),
+            error::not_found(EFUNGIBLE_STORE_EXISTENCE),
         );
         let store = borrow_global_mut<FungibleStore>(store_addr);
         assert!(
@@ -1072,15 +1070,16 @@ module aptos_framework::fungible_asset {
         store_addr: address, amount: u64,
     ): FungibleAsset acquires FungibleStore, ConcurrentFungibleBalance {
         assert!(
-            exists<FungibleStore>(store_addr), error::not_found(EFUNGIBLE_STORE_EXISTENCE)
+            exists<FungibleStore>(store_addr),
+            error::not_found(EFUNGIBLE_STORE_EXISTENCE),
         );
 
         let store = borrow_global_mut<FungibleStore>(store_addr);
         let metadata = store.metadata;
         if (amount != 0) {
             if (store.balance == 0 && concurrent_fungible_balance_exists_inline(
-                    store_addr
-                )) {
+                store_addr
+            )) {
                 let balance_resource =
                     borrow_global_mut<ConcurrentFungibleBalance>(store_addr);
                 assert!(
@@ -1089,9 +1088,8 @@ module aptos_framework::fungible_asset {
                 );
             } else {
                 assert!(
-                    store.balance >= amount, error::invalid_argument(
-                        EINSUFFICIENT_BALANCE
-                    )
+                    store.balance >= amount,
+                    error::invalid_argument(EINSUFFICIENT_BALANCE),
                 );
                 store.balance = store.balance - amount;
             };
@@ -1165,7 +1163,8 @@ module aptos_framework::fungible_asset {
     inline fun borrow_store_resource<T: key>(store: &Object<T>): &FungibleStore acquires FungibleStore {
         let store_addr = object::object_address(store);
         assert!(
-            exists<FungibleStore>(store_addr), error::not_found(EFUNGIBLE_STORE_EXISTENCE)
+            exists<FungibleStore>(store_addr),
+            error::not_found(EFUNGIBLE_STORE_EXISTENCE),
         );
         borrow_global<FungibleStore>(store_addr)
     }
@@ -1178,7 +1177,8 @@ module aptos_framework::fungible_asset {
             error::invalid_argument(ECONCURRENT_SUPPLY_NOT_ENABLED),
         );
         assert!(
-            exists<Supply>(metadata_object_address), error::not_found(ESUPPLY_NOT_FOUND)
+            exists<Supply>(metadata_object_address),
+            error::not_found(ESUPPLY_NOT_FOUND),
         );
         let Supply { current, maximum, } = move_from<Supply>(metadata_object_address);
 
@@ -1293,7 +1293,8 @@ module aptos_framework::fungible_asset {
         assert!(symbol(metadata) == string::utf8(b"@@"), 4);
         assert!(decimals(metadata) == 0, 5);
         assert!(
-            icon_uri(metadata) == string::utf8(b"http://www.example.com/favicon.ico"), 6
+            icon_uri(metadata) == string::utf8(b"http://www.example.com/favicon.ico"),
+            6,
         );
         assert!(project_uri(metadata) == string::utf8(b"http://www.example.com"), 7);
 
@@ -1333,9 +1334,7 @@ module aptos_framework::fungible_asset {
     }
 
     #[test(creator = @0xcafe, aaron = @0xface)]
-    fun test_e2e_basic_flow(
-        creator: &signer, aaron: &signer,
-    ) acquires FungibleStore, Supply, ConcurrentSupply, DispatchFunctionStore, ConcurrentFungibleBalance, Metadata {
+    fun test_e2e_basic_flow(creator: &signer, aaron: &signer,) acquires FungibleStore, Supply, ConcurrentSupply, DispatchFunctionStore, ConcurrentFungibleBalance, Metadata {
         let (mint_ref, transfer_ref, burn_ref, mutate_metadata_ref, test_token) =
             create_fungible_asset(creator);
         let metadata = mint_ref.metadata;
@@ -1375,7 +1374,8 @@ module aptos_framework::fungible_asset {
         assert!(symbol(metadata) == string::utf8(b"mutated_symbol"), 9);
         assert!(decimals(metadata) == 0, 10);
         assert!(
-            icon_uri(metadata) == string::utf8(b"http://www.example.com/favicon.ico"), 11
+            icon_uri(metadata) == string::utf8(b"http://www.example.com/favicon.ico"),
+            11,
         );
         assert!(project_uri(metadata) == string::utf8(b"http://www.example.com"), 12);
     }
@@ -1415,9 +1415,7 @@ module aptos_framework::fungible_asset {
     }
 
     #[test(creator = @0xcafe, aaron = @0xface)]
-    fun test_transfer_with_ref(
-        creator: &signer, aaron: &signer,
-    ) acquires FungibleStore, Supply, ConcurrentSupply, ConcurrentFungibleBalance {
+    fun test_transfer_with_ref(creator: &signer, aaron: &signer,) acquires FungibleStore, Supply, ConcurrentSupply, ConcurrentFungibleBalance {
         let (mint_ref, transfer_ref, _burn_ref, _mutate_metadata_ref, _) =
             create_fungible_asset(creator);
         let metadata = mint_ref.metadata;
@@ -1459,7 +1457,8 @@ module aptos_framework::fungible_asset {
             4,
         );
         assert!(
-            project_uri(metadata) == string::utf8(b"http://www.mutated-example.com"), 5
+            project_uri(metadata) == string::utf8(b"http://www.mutated-example.com"),
+            5,
         );
     }
 
@@ -1481,7 +1480,8 @@ module aptos_framework::fungible_asset {
         assert!(symbol(metadata) == string::utf8(b"mutated_symbol"), 9);
         assert!(decimals(metadata) == 0, 10);
         assert!(
-            icon_uri(metadata) == string::utf8(b"http://www.example.com/favicon.ico"), 11
+            icon_uri(metadata) == string::utf8(b"http://www.example.com/favicon.ico"),
+            11,
         );
         assert!(project_uri(metadata) == string::utf8(b"http://www.example.com"), 12);
     }
@@ -1544,7 +1544,8 @@ module aptos_framework::fungible_asset {
         let creator_store = create_test_store(creator, test_token);
         assert!(exists<FungibleStore>(object::object_address(&creator_store)), 3);
         assert!(
-            !exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)), 4
+            !exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)),
+            4,
         );
 
         let fa = mint(&mint_ref, 30);
@@ -1554,11 +1555,14 @@ module aptos_framework::fungible_asset {
         assert!(exists<FungibleStore>(object::object_address(&creator_store)), 13);
         assert!(borrow_store_resource(&creator_store).balance == 30, 14);
         assert!(
-            !exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)), 15
+            !exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)),
+            15,
         );
 
         features::change_feature_flags_for_testing(
-            fx, vector[supply_feature, balance_feature], vector[default_balance_feature]
+            fx,
+            vector[supply_feature, balance_feature],
+            vector[default_balance_feature],
         );
 
         let extend_ref = object::generate_extend_ref(&creator_ref);
@@ -1574,7 +1578,8 @@ module aptos_framework::fungible_asset {
         assert!(exists<FungibleStore>(object::object_address(&creator_store)), 9);
         assert!(borrow_store_resource(&creator_store).balance == 0, 10);
         assert!(
-            exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)), 11
+            exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)),
+            11,
         );
         assert!(
             aggregator_v2::read(
@@ -1612,7 +1617,8 @@ module aptos_framework::fungible_asset {
         let creator_store = create_test_store(creator, test_token);
         assert!(exists<FungibleStore>(object::object_address(&creator_store)), 3);
         assert!(
-            exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)), 4
+            exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)),
+            4,
         );
 
         let fa = mint(&mint_ref, 30);
@@ -1623,7 +1629,8 @@ module aptos_framework::fungible_asset {
         assert!(exists<FungibleStore>(object::object_address(&creator_store)), 9);
         assert!(borrow_store_resource(&creator_store).balance == 0, 10);
         assert!(
-            exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)), 11
+            exists<ConcurrentFungibleBalance>(object::object_address(&creator_store)),
+            11,
         );
         assert!(
             aggregator_v2::read(

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.spec.move
@@ -135,6 +135,6 @@ spec aptos_framework::fungible_asset {
     ///
     spec module {
         // TODO: verification disabled until this module is specified.
-        pragma verify=false;
+        pragma verify = false;
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -101,8 +101,7 @@ module aptos_framework::genesis {
         );
 
         // put reserved framework reserved accounts under aptos governance
-        let framework_reserved_addresses = vector<address>[@0x2, @0x3, @0x4, @0x5, @0x6, @
-            0x7, @0x8, @0x9, @0xa];
+        let framework_reserved_addresses = vector<address>[@0x2, @0x3, @0x4, @0x5, @0x6, @0x7, @0x8, @0x9, @0xa];
         while (!vector::is_empty(&framework_reserved_addresses)) {
             let address = vector::pop_back<address>(&mut framework_reserved_addresses);
             let (_, framework_signer_cap) =
@@ -295,7 +294,9 @@ module aptos_framework::genesis {
 
                 if (employee_group.beneficiary_resetter != @0x0) {
                     vesting::set_beneficiary_resetter(
-                        admin_signer, contract_address, employee_group.beneficiary_resetter
+                        admin_signer,
+                        contract_address,
+                        employee_group.beneficiary_resetter,
                     );
                 };
 
@@ -560,7 +561,8 @@ module aptos_framework::genesis {
 
         let accounts = vector[
             AccountMap { account_address: addr0, balance: 12345, },
-            AccountMap { account_address: addr1, balance: 67890, },];
+            AccountMap { account_address: addr1, balance: 67890, },
+        ];
 
         create_accounts(aptos_framework, accounts);
         assert!(coin::balance<AptosCoin>(addr0) == 12345, 0);
@@ -593,7 +595,8 @@ module aptos_framework::genesis {
 
         let apt_metadata = object::address_to_object<Metadata>(@aptos_fungible_asset);
         assert!(
-            primary_fungible_store::primary_store_exists(@core_resources, apt_metadata), 2
+            primary_fungible_store::primary_store_exists(@core_resources, apt_metadata),
+            2,
         );
 
         aptos_coin::configure_accounts_for_test(

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -82,7 +82,8 @@ module aptos_framework::genesis {
         // Initialize the aptos framework account. This is the account where system resources and modules will be
         // deployed to. This will be entirely managed by on-chain governance and no entities have the key or privileges
         // to use this account.
-        let (aptos_framework_account, aptos_framework_signer_cap) = account::create_framework_reserved_account(@aptos_framework);
+        let (aptos_framework_account, aptos_framework_signer_cap) =
+            account::create_framework_reserved_account(@aptos_framework);
         // Initialize account configs on aptos framework account.
         account::initialize(&aptos_framework_account);
 
@@ -95,14 +96,20 @@ module aptos_framework::genesis {
         );
 
         // Give the decentralized on-chain governance control over the core framework account.
-        aptos_governance::store_signer_cap(&aptos_framework_account, @aptos_framework, aptos_framework_signer_cap);
+        aptos_governance::store_signer_cap(
+            &aptos_framework_account, @aptos_framework, aptos_framework_signer_cap
+        );
 
         // put reserved framework reserved accounts under aptos governance
-        let framework_reserved_addresses = vector<address>[@0x2, @0x3, @0x4, @0x5, @0x6, @0x7, @0x8, @0x9, @0xa];
+        let framework_reserved_addresses = vector<address>[@0x2, @0x3, @0x4, @0x5, @0x6, @
+            0x7, @0x8, @0x9, @0xa];
         while (!vector::is_empty(&framework_reserved_addresses)) {
             let address = vector::pop_back<address>(&mut framework_reserved_addresses);
-            let (_, framework_signer_cap) = account::create_framework_reserved_account(address);
-            aptos_governance::store_signer_cap(&aptos_framework_account, address, framework_signer_cap);
+            let (_, framework_signer_cap) =
+                account::create_framework_reserved_account(address);
+            aptos_governance::store_signer_cap(
+                &aptos_framework_account, address, framework_signer_cap
+            );
         };
 
         consensus_config::initialize(&aptos_framework_account, consensus_config);
@@ -150,8 +157,7 @@ module aptos_framework::genesis {
 
     /// Only called for testnets and e2e tests.
     fun initialize_core_resources_and_aptos_coin(
-        aptos_framework: &signer,
-        core_resources_auth_key: vector<u8>,
+        aptos_framework: &signer, core_resources_auth_key: vector<u8>,
     ) {
         let (burn_cap, mint_cap) = aptos_coin::initialize(aptos_framework);
 
@@ -166,32 +172,43 @@ module aptos_framework::genesis {
         transaction_fee::store_aptos_coin_mint_cap(aptos_framework, mint_cap);
 
         let core_resources = account::create_account(@core_resources);
-        account::rotate_authentication_key_internal(&core_resources, core_resources_auth_key);
+        account::rotate_authentication_key_internal(
+            &core_resources, core_resources_auth_key
+        );
         aptos_account::register_apt(&core_resources); // registers APT store
-        aptos_coin::configure_accounts_for_test(aptos_framework, &core_resources, mint_cap);
+        aptos_coin::configure_accounts_for_test(
+            aptos_framework, &core_resources, mint_cap
+        );
     }
 
-    fun create_accounts(aptos_framework: &signer, accounts: vector<AccountMap>) {
+    fun create_accounts(
+        aptos_framework: &signer, accounts: vector<AccountMap>
+    ) {
         let unique_accounts = vector::empty();
-        vector::for_each_ref(&accounts, |account_map| {
-            let account_map: &AccountMap = account_map;
-            assert!(
-                !vector::contains(&unique_accounts, &account_map.account_address),
-                error::already_exists(EDUPLICATE_ACCOUNT),
-            );
-            vector::push_back(&mut unique_accounts, account_map.account_address);
+        vector::for_each_ref(
+            &accounts,
+            |account_map| {
+                let account_map: &AccountMap = account_map;
+                assert!(
+                    !vector::contains(&unique_accounts, &account_map.account_address),
+                    error::already_exists(EDUPLICATE_ACCOUNT),
+                );
+                vector::push_back(&mut unique_accounts, account_map.account_address);
 
-            create_account(
-                aptos_framework,
-                account_map.account_address,
-                account_map.balance,
-            );
-        });
+                create_account(
+                    aptos_framework,
+                    account_map.account_address,
+                    account_map.balance,
+                );
+            },
+        );
     }
 
     /// This creates an funds an account if it doesn't exist.
     /// If it exists, it just returns the signer.
-    fun create_account(aptos_framework: &signer, account_address: address, balance: u64): signer {
+    fun create_account(
+        aptos_framework: &signer, account_address: address, balance: u64
+    ): signer {
         if (account::exists_at(account_address)) {
             create_signer(account_address)
         } else {
@@ -209,83 +226,97 @@ module aptos_framework::genesis {
     ) {
         let unique_accounts = vector::empty();
 
-        vector::for_each_ref(&employees, |employee_group| {
-            let j = 0;
-            let employee_group: &EmployeeAccountMap = employee_group;
-            let num_employees_in_group = vector::length(&employee_group.accounts);
+        vector::for_each_ref(
+            &employees,
+            |employee_group| {
+                let j = 0;
+                let employee_group: &EmployeeAccountMap = employee_group;
+                let num_employees_in_group = vector::length(&employee_group.accounts);
 
-            let buy_ins = simple_map::create();
+                let buy_ins = simple_map::create();
 
-            while (j < num_employees_in_group) {
-                let account = vector::borrow(&employee_group.accounts, j);
-                assert!(
-                    !vector::contains(&unique_accounts, account),
-                    error::already_exists(EDUPLICATE_ACCOUNT),
+                while (j < num_employees_in_group) {
+                    let account = vector::borrow(&employee_group.accounts, j);
+                    assert!(
+                        !vector::contains(&unique_accounts, account),
+                        error::already_exists(EDUPLICATE_ACCOUNT),
+                    );
+                    vector::push_back(&mut unique_accounts, *account);
+
+                    let employee = create_signer(*account);
+                    let total = coin::balance<AptosCoin>(*account);
+                    let coins = coin::withdraw<AptosCoin>(&employee, total);
+                    simple_map::add(&mut buy_ins, *account, coins);
+
+                    j = j + 1;
+                };
+
+                let j = 0;
+                let num_vesting_events = vector::length(
+                    &employee_group.vesting_schedule_numerator
                 );
-                vector::push_back(&mut unique_accounts, *account);
+                let schedule = vector::empty();
 
-                let employee = create_signer(*account);
-                let total = coin::balance<AptosCoin>(*account);
-                let coins = coin::withdraw<AptosCoin>(&employee, total);
-                simple_map::add(&mut buy_ins, *account, coins);
+                while (j < num_vesting_events) {
+                    let numerator = vector::borrow(
+                        &employee_group.vesting_schedule_numerator, j
+                    );
+                    let event =
+                        fixed_point32::create_from_rational(
+                            *numerator, employee_group.vesting_schedule_denominator
+                        );
+                    vector::push_back(&mut schedule, event);
 
-                j = j + 1;
-            };
+                    j = j + 1;
+                };
 
-            let j = 0;
-            let num_vesting_events = vector::length(&employee_group.vesting_schedule_numerator);
-            let schedule = vector::empty();
+                let vesting_schedule =
+                    vesting::create_vesting_schedule(
+                        schedule,
+                        employee_vesting_start,
+                        employee_vesting_period_duration,
+                    );
 
-            while (j < num_vesting_events) {
-                let numerator = vector::borrow(&employee_group.vesting_schedule_numerator, j);
-                let event = fixed_point32::create_from_rational(*numerator, employee_group.vesting_schedule_denominator);
-                vector::push_back(&mut schedule, event);
+                let admin = employee_group.validator.validator_config.owner_address;
+                let admin_signer = &create_signer(admin);
+                let contract_address =
+                    vesting::create_vesting_contract(
+                        admin_signer,
+                        &employee_group.accounts,
+                        buy_ins,
+                        vesting_schedule,
+                        admin,
+                        employee_group.validator.validator_config.operator_address,
+                        employee_group.validator.validator_config.voter_address,
+                        employee_group.validator.commission_percentage,
+                        x"",
+                    );
+                let pool_address = vesting::stake_pool_address(contract_address);
 
-                j = j + 1;
-            };
+                if (employee_group.beneficiary_resetter != @0x0) {
+                    vesting::set_beneficiary_resetter(
+                        admin_signer, contract_address, employee_group.beneficiary_resetter
+                    );
+                };
 
-            let vesting_schedule = vesting::create_vesting_schedule(
-                schedule,
-                employee_vesting_start,
-                employee_vesting_period_duration,
-            );
-
-            let admin = employee_group.validator.validator_config.owner_address;
-            let admin_signer = &create_signer(admin);
-            let contract_address = vesting::create_vesting_contract(
-                admin_signer,
-                &employee_group.accounts,
-                buy_ins,
-                vesting_schedule,
-                admin,
-                employee_group.validator.validator_config.operator_address,
-                employee_group.validator.validator_config.voter_address,
-                employee_group.validator.commission_percentage,
-                x"",
-            );
-            let pool_address = vesting::stake_pool_address(contract_address);
-
-            if (employee_group.beneficiary_resetter != @0x0) {
-                vesting::set_beneficiary_resetter(admin_signer, contract_address, employee_group.beneficiary_resetter);
-            };
-
-            let validator = &employee_group.validator.validator_config;
-            assert!(
-                account::exists_at(validator.owner_address),
-                error::not_found(EACCOUNT_DOES_NOT_EXIST),
-            );
-            assert!(
-                account::exists_at(validator.operator_address),
-                error::not_found(EACCOUNT_DOES_NOT_EXIST),
-            );
-            assert!(
-                account::exists_at(validator.voter_address),
-                error::not_found(EACCOUNT_DOES_NOT_EXIST),
-            );
-            if (employee_group.validator.join_during_genesis) {
-                initialize_validator(pool_address, validator);
-            };
-        });
+                let validator = &employee_group.validator.validator_config;
+                assert!(
+                    account::exists_at(validator.owner_address),
+                    error::not_found(EACCOUNT_DOES_NOT_EXIST),
+                );
+                assert!(
+                    account::exists_at(validator.operator_address),
+                    error::not_found(EACCOUNT_DOES_NOT_EXIST),
+                );
+                assert!(
+                    account::exists_at(validator.voter_address),
+                    error::not_found(EACCOUNT_DOES_NOT_EXIST),
+                );
+                if (employee_group.validator.join_during_genesis) {
+                    initialize_validator(pool_address, validator);
+                };
+            },
+        );
     }
 
     fun create_initialize_validators_with_commission(
@@ -293,10 +324,15 @@ module aptos_framework::genesis {
         use_staking_contract: bool,
         validators: vector<ValidatorConfigurationWithCommission>,
     ) {
-        vector::for_each_ref(&validators, |validator| {
-            let validator: &ValidatorConfigurationWithCommission = validator;
-            create_initialize_validator(aptos_framework, validator, use_staking_contract);
-        });
+        vector::for_each_ref(
+            &validators,
+            |validator| {
+                let validator: &ValidatorConfigurationWithCommission = validator;
+                create_initialize_validator(
+                    aptos_framework, validator, use_staking_contract
+                );
+            },
+        );
 
         // Destroy the aptos framework account's ability to mint coins now that we're done with setting up the initial
         // validators.
@@ -315,18 +351,27 @@ module aptos_framework::genesis {
     ///
     /// Network address fields are a vector per account, where each entry is a vector of addresses
     /// encoded in a single BCS byte array.
-    fun create_initialize_validators(aptos_framework: &signer, validators: vector<ValidatorConfiguration>) {
+    fun create_initialize_validators(
+        aptos_framework: &signer, validators: vector<ValidatorConfiguration>
+    ) {
         let validators_with_commission = vector::empty();
-        vector::for_each_reverse(validators, |validator| {
-            let validator_with_commission = ValidatorConfigurationWithCommission {
-                validator_config: validator,
-                commission_percentage: 0,
-                join_during_genesis: true,
-            };
-            vector::push_back(&mut validators_with_commission, validator_with_commission);
-        });
+        vector::for_each_reverse(
+            validators,
+            |validator| {
+                let validator_with_commission = ValidatorConfigurationWithCommission {
+                    validator_config: validator,
+                    commission_percentage: 0,
+                    join_during_genesis: true,
+                };
+                vector::push_back(
+                    &mut validators_with_commission, validator_with_commission
+                );
+            },
+        );
 
-        create_initialize_validators_with_commission(aptos_framework, false, validators_with_commission);
+        create_initialize_validators_with_commission(
+            aptos_framework, false, validators_with_commission
+        );
     }
 
     fun create_initialize_validator(
@@ -336,37 +381,45 @@ module aptos_framework::genesis {
     ) {
         let validator = &commission_config.validator_config;
 
-        let owner = &create_account(aptos_framework, validator.owner_address, validator.stake_amount);
+        let owner =
+            &create_account(
+                aptos_framework, validator.owner_address, validator.stake_amount
+            );
         create_account(aptos_framework, validator.operator_address, 0);
         create_account(aptos_framework, validator.voter_address, 0);
 
         // Initialize the stake pool and join the validator set.
-        let pool_address = if (use_staking_contract) {
-            staking_contract::create_staking_contract(
-                owner,
-                validator.operator_address,
-                validator.voter_address,
-                validator.stake_amount,
-                commission_config.commission_percentage,
-                x"",
-            );
-            staking_contract::stake_pool_address(validator.owner_address, validator.operator_address)
-        } else {
-            stake::initialize_stake_owner(
-                owner,
-                validator.stake_amount,
-                validator.operator_address,
-                validator.voter_address,
-            );
-            validator.owner_address
-        };
+        let pool_address =
+            if (use_staking_contract) {
+                staking_contract::create_staking_contract(
+                    owner,
+                    validator.operator_address,
+                    validator.voter_address,
+                    validator.stake_amount,
+                    commission_config.commission_percentage,
+                    x"",
+                );
+                staking_contract::stake_pool_address(
+                    validator.owner_address, validator.operator_address
+                )
+            } else {
+                stake::initialize_stake_owner(
+                    owner,
+                    validator.stake_amount,
+                    validator.operator_address,
+                    validator.voter_address,
+                );
+                validator.owner_address
+            };
 
         if (commission_config.join_during_genesis) {
             initialize_validator(pool_address, validator);
         };
     }
 
-    fun initialize_validator(pool_address: address, validator: &ValidatorConfiguration) {
+    fun initialize_validator(
+        pool_address: address, validator: &ValidatorConfiguration
+    ) {
         let operator = &create_signer(validator.operator_address);
 
         stake::rotate_consensus_key(
@@ -430,18 +483,22 @@ module aptos_framework::genesis {
             allow_validator_set_change,
             rewards_rate,
             rewards_rate_denominator,
-            voting_power_increase_limit
+            voting_power_increase_limit,
         );
-        features::change_feature_flags_for_verification(aptos_framework, vector[1, 2], vector[]);
+        features::change_feature_flags_for_verification(
+            aptos_framework, vector[1, 2], vector[]
+        );
         initialize_aptos_coin(aptos_framework);
         aptos_governance::initialize_for_verification(
             aptos_framework,
             min_voting_threshold,
             required_proposer_stake,
-            voting_duration_secs
+            voting_duration_secs,
         );
         create_accounts(aptos_framework, accounts);
-        create_employee_validators(employee_vesting_start, employee_vesting_period_duration, employees);
+        create_employee_validators(
+            employee_vesting_start, employee_vesting_period_duration, employees
+        );
         create_initialize_validators_with_commission(aptos_framework, true, validators);
         set_genesis_end(aptos_framework);
     }
@@ -502,15 +559,8 @@ module aptos_framework::genesis {
         let addr1 = @0x121345;
 
         let accounts = vector[
-            AccountMap {
-                account_address: addr0,
-                balance: 12345,
-            },
-            AccountMap {
-                account_address: addr1,
-                balance: 67890,
-            },
-        ];
+            AccountMap { account_address: addr0, balance: 12345, },
+            AccountMap { account_address: addr1, balance: 67890, },];
 
         create_accounts(aptos_framework, accounts);
         assert!(coin::balance<AptosCoin>(addr0) == 12345, 0);
@@ -529,7 +579,9 @@ module aptos_framework::genesis {
         use std::features;
 
         let feature = features::get_new_accounts_default_to_fa_apt_store_feature();
-        features::change_feature_flags_for_testing(aptos_framework, vector[feature], vector[]);
+        features::change_feature_flags_for_testing(
+            aptos_framework, vector[feature], vector[]
+        );
 
         aggregator_factory::initialize_aggregator_factory_for_test(aptos_framework);
 
@@ -540,9 +592,13 @@ module aptos_framework::genesis {
         aptos_account::register_apt(&core_resources); // registers APT store
 
         let apt_metadata = object::address_to_object<Metadata>(@aptos_fungible_asset);
-        assert!(primary_fungible_store::primary_store_exists(@core_resources, apt_metadata), 2);
+        assert!(
+            primary_fungible_store::primary_store_exists(@core_resources, apt_metadata), 2
+        );
 
-        aptos_coin::configure_accounts_for_test(aptos_framework, &core_resources, mint_cap);
+        aptos_coin::configure_accounts_for_test(
+            aptos_framework, &core_resources, mint_cap
+        );
 
         coin::destroy_burn_cap(burn_cap);
         coin::destroy_mint_cap(mint_cap);

--- a/aptos-move/framework/aptos-framework/sources/genesis.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.spec.move
@@ -148,7 +148,8 @@ spec aptos_framework::genesis {
         let addr = std::signer::address_of(aptos_framework);
         aborts_if addr != @aptos_framework;
         aborts_if exists<chain_status::GenesisEndMarker>(@aptos_framework);
-        ensures global<chain_status::GenesisEndMarker>(@aptos_framework) == chain_status::GenesisEndMarker {};
+        ensures global<chain_status::GenesisEndMarker>(@aptos_framework)
+            == chain_status::GenesisEndMarker {};
     }
 
     spec schema InitalizeRequires {
@@ -164,7 +165,10 @@ spec aptos_framework::genesis {
     }
 
     spec schema CompareTimeRequires {
-        let staking_rewards_config = global<staking_config::StakingRewardsConfig>(@aptos_framework);
-        requires staking_rewards_config.last_rewards_rate_period_start_in_secs <= timestamp::spec_now_seconds();
+        let staking_rewards_config = global<staking_config::StakingRewardsConfig>(
+            @aptos_framework
+        );
+        requires staking_rewards_config.last_rewards_rate_period_start_in_secs
+            <= timestamp::spec_now_seconds();
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/guid.move
+++ b/aptos-move/framework/aptos-framework/sources/guid.move
@@ -23,12 +23,7 @@ module aptos_framework::guid {
     public(friend) fun create(addr: address, creation_num_ref: &mut u64): GUID {
         let creation_num = *creation_num_ref;
         *creation_num_ref = creation_num + 1;
-        GUID {
-            id: ID {
-                creation_num,
-                addr,
-            }
-        }
+        GUID { id: ID { creation_num, addr, } }
     }
 
     /// Create a non-privileged id from `addr` and `creation_num`

--- a/aptos-move/framework/aptos-framework/sources/jwks.move
+++ b/aptos-move/framework/aptos-framework/sources/jwks.move
@@ -659,15 +659,18 @@ module aptos_framework::jwks {
                                 b"psply8S991RswM0JQJwv51fooFFvZUtYdL8avyKObshyzj7oJuJD8vkf5DKJJF1XOGi6Wv2D-U4b3htgrVXeOjAvaKTYtrQVUG_Txwjebdm2EvBJ4R6UaOULjavcSkb8VzW4l4AmP_yWoidkHq8n6vfHt9alDAONILi7jPDzRC7NvnHQ_x0hkRVh_OAmOJCpkgb0gx9-U8zSBSmowQmvw15AZ1I0buYZSSugY7jwNS2U716oujAiqtRkC7kg4gPouW_SxMleeo8PyRsHpYCfBME66m-P8Zr9Fh1Qgmqg4cWdy_6wUuNc1cbVY_7w1BpHZtZCNeQ56AHUgUFmo2LAQQ",
                             ), // n
                         ),
-                        new_unsupported_jwk(b"key_id_0", b"key_content_0"),],
+                        new_unsupported_jwk(b"key_id_0", b"key_content_0"),
+                    ],
                 },
                 ProviderJWKs {
                     issuer: b"bob",
                     version: 222,
                     jwks: vector[
                         new_unsupported_jwk(b"key_id_1", b"key_content_1"),
-                        new_unsupported_jwk(b"key_id_2", b"key_content_2"),],
-                },],
+                        new_unsupported_jwk(b"key_id_2", b"key_content_2"),
+                    ],
+                },
+            ],
         };
 
         let patch = new_patch_remove_issuer(b"alice");
@@ -681,8 +684,10 @@ module aptos_framework::jwks {
                             version: 222,
                             jwks: vector[
                                 new_unsupported_jwk(b"key_id_1", b"key_content_1"),
-                                new_unsupported_jwk(b"key_id_2", b"key_content_2"),],
-                        },],
+                                new_unsupported_jwk(b"key_id_2", b"key_content_2"),
+                            ],
+                        },
+                    ],
                 },
             1,
         );
@@ -697,9 +702,10 @@ module aptos_framework::jwks {
                             issuer: b"bob",
                             version: 222,
                             jwks: vector[new_unsupported_jwk(
-                                    b"key_id_2", b"key_content_2"
-                                ),],
-                        },],
+                                b"key_id_2", b"key_content_2"
+                            ),],
+                        },
+                    ],
                 },
             1,
         );
@@ -741,14 +747,15 @@ module aptos_framework::jwks {
                             version: 0,
                             jwks: vector[
                                 new_unsupported_jwk(b"key_id_0", b"key_content_0b"),
-                                new_unsupported_jwk(b"key_id_3", b"key_content_3"),],
+                                new_unsupported_jwk(b"key_id_3", b"key_content_3"),
+                            ],
                         },
                         ProviderJWKs {
                             issuer: b"bob",
                             version: 222,
                             jwks: vector[new_unsupported_jwk(
-                                    b"key_id_2", b"key_content_2b"
-                                ),],
+                                b"key_id_2", b"key_content_2b"
+                            ),],
                         },
                         ProviderJWKs {
                             issuer: b"carl",
@@ -761,8 +768,10 @@ module aptos_framework::jwks {
                                     utf8(
                                         b"sm72oBH-R2Rqt4hkjp66tz5qCtq42TMnVgZg2Pdm_zs7_-EoFyNs9sD1MKsZAFaBPXBHDiWywyaHhLgwETLN9hlJIZPzGCEtV3mXJFSYG-8L6t3kyKi9X1lUTZzbmNpE0tf-eMW-3gs3VQSBJQOcQnuiANxbSXwS3PFmi173C_5fDSuC1RoYGT6X3JqLc3DWUmBGucuQjPaUF0w6LMqEIy0W_WYbW7HImwANT6dT52T72md0JWZuAKsRRnRr_bvaUX8_e3K8Pb1K_t3dD6WSLvtmEfUnGQgLynVl3aV5sRYC0Hy_IkRgoxl2fd8AaZT1X_rdPexYpx152Pl_CHJ79Q",
                                     ), // n
-                                )],
-                        },],
+                                )
+                            ],
+                        },
+                    ],
                 },
             1,
         );
@@ -786,7 +795,8 @@ module aptos_framework::jwks {
             &aptos_framework,
             vector[
                 ProviderJWKs { issuer: b"alice", version: 111, jwks: vector[jwk_0, jwk_1], },
-                ProviderJWKs { issuer: b"bob", version: 222, jwks: vector[jwk_2, jwk_3], },],
+                ProviderJWKs { issuer: b"bob", version: 222, jwks: vector[jwk_2, jwk_3], },
+            ],
         );
         assert!(jwk_3 == get_patched_jwk(b"bob", b"key_id_3"), 1);
         assert!(option::some(jwk_3) == try_get_patched_jwk(b"bob", b"key_id_3"), 1);
@@ -809,7 +819,8 @@ module aptos_framework::jwks {
             vector[
                 new_patch_remove_all(),
                 new_patch_upsert_jwk(b"alice", jwk_1),
-                new_patch_upsert_jwk(b"bob", jwk_3),],
+                new_patch_upsert_jwk(b"bob", jwk_3),
+            ],
         );
         assert!(jwk_3 == get_patched_jwk(b"bob", b"key_id_3"), 1);
         assert!(option::some(jwk_3) == try_get_patched_jwk(b"bob", b"key_id_3"), 1);

--- a/aptos-move/framework/aptos-framework/sources/jwks.move
+++ b/aptos-move/framework/aptos-framework/sources/jwks.move
@@ -177,13 +177,15 @@ module aptos_framework::jwks {
     /// Deprecated by `upsert_oidc_provider_for_next_epoch()`.
     ///
     /// TODO: update all the tests that reference this function, then disable this function.
-    public fun upsert_oidc_provider(fx: &signer, name: vector<u8>, config_url: vector<u8>): Option<vector<u8>> acquires SupportedOIDCProviders {
+    public fun upsert_oidc_provider(
+        fx: &signer, name: vector<u8>, config_url: vector<u8>
+    ): Option<vector<u8>> acquires SupportedOIDCProviders {
         system_addresses::assert_aptos_framework(fx);
         chain_status::assert_genesis();
 
         let provider_set = borrow_global_mut<SupportedOIDCProviders>(@aptos_framework);
 
-        let old_config_url= remove_oidc_provider_internal(provider_set, name);
+        let old_config_url = remove_oidc_provider_internal(provider_set, name);
         vector::push_back(&mut provider_set.providers, OIDCProvider { name, config_url });
         old_config_url
     }
@@ -198,14 +200,17 @@ module aptos_framework::jwks {
     /// );
     /// aptos_framework::aptos_governance::reconfigure(&framework_signer);
     /// ```
-    public fun upsert_oidc_provider_for_next_epoch(fx: &signer, name: vector<u8>, config_url: vector<u8>): Option<vector<u8>> acquires SupportedOIDCProviders {
+    public fun upsert_oidc_provider_for_next_epoch(
+        fx: &signer, name: vector<u8>, config_url: vector<u8>
+    ): Option<vector<u8>> acquires SupportedOIDCProviders {
         system_addresses::assert_aptos_framework(fx);
 
-        let provider_set = if (config_buffer::does_exist<SupportedOIDCProviders>()) {
-            config_buffer::extract<SupportedOIDCProviders>()
-        } else {
-            *borrow_global_mut<SupportedOIDCProviders>(@aptos_framework)
-        };
+        let provider_set =
+            if (config_buffer::does_exist<SupportedOIDCProviders>()) {
+                config_buffer::extract<SupportedOIDCProviders>()
+            } else {
+                *borrow_global_mut<SupportedOIDCProviders>(@aptos_framework)
+            };
 
         let old_config_url = remove_oidc_provider_internal(&mut provider_set, name);
         vector::push_back(&mut provider_set.providers, OIDCProvider { name, config_url });
@@ -233,14 +238,17 @@ module aptos_framework::jwks {
     /// );
     /// aptos_framework::aptos_governance::reconfigure(&framework_signer);
     /// ```
-    public fun remove_oidc_provider_for_next_epoch(fx: &signer, name: vector<u8>): Option<vector<u8>> acquires SupportedOIDCProviders {
+    public fun remove_oidc_provider_for_next_epoch(
+        fx: &signer, name: vector<u8>
+    ): Option<vector<u8>> acquires SupportedOIDCProviders {
         system_addresses::assert_aptos_framework(fx);
 
-        let provider_set = if (config_buffer::does_exist<SupportedOIDCProviders>()) {
-            config_buffer::extract<SupportedOIDCProviders>()
-        } else {
-            *borrow_global_mut<SupportedOIDCProviders>(@aptos_framework)
-        };
+        let provider_set =
+            if (config_buffer::does_exist<SupportedOIDCProviders>()) {
+                config_buffer::extract<SupportedOIDCProviders>()
+            } else {
+                *borrow_global_mut<SupportedOIDCProviders>(@aptos_framework)
+            };
         let ret = remove_oidc_provider_internal(&mut provider_set, name);
         config_buffer::upsert(provider_set);
         ret
@@ -268,50 +276,38 @@ module aptos_framework::jwks {
 
     /// Create a `Patch` that removes all entries.
     public fun new_patch_remove_all(): Patch {
-        Patch {
-            variant: copyable_any::pack(PatchRemoveAll {}),
-        }
+        Patch { variant: copyable_any::pack(PatchRemoveAll {}), }
     }
 
     /// Create a `Patch` that removes the entry of a given issuer, if exists.
     public fun new_patch_remove_issuer(issuer: vector<u8>): Patch {
-        Patch {
-            variant: copyable_any::pack(PatchRemoveIssuer { issuer }),
-        }
+        Patch { variant: copyable_any::pack(PatchRemoveIssuer { issuer }), }
     }
 
     /// Create a `Patch` that removes the entry of a given issuer, if exists.
-    public fun new_patch_remove_jwk(issuer: vector<u8>, jwk_id: vector<u8>): Patch {
-        Patch {
-            variant: copyable_any::pack(PatchRemoveJWK { issuer, jwk_id })
-        }
+    public fun new_patch_remove_jwk(
+        issuer: vector<u8>, jwk_id: vector<u8>
+    ): Patch {
+        Patch { variant: copyable_any::pack(PatchRemoveJWK { issuer, jwk_id }) }
     }
 
     /// Create a `Patch` that upserts a JWK into an issuer's JWK set.
     public fun new_patch_upsert_jwk(issuer: vector<u8>, jwk: JWK): Patch {
-        Patch {
-            variant: copyable_any::pack(PatchUpsertJWK { issuer, jwk })
-        }
+        Patch { variant: copyable_any::pack(PatchUpsertJWK { issuer, jwk }) }
     }
 
     /// Create a `JWK` of variant `RSA_JWK`.
     public fun new_rsa_jwk(kid: String, alg: String, e: String, n: String): JWK {
         JWK {
-            variant: copyable_any::pack(RSA_JWK {
-                kid,
-                kty: utf8(b"RSA"),
-                e,
-                n,
-                alg,
-            }),
+            variant: copyable_any::pack(
+                RSA_JWK { kid, kty: utf8(b"RSA"), e, n, alg, },
+            ),
         }
     }
 
     /// Create a `JWK` of variant `UnsupportedJWK`.
     public fun new_unsupported_jwk(id: vector<u8>, payload: vector<u8>): JWK {
-        JWK {
-            variant: copyable_any::pack(UnsupportedJWK { id, payload })
-        }
+        JWK { variant: copyable_any::pack(UnsupportedJWK { id, payload }) }
     }
 
     /// Initialize some JWK resources. Should only be invoked by genesis.
@@ -325,11 +321,16 @@ module aptos_framework::jwks {
 
     /// Helper function that removes an OIDC provider from the `SupportedOIDCProviders`.
     /// Returns the old config URL of the provider, if any, as an `Option`.
-    fun remove_oidc_provider_internal(provider_set: &mut SupportedOIDCProviders, name: vector<u8>): Option<vector<u8>> {
-        let (name_exists, idx) = vector::find(&provider_set.providers, |obj| {
-            let provider: &OIDCProvider = obj;
-            provider.name == name
-        });
+    fun remove_oidc_provider_internal(
+        provider_set: &mut SupportedOIDCProviders, name: vector<u8>
+    ): Option<vector<u8>> {
+        let (name_exists, idx) = vector::find(
+            &provider_set.providers,
+            |obj| {
+                let provider: &OIDCProvider = obj;
+                provider.name == name
+            },
+        );
 
         if (name_exists) {
             let old_provider = vector::swap_remove(&mut provider_set.providers, idx);
@@ -343,13 +344,18 @@ module aptos_framework::jwks {
     ///
     /// NOTE: It is assumed verification has been done to ensure each update is quorum-certified,
     /// and its `version` equals to the on-chain version + 1.
-    public fun upsert_into_observed_jwks(fx: &signer, provider_jwks_vec: vector<ProviderJWKs>) acquires ObservedJWKs, PatchedJWKs, Patches {
+    public fun upsert_into_observed_jwks(
+        fx: &signer, provider_jwks_vec: vector<ProviderJWKs>
+    ) acquires ObservedJWKs, PatchedJWKs, Patches {
         system_addresses::assert_aptos_framework(fx);
         let observed_jwks = borrow_global_mut<ObservedJWKs>(@aptos_framework);
-        vector::for_each(provider_jwks_vec, |obj| {
-            let provider_jwks: ProviderJWKs = obj;
-            upsert_provider_jwks(&mut observed_jwks.jwks, provider_jwks);
-        });
+        vector::for_each(
+            provider_jwks_vec,
+            |obj| {
+                let provider_jwks: ProviderJWKs = obj;
+                upsert_provider_jwks(&mut observed_jwks.jwks, provider_jwks);
+            },
+        );
 
         let epoch = reconfiguration::current_epoch();
         emit(ObservedJWKsUpdated { epoch, jwks: observed_jwks.jwks });
@@ -359,7 +365,9 @@ module aptos_framework::jwks {
     /// Only used by governance to delete an issuer from `ObservedJWKs`, if it exists.
     ///
     /// Return the potentially existing `ProviderJWKs` of the given issuer.
-    public fun remove_issuer_from_observed_jwks(fx: &signer, issuer: vector<u8>): Option<ProviderJWKs> acquires ObservedJWKs, PatchedJWKs, Patches {
+    public fun remove_issuer_from_observed_jwks(
+        fx: &signer, issuer: vector<u8>
+    ): Option<ProviderJWKs> acquires ObservedJWKs, PatchedJWKs, Patches {
         system_addresses::assert_aptos_framework(fx);
         let observed_jwks = borrow_global_mut<ObservedJWKs>(@aptos_framework);
         let old_value = remove_issuer(&mut observed_jwks.jwks, issuer);
@@ -375,19 +383,27 @@ module aptos_framework::jwks {
     fun regenerate_patched_jwks() acquires PatchedJWKs, Patches, ObservedJWKs {
         let jwks = borrow_global<ObservedJWKs>(@aptos_framework).jwks;
         let patches = borrow_global<Patches>(@aptos_framework);
-        vector::for_each_ref(&patches.patches, |obj|{
-            let patch: &Patch = obj;
-            apply_patch(&mut jwks, *patch);
-        });
+        vector::for_each_ref(
+            &patches.patches,
+            |obj| {
+                let patch: &Patch = obj;
+                apply_patch(&mut jwks, *patch);
+            },
+        );
         *borrow_global_mut<PatchedJWKs>(@aptos_framework) = PatchedJWKs { jwks };
     }
 
     /// Get a JWK by issuer and key ID from a `AllProvidersJWKs`, if it exists.
-    fun try_get_jwk_by_issuer(jwks: &AllProvidersJWKs, issuer: vector<u8>, jwk_id: vector<u8>): Option<JWK> {
-        let (issuer_found, index) = vector::find(&jwks.entries, |obj| {
-            let provider_jwks: &ProviderJWKs = obj;
-            issuer == provider_jwks.issuer
-        });
+    fun try_get_jwk_by_issuer(
+        jwks: &AllProvidersJWKs, issuer: vector<u8>, jwk_id: vector<u8>
+    ): Option<JWK> {
+        let (issuer_found, index) = vector::find(
+            &jwks.entries,
+            |obj| {
+                let provider_jwks: &ProviderJWKs = obj;
+                issuer == provider_jwks.issuer
+            },
+        );
 
         if (issuer_found) {
             try_get_jwk_by_id(vector::borrow(&jwks.entries, index), jwk_id)
@@ -397,11 +413,16 @@ module aptos_framework::jwks {
     }
 
     /// Get a JWK by key ID from a `ProviderJWKs`, if it exists.
-    fun try_get_jwk_by_id(provider_jwks: &ProviderJWKs, jwk_id: vector<u8>): Option<JWK> {
-        let (jwk_id_found, index) = vector::find(&provider_jwks.jwks, |obj|{
-            let jwk: &JWK = obj;
-            jwk_id == get_jwk_id(jwk)
-        });
+    fun try_get_jwk_by_id(
+        provider_jwks: &ProviderJWKs, jwk_id: vector<u8>
+    ): Option<JWK> {
+        let (jwk_id_found, index) = vector::find(
+            &provider_jwks.jwks,
+            |obj| {
+                let jwk: &JWK = obj;
+                jwk_id == get_jwk_id(jwk)
+            },
+        );
 
         if (jwk_id_found) {
             option::some(*vector::borrow(&provider_jwks.jwks, index))
@@ -426,7 +447,9 @@ module aptos_framework::jwks {
 
     /// Upsert a `ProviderJWKs` into an `AllProvidersJWKs`. If this upsert replaced an existing entry, return it.
     /// Maintains the sorted-by-issuer invariant in `AllProvidersJWKs`.
-    fun upsert_provider_jwks(jwks: &mut AllProvidersJWKs, provider_jwks: ProviderJWKs): Option<ProviderJWKs> {
+    fun upsert_provider_jwks(
+        jwks: &mut AllProvidersJWKs, provider_jwks: ProviderJWKs
+    ): Option<ProviderJWKs> {
         // NOTE: Using a linear-time search here because we do not expect too many providers.
         let found = false;
         let index = 0;
@@ -444,15 +467,16 @@ module aptos_framework::jwks {
 
         // Now if `found == true`, `index` points to the JWK we want to update/remove; otherwise, `index` points to
         // where we want to insert.
-        let ret = if (found) {
-            let entry = vector::borrow_mut(&mut jwks.entries, index);
-            let old_entry = option::some(*entry);
-            *entry = provider_jwks;
-            old_entry
-        } else {
-            vector::insert(&mut jwks.entries, index, provider_jwks);
-            option::none()
-        };
+        let ret =
+            if (found) {
+                let entry = vector::borrow_mut(&mut jwks.entries, index);
+                let old_entry = option::some(*entry);
+                *entry = provider_jwks;
+                old_entry
+            } else {
+                vector::insert(&mut jwks.entries, index, provider_jwks);
+                option::none()
+            };
 
         ret
     }
@@ -460,16 +484,20 @@ module aptos_framework::jwks {
     /// Remove the entry of an issuer from a `AllProvidersJWKs` and return the entry, if exists.
     /// Maintains the sorted-by-issuer invariant in `AllProvidersJWKs`.
     fun remove_issuer(jwks: &mut AllProvidersJWKs, issuer: vector<u8>): Option<ProviderJWKs> {
-        let (found, index) = vector::find(&jwks.entries, |obj| {
-            let provider_jwk_set: &ProviderJWKs = obj;
-            provider_jwk_set.issuer == issuer
-        });
+        let (found, index) = vector::find(
+            &jwks.entries,
+            |obj| {
+                let provider_jwk_set: &ProviderJWKs = obj;
+                provider_jwk_set.issuer == issuer
+            },
+        );
 
-        let ret = if (found) {
-            option::some(vector::remove(&mut jwks.entries, index))
-        } else {
-            option::none()
-        };
+        let ret =
+            if (found) {
+                option::some(vector::remove(&mut jwks.entries, index))
+            } else {
+                option::none()
+            };
 
         ret
     }
@@ -492,31 +520,36 @@ module aptos_framework::jwks {
 
         // Now if `found == true`, `index` points to the JWK we want to update/remove; otherwise, `index` points to
         // where we want to insert.
-        let ret = if (found) {
-            let entry = vector::borrow_mut(&mut set.jwks, index);
-            let old_entry = option::some(*entry);
-            *entry = jwk;
-            old_entry
-        } else {
-            vector::insert(&mut set.jwks, index, jwk);
-            option::none()
-        };
+        let ret =
+            if (found) {
+                let entry = vector::borrow_mut(&mut set.jwks, index);
+                let old_entry = option::some(*entry);
+                *entry = jwk;
+                old_entry
+            } else {
+                vector::insert(&mut set.jwks, index, jwk);
+                option::none()
+            };
 
         ret
     }
 
     /// Remove the entry of a key ID from a `ProviderJWKs` and return the entry, if exists.
     fun remove_jwk(jwks: &mut ProviderJWKs, jwk_id: vector<u8>): Option<JWK> {
-        let (found, index) = vector::find(&jwks.jwks, |obj| {
-            let jwk: &JWK = obj;
-            jwk_id == get_jwk_id(jwk)
-        });
+        let (found, index) = vector::find(
+            &jwks.jwks,
+            |obj| {
+                let jwk: &JWK = obj;
+                jwk_id == get_jwk_id(jwk)
+            },
+        );
 
-        let ret = if (found) {
-            option::some(vector::remove(&mut jwks.jwks, index))
-        } else {
-            option::none()
-        };
+        let ret =
+            if (found) {
+                option::some(vector::remove(&mut jwks.jwks, index))
+            } else {
+                option::none()
+            };
 
         ret
     }
@@ -545,15 +578,12 @@ module aptos_framework::jwks {
             // TODO: This is inefficient: we remove the issuer, modify its JWKs & and reinsert the updated issuer. Why
             // not just update it in place?
             let existing_jwk_set = remove_issuer(jwks, cmd.issuer);
-            let jwk_set = if (option::is_some(&existing_jwk_set)) {
-                option::extract(&mut existing_jwk_set)
-            } else {
-                ProviderJWKs {
-                    version: 0,
-                    issuer: cmd.issuer,
-                    jwks: vector[],
-                }
-            };
+            let jwk_set =
+                if (option::is_some(&existing_jwk_set)) {
+                    option::extract(&mut existing_jwk_set)
+                } else {
+                    ProviderJWKs { version: 0, issuer: cmd.issuer, jwks: vector[], }
+                };
             upsert_jwk(&mut jwk_set, cmd.jwk);
             upsert_provider_jwks(jwks, jwk_set);
         } else {
@@ -589,17 +619,14 @@ module aptos_framework::jwks {
             version: 1,
             jwks: vector[jwk_0, jwk_1],
         };
-        let bob_jwks_v1 = ProviderJWKs{
+        let bob_jwks_v1 = ProviderJWKs {
             issuer: b"bob",
             version: 1,
             jwks: vector[jwk_2, jwk_3],
         };
         upsert_into_observed_jwks(fx, vector[bob_jwks_v1]);
         upsert_into_observed_jwks(fx, vector[alice_jwks_v1]);
-        let expected = AllProvidersJWKs { entries: vector[
-            alice_jwks_v1,
-            bob_jwks_v1,
-        ] };
+        let expected = AllProvidersJWKs { entries: vector[alice_jwks_v1, bob_jwks_v1,] };
         assert!(expected == borrow_global<ObservedJWKs>(@aptos_framework).jwks, 2);
 
         let alice_jwks_v2 = ProviderJWKs {
@@ -608,10 +635,7 @@ module aptos_framework::jwks {
             jwks: vector[jwk_1, jwk_4],
         };
         upsert_into_observed_jwks(fx, vector[alice_jwks_v2]);
-        let expected = AllProvidersJWKs { entries: vector[
-            alice_jwks_v2,
-            bob_jwks_v1,
-        ] };
+        let expected = AllProvidersJWKs { entries: vector[alice_jwks_v2, bob_jwks_v1,] };
         assert!(expected == borrow_global<ObservedJWKs>(@aptos_framework).jwks, 3);
 
         remove_issuer_from_observed_jwks(fx, b"alice");
@@ -631,95 +655,117 @@ module aptos_framework::jwks {
                             utf8(b"e4adfb436b9e197e2e1106af2c842284e4986aff"), // kid
                             utf8(b"RS256"), // alg
                             utf8(b"AQAB"), // e
-                            utf8(b"psply8S991RswM0JQJwv51fooFFvZUtYdL8avyKObshyzj7oJuJD8vkf5DKJJF1XOGi6Wv2D-U4b3htgrVXeOjAvaKTYtrQVUG_Txwjebdm2EvBJ4R6UaOULjavcSkb8VzW4l4AmP_yWoidkHq8n6vfHt9alDAONILi7jPDzRC7NvnHQ_x0hkRVh_OAmOJCpkgb0gx9-U8zSBSmowQmvw15AZ1I0buYZSSugY7jwNS2U716oujAiqtRkC7kg4gPouW_SxMleeo8PyRsHpYCfBME66m-P8Zr9Fh1Qgmqg4cWdy_6wUuNc1cbVY_7w1BpHZtZCNeQ56AHUgUFmo2LAQQ"), // n
+                            utf8(
+                                b"psply8S991RswM0JQJwv51fooFFvZUtYdL8avyKObshyzj7oJuJD8vkf5DKJJF1XOGi6Wv2D-U4b3htgrVXeOjAvaKTYtrQVUG_Txwjebdm2EvBJ4R6UaOULjavcSkb8VzW4l4AmP_yWoidkHq8n6vfHt9alDAONILi7jPDzRC7NvnHQ_x0hkRVh_OAmOJCpkgb0gx9-U8zSBSmowQmvw15AZ1I0buYZSSugY7jwNS2U716oujAiqtRkC7kg4gPouW_SxMleeo8PyRsHpYCfBME66m-P8Zr9Fh1Qgmqg4cWdy_6wUuNc1cbVY_7w1BpHZtZCNeQ56AHUgUFmo2LAQQ",
+                            ), // n
                         ),
-                        new_unsupported_jwk(b"key_id_0", b"key_content_0"),
-                    ],
+                        new_unsupported_jwk(b"key_id_0", b"key_content_0"),],
                 },
                 ProviderJWKs {
                     issuer: b"bob",
                     version: 222,
                     jwks: vector[
                         new_unsupported_jwk(b"key_id_1", b"key_content_1"),
-                        new_unsupported_jwk(b"key_id_2", b"key_content_2"),
-                    ],
-                },
-            ],
+                        new_unsupported_jwk(b"key_id_2", b"key_content_2"),],
+                },],
         };
 
         let patch = new_patch_remove_issuer(b"alice");
         apply_patch(&mut jwks, patch);
-        assert!(jwks == AllProvidersJWKs {
-            entries: vector[
-                ProviderJWKs {
-                    issuer: b"bob",
-                    version: 222,
-                    jwks: vector[
-                        new_unsupported_jwk(b"key_id_1", b"key_content_1"),
-                        new_unsupported_jwk(b"key_id_2", b"key_content_2"),
-                    ],
+        assert!(
+            jwks
+                == AllProvidersJWKs {
+                    entries: vector[
+                        ProviderJWKs {
+                            issuer: b"bob",
+                            version: 222,
+                            jwks: vector[
+                                new_unsupported_jwk(b"key_id_1", b"key_content_1"),
+                                new_unsupported_jwk(b"key_id_2", b"key_content_2"),],
+                        },],
                 },
-            ],
-        }, 1);
+            1,
+        );
 
         let patch = new_patch_remove_jwk(b"bob", b"key_id_1");
         apply_patch(&mut jwks, patch);
-        assert!(jwks == AllProvidersJWKs {
-            entries: vector[
-                ProviderJWKs {
-                    issuer: b"bob",
-                    version: 222,
-                    jwks: vector[
-                        new_unsupported_jwk(b"key_id_2", b"key_content_2"),
-                    ],
+        assert!(
+            jwks
+                == AllProvidersJWKs {
+                    entries: vector[
+                        ProviderJWKs {
+                            issuer: b"bob",
+                            version: 222,
+                            jwks: vector[new_unsupported_jwk(
+                                    b"key_id_2", b"key_content_2"
+                                ),],
+                        },],
                 },
-            ],
-        }, 1);
+            1,
+        );
 
-        let patch = new_patch_upsert_jwk(b"carl", new_rsa_jwk(
-            utf8(b"0ad1fec78504f447bae65bcf5afaedb65eec9e81"), // kid
-            utf8(b"RS256"), // alg
-            utf8(b"AQAB"), // e
-            utf8(b"sm72oBH-R2Rqt4hkjp66tz5qCtq42TMnVgZg2Pdm_zs7_-EoFyNs9sD1MKsZAFaBPXBHDiWywyaHhLgwETLN9hlJIZPzGCEtV3mXJFSYG-8L6t3kyKi9X1lUTZzbmNpE0tf-eMW-3gs3VQSBJQOcQnuiANxbSXwS3PFmi173C_5fDSuC1RoYGT6X3JqLc3DWUmBGucuQjPaUF0w6LMqEIy0W_WYbW7HImwANT6dT52T72md0JWZuAKsRRnRr_bvaUX8_e3K8Pb1K_t3dD6WSLvtmEfUnGQgLynVl3aV5sRYC0Hy_IkRgoxl2fd8AaZT1X_rdPexYpx152Pl_CHJ79Q"), // n
-        ));
+        let patch =
+            new_patch_upsert_jwk(
+                b"carl",
+                new_rsa_jwk(
+                    utf8(b"0ad1fec78504f447bae65bcf5afaedb65eec9e81"), // kid
+                    utf8(b"RS256"), // alg
+                    utf8(b"AQAB"), // e
+                    utf8(
+                        b"sm72oBH-R2Rqt4hkjp66tz5qCtq42TMnVgZg2Pdm_zs7_-EoFyNs9sD1MKsZAFaBPXBHDiWywyaHhLgwETLN9hlJIZPzGCEtV3mXJFSYG-8L6t3kyKi9X1lUTZzbmNpE0tf-eMW-3gs3VQSBJQOcQnuiANxbSXwS3PFmi173C_5fDSuC1RoYGT6X3JqLc3DWUmBGucuQjPaUF0w6LMqEIy0W_WYbW7HImwANT6dT52T72md0JWZuAKsRRnRr_bvaUX8_e3K8Pb1K_t3dD6WSLvtmEfUnGQgLynVl3aV5sRYC0Hy_IkRgoxl2fd8AaZT1X_rdPexYpx152Pl_CHJ79Q",
+                    ), // n
+                ),
+            );
         apply_patch(&mut jwks, patch);
-        let edit = new_patch_upsert_jwk(b"bob", new_unsupported_jwk(b"key_id_2", b"key_content_2b"));
+        let edit =
+            new_patch_upsert_jwk(
+                b"bob", new_unsupported_jwk(b"key_id_2", b"key_content_2b")
+            );
         apply_patch(&mut jwks, edit);
-        let edit = new_patch_upsert_jwk(b"alice", new_unsupported_jwk(b"key_id_3", b"key_content_3"));
+        let edit =
+            new_patch_upsert_jwk(
+                b"alice", new_unsupported_jwk(b"key_id_3", b"key_content_3")
+            );
         apply_patch(&mut jwks, edit);
-        let edit = new_patch_upsert_jwk(b"alice", new_unsupported_jwk(b"key_id_0", b"key_content_0b"));
+        let edit =
+            new_patch_upsert_jwk(
+                b"alice", new_unsupported_jwk(b"key_id_0", b"key_content_0b")
+            );
         apply_patch(&mut jwks, edit);
-        assert!(jwks == AllProvidersJWKs {
-            entries: vector[
-                ProviderJWKs {
-                    issuer: b"alice",
-                    version: 0,
-                    jwks: vector[
-                        new_unsupported_jwk(b"key_id_0", b"key_content_0b"),
-                        new_unsupported_jwk(b"key_id_3", b"key_content_3"),
-                    ],
+        assert!(
+            jwks
+                == AllProvidersJWKs {
+                    entries: vector[
+                        ProviderJWKs {
+                            issuer: b"alice",
+                            version: 0,
+                            jwks: vector[
+                                new_unsupported_jwk(b"key_id_0", b"key_content_0b"),
+                                new_unsupported_jwk(b"key_id_3", b"key_content_3"),],
+                        },
+                        ProviderJWKs {
+                            issuer: b"bob",
+                            version: 222,
+                            jwks: vector[new_unsupported_jwk(
+                                    b"key_id_2", b"key_content_2b"
+                                ),],
+                        },
+                        ProviderJWKs {
+                            issuer: b"carl",
+                            version: 0,
+                            jwks: vector[
+                                new_rsa_jwk(
+                                    utf8(b"0ad1fec78504f447bae65bcf5afaedb65eec9e81"), // kid
+                                    utf8(b"RS256"), // alg
+                                    utf8(b"AQAB"), // e
+                                    utf8(
+                                        b"sm72oBH-R2Rqt4hkjp66tz5qCtq42TMnVgZg2Pdm_zs7_-EoFyNs9sD1MKsZAFaBPXBHDiWywyaHhLgwETLN9hlJIZPzGCEtV3mXJFSYG-8L6t3kyKi9X1lUTZzbmNpE0tf-eMW-3gs3VQSBJQOcQnuiANxbSXwS3PFmi173C_5fDSuC1RoYGT6X3JqLc3DWUmBGucuQjPaUF0w6LMqEIy0W_WYbW7HImwANT6dT52T72md0JWZuAKsRRnRr_bvaUX8_e3K8Pb1K_t3dD6WSLvtmEfUnGQgLynVl3aV5sRYC0Hy_IkRgoxl2fd8AaZT1X_rdPexYpx152Pl_CHJ79Q",
+                                    ), // n
+                                )],
+                        },],
                 },
-                ProviderJWKs {
-                    issuer: b"bob",
-                    version: 222,
-                    jwks: vector[
-                        new_unsupported_jwk(b"key_id_2", b"key_content_2b"),
-                    ],
-                },
-                ProviderJWKs {
-                    issuer: b"carl",
-                    version: 0,
-                    jwks: vector[
-                        new_rsa_jwk(
-                            utf8(b"0ad1fec78504f447bae65bcf5afaedb65eec9e81"), // kid
-                            utf8(b"RS256"), // alg
-                            utf8(b"AQAB"), // e
-                            utf8(b"sm72oBH-R2Rqt4hkjp66tz5qCtq42TMnVgZg2Pdm_zs7_-EoFyNs9sD1MKsZAFaBPXBHDiWywyaHhLgwETLN9hlJIZPzGCEtV3mXJFSYG-8L6t3kyKi9X1lUTZzbmNpE0tf-eMW-3gs3VQSBJQOcQnuiANxbSXwS3PFmi173C_5fDSuC1RoYGT6X3JqLc3DWUmBGucuQjPaUF0w6LMqEIy0W_WYbW7HImwANT6dT52T72md0JWZuAKsRRnRr_bvaUX8_e3K8Pb1K_t3dD6WSLvtmEfUnGQgLynVl3aV5sRYC0Hy_IkRgoxl2fd8AaZT1X_rdPexYpx152Pl_CHJ79Q"), // n
-                        )
-                    ],
-                },
-            ],
-        }, 1);
+            1,
+        );
 
         let patch = new_patch_remove_all();
         apply_patch(&mut jwks, patch);
@@ -736,40 +782,35 @@ module aptos_framework::jwks {
         let jwk_3b = new_unsupported_jwk(b"key_id_3", b"key_payload_3b");
 
         // Fake observation from validators.
-        upsert_into_observed_jwks(&aptos_framework, vector [
-            ProviderJWKs {
-                issuer: b"alice",
-                version: 111,
-                jwks: vector[jwk_0, jwk_1],
-            },
-            ProviderJWKs{
-                issuer: b"bob",
-                version: 222,
-                jwks: vector[jwk_2, jwk_3],
-            },
-        ]);
+        upsert_into_observed_jwks(
+            &aptos_framework,
+            vector[
+                ProviderJWKs { issuer: b"alice", version: 111, jwks: vector[jwk_0, jwk_1], },
+                ProviderJWKs { issuer: b"bob", version: 222, jwks: vector[jwk_2, jwk_3], },],
+        );
         assert!(jwk_3 == get_patched_jwk(b"bob", b"key_id_3"), 1);
         assert!(option::some(jwk_3) == try_get_patched_jwk(b"bob", b"key_id_3"), 1);
 
         // Ignore all Bob's keys.
-        set_patches(&aptos_framework, vector[
-            new_patch_remove_issuer(b"bob"),
-        ]);
+        set_patches(&aptos_framework, vector[new_patch_remove_issuer(b"bob"),]);
         assert!(option::none() == try_get_patched_jwk(b"bob", b"key_id_3"), 1);
 
         // Update one of Bob's key..
-        set_patches(&aptos_framework, vector[
-            new_patch_upsert_jwk(b"bob", jwk_3b),
-        ]);
+        set_patches(
+            &aptos_framework,
+            vector[new_patch_upsert_jwk(b"bob", jwk_3b),],
+        );
         assert!(jwk_3b == get_patched_jwk(b"bob", b"key_id_3"), 1);
         assert!(option::some(jwk_3b) == try_get_patched_jwk(b"bob", b"key_id_3"), 1);
 
         // Wipe everything, then add some keys back.
-        set_patches(&aptos_framework, vector[
-            new_patch_remove_all(),
-            new_patch_upsert_jwk(b"alice", jwk_1),
-            new_patch_upsert_jwk(b"bob", jwk_3),
-        ]);
+        set_patches(
+            &aptos_framework,
+            vector[
+                new_patch_remove_all(),
+                new_patch_upsert_jwk(b"alice", jwk_1),
+                new_patch_upsert_jwk(b"bob", jwk_3),],
+        );
         assert!(jwk_3 == get_patched_jwk(b"bob", b"key_id_3"), 1);
         assert!(option::some(jwk_3) == try_get_patched_jwk(b"bob", b"key_id_3"), 1);
     }

--- a/aptos-move/framework/aptos-framework/sources/keyless_account.move
+++ b/aptos-move/framework/aptos-framework/sources/keyless_account.move
@@ -17,7 +17,7 @@ module aptos_framework::keyless_account {
     friend aptos_framework::reconfiguration_with_dkg;
 
     /// The training wheels PK needs to be 32 bytes long.
-    const E_TRAINING_WHEELS_PK_WRONG_SIZE : u64 = 1;
+    const E_TRAINING_WHEELS_PK_WRONG_SIZE: u64 = 1;
 
     /// A serialized BN254 G1 point is invalid.
     const E_INVALID_BN254_G1_SERIALIZATION: u64 = 2;
@@ -68,26 +68,23 @@ module aptos_framework::keyless_account {
     }
 
     #[test_only]
-    public fun initialize_for_test(fx: &signer, vk: Groth16VerificationKey, constants: Configuration) {
+    public fun initialize_for_test(
+        fx: &signer, vk: Groth16VerificationKey, constants: Configuration
+    ) {
         system_addresses::assert_aptos_framework(fx);
 
         move_to(fx, vk);
         move_to(fx, constants);
     }
 
-    public fun new_groth16_verification_key(alpha_g1: vector<u8>,
-                                            beta_g2: vector<u8>,
-                                            gamma_g2: vector<u8>,
-                                            delta_g2: vector<u8>,
-                                            gamma_abc_g1: vector<vector<u8>>
+    public fun new_groth16_verification_key(
+        alpha_g1: vector<u8>,
+        beta_g2: vector<u8>,
+        gamma_g2: vector<u8>,
+        delta_g2: vector<u8>,
+        gamma_abc_g1: vector<vector<u8>>
     ): Groth16VerificationKey {
-        Groth16VerificationKey {
-            alpha_g1,
-            beta_g2,
-            gamma_g2,
-            delta_g2,
-            gamma_abc_g1,
-        }
+        Groth16VerificationKey { alpha_g1, beta_g2, gamma_g2, delta_g2, gamma_abc_g1, }
     }
 
     public fun new_configuration(
@@ -115,12 +112,47 @@ module aptos_framework::keyless_account {
     /// Pre-validate the VK to actively-prevent incorrect VKs from being set on-chain.
     fun validate_groth16_vk(vk: &Groth16VerificationKey) {
         // Could be leveraged to speed up the VM deserialization of the VK by 2x, since it can assume the points are valid.
-        assert!(option::is_some(&crypto_algebra::deserialize<bn254_algebra::G1, bn254_algebra::FormatG1Compr>(&vk.alpha_g1)), E_INVALID_BN254_G1_SERIALIZATION);
-        assert!(option::is_some(&crypto_algebra::deserialize<bn254_algebra::G2, bn254_algebra::FormatG2Compr>(&vk.beta_g2)), E_INVALID_BN254_G2_SERIALIZATION);
-        assert!(option::is_some(&crypto_algebra::deserialize<bn254_algebra::G2, bn254_algebra::FormatG2Compr>(&vk.gamma_g2)), E_INVALID_BN254_G2_SERIALIZATION);
-        assert!(option::is_some(&crypto_algebra::deserialize<bn254_algebra::G2, bn254_algebra::FormatG2Compr>(&vk.delta_g2)), E_INVALID_BN254_G2_SERIALIZATION);
+        assert!(
+            option::is_some(
+                &crypto_algebra::deserialize<bn254_algebra::G1, bn254_algebra::FormatG1Compr>(
+                    &vk.alpha_g1
+                ),
+            ),
+            E_INVALID_BN254_G1_SERIALIZATION,
+        );
+        assert!(
+            option::is_some(
+                &crypto_algebra::deserialize<bn254_algebra::G2, bn254_algebra::FormatG2Compr>(
+                    &vk.beta_g2
+                ),
+            ),
+            E_INVALID_BN254_G2_SERIALIZATION,
+        );
+        assert!(
+            option::is_some(
+                &crypto_algebra::deserialize<bn254_algebra::G2, bn254_algebra::FormatG2Compr>(
+                    &vk.gamma_g2
+                ),
+            ),
+            E_INVALID_BN254_G2_SERIALIZATION,
+        );
+        assert!(
+            option::is_some(
+                &crypto_algebra::deserialize<bn254_algebra::G2, bn254_algebra::FormatG2Compr>(
+                    &vk.delta_g2
+                ),
+            ),
+            E_INVALID_BN254_G2_SERIALIZATION,
+        );
         for (i in 0..vector::length(&vk.gamma_abc_g1)) {
-            assert!(option::is_some(&crypto_algebra::deserialize<bn254_algebra::G1, bn254_algebra::FormatG1Compr>(vector::borrow(&vk.gamma_abc_g1, i))), E_INVALID_BN254_G1_SERIALIZATION);
+            assert!(
+                option::is_some(
+                    &crypto_algebra::deserialize<bn254_algebra::G1, bn254_algebra::FormatG1Compr>(
+                        vector::borrow(&vk.gamma_abc_g1, i)
+                    ),
+                ),
+                E_INVALID_BN254_G1_SERIALIZATION,
+            );
         };
     }
 
@@ -128,7 +160,9 @@ module aptos_framework::keyless_account {
     /// `set_groth16_verification_key_for_next_epoch`.
     ///
     /// WARNING: See `set_groth16_verification_key_for_next_epoch` for caveats.
-    public fun update_groth16_verification_key(fx: &signer, vk: Groth16VerificationKey) {
+    public fun update_groth16_verification_key(
+        fx: &signer, vk: Groth16VerificationKey
+    ) {
         system_addresses::assert_aptos_framework(fx);
         chain_status::assert_genesis();
         // There should not be a previous resource set here.
@@ -152,7 +186,9 @@ module aptos_framework::keyless_account {
         chain_status::assert_genesis();
 
         if (option::is_some(&pk)) {
-            assert!(vector::length(option::borrow(&pk)) == 32, E_TRAINING_WHEELS_PK_WRONG_SIZE)
+            assert!(
+                vector::length(option::borrow(&pk)) == 32, E_TRAINING_WHEELS_PK_WRONG_SIZE
+            )
         };
 
         let config = borrow_global_mut<Configuration>(signer::address_of(fx));
@@ -160,7 +196,9 @@ module aptos_framework::keyless_account {
     }
 
     #[deprecated]
-    public fun update_max_exp_horizon(fx: &signer, max_exp_horizon_secs: u64) acquires Configuration {
+    public fun update_max_exp_horizon(
+        fx: &signer, max_exp_horizon_secs: u64
+    ) acquires Configuration {
         system_addresses::assert_aptos_framework(fx);
         chain_status::assert_genesis();
 
@@ -193,18 +231,21 @@ module aptos_framework::keyless_account {
     /// so that old ZKPs for the old VK cannot be replayed as potentially-valid ZKPs.
     ///
     /// WARNING: If a malicious key is set, this would lead to stolen funds.
-    public fun set_groth16_verification_key_for_next_epoch(fx: &signer, vk: Groth16VerificationKey) {
+    public fun set_groth16_verification_key_for_next_epoch(
+        fx: &signer, vk: Groth16VerificationKey
+    ) {
         system_addresses::assert_aptos_framework(fx);
         config_buffer::upsert<Groth16VerificationKey>(vk);
     }
-
 
     /// Queues up a change to the keyless configuration. The change will only be effective after reconfiguration. Only
     /// callable via governance proposal.
     ///
     /// WARNING: A malicious `Configuration` could lead to DoS attacks, create liveness issues, or enable a malicious
     /// recovery service provider to phish users' accounts.
-    public fun set_configuration_for_next_epoch(fx: &signer, config: Configuration) {
+    public fun set_configuration_for_next_epoch(
+        fx: &signer, config: Configuration
+    ) {
         system_addresses::assert_aptos_framework(fx);
         config_buffer::upsert<Configuration>(config);
     }
@@ -213,7 +254,9 @@ module aptos_framework::keyless_account {
     /// reconfiguration. Only callable via governance proposal.
     ///
     /// WARNING: If a malicious key is set, this *could* lead to stolen funds.
-    public fun update_training_wheels_for_next_epoch(fx: &signer, pk: Option<vector<u8>>) acquires Configuration {
+    public fun update_training_wheels_for_next_epoch(
+        fx: &signer, pk: Option<vector<u8>>
+    ) acquires Configuration {
         system_addresses::assert_aptos_framework(fx);
 
         // If a PK is being set, validate it first.
@@ -223,11 +266,12 @@ module aptos_framework::keyless_account {
             assert!(option::is_some(&vpk), E_TRAINING_WHEELS_PK_WRONG_SIZE)
         };
 
-        let config = if (config_buffer::does_exist<Configuration>()) {
-            config_buffer::extract<Configuration>()
-        } else {
-            *borrow_global<Configuration>(signer::address_of(fx))
-        };
+        let config =
+            if (config_buffer::does_exist<Configuration>()) {
+                config_buffer::extract<Configuration>()
+            } else {
+                *borrow_global<Configuration>(signer::address_of(fx))
+            };
 
         config.training_wheels_pubkey = pk;
 
@@ -236,14 +280,17 @@ module aptos_framework::keyless_account {
 
     /// Convenience method to queues up a change to the max expiration horizon. The change will only be effective after
     /// reconfiguration. Only callable via governance proposal.
-    public fun update_max_exp_horizon_for_next_epoch(fx: &signer, max_exp_horizon_secs: u64) acquires Configuration {
+    public fun update_max_exp_horizon_for_next_epoch(
+        fx: &signer, max_exp_horizon_secs: u64
+    ) acquires Configuration {
         system_addresses::assert_aptos_framework(fx);
 
-        let config = if (config_buffer::does_exist<Configuration>()) {
-            config_buffer::extract<Configuration>()
-        } else {
-            *borrow_global<Configuration>(signer::address_of(fx))
-        };
+        let config =
+            if (config_buffer::does_exist<Configuration>()) {
+                config_buffer::extract<Configuration>()
+            } else {
+                *borrow_global<Configuration>(signer::address_of(fx))
+            };
 
         config.max_exp_horizon_secs = max_exp_horizon_secs;
 
@@ -258,11 +305,12 @@ module aptos_framework::keyless_account {
     public fun remove_all_override_auds_for_next_epoch(fx: &signer) acquires Configuration {
         system_addresses::assert_aptos_framework(fx);
 
-        let config = if (config_buffer::does_exist<Configuration>()) {
-            config_buffer::extract<Configuration>()
-        } else {
-            *borrow_global<Configuration>(signer::address_of(fx))
-        };
+        let config =
+            if (config_buffer::does_exist<Configuration>()) {
+                config_buffer::extract<Configuration>()
+            } else {
+                *borrow_global<Configuration>(signer::address_of(fx))
+            };
 
         config.override_aud_vals = vector[];
 
@@ -276,11 +324,12 @@ module aptos_framework::keyless_account {
     public fun add_override_aud_for_next_epoch(fx: &signer, aud: String) acquires Configuration {
         system_addresses::assert_aptos_framework(fx);
 
-        let config = if (config_buffer::does_exist<Configuration>()) {
-            config_buffer::extract<Configuration>()
-        } else {
-            *borrow_global<Configuration>(signer::address_of(fx))
-        };
+        let config =
+            if (config_buffer::does_exist<Configuration>()) {
+                config_buffer::extract<Configuration>()
+            } else {
+                *borrow_global<Configuration>(signer::address_of(fx))
+            };
 
         vector::push_back(&mut config.override_aud_vals, aud);
 

--- a/aptos-move/framework/aptos-framework/sources/keyless_account.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/keyless_account.spec.move
@@ -1,6 +1,6 @@
 spec aptos_framework::keyless_account {
     spec module {
         // TODO: verification is  disabled until this module is specified.
-        pragma verify=false;
+        pragma verify = false;
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/managed_coin.move
+++ b/aptos-move/framework/aptos-framework/sources/managed_coin.move
@@ -33,8 +33,7 @@ module aptos_framework::managed_coin {
 
     /// Withdraw an `amount` of coin `CoinType` from `account` and burn it.
     public entry fun burn<CoinType>(
-        account: &signer,
-        amount: u64,
+        account: &signer, amount: u64,
     ) acquires Capabilities {
         let account_addr = signer::address_of(account);
 
@@ -58,19 +57,19 @@ module aptos_framework::managed_coin {
         decimals: u8,
         monitor_supply: bool,
     ) {
-        let (burn_cap, freeze_cap, mint_cap) = coin::initialize<CoinType>(
-            account,
-            string::utf8(name),
-            string::utf8(symbol),
-            decimals,
-            monitor_supply,
-        );
+        let (burn_cap, freeze_cap, mint_cap) =
+            coin::initialize<CoinType>(
+                account,
+                string::utf8(name),
+                string::utf8(symbol),
+                decimals,
+                monitor_supply,
+            );
 
-        move_to(account, Capabilities<CoinType> {
-            burn_cap,
-            freeze_cap,
-            mint_cap,
-        });
+        move_to(
+            account,
+            Capabilities<CoinType> { burn_cap, freeze_cap, mint_cap, },
+        );
     }
 
     /// Create new coins `CoinType` and deposit them into dst_addr's account.
@@ -112,15 +111,15 @@ module aptos_framework::managed_coin {
 
     #[test(source = @0xa11ce, destination = @0xb0b, mod_account = @0x1)]
     public entry fun test_end_to_end(
-        source: signer,
-        destination: signer,
-        mod_account: signer
+        source: signer, destination: signer, mod_account: signer
     ) acquires Capabilities {
         let source_addr = signer::address_of(&source);
         let destination_addr = signer::address_of(&destination);
         aptos_framework::account::create_account_for_test(source_addr);
         aptos_framework::account::create_account_for_test(destination_addr);
-        aptos_framework::account::create_account_for_test(signer::address_of(&mod_account));
+        aptos_framework::account::create_account_for_test(
+            signer::address_of(&mod_account)
+        );
         aggregator_factory::initialize_aggregator_factory_for_test(&mod_account);
 
         initialize<FakeMoney>(
@@ -128,7 +127,7 @@ module aptos_framework::managed_coin {
             b"Fake Money",
             b"FMD",
             10,
-            true
+            true,
         );
         assert!(coin::is_coin_initialized<FakeMoney>(), 0);
 
@@ -168,8 +167,12 @@ module aptos_framework::managed_coin {
         let source_addr = signer::address_of(&source);
 
         aptos_framework::account::create_account_for_test(source_addr);
-        aptos_framework::account::create_account_for_test(signer::address_of(&destination));
-        aptos_framework::account::create_account_for_test(signer::address_of(&mod_account));
+        aptos_framework::account::create_account_for_test(
+            signer::address_of(&destination)
+        );
+        aptos_framework::account::create_account_for_test(
+            signer::address_of(&mod_account)
+        );
         aggregator_factory::initialize_aggregator_factory_for_test(&mod_account);
 
         initialize<FakeMoney>(&mod_account, b"Fake money", b"FMD", 1, true);
@@ -190,8 +193,12 @@ module aptos_framework::managed_coin {
         let source_addr = signer::address_of(&source);
 
         aptos_framework::account::create_account_for_test(source_addr);
-        aptos_framework::account::create_account_for_test(signer::address_of(&destination));
-        aptos_framework::account::create_account_for_test(signer::address_of(&mod_account));
+        aptos_framework::account::create_account_for_test(
+            signer::address_of(&destination)
+        );
+        aptos_framework::account::create_account_for_test(
+            signer::address_of(&mod_account)
+        );
         aggregator_factory::initialize_aggregator_factory_for_test(&mod_account);
 
         initialize<FakeMoney>(&mod_account, b"Fake money", b"FMD", 1, true);

--- a/aptos-move/framework/aptos-framework/sources/managed_coin.move
+++ b/aptos-move/framework/aptos-framework/sources/managed_coin.move
@@ -32,9 +32,7 @@ module aptos_framework::managed_coin {
     //
 
     /// Withdraw an `amount` of coin `CoinType` from `account` and burn it.
-    public entry fun burn<CoinType>(
-        account: &signer, amount: u64,
-    ) acquires Capabilities {
+    public entry fun burn<CoinType>(account: &signer, amount: u64,) acquires Capabilities {
         let account_addr = signer::address_of(account);
 
         assert!(

--- a/aptos-move/framework/aptos-framework/sources/managed_coin.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/managed_coin.spec.move
@@ -50,10 +50,7 @@ spec aptos_framework::managed_coin {
         pragma aborts_if_is_strict;
     }
 
-    spec burn<CoinType>(
-        account: &signer,
-        amount: u64,
-    ) {
+    spec burn<CoinType>(account: &signer, amount: u64,) {
         use aptos_std::type_info;
         // TODO(fa_migration)
         pragma verify = false;
@@ -74,12 +71,12 @@ spec aptos_framework::managed_coin {
         aborts_if coin_store.frozen;
         aborts_if balance < amount;
 
-        let addr =  type_info::type_of<CoinType>().account_address;
+        let addr = type_info::type_of<CoinType>().account_address;
         let maybe_supply = global<coin::CoinInfo<CoinType>>(addr).supply;
         // Ensure the amount won't be overflow.
         aborts_if amount == 0;
         aborts_if !exists<coin::CoinInfo<CoinType>>(addr);
-        include coin::CoinSubAbortsIf<CoinType> { amount:amount };
+        include coin::CoinSubAbortsIf<CoinType> { amount: amount };
 
         // Ensure that the global 'supply' decreases by 'amount'.
         ensures coin::supply<CoinType> == old(coin::supply<CoinType>) - amount;
@@ -108,11 +105,7 @@ spec aptos_framework::managed_coin {
 
     /// The Capabilities<CoinType> should not exist in the signer address.
     /// The `dst_addr` should not be frozen.
-    spec mint<CoinType>(
-        account: &signer,
-        dst_addr: address,
-        amount: u64,
-    ) {
+    spec mint<CoinType>(account: &signer, dst_addr: address, amount: u64,) {
         use aptos_std::type_info;
         // TODO(fa_migration)
         pragma verify = false;
@@ -127,7 +120,8 @@ spec aptos_framework::managed_coin {
         include coin::CoinAddAbortsIf<CoinType>;
         ensures coin::supply<CoinType> == old(coin::supply<CoinType>) + amount;
         /// [high-level-req-6]
-        ensures global<coin::CoinStore<CoinType>>(dst_addr).coin.value == old(global<coin::CoinStore<CoinType>>(dst_addr)).coin.value + amount;
+        ensures global<coin::CoinStore<CoinType>>(dst_addr).coin.value
+            == old(global<coin::CoinStore<CoinType>>(dst_addr)).coin.value + amount;
     }
 
     /// An account can only be registered once.
@@ -141,10 +135,14 @@ spec aptos_framework::managed_coin {
         let account_addr = signer::address_of(account);
         let acc = global<account::Account>(account_addr);
 
-        aborts_if !exists<coin::CoinStore<CoinType>>(account_addr) && acc.guid_creation_num + 2 >= account::MAX_GUID_CREATION_NUM;
-        aborts_if !exists<coin::CoinStore<CoinType>>(account_addr) && acc.guid_creation_num + 2 > MAX_U64;
-        aborts_if !exists<coin::CoinStore<CoinType>>(account_addr) && !exists<account::Account>(account_addr);
-        aborts_if !exists<coin::CoinStore<CoinType>>(account_addr) && !type_info::spec_is_struct<CoinType>();
+        aborts_if !exists<coin::CoinStore<CoinType>>(account_addr)
+            && acc.guid_creation_num + 2 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if !exists<coin::CoinStore<CoinType>>(account_addr)
+            && acc.guid_creation_num + 2 > MAX_U64;
+        aborts_if !exists<coin::CoinStore<CoinType>>(account_addr)
+            && !exists<account::Account>(account_addr);
+        aborts_if !exists<coin::CoinStore<CoinType>>(account_addr)
+            && !type_info::spec_is_struct<CoinType>();
         ensures exists<coin::CoinStore<CoinType>>(account_addr);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/multisig_account.move
+++ b/aptos-move/framework/aptos-framework/sources/multisig_account.move
@@ -36,7 +36,12 @@
 /// flat governance structure, clients are encouraged to write their own modules on top of this multisig account module
 /// and implement the governance voting logic on top.
 module aptos_framework::multisig_account {
-    use aptos_framework::account::{Self, SignerCapability, new_event_handle, create_resource_address};
+    use aptos_framework::account::{
+        Self,
+        SignerCapability,
+        new_event_handle,
+        create_resource_address
+    };
     use aptos_framework::aptos_coin::AptosCoin;
     use aptos_framework::chain_id;
     use aptos_framework::create_signer::create_signer;
@@ -99,7 +104,6 @@ module aptos_framework::multisig_account {
     const EMAX_PENDING_TRANSACTIONS_EXCEEDED: u64 = 19;
     /// The multisig v2 enhancement feature is not enabled.
     const EMULTISIG_V2_ENHANCEMENT_NOT_ENABLED: u64 = 20;
-
 
     const ZERO_AUTH_KEY: vector<u8> = x"0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -361,12 +365,12 @@ module aptos_framework::multisig_account {
     #[view]
     /// Return the transaction with the given transaction id.
     public fun get_transaction(
-        multisig_account: address,
-        sequence_number: u64,
+        multisig_account: address, sequence_number: u64,
     ): MultisigTransaction acquires MultisigAccount {
         let multisig_account_resource = borrow_global<MultisigAccount>(multisig_account);
         assert!(
-            sequence_number > 0 && sequence_number < multisig_account_resource.next_sequence_number,
+            sequence_number > 0
+                && sequence_number < multisig_account_resource.next_sequence_number,
             error::invalid_argument(EINVALID_SEQUENCE_NUMBER),
         );
         *table::borrow(&multisig_account_resource.transactions, sequence_number)
@@ -374,15 +378,16 @@ module aptos_framework::multisig_account {
 
     #[view]
     /// Return all pending transactions.
-    public fun get_pending_transactions(
-        multisig_account: address
-    ): vector<MultisigTransaction> acquires MultisigAccount {
+    public fun get_pending_transactions(multisig_account: address): vector<MultisigTransaction> acquires MultisigAccount {
         let pending_transactions: vector<MultisigTransaction> = vector[];
         let multisig_account = borrow_global<MultisigAccount>(multisig_account);
         let i = multisig_account.last_executed_sequence_number + 1;
         let next_sequence_number = multisig_account.next_sequence_number;
         while (i < next_sequence_number) {
-            vector::push_back(&mut pending_transactions, *table::borrow(&multisig_account.transactions, i));
+            vector::push_back(
+                &mut pending_transactions,
+                *table::borrow(&multisig_account.transactions, i),
+            );
             i = i + 1;
         };
         pending_transactions
@@ -391,10 +396,12 @@ module aptos_framework::multisig_account {
     #[view]
     /// Return the payload for the next transaction in the queue.
     public fun get_next_transaction_payload(
-        multisig_account: address, provided_payload: vector<u8>): vector<u8> acquires MultisigAccount {
+        multisig_account: address, provided_payload: vector<u8>
+    ): vector<u8> acquires MultisigAccount {
         let multisig_account_resource = borrow_global<MultisigAccount>(multisig_account);
         let sequence_number = multisig_account_resource.last_executed_sequence_number + 1;
-        let transaction = table::borrow(&multisig_account_resource.transactions, sequence_number);
+        let transaction =
+            table::borrow(&multisig_account_resource.transactions, sequence_number);
 
         if (option::is_some(&transaction.payload)) {
             *option::borrow(&transaction.payload)
@@ -405,79 +412,99 @@ module aptos_framework::multisig_account {
 
     #[view]
     /// Return true if the transaction with given transaction id can be executed now.
-    public fun can_be_executed(multisig_account: address, sequence_number: u64): bool acquires MultisigAccount {
+    public fun can_be_executed(
+        multisig_account: address, sequence_number: u64
+    ): bool acquires MultisigAccount {
         assert_valid_sequence_number(multisig_account, sequence_number);
-        let (num_approvals, _) = num_approvals_and_rejections(multisig_account, sequence_number);
-        sequence_number == last_resolved_sequence_number(multisig_account) + 1 &&
-            num_approvals >= num_signatures_required(multisig_account)
+        let (num_approvals, _) =
+            num_approvals_and_rejections(multisig_account, sequence_number);
+        sequence_number == last_resolved_sequence_number(multisig_account) + 1
+            && num_approvals >= num_signatures_required(multisig_account)
     }
 
     #[view]
     /// Return true if the owner can execute the transaction with given transaction id now.
-    public fun can_execute(owner: address, multisig_account: address, sequence_number: u64): bool acquires MultisigAccount {
+    public fun can_execute(
+        owner: address, multisig_account: address, sequence_number: u64
+    ): bool acquires MultisigAccount {
         assert_valid_sequence_number(multisig_account, sequence_number);
-        let (num_approvals, _) = num_approvals_and_rejections(multisig_account, sequence_number);
+        let (num_approvals, _) =
+            num_approvals_and_rejections(multisig_account, sequence_number);
         if (!has_voted_for_approval(multisig_account, sequence_number, owner)) {
             num_approvals = num_approvals + 1;
         };
-        is_owner(owner, multisig_account) &&
-            sequence_number == last_resolved_sequence_number(multisig_account) + 1 &&
-            num_approvals >= num_signatures_required(multisig_account)
+        is_owner(owner, multisig_account)
+            && sequence_number == last_resolved_sequence_number(multisig_account) + 1
+            && num_approvals >= num_signatures_required(multisig_account)
     }
 
     #[view]
     /// Return true if the transaction with given transaction id can be officially rejected.
-    public fun can_be_rejected(multisig_account: address, sequence_number: u64): bool acquires MultisigAccount {
+    public fun can_be_rejected(
+        multisig_account: address, sequence_number: u64
+    ): bool acquires MultisigAccount {
         assert_valid_sequence_number(multisig_account, sequence_number);
-        let (_, num_rejections) = num_approvals_and_rejections(multisig_account, sequence_number);
-        sequence_number == last_resolved_sequence_number(multisig_account) + 1 &&
-            num_rejections >= num_signatures_required(multisig_account)
+        let (_, num_rejections) =
+            num_approvals_and_rejections(multisig_account, sequence_number);
+        sequence_number == last_resolved_sequence_number(multisig_account) + 1
+            && num_rejections >= num_signatures_required(multisig_account)
     }
 
     #[view]
     /// Return true if the owner can execute the "rejected" transaction with given transaction id now.
-    public fun can_reject(owner: address, multisig_account: address, sequence_number: u64): bool acquires MultisigAccount {
+    public fun can_reject(
+        owner: address, multisig_account: address, sequence_number: u64
+    ): bool acquires MultisigAccount {
         assert_valid_sequence_number(multisig_account, sequence_number);
-        let (_, num_rejections) = num_approvals_and_rejections(multisig_account, sequence_number);
+        let (_, num_rejections) =
+            num_approvals_and_rejections(multisig_account, sequence_number);
         if (!has_voted_for_rejection(multisig_account, sequence_number, owner)) {
             num_rejections = num_rejections + 1;
         };
-        is_owner(owner, multisig_account) &&
-            sequence_number == last_resolved_sequence_number(multisig_account) + 1 &&
-            num_rejections >= num_signatures_required(multisig_account)
+        is_owner(owner, multisig_account)
+            && sequence_number == last_resolved_sequence_number(multisig_account) + 1
+            && num_rejections >= num_signatures_required(multisig_account)
     }
 
     #[view]
     /// Return the predicted address for the next multisig account if created from the given creator address.
     public fun get_next_multisig_account_address(creator: address): address {
         let owner_nonce = account::get_sequence_number(creator);
-        create_resource_address(&creator, create_multisig_account_seed(to_bytes(&owner_nonce)))
+        create_resource_address(
+            &creator, create_multisig_account_seed(to_bytes(&owner_nonce))
+        )
     }
 
     #[view]
     /// Return the id of the last transaction that was executed (successful or failed) or removed.
     public fun last_resolved_sequence_number(multisig_account: address): u64 acquires MultisigAccount {
-        let multisig_account_resource = borrow_global_mut<MultisigAccount>(multisig_account);
+        let multisig_account_resource =
+            borrow_global_mut<MultisigAccount>(multisig_account);
         multisig_account_resource.last_executed_sequence_number
     }
 
     #[view]
     /// Return the id of the next transaction created.
     public fun next_sequence_number(multisig_account: address): u64 acquires MultisigAccount {
-        let multisig_account_resource = borrow_global_mut<MultisigAccount>(multisig_account);
+        let multisig_account_resource =
+            borrow_global_mut<MultisigAccount>(multisig_account);
         multisig_account_resource.next_sequence_number
     }
 
     #[view]
     /// Return a bool tuple indicating whether an owner has voted and if so, whether they voted yes or no.
     public fun vote(
-        multisig_account: address, sequence_number: u64, owner: address): (bool, bool) acquires MultisigAccount {
-        let multisig_account_resource = borrow_global_mut<MultisigAccount>(multisig_account);
+        multisig_account: address, sequence_number: u64, owner: address
+    ): (bool, bool) acquires MultisigAccount {
+        let multisig_account_resource =
+            borrow_global_mut<MultisigAccount>(multisig_account);
         assert!(
-            sequence_number > 0 && sequence_number < multisig_account_resource.next_sequence_number,
+            sequence_number > 0
+                && sequence_number < multisig_account_resource.next_sequence_number,
             error::invalid_argument(EINVALID_SEQUENCE_NUMBER),
         );
-        let transaction = table::borrow(&multisig_account_resource.transactions, sequence_number);
+        let transaction =
+            table::borrow(&multisig_account_resource.transactions, sequence_number);
         let votes = &transaction.votes;
         let voted = simple_map::contains_key(votes, &owner);
         let vote = voted && *simple_map::borrow(votes, &owner);
@@ -485,12 +512,16 @@ module aptos_framework::multisig_account {
     }
 
     #[view]
-    public fun available_transaction_queue_capacity(multisig_account: address): u64 acquires MultisigAccount {
-        let multisig_account_resource = borrow_global_mut<MultisigAccount>(multisig_account);
-        let num_pending_transactions = multisig_account_resource.next_sequence_number - multisig_account_resource.last_executed_sequence_number - 1;
-        if (num_pending_transactions > MAX_PENDING_TRANSACTIONS) {
-            0
-        } else {
+    public fun available_transaction_queue_capacity(
+        multisig_account: address
+    ): u64 acquires MultisigAccount {
+        let multisig_account_resource =
+            borrow_global_mut<MultisigAccount>(multisig_account);
+        let num_pending_transactions =
+            multisig_account_resource.next_sequence_number
+                - multisig_account_resource.last_executed_sequence_number - 1;
+        if (num_pending_transactions > MAX_PENDING_TRANSACTIONS) { 0 }
+        else {
             MAX_PENDING_TRANSACTIONS - num_pending_transactions
         }
     }
@@ -612,7 +643,13 @@ module aptos_framework::multisig_account {
         metadata_keys: vector<String>,
         metadata_values: vector<vector<u8>>,
     ) acquires MultisigAccount {
-        create_with_owners(owner, vector[], num_signatures_required, metadata_keys, metadata_values);
+        create_with_owners(
+            owner,
+            vector[],
+            num_signatures_required,
+            metadata_keys,
+            metadata_values,
+        );
     }
 
     /// Creates a new multisig account with the specified additional owner list and signatures required.
@@ -657,13 +694,13 @@ module aptos_framework::multisig_account {
             owners,
             num_signatures_required,
             metadata_keys,
-            metadata_values
+            metadata_values,
         );
         update_owner_schema(
             get_next_multisig_account_address(bootstrapper_address),
             vector[],
             vector[bootstrapper_address],
-            option::none()
+            option::none(),
         );
     }
 
@@ -675,33 +712,50 @@ module aptos_framework::multisig_account {
         metadata_keys: vector<String>,
         metadata_values: vector<vector<u8>>,
     ) acquires MultisigAccount {
-        assert!(features::multisig_accounts_enabled(), error::unavailable(EMULTISIG_ACCOUNTS_NOT_ENABLED_YET));
         assert!(
-            num_signatures_required > 0 && num_signatures_required <= vector::length(&owners),
+            features::multisig_accounts_enabled(),
+            error::unavailable(EMULTISIG_ACCOUNTS_NOT_ENABLED_YET),
+        );
+        assert!(
+            num_signatures_required > 0
+                && num_signatures_required <= vector::length(&owners),
             error::invalid_argument(EINVALID_SIGNATURES_REQUIRED),
         );
 
         let multisig_address = address_of(multisig_account);
         validate_owners(&owners, multisig_address);
-        move_to(multisig_account, MultisigAccount {
-            owners,
-            num_signatures_required,
-            transactions: table::new<u64, MultisigTransaction>(),
-            metadata: simple_map::create<String, vector<u8>>(),
-            // First transaction will start at id 1 instead of 0.
-            last_executed_sequence_number: 0,
-            next_sequence_number: 1,
-            signer_cap: multisig_account_signer_cap,
-            add_owners_events: new_event_handle<AddOwnersEvent>(multisig_account),
-            remove_owners_events: new_event_handle<RemoveOwnersEvent>(multisig_account),
-            update_signature_required_events: new_event_handle<UpdateSignaturesRequiredEvent>(multisig_account),
-            create_transaction_events: new_event_handle<CreateTransactionEvent>(multisig_account),
-            vote_events: new_event_handle<VoteEvent>(multisig_account),
-            execute_rejected_transaction_events: new_event_handle<ExecuteRejectedTransactionEvent>(multisig_account),
-            execute_transaction_events: new_event_handle<TransactionExecutionSucceededEvent>(multisig_account),
-            transaction_execution_failed_events: new_event_handle<TransactionExecutionFailedEvent>(multisig_account),
-            metadata_updated_events: new_event_handle<MetadataUpdatedEvent>(multisig_account),
-        });
+        move_to(
+            multisig_account,
+            MultisigAccount {
+                owners,
+                num_signatures_required,
+                transactions: table::new<u64, MultisigTransaction>(),
+                metadata: simple_map::create<String, vector<u8>>(),
+                // First transaction will start at id 1 instead of 0.
+                last_executed_sequence_number: 0,
+                next_sequence_number: 1,
+                signer_cap: multisig_account_signer_cap,
+                add_owners_events: new_event_handle<AddOwnersEvent>(multisig_account),
+                remove_owners_events: new_event_handle<RemoveOwnersEvent>(
+                    multisig_account
+                ),
+                update_signature_required_events: new_event_handle<
+                    UpdateSignaturesRequiredEvent>(multisig_account),
+                create_transaction_events: new_event_handle<CreateTransactionEvent>(
+                    multisig_account
+                ),
+                vote_events: new_event_handle<VoteEvent>(multisig_account),
+                execute_rejected_transaction_events: new_event_handle<
+                    ExecuteRejectedTransactionEvent>(multisig_account),
+                execute_transaction_events: new_event_handle<
+                    TransactionExecutionSucceededEvent>(multisig_account),
+                transaction_execution_failed_events: new_event_handle<
+                    TransactionExecutionFailedEvent>(multisig_account),
+                metadata_updated_events: new_event_handle<MetadataUpdatedEvent>(
+                    multisig_account
+                ),
+            },
+        );
 
         update_metadata_internal(multisig_account, metadata_keys, metadata_values, false);
     }
@@ -720,12 +774,13 @@ module aptos_framework::multisig_account {
     /// ensures that a multisig transaction cannot lead to another module obtaining the multisig signer and using it to
     /// maliciously alter the owners list.
     entry fun add_owners(
-        multisig_account: &signer, new_owners: vector<address>) acquires MultisigAccount {
+        multisig_account: &signer, new_owners: vector<address>
+    ) acquires MultisigAccount {
         update_owner_schema(
             address_of(multisig_account),
             new_owners,
             vector[],
-            option::none()
+            option::none(),
         );
     }
 
@@ -739,13 +794,14 @@ module aptos_framework::multisig_account {
             address_of(multisig_account),
             new_owners,
             vector[],
-            option::some(new_num_signatures_required)
+            option::some(new_num_signatures_required),
         );
     }
 
     /// Similar to remove_owners, but only allow removing one owner.
     entry fun remove_owner(
-        multisig_account: &signer, owner_to_remove: address) acquires MultisigAccount {
+        multisig_account: &signer, owner_to_remove: address
+    ) acquires MultisigAccount {
         remove_owners(multisig_account, vector[owner_to_remove]);
     }
 
@@ -757,26 +813,25 @@ module aptos_framework::multisig_account {
     /// ensures that a multisig transaction cannot lead to another module obtaining the multisig signer and using it to
     /// maliciously alter the owners list.
     entry fun remove_owners(
-        multisig_account: &signer, owners_to_remove: vector<address>) acquires MultisigAccount {
+        multisig_account: &signer, owners_to_remove: vector<address>
+    ) acquires MultisigAccount {
         update_owner_schema(
             address_of(multisig_account),
             vector[],
             owners_to_remove,
-            option::none()
+            option::none(),
         );
     }
 
     /// Swap an owner in for an old one, without changing required signatures.
     entry fun swap_owner(
-        multisig_account: &signer,
-        to_swap_in: address,
-        to_swap_out: address
+        multisig_account: &signer, to_swap_in: address, to_swap_out: address
     ) acquires MultisigAccount {
         update_owner_schema(
             address_of(multisig_account),
             vector[to_swap_in],
             vector[to_swap_out],
-            option::none()
+            option::none(),
         );
     }
 
@@ -790,7 +845,7 @@ module aptos_framework::multisig_account {
             address_of(multisig_account),
             to_swap_in,
             to_swap_out,
-            option::none()
+            option::none(),
         );
     }
 
@@ -805,7 +860,7 @@ module aptos_framework::multisig_account {
             address_of(multisig_account),
             new_owners,
             owners_to_remove,
-            option::some(new_num_signatures_required)
+            option::some(new_num_signatures_required),
         );
     }
 
@@ -816,12 +871,13 @@ module aptos_framework::multisig_account {
     /// ensures that a multisig transaction cannot lead to another module obtaining the multisig signer and using it to
     /// maliciously alter the number of signatures required.
     entry fun update_signatures_required(
-        multisig_account: &signer, new_num_signatures_required: u64) acquires MultisigAccount {
+        multisig_account: &signer, new_num_signatures_required: u64
+    ) acquires MultisigAccount {
         update_owner_schema(
             address_of(multisig_account),
             vector[],
             vector[],
-            option::some(new_num_signatures_required)
+            option::some(new_num_signatures_required),
         );
     }
 
@@ -833,7 +889,8 @@ module aptos_framework::multisig_account {
     /// ensures that a multisig transaction cannot lead to another module obtaining the multisig signer and using it to
     /// maliciously alter the number of signatures required.
     entry fun update_metadata(
-        multisig_account: &signer, keys: vector<String>, values: vector<vector<u8>>) acquires MultisigAccount {
+        multisig_account: &signer, keys: vector<String>, values: vector<vector<u8>>
+    ) acquires MultisigAccount {
         update_metadata_internal(multisig_account, keys, values, true);
     }
 
@@ -851,7 +908,8 @@ module aptos_framework::multisig_account {
 
         let multisig_address = address_of(multisig_account);
         assert_multisig_account_exists(multisig_address);
-        let multisig_account_resource = borrow_global_mut<MultisigAccount>(multisig_address);
+        let multisig_account_resource =
+            borrow_global_mut<MultisigAccount>(multisig_address);
         let old_metadata = multisig_account_resource.metadata;
         multisig_account_resource.metadata = simple_map::create<String, vector<u8>>();
         let metadata = &mut multisig_account_resource.metadata;
@@ -875,7 +933,7 @@ module aptos_framework::multisig_account {
                         multisig_account: multisig_address,
                         old_metadata,
                         new_metadata: multisig_account_resource.metadata,
-                    }
+                    },
                 )
             };
             emit_event(
@@ -883,7 +941,7 @@ module aptos_framework::multisig_account {
                 MetadataUpdatedEvent {
                     old_metadata,
                     new_metadata: multisig_account_resource.metadata,
-                }
+                },
             );
         };
     }
@@ -896,7 +954,11 @@ module aptos_framework::multisig_account {
         multisig_account: address,
         payload: vector<u8>,
     ) acquires MultisigAccount {
-        assert!(vector::length(&payload) > 0, error::invalid_argument(EPAYLOAD_CANNOT_BE_EMPTY));
+        assert!(
+            vector::length(&payload) > 0, error::invalid_argument(
+                EPAYLOAD_CANNOT_BE_EMPTY
+            )
+        );
 
         assert_multisig_account_exists(multisig_account);
         assert_is_owner(owner, multisig_account);
@@ -921,7 +983,10 @@ module aptos_framework::multisig_account {
         payload_hash: vector<u8>,
     ) acquires MultisigAccount {
         // Payload hash is a sha3-256 hash, so it must be exactly 32 bytes.
-        assert!(vector::length(&payload_hash) == 32, error::invalid_argument(EINVALID_PAYLOAD_HASH));
+        assert!(
+            vector::length(&payload_hash) == 32,
+            error::invalid_argument(EINVALID_PAYLOAD_HASH),
+        );
 
         assert_multisig_account_exists(multisig_account);
         assert_is_owner(owner, multisig_account);
@@ -939,13 +1004,15 @@ module aptos_framework::multisig_account {
 
     /// Approve a multisig transaction.
     public entry fun approve_transaction(
-        owner: &signer, multisig_account: address, sequence_number: u64) acquires MultisigAccount {
+        owner: &signer, multisig_account: address, sequence_number: u64
+    ) acquires MultisigAccount {
         vote_transanction(owner, multisig_account, sequence_number, true);
     }
 
     /// Reject a multisig transaction.
     public entry fun reject_transaction(
-        owner: &signer, multisig_account: address, sequence_number: u64) acquires MultisigAccount {
+        owner: &signer, multisig_account: address, sequence_number: u64
+    ) acquires MultisigAccount {
         vote_transanction(owner, multisig_account, sequence_number, false);
     }
 
@@ -953,16 +1020,21 @@ module aptos_framework::multisig_account {
     /// Retained for backward compatibility: the function with the typographical error in its name
     /// will continue to be an accessible entry point.
     public entry fun vote_transanction(
-        owner: &signer, multisig_account: address, sequence_number: u64, approved: bool) acquires MultisigAccount {
+        owner: &signer, multisig_account: address, sequence_number: u64, approved: bool
+    ) acquires MultisigAccount {
         assert_multisig_account_exists(multisig_account);
-        let multisig_account_resource = borrow_global_mut<MultisigAccount>(multisig_account);
+        let multisig_account_resource =
+            borrow_global_mut<MultisigAccount>(multisig_account);
         assert_is_owner_internal(owner, multisig_account_resource);
 
         assert!(
             table::contains(&multisig_account_resource.transactions, sequence_number),
             error::not_found(ETRANSACTION_NOT_FOUND),
         );
-        let transaction = table::borrow_mut(&mut multisig_account_resource.transactions, sequence_number);
+        let transaction =
+            table::borrow_mut(
+                &mut multisig_account_resource.transactions, sequence_number
+            );
         let votes = &mut transaction.votes;
         let owner_addr = address_of(owner);
 
@@ -974,37 +1046,40 @@ module aptos_framework::multisig_account {
 
         if (std::features::module_event_migration_enabled()) {
             emit(
-                Vote {
-                    multisig_account,
-                    owner: owner_addr,
-                    sequence_number,
-                    approved,
-                }
+                Vote { multisig_account, owner: owner_addr, sequence_number, approved, },
             );
         };
         emit_event(
             &mut multisig_account_resource.vote_events,
-            VoteEvent {
-                owner: owner_addr,
-                sequence_number,
-                approved,
-            }
+            VoteEvent { owner: owner_addr, sequence_number, approved, },
         );
     }
 
     /// Generic function that can be used to either approve or reject a multisig transaction
     public entry fun vote_transaction(
-        owner: &signer, multisig_account: address, sequence_number: u64, approved: bool) acquires MultisigAccount {
-        assert!(features::multisig_v2_enhancement_feature_enabled(), error::invalid_state(EMULTISIG_V2_ENHANCEMENT_NOT_ENABLED));
+        owner: &signer, multisig_account: address, sequence_number: u64, approved: bool
+    ) acquires MultisigAccount {
+        assert!(
+            features::multisig_v2_enhancement_feature_enabled(),
+            error::invalid_state(EMULTISIG_V2_ENHANCEMENT_NOT_ENABLED),
+        );
         vote_transanction(owner, multisig_account, sequence_number, approved);
     }
 
     /// Generic function that can be used to either approve or reject a batch of transactions within a specified range.
     public entry fun vote_transactions(
-        owner: &signer, multisig_account: address, starting_sequence_number: u64, final_sequence_number: u64, approved: bool) acquires MultisigAccount {
-        assert!(features::multisig_v2_enhancement_feature_enabled(), error::invalid_state(EMULTISIG_V2_ENHANCEMENT_NOT_ENABLED));
+        owner: &signer,
+        multisig_account: address,
+        starting_sequence_number: u64,
+        final_sequence_number: u64,
+        approved: bool
+    ) acquires MultisigAccount {
+        assert!(
+            features::multisig_v2_enhancement_feature_enabled(),
+            error::invalid_state(EMULTISIG_V2_ENHANCEMENT_NOT_ENABLED),
+        );
         let sequence_number = starting_sequence_number;
-        while(sequence_number <= final_sequence_number) {
+        while (sequence_number <= final_sequence_number) {
             vote_transanction(owner, multisig_account, sequence_number, approved);
             sequence_number = sequence_number + 1;
         }
@@ -1012,8 +1087,7 @@ module aptos_framework::multisig_account {
 
     /// Remove the next transaction if it has sufficient owner rejections.
     public entry fun execute_rejected_transaction(
-        owner: &signer,
-        multisig_account: address,
+        owner: &signer, multisig_account: address,
     ) acquires MultisigAccount {
         assert_multisig_account_exists(multisig_account);
         assert_is_owner(owner, multisig_account);
@@ -1027,7 +1101,8 @@ module aptos_framework::multisig_account {
             }
         };
 
-        let multisig_account_resource = borrow_global_mut<MultisigAccount>(multisig_account);
+        let multisig_account_resource =
+            borrow_global_mut<MultisigAccount>(multisig_account);
         let (_, num_rejections) = remove_executed_transaction(multisig_account_resource);
         assert!(
             num_rejections >= multisig_account_resource.num_signatures_required,
@@ -1041,7 +1116,7 @@ module aptos_framework::multisig_account {
                     sequence_number,
                     num_rejections,
                     executor: address_of(owner),
-                }
+                },
             );
         };
         emit_event(
@@ -1050,7 +1125,7 @@ module aptos_framework::multisig_account {
                 sequence_number,
                 num_rejections,
                 executor: owner_addr,
-            }
+            },
         );
     }
 
@@ -1060,10 +1135,19 @@ module aptos_framework::multisig_account {
         multisig_account: address,
         final_sequence_number: u64,
     ) acquires MultisigAccount {
-        assert!(features::multisig_v2_enhancement_feature_enabled(), error::invalid_state(EMULTISIG_V2_ENHANCEMENT_NOT_ENABLED));
-        assert!(last_resolved_sequence_number(multisig_account) < final_sequence_number, error::invalid_argument(EINVALID_SEQUENCE_NUMBER));
-        assert!(final_sequence_number < next_sequence_number(multisig_account), error::invalid_argument(EINVALID_SEQUENCE_NUMBER));
-        while(last_resolved_sequence_number(multisig_account) < final_sequence_number) {
+        assert!(
+            features::multisig_v2_enhancement_feature_enabled(),
+            error::invalid_state(EMULTISIG_V2_ENHANCEMENT_NOT_ENABLED),
+        );
+        assert!(
+            last_resolved_sequence_number(multisig_account) < final_sequence_number,
+            error::invalid_argument(EINVALID_SEQUENCE_NUMBER),
+        );
+        assert!(
+            final_sequence_number < next_sequence_number(multisig_account),
+            error::invalid_argument(EINVALID_SEQUENCE_NUMBER),
+        );
+        while (last_resolved_sequence_number(multisig_account) < final_sequence_number) {
             execute_rejected_transaction(owner, multisig_account);
         }
     }
@@ -1075,7 +1159,8 @@ module aptos_framework::multisig_account {
     ///
     /// Transaction payload is optional if it's already stored on chain for the transaction.
     fun validate_multisig_transaction(
-        owner: &signer, multisig_account: address, payload: vector<u8>) acquires MultisigAccount {
+        owner: &signer, multisig_account: address, payload: vector<u8>
+    ) acquires MultisigAccount {
         assert_multisig_account_exists(multisig_account);
         assert_is_owner(owner, multisig_account);
         let sequence_number = last_resolved_sequence_number(multisig_account) + 1;
@@ -1086,8 +1171,7 @@ module aptos_framework::multisig_account {
                 can_execute(address_of(owner), multisig_account, sequence_number),
                 error::invalid_argument(ENOT_ENOUGH_APPROVALS),
             );
-        }
-        else {
+        } else {
             assert!(
                 can_be_executed(multisig_account, sequence_number),
                 error::invalid_argument(ENOT_ENOUGH_APPROVALS),
@@ -1097,7 +1181,8 @@ module aptos_framework::multisig_account {
         // If the transaction payload is not stored on chain, verify that the provided payload matches the hashes stored
         // on chain.
         let multisig_account_resource = borrow_global<MultisigAccount>(multisig_account);
-        let transaction = table::borrow(&multisig_account_resource.transactions, sequence_number);
+        let transaction =
+            table::borrow(&multisig_account_resource.transactions, sequence_number);
         if (option::is_some(&transaction.payload_hash)) {
             let payload_hash = option::borrow(&transaction.payload_hash);
             assert!(
@@ -1110,8 +1195,7 @@ module aptos_framework::multisig_account {
         // verify that the provided payload matches the stored payload.
         if (features::abort_if_multisig_payload_mismatch_enabled()
             && option::is_some(&transaction.payload)
-            && !vector::is_empty(&payload)
-        ) {
+            && !vector::is_empty(&payload)) {
             let stored_payload = option::borrow(&transaction.payload);
             assert!(
                 payload == *stored_payload,
@@ -1127,8 +1211,10 @@ module aptos_framework::multisig_account {
         multisig_account: address,
         transaction_payload: vector<u8>,
     ) acquires MultisigAccount {
-        let num_approvals = transaction_execution_cleanup_common(executor, multisig_account);
-        let multisig_account_resource = borrow_global_mut<MultisigAccount>(multisig_account);
+        let num_approvals =
+            transaction_execution_cleanup_common(executor, multisig_account);
+        let multisig_account_resource =
+            borrow_global_mut<MultisigAccount>(multisig_account);
         if (std::features::module_event_migration_enabled()) {
             emit(
                 TransactionExecutionSucceeded {
@@ -1137,7 +1223,7 @@ module aptos_framework::multisig_account {
                     transaction_payload,
                     num_approvals,
                     executor,
-                }
+                },
             );
         };
         emit_event(
@@ -1147,7 +1233,7 @@ module aptos_framework::multisig_account {
                 transaction_payload,
                 num_approvals,
                 executor,
-            }
+            },
         );
     }
 
@@ -1159,8 +1245,10 @@ module aptos_framework::multisig_account {
         transaction_payload: vector<u8>,
         execution_error: ExecutionError,
     ) acquires MultisigAccount {
-        let num_approvals = transaction_execution_cleanup_common(executor, multisig_account);
-        let multisig_account_resource = borrow_global_mut<MultisigAccount>(multisig_account);
+        let num_approvals =
+            transaction_execution_cleanup_common(executor, multisig_account);
+        let multisig_account_resource =
+            borrow_global_mut<MultisigAccount>(multisig_account);
         if (std::features::module_event_migration_enabled()) {
             emit(
                 TransactionExecutionFailed {
@@ -1170,7 +1258,7 @@ module aptos_framework::multisig_account {
                     transaction_payload,
                     num_approvals,
                     execution_error,
-                }
+                },
             );
         };
         emit_event(
@@ -1181,17 +1269,21 @@ module aptos_framework::multisig_account {
                 transaction_payload,
                 num_approvals,
                 execution_error,
-            }
+            },
         );
     }
 
     ////////////////////////// Private functions ///////////////////////////////
 
-    inline fun transaction_execution_cleanup_common(executor: address, multisig_account: address): u64 acquires MultisigAccount {
+    inline fun transaction_execution_cleanup_common(
+        executor: address, multisig_account: address
+    ): u64 acquires MultisigAccount {
         let sequence_number = last_resolved_sequence_number(multisig_account) + 1;
-        let implicit_approval = !has_voted_for_approval(multisig_account, sequence_number, executor);
+        let implicit_approval =
+            !has_voted_for_approval(multisig_account, sequence_number, executor);
 
-        let multisig_account_resource = borrow_global_mut<MultisigAccount>(multisig_account);
+        let multisig_account_resource =
+            borrow_global_mut<MultisigAccount>(multisig_account);
         let (num_approvals, _) = remove_executed_transaction(multisig_account_resource);
 
         if (features::multisig_v2_enhancement_feature_enabled() && implicit_approval) {
@@ -1202,17 +1294,13 @@ module aptos_framework::multisig_account {
                         owner: executor,
                         sequence_number,
                         approved: true,
-                    }
+                    },
                 );
             };
             num_approvals = num_approvals + 1;
             emit_event(
                 &mut multisig_account_resource.vote_events,
-                VoteEvent {
-                    owner: executor,
-                    sequence_number,
-                    approved: true,
-                }
+                VoteEvent { owner: executor, sequence_number, approved: true, },
             );
         };
 
@@ -1220,36 +1308,47 @@ module aptos_framework::multisig_account {
     }
 
     // Remove the next transaction in the queue as it's been executed and return the number of approvals it had.
-    fun remove_executed_transaction(multisig_account_resource: &mut MultisigAccount): (u64, u64) {
+    fun remove_executed_transaction(
+        multisig_account_resource: &mut MultisigAccount
+    ): (u64, u64) {
         let sequence_number = multisig_account_resource.last_executed_sequence_number + 1;
-        let transaction = table::remove(&mut multisig_account_resource.transactions, sequence_number);
+        let transaction =
+            table::remove(&mut multisig_account_resource.transactions, sequence_number);
         multisig_account_resource.last_executed_sequence_number = sequence_number;
-        num_approvals_and_rejections_internal(&multisig_account_resource.owners, &transaction)
+        num_approvals_and_rejections_internal(
+            &multisig_account_resource.owners, &transaction
+        )
     }
 
     inline fun add_transaction(
-        creator: address,
-        multisig_account: address,
-        transaction: MultisigTransaction
+        creator: address, multisig_account: address, transaction: MultisigTransaction
     ) {
         if (features::multisig_v2_enhancement_feature_enabled()) {
             assert!(
                 available_transaction_queue_capacity(multisig_account) > 0,
-                error::invalid_state(EMAX_PENDING_TRANSACTIONS_EXCEEDED)
+                error::invalid_state(EMAX_PENDING_TRANSACTIONS_EXCEEDED),
             );
         };
 
-        let multisig_account_resource = borrow_global_mut<MultisigAccount>(multisig_account);
+        let multisig_account_resource =
+            borrow_global_mut<MultisigAccount>(multisig_account);
 
         // The transaction creator also automatically votes for the transaction.
         simple_map::add(&mut transaction.votes, creator, true);
 
         let sequence_number = multisig_account_resource.next_sequence_number;
         multisig_account_resource.next_sequence_number = sequence_number + 1;
-        table::add(&mut multisig_account_resource.transactions, sequence_number, transaction);
+        table::add(
+            &mut multisig_account_resource.transactions, sequence_number, transaction
+        );
         if (std::features::module_event_migration_enabled()) {
             emit(
-                CreateTransaction { multisig_account: multisig_account, creator, sequence_number, transaction }
+                CreateTransaction {
+                    multisig_account: multisig_account,
+                    creator,
+                    sequence_number,
+                    transaction
+                },
             );
         };
         emit_event(
@@ -1261,7 +1360,9 @@ module aptos_framework::multisig_account {
     fun create_multisig_account(owner: &signer): (signer, SignerCapability) {
         let owner_nonce = account::get_sequence_number(address_of(owner));
         let (multisig_signer, multisig_signer_cap) =
-            account::create_resource_account(owner, create_multisig_account_seed(to_bytes(&owner_nonce)));
+            account::create_resource_account(
+                owner, create_multisig_account_seed(to_bytes(&owner_nonce))
+            );
         // Register the account to receive APT as this is not done by default as part of the resource account creation
         // flow.
         if (!coin::is_account_registered<AptosCoin>(address_of(&multisig_signer))) {
@@ -1280,18 +1381,28 @@ module aptos_framework::multisig_account {
         multisig_account_seed
     }
 
-    fun validate_owners(owners: &vector<address>, multisig_account: address) {
+    fun validate_owners(
+        owners: &vector<address>, multisig_account: address
+    ) {
         let distinct_owners: vector<address> = vector[];
-        vector::for_each_ref(owners, |owner| {
-            let owner = *owner;
-            assert!(owner != multisig_account, error::invalid_argument(EOWNER_CANNOT_BE_MULTISIG_ACCOUNT_ITSELF));
-            let (found, _) = vector::index_of(&distinct_owners, &owner);
-            assert!(!found, error::invalid_argument(EDUPLICATE_OWNER));
-            vector::push_back(&mut distinct_owners, owner);
-        });
+        vector::for_each_ref(
+            owners,
+            |owner| {
+                let owner = *owner;
+                assert!(
+                    owner != multisig_account,
+                    error::invalid_argument(EOWNER_CANNOT_BE_MULTISIG_ACCOUNT_ITSELF),
+                );
+                let (found, _) = vector::index_of(&distinct_owners, &owner);
+                assert!(!found, error::invalid_argument(EDUPLICATE_OWNER));
+                vector::push_back(&mut distinct_owners, owner);
+            },
+        );
     }
 
-    inline fun assert_is_owner_internal(owner: &signer, multisig_account: &MultisigAccount) {
+    inline fun assert_is_owner_internal(
+        owner: &signer, multisig_account: &MultisigAccount
+    ) {
         assert!(
             vector::contains(&multisig_account.owners, &address_of(owner)),
             error::permission_denied(ENOT_OWNER),
@@ -1303,53 +1414,75 @@ module aptos_framework::multisig_account {
         assert_is_owner_internal(owner, multisig_account_resource);
     }
 
-    inline fun num_approvals_and_rejections_internal(owners: &vector<address>, transaction: &MultisigTransaction): (u64, u64) {
+    inline fun num_approvals_and_rejections_internal(
+        owners: &vector<address>, transaction: &MultisigTransaction
+    ): (u64, u64) {
         let num_approvals = 0;
         let num_rejections = 0;
 
         let votes = &transaction.votes;
-        vector::for_each_ref(owners, |owner| {
-            if (simple_map::contains_key(votes, owner)) {
-                if (*simple_map::borrow(votes, owner)) {
-                    num_approvals = num_approvals + 1;
-                } else {
-                    num_rejections = num_rejections + 1;
-                };
-            }
-        });
+        vector::for_each_ref(
+            owners,
+            |owner| {
+                if (simple_map::contains_key(votes, owner)) {
+                    if (*simple_map::borrow(votes, owner)) {
+                        num_approvals = num_approvals + 1;
+                    } else {
+                        num_rejections = num_rejections + 1;
+                    };
+                }
+            },
+        );
 
         (num_approvals, num_rejections)
     }
 
-    inline fun num_approvals_and_rejections(multisig_account: address, sequence_number: u64): (u64, u64) acquires MultisigAccount {
+    inline fun num_approvals_and_rejections(
+        multisig_account: address, sequence_number: u64
+    ): (u64, u64) acquires MultisigAccount {
         let multisig_account_resource = borrow_global<MultisigAccount>(multisig_account);
-        let transaction = table::borrow(&multisig_account_resource.transactions, sequence_number);
-        num_approvals_and_rejections_internal(&multisig_account_resource.owners, transaction)
+        let transaction =
+            table::borrow(&multisig_account_resource.transactions, sequence_number);
+        num_approvals_and_rejections_internal(
+            &multisig_account_resource.owners, transaction
+        )
     }
 
-    inline fun has_voted_for_approval(multisig_account: address, sequence_number: u64, owner: address): bool acquires MultisigAccount {
+    inline fun has_voted_for_approval(
+        multisig_account: address, sequence_number: u64, owner: address
+    ): bool acquires MultisigAccount {
         let (voted, vote) = vote(multisig_account, sequence_number, owner);
         voted && vote
     }
 
-    inline fun has_voted_for_rejection(multisig_account: address, sequence_number: u64, owner: address): bool acquires MultisigAccount {
+    inline fun has_voted_for_rejection(
+        multisig_account: address, sequence_number: u64, owner: address
+    ): bool acquires MultisigAccount {
         let (voted, vote) = vote(multisig_account, sequence_number, owner);
         voted && !vote
     }
 
     inline fun assert_multisig_account_exists(multisig_account: address) {
-        assert!(exists<MultisigAccount>(multisig_account), error::invalid_state(EACCOUNT_NOT_MULTISIG));
+        assert!(
+            exists<MultisigAccount>(multisig_account),
+            error::invalid_state(EACCOUNT_NOT_MULTISIG),
+        );
     }
 
-    inline fun assert_valid_sequence_number(multisig_account: address, sequence_number: u64) acquires MultisigAccount {
+    inline fun assert_valid_sequence_number(
+        multisig_account: address, sequence_number: u64
+    ) acquires MultisigAccount {
         let multisig_account_resource = borrow_global<MultisigAccount>(multisig_account);
         assert!(
-            sequence_number > 0 && sequence_number < multisig_account_resource.next_sequence_number,
+            sequence_number > 0
+                && sequence_number < multisig_account_resource.next_sequence_number,
             error::invalid_argument(EINVALID_SEQUENCE_NUMBER),
         );
     }
 
-    inline fun assert_transaction_exists(multisig_account: address, sequence_number: u64) acquires MultisigAccount {
+    inline fun assert_transaction_exists(
+        multisig_account: address, sequence_number: u64
+    ) acquires MultisigAccount {
         let multisig_account_resource = borrow_global<MultisigAccount>(multisig_account);
         assert!(
             table::contains(&multisig_account_resource.transactions, sequence_number),
@@ -1368,41 +1501,53 @@ module aptos_framework::multisig_account {
         let multisig_account_ref_mut =
             borrow_global_mut<MultisigAccount>(multisig_address);
         // Verify no overlap between new owners and owners to remove.
-        vector::for_each_ref(&new_owners, |new_owner_ref| {
-            assert!(
-                !vector::contains(&owners_to_remove, new_owner_ref),
-                error::invalid_argument(EOWNERS_TO_REMOVE_NEW_OWNERS_OVERLAP)
-            )
-        });
+        vector::for_each_ref(
+            &new_owners,
+            |new_owner_ref| {
+                assert!(
+                    !vector::contains(&owners_to_remove, new_owner_ref),
+                    error::invalid_argument(EOWNERS_TO_REMOVE_NEW_OWNERS_OVERLAP),
+                )
+            },
+        );
         // If new owners provided, try to add them and emit an event.
         if (vector::length(&new_owners) > 0) {
             vector::append(&mut multisig_account_ref_mut.owners, new_owners);
             validate_owners(
                 &multisig_account_ref_mut.owners,
-                multisig_address
+                multisig_address,
             );
             if (std::features::module_event_migration_enabled()) {
-                emit(AddOwners { multisig_account: multisig_address, owners_added: new_owners });
+                emit(
+                    AddOwners {
+                        multisig_account: multisig_address,
+                        owners_added: new_owners
+                    },
+                );
             };
             emit_event(
                 &mut multisig_account_ref_mut.add_owners_events,
-                AddOwnersEvent { owners_added: new_owners }
+                AddOwnersEvent { owners_added: new_owners },
             );
         };
         // If owners to remove provided, try to remove them.
         if (vector::length(&owners_to_remove) > 0) {
             let owners_ref_mut = &mut multisig_account_ref_mut.owners;
             let owners_removed = vector[];
-            vector::for_each_ref(&owners_to_remove, |owner_to_remove_ref| {
-                let (found, index) =
-                    vector::index_of(owners_ref_mut, owner_to_remove_ref);
-                if (found) {
-                    vector::push_back(
-                        &mut owners_removed,
-                        vector::swap_remove(owners_ref_mut, index)
+            vector::for_each_ref(
+                &owners_to_remove,
+                |owner_to_remove_ref| {
+                    let (found, index) = vector::index_of(
+                        owners_ref_mut, owner_to_remove_ref
                     );
-                }
-            });
+                    if (found) {
+                        vector::push_back(
+                            &mut owners_removed,
+                            vector::swap_remove(owners_ref_mut, index),
+                        );
+                    }
+                },
+            );
             // Only emit event if owner(s) actually removed.
             if (vector::length(&owners_removed) > 0) {
                 if (std::features::module_event_migration_enabled()) {
@@ -1412,7 +1557,7 @@ module aptos_framework::multisig_account {
                 };
                 emit_event(
                     &mut multisig_account_ref_mut.remove_owners_events,
-                    RemoveOwnersEvent { owners_removed }
+                    RemoveOwnersEvent { owners_removed },
                 );
             }
         };
@@ -1422,21 +1567,20 @@ module aptos_framework::multisig_account {
                 option::extract(&mut optional_new_num_signatures_required);
             assert!(
                 new_num_signatures_required > 0,
-                error::invalid_argument(EINVALID_SIGNATURES_REQUIRED)
+                error::invalid_argument(EINVALID_SIGNATURES_REQUIRED),
             );
             let old_num_signatures_required =
                 multisig_account_ref_mut.num_signatures_required;
             // Only apply update and emit event if a change indicated.
             if (new_num_signatures_required != old_num_signatures_required) {
-                multisig_account_ref_mut.num_signatures_required =
-                    new_num_signatures_required;
+                multisig_account_ref_mut.num_signatures_required = new_num_signatures_required;
                 if (std::features::module_event_migration_enabled()) {
                     emit(
                         UpdateSignaturesRequired {
                             multisig_account: multisig_address,
                             old_num_signatures_required,
                             new_num_signatures_required,
-                        }
+                        },
                     );
                 };
                 emit_event(
@@ -1444,7 +1588,7 @@ module aptos_framework::multisig_account {
                     UpdateSignaturesRequiredEvent {
                         old_num_signatures_required,
                         new_num_signatures_required,
-                    }
+                    },
                 );
             }
         };
@@ -1452,7 +1596,7 @@ module aptos_framework::multisig_account {
         let num_owners = vector::length(&multisig_account_ref_mut.owners);
         assert!(
             num_owners >= multisig_account_ref_mut.num_signatures_required,
-            error::invalid_state(ENOT_ENOUGH_OWNERS)
+            error::invalid_state(ENOT_ENOUGH_OWNERS),
         );
     }
 
@@ -1496,7 +1640,13 @@ module aptos_framework::multisig_account {
     fun setup() {
         let framework_signer = &create_signer(@0x1);
         features::change_feature_flags_for_testing(
-            framework_signer, vector[features::get_multisig_accounts_feature(), features::get_multisig_v2_enhancement_feature(), features::get_abort_if_multisig_payload_mismatch_feature()], vector[]);
+            framework_signer,
+            vector[
+                features::get_multisig_accounts_feature(),
+                features::get_multisig_v2_enhancement_feature(),
+                features::get_abort_if_multisig_payload_mismatch_feature()],
+            vector[],
+        );
         timestamp::set_time_has_started_for_testing(framework_signer);
         chain_id::initialize_for_test(framework_signer, 1);
         let (burn, mint) = aptos_coin::initialize_for_test(framework_signer);
@@ -1508,7 +1658,10 @@ module aptos_framework::multisig_account {
     fun setup_disabled() {
         let framework_signer = &create_signer(@0x1);
         features::change_feature_flags_for_testing(
-            framework_signer, vector[], vector[features::get_multisig_accounts_feature()]);
+            framework_signer,
+            vector[],
+            vector[features::get_multisig_accounts_feature()],
+        );
         timestamp::set_time_has_started_for_testing(framework_signer);
         chain_id::initialize_for_test(framework_signer, 1);
         let (burn, mint) = aptos_coin::initialize_for_test(framework_signer);
@@ -1518,24 +1671,30 @@ module aptos_framework::multisig_account {
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     public entry fun test_end_to_end(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         let owner_2_addr = address_of(owner_2);
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
-        create_with_owners(owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]);
+        create_with_owners(
+            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+        );
 
         // Create three transactions.
         create_transaction(owner_1, multisig_account, PAYLOAD);
         create_transaction(owner_2, multisig_account, PAYLOAD);
         create_transaction_with_hash(owner_3, multisig_account, sha3_256(PAYLOAD));
-        assert!(get_pending_transactions(multisig_account) == vector[
-            get_transaction(multisig_account, 1),
-            get_transaction(multisig_account, 2),
-            get_transaction(multisig_account, 3),
-        ], 0);
+        assert!(
+            get_pending_transactions(multisig_account)
+                == vector[
+                    get_transaction(multisig_account, 1),
+                    get_transaction(multisig_account, 2),
+                    get_transaction(multisig_account, 3),],
+            0,
+        );
 
         // Owner 3 doesn't need to explicitly approve as they created the transaction.
         approve_transaction(owner_1, multisig_account, 3);
@@ -1548,53 +1707,68 @@ module aptos_framework::multisig_account {
         assert!(can_be_executed(multisig_account, 1), 1);
         // First transaction was executed successfully.
         successful_transaction_execution_cleanup(owner_2_addr, multisig_account, vector[]);
-        assert!(get_pending_transactions(multisig_account) == vector[
-            get_transaction(multisig_account, 2),
-            get_transaction(multisig_account, 3),
-        ], 0);
+        assert!(
+            get_pending_transactions(multisig_account)
+                == vector[
+                    get_transaction(multisig_account, 2),
+                    get_transaction(multisig_account, 3),],
+            0,
+        );
 
         reject_transaction(owner_1, multisig_account, 2);
         reject_transaction(owner_3, multisig_account, 2);
         // Second transaction has 1 approval (owner 3) and 2 rejections (owners 1 & 2) and thus can be removed.
         assert!(can_be_rejected(multisig_account, 2), 2);
         execute_rejected_transaction(owner_1, multisig_account);
-        assert!(get_pending_transactions(multisig_account) == vector[
-            get_transaction(multisig_account, 3),
-        ], 0);
+        assert!(
+            get_pending_transactions(multisig_account)
+                == vector[get_transaction(multisig_account, 3),],
+            0,
+        );
 
         // Third transaction can be executed now but execution fails.
-        failed_transaction_execution_cleanup(owner_3_addr, multisig_account, PAYLOAD, execution_error());
+        failed_transaction_execution_cleanup(
+            owner_3_addr, multisig_account, PAYLOAD, execution_error()
+        );
         assert!(get_pending_transactions(multisig_account) == vector[], 0);
     }
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     public entry fun test_end_to_end_with_implicit_votes(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         let owner_2_addr = address_of(owner_2);
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
-        create_with_owners(owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]);
+        create_with_owners(
+            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+        );
 
         // Create three transactions.
         create_transaction(owner_1, multisig_account, PAYLOAD);
         create_transaction(owner_2, multisig_account, PAYLOAD);
-        assert!(get_pending_transactions(multisig_account) == vector[
-            get_transaction(multisig_account, 1),
-            get_transaction(multisig_account, 2),
-        ], 0);
+        assert!(
+            get_pending_transactions(multisig_account)
+                == vector[
+                    get_transaction(multisig_account, 1),
+                    get_transaction(multisig_account, 2),],
+            0,
+        );
 
         reject_transaction(owner_2, multisig_account, 1);
         // Owner 2 can execute the transaction, implicitly voting to approve it,
         // which overrides their previous vote for rejection.
         assert!(can_execute(owner_2_addr, multisig_account, 1), 1);
         // First transaction was executed successfully.
-        successful_transaction_execution_cleanup(owner_2_addr, multisig_account,vector[]);
-        assert!(get_pending_transactions(multisig_account) == vector[
-            get_transaction(multisig_account, 2),
-        ], 0);
+        successful_transaction_execution_cleanup(owner_2_addr, multisig_account, vector[]);
+        assert!(
+            get_pending_transactions(multisig_account)
+                == vector[get_transaction(multisig_account, 2),],
+            0,
+        );
 
         reject_transaction(owner_1, multisig_account, 2);
         // Owner 3 can execute-reject the transaction, implicitly voting to reject it.
@@ -1616,11 +1790,18 @@ module aptos_framework::multisig_account {
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     public entry fun test_create_with_as_many_sigs_required_as_num_owners(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         create_account(owner_1_addr);
-        create_with_owners(owner_1, vector[address_of(owner_2), address_of(owner_3)], 3, vector[], vector[]);
+        create_with_owners(
+            owner_1,
+            vector[address_of(owner_2), address_of(owner_3)],
+            3,
+            vector[],
+            vector[],
+        );
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         assert_multisig_account_exists(multisig_account);
     }
@@ -1628,7 +1809,8 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123)]
     #[expected_failure(abort_code = 0x1000B, location = Self)]
     public entry fun test_create_with_zero_signatures_required_should_fail(
-        owner: &signer) acquires MultisigAccount {
+        owner: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
         create(owner, 0, vector[], vector[]);
@@ -1637,7 +1819,8 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123)]
     #[expected_failure(abort_code = 0x1000B, location = Self)]
     public entry fun test_create_with_too_many_signatures_required_should_fail(
-        owner: &signer) acquires MultisigAccount {
+        owner: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
         create(owner, 2, vector[], vector[]);
@@ -1646,7 +1829,8 @@ module aptos_framework::multisig_account {
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     #[expected_failure(abort_code = 0x10001, location = Self)]
     public entry fun test_create_with_duplicate_owners_should_fail(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner_1));
         create_with_owners(
@@ -1655,17 +1839,18 @@ module aptos_framework::multisig_account {
                 // Duplicate owner 2 addresses.
                 address_of(owner_2),
                 address_of(owner_3),
-                address_of(owner_2),
-            ],
+                address_of(owner_2),],
             2,
             vector[],
-            vector[]);
+            vector[],
+        );
     }
 
     #[test(owner = @0x123)]
     #[expected_failure(abort_code = 0xD000E, location = Self)]
     public entry fun test_create_with_without_feature_flag_enabled_should_fail(
-        owner: &signer) acquires MultisigAccount {
+        owner: &signer
+    ) acquires MultisigAccount {
         setup_disabled();
         create_account(address_of(owner));
         create(owner, 2, vector[], vector[]);
@@ -1674,27 +1859,30 @@ module aptos_framework::multisig_account {
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     #[expected_failure(abort_code = 0x10001, location = Self)]
     public entry fun test_create_with_creator_in_additional_owners_list_should_fail(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner_1));
-        create_with_owners(owner_1, vector[
-            // Duplicate owner 1 addresses.
-            address_of(owner_1),
-            address_of(owner_2),
-            address_of(owner_3),
-        ], 2,
+        create_with_owners(
+            owner_1,
+            vector[
+                // Duplicate owner 1 addresses.
+                address_of(owner_1),
+                address_of(owner_2),
+                address_of(owner_3),],
+            2,
             vector[],
             vector[],
         );
     }
 
     #[test]
-    public entry fun test_create_multisig_account_on_top_of_existing_multi_ed25519_account()
-    acquires MultisigAccount {
+    public entry fun test_create_multisig_account_on_top_of_existing_multi_ed25519_account() acquires MultisigAccount {
         setup();
         let (curr_sk, curr_pk) = multi_ed25519::generate_keys(2, 3);
         let pk_unvalidated = multi_ed25519::public_key_to_unvalidated(&curr_pk);
-        let auth_key = multi_ed25519::unvalidated_public_key_to_authentication_key(&pk_unvalidated);
+        let auth_key =
+            multi_ed25519::unvalidated_public_key_to_authentication_key(&pk_unvalidated);
         let multisig_address = from_bcs::to_address(auth_key);
         create_account(multisig_address);
 
@@ -1722,12 +1910,12 @@ module aptos_framework::multisig_account {
     }
 
     #[test]
-    public entry fun test_create_multisig_account_on_top_of_existing_multi_ed25519_account_and_revoke_auth_key()
-    acquires MultisigAccount {
+    public entry fun test_create_multisig_account_on_top_of_existing_multi_ed25519_account_and_revoke_auth_key() acquires MultisigAccount {
         setup();
         let (curr_sk, curr_pk) = multi_ed25519::generate_keys(2, 3);
         let pk_unvalidated = multi_ed25519::public_key_to_unvalidated(&curr_pk);
-        let auth_key = multi_ed25519::unvalidated_public_key_to_authentication_key(&pk_unvalidated);
+        let auth_key =
+            multi_ed25519::unvalidated_public_key_to_authentication_key(&pk_unvalidated);
         let multisig_address = from_bcs::to_address(auth_key);
         create_account(multisig_address);
 
@@ -1764,11 +1952,18 @@ module aptos_framework::multisig_account {
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     public entry fun test_update_signatures_required(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         create_account(owner_1_addr);
-        create_with_owners(owner_1, vector[address_of(owner_2), address_of(owner_3)], 1, vector[], vector[]);
+        create_with_owners(
+            owner_1,
+            vector[address_of(owner_2), address_of(owner_3)],
+            1,
+            vector[],
+            vector[],
+        );
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         assert!(num_signatures_required(multisig_account) == 1, 0);
         update_signatures_required(&create_signer(multisig_account), 2);
@@ -1799,7 +1994,8 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123)]
     #[expected_failure(abort_code = 0x1000B, location = Self)]
     public entry fun test_update_with_zero_signatures_required_should_fail(
-        owner: & signer) acquires MultisigAccount {
+        owner: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
         create(owner, 1, vector[], vector[]);
@@ -1810,7 +2006,8 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123)]
     #[expected_failure(abort_code = 0x30005, location = Self)]
     public entry fun test_update_with_too_many_signatures_required_should_fail(
-        owner: &signer) acquires MultisigAccount {
+        owner: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
         create(owner, 1, vector[], vector[]);
@@ -1820,7 +2017,8 @@ module aptos_framework::multisig_account {
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     public entry fun test_add_owners(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner_1));
         create(owner_1, 1, vector[], vector[]);
@@ -1834,24 +2032,36 @@ module aptos_framework::multisig_account {
         add_owners(multisig_signer, vector[]);
         assert!(owners(multisig_account) == vector[owner_1_addr], 1);
         add_owners(multisig_signer, vector[owner_2_addr, owner_3_addr]);
-        assert!(owners(multisig_account) == vector[owner_1_addr, owner_2_addr, owner_3_addr], 2);
+        assert!(
+            owners(multisig_account) == vector[owner_1_addr, owner_2_addr, owner_3_addr],
+            2
+        );
     }
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     public entry fun test_remove_owners(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         let owner_2_addr = address_of(owner_2);
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
-        create_with_owners(owner_1, vector[owner_2_addr, owner_3_addr], 1, vector[], vector[]);
+        create_with_owners(
+            owner_1, vector[owner_2_addr, owner_3_addr], 1, vector[], vector[]
+        );
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         let multisig_signer = &create_signer(multisig_account);
-        assert!(owners(multisig_account) == vector[owner_2_addr, owner_3_addr, owner_1_addr], 0);
+        assert!(
+            owners(multisig_account) == vector[owner_2_addr, owner_3_addr, owner_1_addr],
+            0
+        );
         // Removing an empty vector of owners should be no-op.
         remove_owners(multisig_signer, vector[]);
-        assert!(owners(multisig_account) == vector[owner_2_addr, owner_3_addr, owner_1_addr], 1);
+        assert!(
+            owners(multisig_account) == vector[owner_2_addr, owner_3_addr, owner_1_addr],
+            1
+        );
         remove_owners(multisig_signer, vector[owner_2_addr]);
         assert!(owners(multisig_account) == vector[owner_1_addr, owner_3_addr], 2);
         // Removing owners that don't exist should be no-op.
@@ -1865,15 +2075,21 @@ module aptos_framework::multisig_account {
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     #[expected_failure(abort_code = 0x30005, location = Self)]
     public entry fun test_remove_all_owners_should_fail(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         let owner_2_addr = address_of(owner_2);
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
-        create_with_owners(owner_1, vector[owner_2_addr, owner_3_addr], 1, vector[], vector[]);
+        create_with_owners(
+            owner_1, vector[owner_2_addr, owner_3_addr], 1, vector[], vector[]
+        );
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
-        assert!(owners(multisig_account) == vector[owner_2_addr, owner_3_addr, owner_1_addr], 0);
+        assert!(
+            owners(multisig_account) == vector[owner_2_addr, owner_3_addr, owner_1_addr],
+            0
+        );
         let multisig_signer = &create_signer(multisig_account);
         remove_owners(multisig_signer, vector[owner_1_addr, owner_2_addr, owner_3_addr]);
     }
@@ -1881,13 +2097,16 @@ module aptos_framework::multisig_account {
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     #[expected_failure(abort_code = 0x30005, location = Self)]
     public entry fun test_remove_owners_with_fewer_remaining_than_signature_threshold_should_fail(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         let owner_2_addr = address_of(owner_2);
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
-        create_with_owners(owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]);
+        create_with_owners(
+            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+        );
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         let multisig_signer = &create_signer(multisig_account);
         // Remove 2 owners so there's one left, which is less than the signature threshold of 2.
@@ -1896,14 +2115,17 @@ module aptos_framework::multisig_account {
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     public entry fun test_create_transaction(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         let owner_2_addr = address_of(owner_2);
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
-        create_with_owners(owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]);
+        create_with_owners(
+            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+        );
 
         create_transaction(owner_1, multisig_account, PAYLOAD);
         let transaction = get_transaction(multisig_account, 1);
@@ -1920,7 +2142,8 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123)]
     #[expected_failure(abort_code = 0x10004, location = Self)]
     public entry fun test_create_transaction_with_empty_payload_should_fail(
-        owner: &signer) acquires MultisigAccount {
+        owner: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
         create(owner, 1, vector[], vector[]);
@@ -1931,7 +2154,8 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123, non_owner = @0x124)]
     #[expected_failure(abort_code = 0x507D3, location = Self)]
     public entry fun test_create_transaction_with_non_owner_should_fail(
-        owner: &signer, non_owner: &signer) acquires MultisigAccount {
+        owner: &signer, non_owner: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
         create(owner, 1, vector[], vector[]);
@@ -1940,8 +2164,7 @@ module aptos_framework::multisig_account {
     }
 
     #[test(owner = @0x123)]
-    public entry fun test_create_transaction_with_hashes(
-        owner: &signer) acquires MultisigAccount {
+    public entry fun test_create_transaction_with_hashes(owner: &signer) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
         create(owner, 1, vector[], vector[]);
@@ -1952,7 +2175,8 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123)]
     #[expected_failure(abort_code = 0x1000C, location = Self)]
     public entry fun test_create_transaction_with_empty_hash_should_fail(
-        owner: &signer) acquires MultisigAccount {
+        owner: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
         create(owner, 1, vector[], vector[]);
@@ -1963,7 +2187,8 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123, non_owner = @0x124)]
     #[expected_failure(abort_code = 0x507D3, location = Self)]
     public entry fun test_create_transaction_with_hashes_and_non_owner_should_fail(
-        owner: &signer, non_owner: &signer) acquires MultisigAccount {
+        owner: &signer, non_owner: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
         create(owner, 1, vector[], vector[]);
@@ -1973,14 +2198,17 @@ module aptos_framework::multisig_account {
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     public entry fun test_approve_transaction(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         let owner_2_addr = address_of(owner_2);
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
-        create_with_owners(owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]);
+        create_with_owners(
+            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+        );
 
         create_transaction(owner_1, multisig_account, PAYLOAD);
         approve_transaction(owner_2, multisig_account, 1);
@@ -1994,14 +2222,17 @@ module aptos_framework::multisig_account {
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     public entry fun test_validate_transaction_should_not_consider_removed_owners(
-        owner_1: &signer, owner_2: &signer, owner_3: & signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         let owner_2_addr = address_of(owner_2);
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
-        create_with_owners(owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]);
+        create_with_owners(
+            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+        );
 
         // Owner 1 and 2 approved but then owner 1 got removed.
         create_transaction(owner_1, multisig_account, PAYLOAD);
@@ -2018,7 +2249,8 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123)]
     #[expected_failure(abort_code = 0x607D6, location = Self)]
     public entry fun test_approve_transaction_with_invalid_sequence_number_should_fail(
-        owner: &signer) acquires MultisigAccount {
+        owner: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
         let multisig_account = get_next_multisig_account_address(address_of(owner));
@@ -2031,7 +2263,8 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123, non_owner = @0x124)]
     #[expected_failure(abort_code = 0x507D3, location = Self)]
     public entry fun test_approve_transaction_with_non_owner_should_fail(
-        owner: &signer, non_owner: &signer) acquires MultisigAccount {
+        owner: &signer, non_owner: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
         let multisig_account = get_next_multisig_account_address(address_of(owner));
@@ -2043,7 +2276,8 @@ module aptos_framework::multisig_account {
 
     #[test(owner = @0x123)]
     public entry fun test_approval_transaction_after_rejecting(
-        owner: &signer) acquires MultisigAccount {
+        owner: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_addr = address_of(owner);
         create_account(owner_addr);
@@ -2059,14 +2293,17 @@ module aptos_framework::multisig_account {
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     public entry fun test_reject_transaction(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         let owner_2_addr = address_of(owner_2);
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
-        create_with_owners(owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]);
+        create_with_owners(
+            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+        );
 
         create_transaction(owner_1, multisig_account, PAYLOAD);
         reject_transaction(owner_1, multisig_account, 1);
@@ -2081,7 +2318,8 @@ module aptos_framework::multisig_account {
 
     #[test(owner = @0x123)]
     public entry fun test_reject_transaction_after_approving(
-        owner: &signer) acquires MultisigAccount {
+        owner: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_addr = address_of(owner);
         create_account(owner_addr);
@@ -2097,7 +2335,8 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123)]
     #[expected_failure(abort_code = 0x607D6, location = Self)]
     public entry fun test_reject_transaction_with_invalid_sequence_number_should_fail(
-        owner: &signer) acquires MultisigAccount {
+        owner: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
         let multisig_account = get_next_multisig_account_address(address_of(owner));
@@ -2110,7 +2349,8 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123, non_owner = @0x124)]
     #[expected_failure(abort_code = 0x507D3, location = Self)]
     public entry fun test_reject_transaction_with_non_owner_should_fail(
-        owner: &signer, non_owner: &signer) acquires MultisigAccount {
+        owner: &signer, non_owner: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
         let multisig_account = get_next_multisig_account_address(address_of(owner));
@@ -2120,84 +2360,119 @@ module aptos_framework::multisig_account {
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     public entry fun test_execute_transaction_successful(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         let owner_2_addr = address_of(owner_2);
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
-        create_with_owners(owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]);
+        create_with_owners(
+            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+        );
 
         create_transaction(owner_1, multisig_account, PAYLOAD);
         // Owner 1 doesn't need to explicitly approve as they created the transaction.
         approve_transaction(owner_2, multisig_account, 1);
         assert!(can_be_executed(multisig_account, 1), 1);
-        assert!(table::contains(&borrow_global<MultisigAccount>(multisig_account).transactions, 1), 0);
+        assert!(
+            table::contains(
+                &borrow_global<MultisigAccount>(multisig_account).transactions, 1
+            ),
+            0,
+        );
         successful_transaction_execution_cleanup(owner_3_addr, multisig_account, vector[]);
     }
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     public entry fun test_execute_transaction_failed(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         let owner_2_addr = address_of(owner_2);
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
-        create_with_owners(owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]);
+        create_with_owners(
+            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+        );
 
         create_transaction(owner_1, multisig_account, PAYLOAD);
         // Owner 1 doesn't need to explicitly approve as they created the transaction.
         approve_transaction(owner_2, multisig_account, 1);
         assert!(can_be_executed(multisig_account, 1), 1);
-        assert!(table::contains(&borrow_global<MultisigAccount>(multisig_account).transactions, 1), 0);
-        failed_transaction_execution_cleanup(owner_3_addr, multisig_account, vector[], execution_error());
+        assert!(
+            table::contains(
+                &borrow_global<MultisigAccount>(multisig_account).transactions, 1
+            ),
+            0,
+        );
+        failed_transaction_execution_cleanup(
+            owner_3_addr, multisig_account, vector[], execution_error()
+        );
     }
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     public entry fun test_execute_transaction_with_full_payload(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         let owner_2_addr = address_of(owner_2);
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
-        create_with_owners(owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]);
+        create_with_owners(
+            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+        );
 
         create_transaction_with_hash(owner_3, multisig_account, sha3_256(PAYLOAD));
         // Owner 3 doesn't need to explicitly approve as they created the transaction.
         approve_transaction(owner_1, multisig_account, 1);
         assert!(can_be_executed(multisig_account, 1), 1);
-        assert!(table::contains(&borrow_global<MultisigAccount>(multisig_account).transactions, 1), 0);
+        assert!(
+            table::contains(
+                &borrow_global<MultisigAccount>(multisig_account).transactions, 1
+            ),
+            0,
+        );
         successful_transaction_execution_cleanup(owner_3_addr, multisig_account, PAYLOAD);
     }
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     public entry fun test_execute_rejected_transaction(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         let owner_2_addr = address_of(owner_2);
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
-        create_with_owners(owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]);
+        create_with_owners(
+            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+        );
 
         create_transaction(owner_1, multisig_account, PAYLOAD);
         reject_transaction(owner_2, multisig_account, 1);
         reject_transaction(owner_3, multisig_account, 1);
         assert!(can_be_rejected(multisig_account, 1), 1);
-        assert!(table::contains(&borrow_global<MultisigAccount>(multisig_account).transactions, 1), 0);
+        assert!(
+            table::contains(
+                &borrow_global<MultisigAccount>(multisig_account).transactions, 1
+            ),
+            0,
+        );
         execute_rejected_transaction(owner_3, multisig_account);
     }
 
     #[test(owner = @0x123, non_owner = @0x124)]
     #[expected_failure(abort_code = 0x507D3, location = Self)]
     public entry fun test_execute_rejected_transaction_with_non_owner_should_fail(
-        owner: &signer, non_owner: &signer) acquires MultisigAccount {
+        owner: &signer, non_owner: &signer
+    ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
         let multisig_account = get_next_multisig_account_address(address_of(owner));
@@ -2211,30 +2486,27 @@ module aptos_framework::multisig_account {
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     #[expected_failure(abort_code = 0x3000A, location = Self)]
     public entry fun test_execute_rejected_transaction_without_sufficient_rejections_should_fail(
-        owner_1: &signer, owner_2: &signer, owner_3: &signer) acquires MultisigAccount {
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
+    ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
         let owner_2_addr = address_of(owner_2);
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
-        create_with_owners(owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]);
+        create_with_owners(
+            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+        );
 
         create_transaction(owner_1, multisig_account, PAYLOAD);
         approve_transaction(owner_2, multisig_account, 1);
         execute_rejected_transaction(owner_3, multisig_account);
     }
 
-    #[test(
-        owner_1 = @0x123,
-        owner_2 = @0x124,
-        owner_3 = @0x125
-    )]
+    #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     #[expected_failure(abort_code = 0x10012, location = Self)]
     fun test_update_owner_schema_overlap_should_fail(
-        owner_1: &signer,
-        owner_2: &signer,
-        owner_3: &signer
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
     ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
@@ -2247,22 +2519,20 @@ module aptos_framework::multisig_account {
             vector[owner_2_addr, owner_3_addr],
             2,
             vector[],
-            vector[]
+            vector[],
         );
         update_owner_schema(
             multisig_address,
             vector[owner_1_addr],
             vector[owner_1_addr],
-            option::none()
+            option::none(),
         );
     }
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     #[expected_failure(abort_code = 196627, location = Self)]
     fun test_max_pending_transaction_limit_should_fail(
-        owner_1: &signer,
-        owner_2: &signer,
-        owner_3: &signer
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
     ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
@@ -2275,7 +2545,7 @@ module aptos_framework::multisig_account {
             vector[owner_2_addr, owner_3_addr],
             2,
             vector[],
-            vector[]
+            vector[],
         );
 
         let remaining_iterations = MAX_PENDING_TRANSACTIONS + 1;
@@ -2291,7 +2561,7 @@ module aptos_framework::multisig_account {
         multisig_account: address,
         payload: vector<u8>,
     ) acquires MultisigAccount {
-        while(available_transaction_queue_capacity(multisig_account) == 0) {
+        while (available_transaction_queue_capacity(multisig_account) == 0) {
             execute_rejected_transaction(owner, multisig_account)
         };
         create_transaction(owner, multisig_account, payload);
@@ -2299,17 +2569,22 @@ module aptos_framework::multisig_account {
 
     #[test_only]
     fun vote_all_transactions(
-        owner: &signer, multisig_account: address, approved: bool) acquires MultisigAccount {
+        owner: &signer, multisig_account: address, approved: bool
+    ) acquires MultisigAccount {
         let starting_sequence_number = last_resolved_sequence_number(multisig_account) + 1;
         let final_sequence_number = next_sequence_number(multisig_account) - 1;
-        vote_transactions(owner, multisig_account, starting_sequence_number, final_sequence_number, approved);
+        vote_transactions(
+            owner,
+            multisig_account,
+            starting_sequence_number,
+            final_sequence_number,
+            approved,
+        );
     }
 
     #[test(owner_1 = @0x123, owner_2 = @0x124, owner_3 = @0x125)]
     fun test_dos_mitigation_end_to_end(
-        owner_1: &signer,
-        owner_2: &signer,
-        owner_3: &signer
+        owner_1: &signer, owner_2: &signer, owner_3: &signer
     ) acquires MultisigAccount {
         setup();
         let owner_1_addr = address_of(owner_1);
@@ -2322,7 +2597,7 @@ module aptos_framework::multisig_account {
             vector[owner_2_addr, owner_3_addr],
             2,
             vector[],
-            vector[]
+            vector[],
         );
 
         // owner_3 is compromised and creates a bunch of bogus transactions.
@@ -2356,8 +2631,7 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123, non_owner = @0x234)]
     #[expected_failure(abort_code = 329683, location = Self)]
     public entry fun test_create_transaction_should_fail_if_not_owner(
-        owner: &signer,
-        non_owner: &signer
+        owner: &signer, non_owner: &signer
     ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
@@ -2370,8 +2644,7 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123, non_owner = @0x234)]
     #[expected_failure(abort_code = 329683, location = Self)]
     public entry fun test_create_transaction_with_hash_should_fail_if_not_owner(
-        owner: &signer,
-        non_owner: &signer
+        owner: &signer, non_owner: &signer
     ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
@@ -2384,8 +2657,7 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123, non_owner = @0x234)]
     #[expected_failure(abort_code = 329683, location = Self)]
     public entry fun test_reject_transaction_should_fail_if_not_owner(
-        owner: &signer,
-        non_owner: &signer
+        owner: &signer, non_owner: &signer
     ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
@@ -2396,12 +2668,10 @@ module aptos_framework::multisig_account {
         reject_transaction(non_owner, multisig_account, 1);
     }
 
-
     #[test(owner = @0x123, non_owner = @0x234)]
     #[expected_failure(abort_code = 329683, location = Self)]
     public entry fun test_approve_transaction_should_fail_if_not_owner(
-        owner: &signer,
-        non_owner: &signer
+        owner: &signer, non_owner: &signer
     ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
@@ -2415,8 +2685,7 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123, non_owner = @0x234)]
     #[expected_failure(abort_code = 329683, location = Self)]
     public entry fun test_vote_transaction_should_fail_if_not_owner(
-        owner: &signer,
-        non_owner: &signer
+        owner: &signer, non_owner: &signer
     ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
@@ -2430,8 +2699,7 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123, non_owner = @0x234)]
     #[expected_failure(abort_code = 329683, location = Self)]
     public entry fun test_vote_transactions_should_fail_if_not_owner(
-        owner: &signer,
-        non_owner: &signer
+        owner: &signer, non_owner: &signer
     ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
@@ -2445,8 +2713,7 @@ module aptos_framework::multisig_account {
     #[test(owner = @0x123, non_owner = @0x234)]
     #[expected_failure(abort_code = 329683, location = Self)]
     public entry fun test_execute_rejected_transaction_should_fail_if_not_owner(
-        owner: &signer,
-        non_owner: &signer
+        owner: &signer, non_owner: &signer
     ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));
@@ -2458,12 +2725,10 @@ module aptos_framework::multisig_account {
         execute_rejected_transaction(non_owner, multisig_account);
     }
 
-
     #[test(owner = @0x123, non_owner = @0x234)]
     #[expected_failure(abort_code = 329683, location = Self)]
     public entry fun test_execute_rejected_transactions_should_fail_if_not_owner(
-        owner: &signer,
-        non_owner: &signer
+        owner: &signer, non_owner: &signer
     ) acquires MultisigAccount {
         setup();
         create_account(address_of(owner));

--- a/aptos-move/framework/aptos-framework/sources/multisig_account.move
+++ b/aptos-move/framework/aptos-framework/sources/multisig_account.move
@@ -955,9 +955,8 @@ module aptos_framework::multisig_account {
         payload: vector<u8>,
     ) acquires MultisigAccount {
         assert!(
-            vector::length(&payload) > 0, error::invalid_argument(
-                EPAYLOAD_CANNOT_BE_EMPTY
-            )
+            vector::length(&payload) > 0,
+            error::invalid_argument(EPAYLOAD_CANNOT_BE_EMPTY),
         );
 
         assert_multisig_account_exists(multisig_account);
@@ -1644,7 +1643,8 @@ module aptos_framework::multisig_account {
             vector[
                 features::get_multisig_accounts_feature(),
                 features::get_multisig_v2_enhancement_feature(),
-                features::get_abort_if_multisig_payload_mismatch_feature()],
+                features::get_abort_if_multisig_payload_mismatch_feature()
+            ],
             vector[],
         );
         timestamp::set_time_has_started_for_testing(framework_signer);
@@ -1680,7 +1680,11 @@ module aptos_framework::multisig_account {
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         create_with_owners(
-            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+            owner_1,
+            vector[owner_2_addr, owner_3_addr],
+            2,
+            vector[],
+            vector[],
         );
 
         // Create three transactions.
@@ -1692,7 +1696,8 @@ module aptos_framework::multisig_account {
                 == vector[
                     get_transaction(multisig_account, 1),
                     get_transaction(multisig_account, 2),
-                    get_transaction(multisig_account, 3),],
+                    get_transaction(multisig_account, 3),
+                ],
             0,
         );
 
@@ -1711,7 +1716,8 @@ module aptos_framework::multisig_account {
             get_pending_transactions(multisig_account)
                 == vector[
                     get_transaction(multisig_account, 2),
-                    get_transaction(multisig_account, 3),],
+                    get_transaction(multisig_account, 3),
+                ],
             0,
         );
 
@@ -1728,7 +1734,10 @@ module aptos_framework::multisig_account {
 
         // Third transaction can be executed now but execution fails.
         failed_transaction_execution_cleanup(
-            owner_3_addr, multisig_account, PAYLOAD, execution_error()
+            owner_3_addr,
+            multisig_account,
+            PAYLOAD,
+            execution_error(),
         );
         assert!(get_pending_transactions(multisig_account) == vector[], 0);
     }
@@ -1744,7 +1753,11 @@ module aptos_framework::multisig_account {
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         create_with_owners(
-            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+            owner_1,
+            vector[owner_2_addr, owner_3_addr],
+            2,
+            vector[],
+            vector[],
         );
 
         // Create three transactions.
@@ -1754,7 +1767,8 @@ module aptos_framework::multisig_account {
             get_pending_transactions(multisig_account)
                 == vector[
                     get_transaction(multisig_account, 1),
-                    get_transaction(multisig_account, 2),],
+                    get_transaction(multisig_account, 2),
+                ],
             0,
         );
 
@@ -1839,7 +1853,8 @@ module aptos_framework::multisig_account {
                 // Duplicate owner 2 addresses.
                 address_of(owner_2),
                 address_of(owner_3),
-                address_of(owner_2),],
+                address_of(owner_2),
+            ],
             2,
             vector[],
             vector[],
@@ -1869,7 +1884,8 @@ module aptos_framework::multisig_account {
                 // Duplicate owner 1 addresses.
                 address_of(owner_1),
                 address_of(owner_2),
-                address_of(owner_3),],
+                address_of(owner_3),
+            ],
             2,
             vector[],
             vector[],
@@ -2034,7 +2050,7 @@ module aptos_framework::multisig_account {
         add_owners(multisig_signer, vector[owner_2_addr, owner_3_addr]);
         assert!(
             owners(multisig_account) == vector[owner_1_addr, owner_2_addr, owner_3_addr],
-            2
+            2,
         );
     }
 
@@ -2048,19 +2064,23 @@ module aptos_framework::multisig_account {
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
         create_with_owners(
-            owner_1, vector[owner_2_addr, owner_3_addr], 1, vector[], vector[]
+            owner_1,
+            vector[owner_2_addr, owner_3_addr],
+            1,
+            vector[],
+            vector[],
         );
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         let multisig_signer = &create_signer(multisig_account);
         assert!(
             owners(multisig_account) == vector[owner_2_addr, owner_3_addr, owner_1_addr],
-            0
+            0,
         );
         // Removing an empty vector of owners should be no-op.
         remove_owners(multisig_signer, vector[]);
         assert!(
             owners(multisig_account) == vector[owner_2_addr, owner_3_addr, owner_1_addr],
-            1
+            1,
         );
         remove_owners(multisig_signer, vector[owner_2_addr]);
         assert!(owners(multisig_account) == vector[owner_1_addr, owner_3_addr], 2);
@@ -2083,12 +2103,16 @@ module aptos_framework::multisig_account {
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
         create_with_owners(
-            owner_1, vector[owner_2_addr, owner_3_addr], 1, vector[], vector[]
+            owner_1,
+            vector[owner_2_addr, owner_3_addr],
+            1,
+            vector[],
+            vector[],
         );
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         assert!(
             owners(multisig_account) == vector[owner_2_addr, owner_3_addr, owner_1_addr],
-            0
+            0,
         );
         let multisig_signer = &create_signer(multisig_account);
         remove_owners(multisig_signer, vector[owner_1_addr, owner_2_addr, owner_3_addr]);
@@ -2105,7 +2129,11 @@ module aptos_framework::multisig_account {
         let owner_3_addr = address_of(owner_3);
         create_account(owner_1_addr);
         create_with_owners(
-            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+            owner_1,
+            vector[owner_2_addr, owner_3_addr],
+            2,
+            vector[],
+            vector[],
         );
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         let multisig_signer = &create_signer(multisig_account);
@@ -2124,7 +2152,11 @@ module aptos_framework::multisig_account {
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         create_with_owners(
-            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+            owner_1,
+            vector[owner_2_addr, owner_3_addr],
+            2,
+            vector[],
+            vector[],
         );
 
         create_transaction(owner_1, multisig_account, PAYLOAD);
@@ -2207,7 +2239,11 @@ module aptos_framework::multisig_account {
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         create_with_owners(
-            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+            owner_1,
+            vector[owner_2_addr, owner_3_addr],
+            2,
+            vector[],
+            vector[],
         );
 
         create_transaction(owner_1, multisig_account, PAYLOAD);
@@ -2231,7 +2267,11 @@ module aptos_framework::multisig_account {
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         create_with_owners(
-            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+            owner_1,
+            vector[owner_2_addr, owner_3_addr],
+            2,
+            vector[],
+            vector[],
         );
 
         // Owner 1 and 2 approved but then owner 1 got removed.
@@ -2302,7 +2342,11 @@ module aptos_framework::multisig_account {
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         create_with_owners(
-            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+            owner_1,
+            vector[owner_2_addr, owner_3_addr],
+            2,
+            vector[],
+            vector[],
         );
 
         create_transaction(owner_1, multisig_account, PAYLOAD);
@@ -2369,7 +2413,11 @@ module aptos_framework::multisig_account {
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         create_with_owners(
-            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+            owner_1,
+            vector[owner_2_addr, owner_3_addr],
+            2,
+            vector[],
+            vector[],
         );
 
         create_transaction(owner_1, multisig_account, PAYLOAD);
@@ -2396,7 +2444,11 @@ module aptos_framework::multisig_account {
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         create_with_owners(
-            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+            owner_1,
+            vector[owner_2_addr, owner_3_addr],
+            2,
+            vector[],
+            vector[],
         );
 
         create_transaction(owner_1, multisig_account, PAYLOAD);
@@ -2410,7 +2462,10 @@ module aptos_framework::multisig_account {
             0,
         );
         failed_transaction_execution_cleanup(
-            owner_3_addr, multisig_account, vector[], execution_error()
+            owner_3_addr,
+            multisig_account,
+            vector[],
+            execution_error(),
         );
     }
 
@@ -2425,7 +2480,11 @@ module aptos_framework::multisig_account {
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         create_with_owners(
-            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+            owner_1,
+            vector[owner_2_addr, owner_3_addr],
+            2,
+            vector[],
+            vector[],
         );
 
         create_transaction_with_hash(owner_3, multisig_account, sha3_256(PAYLOAD));
@@ -2452,7 +2511,11 @@ module aptos_framework::multisig_account {
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         create_with_owners(
-            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+            owner_1,
+            vector[owner_2_addr, owner_3_addr],
+            2,
+            vector[],
+            vector[],
         );
 
         create_transaction(owner_1, multisig_account, PAYLOAD);
@@ -2495,7 +2558,11 @@ module aptos_framework::multisig_account {
         create_account(owner_1_addr);
         let multisig_account = get_next_multisig_account_address(owner_1_addr);
         create_with_owners(
-            owner_1, vector[owner_2_addr, owner_3_addr], 2, vector[], vector[]
+            owner_1,
+            vector[owner_2_addr, owner_3_addr],
+            2,
+            vector[],
+            vector[],
         );
 
         create_transaction(owner_1, multisig_account, PAYLOAD);

--- a/aptos-move/framework/aptos-framework/sources/multisig_account.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/multisig_account.spec.move
@@ -165,8 +165,7 @@ spec aptos_framework::multisig_account {
     /// Enforcement: Audited that it aborts if the MultisigAccount doesn't exist on the account.
     /// </high-level-req>
 
-    spec module {
-    }
+    spec module {}
 
     spec metadata(multisig_account: address): SimpleMap<String, vector<u8>> {
         aborts_if !exists<MultisigAccount>(multisig_account);
@@ -183,27 +182,31 @@ spec aptos_framework::multisig_account {
         ensures result == global<MultisigAccount>(multisig_account).owners;
     }
 
-    spec get_transaction(
-        multisig_account: address,
-        sequence_number: u64,
-    ): MultisigTransaction {
+    spec get_transaction(multisig_account: address, sequence_number: u64,): MultisigTransaction {
         let multisig_account_resource = global<MultisigAccount>(multisig_account);
         aborts_if !exists<MultisigAccount>(multisig_account);
-        aborts_if sequence_number == 0 || sequence_number >= multisig_account_resource.next_sequence_number;
-        aborts_if !table::spec_contains(multisig_account_resource.transactions, sequence_number);
-        ensures result == table::spec_get(multisig_account_resource.transactions, sequence_number);
+        aborts_if sequence_number == 0
+            || sequence_number >= multisig_account_resource.next_sequence_number;
+        aborts_if !table::spec_contains(
+            multisig_account_resource.transactions, sequence_number
+        );
+        ensures result
+            == table::spec_get(multisig_account_resource.transactions, sequence_number);
     }
 
-    spec get_next_transaction_payload(
-    multisig_account: address, provided_payload: vector<u8>
-    ): vector<u8> {
+    spec get_next_transaction_payload(multisig_account: address, provided_payload: vector<u8>): vector<u8> {
         let multisig_account_resource = global<MultisigAccount>(multisig_account);
         let sequence_number = multisig_account_resource.last_executed_sequence_number + 1;
-        let transaction = table::spec_get(multisig_account_resource.transactions, sequence_number);
+        let transaction = table::spec_get(
+            multisig_account_resource.transactions, sequence_number
+        );
         aborts_if !exists<MultisigAccount>(multisig_account);
         aborts_if multisig_account_resource.last_executed_sequence_number + 1 > MAX_U64;
-        aborts_if !table::spec_contains(multisig_account_resource.transactions, sequence_number);
-        ensures option::spec_is_none(transaction.payload) ==> result == provided_payload;
+        aborts_if !table::spec_contains(
+            multisig_account_resource.transactions, sequence_number
+        );
+        ensures option::spec_is_none(transaction.payload) ==>
+            result == provided_payload;
     }
 
     spec get_next_multisig_account_address(creator: address): address {
@@ -223,21 +226,21 @@ spec aptos_framework::multisig_account {
         ensures result == multisig_account_resource.next_sequence_number;
     }
 
-    spec vote(
-        multisig_account: address,
-        sequence_number: u64,
-        owner: address
-    ): (bool, bool) {
+    spec vote(multisig_account: address, sequence_number: u64, owner: address): (bool, bool) {
         let multisig_account_resource = global<MultisigAccount>(multisig_account);
         aborts_if !exists<MultisigAccount>(multisig_account);
-        aborts_if sequence_number == 0 || sequence_number >= multisig_account_resource.next_sequence_number;
-        aborts_if !table::spec_contains(multisig_account_resource.transactions, sequence_number);
-        let transaction = table::spec_get(multisig_account_resource.transactions, sequence_number);
+        aborts_if sequence_number == 0
+            || sequence_number >= multisig_account_resource.next_sequence_number;
+        aborts_if !table::spec_contains(
+            multisig_account_resource.transactions, sequence_number
+        );
+        let transaction = table::spec_get(
+            multisig_account_resource.transactions, sequence_number
+        );
         let votes = transaction.votes;
         let voted = simple_map::spec_contains_key(votes, owner);
         let vote = voted && simple_map::spec_get(votes, owner);
         ensures result_1 == voted;
         ensures result_2 == vote;
     }
-
 }

--- a/aptos-move/framework/aptos-framework/sources/object.move
+++ b/aptos-move/framework/aptos-framework/sources/object.move
@@ -631,7 +631,8 @@ module aptos_framework::object {
     ) acquires TombStone, ObjectCore {
         let object_addr = object.inner;
         assert!(
-            exists<TombStone>(object_addr), error::invalid_argument(EOBJECT_NOT_BURNT)
+            exists<TombStone>(object_addr),
+            error::invalid_argument(EOBJECT_NOT_BURNT),
         );
 
         let TombStone { original_owner: original_owner_addr } =

--- a/aptos-move/framework/aptos-framework/sources/object.move
+++ b/aptos-move/framework/aptos-framework/sources/object.move
@@ -90,7 +90,8 @@ module aptos_framework::object {
     const OBJECT_FROM_SEED_ADDRESS_SCHEME: u8 = 0xFE;
 
     /// Address where unwanted objects can be forcefully transferred to.
-    const BURN_ADDRESS: address = @0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
+    const BURN_ADDRESS: address =
+        @0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
 
     #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
     /// The core of the object model that defines ownership, transferability, and events.
@@ -216,7 +217,9 @@ module aptos_framework::object {
     native fun create_user_derived_object_address_impl(source: address, derive_from: address): address;
 
     /// Derives an object address from the source address and an object: sha3_256([source | object addr | 0xFC]).
-    public fun create_user_derived_object_address(source: address, derive_from: address): address {
+    public fun create_user_derived_object_address(
+        source: address, derive_from: address
+    ): address {
         if (std::features::object_native_derived_address_enabled()) {
             create_user_derived_object_address_impl(source, derive_from)
         } else {
@@ -228,7 +231,9 @@ module aptos_framework::object {
     }
 
     /// Derives an object from an Account GUID.
-    public fun create_guid_object_address(source: address, creation_num: u64): address {
+    public fun create_guid_object_address(
+        source: address, creation_num: u64
+    ): address {
         let id = guid::create_id(source, creation_num);
         let bytes = bcs::to_bytes(&id);
         vector::push_back(&mut bytes, OBJECT_FROM_GUID_ADDRESS_SCHEME);
@@ -257,8 +262,11 @@ module aptos_framework::object {
 
     /// Create a new object whose address is derived based on the creator account address and another object.
     /// Derivde objects, similar to named objects, cannot be deleted.
-    public(friend) fun create_user_derived_object(creator_address: address, derive_ref: &DeriveRef): ConstructorRef {
-        let obj_addr = create_user_derived_object_address(creator_address, derive_ref.self);
+    public(friend) fun create_user_derived_object(
+        creator_address: address, derive_ref: &DeriveRef
+    ): ConstructorRef {
+        let obj_addr =
+            create_user_derived_object_address(creator_address, derive_ref.self);
         create_object_internal(creator_address, obj_addr, false)
     }
 
@@ -279,8 +287,7 @@ module aptos_framework::object {
 
     /// Create a sticky object at a specific address. Only used by aptos_framework::coin.
     public(friend) fun create_sticky_object_at_address(
-        owner_address: address,
-        object_address: address,
+        owner_address: address, object_address: address,
     ): ConstructorRef {
         create_object_internal(owner_address, object_address, false)
     }
@@ -309,7 +316,9 @@ module aptos_framework::object {
         create_object_from_guid(signer::address_of(creator), guid)
     }
 
-    fun create_object_from_guid(creator_address: address, guid: guid::GUID): ConstructorRef {
+    fun create_object_from_guid(
+        creator_address: address, guid: guid::GUID
+    ): ConstructorRef {
         let bytes = bcs::to_bytes(&guid);
         vector::push_back(&mut bytes, OBJECT_FROM_GUID_ADDRESS_SCHEME);
         let obj_addr = from_bcs::to_address(hash::sha3_256(bytes));
@@ -354,7 +363,10 @@ module aptos_framework::object {
 
     /// Generates the TransferRef, which can be used to manage object transfers.
     public fun generate_transfer_ref(ref: &ConstructorRef): TransferRef {
-        assert!(!exists<Untransferable>(ref.self), error::permission_denied(EOBJECT_NOT_TRANSFERRABLE));
+        assert!(
+            !exists<Untransferable>(ref.self),
+            error::permission_denied(EOBJECT_NOT_TRANSFERRABLE),
+        );
         TransferRef { self: ref.self }
     }
 
@@ -393,9 +405,7 @@ module aptos_framework::object {
     }
 
     /// Generate a new event handle.
-    public fun new_event_handle<T: drop + store>(
-        object: &signer,
-    ): event::EventHandle<T> acquires ObjectCore {
+    public fun new_event_handle<T: drop + store>(object: &signer,): event::EventHandle<T> acquires ObjectCore {
         event::new_event_handle(create_guid(object))
     }
 
@@ -422,7 +432,7 @@ module aptos_framework::object {
         } = object_core;
 
         if (exists<Untransferable>(ref.self)) {
-          let Untransferable {} = move_from<Untransferable>(ref.self);
+            let Untransferable {} = move_from<Untransferable>(ref.self);
         };
 
         event::destroy_handle(transfer_events);
@@ -458,7 +468,10 @@ module aptos_framework::object {
 
     /// Enable direct transfer.
     public fun enable_ungated_transfer(ref: &TransferRef) acquires ObjectCore {
-        assert!(!exists<Untransferable>(ref.self), error::permission_denied(EOBJECT_NOT_TRANSFERRABLE));
+        assert!(
+            !exists<Untransferable>(ref.self),
+            error::permission_denied(EOBJECT_NOT_TRANSFERRABLE),
+        );
         let object = borrow_global_mut<ObjectCore>(ref.self);
         object.allow_ungated_transfer = true;
     }
@@ -466,17 +479,20 @@ module aptos_framework::object {
     /// Create a LinearTransferRef for a one-time transfer. This requires that the owner at the
     /// time of generation is the owner at the time of transferring.
     public fun generate_linear_transfer_ref(ref: &TransferRef): LinearTransferRef acquires ObjectCore {
-        assert!(!exists<Untransferable>(ref.self), error::permission_denied(EOBJECT_NOT_TRANSFERRABLE));
+        assert!(
+            !exists<Untransferable>(ref.self),
+            error::permission_denied(EOBJECT_NOT_TRANSFERRABLE),
+        );
         let owner = owner(Object<ObjectCore> { inner: ref.self });
-        LinearTransferRef {
-            self: ref.self,
-            owner,
-        }
+        LinearTransferRef { self: ref.self, owner, }
     }
 
     /// Transfer to the destination address using a LinearTransferRef.
     public fun transfer_with_ref(ref: LinearTransferRef, to: address) acquires ObjectCore, TombStone {
-        assert!(!exists<Untransferable>(ref.self), error::permission_denied(EOBJECT_NOT_TRANSFERRABLE));
+        assert!(
+            !exists<Untransferable>(ref.self),
+            error::permission_denied(EOBJECT_NOT_TRANSFERRABLE),
+        );
 
         // Undo soft burn if present as we don't want the original owner to be able to reclaim by calling unburn later.
         if (exists<TombStone>(ref.self)) {
@@ -490,20 +506,12 @@ module aptos_framework::object {
         );
         if (std::features::module_event_migration_enabled()) {
             event::emit(
-                Transfer {
-                    object: ref.self,
-                    from: object.owner,
-                    to,
-                },
+                Transfer { object: ref.self, from: object.owner, to, },
             );
         };
         event::emit_event(
             &mut object.transfer_events,
-            TransferEvent {
-                object: ref.self,
-                from: object.owner,
-                to,
-            },
+            TransferEvent { object: ref.self, from: object.owner, to, },
         );
         object.owner = to;
     }
@@ -546,20 +554,12 @@ module aptos_framework::object {
         if (object_core.owner != to) {
             if (std::features::module_event_migration_enabled()) {
                 event::emit(
-                    Transfer {
-                        object,
-                        from: object_core.owner,
-                        to,
-                    },
+                    Transfer { object, from: object_core.owner, to, },
                 );
             };
             event::emit_event(
                 &mut object_core.transfer_events,
-                TransferEvent {
-                    object,
-                    from: object_core.owner,
-                    to,
-                },
+                TransferEvent { object, from: object_core.owner, to, },
             );
             object_core.owner = to;
         };
@@ -577,7 +577,9 @@ module aptos_framework::object {
     /// This checks that the destination address is eventually owned by the owner and that each
     /// object between the two allows for ungated transfers. Note, this is limited to a depth of 8
     /// objects may have cyclic dependencies.
-    fun verify_ungated_and_descendant(owner: address, destination: address) acquires ObjectCore {
+    fun verify_ungated_and_descendant(
+        owner: address, destination: address
+    ) acquires ObjectCore {
         let current_address = destination;
         assert!(
             exists<ObjectCore>(current_address),
@@ -615,7 +617,9 @@ module aptos_framework::object {
     /// Original owners can reclaim burnt objects any time in the future by calling unburn.
     public entry fun burn<T: key>(owner: &signer, object: Object<T>) acquires ObjectCore {
         let original_owner = signer::address_of(owner);
-        assert!(is_owner(object, original_owner), error::permission_denied(ENOT_OBJECT_OWNER));
+        assert!(
+            is_owner(object, original_owner), error::permission_denied(ENOT_OBJECT_OWNER)
+        );
         let object_addr = object.inner;
         move_to(&create_signer(object_addr), TombStone { original_owner });
         transfer_raw_inner(object_addr, BURN_ADDRESS);
@@ -623,14 +627,19 @@ module aptos_framework::object {
 
     /// Allow origin owners to reclaim any objects they previous burnt.
     public entry fun unburn<T: key>(
-        original_owner: &signer,
-        object: Object<T>,
+        original_owner: &signer, object: Object<T>,
     ) acquires TombStone, ObjectCore {
         let object_addr = object.inner;
-        assert!(exists<TombStone>(object_addr), error::invalid_argument(EOBJECT_NOT_BURNT));
+        assert!(
+            exists<TombStone>(object_addr), error::invalid_argument(EOBJECT_NOT_BURNT)
+        );
 
-        let TombStone { original_owner: original_owner_addr } = move_from<TombStone>(object_addr);
-        assert!(original_owner_addr == signer::address_of(original_owner), error::permission_denied(ENOT_OBJECT_OWNER));
+        let TombStone { original_owner: original_owner_addr } =
+            move_from<TombStone>(object_addr);
+        assert!(
+            original_owner_addr == signer::address_of(original_owner),
+            error::permission_denied(ENOT_OBJECT_OWNER),
+        );
         transfer_raw_inner(object_addr, original_owner_addr);
     }
 
@@ -914,7 +923,9 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 131078, location = Self)]
-    fun test_exceeding_maximum_object_nesting_owns_should_fail(creator: &signer) acquires ObjectCore {
+    fun test_exceeding_maximum_object_nesting_owns_should_fail(
+        creator: &signer
+    ) acquires ObjectCore {
         let obj1 = create_simple_object(creator, b"1");
         let obj2 = create_simple_object(creator, b"2");
         let obj3 = create_simple_object(creator, b"3");
@@ -949,7 +960,9 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 131078, location = Self)]
-    fun test_exceeding_maximum_object_nesting_transfer_should_fail(creator: &signer) acquires ObjectCore {
+    fun test_exceeding_maximum_object_nesting_transfer_should_fail(
+        creator: &signer
+    ) acquires ObjectCore {
         let obj1 = create_simple_object(creator, b"1");
         let obj2 = create_simple_object(creator, b"2");
         let obj3 = create_simple_object(creator, b"3");
@@ -1003,7 +1016,9 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 327689, location = Self)]
-    fun test_untransferable_direct_ownership_gen_transfer_ref(creator: &signer) acquires ObjectCore {
+    fun test_untransferable_direct_ownership_gen_transfer_ref(
+        creator: &signer
+    ) acquires ObjectCore {
         let (hero_constructor_ref, _) = create_hero(creator);
         set_untransferable(&hero_constructor_ref);
         generate_transfer_ref(&hero_constructor_ref);
@@ -1011,7 +1026,9 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 327689, location = Self)]
-    fun test_untransferable_direct_ownership_gen_linear_transfer_ref(creator: &signer) acquires ObjectCore {
+    fun test_untransferable_direct_ownership_gen_linear_transfer_ref(
+        creator: &signer
+    ) acquires ObjectCore {
         let (hero_constructor_ref, _) = create_hero(creator);
         let transfer_ref = generate_transfer_ref(&hero_constructor_ref);
         set_untransferable(&hero_constructor_ref);
@@ -1020,7 +1037,9 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 327689, location = Self)]
-    fun test_untransferable_direct_ownership_with_linear_transfer_ref(creator: &signer) acquires ObjectCore, TombStone {
+    fun test_untransferable_direct_ownership_with_linear_transfer_ref(
+        creator: &signer
+    ) acquires ObjectCore, TombStone {
         let (hero_constructor_ref, _) = create_hero(creator);
         let transfer_ref = generate_transfer_ref(&hero_constructor_ref);
         let linear_transfer_ref = generate_linear_transfer_ref(&transfer_ref);
@@ -1040,7 +1059,9 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 327689, location = Self)]
-    fun test_untransferable_indirect_ownership_gen_transfer_ref(creator: &signer) acquires ObjectCore {
+    fun test_untransferable_indirect_ownership_gen_transfer_ref(
+        creator: &signer
+    ) acquires ObjectCore {
         let (_, hero) = create_hero(creator);
         let (weapon_constructor_ref, weapon) = create_weapon(creator);
         transfer_to_object(creator, weapon, hero);
@@ -1050,7 +1071,9 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 327689, location = Self)]
-    fun test_untransferable_indirect_ownership_gen_linear_transfer_ref(creator: &signer) acquires ObjectCore {
+    fun test_untransferable_indirect_ownership_gen_linear_transfer_ref(
+        creator: &signer
+    ) acquires ObjectCore {
         let (_, hero) = create_hero(creator);
         let (weapon_constructor_ref, weapon) = create_weapon(creator);
         transfer_to_object(creator, weapon, hero);
@@ -1061,7 +1084,9 @@ module aptos_framework::object {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 327689, location = Self)]
-    fun test_untransferable_indirect_ownership_with_linear_transfer_ref(creator: &signer) acquires ObjectCore, TombStone {
+    fun test_untransferable_indirect_ownership_with_linear_transfer_ref(
+        creator: &signer
+    ) acquires ObjectCore, TombStone {
         let (_, hero) = create_hero(creator);
         let (weapon_constructor_ref, weapon) = create_weapon(creator);
         transfer_to_object(creator, weapon, hero);

--- a/aptos-move/framework/aptos-framework/sources/object.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/object.spec.move
@@ -56,7 +56,6 @@ spec aptos_framework::object {
         ensures [abstract] result == spec_exists_at<T>(object);
     }
 
-
     spec address_to_object<T: key>(object: address): Object<T> {
         aborts_if !exists<ObjectCore>(object);
         aborts_if !spec_exists_at<T>(object);
@@ -70,20 +69,21 @@ spec aptos_framework::object {
         aborts_if exists<ObjectCore>(unique_address);
 
         ensures exists<ObjectCore>(unique_address);
-        ensures global<ObjectCore>(unique_address) == ObjectCore {
-            guid_creation_num: INIT_GUID_CREATION_NUM + 1,
-            owner: owner_address,
-            allow_ungated_transfer: true,
-            transfer_events: event::EventHandle {
-                counter: 0,
-                guid: guid::GUID {
-                    id: guid::ID {
-                        creation_num: INIT_GUID_CREATION_NUM,
-                        addr: unique_address,
+        ensures global<ObjectCore>(unique_address)
+            == ObjectCore {
+                guid_creation_num: INIT_GUID_CREATION_NUM + 1,
+                owner: owner_address,
+                allow_ungated_transfer: true,
+                transfer_events: event::EventHandle {
+                    counter: 0,
+                    guid: guid::GUID {
+                        id: guid::ID {
+                            creation_num: INIT_GUID_CREATION_NUM,
+                            addr: unique_address,
+                        }
                     }
                 }
-            }
-        };
+            };
         ensures result == ConstructorRef { self: unique_address, can_delete: true };
     }
 
@@ -94,20 +94,21 @@ spec aptos_framework::object {
         aborts_if exists<ObjectCore>(unique_address);
 
         ensures exists<ObjectCore>(unique_address);
-        ensures global<ObjectCore>(unique_address) == ObjectCore {
-            guid_creation_num: INIT_GUID_CREATION_NUM + 1,
-            owner: owner_address,
-            allow_ungated_transfer: true,
-            transfer_events: event::EventHandle {
-                counter: 0,
-                guid: guid::GUID {
-                    id: guid::ID {
-                        creation_num: INIT_GUID_CREATION_NUM,
-                        addr: unique_address,
+        ensures global<ObjectCore>(unique_address)
+            == ObjectCore {
+                guid_creation_num: INIT_GUID_CREATION_NUM + 1,
+                owner: owner_address,
+                allow_ungated_transfer: true,
+                transfer_events: event::EventHandle {
+                    counter: 0,
+                    guid: guid::GUID {
+                        id: guid::ID {
+                            creation_num: INIT_GUID_CREATION_NUM,
+                            addr: unique_address,
+                        }
                     }
                 }
-            }
-        };
+            };
         ensures result == ConstructorRef { self: unique_address, can_delete: false };
     }
 
@@ -122,14 +123,16 @@ spec aptos_framework::object {
 
     spec create_user_derived_object_address_impl(source: address, derive_from: address): address {
         pragma opaque;
-        ensures [abstract] result == spec_create_user_derived_object_address_impl(source, derive_from);
+        ensures [abstract] result
+            == spec_create_user_derived_object_address_impl(source, derive_from);
     }
 
     spec create_user_derived_object_address(source: address, derive_from: address): address {
         pragma opaque;
         pragma aborts_if_is_strict = false;
         aborts_if [abstract] false;
-        ensures [abstract] result == spec_create_user_derived_object_address(source, derive_from);
+        ensures [abstract] result
+            == spec_create_user_derived_object_address(source, derive_from);
     }
 
     spec create_guid_object_address(source: address, creation_num: u64): address {
@@ -156,42 +159,46 @@ spec aptos_framework::object {
         aborts_if exists<ObjectCore>(obj_addr);
 
         ensures exists<ObjectCore>(obj_addr);
-        ensures global<ObjectCore>(obj_addr) == ObjectCore {
-            guid_creation_num: INIT_GUID_CREATION_NUM + 1,
-            owner: creator_address,
-            allow_ungated_transfer: true,
-            transfer_events: event::EventHandle {
-                counter: 0,
-                guid: guid::GUID {
-                    id: guid::ID {
-                        creation_num: INIT_GUID_CREATION_NUM,
-                        addr: obj_addr,
+        ensures global<ObjectCore>(obj_addr)
+            == ObjectCore {
+                guid_creation_num: INIT_GUID_CREATION_NUM + 1,
+                owner: creator_address,
+                allow_ungated_transfer: true,
+                transfer_events: event::EventHandle {
+                    counter: 0,
+                    guid: guid::GUID {
+                        id: guid::ID {
+                            creation_num: INIT_GUID_CREATION_NUM,
+                            addr: obj_addr,
+                        }
                     }
                 }
-            }
-        };
+            };
         ensures result == ConstructorRef { self: obj_addr, can_delete: false };
     }
 
     spec create_user_derived_object(creator_address: address, derive_ref: &DeriveRef): ConstructorRef {
-        let obj_addr = spec_create_user_derived_object_address(creator_address, derive_ref.self);
+        let obj_addr = spec_create_user_derived_object_address(
+            creator_address, derive_ref.self
+        );
         aborts_if exists<ObjectCore>(obj_addr);
 
         ensures exists<ObjectCore>(obj_addr);
-        ensures global<ObjectCore>(obj_addr) == ObjectCore {
-            guid_creation_num: INIT_GUID_CREATION_NUM + 1,
-            owner: creator_address,
-            allow_ungated_transfer: true,
-            transfer_events: event::EventHandle {
-                counter: 0,
-                guid: guid::GUID {
-                    id: guid::ID {
-                        creation_num: INIT_GUID_CREATION_NUM,
-                        addr: obj_addr,
+        ensures global<ObjectCore>(obj_addr)
+            == ObjectCore {
+                guid_creation_num: INIT_GUID_CREATION_NUM + 1,
+                owner: creator_address,
+                allow_ungated_transfer: true,
+                transfer_events: event::EventHandle {
+                    counter: 0,
+                    guid: guid::GUID {
+                        id: guid::ID {
+                            creation_num: INIT_GUID_CREATION_NUM,
+                            addr: obj_addr,
+                        }
                     }
                 }
-            }
-        };
+            };
         ensures result == ConstructorRef { self: obj_addr, can_delete: false };
     }
 
@@ -204,12 +211,7 @@ spec aptos_framework::object {
         let creation_num = object_data.guid_creation_num;
         let addr = signer::address_of(creator);
 
-        let guid = guid::GUID {
-            id: guid::ID {
-                creation_num,
-                addr,
-            }
-        };
+        let guid = guid::GUID { id: guid::ID { creation_num, addr, } };
 
         let bytes_spec = bcs::to_bytes(guid);
         let bytes = concat(bytes_spec, vec<u8>(OBJECT_FROM_GUID_ADDRESS_SCHEME));
@@ -218,24 +220,24 @@ spec aptos_framework::object {
         aborts_if exists<ObjectCore>(obj_addr);
         aborts_if !from_bcs::deserializable<address>(hash_bytes);
 
-        ensures global<account::Account>(addr).guid_creation_num == old(
-            global<account::Account>(addr)
-        ).guid_creation_num + 1;
+        ensures global<account::Account>(addr).guid_creation_num
+            == old(global<account::Account>(addr)).guid_creation_num + 1;
         ensures exists<ObjectCore>(obj_addr);
-        ensures global<ObjectCore>(obj_addr) == ObjectCore {
-            guid_creation_num: INIT_GUID_CREATION_NUM + 1,
-            owner: addr,
-            allow_ungated_transfer: true,
-            transfer_events: event::EventHandle {
-                counter: 0,
-                guid: guid::GUID {
-                    id: guid::ID {
-                        creation_num: INIT_GUID_CREATION_NUM,
-                        addr: obj_addr,
+        ensures global<ObjectCore>(obj_addr)
+            == ObjectCore {
+                guid_creation_num: INIT_GUID_CREATION_NUM + 1,
+                owner: addr,
+                allow_ungated_transfer: true,
+                transfer_events: event::EventHandle {
+                    counter: 0,
+                    guid: guid::GUID {
+                        id: guid::ID {
+                            creation_num: INIT_GUID_CREATION_NUM,
+                            addr: obj_addr,
+                        }
                     }
                 }
-            }
-        };
+            };
         ensures result == ConstructorRef { self: obj_addr, can_delete: true };
     }
 
@@ -247,12 +249,7 @@ spec aptos_framework::object {
         let creation_num = object_data.guid_creation_num;
         let addr = signer::address_of(creator);
 
-        let guid = guid::GUID {
-            id: guid::ID {
-                creation_num,
-                addr,
-            }
-        };
+        let guid = guid::GUID { id: guid::ID { creation_num, addr, } };
 
         let bytes_spec = bcs::to_bytes(guid);
         let bytes = concat(bytes_spec, vec<u8>(OBJECT_FROM_GUID_ADDRESS_SCHEME));
@@ -261,22 +258,24 @@ spec aptos_framework::object {
         aborts_if exists<ObjectCore>(obj_addr);
         aborts_if !from_bcs::deserializable<address>(hash_bytes);
 
-        ensures global<ObjectCore>(addr).guid_creation_num == old(global<ObjectCore>(addr)).guid_creation_num + 1;
+        ensures global<ObjectCore>(addr).guid_creation_num
+            == old(global<ObjectCore>(addr)).guid_creation_num + 1;
         ensures exists<ObjectCore>(obj_addr);
-        ensures global<ObjectCore>(obj_addr) == ObjectCore {
-            guid_creation_num: INIT_GUID_CREATION_NUM + 1,
-            owner: addr,
-            allow_ungated_transfer: true,
-            transfer_events: event::EventHandle {
-                counter: 0,
-                guid: guid::GUID {
-                    id: guid::ID {
-                        creation_num: INIT_GUID_CREATION_NUM,
-                        addr: obj_addr,
+        ensures global<ObjectCore>(obj_addr)
+            == ObjectCore {
+                guid_creation_num: INIT_GUID_CREATION_NUM + 1,
+                owner: addr,
+                allow_ungated_transfer: true,
+                transfer_events: event::EventHandle {
+                    counter: 0,
+                    guid: guid::GUID {
+                        id: guid::ID {
+                            creation_num: INIT_GUID_CREATION_NUM,
+                            addr: obj_addr,
+                        }
                     }
                 }
-            }
-        };
+            };
         ensures result == ConstructorRef { self: obj_addr, can_delete: true };
     }
 
@@ -289,20 +288,21 @@ spec aptos_framework::object {
         aborts_if !from_bcs::deserializable<address>(hash_bytes);
 
         ensures exists<ObjectCore>(obj_addr);
-        ensures global<ObjectCore>(obj_addr) == ObjectCore {
-            guid_creation_num: INIT_GUID_CREATION_NUM + 1,
-            owner: creator_address,
-            allow_ungated_transfer: true,
-            transfer_events: event::EventHandle {
-                counter: 0,
-                guid: guid::GUID {
-                    id: guid::ID {
-                        creation_num: INIT_GUID_CREATION_NUM,
-                        addr: obj_addr,
+        ensures global<ObjectCore>(obj_addr)
+            == ObjectCore {
+                guid_creation_num: INIT_GUID_CREATION_NUM + 1,
+                owner: creator_address,
+                allow_ungated_transfer: true,
+                transfer_events: event::EventHandle {
+                    counter: 0,
+                    guid: guid::GUID {
+                        id: guid::ID {
+                            creation_num: INIT_GUID_CREATION_NUM,
+                            addr: obj_addr,
+                        }
                     }
                 }
-            }
-        };
+            };
         ensures result == ConstructorRef { self: obj_addr, can_delete: true };
     }
 
@@ -311,11 +311,7 @@ spec aptos_framework::object {
         pragma verify = false;
     }
 
-    spec create_object_internal(
-    creator_address: address,
-    object: address,
-    can_delete: bool,
-    ): ConstructorRef {
+    spec create_object_internal(creator_address: address, object: address, can_delete: bool,): ConstructorRef {
         // property 1: Creating an object twice on the same address must never occur.
         /// [high-level-req-1]
         aborts_if exists<ObjectCore>(object);
@@ -347,17 +343,16 @@ spec aptos_framework::object {
         let object_data = global<ObjectCore>(signer::address_of(object));
         aborts_if object_data.guid_creation_num + 1 > MAX_U64;
 
-        ensures result == guid::GUID {
-            id: guid::ID {
-                creation_num: object_data.guid_creation_num,
-                addr: signer::address_of(object)
-            }
-        };
+        ensures result
+            == guid::GUID {
+                id: guid::ID {
+                    creation_num: object_data.guid_creation_num,
+                    addr: signer::address_of(object)
+                }
+            };
     }
 
-    spec new_event_handle<T: drop + store>(
-    object: &signer,
-    ): event::EventHandle<T> {
+    spec new_event_handle<T: drop + store>(object: &signer,): event::EventHandle<T> {
         aborts_if !exists<ObjectCore>(signer::address_of(object));
         //Guid properties
         let object_data = global<ObjectCore>(signer::address_of(object));
@@ -369,10 +364,7 @@ spec aptos_framework::object {
                 addr: signer::address_of(object)
             }
         };
-        ensures result == event::EventHandle<T> {
-            counter: 0,
-            guid,
-        };
+        ensures result == event::EventHandle<T> { counter: 0, guid, };
     }
 
     spec object_from_delete_ref<T: key>(ref: &DeleteRef): Object<T> {
@@ -401,19 +393,14 @@ spec aptos_framework::object {
 
     spec generate_transfer_ref(ref: &ConstructorRef): TransferRef {
         aborts_if exists<Untransferable>(ref.self);
-        ensures result == TransferRef {
-            self: ref.self,
-        };
+        ensures result == TransferRef { self: ref.self, };
     }
 
     spec generate_linear_transfer_ref(ref: &TransferRef): LinearTransferRef {
         aborts_if exists<Untransferable>(ref.self);
         aborts_if !exists<ObjectCore>(ref.self);
         let owner = global<ObjectCore>(ref.self).owner;
-        ensures result == LinearTransferRef {
-            self: ref.self,
-            owner,
-        };
+        ensures result == LinearTransferRef { self: ref.self, owner, };
     }
 
     spec transfer_with_ref(ref: LinearTransferRef, to: address) {
@@ -425,11 +412,7 @@ spec aptos_framework::object {
         ensures global<ObjectCore>(ref.self).owner == to;
     }
 
-    spec transfer_call(
-    owner: &signer,
-    object: address,
-    to: address,
-    ) {
+    spec transfer_call(owner: &signer, object: address, to: address,) {
         pragma aborts_if_is_partial;
         // TODO: Verify the link list loop in verify_ungated_and_descendant
         let owner_address = signer::address_of(owner);
@@ -437,11 +420,7 @@ spec aptos_framework::object {
         aborts_if !global<ObjectCore>(object).allow_ungated_transfer;
     }
 
-    spec transfer<T: key>(
-    owner: &signer,
-    object: Object<T>,
-    to: address,
-    ) {
+    spec transfer<T: key>(owner: &signer, object: Object<T>, to: address,) {
         pragma aborts_if_is_partial;
         // TODO: Verify the link list loop in verify_ungated_and_descendant
         let owner_address = signer::address_of(owner);
@@ -450,11 +429,7 @@ spec aptos_framework::object {
         aborts_if !global<ObjectCore>(object_address).allow_ungated_transfer;
     }
 
-    spec transfer_raw(
-    owner: &signer,
-    object: address,
-    to: address,
-    ) {
+    spec transfer_raw(owner: &signer, object: address, to: address,) {
         pragma aborts_if_is_partial;
         // TODO: Verify the link list loop in verify_ungated_and_descendant
         let owner_address = signer::address_of(owner);
@@ -462,11 +437,7 @@ spec aptos_framework::object {
         aborts_if !global<ObjectCore>(object).allow_ungated_transfer;
     }
 
-    spec transfer_to_object<O: key, T: key> (
-    owner: &signer,
-    object: Object<O>,
-    to: Object<T>,
-    ) {
+    spec transfer_to_object<O: key, T: key>(owner: &signer, object: Object<O>, to: Object<T>,) {
         pragma aborts_if_is_partial;
         // TODO: Verify the link list loop in verify_ungated_and_descendant
         let owner_address = signer::address_of(owner);

--- a/aptos-move/framework/aptos-framework/sources/object_code_deployment.move
+++ b/aptos-move/framework/aptos-framework/sources/object_code_deployment.move
@@ -97,15 +97,18 @@ module aptos_framework::object_code_deployment {
 
         event::emit(Publish { object_address: signer::address_of(code_signer), });
 
-        move_to(code_signer, ManagingRefs {
-            extend_ref: object::generate_extend_ref(constructor_ref),
-        });
+        move_to(
+            code_signer,
+            ManagingRefs { extend_ref: object::generate_extend_ref(constructor_ref), },
+        );
     }
 
     inline fun object_seed(publisher: address): vector<u8> {
         let sequence_number = account::get_sequence_number(publisher) + 1;
         let seeds = vector[];
-        vector::append(&mut seeds, bcs::to_bytes(&OBJECT_CODE_DEPLOYMENT_DOMAIN_SEPARATOR));
+        vector::append(
+            &mut seeds, bcs::to_bytes(&OBJECT_CODE_DEPLOYMENT_DOMAIN_SEPARATOR)
+        );
         vector::append(&mut seeds, bcs::to_bytes(&sequence_number));
         seeds
     }
@@ -127,7 +130,10 @@ module aptos_framework::object_code_deployment {
         );
 
         let code_object_address = object::object_address(&code_object);
-        assert!(exists<ManagingRefs>(code_object_address), error::not_found(ECODE_OBJECT_DOES_NOT_EXIST));
+        assert!(
+            exists<ManagingRefs>(code_object_address),
+            error::not_found(ECODE_OBJECT_DOES_NOT_EXIST),
+        );
 
         let extend_ref = &borrow_global<ManagingRefs>(code_object_address).extend_ref;
         let code_signer = &object::generate_signer_for_extending(extend_ref);
@@ -139,7 +145,9 @@ module aptos_framework::object_code_deployment {
     /// Make an existing upgradable package immutable. Once this is called, the package cannot be made upgradable again.
     /// Each `code_object` should only have one package, as one package is deployed per object in this module.
     /// Requires the `publisher` to be the owner of the `code_object`.
-    public entry fun freeze_code_object(publisher: &signer, code_object: Object<PackageRegistry>) {
+    public entry fun freeze_code_object(
+        publisher: &signer, code_object: Object<PackageRegistry>
+    ) {
         code::freeze_code_object(publisher, code_object);
 
         event::emit(Freeze { object_address: object::object_address(&code_object), });

--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
@@ -297,7 +297,10 @@ module aptos_framework::primary_fungible_store {
                 to, fungible_asset::transfer_ref_metadata(transfer_ref)
             );
         fungible_asset::transfer_with_ref(
-            transfer_ref, from_primary_store, to_primary_store, amount
+            transfer_ref,
+            from_primary_store,
+            to_primary_store,
+            amount,
         );
     }
 
@@ -357,9 +360,7 @@ module aptos_framework::primary_fungible_store {
     }
 
     #[test(creator = @0xcafe, aaron = @0xface)]
-    fun test_basic_flow(
-        creator: &signer, aaron: &signer,
-    ) acquires DeriveRefPod {
+    fun test_basic_flow(creator: &signer, aaron: &signer,) acquires DeriveRefPod {
         let (creator_ref, metadata) = create_test_token(creator);
         let (mint_ref, transfer_ref, burn_ref) =
             init_test_metadata_with_primary_store_enabled(&creator_ref);
@@ -404,9 +405,7 @@ module aptos_framework::primary_fungible_store {
     }
 
     #[test(user_1 = @0xcafe, user_2 = @0xface)]
-    fun test_transfer_to_burnt_store(
-        user_1: &signer, user_2: &signer,
-    ) acquires DeriveRefPod {
+    fun test_transfer_to_burnt_store(user_1: &signer, user_2: &signer,) acquires DeriveRefPod {
         let (creator_ref, metadata) = create_test_token(user_1);
         let (mint_ref, _, _) =
             init_test_metadata_with_primary_store_enabled(&creator_ref);

--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
@@ -13,7 +13,15 @@
 /// fungible asset to it. This emits an deposit event.
 module aptos_framework::primary_fungible_store {
     use aptos_framework::dispatchable_fungible_asset;
-    use aptos_framework::fungible_asset::{Self, FungibleAsset, FungibleStore, Metadata, MintRef, TransferRef, BurnRef};
+    use aptos_framework::fungible_asset::{
+        Self,
+        FungibleAsset,
+        FungibleStore,
+        Metadata,
+        MintRef,
+        TransferRef,
+        BurnRef
+    };
     use aptos_framework::object::{Self, Object, ConstructorRef, DeriveRef};
 
     use std::option::Option;
@@ -50,15 +58,17 @@ module aptos_framework::primary_fungible_store {
             project_uri,
         );
         let metadata_obj = &object::generate_signer(constructor_ref);
-        move_to(metadata_obj, DeriveRefPod {
-            metadata_derive_ref: object::generate_derive_ref(constructor_ref),
-        });
+        move_to(
+            metadata_obj,
+            DeriveRefPod {
+                metadata_derive_ref: object::generate_derive_ref(constructor_ref),
+            },
+        );
     }
 
     /// Ensure that the primary store object for the given address exists. If it doesn't, create it.
     public fun ensure_primary_store_exists<T: key>(
-        owner: address,
-        metadata: Object<T>,
+        owner: address, metadata: Object<T>,
     ): Object<FungibleStore> acquires DeriveRefPod {
         let store_addr = primary_store_address(owner, metadata);
         if (fungible_asset::store_exists(store_addr)) {
@@ -70,8 +80,7 @@ module aptos_framework::primary_fungible_store {
 
     /// Create a primary store object to hold fungible asset for the given address.
     public fun create_primary_store<T: key>(
-        owner_addr: address,
-        metadata: Object<T>,
+        owner_addr: address, metadata: Object<T>,
     ): Object<FungibleStore> acquires DeriveRefPod {
         let metadata_addr = object::object_address(&metadata);
         object::address_to_object<Metadata>(metadata_addr);
@@ -86,41 +95,52 @@ module aptos_framework::primary_fungible_store {
 
     #[view]
     /// Get the address of the primary store for the given account.
-    public fun primary_store_address<T: key>(owner: address, metadata: Object<T>): address {
+    public fun primary_store_address<T: key>(
+        owner: address, metadata: Object<T>
+    ): address {
         let metadata_addr = object::object_address(&metadata);
         object::create_user_derived_object_address(owner, metadata_addr)
     }
 
     #[view]
     /// Get the primary store object for the given account.
-    public fun primary_store<T: key>(owner: address, metadata: Object<T>): Object<FungibleStore> {
+    public fun primary_store<T: key>(owner: address, metadata: Object<T>)
+        : Object<FungibleStore> {
         let store = primary_store_address(owner, metadata);
         object::address_to_object<FungibleStore>(store)
     }
 
     #[view]
     /// Return whether the given account's primary store exists.
-    public fun primary_store_exists<T: key>(account: address, metadata: Object<T>): bool {
+    public fun primary_store_exists<T: key>(
+        account: address, metadata: Object<T>
+    ): bool {
         fungible_asset::store_exists(primary_store_address(account, metadata))
     }
 
     /// Get the address of the primary store for the given account.
     /// Use instead of the corresponding view functions for dispatchable hooks to avoid circular dependencies of modules.
-    public inline fun primary_store_address_inlined<T: key>(owner: address, metadata: Object<T>): address {
+    public inline fun primary_store_address_inlined<T: key>(
+        owner: address, metadata: Object<T>
+    ): address {
         let metadata_addr = object::object_address(&metadata);
         object::create_user_derived_object_address(owner, metadata_addr)
     }
 
     /// Get the primary store object for the given account.
     /// Use instead of the corresponding view functions for dispatchable hooks to avoid circular dependencies of modules.
-    public inline fun primary_store_inlined<T: key>(owner: address, metadata: Object<T>): Object<FungibleStore> {
+    public inline fun primary_store_inlined<T: key>(
+        owner: address, metadata: Object<T>
+    ): Object<FungibleStore> {
         let store = primary_store_address_inlined(owner, metadata);
         object::address_to_object(store)
     }
 
     /// Return whether the given account's primary store exists.
     /// Use instead of the corresponding view functions for dispatchable hooks to avoid circular dependencies of modules.
-    public inline fun primary_store_exists_inlined<T: key>(account: address, metadata: Object<T>): bool {
+    public inline fun primary_store_exists_inlined<T: key>(
+        account: address, metadata: Object<T>
+    ): bool {
         fungible_asset::store_exists(primary_store_address_inlined(account, metadata))
     }
 
@@ -129,13 +149,13 @@ module aptos_framework::primary_fungible_store {
     public fun balance<T: key>(account: address, metadata: Object<T>): u64 {
         if (primary_store_exists(account, metadata)) {
             fungible_asset::balance(primary_store(account, metadata))
-        } else {
-            0
-        }
+        } else { 0 }
     }
 
     #[view]
-    public fun is_balance_at_least<T: key>(account: address, metadata: Object<T>, amount: u64): bool {
+    public fun is_balance_at_least<T: key>(
+        account: address, metadata: Object<T>, amount: u64
+    ): bool {
         if (primary_store_exists(account, metadata)) {
             fungible_asset::is_balance_at_least(primary_store(account, metadata), amount)
         } else {
@@ -148,13 +168,13 @@ module aptos_framework::primary_fungible_store {
     public fun is_frozen<T: key>(account: address, metadata: Object<T>): bool {
         if (primary_store_exists(account, metadata)) {
             fungible_asset::is_frozen(primary_store(account, metadata))
-        } else {
-            false
-        }
+        } else { false }
     }
 
     /// Withdraw `amount` of fungible asset from the given account's primary store.
-    public fun withdraw<T: key>(owner: &signer, metadata: Object<T>, amount: u64): FungibleAsset acquires DeriveRefPod {
+    public fun withdraw<T: key>(
+        owner: &signer, metadata: Object<T>, amount: u64
+    ): FungibleAsset acquires DeriveRefPod {
         let store = ensure_primary_store_exists(signer::address_of(owner), metadata);
         // Check if the store object has been burnt or not. If so, unburn it first.
         may_be_unburn(owner, store);
@@ -182,11 +202,14 @@ module aptos_framework::primary_fungible_store {
         recipient: address,
         amount: u64,
     ) acquires DeriveRefPod {
-        let sender_store = ensure_primary_store_exists(signer::address_of(sender), metadata);
+        let sender_store =
+            ensure_primary_store_exists(signer::address_of(sender), metadata);
         // Check if the sender store object has been burnt or not. If so, unburn it first.
         may_be_unburn(sender, sender_store);
         let recipient_store = ensure_primary_store_exists(recipient, metadata);
-        dispatchable_fungible_asset::transfer(sender, sender_store, recipient_store, amount);
+        dispatchable_fungible_asset::transfer(
+            sender, sender_store, recipient_store, amount
+        );
     }
 
     /// Transfer `amount` of fungible asset from sender's primary store to receiver's primary store.
@@ -198,7 +221,8 @@ module aptos_framework::primary_fungible_store {
         amount: u64,
         expected: u64,
     ) acquires DeriveRefPod {
-        let sender_store = ensure_primary_store_exists(signer::address_of(sender), metadata);
+        let sender_store =
+            ensure_primary_store_exists(signer::address_of(sender), metadata);
         // Check if the sender store object has been burnt or not. If so, unburn it first.
         may_be_unburn(sender, sender_store);
         let recipient_store = ensure_primary_store_exists(recipient, metadata);
@@ -207,40 +231,55 @@ module aptos_framework::primary_fungible_store {
             sender_store,
             recipient_store,
             amount,
-            expected
+            expected,
         );
     }
 
     /// Mint to the primary store of `owner`.
     public fun mint(mint_ref: &MintRef, owner: address, amount: u64) acquires DeriveRefPod {
-        let primary_store = ensure_primary_store_exists(owner, fungible_asset::mint_ref_metadata(mint_ref));
+        let primary_store =
+            ensure_primary_store_exists(
+                owner, fungible_asset::mint_ref_metadata(mint_ref)
+            );
         fungible_asset::mint_to(mint_ref, primary_store, amount);
     }
 
     /// Burn from the primary store of `owner`.
     public fun burn(burn_ref: &BurnRef, owner: address, amount: u64) {
-        let primary_store = primary_store(owner, fungible_asset::burn_ref_metadata(burn_ref));
+        let primary_store =
+            primary_store(owner, fungible_asset::burn_ref_metadata(burn_ref));
         fungible_asset::burn_from(burn_ref, primary_store, amount);
     }
 
     /// Freeze/Unfreeze the primary store of `owner`.
-    public fun set_frozen_flag(transfer_ref: &TransferRef, owner: address, frozen: bool) acquires DeriveRefPod {
-        let primary_store = ensure_primary_store_exists(owner, fungible_asset::transfer_ref_metadata(transfer_ref));
+    public fun set_frozen_flag(
+        transfer_ref: &TransferRef, owner: address, frozen: bool
+    ) acquires DeriveRefPod {
+        let primary_store =
+            ensure_primary_store_exists(
+                owner, fungible_asset::transfer_ref_metadata(transfer_ref)
+            );
         fungible_asset::set_frozen_flag(transfer_ref, primary_store, frozen);
     }
 
     /// Withdraw from the primary store of `owner` ignoring frozen flag.
-    public fun withdraw_with_ref(transfer_ref: &TransferRef, owner: address, amount: u64): FungibleAsset {
-        let from_primary_store = primary_store(owner, fungible_asset::transfer_ref_metadata(transfer_ref));
+    public fun withdraw_with_ref(
+        transfer_ref: &TransferRef, owner: address, amount: u64
+    ): FungibleAsset {
+        let from_primary_store =
+            primary_store(owner, fungible_asset::transfer_ref_metadata(transfer_ref));
         fungible_asset::withdraw_with_ref(transfer_ref, from_primary_store, amount)
     }
 
     /// Deposit from the primary store of `owner` ignoring frozen flag.
-    public fun deposit_with_ref(transfer_ref: &TransferRef, owner: address, fa: FungibleAsset) acquires DeriveRefPod {
-        let from_primary_store = ensure_primary_store_exists(
-            owner,
-            fungible_asset::transfer_ref_metadata(transfer_ref)
-        );
+    public fun deposit_with_ref(
+        transfer_ref: &TransferRef, owner: address, fa: FungibleAsset
+    ) acquires DeriveRefPod {
+        let from_primary_store =
+            ensure_primary_store_exists(
+                owner,
+                fungible_asset::transfer_ref_metadata(transfer_ref),
+            );
         fungible_asset::deposit_with_ref(transfer_ref, from_primary_store, fa);
     }
 
@@ -251,9 +290,15 @@ module aptos_framework::primary_fungible_store {
         to: address,
         amount: u64
     ) acquires DeriveRefPod {
-        let from_primary_store = primary_store(from, fungible_asset::transfer_ref_metadata(transfer_ref));
-        let to_primary_store = ensure_primary_store_exists(to, fungible_asset::transfer_ref_metadata(transfer_ref));
-        fungible_asset::transfer_with_ref(transfer_ref, from_primary_store, to_primary_store, amount);
+        let from_primary_store =
+            primary_store(from, fungible_asset::transfer_ref_metadata(transfer_ref));
+        let to_primary_store =
+            ensure_primary_store_exists(
+                to, fungible_asset::transfer_ref_metadata(transfer_ref)
+            );
+        fungible_asset::transfer_with_ref(
+            transfer_ref, from_primary_store, to_primary_store, amount
+        );
     }
 
     fun may_be_unburn(owner: &signer, store: Object<FungibleStore>) {
@@ -313,11 +358,11 @@ module aptos_framework::primary_fungible_store {
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     fun test_basic_flow(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) acquires DeriveRefPod {
         let (creator_ref, metadata) = create_test_token(creator);
-        let (mint_ref, transfer_ref, burn_ref) = init_test_metadata_with_primary_store_enabled(&creator_ref);
+        let (mint_ref, transfer_ref, burn_ref) =
+            init_test_metadata_with_primary_store_enabled(&creator_ref);
         let creator_address = signer::address_of(creator);
         let aaron_address = signer::address_of(aaron);
         assert!(balance(creator_address, metadata) == 0, 1);
@@ -341,11 +386,11 @@ module aptos_framework::primary_fungible_store {
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     fun test_basic_flow_with_min_balance(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) acquires DeriveRefPod {
         let (creator_ref, metadata) = create_test_token(creator);
-        let (mint_ref, _transfer_ref, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
+        let (mint_ref, _transfer_ref, _) =
+            init_test_metadata_with_primary_store_enabled(&creator_ref);
         let creator_address = signer::address_of(creator);
         let aaron_address = signer::address_of(aaron);
         assert!(balance(creator_address, metadata) == 0, 1);
@@ -360,11 +405,11 @@ module aptos_framework::primary_fungible_store {
 
     #[test(user_1 = @0xcafe, user_2 = @0xface)]
     fun test_transfer_to_burnt_store(
-        user_1: &signer,
-        user_2: &signer,
+        user_1: &signer, user_2: &signer,
     ) acquires DeriveRefPod {
         let (creator_ref, metadata) = create_test_token(user_1);
-        let (mint_ref, _, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
+        let (mint_ref, _, _) =
+            init_test_metadata_with_primary_store_enabled(&creator_ref);
         let user_1_address = signer::address_of(user_1);
         let user_2_address = signer::address_of(user_2);
         mint(&mint_ref, user_1_address, 100);
@@ -384,11 +429,11 @@ module aptos_framework::primary_fungible_store {
 
     #[test(user_1 = @0xcafe, user_2 = @0xface)]
     fun test_withdraw_from_burnt_store(
-        user_1: &signer,
-        user_2: &signer,
+        user_1: &signer, user_2: &signer,
     ) acquires DeriveRefPod {
         let (creator_ref, metadata) = create_test_token(user_1);
-        let (mint_ref, _, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
+        let (mint_ref, _, _) =
+            init_test_metadata_with_primary_store_enabled(&creator_ref);
         let user_1_address = signer::address_of(user_1);
         let user_2_address = signer::address_of(user_2);
         mint(&mint_ref, user_1_address, 100);

--- a/aptos-move/framework/aptos-framework/sources/randomness.move
+++ b/aptos-move/framework/aptos-framework/sources/randomness.move
@@ -278,11 +278,11 @@ module aptos_framework::randomness {
         let sample = r1 % range;
         let i = 0;
         while ({
-                spec {
-                    invariant sample >= 0 && sample < max_excl - min_incl;
-                };
-                i < 256
-            }) {
+            spec {
+                invariant sample >= 0 && sample < max_excl - min_incl;
+            };
+            i < 256
+        }) {
             sample = safe_add_mod(sample, sample, range);
             i = i + 1;
         };
@@ -309,12 +309,12 @@ module aptos_framework::randomness {
         // Initialize into [0, 1, ..., n-1].
         let i = 0;
         while ({
-                spec {
-                    invariant i <= n;
-                    invariant len(values) == i;
-                };
-                i < n
-            }) {
+            spec {
+                invariant i <= n;
+                invariant len(values) == i;
+            };
+            i < n
+        }) {
             std::vector::push_back(&mut values, i);
             i = i + 1;
         };
@@ -325,11 +325,11 @@ module aptos_framework::randomness {
         // Shuffle.
         let tail = n - 1;
         while ({
-                spec {
-                    invariant tail >= 0 && tail < len(values);
-                };
-                tail > 0
-            }) {
+            spec {
+                invariant tail >= 0 && tail < len(values);
+            };
+            tail > 0
+        }) {
             let pop_position = u64_range_internal(0, tail + 1);
             spec {
                 assert pop_position < len(values);

--- a/aptos-move/framework/aptos-framework/sources/randomness.move
+++ b/aptos-move/framework/aptos-framework/sources/randomness.move
@@ -26,7 +26,8 @@ module aptos_framework::randomness {
     /// `#[randomness]` annotation. Otherwise, malicious users can bias randomness result.
     const E_API_USE_IS_BIASIBLE: u64 = 1;
 
-    const MAX_U256: u256 = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+    const MAX_U256: u256 =
+        115792089237316195423570985008687907853269984665640564039457584007913129639935;
 
     /// 32-byte randomness seed unique to every block.
     /// This resource is updated in every block prologue.
@@ -38,30 +39,30 @@ module aptos_framework::randomness {
 
     #[event]
     /// Event emitted every time a public randomness API in this module is called.
-    struct RandomnessGeneratedEvent has store, drop {
-    }
+    struct RandomnessGeneratedEvent has store, drop {}
 
     /// Called in genesis.move.
     /// Must be called in tests to initialize the `PerBlockRandomness` resource.
     public fun initialize(framework: &signer) {
         system_addresses::assert_aptos_framework(framework);
         if (!exists<PerBlockRandomness>(@aptos_framework)) {
-            move_to(framework, PerBlockRandomness {
-                epoch: 0,
-                round: 0,
-                seed: option::none(),
-            });
+            move_to(
+                framework,
+                PerBlockRandomness { epoch: 0, round: 0, seed: option::none(), },
+            );
         }
     }
 
     #[test_only]
-    public fun initialize_for_testing(framework: &signer) acquires  PerBlockRandomness {
+    public fun initialize_for_testing(framework: &signer) acquires PerBlockRandomness {
         initialize(framework);
         set_seed(x"0000000000000000000000000000000000000000000000000000000000000000");
     }
 
     /// Invoked in block prologues to update the block-level randomness seed.
-    public(friend) fun on_new_block(vm: &signer, epoch: u64, round: u64, seed_for_new_block: Option<vector<u8>>) acquires PerBlockRandomness {
+    public(friend) fun on_new_block(
+        vm: &signer, epoch: u64, round: u64, seed_for_new_block: Option<vector<u8>>
+    ) acquires PerBlockRandomness {
         system_addresses::assert_vm(vm);
         if (exists<PerBlockRandomness>(@aptos_framework)) {
             let randomness = borrow_global_mut<PerBlockRandomness>(@aptos_framework);
@@ -277,11 +278,11 @@ module aptos_framework::randomness {
         let sample = r1 % range;
         let i = 0;
         while ({
-            spec {
-                invariant sample >= 0 && sample < max_excl - min_incl;
-            };
-            i < 256
-        }) {
+                spec {
+                    invariant sample >= 0 && sample < max_excl - min_incl;
+                };
+                i < 256
+            }) {
             sample = safe_add_mod(sample, sample, range);
             i = i + 1;
         };
@@ -301,19 +302,19 @@ module aptos_framework::randomness {
     public fun permutation(n: u64): vector<u64> acquires PerBlockRandomness {
         let values = vector[];
 
-        if(n == 0) {
+        if (n == 0) {
             return vector[]
         };
 
         // Initialize into [0, 1, ..., n-1].
         let i = 0;
         while ({
-            spec {
-                invariant i <= n;
-                invariant len(values) == i;
-            };
-            i < n
-        }) {
+                spec {
+                    invariant i <= n;
+                    invariant len(values) == i;
+                };
+                i < n
+            }) {
             std::vector::push_back(&mut values, i);
             i = i + 1;
         };
@@ -324,11 +325,11 @@ module aptos_framework::randomness {
         // Shuffle.
         let tail = n - 1;
         while ({
-            spec {
-                invariant tail >= 0 && tail < len(values);
-            };
-            tail > 0
-        }) {
+                spec {
+                    invariant tail >= 0 && tail < len(values);
+                };
+                tail > 0
+            }) {
             let pop_position = u64_range_internal(0, tail + 1);
             spec {
                 assert pop_position < len(values);
@@ -352,9 +353,8 @@ module aptos_framework::randomness {
     /// Compute `(a + b) % m`, assuming `m >= 1, 0 <= a < m, 0<= b < m`.
     inline fun safe_add_mod(a: u256, b: u256, m: u256): u256 {
         let neg_b = m - b;
-        if (a < neg_b) {
-            a + b
-        } else {
+        if (a < neg_b) { a + b }
+        else {
             a - neg_b
         }
     }
@@ -362,9 +362,8 @@ module aptos_framework::randomness {
     #[verify_only]
     fun safe_add_mod_for_verification(a: u256, b: u256, m: u256): u256 {
         let neg_b = m - b;
-        if (a < neg_b) {
-            a + b
-        } else {
+        if (a < neg_b) { a + b }
+        else {
             a - neg_b
         }
     }
@@ -385,13 +384,69 @@ module aptos_framework::randomness {
         assert!(2 == safe_add_mod(4, 3, 5), 1);
         assert!(7 == safe_add_mod(3, 4, 9), 1);
         assert!(7 == safe_add_mod(4, 3, 9), 1);
-        assert!(0xfffffffffffffffffffffffffffffffffffffffffffffffe == safe_add_mod(0xfffffffffffffffffffffffffffffffffffffffffffffffd, 0x000000000000000000000000000000000000000000000001, 0xffffffffffffffffffffffffffffffffffffffffffffffff), 1);
-        assert!(0xfffffffffffffffffffffffffffffffffffffffffffffffe == safe_add_mod(0x000000000000000000000000000000000000000000000001, 0xfffffffffffffffffffffffffffffffffffffffffffffffd, 0xffffffffffffffffffffffffffffffffffffffffffffffff), 1);
-        assert!(0x000000000000000000000000000000000000000000000000 == safe_add_mod(0xfffffffffffffffffffffffffffffffffffffffffffffffd, 0x000000000000000000000000000000000000000000000002, 0xffffffffffffffffffffffffffffffffffffffffffffffff), 1);
-        assert!(0x000000000000000000000000000000000000000000000000 == safe_add_mod(0x000000000000000000000000000000000000000000000002, 0xfffffffffffffffffffffffffffffffffffffffffffffffd, 0xffffffffffffffffffffffffffffffffffffffffffffffff), 1);
-        assert!(0x000000000000000000000000000000000000000000000001 == safe_add_mod(0xfffffffffffffffffffffffffffffffffffffffffffffffd, 0x000000000000000000000000000000000000000000000003, 0xffffffffffffffffffffffffffffffffffffffffffffffff), 1);
-        assert!(0x000000000000000000000000000000000000000000000001 == safe_add_mod(0x000000000000000000000000000000000000000000000003, 0xfffffffffffffffffffffffffffffffffffffffffffffffd, 0xffffffffffffffffffffffffffffffffffffffffffffffff), 1);
-        assert!(0xfffffffffffffffffffffffffffffffffffffffffffffffd == safe_add_mod(0xfffffffffffffffffffffffffffffffffffffffffffffffe, 0xfffffffffffffffffffffffffffffffffffffffffffffffe, 0xffffffffffffffffffffffffffffffffffffffffffffffff), 1);
+        assert!(
+            0xfffffffffffffffffffffffffffffffffffffffffffffffe
+                == safe_add_mod(
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffd,
+                    0x000000000000000000000000000000000000000000000001,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffff,
+                ),
+            1,
+        );
+        assert!(
+            0xfffffffffffffffffffffffffffffffffffffffffffffffe
+                == safe_add_mod(
+                    0x000000000000000000000000000000000000000000000001,
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffd,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffff,
+                ),
+            1,
+        );
+        assert!(
+            0x000000000000000000000000000000000000000000000000
+                == safe_add_mod(
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffd,
+                    0x000000000000000000000000000000000000000000000002,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffff,
+                ),
+            1,
+        );
+        assert!(
+            0x000000000000000000000000000000000000000000000000
+                == safe_add_mod(
+                    0x000000000000000000000000000000000000000000000002,
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffd,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffff,
+                ),
+            1,
+        );
+        assert!(
+            0x000000000000000000000000000000000000000000000001
+                == safe_add_mod(
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffd,
+                    0x000000000000000000000000000000000000000000000003,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffff,
+                ),
+            1,
+        );
+        assert!(
+            0x000000000000000000000000000000000000000000000001
+                == safe_add_mod(
+                    0x000000000000000000000000000000000000000000000003,
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffd,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffff,
+                ),
+            1,
+        );
+        assert!(
+            0xfffffffffffffffffffffffffffffffffffffffffffffffd
+                == safe_add_mod(
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffe,
+                    0xfffffffffffffffffffffffffffffffffffffffffffffffe,
+                    0xffffffffffffffffffffffffffffffffffffffffffffffff,
+                ),
+            1,
+        );
     }
 
     #[test(fx = @aptos_framework)]
@@ -524,7 +579,7 @@ module aptos_framework::randomness {
 
         for (i in 0..n) {
             let bit = vector::borrow(&present, i);
-            if(*bit == false) {
+            if (*bit == false) {
                 return false
             };
         };
@@ -559,12 +614,12 @@ module aptos_framework::randomness {
         let permutations = table_with_length::new<vector<u64>, bool>();
 
         // This loop will not exit until all permutations are created
-        while(table_with_length::length(&permutations) < num_permutations) {
+        while (table_with_length::length(&permutations) < num_permutations) {
             let v = permutation(size);
             assert!(vector::length(&v) == size, 0);
             assert!(is_permutation(&v), 0);
 
-            if(table_with_length::contains(&permutations, v) == false) {
+            if (table_with_length::contains(&permutations, v) == false) {
                 table_with_length::add(&mut permutations, v, true);
             }
         };

--- a/aptos-move/framework/aptos-framework/sources/randomness.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/randomness.spec.move
@@ -3,7 +3,8 @@ spec aptos_framework::randomness {
     spec module {
         use aptos_framework::chain_status;
         pragma verify = true;
-        invariant [suspendable] chain_status::is_operating() ==> exists<PerBlockRandomness>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<PerBlockRandomness>(@aptos_framework);
         global var: vector<u8>;
     }
 
@@ -29,12 +30,17 @@ spec aptos_framework::randomness {
         aborts_if framework_addr != @aptos_framework;
     }
 
-    spec on_new_block(vm: &signer, epoch: u64, round: u64, seed_for_new_block: Option<vector<u8>>) {
+    spec on_new_block(
+        vm: &signer, epoch: u64, round: u64, seed_for_new_block: Option<vector<u8>>
+    ) {
         use std::signer;
         aborts_if signer::address_of(vm) != @vm;
-        ensures exists<PerBlockRandomness>(@aptos_framework) ==> global<PerBlockRandomness>(@aptos_framework).seed == seed_for_new_block;
-        ensures exists<PerBlockRandomness>(@aptos_framework) ==> global<PerBlockRandomness>(@aptos_framework).epoch == epoch;
-        ensures exists<PerBlockRandomness>(@aptos_framework) ==> global<PerBlockRandomness>(@aptos_framework).round == round;
+        ensures exists<PerBlockRandomness>(@aptos_framework) ==>
+            global<PerBlockRandomness>(@aptos_framework).seed == seed_for_new_block;
+        ensures exists<PerBlockRandomness>(@aptos_framework) ==>
+            global<PerBlockRandomness>(@aptos_framework).epoch == epoch;
+        ensures exists<PerBlockRandomness>(@aptos_framework) ==>
+            global<PerBlockRandomness>(@aptos_framework).round == round;
     }
 
     spec next_32_bytes(): vector<u8> {
@@ -46,7 +52,8 @@ spec aptos_framework::randomness {
         let txn_hash = transaction_context::spec_get_txn_hash();
         let txn_counter = spec_fetch_and_increment_txn_counter();
         ensures len(result) == 32;
-        ensures result == hash::sha3_256(concat(concat(concat(input, seed), txn_hash), txn_counter));
+        ensures result
+            == hash::sha3_256(concat(concat(concat(input, seed), txn_hash), txn_counter));
     }
 
     spec schema NextBlobAbortsIf {
@@ -105,7 +112,6 @@ spec aptos_framework::randomness {
         ensures result >= min_incl && result < max_excl;
     }
 
-
     spec u64_range(min_incl: u64, max_excl: u64): u64 {
         pragma verify_duration_estimate = 120;
         include NextBlobAbortsIf;
@@ -134,9 +140,8 @@ spec aptos_framework::randomness {
     }
 
     spec fun spec_safe_add_mod(a: u256, b: u256, m: u256): u256 {
-        if (a < m - b) {
-            a + b
-        } else {
+        if (a < m - b) { a + b }
+        else {
             a - (m - b)
         }
     }

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -71,14 +71,17 @@ module aptos_framework::reconfiguration {
         system_addresses::assert_aptos_framework(aptos_framework);
 
         // assert it matches `new_epoch_event_key()`, otherwise the event can't be recognized
-        assert!(account::get_guid_next_creation_num(signer::address_of(aptos_framework)) == 2, error::invalid_state(EINVALID_GUID_FOR_EVENT));
+        assert!(
+            account::get_guid_next_creation_num(signer::address_of(aptos_framework)) == 2,
+            error::invalid_state(EINVALID_GUID_FOR_EVENT),
+        );
         move_to<Configuration>(
             aptos_framework,
             Configuration {
                 epoch: 0,
                 last_reconfiguration_time: 0,
                 events: account::new_event_handle<NewEpochEvent>(aptos_framework),
-            }
+            },
         );
     }
 
@@ -96,7 +99,9 @@ module aptos_framework::reconfiguration {
         system_addresses::assert_aptos_framework(aptos_framework);
 
         assert!(!reconfiguration_enabled(), error::invalid_state(ECONFIGURATION));
-        DisableReconfiguration {} = move_from<DisableReconfiguration>(signer::address_of(aptos_framework));
+        DisableReconfiguration {} = move_from<DisableReconfiguration>(
+            signer::address_of(aptos_framework)
+        );
     }
 
     fun reconfiguration_enabled(): bool {
@@ -106,9 +111,9 @@ module aptos_framework::reconfiguration {
     /// Signal validators to start using new configuration. Must be called from friend config modules.
     public(friend) fun reconfigure() acquires Configuration {
         // Do not do anything if genesis has not finished.
-        if (chain_status::is_genesis() || timestamp::now_microseconds() == 0 || !reconfiguration_enabled()) {
-            return
-        };
+        if (chain_status::is_genesis()
+            || timestamp::now_microseconds() == 0
+            || !reconfiguration_enabled()) { return };
 
         let config_ref = borrow_global_mut<Configuration>(@aptos_framework);
         let current_time = timestamp::now_microseconds();
@@ -125,9 +130,7 @@ module aptos_framework::reconfiguration {
         // Thus, this check ensures that a transaction that does multiple "reconfiguration required" actions emits only
         // one reconfiguration event.
         //
-        if (current_time == config_ref.last_reconfiguration_time) {
-            return
-        };
+        if (current_time == config_ref.last_reconfiguration_time) { return };
 
         reconfiguration_state::on_reconfig_start();
 
@@ -149,7 +152,10 @@ module aptos_framework::reconfiguration {
         stake::on_new_epoch();
         storage_gas::on_reconfig();
 
-        assert!(current_time > config_ref.last_reconfiguration_time, error::invalid_state(EINVALID_BLOCK_TIME));
+        assert!(
+            current_time > config_ref.last_reconfiguration_time,
+            error::invalid_state(EINVALID_BLOCK_TIME),
+        );
         config_ref.last_reconfiguration_time = current_time;
         spec {
             assume config_ref.epoch + 1 <= MAX_U64;
@@ -158,16 +164,12 @@ module aptos_framework::reconfiguration {
 
         if (std::features::module_event_migration_enabled()) {
             event::emit(
-                NewEpoch {
-                    epoch: config_ref.epoch,
-                },
+                NewEpoch { epoch: config_ref.epoch, },
             );
         };
         event::emit_event<NewEpochEvent>(
             &mut config_ref.events,
-            NewEpochEvent {
-                epoch: config_ref.epoch,
-            },
+            NewEpochEvent { epoch: config_ref.epoch, },
         );
 
         reconfiguration_state::on_reconfig_finish();
@@ -185,21 +187,20 @@ module aptos_framework::reconfiguration {
     /// reconfiguration event.
     fun emit_genesis_reconfiguration_event() acquires Configuration {
         let config_ref = borrow_global_mut<Configuration>(@aptos_framework);
-        assert!(config_ref.epoch == 0 && config_ref.last_reconfiguration_time == 0, error::invalid_state(ECONFIGURATION));
+        assert!(
+            config_ref.epoch == 0 && config_ref.last_reconfiguration_time == 0,
+            error::invalid_state(ECONFIGURATION),
+        );
         config_ref.epoch = 1;
 
         if (std::features::module_event_migration_enabled()) {
             event::emit(
-                NewEpoch {
-                    epoch: config_ref.epoch,
-                },
+                NewEpoch { epoch: config_ref.epoch, },
             );
         };
         event::emit_event<NewEpochEvent>(
             &mut config_ref.events,
-            NewEpochEvent {
-                epoch: config_ref.epoch,
-            },
+            NewEpochEvent { epoch: config_ref.epoch, },
         );
     }
 
@@ -213,7 +214,7 @@ module aptos_framework::reconfiguration {
                 epoch: 0,
                 last_reconfiguration_time: 0,
                 events: account::new_event_handle<NewEpochEvent>(account),
-            }
+            },
         );
     }
 
@@ -228,9 +229,7 @@ module aptos_framework::reconfiguration {
     public fun reconfigure_for_test_custom() acquires Configuration {
         let config_ref = borrow_global_mut<Configuration>(@aptos_framework);
         let current_time = timestamp::now_microseconds();
-        if (current_time == config_ref.last_reconfiguration_time) {
-            return
-        };
+        if (current_time == config_ref.last_reconfiguration_time) { return };
         config_ref.last_reconfiguration_time = current_time;
         config_ref.epoch = config_ref.epoch + 1;
     }

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -163,9 +163,7 @@ module aptos_framework::reconfiguration {
         config_ref.epoch = config_ref.epoch + 1;
 
         if (std::features::module_event_migration_enabled()) {
-            event::emit(
-                NewEpoch { epoch: config_ref.epoch, },
-            );
+            event::emit(NewEpoch { epoch: config_ref.epoch, });
         };
         event::emit_event<NewEpochEvent>(
             &mut config_ref.events,
@@ -194,9 +192,7 @@ module aptos_framework::reconfiguration {
         config_ref.epoch = 1;
 
         if (std::features::module_event_migration_enabled()) {
-            event::emit(
-                NewEpoch { epoch: config_ref.epoch, },
-            );
+            event::emit(NewEpoch { epoch: config_ref.epoch, });
         };
         event::emit_event<NewEpochEvent>(
             &mut config_ref.events,

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.spec.move
@@ -47,7 +47,8 @@ spec aptos_framework::reconfiguration {
         pragma aborts_if_is_strict;
 
         // After genesis, `Configuration` exists.
-        invariant [suspendable] chain_status::is_operating() ==> exists<Configuration>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<Configuration>(@aptos_framework);
         invariant [suspendable] chain_status::is_operating() ==>
             (timestamp::spec_now_microseconds() >= last_reconfiguration_time());
     }
@@ -79,15 +80,13 @@ spec aptos_framework::reconfiguration {
         /// [high-level-req-1]
         ensures exists<Configuration>(@aptos_framework);
         ensures config.epoch == 0 && config.last_reconfiguration_time == 0;
-        ensures config.events == event::EventHandle<NewEpochEvent> {
-            counter: 0,
-            guid: guid::GUID {
-                id: guid::ID {
-                    creation_num: 2,
-                    addr: @aptos_framework
+        ensures config.events
+            == event::EventHandle<NewEpochEvent> {
+                counter: 0,
+                guid: guid::GUID {
+                    id: guid::ID { creation_num: 2, addr: @aptos_framework }
                 }
-            }
-        };
+            };
     }
 
     spec current_epoch(): u64 {
@@ -135,9 +134,15 @@ spec aptos_framework::reconfiguration {
         pragma verify_duration_estimate = 600;
         requires exists<stake::ValidatorFees>(@aptos_framework);
 
-        let success = !(chain_status::is_genesis() || timestamp::spec_now_microseconds() == 0 || !reconfiguration_enabled())
-            && timestamp::spec_now_microseconds() != global<Configuration>(@aptos_framework).last_reconfiguration_time;
-        include features::spec_periodical_reward_rate_decrease_enabled() ==> staking_config::StakingRewardsConfigEnabledRequirement;
+        let success = !(
+                chain_status::is_genesis()
+                || timestamp::spec_now_microseconds() == 0
+                || !reconfiguration_enabled()
+            )
+            && timestamp::spec_now_microseconds()
+                != global<Configuration>(@aptos_framework).last_reconfiguration_time;
+        include features::spec_periodical_reward_rate_decrease_enabled() ==>
+            staking_config::StakingRewardsConfigEnabledRequirement;
         include success ==> aptos_coin::ExistsAptosCoin;
         include transaction_fee::RequiresCollectedFeesPerValueLeqBlockAptosSupply;
         aborts_if false;
@@ -145,15 +150,21 @@ spec aptos_framework::reconfiguration {
         // but its existing ensure conditions satisfy hp.
         // The property below is not proved within 500s and still cause an timeout
         // property 3: Synchronization of NewEpochEvent counter with configuration epoch.
-        ensures success ==> global<Configuration>(@aptos_framework).epoch == old(global<Configuration>(@aptos_framework).epoch) + 1;
-        ensures success ==> global<Configuration>(@aptos_framework).last_reconfiguration_time == timestamp::spec_now_microseconds();
+        ensures success ==>
+            global<Configuration>(@aptos_framework).epoch
+                == old(global<Configuration>(@aptos_framework).epoch) + 1;
+        ensures success ==>
+            global<Configuration>(@aptos_framework).last_reconfiguration_time
+                == timestamp::spec_now_microseconds();
         // We remove the ensures of event increment due to inconsisency
         // TODO: property 4: Only performs reconfiguration if genesis has started and reconfiguration is enabled.
         // Also, the last reconfiguration must not be the current time, returning early without further actions otherwise.
         // property 5: Consecutive reconfigurations without the passage of time are not permitted.
         /// [high-level-req-4]
         /// [high-level-req-5]
-        ensures !success ==> global<Configuration>(@aptos_framework).epoch == old(global<Configuration>(@aptos_framework).epoch);
+        ensures !success ==>
+            global<Configuration>(@aptos_framework).epoch
+                == old(global<Configuration>(@aptos_framework).epoch);
     }
 
     spec reconfiguration_enabled {

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.spec.move
@@ -135,10 +135,10 @@ spec aptos_framework::reconfiguration {
         requires exists<stake::ValidatorFees>(@aptos_framework);
 
         let success = !(
-                chain_status::is_genesis()
+            chain_status::is_genesis()
                 || timestamp::spec_now_microseconds() == 0
                 || !reconfiguration_enabled()
-            )
+        )
             && timestamp::spec_now_microseconds()
                 != global<Configuration>(@aptos_framework).last_reconfiguration_time;
         include features::spec_periodical_reward_rate_decrease_enabled() ==>

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration_state.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration_state.move
@@ -39,9 +39,10 @@ module aptos_framework::reconfiguration_state {
     public fun initialize(fx: &signer) {
         system_addresses::assert_aptos_framework(fx);
         if (!exists<State>(@aptos_framework)) {
-            move_to(fx, State {
-                variant: copyable_any::pack(StateInactive {})
-            })
+            move_to(
+                fx,
+                State { variant: copyable_any::pack(StateInactive {}) },
+            )
         }
     }
 
@@ -67,11 +68,12 @@ module aptos_framework::reconfiguration_state {
     public(friend) fun on_reconfig_start() acquires State {
         if (exists<State>(@aptos_framework)) {
             let state = borrow_global_mut<State>(@aptos_framework);
-            let variant_type_name = *string::bytes(copyable_any::type_name(&state.variant));
+            let variant_type_name =
+                *string::bytes(copyable_any::type_name(&state.variant));
             if (variant_type_name == b"0x1::reconfiguration_state::StateInactive") {
-                state.variant = copyable_any::pack(StateActive {
-                    start_time_secs: timestamp::now_seconds()
-                });
+                state.variant = copyable_any::pack(
+                    StateActive { start_time_secs: timestamp::now_seconds() }
+                );
             }
         };
     }
@@ -94,7 +96,8 @@ module aptos_framework::reconfiguration_state {
     public(friend) fun on_reconfig_finish() acquires State {
         if (exists<State>(@aptos_framework)) {
             let state = borrow_global_mut<State>(@aptos_framework);
-            let variant_type_name = *string::bytes(copyable_any::type_name(&state.variant));
+            let variant_type_name =
+                *string::bytes(copyable_any::type_name(&state.variant));
             if (variant_type_name == b"0x1::reconfiguration_state::StateActive") {
                 state.variant = copyable_any::pack(StateInactive {});
             } else {

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration_state.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration_state.spec.move
@@ -2,7 +2,8 @@ spec aptos_framework::reconfiguration_state {
 
     spec module {
         use aptos_framework::chain_status;
-        invariant [suspendable] chain_status::is_operating() ==> exists<State>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<State>(@aptos_framework);
     }
 
     spec initialize(fx: &signer) {
@@ -11,7 +12,8 @@ spec aptos_framework::reconfiguration_state {
         aborts_if signer::address_of(fx) != @aptos_framework;
         let post post_state = global<State>(@aptos_framework);
         ensures exists<State>(@aptos_framework);
-        ensures !exists<State>(@aptos_framework) ==> from_bcs::deserializable<StateInactive>(post_state.variant.data);
+        ensures !exists<State>(@aptos_framework) ==>
+            from_bcs::deserializable<StateInactive>(post_state.variant.data);
     }
 
     spec initialize_for_testing(fx: &signer) {
@@ -24,25 +26,31 @@ spec aptos_framework::reconfiguration_state {
     }
 
     spec fun spec_is_in_progress(): bool {
-        if (!exists<State>(@aptos_framework)) {
-            false
-        } else {
-            copyable_any::type_name(global<State>(@aptos_framework).variant).bytes == b"0x1::reconfiguration_state::StateActive"
+        if (!exists<State>(@aptos_framework)) { false }
+        else {
+            copyable_any::type_name(global<State>(@aptos_framework).variant).bytes
+                == b"0x1::reconfiguration_state::StateActive"
         }
     }
 
     spec State {
         use aptos_std::from_bcs;
         use aptos_std::type_info;
-        invariant copyable_any::type_name(variant).bytes == b"0x1::reconfiguration_state::StateActive" ||
-            copyable_any::type_name(variant).bytes == b"0x1::reconfiguration_state::StateInactive";
-        invariant copyable_any::type_name(variant).bytes == b"0x1::reconfiguration_state::StateActive"
-            ==> from_bcs::deserializable<StateActive>(variant.data);
-        invariant copyable_any::type_name(variant).bytes == b"0x1::reconfiguration_state::StateInactive"
-            ==> from_bcs::deserializable<StateInactive>(variant.data);
-        invariant copyable_any::type_name(variant).bytes == b"0x1::reconfiguration_state::StateActive" ==>
+        invariant copyable_any::type_name(variant).bytes
+            == b"0x1::reconfiguration_state::StateActive"
+            || copyable_any::type_name(variant).bytes
+                == b"0x1::reconfiguration_state::StateInactive";
+        invariant copyable_any::type_name(variant).bytes
+            == b"0x1::reconfiguration_state::StateActive" ==>
+            from_bcs::deserializable<StateActive>(variant.data);
+        invariant copyable_any::type_name(variant).bytes
+            == b"0x1::reconfiguration_state::StateInactive" ==>
+            from_bcs::deserializable<StateInactive>(variant.data);
+        invariant copyable_any::type_name(variant).bytes
+            == b"0x1::reconfiguration_state::StateActive" ==>
             type_info::type_name<StateActive>() == variant.type_name;
-        invariant copyable_any::type_name(variant).bytes == b"0x1::reconfiguration_state::StateInactive" ==>
+        invariant copyable_any::type_name(variant).bytes
+            == b"0x1::reconfiguration_state::StateInactive" ==>
             type_info::type_name<StateInactive>() == variant.type_name;
     }
 
@@ -54,19 +62,31 @@ spec aptos_framework::reconfiguration_state {
         requires exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
         let state = Any {
             type_name: type_info::type_name<StateActive>(),
-            data: bcs::serialize(StateActive {
-                start_time_secs: timestamp::spec_now_seconds()
-            })
+            data: bcs::serialize(
+                StateActive { start_time_secs: timestamp::spec_now_seconds() }
+            )
         };
         let pre_state = global<State>(@aptos_framework);
         let post post_state = global<State>(@aptos_framework);
-        ensures (exists<State>(@aptos_framework) && copyable_any::type_name(pre_state.variant).bytes
-            == b"0x1::reconfiguration_state::StateInactive") ==> copyable_any::type_name(post_state.variant).bytes
-            == b"0x1::reconfiguration_state::StateActive";
-        ensures (exists<State>(@aptos_framework) && copyable_any::type_name(pre_state.variant).bytes
-            == b"0x1::reconfiguration_state::StateInactive") ==> post_state.variant == state;
-        ensures (exists<State>(@aptos_framework) && copyable_any::type_name(pre_state.variant).bytes
-            == b"0x1::reconfiguration_state::StateInactive") ==> from_bcs::deserializable<StateActive>(post_state.variant.data);
+        ensures (
+            exists<State>(@aptos_framework)
+                && copyable_any::type_name(pre_state.variant).bytes
+                    == b"0x1::reconfiguration_state::StateInactive"
+        ) ==>
+            copyable_any::type_name(post_state.variant).bytes
+                == b"0x1::reconfiguration_state::StateActive";
+        ensures (
+            exists<State>(@aptos_framework)
+                && copyable_any::type_name(pre_state.variant).bytes
+                    == b"0x1::reconfiguration_state::StateInactive"
+        ) ==>
+            post_state.variant == state;
+        ensures (
+            exists<State>(@aptos_framework)
+                && copyable_any::type_name(pre_state.variant).bytes
+                    == b"0x1::reconfiguration_state::StateInactive"
+        ) ==>
+            from_bcs::deserializable<StateActive>(post_state.variant.data);
     }
 
     spec start_time_secs(): u64 {
@@ -83,27 +103,25 @@ spec aptos_framework::reconfiguration_state {
         requires exists<State>(@aptos_framework);
         requires copyable_any::type_name(global<State>(@aptos_framework).variant).bytes
             == b"0x1::reconfiguration_state::StateActive";
-        include UnpackRequiresStateActive {
-            x:  global<State>(@aptos_framework).variant
-        };
+        include UnpackRequiresStateActive { x: global<State>(@aptos_framework).variant };
     }
 
     spec schema UnpackRequiresStateActive {
         use aptos_std::from_bcs;
         use aptos_std::type_info;
         x: Any;
-        requires type_info::type_name<StateActive>() == x.type_name && from_bcs::deserializable<StateActive>(x.data);
+        requires type_info::type_name<StateActive>() == x.type_name
+            && from_bcs::deserializable<StateActive>(x.data);
     }
 
     spec schema StartTimeSecsAbortsIf {
         aborts_if !exists<State>(@aptos_framework);
-        include  copyable_any::type_name(global<State>(@aptos_framework).variant).bytes
+        include copyable_any::type_name(global<State>(@aptos_framework).variant).bytes
             == b"0x1::reconfiguration_state::StateActive" ==>
-        copyable_any::UnpackAbortsIf<StateActive> {
-            x:  global<State>(@aptos_framework).variant
-        };
+            copyable_any::UnpackAbortsIf<StateActive> {
+                x: global<State>(@aptos_framework).variant
+            };
         aborts_if copyable_any::type_name(global<State>(@aptos_framework).variant).bytes
             != b"0x1::reconfiguration_state::StateActive";
     }
-
 }

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration_with_dkg.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration_with_dkg.spec.move
@@ -12,8 +12,8 @@ spec aptos_framework::reconfiguration_with_dkg {
         requires chain_status::is_operating();
         include stake::ResourceRequirement;
         include stake::GetReconfigStartTimeRequirement;
-        include features::spec_periodical_reward_rate_decrease_enabled(
-        ) ==> staking_config::StakingRewardsConfigEnabledRequirement;
+        include features::spec_periodical_reward_rate_decrease_enabled() ==>
+            staking_config::StakingRewardsConfigEnabledRequirement;
         aborts_if false;
         pragma verify_duration_estimate = 600; // TODO: set because of timeout (property proved).
     }
@@ -66,9 +66,7 @@ spec aptos_framework::reconfiguration_with_dkg {
     spec finish_with_dkg_result(account: &signer, dkg_result: vector<u8>) {
         use aptos_framework::dkg;
         pragma verify_duration_estimate = 1500;
-        include FinishRequirement {
-            framework: account
-        };
+        include FinishRequirement { framework: account };
         requires dkg::has_incomplete_session();
         aborts_if false;
     }

--- a/aptos-move/framework/aptos-framework/sources/resource_account.move
+++ b/aptos-move/framework/aptos-framework/sources/resource_account.move
@@ -88,7 +88,8 @@ module aptos_framework::resource_account {
         seed: vector<u8>,
         optional_auth_key: vector<u8>,
     ) acquires Container {
-        let (resource, resource_signer_cap) = account::create_resource_account(origin, seed);
+        let (resource, resource_signer_cap) =
+            account::create_resource_account(origin, seed);
         rotate_account_authentication_key_and_store_capability(
             origin,
             resource,
@@ -108,7 +109,8 @@ module aptos_framework::resource_account {
         optional_auth_key: vector<u8>,
         fund_amount: u64,
     ) acquires Container {
-        let (resource, resource_signer_cap) = account::create_resource_account(origin, seed);
+        let (resource, resource_signer_cap) =
+            account::create_resource_account(origin, seed);
         coin::register<AptosCoin>(&resource);
         coin::transfer<AptosCoin>(origin, signer::address_of(&resource), fund_amount);
         rotate_account_authentication_key_and_store_capability(
@@ -127,7 +129,8 @@ module aptos_framework::resource_account {
         metadata_serialized: vector<u8>,
         code: vector<vector<u8>>,
     ) acquires Container {
-        let (resource, resource_signer_cap) = account::create_resource_account(origin, seed);
+        let (resource, resource_signer_cap) =
+            account::create_resource_account(origin, seed);
         aptos_framework::code::publish_package_txn(&resource, metadata_serialized, code);
         rotate_account_authentication_key_and_store_capability(
             origin,
@@ -152,11 +155,12 @@ module aptos_framework::resource_account {
         let resource_addr = signer::address_of(&resource);
         simple_map::add(&mut container.store, resource_addr, resource_signer_cap);
 
-        let auth_key = if (vector::is_empty(&optional_auth_key)) {
-            account::get_authentication_key(origin_addr)
-        } else {
-            optional_auth_key
-        };
+        let auth_key =
+            if (vector::is_empty(&optional_auth_key)) {
+                account::get_authentication_key(origin_addr)
+            } else {
+                optional_auth_key
+            };
         account::rotate_authentication_key_internal(&resource, auth_key);
     }
 
@@ -164,19 +168,21 @@ module aptos_framework::resource_account {
     /// account and rotate the account's auth key to 0x0 making the account inaccessible without
     /// the SignerCapability.
     public fun retrieve_resource_account_cap(
-        resource: &signer,
-        source_addr: address,
+        resource: &signer, source_addr: address,
     ): account::SignerCapability acquires Container {
-        assert!(exists<Container>(source_addr), error::not_found(ECONTAINER_NOT_PUBLISHED));
+        assert!(
+            exists<Container>(source_addr), error::not_found(ECONTAINER_NOT_PUBLISHED)
+        );
 
         let resource_addr = signer::address_of(resource);
         let (resource_signer_cap, empty_container) = {
             let container = borrow_global_mut<Container>(source_addr);
             assert!(
                 simple_map::contains_key(&container.store, &resource_addr),
-                error::invalid_argument(EUNAUTHORIZED_NOT_OWNER)
+                error::invalid_argument(EUNAUTHORIZED_NOT_OWNER),
             );
-            let (_resource_addr, signer_cap) = simple_map::remove(&mut container.store, &resource_addr);
+            let (_resource_addr, signer_cap) =
+                simple_map::remove(&mut container.store, &resource_addr);
             (signer_cap, simple_map::length(&container.store) == 0)
         };
 
@@ -200,7 +206,8 @@ module aptos_framework::resource_account {
         create_resource_account(&user, copy seed, vector::empty());
         let container = borrow_global<Container>(user_addr);
 
-        let resource_addr = aptos_framework::account::create_resource_address(&user_addr, seed);
+        let resource_addr =
+            aptos_framework::account::create_resource_address(&user_addr, seed);
         let resource_cap = simple_map::borrow(&container.store, &resource_addr);
 
         let resource = account::create_signer_with_capability(resource_cap);
@@ -240,7 +247,8 @@ module aptos_framework::resource_account {
         let seed = x"01";
         create_resource_account_and_fund(&user, copy seed, vector::empty(), 10);
 
-        let resource_addr = aptos_framework::account::create_resource_address(&user_addr, seed);
+        let resource_addr =
+            aptos_framework::account::create_resource_address(&user_addr, seed);
         coin::transfer<AptosCoin>(&user, resource_addr, 10);
 
         coin::destroy_burn_cap(burn);
@@ -257,7 +265,8 @@ module aptos_framework::resource_account {
         let seed = x"01";
         create_resource_account(&user, copy seed, vector::empty());
 
-        let resource_addr = aptos_framework::account::create_resource_address(&user_addr, seed);
+        let resource_addr =
+            aptos_framework::account::create_resource_address(&user_addr, seed);
         let coin = coin::mint<AptosCoin>(100, &mint);
         coin::deposit(resource_addr, coin);
 

--- a/aptos-move/framework/aptos-framework/sources/resource_account.move
+++ b/aptos-move/framework/aptos-framework/sources/resource_account.move
@@ -171,7 +171,8 @@ module aptos_framework::resource_account {
         resource: &signer, source_addr: address,
     ): account::SignerCapability acquires Container {
         assert!(
-            exists<Container>(source_addr), error::not_found(ECONTAINER_NOT_PUBLISHED)
+            exists<Container>(source_addr),
+            error::not_found(ECONTAINER_NOT_PUBLISHED),
         );
 
         let resource_addr = signer::address_of(resource);

--- a/aptos-move/framework/aptos-framework/sources/resource_account.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/resource_account.spec.move
@@ -143,7 +143,7 @@ spec aptos_framework::resource_account {
         aborts_if get
             && !(
                 exists<Account>(resource_addr)
-                && len(global<Account>(source_addr).authentication_key) == 32
+                    && len(global<Account>(source_addr).authentication_key) == 32
             );
         aborts_if !get
             && !(exists<Account>(resource_addr)

--- a/aptos-move/framework/aptos-framework/sources/resource_account.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/resource_account.spec.move
@@ -64,9 +64,7 @@ spec aptos_framework::resource_account {
     }
 
     spec create_resource_account(
-        origin: &signer,
-        seed: vector<u8>,
-        optional_auth_key: vector<u8>,
+        origin: &signer, seed: vector<u8>, optional_auth_key: vector<u8>,
     ) {
         let source_addr = signer::address_of(origin);
         let resource_addr = account::spec_create_resource_address(source_addr, seed);
@@ -74,10 +72,7 @@ spec aptos_framework::resource_account {
     }
 
     spec create_resource_account_and_fund(
-        origin: &signer,
-        seed: vector<u8>,
-        optional_auth_key: vector<u8>,
-        fund_amount: u64,
+        origin: &signer, seed: vector<u8>, optional_auth_key: vector<u8>, fund_amount: u64,
     ) {
         use aptos_framework::aptos_account;
         // TODO(fa_migration)
@@ -86,12 +81,16 @@ spec aptos_framework::resource_account {
         let resource_addr = account::spec_create_resource_address(source_addr, seed);
         let coin_store_resource = global<coin::CoinStore<AptosCoin>>(resource_addr);
 
-        include aptos_account::WithdrawAbortsIf<AptosCoin>{from: origin, amount: fund_amount};
-        include aptos_account::GuidAbortsIf<AptosCoin>{to: resource_addr};
+        include aptos_account::WithdrawAbortsIf<AptosCoin> {
+            from: origin,
+            amount: fund_amount
+        };
+        include aptos_account::GuidAbortsIf<AptosCoin> { to: resource_addr };
         include RotateAccountAuthenticationKeyAndStoreCapabilityAbortsIfWithoutAccountLimit;
 
         //coin property
-        aborts_if coin::spec_is_account_registered<AptosCoin>(resource_addr) && coin_store_resource.frozen;
+        aborts_if coin::spec_is_account_registered<AptosCoin>(resource_addr)
+            && coin_store_resource.frozen;
         /// [high-level-req-3]
         ensures exists<aptos_framework::coin::CoinStore<AptosCoin>>(resource_addr);
     }
@@ -123,7 +122,8 @@ spec aptos_framework::resource_account {
         ensures exists<Container>(signer::address_of(origin));
         /// [high-level-req-5]
         ensures vector::length(optional_auth_key) != 0 ==>
-            global<aptos_framework::account::Account>(resource_addr).authentication_key == optional_auth_key;
+            global<aptos_framework::account::Account>(resource_addr).authentication_key
+                == optional_auth_key;
     }
 
     spec schema RotateAccountAuthenticationKeyAndStoreCapabilityAbortsIf {
@@ -138,11 +138,20 @@ spec aptos_framework::resource_account {
 
         aborts_if get && !exists<Account>(source_addr);
         /// [high-level-req-4]
-        aborts_if exists<Container>(source_addr) && simple_map::spec_contains_key(container.store, resource_addr);
-        aborts_if get && !(exists<Account>(resource_addr) && len(global<Account>(source_addr).authentication_key) == 32);
-        aborts_if !get && !(exists<Account>(resource_addr) && len(optional_auth_key) == 32);
+        aborts_if exists<Container>(source_addr)
+            && simple_map::spec_contains_key(container.store, resource_addr);
+        aborts_if get
+            && !(
+                exists<Account>(resource_addr)
+                && len(global<Account>(source_addr).authentication_key) == 32
+            );
+        aborts_if !get
+            && !(exists<Account>(resource_addr)
+                && len(optional_auth_key) == 32);
 
-        ensures simple_map::spec_contains_key(global<Container>(source_addr).store, resource_addr);
+        ensures simple_map::spec_contains_key(
+            global<Container>(source_addr).store, resource_addr
+        );
         ensures exists<Container>(source_addr);
     }
 
@@ -158,22 +167,25 @@ spec aptos_framework::resource_account {
         requires source_addr != resource_addr;
 
         aborts_if len(ZERO_AUTH_KEY) != 32;
-        include account::exists_at(resource_addr) ==> account::CreateResourceAccountAbortsIf;
-        include !account::exists_at(resource_addr) ==> account::CreateAccountAbortsIf {addr: resource_addr};
+        include account::exists_at(resource_addr) ==>
+            account::CreateResourceAccountAbortsIf;
+        include !account::exists_at(resource_addr) ==>
+            account::CreateAccountAbortsIf { addr: resource_addr };
 
         aborts_if get && !exists<account::Account>(source_addr);
-        aborts_if exists<Container>(source_addr) && simple_map::spec_contains_key(container.store, resource_addr);
-        aborts_if get && len(global<account::Account>(source_addr).authentication_key) != 32;
+        aborts_if exists<Container>(source_addr)
+            && simple_map::spec_contains_key(container.store, resource_addr);
+        aborts_if get && len(global<account::Account>(source_addr).authentication_key) !=
+            32;
         aborts_if !get && len(optional_auth_key) != 32;
 
-        ensures simple_map::spec_contains_key(global<Container>(source_addr).store, resource_addr);
+        ensures simple_map::spec_contains_key(
+            global<Container>(source_addr).store, resource_addr
+        );
         ensures exists<Container>(source_addr);
     }
 
-    spec retrieve_resource_account_cap(
-        resource: &signer,
-        source_addr: address,
-    ) : account::SignerCapability  {
+    spec retrieve_resource_account_cap(resource: &signer, source_addr: address,): account::SignerCapability {
         /// [high-level-req-6]
         aborts_if !exists<Container>(source_addr);
         let resource_addr = signer::address_of(resource);
@@ -183,8 +195,13 @@ spec aptos_framework::resource_account {
         aborts_if !simple_map::spec_contains_key(container.store, resource_addr);
         aborts_if !exists<account::Account>(resource_addr);
         /// [high-level-req-8]
-        ensures simple_map::spec_contains_key(old(global<Container>(source_addr)).store, resource_addr) &&
-            simple_map::spec_len(old(global<Container>(source_addr)).store) == 1 ==> !exists<Container>(source_addr);
-        ensures exists<Container>(source_addr) ==> !simple_map::spec_contains_key(global<Container>(source_addr).store, resource_addr);
+        ensures simple_map::spec_contains_key(
+            old(global<Container>(source_addr)).store, resource_addr
+        ) && simple_map::spec_len(old(global<Container>(source_addr)).store) == 1 ==>
+            !exists<Container>(source_addr);
+        ensures exists<Container>(source_addr) ==>
+            !simple_map::spec_contains_key(
+                global<Container>(source_addr).store, resource_addr
+            );
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -141,7 +141,8 @@ module aptos_framework::stake {
         add_stake_events: EventHandle<AddStakeEvent>,
         reactivate_stake_events: EventHandle<ReactivateStakeEvent>,
         rotate_consensus_key_events: EventHandle<RotateConsensusKeyEvent>,
-        update_network_and_fullnode_addresses_events: EventHandle<UpdateNetworkAndFullnodeAddressesEvent>,
+        update_network_and_fullnode_addresses_events: EventHandle<
+            UpdateNetworkAndFullnodeAddressesEvent>,
         increase_lockup_events: EventHandle<IncreaseLockupEvent>,
         join_validator_set_events: EventHandle<JoinValidatorSetEvent>,
         distribute_rewards_events: EventHandle<DistributeRewardsEvent>,
@@ -350,14 +351,17 @@ module aptos_framework::stake {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert!(
             !exists<ValidatorFees>(@aptos_framework),
-            error::already_exists(EFEES_TABLE_ALREADY_EXISTS)
+            error::already_exists(EFEES_TABLE_ALREADY_EXISTS),
         );
         move_to(aptos_framework, ValidatorFees { fees_table: table::new() });
     }
 
     /// Stores the transaction fee collected to the specified validator address.
-    public(friend) fun add_transaction_fee(validator_addr: address, fee: Coin<AptosCoin>) acquires ValidatorFees {
-        let fees_table = &mut borrow_global_mut<ValidatorFees>(@aptos_framework).fees_table;
+    public(friend) fun add_transaction_fee(
+        validator_addr: address, fee: Coin<AptosCoin>
+    ) acquires ValidatorFees {
+        let fees_table =
+            &mut borrow_global_mut<ValidatorFees>(@aptos_framework).fees_table;
         if (table::contains(fees_table, validator_addr)) {
             let collected_fee = table::borrow_mut(fees_table, validator_addr);
             coin::merge(collected_fee, fee);
@@ -380,9 +384,8 @@ module aptos_framework::stake {
     public fun get_remaining_lockup_secs(pool_address: address): u64 acquires StakePool {
         assert_stake_pool_exists(pool_address);
         let lockup_time = borrow_global<StakePool>(pool_address).locked_until_secs;
-        if (lockup_time <= timestamp::now_seconds()) {
-            0
-        } else {
+        if (lockup_time <= timestamp::now_seconds()) { 0 }
+        else {
             lockup_time - timestamp::now_seconds()
         }
     }
@@ -407,9 +410,13 @@ module aptos_framework::stake {
         let validator_set = borrow_global<ValidatorSet>(@aptos_framework);
         if (option::is_some(&find_validator(&validator_set.pending_active, pool_address))) {
             VALIDATOR_STATUS_PENDING_ACTIVE
-        } else if (option::is_some(&find_validator(&validator_set.active_validators, pool_address))) {
+        } else if (option::is_some(
+                &find_validator(&validator_set.active_validators, pool_address)
+            )) {
             VALIDATOR_STATUS_ACTIVE
-        } else if (option::is_some(&find_validator(&validator_set.pending_inactive, pool_address))) {
+        } else if (option::is_some(
+                &find_validator(&validator_set.pending_inactive, pool_address)
+            )) {
             VALIDATOR_STATUS_PENDING_INACTIVE
         } else {
             VALIDATOR_STATUS_INACTIVE
@@ -423,13 +430,14 @@ module aptos_framework::stake {
         assert_stake_pool_exists(pool_address);
         let validator_state = get_validator_state(pool_address);
         // Both active and pending inactive validators can still vote in the current epoch.
-        if (validator_state == VALIDATOR_STATUS_ACTIVE || validator_state == VALIDATOR_STATUS_PENDING_INACTIVE) {
-            let active_stake = coin::value(&borrow_global<StakePool>(pool_address).active);
-            let pending_inactive_stake = coin::value(&borrow_global<StakePool>(pool_address).pending_inactive);
+        if (validator_state == VALIDATOR_STATUS_ACTIVE
+                || validator_state == VALIDATOR_STATUS_PENDING_INACTIVE) {
+            let active_stake =
+                coin::value(&borrow_global<StakePool>(pool_address).active);
+            let pending_inactive_stake =
+                coin::value(&borrow_global<StakePool>(pool_address).pending_inactive);
             active_stake + pending_inactive_stake
-        } else {
-            0
-        }
+        } else { 0 }
     }
 
     #[view]
@@ -461,19 +469,27 @@ module aptos_framework::stake {
     #[view]
     /// Return the number of successful and failed proposals for the proposal at the given validator index.
     public fun get_current_epoch_proposal_counts(validator_index: u64): (u64, u64) acquires ValidatorPerformance {
-        let validator_performances = &borrow_global<ValidatorPerformance>(@aptos_framework).validators;
-        let validator_performance = vector::borrow(validator_performances, validator_index);
-        (validator_performance.successful_proposals, validator_performance.failed_proposals)
+        let validator_performances =
+            &borrow_global<ValidatorPerformance>(@aptos_framework).validators;
+        let validator_performance = vector::borrow(
+            validator_performances, validator_index
+        );
+        (
+            validator_performance.successful_proposals, validator_performance.failed_proposals
+        )
     }
 
     #[view]
     /// Return the validator's config.
-    public fun get_validator_config(
-        pool_address: address
-    ): (vector<u8>, vector<u8>, vector<u8>) acquires ValidatorConfig {
+    public fun get_validator_config(pool_address: address)
+        : (vector<u8>, vector<u8>, vector<u8>) acquires ValidatorConfig {
         assert_stake_pool_exists(pool_address);
         let validator_config = borrow_global<ValidatorConfig>(pool_address);
-        (validator_config.consensus_pubkey, validator_config.network_addresses, validator_config.fullnode_addresses)
+        (
+            validator_config.consensus_pubkey,
+            validator_config.network_addresses,
+            validator_config.fullnode_addresses
+        )
     }
 
     #[view]
@@ -485,31 +501,33 @@ module aptos_framework::stake {
     public(friend) fun initialize(aptos_framework: &signer) {
         system_addresses::assert_aptos_framework(aptos_framework);
 
-        move_to(aptos_framework, ValidatorSet {
-            consensus_scheme: 0,
-            active_validators: vector::empty(),
-            pending_active: vector::empty(),
-            pending_inactive: vector::empty(),
-            total_voting_power: 0,
-            total_joining_power: 0,
-        });
+        move_to(
+            aptos_framework,
+            ValidatorSet {
+                consensus_scheme: 0,
+                active_validators: vector::empty(),
+                pending_active: vector::empty(),
+                pending_inactive: vector::empty(),
+                total_voting_power: 0,
+                total_joining_power: 0,
+            },
+        );
 
-        move_to(aptos_framework, ValidatorPerformance {
-            validators: vector::empty(),
-        });
+        move_to(aptos_framework, ValidatorPerformance { validators: vector::empty(), });
     }
 
     /// This is only called during Genesis, which is where MintCapability<AptosCoin> can be created.
     /// Beyond genesis, no one can create AptosCoin mint/burn capabilities.
-    public(friend) fun store_aptos_coin_mint_cap(aptos_framework: &signer, mint_cap: MintCapability<AptosCoin>) {
+    public(friend) fun store_aptos_coin_mint_cap(
+        aptos_framework: &signer, mint_cap: MintCapability<AptosCoin>
+    ) {
         system_addresses::assert_aptos_framework(aptos_framework);
         move_to(aptos_framework, AptosCoinCapabilities { mint_cap })
     }
 
     /// Allow on chain governance to remove validators from the validator set.
     public fun remove_validators(
-        aptos_framework: &signer,
-        validators: &vector<address>,
+        aptos_framework: &signer, validators: &vector<address>,
     ) acquires ValidatorSet {
         assert_reconfig_not_in_progress();
         system_addresses::assert_aptos_framework(aptos_framework);
@@ -524,20 +542,23 @@ module aptos_framework::stake {
         let i = 0;
         // Remove each validator from the validator set.
         while ({
-            spec {
-                invariant i <= len_validators;
-                invariant spec_validators_are_initialized(active_validators);
-                invariant spec_validator_indices_are_valid(active_validators);
-                invariant spec_validators_are_initialized(pending_inactive);
-                invariant spec_validator_indices_are_valid(pending_inactive);
-                invariant ghost_active_num + ghost_pending_inactive_num == len(active_validators) + len(pending_inactive);
-            };
-            i < len_validators
-        }) {
+                spec {
+                    invariant i <= len_validators;
+                    invariant spec_validators_are_initialized(active_validators);
+                    invariant spec_validator_indices_are_valid(active_validators);
+                    invariant spec_validators_are_initialized(pending_inactive);
+                    invariant spec_validator_indices_are_valid(pending_inactive);
+                    invariant ghost_active_num + ghost_pending_inactive_num
+                        == len(active_validators) + len(pending_inactive);
+                };
+                i < len_validators
+            }) {
             let validator = *vector::borrow(validators, i);
             let validator_index = find_validator(active_validators, validator);
             if (option::is_some(&validator_index)) {
-                let validator_info = vector::swap_remove(active_validators, *option::borrow(&validator_index));
+                let validator_info = vector::swap_remove(
+                    active_validators, *option::borrow(&validator_index)
+                );
                 vector::push_back(pending_inactive, validator_info);
                 spec {
                     update ghost_active_num = ghost_active_num - 1;
@@ -559,12 +580,15 @@ module aptos_framework::stake {
         voter: address,
     ) acquires AllowedValidators, OwnerCapability, StakePool, ValidatorSet {
         initialize_owner(owner);
-        move_to(owner, ValidatorConfig {
-            consensus_pubkey: vector::empty(),
-            network_addresses: vector::empty(),
-            fullnode_addresses: vector::empty(),
-            validator_index: 0,
-        });
+        move_to(
+            owner,
+            ValidatorConfig {
+                consensus_pubkey: vector::empty(),
+                network_addresses: vector::empty(),
+                fullnode_addresses: vector::empty(),
+                validator_index: 0,
+            },
+        );
 
         if (initial_stake_amount > 0) {
             add_stake(owner, initial_stake_amount);
@@ -588,50 +612,73 @@ module aptos_framework::stake {
         fullnode_addresses: vector<u8>,
     ) acquires AllowedValidators {
         // Checks the public key has a valid proof-of-possession to prevent rogue-key attacks.
-        let pubkey_from_pop = &mut bls12381::public_key_from_bytes_with_pop(
-            consensus_pubkey,
-            &proof_of_possession_from_bytes(proof_of_possession)
+        let pubkey_from_pop =
+            &mut bls12381::public_key_from_bytes_with_pop(
+                consensus_pubkey,
+                &proof_of_possession_from_bytes(proof_of_possession),
+            );
+        assert!(
+            option::is_some(pubkey_from_pop), error::invalid_argument(EINVALID_PUBLIC_KEY)
         );
-        assert!(option::is_some(pubkey_from_pop), error::invalid_argument(EINVALID_PUBLIC_KEY));
 
         initialize_owner(account);
-        move_to(account, ValidatorConfig {
-            consensus_pubkey,
-            network_addresses,
-            fullnode_addresses,
-            validator_index: 0,
-        });
+        move_to(
+            account,
+            ValidatorConfig {
+                consensus_pubkey,
+                network_addresses,
+                fullnode_addresses,
+                validator_index: 0,
+            },
+        );
     }
 
     fun initialize_owner(owner: &signer) acquires AllowedValidators {
         let owner_address = signer::address_of(owner);
         assert!(is_allowed(owner_address), error::not_found(EINELIGIBLE_VALIDATOR));
-        assert!(!stake_pool_exists(owner_address), error::already_exists(EALREADY_REGISTERED));
+        assert!(
+            !stake_pool_exists(owner_address), error::already_exists(EALREADY_REGISTERED)
+        );
 
-        move_to(owner, StakePool {
-            active: coin::zero<AptosCoin>(),
-            pending_active: coin::zero<AptosCoin>(),
-            pending_inactive: coin::zero<AptosCoin>(),
-            inactive: coin::zero<AptosCoin>(),
-            locked_until_secs: 0,
-            operator_address: owner_address,
-            delegated_voter: owner_address,
-            // Events.
-            initialize_validator_events: account::new_event_handle<RegisterValidatorCandidateEvent>(owner),
-            set_operator_events: account::new_event_handle<SetOperatorEvent>(owner),
-            add_stake_events: account::new_event_handle<AddStakeEvent>(owner),
-            reactivate_stake_events: account::new_event_handle<ReactivateStakeEvent>(owner),
-            rotate_consensus_key_events: account::new_event_handle<RotateConsensusKeyEvent>(owner),
-            update_network_and_fullnode_addresses_events: account::new_event_handle<UpdateNetworkAndFullnodeAddressesEvent>(
-                owner
-            ),
-            increase_lockup_events: account::new_event_handle<IncreaseLockupEvent>(owner),
-            join_validator_set_events: account::new_event_handle<JoinValidatorSetEvent>(owner),
-            distribute_rewards_events: account::new_event_handle<DistributeRewardsEvent>(owner),
-            unlock_stake_events: account::new_event_handle<UnlockStakeEvent>(owner),
-            withdraw_stake_events: account::new_event_handle<WithdrawStakeEvent>(owner),
-            leave_validator_set_events: account::new_event_handle<LeaveValidatorSetEvent>(owner),
-        });
+        move_to(
+            owner,
+            StakePool {
+                active: coin::zero<AptosCoin>(),
+                pending_active: coin::zero<AptosCoin>(),
+                pending_inactive: coin::zero<AptosCoin>(),
+                inactive: coin::zero<AptosCoin>(),
+                locked_until_secs: 0,
+                operator_address: owner_address,
+                delegated_voter: owner_address,
+                // Events.
+                initialize_validator_events: account::new_event_handle<
+                    RegisterValidatorCandidateEvent>(owner),
+                set_operator_events: account::new_event_handle<SetOperatorEvent>(owner),
+                add_stake_events: account::new_event_handle<AddStakeEvent>(owner),
+                reactivate_stake_events: account::new_event_handle<ReactivateStakeEvent>(
+                    owner
+                ),
+                rotate_consensus_key_events: account::new_event_handle<
+                    RotateConsensusKeyEvent>(owner),
+                update_network_and_fullnode_addresses_events: account::new_event_handle<
+                    UpdateNetworkAndFullnodeAddressesEvent>(owner),
+                increase_lockup_events: account::new_event_handle<IncreaseLockupEvent>(
+                    owner
+                ),
+                join_validator_set_events: account::new_event_handle<JoinValidatorSetEvent>(
+                    owner
+                ),
+                distribute_rewards_events: account::new_event_handle<DistributeRewardsEvent>(
+                    owner
+                ),
+                unlock_stake_events: account::new_event_handle<UnlockStakeEvent>(owner),
+                withdraw_stake_events: account::new_event_handle<WithdrawStakeEvent>(
+                    owner
+                ),
+                leave_validator_set_events: account::new_event_handle<
+                    LeaveValidatorSetEvent>(owner),
+            },
+        );
 
         move_to(owner, OwnerCapability { pool_address: owner_address });
     }
@@ -645,8 +692,13 @@ module aptos_framework::stake {
 
     /// Deposit `owner_cap` into `account`. This requires `account` to not already have ownership of another
     /// staking pool.
-    public fun deposit_owner_cap(owner: &signer, owner_cap: OwnerCapability) {
-        assert!(!exists<OwnerCapability>(signer::address_of(owner)), error::not_found(EOWNER_CAP_ALREADY_EXISTS));
+    public fun deposit_owner_cap(
+        owner: &signer, owner_cap: OwnerCapability
+    ) {
+        assert!(
+            !exists<OwnerCapability>(signer::address_of(owner)),
+            error::not_found(EOWNER_CAP_ALREADY_EXISTS),
+        );
         move_to(owner, owner_cap);
     }
 
@@ -664,7 +716,9 @@ module aptos_framework::stake {
     }
 
     /// Allows an account with ownership capability to change the operator of the stake pool.
-    public fun set_operator_with_cap(owner_cap: &OwnerCapability, new_operator: address) acquires StakePool {
+    public fun set_operator_with_cap(
+        owner_cap: &OwnerCapability, new_operator: address
+    ) acquires StakePool {
         let pool_address = owner_cap.pool_address;
         assert_stake_pool_exists(pool_address);
         let stake_pool = borrow_global_mut<StakePool>(pool_address);
@@ -673,26 +727,20 @@ module aptos_framework::stake {
 
         if (std::features::module_event_migration_enabled()) {
             event::emit(
-                SetOperator {
-                    pool_address,
-                    old_operator,
-                    new_operator,
-                },
+                SetOperator { pool_address, old_operator, new_operator, },
             );
         };
 
         event::emit_event(
             &mut stake_pool.set_operator_events,
-            SetOperatorEvent {
-                pool_address,
-                old_operator,
-                new_operator,
-            },
+            SetOperatorEvent { pool_address, old_operator, new_operator, },
         );
     }
 
     /// Allows an owner to change the delegated voter of the stake pool.
-    public entry fun set_delegated_voter(owner: &signer, new_voter: address) acquires OwnerCapability, StakePool {
+    public entry fun set_delegated_voter(
+        owner: &signer, new_voter: address
+    ) acquires OwnerCapability, StakePool {
         let owner_address = signer::address_of(owner);
         assert_owner_cap_exists(owner_address);
         let ownership_cap = borrow_global<OwnerCapability>(owner_address);
@@ -700,7 +748,9 @@ module aptos_framework::stake {
     }
 
     /// Allows an owner to change the delegated voter of the stake pool.
-    public fun set_delegated_voter_with_cap(owner_cap: &OwnerCapability, new_voter: address) acquires StakePool {
+    public fun set_delegated_voter_with_cap(
+        owner_cap: &OwnerCapability, new_voter: address
+    ) acquires StakePool {
         let pool_address = owner_cap.pool_address;
         assert_stake_pool_exists(pool_address);
         let stake_pool = borrow_global_mut<StakePool>(pool_address);
@@ -716,7 +766,9 @@ module aptos_framework::stake {
     }
 
     /// Add `coins` into `pool_address`. this requires the corresponding `owner_cap` to be passed in.
-    public fun add_stake_with_cap(owner_cap: &OwnerCapability, coins: Coin<AptosCoin>) acquires StakePool, ValidatorSet {
+    public fun add_stake_with_cap(
+        owner_cap: &OwnerCapability, coins: Coin<AptosCoin>
+    ) acquires StakePool, ValidatorSet {
         assert_reconfig_not_in_progress();
         let pool_address = owner_cap.pool_address;
         assert_stake_pool_exists(pool_address);
@@ -732,8 +784,11 @@ module aptos_framework::stake {
         // Inactive validator's total stake will be tracked when they join the validator set.
         let validator_set = borrow_global_mut<ValidatorSet>(@aptos_framework);
         // Search directly rather using get_validator_state to save on unnecessary loops.
-        if (option::is_some(&find_validator(&validator_set.active_validators, pool_address)) ||
-            option::is_some(&find_validator(&validator_set.pending_active, pool_address))) {
+        if (option::is_some(
+                &find_validator(&validator_set.active_validators, pool_address)
+            ) || option::is_some(
+                &find_validator(&validator_set.pending_active, pool_address)
+            )) {
             update_voting_power_increase(amount);
         };
 
@@ -746,24 +801,21 @@ module aptos_framework::stake {
             coin::merge<AptosCoin>(&mut stake_pool.active, coins);
         };
 
-        let (_, maximum_stake) = staking_config::get_required_stake(&staking_config::get());
+        let (_, maximum_stake) =
+            staking_config::get_required_stake(&staking_config::get());
         let voting_power = get_next_epoch_voting_power(stake_pool);
-        assert!(voting_power <= maximum_stake, error::invalid_argument(ESTAKE_EXCEEDS_MAX));
+        assert!(
+            voting_power <= maximum_stake, error::invalid_argument(ESTAKE_EXCEEDS_MAX)
+        );
 
         if (std::features::module_event_migration_enabled()) {
             event::emit(
-                AddStake {
-                    pool_address,
-                    amount_added: amount,
-                },
+                AddStake { pool_address, amount_added: amount, },
             );
         };
         event::emit_event(
             &mut stake_pool.add_stake_events,
-            AddStakeEvent {
-                pool_address,
-                amount_added: amount,
-            },
+            AddStakeEvent { pool_address, amount_added: amount, },
         );
     }
 
@@ -776,7 +828,9 @@ module aptos_framework::stake {
         reactivate_stake_with_cap(ownership_cap, amount);
     }
 
-    public fun reactivate_stake_with_cap(owner_cap: &OwnerCapability, amount: u64) acquires StakePool {
+    public fun reactivate_stake_with_cap(
+        owner_cap: &OwnerCapability, amount: u64
+    ) acquires StakePool {
         assert_reconfig_not_in_progress();
         let pool_address = owner_cap.pool_address;
         assert_stake_pool_exists(pool_address);
@@ -794,18 +848,12 @@ module aptos_framework::stake {
 
         if (std::features::module_event_migration_enabled()) {
             event::emit(
-                ReactivateStake {
-                    pool_address,
-                    amount,
-                },
+                ReactivateStake { pool_address, amount, },
             );
         };
         event::emit_event(
             &mut stake_pool.reactivate_stake_events,
-            ReactivateStakeEvent {
-                pool_address,
-                amount,
-            },
+            ReactivateStakeEvent { pool_address, amount, },
         );
     }
 
@@ -820,17 +868,25 @@ module aptos_framework::stake {
         assert_stake_pool_exists(pool_address);
 
         let stake_pool = borrow_global_mut<StakePool>(pool_address);
-        assert!(signer::address_of(operator) == stake_pool.operator_address, error::unauthenticated(ENOT_OPERATOR));
+        assert!(
+            signer::address_of(operator) == stake_pool.operator_address,
+            error::unauthenticated(ENOT_OPERATOR),
+        );
 
-        assert!(exists<ValidatorConfig>(pool_address), error::not_found(EVALIDATOR_CONFIG));
+        assert!(
+            exists<ValidatorConfig>(pool_address), error::not_found(EVALIDATOR_CONFIG)
+        );
         let validator_info = borrow_global_mut<ValidatorConfig>(pool_address);
         let old_consensus_pubkey = validator_info.consensus_pubkey;
         // Checks the public key has a valid proof-of-possession to prevent rogue-key attacks.
-        let pubkey_from_pop = &mut bls12381::public_key_from_bytes_with_pop(
-            new_consensus_pubkey,
-            &proof_of_possession_from_bytes(proof_of_possession)
+        let pubkey_from_pop =
+            &mut bls12381::public_key_from_bytes_with_pop(
+                new_consensus_pubkey,
+                &proof_of_possession_from_bytes(proof_of_possession),
+            );
+        assert!(
+            option::is_some(pubkey_from_pop), error::invalid_argument(EINVALID_PUBLIC_KEY)
         );
-        assert!(option::is_some(pubkey_from_pop), error::invalid_argument(EINVALID_PUBLIC_KEY));
         validator_info.consensus_pubkey = new_consensus_pubkey;
 
         if (std::features::module_event_migration_enabled()) {
@@ -862,8 +918,13 @@ module aptos_framework::stake {
         assert_reconfig_not_in_progress();
         assert_stake_pool_exists(pool_address);
         let stake_pool = borrow_global_mut<StakePool>(pool_address);
-        assert!(signer::address_of(operator) == stake_pool.operator_address, error::unauthenticated(ENOT_OPERATOR));
-        assert!(exists<ValidatorConfig>(pool_address), error::not_found(EVALIDATOR_CONFIG));
+        assert!(
+            signer::address_of(operator) == stake_pool.operator_address,
+            error::unauthenticated(ENOT_OPERATOR),
+        );
+        assert!(
+            exists<ValidatorConfig>(pool_address), error::not_found(EVALIDATOR_CONFIG)
+        );
         let validator_info = borrow_global_mut<ValidatorConfig>(pool_address);
         let old_network_addresses = validator_info.network_addresses;
         validator_info.network_addresses = new_network_addresses;
@@ -911,8 +972,13 @@ module aptos_framework::stake {
 
         let stake_pool = borrow_global_mut<StakePool>(pool_address);
         let old_locked_until_secs = stake_pool.locked_until_secs;
-        let new_locked_until_secs = timestamp::now_seconds() + staking_config::get_recurring_lockup_duration(&config);
-        assert!(old_locked_until_secs < new_locked_until_secs, error::invalid_argument(EINVALID_LOCKUP));
+        let new_locked_until_secs =
+            timestamp::now_seconds()
+                + staking_config::get_recurring_lockup_duration(&config);
+        assert!(
+            old_locked_until_secs < new_locked_until_secs,
+            error::invalid_argument(EINVALID_LOCKUP),
+        );
         stake_pool.locked_until_secs = new_locked_until_secs;
 
         if (std::features::module_event_migration_enabled()) {
@@ -936,8 +1002,7 @@ module aptos_framework::stake {
 
     /// This can only called by the operator of the validator/staking pool.
     public entry fun join_validator_set(
-        operator: &signer,
-        pool_address: address
+        operator: &signer, pool_address: address
     ) acquires StakePool, ValidatorConfig, ValidatorSet {
         assert!(
             staking_config::get_allow_validator_set_change(&staking_config::get()),
@@ -954,13 +1019,15 @@ module aptos_framework::stake {
     ///
     /// This internal version can only be called by the Genesis module during Genesis.
     public(friend) fun join_validator_set_internal(
-        operator: &signer,
-        pool_address: address
+        operator: &signer, pool_address: address
     ) acquires StakePool, ValidatorConfig, ValidatorSet {
         assert_reconfig_not_in_progress();
         assert_stake_pool_exists(pool_address);
         let stake_pool = borrow_global_mut<StakePool>(pool_address);
-        assert!(signer::address_of(operator) == stake_pool.operator_address, error::unauthenticated(ENOT_OPERATOR));
+        assert!(
+            signer::address_of(operator) == stake_pool.operator_address,
+            error::unauthenticated(ENOT_OPERATOR),
+        );
         assert!(
             get_validator_state(pool_address) == VALIDATOR_STATUS_INACTIVE,
             error::invalid_state(EALREADY_ACTIVE_VALIDATOR),
@@ -977,18 +1044,23 @@ module aptos_framework::stake {
 
         // Add validator to pending_active, to be activated in the next epoch.
         let validator_config = borrow_global_mut<ValidatorConfig>(pool_address);
-        assert!(!vector::is_empty(&validator_config.consensus_pubkey), error::invalid_argument(EINVALID_PUBLIC_KEY));
+        assert!(
+            !vector::is_empty(&validator_config.consensus_pubkey),
+            error::invalid_argument(EINVALID_PUBLIC_KEY),
+        );
 
         // Validate the current validator set size has not exceeded the limit.
         let validator_set = borrow_global_mut<ValidatorSet>(@aptos_framework);
         vector::push_back(
             &mut validator_set.pending_active,
-            generate_validator_info(pool_address, stake_pool, *validator_config)
+            generate_validator_info(pool_address, stake_pool, *validator_config),
         );
-        let validator_set_size = vector::length(&validator_set.active_validators) + vector::length(
-            &validator_set.pending_active
+        let validator_set_size = vector::length(&validator_set.active_validators)
+            + vector::length(&validator_set.pending_active);
+        assert!(
+            validator_set_size <= MAX_VALIDATOR_SET_SIZE,
+            error::invalid_argument(EVALIDATOR_SET_TOO_LARGE),
         );
-        assert!(validator_set_size <= MAX_VALIDATOR_SET_SIZE, error::invalid_argument(EVALIDATOR_SET_TOO_LARGE));
 
         if (std::features::module_event_migration_enabled()) {
             event::emit(JoinValidatorSet { pool_address });
@@ -1012,9 +1084,7 @@ module aptos_framework::stake {
     public fun unlock_with_cap(amount: u64, owner_cap: &OwnerCapability) acquires StakePool {
         assert_reconfig_not_in_progress();
         // Short-circuit if amount to unlock is 0 so we don't emit events.
-        if (amount == 0) {
-            return
-        };
+        if (amount == 0) { return };
 
         // Unlocked coins are moved to pending_inactive. When the current lockup cycle expires, they will be moved into
         // inactive in the earliest possible epoch transition.
@@ -1028,25 +1098,18 @@ module aptos_framework::stake {
 
         if (std::features::module_event_migration_enabled()) {
             event::emit(
-                UnlockStake {
-                    pool_address,
-                    amount_unlocked: amount,
-                },
+                UnlockStake { pool_address, amount_unlocked: amount, },
             );
         };
         event::emit_event(
             &mut stake_pool.unlock_stake_events,
-            UnlockStakeEvent {
-                pool_address,
-                amount_unlocked: amount,
-            },
+            UnlockStakeEvent { pool_address, amount_unlocked: amount, },
         );
     }
 
     /// Withdraw from `account`'s inactive stake.
     public entry fun withdraw(
-        owner: &signer,
-        withdraw_amount: u64
+        owner: &signer, withdraw_amount: u64
     ) acquires OwnerCapability, StakePool, ValidatorSet {
         let owner_address = signer::address_of(owner);
         assert_owner_cap_exists(owner_address);
@@ -1057,8 +1120,7 @@ module aptos_framework::stake {
 
     /// Withdraw from `pool_address`'s inactive stake with the corresponding `owner_cap`.
     public fun withdraw_with_cap(
-        owner_cap: &OwnerCapability,
-        withdraw_amount: u64
+        owner_cap: &OwnerCapability, withdraw_amount: u64
     ): Coin<AptosCoin> acquires StakePool, ValidatorSet {
         assert_reconfig_not_in_progress();
         let pool_address = owner_cap.pool_address;
@@ -1067,9 +1129,10 @@ module aptos_framework::stake {
         // There's an edge case where a validator unlocks their stake and leaves the validator set before
         // the stake is fully unlocked (the current lockup cycle has not expired yet).
         // This can leave their stake stuck in pending_inactive even after the current lockup cycle expires.
-        if (get_validator_state(pool_address) == VALIDATOR_STATUS_INACTIVE &&
-            timestamp::now_seconds() >= stake_pool.locked_until_secs) {
-            let pending_inactive_stake = coin::extract_all(&mut stake_pool.pending_inactive);
+        if (get_validator_state(pool_address) == VALIDATOR_STATUS_INACTIVE
+                && timestamp::now_seconds() >= stake_pool.locked_until_secs) {
+            let pending_inactive_stake =
+                coin::extract_all(&mut stake_pool.pending_inactive);
             coin::merge(&mut stake_pool.inactive, pending_inactive_stake);
         };
 
@@ -1079,18 +1142,12 @@ module aptos_framework::stake {
 
         if (std::features::module_event_migration_enabled()) {
             event::emit(
-                WithdrawStake {
-                    pool_address,
-                    amount_withdrawn: withdraw_amount,
-                },
+                WithdrawStake { pool_address, amount_withdrawn: withdraw_amount, },
             );
         };
         event::emit_event(
             &mut stake_pool.withdraw_stake_events,
-            WithdrawStakeEvent {
-                pool_address,
-                amount_withdrawn: withdraw_amount,
-            },
+            WithdrawStakeEvent { pool_address, amount_withdrawn: withdraw_amount, },
         );
 
         coin::extract(&mut stake_pool.inactive, withdraw_amount)
@@ -1103,8 +1160,7 @@ module aptos_framework::stake {
     ///
     /// Can only be called by the operator of the validator/staking pool.
     public entry fun leave_validator_set(
-        operator: &signer,
-        pool_address: address
+        operator: &signer, pool_address: address
     ) acquires StakePool, ValidatorSet {
         assert_reconfig_not_in_progress();
         let config = staking_config::get();
@@ -1116,14 +1172,20 @@ module aptos_framework::stake {
         assert_stake_pool_exists(pool_address);
         let stake_pool = borrow_global_mut<StakePool>(pool_address);
         // Account has to be the operator.
-        assert!(signer::address_of(operator) == stake_pool.operator_address, error::unauthenticated(ENOT_OPERATOR));
+        assert!(
+            signer::address_of(operator) == stake_pool.operator_address,
+            error::unauthenticated(ENOT_OPERATOR),
+        );
 
         let validator_set = borrow_global_mut<ValidatorSet>(@aptos_framework);
         // If the validator is still pending_active, directly kick the validator out.
-        let maybe_pending_active_index = find_validator(&validator_set.pending_active, pool_address);
+        let maybe_pending_active_index =
+            find_validator(&validator_set.pending_active, pool_address);
         if (option::is_some(&maybe_pending_active_index)) {
             vector::swap_remove(
-                &mut validator_set.pending_active, option::extract(&mut maybe_pending_active_index));
+                &mut validator_set.pending_active,
+                option::extract(&mut maybe_pending_active_index),
+            );
 
             // Decrease the voting power increase as the pending validator's voting power was added when they requested
             // to join. Now that they changed their mind, their voting power should not affect the joining limit of this
@@ -1133,17 +1195,26 @@ module aptos_framework::stake {
             // rounding error somewhere that can lead to an underflow, we still want to allow this transaction to
             // succeed.
             if (validator_set.total_joining_power > validator_stake) {
-                validator_set.total_joining_power = validator_set.total_joining_power - validator_stake;
+                validator_set.total_joining_power = validator_set.total_joining_power
+                    - validator_stake;
             } else {
                 validator_set.total_joining_power = 0;
             };
         } else {
             // Validate that the validator is already part of the validator set.
-            let maybe_active_index = find_validator(&validator_set.active_validators, pool_address);
-            assert!(option::is_some(&maybe_active_index), error::invalid_state(ENOT_VALIDATOR));
+            let maybe_active_index =
+                find_validator(&validator_set.active_validators, pool_address);
+            assert!(
+                option::is_some(&maybe_active_index), error::invalid_state(ENOT_VALIDATOR)
+            );
             let validator_info = vector::swap_remove(
-                &mut validator_set.active_validators, option::extract(&mut maybe_active_index));
-            assert!(vector::length(&validator_set.active_validators) > 0, error::invalid_state(ELAST_VALIDATOR));
+                &mut validator_set.active_validators,
+                option::extract(&mut maybe_active_index),
+            );
+            assert!(
+                vector::length(&validator_set.active_validators) > 0,
+                error::invalid_state(ELAST_VALIDATOR),
+            );
             vector::push_back(&mut validator_set.pending_inactive, validator_info);
 
             if (std::features::module_event_migration_enabled()) {
@@ -1151,9 +1222,7 @@ module aptos_framework::stake {
             };
             event::emit_event(
                 &mut stake_pool.leave_validator_set_events,
-                LeaveValidatorSetEvent {
-                    pool_address,
-                },
+                LeaveValidatorSetEvent { pool_address, },
             );
         };
     }
@@ -1164,14 +1233,14 @@ module aptos_framework::stake {
     public fun is_current_epoch_validator(pool_address: address): bool acquires ValidatorSet {
         assert_stake_pool_exists(pool_address);
         let validator_state = get_validator_state(pool_address);
-        validator_state == VALIDATOR_STATUS_ACTIVE || validator_state == VALIDATOR_STATUS_PENDING_INACTIVE
+        validator_state == VALIDATOR_STATUS_ACTIVE
+            || validator_state == VALIDATOR_STATUS_PENDING_INACTIVE
     }
 
     /// Update the validator performance (proposal statistics). This is only called by block::prologue().
     /// This function cannot abort.
     public(friend) fun update_performance_statistics(
-        proposer_index: Option<u64>,
-        failed_proposer_indices: vector<u64>
+        proposer_index: Option<u64>, failed_proposer_indices: vector<u64>
     ) acquires ValidatorPerformance {
         // Validator set cannot change until the end of the epoch, so the validator index in arguments should
         // match with those of the validators in ValidatorPerformance resource.
@@ -1188,7 +1257,9 @@ module aptos_framework::stake {
             // Here, and in all other vector::borrow, skip any validator indices that are out of bounds,
             // this ensures that this function doesn't abort if there are out of bounds errors.
             if (cur_proposer_index < validator_len) {
-                let validator = vector::borrow_mut(&mut validator_perf.validators, cur_proposer_index);
+                let validator = vector::borrow_mut(
+                    &mut validator_perf.validators, cur_proposer_index
+                );
                 spec {
                     assume validator.successful_proposals + 1 <= MAX_U64;
                 };
@@ -1199,19 +1270,28 @@ module aptos_framework::stake {
         let f = 0;
         let f_len = vector::length(&failed_proposer_indices);
         while ({
-            spec {
-                invariant len(validator_perf.validators) == validator_len;
-                invariant (option::spec_is_some(ghost_proposer_idx) && option::spec_borrow(
-                    ghost_proposer_idx
-                ) < validator_len) ==>
-                    (validator_perf.validators[option::spec_borrow(ghost_proposer_idx)].successful_proposals ==
-                        ghost_valid_perf.validators[option::spec_borrow(ghost_proposer_idx)].successful_proposals + 1);
-            };
-            f < f_len
-        }) {
+                spec {
+                    invariant len(validator_perf.validators) == validator_len;
+                    invariant (
+                        option::spec_is_some(ghost_proposer_idx)
+                            && option::spec_borrow(ghost_proposer_idx) < validator_len
+                    ) ==>
+                        (
+                            validator_perf.validators[option::spec_borrow(
+                                    ghost_proposer_idx
+                                )].successful_proposals
+                                == ghost_valid_perf.validators[option::spec_borrow(
+                                        ghost_proposer_idx
+                                    )].successful_proposals + 1
+                        );
+                };
+                f < f_len
+            }) {
             let validator_index = *vector::borrow(&failed_proposer_indices, f);
             if (validator_index < validator_len) {
-                let validator = vector::borrow_mut(&mut validator_perf.validators, validator_index);
+                let validator = vector::borrow_mut(
+                    &mut validator_perf.validators, validator_index
+                );
                 spec {
                     assume validator.failed_proposals + 1 <= MAX_U64;
                 };
@@ -1231,24 +1311,29 @@ module aptos_framework::stake {
     /// pending inactive validators so they no longer can vote.
     /// 4. The validator's voting power in the validator set is updated to be the corresponding staking pool's voting
     /// power.
-    public(friend) fun on_new_epoch(
-    ) acquires StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
+    public(friend) fun on_new_epoch() acquires StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         let validator_set = borrow_global_mut<ValidatorSet>(@aptos_framework);
         let config = staking_config::get();
         let validator_perf = borrow_global_mut<ValidatorPerformance>(@aptos_framework);
 
         // Process pending stake and distribute transaction fees and rewards for each currently active validator.
-        vector::for_each_ref(&validator_set.active_validators, |validator| {
-            let validator: &ValidatorInfo = validator;
-            update_stake_pool(validator_perf, validator.addr, &config);
-        });
+        vector::for_each_ref(
+            &validator_set.active_validators,
+            |validator| {
+                let validator: &ValidatorInfo = validator;
+                update_stake_pool(validator_perf, validator.addr, &config);
+            },
+        );
 
         // Process pending stake and distribute transaction fees and rewards for each currently pending_inactive validator
         // (requested to leave but not removed yet).
-        vector::for_each_ref(&validator_set.pending_inactive, |validator| {
-            let validator: &ValidatorInfo = validator;
-            update_stake_pool(validator_perf, validator.addr, &config);
-        });
+        vector::for_each_ref(
+            &validator_set.pending_inactive,
+            |validator| {
+                let validator: &ValidatorInfo = validator;
+                update_stake_pool(validator_perf, validator.addr, &config);
+            },
+        );
 
         // Activate currently pending_active validators.
         append(&mut validator_set.active_validators, &mut validator_set.pending_active);
@@ -1265,24 +1350,28 @@ module aptos_framework::stake {
         let total_voting_power = 0;
         let i = 0;
         while ({
-            spec {
-                invariant spec_validators_are_initialized(next_epoch_validators);
-                invariant i <= vlen;
-            };
-            i < vlen
-        }) {
-            let old_validator_info = vector::borrow_mut(&mut validator_set.active_validators, i);
+                spec {
+                    invariant spec_validators_are_initialized(next_epoch_validators);
+                    invariant i <= vlen;
+                };
+                i < vlen
+            }) {
+            let old_validator_info = vector::borrow_mut(
+                &mut validator_set.active_validators, i
+            );
             let pool_address = old_validator_info.addr;
             let validator_config = borrow_global_mut<ValidatorConfig>(pool_address);
             let stake_pool = borrow_global_mut<StakePool>(pool_address);
-            let new_validator_info = generate_validator_info(pool_address, stake_pool, *validator_config);
+            let new_validator_info =
+                generate_validator_info(pool_address, stake_pool, *validator_config);
 
             // A validator needs at least the min stake required to join the validator set.
             if (new_validator_info.voting_power >= minimum_stake) {
                 spec {
                     assume total_voting_power + new_validator_info.voting_power <= MAX_U128;
                 };
-                total_voting_power = total_voting_power + (new_validator_info.voting_power as u128);
+                total_voting_power = total_voting_power
+                    + (new_validator_info.voting_power as u128);
                 vector::push_back(&mut next_epoch_validators, new_validator_info);
             };
             i = i + 1;
@@ -1294,43 +1383,54 @@ module aptos_framework::stake {
 
         // Update validator indices, reset performance scores, and renew lockups.
         validator_perf.validators = vector::empty();
-        let recurring_lockup_duration_secs = staking_config::get_recurring_lockup_duration(&config);
+        let recurring_lockup_duration_secs =
+            staking_config::get_recurring_lockup_duration(&config);
         let vlen = vector::length(&validator_set.active_validators);
         let validator_index = 0;
         while ({
-            spec {
-                invariant spec_validators_are_initialized(validator_set.active_validators);
-                invariant len(validator_set.pending_active) == 0;
-                invariant len(validator_set.pending_inactive) == 0;
-                invariant 0 <= validator_index && validator_index <= vlen;
-                invariant vlen == len(validator_set.active_validators);
-                invariant forall i in 0..validator_index:
-                    global<ValidatorConfig>(validator_set.active_validators[i].addr).validator_index < validator_index;
-                invariant forall i in 0..validator_index:
-                    validator_set.active_validators[i].config.validator_index < validator_index;
-                invariant len(validator_perf.validators) == validator_index;
-            };
-            validator_index < vlen
-        }) {
-            let validator_info = vector::borrow_mut(&mut validator_set.active_validators, validator_index);
+                spec {
+                    invariant spec_validators_are_initialized(
+                        validator_set.active_validators
+                    );
+                    invariant len(validator_set.pending_active) == 0;
+                    invariant len(validator_set.pending_inactive) == 0;
+                    invariant 0 <= validator_index && validator_index <= vlen;
+                    invariant vlen == len(validator_set.active_validators);
+                    invariant forall i in 0..validator_index: global<ValidatorConfig>(
+                        validator_set.active_validators[i].addr
+                    ).validator_index < validator_index;
+                    invariant forall i in 0..validator_index: validator_set.active_validators[i]
+                        .config.validator_index < validator_index;
+                    invariant len(validator_perf.validators) == validator_index;
+                };
+                validator_index < vlen
+            }) {
+            let validator_info = vector::borrow_mut(
+                &mut validator_set.active_validators, validator_index
+            );
             validator_info.config.validator_index = validator_index;
-            let validator_config = borrow_global_mut<ValidatorConfig>(validator_info.addr);
+            let validator_config =
+                borrow_global_mut<ValidatorConfig>(validator_info.addr);
             validator_config.validator_index = validator_index;
 
-            vector::push_back(&mut validator_perf.validators, IndividualValidatorPerformance {
-                successful_proposals: 0,
-                failed_proposals: 0,
-            });
+            vector::push_back(
+                &mut validator_perf.validators,
+                IndividualValidatorPerformance {
+                    successful_proposals: 0,
+                    failed_proposals: 0,
+                },
+            );
 
             // Automatically renew a validator's lockup for validators that will still be in the validator set in the
             // next epoch.
             let stake_pool = borrow_global_mut<StakePool>(validator_info.addr);
             let now_secs = timestamp::now_seconds();
-            let reconfig_start_secs = if (chain_status::is_operating()) {
-                get_reconfig_start_time_secs()
-            } else {
-                now_secs
-            };
+            let reconfig_start_secs =
+                if (chain_status::is_operating()) {
+                    get_reconfig_start_time_secs()
+                } else {
+                    now_secs
+                };
             if (stake_pool.locked_until_secs <= reconfig_start_secs) {
                 spec {
                     assume now_secs + recurring_lockup_duration_secs <= MAX_U64;
@@ -1353,14 +1453,14 @@ module aptos_framework::stake {
         validator_consensus_infos_from_validator_set(validator_set)
     }
 
-
     public fun next_validator_consensus_infos(): vector<ValidatorConsensusInfo> acquires ValidatorSet, ValidatorPerformance, StakePool, ValidatorFees, ValidatorConfig {
         // Init.
         let cur_validator_set = borrow_global<ValidatorSet>(@aptos_framework);
         let staking_config = staking_config::get();
         let validator_perf = borrow_global<ValidatorPerformance>(@aptos_framework);
         let (minimum_stake, _) = staking_config::get_required_stake(&staking_config);
-        let (rewards_rate, rewards_rate_denominator) = staking_config::get_reward_rate(&staking_config);
+        let (rewards_rate, rewards_rate_denominator) =
+            staking_config::get_reward_rate(&staking_config);
 
         // Compute new validator set.
         let new_active_validators = vector[];
@@ -1374,60 +1474,76 @@ module aptos_framework::stake {
         };
         let num_candidates = num_cur_actives + num_cur_pending_actives;
         while ({
-            spec {
-                invariant candidate_idx <= num_candidates;
-                invariant spec_validators_are_initialized(new_active_validators);
-                invariant len(new_active_validators) == num_new_actives;
-                invariant forall i in 0..len(new_active_validators):
-                    new_active_validators[i].config.validator_index == i;
-                invariant num_new_actives <= candidate_idx;
-                invariant spec_validators_are_initialized(new_active_validators);
-            };
-            candidate_idx < num_candidates
-        }) {
+                spec {
+                    invariant candidate_idx <= num_candidates;
+                    invariant spec_validators_are_initialized(new_active_validators);
+                    invariant len(new_active_validators) == num_new_actives;
+                    invariant forall i in 0..len(new_active_validators): new_active_validators[i]
+                        .config.validator_index == i;
+                    invariant num_new_actives <= candidate_idx;
+                    invariant spec_validators_are_initialized(new_active_validators);
+                };
+                candidate_idx < num_candidates
+            }) {
             let candidate_in_current_validator_set = candidate_idx < num_cur_actives;
-            let candidate = if (candidate_idx < num_cur_actives) {
-                vector::borrow(&cur_validator_set.active_validators, candidate_idx)
-            } else {
-                vector::borrow(&cur_validator_set.pending_active, candidate_idx - num_cur_actives)
-            };
+            let candidate =
+                if (candidate_idx < num_cur_actives) {
+                    vector::borrow(&cur_validator_set.active_validators, candidate_idx)
+                } else {
+                    vector::borrow(
+                        &cur_validator_set.pending_active, candidate_idx - num_cur_actives
+                    )
+                };
             let stake_pool = borrow_global<StakePool>(candidate.addr);
             let cur_active = coin::value(&stake_pool.active);
             let cur_pending_active = coin::value(&stake_pool.pending_active);
             let cur_pending_inactive = coin::value(&stake_pool.pending_inactive);
 
-            let cur_reward = if (candidate_in_current_validator_set && cur_active > 0) {
-                spec {
-                    assert candidate.config.validator_index < len(validator_perf.validators);
-                };
-                let cur_perf = vector::borrow(&validator_perf.validators, candidate.config.validator_index);
-                spec {
-                    assume cur_perf.successful_proposals + cur_perf.failed_proposals <= MAX_U64;
-                };
-                calculate_rewards_amount(cur_active, cur_perf.successful_proposals, cur_perf.successful_proposals + cur_perf.failed_proposals, rewards_rate, rewards_rate_denominator)
-            } else {
-                0
-            };
+            let cur_reward =
+                if (candidate_in_current_validator_set && cur_active > 0) {
+                    spec {
+                        assert candidate.config.validator_index
+                            < len(validator_perf.validators);
+                    };
+                    let cur_perf = vector::borrow(
+                        &validator_perf.validators, candidate.config.validator_index
+                    );
+                    spec {
+                        assume cur_perf.successful_proposals + cur_perf.failed_proposals
+                            <= MAX_U64;
+                    };
+                    calculate_rewards_amount(
+                        cur_active,
+                        cur_perf.successful_proposals,
+                        cur_perf.successful_proposals + cur_perf.failed_proposals,
+                        rewards_rate,
+                        rewards_rate_denominator,
+                    )
+                } else { 0 };
 
             let cur_fee = 0;
             if (features::collect_and_distribute_gas_fees()) {
-                let fees_table = &borrow_global<ValidatorFees>(@aptos_framework).fees_table;
+                let fees_table =
+                    &borrow_global<ValidatorFees>(@aptos_framework).fees_table;
                 if (table::contains(fees_table, candidate.addr)) {
                     let fee_coin = table::borrow(fees_table, candidate.addr);
                     cur_fee = coin::value(fee_coin);
                 }
             };
 
-            let lockup_expired = get_reconfig_start_time_secs() >= stake_pool.locked_until_secs;
+            let lockup_expired =
+                get_reconfig_start_time_secs() >= stake_pool.locked_until_secs;
             spec {
                 assume cur_active + cur_pending_active + cur_reward + cur_fee <= MAX_U64;
-                assume cur_active + cur_pending_inactive + cur_pending_active + cur_reward + cur_fee <= MAX_U64;
+                assume cur_active + cur_pending_inactive + cur_pending_active + cur_reward
+                    + cur_fee <= MAX_U64;
             };
             let new_voting_power =
                 cur_active
-                + if (lockup_expired) { 0 } else { cur_pending_inactive }
-                + cur_pending_active
-                + cur_reward + cur_fee;
+                    + if (lockup_expired) { 0 }
+                    else {
+                        cur_pending_inactive
+                    } + cur_pending_active + cur_reward + cur_fee;
 
             if (new_voting_power >= minimum_stake) {
                 let config = *borrow_global<ValidatorConfig>(candidate.addr);
@@ -1462,7 +1578,9 @@ module aptos_framework::stake {
         validator_consensus_infos_from_validator_set(&new_validator_set)
     }
 
-    fun validator_consensus_infos_from_validator_set(validator_set: &ValidatorSet): vector<ValidatorConsensusInfo> {
+    fun validator_consensus_infos_from_validator_set(
+        validator_set: &ValidatorSet
+    ): vector<ValidatorConsensusInfo> {
         let validator_consensus_infos = vector[];
 
         let num_active = vector::length(&validator_set.active_validators);
@@ -1475,64 +1593,95 @@ module aptos_framework::stake {
         // Pre-fill the return value with dummy values.
         let idx = 0;
         while ({
-            spec {
-                invariant idx <= len(validator_set.active_validators) + len(validator_set.pending_inactive);
-                invariant len(validator_consensus_infos) == idx;
-                invariant len(validator_consensus_infos) <= len(validator_set.active_validators) + len(validator_set.pending_inactive);
-            };
-            idx < total
-        }) {
-            vector::push_back(&mut validator_consensus_infos, validator_consensus_info::default());
+                spec {
+                    invariant idx
+                        <= len(validator_set.active_validators)
+                            + len(validator_set.pending_inactive);
+                    invariant len(validator_consensus_infos) == idx;
+                    invariant len(validator_consensus_infos)
+                        <= len(validator_set.active_validators)
+                            + len(validator_set.pending_inactive);
+                };
+                idx < total
+            }) {
+            vector::push_back(
+                &mut validator_consensus_infos, validator_consensus_info::default()
+            );
             idx = idx + 1;
         };
         spec {
-            assert len(validator_consensus_infos) == len(validator_set.active_validators) + len(validator_set.pending_inactive);
-            assert spec_validator_indices_are_valid_config(validator_set.active_validators,
-                len(validator_set.active_validators) + len(validator_set.pending_inactive));
+            assert len(validator_consensus_infos)
+                == len(validator_set.active_validators)
+                    + len(validator_set.pending_inactive);
+            assert spec_validator_indices_are_valid_config(
+                validator_set.active_validators,
+                len(validator_set.active_validators) + len(validator_set.pending_inactive)
+            );
         };
 
-        vector::for_each_ref(&validator_set.active_validators, |obj| {
-            let vi: &ValidatorInfo = obj;
-            spec {
-                assume len(validator_consensus_infos) == len(validator_set.active_validators) + len(validator_set.pending_inactive);
-                assert vi.config.validator_index < len(validator_consensus_infos);
-            };
-            let vci = vector::borrow_mut(&mut validator_consensus_infos, vi.config.validator_index);
-            *vci = validator_consensus_info::new(
-                vi.addr,
-                vi.config.consensus_pubkey,
-                vi.voting_power
-            );
-            spec {
-                assert len(validator_consensus_infos) == len(validator_set.active_validators) + len(validator_set.pending_inactive);
-            };
-        });
+        vector::for_each_ref(
+            &validator_set.active_validators,
+            |obj| {
+                let vi: &ValidatorInfo = obj;
+                spec {
+                    assume len(validator_consensus_infos)
+                        == len(validator_set.active_validators)
+                            + len(validator_set.pending_inactive);
+                    assert vi.config.validator_index < len(validator_consensus_infos);
+                };
+                let vci = vector::borrow_mut(
+                    &mut validator_consensus_infos, vi.config.validator_index
+                );
+                *vci = validator_consensus_info::new(
+                    vi.addr,
+                    vi.config.consensus_pubkey,
+                    vi.voting_power,
+                );
+                spec {
+                    assert len(validator_consensus_infos)
+                        == len(validator_set.active_validators)
+                            + len(validator_set.pending_inactive);
+                };
+            },
+        );
 
-        vector::for_each_ref(&validator_set.pending_inactive, |obj| {
-            let vi: &ValidatorInfo = obj;
-            spec {
-                assume len(validator_consensus_infos) == len(validator_set.active_validators) + len(validator_set.pending_inactive);
-                assert vi.config.validator_index < len(validator_consensus_infos);
-            };
-            let vci = vector::borrow_mut(&mut validator_consensus_infos, vi.config.validator_index);
-            *vci = validator_consensus_info::new(
-                vi.addr,
-                vi.config.consensus_pubkey,
-                vi.voting_power
-            );
-            spec {
-                assert len(validator_consensus_infos) == len(validator_set.active_validators) + len(validator_set.pending_inactive);
-            };
-        });
+        vector::for_each_ref(
+            &validator_set.pending_inactive,
+            |obj| {
+                let vi: &ValidatorInfo = obj;
+                spec {
+                    assume len(validator_consensus_infos)
+                        == len(validator_set.active_validators)
+                            + len(validator_set.pending_inactive);
+                    assert vi.config.validator_index < len(validator_consensus_infos);
+                };
+                let vci = vector::borrow_mut(
+                    &mut validator_consensus_infos, vi.config.validator_index
+                );
+                *vci = validator_consensus_info::new(
+                    vi.addr,
+                    vi.config.consensus_pubkey,
+                    vi.voting_power,
+                );
+                spec {
+                    assert len(validator_consensus_infos)
+                        == len(validator_set.active_validators)
+                            + len(validator_set.pending_inactive);
+                };
+            },
+        );
 
         validator_consensus_infos
     }
 
     fun addresses_from_validator_infos(infos: &vector<ValidatorInfo>): vector<address> {
-        vector::map_ref(infos, |obj| {
-            let info: &ValidatorInfo = obj;
-            info.addr
-        })
+        vector::map_ref(
+            infos,
+            |obj| {
+                let info: &ValidatorInfo = obj;
+                info.addr
+            },
+        )
     }
 
     /// Calculate the stake amount of a stake pool for the next epoch.
@@ -1549,39 +1698,49 @@ module aptos_framework::stake {
     ) acquires StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorFees {
         let stake_pool = borrow_global_mut<StakePool>(pool_address);
         let validator_config = borrow_global<ValidatorConfig>(pool_address);
-        let cur_validator_perf = vector::borrow(&validator_perf.validators, validator_config.validator_index);
+        let cur_validator_perf = vector::borrow(
+            &validator_perf.validators, validator_config.validator_index
+        );
         let num_successful_proposals = cur_validator_perf.successful_proposals;
         spec {
             // The following addition should not overflow because `num_total_proposals` cannot be larger than 86400,
             // the maximum number of proposals in a day (1 proposal per second).
-            assume cur_validator_perf.successful_proposals + cur_validator_perf.failed_proposals <= MAX_U64;
+            assume cur_validator_perf.successful_proposals
+                + cur_validator_perf.failed_proposals <= MAX_U64;
         };
-        let num_total_proposals = cur_validator_perf.successful_proposals + cur_validator_perf.failed_proposals;
-        let (rewards_rate, rewards_rate_denominator) = staking_config::get_reward_rate(staking_config);
-        let rewards_active = distribute_rewards(
-            &mut stake_pool.active,
-            num_successful_proposals,
-            num_total_proposals,
-            rewards_rate,
-            rewards_rate_denominator
-        );
-        let rewards_pending_inactive = distribute_rewards(
-            &mut stake_pool.pending_inactive,
-            num_successful_proposals,
-            num_total_proposals,
-            rewards_rate,
-            rewards_rate_denominator
-        );
+        let num_total_proposals =
+            cur_validator_perf.successful_proposals + cur_validator_perf.failed_proposals;
+        let (rewards_rate, rewards_rate_denominator) =
+            staking_config::get_reward_rate(staking_config);
+        let rewards_active =
+            distribute_rewards(
+                &mut stake_pool.active,
+                num_successful_proposals,
+                num_total_proposals,
+                rewards_rate,
+                rewards_rate_denominator,
+            );
+        let rewards_pending_inactive =
+            distribute_rewards(
+                &mut stake_pool.pending_inactive,
+                num_successful_proposals,
+                num_total_proposals,
+                rewards_rate,
+                rewards_rate_denominator,
+            );
         spec {
             assume rewards_active + rewards_pending_inactive <= MAX_U64;
         };
         let rewards_amount = rewards_active + rewards_pending_inactive;
         // Pending active stake can now be active.
-        coin::merge(&mut stake_pool.active, coin::extract_all(&mut stake_pool.pending_active));
+        coin::merge(
+            &mut stake_pool.active, coin::extract_all(&mut stake_pool.pending_active)
+        );
 
         // Additionally, distribute transaction fees.
         if (features::collect_and_distribute_gas_fees()) {
-            let fees_table = &mut borrow_global_mut<ValidatorFees>(@aptos_framework).fees_table;
+            let fees_table =
+                &mut borrow_global_mut<ValidatorFees>(@aptos_framework).fees_table;
             if (table::contains(fees_table, pool_address)) {
                 let coin = table::remove(fees_table, pool_address);
                 coin::merge(&mut stake_pool.active, coin);
@@ -1602,10 +1761,7 @@ module aptos_framework::stake {
         };
         event::emit_event(
             &mut stake_pool.distribute_rewards_events,
-            DistributeRewardsEvent {
-                pool_address,
-                rewards_amount,
-            },
+            DistributeRewardsEvent { pool_address, rewards_amount, },
         );
     }
 
@@ -1635,13 +1791,14 @@ module aptos_framework::stake {
         };
         // The rewards amount is equal to (stake amount * rewards rate * performance multiplier).
         // We do multiplication in u128 before division to avoid the overflow and minimize the rounding error.
-        let rewards_numerator = (stake_amount as u128) * (rewards_rate as u128) * (num_successful_proposals as u128);
-        let rewards_denominator = (rewards_rate_denominator as u128) * (num_total_proposals as u128);
+        let rewards_numerator =
+            (stake_amount as u128) * (rewards_rate as u128)
+                * (num_successful_proposals as u128);
+        let rewards_denominator =
+            (rewards_rate_denominator as u128) * (num_total_proposals as u128);
         if (rewards_denominator > 0) {
             ((rewards_numerator / rewards_denominator) as u64)
-        } else {
-            0
-        }
+        } else { 0 }
     }
 
     /// Mint rewards corresponding to current epoch's `stake` and `num_successful_votes`.
@@ -1653,19 +1810,19 @@ module aptos_framework::stake {
         rewards_rate_denominator: u64,
     ): u64 acquires AptosCoinCapabilities {
         let stake_amount = coin::value(stake);
-        let rewards_amount = if (stake_amount > 0) {
-            calculate_rewards_amount(
-                stake_amount,
-                num_successful_proposals,
-                num_total_proposals,
-                rewards_rate,
-                rewards_rate_denominator
-            )
-        } else {
-            0
-        };
+        let rewards_amount =
+            if (stake_amount > 0) {
+                calculate_rewards_amount(
+                    stake_amount,
+                    num_successful_proposals,
+                    num_total_proposals,
+                    rewards_rate,
+                    rewards_rate_denominator,
+                )
+            } else { 0 };
         if (rewards_amount > 0) {
-            let mint_cap = &borrow_global<AptosCoinCapabilities>(@aptos_framework).mint_cap;
+            let mint_cap =
+                &borrow_global<AptosCoinCapabilities>(@aptos_framework).mint_cap;
             let rewards = coin::mint(rewards_amount, mint_cap);
             coin::merge(stake, rewards);
         };
@@ -1682,11 +1839,11 @@ module aptos_framework::stake {
         let i = 0;
         let len = vector::length(v);
         while ({
-            spec {
-                invariant !(exists j in 0..i: v[j].addr == addr);
-            };
-            i < len
-        }) {
+                spec {
+                    invariant !(exists j in 0..i: v[j].addr == addr);
+                };
+                i < len
+            }) {
             if (vector::borrow(v, i).addr == addr) {
                 return option::some(i)
             };
@@ -1695,13 +1852,11 @@ module aptos_framework::stake {
         option::none()
     }
 
-    fun generate_validator_info(addr: address, stake_pool: &StakePool, config: ValidatorConfig): ValidatorInfo {
+    fun generate_validator_info(
+        addr: address, stake_pool: &StakePool, config: ValidatorConfig
+    ): ValidatorInfo {
         let voting_power = get_next_epoch_voting_power(stake_pool);
-        ValidatorInfo {
-            addr,
-            voting_power,
-            config,
-        }
+        ValidatorInfo { addr, voting_power, config, }
     }
 
     /// Returns validator's next epoch voting power, including pending_active, active, and pending_inactive stake.
@@ -1718,20 +1873,28 @@ module aptos_framework::stake {
     fun update_voting_power_increase(increase_amount: u64) acquires ValidatorSet {
         let validator_set = borrow_global_mut<ValidatorSet>(@aptos_framework);
         let voting_power_increase_limit =
-            (staking_config::get_voting_power_increase_limit(&staking_config::get()) as u128);
-        validator_set.total_joining_power = validator_set.total_joining_power + (increase_amount as u128);
+            (
+                staking_config::get_voting_power_increase_limit(&staking_config::get()) as u128
+            );
+        validator_set.total_joining_power = validator_set.total_joining_power
+            + (increase_amount as u128);
 
         // Only validator voting power increase if the current validator set's voting power > 0.
         if (validator_set.total_voting_power > 0) {
             assert!(
-                validator_set.total_joining_power <= validator_set.total_voting_power * voting_power_increase_limit / 100,
+                validator_set.total_joining_power
+                    <= validator_set.total_voting_power * voting_power_increase_limit /
+                    100,
                 error::invalid_argument(EVOTING_POWER_INCREASE_EXCEEDS_LIMIT),
             );
         }
     }
 
     fun assert_stake_pool_exists(pool_address: address) {
-        assert!(stake_pool_exists(pool_address), error::invalid_argument(ESTAKE_POOL_DOES_NOT_EXIST));
+        assert!(
+            stake_pool_exists(pool_address),
+            error::invalid_argument(ESTAKE_POOL_DOES_NOT_EXIST),
+        );
     }
 
     /// This provides an ACL for Testnet purposes. In testnet, everyone is a whale, a whale can be a validator.
@@ -1742,8 +1905,7 @@ module aptos_framework::stake {
     }
 
     public fun configure_allowed_validators(
-        aptos_framework: &signer,
-        accounts: vector<address>
+        aptos_framework: &signer, accounts: vector<address>
     ) acquires AllowedValidators {
         let aptos_framework_address = signer::address_of(aptos_framework);
         system_addresses::assert_aptos_framework(aptos_framework);
@@ -1756,9 +1918,8 @@ module aptos_framework::stake {
     }
 
     fun is_allowed(account: address): bool acquires AllowedValidators {
-        if (!exists<AllowedValidators>(@aptos_framework)) {
-            true
-        } else {
+        if (!exists<AllowedValidators>(@aptos_framework)) { true }
+        else {
             let allowed = borrow_global<AllowedValidators>(@aptos_framework);
             vector::contains(&allowed.accounts, &account)
         }
@@ -1769,7 +1930,10 @@ module aptos_framework::stake {
     }
 
     fun assert_reconfig_not_in_progress() {
-        assert!(!reconfiguration_state::is_in_progress(), error::invalid_state(ERECONFIGURATION_IN_PROGRESS));
+        assert!(
+            !reconfiguration_state::is_in_progress(),
+            error::invalid_state(ERECONFIGURATION_IN_PROGRESS),
+        );
     }
 
     #[test_only]
@@ -1790,7 +1954,16 @@ module aptos_framework::stake {
     #[test_only]
     public fun initialize_for_test(aptos_framework: &signer) {
         reconfiguration_state::initialize(aptos_framework);
-        initialize_for_test_custom(aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100, 1000000);
+        initialize_for_test_custom(
+            aptos_framework,
+            100,
+            10000,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            100,
+            1000000,
+        );
     }
 
     #[test_only]
@@ -1811,8 +1984,7 @@ module aptos_framework::stake {
     }
 
     #[test_only]
-    public fun fast_forward_to_unlock(pool_address: address)
-    acquires AptosCoinCapabilities, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
+    public fun fast_forward_to_unlock(pool_address: address) acquires AptosCoinCapabilities, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         let expiration_time = get_lockup_secs(pool_address);
         timestamp::update_global_time_for_test_secs(expiration_time);
         end_epoch();
@@ -1867,8 +2039,7 @@ module aptos_framework::stake {
     }
 
     #[test_only]
-    public fun mint_and_add_stake(
-        account: &signer, amount: u64) acquires AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorSet {
+    public fun mint_and_add_stake(account: &signer, amount: u64) acquires AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorSet {
         mint(account, amount);
         add_stake(account, amount);
     }
@@ -1889,7 +2060,9 @@ module aptos_framework::stake {
 
         let pk_bytes = bls12381::public_key_to_bytes(public_key);
         let pop_bytes = bls12381::proof_of_possession_to_bytes(proof_of_possession);
-        initialize_validator(validator, pk_bytes, pop_bytes, vector::empty(), vector::empty());
+        initialize_validator(
+            validator, pk_bytes, pop_bytes, vector::empty(), vector::empty()
+        );
 
         if (amount > 0) {
             mint_and_add_stake(validator, amount);
@@ -1914,30 +2087,36 @@ module aptos_framework::stake {
         while (i < vector::length(&active_validator_addresses)) {
             let validator_address = vector::borrow(&active_validator_addresses, i);
             let pk = vector::borrow(&public_keys, i);
-            vector::push_back(&mut active_validators, ValidatorInfo {
-                addr: *validator_address,
-                voting_power: 0,
-                config: ValidatorConfig {
-                    consensus_pubkey: bls12381::public_key_to_bytes(pk),
-                    network_addresses: b"",
-                    fullnode_addresses: b"",
-                    validator_index: 0,
-                }
-            });
+            vector::push_back(
+                &mut active_validators,
+                ValidatorInfo {
+                    addr: *validator_address,
+                    voting_power: 0,
+                    config: ValidatorConfig {
+                        consensus_pubkey: bls12381::public_key_to_bytes(pk),
+                        network_addresses: b"",
+                        fullnode_addresses: b"",
+                        validator_index: 0,
+                    }
+                },
+            );
             i = i + 1;
         };
 
-        move_to(aptos_framework, ValidatorSet {
-            consensus_scheme: 0,
-            // active validators for the current epoch
-            active_validators,
-            // pending validators to leave in next epoch (still active)
-            pending_inactive: vector::empty<ValidatorInfo>(),
-            // pending validators to join in next epoch
-            pending_active: vector::empty<ValidatorInfo>(),
-            total_voting_power: 0,
-            total_joining_power: 0,
-        });
+        move_to(
+            aptos_framework,
+            ValidatorSet {
+                consensus_scheme: 0,
+                // active validators for the current epoch
+                active_validators,
+                // pending validators to leave in next epoch (still active)
+                pending_inactive: vector::empty<ValidatorInfo>(),
+                // pending validators to join in next epoch
+                pending_active: vector::empty<ValidatorInfo>(),
+                total_voting_power: 0,
+                total_joining_power: 0,
+            },
+        );
     }
 
     #[test_only]
@@ -1958,14 +2137,16 @@ module aptos_framework::stake {
     // Allows unit tests to set custom validator performances.
     #[test_only]
     public fun update_validator_performances_for_test(
-        proposer_index: Option<u64>,
-        failed_proposer_indices: vector<u64>,
+        proposer_index: Option<u64>, failed_proposer_indices: vector<u64>,
     ) acquires ValidatorPerformance {
         update_performance_statistics(proposer_index, failed_proposer_indices);
     }
 
     #[test_only]
-    public fun generate_identity(): (bls12381::SecretKey, bls12381::PublicKey, bls12381::ProofOfPossession) {
+    public fun generate_identity()
+        : (
+        bls12381::SecretKey, bls12381::PublicKey, bls12381::ProofOfPossession
+    ) {
         let (sk, pkpop) = bls12381::generate_keys();
         let pop = bls12381::generate_proof_of_possession(&sk);
         let unvalidated_pk = bls12381::public_key_with_pop_to_normal(&pkpop);
@@ -1975,8 +2156,7 @@ module aptos_framework::stake {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x10007, location = Self)]
     public entry fun test_inactive_validator_can_add_stake_if_exceeding_max_allowed(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -1993,7 +2173,16 @@ module aptos_framework::stake {
         validator_1: &signer,
         validator_2: &signer,
     ) acquires AllowedValidators, AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
-        initialize_for_test_custom(aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 100000);
+        initialize_for_test_custom(
+            aptos_framework,
+            50,
+            10000,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            100000,
+        );
         // Have one validator join the set to ensure the validator set is not empty when main validator joins.
         let (_sk_1, pk_1, pop_1) = generate_identity();
         initialize_test_validator(&pk_1, &pop_1, validator_1, 100, true, true);
@@ -2009,8 +2198,7 @@ module aptos_framework::stake {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x10007, location = Self)]
     public entry fun test_active_validator_cannot_add_stake_if_exceeding_max_allowed(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         initialize_for_test(aptos_framework);
         // Validator joins validator set and waits for epoch end so it's in the validator set.
@@ -2024,8 +2212,7 @@ module aptos_framework::stake {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x10007, location = Self)]
     public entry fun test_active_validator_with_pending_inactive_stake_cannot_add_stake_if_exceeding_max_allowed(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         initialize_for_test(aptos_framework);
         // Validator joins validator set and waits for epoch end so it's in the validator set.
@@ -2062,8 +2249,7 @@ module aptos_framework::stake {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_end_to_end(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -2119,8 +2305,7 @@ module aptos_framework::stake {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_inactive_validator_with_existing_lockup_join_validator_set(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -2130,7 +2315,9 @@ module aptos_framework::stake {
         increase_lockup(validator);
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS / 2);
         let validator_address = signer::address_of(validator);
-        assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS / 2, 1);
+        assert!(
+            get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS / 2, 1
+        );
 
         // Join the validator set with an existing lockup
         join_validator_set(validator, validator_address);
@@ -2138,15 +2325,18 @@ module aptos_framework::stake {
         // Validator is added to the set but lockup time shouldn't have changed.
         end_epoch();
         assert!(get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 2);
-        assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS / 2 - EPOCH_DURATION, 3);
+        assert!(
+            get_remaining_lockup_secs(validator_address)
+                == LOCKUP_CYCLE_SECONDS / 2 - EPOCH_DURATION,
+            3,
+        );
         assert_validator_state(validator_address, 100, 0, 0, 0, 0);
     }
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x10012, location = Self)]
     public entry fun test_cannot_reduce_lockup(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -2168,7 +2358,9 @@ module aptos_framework::stake {
         validator_2: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         // Only 50% voting power increase is allowed in each epoch.
-        initialize_for_test_custom(aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 50);
+        initialize_for_test_custom(
+            aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 50
+        );
         let (_sk_1, pk_1, pop_1) = generate_identity();
         let (_sk_2, pk_2, pop_2) = generate_identity();
         initialize_test_validator(&pk_1, &pop_1, validator_1, 100, false, false);
@@ -2189,7 +2381,16 @@ module aptos_framework::stake {
         validator_1: &signer,
         validator_2: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
-        initialize_for_test_custom(aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 10000);
+        initialize_for_test_custom(
+            aptos_framework,
+            50,
+            10000,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            10000,
+        );
         // Need 1 validator to be in the active validator set so joining limit works.
         let (_sk_1, pk_1, pop_1) = generate_identity();
         let (_sk_2, pk_2, pop_2) = generate_identity();
@@ -2199,7 +2400,9 @@ module aptos_framework::stake {
         // Add more stake while still pending_active.
         let validator_2_address = signer::address_of(validator_2);
         join_validator_set(validator_2, validator_2_address);
-        assert!(get_validator_state(validator_2_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 0);
+        assert!(
+            get_validator_state(validator_2_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 0
+        );
         mint_and_add_stake(validator_2, 100);
         assert_validator_state(validator_2_address, 200, 0, 0, 0, 0);
     }
@@ -2212,7 +2415,9 @@ module aptos_framework::stake {
         validator_2: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         // 100% voting power increase is allowed in each epoch.
-        initialize_for_test_custom(aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 100);
+        initialize_for_test_custom(
+            aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 100
+        );
         // Need 1 validator to be in the active validator set so joining limit works.
         let (_sk_1, pk_1, pop_1) = generate_identity();
         initialize_test_validator(&pk_1, &pop_1, validator_1, 100, true, true);
@@ -2228,18 +2433,21 @@ module aptos_framework::stake {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_pending_active_validator_leaves_validator_set(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         initialize_for_test(aptos_framework);
         // Validator joins but epoch hasn't ended, so the validator is still pending_active.
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100, true, false);
         let validator_address = signer::address_of(validator);
-        assert!(get_validator_state(validator_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 0);
+        assert!(
+            get_validator_state(validator_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 0
+        );
 
         // Check that voting power increase is tracked.
-        assert!(borrow_global<ValidatorSet>(@aptos_framework).total_joining_power == 100, 0);
+        assert!(
+            borrow_global<ValidatorSet>(@aptos_framework).total_joining_power == 100, 0
+        );
 
         // Leave the validator set immediately.
         leave_validator_set(validator, validator_address);
@@ -2252,11 +2460,12 @@ module aptos_framework::stake {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000D, location = Self)]
     public entry fun test_active_validator_cannot_add_more_stake_than_limit_in_multiple_epochs(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         // Only 50% voting power increase is allowed in each epoch.
-        initialize_for_test_custom(aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 50);
+        initialize_for_test_custom(
+            aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 50
+        );
         // Add initial stake and join the validator set.
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100, true, true);
@@ -2274,11 +2483,12 @@ module aptos_framework::stake {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000D, location = Self)]
     public entry fun test_active_validator_cannot_add_more_stake_than_limit(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         // Only 50% voting power increase is allowed in each epoch.
-        initialize_for_test_custom(aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 50);
+        initialize_for_test_custom(
+            aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 50
+        );
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100, true, true);
 
@@ -2288,11 +2498,12 @@ module aptos_framework::stake {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_unlock_partial_stake(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         // Reward rate = 10%.
-        initialize_for_test_custom(aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 100);
+        initialize_for_test_custom(
+            aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 100
+        );
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100, true, true);
 
@@ -2314,8 +2525,7 @@ module aptos_framework::stake {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_can_withdraw_all_stake_and_rewards_at_once(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -2329,7 +2539,11 @@ module aptos_framework::stake {
         assert_validator_state(validator_address, 101, 0, 0, 0, 0);
 
         // Unlock all coins while still having a lockup.
-        assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS - EPOCH_DURATION, 2);
+        assert!(
+            get_remaining_lockup_secs(validator_address)
+                == LOCKUP_CYCLE_SECONDS - EPOCH_DURATION,
+            2,
+        );
         unlock(validator, 101);
         assert_validator_state(validator_address, 0, 0, 0, 101, 0);
 
@@ -2351,8 +2565,7 @@ module aptos_framework::stake {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_unlocking_more_than_available_stake_should_cap(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -2365,8 +2578,7 @@ module aptos_framework::stake {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_withdraw_should_cap_by_inactive_stake(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         initialize_for_test(aptos_framework);
         // Initial balance = 900 (idle) + 100 (staked) = 1000.
@@ -2390,8 +2602,7 @@ module aptos_framework::stake {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_can_reactivate_pending_inactive_stake(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -2409,8 +2620,7 @@ module aptos_framework::stake {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_reactivate_more_than_available_pending_inactive_stake_should_cap(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -2426,8 +2636,7 @@ module aptos_framework::stake {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_having_insufficient_remaining_stake_after_withdrawal_gets_kicked(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -2469,7 +2678,9 @@ module aptos_framework::stake {
         assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 0);
         leave_validator_set(validator, validator_address);
         // Validator is in pending_inactive state but is technically still part of the validator set.
-        assert!(get_validator_state(validator_address) == VALIDATOR_STATUS_PENDING_INACTIVE, 2);
+        assert!(
+            get_validator_state(validator_address) == VALIDATOR_STATUS_PENDING_INACTIVE, 2
+        );
         assert_validator_state(validator_address, 100, 0, 0, 0, 1);
         end_epoch();
 
@@ -2477,7 +2688,11 @@ module aptos_framework::stake {
         assert!(get_validator_state(validator_address) == VALIDATOR_STATUS_INACTIVE, 3);
         // However, their stake, including rewards, should still subject to the existing lockup.
         assert_validator_state(validator_address, 101, 0, 0, 0, 1);
-        assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS - EPOCH_DURATION, 4);
+        assert!(
+            get_remaining_lockup_secs(validator_address)
+                == LOCKUP_CYCLE_SECONDS - EPOCH_DURATION,
+            4,
+        );
 
         // If they try to unlock, their stake is moved to pending_inactive and would only be withdrawable after the
         // lockup has expired.
@@ -2533,7 +2748,9 @@ module aptos_framework::stake {
         validator_2: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         // Only 50% voting power increase is allowed in each epoch.
-        initialize_for_test_custom(aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 50);
+        initialize_for_test_custom(
+            aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 50
+        );
         let (_sk_1, pk_1, pop_1) = generate_identity();
         let (_sk_2, pk_2, pop_2) = generate_identity();
         initialize_test_validator(&pk_1, &pop_1, validator_1, 100, true, false);
@@ -2557,7 +2774,16 @@ module aptos_framework::stake {
         let validator_2_address = signer::address_of(validator_2);
         let validator_3_address = signer::address_of(validator_3);
 
-        initialize_for_test_custom(aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100, 100);
+        initialize_for_test_custom(
+            aptos_framework,
+            100,
+            10000,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            100,
+            100,
+        );
         let (_sk_1, pk_1, pop_1) = generate_identity();
         let pk_1_bytes = bls12381::public_key_to_bytes(&pk_1);
         let (_sk_2, pk_2, pop_2) = generate_identity();
@@ -2592,29 +2818,34 @@ module aptos_framework::stake {
         leave_validator_set(validator_2, validator_2_address);
         join_validator_set(validator_3, validator_3_address);
         // Validator 2 is not effectively removed until next epoch.
-        assert!(get_validator_state(validator_2_address) == VALIDATOR_STATUS_PENDING_INACTIVE, 6);
+        assert!(
+            get_validator_state(validator_2_address) == VALIDATOR_STATUS_PENDING_INACTIVE,
+            6,
+        );
         assert!(
             vector::borrow(
                 &borrow_global<ValidatorSet>(@aptos_framework).pending_inactive,
-                0
+                0,
             ).addr == validator_2_address,
-            0
+            0,
         );
         // Validator 3 is not effectively added until next epoch.
-        assert!(get_validator_state(validator_3_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 7);
+        assert!(
+            get_validator_state(validator_3_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 7
+        );
         assert!(
             vector::borrow(
                 &borrow_global<ValidatorSet>(@aptos_framework).pending_active,
-                0
+                0,
             ).addr == validator_3_address,
-            0
+            0,
         );
         assert!(
             vector::borrow(
                 &borrow_global<ValidatorSet>(@aptos_framework).active_validators,
-                0
+                0,
             ).config.consensus_pubkey == pk_1_bytes,
-            0
+            0,
         );
 
         // Changes applied after new epoch
@@ -2630,9 +2861,9 @@ module aptos_framework::stake {
         assert!(
             vector::borrow(
                 &borrow_global<ValidatorSet>(@aptos_framework).active_validators,
-                0
+                0,
             ).config.consensus_pubkey == pk_1b_bytes,
-            0
+            0,
         );
 
         // Validators without enough stake will be removed.
@@ -2644,10 +2875,18 @@ module aptos_framework::stake {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_delegated_staking_with_owner_cap(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
-        initialize_for_test_custom(aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100, 100);
+        initialize_for_test_custom(
+            aptos_framework,
+            100,
+            10000,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            100,
+            100,
+        );
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 0, false, false);
         let owner_cap = extract_owner_cap(validator);
@@ -2697,10 +2936,18 @@ module aptos_framework::stake {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000A, location = Self)]
     public entry fun test_validator_cannot_join_post_genesis(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
-        initialize_for_test_custom(aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, false, 1, 100, 100);
+        initialize_for_test_custom(
+            aptos_framework,
+            100,
+            10000,
+            LOCKUP_CYCLE_SECONDS,
+            false,
+            1,
+            100,
+            100,
+        );
 
         // Joining the validator set should fail as post genesis validator set change is not allowed.
         let (_sk, pk, pop) = generate_identity();
@@ -2710,8 +2957,7 @@ module aptos_framework::stake {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000E, location = Self)]
     public entry fun test_invalid_pool_address(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -2722,10 +2968,18 @@ module aptos_framework::stake {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000A, location = Self)]
     public entry fun test_validator_cannot_leave_post_genesis(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
-        initialize_for_test_custom(aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, false, 1, 100, 100);
+        initialize_for_test_custom(
+            aptos_framework,
+            100,
+            10000,
+            LOCKUP_CYCLE_SECONDS,
+            false,
+            1,
+            100,
+            100,
+        );
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100, false, false);
 
@@ -2738,14 +2992,7 @@ module aptos_framework::stake {
         leave_validator_set(validator, validator_address);
     }
 
-    #[test(
-        aptos_framework = @aptos_framework,
-        validator_1 = @aptos_framework,
-        validator_2 = @0x2,
-        validator_3 = @0x3,
-        validator_4 = @0x4,
-        validator_5 = @0x5
-    )]
+    #[test(aptos_framework = @aptos_framework, validator_1 = @aptos_framework, validator_2 = @0x2, validator_3 = @0x3, validator_4 = @0x4, validator_5 = @0x5)]
     fun test_validator_consensus_infos_from_validator_set(
         aptos_framework: &signer,
         validator_1: &signer,
@@ -2781,44 +3028,61 @@ module aptos_framework::stake {
         join_validator_set(validator_1, v1_addr);
         join_validator_set(validator_5, v5_addr);
         end_epoch();
-        let vci_vec_0 = validator_consensus_infos_from_validator_set(borrow_global<ValidatorSet>(@aptos_framework));
-        let vci_addrs = vector::map_ref(&vci_vec_0, |obj|{
-            let vci: &ValidatorConsensusInfo = obj;
-            validator_consensus_info::get_addr(vci)
-        });
-        let vci_pks = vector::map_ref(&vci_vec_0, |obj|{
-            let vci: &ValidatorConsensusInfo = obj;
-            validator_consensus_info::get_pk_bytes(vci)
-        });
-        let vci_voting_powers = vector::map_ref(&vci_vec_0, |obj|{
-            let vci: &ValidatorConsensusInfo = obj;
-            validator_consensus_info::get_voting_power(vci)
-        });
+        let vci_vec_0 =
+            validator_consensus_infos_from_validator_set(
+                borrow_global<ValidatorSet>(@aptos_framework)
+            );
+        let vci_addrs = vector::map_ref(
+            &vci_vec_0,
+            |obj| {
+                let vci: &ValidatorConsensusInfo = obj;
+                validator_consensus_info::get_addr(vci)
+            },
+        );
+        let vci_pks = vector::map_ref(
+            &vci_vec_0,
+            |obj| {
+                let vci: &ValidatorConsensusInfo = obj;
+                validator_consensus_info::get_pk_bytes(vci)
+            },
+        );
+        let vci_voting_powers = vector::map_ref(
+            &vci_vec_0,
+            |obj| {
+                let vci: &ValidatorConsensusInfo = obj;
+                validator_consensus_info::get_voting_power(vci)
+            },
+        );
         assert!(vector[@0x5, @aptos_framework, @0x3] == vci_addrs, 1);
         assert!(vector[pk_5_bytes, pk_1_bytes, pk_3_bytes] == vci_pks, 2);
         assert!(vector[105, 101, 103] == vci_voting_powers, 3);
         leave_validator_set(validator_3, v3_addr);
-        let vci_vec_1 = validator_consensus_infos_from_validator_set(borrow_global<ValidatorSet>(@aptos_framework));
+        let vci_vec_1 =
+            validator_consensus_infos_from_validator_set(
+                borrow_global<ValidatorSet>(@aptos_framework)
+            );
         assert!(vci_vec_0 == vci_vec_1, 11);
         join_validator_set(validator_2, v2_addr);
-        let vci_vec_2 = validator_consensus_infos_from_validator_set(borrow_global<ValidatorSet>(@aptos_framework));
+        let vci_vec_2 =
+            validator_consensus_infos_from_validator_set(
+                borrow_global<ValidatorSet>(@aptos_framework)
+            );
         assert!(vci_vec_0 == vci_vec_2, 12);
         leave_validator_set(validator_1, v1_addr);
-        let vci_vec_3 = validator_consensus_infos_from_validator_set(borrow_global<ValidatorSet>(@aptos_framework));
+        let vci_vec_3 =
+            validator_consensus_infos_from_validator_set(
+                borrow_global<ValidatorSet>(@aptos_framework)
+            );
         assert!(vci_vec_0 == vci_vec_3, 13);
         join_validator_set(validator_4, v4_addr);
-        let vci_vec_4 = validator_consensus_infos_from_validator_set(borrow_global<ValidatorSet>(@aptos_framework));
+        let vci_vec_4 =
+            validator_consensus_infos_from_validator_set(
+                borrow_global<ValidatorSet>(@aptos_framework)
+            );
         assert!(vci_vec_0 == vci_vec_4, 14);
     }
 
-    #[test(
-        aptos_framework = @aptos_framework,
-        validator_1 = @aptos_framework,
-        validator_2 = @0x2,
-        validator_3 = @0x3,
-        validator_4 = @0x4,
-        validator_5 = @0x5
-    )]
+    #[test(aptos_framework = @aptos_framework, validator_1 = @aptos_framework, validator_2 = @0x2, validator_3 = @0x3, validator_4 = @0x4, validator_5 = @0x5)]
     public entry fun test_staking_validator_index(
         aptos_framework: &signer,
         validator_1: &signer,
@@ -2903,8 +3167,10 @@ module aptos_framework::stake {
 
         // Validator 2 failed proposal.
         let failed_proposer_indices = vector::empty<u64>();
-        let validator_1_index = borrow_global<ValidatorConfig>(validator_1_address).validator_index;
-        let validator_2_index = borrow_global<ValidatorConfig>(validator_2_address).validator_index;
+        let validator_1_index =
+            borrow_global<ValidatorConfig>(validator_1_address).validator_index;
+        let validator_2_index =
+            borrow_global<ValidatorConfig>(validator_2_address).validator_index;
         vector::push_back(&mut failed_proposer_indices, validator_2_index);
         let proposer_indices = option::some(validator_1_index);
         update_performance_statistics(proposer_indices, failed_proposer_indices);
@@ -2918,8 +3184,10 @@ module aptos_framework::stake {
         unlock(validator_2, 100);
         leave_validator_set(validator_2, validator_2_address);
         let failed_proposer_indices = vector::empty<u64>();
-        let validator_1_index = borrow_global<ValidatorConfig>(validator_1_address).validator_index;
-        let validator_2_index = borrow_global<ValidatorConfig>(validator_2_address).validator_index;
+        let validator_1_index =
+            borrow_global<ValidatorConfig>(validator_1_address).validator_index;
+        let validator_2_index =
+            borrow_global<ValidatorConfig>(validator_2_address).validator_index;
         vector::push_back(&mut failed_proposer_indices, validator_1_index);
         vector::push_back(&mut failed_proposer_indices, validator_2_index);
         update_performance_statistics(option::none(), failed_proposer_indices);
@@ -2966,7 +3234,11 @@ module aptos_framework::stake {
             genesis_time_in_secs,
             fixed_point64::create_from_rational(50, 100),
         );
-        features::change_feature_flags_for_testing(aptos_framework, vector[features::get_periodical_reward_rate_decrease_feature()], vector[]);
+        features::change_feature_flags_for_testing(
+            aptos_framework,
+            vector[features::get_periodical_reward_rate_decrease_feature()],
+            vector[],
+        );
 
         // For some reason, this epoch is very long. It has been 1 year since genesis when the epoch ends.
         timestamp::fast_forward_seconds(one_year_in_secs - EPOCH_DURATION * 3);
@@ -2991,8 +3263,7 @@ module aptos_framework::stake {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_update_performance_statistics_should_not_fail_due_to_out_of_bounds(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         initialize_for_test(aptos_framework);
 
@@ -3000,7 +3271,8 @@ module aptos_framework::stake {
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100, true, true);
 
-        let valid_validator_index = borrow_global<ValidatorConfig>(validator_address).validator_index;
+        let valid_validator_index =
+            borrow_global<ValidatorConfig>(validator_address).validator_index;
         let out_of_bounds_index = valid_validator_index + 100;
 
         // Invalid validator index in the failed proposers vector should not lead to abort.
@@ -3022,10 +3294,18 @@ module aptos_framework::stake {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000B, location = Self)]
     public entry fun test_invalid_config(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorSet {
-        initialize_for_test_custom(aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100, 100);
+        initialize_for_test_custom(
+            aptos_framework,
+            50,
+            10000,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            100,
+            100,
+        );
 
         // Call initialize_stake_owner, which only initializes the stake pool but not validator config.
         let validator_address = signer::address_of(validator);
@@ -3040,10 +3320,18 @@ module aptos_framework::stake {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_valid_config(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorSet {
-        initialize_for_test_custom(aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100, 100);
+        initialize_for_test_custom(
+            aptos_framework,
+            50,
+            10000,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            100,
+            100,
+        );
 
         // Call initialize_stake_owner, which only initializes the stake pool but not validator config.
         let validator_address = signer::address_of(validator);
@@ -3069,13 +3357,14 @@ module aptos_framework::stake {
         let num_total_proposals = 200;
         let rewards_rate = 700;
         let rewards_rate_denominator = 777;
-        let rewards_amount = calculate_rewards_amount(
-            stake_amount,
-            num_successful_proposals,
-            num_total_proposals,
-            rewards_rate,
-            rewards_rate_denominator
-        );
+        let rewards_amount =
+            calculate_rewards_amount(
+                stake_amount,
+                num_successful_proposals,
+                num_total_proposals,
+                rewards_rate,
+                rewards_rate_denominator,
+            );
         // Consider `amount_imprecise` and `amount_precise` defined as follows:
         // amount_imprecise = (stake_amount * rewards_rate / rewards_rate_denominator) * num_successful_proposals / num_total_proposals
         // amount_precise = stake_amount * rewards_rate * num_successful_proposals / (rewards_rate_denominator * num_total_proposals)
@@ -3090,25 +3379,29 @@ module aptos_framework::stake {
         let rewards_rate = 3141592;
         let rewards_rate_denominator = 10000000;
         // This should not abort due to an arithmetic overflow.
-        let rewards_amount = calculate_rewards_amount(
-            stake_amount,
-            num_successful_proposals,
-            num_total_proposals,
-            rewards_rate,
-            rewards_rate_denominator
-        );
+        let rewards_amount =
+            calculate_rewards_amount(
+                stake_amount,
+                num_successful_proposals,
+                num_total_proposals,
+                rewards_rate,
+                rewards_rate_denominator,
+            );
         assert!(rewards_amount == 31412778408000000, 0);
     }
 
     #[test_only]
     public fun set_validator_perf_at_least_one_block() acquires ValidatorPerformance {
         let validator_perf = borrow_global_mut<ValidatorPerformance>(@aptos_framework);
-        vector::for_each_mut(&mut validator_perf.validators, |validator|{
-            let validator: &mut IndividualValidatorPerformance = validator;
-            if (validator.successful_proposals + validator.failed_proposals < 1) {
-                validator.successful_proposals = 1;
-            };
-        });
+        vector::for_each_mut(
+            &mut validator_perf.validators,
+            |validator| {
+                let validator: &mut IndividualValidatorPerformance = validator;
+                if (validator.successful_proposals + validator.failed_proposals < 1) {
+                    validator.successful_proposals = 1;
+                };
+            },
+        );
     }
 
     #[test(aptos_framework = @0x1, validator_1 = @0x123, validator_2 = @0x234)]
@@ -3122,18 +3415,30 @@ module aptos_framework::stake {
         let (_sk_2, pk_2, pop_2) = generate_identity();
         initialize_test_validator(&pk_1, &pop_1, validator_1, 100, true, false);
         initialize_test_validator(&pk_2, &pop_2, validator_2, 100, true, true);
-        assert!(vector::length(&borrow_global<ValidatorSet>(@aptos_framework).active_validators) == 2, 0);
+        assert!(
+            vector::length(
+                &borrow_global<ValidatorSet>(@aptos_framework).active_validators
+            ) == 2,
+            0,
+        );
 
         // Remove validator 1 from the active validator set. Only validator 2 remains.
         let validator_to_remove = signer::address_of(validator_1);
         remove_validators(aptos_framework, &vector[validator_to_remove]);
-        assert!(vector::length(&borrow_global<ValidatorSet>(@aptos_framework).active_validators) == 1, 0);
-        assert!(get_validator_state(validator_to_remove) == VALIDATOR_STATUS_PENDING_INACTIVE, 1);
+        assert!(
+            vector::length(
+                &borrow_global<ValidatorSet>(@aptos_framework).active_validators
+            ) == 1,
+            0,
+        );
+        assert!(
+            get_validator_state(validator_to_remove) == VALIDATOR_STATUS_PENDING_INACTIVE,
+            1,
+        );
     }
 
     #[test_only]
-    public fun end_epoch(
-    ) acquires StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
+    public fun end_epoch() acquires StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         // Set the number of blocks to 1, to give out rewards to non-failing validators.
         set_validator_perf_at_least_one_block();
         timestamp::fast_forward_seconds(EPOCH_DURATION);
@@ -3156,9 +3461,15 @@ module aptos_framework::stake {
         let actual_inactive_stake = coin::value(&stake_pool.inactive);
         assert!(actual_inactive_stake == inactive_stake, actual_inactive_stake);
         let actual_pending_active_stake = coin::value(&stake_pool.pending_active);
-        assert!(actual_pending_active_stake == pending_active_stake, actual_pending_active_stake);
+        assert!(
+            actual_pending_active_stake == pending_active_stake,
+            actual_pending_active_stake,
+        );
         let actual_pending_inactive_stake = coin::value(&stake_pool.pending_inactive);
-        assert!(actual_pending_inactive_stake == pending_inactive_stake, actual_pending_inactive_stake);
+        assert!(
+            actual_pending_inactive_stake == pending_inactive_stake,
+            actual_pending_inactive_stake,
+        );
     }
 
     #[test_only]
@@ -3170,15 +3481,23 @@ module aptos_framework::stake {
         pending_inactive_stake: u64,
         validator_index: u64,
     ) acquires StakePool, ValidatorConfig {
-        assert_stake_pool(pool_address, active_stake, inactive_stake, pending_active_stake, pending_inactive_stake);
+        assert_stake_pool(
+            pool_address,
+            active_stake,
+            inactive_stake,
+            pending_active_stake,
+            pending_inactive_stake,
+        );
         let validator_config = borrow_global<ValidatorConfig>(pool_address);
-        assert!(validator_config.validator_index == validator_index, validator_config.validator_index);
+        assert!(
+            validator_config.validator_index == validator_index,
+            validator_config.validator_index,
+        );
     }
 
     #[test(aptos_framework = @0x1, validator = @0x123)]
     public entry fun test_allowed_validators(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, ValidatorSet {
         let addr = signer::address_of(validator);
         let (burn, mint) = aptos_coin::initialize_for_test(aptos_framework);
@@ -3194,8 +3513,7 @@ module aptos_framework::stake {
     #[test(aptos_framework = @0x1, validator = @0x123)]
     #[expected_failure(abort_code = 0x60011, location = Self)]
     public entry fun test_not_allowed_validators(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, ValidatorSet {
         configure_allowed_validators(aptos_framework, vector[]);
         let (burn, mint) = aptos_coin::initialize_for_test(aptos_framework);
@@ -3210,7 +3528,8 @@ module aptos_framework::stake {
 
     #[test_only]
     public fun with_rewards(amount: u64): u64 {
-        let (numerator, denominator) = staking_config::get_reward_rate(&staking_config::get());
+        let (numerator, denominator) =
+            staking_config::get_reward_rate(&staking_config::get());
         amount + amount * numerator / denominator
     }
 
@@ -3238,7 +3557,9 @@ module aptos_framework::stake {
         validator_3: &signer,
     ) acquires AllowedValidators, AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         // Make sure that fees collection and distribution is enabled.
-        features::change_feature_flags_for_testing(aptos_framework, vector[COLLECT_AND_DISTRIBUTE_GAS_FEES], vector[]);
+        features::change_feature_flags_for_testing(
+            aptos_framework, vector[COLLECT_AND_DISTRIBUTE_GAS_FEES], vector[]
+        );
         assert!(features::collect_and_distribute_gas_fees(), 0);
 
         // Initialize staking and validator fees table.

--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -411,12 +411,12 @@ module aptos_framework::stake {
         if (option::is_some(&find_validator(&validator_set.pending_active, pool_address))) {
             VALIDATOR_STATUS_PENDING_ACTIVE
         } else if (option::is_some(
-                &find_validator(&validator_set.active_validators, pool_address)
-            )) {
+            &find_validator(&validator_set.active_validators, pool_address)
+        )) {
             VALIDATOR_STATUS_ACTIVE
         } else if (option::is_some(
-                &find_validator(&validator_set.pending_inactive, pool_address)
-            )) {
+            &find_validator(&validator_set.pending_inactive, pool_address)
+        )) {
             VALIDATOR_STATUS_PENDING_INACTIVE
         } else {
             VALIDATOR_STATUS_INACTIVE
@@ -431,7 +431,7 @@ module aptos_framework::stake {
         let validator_state = get_validator_state(pool_address);
         // Both active and pending inactive validators can still vote in the current epoch.
         if (validator_state == VALIDATOR_STATUS_ACTIVE
-                || validator_state == VALIDATOR_STATUS_PENDING_INACTIVE) {
+            || validator_state == VALIDATOR_STATUS_PENDING_INACTIVE) {
             let active_stake =
                 coin::value(&borrow_global<StakePool>(pool_address).active);
             let pending_inactive_stake =
@@ -542,17 +542,17 @@ module aptos_framework::stake {
         let i = 0;
         // Remove each validator from the validator set.
         while ({
-                spec {
-                    invariant i <= len_validators;
-                    invariant spec_validators_are_initialized(active_validators);
-                    invariant spec_validator_indices_are_valid(active_validators);
-                    invariant spec_validators_are_initialized(pending_inactive);
-                    invariant spec_validator_indices_are_valid(pending_inactive);
-                    invariant ghost_active_num + ghost_pending_inactive_num
-                        == len(active_validators) + len(pending_inactive);
-                };
-                i < len_validators
-            }) {
+            spec {
+                invariant i <= len_validators;
+                invariant spec_validators_are_initialized(active_validators);
+                invariant spec_validator_indices_are_valid(active_validators);
+                invariant spec_validators_are_initialized(pending_inactive);
+                invariant spec_validator_indices_are_valid(pending_inactive);
+                invariant ghost_active_num + ghost_pending_inactive_num
+                    == len(active_validators) + len(pending_inactive);
+            };
+            i < len_validators
+        }) {
             let validator = *vector::borrow(validators, i);
             let validator_index = find_validator(active_validators, validator);
             if (option::is_some(&validator_index)) {
@@ -618,7 +618,8 @@ module aptos_framework::stake {
                 &proof_of_possession_from_bytes(proof_of_possession),
             );
         assert!(
-            option::is_some(pubkey_from_pop), error::invalid_argument(EINVALID_PUBLIC_KEY)
+            option::is_some(pubkey_from_pop),
+            error::invalid_argument(EINVALID_PUBLIC_KEY),
         );
 
         initialize_owner(account);
@@ -637,7 +638,8 @@ module aptos_framework::stake {
         let owner_address = signer::address_of(owner);
         assert!(is_allowed(owner_address), error::not_found(EINELIGIBLE_VALIDATOR));
         assert!(
-            !stake_pool_exists(owner_address), error::already_exists(EALREADY_REGISTERED)
+            !stake_pool_exists(owner_address),
+            error::already_exists(EALREADY_REGISTERED),
         );
 
         move_to(
@@ -785,10 +787,10 @@ module aptos_framework::stake {
         let validator_set = borrow_global_mut<ValidatorSet>(@aptos_framework);
         // Search directly rather using get_validator_state to save on unnecessary loops.
         if (option::is_some(
-                &find_validator(&validator_set.active_validators, pool_address)
-            ) || option::is_some(
-                &find_validator(&validator_set.pending_active, pool_address)
-            )) {
+            &find_validator(&validator_set.active_validators, pool_address)
+        ) || option::is_some(
+            &find_validator(&validator_set.pending_active, pool_address)
+        )) {
             update_voting_power_increase(amount);
         };
 
@@ -848,7 +850,7 @@ module aptos_framework::stake {
 
         if (std::features::module_event_migration_enabled()) {
             event::emit(
-                ReactivateStake { pool_address, amount, },
+                ReactivateStake { pool_address, amount, }
             );
         };
         event::emit_event(
@@ -874,7 +876,8 @@ module aptos_framework::stake {
         );
 
         assert!(
-            exists<ValidatorConfig>(pool_address), error::not_found(EVALIDATOR_CONFIG)
+            exists<ValidatorConfig>(pool_address),
+            error::not_found(EVALIDATOR_CONFIG),
         );
         let validator_info = borrow_global_mut<ValidatorConfig>(pool_address);
         let old_consensus_pubkey = validator_info.consensus_pubkey;
@@ -885,7 +888,8 @@ module aptos_framework::stake {
                 &proof_of_possession_from_bytes(proof_of_possession),
             );
         assert!(
-            option::is_some(pubkey_from_pop), error::invalid_argument(EINVALID_PUBLIC_KEY)
+            option::is_some(pubkey_from_pop),
+            error::invalid_argument(EINVALID_PUBLIC_KEY),
         );
         validator_info.consensus_pubkey = new_consensus_pubkey;
 
@@ -923,7 +927,8 @@ module aptos_framework::stake {
             error::unauthenticated(ENOT_OPERATOR),
         );
         assert!(
-            exists<ValidatorConfig>(pool_address), error::not_found(EVALIDATOR_CONFIG)
+            exists<ValidatorConfig>(pool_address),
+            error::not_found(EVALIDATOR_CONFIG),
         );
         let validator_info = borrow_global_mut<ValidatorConfig>(pool_address);
         let old_network_addresses = validator_info.network_addresses;
@@ -1108,9 +1113,7 @@ module aptos_framework::stake {
     }
 
     /// Withdraw from `account`'s inactive stake.
-    public entry fun withdraw(
-        owner: &signer, withdraw_amount: u64
-    ) acquires OwnerCapability, StakePool, ValidatorSet {
+    public entry fun withdraw(owner: &signer, withdraw_amount: u64) acquires OwnerCapability, StakePool, ValidatorSet {
         let owner_address = signer::address_of(owner);
         assert_owner_cap_exists(owner_address);
         let ownership_cap = borrow_global<OwnerCapability>(owner_address);
@@ -1130,7 +1133,7 @@ module aptos_framework::stake {
         // the stake is fully unlocked (the current lockup cycle has not expired yet).
         // This can leave their stake stuck in pending_inactive even after the current lockup cycle expires.
         if (get_validator_state(pool_address) == VALIDATOR_STATUS_INACTIVE
-                && timestamp::now_seconds() >= stake_pool.locked_until_secs) {
+            && timestamp::now_seconds() >= stake_pool.locked_until_secs) {
             let pending_inactive_stake =
                 coin::extract_all(&mut stake_pool.pending_inactive);
             coin::merge(&mut stake_pool.inactive, pending_inactive_stake);
@@ -1205,7 +1208,8 @@ module aptos_framework::stake {
             let maybe_active_index =
                 find_validator(&validator_set.active_validators, pool_address);
             assert!(
-                option::is_some(&maybe_active_index), error::invalid_state(ENOT_VALIDATOR)
+                option::is_some(&maybe_active_index),
+                error::invalid_state(ENOT_VALIDATOR),
             );
             let validator_info = vector::swap_remove(
                 &mut validator_set.active_validators,
@@ -1270,23 +1274,22 @@ module aptos_framework::stake {
         let f = 0;
         let f_len = vector::length(&failed_proposer_indices);
         while ({
-                spec {
-                    invariant len(validator_perf.validators) == validator_len;
-                    invariant (
-                        option::spec_is_some(ghost_proposer_idx)
-                            && option::spec_borrow(ghost_proposer_idx) < validator_len
-                    ) ==>
-                        (
-                            validator_perf.validators[option::spec_borrow(
-                                    ghost_proposer_idx
-                                )].successful_proposals
-                                == ghost_valid_perf.validators[option::spec_borrow(
-                                        ghost_proposer_idx
-                                    )].successful_proposals + 1
-                        );
-                };
-                f < f_len
-            }) {
+            spec {
+                invariant len(validator_perf.validators) == validator_len;
+                invariant (
+                    option::spec_is_some(ghost_proposer_idx)
+                        && option::spec_borrow(ghost_proposer_idx) < validator_len
+                ) ==>
+                    (
+                        validator_perf.validators[option::spec_borrow(ghost_proposer_idx)]
+                        .successful_proposals
+                            == ghost_valid_perf.validators[option::spec_borrow(
+                                ghost_proposer_idx
+                            )].successful_proposals + 1
+                    );
+            };
+            f < f_len
+        }) {
             let validator_index = *vector::borrow(&failed_proposer_indices, f);
             if (validator_index < validator_len) {
                 let validator = vector::borrow_mut(
@@ -1350,12 +1353,12 @@ module aptos_framework::stake {
         let total_voting_power = 0;
         let i = 0;
         while ({
-                spec {
-                    invariant spec_validators_are_initialized(next_epoch_validators);
-                    invariant i <= vlen;
-                };
-                i < vlen
-            }) {
+            spec {
+                invariant spec_validators_are_initialized(next_epoch_validators);
+                invariant i <= vlen;
+            };
+            i < vlen
+        }) {
             let old_validator_info = vector::borrow_mut(
                 &mut validator_set.active_validators, i
             );
@@ -1388,23 +1391,22 @@ module aptos_framework::stake {
         let vlen = vector::length(&validator_set.active_validators);
         let validator_index = 0;
         while ({
-                spec {
-                    invariant spec_validators_are_initialized(
-                        validator_set.active_validators
-                    );
-                    invariant len(validator_set.pending_active) == 0;
-                    invariant len(validator_set.pending_inactive) == 0;
-                    invariant 0 <= validator_index && validator_index <= vlen;
-                    invariant vlen == len(validator_set.active_validators);
-                    invariant forall i in 0..validator_index: global<ValidatorConfig>(
-                        validator_set.active_validators[i].addr
-                    ).validator_index < validator_index;
-                    invariant forall i in 0..validator_index: validator_set.active_validators[i]
-                        .config.validator_index < validator_index;
-                    invariant len(validator_perf.validators) == validator_index;
-                };
-                validator_index < vlen
-            }) {
+            spec {
+                invariant spec_validators_are_initialized(validator_set.active_validators);
+                invariant len(validator_set.pending_active) == 0;
+                invariant len(validator_set.pending_inactive) == 0;
+                invariant 0 <= validator_index && validator_index <= vlen;
+                invariant vlen == len(validator_set.active_validators);
+                invariant forall i in 0..validator_index:
+                    global<ValidatorConfig>(validator_set.active_validators[i].addr).validator_index
+                        < validator_index;
+                invariant forall i in 0..validator_index:
+                    validator_set.active_validators[i].config.validator_index
+                        < validator_index;
+                invariant len(validator_perf.validators) == validator_index;
+            };
+            validator_index < vlen
+        }) {
             let validator_info = vector::borrow_mut(
                 &mut validator_set.active_validators, validator_index
             );
@@ -1474,17 +1476,17 @@ module aptos_framework::stake {
         };
         let num_candidates = num_cur_actives + num_cur_pending_actives;
         while ({
-                spec {
-                    invariant candidate_idx <= num_candidates;
-                    invariant spec_validators_are_initialized(new_active_validators);
-                    invariant len(new_active_validators) == num_new_actives;
-                    invariant forall i in 0..len(new_active_validators): new_active_validators[i]
-                        .config.validator_index == i;
-                    invariant num_new_actives <= candidate_idx;
-                    invariant spec_validators_are_initialized(new_active_validators);
-                };
-                candidate_idx < num_candidates
-            }) {
+            spec {
+                invariant candidate_idx <= num_candidates;
+                invariant spec_validators_are_initialized(new_active_validators);
+                invariant len(new_active_validators) == num_new_actives;
+                invariant forall i in 0..len(new_active_validators):
+                    new_active_validators[i].config.validator_index == i;
+                invariant num_new_actives <= candidate_idx;
+                invariant spec_validators_are_initialized(new_active_validators);
+            };
+            candidate_idx < num_candidates
+        }) {
             let candidate_in_current_validator_set = candidate_idx < num_cur_actives;
             let candidate =
                 if (candidate_idx < num_cur_actives) {
@@ -1593,17 +1595,17 @@ module aptos_framework::stake {
         // Pre-fill the return value with dummy values.
         let idx = 0;
         while ({
-                spec {
-                    invariant idx
-                        <= len(validator_set.active_validators)
-                            + len(validator_set.pending_inactive);
-                    invariant len(validator_consensus_infos) == idx;
-                    invariant len(validator_consensus_infos)
-                        <= len(validator_set.active_validators)
-                            + len(validator_set.pending_inactive);
-                };
-                idx < total
-            }) {
+            spec {
+                invariant idx
+                    <= len(validator_set.active_validators)
+                        + len(validator_set.pending_inactive);
+                invariant len(validator_consensus_infos) == idx;
+                invariant len(validator_consensus_infos)
+                    <= len(validator_set.active_validators)
+                        + len(validator_set.pending_inactive);
+            };
+            idx < total
+        }) {
             vector::push_back(
                 &mut validator_consensus_infos, validator_consensus_info::default()
             );
@@ -1839,11 +1841,11 @@ module aptos_framework::stake {
         let i = 0;
         let len = vector::length(v);
         while ({
-                spec {
-                    invariant !(exists j in 0..i: v[j].addr == addr);
-                };
-                i < len
-            }) {
+            spec {
+                invariant !(exists j in 0..i: v[j].addr == addr);
+            };
+            i < len
+        }) {
             if (vector::borrow(v, i).addr == addr) {
                 return option::some(i)
             };
@@ -2061,7 +2063,11 @@ module aptos_framework::stake {
         let pk_bytes = bls12381::public_key_to_bytes(public_key);
         let pop_bytes = bls12381::proof_of_possession_to_bytes(proof_of_possession);
         initialize_validator(
-            validator, pk_bytes, pop_bytes, vector::empty(), vector::empty()
+            validator,
+            pk_bytes,
+            pop_bytes,
+            vector::empty(),
+            vector::empty(),
         );
 
         if (amount > 0) {
@@ -2316,7 +2322,8 @@ module aptos_framework::stake {
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS / 2);
         let validator_address = signer::address_of(validator);
         assert!(
-            get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS / 2, 1
+            get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS / 2,
+            1,
         );
 
         // Join the validator set with an existing lockup
@@ -2359,7 +2366,14 @@ module aptos_framework::stake {
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         // Only 50% voting power increase is allowed in each epoch.
         initialize_for_test_custom(
-            aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 50
+            aptos_framework,
+            50,
+            10000,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            50,
         );
         let (_sk_1, pk_1, pop_1) = generate_identity();
         let (_sk_2, pk_2, pop_2) = generate_identity();
@@ -2416,7 +2430,14 @@ module aptos_framework::stake {
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         // 100% voting power increase is allowed in each epoch.
         initialize_for_test_custom(
-            aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 100
+            aptos_framework,
+            50,
+            10000,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            100,
         );
         // Need 1 validator to be in the active validator set so joining limit works.
         let (_sk_1, pk_1, pop_1) = generate_identity();
@@ -2464,7 +2485,14 @@ module aptos_framework::stake {
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         // Only 50% voting power increase is allowed in each epoch.
         initialize_for_test_custom(
-            aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 50
+            aptos_framework,
+            50,
+            10000,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            50,
         );
         // Add initial stake and join the validator set.
         let (_sk, pk, pop) = generate_identity();
@@ -2487,7 +2515,14 @@ module aptos_framework::stake {
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         // Only 50% voting power increase is allowed in each epoch.
         initialize_for_test_custom(
-            aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 50
+            aptos_framework,
+            50,
+            10000,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            50,
         );
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100, true, true);
@@ -2502,7 +2537,14 @@ module aptos_framework::stake {
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         // Reward rate = 10%.
         initialize_for_test_custom(
-            aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 100
+            aptos_framework,
+            50,
+            10000,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            100,
         );
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100, true, true);
@@ -2749,7 +2791,14 @@ module aptos_framework::stake {
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet, ValidatorFees {
         // Only 50% voting power increase is allowed in each epoch.
         initialize_for_test_custom(
-            aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10, 50
+            aptos_framework,
+            50,
+            10000,
+            LOCKUP_CYCLE_SECONDS,
+            true,
+            1,
+            10,
+            50,
         );
         let (_sk_1, pk_1, pop_1) = generate_identity();
         let (_sk_2, pk_2, pop_2) = generate_identity();
@@ -2763,7 +2812,14 @@ module aptos_framework::stake {
         mint_and_add_stake(validator_1, 51);
     }
 
-    #[test(aptos_framework = @0x1, validator_1 = @0x123, validator_2 = @0x234, validator_3 = @0x345)]
+    #[
+        test(
+            aptos_framework = @0x1,
+            validator_1 = @0x123,
+            validator_2 = @0x234,
+            validator_3 = @0x345
+        )
+    ]
     public entry fun test_multiple_validators_join_and_leave(
         aptos_framework: &signer,
         validator_1: &signer,
@@ -2992,7 +3048,16 @@ module aptos_framework::stake {
         leave_validator_set(validator, validator_address);
     }
 
-    #[test(aptos_framework = @aptos_framework, validator_1 = @aptos_framework, validator_2 = @0x2, validator_3 = @0x3, validator_4 = @0x4, validator_5 = @0x5)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            validator_1 = @aptos_framework,
+            validator_2 = @0x2,
+            validator_3 = @0x3,
+            validator_4 = @0x4,
+            validator_5 = @0x5
+        )
+    ]
     fun test_validator_consensus_infos_from_validator_set(
         aptos_framework: &signer,
         validator_1: &signer,
@@ -3082,7 +3147,16 @@ module aptos_framework::stake {
         assert!(vci_vec_0 == vci_vec_4, 14);
     }
 
-    #[test(aptos_framework = @aptos_framework, validator_1 = @aptos_framework, validator_2 = @0x2, validator_3 = @0x3, validator_4 = @0x4, validator_5 = @0x5)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            validator_1 = @aptos_framework,
+            validator_2 = @0x2,
+            validator_3 = @0x3,
+            validator_4 = @0x4,
+            validator_5 = @0x5
+        )
+    ]
     public entry fun test_staking_validator_index(
         aptos_framework: &signer,
         validator_1: &signer,
@@ -3549,7 +3623,14 @@ module aptos_framework::stake {
     #[test_only]
     const COLLECT_AND_DISTRIBUTE_GAS_FEES: u64 = 6;
 
-    #[test(aptos_framework = @0x1, validator_1 = @0x123, validator_2 = @0x234, validator_3 = @0x345)]
+    #[
+        test(
+            aptos_framework = @0x1,
+            validator_1 = @0x123,
+            validator_2 = @0x234,
+            validator_3 = @0x345
+        )
+    ]
     fun test_distribute_validator_fees(
         aptos_framework: &signer,
         validator_1: &signer,

--- a/aptos-move/framework/aptos-framework/sources/stake.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.spec.move
@@ -43,11 +43,15 @@ spec aptos_framework::stake {
     spec module {
         pragma verify = true;
         // The validator set should satisfy its desired invariant.
-        invariant [suspendable] exists<ValidatorSet>(@aptos_framework) ==> validator_set_is_valid();
+        invariant [suspendable] exists<ValidatorSet>(@aptos_framework) ==>
+            validator_set_is_valid();
         // After genesis, `AptosCoinCapabilities`, `ValidatorPerformance` and `ValidatorSet` exist.
-        invariant [suspendable] chain_status::is_operating() ==> exists<AptosCoinCapabilities>(@aptos_framework);
-        invariant [suspendable] chain_status::is_operating() ==> exists<ValidatorPerformance>(@aptos_framework);
-        invariant [suspendable] chain_status::is_operating() ==> exists<ValidatorSet>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<AptosCoinCapabilities>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<ValidatorPerformance>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<ValidatorSet>(@aptos_framework);
 
         // property 2: The owner of a validator remains immutable.
         apply ValidatorOwnerNoChange to *;
@@ -70,22 +74,32 @@ spec aptos_framework::stake {
     }
 
     spec schema ValidatorNotChangeDuringReconfig {
-        ensures (reconfiguration_state::spec_is_in_progress() && old(exists<ValidatorSet>(@aptos_framework))) ==>
-            old(global<ValidatorSet>(@aptos_framework)) == global<ValidatorSet>(@aptos_framework);
+        ensures (
+            reconfiguration_state::spec_is_in_progress()
+                && old(exists<ValidatorSet>(@aptos_framework))
+        ) ==>
+            old(global<ValidatorSet>(@aptos_framework))
+                == global<ValidatorSet>(@aptos_framework);
     }
 
     spec schema StakePoolNotChangeDuringReconfig {
         ensures forall a: address where old(exists<StakePool>(a)): reconfiguration_state::spec_is_in_progress() ==>
-            (old(global<StakePool>(a).pending_inactive) == global<StakePool>(a).pending_inactive &&
-            old(global<StakePool>(a).pending_active) == global<StakePool>(a).pending_active &&
-            old(global<StakePool>(a).inactive) == global<StakePool>(a).inactive &&
-            old(global<StakePool>(a).active) == global<StakePool>(a).active);
+
+            (
+                old(global<StakePool>(a).pending_inactive)
+                    == global<StakePool>(a).pending_inactive
+                && old(global<StakePool>(a).pending_active)
+                    == global<StakePool>(a).pending_active
+                && old(global<StakePool>(a).inactive) == global<StakePool>(a).inactive
+                && old(global<StakePool>(a).active) == global<StakePool>(a).active
+            );
     }
 
     spec schema ValidatorOwnerNoChange {
         /// [high-level-req-2]
-        ensures forall addr: address where old(exists<OwnerCapability>(addr)):
-            old(global<OwnerCapability>(addr)).pool_address == global<OwnerCapability>(addr).pool_address;
+        ensures forall addr: address where old(exists<OwnerCapability>(addr)): old(
+            global<OwnerCapability>(addr)
+        ).pool_address == global<OwnerCapability>(addr).pool_address;
     }
 
     // property 3: The total staked value in the stake pool should be constant (excluding adding and withdrawing operations).
@@ -94,8 +108,11 @@ spec aptos_framework::stake {
         let stake_pool = global<StakePool>(pool_address);
         let post post_stake_pool = global<StakePool>(pool_address);
         /// [high-level-req-3]
-        ensures stake_pool.active.value + stake_pool.inactive.value + stake_pool.pending_active.value + stake_pool.pending_inactive.value ==
-            post_stake_pool.active.value + post_stake_pool.inactive.value + post_stake_pool.pending_active.value + post_stake_pool.pending_inactive.value;
+        ensures stake_pool.active.value + stake_pool.inactive.value
+            + stake_pool.pending_active.value + stake_pool.pending_inactive.value
+            == post_stake_pool.active.value + post_stake_pool.inactive.value
+                + post_stake_pool.pending_active.value
+                + post_stake_pool.pending_inactive.value;
     }
 
     // A desired invariant for the validator set.
@@ -105,14 +122,13 @@ spec aptos_framework::stake {
     }
 
     spec fun validator_set_is_valid_impl(validator_set: ValidatorSet): bool {
-        spec_validators_are_initialized(validator_set.active_validators) &&
-            spec_validators_are_initialized(validator_set.pending_inactive) &&
-            spec_validators_are_initialized(validator_set.pending_active) &&
-            spec_validator_indices_are_valid(validator_set.active_validators) &&
-            spec_validator_indices_are_valid(validator_set.pending_inactive)
+        spec_validators_are_initialized(validator_set.active_validators)
+            && spec_validators_are_initialized(validator_set.pending_inactive)
+            && spec_validators_are_initialized(validator_set.pending_active)
+            && spec_validator_indices_are_valid(validator_set.active_validators)
+            && spec_validator_indices_are_valid(validator_set.pending_inactive)
             && spec_validator_indices_active_pending_inactive(validator_set)
     }
-
 
     // -----------------------
     // Function specifications
@@ -131,30 +147,34 @@ spec aptos_framework::stake {
         proof_of_possession: vector<u8>,
         network_addresses: vector<u8>,
         fullnode_addresses: vector<u8>,
-    ){
+    ) {
         let pubkey_from_pop = bls12381::spec_public_key_from_bytes_with_pop(
             consensus_pubkey,
-            proof_of_possession_from_bytes(proof_of_possession)
+            proof_of_possession_from_bytes(proof_of_possession),
         );
         aborts_if !option::spec_is_some(pubkey_from_pop);
         let addr = signer::address_of(account);
         let post_addr = signer::address_of(account);
         let allowed = global<AllowedValidators>(@aptos_framework);
         aborts_if exists<ValidatorConfig>(addr);
-        aborts_if exists<AllowedValidators>(@aptos_framework) && !vector::spec_contains(allowed.accounts, addr);
+        aborts_if exists<AllowedValidators>(@aptos_framework)
+            && !vector::spec_contains(allowed.accounts, addr);
         aborts_if stake_pool_exists(addr);
         aborts_if exists<OwnerCapability>(addr);
         aborts_if !exists<account::Account>(addr);
         aborts_if global<account::Account>(addr).guid_creation_num + 12 > MAX_U64;
-        aborts_if global<account::Account>(addr).guid_creation_num + 12 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if global<account::Account>(addr).guid_creation_num + 12
+            >= account::MAX_GUID_CREATION_NUM;
         ensures exists<StakePool>(post_addr);
-        ensures global<OwnerCapability>(post_addr) == OwnerCapability { pool_address: post_addr };
-        ensures global<ValidatorConfig>(post_addr) == ValidatorConfig {
-            consensus_pubkey,
-            network_addresses,
-            fullnode_addresses,
-            validator_index: 0,
-        };
+        ensures global<OwnerCapability>(post_addr)
+            == OwnerCapability { pool_address: post_addr };
+        ensures global<ValidatorConfig>(post_addr)
+            == ValidatorConfig {
+                consensus_pubkey,
+                network_addresses,
+                fullnode_addresses,
+                validator_index: 0,
+            };
     }
 
     // `Validator` is initialized once.
@@ -169,11 +189,7 @@ spec aptos_framework::stake {
         ensures exists<ValidatorPerformance>(aptos_addr);
     }
 
-    spec join_validator_set(
-        operator: &signer,
-        pool_address: address
-    )
-    {
+    spec join_validator_set(operator: &signer, pool_address: address) {
         // This function casue timeout (property proved)
         // pragma verify_duration_estimate = 120;
         pragma disable_invariants_in_body;
@@ -188,9 +204,15 @@ spec aptos_framework::stake {
         let validator_set = global<ValidatorSet>(@aptos_framework);
         let post p_validator_set = global<ValidatorSet>(@aptos_framework);
         aborts_if signer::address_of(operator) != stake_pool.operator_address;
-        aborts_if option::spec_is_some(spec_find_validator(validator_set.active_validators, pool_address)) ||
-                    option::spec_is_some(spec_find_validator(validator_set.pending_inactive, pool_address)) ||
-                        option::spec_is_some(spec_find_validator(validator_set.pending_active, pool_address));
+        aborts_if option::spec_is_some(
+                spec_find_validator(validator_set.active_validators, pool_address)
+            )
+            || option::spec_is_some(
+                    spec_find_validator(validator_set.pending_inactive, pool_address)
+                )
+            || option::spec_is_some(
+                spec_find_validator(validator_set.pending_active, pool_address)
+            );
 
         let config = staking_config::get();
         let voting_power = get_next_epoch_voting_power(stake_pool);
@@ -198,20 +220,24 @@ spec aptos_framework::stake {
         let minimum_stake = config.minimum_stake;
         let maximum_stake = config.maximum_stake;
         aborts_if voting_power < minimum_stake;
-        aborts_if voting_power >maximum_stake;
+        aborts_if voting_power > maximum_stake;
 
         let validator_config = global<ValidatorConfig>(pool_address);
         aborts_if vector::is_empty(validator_config.consensus_pubkey);
 
-        let validator_set_size = vector::length(validator_set.active_validators) + vector::length(validator_set.pending_active) + 1;
+        let validator_set_size = vector::length(validator_set.active_validators)
+            + vector::length(validator_set.pending_active) + 1;
         aborts_if validator_set_size > MAX_VALIDATOR_SET_SIZE;
 
-        let voting_power_increase_limit = (staking_config::get_voting_power_increase_limit(config) as u128);
+        let voting_power_increase_limit = (
+            staking_config::get_voting_power_increase_limit(config) as u128
+        );
 
         aborts_if (validator_set.total_joining_power + (voting_power as u128)) > MAX_U128;
         aborts_if validator_set.total_voting_power * voting_power_increase_limit > MAX_U128;
-        aborts_if validator_set.total_voting_power > 0 &&
-            (validator_set.total_joining_power + (voting_power as u128)) * 100 > validator_set.total_voting_power * voting_power_increase_limit;
+        aborts_if validator_set.total_voting_power > 0
+            && (validator_set.total_joining_power + (voting_power as u128)) * 100
+                > validator_set.total_voting_power * voting_power_increase_limit;
 
         let post p_validator_info = ValidatorInfo {
             addr: pool_address,
@@ -219,15 +245,12 @@ spec aptos_framework::stake {
             config: validator_config,
         };
 
-        ensures validator_set.total_joining_power + voting_power == p_validator_set.total_joining_power;
+        ensures validator_set.total_joining_power + voting_power
+            == p_validator_set.total_joining_power;
         ensures vector::spec_contains(p_validator_set.pending_active, p_validator_info);
     }
 
-    spec withdraw(
-        owner: &signer,
-        withdraw_amount: u64
-    )
-    {
+    spec withdraw(owner: &signer, withdraw_amount: u64) {
         // TODO(fa_migration)
         pragma verify = false;
         aborts_if reconfiguration_state::spec_is_in_progress();
@@ -240,33 +263,52 @@ spec aptos_framework::stake {
         aborts_if !exists<ValidatorSet>(@aptos_framework);
 
         let validator_set = global<ValidatorSet>(@aptos_framework);
-        let bool_find_validator = !option::spec_is_some(spec_find_validator(validator_set.active_validators, pool_address)) &&
-                    !option::spec_is_some(spec_find_validator(validator_set.pending_inactive, pool_address)) &&
-                        !option::spec_is_some(spec_find_validator(validator_set.pending_active, pool_address));
-        aborts_if bool_find_validator && !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
-        let new_withdraw_amount_1 = min(withdraw_amount, stake_pool.inactive.value + stake_pool.pending_inactive.value);
+        let bool_find_validator = !option::spec_is_some(
+                spec_find_validator(validator_set.active_validators, pool_address)
+            )
+            && !option::spec_is_some(
+                    spec_find_validator(validator_set.pending_inactive, pool_address)
+                )
+            && !option::spec_is_some(
+                spec_find_validator(validator_set.pending_active, pool_address)
+            );
+        aborts_if bool_find_validator
+            && !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
+        let new_withdraw_amount_1 = min(
+            withdraw_amount, stake_pool.inactive.value + stake_pool.pending_inactive.value
+        );
         let new_withdraw_amount_2 = min(withdraw_amount, stake_pool.inactive.value);
-        aborts_if bool_find_validator && timestamp::now_seconds() > stake_pool.locked_until_secs &&
-                    new_withdraw_amount_1 > 0 && stake_pool.inactive.value + stake_pool.pending_inactive.value < new_withdraw_amount_1;
-        aborts_if !(bool_find_validator && exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework)) &&
-                    new_withdraw_amount_2 > 0 && stake_pool.inactive.value < new_withdraw_amount_2;
+        aborts_if bool_find_validator
+            && timestamp::now_seconds() > stake_pool.locked_until_secs
+            && new_withdraw_amount_1 > 0
+            && stake_pool.inactive.value + stake_pool.pending_inactive.value
+                < new_withdraw_amount_1;
+        aborts_if !(
+                bool_find_validator
+                && exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework)
+            )
+            && new_withdraw_amount_2 > 0
+            && stake_pool.inactive.value < new_withdraw_amount_2;
         aborts_if !exists<coin::CoinStore<AptosCoin>>(addr);
-        include coin::DepositAbortsIf<AptosCoin>{account_addr: addr};
+        include coin::DepositAbortsIf<AptosCoin> { account_addr: addr };
 
         let coin_store = global<coin::CoinStore<AptosCoin>>(addr);
         let post p_coin_store = global<coin::CoinStore<AptosCoin>>(addr);
-        ensures bool_find_validator && timestamp::now_seconds() > stake_pool.locked_until_secs
-                    && exists<account::Account>(addr) && exists<coin::CoinStore<AptosCoin>>(addr) ==>
-                        coin_store.coin.value + new_withdraw_amount_1 == p_coin_store.coin.value;
-        ensures !(bool_find_validator && exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework))
-                    && exists<account::Account>(addr) && exists<coin::CoinStore<AptosCoin>>(addr) ==>
-                        coin_store.coin.value + new_withdraw_amount_2 == p_coin_store.coin.value;
+        ensures bool_find_validator
+            && timestamp::now_seconds() > stake_pool.locked_until_secs
+            && exists<account::Account>(addr)
+            && exists<coin::CoinStore<AptosCoin>>(addr) ==>
+            coin_store.coin.value + new_withdraw_amount_1 == p_coin_store.coin.value;
+        ensures !(
+                bool_find_validator
+                && exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework)
+            )
+            && exists<account::Account>(addr)
+            && exists<coin::CoinStore<AptosCoin>>(addr) ==>
+            coin_store.coin.value + new_withdraw_amount_2 == p_coin_store.coin.value;
     }
 
-    spec leave_validator_set(
-        operator: &signer,
-        pool_address: address
-    ) {
+    spec leave_validator_set(operator: &signer, pool_address: address) {
         pragma disable_invariants_in_body;
         requires chain_status::is_operating();
         aborts_if reconfiguration_state::spec_is_in_progress();
@@ -279,7 +321,9 @@ spec aptos_framework::stake {
         aborts_if signer::address_of(operator) != stake_pool.operator_address;
 
         let validator_set = global<ValidatorSet>(@aptos_framework);
-        let validator_find_bool = option::spec_is_some(spec_find_validator(validator_set.pending_active, pool_address));
+        let validator_find_bool = option::spec_is_some(
+            spec_find_validator(validator_set.pending_active, pool_address)
+        );
         let active_validators = validator_set.active_validators;
         let pending_active = validator_set.pending_active;
 
@@ -287,18 +331,31 @@ spec aptos_framework::stake {
         let post post_active_validators = post_validator_set.active_validators;
         let pending_inactive_validators = validator_set.pending_inactive;
         let post post_pending_inactive_validators = post_validator_set.pending_inactive;
-        ensures len(active_validators) + len(pending_inactive_validators) == len(post_active_validators)
-            + len(post_pending_inactive_validators);
+        ensures len(active_validators) + len(pending_inactive_validators)
+            == len(post_active_validators) + len(post_pending_inactive_validators);
 
-        aborts_if !validator_find_bool && !option::spec_is_some(spec_find_validator(active_validators, pool_address));
-        aborts_if !validator_find_bool && vector::length(validator_set.active_validators) <= option::spec_borrow(spec_find_validator(active_validators, pool_address));
-        aborts_if !validator_find_bool && vector::length(validator_set.active_validators) < 2;
-        aborts_if validator_find_bool && vector::length(validator_set.pending_active) <= option::spec_borrow(spec_find_validator(pending_active, pool_address));
+        aborts_if !validator_find_bool
+            && !option::spec_is_some(spec_find_validator(active_validators, pool_address));
+        aborts_if !validator_find_bool
+            && vector::length(validator_set.active_validators)
+                <= option::spec_borrow(
+                    spec_find_validator(active_validators, pool_address)
+                );
+        aborts_if !validator_find_bool
+            && vector::length(validator_set.active_validators) < 2;
+        aborts_if validator_find_bool
+            && vector::length(validator_set.pending_active)
+                <= option::spec_borrow(spec_find_validator(pending_active, pool_address));
         let post p_validator_set = global<ValidatorSet>(@aptos_framework);
         let validator_stake = (get_next_epoch_voting_power(stake_pool) as u128);
         ensures validator_find_bool && validator_set.total_joining_power > validator_stake ==>
-                    p_validator_set.total_joining_power == validator_set.total_joining_power - validator_stake;
-        ensures !validator_find_bool ==> !option::spec_is_some(spec_find_validator(p_validator_set.pending_active, pool_address));
+
+            p_validator_set.total_joining_power
+                == validator_set.total_joining_power - validator_stake;
+        ensures !validator_find_bool ==>
+            !option::spec_is_some(
+                spec_find_validator(p_validator_set.pending_active, pool_address)
+            );
     }
 
     spec extract_owner_cap(owner: &signer): OwnerCapability {
@@ -326,10 +383,11 @@ spec aptos_framework::stake {
         aborts_if amount != 0 && !exists<StakePool>(pool_address);
         modifies global<StakePool>(pool_address);
         include StakedValueNochange;
-        let min_amount = aptos_std::math64::min(amount,pre_stake_pool.active.value);
+        let min_amount = aptos_std::math64::min(amount, pre_stake_pool.active.value);
 
         ensures stake_pool.active.value == pre_stake_pool.active.value - min_amount;
-        ensures stake_pool.pending_inactive.value == pre_stake_pool.pending_inactive.value + min_amount;
+        ensures stake_pool.pending_inactive.value
+            == pre_stake_pool.pending_inactive.value + min_amount;
     }
 
     // Only active validator can update locked_until_secs.
@@ -392,9 +450,12 @@ spec aptos_framework::stake {
         let pre_stake_pool = global<StakePool>(pool_address);
         let post stake_pool = global<StakePool>(pool_address);
         modifies global<StakePool>(pool_address);
-        let min_amount = aptos_std::math64::min(amount, pre_stake_pool.pending_inactive.value);
+        let min_amount = aptos_std::math64::min(
+            amount, pre_stake_pool.pending_inactive.value
+        );
 
-        ensures stake_pool.pending_inactive.value == pre_stake_pool.pending_inactive.value - min_amount;
+        ensures stake_pool.pending_inactive.value
+            == pre_stake_pool.pending_inactive.value - min_amount;
         ensures stake_pool.active.value == pre_stake_pool.active.value + min_amount;
     }
 
@@ -412,7 +473,7 @@ spec aptos_framework::stake {
         aborts_if !exists<ValidatorConfig>(pool_address);
         let pubkey_from_pop = bls12381::spec_public_key_from_bytes_with_pop(
             new_consensus_pubkey,
-            proof_of_possession_from_bytes(proof_of_possession)
+            proof_of_possession_from_bytes(proof_of_possession),
         );
         aborts_if !option::spec_is_some(pubkey_from_pop);
         modifies global<ValidatorConfig>(pool_address);
@@ -453,9 +514,15 @@ spec aptos_framework::stake {
         let validator_perf = global<ValidatorPerformance>(@aptos_framework);
         let post post_validator_perf = global<ValidatorPerformance>(@aptos_framework);
         let validator_len = len(validator_perf.validators);
-        ensures (option::spec_is_some(ghost_proposer_idx) && option::spec_borrow(ghost_proposer_idx) < validator_len) ==>
-            (post_validator_perf.validators[option::spec_borrow(ghost_proposer_idx)].successful_proposals ==
-                validator_perf.validators[option::spec_borrow(ghost_proposer_idx)].successful_proposals + 1);
+        ensures (
+            option::spec_is_some(ghost_proposer_idx)
+                && option::spec_borrow(ghost_proposer_idx) < validator_len
+        ) ==>
+            (
+                post_validator_perf.validators[option::spec_borrow(ghost_proposer_idx)].successful_proposals ==
+                 validator_perf.validators[option::spec_borrow(ghost_proposer_idx)].successful_proposals
+                + 1
+            );
     }
 
     spec next_validator_consensus_infos {
@@ -464,7 +531,8 @@ spec aptos_framework::stake {
         aborts_if false;
         include ResourceRequirement;
         include GetReconfigStartTimeRequirement;
-        include features::spec_periodical_reward_rate_decrease_enabled() ==> staking_config::StakingRewardsConfigEnabledRequirement;
+        include features::spec_periodical_reward_rate_decrease_enabled() ==>
+            staking_config::StakingRewardsConfigEnabledRequirement;
     }
 
     spec update_stake_pool {
@@ -480,19 +548,28 @@ spec aptos_framework::stake {
         let validator_config = global<ValidatorConfig>(pool_address);
         let cur_validator_perf = validator_perf.validators[validator_config.validator_index];
         let num_successful_proposals = cur_validator_perf.successful_proposals;
-        let num_total_proposals = cur_validator_perf.successful_proposals + cur_validator_perf.failed_proposals;
+        let num_total_proposals = cur_validator_perf.successful_proposals
+            + cur_validator_perf.failed_proposals;
         let rewards_rate = spec_get_reward_rate_1(staking_config);
         let rewards_rate_denominator = spec_get_reward_rate_2(staking_config);
         let rewards_amount_1 = if (stake_pool.active.value > 0) {
-            spec_rewards_amount(stake_pool.active.value, num_successful_proposals, num_total_proposals, rewards_rate, rewards_rate_denominator)
-        } else {
-            0
-        };
+            spec_rewards_amount(
+                stake_pool.active.value,
+                num_successful_proposals,
+                num_total_proposals,
+                rewards_rate,
+                rewards_rate_denominator,
+            )
+        } else { 0 };
         let rewards_amount_2 = if (stake_pool.pending_inactive.value > 0) {
-            spec_rewards_amount(stake_pool.pending_inactive.value, num_successful_proposals, num_total_proposals, rewards_rate, rewards_rate_denominator)
-        } else {
-            0
-        };
+            spec_rewards_amount(
+                stake_pool.pending_inactive.value,
+                num_successful_proposals,
+                num_total_proposals,
+                rewards_rate,
+                rewards_rate_denominator,
+            )
+        } else { 0 };
         let post post_stake_pool = global<StakePool>(pool_address);
         let post post_active_value = post_stake_pool.active.value;
         let post post_pending_inactive_value = post_stake_pool.pending_inactive.value;
@@ -501,18 +578,27 @@ spec aptos_framework::stake {
         let post post_inactive_value = post_stake_pool.inactive.value;
         ensures post_stake_pool.pending_active.value == 0;
         // the amount stored in the stake pool should not changed after the update
-        ensures if (features::spec_is_enabled(features::COLLECT_AND_DISTRIBUTE_GAS_FEES) && table::spec_contains(fees_table, pool_address)) {
-            !table::spec_contains(post_fees_table, pool_address) &&
-            post_active_value == stake_pool.active.value + rewards_amount_1 + stake_pool.pending_active.value + table::spec_get(fees_table, pool_address).value
+        ensures if (features::spec_is_enabled(features::COLLECT_AND_DISTRIBUTE_GAS_FEES)
+                && table::spec_contains(fees_table, pool_address)) {
+            !table::spec_contains(post_fees_table, pool_address)
+                && post_active_value
+                    == stake_pool.active.value + rewards_amount_1
+                        + stake_pool.pending_active.value
+                        + table::spec_get(fees_table, pool_address).value
         } else {
-            post_active_value == stake_pool.active.value + rewards_amount_1 + stake_pool.pending_active.value
+            post_active_value
+                == stake_pool.active.value + rewards_amount_1
+                    + stake_pool.pending_active.value
         };
         // when current lockup cycle has expired, pending inactive should be fully unlocked and moved into inactive
         ensures if (spec_get_reconfig_start_time_secs() >= stake_pool.locked_until_secs) {
-            post_pending_inactive_value == 0 &&
-            post_inactive_value == stake_pool.inactive.value + stake_pool.pending_inactive.value + rewards_amount_2
+            post_pending_inactive_value == 0
+                && post_inactive_value
+                    == stake_pool.inactive.value + stake_pool.pending_inactive.value
+                        + rewards_amount_2
         } else {
-            post_pending_inactive_value == stake_pool.pending_inactive.value + rewards_amount_2
+            post_pending_inactive_value
+                == stake_pool.pending_inactive.value + rewards_amount_2
         };
     }
 
@@ -524,15 +610,16 @@ spec aptos_framework::stake {
 
         aborts_if !exists<StakePool>(pool_address);
         aborts_if !exists<ValidatorConfig>(pool_address);
-        aborts_if global<ValidatorConfig>(pool_address).validator_index >= len(validator_perf.validators);
+        aborts_if global<ValidatorConfig>(pool_address).validator_index
+            >= len(validator_perf.validators);
 
         let aptos_addr = type_info::type_of<AptosCoin>().account_address;
         aborts_if !exists<ValidatorFees>(aptos_addr);
 
         let stake_pool = global<StakePool>(pool_address);
 
-        include DistributeRewardsAbortsIf {stake: stake_pool.active};
-        include DistributeRewardsAbortsIf {stake: stake_pool.pending_inactive};
+        include DistributeRewardsAbortsIf { stake: stake_pool.active };
+        include DistributeRewardsAbortsIf { stake: stake_pool.pending_inactive };
     }
 
     spec distribute_rewards {
@@ -545,21 +632,27 @@ spec aptos_framework::stake {
         include DistributeRewardsAbortsIf;
 
         ensures old(stake.value) > 0 ==>
-            result == spec_rewards_amount(
-                old(stake.value),
-                num_successful_proposals,
-                num_total_proposals,
-                rewards_rate,
-                rewards_rate_denominator);
+            result
+                == spec_rewards_amount(
+                    old(stake.value),
+                    num_successful_proposals,
+                    num_total_proposals,
+                    rewards_rate,
+                    rewards_rate_denominator,
+                );
         ensures old(stake.value) > 0 ==>
-            stake.value == old(stake.value) + spec_rewards_amount(
-                old(stake.value),
-                num_successful_proposals,
-                num_total_proposals,
-                rewards_rate,
-                rewards_rate_denominator);
+            stake.value
+                == old(stake.value)
+                    + spec_rewards_amount(
+                        old(stake.value),
+                        num_successful_proposals,
+                        num_total_proposals,
+                        rewards_rate,
+                        rewards_rate_denominator,
+                    );
         ensures old(stake.value) == 0 ==> result == 0;
-        ensures old(stake.value) == 0 ==> stake.value == old(stake.value);
+        ensures old(stake.value) == 0 ==>
+            stake.value == old(stake.value);
     }
 
     spec schema DistributeRewardsAbortsIf {
@@ -573,15 +666,20 @@ spec aptos_framework::stake {
 
         let stake_amount = coin::value(stake);
         let rewards_amount = if (stake_amount > 0) {
-            spec_rewards_amount(stake_amount, num_successful_proposals, num_total_proposals, rewards_rate, rewards_rate_denominator)
-        } else {
-            0
-        };
+            spec_rewards_amount(
+                stake_amount,
+                num_successful_proposals,
+                num_total_proposals,
+                rewards_rate,
+                rewards_rate_denominator,
+            )
+        } else { 0 };
         let amount = rewards_amount;
         let addr = type_info::type_of<AptosCoin>().account_address;
         aborts_if (rewards_amount > 0) && !exists<coin::CoinInfo<AptosCoin>>(addr);
         modifies global<coin::CoinInfo<AptosCoin>>(addr);
-        include (rewards_amount > 0) ==> coin::CoinAddAbortsIf<AptosCoin> { amount: amount };
+        include (rewards_amount > 0) ==>
+            coin::CoinAddAbortsIf<AptosCoin> { amount: amount };
     }
 
     spec get_reconfig_start_time_secs(): u64 {
@@ -609,31 +707,41 @@ spec aptos_framework::stake {
         requires rewards_rate_denominator > 0;
         requires rewards_rate <= rewards_rate_denominator;
         requires num_successful_proposals <= num_total_proposals;
-        ensures [concrete] (rewards_rate_denominator * num_total_proposals == 0) ==> result == 0;
-        ensures [concrete] (rewards_rate_denominator * num_total_proposals > 0) ==> {
-            let amount = ((stake_amount * rewards_rate * num_successful_proposals) /
-                (rewards_rate_denominator * num_total_proposals));
-            result == amount
-        };
+        ensures [concrete](rewards_rate_denominator * num_total_proposals == 0) ==> result ==
+             0;
+        ensures [concrete](rewards_rate_denominator * num_total_proposals > 0) ==>
+            {
+                let amount =
+                    (
+                        (stake_amount * rewards_rate * num_successful_proposals)
+                            / (rewards_rate_denominator * num_total_proposals)
+                    );
+                result == amount
+            };
         aborts_if false;
 
         // Used an uninterpreted spec function to avoid dealing with the arithmetic overflow and non-linear arithmetic.
-        ensures [abstract] result == spec_rewards_amount(
-            stake_amount,
-            num_successful_proposals,
-            num_total_proposals,
-            rewards_rate,
-            rewards_rate_denominator);
+        ensures [abstract] result
+            == spec_rewards_amount(
+                stake_amount,
+                num_successful_proposals,
+                num_total_proposals,
+                rewards_rate,
+                rewards_rate_denominator,
+            );
     }
 
     spec find_validator {
         pragma opaque;
         aborts_if false;
-        ensures option::is_none(result) ==> (forall i in 0..len(v): v[i].addr != addr);
-        ensures option::is_some(result) ==> v[option::borrow(result)].addr == addr;
+        ensures option::is_none(result) ==>
+            (forall i in 0..len(v): v[i].addr != addr);
+        ensures option::is_some(result) ==>
+            v[option::borrow(result)].addr == addr;
         // Additional postcondition to help the quantifier instantiation.
-        ensures option::is_some(result) ==> spec_contains(v, addr);
-        ensures [abstract] result == spec_find_validator(v,addr);
+        ensures option::is_some(result) ==>
+            spec_contains(v, addr);
+        ensures [abstract] result == spec_find_validator(v, addr);
     }
 
     spec append {
@@ -644,7 +752,11 @@ spec aptos_framework::stake {
         // The prefix of the new `v1` is the same as the old `v1`.
         ensures (forall i in 0..old(len(v1)): v1[i] == old(v1[i]));
         // The suffix of the new `v1` is the same as the reverse of the old `v2`.
-        ensures (forall i in old(len(v1))..len(v1): v1[i] == old(v2[len(v2) - (i - len(v1)) - 1]));
+        ensures (
+            forall i in old(len(v1))..len(v1): v1[i] == old(
+                v2[len(v2) - (i - len(v1)) - 1]
+            )
+        );
     }
 
     spec remove_validators {
@@ -657,8 +769,8 @@ spec aptos_framework::stake {
         let post post_pending_inactive_validators = post_validator_set.pending_inactive;
 
         invariant len(active_validators) > 0;
-        ensures len(active_validators) + len(pending_inactive_validators) == len(post_active_validators)
-            + len(post_pending_inactive_validators);
+        ensures len(active_validators) + len(pending_inactive_validators)
+            == len(post_active_validators) + len(post_pending_inactive_validators);
     }
 
     spec is_current_epoch_validator {
@@ -670,14 +782,18 @@ spec aptos_framework::stake {
     spec get_validator_state {
         aborts_if !exists<ValidatorSet>(@aptos_framework);
         let validator_set = global<ValidatorSet>(@aptos_framework);
-        ensures result == VALIDATOR_STATUS_PENDING_ACTIVE ==> spec_contains(validator_set.pending_active, pool_address);
-        ensures result == VALIDATOR_STATUS_ACTIVE ==> spec_contains(validator_set.active_validators, pool_address);
-        ensures result == VALIDATOR_STATUS_PENDING_INACTIVE ==> spec_contains(validator_set.pending_inactive, pool_address);
-        ensures result == VALIDATOR_STATUS_INACTIVE ==> (
-            !spec_contains(validator_set.pending_active, pool_address)
+        ensures result == VALIDATOR_STATUS_PENDING_ACTIVE ==>
+            spec_contains(validator_set.pending_active, pool_address);
+        ensures result == VALIDATOR_STATUS_ACTIVE ==>
+            spec_contains(validator_set.active_validators, pool_address);
+        ensures result == VALIDATOR_STATUS_PENDING_INACTIVE ==>
+            spec_contains(validator_set.pending_inactive, pool_address);
+        ensures result == VALIDATOR_STATUS_INACTIVE ==>
+            (
+                !spec_contains(validator_set.pending_active, pool_address)
                 && !spec_contains(validator_set.active_validators, pool_address)
                 && !spec_contains(validator_set.pending_inactive, pool_address)
-        );
+            );
     }
 
     spec add_stake_with_cap {
@@ -700,22 +816,20 @@ spec aptos_framework::stake {
     }
 
     spec initialize_stake_owner(
-        owner: &signer,
-        initial_stake_amount: u64,
-        operator: address,
-        voter: address,
+        owner: &signer, initial_stake_amount: u64, operator: address, voter: address,
     ) {
         // TODO: These function failed in github CI
         pragma verify_duration_estimate = 120;
 
         include ResourceRequirement;
         let addr = signer::address_of(owner);
-        ensures global<ValidatorConfig>(addr) == ValidatorConfig {
-            consensus_pubkey: vector::empty(),
-            network_addresses: vector::empty(),
-            fullnode_addresses: vector::empty(),
-            validator_index: 0,
-        };
+        ensures global<ValidatorConfig>(addr)
+            == ValidatorConfig {
+                consensus_pubkey: vector::empty(),
+                network_addresses: vector::empty(),
+                fullnode_addresses: vector::empty(),
+                validator_index: 0,
+            };
         ensures global<OwnerCapability>(addr) == OwnerCapability { pool_address: addr };
         let post stakepool = global<StakePool>(addr);
         let post active = stakepool.active.value;
@@ -735,8 +849,8 @@ spec aptos_framework::stake {
         ensures if (table::spec_contains(fees_table, validator_addr)) {
             post_collected_fee.value == collected_fee.value + fee.value
         } else {
-            table::spec_contains(post_fees_table, validator_addr) &&
-            table::spec_get(post_fees_table, validator_addr) == fee
+            table::spec_contains(post_fees_table, validator_addr)
+                && table::spec_get(post_fees_table, validator_addr) == fee
         };
     }
 
@@ -751,13 +865,18 @@ spec aptos_framework::stake {
         let staking_config = global<staking_config::StakingConfig>(aptos);
         let voting_power_increase_limit = staking_config.voting_power_increase_limit;
         aborts_if pre_validator_set.total_joining_power + increase_amount > MAX_U128;
-        aborts_if pre_validator_set.total_voting_power > 0 && pre_validator_set.total_voting_power * voting_power_increase_limit > MAX_U128;
-        aborts_if pre_validator_set.total_voting_power > 0 &&
-            pre_validator_set.total_joining_power + increase_amount > pre_validator_set.total_voting_power * voting_power_increase_limit / 100;
+        aborts_if pre_validator_set.total_voting_power > 0
+            && pre_validator_set.total_voting_power * voting_power_increase_limit
+                > MAX_U128;
+        aborts_if pre_validator_set.total_voting_power > 0
+            && pre_validator_set.total_joining_power + increase_amount
+                > pre_validator_set.total_voting_power * voting_power_increase_limit / 100;
         // Correctly modified total_joining_power and the value of total_voting_power is legal.
         ensures validator_set.total_voting_power > 0 ==>
-            validator_set.total_joining_power <= validator_set.total_voting_power * voting_power_increase_limit / 100;
-        ensures validator_set.total_joining_power == pre_validator_set.total_joining_power + increase_amount;
+            validator_set.total_joining_power
+                <= validator_set.total_voting_power * voting_power_increase_limit / 100;
+        ensures validator_set.total_joining_power
+            == pre_validator_set.total_joining_power + increase_amount;
     }
 
     spec assert_stake_pool_exists(pool_address: address) {
@@ -776,13 +895,18 @@ spec aptos_framework::stake {
         aborts_if !exists<OwnerCapability>(owner);
     }
 
-    spec validator_consensus_infos_from_validator_set(validator_set: &ValidatorSet): vector<ValidatorConsensusInfo> {
+    spec validator_consensus_infos_from_validator_set(validator_set: &ValidatorSet): vector<
+        ValidatorConsensusInfo> {
         aborts_if false;
-        invariant spec_validator_indices_are_valid_config(validator_set.active_validators,
-            len(validator_set.active_validators) + len(validator_set.pending_inactive));
-        invariant len(validator_set.pending_inactive) == 0 ||
-            spec_validator_indices_are_valid_config(validator_set.pending_inactive,
-                len(validator_set.active_validators) + len(validator_set.pending_inactive));
+        invariant spec_validator_indices_are_valid_config(
+            validator_set.active_validators,
+            len(validator_set.active_validators) + len(validator_set.pending_inactive),
+        );
+        invariant len(validator_set.pending_inactive) == 0
+            || spec_validator_indices_are_valid_config(
+                validator_set.pending_inactive,
+                len(validator_set.active_validators) + len(validator_set.pending_inactive),
+            );
     }
 
     // ---------------------------------
@@ -800,23 +924,35 @@ spec aptos_framework::stake {
         let validator_set = global<ValidatorSet>(@aptos_framework);
         let voting_power_increase_limit = config.voting_power_increase_limit;
         let post post_validator_set = global<ValidatorSet>(@aptos_framework);
-        let update_voting_power_increase = amount != 0 && (spec_contains(validator_set.active_validators, pool_address)
-                                                           || spec_contains(validator_set.pending_active, pool_address));
-        aborts_if update_voting_power_increase && validator_set.total_joining_power + amount > MAX_U128;
-        ensures update_voting_power_increase ==> post_validator_set.total_joining_power == validator_set.total_joining_power + amount;
-        aborts_if update_voting_power_increase && validator_set.total_voting_power > 0
-                && validator_set.total_voting_power * voting_power_increase_limit > MAX_U128;
-        aborts_if update_voting_power_increase && validator_set.total_voting_power > 0
-                && validator_set.total_joining_power + amount > validator_set.total_voting_power * voting_power_increase_limit / 100;
+        let update_voting_power_increase = amount != 0
+            && (
+                spec_contains(validator_set.active_validators, pool_address)
+                    || spec_contains(validator_set.pending_active, pool_address)
+            );
+        aborts_if update_voting_power_increase
+            && validator_set.total_joining_power + amount > MAX_U128;
+        ensures update_voting_power_increase ==>
+            post_validator_set.total_joining_power
+                == validator_set.total_joining_power + amount;
+        aborts_if update_voting_power_increase
+            && validator_set.total_voting_power > 0
+            && validator_set.total_voting_power * voting_power_increase_limit > MAX_U128;
+        aborts_if update_voting_power_increase
+            && validator_set.total_voting_power > 0
+            && validator_set.total_joining_power + amount
+                > validator_set.total_voting_power * voting_power_increase_limit / 100;
         let stake_pool = global<StakePool>(pool_address);
         let post post_stake_pool = global<StakePool>(pool_address);
         let value_pending_active = stake_pool.pending_active.value;
         let value_active = stake_pool.active.value;
-        ensures amount != 0 && spec_is_current_epoch_validator(pool_address) ==> post_stake_pool.pending_active.value == value_pending_active + amount;
-        ensures amount != 0 && !spec_is_current_epoch_validator(pool_address) ==> post_stake_pool.active.value == value_active + amount;
+        ensures amount != 0 && spec_is_current_epoch_validator(pool_address) ==>
+            post_stake_pool.pending_active.value == value_pending_active + amount;
+        ensures amount != 0 && !spec_is_current_epoch_validator(pool_address) ==>
+            post_stake_pool.active.value == value_active + amount;
         let maximum_stake = config.maximum_stake;
         let value_pending_inactive = stake_pool.pending_inactive.value;
-        let next_epoch_voting_power = value_pending_active + value_active + value_pending_inactive;
+        let next_epoch_voting_power = value_pending_active + value_active
+            + value_pending_inactive;
         let voting_power = next_epoch_voting_power + amount;
         aborts_if amount != 0 && voting_power > MAX_U64;
         aborts_if amount != 0 && voting_power > maximum_stake;
@@ -834,9 +970,8 @@ spec aptos_framework::stake {
     }
 
     spec fun spec_is_allowed(account: address): bool {
-        if (!exists<AllowedValidators>(@aptos_framework)) {
-            true
-        } else {
+        if (!exists<AllowedValidators>(@aptos_framework)) { true }
+        else {
             let allowed = global<AllowedValidators>(@aptos_framework);
             contains(allowed.accounts, account)
         }
@@ -846,36 +981,40 @@ spec aptos_framework::stake {
 
     // A predicate that all given validators have been initialized.
     spec fun spec_validators_are_initialized(validators: vector<ValidatorInfo>): bool {
-        forall i in 0..len(validators):
-            spec_has_stake_pool(validators[i].addr) &&
-                spec_has_validator_config(validators[i].addr)
+        forall i in 0..len(validators): spec_has_stake_pool(validators[i].addr)
+            && spec_has_validator_config(validators[i].addr)
     }
 
     spec fun spec_validators_are_initialized_addrs(addrs: vector<address>): bool {
-        forall i in 0..len(addrs):
-            spec_has_stake_pool(addrs[i]) &&
-                spec_has_validator_config(addrs[i])
+        forall i in 0..len(addrs): spec_has_stake_pool(addrs[i])
+            && spec_has_validator_config(addrs[i])
     }
-
 
     // A predicate that the validator index of each given validator in-range.
     spec fun spec_validator_indices_are_valid(validators: vector<ValidatorInfo>): bool {
-        spec_validator_indices_are_valid_addr(validators, spec_validator_index_upper_bound()) &&
-            spec_validator_indices_are_valid_config(validators, spec_validator_index_upper_bound())
+        spec_validator_indices_are_valid_addr(
+            validators, spec_validator_index_upper_bound()
+        ) && spec_validator_indices_are_valid_config(
+            validators, spec_validator_index_upper_bound()
+        )
     }
 
-    spec fun spec_validator_indices_are_valid_addr(validators: vector<ValidatorInfo>, upper_bound: u64): bool {
-        forall i in 0..len(validators):
-            global<ValidatorConfig>(validators[i].addr).validator_index < upper_bound
+    spec fun spec_validator_indices_are_valid_addr(
+        validators: vector<ValidatorInfo>, upper_bound: u64
+    ): bool {
+        forall i in 0..len(validators): global<ValidatorConfig>(validators[i].addr).validator_index
+            < upper_bound
     }
 
-    spec fun spec_validator_indices_are_valid_config(validators: vector<ValidatorInfo>, upper_bound: u64): bool {
-        forall i in 0..len(validators):
-            validators[i].config.validator_index < upper_bound
+    spec fun spec_validator_indices_are_valid_config(
+        validators: vector<ValidatorInfo>, upper_bound: u64
+    ): bool {
+        forall i in 0..len(validators): validators[i].config.validator_index < upper_bound
     }
 
     spec fun spec_validator_indices_active_pending_inactive(validator_set: ValidatorSet): bool {
-        len(validator_set.pending_inactive) + len(validator_set.active_validators) == spec_validator_index_upper_bound()
+        len(validator_set.pending_inactive) + len(validator_set.active_validators)
+            == spec_validator_index_upper_bound()
     }
 
     // The upper bound of validator indices.
@@ -907,8 +1046,10 @@ spec aptos_framework::stake {
     spec fun spec_is_current_epoch_validator(pool_address: address): bool {
         let validator_set = global<ValidatorSet>(@aptos_framework);
         !spec_contains(validator_set.pending_active, pool_address)
-            && (spec_contains(validator_set.active_validators, pool_address)
-            || spec_contains(validator_set.pending_inactive, pool_address))
+            && (
+                spec_contains(validator_set.active_validators, pool_address)
+                    || spec_contains(validator_set.pending_inactive, pool_address)
+            )
     }
 
     // These resources are required to successfully execute `on_new_epoch`, which cannot
@@ -918,7 +1059,8 @@ spec aptos_framework::stake {
         requires exists<ValidatorPerformance>(@aptos_framework);
         requires exists<ValidatorSet>(@aptos_framework);
         requires exists<StakingConfig>(@aptos_framework);
-        requires exists<StakingRewardsConfig>(@aptos_framework) || !features::spec_periodical_reward_rate_decrease_enabled();
+        requires exists<StakingRewardsConfig>(@aptos_framework)
+            || !features::spec_periodical_reward_rate_decrease_enabled();
         requires exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
         requires exists<ValidatorFees>(@aptos_framework);
     }
@@ -927,31 +1069,40 @@ spec aptos_framework::stake {
     // So we write two helper functions here to model function staking_config::get_reward_rate().
     spec fun spec_get_reward_rate_1(config: StakingConfig): num {
         if (features::spec_periodical_reward_rate_decrease_enabled()) {
-            let epoch_rewards_rate = global<staking_config::StakingRewardsConfig>(@aptos_framework).rewards_rate;
-            if (epoch_rewards_rate.value == 0) {
-                0
-            } else {
-                let denominator_0 = aptos_std::fixed_point64::spec_divide_u128(staking_config::MAX_REWARDS_RATE, epoch_rewards_rate);
+            let epoch_rewards_rate =
+                global<staking_config::StakingRewardsConfig>(@aptos_framework).rewards_rate;
+            if (epoch_rewards_rate.value == 0) { 0 }
+            else {
+                let denominator_0 =
+                    aptos_std::fixed_point64::spec_divide_u128(
+                        staking_config::MAX_REWARDS_RATE, epoch_rewards_rate
+                    );
                 let denominator = if (denominator_0 > MAX_U64) {
                     MAX_U64
                 } else {
                     denominator_0
                 };
-                let nominator = aptos_std::fixed_point64::spec_multiply_u128(denominator, epoch_rewards_rate);
+                let nominator =
+                    aptos_std::fixed_point64::spec_multiply_u128(
+                        denominator, epoch_rewards_rate
+                    );
                 nominator
             }
         } else {
-                config.rewards_rate
+            config.rewards_rate
         }
     }
 
     spec fun spec_get_reward_rate_2(config: StakingConfig): num {
         if (features::spec_periodical_reward_rate_decrease_enabled()) {
-            let epoch_rewards_rate = global<staking_config::StakingRewardsConfig>(@aptos_framework).rewards_rate;
-            if (epoch_rewards_rate.value == 0) {
-                1
-            } else {
-                let denominator_0 = aptos_std::fixed_point64::spec_divide_u128(staking_config::MAX_REWARDS_RATE, epoch_rewards_rate);
+            let epoch_rewards_rate =
+                global<staking_config::StakingRewardsConfig>(@aptos_framework).rewards_rate;
+            if (epoch_rewards_rate.value == 0) { 1 }
+            else {
+                let denominator_0 =
+                    aptos_std::fixed_point64::spec_divide_u128(
+                        staking_config::MAX_REWARDS_RATE, epoch_rewards_rate
+                    );
                 let denominator = if (denominator_0 > MAX_U64) {
                     MAX_U64
                 } else {
@@ -960,7 +1111,7 @@ spec aptos_framework::stake {
                 denominator
             }
         } else {
-                config.rewards_rate_denominator
+            config.rewards_rate_denominator
         }
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/stake.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.spec.move
@@ -83,23 +83,23 @@ spec aptos_framework::stake {
     }
 
     spec schema StakePoolNotChangeDuringReconfig {
-        ensures forall a: address where old(exists<StakePool>(a)): reconfiguration_state::spec_is_in_progress() ==>
-
+        ensures forall a: address where old(exists<StakePool>(a)):
+            reconfiguration_state::spec_is_in_progress() ==>
             (
                 old(global<StakePool>(a).pending_inactive)
                     == global<StakePool>(a).pending_inactive
-                && old(global<StakePool>(a).pending_active)
-                    == global<StakePool>(a).pending_active
-                && old(global<StakePool>(a).inactive) == global<StakePool>(a).inactive
-                && old(global<StakePool>(a).active) == global<StakePool>(a).active
+                    && old(global<StakePool>(a).pending_active)
+                        == global<StakePool>(a).pending_active
+                    && old(global<StakePool>(a).inactive) == global<StakePool>(a).inactive
+                    && old(global<StakePool>(a).active) == global<StakePool>(a).active
             );
     }
 
     spec schema ValidatorOwnerNoChange {
         /// [high-level-req-2]
-        ensures forall addr: address where old(exists<OwnerCapability>(addr)): old(
-            global<OwnerCapability>(addr)
-        ).pool_address == global<OwnerCapability>(addr).pool_address;
+        ensures forall addr: address where old(exists<OwnerCapability>(addr)):
+            old(global<OwnerCapability>(addr)).pool_address
+                == global<OwnerCapability>(addr).pool_address;
     }
 
     // property 3: The total staked value in the stake pool should be constant (excluding adding and withdrawing operations).
@@ -205,11 +205,11 @@ spec aptos_framework::stake {
         let post p_validator_set = global<ValidatorSet>(@aptos_framework);
         aborts_if signer::address_of(operator) != stake_pool.operator_address;
         aborts_if option::spec_is_some(
-                spec_find_validator(validator_set.active_validators, pool_address)
-            )
+            spec_find_validator(validator_set.active_validators, pool_address)
+        )
             || option::spec_is_some(
-                    spec_find_validator(validator_set.pending_inactive, pool_address)
-                )
+                spec_find_validator(validator_set.pending_inactive, pool_address)
+            )
             || option::spec_is_some(
                 spec_find_validator(validator_set.pending_active, pool_address)
             );
@@ -264,11 +264,11 @@ spec aptos_framework::stake {
 
         let validator_set = global<ValidatorSet>(@aptos_framework);
         let bool_find_validator = !option::spec_is_some(
-                spec_find_validator(validator_set.active_validators, pool_address)
-            )
+            spec_find_validator(validator_set.active_validators, pool_address)
+        )
             && !option::spec_is_some(
-                    spec_find_validator(validator_set.pending_inactive, pool_address)
-                )
+                spec_find_validator(validator_set.pending_inactive, pool_address)
+            )
             && !option::spec_is_some(
                 spec_find_validator(validator_set.pending_active, pool_address)
             );
@@ -284,9 +284,9 @@ spec aptos_framework::stake {
             && stake_pool.inactive.value + stake_pool.pending_inactive.value
                 < new_withdraw_amount_1;
         aborts_if !(
-                bool_find_validator
+            bool_find_validator
                 && exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework)
-            )
+        )
             && new_withdraw_amount_2 > 0
             && stake_pool.inactive.value < new_withdraw_amount_2;
         aborts_if !exists<coin::CoinStore<AptosCoin>>(addr);
@@ -300,9 +300,9 @@ spec aptos_framework::stake {
             && exists<coin::CoinStore<AptosCoin>>(addr) ==>
             coin_store.coin.value + new_withdraw_amount_1 == p_coin_store.coin.value;
         ensures !(
-                bool_find_validator
+            bool_find_validator
                 && exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework)
-            )
+        )
             && exists<account::Account>(addr)
             && exists<coin::CoinStore<AptosCoin>>(addr) ==>
             coin_store.coin.value + new_withdraw_amount_2 == p_coin_store.coin.value;
@@ -350,8 +350,8 @@ spec aptos_framework::stake {
         let validator_stake = (get_next_epoch_voting_power(stake_pool) as u128);
         ensures validator_find_bool && validator_set.total_joining_power > validator_stake ==>
 
-            p_validator_set.total_joining_power
-                == validator_set.total_joining_power - validator_stake;
+        p_validator_set.total_joining_power
+            == validator_set.total_joining_power - validator_stake;
         ensures !validator_find_bool ==>
             !option::spec_is_some(
                 spec_find_validator(p_validator_set.pending_active, pool_address)
@@ -579,7 +579,7 @@ spec aptos_framework::stake {
         ensures post_stake_pool.pending_active.value == 0;
         // the amount stored in the stake pool should not changed after the update
         ensures if (features::spec_is_enabled(features::COLLECT_AND_DISTRIBUTE_GAS_FEES)
-                && table::spec_contains(fees_table, pool_address)) {
+            && table::spec_contains(fees_table, pool_address)) {
             !table::spec_contains(post_fees_table, pool_address)
                 && post_active_value
                     == stake_pool.active.value + rewards_amount_1
@@ -753,9 +753,10 @@ spec aptos_framework::stake {
         ensures (forall i in 0..old(len(v1)): v1[i] == old(v1[i]));
         // The suffix of the new `v1` is the same as the reverse of the old `v2`.
         ensures (
-            forall i in old(len(v1))..len(v1): v1[i] == old(
-                v2[len(v2) - (i - len(v1)) - 1]
-            )
+            forall i in old(len(v1))..len(v1):
+                v1[i] == old(
+                    v2[len(v2) - (i - len(v1)) - 1]
+                )
         );
     }
 
@@ -791,8 +792,8 @@ spec aptos_framework::stake {
         ensures result == VALIDATOR_STATUS_INACTIVE ==>
             (
                 !spec_contains(validator_set.pending_active, pool_address)
-                && !spec_contains(validator_set.active_validators, pool_address)
-                && !spec_contains(validator_set.pending_inactive, pool_address)
+                    && !spec_contains(validator_set.active_validators, pool_address)
+                    && !spec_contains(validator_set.pending_inactive, pool_address)
             );
     }
 
@@ -981,13 +982,14 @@ spec aptos_framework::stake {
 
     // A predicate that all given validators have been initialized.
     spec fun spec_validators_are_initialized(validators: vector<ValidatorInfo>): bool {
-        forall i in 0..len(validators): spec_has_stake_pool(validators[i].addr)
-            && spec_has_validator_config(validators[i].addr)
+        forall i in 0..len(validators):
+            spec_has_stake_pool(validators[i].addr)
+                && spec_has_validator_config(validators[i].addr)
     }
 
     spec fun spec_validators_are_initialized_addrs(addrs: vector<address>): bool {
-        forall i in 0..len(addrs): spec_has_stake_pool(addrs[i])
-            && spec_has_validator_config(addrs[i])
+        forall i in 0..len(addrs):
+            spec_has_stake_pool(addrs[i]) && spec_has_validator_config(addrs[i])
     }
 
     // A predicate that the validator index of each given validator in-range.
@@ -1002,14 +1004,15 @@ spec aptos_framework::stake {
     spec fun spec_validator_indices_are_valid_addr(
         validators: vector<ValidatorInfo>, upper_bound: u64
     ): bool {
-        forall i in 0..len(validators): global<ValidatorConfig>(validators[i].addr).validator_index
-            < upper_bound
+        forall i in 0..len(validators):
+            global<ValidatorConfig>(validators[i].addr).validator_index < upper_bound
     }
 
     spec fun spec_validator_indices_are_valid_config(
         validators: vector<ValidatorInfo>, upper_bound: u64
     ): bool {
-        forall i in 0..len(validators): validators[i].config.validator_index < upper_bound
+        forall i in 0..len(validators):
+            validators[i].config.validator_index < upper_bound
     }
 
     spec fun spec_validator_indices_active_pending_inactive(validator_set: ValidatorSet): bool {

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.move
@@ -117,7 +117,9 @@ module aptos_framework::staking_contract {
         new_commission_percentage: u64,
     }
 
-    #[resource_group_member(group = aptos_framework::staking_contract::StakingGroupContainer)]
+    #[resource_group_member(
+        group = aptos_framework::staking_contract::StakingGroupContainer
+    )]
     struct StakingGroupUpdateCommissionEvent has key {
         update_commission_events: EventHandle<UpdateCommissionEvent>,
     }
@@ -549,7 +551,10 @@ module aptos_framework::staking_contract {
         let staking_contract =
             simple_map::borrow_mut(&mut store.staking_contracts, &operator);
         distribute_internal(
-            staker_address, operator, staking_contract, &mut store.distribute_events
+            staker_address,
+            operator,
+            staking_contract,
+            &mut store.distribute_events,
         );
         request_commission_internal(
             operator,
@@ -599,8 +604,8 @@ module aptos_framework::staking_contract {
         let account_addr = signer::address_of(account);
         assert!(
             account_addr == staker
-            || account_addr == operator
-            || account_addr == beneficiary_for_operator(operator),
+                || account_addr == operator
+                || account_addr == beneficiary_for_operator(operator),
             error::unauthenticated(ENOT_STAKER_OR_OPERATOR_OR_BENEFICIARY),
         );
         assert_staking_contract_exists(staker, operator);
@@ -613,7 +618,10 @@ module aptos_framework::staking_contract {
 
         // Force distribution of any already inactive stake.
         distribute_internal(
-            staker, operator, staking_contract, &mut store.distribute_events
+            staker,
+            operator,
+            staking_contract,
+            &mut store.distribute_events,
         );
 
         request_commission_internal(
@@ -694,7 +702,10 @@ module aptos_framework::staking_contract {
 
         // Force distribution of any already inactive stake.
         distribute_internal(
-            staker_address, operator, staking_contract, &mut store.distribute_events
+            staker_address,
+            operator,
+            staking_contract,
+            &mut store.distribute_events,
         );
 
         // For simplicity, we request commission to be paid out first. This avoids having to ensure to staker doesn't
@@ -855,7 +866,10 @@ module aptos_framework::staking_contract {
         let staking_contract =
             simple_map::borrow_mut(&mut store.staking_contracts, &operator);
         distribute_internal(
-            staker, operator, staking_contract, &mut store.distribute_events
+            staker,
+            operator,
+            staking_contract,
+            &mut store.distribute_events,
         );
     }
 
@@ -937,7 +951,8 @@ module aptos_framework::staking_contract {
         staker: address, operator: address
     ) acquires Store {
         assert!(
-            exists<Store>(staker), error::not_found(ENO_STAKING_CONTRACT_FOUND_FOR_STAKER)
+            exists<Store>(staker),
+            error::not_found(ENO_STAKING_CONTRACT_FOUND_FOR_STAKER),
         );
         let staking_contracts = &mut borrow_global_mut<Store>(staker).staking_contracts;
         assert!(
@@ -1049,7 +1064,10 @@ module aptos_framework::staking_contract {
                             distribution_pool, unpaid_commission, updated_total_coins
                         );
                     pool_u64::transfer_shares(
-                        distribution_pool, shareholder, operator, shares_to_transfer
+                        distribution_pool,
+                        shareholder,
+                        operator,
+                        shares_to_transfer,
                     );
                 };
             },
@@ -1165,7 +1183,9 @@ module aptos_framework::staking_contract {
             vector::empty<u8>(),
         );
         std::features::change_feature_flags_for_testing(
-            aptos_framework, vector[MODULE_EVENT, OPERATOR_BENEFICIARY_CHANGE], vector[]
+            aptos_framework,
+            vector[MODULE_EVENT, OPERATOR_BENEFICIARY_CHANGE],
+            vector[],
         );
     }
 
@@ -1184,7 +1204,7 @@ module aptos_framework::staking_contract {
         stake::assert_stake_pool(pool_address, INITIAL_BALANCE, 0, 0, 0);
         assert!(
             last_recorded_principal(staker_address, operator_address) == INITIAL_BALANCE,
-            0
+            0,
         );
 
         // Operator joins the validator set.
@@ -1207,7 +1227,10 @@ module aptos_framework::staking_contract {
             last_recorded_principal(staker_address, operator_address) == new_balance, 0
         );
         assert_distribution(
-            staker_address, operator_address, operator_address, expected_commission_1
+            staker_address,
+            operator_address,
+            operator_address,
+            expected_commission_1,
         );
         stake::fast_forward_to_unlock(pool_address);
 
@@ -1243,7 +1266,10 @@ module aptos_framework::staking_contract {
         new_balance = new_balance - expected_commission_2;
         request_commission(operator, staker_address, operator_address);
         assert_distribution(
-            staker_address, operator_address, operator_address, expected_commission_2
+            staker_address,
+            operator_address,
+            operator_address,
+            expected_commission_2,
         );
         assert!(
             last_recorded_principal(staker_address, operator_address) == new_balance, 0
@@ -1267,11 +1293,17 @@ module aptos_framework::staking_contract {
         unlock_stake(staker, operator_address, new_balance);
         stake::assert_stake_pool(pool_address, 0, 0, 0, new_balance);
         assert_distribution(
-            staker_address, operator_address, operator_address, unpaid_commission
+            staker_address,
+            operator_address,
+            operator_address,
+            unpaid_commission,
         );
         let withdrawn_amount = new_balance - unpaid_commission;
         assert_distribution(
-            staker_address, operator_address, staker_address, withdrawn_amount
+            staker_address,
+            operator_address,
+            staker_address,
+            withdrawn_amount,
         );
         assert!(last_recorded_principal(staker_address, operator_address) == 0, 0);
 
@@ -1323,15 +1355,24 @@ module aptos_framework::staking_contract {
             (new_balance - last_recorded_principal(staker_address, operator_address)) / 10;
         request_commission(operator, staker_address, operator_address);
         assert_distribution(
-            staker_address, operator_address, operator_address, expected_commission
+            staker_address,
+            operator_address,
+            operator_address,
+            expected_commission,
         );
         request_commission(operator, staker_address, operator_address);
         assert_distribution(
-            staker_address, operator_address, operator_address, expected_commission
+            staker_address,
+            operator_address,
+            operator_address,
+            expected_commission,
         );
         request_commission(operator, staker_address, operator_address);
         assert_distribution(
-            staker_address, operator_address, operator_address, expected_commission
+            staker_address,
+            operator_address,
+            operator_address,
+            expected_commission,
         );
     }
 
@@ -1360,10 +1401,16 @@ module aptos_framework::staking_contract {
         let expected_commission = accumulated_rewards / 10;
         let staker_rewards = accumulated_rewards - expected_commission;
         assert_distribution(
-            staker_address, operator_address, staker_address, staker_rewards
+            staker_address,
+            operator_address,
+            staker_address,
+            staker_rewards,
         );
         assert_distribution(
-            staker_address, operator_address, operator_address, expected_commission
+            staker_address,
+            operator_address,
+            operator_address,
+            expected_commission,
         );
     }
 
@@ -1440,7 +1487,9 @@ module aptos_framework::staking_contract {
         assert!(origin_lockup_expiration < stake::get_lockup_secs(pool_address), 0);
     }
 
-    #[test(aptos_framework = @0x1, staker = @0x123, operator_1 = @0x234, operator_2 = @0x345)]
+    #[test(
+        aptos_framework = @0x1, staker = @0x123, operator_1 = @0x234, operator_2 = @0x345
+    )]
     public entry fun test_staker_can_switch_operator(
         aptos_framework: &signer,
         staker: &signer,
@@ -1476,7 +1525,11 @@ module aptos_framework::staking_contract {
         // Unpaid commission should be unlocked from the stake pool.
         new_balance = new_balance - commission_for_operator_1;
         stake::assert_stake_pool(
-            pool_address, new_balance, 0, 0, commission_for_operator_1
+            pool_address,
+            new_balance,
+            0,
+            0,
+            commission_for_operator_1,
         );
         assert!(
             last_recorded_principal(staker_address, operator_2_address) == new_balance, 0
@@ -1515,7 +1568,11 @@ module aptos_framework::staking_contract {
             operator_1_balance,
         );
         stake::assert_stake_pool(
-            pool_address, new_balance, 0, 0, commission_for_operator_2
+            pool_address,
+            new_balance,
+            0,
+            0,
+            commission_for_operator_2,
         );
         assert!(
             last_recorded_principal(staker_address, operator_2_address) == new_balance, 0
@@ -1542,7 +1599,9 @@ module aptos_framework::staking_contract {
         );
     }
 
-    #[test(aptos_framework = @0x1, staker = @0x123, operator_1 = @0x234, operator_2 = @0x345)]
+    #[test(
+        aptos_framework = @0x1, staker = @0x123, operator_1 = @0x234, operator_2 = @0x345
+    )]
     public entry fun test_staker_can_switch_operator_with_same_commission(
         aptos_framework: &signer,
         staker: &signer,
@@ -1564,7 +1623,15 @@ module aptos_framework::staking_contract {
         assert!(commission_percentage(staker_address, operator_2_address) == 10, 2);
     }
 
-    #[test(aptos_framework = @0x1, staker = @0x123, operator1 = @0x234, beneficiary = @0x345, operator2 = @0x456)]
+    #[
+        test(
+            aptos_framework = @0x1,
+            staker = @0x123,
+            operator1 = @0x234,
+            beneficiary = @0x345,
+            operator2 = @0x456
+        )
+    ]
     public entry fun test_operator_can_set_beneficiary(
         aptos_framework: &signer,
         staker: &signer,
@@ -1618,7 +1685,10 @@ module aptos_framework::staking_contract {
             last_recorded_principal(staker_address, operator1_address) == new_balance, 0
         );
         assert_distribution(
-            staker_address, operator1_address, operator1_address, expected_commission_1
+            staker_address,
+            operator1_address,
+            operator1_address,
+            expected_commission_1,
         );
         stake::fast_forward_to_unlock(pool_address);
 
@@ -1695,10 +1765,16 @@ module aptos_framework::staking_contract {
             withdrawn_stake + unpaid_commission,
         );
         assert_distribution(
-            staker_address, operator_address, operator_address, unpaid_commission
+            staker_address,
+            operator_address,
+            operator_address,
+            unpaid_commission,
         );
         assert_distribution(
-            staker_address, operator_address, staker_address, withdrawn_stake
+            staker_address,
+            operator_address,
+            staker_address,
+            withdrawn_stake,
         );
         assert!(
             last_recorded_principal(staker_address, operator_address) == new_balance, 0
@@ -1753,7 +1829,10 @@ module aptos_framework::staking_contract {
         stake::assert_stake_pool(pool_address, new_balance, 0, 0, withdrawn_stake);
         assert_distribution(staker_address, operator_address, operator_address, 0);
         assert_distribution(
-            staker_address, operator_address, staker_address, withdrawn_stake
+            staker_address,
+            operator_address,
+            staker_address,
+            withdrawn_stake,
         );
         assert!(
             last_recorded_principal(staker_address, operator_address) == new_balance, 0
@@ -1803,10 +1882,16 @@ module aptos_framework::staking_contract {
             withdrawn_stake + unpaid_commission,
         );
         assert_distribution(
-            staker_address, operator_address, operator_address, unpaid_commission
+            staker_address,
+            operator_address,
+            operator_address,
+            unpaid_commission,
         );
         assert_distribution(
-            staker_address, operator_address, staker_address, withdrawn_stake
+            staker_address,
+            operator_address,
+            staker_address,
+            withdrawn_stake,
         );
         assert!(
             last_recorded_principal(staker_address, operator_address) == new_balance, 0
@@ -1835,10 +1920,16 @@ module aptos_framework::staking_contract {
         );
         // There's some small rounding error here.
         assert_distribution(
-            staker_address, operator_address, operator_address, unpaid_commission - 1
+            staker_address,
+            operator_address,
+            operator_address,
+            unpaid_commission - 1,
         );
         assert_distribution(
-            staker_address, operator_address, staker_address, withdrawn_stake
+            staker_address,
+            operator_address,
+            staker_address,
+            withdrawn_stake,
         );
         assert!(
             last_recorded_principal(staker_address, operator_address) == new_balance, 0
@@ -1878,7 +1969,12 @@ module aptos_framework::staking_contract {
         );
     }
 
-    #[test(staker = @0xe256f4f4e2986cada739e339895cf5585082ff247464cab8ec56eea726bd2263, operator = @0x9f0a211d218b082987408f1e393afe1ba0c202c6d280f081399788d3360c7f09)]
+    #[
+        test(
+            staker = @0xe256f4f4e2986cada739e339895cf5585082ff247464cab8ec56eea726bd2263,
+            operator = @0x9f0a211d218b082987408f1e393afe1ba0c202c6d280f081399788d3360c7f09
+        )
+    ]
     public entry fun test_get_expected_stake_pool_address(
         staker: address, operator: address
     ) {

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.move
@@ -296,7 +296,9 @@ module aptos_framework::staking_contract {
     /// 3. The commission amount owned from those accumulated rewards.
     ///
     /// This errors out the staking contract with the provided staker and operator doesn't exist.
-    public fun staking_contract_amounts(staker: address, operator: address): (u64, u64, u64) acquires Store {
+    public fun staking_contract_amounts(
+        staker: address, operator: address
+    ): (u64, u64, u64) acquires Store {
         assert_staking_contract_exists(staker, operator);
         let staking_contracts = &borrow_global<Store>(staker).staking_contracts;
         let staking_contract = simple_map::borrow(staking_contracts, &operator);
@@ -307,10 +309,14 @@ module aptos_framework::staking_contract {
     /// Return the number of pending distributions (e.g. commission, withdrawals from stakers).
     ///
     /// This errors out the staking contract with the provided staker and operator doesn't exist.
-    public fun pending_distribution_counts(staker: address, operator: address): u64 acquires Store {
+    public fun pending_distribution_counts(
+        staker: address, operator: address
+    ): u64 acquires Store {
         assert_staking_contract_exists(staker, operator);
         let staking_contracts = &borrow_global<Store>(staker).staking_contracts;
-        pool_u64::shareholders_count(&simple_map::borrow(staking_contracts, &operator).distribution_pool)
+        pool_u64::shareholders_count(
+            &simple_map::borrow(staking_contracts, &operator).distribution_pool
+        )
     }
 
     #[view]
@@ -357,7 +363,13 @@ module aptos_framework::staking_contract {
     ) acquires Store {
         let staked_coins = coin::withdraw<AptosCoin>(staker, amount);
         create_staking_contract_with_coins(
-            staker, operator, voter, staked_coins, commission_percentage, contract_creation_seed);
+            staker,
+            operator,
+            voter,
+            staked_coins,
+            commission_percentage,
+            contract_creation_seed,
+        );
     }
 
     /// Staker can call this function to create a simple staking contract with a specified operator.
@@ -376,9 +388,13 @@ module aptos_framework::staking_contract {
         );
         // The amount should be at least the min_stake_required, so the stake pool will be eligible to join the
         // validator set.
-        let (min_stake_required, _) = staking_config::get_required_stake(&staking_config::get());
+        let (min_stake_required, _) =
+            staking_config::get_required_stake(&staking_config::get());
         let principal = coin::value(&coins);
-        assert!(principal >= min_stake_required, error::invalid_argument(EINSUFFICIENT_STAKE_AMOUNT));
+        assert!(
+            principal >= min_stake_required,
+            error::invalid_argument(EINSUFFICIENT_STAKE_AMOUNT),
+        );
 
         // Initialize Store resource if this is the first time the staker has delegated to anyone.
         let staker_address = signer::address_of(staker);
@@ -391,7 +407,7 @@ module aptos_framework::staking_contract {
         let staking_contracts = &mut store.staking_contracts;
         assert!(
             !simple_map::contains_key(staking_contracts, &operator),
-            error::already_exists(ESTAKING_CONTRACT_ALREADY_EXISTS)
+            error::already_exists(ESTAKING_CONTRACT_ALREADY_EXISTS),
         );
 
         // Initialize the stake pool in a new resource account. This allows the same staker to contract with multiple
@@ -404,35 +420,56 @@ module aptos_framework::staking_contract {
 
         // Create the contract record.
         let pool_address = signer::address_of(&stake_pool_signer);
-        simple_map::add(staking_contracts, operator, StakingContract {
-            principal,
-            pool_address,
-            owner_cap,
-            commission_percentage,
-            // Make sure we don't have too many pending recipients in the distribution pool.
-            // Otherwise, a griefing attack is possible where the staker can keep switching operators and create too
-            // many pending distributions. This can lead to out-of-gas failure whenever distribute() is called.
-            distribution_pool: pool_u64::create(MAXIMUM_PENDING_DISTRIBUTIONS),
-            signer_cap: stake_pool_signer_cap,
-        });
+        simple_map::add(
+            staking_contracts,
+            operator,
+            StakingContract {
+                principal,
+                pool_address,
+                owner_cap,
+                commission_percentage,
+                // Make sure we don't have too many pending recipients in the distribution pool.
+                // Otherwise, a griefing attack is possible where the staker can keep switching operators and create too
+                // many pending distributions. This can lead to out-of-gas failure whenever distribute() is called.
+                distribution_pool: pool_u64::create(MAXIMUM_PENDING_DISTRIBUTIONS),
+                signer_cap: stake_pool_signer_cap,
+            },
+        );
 
         if (std::features::module_event_migration_enabled()) {
-            emit(CreateStakingContract { operator, voter, pool_address, principal, commission_percentage });
+            emit(
+                CreateStakingContract {
+                    operator,
+                    voter,
+                    pool_address,
+                    principal,
+                    commission_percentage
+                },
+            );
         };
         emit_event(
             &mut store.create_staking_contract_events,
-            CreateStakingContractEvent { operator, voter, pool_address, principal, commission_percentage },
+            CreateStakingContractEvent {
+                operator,
+                voter,
+                pool_address,
+                principal,
+                commission_percentage
+            },
         );
         pool_address
     }
 
     /// Add more stake to an existing staking contract.
-    public entry fun add_stake(staker: &signer, operator: address, amount: u64) acquires Store {
+    public entry fun add_stake(
+        staker: &signer, operator: address, amount: u64
+    ) acquires Store {
         let staker_address = signer::address_of(staker);
         assert_staking_contract_exists(staker_address, operator);
 
         let store = borrow_global_mut<Store>(staker_address);
-        let staking_contract = simple_map::borrow_mut(&mut store.staking_contracts, &operator);
+        let staking_contract =
+            simple_map::borrow_mut(&mut store.staking_contracts, &operator);
 
         // Add the stake to the stake pool.
         let staked_coins = coin::withdraw<AptosCoin>(staker, amount);
@@ -450,12 +487,15 @@ module aptos_framework::staking_contract {
     }
 
     /// Convenient function to allow the staker to update the voter address in a staking contract they made.
-    public entry fun update_voter(staker: &signer, operator: address, new_voter: address) acquires Store {
+    public entry fun update_voter(
+        staker: &signer, operator: address, new_voter: address
+    ) acquires Store {
         let staker_address = signer::address_of(staker);
         assert_staking_contract_exists(staker_address, operator);
 
         let store = borrow_global_mut<Store>(staker_address);
-        let staking_contract = simple_map::borrow_mut(&mut store.staking_contracts, &operator);
+        let staking_contract =
+            simple_map::borrow_mut(&mut store.staking_contracts, &operator);
         let pool_address = staking_contract.pool_address;
         let old_voter = stake::get_delegated_voter(pool_address);
         stake::set_delegated_voter_with_cap(&staking_contract.owner_cap, new_voter);
@@ -476,22 +516,23 @@ module aptos_framework::staking_contract {
         assert_staking_contract_exists(staker_address, operator);
 
         let store = borrow_global_mut<Store>(staker_address);
-        let staking_contract = simple_map::borrow_mut(&mut store.staking_contracts, &operator);
+        let staking_contract =
+            simple_map::borrow_mut(&mut store.staking_contracts, &operator);
         let pool_address = staking_contract.pool_address;
         stake::increase_lockup_with_cap(&staking_contract.owner_cap);
 
         if (std::features::module_event_migration_enabled()) {
             emit(ResetLockup { operator, pool_address });
         };
-        emit_event(&mut store.reset_lockup_events, ResetLockupEvent { operator, pool_address });
+        emit_event(
+            &mut store.reset_lockup_events, ResetLockupEvent { operator, pool_address }
+        );
     }
 
     /// Convenience function to allow a staker to update the commission percentage paid to the operator.
     /// TODO: fix the typo in function name. commision -> commission
     public entry fun update_commision(
-        staker: &signer,
-        operator: address,
-        new_commission_percentage: u64
+        staker: &signer, operator: address, new_commission_percentage: u64
     ) acquires Store, BeneficiaryForOperator, StakingGroupUpdateCommissionEvent {
         assert!(
             new_commission_percentage >= 0 && new_commission_percentage <= 100,
@@ -499,11 +540,17 @@ module aptos_framework::staking_contract {
         );
 
         let staker_address = signer::address_of(staker);
-        assert!(exists<Store>(staker_address), error::not_found(ENO_STAKING_CONTRACT_FOUND_FOR_STAKER));
+        assert!(
+            exists<Store>(staker_address),
+            error::not_found(ENO_STAKING_CONTRACT_FOUND_FOR_STAKER),
+        );
 
         let store = borrow_global_mut<Store>(staker_address);
-        let staking_contract = simple_map::borrow_mut(&mut store.staking_contracts, &operator);
-        distribute_internal(staker_address, operator, staking_contract, &mut store.distribute_events);
+        let staking_contract =
+            simple_map::borrow_mut(&mut store.staking_contracts, &operator);
+        distribute_internal(
+            staker_address, operator, staking_contract, &mut store.distribute_events
+        );
         request_commission_internal(
             operator,
             staking_contract,
@@ -516,20 +563,29 @@ module aptos_framework::staking_contract {
             move_to(
                 staker,
                 StakingGroupUpdateCommissionEvent {
-                    update_commission_events: account::new_event_handle<UpdateCommissionEvent>(
-                        staker
-                    )
-                }
+                    update_commission_events: account::new_event_handle<
+                        UpdateCommissionEvent>(staker)
+                },
             )
         };
         if (std::features::module_event_migration_enabled()) {
             emit(
-                UpdateCommission { staker: staker_address, operator, old_commission_percentage, new_commission_percentage }
+                UpdateCommission {
+                    staker: staker_address,
+                    operator,
+                    old_commission_percentage,
+                    new_commission_percentage
+                },
             );
         };
         emit_event(
             &mut borrow_global_mut<StakingGroupUpdateCommissionEvent>(staker_address).update_commission_events,
-            UpdateCommissionEvent { staker: staker_address, operator, old_commission_percentage, new_commission_percentage }
+            UpdateCommissionEvent {
+                staker: staker_address,
+                operator,
+                old_commission_percentage,
+                new_commission_percentage
+            },
         );
     }
 
@@ -538,26 +594,27 @@ module aptos_framework::staking_contract {
     ///
     /// Only staker, operator or beneficiary can call this.
     public entry fun request_commission(
-        account: &signer,
-        staker: address,
-        operator: address
+        account: &signer, staker: address, operator: address
     ) acquires Store, BeneficiaryForOperator {
         let account_addr = signer::address_of(account);
         assert!(
-            account_addr == staker || account_addr == operator || account_addr == beneficiary_for_operator(operator),
-            error::unauthenticated(ENOT_STAKER_OR_OPERATOR_OR_BENEFICIARY)
+            account_addr == staker
+            || account_addr == operator
+            || account_addr == beneficiary_for_operator(operator),
+            error::unauthenticated(ENOT_STAKER_OR_OPERATOR_OR_BENEFICIARY),
         );
         assert_staking_contract_exists(staker, operator);
 
         let store = borrow_global_mut<Store>(staker);
-        let staking_contract = simple_map::borrow_mut(&mut store.staking_contracts, &operator);
+        let staking_contract =
+            simple_map::borrow_mut(&mut store.staking_contracts, &operator);
         // Short-circuit if zero commission.
-        if (staking_contract.commission_percentage == 0) {
-            return
-        };
+        if (staking_contract.commission_percentage == 0) { return };
 
         // Force distribution of any already inactive stake.
-        distribute_internal(staker, operator, staking_contract, &mut store.distribute_events);
+        distribute_internal(
+            staker, operator, staking_contract, &mut store.distribute_events
+        );
 
         request_commission_internal(
             operator,
@@ -584,7 +641,13 @@ module aptos_framework::staking_contract {
         };
 
         // Add a distribution for the operator.
-        add_distribution(operator, staking_contract, operator, commission_amount, add_distribution_events);
+        add_distribution(
+            operator,
+            staking_contract,
+            operator,
+            commission_amount,
+            add_distribution_events,
+        );
 
         // Request to unlock the commission from the stake pool.
         // This won't become fully unlocked until the stake pool's lockup expires.
@@ -592,11 +655,23 @@ module aptos_framework::staking_contract {
 
         let pool_address = staking_contract.pool_address;
         if (std::features::module_event_migration_enabled()) {
-            emit(RequestCommission { operator, pool_address, accumulated_rewards, commission_amount });
+            emit(
+                RequestCommission {
+                    operator,
+                    pool_address,
+                    accumulated_rewards,
+                    commission_amount
+                },
+            );
         };
         emit_event(
             request_commission_events,
-            RequestCommissionEvent { operator, pool_address, accumulated_rewards, commission_amount },
+            RequestCommissionEvent {
+                operator,
+                pool_address,
+                accumulated_rewards,
+                commission_amount
+            },
         );
 
         commission_amount
@@ -605,9 +680,7 @@ module aptos_framework::staking_contract {
     /// Staker can call this to request withdrawal of part or all of their staking_contract.
     /// This also triggers paying commission to the operator for accounting simplicity.
     public entry fun unlock_stake(
-        staker: &signer,
-        operator: address,
-        amount: u64
+        staker: &signer, operator: address, amount: u64
     ) acquires Store, BeneficiaryForOperator {
         // Short-circuit if amount is 0.
         if (amount == 0) return;
@@ -616,19 +689,23 @@ module aptos_framework::staking_contract {
         assert_staking_contract_exists(staker_address, operator);
 
         let store = borrow_global_mut<Store>(staker_address);
-        let staking_contract = simple_map::borrow_mut(&mut store.staking_contracts, &operator);
+        let staking_contract =
+            simple_map::borrow_mut(&mut store.staking_contracts, &operator);
 
         // Force distribution of any already inactive stake.
-        distribute_internal(staker_address, operator, staking_contract, &mut store.distribute_events);
+        distribute_internal(
+            staker_address, operator, staking_contract, &mut store.distribute_events
+        );
 
         // For simplicity, we request commission to be paid out first. This avoids having to ensure to staker doesn't
         // withdraw into the commission portion.
-        let commission_paid = request_commission_internal(
-            operator,
-            staking_contract,
-            &mut store.add_distribution_events,
-            &mut store.request_commission_events,
-        );
+        let commission_paid =
+            request_commission_internal(
+                operator,
+                staking_contract,
+                &mut store.add_distribution_events,
+                &mut store.request_commission_events,
+            );
 
         // If there's less active stake remaining than the amount requested (potentially due to commission),
         // only withdraw up to the active amount.
@@ -639,7 +716,13 @@ module aptos_framework::staking_contract {
         staking_contract.principal = staking_contract.principal - amount;
 
         // Record a distribution for the staker.
-        add_distribution(operator, staking_contract, staker_address, amount, &mut store.add_distribution_events);
+        add_distribution(
+            operator,
+            staking_contract,
+            staker_address,
+            amount,
+            &mut store.add_distribution_events,
+        );
 
         // Request to unlock the distribution amount from the stake pool.
         // This won't become fully unlocked until the stake pool's lockup expires.
@@ -661,7 +744,8 @@ module aptos_framework::staking_contract {
         assert_staking_contract_exists(staker_address, operator);
 
         // Calculate how much rewards belongs to the staker after commission is paid.
-        let (_, accumulated_rewards, unpaid_commission) = staking_contract_amounts(staker_address, operator);
+        let (_, accumulated_rewards, unpaid_commission) =
+            staking_contract_amounts(staker_address, operator);
         let staker_rewards = accumulated_rewards - unpaid_commission;
         unlock_stake(staker, operator, staker_rewards);
     }
@@ -699,7 +783,12 @@ module aptos_framework::staking_contract {
 
         let (_, staking_contract) = simple_map::remove(staking_contracts, &old_operator);
         // Force distribution of any already inactive stake.
-        distribute_internal(staker_address, old_operator, &mut staking_contract, &mut store.distribute_events);
+        distribute_internal(
+            staker_address,
+            old_operator,
+            &mut staking_contract,
+            &mut store.distribute_events,
+        );
 
         // For simplicity, we request commission to be paid out first. This avoids having to ensure to staker doesn't
         // withdraw into the commission portion.
@@ -721,7 +810,7 @@ module aptos_framework::staking_contract {
         };
         emit_event(
             &mut store.switch_operator_events,
-            SwitchOperatorEvent { pool_address, old_operator, new_operator }
+            SwitchOperatorEvent { pool_address, old_operator, new_operator },
         );
     }
 
@@ -729,27 +818,33 @@ module aptos_framework::staking_contract {
     /// beneficiary. To ensures payment to the current beneficiary, one should first call `distribute` before switching
     /// the beneficiary. An operator can set one beneficiary for staking contract pools, not a separate one for each pool.
     public entry fun set_beneficiary_for_operator(
-        operator: &signer,
-        new_beneficiary: address
+        operator: &signer, new_beneficiary: address
     ) acquires BeneficiaryForOperator {
-        assert!(features::operator_beneficiary_change_enabled(), std::error::invalid_state(
-            EOPERATOR_BENEFICIARY_CHANGE_NOT_SUPPORTED
-        ));
+        assert!(
+            features::operator_beneficiary_change_enabled(),
+            std::error::invalid_state(EOPERATOR_BENEFICIARY_CHANGE_NOT_SUPPORTED),
+        );
         // The beneficiay address of an operator is stored under the operator's address.
         // So, the operator does not need to be validated with respect to a staking pool.
         let operator_addr = signer::address_of(operator);
         let old_beneficiary = beneficiary_for_operator(operator_addr);
         if (exists<BeneficiaryForOperator>(operator_addr)) {
-            borrow_global_mut<BeneficiaryForOperator>(operator_addr).beneficiary_for_operator = new_beneficiary;
+            borrow_global_mut<BeneficiaryForOperator>(operator_addr).beneficiary_for_operator =
+                 new_beneficiary;
         } else {
-            move_to(operator, BeneficiaryForOperator { beneficiary_for_operator: new_beneficiary });
+            move_to(
+                operator,
+                BeneficiaryForOperator { beneficiary_for_operator: new_beneficiary },
+            );
         };
 
-        emit(SetBeneficiaryForOperator {
-            operator: operator_addr,
-            old_beneficiary,
-            new_beneficiary,
-        });
+        emit(
+            SetBeneficiaryForOperator {
+                operator: operator_addr,
+                old_beneficiary,
+                new_beneficiary,
+            },
+        );
     }
 
     /// Allow anyone to distribute already unlocked funds. This does not affect reward compounding and therefore does
@@ -757,8 +852,11 @@ module aptos_framework::staking_contract {
     public entry fun distribute(staker: address, operator: address) acquires Store, BeneficiaryForOperator {
         assert_staking_contract_exists(staker, operator);
         let store = borrow_global_mut<Store>(staker);
-        let staking_contract = simple_map::borrow_mut(&mut store.staking_contracts, &operator);
-        distribute_internal(staker, operator, staking_contract, &mut store.distribute_events);
+        let staking_contract =
+            simple_map::borrow_mut(&mut store.staking_contracts, &operator);
+        distribute_internal(
+            staker, operator, staking_contract, &mut store.distribute_events
+        );
     }
 
     /// Distribute all unlocked (inactive) funds according to distribution shares.
@@ -771,7 +869,10 @@ module aptos_framework::staking_contract {
         let pool_address = staking_contract.pool_address;
         let (_, inactive, _, pending_inactive) = stake::get_stake(pool_address);
         let total_potential_withdrawable = inactive + pending_inactive;
-        let coins = stake::withdraw_with_cap(&staking_contract.owner_cap, total_potential_withdrawable);
+        let coins =
+            stake::withdraw_with_cap(
+                &staking_contract.owner_cap, total_potential_withdrawable
+            );
         let distribution_amount = coin::value(&coins);
         if (distribution_amount == 0) {
             coin::destroy_zero(coins);
@@ -780,26 +881,45 @@ module aptos_framework::staking_contract {
 
         let distribution_pool = &mut staking_contract.distribution_pool;
         update_distribution_pool(
-            distribution_pool, distribution_amount, operator, staking_contract.commission_percentage);
+            distribution_pool,
+            distribution_amount,
+            operator,
+            staking_contract.commission_percentage,
+        );
 
         // Buy all recipients out of the distribution pool.
         while (pool_u64::shareholders_count(distribution_pool) > 0) {
             let recipients = pool_u64::shareholders(distribution_pool);
             let recipient = *vector::borrow(&mut recipients, 0);
             let current_shares = pool_u64::shares(distribution_pool, recipient);
-            let amount_to_distribute = pool_u64::redeem_shares(distribution_pool, recipient, current_shares);
+            let amount_to_distribute =
+                pool_u64::redeem_shares(distribution_pool, recipient, current_shares);
             // If the recipient is the operator, send the commission to the beneficiary instead.
             if (recipient == operator) {
                 recipient = beneficiary_for_operator(operator);
             };
-            aptos_account::deposit_coins(recipient, coin::extract(&mut coins, amount_to_distribute));
+            aptos_account::deposit_coins(
+                recipient, coin::extract(&mut coins, amount_to_distribute)
+            );
 
             if (std::features::module_event_migration_enabled()) {
-                emit(Distribute { operator, pool_address, recipient, amount: amount_to_distribute });
+                emit(
+                    Distribute {
+                        operator,
+                        pool_address,
+                        recipient,
+                        amount: amount_to_distribute
+                    },
+                );
             };
             emit_event(
                 distribute_events,
-                DistributeEvent { operator, pool_address, recipient, amount: amount_to_distribute }
+                DistributeEvent {
+                    operator,
+                    pool_address,
+                    recipient,
+                    amount: amount_to_distribute
+                },
             );
         };
 
@@ -813,8 +933,12 @@ module aptos_framework::staking_contract {
     }
 
     /// Assert that a staking_contract exists for the staker/operator pair.
-    fun assert_staking_contract_exists(staker: address, operator: address) acquires Store {
-        assert!(exists<Store>(staker), error::not_found(ENO_STAKING_CONTRACT_FOUND_FOR_STAKER));
+    fun assert_staking_contract_exists(
+        staker: address, operator: address
+    ) acquires Store {
+        assert!(
+            exists<Store>(staker), error::not_found(ENO_STAKING_CONTRACT_FOUND_FOR_STAKER)
+        );
         let staking_contracts = &mut borrow_global_mut<Store>(staker).staking_contracts;
         assert!(
             simple_map::contains_key(staking_contracts, &operator),
@@ -831,9 +955,14 @@ module aptos_framework::staking_contract {
         add_distribution_events: &mut EventHandle<AddDistributionEvent>
     ) {
         let distribution_pool = &mut staking_contract.distribution_pool;
-        let (_, _, _, total_distribution_amount) = stake::get_stake(staking_contract.pool_address);
+        let (_, _, _, total_distribution_amount) =
+            stake::get_stake(staking_contract.pool_address);
         update_distribution_pool(
-            distribution_pool, total_distribution_amount, operator, staking_contract.commission_percentage);
+            distribution_pool,
+            total_distribution_amount,
+            operator,
+            staking_contract.commission_percentage,
+        );
 
         pool_u64::buy_in(distribution_pool, recipient, coins_amount);
         let pool_address = staking_contract.pool_address;
@@ -842,20 +971,24 @@ module aptos_framework::staking_contract {
         };
         emit_event(
             add_distribution_events,
-            AddDistributionEvent { operator, pool_address, amount: coins_amount }
+            AddDistributionEvent { operator, pool_address, amount: coins_amount },
         );
     }
 
     /// Calculate accumulated rewards and commissions since last update.
-    fun get_staking_contract_amounts_internal(staking_contract: &StakingContract): (u64, u64, u64) {
+    fun get_staking_contract_amounts_internal(
+        staking_contract: &StakingContract
+    ): (u64, u64, u64) {
         // Pending_inactive is not included in the calculation because pending_inactive can only come from:
         // 1. Outgoing commissions. This means commission has already been extracted.
         // 2. Stake withdrawals from stakers. This also means commission has already been extracted as
         // request_commission_internal is called in unlock_stake
-        let (active, _, pending_active, _) = stake::get_stake(staking_contract.pool_address);
+        let (active, _, pending_active, _) =
+            stake::get_stake(staking_contract.pool_address);
         let total_active_stake = active + pending_active;
         let accumulated_rewards = total_active_stake - staking_contract.principal;
-        let commission_amount = accumulated_rewards * staking_contract.commission_percentage / 100;
+        let commission_amount =
+            accumulated_rewards * staking_contract.commission_percentage / 100;
 
         (total_active_stake, accumulated_rewards, commission_amount)
     }
@@ -867,10 +1000,13 @@ module aptos_framework::staking_contract {
         contract_creation_seed: vector<u8>,
     ): (signer, SignerCapability, OwnerCapability) {
         // Generate a seed that will be used to create the resource account that hosts the staking contract.
-        let seed = create_resource_account_seed(
-            signer::address_of(staker), operator, contract_creation_seed);
+        let seed =
+            create_resource_account_seed(
+                signer::address_of(staker), operator, contract_creation_seed
+            );
 
-        let (stake_pool_signer, stake_pool_signer_cap) = account::create_resource_account(staker, seed);
+        let (stake_pool_signer, stake_pool_signer_cap) =
+            account::create_resource_account(staker, seed);
         stake::initialize_stake_owner(&stake_pool_signer, 0, operator, voter);
 
         // Extract owner_cap from the StakePool, so we have control over it in the staking_contracts flow.
@@ -888,28 +1024,36 @@ module aptos_framework::staking_contract {
         commission_percentage: u64,
     ) {
         // Short-circuit and do nothing if the pool's total value has not changed.
-        if (pool_u64::total_coins(distribution_pool) == updated_total_coins) {
-            return
-        };
+        if (pool_u64::total_coins(distribution_pool) == updated_total_coins) { return };
 
         // Charge all stakeholders (except for the operator themselves) commission on any rewards earnt relatively to the
         // previous value of the distribution pool.
         let shareholders = &pool_u64::shareholders(distribution_pool);
-        vector::for_each_ref(shareholders, |shareholder| {
-            let shareholder: address = *shareholder;
-            if (shareholder != operator) {
-                let shares = pool_u64::shares(distribution_pool, shareholder);
-                let previous_worth = pool_u64::balance(distribution_pool, shareholder);
-                let current_worth = pool_u64::shares_to_amount_with_total_coins(
-                    distribution_pool, shares, updated_total_coins);
-                let unpaid_commission = (current_worth - previous_worth) * commission_percentage / 100;
-                // Transfer shares from current shareholder to the operator as payment.
-                // The value of the shares should use the updated pool's total value.
-                let shares_to_transfer = pool_u64::amount_to_shares_with_total_coins(
-                    distribution_pool, unpaid_commission, updated_total_coins);
-                pool_u64::transfer_shares(distribution_pool, shareholder, operator, shares_to_transfer);
-            };
-        });
+        vector::for_each_ref(
+            shareholders,
+            |shareholder| {
+                let shareholder: address = *shareholder;
+                if (shareholder != operator) {
+                    let shares = pool_u64::shares(distribution_pool, shareholder);
+                    let previous_worth = pool_u64::balance(distribution_pool, shareholder);
+                    let current_worth =
+                        pool_u64::shares_to_amount_with_total_coins(
+                            distribution_pool, shares, updated_total_coins
+                        );
+                    let unpaid_commission =
+                        (current_worth - previous_worth) * commission_percentage / 100;
+                    // Transfer shares from current shareholder to the operator as payment.
+                    // The value of the shares should use the updated pool's total value.
+                    let shares_to_transfer =
+                        pool_u64::amount_to_shares_with_total_coins(
+                            distribution_pool, unpaid_commission, updated_total_coins
+                        );
+                    pool_u64::transfer_shares(
+                        distribution_pool, shareholder, operator, shares_to_transfer
+                    );
+                };
+            },
+        );
 
         pool_u64::update_total_coins(distribution_pool, updated_total_coins);
     }
@@ -935,14 +1079,19 @@ module aptos_framework::staking_contract {
         Store {
             staking_contracts: simple_map::create<address, StakingContract>(),
             // Events.
-            create_staking_contract_events: account::new_event_handle<CreateStakingContractEvent>(staker),
+            create_staking_contract_events: account::new_event_handle<
+                CreateStakingContractEvent>(staker),
             update_voter_events: account::new_event_handle<UpdateVoterEvent>(staker),
             reset_lockup_events: account::new_event_handle<ResetLockupEvent>(staker),
             add_stake_events: account::new_event_handle<AddStakeEvent>(staker),
-            request_commission_events: account::new_event_handle<RequestCommissionEvent>(staker),
+            request_commission_events: account::new_event_handle<RequestCommissionEvent>(
+                staker
+            ),
             unlock_stake_events: account::new_event_handle<UnlockStakeEvent>(staker),
             switch_operator_events: account::new_event_handle<SwitchOperatorEvent>(staker),
-            add_distribution_events: account::new_event_handle<AddDistributionEvent>(staker),
+            add_distribution_events: account::new_event_handle<AddDistributionEvent>(
+                staker
+            ),
             distribute_events: account::new_event_handle<DistributeEvent>(staker),
         }
     }
@@ -968,7 +1117,9 @@ module aptos_framework::staking_contract {
     const OPERATOR_BENEFICIARY_CHANGE: u64 = 39;
 
     #[test_only]
-    public fun setup(aptos_framework: &signer, staker: &signer, operator: &signer, initial_balance: u64) {
+    public fun setup(
+        aptos_framework: &signer, staker: &signer, operator: &signer, initial_balance: u64
+    ) {
         // Reward rate of 0.1% per epoch.
         stake::initialize_for_test_custom(
             aptos_framework,
@@ -978,7 +1129,7 @@ module aptos_framework::staking_contract {
             true,
             10,
             10000,
-            1000000
+            1000000,
         );
 
         let staker_address = signer::address_of(staker);
@@ -1005,15 +1156,22 @@ module aptos_framework::staking_contract {
         let operator_address = signer::address_of(operator);
 
         // Voter is initially set to operator but then updated to be staker.
-        create_staking_contract(staker, operator_address, operator_address, amount, commission, vector::empty<u8>());
-        std::features::change_feature_flags_for_testing(aptos_framework, vector[MODULE_EVENT, OPERATOR_BENEFICIARY_CHANGE], vector[]);
+        create_staking_contract(
+            staker,
+            operator_address,
+            operator_address,
+            amount,
+            commission,
+            vector::empty<u8>(),
+        );
+        std::features::change_feature_flags_for_testing(
+            aptos_framework, vector[MODULE_EVENT, OPERATOR_BENEFICIARY_CHANGE], vector[]
+        );
     }
 
     #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
     public entry fun test_end_to_end(
-        aptos_framework: &signer,
-        staker: &signer,
-        operator: &signer
+        aptos_framework: &signer, staker: &signer, operator: &signer
     ) acquires Store, BeneficiaryForOperator {
         setup_staking_contract(aptos_framework, staker, operator, INITIAL_BALANCE, 10);
         let staker_address = signer::address_of(staker);
@@ -1024,7 +1182,10 @@ module aptos_framework::staking_contract {
         // Verify that the stake pool has been set up properly.
         let pool_address = stake_pool_address(staker_address, operator_address);
         stake::assert_stake_pool(pool_address, INITIAL_BALANCE, 0, 0, 0);
-        assert!(last_recorded_principal(staker_address, operator_address) == INITIAL_BALANCE, 0);
+        assert!(
+            last_recorded_principal(staker_address, operator_address) == INITIAL_BALANCE,
+            0
+        );
 
         // Operator joins the validator set.
         let (_sk, pk, pop) = stake::generate_identity();
@@ -1037,12 +1198,17 @@ module aptos_framework::staking_contract {
         stake::assert_stake_pool(pool_address, new_balance, 0, 0, 0);
 
         // Operator claims 10% of rewards so far as commissions.
-        let expected_commission_1 = (new_balance - last_recorded_principal(staker_address, operator_address)) / 10;
+        let expected_commission_1 =
+            (new_balance - last_recorded_principal(staker_address, operator_address)) / 10;
         new_balance = new_balance - expected_commission_1;
         request_commission(operator, staker_address, operator_address);
         stake::assert_stake_pool(pool_address, new_balance, 0, 0, expected_commission_1);
-        assert!(last_recorded_principal(staker_address, operator_address) == new_balance, 0);
-        assert_distribution(staker_address, operator_address, operator_address, expected_commission_1);
+        assert!(
+            last_recorded_principal(staker_address, operator_address) == new_balance, 0
+        );
+        assert_distribution(
+            staker_address, operator_address, operator_address, expected_commission_1
+        );
         stake::fast_forward_to_unlock(pool_address);
 
         // Both original stake and operator commissions have received rewards.
@@ -1061,18 +1227,27 @@ module aptos_framework::staking_contract {
         let previous_principal = last_recorded_principal(staker_address, operator_address);
         add_stake(staker, operator_address, INITIAL_BALANCE);
         stake::assert_stake_pool(pool_address, new_balance, 0, INITIAL_BALANCE, 0);
-        assert!(last_recorded_principal(staker_address, operator_address) == previous_principal + INITIAL_BALANCE, 0);
+        assert!(
+            last_recorded_principal(staker_address, operator_address)
+                == previous_principal + INITIAL_BALANCE,
+            0,
+        );
 
         // The newly added stake didn't receive any rewards because it was only added in the new epoch.
         stake::end_epoch();
         new_balance = with_rewards(new_balance) + INITIAL_BALANCE;
 
         // Second round of commission request/withdrawal.
-        let expected_commission_2 = (new_balance - last_recorded_principal(staker_address, operator_address)) / 10;
+        let expected_commission_2 =
+            (new_balance - last_recorded_principal(staker_address, operator_address)) / 10;
         new_balance = new_balance - expected_commission_2;
         request_commission(operator, staker_address, operator_address);
-        assert_distribution(staker_address, operator_address, operator_address, expected_commission_2);
-        assert!(last_recorded_principal(staker_address, operator_address) == new_balance, 0);
+        assert_distribution(
+            staker_address, operator_address, operator_address, expected_commission_2
+        );
+        assert!(
+            last_recorded_principal(staker_address, operator_address) == new_balance, 0
+        );
         stake::fast_forward_to_unlock(pool_address);
         expected_commission_2 = with_rewards(expected_commission_2);
         distribute(staker_address, operator_address);
@@ -1087,18 +1262,24 @@ module aptos_framework::staking_contract {
         new_balance = with_rewards(new_balance);
 
         // Staker withdraws all stake, which should also request commission distribution.
-        let unpaid_commission = (new_balance - last_recorded_principal(staker_address, operator_address)) / 10;
+        let unpaid_commission =
+            (new_balance - last_recorded_principal(staker_address, operator_address)) / 10;
         unlock_stake(staker, operator_address, new_balance);
         stake::assert_stake_pool(pool_address, 0, 0, 0, new_balance);
-        assert_distribution(staker_address, operator_address, operator_address, unpaid_commission);
+        assert_distribution(
+            staker_address, operator_address, operator_address, unpaid_commission
+        );
         let withdrawn_amount = new_balance - unpaid_commission;
-        assert_distribution(staker_address, operator_address, staker_address, withdrawn_amount);
+        assert_distribution(
+            staker_address, operator_address, staker_address, withdrawn_amount
+        );
         assert!(last_recorded_principal(staker_address, operator_address) == 0, 0);
 
         // End epoch. The stake pool should get kicked out of the validator set as it has 0 remaining active stake.
         stake::fast_forward_to_unlock(pool_address);
         // Operator should still earn 10% commission on the rewards on top of the staker's withdrawn_amount.
-        let commission_on_withdrawn_amount = (with_rewards(withdrawn_amount) - withdrawn_amount) / 10;
+        let commission_on_withdrawn_amount =
+            (with_rewards(withdrawn_amount) - withdrawn_amount) / 10;
         unpaid_commission = with_rewards(unpaid_commission) + commission_on_withdrawn_amount;
         withdrawn_amount = with_rewards(withdrawn_amount) - commission_on_withdrawn_amount;
         stake::assert_stake_pool(pool_address, 0, with_rewards(new_balance), 0, 0);
@@ -1108,7 +1289,10 @@ module aptos_framework::staking_contract {
         distribute(staker_address, operator_address);
         assert_no_pending_distributions(staker_address, operator_address);
         operator_balance = coin::balance<AptosCoin>(operator_address);
-        assert!(operator_balance == expected_operator_balance + unpaid_commission, operator_balance);
+        assert!(
+            operator_balance == expected_operator_balance + unpaid_commission,
+            operator_balance,
+        );
         let staker_balance = coin::balance<AptosCoin>(staker_address);
         // Staker receives the extra dust due to rounding error.
         assert!(staker_balance == withdrawn_amount + 1, staker_balance);
@@ -1117,7 +1301,8 @@ module aptos_framework::staking_contract {
 
     #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
     public entry fun test_operator_cannot_request_same_commission_multiple_times(
-        aptos_framework: &signer, staker: &signer, operator: &signer) acquires Store, BeneficiaryForOperator {
+        aptos_framework: &signer, staker: &signer, operator: &signer
+    ) acquires Store, BeneficiaryForOperator {
         setup_staking_contract(aptos_framework, staker, operator, INITIAL_BALANCE, 10);
         let staker_address = signer::address_of(staker);
         let operator_address = signer::address_of(operator);
@@ -1134,18 +1319,26 @@ module aptos_framework::staking_contract {
         stake::assert_stake_pool(pool_address, new_balance, 0, 0, 0);
 
         // Operator tries to request commission multiple times. But their distribution shouldn't change.
-        let expected_commission = (new_balance - last_recorded_principal(staker_address, operator_address)) / 10;
+        let expected_commission =
+            (new_balance - last_recorded_principal(staker_address, operator_address)) / 10;
         request_commission(operator, staker_address, operator_address);
-        assert_distribution(staker_address, operator_address, operator_address, expected_commission);
+        assert_distribution(
+            staker_address, operator_address, operator_address, expected_commission
+        );
         request_commission(operator, staker_address, operator_address);
-        assert_distribution(staker_address, operator_address, operator_address, expected_commission);
+        assert_distribution(
+            staker_address, operator_address, operator_address, expected_commission
+        );
         request_commission(operator, staker_address, operator_address);
-        assert_distribution(staker_address, operator_address, operator_address, expected_commission);
+        assert_distribution(
+            staker_address, operator_address, operator_address, expected_commission
+        );
     }
 
     #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
     public entry fun test_unlock_rewards(
-        aptos_framework: &signer, staker: &signer, operator: &signer) acquires Store, BeneficiaryForOperator {
+        aptos_framework: &signer, staker: &signer, operator: &signer
+    ) acquires Store, BeneficiaryForOperator {
         setup_staking_contract(aptos_framework, staker, operator, INITIAL_BALANCE, 10);
         let staker_address = signer::address_of(staker);
         let operator_address = signer::address_of(operator);
@@ -1166,8 +1359,12 @@ module aptos_framework::staking_contract {
         let accumulated_rewards = new_balance - INITIAL_BALANCE;
         let expected_commission = accumulated_rewards / 10;
         let staker_rewards = accumulated_rewards - expected_commission;
-        assert_distribution(staker_address, operator_address, staker_address, staker_rewards);
-        assert_distribution(staker_address, operator_address, operator_address, expected_commission);
+        assert_distribution(
+            staker_address, operator_address, staker_address, staker_rewards
+        );
+        assert_distribution(
+            staker_address, operator_address, operator_address, expected_commission
+        );
     }
 
     #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
@@ -1180,7 +1377,14 @@ module aptos_framework::staking_contract {
         setup_staking_contract(aptos_framework, staker, operator, INITIAL_BALANCE, 10);
         let operator_address = signer::address_of(operator);
         stake::mint(staker, INITIAL_BALANCE);
-        create_staking_contract(staker, operator_address, operator_address, INITIAL_BALANCE, 10, vector::empty<u8>());
+        create_staking_contract(
+            staker,
+            operator_address,
+            operator_address,
+            INITIAL_BALANCE,
+            10,
+            vector::empty<u8>(),
+        );
     }
 
     #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
@@ -1263,11 +1467,20 @@ module aptos_framework::staking_contract {
         // commission to operator 1.
         let new_balance = with_rewards(INITIAL_BALANCE);
         let commission_for_operator_1 = (new_balance - INITIAL_BALANCE) / 10;
-        assert_distribution(staker_address, operator_2_address, operator_1_address, commission_for_operator_1);
+        assert_distribution(
+            staker_address,
+            operator_2_address,
+            operator_1_address,
+            commission_for_operator_1,
+        );
         // Unpaid commission should be unlocked from the stake pool.
         new_balance = new_balance - commission_for_operator_1;
-        stake::assert_stake_pool(pool_address, new_balance, 0, 0, commission_for_operator_1);
-        assert!(last_recorded_principal(staker_address, operator_2_address) == new_balance, 0);
+        stake::assert_stake_pool(
+            pool_address, new_balance, 0, 0, commission_for_operator_1
+        );
+        assert!(
+            last_recorded_principal(staker_address, operator_2_address) == new_balance, 0
+        );
 
         // The stake pool's validator should not have left the validator set.
         assert!(stake_pool_address(staker_address, operator_2_address) == pool_address, 1);
@@ -1280,19 +1493,33 @@ module aptos_framework::staking_contract {
         // operator_2;
         let commission_on_operator_1_distribution =
             (with_rewards(commission_for_operator_1) - commission_for_operator_1) / 5;
-        commission_for_operator_1 = with_rewards(commission_for_operator_1) - commission_on_operator_1_distribution;
+        commission_for_operator_1 = with_rewards(commission_for_operator_1)
+            - commission_on_operator_1_distribution;
 
         // Verify that when commissions are withdrawn, previous pending distribution to operator 1 also happens.
         // Then new commission of 20% is paid to operator 2.
         let commission_for_operator_2 =
-            (new_balance - last_recorded_principal(staker_address, operator_2_address)) / 5;
+            (new_balance - last_recorded_principal(staker_address, operator_2_address)) /
+                5;
         new_balance = new_balance - commission_for_operator_2;
         request_commission(operator_2, staker_address, operator_2_address);
-        assert_distribution(staker_address, operator_2_address, operator_2_address, commission_for_operator_2);
+        assert_distribution(
+            staker_address,
+            operator_2_address,
+            operator_2_address,
+            commission_for_operator_2,
+        );
         let operator_1_balance = coin::balance<AptosCoin>(operator_1_address);
-        assert!(operator_1_balance == INITIAL_BALANCE + commission_for_operator_1, operator_1_balance);
-        stake::assert_stake_pool(pool_address, new_balance, 0, 0, commission_for_operator_2);
-        assert!(last_recorded_principal(staker_address, operator_2_address) == new_balance, 0);
+        assert!(
+            operator_1_balance == INITIAL_BALANCE + commission_for_operator_1,
+            operator_1_balance,
+        );
+        stake::assert_stake_pool(
+            pool_address, new_balance, 0, 0, commission_for_operator_2
+        );
+        assert!(
+            last_recorded_principal(staker_address, operator_2_address) == new_balance, 0
+        );
         stake::fast_forward_to_unlock(pool_address);
 
         // Operator 2's commission is distributed.
@@ -1301,7 +1528,9 @@ module aptos_framework::staking_contract {
         new_balance = with_rewards(new_balance);
         commission_for_operator_2 = with_rewards(commission_for_operator_2);
         assert!(
-            operator_2_balance == INITIAL_BALANCE + commission_for_operator_2 + commission_on_operator_1_distribution,
+            operator_2_balance
+                == INITIAL_BALANCE + commission_for_operator_2
+                    + commission_on_operator_1_distribution,
             operator_2_balance,
         );
         stake::assert_stake_pool(
@@ -1326,7 +1555,9 @@ module aptos_framework::staking_contract {
         let operator_2_address = signer::address_of(operator_2);
 
         // Switch operators.
-        switch_operator_with_same_commission(staker, operator_1_address, operator_2_address);
+        switch_operator_with_same_commission(
+            staker, operator_1_address, operator_2_address
+        );
         // The staking_contract should now be associated with operator 2 but with same commission rate.
         assert!(staking_contract_exists(staker_address, operator_2_address), 0);
         assert!(!staking_contract_exists(staker_address, operator_1_address), 1);
@@ -1355,7 +1586,10 @@ module aptos_framework::staking_contract {
         // Verify that the stake pool has been set up properly.
         let pool_address = stake_pool_address(staker_address, operator1_address);
         stake::assert_stake_pool(pool_address, INITIAL_BALANCE, 0, 0, 0);
-        assert!(last_recorded_principal(staker_address, operator1_address) == INITIAL_BALANCE, 0);
+        assert!(
+            last_recorded_principal(staker_address, operator1_address) == INITIAL_BALANCE,
+            0,
+        );
         assert!(stake::get_operator(pool_address) == operator1_address, 0);
         assert!(beneficiary_for_operator(operator1_address) == operator1_address, 0);
 
@@ -1374,12 +1608,18 @@ module aptos_framework::staking_contract {
         stake::assert_stake_pool(pool_address, new_balance, 0, 0, 0);
 
         // Operator claims 10% of rewards so far as commissions.
-        let expected_commission_1 = (new_balance - last_recorded_principal(staker_address, operator1_address)) / 10;
+        let expected_commission_1 =
+            (new_balance - last_recorded_principal(staker_address, operator1_address)) /
+                10;
         new_balance = new_balance - expected_commission_1;
         request_commission(operator1, staker_address, operator1_address);
         stake::assert_stake_pool(pool_address, new_balance, 0, 0, expected_commission_1);
-        assert!(last_recorded_principal(staker_address, operator1_address) == new_balance, 0);
-        assert_distribution(staker_address, operator1_address, operator1_address, expected_commission_1);
+        assert!(
+            last_recorded_principal(staker_address, operator1_address) == new_balance, 0
+        );
+        assert_distribution(
+            staker_address, operator1_address, operator1_address, expected_commission_1
+        );
         stake::fast_forward_to_unlock(pool_address);
 
         // Both original stake and operator commissions have received rewards.
@@ -1401,7 +1641,8 @@ module aptos_framework::staking_contract {
         switch_operator(staker, operator1_address, operator2_address, 10);
 
         stake::end_epoch();
-        let (_, accumulated_rewards, _) = staking_contract_amounts(staker_address, operator2_address);
+        let (_, accumulated_rewards, _) =
+            staking_contract_amounts(staker_address, operator2_address);
 
         let expected_commission = accumulated_rewards / 10;
 
@@ -1416,12 +1657,15 @@ module aptos_framework::staking_contract {
 
         // Assert that the rewards go to operator2, and the balance of the operator1's beneficiay remains the same.
         assert!(coin::balance<AptosCoin>(operator2_address) >= expected_commission, 1);
-        assert!(coin::balance<AptosCoin>(beneficiary_address) == old_beneficiay_balance, 1);
+        assert!(
+            coin::balance<AptosCoin>(beneficiary_address) == old_beneficiay_balance, 1
+        );
     }
 
     #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
     public entry fun test_staker_can_withdraw_partial_stake(
-        aptos_framework: &signer, staker: &signer, operator: &signer) acquires Store, BeneficiaryForOperator {
+        aptos_framework: &signer, staker: &signer, operator: &signer
+    ) acquires Store, BeneficiaryForOperator {
         let initial_balance = INITIAL_BALANCE * 2;
         setup_staking_contract(aptos_framework, staker, operator, initial_balance, 10);
         let staker_address = signer::address_of(staker);
@@ -1443,10 +1687,22 @@ module aptos_framework::staking_contract {
         let unpaid_commission = (new_balance - initial_balance) / 10;
         let new_balance = new_balance - withdrawn_stake - unpaid_commission;
         unlock_stake(staker, operator_address, withdrawn_stake);
-        stake::assert_stake_pool(pool_address, new_balance, 0, 0, withdrawn_stake + unpaid_commission);
-        assert_distribution(staker_address, operator_address, operator_address, unpaid_commission);
-        assert_distribution(staker_address, operator_address, staker_address, withdrawn_stake);
-        assert!(last_recorded_principal(staker_address, operator_address) == new_balance, 0);
+        stake::assert_stake_pool(
+            pool_address,
+            new_balance,
+            0,
+            0,
+            withdrawn_stake + unpaid_commission,
+        );
+        assert_distribution(
+            staker_address, operator_address, operator_address, unpaid_commission
+        );
+        assert_distribution(
+            staker_address, operator_address, staker_address, withdrawn_stake
+        );
+        assert!(
+            last_recorded_principal(staker_address, operator_address) == new_balance, 0
+        );
 
         // The validator is still in the active set as its remaining stake is still above min required.
         stake::fast_forward_to_unlock(pool_address);
@@ -1454,10 +1710,17 @@ module aptos_framework::staking_contract {
         unpaid_commission = with_rewards(unpaid_commission);
         // Commission should still be charged on the rewards on top of withdrawn_stake.
         // So the operator should receive 10% of the rewards on top of withdrawn_stake.
-        let commission_on_withdrawn_stake = (with_rewards(withdrawn_stake) - withdrawn_stake) / 10;
+        let commission_on_withdrawn_stake =
+            (with_rewards(withdrawn_stake) - withdrawn_stake) / 10;
         unpaid_commission = unpaid_commission + commission_on_withdrawn_stake;
         withdrawn_stake = with_rewards(withdrawn_stake) - commission_on_withdrawn_stake;
-        stake::assert_stake_pool(pool_address, new_balance, withdrawn_stake + unpaid_commission, 0, 0);
+        stake::assert_stake_pool(
+            pool_address,
+            new_balance,
+            withdrawn_stake + unpaid_commission,
+            0,
+            0,
+        );
         assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_ACTIVE, 0);
 
         // Distribute and verify balances.
@@ -1471,7 +1734,8 @@ module aptos_framework::staking_contract {
 
     #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
     public entry fun test_staker_can_withdraw_partial_stake_if_operator_never_joined_validator_set(
-        aptos_framework: &signer, staker: &signer, operator: &signer) acquires Store, BeneficiaryForOperator {
+        aptos_framework: &signer, staker: &signer, operator: &signer
+    ) acquires Store, BeneficiaryForOperator {
         let initial_balance = INITIAL_BALANCE * 2;
         setup_staking_contract(aptos_framework, staker, operator, initial_balance, 10);
         let staker_address = signer::address_of(staker);
@@ -1488,8 +1752,12 @@ module aptos_framework::staking_contract {
         unlock_stake(staker, operator_address, withdrawn_stake);
         stake::assert_stake_pool(pool_address, new_balance, 0, 0, withdrawn_stake);
         assert_distribution(staker_address, operator_address, operator_address, 0);
-        assert_distribution(staker_address, operator_address, staker_address, withdrawn_stake);
-        assert!(last_recorded_principal(staker_address, operator_address) == new_balance, 0);
+        assert_distribution(
+            staker_address, operator_address, staker_address, withdrawn_stake
+        );
+        assert!(
+            last_recorded_principal(staker_address, operator_address) == new_balance, 0
+        );
 
         // Distribute and verify balances.
         distribute(staker_address, operator_address);
@@ -1504,7 +1772,8 @@ module aptos_framework::staking_contract {
 
     #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
     public entry fun test_multiple_distributions_added_before_distribute(
-        aptos_framework: &signer, staker: &signer, operator: &signer) acquires Store, BeneficiaryForOperator {
+        aptos_framework: &signer, staker: &signer, operator: &signer
+    ) acquires Store, BeneficiaryForOperator {
         let initial_balance = INITIAL_BALANCE * 2;
         setup_staking_contract(aptos_framework, staker, operator, initial_balance, 10);
         let staker_address = signer::address_of(staker);
@@ -1526,34 +1795,59 @@ module aptos_framework::staking_contract {
         let unpaid_commission = (new_balance - initial_balance) / 10;
         let new_balance = new_balance - withdrawn_stake - unpaid_commission;
         unlock_stake(staker, operator_address, withdrawn_stake);
-        stake::assert_stake_pool(pool_address, new_balance, 0, 0, withdrawn_stake + unpaid_commission);
-        assert_distribution(staker_address, operator_address, operator_address, unpaid_commission);
-        assert_distribution(staker_address, operator_address, staker_address, withdrawn_stake);
-        assert!(last_recorded_principal(staker_address, operator_address) == new_balance, 0);
+        stake::assert_stake_pool(
+            pool_address,
+            new_balance,
+            0,
+            0,
+            withdrawn_stake + unpaid_commission,
+        );
+        assert_distribution(
+            staker_address, operator_address, operator_address, unpaid_commission
+        );
+        assert_distribution(
+            staker_address, operator_address, staker_address, withdrawn_stake
+        );
+        assert!(
+            last_recorded_principal(staker_address, operator_address) == new_balance, 0
+        );
 
         // End epoch to generate some rewards. Staker withdraws another 1/4 of the stake.
         // Commission should be charged on the rewards earned on the previous 1/4 stake withdrawal.
         stake::end_epoch();
-        let commission_on_withdrawn_stake = (with_rewards(withdrawn_stake) - withdrawn_stake) / 10;
+        let commission_on_withdrawn_stake =
+            (with_rewards(withdrawn_stake) - withdrawn_stake) / 10;
         let commission_on_new_balance = (with_rewards(new_balance) - new_balance) / 10;
-        unpaid_commission = with_rewards(unpaid_commission) + commission_on_withdrawn_stake + commission_on_new_balance;
+        unpaid_commission = with_rewards(unpaid_commission) + commission_on_withdrawn_stake
+            + commission_on_new_balance;
         new_balance = with_rewards(new_balance) - commission_on_new_balance;
         let new_withdrawn_stake = new_balance / 4;
         unlock_stake(staker, operator_address, new_withdrawn_stake);
         new_balance = new_balance - new_withdrawn_stake;
-        withdrawn_stake = with_rewards(withdrawn_stake) - commission_on_withdrawn_stake + new_withdrawn_stake;
-        stake::assert_stake_pool(pool_address, new_balance, 0, 0, withdrawn_stake + unpaid_commission);
+        withdrawn_stake = with_rewards(withdrawn_stake) - commission_on_withdrawn_stake
+            + new_withdrawn_stake;
+        stake::assert_stake_pool(
+            pool_address,
+            new_balance,
+            0,
+            0,
+            withdrawn_stake + unpaid_commission,
+        );
         // There's some small rounding error here.
-        assert_distribution(staker_address, operator_address, operator_address, unpaid_commission - 1);
-        assert_distribution(staker_address, operator_address, staker_address, withdrawn_stake);
-        assert!(last_recorded_principal(staker_address, operator_address) == new_balance, 0);
+        assert_distribution(
+            staker_address, operator_address, operator_address, unpaid_commission - 1
+        );
+        assert_distribution(
+            staker_address, operator_address, staker_address, withdrawn_stake
+        );
+        assert!(
+            last_recorded_principal(staker_address, operator_address) == new_balance, 0
+        );
     }
 
     #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
     public entry fun test_update_commission(
-        aptos_framework: &signer,
-        staker: &signer,
-        operator: &signer
+        aptos_framework: &signer, staker: &signer, operator: &signer
     ) acquires Store, BeneficiaryForOperator, StakingGroupUpdateCommissionEvent {
         let initial_balance = INITIAL_BALANCE * 2;
         setup_staking_contract(aptos_framework, staker, operator, initial_balance, 10);
@@ -1575,32 +1869,47 @@ module aptos_framework::staking_contract {
         update_commision(staker, operator_address, 5);
         stake::end_epoch();
         let balance_2epoch = with_rewards(balance_1epoch - unpaid_commission);
-        stake::assert_stake_pool(pool_address, balance_2epoch, 0, 0, with_rewards(unpaid_commission));
+        stake::assert_stake_pool(
+            pool_address,
+            balance_2epoch,
+            0,
+            0,
+            with_rewards(unpaid_commission),
+        );
     }
 
-    #[test(
-        staker = @0xe256f4f4e2986cada739e339895cf5585082ff247464cab8ec56eea726bd2263,
-        operator = @0x9f0a211d218b082987408f1e393afe1ba0c202c6d280f081399788d3360c7f09
-    )]
-    public entry fun test_get_expected_stake_pool_address(staker: address, operator: address) {
-        let pool_address = get_expected_stake_pool_address(staker, operator, vector[0x42, 0x42]);
-        assert!(pool_address == @0x9d9648031ada367c26f7878eb0b0406ae6a969b1a43090269e5cdfabe1b48f0f, 0);
-    }
-
-    #[test_only]
-    public fun assert_staking_contract(
-        staker: address, operator: address, principal: u64, commission_percentage: u64) acquires Store {
-        let staking_contract = simple_map::borrow(&borrow_global<Store>(staker).staking_contracts, &operator);
-        assert!(staking_contract.principal == principal, staking_contract.principal);
+    #[test(staker = @0xe256f4f4e2986cada739e339895cf5585082ff247464cab8ec56eea726bd2263, operator = @0x9f0a211d218b082987408f1e393afe1ba0c202c6d280f081399788d3360c7f09)]
+    public entry fun test_get_expected_stake_pool_address(
+        staker: address, operator: address
+    ) {
+        let pool_address =
+            get_expected_stake_pool_address(staker, operator, vector[0x42, 0x42]);
         assert!(
-            staking_contract.commission_percentage == commission_percentage,
-            staking_contract.commission_percentage
+            pool_address
+                == @0x9d9648031ada367c26f7878eb0b0406ae6a969b1a43090269e5cdfabe1b48f0f,
+            0,
         );
     }
 
     #[test_only]
-    public fun assert_no_pending_distributions(staker: address, operator: address) acquires Store {
-        let staking_contract = simple_map::borrow(&borrow_global<Store>(staker).staking_contracts, &operator);
+    public fun assert_staking_contract(
+        staker: address, operator: address, principal: u64, commission_percentage: u64
+    ) acquires Store {
+        let staking_contract =
+            simple_map::borrow(&borrow_global<Store>(staker).staking_contracts, &operator);
+        assert!(staking_contract.principal == principal, staking_contract.principal);
+        assert!(
+            staking_contract.commission_percentage == commission_percentage,
+            staking_contract.commission_percentage,
+        );
+    }
+
+    #[test_only]
+    public fun assert_no_pending_distributions(
+        staker: address, operator: address
+    ) acquires Store {
+        let staking_contract =
+            simple_map::borrow(&borrow_global<Store>(staker).staking_contracts, &operator);
         let distribution_pool = &staking_contract.distribution_pool;
         let shareholders_count = pool_u64::shareholders_count(distribution_pool);
         assert!(shareholders_count == 0, shareholders_count);
@@ -1610,9 +1919,12 @@ module aptos_framework::staking_contract {
 
     #[test_only]
     public fun assert_distribution(
-        staker: address, operator: address, recipient: address, coins_amount: u64) acquires Store {
-        let staking_contract = simple_map::borrow(&borrow_global<Store>(staker).staking_contracts, &operator);
-        let distribution_balance = pool_u64::balance(&staking_contract.distribution_pool, recipient);
+        staker: address, operator: address, recipient: address, coins_amount: u64
+    ) acquires Store {
+        let staking_contract =
+            simple_map::borrow(&borrow_global<Store>(staker).staking_contracts, &operator);
+        let distribution_balance =
+            pool_u64::balance(&staking_contract.distribution_pool, recipient);
         assert!(distribution_balance == coins_amount, distribution_balance);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.spec.move
@@ -415,7 +415,8 @@ spec aptos_framework::staking_contract {
 
         let seed_0 = bcs::to_bytes(staker_address);
         let seed_1 = concat(
-            concat(concat(seed_0, bcs::to_bytes(operator)), SALT), contract_creation_seed
+            concat(concat(seed_0, bcs::to_bytes(operator)), SALT),
+            contract_creation_seed,
         );
         let resource_addr = account::spec_create_resource_address(staker_address, seed_1);
         include CreateStakePoolAbortsIf { resource_addr };
@@ -602,7 +603,8 @@ spec aptos_framework::staking_contract {
     spec schema PreconditionsInCreateContract {
         requires exists<stake::ValidatorPerformance>(@aptos_framework);
         requires exists<stake::ValidatorSet>(@aptos_framework);
-        requires exists<staking_config::StakingRewardsConfig>(@aptos_framework) || !std::features::spec_periodical_reward_rate_decrease_enabled();
+        requires exists<staking_config::StakingRewardsConfig>(@aptos_framework)
+            || !std::features::spec_periodical_reward_rate_decrease_enabled();
         requires exists<stake::ValidatorFees>(@aptos_framework);
         requires exists<aptos_framework::timestamp::CurrentTimeMicroseconds>(
             @aptos_framework
@@ -619,9 +621,7 @@ spec aptos_framework::staking_contract {
         // postconditions account::create_resource_account()
         let acc = global<account::Account>(resource_addr);
         aborts_if exists<account::Account>(resource_addr)
-            && (
-                len(acc.signer_capability_offer.for.vec) != 0 || acc.sequence_number != 0
-            );
+            && (len(acc.signer_capability_offer.for.vec) != 0 || acc.sequence_number != 0);
         aborts_if !exists<account::Account>(resource_addr)
             && len(bcs::to_bytes(resource_addr)) != 32;
         aborts_if len(account::ZERO_AUTH_KEY) != 32;

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.spec.move
@@ -90,14 +90,16 @@ spec aptos_framework::staking_contract {
     spec commission_percentage(staker: address, operator: address): u64 {
         include ContractExistsAbortsIf;
         let staking_contracts = global<Store>(staker).staking_contracts;
-        ensures result == simple_map::spec_get(staking_contracts, operator).commission_percentage;
+        ensures result
+            == simple_map::spec_get(staking_contracts, operator).commission_percentage;
     }
 
     /// Staking_contract exists the stacker/operator pair.
     spec staking_contract_amounts(staker: address, operator: address): (u64, u64, u64) {
         // TODO: set because of timeout (property proved).
         pragma verify_duration_estimate = 120;
-        requires staking_contract.commission_percentage >= 0 && staking_contract.commission_percentage <= 100;
+        requires staking_contract.commission_percentage >= 0
+            && staking_contract.commission_percentage <= 100;
         let staking_contracts = global<Store>(staker).staking_contracts;
         let staking_contract = simple_map::spec_get(staking_contracts, operator);
 
@@ -133,9 +135,8 @@ spec aptos_framework::staking_contract {
     }
 
     spec fun spec_staking_contract_exists(staker: address, operator: address): bool {
-        if (!exists<Store>(staker)) {
-            false
-        } else {
+        if (!exists<Store>(staker)) { false }
+        else {
             let store = global<Store>(staker);
             simple_map::spec_contains_key(store.staking_contracts, operator)
         }
@@ -143,12 +144,12 @@ spec aptos_framework::staking_contract {
 
     /// Account is not frozen and sufficient to withdraw.
     spec create_staking_contract(
-    staker: &signer,
-    operator: address,
-    voter: address,
-    amount: u64,
-    commission_percentage: u64,
-    contract_creation_seed: vector<u8>,
+        staker: &signer,
+        operator: address,
+        voter: address,
+        amount: u64,
+        commission_percentage: u64,
+        contract_creation_seed: vector<u8>,
     ) {
         pragma aborts_if_is_partial;
         pragma verify_duration_estimate = 120;
@@ -161,12 +162,12 @@ spec aptos_framework::staking_contract {
     /// Initialize Store resource if this is the first time the staker has delegated to anyone.
     /// Cannot create the staking contract if it already exists.
     spec create_staking_contract_with_coins(
-    staker: &signer,
-    operator: address,
-    voter: address,
-    coins: Coin<AptosCoin>,
-    commission_percentage: u64,
-    contract_creation_seed: vector<u8>,
+        staker: &signer,
+        operator: address,
+        voter: address,
+        coins: Coin<AptosCoin>,
+        commission_percentage: u64,
+        contract_creation_seed: vector<u8>,
     ): address {
         pragma verify_duration_estimate = 120;
         pragma aborts_if_is_partial;
@@ -208,7 +209,9 @@ spec aptos_framework::staking_contract {
         include stake::AddStakeWithCapAbortsIfAndEnsures { owner_cap };
 
         let post post_store = global<Store>(staker_address);
-        let post post_staking_contract = simple_map::spec_get(post_store.staking_contracts, operator);
+        let post post_staking_contract = simple_map::spec_get(
+            post_store.staking_contracts, operator
+        );
         aborts_if staking_contract.principal + amount > MAX_U64;
 
         // property 3: Adding stake to the stake pool increases the principal value of the pool, reflecting the
@@ -223,7 +226,9 @@ spec aptos_framework::staking_contract {
         include UpdateVoterSchema { staker: staker_address };
 
         let post store = global<Store>(staker_address);
-        let post staking_contract = simple_map::spec_get(store.staking_contracts, operator);
+        let post staking_contract = simple_map::spec_get(
+            store.staking_contracts, operator
+        );
         let post pool_address = staking_contract.owner_cap.pool_address;
         let post new_delegated_voter = global<stake::StakePool>(pool_address).delegated_voter;
         // property 4: The staker may update the voter of a staking contract, enabling them
@@ -240,7 +245,7 @@ spec aptos_framework::staking_contract {
         include IncreaseLockupWithCapAbortsIf { staker: staker_address };
     }
 
-    spec update_commision (staker: &signer, operator: address, new_commission_percentage: u64) {
+    spec update_commision(staker: &signer, operator: address, new_commission_percentage: u64) {
         // TODO: Call `distribute_internal` and could not verify `update_distribution_pool`.
         // TODO: A data invariant not hold happened here involve with 'pool_u64' #L16.
         pragma verify = false;
@@ -260,10 +265,10 @@ spec aptos_framework::staking_contract {
     }
 
     spec request_commission_internal(
-    operator: address,
-    staking_contract: &mut StakingContract,
-    add_distribution_events: &mut EventHandle<AddDistributionEvent>,
-    request_commission_events: &mut EventHandle<RequestCommissionEvent>,
+        operator: address,
+        staking_contract: &mut StakingContract,
+        add_distribution_events: &mut EventHandle<AddDistributionEvent>,
+        request_commission_events: &mut EventHandle<RequestCommissionEvent>,
     ): u64 {
         // TODO: A data invariant not hold happened here involve with 'pool_u64' #L16.
         pragma verify = false;
@@ -276,7 +281,8 @@ spec aptos_framework::staking_contract {
         // TODO: Set because of timeout (estimate unknown).
         pragma verify = false;
         /// [high-level-req-4]
-        requires staking_contract.commission_percentage >= 0 && staking_contract.commission_percentage <= 100;
+        requires staking_contract.commission_percentage >= 0
+            && staking_contract.commission_percentage <= 100;
         let staker_address = signer::address_of(staker);
         let staking_contracts = global<Store>(staker_address).staking_contracts;
         let staking_contract = simple_map::spec_get(staking_contracts, operator);
@@ -294,9 +300,7 @@ spec aptos_framework::staking_contract {
 
     /// Staking_contract exists the stacker/operator pair.
     spec switch_operator_with_same_commission(
-    staker: &signer,
-    old_operator: address,
-    new_operator: address,
+        staker: &signer, old_operator: address, new_operator: address,
     ) {
         // TODO: These function passed locally however failed in github CI
         pragma verify_duration_estimate = 120;
@@ -308,10 +312,10 @@ spec aptos_framework::staking_contract {
 
     /// Staking_contract exists the stacker/operator pair.
     spec switch_operator(
-    staker: &signer,
-    old_operator: address,
-    new_operator: address,
-    new_commission_percentage: u64,
+        staker: &signer,
+        old_operator: address,
+        new_operator: address,
+        new_commission_percentage: u64,
     ) {
         // TODO: Call `update_distribution_pool` and could not verify `update_distribution_pool`.
         // TODO: Set because of timeout (estimate unknown).
@@ -346,10 +350,10 @@ spec aptos_framework::staking_contract {
     /// The StakePool exists under the pool_address of StakingContract.
     /// The value of inactive and pending_inactive in the stake_pool is up to MAX_U64.
     spec distribute_internal(
-    staker: address,
-    operator: address,
-    staking_contract: &mut StakingContract,
-    distribute_events: &mut EventHandle<DistributeEvent>,
+        staker: address,
+        operator: address,
+        staking_contract: &mut StakingContract,
+        distribute_events: &mut EventHandle<DistributeEvent>,
     ) {
         // TODO: These function passed locally however failed in github CI
         pragma verify_duration_estimate = 120;
@@ -368,18 +372,20 @@ spec aptos_framework::staking_contract {
     }
 
     spec add_distribution(
-    operator: address,
-    staking_contract: &mut StakingContract,
-    recipient: address,
-    coins_amount: u64,
-    add_distribution_events: &mut EventHandle<AddDistributionEvent>,
+        operator: address,
+        staking_contract: &mut StakingContract,
+        recipient: address,
+        coins_amount: u64,
+        add_distribution_events: &mut EventHandle<AddDistributionEvent>,
     ) {
         // TODO: Call `update_distribution_pool` and could not verify `update_distribution_pool`.
         pragma verify = false;
     }
 
     /// The StakePool exists under the pool_address of StakingContract.
-    spec get_staking_contract_amounts_internal(staking_contract: &StakingContract): (u64, u64, u64) {
+    spec get_staking_contract_amounts_internal(staking_contract: &StakingContract): (
+        u64, u64, u64
+    ) {
         pragma verify_duration_estimate = 120;
         include GetStakingContractAmountsAbortsIf;
 
@@ -389,17 +395,18 @@ spec aptos_framework::staking_contract {
         let pending_active = coin::value(stake_pool.pending_active);
         let total_active_stake = active + pending_active;
         let accumulated_rewards = total_active_stake - staking_contract.principal;
-        let commission_amount = accumulated_rewards * staking_contract.commission_percentage / 100;
+        let commission_amount = accumulated_rewards
+            * staking_contract.commission_percentage / 100;
         ensures result_1 == total_active_stake;
         ensures result_2 == accumulated_rewards;
         ensures result_3 == commission_amount;
     }
 
     spec create_stake_pool(
-    staker: &signer,
-    operator: address,
-    voter: address,
-    contract_creation_seed: vector<u8>,
+        staker: &signer,
+        operator: address,
+        voter: address,
+        contract_creation_seed: vector<u8>,
     ): (signer, SignerCapability, OwnerCapability) {
         pragma verify_duration_estimate = 120;
         include stake::ResourceRequirement;
@@ -407,13 +414,16 @@ spec aptos_framework::staking_contract {
         // postconditions account::create_resource_account()
 
         let seed_0 = bcs::to_bytes(staker_address);
-        let seed_1 = concat(concat(concat(seed_0, bcs::to_bytes(operator)), SALT), contract_creation_seed);
+        let seed_1 = concat(
+            concat(concat(seed_0, bcs::to_bytes(operator)), SALT), contract_creation_seed
+        );
         let resource_addr = account::spec_create_resource_address(staker_address, seed_1);
         include CreateStakePoolAbortsIf { resource_addr };
         ensures exists<account::Account>(resource_addr);
         let post post_account = global<account::Account>(resource_addr);
         ensures post_account.authentication_key == account::ZERO_AUTH_KEY;
-        ensures post_account.signer_capability_offer.for == std::option::spec_some(resource_addr);
+        ensures post_account.signer_capability_offer.for
+            == std::option::spec_some(resource_addr);
 
         // postconditions stake::initialize_stake_owner()
         ensures exists<stake::StakePool>(resource_addr);
@@ -422,18 +432,20 @@ spec aptos_framework::staking_contract {
         let post post_stake_pool = global<stake::StakePool>(post_pool_address);
         let post post_operator = post_stake_pool.operator_address;
         let post post_delegated_voter = post_stake_pool.delegated_voter;
-        ensures resource_addr != operator ==> post_operator == operator;
-        ensures resource_addr != voter ==> post_delegated_voter == voter;
+        ensures resource_addr != operator ==>
+            post_operator == operator;
+        ensures resource_addr != voter ==>
+            post_delegated_voter == voter;
         ensures signer::address_of(result_1) == resource_addr;
         ensures result_2 == SignerCapability { account: resource_addr };
         ensures result_3 == OwnerCapability { pool_address: resource_addr };
     }
 
     spec update_distribution_pool(
-    distribution_pool: &mut Pool,
-    updated_total_coins: u64,
-    operator: address,
-    commission_percentage: u64,
+        distribution_pool: &mut Pool,
+        updated_total_coins: u64,
+        operator: address,
+        commission_percentage: u64,
     ) {
         // TODO: complex aborts conditions in the cycle.
         // pragma verify = false;
@@ -524,17 +536,21 @@ spec aptos_framework::staking_contract {
         let config = global<staking_config::StakingConfig>(@aptos_framework);
         let stake_pool = global<stake::StakePool>(pool_address);
         let old_locked_until_secs = stake_pool.locked_until_secs;
-        let seconds = global<timestamp::CurrentTimeMicroseconds>(
-            @aptos_framework
-        ).microseconds / timestamp::MICRO_CONVERSION_FACTOR;
+        let seconds = global<timestamp::CurrentTimeMicroseconds>(@aptos_framework).microseconds
+            / timestamp::MICRO_CONVERSION_FACTOR;
         let new_locked_until_secs = seconds + config.recurring_lockup_duration_secs;
         aborts_if seconds + config.recurring_lockup_duration_secs > MAX_U64;
-        aborts_if old_locked_until_secs > new_locked_until_secs || old_locked_until_secs == new_locked_until_secs;
+        aborts_if old_locked_until_secs > new_locked_until_secs
+            || old_locked_until_secs == new_locked_until_secs;
         aborts_if !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
 
         let post post_store = global<Store>(staker);
-        let post post_staking_contract = simple_map::spec_get(post_store.staking_contracts, operator);
-        let post post_stake_pool = global<stake::StakePool>(post_staking_contract.owner_cap.pool_address);
+        let post post_staking_contract = simple_map::spec_get(
+            post_store.staking_contracts, operator
+        );
+        let post post_stake_pool = global<stake::StakePool>(
+            post_staking_contract.owner_cap.pool_address
+        );
         ensures post_stake_pool.locked_until_secs == new_locked_until_secs;
     }
 
@@ -554,8 +570,10 @@ spec aptos_framework::staking_contract {
 
         let staker_address = signer::address_of(staker);
         let account = global<account::Account>(staker_address);
-        aborts_if !exists<Store>(staker_address) && !exists<account::Account>(staker_address);
-        aborts_if !exists<Store>(staker_address) && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if !exists<Store>(staker_address)
+            && !exists<account::Account>(staker_address);
+        aborts_if !exists<Store>(staker_address)
+            && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
         /// [high-level-req-1]
         ensures exists<Store>(staker_address);
 
@@ -571,7 +589,6 @@ spec aptos_framework::staking_contract {
         // let resource_addr = account::spec_create_resource_address(staker_address, seed_1);
         // include CreateStakePoolAbortsIf {resource_addr};
 
-
         // Verify stake::add_stake_with_cap()
         let owner_cap = simple_map::spec_get(store.staking_contracts, operator).owner_cap;
         // TODO: this property causes timeout
@@ -585,11 +602,11 @@ spec aptos_framework::staking_contract {
     spec schema PreconditionsInCreateContract {
         requires exists<stake::ValidatorPerformance>(@aptos_framework);
         requires exists<stake::ValidatorSet>(@aptos_framework);
-        requires exists<staking_config::StakingRewardsConfig>(
-            @aptos_framework
-        ) || !std::features::spec_periodical_reward_rate_decrease_enabled();
+        requires exists<staking_config::StakingRewardsConfig>(@aptos_framework) || !std::features::spec_periodical_reward_rate_decrease_enabled();
         requires exists<stake::ValidatorFees>(@aptos_framework);
-        requires exists<aptos_framework::timestamp::CurrentTimeMicroseconds>(@aptos_framework);
+        requires exists<aptos_framework::timestamp::CurrentTimeMicroseconds>(
+            @aptos_framework
+        );
         requires exists<stake::AptosCoinCapabilities>(@aptos_framework);
     }
 
@@ -601,21 +618,23 @@ spec aptos_framework::staking_contract {
 
         // postconditions account::create_resource_account()
         let acc = global<account::Account>(resource_addr);
-        aborts_if exists<account::Account>(resource_addr) && (len(
-            acc.signer_capability_offer.for.vec
-        ) != 0 || acc.sequence_number != 0);
-        aborts_if !exists<account::Account>(resource_addr) && len(bcs::to_bytes(resource_addr)) != 32;
+        aborts_if exists<account::Account>(resource_addr)
+            && (
+                len(acc.signer_capability_offer.for.vec) != 0 || acc.sequence_number != 0
+            );
+        aborts_if !exists<account::Account>(resource_addr)
+            && len(bcs::to_bytes(resource_addr)) != 32;
         aborts_if len(account::ZERO_AUTH_KEY) != 32;
 
         // postconditions stake::initialize_stake_owner()
         aborts_if exists<stake::ValidatorConfig>(resource_addr);
         let allowed = global<stake::AllowedValidators>(@aptos_framework);
-        aborts_if exists<stake::AllowedValidators>(@aptos_framework) && !contains(allowed.accounts, resource_addr);
+        aborts_if exists<stake::AllowedValidators>(@aptos_framework)
+            && !contains(allowed.accounts, resource_addr);
         aborts_if exists<stake::StakePool>(resource_addr);
         aborts_if exists<stake::OwnerCapability>(resource_addr);
         // 12 is the times that calls 'events::guids'
-        aborts_if exists<account::Account>(
-            resource_addr
-        ) && acc.guid_creation_num + 12 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if exists<account::Account>(resource_addr)
+            && acc.guid_creation_num + 12 >= account::MAX_GUID_CREATION_NUM;
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/staking_proxy.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_proxy.move
@@ -6,64 +6,95 @@ module aptos_framework::staking_proxy {
     use aptos_framework::staking_contract;
     use aptos_framework::vesting;
 
-    public entry fun set_operator(owner: &signer, old_operator: address, new_operator: address) {
+    public entry fun set_operator(
+        owner: &signer, old_operator: address, new_operator: address
+    ) {
         set_vesting_contract_operator(owner, old_operator, new_operator);
         set_staking_contract_operator(owner, old_operator, new_operator);
         set_stake_pool_operator(owner, new_operator);
     }
 
-    public entry fun set_voter(owner: &signer, operator: address, new_voter: address) {
+    public entry fun set_voter(
+        owner: &signer, operator: address, new_voter: address
+    ) {
         set_vesting_contract_voter(owner, operator, new_voter);
         set_staking_contract_voter(owner, operator, new_voter);
         set_stake_pool_voter(owner, new_voter);
     }
 
-    public entry fun set_vesting_contract_operator(owner: &signer, old_operator: address, new_operator: address) {
+    public entry fun set_vesting_contract_operator(
+        owner: &signer, old_operator: address, new_operator: address
+    ) {
         let owner_address = signer::address_of(owner);
         let vesting_contracts = &vesting::vesting_contracts(owner_address);
-        vector::for_each_ref(vesting_contracts, |vesting_contract| {
-            let vesting_contract = *vesting_contract;
-            if (vesting::operator(vesting_contract) == old_operator) {
-                let current_commission_percentage = vesting::operator_commission_percentage(vesting_contract);
-                vesting::update_operator(owner, vesting_contract, new_operator, current_commission_percentage);
-            };
-        });
+        vector::for_each_ref(
+            vesting_contracts,
+            |vesting_contract| {
+                let vesting_contract = *vesting_contract;
+                if (vesting::operator(vesting_contract) == old_operator) {
+                    let current_commission_percentage =
+                        vesting::operator_commission_percentage(vesting_contract);
+                    vesting::update_operator(
+                        owner,
+                        vesting_contract,
+                        new_operator,
+                        current_commission_percentage,
+                    );
+                };
+            },
+        );
     }
 
-    public entry fun set_staking_contract_operator(owner: &signer, old_operator: address, new_operator: address) {
+    public entry fun set_staking_contract_operator(
+        owner: &signer, old_operator: address, new_operator: address
+    ) {
         let owner_address = signer::address_of(owner);
         if (staking_contract::staking_contract_exists(owner_address, old_operator)) {
-            let current_commission_percentage = staking_contract::commission_percentage(owner_address, old_operator);
-            staking_contract::switch_operator(owner, old_operator, new_operator, current_commission_percentage);
+            let current_commission_percentage =
+                staking_contract::commission_percentage(owner_address, old_operator);
+            staking_contract::switch_operator(
+                owner, old_operator, new_operator, current_commission_percentage
+            );
         };
     }
 
-    public entry fun set_stake_pool_operator(owner: &signer, new_operator: address) {
+    public entry fun set_stake_pool_operator(
+        owner: &signer, new_operator: address
+    ) {
         let owner_address = signer::address_of(owner);
         if (stake::stake_pool_exists(owner_address)) {
             stake::set_operator(owner, new_operator);
         };
     }
 
-    public entry fun set_vesting_contract_voter(owner: &signer, operator: address, new_voter: address) {
+    public entry fun set_vesting_contract_voter(
+        owner: &signer, operator: address, new_voter: address
+    ) {
         let owner_address = signer::address_of(owner);
         let vesting_contracts = &vesting::vesting_contracts(owner_address);
-        vector::for_each_ref(vesting_contracts, |vesting_contract| {
-            let vesting_contract = *vesting_contract;
-            if (vesting::operator(vesting_contract) == operator) {
-                vesting::update_voter(owner, vesting_contract, new_voter);
-            };
-        });
+        vector::for_each_ref(
+            vesting_contracts,
+            |vesting_contract| {
+                let vesting_contract = *vesting_contract;
+                if (vesting::operator(vesting_contract) == operator) {
+                    vesting::update_voter(owner, vesting_contract, new_voter);
+                };
+            },
+        );
     }
 
-    public entry fun set_staking_contract_voter(owner: &signer, operator: address, new_voter: address) {
+    public entry fun set_staking_contract_voter(
+        owner: &signer, operator: address, new_voter: address
+    ) {
         let owner_address = signer::address_of(owner);
         if (staking_contract::staking_contract_exists(owner_address, operator)) {
             staking_contract::update_voter(owner, operator, new_voter);
         };
     }
 
-    public entry fun set_stake_pool_voter(owner: &signer, new_voter: address) {
+    public entry fun set_stake_pool_voter(
+        owner: &signer, new_voter: address
+    ) {
         if (stake::stake_pool_exists(signer::address_of(owner))) {
             stake::set_delegated_voter(owner, new_voter);
         };
@@ -72,13 +103,7 @@ module aptos_framework::staking_proxy {
     #[test_only]
     const INITIAL_BALANCE: u64 = 100000000000000; // 1M APT coins with 8 decimals.
 
-    #[test(
-        aptos_framework = @0x1,
-        owner = @0x123,
-        operator_1 = @0x234,
-        operator_2 = @0x345,
-        new_operator = @0x567,
-    )]
+    #[test(aptos_framework = @0x1, owner = @0x123, operator_1 = @0x234, operator_2 = @0x345, new_operator = @0x567,)]
     public entry fun test_set_operator(
         aptos_framework: &signer,
         owner: &signer,
@@ -91,13 +116,29 @@ module aptos_framework::staking_proxy {
         let operator_2_address = signer::address_of(operator_2);
         let new_operator_address = signer::address_of(new_operator);
         vesting::setup(
-            aptos_framework, &vector[owner_address, operator_1_address, operator_2_address, new_operator_address]);
-        staking_contract::setup_staking_contract(aptos_framework, owner, operator_1, INITIAL_BALANCE, 0);
-        staking_contract::setup_staking_contract(aptos_framework, owner, operator_2, INITIAL_BALANCE, 0);
+            aptos_framework,
+            &vector[
+                owner_address,
+                operator_1_address,
+                operator_2_address,
+                new_operator_address],
+        );
+        staking_contract::setup_staking_contract(
+            aptos_framework, owner, operator_1, INITIAL_BALANCE, 0
+        );
+        staking_contract::setup_staking_contract(
+            aptos_framework, owner, operator_2, INITIAL_BALANCE, 0
+        );
 
-        let vesting_contract_1 = vesting::setup_vesting_contract(owner, &vector[@11], &vector[INITIAL_BALANCE], owner_address, 0);
+        let vesting_contract_1 =
+            vesting::setup_vesting_contract(
+                owner, &vector[@11], &vector[INITIAL_BALANCE], owner_address, 0
+            );
         vesting::update_operator(owner, vesting_contract_1, operator_1_address, 0);
-        let vesting_contract_2 = vesting::setup_vesting_contract(owner, &vector[@12], &vector[INITIAL_BALANCE], owner_address, 0);
+        let vesting_contract_2 =
+            vesting::setup_vesting_contract(
+                owner, &vector[@12], &vector[INITIAL_BALANCE], owner_address, 0
+            );
         vesting::update_operator(owner, vesting_contract_2, operator_2_address, 0);
 
         let (_sk, pk, pop) = stake::generate_identity();
@@ -109,21 +150,24 @@ module aptos_framework::staking_proxy {
         assert!(stake::get_operator(owner_address) == new_operator_address, 0);
         // Staking contract has been switched from operator 1 to new operator.
         // Staking contract with operator_2 should stay unchanged.
-        assert!(staking_contract::staking_contract_exists(owner_address, new_operator_address), 1);
-        assert!(!staking_contract::staking_contract_exists(owner_address, operator_1_address), 2);
-        assert!(staking_contract::staking_contract_exists(owner_address, operator_2_address), 3);
+        assert!(
+            staking_contract::staking_contract_exists(owner_address, new_operator_address),
+            1,
+        );
+        assert!(
+            !staking_contract::staking_contract_exists(owner_address, operator_1_address),
+            2,
+        );
+        assert!(
+            staking_contract::staking_contract_exists(owner_address, operator_2_address),
+            3
+        );
         // Vesting contract 1 has been switched from operator 1 to new operator while vesting contract 2 stays unchanged
         assert!(vesting::operator(vesting_contract_1) == new_operator_address, 4);
         assert!(vesting::operator(vesting_contract_2) == operator_2_address, 5);
     }
 
-    #[test(
-        aptos_framework = @0x1,
-        owner = @0x123,
-        operator_1 = @0x234,
-        operator_2 = @0x345,
-        new_operator = @0x567,
-    )]
+    #[test(aptos_framework = @0x1, owner = @0x123, operator_1 = @0x234, operator_2 = @0x345, new_operator = @0x567,)]
     public entry fun test_set_operator_nothing_to_change(
         aptos_framework: &signer,
         owner: &signer,
@@ -136,26 +180,39 @@ module aptos_framework::staking_proxy {
         let operator_2_address = signer::address_of(operator_2);
         let new_operator_address = signer::address_of(new_operator);
         vesting::setup(
-            aptos_framework, &vector[owner_address, operator_1_address, operator_2_address, new_operator_address]);
-        staking_contract::setup_staking_contract(aptos_framework, owner, operator_2, INITIAL_BALANCE, 0);
+            aptos_framework,
+            &vector[
+                owner_address,
+                operator_1_address,
+                operator_2_address,
+                new_operator_address],
+        );
+        staking_contract::setup_staking_contract(
+            aptos_framework, owner, operator_2, INITIAL_BALANCE, 0
+        );
 
-        let vesting_contract_2 = vesting::setup_vesting_contract(owner, &vector[@12], &vector[INITIAL_BALANCE], owner_address, 0);
+        let vesting_contract_2 =
+            vesting::setup_vesting_contract(
+                owner, &vector[@12], &vector[INITIAL_BALANCE], owner_address, 0
+            );
         vesting::update_operator(owner, vesting_contract_2, operator_2_address, 0);
 
         set_operator(owner, operator_1_address, new_operator_address);
         // No staking or vesting contracts changed.
-        assert!(!staking_contract::staking_contract_exists(owner_address, new_operator_address), 0);
-        assert!(staking_contract::staking_contract_exists(owner_address, operator_2_address), 1);
+        assert!(
+            !staking_contract::staking_contract_exists(
+                owner_address, new_operator_address
+            ),
+            0,
+        );
+        assert!(
+            staking_contract::staking_contract_exists(owner_address, operator_2_address),
+            1
+        );
         assert!(vesting::operator(vesting_contract_2) == operator_2_address, 2);
     }
 
-    #[test(
-        aptos_framework = @0x1,
-        owner = @0x123,
-        operator_1 = @0x234,
-        operator_2 = @0x345,
-        new_voter = @0x567,
-    )]
+    #[test(aptos_framework = @0x1, owner = @0x123, operator_1 = @0x234, operator_2 = @0x345, new_voter = @0x567,)]
     public entry fun test_set_voter(
         aptos_framework: &signer,
         owner: &signer,
@@ -168,13 +225,29 @@ module aptos_framework::staking_proxy {
         let operator_2_address = signer::address_of(operator_2);
         let new_voter_address = signer::address_of(new_voter);
         vesting::setup(
-            aptos_framework, &vector[owner_address, operator_1_address, operator_2_address, new_voter_address]);
-        staking_contract::setup_staking_contract(aptos_framework, owner, operator_1, INITIAL_BALANCE, 0);
-        staking_contract::setup_staking_contract(aptos_framework, owner, operator_2, INITIAL_BALANCE, 0);
+            aptos_framework,
+            &vector[
+                owner_address,
+                operator_1_address,
+                operator_2_address,
+                new_voter_address],
+        );
+        staking_contract::setup_staking_contract(
+            aptos_framework, owner, operator_1, INITIAL_BALANCE, 0
+        );
+        staking_contract::setup_staking_contract(
+            aptos_framework, owner, operator_2, INITIAL_BALANCE, 0
+        );
 
-        let vesting_contract_1 = vesting::setup_vesting_contract(owner, &vector[@11], &vector[INITIAL_BALANCE], owner_address, 0);
+        let vesting_contract_1 =
+            vesting::setup_vesting_contract(
+                owner, &vector[@11], &vector[INITIAL_BALANCE], owner_address, 0
+            );
         vesting::update_operator(owner, vesting_contract_1, operator_1_address, 0);
-        let vesting_contract_2 = vesting::setup_vesting_contract(owner, &vector[@12], &vector[INITIAL_BALANCE], owner_address, 0);
+        let vesting_contract_2 =
+            vesting::setup_vesting_contract(
+                owner, &vector[@12], &vector[INITIAL_BALANCE], owner_address, 0
+            );
         vesting::update_operator(owner, vesting_contract_2, operator_2_address, 0);
 
         let (_sk, pk, pop) = stake::generate_identity();
@@ -185,8 +258,10 @@ module aptos_framework::staking_proxy {
         assert!(stake::get_delegated_voter(owner_address) == new_voter_address, 0);
         // Staking contract with operator 1's voter has been updated.
         // Staking contract with operator_2 should stay unchanged.
-        let stake_pool_address_1 = staking_contract::stake_pool_address(owner_address, operator_1_address);
-        let stake_pool_address_2 = staking_contract::stake_pool_address(owner_address, operator_2_address);
+        let stake_pool_address_1 =
+            staking_contract::stake_pool_address(owner_address, operator_1_address);
+        let stake_pool_address_2 =
+            staking_contract::stake_pool_address(owner_address, operator_2_address);
         assert!(stake::get_delegated_voter(stake_pool_address_1) == new_voter_address, 1);
         assert!(stake::get_delegated_voter(stake_pool_address_2) == operator_2_address, 2);
         // Vesting contract 1's voter has been updated while vesting contract 2's stays unchanged.
@@ -194,13 +269,7 @@ module aptos_framework::staking_proxy {
         assert!(vesting::voter(vesting_contract_2) == owner_address, 4);
     }
 
-    #[test(
-        aptos_framework = @0x1,
-        owner = @0x123,
-        operator_1 = @0x234,
-        operator_2 = @0x345,
-        new_voter = @0x567,
-    )]
+    #[test(aptos_framework = @0x1, owner = @0x123, operator_1 = @0x234, operator_2 = @0x345, new_voter = @0x567,)]
     public entry fun test_set_voter_nothing_to_change(
         aptos_framework: &signer,
         owner: &signer,
@@ -213,15 +282,27 @@ module aptos_framework::staking_proxy {
         let operator_2_address = signer::address_of(operator_2);
         let new_voter_address = signer::address_of(new_voter);
         vesting::setup(
-            aptos_framework, &vector[owner_address, operator_1_address, operator_2_address, new_voter_address]);
-        staking_contract::setup_staking_contract(aptos_framework, owner, operator_2, INITIAL_BALANCE, 0);
+            aptos_framework,
+            &vector[
+                owner_address,
+                operator_1_address,
+                operator_2_address,
+                new_voter_address],
+        );
+        staking_contract::setup_staking_contract(
+            aptos_framework, owner, operator_2, INITIAL_BALANCE, 0
+        );
 
-        let vesting_contract_2 = vesting::setup_vesting_contract(owner, &vector[@12], &vector[INITIAL_BALANCE], owner_address, 0);
+        let vesting_contract_2 =
+            vesting::setup_vesting_contract(
+                owner, &vector[@12], &vector[INITIAL_BALANCE], owner_address, 0
+            );
         vesting::update_operator(owner, vesting_contract_2, operator_2_address, 0);
 
         set_operator(owner, operator_1_address, new_voter_address);
         // No staking or vesting contracts changed.
-        let stake_pool_address = staking_contract::stake_pool_address(owner_address, operator_2_address);
+        let stake_pool_address =
+            staking_contract::stake_pool_address(owner_address, operator_2_address);
         assert!(stake::get_delegated_voter(stake_pool_address) == operator_2_address, 0);
         assert!(vesting::voter(vesting_contract_2) == owner_address, 1);
     }

--- a/aptos-move/framework/aptos-framework/sources/staking_proxy.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_proxy.move
@@ -53,7 +53,10 @@ module aptos_framework::staking_proxy {
             let current_commission_percentage =
                 staking_contract::commission_percentage(owner_address, old_operator);
             staking_contract::switch_operator(
-                owner, old_operator, new_operator, current_commission_percentage
+                owner,
+                old_operator,
+                new_operator,
+                current_commission_percentage,
             );
         };
     }
@@ -103,7 +106,15 @@ module aptos_framework::staking_proxy {
     #[test_only]
     const INITIAL_BALANCE: u64 = 100000000000000; // 1M APT coins with 8 decimals.
 
-    #[test(aptos_framework = @0x1, owner = @0x123, operator_1 = @0x234, operator_2 = @0x345, new_operator = @0x567,)]
+    #[
+        test(
+            aptos_framework = @0x1,
+            owner = @0x123,
+            operator_1 = @0x234,
+            operator_2 = @0x345,
+            new_operator = @0x567,
+        )
+    ]
     public entry fun test_set_operator(
         aptos_framework: &signer,
         owner: &signer,
@@ -121,7 +132,8 @@ module aptos_framework::staking_proxy {
                 owner_address,
                 operator_1_address,
                 operator_2_address,
-                new_operator_address],
+                new_operator_address
+            ],
         );
         staking_contract::setup_staking_contract(
             aptos_framework, owner, operator_1, INITIAL_BALANCE, 0
@@ -132,12 +144,20 @@ module aptos_framework::staking_proxy {
 
         let vesting_contract_1 =
             vesting::setup_vesting_contract(
-                owner, &vector[@11], &vector[INITIAL_BALANCE], owner_address, 0
+                owner,
+                &vector[@11],
+                &vector[INITIAL_BALANCE],
+                owner_address,
+                0,
             );
         vesting::update_operator(owner, vesting_contract_1, operator_1_address, 0);
         let vesting_contract_2 =
             vesting::setup_vesting_contract(
-                owner, &vector[@12], &vector[INITIAL_BALANCE], owner_address, 0
+                owner,
+                &vector[@12],
+                &vector[INITIAL_BALANCE],
+                owner_address,
+                0,
             );
         vesting::update_operator(owner, vesting_contract_2, operator_2_address, 0);
 
@@ -160,14 +180,22 @@ module aptos_framework::staking_proxy {
         );
         assert!(
             staking_contract::staking_contract_exists(owner_address, operator_2_address),
-            3
+            3,
         );
         // Vesting contract 1 has been switched from operator 1 to new operator while vesting contract 2 stays unchanged
         assert!(vesting::operator(vesting_contract_1) == new_operator_address, 4);
         assert!(vesting::operator(vesting_contract_2) == operator_2_address, 5);
     }
 
-    #[test(aptos_framework = @0x1, owner = @0x123, operator_1 = @0x234, operator_2 = @0x345, new_operator = @0x567,)]
+    #[
+        test(
+            aptos_framework = @0x1,
+            owner = @0x123,
+            operator_1 = @0x234,
+            operator_2 = @0x345,
+            new_operator = @0x567,
+        )
+    ]
     public entry fun test_set_operator_nothing_to_change(
         aptos_framework: &signer,
         owner: &signer,
@@ -185,7 +213,8 @@ module aptos_framework::staking_proxy {
                 owner_address,
                 operator_1_address,
                 operator_2_address,
-                new_operator_address],
+                new_operator_address
+            ],
         );
         staking_contract::setup_staking_contract(
             aptos_framework, owner, operator_2, INITIAL_BALANCE, 0
@@ -193,7 +222,11 @@ module aptos_framework::staking_proxy {
 
         let vesting_contract_2 =
             vesting::setup_vesting_contract(
-                owner, &vector[@12], &vector[INITIAL_BALANCE], owner_address, 0
+                owner,
+                &vector[@12],
+                &vector[INITIAL_BALANCE],
+                owner_address,
+                0,
             );
         vesting::update_operator(owner, vesting_contract_2, operator_2_address, 0);
 
@@ -207,12 +240,20 @@ module aptos_framework::staking_proxy {
         );
         assert!(
             staking_contract::staking_contract_exists(owner_address, operator_2_address),
-            1
+            1,
         );
         assert!(vesting::operator(vesting_contract_2) == operator_2_address, 2);
     }
 
-    #[test(aptos_framework = @0x1, owner = @0x123, operator_1 = @0x234, operator_2 = @0x345, new_voter = @0x567,)]
+    #[
+        test(
+            aptos_framework = @0x1,
+            owner = @0x123,
+            operator_1 = @0x234,
+            operator_2 = @0x345,
+            new_voter = @0x567,
+        )
+    ]
     public entry fun test_set_voter(
         aptos_framework: &signer,
         owner: &signer,
@@ -230,7 +271,8 @@ module aptos_framework::staking_proxy {
                 owner_address,
                 operator_1_address,
                 operator_2_address,
-                new_voter_address],
+                new_voter_address
+            ],
         );
         staking_contract::setup_staking_contract(
             aptos_framework, owner, operator_1, INITIAL_BALANCE, 0
@@ -241,12 +283,20 @@ module aptos_framework::staking_proxy {
 
         let vesting_contract_1 =
             vesting::setup_vesting_contract(
-                owner, &vector[@11], &vector[INITIAL_BALANCE], owner_address, 0
+                owner,
+                &vector[@11],
+                &vector[INITIAL_BALANCE],
+                owner_address,
+                0,
             );
         vesting::update_operator(owner, vesting_contract_1, operator_1_address, 0);
         let vesting_contract_2 =
             vesting::setup_vesting_contract(
-                owner, &vector[@12], &vector[INITIAL_BALANCE], owner_address, 0
+                owner,
+                &vector[@12],
+                &vector[INITIAL_BALANCE],
+                owner_address,
+                0,
             );
         vesting::update_operator(owner, vesting_contract_2, operator_2_address, 0);
 
@@ -269,7 +319,15 @@ module aptos_framework::staking_proxy {
         assert!(vesting::voter(vesting_contract_2) == owner_address, 4);
     }
 
-    #[test(aptos_framework = @0x1, owner = @0x123, operator_1 = @0x234, operator_2 = @0x345, new_voter = @0x567,)]
+    #[
+        test(
+            aptos_framework = @0x1,
+            owner = @0x123,
+            operator_1 = @0x234,
+            operator_2 = @0x345,
+            new_voter = @0x567,
+        )
+    ]
     public entry fun test_set_voter_nothing_to_change(
         aptos_framework: &signer,
         owner: &signer,
@@ -287,7 +345,8 @@ module aptos_framework::staking_proxy {
                 owner_address,
                 operator_1_address,
                 operator_2_address,
-                new_voter_address],
+                new_voter_address
+            ],
         );
         staking_contract::setup_staking_contract(
             aptos_framework, owner, operator_2, INITIAL_BALANCE, 0
@@ -295,7 +354,11 @@ module aptos_framework::staking_proxy {
 
         let vesting_contract_2 =
             vesting::setup_vesting_contract(
-                owner, &vector[@12], &vector[INITIAL_BALANCE], owner_address, 0
+                owner,
+                &vector[@12],
+                &vector[INITIAL_BALANCE],
+                owner_address,
+                0,
             );
         vesting::update_operator(owner, vesting_contract_2, operator_2_address, 0);
 

--- a/aptos-move/framework/aptos-framework/sources/staking_proxy.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_proxy.spec.move
@@ -149,7 +149,7 @@ spec aptos_framework::staking_proxy {
         aborts_if stake::stake_pool_exists(owner_address)
             && !(
                 exists<stake::OwnerCapability>(owner_address)
-                && stake::stake_pool_exists(pool_address)
+                    && stake::stake_pool_exists(pool_address)
             );
         ensures stake::stake_pool_exists(owner_address) ==>
             global<stake::StakePool>(pool_address).operator_address == new_operator;
@@ -201,7 +201,7 @@ spec aptos_framework::staking_proxy {
         aborts_if stake::stake_pool_exists(owner_address)
             && !(
                 exists<stake::OwnerCapability>(owner_address)
-                && stake::stake_pool_exists(pool_address)
+                    && stake::stake_pool_exists(pool_address)
             );
         ensures stake::stake_pool_exists(owner_address) ==>
             global<stake::StakePool>(pool_address).delegated_voter == new_voter;

--- a/aptos-move/framework/aptos-framework/sources/staking_proxy.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_proxy.spec.move
@@ -62,12 +62,16 @@ spec aptos_framework::staking_proxy {
         include SetStakePoolVoterAbortsIf;
     }
 
-    spec set_vesting_contract_operator(owner: &signer, old_operator: address, new_operator: address) {
+    spec set_vesting_contract_operator(
+        owner: &signer, old_operator: address, new_operator: address
+    ) {
         // TODO: Can't verify `update_voter` in while loop.
         pragma verify = false;
     }
 
-    spec set_staking_contract_operator(owner: &signer, old_operator: address, new_operator: address) {
+    spec set_staking_contract_operator(
+        owner: &signer, old_operator: address, new_operator: address
+    ) {
         pragma aborts_if_is_partial;
         pragma verify = false;
         // TODO: Verify timeout and can't verify `staking_contract::switch_operator`.
@@ -85,11 +89,14 @@ spec aptos_framework::staking_proxy {
 
         let owner_address = signer::address_of(owner);
         let store = global<Store>(owner_address);
-        let staking_contract_exists = exists<Store>(owner_address) && simple_map::spec_contains_key(store.staking_contracts, old_operator);
-        aborts_if staking_contract_exists && simple_map::spec_contains_key(store.staking_contracts, new_operator);
+        let staking_contract_exists = exists<Store>(owner_address)
+            && simple_map::spec_contains_key(store.staking_contracts, old_operator);
+        aborts_if staking_contract_exists
+            && simple_map::spec_contains_key(store.staking_contracts, new_operator);
 
         let post post_store = global<Store>(owner_address);
-        ensures staking_contract_exists ==> !simple_map::spec_contains_key(post_store.staking_contracts, old_operator);
+        ensures staking_contract_exists ==>
+            !simple_map::spec_contains_key(post_store.staking_contracts, old_operator);
 
         let staking_contract = simple_map::spec_get(store.staking_contracts, old_operator);
         let stake_pool = global<stake::StakePool>(staking_contract.pool_address);
@@ -97,20 +104,28 @@ spec aptos_framework::staking_proxy {
         let pending_active = coin::value(stake_pool.pending_active);
         let total_active_stake = active + pending_active;
         let accumulated_rewards = total_active_stake - staking_contract.principal;
-        let commission_amount = accumulated_rewards * staking_contract.commission_percentage / 100;
-        aborts_if staking_contract_exists && !exists<stake::StakePool>(staking_contract.pool_address);
+        let commission_amount = accumulated_rewards
+            * staking_contract.commission_percentage / 100;
+        aborts_if staking_contract_exists
+            && !exists<stake::StakePool>(staking_contract.pool_address);
         // the following property caused timeout
         ensures staking_contract_exists ==>
-            simple_map::spec_get(post_store.staking_contracts, new_operator).principal == total_active_stake - commission_amount;
+            simple_map::spec_get(post_store.staking_contracts, new_operator).principal
+                == total_active_stake - commission_amount;
 
         let pool_address = staking_contract.owner_cap.pool_address;
         let current_commission_percentage = staking_contract.commission_percentage;
-        aborts_if staking_contract_exists && commission_amount != 0 && !exists<stake::StakePool>(pool_address);
-        ensures staking_contract_exists && commission_amount != 0 ==>
+        aborts_if staking_contract_exists
+            && commission_amount != 0
+            && !exists<stake::StakePool>(pool_address);
+        ensures staking_contract_exists
+            && commission_amount != 0 ==>
             global<stake::StakePool>(pool_address).operator_address == new_operator
-            && simple_map::spec_get(post_store.staking_contracts, new_operator).commission_percentage == current_commission_percentage;
+                && simple_map::spec_get(post_store.staking_contracts, new_operator).commission_percentage ==
+                     current_commission_percentage;
 
-        ensures staking_contract_exists ==> simple_map::spec_contains_key(post_store.staking_contracts, new_operator);
+        ensures staking_contract_exists ==>
+            simple_map::spec_contains_key(post_store.staking_contracts, new_operator);
     }
 
     spec set_vesting_contract_voter(owner: &signer, operator: address, new_voter: address) {
@@ -131,8 +146,13 @@ spec aptos_framework::staking_proxy {
         let owner_address = signer::address_of(owner);
         let ownership_cap = borrow_global<stake::OwnerCapability>(owner_address);
         let pool_address = ownership_cap.pool_address;
-        aborts_if stake::stake_pool_exists(owner_address) && !(exists<stake::OwnerCapability>(owner_address) && stake::stake_pool_exists(pool_address));
-        ensures stake::stake_pool_exists(owner_address) ==> global<stake::StakePool>(pool_address).operator_address == new_operator;
+        aborts_if stake::stake_pool_exists(owner_address)
+            && !(
+                exists<stake::OwnerCapability>(owner_address)
+                && stake::stake_pool_exists(pool_address)
+            );
+        ensures stake::stake_pool_exists(owner_address) ==>
+            global<stake::StakePool>(pool_address).operator_address == new_operator;
     }
 
     spec set_staking_contract_voter(owner: &signer, operator: address, new_voter: address) {
@@ -152,16 +172,19 @@ spec aptos_framework::staking_proxy {
         let owner_address = signer::address_of(owner);
         let staker = owner_address;
         let store = global<Store>(staker);
-        let staking_contract_exists = exists<Store>(staker) && simple_map::spec_contains_key(store.staking_contracts, operator);
+        let staking_contract_exists = exists<Store>(staker)
+            && simple_map::spec_contains_key(store.staking_contracts, operator);
         let staker_address = owner_address;
         let staking_contract = simple_map::spec_get(store.staking_contracts, operator);
         let pool_address = staking_contract.pool_address;
         let pool_address1 = staking_contract.owner_cap.pool_address;
 
         aborts_if staking_contract_exists && !exists<stake::StakePool>(pool_address);
-        aborts_if staking_contract_exists && !exists<stake::StakePool>(staking_contract.owner_cap.pool_address);
+        aborts_if staking_contract_exists
+            && !exists<stake::StakePool>(staking_contract.owner_cap.pool_address);
 
-        ensures staking_contract_exists ==> global<stake::StakePool>(pool_address1).delegated_voter == new_voter;
+        ensures staking_contract_exists ==>
+            global<stake::StakePool>(pool_address1).delegated_voter == new_voter;
     }
 
     spec set_stake_pool_voter(owner: &signer, new_voter: address) {
@@ -175,7 +198,12 @@ spec aptos_framework::staking_proxy {
         let owner_address = signer::address_of(owner);
         let ownership_cap = global<stake::OwnerCapability>(owner_address);
         let pool_address = ownership_cap.pool_address;
-        aborts_if stake::stake_pool_exists(owner_address) && !(exists<stake::OwnerCapability>(owner_address) && stake::stake_pool_exists(pool_address));
-        ensures stake::stake_pool_exists(owner_address) ==> global<stake::StakePool>(pool_address).delegated_voter == new_voter;
+        aborts_if stake::stake_pool_exists(owner_address)
+            && !(
+                exists<stake::OwnerCapability>(owner_address)
+                && stake::stake_pool_exists(pool_address)
+            );
+        ensures stake::stake_pool_exists(owner_address) ==>
+            global<stake::StakePool>(pool_address).delegated_voter == new_voter;
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/state_storage.move
+++ b/aptos-move/framework/aptos-framework/sources/state_storage.move
@@ -25,21 +25,18 @@ module aptos_framework::state_storage {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert!(
             !exists<StateStorageUsage>(@aptos_framework),
-            error::already_exists(ESTATE_STORAGE_USAGE)
+            error::already_exists(ESTATE_STORAGE_USAGE),
         );
-        move_to(aptos_framework, StateStorageUsage {
-            epoch: 0,
-            usage: Usage {
-                items: 0,
-                bytes: 0,
-            }
-        });
+        move_to(
+            aptos_framework,
+            StateStorageUsage { epoch: 0, usage: Usage { items: 0, bytes: 0, } },
+        );
     }
 
     public(friend) fun on_new_block(epoch: u64) acquires StateStorageUsage {
         assert!(
             exists<StateStorageUsage>(@aptos_framework),
-            error::not_found(ESTATE_STORAGE_USAGE)
+            error::not_found(ESTATE_STORAGE_USAGE),
         );
         let usage = borrow_global_mut<StateStorageUsage>(@aptos_framework);
         if (epoch != usage.epoch) {
@@ -51,7 +48,7 @@ module aptos_framework::state_storage {
     public(friend) fun current_items_and_bytes(): (u64, u64) acquires StateStorageUsage {
         assert!(
             exists<StateStorageUsage>(@aptos_framework),
-            error::not_found(ESTATE_STORAGE_USAGE)
+            error::not_found(ESTATE_STORAGE_USAGE),
         );
         let usage = borrow_global<StateStorageUsage>(@aptos_framework);
         (usage.usage.items, usage.usage.bytes)
@@ -67,14 +64,11 @@ module aptos_framework::state_storage {
     public fun set_for_test(epoch: u64, items: u64, bytes: u64) acquires StateStorageUsage {
         assert!(
             exists<StateStorageUsage>(@aptos_framework),
-            error::not_found(ESTATE_STORAGE_USAGE)
+            error::not_found(ESTATE_STORAGE_USAGE),
         );
         let usage = borrow_global_mut<StateStorageUsage>(@aptos_framework);
         usage.epoch = epoch;
-        usage.usage = Usage {
-            items,
-            bytes
-        };
+        usage.usage = Usage { items, bytes };
     }
 
     // ======================== deprecated ============================

--- a/aptos-move/framework/aptos-framework/sources/state_storage.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/state_storage.spec.move
@@ -45,8 +45,10 @@ spec aptos_framework::state_storage {
         // After genesis, `StateStorageUsage` and `GasParameter` exist.
         /// [high-level-req-1]
         /// [high-level-req-5.3]
-        invariant [suspendable] chain_status::is_operating() ==> exists<StateStorageUsage>(@aptos_framework);
-        invariant [suspendable] chain_status::is_operating() ==> exists<GasParameter>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<StateStorageUsage>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<GasParameter>(@aptos_framework);
     }
 
     /// ensure caller is admin.
@@ -61,7 +63,9 @@ spec aptos_framework::state_storage {
         ensures exists<StateStorageUsage>(@aptos_framework);
         let post state_usage = global<StateStorageUsage>(@aptos_framework);
         /// [high-level-req-2]
-        ensures state_usage.epoch == 0 && state_usage.usage.bytes == 0 && state_usage.usage.items == 0;
+        ensures state_usage.epoch == 0
+            && state_usage.usage.bytes == 0
+            && state_usage.usage.items == 0;
     }
 
     spec on_new_block(epoch: u64) {

--- a/aptos-move/framework/aptos-framework/sources/storage_gas.move
+++ b/aptos-move/framework/aptos-framework/sources/storage_gas.move
@@ -298,20 +298,15 @@ module aptos_framework::storage_gas {
     /// | 95%   | 63.72%              |
     /// | 99%   | 91.38%              |
     public fun base_8192_exponential_curve(min_gas: u64, max_gas: u64): GasCurve {
-        new_gas_curve(min_gas, max_gas,
+        new_gas_curve(
+            min_gas,
+            max_gas,
             vector[
-                new_point(1000, 2),
-                new_point(2000, 6),
-                new_point(3000, 17),
-                new_point(4000, 44),
-                new_point(5000, 109),
-                new_point(6000, 271),
-                new_point(7000, 669),
-                new_point(8000, 1648),
-                new_point(9000, 4061),
-                new_point(9500, 6372),
-                new_point(9900, 9138),
-            ]
+                new_point(1000, 2), new_point(2000, 6), new_point(3000, 17), new_point(
+                    4000, 44
+                ), new_point(5000, 109), new_point(6000, 271), new_point(7000, 669), new_point(
+                    8000, 1648
+                ), new_point(9000, 4061), new_point(9500, 6372), new_point(9900, 9138),],
         )
     }
 
@@ -326,41 +321,46 @@ module aptos_framework::storage_gas {
     public fun new_point(x: u64, y: u64): Point {
         assert!(
             x <= BASIS_POINT_DENOMINATION && y <= BASIS_POINT_DENOMINATION,
-            error::invalid_argument(EINVALID_POINT_RANGE)
+            error::invalid_argument(EINVALID_POINT_RANGE),
         );
         Point { x, y }
     }
 
-    public fun new_gas_curve(min_gas: u64, max_gas: u64, points: vector<Point>): GasCurve {
+    public fun new_gas_curve(
+        min_gas: u64, max_gas: u64, points: vector<Point>
+    ): GasCurve {
         assert!(max_gas >= min_gas, error::invalid_argument(EINVALID_GAS_RANGE));
-        assert!(max_gas <= MAX_U64 / BASIS_POINT_DENOMINATION, error::invalid_argument(EINVALID_GAS_RANGE));
+        assert!(
+            max_gas <= MAX_U64 / BASIS_POINT_DENOMINATION,
+            error::invalid_argument(EINVALID_GAS_RANGE),
+        );
         validate_points(&points);
-        GasCurve {
-            min_gas,
-            max_gas,
-            points
-        }
+        GasCurve { min_gas, max_gas, points }
     }
 
-    public fun new_usage_gas_config(target_usage: u64, read_curve: GasCurve, create_curve: GasCurve, write_curve: GasCurve): UsageGasConfig {
+    public fun new_usage_gas_config(
+        target_usage: u64,
+        read_curve: GasCurve,
+        create_curve: GasCurve,
+        write_curve: GasCurve
+    ): UsageGasConfig {
         assert!(target_usage > 0, error::invalid_argument(EZERO_TARGET_USAGE));
-        assert!(target_usage <= MAX_U64 / BASIS_POINT_DENOMINATION, error::invalid_argument(ETARGET_USAGE_TOO_BIG));
-        UsageGasConfig {
-            target_usage,
-            read_curve,
-            create_curve,
-            write_curve,
-        }
+        assert!(
+            target_usage <= MAX_U64 / BASIS_POINT_DENOMINATION,
+            error::invalid_argument(ETARGET_USAGE_TOO_BIG),
+        );
+        UsageGasConfig { target_usage, read_curve, create_curve, write_curve, }
     }
 
-    public fun new_storage_gas_config(item_config: UsageGasConfig, byte_config: UsageGasConfig): StorageGasConfig {
-        StorageGasConfig {
-            item_config,
-            byte_config
-        }
+    public fun new_storage_gas_config(
+        item_config: UsageGasConfig, byte_config: UsageGasConfig
+    ): StorageGasConfig {
+        StorageGasConfig { item_config, byte_config }
     }
 
-    public(friend) fun set_config(aptos_framework: &signer, config: StorageGasConfig) acquires StorageGasConfig {
+    public(friend) fun set_config(
+        aptos_framework: &signer, config: StorageGasConfig
+    ) acquires StorageGasConfig {
         system_addresses::assert_aptos_framework(aptos_framework);
         *borrow_global_mut<StorageGasConfig>(@aptos_framework) = config;
     }
@@ -390,7 +390,7 @@ module aptos_framework::storage_gas {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert!(
             !exists<StorageGasConfig>(@aptos_framework),
-            error::already_exists(ESTORAGE_GAS_CONFIG)
+            error::already_exists(ESTORAGE_GAS_CONFIG),
         );
 
         let k: u64 = 1000;
@@ -405,26 +405,29 @@ module aptos_framework::storage_gas {
         let byte_config = UsageGasConfig {
             target_usage: 1 * m * m, // 1TB
             read_curve: base_8192_exponential_curve(300, 300 * 100),
-            create_curve: base_8192_exponential_curve(5 * k,  5 * k * 100),
-            write_curve: base_8192_exponential_curve(5 * k,  5 * k * 100),
+            create_curve: base_8192_exponential_curve(5 * k, 5 * k * 100),
+            write_curve: base_8192_exponential_curve(5 * k, 5 * k * 100),
         };
-        move_to(aptos_framework, StorageGasConfig {
-            item_config,
-            byte_config,
-        });
+        move_to(
+            aptos_framework,
+            StorageGasConfig { item_config, byte_config, },
+        );
 
         assert!(
             !exists<StorageGas>(@aptos_framework),
-            error::already_exists(ESTORAGE_GAS)
+            error::already_exists(ESTORAGE_GAS),
         );
-        move_to(aptos_framework, StorageGas {
-            per_item_read: 300 * k,
-            per_item_create: 5 * m,
-            per_item_write: 300 * k,
-            per_byte_read: 300,
-            per_byte_create: 5 * k,
-            per_byte_write: 5 * k,
-        });
+        move_to(
+            aptos_framework,
+            StorageGas {
+                per_item_read: 300 * k,
+                per_item_create: 5 * m,
+                per_item_write: 300 * k,
+                per_byte_read: 300,
+                per_byte_create: 5 * k,
+                per_byte_write: 5 * k,
+            },
+        );
     }
 
     fun validate_points(points: &vector<Point>) {
@@ -434,65 +437,107 @@ module aptos_framework::storage_gas {
         };
         let i = 0;
         while ({
-            spec {
-                invariant forall j in 0..i: {
-                    let cur = if (j == 0) { Point { x: 0, y: 0 } } else { points[j - 1] };
-                    let next = if (j == len) { Point { x: BASIS_POINT_DENOMINATION, y: BASIS_POINT_DENOMINATION } } else { points[j] };
-                    cur.x < next.x && cur.y <= next.y
+                spec {
+                    invariant forall j in 0..i: {
+                        let cur = if (j == 0) {
+                            Point { x: 0, y: 0 }
+                        } else {
+                            points[j - 1]
+                        };
+                        let next =
+                            if (j == len) {
+                                Point {
+                                    x: BASIS_POINT_DENOMINATION,
+                                    y: BASIS_POINT_DENOMINATION
+                                }
+                            } else {
+                                points[j]
+                            };
+                        cur.x < next.x && cur.y <= next.y
+                    };
                 };
+                i <= len
+            }) {
+            let cur = if (i == 0) {
+                &Point { x: 0, y: 0 }
+            } else {
+                vector::borrow(points, i - 1)
             };
-            i <= len
-        }) {
-            let cur = if (i == 0) { &Point { x: 0, y: 0 } } else { vector::borrow(points, i - 1) };
-            let next = if (i == len) { &Point { x: BASIS_POINT_DENOMINATION, y: BASIS_POINT_DENOMINATION } } else { vector::borrow(points, i) };
-            assert!(cur.x < next.x && cur.y <= next.y, error::invalid_argument(EINVALID_MONOTONICALLY_NON_DECREASING_CURVE));
+            let next =
+                if (i == len) {
+                    &Point { x: BASIS_POINT_DENOMINATION, y: BASIS_POINT_DENOMINATION }
+                } else {
+                    vector::borrow(points, i)
+                };
+            assert!(
+                cur.x < next.x && cur.y <= next.y,
+                error::invalid_argument(EINVALID_MONOTONICALLY_NON_DECREASING_CURVE),
+            );
             i = i + 1;
         }
     }
 
-    fun calculate_gas(max_usage: u64, current_usage: u64, curve: &GasCurve): u64 {
-        let capped_current_usage = if (current_usage > max_usage) max_usage else current_usage;
+    fun calculate_gas(
+        max_usage: u64, current_usage: u64, curve: &GasCurve
+    ): u64 {
+        let capped_current_usage = if (current_usage > max_usage) max_usage
+        else current_usage;
         let points = &curve.points;
         let num_points = vector::length(points);
         let current_usage_bps = capped_current_usage * BASIS_POINT_DENOMINATION / max_usage;
 
         // Check the corner case that current_usage_bps drops before the first point.
-        let (left, right) = if (num_points == 0) {
-            (&Point { x: 0, y: 0 }, &Point { x: BASIS_POINT_DENOMINATION, y: BASIS_POINT_DENOMINATION })
-        } else if (current_usage_bps < vector::borrow(points, 0).x) {
-            (&Point { x: 0, y: 0 }, vector::borrow(points, 0))
-        } else if (vector::borrow(points, num_points - 1).x <= current_usage_bps) {
-            (vector::borrow(points, num_points - 1), &Point { x: BASIS_POINT_DENOMINATION, y: BASIS_POINT_DENOMINATION })
-        } else {
-            let (i, j) = (0, num_points - 2);
-            while ({
-                spec {
-                    invariant i <= j;
-                    invariant j < num_points - 1;
-                    invariant points[i].x <= current_usage_bps;
-                    invariant current_usage_bps < points[j + 1].x;
-                };
-                i < j
-            }) {
-                let mid = j - (j - i) / 2;
-                if (current_usage_bps < vector::borrow(points, mid).x) {
-                    spec {
-                        // j is strictly decreasing.
-                        assert mid - 1 < j;
+        let (left, right) =
+            if (num_points == 0) {
+                (
+                    &Point { x: 0, y: 0 },
+                    &Point { x: BASIS_POINT_DENOMINATION, y: BASIS_POINT_DENOMINATION }
+                )
+            } else if (current_usage_bps < vector::borrow(points, 0).x) {
+                (&Point { x: 0, y: 0 }, vector::borrow(points, 0))
+            } else if (vector::borrow(points, num_points - 1).x <= current_usage_bps) {
+                (
+                    vector::borrow(points, num_points - 1),
+                    &Point { x: BASIS_POINT_DENOMINATION, y: BASIS_POINT_DENOMINATION }
+                )
+            } else {
+                let (i, j) = (0, num_points - 2);
+                while ({
+                        spec {
+                            invariant i <= j;
+                            invariant j < num_points - 1;
+                            invariant points[i].x <= current_usage_bps;
+                            invariant current_usage_bps < points[j + 1].x;
+                        };
+                        i < j
+                    }) {
+                    let mid = j - (j - i) / 2;
+                    if (current_usage_bps < vector::borrow(points, mid).x) {
+                        spec {
+                            // j is strictly decreasing.
+                            assert mid - 1 < j;
+                        };
+                        j = mid - 1;
+                    } else {
+                        spec {
+                            // i is strictly increasing.
+                            assert i < mid;
+                        };
+                        i = mid;
                     };
-                    j = mid - 1;
-                } else {
-                    spec {
-                        // i is strictly increasing.
-                        assert i < mid;
-                    };
-                    i = mid;
                 };
+                (vector::borrow(points, i), vector::borrow(points, i + 1))
             };
-            (vector::borrow(points, i), vector::borrow(points, i + 1))
-        };
-        let y_interpolated = interpolate(left.x, right.x, left.y, right.y, current_usage_bps);
-        interpolate(0, BASIS_POINT_DENOMINATION, curve.min_gas, curve.max_gas, y_interpolated)
+        let y_interpolated = interpolate(
+            left.x, right.x, left.y, right.y, current_usage_bps
+        );
+        interpolate(
+            0,
+            BASIS_POINT_DENOMINATION,
+            curve.min_gas,
+            curve.max_gas,
+            y_interpolated,
+        )
     }
 
     // Interpolates y for x on the line between (x0, y0) and (x1, y1).
@@ -515,11 +560,11 @@ module aptos_framework::storage_gas {
     public(friend) fun on_reconfig() acquires StorageGas, StorageGasConfig {
         assert!(
             exists<StorageGasConfig>(@aptos_framework),
-            error::not_found(ESTORAGE_GAS_CONFIG)
+            error::not_found(ESTORAGE_GAS_CONFIG),
         );
         assert!(
             exists<StorageGas>(@aptos_framework),
-            error::not_found(ESTORAGE_GAS)
+            error::not_found(ESTORAGE_GAS),
         );
         let (items, bytes) = state_storage::current_items_and_bytes();
         let gas_config = borrow_global<StorageGasConfig>(@aptos_framework);
@@ -559,7 +604,17 @@ module aptos_framework::storage_gas {
             let old_standard_curve_gas = 1;
             while (i <= target + 7) {
                 assert!(calculate_gas(target, i, &constant_curve) == 5, 0);
-                assert!(calculate_gas(target, i, &linear_curve) == (if (i < target) { 1 + 999 * (i * BASIS_POINT_DENOMINATION / target) / BASIS_POINT_DENOMINATION } else { 1000 }), 0);
+                assert!(
+                    calculate_gas(target, i, &linear_curve)
+                        == (
+                            if (i < target) {
+                                1
+                                    + 999 * (i * BASIS_POINT_DENOMINATION / target)
+                                        / BASIS_POINT_DENOMINATION
+                            } else { 1000 }
+                        ),
+                    0,
+                );
                 let new_standard_curve_gas = calculate_gas(target, i, &standard_curve);
                 assert!(new_standard_curve_gas >= old_standard_curve_gas, 0);
                 old_standard_curve_gas = new_standard_curve_gas;
@@ -574,13 +629,20 @@ module aptos_framework::storage_gas {
     fun test_set_storage_gas_config(framework: signer) acquires StorageGas, StorageGasConfig {
         state_storage::initialize(&framework);
         initialize(&framework);
-        let item_curve = new_gas_curve(1000, 2000,
-            vector[new_point(3000, 0), new_point(5000, 5000), new_point(8000, 5000)]
-        );
-        let byte_curve = new_gas_curve(0, 1000, vector::singleton<Point>(new_point(5000, 3000)));
-        let item_usage_config = new_usage_gas_config(100, copy item_curve, copy item_curve, copy item_curve);
-        let byte_usage_config = new_usage_gas_config(2000, copy byte_curve, copy byte_curve, copy byte_curve);
-        let storage_gas_config = new_storage_gas_config(item_usage_config, byte_usage_config);
+        let item_curve =
+            new_gas_curve(
+                1000,
+                2000,
+                vector[new_point(3000, 0), new_point(5000, 5000), new_point(8000, 5000)],
+            );
+        let byte_curve =
+            new_gas_curve(0, 1000, vector::singleton<Point>(new_point(5000, 3000)));
+        let item_usage_config =
+            new_usage_gas_config(100, copy item_curve, copy item_curve, copy item_curve);
+        let byte_usage_config =
+            new_usage_gas_config(2000, copy byte_curve, copy byte_curve, copy byte_curve);
+        let storage_gas_config =
+            new_storage_gas_config(item_usage_config, byte_usage_config);
         set_config(&framework, storage_gas_config);
         {
             state_storage::set_for_test(0, 20, 100);

--- a/aptos-move/framework/aptos-framework/sources/storage_gas.move
+++ b/aptos-move/framework/aptos-framework/sources/storage_gas.move
@@ -306,7 +306,8 @@ module aptos_framework::storage_gas {
                     4000, 44
                 ), new_point(5000, 109), new_point(6000, 271), new_point(7000, 669), new_point(
                     8000, 1648
-                ), new_point(9000, 4061), new_point(9500, 6372), new_point(9900, 9138),],
+                ), new_point(9000, 4061), new_point(9500, 6372), new_point(9900, 9138),
+            ],
         )
     }
 
@@ -437,8 +438,9 @@ module aptos_framework::storage_gas {
         };
         let i = 0;
         while ({
-                spec {
-                    invariant forall j in 0..i: {
+            spec {
+                invariant forall j in 0..i:
+                    {
                         let cur = if (j == 0) {
                             Point { x: 0, y: 0 }
                         } else {
@@ -455,9 +457,9 @@ module aptos_framework::storage_gas {
                             };
                         cur.x < next.x && cur.y <= next.y
                     };
-                };
-                i <= len
-            }) {
+            };
+            i <= len
+        }) {
             let cur = if (i == 0) {
                 &Point { x: 0, y: 0 }
             } else {
@@ -503,14 +505,14 @@ module aptos_framework::storage_gas {
             } else {
                 let (i, j) = (0, num_points - 2);
                 while ({
-                        spec {
-                            invariant i <= j;
-                            invariant j < num_points - 1;
-                            invariant points[i].x <= current_usage_bps;
-                            invariant current_usage_bps < points[j + 1].x;
-                        };
-                        i < j
-                    }) {
+                    spec {
+                        invariant i <= j;
+                        invariant j < num_points - 1;
+                        invariant points[i].x <= current_usage_bps;
+                        invariant current_usage_bps < points[j + 1].x;
+                    };
+                    i < j
+                }) {
                     let mid = j - (j - i) / 2;
                     if (current_usage_bps < vector::borrow(points, mid).x) {
                         spec {

--- a/aptos-move/framework/aptos-framework/sources/storage_gas.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/storage_gas.spec.move
@@ -17,12 +17,11 @@ spec aptos_framework::storage_gas {
         /// that is, the gas-curve is a monotonically increasing function.
         invariant (len(points) > 0 ==> points[0].x > 0)
             && (len(points) > 0 ==>
-                    points[len(points) - 1].x < BASIS_POINT_DENOMINATION)
+                points[len(points) - 1].x < BASIS_POINT_DENOMINATION)
             && (
-                forall i in 0..len(points) - 1: (
-                    points[i].x < points[i + 1].x
-                    && points[i].y <= points[i + 1].y
-                )
+                forall i in 0..len(points) - 1:
+                    (points[i].x < points[i + 1].x
+                        && points[i].y <= points[i + 1].y)
             );
     }
 
@@ -196,9 +195,8 @@ spec aptos_framework::storage_gas {
         points: vector<Point>;
 
         /// [high-level-req-2]
-        aborts_if exists i in 0..len(points) - 1: (
-            points[i].x >= points[i + 1].x || points[i].y > points[i + 1].y
-        );
+        aborts_if exists i in 0..len(points) - 1:
+            (points[i].x >= points[i + 1].x || points[i].y > points[i + 1].y);
         aborts_if len(points) > 0 && points[0].x == 0;
         aborts_if len(points) > 0 && points[len(points) - 1].x == BASIS_POINT_DENOMINATION;
     }

--- a/aptos-move/framework/aptos-framework/sources/storage_gas.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/storage_gas.spec.move
@@ -16,15 +16,20 @@ spec aptos_framework::storage_gas {
         /// Invariant 3: The x-coordinate increases monotonically and the y-coordinate increasing strictly monotonically,
         /// that is, the gas-curve is a monotonically increasing function.
         invariant (len(points) > 0 ==> points[0].x > 0)
-            && (len(points) > 0 ==> points[len(points) - 1].x < BASIS_POINT_DENOMINATION)
-            && (forall i in 0..len(points) - 1: (points[i].x < points[i + 1].x && points[i].y <= points[i + 1].y));
+            && (len(points) > 0 ==>
+                    points[len(points) - 1].x < BASIS_POINT_DENOMINATION)
+            && (
+                forall i in 0..len(points) - 1: (
+                    points[i].x < points[i + 1].x
+                    && points[i].y <= points[i + 1].y
+                )
+            );
     }
 
     spec UsageGasConfig {
         invariant target_usage > 0;
         invariant target_usage <= MAX_U64 / BASIS_POINT_DENOMINATION;
     }
-
 
     // -----------------
     // Global invariants
@@ -66,10 +71,11 @@ spec aptos_framework::storage_gas {
         pragma verify = true;
         pragma aborts_if_is_strict;
         // After genesis, `StateStorageUsage` and `GasParameter` exist.
-        invariant [suspendable] chain_status::is_operating() ==> exists<StorageGasConfig>(@aptos_framework);
-        invariant [suspendable] chain_status::is_operating() ==> exists<StorageGas>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<StorageGasConfig>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<StorageGas>(@aptos_framework);
     }
-
 
     // -----------------------
     // Function specifications
@@ -92,23 +98,20 @@ spec aptos_framework::storage_gas {
         include NewGasCurveAbortsIf;
         include ValidatePointsAbortsIf;
         /// [high-level-req-3]
-        ensures result == GasCurve {
-            min_gas,
-            max_gas,
-            points
-        };
+        ensures result == GasCurve { min_gas, max_gas, points };
     }
 
-    spec new_usage_gas_config(target_usage: u64, read_curve: GasCurve, create_curve: GasCurve, write_curve: GasCurve): UsageGasConfig {
+    spec new_usage_gas_config(
+        target_usage: u64,
+        read_curve: GasCurve,
+        create_curve: GasCurve,
+        write_curve: GasCurve
+    ): UsageGasConfig {
         aborts_if target_usage == 0;
         aborts_if target_usage > MAX_U64 / BASIS_POINT_DENOMINATION;
         /// [high-level-req-4]
-        ensures result == UsageGasConfig {
-            target_usage,
-            read_curve,
-            create_curve,
-            write_curve,
-        };
+        ensures result
+            == UsageGasConfig { target_usage, read_curve, create_curve, write_curve, };
     }
 
     spec new_storage_gas_config(item_config: UsageGasConfig, byte_config: UsageGasConfig): StorageGasConfig {
@@ -120,7 +123,7 @@ spec aptos_framework::storage_gas {
 
     /// Signer address must be @aptos_framework and StorageGasConfig exists.
     spec set_config(aptos_framework: &signer, config: StorageGasConfig) {
-        include system_addresses::AbortsIfNotAptosFramework{ account: aptos_framework };
+        include system_addresses::AbortsIfNotAptosFramework { account: aptos_framework };
         aborts_if !exists<StorageGasConfig>(@aptos_framework);
     }
 
@@ -128,7 +131,7 @@ spec aptos_framework::storage_gas {
     /// Address @aptos_framework does not exist StorageGasConfig and StorageGas before the function call is restricted
     /// and exists after the function is executed.
     spec initialize(aptos_framework: &signer) {
-        include system_addresses::AbortsIfNotAptosFramework{ account: aptos_framework };
+        include system_addresses::AbortsIfNotAptosFramework { account: aptos_framework };
         pragma verify_duration_estimate = 120;
         aborts_if exists<StorageGasConfig>(@aptos_framework);
         aborts_if exists<StorageGas>(@aptos_framework);
@@ -156,7 +159,9 @@ spec aptos_framework::storage_gas {
         ensures [abstract] result == spec_calculate_gas(max_usage, current_usage, curve);
     }
 
-    spec interpolate(x0: u64, x1: u64, y0: u64, y1: u64, x: u64): u64 {
+    spec interpolate(
+        x0: u64, x1: u64, y0: u64, y1: u64, x: u64
+    ): u64 {
         pragma opaque;
         pragma intrinsic;
 
@@ -171,7 +176,6 @@ spec aptos_framework::storage_gas {
         aborts_if !exists<StorageGas>(@aptos_framework);
         aborts_if !exists<state_storage::StateStorageUsage>(@aptos_framework);
     }
-
 
     // ---------------------------------
     // Spec helper functions and schemas

--- a/aptos-move/framework/aptos-framework/sources/system_addresses.move
+++ b/aptos-move/framework/aptos-framework/sources/system_addresses.move
@@ -16,7 +16,10 @@ module aptos_framework::system_addresses {
     }
 
     public fun assert_core_resource_address(addr: address) {
-        assert!(is_core_resource_address(addr), error::permission_denied(ENOT_CORE_RESOURCE_ADDRESS))
+        assert!(
+            is_core_resource_address(addr),
+            error::permission_denied(ENOT_CORE_RESOURCE_ADDRESS),
+        )
     }
 
     public fun is_core_resource_address(addr: address): bool {
@@ -43,16 +46,16 @@ module aptos_framework::system_addresses {
 
     /// Return true if `addr` is 0x0 or under the on chain governance's control.
     public fun is_framework_reserved_address(addr: address): bool {
-        is_aptos_framework_address(addr) ||
-            addr == @0x2 ||
-            addr == @0x3 ||
-            addr == @0x4 ||
-            addr == @0x5 ||
-            addr == @0x6 ||
-            addr == @0x7 ||
-            addr == @0x8 ||
-            addr == @0x9 ||
-            addr == @0xa
+        is_aptos_framework_address(addr)
+            || addr == @0x2
+            || addr == @0x3
+            || addr == @0x4
+            || addr == @0x5
+            || addr == @0x6
+            || addr == @0x7
+            || addr == @0x8
+            || addr == @0x9
+            || addr == @0xa
     }
 
     /// Return true if `addr` is 0x1.

--- a/aptos-move/framework/aptos-framework/sources/system_addresses.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/system_addresses.spec.move
@@ -64,6 +64,7 @@ spec aptos_framework::system_addresses {
     spec assert_framework_reserved(addr: address) {
         aborts_if !is_framework_reserved_address(addr);
     }
+
     /// Specifies that a function aborts if the account does not have the aptos framework address.
     spec schema AbortsIfNotAptosFramework {
         account: signer;

--- a/aptos-move/framework/aptos-framework/sources/timestamp.move
+++ b/aptos-move/framework/aptos-framework/sources/timestamp.move
@@ -30,9 +30,7 @@ module aptos_framework::timestamp {
 
     /// Updates the wall clock time by consensus. Requires VM privilege and will be invoked during block prologue.
     public fun update_global_time(
-        account: &signer,
-        proposer: address,
-        timestamp: u64
+        account: &signer, proposer: address, timestamp: u64
     ) acquires CurrentTimeMicroseconds {
         // Can only be invoked by AptosVM signer.
         system_addresses::assert_vm(account);

--- a/aptos-move/framework/aptos-framework/sources/timestamp.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/timestamp.spec.move
@@ -33,14 +33,16 @@ spec aptos_framework::timestamp {
         use aptos_framework::chain_status;
         /// [high-level-req-1]
         /// [high-level-req-2]
-        invariant [suspendable] chain_status::is_operating() ==> exists<CurrentTimeMicroseconds>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<CurrentTimeMicroseconds>(@aptos_framework);
     }
 
     spec update_global_time {
         use aptos_framework::chain_status;
         requires chain_status::is_operating();
         include UpdateGlobalTimeAbortsIf;
-        ensures (proposer != @vm_reserved) ==> (spec_now_microseconds() == timestamp);
+        ensures (proposer != @vm_reserved) ==>
+            (spec_now_microseconds() == timestamp);
     }
 
     spec schema UpdateGlobalTimeAbortsIf {

--- a/aptos-move/framework/aptos-framework/sources/transaction_context.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_context.move
@@ -63,9 +63,7 @@ module aptos_framework::transaction_context {
     /// This method runs `generate_unique_address` native function and returns
     /// the generated unique address wrapped in the AUID class.
     public fun generate_auid(): AUID {
-        return AUID {
-            unique_address: generate_unique_address()
-        }
+        return AUID { unique_address: generate_unique_address() }
     }
 
     /// Returns the unique address wrapped in the given AUID struct.
@@ -76,18 +74,26 @@ module aptos_framework::transaction_context {
     /// Returns the sender's address for the current transaction.
     /// This function aborts if called outside of the transaction prologue, execution, or epilogue phases.
     public fun sender(): address {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
+        assert!(
+            features::transaction_context_extension_enabled(),
+            error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED),
+        );
         sender_internal()
     }
+
     native fun sender_internal(): address;
 
     /// Returns the list of the secondary signers for the current transaction.
     /// If the current transaction has no secondary signers, this function returns an empty vector.
     /// This function aborts if called outside of the transaction prologue, execution, or epilogue phases.
     public fun secondary_signers(): vector<address> {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
+        assert!(
+            features::transaction_context_extension_enabled(),
+            error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED),
+        );
         secondary_signers_internal()
     }
+
     native fun secondary_signers_internal(): vector<address>;
 
     /// Returns the gas payer address for the current transaction.
@@ -95,90 +101,136 @@ module aptos_framework::transaction_context {
     /// or the address of the separate gas fee payer if one is specified.
     /// This function aborts if called outside of the transaction prologue, execution, or epilogue phases.
     public fun gas_payer(): address {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
+        assert!(
+            features::transaction_context_extension_enabled(),
+            error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED),
+        );
         gas_payer_internal()
     }
+
     native fun gas_payer_internal(): address;
 
     /// Returns the max gas amount in units which is specified for the current transaction.
     /// This function aborts if called outside of the transaction prologue, execution, or epilogue phases.
     public fun max_gas_amount(): u64 {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
+        assert!(
+            features::transaction_context_extension_enabled(),
+            error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED),
+        );
         max_gas_amount_internal()
     }
+
     native fun max_gas_amount_internal(): u64;
 
     /// Returns the gas unit price in Octas which is specified for the current transaction.
     /// This function aborts if called outside of the transaction prologue, execution, or epilogue phases.
     public fun gas_unit_price(): u64 {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
+        assert!(
+            features::transaction_context_extension_enabled(),
+            error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED),
+        );
         gas_unit_price_internal()
     }
+
     native fun gas_unit_price_internal(): u64;
 
     /// Returns the chain ID specified for the current transaction.
     /// This function aborts if called outside of the transaction prologue, execution, or epilogue phases.
     public fun chain_id(): u8 {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
+        assert!(
+            features::transaction_context_extension_enabled(),
+            error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED),
+        );
         chain_id_internal()
     }
+
     native fun chain_id_internal(): u8;
 
     /// Returns the entry function payload if the current transaction has such a payload. Otherwise, return `None`.
     /// This function aborts if called outside of the transaction prologue, execution, or epilogue phases.
     public fun entry_function_payload(): Option<EntryFunctionPayload> {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
+        assert!(
+            features::transaction_context_extension_enabled(),
+            error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED),
+        );
         entry_function_payload_internal()
     }
+
     native fun entry_function_payload_internal(): Option<EntryFunctionPayload>;
 
     /// Returns the account address of the entry function payload.
     public fun account_address(payload: &EntryFunctionPayload): address {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
+        assert!(
+            features::transaction_context_extension_enabled(),
+            error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED),
+        );
         payload.account_address
     }
 
     /// Returns the module name of the entry function payload.
     public fun module_name(payload: &EntryFunctionPayload): String {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
+        assert!(
+            features::transaction_context_extension_enabled(),
+            error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED),
+        );
         payload.module_name
     }
 
     /// Returns the function name of the entry function payload.
     public fun function_name(payload: &EntryFunctionPayload): String {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
+        assert!(
+            features::transaction_context_extension_enabled(),
+            error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED),
+        );
         payload.function_name
     }
 
     /// Returns the type arguments names of the entry function payload.
     public fun type_arg_names(payload: &EntryFunctionPayload): vector<String> {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
+        assert!(
+            features::transaction_context_extension_enabled(),
+            error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED),
+        );
         payload.ty_args_names
     }
 
     /// Returns the arguments of the entry function payload.
     public fun args(payload: &EntryFunctionPayload): vector<vector<u8>> {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
+        assert!(
+            features::transaction_context_extension_enabled(),
+            error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED),
+        );
         payload.args
     }
 
     /// Returns the multisig payload if the current transaction has such a payload. Otherwise, return `None`.
     /// This function aborts if called outside of the transaction prologue, execution, or epilogue phases.
     public fun multisig_payload(): Option<MultisigPayload> {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
+        assert!(
+            features::transaction_context_extension_enabled(),
+            error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED),
+        );
         multisig_payload_internal()
     }
+
     native fun multisig_payload_internal(): Option<MultisigPayload>;
 
     /// Returns the multisig account address of the multisig payload.
     public fun multisig_address(payload: &MultisigPayload): address {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
+        assert!(
+            features::transaction_context_extension_enabled(),
+            error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED),
+        );
         payload.multisig_address
     }
 
     /// Returns the inner entry function payload of the multisig payload.
-    public fun inner_entry_function_payload(payload: &MultisigPayload): Option<EntryFunctionPayload> {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
+    public fun inner_entry_function_payload(payload: &MultisigPayload)
+        : Option<EntryFunctionPayload> {
+        assert!(
+            features::transaction_context_extension_enabled(),
+            error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED),
+        );
         payload.entry_function_payload
     }
 
@@ -205,56 +257,56 @@ module aptos_framework::transaction_context {
     }
 
     #[test]
-    #[expected_failure(abort_code=196609, location = Self)]
+    #[expected_failure(abort_code = 196609, location = Self)]
     fun test_call_sender() {
         // expected to fail with the error code of `invalid_state(E_TRANSACTION_CONTEXT_NOT_AVAILABLE)`
         let _sender = sender();
     }
 
     #[test]
-    #[expected_failure(abort_code=196609, location = Self)]
+    #[expected_failure(abort_code = 196609, location = Self)]
     fun test_call_secondary_signers() {
         // expected to fail with the error code of `invalid_state(E_TRANSACTION_CONTEXT_NOT_AVAILABLE)`
         let _secondary_signers = secondary_signers();
     }
 
     #[test]
-    #[expected_failure(abort_code=196609, location = Self)]
+    #[expected_failure(abort_code = 196609, location = Self)]
     fun test_call_gas_payer() {
         // expected to fail with the error code of `invalid_state(E_TRANSACTION_CONTEXT_NOT_AVAILABLE)`
         let _gas_payer = gas_payer();
     }
 
     #[test]
-    #[expected_failure(abort_code=196609, location = Self)]
+    #[expected_failure(abort_code = 196609, location = Self)]
     fun test_call_max_gas_amount() {
         // expected to fail with the error code of `invalid_state(E_TRANSACTION_CONTEXT_NOT_AVAILABLE)`
         let _max_gas_amount = max_gas_amount();
     }
 
     #[test]
-    #[expected_failure(abort_code=196609, location = Self)]
+    #[expected_failure(abort_code = 196609, location = Self)]
     fun test_call_gas_unit_price() {
         // expected to fail with the error code of `invalid_state(E_TRANSACTION_CONTEXT_NOT_AVAILABLE)`
         let _gas_unit_price = gas_unit_price();
     }
 
     #[test]
-    #[expected_failure(abort_code=196609, location = Self)]
+    #[expected_failure(abort_code = 196609, location = Self)]
     fun test_call_chain_id() {
         // expected to fail with the error code of `invalid_state(E_TRANSACTION_CONTEXT_NOT_AVAILABLE)`
         let _chain_id = chain_id();
     }
 
     #[test]
-    #[expected_failure(abort_code=196609, location = Self)]
+    #[expected_failure(abort_code = 196609, location = Self)]
     fun test_call_entry_function_payload() {
         // expected to fail with the error code of `invalid_state(E_TRANSACTION_CONTEXT_NOT_AVAILABLE)`
         let _entry_fun = entry_function_payload();
     }
 
     #[test]
-    #[expected_failure(abort_code=196609, location = Self)]
+    #[expected_failure(abort_code = 196609, location = Self)]
     fun test_call_multisig_payload() {
         // expected to fail with the error code of `invalid_state(E_TRANSACTION_CONTEXT_NOT_AVAILABLE)`
         let _multisig = multisig_payload();

--- a/aptos-move/framework/aptos-framework/sources/transaction_context.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_context.spec.move
@@ -41,13 +41,17 @@ spec aptos_framework::transaction_context {
         ensures [abstract] result == spec_get_script_hash();
         ensures [abstract] len(result) == 32;
     }
+
     spec fun spec_get_script_hash(): vector<u8>;
+
     spec get_txn_hash(): vector<u8> {
         pragma opaque;
         aborts_if [abstract] false;
         ensures result == spec_get_txn_hash();
     }
+
     spec fun spec_get_txn_hash(): vector<u8>;
+
     spec get_transaction_hash(): vector<u8> {
         pragma opaque;
         aborts_if [abstract] false;
@@ -56,17 +60,21 @@ spec aptos_framework::transaction_context {
         /// [high-level-req-1]
         ensures [abstract] len(result) == 32;
     }
+
     spec generate_unique_address(): address {
         pragma opaque;
         ensures [abstract] result == spec_generate_unique_address();
     }
+
     spec fun spec_generate_unique_address(): address;
+
     spec generate_auid_address(): address {
         pragma opaque;
         // property 3: Generating the unique address should return a vector with 32 bytes, if the auid feature flag is enabled.
         /// [high-level-req-3]
         ensures [abstract] result == spec_generate_unique_address();
     }
+
     spec auid_address(auid: &AUID): address {
         // property 2: Fetching the unique address should never abort.
         /// [high-level-req-2]
@@ -77,26 +85,32 @@ spec aptos_framework::transaction_context {
         //TODO: temporary mockup
         pragma opaque;
     }
+
     spec secondary_signers_internal(): vector<address> {
         //TODO: temporary mockup
         pragma opaque;
     }
+
     spec gas_payer_internal(): address {
         //TODO: temporary mockup
         pragma opaque;
     }
+
     spec max_gas_amount_internal(): u64 {
         //TODO: temporary mockup
         pragma opaque;
     }
+
     spec gas_unit_price_internal(): u64 {
         //TODO: temporary mockup
         pragma opaque;
     }
+
     spec chain_id_internal(): u8 {
         //TODO: temporary mockup
         pragma opaque;
     }
+
     spec entry_function_payload_internal(): Option<EntryFunctionPayload> {
         //TODO: temporary mockup
         pragma opaque;

--- a/aptos-move/framework/aptos-framework/sources/transaction_fee.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_fee.move
@@ -1,6 +1,12 @@
 /// This module provides an interface to burn or collect and redistribute transaction fees.
 module aptos_framework::transaction_fee {
-    use aptos_framework::coin::{Self, AggregatableCoin, BurnCapability, Coin, MintCapability};
+    use aptos_framework::coin::{
+        Self,
+        AggregatableCoin,
+        BurnCapability,
+        Coin,
+        MintCapability
+    };
     use aptos_framework::aptos_account;
     use aptos_framework::aptos_coin::AptosCoin;
     use aptos_framework::stake;
@@ -87,11 +93,13 @@ module aptos_framework::transaction_fee {
 
     /// Initializes the resource storing information about gas fees collection and
     /// distribution. Should be called by on-chain governance.
-    public fun initialize_fee_collection_and_distribution(aptos_framework: &signer, burn_percentage: u8) {
+    public fun initialize_fee_collection_and_distribution(
+        aptos_framework: &signer, burn_percentage: u8
+    ) {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert!(
             !exists<CollectedFeesPerBlock>(@aptos_framework),
-            error::already_exists(EALREADY_COLLECTING_FEES)
+            error::already_exists(EALREADY_COLLECTING_FEES),
         );
         assert!(burn_percentage <= 100, error::out_of_range(EINVALID_BURN_PERCENTAGE));
 
@@ -113,8 +121,7 @@ module aptos_framework::transaction_fee {
 
     /// Sets the burn percentage for collected fees to a new value. Should be called by on-chain governance.
     public fun upgrade_burn_percentage(
-        aptos_framework: &signer,
-        new_burn_percentage: u8
+        aptos_framework: &signer, new_burn_percentage: u8
     ) acquires AptosCoinCapabilities, CollectedFeesPerBlock {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert!(new_burn_percentage <= 100, error::out_of_range(EINVALID_BURN_PERCENTAGE));
@@ -126,22 +133,28 @@ module aptos_framework::transaction_fee {
 
         if (is_fees_collection_enabled()) {
             // Upgrade has no effect unless fees are being collected.
-            let burn_percentage = &mut borrow_global_mut<CollectedFeesPerBlock>(@aptos_framework).burn_percentage;
+            let burn_percentage =
+                &mut borrow_global_mut<CollectedFeesPerBlock>(@aptos_framework).burn_percentage;
             *burn_percentage = new_burn_percentage
         }
     }
 
     /// Registers the proposer of the block for gas fees collection. This function
     /// can only be called at the beginning of the block.
-    public(friend) fun register_proposer_for_fee_collection(proposer_addr: address) acquires CollectedFeesPerBlock {
+    public(friend) fun register_proposer_for_fee_collection(
+        proposer_addr: address
+    ) acquires CollectedFeesPerBlock {
         if (is_fees_collection_enabled()) {
-            let collected_fees = borrow_global_mut<CollectedFeesPerBlock>(@aptos_framework);
+            let collected_fees =
+                borrow_global_mut<CollectedFeesPerBlock>(@aptos_framework);
             let _ = option::swap_or_fill(&mut collected_fees.proposer, proposer_addr);
         }
     }
 
     /// Burns a specified fraction of the coin.
-    fun burn_coin_fraction(coin: &mut Coin<AptosCoin>, burn_percentage: u8) acquires AptosCoinCapabilities {
+    fun burn_coin_fraction(
+        coin: &mut Coin<AptosCoin>, burn_percentage: u8
+    ) acquires AptosCoinCapabilities {
         assert!(burn_percentage <= 100, error::out_of_range(EINVALID_BURN_PERCENTAGE));
 
         let collected_amount = coin::value(coin);
@@ -163,9 +176,7 @@ module aptos_framework::transaction_fee {
     /// end of an epoch, and records it in the system. This function can only be called
     /// at the beginning of the block or during reconfiguration.
     public(friend) fun process_collected_fees() acquires AptosCoinCapabilities, CollectedFeesPerBlock {
-        if (!is_fees_collection_enabled()) {
-            return
-        };
+        if (!is_fees_collection_enabled()) { return };
         let collected_fees = borrow_global_mut<CollectedFeesPerBlock>(@aptos_framework);
 
         // If there are no collected fees, only unset the proposer. See the rationale for
@@ -210,10 +221,12 @@ module aptos_framework::transaction_fee {
     /// Burn transaction fees in epilogue.
     public(friend) fun burn_fee(account: address, fee: u64) acquires AptosFABurnCapabilities, AptosCoinCapabilities {
         if (exists<AptosFABurnCapabilities>(@aptos_framework)) {
-            let burn_ref = &borrow_global<AptosFABurnCapabilities>(@aptos_framework).burn_ref;
+            let burn_ref =
+                &borrow_global<AptosFABurnCapabilities>(@aptos_framework).burn_ref;
             aptos_account::burn_from_fungible_store(burn_ref, account, fee);
         } else {
-            let burn_cap = &borrow_global<AptosCoinCapabilities>(@aptos_framework).burn_cap;
+            let burn_cap =
+                &borrow_global<AptosCoinCapabilities>(@aptos_framework).burn_cap;
             if (features::operations_default_to_fa_apt_store_enabled()) {
                 let (burn_ref, burn_receipt) = coin::get_paired_burn_ref(burn_cap);
                 aptos_account::burn_from_fungible_store(&burn_ref, account, fee);
@@ -247,7 +260,9 @@ module aptos_framework::transaction_fee {
     }
 
     /// Only called during genesis.
-    public(friend) fun store_aptos_coin_burn_cap(aptos_framework: &signer, burn_cap: BurnCapability<AptosCoin>) {
+    public(friend) fun store_aptos_coin_burn_cap(
+        aptos_framework: &signer, burn_cap: BurnCapability<AptosCoin>
+    ) {
         system_addresses::assert_aptos_framework(aptos_framework);
 
         if (features::operations_default_to_fa_apt_store_enabled()) {
@@ -259,17 +274,21 @@ module aptos_framework::transaction_fee {
     }
 
     public entry fun convert_to_aptos_fa_burn_ref(aptos_framework: &signer) acquires AptosCoinCapabilities {
-        assert!(features::operations_default_to_fa_apt_store_enabled(), EFA_GAS_CHARGING_NOT_ENABLED);
+        assert!(
+            features::operations_default_to_fa_apt_store_enabled(),
+            EFA_GAS_CHARGING_NOT_ENABLED,
+        );
         system_addresses::assert_aptos_framework(aptos_framework);
-        let AptosCoinCapabilities {
-            burn_cap,
-        } = move_from<AptosCoinCapabilities>(signer::address_of(aptos_framework));
+        let AptosCoinCapabilities { burn_cap, } =
+            move_from<AptosCoinCapabilities>(signer::address_of(aptos_framework));
         let burn_ref = coin::convert_and_take_paired_burn_ref(burn_cap);
         move_to(aptos_framework, AptosFABurnCapabilities { burn_ref });
     }
 
     /// Only called during genesis.
-    public(friend) fun store_aptos_coin_mint_cap(aptos_framework: &signer, mint_cap: MintCapability<AptosCoin>) {
+    public(friend) fun store_aptos_coin_mint_cap(
+        aptos_framework: &signer, mint_cap: MintCapability<AptosCoin>
+    ) {
         system_addresses::assert_aptos_framework(aptos_framework);
         move_to(aptos_framework, AptosCoinMintCapability { mint_cap })
     }
@@ -290,7 +309,9 @@ module aptos_framework::transaction_fee {
     use aptos_framework::object;
 
     #[test(aptos_framework = @aptos_framework)]
-    fun test_initialize_fee_collection_and_distribution(aptos_framework: signer) acquires CollectedFeesPerBlock {
+    fun test_initialize_fee_collection_and_distribution(
+        aptos_framework: signer
+    ) acquires CollectedFeesPerBlock {
         aggregator_factory::initialize_aggregator_factory_for_test(&aptos_framework);
         initialize_fee_collection_and_distribution(&aptos_framework, 25);
 
@@ -365,7 +386,11 @@ module aptos_framework::transaction_fee {
         aptos_account::create_account(alice_addr);
         aptos_account::create_account(bob_addr);
         aptos_account::create_account(carol_addr);
-        assert!(object::object_address(&coin::ensure_paired_metadata<AptosCoin>()) == @aptos_fungible_asset, 0);
+        assert!(
+            object::object_address(&coin::ensure_paired_metadata<AptosCoin>())
+                == @aptos_fungible_asset,
+            0,
+        );
         coin::deposit(alice_addr, coin::mint(10000, &mint_cap));
         coin::deposit(bob_addr, coin::mint(10000, &mint_cap));
         coin::deposit(carol_addr, coin::mint(10000, &mint_cap));

--- a/aptos-move/framework/aptos-framework/sources/transaction_fee.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_fee.move
@@ -363,7 +363,11 @@ module aptos_framework::transaction_fee {
         coin::destroy_mint_cap(mint_cap);
     }
 
-    #[test(aptos_framework = @aptos_framework, alice = @0xa11ce, bob = @0xb0b, carol = @0xca101)]
+    #[
+        test(
+            aptos_framework = @aptos_framework, alice = @0xa11ce, bob = @0xb0b, carol = @0xca101
+        )
+    ]
     fun test_fees_distribution(
         aptos_framework: signer,
         alice: signer,

--- a/aptos-move/framework/aptos-framework/sources/transaction_fee.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_fee.spec.move
@@ -58,7 +58,9 @@ spec aptos_framework::transaction_fee {
         pragma aborts_if_is_strict;
         // property 1: Given the blockchain is in an operating state, it guarantees that the Aptos framework signer may burn Aptos coins.
         /// [high-level-req-1]
-        invariant [suspendable] chain_status::is_operating() ==> exists<AptosCoinCapabilities>(@aptos_framework) || exists<AptosFABurnCapabilities>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==>
+            exists<AptosCoinCapabilities>(@aptos_framework)
+                || exists<AptosFABurnCapabilities>(@aptos_framework);
     }
 
     spec CollectedFeesPerBlock {
@@ -67,7 +69,9 @@ spec aptos_framework::transaction_fee {
         invariant burn_percentage <= 100;
     }
 
-    spec initialize_fee_collection_and_distribution(aptos_framework: &signer, burn_percentage: u8) {
+    spec initialize_fee_collection_and_distribution(
+        aptos_framework: &signer, burn_percentage: u8
+    ) {
         use std::signer;
         use aptos_framework::stake::ValidatorFees;
         use aptos_framework::aggregator_factory;
@@ -110,7 +114,8 @@ spec aptos_framework::transaction_fee {
 
         // The effect of upgrading the burn percentage
         ensures exists<CollectedFeesPerBlock>(@aptos_framework) ==>
-            global<CollectedFeesPerBlock>(@aptos_framework).burn_percentage == new_burn_percentage;
+            global<CollectedFeesPerBlock>(@aptos_framework).burn_percentage
+                == new_burn_percentage;
     }
 
     spec register_proposer_for_fee_collection(proposer_addr: address) {
@@ -118,7 +123,8 @@ spec aptos_framework::transaction_fee {
         // property 6: Ensure the presence of the resource.
         /// [high-level-req-6.1]
         ensures is_fees_collection_enabled() ==>
-            option::spec_borrow(global<CollectedFeesPerBlock>(@aptos_framework).proposer) == proposer_addr;
+            option::spec_borrow(global<CollectedFeesPerBlock>(@aptos_framework).proposer)
+                == proposer_addr;
     }
 
     spec burn_coin_fraction(coin: &mut Coin<AptosCoin>, burn_percentage: u8) {
@@ -131,7 +137,8 @@ spec aptos_framework::transaction_fee {
 
         let amount_to_burn = (burn_percentage * coin::value(coin)) / 100;
         // include (amount_to_burn > 0) ==> coin::AbortsIfNotExistCoinInfo<AptosCoin>;
-        include amount_to_burn > 0 ==> coin::CoinSubAbortsIf<AptosCoin> { amount: amount_to_burn };
+        include amount_to_burn > 0 ==>
+            coin::CoinSubAbortsIf<AptosCoin> { amount: amount_to_burn };
         ensures coin.value == old(coin).value - amount_to_burn;
     }
 
@@ -144,12 +151,14 @@ spec aptos_framework::transaction_fee {
         use aptos_framework::aggregator;
         let maybe_supply = coin::get_coin_supply_opt<AptosCoin>();
         // property 6: Ensure the presence of the resource.
-        requires
-            (is_fees_collection_enabled() && option::is_some(maybe_supply)) ==>
-                (aggregator::spec_aggregator_get_val(global<CollectedFeesPerBlock>(@aptos_framework).amount.value) <=
-                    optional_aggregator::optional_aggregator_value(
-                        option::spec_borrow(coin::get_coin_supply_opt<AptosCoin>())
-                    ));
+        requires (is_fees_collection_enabled() && option::is_some(maybe_supply)) ==>
+            (
+                aggregator::spec_aggregator_get_val(
+                    global<CollectedFeesPerBlock>(@aptos_framework).amount.value
+                ) <= optional_aggregator::optional_aggregator_value(
+                    option::spec_borrow(coin::get_coin_supply_opt<AptosCoin>()),
+                )
+            );
     }
 
     spec schema ProcessCollectedFeesRequiresAndEnsures {
@@ -168,25 +177,31 @@ spec aptos_framework::transaction_fee {
         let collected_fees = global<CollectedFeesPerBlock>(@aptos_framework);
         let post post_collected_fees = global<CollectedFeesPerBlock>(@aptos_framework);
         let pre_amount = aggregator::spec_aggregator_get_val(collected_fees.amount.value);
-        let post post_amount = aggregator::spec_aggregator_get_val(post_collected_fees.amount.value);
+        let post post_amount = aggregator::spec_aggregator_get_val(
+            post_collected_fees.amount.value
+        );
         let fees_table = global<stake::ValidatorFees>(@aptos_framework).fees_table;
         let post post_fees_table = global<stake::ValidatorFees>(@aptos_framework).fees_table;
         let proposer = option::spec_borrow(collected_fees.proposer);
         let fee_to_add = pre_amount - pre_amount * collected_fees.burn_percentage / 100;
-        ensures is_fees_collection_enabled() ==> option::spec_is_none(post_collected_fees.proposer) && post_amount == 0;
-        ensures is_fees_collection_enabled() && aggregator::spec_read(collected_fees.amount.value) > 0 &&
-            option::spec_is_some(collected_fees.proposer) ==>
+        ensures is_fees_collection_enabled() ==>
+            option::spec_is_none(post_collected_fees.proposer) && post_amount == 0;
+        ensures is_fees_collection_enabled()
+            && aggregator::spec_read(collected_fees.amount.value) > 0
+            && option::spec_is_some(collected_fees.proposer) ==>
             if (proposer != @vm_reserved) {
                 if (table::spec_contains(fees_table, proposer)) {
-                    table::spec_get(post_fees_table, proposer).value == table::spec_get(
-                        fees_table,
-                        proposer
-                    ).value + fee_to_add
+                    table::spec_get(post_fees_table, proposer).value
+                        == table::spec_get(
+                            fees_table,
+                            proposer,
+                        ).value + fee_to_add
                 } else {
                     table::spec_get(post_fees_table, proposer).value == fee_to_add
                 }
             } else {
-                option::spec_is_none(post_collected_fees.proposer) && post_amount == 0
+                option::spec_is_none(post_collected_fees.proposer)
+                    && post_amount == 0
             };
     }
 
@@ -216,8 +231,11 @@ spec aptos_framework::transaction_fee {
 
         // modifies global<CoinStore<AptosCoin>>(account_addr);
 
-        aborts_if amount != 0 && !(exists<CoinInfo<AptosCoin>>(aptos_addr)
-            && exists<CoinStore<AptosCoin>>(account_addr));
+        aborts_if amount != 0
+            && !(
+                exists<CoinInfo<AptosCoin>>(aptos_addr)
+                && exists<CoinStore<AptosCoin>>(account_addr)
+            );
         aborts_if coin_store.coin.value < amount;
 
         let maybe_supply = global<CoinInfo<AptosCoin>>(aptos_addr).supply;
@@ -275,22 +293,23 @@ spec aptos_framework::transaction_fee {
         aborts_if !exists<CollectedFeesPerBlock>(@aptos_framework);
         aborts_if fee > 0 && !exists<coin::CoinStore<AptosCoin>>(account);
         aborts_if fee > 0 && coin_store.coin.value < fee;
-        aborts_if fee > 0 && aggregator::spec_aggregator_get_val(aggr)
-            + fee > aggregator::spec_get_limit(aggr);
-        aborts_if fee > 0 && aggregator::spec_aggregator_get_val(aggr)
-            + fee > MAX_U128;
+        aborts_if fee > 0
+            && aggregator::spec_aggregator_get_val(aggr) + fee
+                > aggregator::spec_get_limit(aggr);
+        aborts_if fee > 0 && aggregator::spec_aggregator_get_val(aggr) + fee > MAX_U128;
 
         let post post_coin_store = global<coin::CoinStore<AptosCoin>>(account);
         let post post_collected_fees = global<CollectedFeesPerBlock>(@aptos_framework).amount;
         ensures post_coin_store.coin.value == coin_store.coin.value - fee;
-        ensures aggregator::spec_aggregator_get_val(post_collected_fees.value) == aggregator::spec_aggregator_get_val(
-            aggr
-        ) + fee;
+        ensures aggregator::spec_aggregator_get_val(post_collected_fees.value)
+            == aggregator::spec_aggregator_get_val(aggr) + fee;
     }
 
     /// Ensure caller is admin.
     /// Aborts if `AptosCoinCapabilities` already exists.
-    spec store_aptos_coin_burn_cap(aptos_framework: &signer, burn_cap: BurnCapability<AptosCoin>) {
+    spec store_aptos_coin_burn_cap(
+        aptos_framework: &signer, burn_cap: BurnCapability<AptosCoin>
+    ) {
         use std::signer;
 
         // TODO(fa_migration)
@@ -302,12 +321,16 @@ spec aptos_framework::transaction_fee {
         aborts_if exists<AptosFABurnCapabilities>(addr);
         aborts_if exists<AptosCoinCapabilities>(addr);
 
-        ensures exists<AptosFABurnCapabilities>(addr) || exists<AptosCoinCapabilities>(addr);
+        ensures exists<AptosFABurnCapabilities>(addr) || exists<AptosCoinCapabilities>(
+            addr
+        );
     }
 
     /// Ensure caller is admin.
     /// Aborts if `AptosCoinMintCapability` already exists.
-    spec store_aptos_coin_mint_cap(aptos_framework: &signer, mint_cap: MintCapability<AptosCoin>) {
+    spec store_aptos_coin_mint_cap(
+        aptos_framework: &signer, mint_cap: MintCapability<AptosCoin>
+    ) {
         use std::signer;
         let addr = signer::address_of(aptos_framework);
         aborts_if !system_addresses::is_aptos_framework_address(addr);

--- a/aptos-move/framework/aptos-framework/sources/transaction_fee.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_fee.spec.move
@@ -234,7 +234,7 @@ spec aptos_framework::transaction_fee {
         aborts_if amount != 0
             && !(
                 exists<CoinInfo<AptosCoin>>(aptos_addr)
-                && exists<CoinStore<AptosCoin>>(account_addr)
+                    && exists<CoinStore<AptosCoin>>(account_addr)
             );
         aborts_if coin_store.coin.value < amount;
 

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.move
@@ -59,15 +59,18 @@ module aptos_framework::transaction_validation {
     ) {
         system_addresses::assert_aptos_framework(aptos_framework);
 
-        move_to(aptos_framework, TransactionValidation {
-            module_addr: @aptos_framework,
-            module_name: b"transaction_validation",
-            script_prologue_name,
-            // module_prologue_name is deprecated and not used.
-            module_prologue_name,
-            multi_agent_prologue_name,
-            user_epilogue_name,
-        });
+        move_to(
+            aptos_framework,
+            TransactionValidation {
+                module_addr: @aptos_framework,
+                module_name: b"transaction_validation",
+                script_prologue_name,
+                // module_prologue_name is deprecated and not used.
+                module_prologue_name,
+                multi_agent_prologue_name,
+                user_epilogue_name,
+            },
+        );
     }
 
     fun prologue_common(
@@ -84,43 +87,48 @@ module aptos_framework::transaction_validation {
             timestamp::now_seconds() < txn_expiration_time,
             error::invalid_argument(PROLOGUE_ETRANSACTION_EXPIRED),
         );
-        assert!(chain_id::get() == chain_id, error::invalid_argument(PROLOGUE_EBAD_CHAIN_ID));
+        assert!(
+            chain_id::get() == chain_id, error::invalid_argument(PROLOGUE_EBAD_CHAIN_ID)
+        );
 
         let transaction_sender = signer::address_of(&sender);
 
-        if (
-            transaction_sender == gas_payer
-                || account::exists_at(transaction_sender)
-                || !features::sponsored_automatic_account_creation_enabled()
-                || txn_sequence_number > 0
-        ) {
-            assert!(account::exists_at(transaction_sender), error::invalid_argument(PROLOGUE_EACCOUNT_DOES_NOT_EXIST));
+        if (transaction_sender == gas_payer
+            || account::exists_at(transaction_sender)
+            || !features::sponsored_automatic_account_creation_enabled()
+            || txn_sequence_number > 0) {
             assert!(
-                txn_authentication_key == account::get_authentication_key(transaction_sender),
+                account::exists_at(transaction_sender),
+                error::invalid_argument(PROLOGUE_EACCOUNT_DOES_NOT_EXIST),
+            );
+            assert!(
+                txn_authentication_key
+                    == account::get_authentication_key(transaction_sender),
                 error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY),
             );
 
-            let account_sequence_number = account::get_sequence_number(transaction_sender);
+            let account_sequence_number =
+                account::get_sequence_number(transaction_sender);
             assert!(
                 txn_sequence_number < (1u64 << 63),
-                error::out_of_range(PROLOGUE_ESEQUENCE_NUMBER_TOO_BIG)
+                error::out_of_range(PROLOGUE_ESEQUENCE_NUMBER_TOO_BIG),
             );
 
             assert!(
                 txn_sequence_number >= account_sequence_number,
-                error::invalid_argument(PROLOGUE_ESEQUENCE_NUMBER_TOO_OLD)
+                error::invalid_argument(PROLOGUE_ESEQUENCE_NUMBER_TOO_OLD),
             );
 
             assert!(
                 txn_sequence_number == account_sequence_number,
-                error::invalid_argument(PROLOGUE_ESEQUENCE_NUMBER_TOO_NEW)
+                error::invalid_argument(PROLOGUE_ESEQUENCE_NUMBER_TOO_NEW),
             );
         } else {
             // In this case, the transaction is sponsored and the account does not exist, so ensure
             // the default values match.
             assert!(
                 txn_sequence_number == 0,
-                error::invalid_argument(PROLOGUE_ESEQUENCE_NUMBER_TOO_NEW)
+                error::invalid_argument(PROLOGUE_ESEQUENCE_NUMBER_TOO_NEW),
             );
 
             assert!(
@@ -133,13 +141,15 @@ module aptos_framework::transaction_validation {
 
         if (features::operations_default_to_fa_apt_store_enabled()) {
             assert!(
-                aptos_account::is_fungible_balance_at_least(gas_payer, max_transaction_fee),
-                error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
+                aptos_account::is_fungible_balance_at_least(
+                    gas_payer, max_transaction_fee
+                ),
+                error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
             );
         } else {
             assert!(
                 coin::is_balance_at_least<AptosCoin>(gas_payer, max_transaction_fee),
-                error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT)
+                error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
             );
         }
     }
@@ -163,7 +173,7 @@ module aptos_framework::transaction_validation {
             txn_gas_price,
             txn_max_gas_units,
             txn_expiration_time,
-            chain_id
+            chain_id,
         )
     }
 
@@ -189,7 +199,9 @@ module aptos_framework::transaction_validation {
             txn_expiration_time,
             chain_id,
         );
-        multi_agent_common_prologue(secondary_signer_addresses, secondary_signer_public_key_hashes);
+        multi_agent_common_prologue(
+            secondary_signer_addresses, secondary_signer_public_key_hashes
+        );
     }
 
     fun multi_agent_common_prologue(
@@ -204,21 +216,27 @@ module aptos_framework::transaction_validation {
 
         let i = 0;
         while ({
-            spec {
-                invariant i <= num_secondary_signers;
-                invariant forall j in 0..i:
-                    account::exists_at(secondary_signer_addresses[j])
-                        && secondary_signer_public_key_hashes[j]
+                spec {
+                    invariant i <= num_secondary_signers;
+                    invariant forall j in 0..i: account::exists_at(
+                        secondary_signer_addresses[j]
+                    ) && secondary_signer_public_key_hashes[j]
                         == account::get_authentication_key(secondary_signer_addresses[j]);
-            };
-            (i < num_secondary_signers)
-        }) {
+                };
+                (i < num_secondary_signers)
+            }) {
             let secondary_address = *vector::borrow(&secondary_signer_addresses, i);
-            assert!(account::exists_at(secondary_address), error::invalid_argument(PROLOGUE_EACCOUNT_DOES_NOT_EXIST));
-
-            let signer_public_key_hash = *vector::borrow(&secondary_signer_public_key_hashes, i);
             assert!(
-                signer_public_key_hash == account::get_authentication_key(secondary_address),
+                account::exists_at(secondary_address),
+                error::invalid_argument(PROLOGUE_EACCOUNT_DOES_NOT_EXIST),
+            );
+
+            let signer_public_key_hash =
+                *vector::borrow(&secondary_signer_public_key_hashes, i);
+            assert!(
+                signer_public_key_hash == account::get_authentication_key(
+                    secondary_address
+                ),
                 error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY),
             );
             i = i + 1;
@@ -238,7 +256,10 @@ module aptos_framework::transaction_validation {
         txn_expiration_time: u64,
         chain_id: u8,
     ) {
-        assert!(features::fee_payer_enabled(), error::invalid_state(PROLOGUE_EFEE_PAYER_NOT_ENABLED));
+        assert!(
+            features::fee_payer_enabled(),
+            error::invalid_state(PROLOGUE_EFEE_PAYER_NOT_ENABLED),
+        );
         prologue_common(
             sender,
             fee_payer_address,
@@ -249,9 +270,13 @@ module aptos_framework::transaction_validation {
             txn_expiration_time,
             chain_id,
         );
-        multi_agent_common_prologue(secondary_signer_addresses, secondary_signer_public_key_hashes);
+        multi_agent_common_prologue(
+            secondary_signer_addresses, secondary_signer_public_key_hashes
+        );
         assert!(
-            fee_payer_public_key_hash == account::get_authentication_key(fee_payer_address),
+            fee_payer_public_key_hash == account::get_authentication_key(
+                fee_payer_address
+            ),
             error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY),
         );
     }
@@ -266,7 +291,14 @@ module aptos_framework::transaction_validation {
         gas_units_remaining: u64
     ) {
         let addr = signer::address_of(&account);
-        epilogue_gas_payer(account, addr, storage_fee_refunded, txn_gas_price, txn_max_gas_units, gas_units_remaining);
+        epilogue_gas_payer(
+            account,
+            addr,
+            storage_fee_refunded,
+            txn_gas_price,
+            txn_max_gas_units,
+            gas_units_remaining,
+        );
     }
 
     /// Epilogue function with explicit gas payer specified, is run after a transaction is successfully executed.
@@ -279,12 +311,14 @@ module aptos_framework::transaction_validation {
         txn_max_gas_units: u64,
         gas_units_remaining: u64
     ) {
-        assert!(txn_max_gas_units >= gas_units_remaining, error::invalid_argument(EOUT_OF_GAS));
+        assert!(
+            txn_max_gas_units >= gas_units_remaining, error::invalid_argument(EOUT_OF_GAS)
+        );
         let gas_used = txn_max_gas_units - gas_units_remaining;
 
         assert!(
             (txn_gas_price as u128) * (gas_used as u128) <= MAX_U64,
-            error::out_of_range(EOUT_OF_GAS)
+            error::out_of_range(EOUT_OF_GAS),
         );
         let transaction_fee_amount = txn_gas_price * gas_used;
 
@@ -292,7 +326,9 @@ module aptos_framework::transaction_validation {
         // to do failed transaction cleanup.
         if (features::operations_default_to_fa_apt_store_enabled()) {
             assert!(
-                aptos_account::is_fungible_balance_at_least(gas_payer, transaction_fee_amount),
+                aptos_account::is_fungible_balance_at_least(
+                    gas_payer, transaction_fee_amount
+                ),
                 error::out_of_range(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
             );
         } else {
@@ -302,20 +338,21 @@ module aptos_framework::transaction_validation {
             );
         };
 
-        let amount_to_burn = if (features::collect_and_distribute_gas_fees()) {
-            // TODO(gas): We might want to distinguish the refundable part of the charge and burn it or track
-            // it separately, so that we don't increase the total supply by refunding.
+        let amount_to_burn =
+            if (features::collect_and_distribute_gas_fees()) {
+                // TODO(gas): We might want to distinguish the refundable part of the charge and burn it or track
+                // it separately, so that we don't increase the total supply by refunding.
 
-            // If transaction fees are redistributed to validators, collect them here for
-            // later redistribution.
-            transaction_fee::collect_fee(gas_payer, transaction_fee_amount);
-            0
-        } else {
-            // Otherwise, just burn the fee.
-            // TODO: this branch should be removed completely when transaction fee collection
-            // is tested and is fully proven to work well.
-            transaction_fee_amount
-        };
+                // If transaction fees are redistributed to validators, collect them here for
+                // later redistribution.
+                transaction_fee::collect_fee(gas_payer, transaction_fee_amount);
+                0
+            } else {
+                // Otherwise, just burn the fee.
+                // TODO: this branch should be removed completely when transaction fee collection
+                // is tested and is fully proven to work well.
+                transaction_fee_amount
+            };
 
         if (amount_to_burn > storage_fee_refunded) {
             let burn_amount = amount_to_burn - storage_fee_refunded;

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.move
@@ -216,15 +216,14 @@ module aptos_framework::transaction_validation {
 
         let i = 0;
         while ({
-                spec {
-                    invariant i <= num_secondary_signers;
-                    invariant forall j in 0..i: account::exists_at(
-                        secondary_signer_addresses[j]
-                    ) && secondary_signer_public_key_hashes[j]
-                        == account::get_authentication_key(secondary_signer_addresses[j]);
-                };
-                (i < num_secondary_signers)
-            }) {
+            spec {
+                invariant i <= num_secondary_signers;
+                invariant forall j in 0..i:
+                    account::exists_at(secondary_signer_addresses[j]) && secondary_signer_public_key_hashes[j] ==
+                         account::get_authentication_key(secondary_signer_addresses[j]);
+            };
+            (i < num_secondary_signers)
+        }) {
             let secondary_address = *vector::borrow(&secondary_signer_addresses, i);
             assert!(
                 account::exists_at(secondary_address),

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.spec.move
@@ -31,11 +31,11 @@ spec aptos_framework::transaction_validation {
     /// Ensure caller is `aptos_framework`.
     /// Aborts if TransactionValidation already exists.
     spec initialize(
-    aptos_framework: &signer,
-    script_prologue_name: vector<u8>,
-    module_prologue_name: vector<u8>,
-    multi_agent_prologue_name: vector<u8>,
-    user_epilogue_name: vector<u8>,
+        aptos_framework: &signer,
+        script_prologue_name: vector<u8>,
+        module_prologue_name: vector<u8>,
+        multi_agent_prologue_name: vector<u8>,
+        user_epilogue_name: vector<u8>,
     ) {
         use std::signer;
         let addr = signer::address_of(aptos_framework);
@@ -70,18 +70,30 @@ spec aptos_framework::transaction_validation {
         let transaction_sender = signer::address_of(sender);
 
         aborts_if (
-            !features::spec_is_enabled(features::SPONSORED_AUTOMATIC_ACCOUNT_CREATION)
+                !features::spec_is_enabled(features::SPONSORED_AUTOMATIC_ACCOUNT_CREATION)
                 || account::exists_at(transaction_sender)
                 || transaction_sender == gas_payer
                 || txn_sequence_number > 0
-        ) && (
-            !(txn_sequence_number >= global<Account>(transaction_sender).sequence_number)
-                || !(txn_authentication_key == global<Account>(transaction_sender).authentication_key)
+            )
+            && (
+                !(
+                    txn_sequence_number
+                        >= global<Account>(transaction_sender).sequence_number
+                )
+                || !(
+                    txn_authentication_key
+                        == global<Account>(transaction_sender).authentication_key
+                )
                 || !account::exists_at(transaction_sender)
-                || !(txn_sequence_number == global<Account>(transaction_sender).sequence_number)
-        );
+                || !(
+                    txn_sequence_number
+                        == global<Account>(transaction_sender).sequence_number
+                )
+            );
 
-        aborts_if features::spec_is_enabled(features::SPONSORED_AUTOMATIC_ACCOUNT_CREATION)
+        aborts_if features::spec_is_enabled(
+                features::SPONSORED_AUTOMATIC_ACCOUNT_CREATION
+            )
             && transaction_sender != gas_payer
             && txn_sequence_number == 0
             && !account::exists_at(transaction_sender)
@@ -94,18 +106,20 @@ spec aptos_framework::transaction_validation {
         aborts_if !exists<CoinStore<AptosCoin>>(gas_payer);
         // property 1: The sender of a transaction should have sufficient coin balance to pay the transaction fee.
         /// [high-level-req-1]
-        aborts_if !(global<CoinStore<AptosCoin>>(gas_payer).coin.value >= max_transaction_fee);
+        aborts_if !(
+            global<CoinStore<AptosCoin>>(gas_payer).coin.value >= max_transaction_fee
+        );
     }
 
     spec prologue_common(
-    sender: signer,
-    gas_payer: address,
-    txn_sequence_number: u64,
-    txn_authentication_key: vector<u8>,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    txn_expiration_time: u64,
-    chain_id: u8,
+        sender: signer,
+        gas_payer: address,
+        txn_sequence_number: u64,
+        txn_authentication_key: vector<u8>,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        txn_expiration_time: u64,
+        chain_id: u8,
     ) {
         // TODO(fa_migration)
         pragma verify = false;
@@ -113,14 +127,14 @@ spec aptos_framework::transaction_validation {
     }
 
     spec script_prologue(
-    sender: signer,
-    txn_sequence_number: u64,
-    txn_public_key: vector<u8>,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    txn_expiration_time: u64,
-    chain_id: u8,
-    _script_hash: vector<u8>,
+        sender: signer,
+        txn_sequence_number: u64,
+        txn_public_key: vector<u8>,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        txn_expiration_time: u64,
+        chain_id: u8,
+        _script_hash: vector<u8>,
     ) {
         // TODO(fa_migration)
         pragma verify = false;
@@ -141,21 +155,21 @@ spec aptos_framework::transaction_validation {
         // If any account does not exist, or public key hash does not match, abort.
         // property 2: All secondary signer addresses are verified to be authentic through a validation process.
         /// [high-level-req-2]
-        aborts_if exists i in 0..num_secondary_signers:
-            !account::exists_at(secondary_signer_addresses[i])
-                || secondary_signer_public_key_hashes[i] !=
-                account::get_authentication_key(secondary_signer_addresses[i]);
+        aborts_if exists i in 0..num_secondary_signers: !account::exists_at(
+            secondary_signer_addresses[i]
+        ) || secondary_signer_public_key_hashes[i]
+            != account::get_authentication_key(secondary_signer_addresses[i]);
 
         // By the end, all secondary signers account should exist and public key hash should match.
-        ensures forall i in 0..num_secondary_signers:
-            account::exists_at(secondary_signer_addresses[i])
-                && secondary_signer_public_key_hashes[i] ==
-                account::get_authentication_key(secondary_signer_addresses[i]);
+        ensures forall i in 0..num_secondary_signers: account::exists_at(
+            secondary_signer_addresses[i]
+        ) && secondary_signer_public_key_hashes[i]
+            == account::get_authentication_key(secondary_signer_addresses[i]);
     }
 
     spec multi_agent_common_prologue(
-    secondary_signer_addresses: vector<address>,
-    secondary_signer_public_key_hashes: vector<vector<u8>>,
+        secondary_signer_addresses: vector<address>,
+        secondary_signer_public_key_hashes: vector<vector<u8>>,
     ) {
         include MultiAgentPrologueCommonAbortsIf {
             secondary_signer_addresses,
@@ -165,16 +179,16 @@ spec aptos_framework::transaction_validation {
 
     /// Aborts if length of public key hashed vector
     /// not equal the number of singers.
-    spec multi_agent_script_prologue (
-    sender: signer,
-    txn_sequence_number: u64,
-    txn_sender_public_key: vector<u8>,
-    secondary_signer_addresses: vector<address>,
-    secondary_signer_public_key_hashes: vector<vector<u8>>,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    txn_expiration_time: u64,
-    chain_id: u8,
+    spec multi_agent_script_prologue(
+        sender: signer,
+        txn_sequence_number: u64,
+        txn_sender_public_key: vector<u8>,
+        secondary_signer_addresses: vector<address>,
+        secondary_signer_public_key_hashes: vector<vector<u8>>,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        txn_expiration_time: u64,
+        chain_id: u8,
     ) {
         pragma verify_duration_estimate = 120;
         let gas_payer = signer::address_of(sender);
@@ -192,17 +206,17 @@ spec aptos_framework::transaction_validation {
     }
 
     spec fee_payer_script_prologue(
-    sender: signer,
-    txn_sequence_number: u64,
-    txn_sender_public_key: vector<u8>,
-    secondary_signer_addresses: vector<address>,
-    secondary_signer_public_key_hashes: vector<vector<u8>>,
-    fee_payer_address: address,
-    fee_payer_public_key_hash: vector<u8>,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    txn_expiration_time: u64,
-    chain_id: u8,
+        sender: signer,
+        txn_sequence_number: u64,
+        txn_sender_public_key: vector<u8>,
+        secondary_signer_addresses: vector<address>,
+        secondary_signer_public_key_hashes: vector<vector<u8>>,
+        fee_payer_address: address,
+        fee_payer_public_key_hash: vector<u8>,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        txn_expiration_time: u64,
+        chain_id: u8,
     ) {
         pragma verify_duration_estimate = 120;
 
@@ -219,7 +233,9 @@ spec aptos_framework::transaction_validation {
         };
 
         aborts_if !account::exists_at(gas_payer);
-        aborts_if !(fee_payer_public_key_hash == account::get_authentication_key(gas_payer));
+        aborts_if !(
+            fee_payer_public_key_hash == account::get_authentication_key(gas_payer)
+        );
         aborts_if !features::spec_fee_payer_enabled();
     }
 
@@ -227,11 +243,11 @@ spec aptos_framework::transaction_validation {
     /// `AptosCoinCapabilities` and `CoinInfo` should exists.
     /// Skip transaction_fee::burn_fee verification.
     spec epilogue(
-    account: signer,
-    storage_fee_refunded: u64,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    gas_units_remaining: u64
+        account: signer,
+        storage_fee_refunded: u64,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        gas_units_remaining: u64
     ) {
         // TODO(fa_migration)
         pragma verify = false;
@@ -242,12 +258,12 @@ spec aptos_framework::transaction_validation {
     /// `AptosCoinCapabilities` and `CoinInfo` should exist.
     /// Skip transaction_fee::burn_fee verification.
     spec epilogue_gas_payer(
-    account: signer,
-    gas_payer: address,
-    storage_fee_refunded: u64,
-    txn_gas_price: u64,
-    txn_max_gas_units: u64,
-    gas_units_remaining: u64
+        account: signer,
+        gas_payer: address,
+        storage_fee_refunded: u64,
+        txn_gas_price: u64,
+        txn_max_gas_units: u64,
+        gas_units_remaining: u64
     ) {
         // TODO(fa_migration)
         pragma verify = false;
@@ -263,7 +279,11 @@ spec aptos_framework::transaction_validation {
         use aptos_framework::coin;
         use aptos_framework::coin::{CoinStore, CoinInfo};
         use aptos_framework::optional_aggregator;
-        use aptos_framework::transaction_fee::{AptosCoinCapabilities, AptosCoinMintCapability, CollectedFeesPerBlock};
+        use aptos_framework::transaction_fee::{
+            AptosCoinCapabilities,
+            AptosCoinMintCapability,
+            CollectedFeesPerBlock
+        };
 
         account: signer;
         gas_payer: address;
@@ -293,9 +313,10 @@ spec aptos_framework::transaction_validation {
         // ensures balance == pre_balance - transaction_fee_amount + storage_fee_refunded;
         ensures account.sequence_number == pre_account.sequence_number + 1;
 
-
         // Check fee collection.
-        let collect_fee_enabled = features::spec_is_enabled(features::COLLECT_AND_DISTRIBUTE_GAS_FEES);
+        let collect_fee_enabled = features::spec_is_enabled(
+            features::COLLECT_AND_DISTRIBUTE_GAS_FEES
+        );
         let collected_fees = global<CollectedFeesPerBlock>(@aptos_framework).amount;
         let aggr = collected_fees.value;
         let aggr_val = aggregator::spec_aggregator_get_val(aggr);
@@ -303,13 +324,14 @@ spec aptos_framework::transaction_validation {
 
         /// [high-level-req-3]
         aborts_if collect_fee_enabled && !exists<CollectedFeesPerBlock>(@aptos_framework);
-        aborts_if collect_fee_enabled && transaction_fee_amount > 0 && aggr_val + transaction_fee_amount > aggr_lim;
+        aborts_if collect_fee_enabled
+            && transaction_fee_amount > 0
+            && aggr_val + transaction_fee_amount > aggr_lim;
 
         // Check burning.
         //   (Check the total supply aggregator when enabled.)
-        let amount_to_burn = if (collect_fee_enabled) {
-            0
-        } else {
+        let amount_to_burn = if (collect_fee_enabled) { 0 }
+        else {
             transaction_fee_amount - storage_fee_refunded
         };
         let apt_addr = type_info::type_of<AptosCoin>().account_address;
@@ -319,12 +341,17 @@ spec aptos_framework::transaction_validation {
         let apt_supply_value = optional_aggregator::optional_aggregator_value(apt_supply);
         let post post_maybe_apt_supply = global<CoinInfo<AptosCoin>>(apt_addr).supply;
         let post post_apt_supply = option::spec_borrow(post_maybe_apt_supply);
-        let post post_apt_supply_value = optional_aggregator::optional_aggregator_value(post_apt_supply);
+        let post post_apt_supply_value = optional_aggregator::optional_aggregator_value(
+            post_apt_supply
+        );
 
         aborts_if amount_to_burn > 0 && !exists<AptosCoinCapabilities>(@aptos_framework);
         aborts_if amount_to_burn > 0 && !exists<CoinInfo<AptosCoin>>(apt_addr);
-        aborts_if amount_to_burn > 0 && total_supply_enabled && apt_supply_value < amount_to_burn;
-        ensures total_supply_enabled ==> apt_supply_value - amount_to_burn == post_apt_supply_value;
+        aborts_if amount_to_burn > 0
+            && total_supply_enabled
+            && apt_supply_value < amount_to_burn;
+        ensures total_supply_enabled ==>
+            apt_supply_value - amount_to_burn == post_apt_supply_value;
 
         // Check minting.
         let amount_to_mint = if (collect_fee_enabled) {
@@ -338,7 +365,8 @@ spec aptos_framework::transaction_validation {
         aborts_if amount_to_mint > 0 && !exists<CoinStore<AptosCoin>>(addr);
         aborts_if amount_to_mint > 0 && !exists<AptosCoinMintCapability>(@aptos_framework);
         aborts_if amount_to_mint > 0 && total_supply + amount_to_mint > MAX_U128;
-        ensures amount_to_mint > 0 ==> post_total_supply == total_supply + amount_to_mint;
+        ensures amount_to_mint > 0 ==>
+            post_total_supply == total_supply + amount_to_mint;
 
         let aptos_addr = type_info::type_of<AptosCoin>().account_address;
         aborts_if (amount_to_mint != 0) && !exists<coin::CoinInfo<AptosCoin>>(aptos_addr);

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.spec.move
@@ -70,30 +70,30 @@ spec aptos_framework::transaction_validation {
         let transaction_sender = signer::address_of(sender);
 
         aborts_if (
-                !features::spec_is_enabled(features::SPONSORED_AUTOMATIC_ACCOUNT_CREATION)
+            !features::spec_is_enabled(features::SPONSORED_AUTOMATIC_ACCOUNT_CREATION)
                 || account::exists_at(transaction_sender)
                 || transaction_sender == gas_payer
                 || txn_sequence_number > 0
-            )
+        )
             && (
                 !(
                     txn_sequence_number
                         >= global<Account>(transaction_sender).sequence_number
                 )
-                || !(
-                    txn_authentication_key
-                        == global<Account>(transaction_sender).authentication_key
-                )
-                || !account::exists_at(transaction_sender)
-                || !(
-                    txn_sequence_number
-                        == global<Account>(transaction_sender).sequence_number
-                )
+                    || !(
+                        txn_authentication_key
+                            == global<Account>(transaction_sender).authentication_key
+                    )
+                    || !account::exists_at(transaction_sender)
+                    || !(
+                        txn_sequence_number
+                            == global<Account>(transaction_sender).sequence_number
+                    )
             );
 
         aborts_if features::spec_is_enabled(
-                features::SPONSORED_AUTOMATIC_ACCOUNT_CREATION
-            )
+            features::SPONSORED_AUTOMATIC_ACCOUNT_CREATION
+        )
             && transaction_sender != gas_payer
             && txn_sequence_number == 0
             && !account::exists_at(transaction_sender)
@@ -155,16 +155,16 @@ spec aptos_framework::transaction_validation {
         // If any account does not exist, or public key hash does not match, abort.
         // property 2: All secondary signer addresses are verified to be authentic through a validation process.
         /// [high-level-req-2]
-        aborts_if exists i in 0..num_secondary_signers: !account::exists_at(
-            secondary_signer_addresses[i]
-        ) || secondary_signer_public_key_hashes[i]
-            != account::get_authentication_key(secondary_signer_addresses[i]);
+        aborts_if exists i in 0..num_secondary_signers:
+            !account::exists_at(secondary_signer_addresses[i])
+                || secondary_signer_public_key_hashes[i]
+                    != account::get_authentication_key(secondary_signer_addresses[i]);
 
         // By the end, all secondary signers account should exist and public key hash should match.
-        ensures forall i in 0..num_secondary_signers: account::exists_at(
-            secondary_signer_addresses[i]
-        ) && secondary_signer_public_key_hashes[i]
-            == account::get_authentication_key(secondary_signer_addresses[i]);
+        ensures forall i in 0..num_secondary_signers:
+            account::exists_at(secondary_signer_addresses[i])
+                && secondary_signer_public_key_hashes[i]
+                    == account::get_authentication_key(secondary_signer_addresses[i]);
     }
 
     spec multi_agent_common_prologue(

--- a/aptos-move/framework/aptos-framework/sources/validator_consensus_info.move
+++ b/aptos-move/framework/aptos-framework/sources/validator_consensus_info.move
@@ -9,20 +9,13 @@ module aptos_framework::validator_consensus_info {
 
     /// Create a default `ValidatorConsensusInfo` object. Value may be invalid. Only for place holding prupose.
     public fun default(): ValidatorConsensusInfo {
-        ValidatorConsensusInfo {
-            addr: @vm,
-            pk_bytes: vector[],
-            voting_power: 0,
-        }
+        ValidatorConsensusInfo { addr: @vm, pk_bytes: vector[], voting_power: 0, }
     }
 
     /// Create a `ValidatorConsensusInfo` object.
-    public fun new(addr: address, pk_bytes: vector<u8>, voting_power: u64): ValidatorConsensusInfo {
-        ValidatorConsensusInfo {
-            addr,
-            pk_bytes,
-            voting_power,
-        }
+    public fun new(addr: address, pk_bytes: vector<u8>, voting_power: u64)
+        : ValidatorConsensusInfo {
+        ValidatorConsensusInfo { addr, pk_bytes, voting_power, }
     }
 
     /// Get `ValidatorConsensusInfo.addr`.

--- a/aptos-move/framework/aptos-framework/sources/vesting.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.move
@@ -166,7 +166,6 @@ module aptos_framework::vesting {
         vesting_contracts: vector<address>,
         // Used to create resource accounts for new vesting contracts so there's no address collision.
         nonce: u64,
-
         create_events: EventHandle<CreateVestingContractEvent>,
     }
 
@@ -374,16 +373,22 @@ module aptos_framework::vesting {
     /// This is the same as the shareholder address by default and only different if it's been explicitly set.
     ///
     /// This errors out if the vesting contract with the provided address doesn't exist.
-    public fun beneficiary(vesting_contract_address: address, shareholder: address): address acquires VestingContract {
+    public fun beneficiary(
+        vesting_contract_address: address, shareholder: address
+    ): address acquires VestingContract {
         assert_vesting_contract_exists(vesting_contract_address);
-        get_beneficiary(borrow_global<VestingContract>(vesting_contract_address), shareholder)
+        get_beneficiary(
+            borrow_global<VestingContract>(vesting_contract_address), shareholder
+        )
     }
 
     #[view]
     /// Return the percentage of accumulated rewards that is paid to the operator as commission.
     ///
     /// This errors out if the vesting contract with the provided address doesn't exist.
-    public fun operator_commission_percentage(vesting_contract_address: address): u64 acquires VestingContract {
+    public fun operator_commission_percentage(
+        vesting_contract_address: address
+    ): u64 acquires VestingContract {
         assert_vesting_contract_exists(vesting_contract_address);
         borrow_global<VestingContract>(vesting_contract_address).staking.commission_percentage
     }
@@ -437,12 +442,16 @@ module aptos_framework::vesting {
     /// This excludes any unpaid commission that the operator has not collected.
     ///
     /// This errors out if the vesting contract with the provided address doesn't exist.
-    public fun total_accumulated_rewards(vesting_contract_address: address): u64 acquires VestingContract {
+    public fun total_accumulated_rewards(
+        vesting_contract_address: address
+    ): u64 acquires VestingContract {
         assert_active_vesting_contract(vesting_contract_address);
 
         let vesting_contract = borrow_global<VestingContract>(vesting_contract_address);
         let (total_active_stake, _, commission_amount) =
-            staking_contract::staking_contract_amounts(vesting_contract_address, vesting_contract.staking.operator);
+            staking_contract::staking_contract_amounts(
+                vesting_contract_address, vesting_contract.staking.operator
+            );
         total_active_stake - vesting_contract.remaining_grant - commission_amount
     }
 
@@ -452,14 +461,19 @@ module aptos_framework::vesting {
     ///
     /// This errors out if the vesting contract with the provided address doesn't exist.
     public fun accumulated_rewards(
-        vesting_contract_address: address, shareholder_or_beneficiary: address): u64 acquires VestingContract {
+        vesting_contract_address: address, shareholder_or_beneficiary: address
+    ): u64 acquires VestingContract {
         assert_active_vesting_contract(vesting_contract_address);
 
-        let total_accumulated_rewards = total_accumulated_rewards(vesting_contract_address);
-        let shareholder = shareholder(vesting_contract_address, shareholder_or_beneficiary);
+        let total_accumulated_rewards =
+            total_accumulated_rewards(vesting_contract_address);
+        let shareholder =
+            shareholder(vesting_contract_address, shareholder_or_beneficiary);
         let vesting_contract = borrow_global<VestingContract>(vesting_contract_address);
         let shares = pool_u64::shares(&vesting_contract.grant_pool, shareholder);
-        pool_u64::shares_to_amount_with_total_coins(&vesting_contract.grant_pool, shares, total_accumulated_rewards)
+        pool_u64::shares_to_amount_with_total_coins(
+            &vesting_contract.grant_pool, shares, total_accumulated_rewards
+        )
     }
 
     #[view]
@@ -478,8 +492,7 @@ module aptos_framework::vesting {
     ///
     /// This returns 0x0 if no shareholder is found for the given beneficiary / the address is not a shareholder itself.
     public fun shareholder(
-        vesting_contract_address: address,
-        shareholder_or_beneficiary: address
+        vesting_contract_address: address, shareholder_or_beneficiary: address
     ): address acquires VestingContract {
         assert_active_vesting_contract(vesting_contract_address);
 
@@ -489,14 +502,16 @@ module aptos_framework::vesting {
         };
         let vesting_contract = borrow_global<VestingContract>(vesting_contract_address);
         let result = @0x0;
-        vector::any(shareholders, |shareholder| {
-            if (shareholder_or_beneficiary == get_beneficiary(vesting_contract, *shareholder)) {
-                result = *shareholder;
-                true
-            } else {
-                false
-            }
-        });
+        vector::any(
+            shareholders,
+            |shareholder| {
+                if (shareholder_or_beneficiary
+                        == get_beneficiary(vesting_contract, *shareholder)) {
+                    result = *shareholder;
+                    true
+                } else { false }
+            },
+        );
 
         result
     }
@@ -507,8 +522,14 @@ module aptos_framework::vesting {
         start_timestamp_secs: u64,
         period_duration: u64,
     ): VestingSchedule {
-        assert!(vector::length(&schedule) > 0, error::invalid_argument(EEMPTY_VESTING_SCHEDULE));
-        assert!(period_duration > 0, error::invalid_argument(EZERO_VESTING_SCHEDULE_PERIOD));
+        assert!(
+            vector::length(&schedule) > 0, error::invalid_argument(
+                EEMPTY_VESTING_SCHEDULE
+            )
+        );
+        assert!(
+            period_duration > 0, error::invalid_argument(EZERO_VESTING_SCHEDULE_PERIOD)
+        );
         assert!(
             start_timestamp_secs >= timestamp::now_seconds(),
             error::invalid_argument(EVESTING_START_TOO_SOON),
@@ -540,7 +561,9 @@ module aptos_framework::vesting {
             error::invalid_argument(EINVALID_WITHDRAWAL_ADDRESS),
         );
         assert_account_is_registered_for_apt(withdrawal_address);
-        assert!(vector::length(shareholders) > 0, error::invalid_argument(ENO_SHAREHOLDERS));
+        assert!(
+            vector::length(shareholders) > 0, error::invalid_argument(ENO_SHAREHOLDERS)
+        );
         assert!(
             simple_map::length(&buy_ins) == vector::length(shareholders),
             error::invalid_argument(ESHARES_LENGTH_MISMATCH),
@@ -550,35 +573,49 @@ module aptos_framework::vesting {
         let grant = coin::zero<AptosCoin>();
         let grant_amount = 0;
         let grant_pool = pool_u64::create(MAXIMUM_SHAREHOLDERS);
-        vector::for_each_ref(shareholders, |shareholder| {
-            let shareholder: address = *shareholder;
-            let (_, buy_in) = simple_map::remove(&mut buy_ins, &shareholder);
-            let buy_in_amount = coin::value(&buy_in);
-            coin::merge(&mut grant, buy_in);
-            pool_u64::buy_in(
-                &mut grant_pool,
-                shareholder,
-                buy_in_amount,
-            );
-            grant_amount = grant_amount + buy_in_amount;
-        });
+        vector::for_each_ref(
+            shareholders,
+            |shareholder| {
+                let shareholder: address = *shareholder;
+                let (_, buy_in) = simple_map::remove(&mut buy_ins, &shareholder);
+                let buy_in_amount = coin::value(&buy_in);
+                coin::merge(&mut grant, buy_in);
+                pool_u64::buy_in(
+                    &mut grant_pool,
+                    shareholder,
+                    buy_in_amount,
+                );
+                grant_amount = grant_amount + buy_in_amount;
+            },
+        );
         assert!(grant_amount > 0, error::invalid_argument(EZERO_GRANT));
 
         // If this is the first time this admin account has created a vesting contract, initialize the admin store.
         let admin_address = signer::address_of(admin);
         if (!exists<AdminStore>(admin_address)) {
-            move_to(admin, AdminStore {
-                vesting_contracts: vector::empty<address>(),
-                nonce: 0,
-                create_events: new_event_handle<CreateVestingContractEvent>(admin),
-            });
+            move_to(
+                admin,
+                AdminStore {
+                    vesting_contracts: vector::empty<address>(),
+                    nonce: 0,
+                    create_events: new_event_handle<CreateVestingContractEvent>(admin),
+                },
+            );
         };
 
         // Initialize the vesting contract in a new resource account. This allows the same admin to create multiple
         // pools.
-        let (contract_signer, contract_signer_cap) = create_vesting_contract_account(admin, contract_creation_seed);
-        let pool_address = staking_contract::create_staking_contract_with_coins(
-            &contract_signer, operator, voter, grant, commission_percentage, contract_creation_seed);
+        let (contract_signer, contract_signer_cap) =
+            create_vesting_contract_account(admin, contract_creation_seed);
+        let pool_address =
+            staking_contract::create_staking_contract_with_coins(
+                &contract_signer,
+                operator,
+                voter,
+                grant,
+                commission_percentage,
+                contract_creation_seed,
+            );
 
         // Add the newly created vesting contract's address to the admin store.
         let contract_address = signer::address_of(&contract_signer);
@@ -610,26 +647,42 @@ module aptos_framework::vesting {
             },
         );
 
-        move_to(&contract_signer, VestingContract {
-            state: VESTING_POOL_ACTIVE,
-            admin: admin_address,
-            grant_pool,
-            beneficiaries: simple_map::create<address, address>(),
-            vesting_schedule,
-            withdrawal_address,
-            staking: StakingInfo { pool_address, operator, voter, commission_percentage },
-            remaining_grant: grant_amount,
-            signer_cap: contract_signer_cap,
-            update_operator_events: new_event_handle<UpdateOperatorEvent>(&contract_signer),
-            update_voter_events: new_event_handle<UpdateVoterEvent>(&contract_signer),
-            reset_lockup_events: new_event_handle<ResetLockupEvent>(&contract_signer),
-            set_beneficiary_events: new_event_handle<SetBeneficiaryEvent>(&contract_signer),
-            unlock_rewards_events: new_event_handle<UnlockRewardsEvent>(&contract_signer),
-            vest_events: new_event_handle<VestEvent>(&contract_signer),
-            distribute_events: new_event_handle<DistributeEvent>(&contract_signer),
-            terminate_events: new_event_handle<TerminateEvent>(&contract_signer),
-            admin_withdraw_events: new_event_handle<AdminWithdrawEvent>(&contract_signer),
-        });
+        move_to(
+            &contract_signer,
+            VestingContract {
+                state: VESTING_POOL_ACTIVE,
+                admin: admin_address,
+                grant_pool,
+                beneficiaries: simple_map::create<address, address>(),
+                vesting_schedule,
+                withdrawal_address,
+                staking: StakingInfo {
+                    pool_address,
+                    operator,
+                    voter,
+                    commission_percentage
+                },
+                remaining_grant: grant_amount,
+                signer_cap: contract_signer_cap,
+                update_operator_events: new_event_handle<UpdateOperatorEvent>(
+                    &contract_signer
+                ),
+                update_voter_events: new_event_handle<UpdateVoterEvent>(&contract_signer),
+                reset_lockup_events: new_event_handle<ResetLockupEvent>(&contract_signer),
+                set_beneficiary_events: new_event_handle<SetBeneficiaryEvent>(
+                    &contract_signer
+                ),
+                unlock_rewards_events: new_event_handle<UnlockRewardsEvent>(
+                    &contract_signer
+                ),
+                vest_events: new_event_handle<VestEvent>(&contract_signer),
+                distribute_events: new_event_handle<DistributeEvent>(&contract_signer),
+                terminate_events: new_event_handle<TerminateEvent>(&contract_signer),
+                admin_withdraw_events: new_event_handle<AdminWithdrawEvent>(
+                    &contract_signer
+                ),
+            },
+        );
 
         simple_map::destroy_empty(buy_ins);
         contract_address
@@ -643,15 +696,20 @@ module aptos_framework::vesting {
     }
 
     /// Call `unlock_rewards` for many vesting contracts.
-    public entry fun unlock_rewards_many(contract_addresses: vector<address>) acquires VestingContract {
+    public entry fun unlock_rewards_many(
+        contract_addresses: vector<address>
+    ) acquires VestingContract {
         let len = vector::length(&contract_addresses);
 
         assert!(len != 0, error::invalid_argument(EVEC_EMPTY_FOR_MANY_FUNCTION));
 
-        vector::for_each_ref(&contract_addresses, |contract_address| {
-            let contract_address: address = *contract_address;
-            unlock_rewards(contract_address);
-        });
+        vector::for_each_ref(
+            &contract_addresses,
+            |contract_address| {
+                let contract_address: address = *contract_address;
+                unlock_rewards(contract_address);
+            },
+        );
     }
 
     /// Unlock any vested portion of the grant.
@@ -663,30 +721,29 @@ module aptos_framework::vesting {
         // expires.
         let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
         // Short-circuit if vesting hasn't started yet.
-        if (vesting_contract.vesting_schedule.start_timestamp_secs > timestamp::now_seconds()) {
-            return
-        };
+        if (vesting_contract.vesting_schedule.start_timestamp_secs
+                > timestamp::now_seconds()) { return };
 
         // Check if the next vested period has already passed. If not, short-circuit since there's nothing to vest.
         let vesting_schedule = &mut vesting_contract.vesting_schedule;
         let last_vested_period = vesting_schedule.last_vested_period;
         let next_period_to_vest = last_vested_period + 1;
         let last_completed_period =
-            (timestamp::now_seconds() - vesting_schedule.start_timestamp_secs) / vesting_schedule.period_duration;
-        if (last_completed_period < next_period_to_vest) {
-            return
-        };
+            (timestamp::now_seconds() - vesting_schedule.start_timestamp_secs)
+                / vesting_schedule.period_duration;
+        if (last_completed_period < next_period_to_vest) { return };
 
         // Calculate how much has vested, excluding rewards.
         // Index is 0-based while period is 1-based so we need to subtract 1.
         let schedule = &vesting_schedule.schedule;
         let schedule_index = next_period_to_vest - 1;
-        let vesting_fraction = if (schedule_index < vector::length(schedule)) {
-            *vector::borrow(schedule, schedule_index)
-        } else {
-            // Last vesting schedule fraction will repeat until the grant runs out.
-            *vector::borrow(schedule, vector::length(schedule) - 1)
-        };
+        let vesting_fraction =
+            if (schedule_index < vector::length(schedule)) {
+                *vector::borrow(schedule, schedule_index)
+            } else {
+                // Last vesting schedule fraction will repeat until the grant runs out.
+                *vector::borrow(schedule, vector::length(schedule) - 1)
+            };
         let total_grant = pool_u64::total_coins(&vesting_contract.grant_pool);
         let vested_amount = fixed_point32::multiply_u64(total_grant, vesting_fraction);
         // Cap vested amount by the remaining grant amount so we don't try to distribute more than what's remaining.
@@ -724,10 +781,13 @@ module aptos_framework::vesting {
 
         assert!(len != 0, error::invalid_argument(EVEC_EMPTY_FOR_MANY_FUNCTION));
 
-        vector::for_each_ref(&contract_addresses, |contract_address| {
-            let contract_address = *contract_address;
-            vest(contract_address);
-        });
+        vector::for_each_ref(
+            &contract_addresses,
+            |contract_address| {
+                let contract_address = *contract_address;
+                vest(contract_address);
+            },
+        );
     }
 
     /// Distribute any withdrawable stake from the stake pool.
@@ -745,14 +805,20 @@ module aptos_framework::vesting {
         // Distribute coins to all shareholders in the vesting contract.
         let grant_pool = &vesting_contract.grant_pool;
         let shareholders = &pool_u64::shareholders(grant_pool);
-        vector::for_each_ref(shareholders, |shareholder| {
-            let shareholder = *shareholder;
-            let shares = pool_u64::shares(grant_pool, shareholder);
-            let amount = pool_u64::shares_to_amount_with_total_coins(grant_pool, shares, total_distribution_amount);
-            let share_of_coins = coin::extract(&mut coins, amount);
-            let recipient_address = get_beneficiary(vesting_contract, shareholder);
-            aptos_account::deposit_coins(recipient_address, share_of_coins);
-        });
+        vector::for_each_ref(
+            shareholders,
+            |shareholder| {
+                let shareholder = *shareholder;
+                let shares = pool_u64::shares(grant_pool, shareholder);
+                let amount =
+                    pool_u64::shares_to_amount_with_total_coins(
+                        grant_pool, shares, total_distribution_amount
+                    );
+                let share_of_coins = coin::extract(&mut coins, amount);
+                let recipient_address = get_beneficiary(vesting_contract, shareholder);
+                aptos_account::deposit_coins(recipient_address, share_of_coins);
+            },
+        );
 
         // Send any remaining "dust" (leftover due to rounding error) to the withdrawal address.
         if (coin::value(&coins) > 0) {
@@ -786,14 +852,19 @@ module aptos_framework::vesting {
 
         assert!(len != 0, error::invalid_argument(EVEC_EMPTY_FOR_MANY_FUNCTION));
 
-        vector::for_each_ref(&contract_addresses, |contract_address| {
-            let contract_address = *contract_address;
-            distribute(contract_address);
-        });
+        vector::for_each_ref(
+            &contract_addresses,
+            |contract_address| {
+                let contract_address = *contract_address;
+                distribute(contract_address);
+            },
+        );
     }
 
     /// Terminate the vesting contract and send all funds back to the withdrawal address.
-    public entry fun terminate_vesting_contract(admin: &signer, contract_address: address) acquires VestingContract {
+    public entry fun terminate_vesting_contract(
+        admin: &signer, contract_address: address
+    ) acquires VestingContract {
         assert_active_vesting_contract(contract_address);
 
         // Distribute all withdrawable coins, which should have been from previous rewards withdrawal or vest.
@@ -801,7 +872,8 @@ module aptos_framework::vesting {
 
         let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
         verify_admin(admin, vesting_contract);
-        let (active_stake, _, pending_active_stake, _) = stake::get_stake(vesting_contract.staking.pool_address);
+        let (active_stake, _, pending_active_stake, _) =
+            stake::get_stake(vesting_contract.staking.pool_address);
         assert!(pending_active_stake == 0, error::invalid_state(EPENDING_STAKE_FOUND));
 
         // Unlock all remaining active stake.
@@ -828,11 +900,13 @@ module aptos_framework::vesting {
 
     /// Withdraw all funds to the preset vesting contract's withdrawal address. This can only be called if the contract
     /// has already been terminated.
-    public entry fun admin_withdraw(admin: &signer, contract_address: address) acquires VestingContract {
+    public entry fun admin_withdraw(
+        admin: &signer, contract_address: address
+    ) acquires VestingContract {
         let vesting_contract = borrow_global<VestingContract>(contract_address);
         assert!(
             vesting_contract.state == VESTING_POOL_TERMINATED,
-            error::invalid_state(EVESTING_CONTRACT_STILL_ACTIVE)
+            error::invalid_state(EVESTING_CONTRACT_STILL_ACTIVE),
         );
 
         let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
@@ -874,7 +948,9 @@ module aptos_framework::vesting {
         verify_admin(admin, vesting_contract);
         let contract_signer = &get_vesting_account_signer_internal(vesting_contract);
         let old_operator = vesting_contract.staking.operator;
-        staking_contract::switch_operator(contract_signer, old_operator, new_operator, commission_percentage);
+        staking_contract::switch_operator(
+            contract_signer, old_operator, new_operator, commission_percentage
+        );
         vesting_contract.staking.operator = new_operator;
         vesting_contract.staking.commission_percentage = commission_percentage;
 
@@ -921,7 +997,9 @@ module aptos_framework::vesting {
         let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
         verify_admin(admin, vesting_contract);
         let contract_signer = &get_vesting_account_signer_internal(vesting_contract);
-        staking_contract::update_commision(contract_signer, operator, new_commission_percentage);
+        staking_contract::update_commision(
+            contract_signer, operator, new_commission_percentage
+        );
         vesting_contract.staking.commission_percentage = new_commission_percentage;
         // This function does not emit an event. Instead, `staking_contract::update_commission_percentage`
         // emits the event for this commission percentage update.
@@ -936,7 +1014,9 @@ module aptos_framework::vesting {
         verify_admin(admin, vesting_contract);
         let contract_signer = &get_vesting_account_signer_internal(vesting_contract);
         let old_voter = vesting_contract.staking.voter;
-        staking_contract::update_voter(contract_signer, vesting_contract.staking.operator, new_voter);
+        staking_contract::update_voter(
+            contract_signer, vesting_contract.staking.operator, new_voter
+        );
         vesting_contract.staking.voter = new_voter;
 
         if (std::features::module_event_migration_enabled()) {
@@ -963,8 +1043,7 @@ module aptos_framework::vesting {
     }
 
     public entry fun reset_lockup(
-        admin: &signer,
-        contract_address: address,
+        admin: &signer, contract_address: address,
     ) acquires VestingContract {
         let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
         verify_admin(admin, vesting_contract);
@@ -977,7 +1056,9 @@ module aptos_framework::vesting {
                     admin: vesting_contract.admin,
                     vesting_contract_address: contract_address,
                     staking_pool_address: vesting_contract.staking.pool_address,
-                    new_lockup_expiration_secs: stake::get_lockup_secs(vesting_contract.staking.pool_address),
+                    new_lockup_expiration_secs: stake::get_lockup_secs(
+                        vesting_contract.staking.pool_address
+                    ),
                 },
             );
         };
@@ -987,7 +1068,9 @@ module aptos_framework::vesting {
                 admin: vesting_contract.admin,
                 vesting_contract_address: contract_address,
                 staking_pool_address: vesting_contract.staking.pool_address,
-                new_lockup_expiration_secs: stake::get_lockup_secs(vesting_contract.staking.pool_address),
+                new_lockup_expiration_secs: stake::get_lockup_secs(
+                    vesting_contract.staking.pool_address
+                ),
             },
         );
     }
@@ -1047,8 +1130,9 @@ module aptos_framework::vesting {
         let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
         let addr = signer::address_of(account);
         assert!(
-            addr == vesting_contract.admin ||
-                addr == get_role_holder(contract_address, utf8(ROLE_BENEFICIARY_RESETTER)),
+            addr == vesting_contract.admin
+                || addr
+                    == get_role_holder(contract_address, utf8(ROLE_BENEFICIARY_RESETTER)),
             error::permission_denied(EPERMISSION_DENIED),
         );
 
@@ -1069,11 +1153,13 @@ module aptos_framework::vesting {
 
         if (!exists<VestingAccountManagement>(contract_address)) {
             let contract_signer = &get_vesting_account_signer_internal(vesting_contract);
-            move_to(contract_signer, VestingAccountManagement {
-                roles: simple_map::create<String, address>(),
-            })
+            move_to(
+                contract_signer,
+                VestingAccountManagement { roles: simple_map::create<String, address>(), },
+            )
         };
-        let roles = &mut borrow_global_mut<VestingAccountManagement>(contract_address).roles;
+        let roles =
+            &mut borrow_global_mut<VestingAccountManagement>(contract_address).roles;
         if (simple_map::contains_key(roles, &role)) {
             *simple_map::borrow_mut(roles, &role) = role_holder;
         } else {
@@ -1086,19 +1172,23 @@ module aptos_framework::vesting {
         contract_address: address,
         beneficiary_resetter: address,
     ) acquires VestingAccountManagement, VestingContract {
-        set_management_role(admin, contract_address, utf8(ROLE_BENEFICIARY_RESETTER), beneficiary_resetter);
+        set_management_role(
+            admin, contract_address, utf8(ROLE_BENEFICIARY_RESETTER), beneficiary_resetter
+        );
     }
 
     /// Set the beneficiary for the operator.
     public entry fun set_beneficiary_for_operator(
-        operator: &signer,
-        new_beneficiary: address,
+        operator: &signer, new_beneficiary: address,
     ) {
         staking_contract::set_beneficiary_for_operator(operator, new_beneficiary);
     }
 
     public fun get_role_holder(contract_address: address, role: String): address acquires VestingAccountManagement {
-        assert!(exists<VestingAccountManagement>(contract_address), error::not_found(EVESTING_ACCOUNT_HAS_NO_ROLES));
+        assert!(
+            exists<VestingAccountManagement>(contract_address),
+            error::not_found(EVESTING_ACCOUNT_HAS_NO_ROLES),
+        );
         let roles = &borrow_global<VestingAccountManagement>(contract_address).roles;
         assert!(simple_map::contains_key(roles, &role), error::not_found(EROLE_NOT_FOUND));
         *simple_map::borrow(roles, &role)
@@ -1107,21 +1197,24 @@ module aptos_framework::vesting {
     /// For emergency use in case the admin needs emergency control of vesting contract account.
     /// This doesn't give the admin total power as the admin would still need to follow the rules set by
     /// staking_contract and stake modules.
-    public fun get_vesting_account_signer(admin: &signer, contract_address: address): signer acquires VestingContract {
+    public fun get_vesting_account_signer(
+        admin: &signer, contract_address: address
+    ): signer acquires VestingContract {
         let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
         verify_admin(admin, vesting_contract);
         get_vesting_account_signer_internal(vesting_contract)
     }
 
-    fun get_vesting_account_signer_internal(vesting_contract: &VestingContract): signer {
+    fun get_vesting_account_signer_internal(
+        vesting_contract: &VestingContract
+    ): signer {
         account::create_signer_with_capability(&vesting_contract.signer_cap)
     }
 
     /// Create a salt for generating the resource accounts that will be holding the VestingContract.
     /// This address should be deterministic for the same admin and vesting contract creation nonce.
     fun create_vesting_contract_account(
-        admin: &signer,
-        contract_creation_seed: vector<u8>,
+        admin: &signer, contract_creation_seed: vector<u8>,
     ): (signer, SignerCapability) acquires AdminStore {
         let admin_store = borrow_global_mut<AdminStore>(signer::address_of(admin));
         let seed = bcs::to_bytes(&signer::address_of(admin));
@@ -1142,25 +1235,38 @@ module aptos_framework::vesting {
     }
 
     fun verify_admin(admin: &signer, vesting_contract: &VestingContract) {
-        assert!(signer::address_of(admin) == vesting_contract.admin, error::unauthenticated(ENOT_ADMIN));
+        assert!(
+            signer::address_of(admin) == vesting_contract.admin,
+            error::unauthenticated(ENOT_ADMIN),
+        );
     }
 
     fun assert_vesting_contract_exists(contract_address: address) {
-        assert!(exists<VestingContract>(contract_address), error::not_found(EVESTING_CONTRACT_NOT_FOUND));
+        assert!(
+            exists<VestingContract>(contract_address),
+            error::not_found(EVESTING_CONTRACT_NOT_FOUND),
+        );
     }
 
     fun assert_active_vesting_contract(contract_address: address) acquires VestingContract {
         assert_vesting_contract_exists(contract_address);
         let vesting_contract = borrow_global<VestingContract>(contract_address);
-        assert!(vesting_contract.state == VESTING_POOL_ACTIVE, error::invalid_state(EVESTING_CONTRACT_NOT_ACTIVE));
+        assert!(
+            vesting_contract.state == VESTING_POOL_ACTIVE,
+            error::invalid_state(EVESTING_CONTRACT_NOT_ACTIVE),
+        );
     }
 
     fun unlock_stake(vesting_contract: &VestingContract, amount: u64) {
         let contract_signer = &get_vesting_account_signer_internal(vesting_contract);
-        staking_contract::unlock_stake(contract_signer, vesting_contract.staking.operator, amount);
+        staking_contract::unlock_stake(
+            contract_signer, vesting_contract.staking.operator, amount
+        );
     }
 
-    fun withdraw_stake(vesting_contract: &VestingContract, contract_address: address): Coin<AptosCoin> {
+    fun withdraw_stake(
+        vesting_contract: &VestingContract, contract_address: address
+    ): Coin<AptosCoin> {
         // Claim any withdrawable distribution from the staking contract. The withdrawn coins will be sent directly to
         // the vesting contract's account.
         staking_contract::distribute(contract_address, vesting_contract.staking.operator);
@@ -1221,17 +1327,22 @@ module aptos_framework::vesting {
             true,
             10,
             10000,
-            1000000
+            1000000,
         );
 
-        vector::for_each_ref(accounts, |addr| {
-            let addr: address = *addr;
-            if (!account::exists_at(addr)) {
-                create_account(addr);
-            };
-        });
+        vector::for_each_ref(
+            accounts,
+            |addr| {
+                let addr: address = *addr;
+                if (!account::exists_at(addr)) {
+                    create_account(addr);
+                };
+            },
+        );
 
-        std::features::change_feature_flags_for_testing(aptos_framework, vector[MODULE_EVENT, OPERATOR_BENEFICIARY_CHANGE], vector[]);
+        std::features::change_feature_flags_for_testing(
+            aptos_framework, vector[MODULE_EVENT, OPERATOR_BENEFICIARY_CHANGE], vector[]
+        );
     }
 
     #[test_only]
@@ -1264,21 +1375,31 @@ module aptos_framework::vesting {
         vesting_denominator: u64,
     ): address acquires AdminStore {
         let schedule = vector::empty<FixedPoint32>();
-        vector::for_each_ref(vesting_numerators, |num| {
-            vector::push_back(&mut schedule, fixed_point32::create_from_rational(*num, vesting_denominator));
-        });
-        let vesting_schedule = create_vesting_schedule(
-            schedule,
-            timestamp::now_seconds() + VESTING_SCHEDULE_CLIFF,
-            VESTING_PERIOD,
+        vector::for_each_ref(
+            vesting_numerators,
+            |num| {
+                vector::push_back(
+                    &mut schedule,
+                    fixed_point32::create_from_rational(*num, vesting_denominator),
+                );
+            },
         );
+        let vesting_schedule =
+            create_vesting_schedule(
+                schedule,
+                timestamp::now_seconds() + VESTING_SCHEDULE_CLIFF,
+                VESTING_PERIOD,
+            );
 
         let admin_address = signer::address_of(admin);
         let buy_ins = simple_map::create<address, Coin<AptosCoin>>();
-        vector::enumerate_ref(shares, |i, share| {
-            let shareholder = *vector::borrow(shareholders, i);
-            simple_map::add(&mut buy_ins, shareholder, stake::mint_coins(*share));
-        });
+        vector::enumerate_ref(
+            shares,
+            |i, share| {
+                let shareholder = *vector::borrow(shareholders, i);
+                simple_map::add(&mut buy_ins, shareholder, stake::mint_coins(*share));
+            },
+        );
 
         create_vesting_contract(
             admin,
@@ -1312,16 +1433,30 @@ module aptos_framework::vesting {
 
         // Create the vesting contract.
         setup(
-            aptos_framework, &vector[admin_address, withdrawal_address, shareholder_1_address, shareholder_2_address]);
-        let contract_address = setup_vesting_contract(admin, shareholders, shares, withdrawal_address, 0);
-        assert!(vector::length(&borrow_global<AdminStore>(admin_address).vesting_contracts) == 1, 0);
+            aptos_framework,
+            &vector[
+                admin_address,
+                withdrawal_address,
+                shareholder_1_address,
+                shareholder_2_address],
+        );
+        let contract_address =
+            setup_vesting_contract(admin, shareholders, shares, withdrawal_address, 0);
+        assert!(
+            vector::length(&borrow_global<AdminStore>(admin_address).vesting_contracts) ==
+            1,
+            0,
+        );
         let stake_pool_address = stake_pool_address(contract_address);
         stake::assert_stake_pool(stake_pool_address, GRANT_AMOUNT, 0, 0, 0);
 
         // The stake pool is still in pending active stake, so unlock_rewards and vest shouldn't do anything.
         let (_sk, pk, pop) = stake::generate_identity();
         stake::join_validator_set_for_test(&pk, &pop, admin, stake_pool_address, false);
-        assert!(stake::get_validator_state(stake_pool_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 1);
+        assert!(
+            stake::get_validator_state(stake_pool_address) == VALIDATOR_STATUS_PENDING_ACTIVE,
+            1,
+        );
         unlock_rewards(contract_address);
         vest(contract_address);
         stake::assert_stake_pool(stake_pool_address, GRANT_AMOUNT, 0, 0, 0);
@@ -1329,7 +1464,9 @@ module aptos_framework::vesting {
         // Wait for the validator to join the validator set. No rewards are earnt yet so unlock_rewards and vest should
         // still do nothing.
         stake::end_epoch();
-        assert!(stake::get_validator_state(stake_pool_address) == VALIDATOR_STATUS_ACTIVE, 2);
+        assert!(
+            stake::get_validator_state(stake_pool_address) == VALIDATOR_STATUS_ACTIVE, 2
+        );
         unlock_rewards(contract_address);
         vest(contract_address);
         stake::assert_stake_pool(stake_pool_address, GRANT_AMOUNT, 0, 0, 0);
@@ -1375,8 +1512,13 @@ module aptos_framework::vesting {
         let vested_amount = fraction(GRANT_AMOUNT, 3, 48);
         let remaining_grant = GRANT_AMOUNT - vested_amount;
         let pending_distribution = rewards + vested_amount;
-        assert!(remaining_grant(contract_address) == remaining_grant, remaining_grant(contract_address));
-        stake::assert_stake_pool(stake_pool_address, remaining_grant, 0, 0, pending_distribution);
+        assert!(
+            remaining_grant(contract_address) == remaining_grant,
+            remaining_grant(contract_address),
+        );
+        stake::assert_stake_pool(
+            stake_pool_address, remaining_grant, 0, 0, pending_distribution
+        );
 
         // Fast forward to the end of the fourth period. We can call vest() 3 times to vest the last 3 periods.
         timestamp::fast_forward_seconds(VESTING_PERIOD * 3);
@@ -1384,17 +1526,23 @@ module aptos_framework::vesting {
         vested_amount = fraction(GRANT_AMOUNT, 2, 48);
         remaining_grant = remaining_grant - vested_amount;
         pending_distribution = pending_distribution + vested_amount;
-        stake::assert_stake_pool(stake_pool_address, remaining_grant, 0, 0, pending_distribution);
+        stake::assert_stake_pool(
+            stake_pool_address, remaining_grant, 0, 0, pending_distribution
+        );
         vest(contract_address);
         vested_amount = fraction(GRANT_AMOUNT, 1, 48);
         remaining_grant = remaining_grant - vested_amount;
         pending_distribution = pending_distribution + vested_amount;
-        stake::assert_stake_pool(stake_pool_address, remaining_grant, 0, 0, pending_distribution);
+        stake::assert_stake_pool(
+            stake_pool_address, remaining_grant, 0, 0, pending_distribution
+        );
         // The last vesting fraction (1/48) is repeated beyond the first 3 periods.
         vest(contract_address);
         remaining_grant = remaining_grant - vested_amount;
         pending_distribution = pending_distribution + vested_amount;
-        stake::assert_stake_pool(stake_pool_address, remaining_grant, 0, 0, pending_distribution);
+        stake::assert_stake_pool(
+            stake_pool_address, remaining_grant, 0, 0, pending_distribution
+        );
         assert!(remaining_grant(contract_address) == remaining_grant, 0);
 
         stake::end_epoch();
@@ -1402,8 +1550,16 @@ module aptos_framework::vesting {
         pending_distribution = with_rewards(pending_distribution);
         distribute(contract_address);
         stake::assert_stake_pool(stake_pool_address, total_active, 0, 0, 0);
-        assert!(coin::balance<AptosCoin>(shareholder_1_address) == shareholder_1_bal + pending_distribution / 4, 0);
-        assert!(coin::balance<AptosCoin>(shareholder_2_address) == shareholder_2_bal + pending_distribution * 3 / 4, 1);
+        assert!(
+            coin::balance<AptosCoin>(shareholder_1_address)
+                == shareholder_1_bal + pending_distribution / 4,
+            0,
+        );
+        assert!(
+            coin::balance<AptosCoin>(shareholder_2_address)
+                == shareholder_2_bal + pending_distribution * 3 / 4,
+            1,
+        );
         // Withdrawal address receives the left-over dust of 1 coin due to rounding error.
         assert!(coin::balance<AptosCoin>(withdrawal_address) == 1, 0);
 
@@ -1416,14 +1572,16 @@ module aptos_framework::vesting {
         stake::assert_stake_pool(stake_pool_address, 0, withdrawn_amount, 0, 0);
         let previous_bal = coin::balance<AptosCoin>(withdrawal_address);
         admin_withdraw(admin, contract_address);
-        assert!(coin::balance<AptosCoin>(withdrawal_address) == previous_bal + withdrawn_amount, 0);
+        assert!(
+            coin::balance<AptosCoin>(withdrawal_address) == previous_bal + withdrawn_amount,
+            0,
+        );
     }
 
     #[test(aptos_framework = @0x1, admin = @0x123)]
     #[expected_failure(abort_code = 0x1000C, location = Self)]
     public entry fun test_create_vesting_contract_with_zero_grant_should_fail(
-        aptos_framework: &signer,
-        admin: &signer,
+        aptos_framework: &signer, admin: &signer,
     ) acquires AdminStore {
         let admin_address = signer::address_of(admin);
         setup(aptos_framework, &vector[admin_address]);
@@ -1433,8 +1591,7 @@ module aptos_framework::vesting {
     #[test(aptos_framework = @0x1, admin = @0x123)]
     #[expected_failure(abort_code = 0x10004, location = Self)]
     public entry fun test_create_vesting_contract_with_no_shareholders_should_fail(
-        aptos_framework: &signer,
-        admin: &signer,
+        aptos_framework: &signer, admin: &signer,
     ) acquires AdminStore {
         let admin_address = signer::address_of(admin);
         setup(aptos_framework, &vector[admin_address]);
@@ -1444,8 +1601,7 @@ module aptos_framework::vesting {
     #[test(aptos_framework = @0x1, admin = @0x123)]
     #[expected_failure(abort_code = 0x10005, location = Self)]
     public entry fun test_create_vesting_contract_with_mistmaching_shareholders_should_fail(
-        aptos_framework: &signer,
-        admin: &signer,
+        aptos_framework: &signer, admin: &signer,
     ) acquires AdminStore {
         let admin_address = signer::address_of(admin);
         setup(aptos_framework, &vector[admin_address]);
@@ -1455,8 +1611,7 @@ module aptos_framework::vesting {
     #[test(aptos_framework = @0x1, admin = @0x123)]
     #[expected_failure(abort_code = 0x60001, location = aptos_framework::aptos_account)]
     public entry fun test_create_vesting_contract_with_invalid_withdrawal_address_should_fail(
-        aptos_framework: &signer,
-        admin: &signer,
+        aptos_framework: &signer, admin: &signer,
     ) acquires AdminStore {
         let admin_address = signer::address_of(admin);
         setup(aptos_framework, &vector[admin_address]);
@@ -1466,8 +1621,7 @@ module aptos_framework::vesting {
     #[test(aptos_framework = @0x1, admin = @0x123)]
     #[expected_failure(abort_code = 0x60001, location = aptos_framework::aptos_account)]
     public entry fun test_create_vesting_contract_with_missing_withdrawal_account_should_fail(
-        aptos_framework: &signer,
-        admin: &signer,
+        aptos_framework: &signer, admin: &signer,
     ) acquires AdminStore {
         let admin_address = signer::address_of(admin);
         setup(aptos_framework, &vector[admin_address]);
@@ -1477,8 +1631,7 @@ module aptos_framework::vesting {
     #[test(aptos_framework = @0x1, admin = @0x123)]
     #[expected_failure(abort_code = 0x60002, location = aptos_framework::aptos_account)]
     public entry fun test_create_vesting_contract_with_unregistered_withdrawal_account_should_fail(
-        aptos_framework: &signer,
-        admin: &signer,
+        aptos_framework: &signer, admin: &signer,
     ) acquires AdminStore {
         let admin_address = signer::address_of(admin);
         setup(aptos_framework, &vector[admin_address]);
@@ -1488,27 +1641,34 @@ module aptos_framework::vesting {
 
     #[test(aptos_framework = @0x1)]
     #[expected_failure(abort_code = 0x10002, location = Self)]
-    public entry fun test_create_empty_vesting_schedule_should_fail(aptos_framework: &signer) {
+    public entry fun test_create_empty_vesting_schedule_should_fail(
+        aptos_framework: &signer
+    ) {
         setup(aptos_framework, &vector[]);
         create_vesting_schedule(vector[], 1, 1);
     }
 
     #[test(aptos_framework = @0x1)]
     #[expected_failure(abort_code = 0x10003, location = Self)]
-    public entry fun test_create_vesting_schedule_with_zero_period_duration_should_fail(aptos_framework: &signer) {
+    public entry fun test_create_vesting_schedule_with_zero_period_duration_should_fail(
+        aptos_framework: &signer
+    ) {
         setup(aptos_framework, &vector[]);
         create_vesting_schedule(vector[fixed_point32::create_from_rational(1, 1)], 1, 0);
     }
 
     #[test(aptos_framework = @0x1, admin = @0x123)]
     #[expected_failure(abort_code = 0x10006, location = Self)]
-    public entry fun test_create_vesting_schedule_with_invalid_vesting_start_should_fail(aptos_framework: &signer) {
+    public entry fun test_create_vesting_schedule_with_invalid_vesting_start_should_fail(
+        aptos_framework: &signer
+    ) {
         setup(aptos_framework, &vector[]);
         timestamp::update_global_time_for_test_secs(1000);
         create_vesting_schedule(
             vector[fixed_point32::create_from_rational(1, 1)],
             900,
-            1);
+            1,
+        );
     }
 
     #[test(aptos_framework = @0x1, admin = @0x123, shareholder = @0x234)]
@@ -1520,8 +1680,14 @@ module aptos_framework::vesting {
         let admin_address = signer::address_of(admin);
         let shareholder_address = signer::address_of(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+        let contract_address =
+            setup_vesting_contract(
+                admin,
+                &vector[shareholder_address],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
+            );
 
         // Operator needs to join the validator set for the stake pool to earn rewards.
         let stake_pool_address = stake_pool_address(contract_address);
@@ -1529,7 +1695,9 @@ module aptos_framework::vesting {
         stake::join_validator_set_for_test(&pk, &pop, admin, stake_pool_address, true);
 
         // Fast forward to the end of the first period. vest() should now unlock 3/48 of the tokens.
-        timestamp::update_global_time_for_test_secs(vesting_start_secs(contract_address) + VESTING_PERIOD);
+        timestamp::update_global_time_for_test_secs(
+            vesting_start_secs(contract_address) + VESTING_PERIOD
+        );
         vest(contract_address);
         let vested_amount = fraction(GRANT_AMOUNT, 3, 48);
         let remaining_grant = GRANT_AMOUNT - vested_amount;
@@ -1551,8 +1719,14 @@ module aptos_framework::vesting {
         let admin_address = signer::address_of(admin);
         let shareholder_address = signer::address_of(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+        let contract_address =
+            setup_vesting_contract(
+                admin,
+                &vector[shareholder_address],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
+            );
 
         // Operator needs to join the validator set for the stake pool to earn rewards.
         let stake_pool_address = stake_pool_address(contract_address);
@@ -1581,9 +1755,17 @@ module aptos_framework::vesting {
         let admin_address = signer::address_of(admin);
         let operator_address = signer::address_of(operator);
         let shareholder_address = signer::address_of(shareholder);
-        setup(aptos_framework, &vector[admin_address, shareholder_address, operator_address]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+        setup(
+            aptos_framework, &vector[admin_address, shareholder_address, operator_address]
+        );
+        let contract_address =
+            setup_vesting_contract(
+                admin,
+                &vector[shareholder_address],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
+            );
         assert!(operator_commission_percentage(contract_address) == 0, 0);
 
         // 10% commission will be paid to the operator.
@@ -1601,7 +1783,9 @@ module aptos_framework::vesting {
         let commission = accumulated_rewards / 10; // 10%.
         let staker_rewards = accumulated_rewards - commission;
         unlock_rewards(contract_address);
-        stake::assert_stake_pool(stake_pool_address, GRANT_AMOUNT, 0, 0, accumulated_rewards);
+        stake::assert_stake_pool(
+            stake_pool_address, GRANT_AMOUNT, 0, 0, accumulated_rewards
+        );
         assert!(remaining_grant(contract_address) == GRANT_AMOUNT, 0);
 
         // Distribution should pay commission to operator first and remaining amount to shareholders.
@@ -1611,10 +1795,11 @@ module aptos_framework::vesting {
             with_rewards(GRANT_AMOUNT),
             with_rewards(accumulated_rewards),
             0,
-            0
+            0,
         );
         // Operator also earns more commission from the rewards earnt on the withdrawn rewards.
-        let commission_on_staker_rewards = (with_rewards(staker_rewards) - staker_rewards) / 10;
+        let commission_on_staker_rewards =
+            (with_rewards(staker_rewards) - staker_rewards) / 10;
         staker_rewards = with_rewards(staker_rewards) - commission_on_staker_rewards;
         commission = with_rewards(commission) + commission_on_staker_rewards;
         distribute(contract_address);
@@ -1633,9 +1818,17 @@ module aptos_framework::vesting {
         let admin_address = signer::address_of(admin);
         let operator_address = signer::address_of(operator);
         let shareholder_address = signer::address_of(shareholder);
-        setup(aptos_framework, &vector[admin_address, shareholder_address, operator_address]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+        setup(
+            aptos_framework, &vector[admin_address, shareholder_address, operator_address]
+        );
+        let contract_address =
+            setup_vesting_contract(
+                admin,
+                &vector[shareholder_address],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
+            );
         assert!(operator_commission_percentage(contract_address) == 0, 0);
 
         // 10% commission will be paid to the operator.
@@ -1658,7 +1851,9 @@ module aptos_framework::vesting {
 
         // Unlock vesting rewards. This should still pay out the accumulated rewards to shareholders.
         unlock_rewards(contract_address);
-        stake::assert_stake_pool(stake_pool_address, GRANT_AMOUNT, 0, 0, accumulated_rewards);
+        stake::assert_stake_pool(
+            stake_pool_address, GRANT_AMOUNT, 0, 0, accumulated_rewards
+        );
         assert!(remaining_grant(contract_address) == GRANT_AMOUNT, 0);
 
         // Distribution should pay commission to operator first and remaining amount to shareholders.
@@ -1668,10 +1863,11 @@ module aptos_framework::vesting {
             with_rewards(GRANT_AMOUNT),
             with_rewards(accumulated_rewards),
             0,
-            0
+            0,
         );
         // Operator also earns more commission from the rewards earnt on the withdrawn rewards.
-        let commission_on_staker_rewards = (with_rewards(staker_rewards) - staker_rewards) / 10;
+        let commission_on_staker_rewards =
+            (with_rewards(staker_rewards) - staker_rewards) / 10;
         staker_rewards = with_rewards(staker_rewards) - commission_on_staker_rewards;
         commission = with_rewards(commission) + commission_on_staker_rewards;
         distribute(contract_address);
@@ -1689,8 +1885,10 @@ module aptos_framework::vesting {
         let admin_address = signer::address_of(admin);
         let operator_address = signer::address_of(operator);
         setup(aptos_framework, &vector[admin_address, @11, operator_address]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 10);
+        let contract_address =
+            setup_vesting_contract(
+                admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 10
+            );
 
         update_operator_with_same_commission(admin, contract_address, operator_address);
         assert!(operator_commission_percentage(contract_address) == 10, 0);
@@ -1706,9 +1904,17 @@ module aptos_framework::vesting {
         let admin_address = signer::address_of(admin);
         let operator_address = signer::address_of(operator);
         let shareholder_address = signer::address_of(shareholder);
-        setup(aptos_framework, &vector[admin_address, shareholder_address, operator_address]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+        setup(
+            aptos_framework, &vector[admin_address, shareholder_address, operator_address]
+        );
+        let contract_address =
+            setup_vesting_contract(
+                admin,
+                &vector[shareholder_address],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
+            );
         assert!(operator_commission_percentage(contract_address) == 0, 0);
         let stake_pool_address = stake_pool_address(contract_address);
 
@@ -1724,10 +1930,10 @@ module aptos_framework::vesting {
 
         // Stake pool earns some rewards.
         stake::end_epoch();
-        let (_, accumulated_rewards, _) = staking_contract::staking_contract_amounts(
-            contract_address,
-            operator_address
-        );
+        let (_, accumulated_rewards, _) =
+            staking_contract::staking_contract_amounts(
+                contract_address, operator_address
+            );
 
         // Update commission percentage to 20%. This also immediately requests commission.
         update_commission_percentage(admin, contract_address, 20);
@@ -1740,10 +1946,10 @@ module aptos_framework::vesting {
 
         // Stake pool earns some more rewards.
         stake::end_epoch();
-        let (_, accumulated_rewards, _) = staking_contract::staking_contract_amounts(
-            contract_address,
-            operator_address
-        );
+        let (_, accumulated_rewards, _) =
+            staking_contract::staking_contract_amounts(
+                contract_address, operator_address
+            );
 
         // Request commission again.
         staking_contract::request_commission(operator, contract_address, operator_address);
@@ -1761,14 +1967,7 @@ module aptos_framework::vesting {
         assert!(coin::balance<AptosCoin>(operator_address) == expected_commission, 1);
     }
 
-    #[test(
-        aptos_framework = @0x1,
-        admin = @0x123,
-        shareholder = @0x234,
-        operator1 = @0x345,
-        beneficiary = @0x456,
-        operator2 = @0x567
-    )]
+    #[test(aptos_framework = @0x1, admin = @0x123, shareholder = @0x234, operator1 = @0x345, beneficiary = @0x456, operator2 = @0x567)]
     public entry fun test_set_beneficiary_for_operator(
         aptos_framework: &signer,
         admin: &signer,
@@ -1782,16 +1981,37 @@ module aptos_framework::vesting {
         let operator_address2 = signer::address_of(operator2);
         let shareholder_address = signer::address_of(shareholder);
         let beneficiary_address = signer::address_of(beneficiary);
-        setup(aptos_framework, &vector[admin_address, shareholder_address, operator_address1, beneficiary_address]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+        setup(
+            aptos_framework,
+            &vector[
+                admin_address,
+                shareholder_address,
+                operator_address1,
+                beneficiary_address],
+        );
+        let contract_address =
+            setup_vesting_contract(
+                admin,
+                &vector[shareholder_address],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
+            );
         assert!(operator_commission_percentage(contract_address) == 0, 0);
         let stake_pool_address = stake_pool_address(contract_address);
         // 10% commission will be paid to the operator.
         update_operator(admin, contract_address, operator_address1, 10);
-        assert!(staking_contract::beneficiary_for_operator(operator_address1) == operator_address1, 0);
+        assert!(
+            staking_contract::beneficiary_for_operator(operator_address1)
+                == operator_address1,
+            0,
+        );
         set_beneficiary_for_operator(operator1, beneficiary_address);
-        assert!(staking_contract::beneficiary_for_operator(operator_address1) == beneficiary_address, 0);
+        assert!(
+            staking_contract::beneficiary_for_operator(operator_address1)
+                == beneficiary_address,
+            0,
+        );
 
         // Operator needs to join the validator set for the stake pool to earn rewards.
         let (_sk, pk, pop) = stake::generate_identity();
@@ -1802,14 +2022,17 @@ module aptos_framework::vesting {
 
         // Stake pool earns some rewards.
         stake::end_epoch();
-        let (_, accumulated_rewards, _) = staking_contract::staking_contract_amounts(contract_address,
-            operator_address1
-        );
+        let (_, accumulated_rewards, _) =
+            staking_contract::staking_contract_amounts(
+                contract_address, operator_address1
+            );
         // Commission is calculated using the previous commission percentage which is 10%.
         let expected_commission = accumulated_rewards / 10;
 
         // Request commission.
-        staking_contract::request_commission(operator1, contract_address, operator_address1);
+        staking_contract::request_commission(
+            operator1, contract_address, operator_address1
+        );
         // Unlocks the commission.
         stake::fast_forward_to_unlock(stake_pool_address);
         expected_commission = with_rewards(expected_commission);
@@ -1826,14 +2049,17 @@ module aptos_framework::vesting {
         update_operator(admin, contract_address, operator_address2, 10);
 
         stake::end_epoch();
-        let (_, accumulated_rewards, _) = staking_contract::staking_contract_amounts(contract_address,
-            operator_address2
-        );
+        let (_, accumulated_rewards, _) =
+            staking_contract::staking_contract_amounts(
+                contract_address, operator_address2
+            );
 
         let expected_commission = accumulated_rewards / 10;
 
         // Request commission.
-        staking_contract::request_commission(operator2, contract_address, operator_address2);
+        staking_contract::request_commission(
+            operator2, contract_address, operator_address2
+        );
         // Unlocks the commission.
         stake::fast_forward_to_unlock(stake_pool_address);
         expected_commission = with_rewards(expected_commission);
@@ -1843,7 +2069,9 @@ module aptos_framework::vesting {
 
         // Assert that the rewards go to operator2, and the balance of the operator1's beneficiay remains the same.
         assert!(coin::balance<AptosCoin>(operator_address2) >= expected_commission, 1);
-        assert!(coin::balance<AptosCoin>(beneficiary_address) == old_beneficiay_balance, 1);
+        assert!(
+            coin::balance<AptosCoin>(beneficiary_address) == old_beneficiay_balance, 1
+        );
     }
 
     #[test(aptos_framework = @0x1, admin = @0x123, shareholder = @0x234)]
@@ -1856,8 +2084,14 @@ module aptos_framework::vesting {
         let admin_address = signer::address_of(admin);
         let shareholder_address = signer::address_of(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+        let contract_address =
+            setup_vesting_contract(
+                admin,
+                &vector[shareholder_address],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
+            );
 
         // Immediately terminate. Calling unlock_rewards should now fail.
         terminate_vesting_contract(admin, contract_address);
@@ -1873,19 +2107,22 @@ module aptos_framework::vesting {
         let admin_address = signer::address_of(admin);
         let shareholder_address = signer::address_of(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
-        let contract_address = setup_vesting_contract_with_schedule(
-            admin,
-            &vector[shareholder_address],
-            &vector[GRANT_AMOUNT],
-            admin_address,
-            0,
-            &vector[0, 3, 0, 2],
-            48,
-        );
+        let contract_address =
+            setup_vesting_contract_with_schedule(
+                admin,
+                &vector[shareholder_address],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
+                &vector[0, 3, 0, 2],
+                48,
+            );
         let stake_pool_address = stake_pool_address(contract_address);
 
         // First vest() should unlock 0 according to schedule.
-        timestamp::update_global_time_for_test_secs(vesting_start_secs(contract_address) + VESTING_PERIOD);
+        timestamp::update_global_time_for_test_secs(
+            vesting_start_secs(contract_address) + VESTING_PERIOD
+        );
         vest(contract_address);
         stake::assert_stake_pool(stake_pool_address, GRANT_AMOUNT, 0, 0, 0);
         assert!(remaining_grant(contract_address) == GRANT_AMOUNT, 0);
@@ -1924,20 +2161,23 @@ module aptos_framework::vesting {
         let admin_address = signer::address_of(admin);
         let shareholder_address = signer::address_of(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
-        let contract_address = setup_vesting_contract_with_schedule(
-            admin,
-            &vector[shareholder_address],
-            &vector[GRANT_AMOUNT],
-            admin_address,
-            0,
-            // First vest = 3/4 but last vest should only be for the remaining 1/4.
-            &vector[3],
-            4,
-        );
+        let contract_address =
+            setup_vesting_contract_with_schedule(
+                admin,
+                &vector[shareholder_address],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
+                // First vest = 3/4 but last vest should only be for the remaining 1/4.
+                &vector[3],
+                4,
+            );
         let stake_pool_address = stake_pool_address(contract_address);
 
         // First vest is 3/48
-        timestamp::update_global_time_for_test_secs(vesting_start_secs(contract_address) + VESTING_PERIOD);
+        timestamp::update_global_time_for_test_secs(
+            vesting_start_secs(contract_address) + VESTING_PERIOD
+        );
         vest(contract_address);
         let vested_amount = fraction(GRANT_AMOUNT, 3, 4);
         let remaining_grant = GRANT_AMOUNT - vested_amount;
@@ -1965,8 +2205,14 @@ module aptos_framework::vesting {
         let admin_address = signer::address_of(admin);
         let shareholder_address = signer::address_of(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+        let contract_address =
+            setup_vesting_contract(
+                admin,
+                &vector[shareholder_address],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
+            );
 
         // Immediately terminate. Calling vest should now fail.
         terminate_vesting_contract(admin, contract_address);
@@ -1983,8 +2229,14 @@ module aptos_framework::vesting {
         let admin_address = signer::address_of(admin);
         let shareholder_address = signer::address_of(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+        let contract_address =
+            setup_vesting_contract(
+                admin,
+                &vector[shareholder_address],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
+            );
 
         // Call terminate_vesting_contract twice should fail.
         terminate_vesting_contract(admin, contract_address);
@@ -2001,8 +2253,14 @@ module aptos_framework::vesting {
         let admin_address = signer::address_of(admin);
         let shareholder_address = signer::address_of(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+        let contract_address =
+            setup_vesting_contract(
+                admin,
+                &vector[shareholder_address],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
+            );
 
         // Calling admin_withdraw should fail as contract has not been terminated.
         admin_withdraw(admin, contract_address);
@@ -2011,44 +2269,57 @@ module aptos_framework::vesting {
     #[test(aptos_framework = @0x1, admin = @0x123)]
     #[expected_failure(abort_code = 0x60001, location = aptos_framework::aptos_account)]
     public entry fun test_set_beneficiary_with_missing_account_should_fail(
-        aptos_framework: &signer,
-        admin: &signer,
+        aptos_framework: &signer, admin: &signer,
     ) acquires AdminStore, VestingContract {
         let admin_address = signer::address_of(admin);
         setup(aptos_framework, &vector[admin_address]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[@1, @2], &vector[GRANT_AMOUNT, GRANT_AMOUNT], admin_address, 0);
+        let contract_address =
+            setup_vesting_contract(
+                admin,
+                &vector[@1, @2],
+                &vector[GRANT_AMOUNT, GRANT_AMOUNT],
+                admin_address,
+                0,
+            );
         set_beneficiary(admin, contract_address, @1, @11);
     }
 
     #[test(aptos_framework = @0x1, admin = @0x123)]
     #[expected_failure(abort_code = 0x60002, location = aptos_framework::aptos_account)]
     public entry fun test_set_beneficiary_with_unregistered_account_should_fail(
-        aptos_framework: &signer,
-        admin: &signer,
+        aptos_framework: &signer, admin: &signer,
     ) acquires AdminStore, VestingContract {
         let admin_address = signer::address_of(admin);
         setup(aptos_framework, &vector[admin_address]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[@1, @2], &vector[GRANT_AMOUNT, GRANT_AMOUNT], admin_address, 0);
+        let contract_address =
+            setup_vesting_contract(
+                admin,
+                &vector[@1, @2],
+                &vector[GRANT_AMOUNT, GRANT_AMOUNT],
+                admin_address,
+                0,
+            );
         create_account_for_test(@11);
         set_beneficiary(admin, contract_address, @1, @11);
     }
 
     #[test(aptos_framework = @0x1, admin = @0x123)]
     public entry fun test_set_beneficiary_should_send_distribution(
-        aptos_framework: &signer,
-        admin: &signer,
+        aptos_framework: &signer, admin: &signer,
     ) acquires AdminStore, VestingContract {
         let admin_address = signer::address_of(admin);
         setup(aptos_framework, &vector[admin_address, @11]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[@1], &vector[GRANT_AMOUNT], admin_address, 0);
+        let contract_address =
+            setup_vesting_contract(
+                admin, &vector[@1], &vector[GRANT_AMOUNT], admin_address, 0
+            );
         set_beneficiary(admin, contract_address, @1, @11);
         assert!(beneficiary(contract_address, @1) == @11, 0);
 
         // Fast forward to the end of the first period. vest() should now unlock 3/48 of the tokens.
-        timestamp::update_global_time_for_test_secs(vesting_start_secs(contract_address) + VESTING_PERIOD);
+        timestamp::update_global_time_for_test_secs(
+            vesting_start_secs(contract_address) + VESTING_PERIOD
+        );
         vest(contract_address);
 
         // Distribution should go to the beneficiary account.
@@ -2062,13 +2333,14 @@ module aptos_framework::vesting {
 
     #[test(aptos_framework = @0x1, admin = @0x123)]
     public entry fun test_set_management_role(
-        aptos_framework: &signer,
-        admin: &signer,
+        aptos_framework: &signer, admin: &signer,
     ) acquires AdminStore, VestingAccountManagement, VestingContract {
         let admin_address = signer::address_of(admin);
         setup(aptos_framework, &vector[admin_address]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0);
+        let contract_address =
+            setup_vesting_contract(
+                admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0
+            );
         let role = utf8(b"RANDOM");
         set_management_role(admin, contract_address, role, @12);
         assert!(get_role_holder(contract_address, role) == @12, 0);
@@ -2078,18 +2350,21 @@ module aptos_framework::vesting {
 
     #[test(aptos_framework = @0x1, admin = @0x123)]
     public entry fun test_reset_beneficiary(
-        aptos_framework: &signer,
-        admin: &signer,
+        aptos_framework: &signer, admin: &signer,
     ) acquires AdminStore, VestingAccountManagement, VestingContract {
         let admin_address = signer::address_of(admin);
         setup(aptos_framework, &vector[admin_address, @11, @12]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0);
+        let contract_address =
+            setup_vesting_contract(
+                admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0
+            );
         set_beneficiary(admin, contract_address, @11, @12);
         assert!(beneficiary(contract_address, @11) == @12, 0);
 
         // Fast forward to the end of the first period. vest() should now unlock 3/48 of the tokens.
-        timestamp::update_global_time_for_test_secs(vesting_start_secs(contract_address) + VESTING_PERIOD);
+        timestamp::update_global_time_for_test_secs(
+            vesting_start_secs(contract_address) + VESTING_PERIOD
+        );
         vest(contract_address);
 
         // Reset the beneficiary.
@@ -2112,15 +2387,22 @@ module aptos_framework::vesting {
     ) acquires AdminStore, VestingAccountManagement, VestingContract {
         let admin_address = signer::address_of(admin);
         setup(aptos_framework, &vector[admin_address, @11, @12]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0);
+        let contract_address =
+            setup_vesting_contract(
+                admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0
+            );
         set_beneficiary(admin, contract_address, @11, @12);
         assert!(beneficiary(contract_address, @11) == @12, 0);
 
         // Reset the beneficiary with the resetter role.
         let resetter_address = signer::address_of(resetter);
         set_beneficiary_resetter(admin, contract_address, resetter_address);
-        assert!(simple_map::length(&borrow_global<VestingAccountManagement>(contract_address).roles) == 1, 0);
+        assert!(
+            simple_map::length(
+                &borrow_global<VestingAccountManagement>(contract_address).roles
+            ) == 1,
+            0,
+        );
         reset_beneficiary(resetter, contract_address, @11);
         assert!(beneficiary(contract_address, @11) == @11, 0);
     }
@@ -2135,8 +2417,10 @@ module aptos_framework::vesting {
     ) acquires AdminStore, VestingAccountManagement, VestingContract {
         let admin_address = signer::address_of(admin);
         setup(aptos_framework, &vector[admin_address, @11]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0);
+        let contract_address =
+            setup_vesting_contract(
+                admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0
+            );
 
         // Reset the beneficiary with a random account. This should failed.
         set_beneficiary_resetter(admin, contract_address, signer::address_of(resetter));
@@ -2145,13 +2429,14 @@ module aptos_framework::vesting {
 
     #[test(aptos_framework = @0x1, admin = @0x123, resetter = @0x234, random = @0x345)]
     public entry fun test_shareholder(
-        aptos_framework: &signer,
-        admin: &signer,
+        aptos_framework: &signer, admin: &signer,
     ) acquires AdminStore, VestingContract {
         let admin_address = signer::address_of(admin);
         setup(aptos_framework, &vector[admin_address, @11, @12]);
-        let contract_address = setup_vesting_contract(
-            admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0);
+        let contract_address =
+            setup_vesting_contract(
+                admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0
+            );
 
         // Confirm that the lookup returns the same address when a shareholder is
         // passed for which there is no beneficiary.
@@ -2172,12 +2457,15 @@ module aptos_framework::vesting {
     #[test_only]
     fun get_accumulated_rewards(contract_address: address): u64 acquires VestingContract {
         let vesting_contract = borrow_global<VestingContract>(contract_address);
-        let (active_stake, _, _, _) = stake::get_stake(vesting_contract.staking.pool_address);
+        let (active_stake, _, _, _) =
+            stake::get_stake(vesting_contract.staking.pool_address);
         active_stake - vesting_contract.remaining_grant
     }
 
     #[test_only]
     fun fraction(total: u64, numerator: u64, denominator: u64): u64 {
-        fixed_point32::multiply_u64(total, fixed_point32::create_from_rational(numerator, denominator))
+        fixed_point32::multiply_u64(
+            total, fixed_point32::create_from_rational(numerator, denominator)
+        )
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/vesting.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.move
@@ -506,7 +506,7 @@ module aptos_framework::vesting {
             shareholders,
             |shareholder| {
                 if (shareholder_or_beneficiary
-                        == get_beneficiary(vesting_contract, *shareholder)) {
+                    == get_beneficiary(vesting_contract, *shareholder)) {
                     result = *shareholder;
                     true
                 } else { false }
@@ -523,9 +523,8 @@ module aptos_framework::vesting {
         period_duration: u64,
     ): VestingSchedule {
         assert!(
-            vector::length(&schedule) > 0, error::invalid_argument(
-                EEMPTY_VESTING_SCHEDULE
-            )
+            vector::length(&schedule) > 0,
+            error::invalid_argument(EEMPTY_VESTING_SCHEDULE),
         );
         assert!(
             period_duration > 0, error::invalid_argument(EZERO_VESTING_SCHEDULE_PERIOD)
@@ -722,7 +721,7 @@ module aptos_framework::vesting {
         let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
         // Short-circuit if vesting hasn't started yet.
         if (vesting_contract.vesting_schedule.start_timestamp_secs
-                > timestamp::now_seconds()) { return };
+            > timestamp::now_seconds()) { return };
 
         // Check if the next vested period has already passed. If not, short-circuit since there's nothing to vest.
         let vesting_schedule = &mut vesting_contract.vesting_schedule;
@@ -949,7 +948,10 @@ module aptos_framework::vesting {
         let contract_signer = &get_vesting_account_signer_internal(vesting_contract);
         let old_operator = vesting_contract.staking.operator;
         staking_contract::switch_operator(
-            contract_signer, old_operator, new_operator, commission_percentage
+            contract_signer,
+            old_operator,
+            new_operator,
+            commission_percentage,
         );
         vesting_contract.staking.operator = new_operator;
         vesting_contract.staking.commission_percentage = commission_percentage;
@@ -1173,7 +1175,10 @@ module aptos_framework::vesting {
         beneficiary_resetter: address,
     ) acquires VestingAccountManagement, VestingContract {
         set_management_role(
-            admin, contract_address, utf8(ROLE_BENEFICIARY_RESETTER), beneficiary_resetter
+            admin,
+            contract_address,
+            utf8(ROLE_BENEFICIARY_RESETTER),
+            beneficiary_resetter,
         );
     }
 
@@ -1341,7 +1346,9 @@ module aptos_framework::vesting {
         );
 
         std::features::change_feature_flags_for_testing(
-            aptos_framework, vector[MODULE_EVENT, OPERATOR_BENEFICIARY_CHANGE], vector[]
+            aptos_framework,
+            vector[MODULE_EVENT, OPERATOR_BENEFICIARY_CHANGE],
+            vector[],
         );
     }
 
@@ -1414,7 +1421,15 @@ module aptos_framework::vesting {
         )
     }
 
-    #[test(aptos_framework = @0x1, admin = @0x123, shareholder_1 = @0x234, shareholder_2 = @0x345, withdrawal = @111)]
+    #[
+        test(
+            aptos_framework = @0x1,
+            admin = @0x123,
+            shareholder_1 = @0x234,
+            shareholder_2 = @0x345,
+            withdrawal = @111
+        )
+    ]
     public entry fun test_end_to_end(
         aptos_framework: &signer,
         admin: &signer,
@@ -1438,7 +1453,8 @@ module aptos_framework::vesting {
                 admin_address,
                 withdrawal_address,
                 shareholder_1_address,
-                shareholder_2_address],
+                shareholder_2_address
+            ],
         );
         let contract_address =
             setup_vesting_contract(admin, shareholders, shares, withdrawal_address, 0);
@@ -1517,7 +1533,11 @@ module aptos_framework::vesting {
             remaining_grant(contract_address),
         );
         stake::assert_stake_pool(
-            stake_pool_address, remaining_grant, 0, 0, pending_distribution
+            stake_pool_address,
+            remaining_grant,
+            0,
+            0,
+            pending_distribution,
         );
 
         // Fast forward to the end of the fourth period. We can call vest() 3 times to vest the last 3 periods.
@@ -1527,21 +1547,33 @@ module aptos_framework::vesting {
         remaining_grant = remaining_grant - vested_amount;
         pending_distribution = pending_distribution + vested_amount;
         stake::assert_stake_pool(
-            stake_pool_address, remaining_grant, 0, 0, pending_distribution
+            stake_pool_address,
+            remaining_grant,
+            0,
+            0,
+            pending_distribution,
         );
         vest(contract_address);
         vested_amount = fraction(GRANT_AMOUNT, 1, 48);
         remaining_grant = remaining_grant - vested_amount;
         pending_distribution = pending_distribution + vested_amount;
         stake::assert_stake_pool(
-            stake_pool_address, remaining_grant, 0, 0, pending_distribution
+            stake_pool_address,
+            remaining_grant,
+            0,
+            0,
+            pending_distribution,
         );
         // The last vesting fraction (1/48) is repeated beyond the first 3 periods.
         vest(contract_address);
         remaining_grant = remaining_grant - vested_amount;
         pending_distribution = pending_distribution + vested_amount;
         stake::assert_stake_pool(
-            stake_pool_address, remaining_grant, 0, 0, pending_distribution
+            stake_pool_address,
+            remaining_grant,
+            0,
+            0,
+            pending_distribution,
         );
         assert!(remaining_grant(contract_address) == remaining_grant, 0);
 
@@ -1756,7 +1788,8 @@ module aptos_framework::vesting {
         let operator_address = signer::address_of(operator);
         let shareholder_address = signer::address_of(shareholder);
         setup(
-            aptos_framework, &vector[admin_address, shareholder_address, operator_address]
+            aptos_framework,
+            &vector[admin_address, shareholder_address, operator_address],
         );
         let contract_address =
             setup_vesting_contract(
@@ -1784,7 +1817,11 @@ module aptos_framework::vesting {
         let staker_rewards = accumulated_rewards - commission;
         unlock_rewards(contract_address);
         stake::assert_stake_pool(
-            stake_pool_address, GRANT_AMOUNT, 0, 0, accumulated_rewards
+            stake_pool_address,
+            GRANT_AMOUNT,
+            0,
+            0,
+            accumulated_rewards,
         );
         assert!(remaining_grant(contract_address) == GRANT_AMOUNT, 0);
 
@@ -1819,7 +1856,8 @@ module aptos_framework::vesting {
         let operator_address = signer::address_of(operator);
         let shareholder_address = signer::address_of(shareholder);
         setup(
-            aptos_framework, &vector[admin_address, shareholder_address, operator_address]
+            aptos_framework,
+            &vector[admin_address, shareholder_address, operator_address],
         );
         let contract_address =
             setup_vesting_contract(
@@ -1852,7 +1890,11 @@ module aptos_framework::vesting {
         // Unlock vesting rewards. This should still pay out the accumulated rewards to shareholders.
         unlock_rewards(contract_address);
         stake::assert_stake_pool(
-            stake_pool_address, GRANT_AMOUNT, 0, 0, accumulated_rewards
+            stake_pool_address,
+            GRANT_AMOUNT,
+            0,
+            0,
+            accumulated_rewards,
         );
         assert!(remaining_grant(contract_address) == GRANT_AMOUNT, 0);
 
@@ -1887,7 +1929,11 @@ module aptos_framework::vesting {
         setup(aptos_framework, &vector[admin_address, @11, operator_address]);
         let contract_address =
             setup_vesting_contract(
-                admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 10
+                admin,
+                &vector[@11],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                10,
             );
 
         update_operator_with_same_commission(admin, contract_address, operator_address);
@@ -1905,7 +1951,8 @@ module aptos_framework::vesting {
         let operator_address = signer::address_of(operator);
         let shareholder_address = signer::address_of(shareholder);
         setup(
-            aptos_framework, &vector[admin_address, shareholder_address, operator_address]
+            aptos_framework,
+            &vector[admin_address, shareholder_address, operator_address],
         );
         let contract_address =
             setup_vesting_contract(
@@ -1967,7 +2014,16 @@ module aptos_framework::vesting {
         assert!(coin::balance<AptosCoin>(operator_address) == expected_commission, 1);
     }
 
-    #[test(aptos_framework = @0x1, admin = @0x123, shareholder = @0x234, operator1 = @0x345, beneficiary = @0x456, operator2 = @0x567)]
+    #[
+        test(
+            aptos_framework = @0x1,
+            admin = @0x123,
+            shareholder = @0x234,
+            operator1 = @0x345,
+            beneficiary = @0x456,
+            operator2 = @0x567
+        )
+    ]
     public entry fun test_set_beneficiary_for_operator(
         aptos_framework: &signer,
         admin: &signer,
@@ -1987,7 +2043,8 @@ module aptos_framework::vesting {
                 admin_address,
                 shareholder_address,
                 operator_address1,
-                beneficiary_address],
+                beneficiary_address
+            ],
         );
         let contract_address =
             setup_vesting_contract(
@@ -2311,7 +2368,11 @@ module aptos_framework::vesting {
         setup(aptos_framework, &vector[admin_address, @11]);
         let contract_address =
             setup_vesting_contract(
-                admin, &vector[@1], &vector[GRANT_AMOUNT], admin_address, 0
+                admin,
+                &vector[@1],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
             );
         set_beneficiary(admin, contract_address, @1, @11);
         assert!(beneficiary(contract_address, @1) == @11, 0);
@@ -2339,7 +2400,11 @@ module aptos_framework::vesting {
         setup(aptos_framework, &vector[admin_address]);
         let contract_address =
             setup_vesting_contract(
-                admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0
+                admin,
+                &vector[@11],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
             );
         let role = utf8(b"RANDOM");
         set_management_role(admin, contract_address, role, @12);
@@ -2356,7 +2421,11 @@ module aptos_framework::vesting {
         setup(aptos_framework, &vector[admin_address, @11, @12]);
         let contract_address =
             setup_vesting_contract(
-                admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0
+                admin,
+                &vector[@11],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
             );
         set_beneficiary(admin, contract_address, @11, @12);
         assert!(beneficiary(contract_address, @11) == @12, 0);
@@ -2389,7 +2458,11 @@ module aptos_framework::vesting {
         setup(aptos_framework, &vector[admin_address, @11, @12]);
         let contract_address =
             setup_vesting_contract(
-                admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0
+                admin,
+                &vector[@11],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
             );
         set_beneficiary(admin, contract_address, @11, @12);
         assert!(beneficiary(contract_address, @11) == @12, 0);
@@ -2419,7 +2492,11 @@ module aptos_framework::vesting {
         setup(aptos_framework, &vector[admin_address, @11]);
         let contract_address =
             setup_vesting_contract(
-                admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0
+                admin,
+                &vector[@11],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
             );
 
         // Reset the beneficiary with a random account. This should failed.
@@ -2435,7 +2512,11 @@ module aptos_framework::vesting {
         setup(aptos_framework, &vector[admin_address, @11, @12]);
         let contract_address =
             setup_vesting_contract(
-                admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0
+                admin,
+                &vector[@11],
+                &vector[GRANT_AMOUNT],
+                admin_address,
+                0,
             );
 
         // Confirm that the lookup returns the same address when a shareholder is

--- a/aptos-move/framework/aptos-framework/sources/vesting.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.spec.move
@@ -108,8 +108,8 @@ spec aptos_framework::vesting {
         pragma aborts_if_is_strict;
         // property 2: The vesting pool should not exceed a maximum of 30 shareholders.
         /// [high-level-spec-2]
-        invariant forall a: address where exists<VestingContract>(a): global<
-            VestingContract>(a).grant_pool.shareholders_limit <= MAXIMUM_SHAREHOLDERS;
+        invariant forall a: address where exists<VestingContract>(a):
+            global<VestingContract>(a).grant_pool.shareholders_limit <= MAXIMUM_SHAREHOLDERS;
     }
 
     spec stake_pool_address(vesting_contract_address: address): address {
@@ -338,14 +338,15 @@ spec aptos_framework::vesting {
     spec schema PreconditionAbortsIf {
         contract_addresses: vector<address>;
 
-        requires forall i in 0..len(contract_addresses): simple_map::spec_get(
-            global<staking_contract::Store>(contract_addresses[i]).staking_contracts,
-            global<VestingContract>(contract_addresses[i]).staking.operator,
-        ).commission_percentage >= 0
-            && simple_map::spec_get(
+        requires forall i in 0..len(contract_addresses):
+            simple_map::spec_get(
                 global<staking_contract::Store>(contract_addresses[i]).staking_contracts,
                 global<VestingContract>(contract_addresses[i]).staking.operator,
-            ).commission_percentage <= 100;
+            ).commission_percentage >= 0
+                && simple_map::spec_get(
+                    global<staking_contract::Store>(contract_addresses[i]).staking_contracts,
+                    global<VestingContract>(contract_addresses[i]).staking.operator,
+                ).commission_percentage <= 100;
     }
 
     spec distribute(contract_address: address) {
@@ -661,8 +662,8 @@ spec aptos_framework::vesting {
         aborts_if !exists<stake::ValidatorSet>(@aptos_framework);
         let validator_set = global<stake::ValidatorSet>(@aptos_framework);
         let inactive_state = !stake::spec_contains(
-                validator_set.pending_active, pool_address_1
-            )
+            validator_set.pending_active, pool_address_1
+        )
             && !stake::spec_contains(validator_set.active_validators, pool_address_1)
             && !stake::spec_contains(validator_set.pending_inactive, pool_address_1);
         let inactive_1 = stake_pool_1.inactive.value;

--- a/aptos-move/framework/aptos-framework/sources/vesting.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.spec.move
@@ -108,8 +108,8 @@ spec aptos_framework::vesting {
         pragma aborts_if_is_strict;
         // property 2: The vesting pool should not exceed a maximum of 30 shareholders.
         /// [high-level-spec-2]
-        invariant forall a: address where exists<VestingContract>(a):
-            global<VestingContract>(a).grant_pool.shareholders_limit <= MAXIMUM_SHAREHOLDERS;
+        invariant forall a: address where exists<VestingContract>(a): global<
+            VestingContract>(a).grant_pool.shareholders_limit <= MAXIMUM_SHAREHOLDERS;
     }
 
     spec stake_pool_address(vesting_contract_address: address): address {
@@ -166,9 +166,12 @@ spec aptos_framework::vesting {
         // Note: commission percentage should not be under 0 or higher than 100, cause it's a percentage number
         // This requirement will solve the timeout issue of total_accumulated_rewards
         // However, accumulated_rewards is still timeout
-        requires staking_contract.commission_percentage >= 0 && staking_contract.commission_percentage <= 100;
+        requires staking_contract.commission_percentage >= 0
+            && staking_contract.commission_percentage <= 100;
 
-        include ActiveVestingContractAbortsIf<VestingContract>{contract_address: vesting_contract_address};
+        include ActiveVestingContractAbortsIf<VestingContract> {
+            contract_address: vesting_contract_address
+        };
         let vesting_contract = global<VestingContract>(vesting_contract_address);
 
         let staker = vesting_contract_address;
@@ -185,17 +188,21 @@ spec aptos_framework::vesting {
         let pending_active = coin::value(stake_pool.pending_active);
         let total_active_stake = active + pending_active;
         let accumulated_rewards = total_active_stake - staking_contract.principal;
-        let commission_amount = accumulated_rewards * staking_contract.commission_percentage / 100;
+        let commission_amount = accumulated_rewards
+            * staking_contract.commission_percentage / 100;
         aborts_if !exists<stake::StakePool>(pool_address);
         aborts_if active + pending_active > MAX_U64;
         aborts_if total_active_stake < staking_contract.principal;
         aborts_if accumulated_rewards * staking_contract.commission_percentage > MAX_U64;
         // This two item both contribute to the timeout
-        aborts_if (vesting_contract.remaining_grant + commission_amount) > total_active_stake;
+        aborts_if (vesting_contract.remaining_grant + commission_amount)
+            > total_active_stake;
         aborts_if total_active_stake < vesting_contract.remaining_grant;
     }
 
-    spec accumulated_rewards(vesting_contract_address: address, shareholder_or_beneficiary: address): u64 {
+    spec accumulated_rewards(
+        vesting_contract_address: address, shareholder_or_beneficiary: address
+    ): u64 {
         // TODO: A severe timeout can not be resolved.
         pragma verify = false;
 
@@ -212,34 +219,47 @@ spec aptos_framework::vesting {
         let pending_active = coin::value(stake_pool.pending_active);
         let total_active_stake = active + pending_active;
         let accumulated_rewards = total_active_stake - staking_contract.principal;
-        let commission_amount = accumulated_rewards * staking_contract.commission_percentage / 100;
-        let total_accumulated_rewards = total_active_stake - vesting_contract.remaining_grant - commission_amount;
+        let commission_amount = accumulated_rewards
+            * staking_contract.commission_percentage / 100;
+        let total_accumulated_rewards = total_active_stake
+            - vesting_contract.remaining_grant - commission_amount;
 
-        let shareholder = spec_shareholder(vesting_contract_address, shareholder_or_beneficiary);
+        let shareholder = spec_shareholder(
+            vesting_contract_address, shareholder_or_beneficiary
+        );
         let pool = vesting_contract.grant_pool;
         let shares = pool_u64::spec_shares(pool, shareholder);
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0
+        aborts_if pool.total_coins > 0
+            && pool.total_shares > 0
             && (shares * total_accumulated_rewards) / pool.total_shares > MAX_U64;
 
-        ensures result == pool_u64::spec_shares_to_amount_with_total_coins(pool, shares, total_accumulated_rewards);
+        ensures result
+            == pool_u64::spec_shares_to_amount_with_total_coins(
+                pool, shares, total_accumulated_rewards
+            );
     }
 
     spec shareholders(vesting_contract_address: address): vector<address> {
-        include ActiveVestingContractAbortsIf<VestingContract>{contract_address: vesting_contract_address};
+        include ActiveVestingContractAbortsIf<VestingContract> {
+            contract_address: vesting_contract_address
+        };
     }
 
-    spec fun spec_shareholder(vesting_contract_address: address, shareholder_or_beneficiary: address): address;
+    spec fun spec_shareholder(
+        vesting_contract_address: address, shareholder_or_beneficiary: address
+    ): address;
 
     spec shareholder(vesting_contract_address: address, shareholder_or_beneficiary: address): address {
         pragma opaque;
-        include ActiveVestingContractAbortsIf<VestingContract>{contract_address: vesting_contract_address};
-        ensures [abstract] result == spec_shareholder(vesting_contract_address, shareholder_or_beneficiary);
+        include ActiveVestingContractAbortsIf<VestingContract> {
+            contract_address: vesting_contract_address
+        };
+        ensures [abstract] result
+            == spec_shareholder(vesting_contract_address, shareholder_or_beneficiary);
     }
 
     spec create_vesting_schedule(
-        schedule: vector<FixedPoint32>,
-        start_timestamp_secs: u64,
-        period_duration: u64,
+        schedule: vector<FixedPoint32>, start_timestamp_secs: u64, period_duration: u64,
     ): VestingSchedule {
         /// [high-level-req-6]
         aborts_if !(len(schedule) > 0);
@@ -252,7 +272,8 @@ spec aptos_framework::vesting {
         // TODO: Data invariant does not hold.
         pragma verify = false;
         /// [high-level-req-10]
-        aborts_if withdrawal_address == @aptos_framework || withdrawal_address == @vm_reserved;
+        aborts_if withdrawal_address == @aptos_framework
+            || withdrawal_address == @vm_reserved;
         aborts_if !exists<account::Account>(withdrawal_address);
         aborts_if !exists<coin::CoinStore<AptosCoin>>(withdrawal_address);
         aborts_if len(shareholders) == 0;
@@ -272,7 +293,9 @@ spec aptos_framework::vesting {
         contract_address: address;
 
         // Cause timeout here
-        include TotalAccumulatedRewardsAbortsIf { vesting_contract_address: contract_address };
+        include TotalAccumulatedRewardsAbortsIf {
+            vesting_contract_address: contract_address
+        };
 
         let vesting_contract = global<VestingContract>(contract_address);
         let operator = vesting_contract.staking.operator;
@@ -284,8 +307,10 @@ spec aptos_framework::vesting {
         let pending_active = coin::value(stake_pool.pending_active);
         let total_active_stake = active + pending_active;
         let accumulated_rewards = total_active_stake - staking_contract.principal;
-        let commission_amount = accumulated_rewards * staking_contract.commission_percentage / 100;
-        let amount = total_active_stake - vesting_contract.remaining_grant - commission_amount;
+        let commission_amount = accumulated_rewards
+            * staking_contract.commission_percentage / 100;
+        let amount = total_active_stake - vesting_contract.remaining_grant
+            - commission_amount;
 
         include UnlockStakeAbortsIf { vesting_contract, amount };
     }
@@ -313,8 +338,14 @@ spec aptos_framework::vesting {
     spec schema PreconditionAbortsIf {
         contract_addresses: vector<address>;
 
-        requires forall i in 0..len(contract_addresses): simple_map::spec_get(global<staking_contract::Store>(contract_addresses[i]).staking_contracts, global<VestingContract>(contract_addresses[i]).staking.operator).commission_percentage >= 0
-            && simple_map::spec_get(global<staking_contract::Store>(contract_addresses[i]).staking_contracts, global<VestingContract>(contract_addresses[i]).staking.operator).commission_percentage <= 100;
+        requires forall i in 0..len(contract_addresses): simple_map::spec_get(
+            global<staking_contract::Store>(contract_addresses[i]).staking_contracts,
+            global<VestingContract>(contract_addresses[i]).staking.operator,
+        ).commission_percentage >= 0
+            && simple_map::spec_get(
+                global<staking_contract::Store>(contract_addresses[i]).staking_contracts,
+                global<VestingContract>(contract_addresses[i]).staking.operator,
+            ).commission_percentage <= 100;
     }
 
     spec distribute(contract_address: address) {
@@ -366,36 +397,36 @@ spec aptos_framework::vesting {
         let vesting_contract = global<VestingContract>(contract_address);
         let acc = vesting_contract.signer_cap.account;
         let old_operator = vesting_contract.staking.operator;
-        include staking_contract::ContractExistsAbortsIf { staker: acc, operator: old_operator };
+        include staking_contract::ContractExistsAbortsIf {
+            staker: acc,
+            operator: old_operator
+        };
         let store = global<staking_contract::Store>(acc);
         let staking_contracts = store.staking_contracts;
         aborts_if simple_map::spec_contains_key(staking_contracts, new_operator);
 
         let staking_contract = simple_map::spec_get(staking_contracts, old_operator);
-        include DistributeInternalAbortsIf { staker: acc, operator: old_operator, staking_contract, distribute_events: store.distribute_events };
+        include DistributeInternalAbortsIf {
+            staker: acc,
+            operator: old_operator,
+            staking_contract,
+            distribute_events: store.distribute_events
+        };
     }
 
     spec update_operator_with_same_commission(
-        admin: &signer,
-        contract_address: address,
-        new_operator: address,
+        admin: &signer, contract_address: address, new_operator: address,
     ) {
         pragma verify = false;
     }
 
     spec update_commission_percentage(
-        admin: &signer,
-        contract_address: address,
-        new_commission_percentage: u64,
+        admin: &signer, contract_address: address, new_commission_percentage: u64,
     ) {
         pragma verify = false;
     }
 
-    spec update_voter(
-        admin: &signer,
-        contract_address: address,
-        new_voter: address,
-    ) {
+    spec update_voter(admin: &signer, contract_address: address, new_voter: address,) {
         // TODO: set because of timeout (property proved)
         pragma verify_duration_estimate = 300;
         include VerifyAdminAbortsIf;
@@ -407,10 +438,7 @@ spec aptos_framework::vesting {
         include staking_contract::UpdateVoterSchema;
     }
 
-    spec reset_lockup(
-        admin: &signer,
-        contract_address: address,
-    ) {
+    spec reset_lockup(admin: &signer, contract_address: address,) {
         // TODO: set because of timeout (property proved)
         pragma verify_duration_estimate = 300;
         aborts_if !exists<VestingContract>(contract_address);
@@ -420,8 +448,8 @@ spec aptos_framework::vesting {
         let operator = vesting_contract.staking.operator;
         let staker = vesting_contract.signer_cap.account;
 
-        include staking_contract::ContractExistsAbortsIf {staker, operator};
-        include staking_contract::IncreaseLockupWithCapAbortsIf {staker, operator};
+        include staking_contract::ContractExistsAbortsIf { staker, operator };
+        include staking_contract::IncreaseLockupWithCapAbortsIf { staker, operator };
 
         let store = global<staking_contract::Store>(staker);
         let staking_contract = simple_map::spec_get(store.staking_contracts, operator);
@@ -442,53 +470,47 @@ spec aptos_framework::vesting {
         aborts_if !coin::spec_is_account_registered<AptosCoin>(new_beneficiary);
         include VerifyAdminAbortsIf;
         let post vesting_contract = global<VestingContract>(contract_address);
-        ensures simple_map::spec_contains_key(vesting_contract.beneficiaries,shareholder);
+        ensures simple_map::spec_contains_key(vesting_contract.beneficiaries, shareholder);
     }
 
-    spec reset_beneficiary(
-        account: &signer,
-        contract_address: address,
-        shareholder: address,
-    ) {
+    spec reset_beneficiary(account: &signer, contract_address: address, shareholder: address,) {
         aborts_if !exists<VestingContract>(contract_address);
 
         let addr = signer::address_of(account);
         let vesting_contract = global<VestingContract>(contract_address);
-        aborts_if addr != vesting_contract.admin && !std::string::spec_internal_check_utf8(ROLE_BENEFICIARY_RESETTER);
-        aborts_if addr != vesting_contract.admin && !exists<VestingAccountManagement>(contract_address);
+        aborts_if addr != vesting_contract.admin
+            && !std::string::spec_internal_check_utf8(ROLE_BENEFICIARY_RESETTER);
+        aborts_if addr != vesting_contract.admin
+            && !exists<VestingAccountManagement>(contract_address);
         let roles = global<VestingAccountManagement>(contract_address).roles;
         let role = std::string::spec_utf8(ROLE_BENEFICIARY_RESETTER);
-        aborts_if addr != vesting_contract.admin && !simple_map::spec_contains_key(roles, role);
-        aborts_if addr != vesting_contract.admin && addr != simple_map::spec_get(roles, role);
+        aborts_if addr != vesting_contract.admin
+            && !simple_map::spec_contains_key(roles, role);
+        aborts_if addr != vesting_contract.admin
+            && addr != simple_map::spec_get(roles, role);
 
         let post post_vesting_contract = global<VestingContract>(contract_address);
-        ensures !simple_map::spec_contains_key(post_vesting_contract.beneficiaries,shareholder);
+        ensures !simple_map::spec_contains_key(
+            post_vesting_contract.beneficiaries, shareholder
+        );
     }
 
     spec set_management_role(
-        admin: &signer,
-        contract_address: address,
-        role: String,
-        role_holder: address,
+        admin: &signer, contract_address: address, role: String, role_holder: address,
     ) {
         pragma aborts_if_is_partial;
         include SetManagementRoleAbortsIf;
     }
 
     spec set_beneficiary_resetter(
-        admin: &signer,
-        contract_address: address,
-        beneficiary_resetter: address,
+        admin: &signer, contract_address: address, beneficiary_resetter: address,
     ) {
         pragma aborts_if_is_partial;
         aborts_if !std::string::spec_internal_check_utf8(ROLE_BENEFICIARY_RESETTER);
         include SetManagementRoleAbortsIf;
     }
 
-    spec set_beneficiary_for_operator(
-        operator: &signer,
-        new_beneficiary: address,
-    ) {
+    spec set_beneficiary_for_operator(operator: &signer, new_beneficiary: address,) {
         // TODO: temporary mockup
         pragma verify = false;
     }
@@ -496,7 +518,7 @@ spec aptos_framework::vesting {
     spec get_role_holder(contract_address: address, role: String): address {
         aborts_if !exists<VestingAccountManagement>(contract_address);
         let roles = global<VestingAccountManagement>(contract_address).roles;
-        aborts_if !simple_map::spec_contains_key(roles,role);
+        aborts_if !simple_map::spec_contains_key(roles, role);
     }
 
     spec get_vesting_account_signer(admin: &signer, contract_address: address): signer {
@@ -509,10 +531,9 @@ spec aptos_framework::vesting {
 
     spec fun spec_get_vesting_account_signer(vesting_contract: VestingContract): signer;
 
-    spec create_vesting_contract_account(
-        admin: &signer,
-        contract_creation_seed: vector<u8>,
-    ): (signer, SignerCapability) {
+    spec create_vesting_contract_account(admin: &signer, contract_creation_seed: vector<u8>,): (
+        signer, SignerCapability
+    ) {
         pragma verify_duration_estimate = 300;
         let admin_addr = signer::address_of(admin);
         let admin_store = global<AdminStore>(admin_addr);
@@ -529,15 +550,22 @@ spec aptos_framework::vesting {
         aborts_if len(account::ZERO_AUTH_KEY) != 32;
         aborts_if admin_store.nonce + 1 > MAX_U64;
         let ea = account::exists_at(resource_addr);
-        include if (ea) account::CreateResourceAccountAbortsIf else account::CreateAccountAbortsIf {addr: resource_addr};
+        include if (ea) account::CreateResourceAccountAbortsIf else
+            account::CreateAccountAbortsIf { addr: resource_addr };
 
         let acc = global<account::Account>(resource_addr);
         let post post_acc = global<account::Account>(resource_addr);
-        aborts_if !exists<coin::CoinStore<AptosCoin>>(resource_addr) && !aptos_std::type_info::spec_is_struct<AptosCoin>();
-        aborts_if !exists<coin::CoinStore<AptosCoin>>(resource_addr) && ea && acc.guid_creation_num + 2 > MAX_U64;
-        aborts_if !exists<coin::CoinStore<AptosCoin>>(resource_addr) && ea && acc.guid_creation_num + 2 >= account::MAX_GUID_CREATION_NUM;
-        ensures exists<account::Account>(resource_addr) && post_acc.authentication_key == account::ZERO_AUTH_KEY &&
-                exists<coin::CoinStore<AptosCoin>>(resource_addr);
+        aborts_if !exists<coin::CoinStore<AptosCoin>>(resource_addr)
+            && !aptos_std::type_info::spec_is_struct<AptosCoin>();
+        aborts_if !exists<coin::CoinStore<AptosCoin>>(resource_addr)
+            && ea
+            && acc.guid_creation_num + 2 > MAX_U64;
+        aborts_if !exists<coin::CoinStore<AptosCoin>>(resource_addr)
+            && ea
+            && acc.guid_creation_num + 2 >= account::MAX_GUID_CREATION_NUM;
+        ensures exists<account::Account>(resource_addr)
+            && post_acc.authentication_key == account::ZERO_AUTH_KEY
+            && exists<coin::CoinStore<AptosCoin>>(resource_addr);
         ensures signer::address_of(result_1) == resource_addr;
         ensures result_2.account == resource_addr;
     }
@@ -569,15 +597,23 @@ spec aptos_framework::vesting {
         // verify staking_contract::unlock_stake()
         let acc = vesting_contract.signer_cap.account;
         let operator = vesting_contract.staking.operator;
-        include amount != 0 ==> staking_contract::ContractExistsAbortsIf { staker: acc, operator };
+        include amount != 0 ==>
+            staking_contract::ContractExistsAbortsIf { staker: acc, operator };
 
         // verify staking_contract::distribute_internal()
         let store = global<staking_contract::Store>(acc);
         let staking_contract = simple_map::spec_get(store.staking_contracts, operator);
-        include amount != 0 ==> DistributeInternalAbortsIf { staker: acc, operator, staking_contract, distribute_events: store.distribute_events };
+        include amount != 0 ==>
+            DistributeInternalAbortsIf {
+                staker: acc,
+                operator,
+                staking_contract,
+                distribute_events: store.distribute_events
+            };
     }
 
-    spec withdraw_stake(vesting_contract: &VestingContract, contract_address: address): Coin<AptosCoin> {
+    spec withdraw_stake(vesting_contract: &VestingContract, contract_address: address): Coin<
+        AptosCoin> {
         // TODO: Calls `staking_contract::distribute` which is not verified.
         pragma verify = false;
         include WithdrawStakeAbortsIf;
@@ -588,16 +624,24 @@ spec aptos_framework::vesting {
         contract_address: address;
 
         let operator = vesting_contract.staking.operator;
-        include staking_contract::ContractExistsAbortsIf { staker: contract_address, operator };
+        include staking_contract::ContractExistsAbortsIf {
+            staker: contract_address,
+            operator
+        };
 
         // verify staking_contract::distribute_internal()
         let store = global<staking_contract::Store>(contract_address);
         let staking_contract = simple_map::spec_get(store.staking_contracts, operator);
-        include DistributeInternalAbortsIf { staker: contract_address, operator, staking_contract, distribute_events: store.distribute_events };
+        include DistributeInternalAbortsIf {
+            staker: contract_address,
+            operator,
+            staking_contract,
+            distribute_events: store.distribute_events
+        };
     }
 
     spec schema DistributeInternalAbortsIf {
-        staker: address;    // The verification below does not contain the loop in staking_contract::update_distribution_pool().
+        staker: address; // The verification below does not contain the loop in staking_contract::update_distribution_pool().
         operator: address;
         staking_contract: staking_contract::StakingContract;
         distribute_events: EventHandle<staking_contract::DistributeEvent>;
@@ -616,13 +660,16 @@ spec aptos_framework::vesting {
         let stake_pool_1 = global<stake::StakePool>(pool_address_1);
         aborts_if !exists<stake::ValidatorSet>(@aptos_framework);
         let validator_set = global<stake::ValidatorSet>(@aptos_framework);
-        let inactive_state = !stake::spec_contains(validator_set.pending_active, pool_address_1)
+        let inactive_state = !stake::spec_contains(
+                validator_set.pending_active, pool_address_1
+            )
             && !stake::spec_contains(validator_set.active_validators, pool_address_1)
             && !stake::spec_contains(validator_set.pending_inactive, pool_address_1);
         let inactive_1 = stake_pool_1.inactive.value;
         let pending_inactive_1 = stake_pool_1.pending_inactive.value;
         let new_inactive_1 = inactive_1 + pending_inactive_1;
-        aborts_if inactive_state && timestamp::spec_now_seconds() >= stake_pool_1.locked_until_secs
+        aborts_if inactive_state
+            && timestamp::spec_now_seconds() >= stake_pool_1.locked_until_secs
             && inactive_1 + pending_inactive_1 > MAX_U64;
     }
 

--- a/aptos-move/framework/aptos-framework/sources/voting.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.move
@@ -190,15 +190,24 @@ module aptos_framework::voting {
 
     public fun register<ProposalType: store>(account: &signer) {
         let addr = signer::address_of(account);
-        assert!(!exists<VotingForum<ProposalType>>(addr), error::already_exists(EVOTING_FORUM_ALREADY_REGISTERED));
+        assert!(
+            !exists<VotingForum<ProposalType>>(addr),
+            error::already_exists(EVOTING_FORUM_ALREADY_REGISTERED),
+        );
 
         let voting_forum = VotingForum<ProposalType> {
             next_proposal_id: 0,
             proposals: table::new<u64, Proposal<ProposalType>>(),
             events: VotingEvents {
-                create_proposal_events: account::new_event_handle<CreateProposalEvent>(account),
-                register_forum_events: account::new_event_handle<RegisterForumEvent>(account),
-                resolve_proposal_events: account::new_event_handle<ResolveProposal>(account),
+                create_proposal_events: account::new_event_handle<CreateProposalEvent>(
+                    account
+                ),
+                register_forum_events: account::new_event_handle<RegisterForumEvent>(
+                    account
+                ),
+                resolve_proposal_events: account::new_event_handle<ResolveProposal>(
+                    account
+                ),
                 vote_events: account::new_event_handle<VoteEvent>(account),
             }
         };
@@ -253,7 +262,7 @@ module aptos_framework::voting {
             expiration_secs,
             early_resolution_vote_threshold,
             metadata,
-            false
+            false,
         )
     }
 
@@ -288,41 +297,58 @@ module aptos_framework::voting {
             );
         };
         // Make sure the execution script's hash is not empty.
-        assert!(vector::length(&execution_hash) > 0, error::invalid_argument(EPROPOSAL_EMPTY_EXECUTION_HASH));
+        assert!(
+            vector::length(&execution_hash) > 0,
+            error::invalid_argument(EPROPOSAL_EMPTY_EXECUTION_HASH),
+        );
 
-        let voting_forum = borrow_global_mut<VotingForum<ProposalType>>(voting_forum_address);
+        let voting_forum =
+            borrow_global_mut<VotingForum<ProposalType>>(voting_forum_address);
         let proposal_id = voting_forum.next_proposal_id;
         voting_forum.next_proposal_id = voting_forum.next_proposal_id + 1;
 
         // Add a flag to indicate if this proposal is single-step or multi-step.
-        simple_map::add(&mut metadata, utf8(IS_MULTI_STEP_PROPOSAL_KEY), to_bytes(&is_multi_step_proposal));
+        simple_map::add(
+            &mut metadata,
+            utf8(IS_MULTI_STEP_PROPOSAL_KEY),
+            to_bytes(&is_multi_step_proposal),
+        );
 
-        let is_multi_step_in_execution_key = utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
+        let is_multi_step_in_execution_key =
+            utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
         if (is_multi_step_proposal) {
             // If the given proposal is a multi-step proposal, we will add a flag to indicate if this multi-step proposal is in execution.
             // This value is by default false. We turn this value to true when we start executing the multi-step proposal. This value
             // will be used to disable further voting after we started executing the multi-step proposal.
-            simple_map::add(&mut metadata, is_multi_step_in_execution_key, to_bytes(&false));
+            simple_map::add(
+                &mut metadata, is_multi_step_in_execution_key, to_bytes(&false)
+            );
             // If the proposal is a single-step proposal, we check if the metadata passed by the client has the IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY key.
             // If they have the key, we will remove it, because a single-step proposal that doesn't need this key.
-        } else if (simple_map::contains_key(&mut metadata, &is_multi_step_in_execution_key)) {
+        } else if (simple_map::contains_key(
+                &mut metadata, &is_multi_step_in_execution_key
+            )) {
             simple_map::remove(&mut metadata, &is_multi_step_in_execution_key);
         };
 
-        table::add(&mut voting_forum.proposals, proposal_id, Proposal {
-            proposer,
-            creation_time_secs: timestamp::now_seconds(),
-            execution_content: option::some<ProposalType>(execution_content),
-            execution_hash,
-            metadata,
-            min_vote_threshold,
-            expiration_secs,
-            early_resolution_vote_threshold,
-            yes_votes: 0,
-            no_votes: 0,
-            is_resolved: false,
-            resolution_time_secs: 0,
-        });
+        table::add(
+            &mut voting_forum.proposals,
+            proposal_id,
+            Proposal {
+                proposer,
+                creation_time_secs: timestamp::now_seconds(),
+                execution_content: option::some<ProposalType>(execution_content),
+                execution_hash,
+                metadata,
+                min_vote_threshold,
+                expiration_secs,
+                early_resolution_vote_threshold,
+                yes_votes: 0,
+                no_votes: 0,
+                is_resolved: false,
+                resolution_time_secs: 0,
+            },
+        );
 
         if (std::features::module_event_migration_enabled()) {
             event::emit(
@@ -366,21 +392,28 @@ module aptos_framework::voting {
         num_votes: u64,
         should_pass: bool,
     ) acquires VotingForum {
-        let voting_forum = borrow_global_mut<VotingForum<ProposalType>>(voting_forum_address);
+        let voting_forum =
+            borrow_global_mut<VotingForum<ProposalType>>(voting_forum_address);
         let proposal = table::borrow_mut(&mut voting_forum.proposals, proposal_id);
         // Voting might still be possible after the proposal has enough yes votes to be resolved early. This would only
         // lead to possible proposal resolution failure if the resolve early threshold is not definitive (e.g. < 50% + 1
         // of the total voting token's supply). In this case, more voting might actually still be desirable.
         // Governance mechanisms built on this voting module can apply additional rules on when voting is closed as
         // appropriate.
-        assert!(!is_voting_period_over(proposal), error::invalid_state(EPROPOSAL_VOTING_ALREADY_ENDED));
+        assert!(
+            !is_voting_period_over(proposal),
+            error::invalid_state(EPROPOSAL_VOTING_ALREADY_ENDED),
+        );
         assert!(!proposal.is_resolved, error::invalid_state(EPROPOSAL_ALREADY_RESOLVED));
         // Assert this proposal is single-step, or if the proposal is multi-step, it is not in execution yet.
-        assert!(!simple_map::contains_key(&proposal.metadata, &utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY))
-            || *simple_map::borrow(&proposal.metadata, &utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY)) == to_bytes(
-            &false
-        ),
-            error::invalid_state(EMULTI_STEP_PROPOSAL_IN_EXECUTION));
+        assert!(
+            !simple_map::contains_key(
+                &proposal.metadata, &utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY)
+            ) || *simple_map::borrow(
+                &proposal.metadata, &utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY)
+            ) == to_bytes(&false),
+            error::invalid_state(EMULTI_STEP_PROPOSAL_IN_EXECUTION),
+        );
 
         if (should_pass) {
             proposal.yes_votes = proposal.yes_votes + (num_votes as u128);
@@ -408,20 +441,32 @@ module aptos_framework::voting {
 
     /// Common checks on if a proposal is resolvable, regardless if the proposal is single-step or multi-step.
     fun is_proposal_resolvable<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ) acquires VotingForum {
-        let proposal_state = get_proposal_state<ProposalType>(voting_forum_address, proposal_id);
-        assert!(proposal_state == PROPOSAL_STATE_SUCCEEDED, error::invalid_state(EPROPOSAL_CANNOT_BE_RESOLVED));
+        let proposal_state =
+            get_proposal_state<ProposalType>(voting_forum_address, proposal_id);
+        assert!(
+            proposal_state == PROPOSAL_STATE_SUCCEEDED,
+            error::invalid_state(EPROPOSAL_CANNOT_BE_RESOLVED),
+        );
 
-        let voting_forum = borrow_global_mut<VotingForum<ProposalType>>(voting_forum_address);
+        let voting_forum =
+            borrow_global_mut<VotingForum<ProposalType>>(voting_forum_address);
         let proposal = table::borrow_mut(&mut voting_forum.proposals, proposal_id);
         assert!(!proposal.is_resolved, error::invalid_state(EPROPOSAL_ALREADY_RESOLVED));
 
         // We need to make sure that the resolution is happening in
         // a separate transaction from the last vote to guard against any potential flashloan attacks.
-        let resolvable_time = to_u64(*simple_map::borrow(&proposal.metadata, &utf8(RESOLVABLE_TIME_METADATA_KEY)));
-        assert!(timestamp::now_seconds() > resolvable_time, error::invalid_state(ERESOLUTION_CANNOT_BE_ATOMIC));
+        let resolvable_time =
+            to_u64(
+                *simple_map::borrow(
+                    &proposal.metadata, &utf8(RESOLVABLE_TIME_METADATA_KEY)
+                ),
+            );
+        assert!(
+            timestamp::now_seconds() > resolvable_time,
+            error::invalid_state(ERESOLUTION_CANNOT_BE_ATOMIC),
+        );
 
         assert!(
             transaction_context::get_script_hash() == proposal.execution_hash,
@@ -435,22 +480,28 @@ module aptos_framework::voting {
     /// @param voting_forum_address The address of the forum where the proposals are stored.
     /// @param proposal_id The proposal id.
     public fun resolve<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): ProposalType acquires VotingForum {
         is_proposal_resolvable<ProposalType>(voting_forum_address, proposal_id);
 
-        let voting_forum = borrow_global_mut<VotingForum<ProposalType>>(voting_forum_address);
+        let voting_forum =
+            borrow_global_mut<VotingForum<ProposalType>>(voting_forum_address);
         let proposal = table::borrow_mut(&mut voting_forum.proposals, proposal_id);
 
         // Assert that the specified proposal is not a multi-step proposal.
         let multi_step_key = utf8(IS_MULTI_STEP_PROPOSAL_KEY);
-        let has_multi_step_key = simple_map::contains_key(&proposal.metadata, &multi_step_key);
+        let has_multi_step_key =
+            simple_map::contains_key(&proposal.metadata, &multi_step_key);
         if (has_multi_step_key) {
-            let is_multi_step_proposal = from_bcs::to_bool(*simple_map::borrow(&proposal.metadata, &multi_step_key));
+            let is_multi_step_proposal =
+                from_bcs::to_bool(
+                    *simple_map::borrow(&proposal.metadata, &multi_step_key)
+                );
             assert!(
                 !is_multi_step_proposal,
-                error::permission_denied(EMULTI_STEP_PROPOSAL_CANNOT_USE_SINGLE_STEP_RESOLVE_FUNCTION)
+                error::permission_denied(
+                    EMULTI_STEP_PROPOSAL_CANNOT_USE_SINGLE_STEP_RESOLVE_FUNCTION
+                ),
             );
         };
 
@@ -496,29 +547,33 @@ module aptos_framework::voting {
     ) acquires VotingForum {
         is_proposal_resolvable<ProposalType>(voting_forum_address, proposal_id);
 
-        let voting_forum = borrow_global_mut<VotingForum<ProposalType>>(voting_forum_address);
+        let voting_forum =
+            borrow_global_mut<VotingForum<ProposalType>>(voting_forum_address);
         let proposal = table::borrow_mut(&mut voting_forum.proposals, proposal_id);
 
         // Update the IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY key to indicate that the multi-step proposal is in execution.
         let multi_step_in_execution_key = utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
         if (simple_map::contains_key(&proposal.metadata, &multi_step_in_execution_key)) {
-            let is_multi_step_proposal_in_execution_value = simple_map::borrow_mut(
-                &mut proposal.metadata,
-                &multi_step_in_execution_key
-            );
+            let is_multi_step_proposal_in_execution_value =
+                simple_map::borrow_mut(
+                    &mut proposal.metadata,
+                    &multi_step_in_execution_key,
+                );
             *is_multi_step_proposal_in_execution_value = to_bytes(&true);
         };
 
         let multi_step_key = utf8(IS_MULTI_STEP_PROPOSAL_KEY);
-        let is_multi_step = simple_map::contains_key(&proposal.metadata, &multi_step_key) && from_bcs::to_bool(
-            *simple_map::borrow(&proposal.metadata, &multi_step_key)
-        );
+        let is_multi_step =
+            simple_map::contains_key(&proposal.metadata, &multi_step_key)
+                && from_bcs::to_bool(
+                    *simple_map::borrow(&proposal.metadata, &multi_step_key)
+                );
         let next_execution_hash_is_empty = vector::length(&next_execution_hash) == 0;
 
         // Assert that if this proposal is single-step, the `next_execution_hash` parameter is empty.
         assert!(
             is_multi_step || next_execution_hash_is_empty,
-            error::invalid_argument(ESINGLE_STEP_PROPOSAL_CANNOT_HAVE_NEXT_EXECUTION_HASH)
+            error::invalid_argument(ESINGLE_STEP_PROPOSAL_CANNOT_HAVE_NEXT_EXECUTION_HASH),
         );
 
         // If the `next_execution_hash` parameter is empty, it means that either
@@ -531,10 +586,11 @@ module aptos_framework::voting {
 
             // Set the `IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY` value to false upon successful resolution of the last step of a multi-step proposal.
             if (is_multi_step) {
-                let is_multi_step_proposal_in_execution_value = simple_map::borrow_mut(
-                    &mut proposal.metadata,
-                    &multi_step_in_execution_key
-                );
+                let is_multi_step_proposal_in_execution_value =
+                    simple_map::borrow_mut(
+                        &mut proposal.metadata,
+                        &multi_step_in_execution_key,
+                    );
                 *is_multi_step_proposal_in_execution_value = to_bytes(&false);
             };
         } else {
@@ -571,15 +627,16 @@ module aptos_framework::voting {
 
     #[view]
     /// Return the next unassigned proposal id
-    public fun next_proposal_id<ProposalType: store>(voting_forum_address: address, ): u64 acquires VotingForum {
+    public fun next_proposal_id<ProposalType: store>(
+        voting_forum_address: address,
+    ): u64 acquires VotingForum {
         let voting_forum = borrow_global<VotingForum<ProposalType>>(voting_forum_address);
         voting_forum.next_proposal_id
     }
 
     #[view]
     public fun get_proposer<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64
+        voting_forum_address: address, proposal_id: u64
     ): address acquires VotingForum {
         let proposal = get_proposal<ProposalType>(voting_forum_address, proposal_id);
         proposal.proposer
@@ -587,18 +644,21 @@ module aptos_framework::voting {
 
     #[view]
     public fun is_voting_closed<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64
+        voting_forum_address: address, proposal_id: u64
     ): bool acquires VotingForum {
         let proposal = get_proposal<ProposalType>(voting_forum_address, proposal_id);
         can_be_resolved_early(proposal) || is_voting_period_over(proposal)
     }
 
     /// Return true if the proposal has reached early resolution threshold (if specified).
-    public fun can_be_resolved_early<ProposalType: store>(proposal: &Proposal<ProposalType>): bool {
+    public fun can_be_resolved_early<ProposalType: store>(
+        proposal: &Proposal<ProposalType>
+    ): bool {
         if (option::is_some(&proposal.early_resolution_vote_threshold)) {
-            let early_resolution_threshold = *option::borrow(&proposal.early_resolution_vote_threshold);
-            if (proposal.yes_votes >= early_resolution_threshold || proposal.no_votes >= early_resolution_threshold) {
+            let early_resolution_threshold =
+                *option::borrow(&proposal.early_resolution_vote_threshold);
+            if (proposal.yes_votes >= early_resolution_threshold
+                    || proposal.no_votes >= early_resolution_threshold) {
                 return true
             };
         };
@@ -607,8 +667,7 @@ module aptos_framework::voting {
 
     #[view]
     public fun get_proposal_metadata<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): SimpleMap<String, vector<u8>> acquires VotingForum {
         let proposal = get_proposal<ProposalType>(voting_forum_address, proposal_id);
         proposal.metadata
@@ -631,8 +690,7 @@ module aptos_framework::voting {
     /// @param proposal_id The proposal id.
     /// @return Proposal state as an enum value.
     public fun get_proposal_state<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): u64 acquires VotingForum {
         if (is_voting_closed<ProposalType>(voting_forum_address, proposal_id)) {
             let proposal = get_proposal<ProposalType>(voting_forum_address, proposal_id);
@@ -652,8 +710,7 @@ module aptos_framework::voting {
     #[view]
     /// Return the proposal's creation time.
     public fun get_proposal_creation_secs<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): u64 acquires VotingForum {
         let proposal = get_proposal<ProposalType>(voting_forum_address, proposal_id);
         proposal.creation_time_secs
@@ -662,8 +719,7 @@ module aptos_framework::voting {
     #[view]
     /// Return the proposal's expiration time.
     public fun get_proposal_expiration_secs<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): u64 acquires VotingForum {
         let proposal = get_proposal<ProposalType>(voting_forum_address, proposal_id);
         proposal.expiration_secs
@@ -672,8 +728,7 @@ module aptos_framework::voting {
     #[view]
     /// Return the proposal's execution hash.
     public fun get_execution_hash<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): vector<u8> acquires VotingForum {
         let proposal = get_proposal<ProposalType>(voting_forum_address, proposal_id);
         proposal.execution_hash
@@ -682,8 +737,7 @@ module aptos_framework::voting {
     #[view]
     /// Return the proposal's minimum vote threshold
     public fun get_min_vote_threshold<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): u128 acquires VotingForum {
         let proposal = get_proposal<ProposalType>(voting_forum_address, proposal_id);
         proposal.min_vote_threshold
@@ -692,8 +746,7 @@ module aptos_framework::voting {
     #[view]
     /// Return the proposal's early resolution minimum vote threshold (optionally set)
     public fun get_early_resolution_vote_threshold<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): Option<u128> acquires VotingForum {
         let proposal = get_proposal<ProposalType>(voting_forum_address, proposal_id);
         proposal.early_resolution_vote_threshold
@@ -702,8 +755,7 @@ module aptos_framework::voting {
     #[view]
     /// Return the proposal's current vote count (yes_votes, no_votes)
     public fun get_votes<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): (u128, u128) acquires VotingForum {
         let proposal = get_proposal<ProposalType>(voting_forum_address, proposal_id);
         (proposal.yes_votes, proposal.no_votes)
@@ -712,8 +764,7 @@ module aptos_framework::voting {
     #[view]
     /// Return true if the governance proposal has already been resolved.
     public fun is_resolved<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): bool acquires VotingForum {
         let proposal = get_proposal<ProposalType>(voting_forum_address, proposal_id);
         proposal.is_resolved
@@ -721,8 +772,7 @@ module aptos_framework::voting {
 
     #[view]
     public fun get_resolution_time_secs<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): u64 acquires VotingForum {
         let proposal = get_proposal<ProposalType>(voting_forum_address, proposal_id);
         proposal.resolution_time_secs
@@ -731,27 +781,30 @@ module aptos_framework::voting {
     #[view]
     /// Return true if the multi-step governance proposal is in execution.
     public fun is_multi_step_proposal_in_execution<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): bool acquires VotingForum {
         let voting_forum = borrow_global<VotingForum<ProposalType>>(voting_forum_address);
         let proposal = table::borrow(&voting_forum.proposals, proposal_id);
-        let is_multi_step_in_execution_key = utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
+        let is_multi_step_in_execution_key =
+            utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
         assert!(
             simple_map::contains_key(&proposal.metadata, &is_multi_step_in_execution_key),
-            error::invalid_argument(EPROPOSAL_IS_SINGLE_STEP)
+            error::invalid_argument(EPROPOSAL_IS_SINGLE_STEP),
         );
-        from_bcs::to_bool(*simple_map::borrow(&proposal.metadata, &is_multi_step_in_execution_key))
+        from_bcs::to_bool(
+            *simple_map::borrow(&proposal.metadata, &is_multi_step_in_execution_key)
+        )
     }
 
     /// Return true if the voting period of the given proposal has already ended.
-    fun is_voting_period_over<ProposalType: store>(proposal: &Proposal<ProposalType>): bool {
+    fun is_voting_period_over<ProposalType: store>(
+        proposal: &Proposal<ProposalType>
+    ): bool {
         timestamp::now_seconds() > proposal.expiration_secs
     }
 
     inline fun get_proposal<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): &Proposal<ProposalType> acquires VotingForum {
         let voting_forum = borrow_global<VotingForum<ProposalType>>(voting_forum_address);
         table::borrow(&voting_forum.proposals, proposal_id)
@@ -789,7 +842,7 @@ module aptos_framework::voting {
                 timestamp::now_seconds() + VOTING_DURATION_SECS,
                 early_resolution_threshold,
                 metadata,
-                use_generic_create_proposal_function
+                use_generic_create_proposal_function,
             )
         } else {
             create_proposal<TestProposal>(
@@ -815,10 +868,14 @@ module aptos_framework::voting {
         if (is_multi_step) {
             let execution_hash = vector::empty<u8>();
             vector::push_back(&mut execution_hash, 1);
-            resolve_proposal_v2<TestProposal>(voting_forum_address, proposal_id, execution_hash);
+            resolve_proposal_v2<TestProposal>(
+                voting_forum_address, proposal_id, execution_hash
+            );
 
             if (finish_multi_step_execution) {
-                resolve_proposal_v2<TestProposal>(voting_forum_address, proposal_id, vector::empty<u8>());
+                resolve_proposal_v2<TestProposal>(
+                    voting_forum_address, proposal_id, vector::empty<u8>()
+                );
             };
         } else {
             let proposal = resolve<TestProposal>(voting_forum_address, proposal_id);
@@ -828,16 +885,14 @@ module aptos_framework::voting {
 
     #[test_only]
     public fun create_test_proposal(
-        governance: &signer,
-        early_resolution_threshold: Option<u128>,
+        governance: &signer, early_resolution_threshold: Option<u128>,
     ): u64 acquires VotingForum {
         create_test_proposal_generic(governance, early_resolution_threshold, false)
     }
 
     #[test_only]
     public fun create_proposal_with_empty_execution_hash_should_fail_generic(
-        governance: &signer,
-        is_multi_step: bool
+        governance: &signer, is_multi_step: bool
     ) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         let governance_address = signer::address_of(governance);
@@ -856,7 +911,7 @@ module aptos_framework::voting {
                 100000,
                 option::none<u128>(),
                 simple_map::create<String, vector<u8>>(),
-                is_multi_step
+                is_multi_step,
             );
         } else {
             create_proposal<TestProposal>(
@@ -874,7 +929,9 @@ module aptos_framework::voting {
 
     #[test(governance = @0x123)]
     #[expected_failure(abort_code = 0x10004, location = Self)]
-    public fun create_proposal_with_empty_execution_hash_should_fail(governance: &signer) acquires VotingForum {
+    public fun create_proposal_with_empty_execution_hash_should_fail(
+        governance: &signer
+    ) acquires VotingForum {
         create_proposal_with_empty_execution_hash_should_fail_generic(governance, false);
     }
 
@@ -899,8 +956,15 @@ module aptos_framework::voting {
         // Register voting forum and create a proposal.
         let governance_address = signer::address_of(governance);
         account::create_account_for_test(governance_address);
-        let proposal_id = create_test_proposal_generic(governance, option::none<u128>(), use_create_multi_step);
-        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_PENDING, 0);
+        let proposal_id =
+            create_test_proposal_generic(
+                governance, option::none<u128>(), use_create_multi_step
+            );
+        assert!(
+            get_proposal_state<TestProposal>(governance_address, proposal_id)
+                == PROPOSAL_STATE_PENDING,
+            0,
+        );
 
         // Vote.
         let proof = TestProposal {};
@@ -909,52 +973,60 @@ module aptos_framework::voting {
 
         // Resolve.
         timestamp::fast_forward_seconds(VOTING_DURATION_SECS + 1);
-        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_SUCCEEDED, 1);
+        assert!(
+            get_proposal_state<TestProposal>(governance_address, proposal_id)
+                == PROPOSAL_STATE_SUCCEEDED,
+            1,
+        );
 
         // This if statement is specifically for the test `test_voting_passed_single_step_can_use_generic_function()`.
         // It's testing when we have a single-step proposal that was created by the single-step `create_proposal()`,
         // we should be able to successfully resolve it using the generic `resolve_proposal_v2` function.
         if (!use_create_multi_step && use_resolve_multi_step) {
-            resolve_proposal_v2<TestProposal>(governance_address, proposal_id, vector::empty<u8>());
+            resolve_proposal_v2<TestProposal>(
+                governance_address, proposal_id, vector::empty<u8>()
+            );
         } else {
-            resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, use_resolve_multi_step, true);
+            resolve_proposal_for_test<TestProposal>(
+                governance_address, proposal_id, use_resolve_multi_step, true
+            );
         };
         let voting_forum = borrow_global<VotingForum<TestProposal>>(governance_address);
         assert!(table::borrow(&voting_forum.proposals, proposal_id).is_resolved, 2);
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
-    public entry fun test_voting_passed(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+    public entry fun test_voting_passed(
+        aptos_framework: &signer, governance: &signer
+    ) acquires VotingForum {
         test_voting_passed_generic(aptos_framework, governance, false, false);
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
-    public entry fun test_voting_passed_multi_step(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+    public entry fun test_voting_passed_multi_step(
+        aptos_framework: &signer, governance: &signer
+    ) acquires VotingForum {
         test_voting_passed_generic(aptos_framework, governance, true, true);
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x5000a, location = Self)]
     public entry fun test_voting_passed_multi_step_cannot_use_single_step_resolve_function(
-        aptos_framework: &signer,
-        governance: &signer
+        aptos_framework: &signer, governance: &signer
     ) acquires VotingForum {
         test_voting_passed_generic(aptos_framework, governance, true, false);
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     public entry fun test_voting_passed_single_step_can_use_generic_function(
-        aptos_framework: &signer,
-        governance: &signer
+        aptos_framework: &signer, governance: &signer
     ) acquires VotingForum {
         test_voting_passed_generic(aptos_framework, governance, false, true);
     }
 
     #[test_only]
     public entry fun test_cannot_resolve_twice_generic(
-        aptos_framework: &signer,
-        governance: &signer,
-        is_multi_step: bool
+        aptos_framework: &signer, governance: &signer, is_multi_step: bool
     ) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(aptos_framework);
@@ -962,8 +1034,13 @@ module aptos_framework::voting {
         // Register voting forum and create a proposal.
         let governance_address = signer::address_of(governance);
         account::create_account_for_test(governance_address);
-        let proposal_id = create_test_proposal_generic(governance, option::none<u128>(), is_multi_step);
-        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_PENDING, 0);
+        let proposal_id =
+            create_test_proposal_generic(governance, option::none<u128>(), is_multi_step);
+        assert!(
+            get_proposal_state<TestProposal>(governance_address, proposal_id)
+                == PROPOSAL_STATE_PENDING,
+            0,
+        );
 
         // Vote.
         let proof = TestProposal {};
@@ -972,31 +1049,38 @@ module aptos_framework::voting {
 
         // Resolve.
         timestamp::fast_forward_seconds(VOTING_DURATION_SECS + 1);
-        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_SUCCEEDED, 1);
-        resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, is_multi_step, true);
-        resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, is_multi_step, true);
+        assert!(
+            get_proposal_state<TestProposal>(governance_address, proposal_id)
+                == PROPOSAL_STATE_SUCCEEDED,
+            1,
+        );
+        resolve_proposal_for_test<TestProposal>(
+            governance_address, proposal_id, is_multi_step, true
+        );
+        resolve_proposal_for_test<TestProposal>(
+            governance_address, proposal_id, is_multi_step, true
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x30003, location = Self)]
-    public entry fun test_cannot_resolve_twice(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+    public entry fun test_cannot_resolve_twice(
+        aptos_framework: &signer, governance: &signer
+    ) acquires VotingForum {
         test_cannot_resolve_twice_generic(aptos_framework, governance, false);
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x30003, location = Self)]
     public entry fun test_cannot_resolve_twice_multi_step(
-        aptos_framework: &signer,
-        governance: &signer
+        aptos_framework: &signer, governance: &signer
     ) acquires VotingForum {
         test_cannot_resolve_twice_generic(aptos_framework, governance, true);
     }
 
     #[test_only]
     public entry fun test_voting_passed_early_generic(
-        aptos_framework: &signer,
-        governance: &signer,
-        is_multi_step: bool
+        aptos_framework: &signer, governance: &signer, is_multi_step: bool
     ) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(aptos_framework);
@@ -1004,12 +1088,20 @@ module aptos_framework::voting {
         // Register voting forum and create a proposal.
         let governance_address = signer::address_of(governance);
         account::create_account_for_test(governance_address);
-        let proposal_id = create_test_proposal_generic(governance, option::some(100), is_multi_step);
-        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_PENDING, 0);
+        let proposal_id =
+            create_test_proposal_generic(governance, option::some(100), is_multi_step);
+        assert!(
+            get_proposal_state<TestProposal>(governance_address, proposal_id)
+                == PROPOSAL_STATE_PENDING,
+            0,
+        );
 
         // Assert that IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY has value `false` in proposal.metadata.
         if (is_multi_step) {
-            assert!(!is_multi_step_proposal_in_execution<TestProposal>(governance_address, 0), 1);
+            assert!(
+                !is_multi_step_proposal_in_execution<TestProposal>(governance_address, 0),
+                1,
+            );
         };
 
         // Vote.
@@ -1020,86 +1112,107 @@ module aptos_framework::voting {
 
         // Resolve early. Need to increase timestamp as resolution cannot happen in the same tx.
         timestamp::fast_forward_seconds(1);
-        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_SUCCEEDED, 2);
+        assert!(
+            get_proposal_state<TestProposal>(governance_address, proposal_id)
+                == PROPOSAL_STATE_SUCCEEDED,
+            2,
+        );
 
         if (is_multi_step) {
             // Assert that IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY still has value `false` in proposal.metadata before execution.
-            assert!(!is_multi_step_proposal_in_execution<TestProposal>(governance_address, 0), 3);
-            resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, is_multi_step, false);
+            assert!(
+                !is_multi_step_proposal_in_execution<TestProposal>(governance_address, 0),
+                3,
+            );
+            resolve_proposal_for_test<TestProposal>(
+                governance_address, proposal_id, is_multi_step, false
+            );
 
             // Assert that the multi-step proposal is in execution but not resolved yet.
-            assert!(is_multi_step_proposal_in_execution<TestProposal>(governance_address, 0), 4);
-            let voting_forum = borrow_global_mut<VotingForum<TestProposal>>(governance_address);
+            assert!(
+                is_multi_step_proposal_in_execution<TestProposal>(governance_address, 0),
+                4
+            );
+            let voting_forum =
+                borrow_global_mut<VotingForum<TestProposal>>(governance_address);
             let proposal = table::borrow_mut(&mut voting_forum.proposals, proposal_id);
             assert!(!proposal.is_resolved, 5);
         };
 
-        resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, is_multi_step, true);
-        let voting_forum = borrow_global_mut<VotingForum<TestProposal>>(governance_address);
+        resolve_proposal_for_test<TestProposal>(
+            governance_address, proposal_id, is_multi_step, true
+        );
+        let voting_forum =
+            borrow_global_mut<VotingForum<TestProposal>>(governance_address);
         assert!(table::borrow(&voting_forum.proposals, proposal_id).is_resolved, 6);
 
         // Assert that the IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY value is set back to `false` upon successful resolution of this multi-step proposal.
         if (is_multi_step) {
-            assert!(!is_multi_step_proposal_in_execution<TestProposal>(governance_address, 0), 7);
+            assert!(
+                !is_multi_step_proposal_in_execution<TestProposal>(governance_address, 0),
+                7,
+            );
         };
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
-    public entry fun test_voting_passed_early(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+    public entry fun test_voting_passed_early(
+        aptos_framework: &signer, governance: &signer
+    ) acquires VotingForum {
         test_voting_passed_early_generic(aptos_framework, governance, false);
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     public entry fun test_voting_passed_early_multi_step(
-        aptos_framework: &signer,
-        governance: &signer
+        aptos_framework: &signer, governance: &signer
     ) acquires VotingForum {
         test_voting_passed_early_generic(aptos_framework, governance, true);
     }
 
     #[test_only]
     public entry fun test_voting_passed_early_in_same_tx_should_fail_generic(
-        aptos_framework: &signer,
-        governance: &signer,
-        is_multi_step: bool
+        aptos_framework: &signer, governance: &signer, is_multi_step: bool
     ) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(aptos_framework);
         let governance_address = signer::address_of(governance);
         account::create_account_for_test(governance_address);
-        let proposal_id = create_test_proposal_generic(governance, option::some(100), is_multi_step);
+        let proposal_id =
+            create_test_proposal_generic(governance, option::some(100), is_multi_step);
         let proof = TestProposal {};
         vote<TestProposal>(&proof, governance_address, proposal_id, 40, true);
         vote<TestProposal>(&proof, governance_address, proposal_id, 60, true);
         let TestProposal {} = proof;
 
         // Resolving early should fail since timestamp hasn't changed since the last vote.
-        resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, is_multi_step, true);
+        resolve_proposal_for_test<TestProposal>(
+            governance_address, proposal_id, is_multi_step, true
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x30008, location = Self)]
     public entry fun test_voting_passed_early_in_same_tx_should_fail(
-        aptos_framework: &signer,
-        governance: &signer
+        aptos_framework: &signer, governance: &signer
     ) acquires VotingForum {
-        test_voting_passed_early_in_same_tx_should_fail_generic(aptos_framework, governance, false);
+        test_voting_passed_early_in_same_tx_should_fail_generic(
+            aptos_framework, governance, false
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x30008, location = Self)]
     public entry fun test_voting_passed_early_in_same_tx_should_fail_multi_step(
-        aptos_framework: &signer,
-        governance: &signer
+        aptos_framework: &signer, governance: &signer
     ) acquires VotingForum {
-        test_voting_passed_early_in_same_tx_should_fail_generic(aptos_framework, governance, true);
+        test_voting_passed_early_in_same_tx_should_fail_generic(
+            aptos_framework, governance, true
+        );
     }
 
     #[test_only]
     public entry fun test_voting_failed_generic(
-        aptos_framework: &signer,
-        governance: &signer,
-        is_multi_step: bool
+        aptos_framework: &signer, governance: &signer, is_multi_step: bool
     ) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(aptos_framework);
@@ -1107,7 +1220,8 @@ module aptos_framework::voting {
         // Register voting forum and create a proposal.
         let governance_address = signer::address_of(governance);
         account::create_account_for_test(governance_address);
-        let proposal_id = create_test_proposal_generic(governance, option::none<u128>(), is_multi_step);
+        let proposal_id =
+            create_test_proposal_generic(governance, option::none<u128>(), is_multi_step);
 
         // Vote.
         let proof = TestProposal {};
@@ -1117,27 +1231,36 @@ module aptos_framework::voting {
 
         // Resolve.
         timestamp::fast_forward_seconds(VOTING_DURATION_SECS + 1);
-        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_FAILED, 1);
-        resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, is_multi_step, true);
+        assert!(
+            get_proposal_state<TestProposal>(governance_address, proposal_id)
+                == PROPOSAL_STATE_FAILED,
+            1,
+        );
+        resolve_proposal_for_test<TestProposal>(
+            governance_address, proposal_id, is_multi_step, true
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x30002, location = Self)]
-    public entry fun test_voting_failed(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+    public entry fun test_voting_failed(
+        aptos_framework: &signer, governance: &signer
+    ) acquires VotingForum {
         test_voting_failed_generic(aptos_framework, governance, false);
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x30002, location = Self)]
-    public entry fun test_voting_failed_multi_step(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+    public entry fun test_voting_failed_multi_step(
+        aptos_framework: &signer, governance: &signer
+    ) acquires VotingForum {
         test_voting_failed_generic(aptos_framework, governance, true);
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x30005, location = Self)]
     public entry fun test_cannot_vote_after_voting_period_is_over(
-        aptos_framework: signer,
-        governance: signer
+        aptos_framework: signer, governance: signer
     ) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(&aptos_framework);
@@ -1154,8 +1277,7 @@ module aptos_framework::voting {
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x30009, location = Self)]
     public entry fun test_cannot_vote_after_multi_step_proposal_starts_executing(
-        aptos_framework: signer,
-        governance: signer
+        aptos_framework: signer, governance: signer
     ) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(&aptos_framework);
@@ -1163,8 +1285,13 @@ module aptos_framework::voting {
         // Register voting forum and create a proposal.
         let governance_address = signer::address_of(&governance);
         account::create_account_for_test(governance_address);
-        let proposal_id = create_test_proposal_generic(&governance, option::some(100), true);
-        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_PENDING, 0);
+        let proposal_id =
+            create_test_proposal_generic(&governance, option::some(100), true);
+        assert!(
+            get_proposal_state<TestProposal>(governance_address, proposal_id)
+                == PROPOSAL_STATE_PENDING,
+            0,
+        );
 
         // Vote.
         let proof = TestProposal {};
@@ -1172,17 +1299,21 @@ module aptos_framework::voting {
 
         // Resolve early.
         timestamp::fast_forward_seconds(1);
-        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_SUCCEEDED, 1);
-        resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, true, false);
+        assert!(
+            get_proposal_state<TestProposal>(governance_address, proposal_id)
+                == PROPOSAL_STATE_SUCCEEDED,
+            1,
+        );
+        resolve_proposal_for_test<TestProposal>(
+            governance_address, proposal_id, true, false
+        );
         vote<TestProposal>(&proof, governance_address, proposal_id, 100, false);
         let TestProposal {} = proof;
     }
 
     #[test_only]
     public entry fun test_voting_failed_early_generic(
-        aptos_framework: &signer,
-        governance: &signer,
-        is_multi_step: bool
+        aptos_framework: &signer, governance: &signer, is_multi_step: bool
     ) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(aptos_framework);
@@ -1190,7 +1321,8 @@ module aptos_framework::voting {
         // Register voting forum and create a proposal.
         let governance_address = signer::address_of(governance);
         account::create_account_for_test(governance_address);
-        let proposal_id = create_test_proposal_generic(governance, option::some(100), is_multi_step);
+        let proposal_id =
+            create_test_proposal_generic(governance, option::some(100), is_multi_step);
 
         // Vote.
         let proof = TestProposal {};
@@ -1200,21 +1332,28 @@ module aptos_framework::voting {
 
         // Resolve.
         timestamp::fast_forward_seconds(VOTING_DURATION_SECS + 1);
-        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_FAILED, 1);
-        resolve_proposal_for_test<TestProposal>(governance_address, proposal_id, is_multi_step, true);
+        assert!(
+            get_proposal_state<TestProposal>(governance_address, proposal_id)
+                == PROPOSAL_STATE_FAILED,
+            1,
+        );
+        resolve_proposal_for_test<TestProposal>(
+            governance_address, proposal_id, is_multi_step, true
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x30002, location = Self)]
-    public entry fun test_voting_failed_early(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+    public entry fun test_voting_failed_early(
+        aptos_framework: &signer, governance: &signer
+    ) acquires VotingForum {
         test_voting_failed_early_generic(aptos_framework, governance, true);
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x30002, location = Self)]
     public entry fun test_voting_failed_early_multi_step(
-        aptos_framework: &signer,
-        governance: &signer
+        aptos_framework: &signer, governance: &signer
     ) acquires VotingForum {
         test_voting_failed_early_generic(aptos_framework, governance, false);
     }
@@ -1235,31 +1374,40 @@ module aptos_framework::voting {
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x10007, location = Self)]
     public entry fun test_cannot_set_min_threshold_higher_than_early_resolution(
-        aptos_framework: &signer,
-        governance: &signer,
+        aptos_framework: &signer, governance: &signer,
     ) acquires VotingForum {
-        test_cannot_set_min_threshold_higher_than_early_resolution_generic(aptos_framework, governance, false);
+        test_cannot_set_min_threshold_higher_than_early_resolution_generic(
+            aptos_framework, governance, false
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
     #[expected_failure(abort_code = 0x10007, location = Self)]
     public entry fun test_cannot_set_min_threshold_higher_than_early_resolution_multi_step(
-        aptos_framework: &signer,
-        governance: &signer,
+        aptos_framework: &signer, governance: &signer,
     ) acquires VotingForum {
-        test_cannot_set_min_threshold_higher_than_early_resolution_generic(aptos_framework, governance, true);
+        test_cannot_set_min_threshold_higher_than_early_resolution_generic(
+            aptos_framework, governance, true
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, governance = @0x123)]
-    public entry fun test_replace_execution_hash(aptos_framework: &signer, governance: &signer) acquires VotingForum {
+    public entry fun test_replace_execution_hash(
+        aptos_framework: &signer, governance: &signer
+    ) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(aptos_framework);
 
         // Register voting forum and create a proposal.
         let governance_address = signer::address_of(governance);
         account::create_account_for_test(governance_address);
-        let proposal_id = create_test_proposal_generic(governance, option::none<u128>(), true);
-        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_PENDING, 0);
+        let proposal_id =
+            create_test_proposal_generic(governance, option::none<u128>(), true);
+        assert!(
+            get_proposal_state<TestProposal>(governance_address, proposal_id)
+                == PROPOSAL_STATE_PENDING,
+            0,
+        );
 
         // Vote.
         let proof = TestProposal {};
@@ -1268,7 +1416,11 @@ module aptos_framework::voting {
 
         // Resolve.
         timestamp::fast_forward_seconds(VOTING_DURATION_SECS + 1);
-        assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_SUCCEEDED, 1);
+        assert!(
+            get_proposal_state<TestProposal>(governance_address, proposal_id)
+                == PROPOSAL_STATE_SUCCEEDED,
+            1,
+        );
 
         resolve_proposal_v2<TestProposal>(governance_address, proposal_id, vector[10u8]);
         let voting_forum = borrow_global<VotingForum<TestProposal>>(governance_address);

--- a/aptos-move/framework/aptos-framework/sources/voting.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.move
@@ -326,8 +326,8 @@ module aptos_framework::voting {
             // If the proposal is a single-step proposal, we check if the metadata passed by the client has the IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY key.
             // If they have the key, we will remove it, because a single-step proposal that doesn't need this key.
         } else if (simple_map::contains_key(
-                &mut metadata, &is_multi_step_in_execution_key
-            )) {
+            &mut metadata, &is_multi_step_in_execution_key
+        )) {
             simple_map::remove(&mut metadata, &is_multi_step_in_execution_key);
         };
 
@@ -658,7 +658,7 @@ module aptos_framework::voting {
             let early_resolution_threshold =
                 *option::borrow(&proposal.early_resolution_vote_threshold);
             if (proposal.yes_votes >= early_resolution_threshold
-                    || proposal.no_votes >= early_resolution_threshold) {
+                || proposal.no_votes >= early_resolution_threshold) {
                 return true
             };
         };
@@ -988,7 +988,10 @@ module aptos_framework::voting {
             );
         } else {
             resolve_proposal_for_test<TestProposal>(
-                governance_address, proposal_id, use_resolve_multi_step, true
+                governance_address,
+                proposal_id,
+                use_resolve_multi_step,
+                true,
             );
         };
         let voting_forum = borrow_global<VotingForum<TestProposal>>(governance_address);
@@ -1125,13 +1128,16 @@ module aptos_framework::voting {
                 3,
             );
             resolve_proposal_for_test<TestProposal>(
-                governance_address, proposal_id, is_multi_step, false
+                governance_address,
+                proposal_id,
+                is_multi_step,
+                false,
             );
 
             // Assert that the multi-step proposal is in execution but not resolved yet.
             assert!(
                 is_multi_step_proposal_in_execution<TestProposal>(governance_address, 0),
-                4
+                4,
             );
             let voting_forum =
                 borrow_global_mut<VotingForum<TestProposal>>(governance_address);

--- a/aptos-move/framework/aptos-framework/sources/voting.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.spec.move
@@ -247,9 +247,8 @@ spec aptos_framework::voting {
         aborts_if timestamp::spec_now_seconds()
             <= from_bcs::deserialize<u64>(
                 simple_map::spec_get(
-                    proposal.metadata, std::string::spec_utf8(
-                        RESOLVABLE_TIME_METADATA_KEY
-                    )
+                    proposal.metadata,
+                    std::string::spec_utf8(RESOLVABLE_TIME_METADATA_KEY),
                 ),
             );
         aborts_if transaction_context::spec_get_script_hash() != proposal.execution_hash;
@@ -322,8 +321,8 @@ spec aptos_framework::voting {
                 == std::bcs::serialize(true);
         ensures (
             simple_map::spec_contains_key(proposal.metadata, multi_step_in_execution_key)
-            && (len(next_execution_hash) == 0
-                && !is_multi_step)
+                && (len(next_execution_hash) == 0
+                    && !is_multi_step)
         ) ==>
             simple_map::spec_get(post_proposal.metadata, multi_step_in_execution_key)
                 == std::bcs::serialize(true);
@@ -397,7 +396,7 @@ spec aptos_framework::voting {
             let early_resolution_threshold =
                 option::spec_borrow(proposal.early_resolution_vote_threshold);
             if (proposal.yes_votes >= early_resolution_threshold
-                    || proposal.no_votes >= early_resolution_threshold) { true }
+                || proposal.no_votes >= early_resolution_threshold) { true }
             else { false }
         } else { false }
     }

--- a/aptos-move/framework/aptos-framework/sources/voting.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.spec.move
@@ -72,10 +72,13 @@ spec aptos_framework::voting {
         use aptos_framework::chain_status;
 
         requires chain_status::is_operating();
-        include CreateProposalAbortsIfAndEnsures<ProposalType>{is_multi_step_proposal: false};
+        include CreateProposalAbortsIfAndEnsures<ProposalType> {
+            is_multi_step_proposal: false
+        };
         // property 1: Verify the proposal_id of the newly created proposal.
         /// [high-level-req-1]
-        ensures result == old(global<VotingForum<ProposalType>>(voting_forum_address)).next_proposal_id;
+        ensures result
+            == old(global<VotingForum<ProposalType>>(voting_forum_address)).next_proposal_id;
     }
 
     // The min_vote_threshold lower thanearly_resolution_vote_threshold.
@@ -99,7 +102,8 @@ spec aptos_framework::voting {
         requires chain_status::is_operating();
         include CreateProposalAbortsIfAndEnsures<ProposalType>;
         // property 1: Verify the proposal_id of the newly created proposal.
-        ensures result == old(global<VotingForum<ProposalType>>(voting_forum_address)).next_proposal_id;
+        ensures result
+            == old(global<VotingForum<ProposalType>>(voting_forum_address)).next_proposal_id;
     }
 
     spec schema CreateProposalAbortsIfAndEnsures<ProposalType> {
@@ -114,24 +118,34 @@ spec aptos_framework::voting {
         let proposal_id = voting_forum.next_proposal_id;
 
         aborts_if !exists<VotingForum<ProposalType>>(voting_forum_address);
-        aborts_if table::spec_contains(voting_forum.proposals,proposal_id);
-        aborts_if len(early_resolution_vote_threshold.vec) != 0 && min_vote_threshold > early_resolution_vote_threshold.vec[0];
+        aborts_if table::spec_contains(voting_forum.proposals, proposal_id);
+        aborts_if len(early_resolution_vote_threshold.vec) != 0
+            && min_vote_threshold > early_resolution_vote_threshold.vec[0];
         aborts_if !std::string::spec_internal_check_utf8(IS_MULTI_STEP_PROPOSAL_KEY);
-        aborts_if !std::string::spec_internal_check_utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
+        aborts_if !std::string::spec_internal_check_utf8(
+            IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY
+        );
         aborts_if len(execution_hash) == 0;
         let execution_key = std::string::spec_utf8(IS_MULTI_STEP_PROPOSAL_KEY);
         aborts_if simple_map::spec_contains_key(metadata, execution_key);
         aborts_if voting_forum.next_proposal_id + 1 > MAX_U64;
-        let is_multi_step_in_execution_key = std::string::spec_utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
-        aborts_if is_multi_step_proposal && simple_map::spec_contains_key(metadata, is_multi_step_in_execution_key);
+        let is_multi_step_in_execution_key = std::string::spec_utf8(
+            IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY
+        );
+        aborts_if is_multi_step_proposal
+            && simple_map::spec_contains_key(metadata, is_multi_step_in_execution_key);
 
-        let post post_voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
-        let post post_metadata = table::spec_get(post_voting_forum.proposals, proposal_id).metadata;
+        let post post_voting_forum = global<VotingForum<ProposalType>>(
+            voting_forum_address
+        );
+        let post post_metadata = table::spec_get(post_voting_forum.proposals, proposal_id)
+            .metadata;
         ensures post_voting_forum.next_proposal_id == voting_forum.next_proposal_id + 1;
         // property 1: Ensure that newly created proposals exist in the voting forum proposals table.
         ensures table::spec_contains(post_voting_forum.proposals, proposal_id);
         ensures if (is_multi_step_proposal) {
-            simple_map::spec_get(post_metadata, is_multi_step_in_execution_key) == std::bcs::serialize(false)
+            simple_map::spec_get(post_metadata, is_multi_step_in_execution_key)
+                == std::bcs::serialize(false)
         } else {
             !simple_map::spec_contains_key(post_metadata, is_multi_step_in_execution_key)
         };
@@ -160,15 +174,26 @@ spec aptos_framework::voting {
         aborts_if proposal.is_resolved;
         aborts_if !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
         // Assert this proposal is single-step, or if the proposal is multi-step, it is not in execution yet.
-        aborts_if !std::string::spec_internal_check_utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
-        let execution_key = std::string::spec_utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
-        aborts_if simple_map::spec_contains_key(proposal.metadata, execution_key) &&
-                  simple_map::spec_get(proposal.metadata, execution_key) != std::bcs::serialize(false);
-        aborts_if if (should_pass) { proposal.yes_votes + num_votes > MAX_U128 } else { proposal.no_votes + num_votes > MAX_U128 };
+        aborts_if !std::string::spec_internal_check_utf8(
+            IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY
+        );
+        let execution_key = std::string::spec_utf8(
+            IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY
+        );
+        aborts_if simple_map::spec_contains_key(proposal.metadata, execution_key)
+            && simple_map::spec_get(proposal.metadata, execution_key)
+                != std::bcs::serialize(false);
+        aborts_if if (should_pass) {
+            proposal.yes_votes + num_votes > MAX_U128
+        } else {
+            proposal.no_votes + num_votes > MAX_U128
+        };
 
         aborts_if !std::string::spec_internal_check_utf8(RESOLVABLE_TIME_METADATA_KEY);
 
-        let post post_voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
+        let post post_voting_forum = global<VotingForum<ProposalType>>(
+            voting_forum_address
+        );
         let post post_proposal = table::spec_get(post_voting_forum.proposals, proposal_id);
         ensures if (should_pass) {
             post_proposal.yes_votes == proposal.yes_votes + num_votes
@@ -181,8 +206,7 @@ spec aptos_framework::voting {
     }
 
     spec is_proposal_resolvable<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ) {
         use aptos_framework::chain_status;
         // Ensures existence of Timestamp
@@ -198,24 +222,40 @@ spec aptos_framework::voting {
 
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
         let proposal = table::spec_get(voting_forum.proposals, proposal_id);
-        let voting_closed = spec_is_voting_closed<ProposalType>(voting_forum_address, proposal_id);
+        let voting_closed = spec_is_voting_closed<ProposalType>(
+            voting_forum_address, proposal_id
+        );
         // Avoid Overflow
-        aborts_if voting_closed && (proposal.yes_votes <= proposal.no_votes || proposal.yes_votes + proposal.no_votes < proposal.min_vote_threshold);
+        aborts_if voting_closed
+            && (
+                proposal.yes_votes <= proposal.no_votes
+                    || proposal.yes_votes + proposal.no_votes < proposal.min_vote_threshold
+            );
         // Resolvable_time Properties
         aborts_if !voting_closed;
 
         aborts_if proposal.is_resolved;
         aborts_if !std::string::spec_internal_check_utf8(RESOLVABLE_TIME_METADATA_KEY);
-        aborts_if !simple_map::spec_contains_key(proposal.metadata, std::string::spec_utf8(RESOLVABLE_TIME_METADATA_KEY));
-        aborts_if !from_bcs::deserializable<u64>(simple_map::spec_get(proposal.metadata, std::string::spec_utf8(RESOLVABLE_TIME_METADATA_KEY)));
-        aborts_if timestamp::spec_now_seconds() <= from_bcs::deserialize<u64>(simple_map::spec_get(proposal.metadata, std::string::spec_utf8(RESOLVABLE_TIME_METADATA_KEY)));
+        aborts_if !simple_map::spec_contains_key(
+            proposal.metadata, std::string::spec_utf8(RESOLVABLE_TIME_METADATA_KEY)
+        );
+        aborts_if !from_bcs::deserializable<u64>(
+            simple_map::spec_get(
+                proposal.metadata, std::string::spec_utf8(RESOLVABLE_TIME_METADATA_KEY)
+            ),
+        );
+        aborts_if timestamp::spec_now_seconds()
+            <= from_bcs::deserialize<u64>(
+                simple_map::spec_get(
+                    proposal.metadata, std::string::spec_utf8(
+                        RESOLVABLE_TIME_METADATA_KEY
+                    )
+                ),
+            );
         aborts_if transaction_context::spec_get_script_hash() != proposal.execution_hash;
     }
 
-    spec resolve<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
-    ): ProposalType {
+    spec resolve<ProposalType: store>(voting_forum_address: address, proposal_id: u64,): ProposalType {
         use aptos_framework::chain_status;
         // Ensures existence of Timestamp
         requires chain_status::is_operating();
@@ -225,11 +265,21 @@ spec aptos_framework::voting {
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
         let proposal = table::spec_get(voting_forum.proposals, proposal_id);
         let multi_step_key = std::string::spec_utf8(IS_MULTI_STEP_PROPOSAL_KEY);
-        let has_multi_step_key = simple_map::spec_contains_key(proposal.metadata, multi_step_key);
-        aborts_if has_multi_step_key && !from_bcs::deserializable<bool>(simple_map::spec_get(proposal.metadata, multi_step_key));
-        aborts_if has_multi_step_key && from_bcs::deserialize<bool>(simple_map::spec_get(proposal.metadata, multi_step_key));
+        let has_multi_step_key = simple_map::spec_contains_key(
+            proposal.metadata, multi_step_key
+        );
+        aborts_if has_multi_step_key
+            && !from_bcs::deserializable<bool>(
+                simple_map::spec_get(proposal.metadata, multi_step_key)
+            );
+        aborts_if has_multi_step_key
+            && from_bcs::deserialize<bool>(
+                simple_map::spec_get(proposal.metadata, multi_step_key)
+            );
 
-        let post post_voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
+        let post post_voting_forum = global<VotingForum<ProposalType>>(
+            voting_forum_address
+        );
         let post post_proposal = table::spec_get(post_voting_forum.proposals, proposal_id);
         aborts_if !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
         // property 3: Ensure that proposal is successfully resolved.
@@ -243,9 +293,7 @@ spec aptos_framework::voting {
     }
 
     spec resolve_proposal_v2<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
-        next_execution_hash: vector<u8>,
+        voting_forum_address: address, proposal_id: u64, next_execution_hash: vector<u8>,
     ) {
         use aptos_framework::chain_status;
         pragma verify_duration_estimate = 300;
@@ -255,38 +303,68 @@ spec aptos_framework::voting {
         include IsProposalResolvableAbortsIf<ProposalType>;
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
         let proposal = table::spec_get(voting_forum.proposals, proposal_id);
-        let post post_voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
+        let post post_voting_forum = global<VotingForum<ProposalType>>(
+            voting_forum_address
+        );
         let post post_proposal = table::spec_get(post_voting_forum.proposals, proposal_id);
-        let multi_step_in_execution_key = std::string::spec_utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
-        aborts_if !std::string::spec_internal_check_utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
+        let multi_step_in_execution_key = std::string::spec_utf8(
+            IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY
+        );
+        aborts_if !std::string::spec_internal_check_utf8(
+            IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY
+        );
         aborts_if !std::string::spec_internal_check_utf8(IS_MULTI_STEP_PROPOSAL_KEY);
-        ensures (simple_map::spec_contains_key(proposal.metadata, multi_step_in_execution_key) && len(next_execution_hash) != 0) ==>
-            simple_map::spec_get(post_proposal.metadata, multi_step_in_execution_key) == std::bcs::serialize(true);
-        ensures (simple_map::spec_contains_key(proposal.metadata, multi_step_in_execution_key) &&
-            (len(next_execution_hash) == 0 && !is_multi_step)) ==>
-            simple_map::spec_get(post_proposal.metadata, multi_step_in_execution_key) == std::bcs::serialize(true);
+        ensures (
+            simple_map::spec_contains_key(proposal.metadata, multi_step_in_execution_key)
+                && len(next_execution_hash) != 0
+        ) ==>
+            simple_map::spec_get(post_proposal.metadata, multi_step_in_execution_key)
+                == std::bcs::serialize(true);
+        ensures (
+            simple_map::spec_contains_key(proposal.metadata, multi_step_in_execution_key)
+            && (len(next_execution_hash) == 0
+                && !is_multi_step)
+        ) ==>
+            simple_map::spec_get(post_proposal.metadata, multi_step_in_execution_key)
+                == std::bcs::serialize(true);
 
         let multi_step_key = std::string::spec_utf8(IS_MULTI_STEP_PROPOSAL_KEY);
-        aborts_if simple_map::spec_contains_key(proposal.metadata, multi_step_key) &&
-            !from_bcs::deserializable<bool>(simple_map::spec_get(proposal.metadata, multi_step_key));
-        let is_multi_step = simple_map::spec_contains_key(proposal.metadata, multi_step_key) &&
-            from_bcs::deserialize(simple_map::spec_get(proposal.metadata, multi_step_key));
+        aborts_if simple_map::spec_contains_key(proposal.metadata, multi_step_key)
+            && !from_bcs::deserializable<bool>(
+                simple_map::spec_get(proposal.metadata, multi_step_key)
+            );
+        let is_multi_step = simple_map::spec_contains_key(
+            proposal.metadata, multi_step_key
+        ) && from_bcs::deserialize(
+            simple_map::spec_get(proposal.metadata, multi_step_key)
+        );
         aborts_if !is_multi_step && len(next_execution_hash) != 0;
 
-        aborts_if len(next_execution_hash) == 0 && !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
-        aborts_if len(next_execution_hash) == 0 && is_multi_step && !simple_map::spec_contains_key(proposal.metadata, multi_step_in_execution_key);
+        aborts_if len(next_execution_hash) == 0
+            && !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
+        aborts_if len(next_execution_hash) == 0
+            && is_multi_step
+            && !simple_map::spec_contains_key(
+                proposal.metadata, multi_step_in_execution_key
+            );
         // property 4: For single-step proposals, it ensures that the next_execution_hash parameter is empty and resolves the proposal.
         /// [high-level-req-4]
-        ensures len(next_execution_hash) == 0 ==> post_proposal.resolution_time_secs == timestamp::spec_now_seconds();
-        ensures len(next_execution_hash) == 0 ==> post_proposal.is_resolved == true;
-        ensures (len(next_execution_hash) == 0 && is_multi_step) ==> simple_map::spec_get(post_proposal.metadata, multi_step_in_execution_key) == std::bcs::serialize(false);
+        ensures len(next_execution_hash) == 0 ==>
+            post_proposal.resolution_time_secs == timestamp::spec_now_seconds();
+        ensures len(next_execution_hash) == 0 ==>
+            post_proposal.is_resolved == true;
+        ensures (len(next_execution_hash) == 0 && is_multi_step) ==>
+            simple_map::spec_get(post_proposal.metadata, multi_step_in_execution_key)
+                == std::bcs::serialize(false);
         // property 4: For multi-step proposals, it ensures that the next_execution_hash parameter contains the hash of the next step.
-        ensures len(next_execution_hash) != 0 ==> post_proposal.execution_hash == next_execution_hash;
+        ensures len(next_execution_hash) != 0 ==>
+            post_proposal.execution_hash == next_execution_hash;
     }
 
     spec next_proposal_id<ProposalType: store>(voting_forum_address: address): u64 {
         aborts_if !exists<VotingForum<ProposalType>>(voting_forum_address);
-        ensures result == global<VotingForum<ProposalType>>(voting_forum_address).next_proposal_id;
+        ensures result
+            == global<VotingForum<ProposalType>>(voting_forum_address).next_proposal_id;
     }
 
     spec is_voting_closed<ProposalType: store>(voting_forum_address: address, proposal_id: u64): bool {
@@ -295,13 +373,18 @@ spec aptos_framework::voting {
         requires chain_status::is_operating();
         include AbortsIfNotContainProposalID<ProposalType>;
         aborts_if !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
-        ensures result == spec_is_voting_closed<ProposalType>(voting_forum_address, proposal_id);
+        ensures result
+            == spec_is_voting_closed<ProposalType>(voting_forum_address, proposal_id);
     }
 
-    spec fun spec_is_voting_closed<ProposalType: store>(voting_forum_address: address, proposal_id: u64): bool {
+    spec fun spec_is_voting_closed<ProposalType: store>(
+        voting_forum_address: address, proposal_id: u64
+    ): bool {
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
         let proposal = table::spec_get(voting_forum.proposals, proposal_id);
-        spec_can_be_resolved_early<ProposalType>(proposal) || is_voting_period_over(proposal)
+        spec_can_be_resolved_early<ProposalType>(proposal) || is_voting_period_over(
+            proposal
+        )
     }
 
     spec can_be_resolved_early<ProposalType: store>(proposal: &Proposal<ProposalType>): bool {
@@ -311,15 +394,12 @@ spec aptos_framework::voting {
 
     spec fun spec_can_be_resolved_early<ProposalType: store>(proposal: Proposal<ProposalType>): bool {
         if (option::spec_is_some(proposal.early_resolution_vote_threshold)) {
-            let early_resolution_threshold = option::spec_borrow(proposal.early_resolution_vote_threshold);
-            if (proposal.yes_votes >= early_resolution_threshold || proposal.no_votes >= early_resolution_threshold) {
-                true
-            } else{
-                false
-            }
-        } else {
-            false
-        }
+            let early_resolution_threshold =
+                option::spec_borrow(proposal.early_resolution_vote_threshold);
+            if (proposal.yes_votes >= early_resolution_threshold
+                    || proposal.no_votes >= early_resolution_threshold) { true }
+            else { false }
+        } else { false }
     }
 
     spec fun spec_get_proposal_state<ProposalType>(
@@ -328,8 +408,13 @@ spec aptos_framework::voting {
         voting_forum: VotingForum<ProposalType>
     ): u64 {
         let proposal = table::spec_get(voting_forum.proposals, proposal_id);
-        let voting_closed = spec_is_voting_closed<ProposalType>(voting_forum_address, proposal_id);
-        let proposal_vote_cond = (proposal.yes_votes > proposal.no_votes && proposal.yes_votes + proposal.no_votes >= proposal.min_vote_threshold);
+        let voting_closed =
+            spec_is_voting_closed<ProposalType>(voting_forum_address, proposal_id);
+        let proposal_vote_cond =
+            (
+                proposal.yes_votes > proposal.no_votes
+                    && proposal.yes_votes + proposal.no_votes >= proposal.min_vote_threshold
+            );
         if (voting_closed && proposal_vote_cond) {
             PROPOSAL_STATE_SUCCEEDED
         } else if (voting_closed && !proposal_vote_cond) {
@@ -340,8 +425,7 @@ spec aptos_framework::voting {
     }
 
     spec fun spec_get_proposal_expiration_secs<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): u64 {
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
         let proposal = table::spec_get(voting_forum.proposals, proposal_id);
@@ -349,8 +433,7 @@ spec aptos_framework::voting {
     }
 
     spec get_proposal_state<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): u64 {
 
         use aptos_framework::chain_status;
@@ -362,13 +445,11 @@ spec aptos_framework::voting {
         include AbortsIfNotContainProposalID<ProposalType>;
 
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
-        ensures result == spec_get_proposal_state(voting_forum_address, proposal_id, voting_forum);
+        ensures result
+            == spec_get_proposal_state(voting_forum_address, proposal_id, voting_forum);
     }
 
-    spec get_proposer<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
-    ): address {
+    spec get_proposer<ProposalType: store>(voting_forum_address: address, proposal_id: u64,): address {
         include AbortsIfNotContainProposalID<ProposalType>;
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
         let proposal = table::spec_get(voting_forum.proposals, proposal_id);
@@ -376,8 +457,7 @@ spec aptos_framework::voting {
     }
 
     spec get_proposal_creation_secs<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): u64 {
         include AbortsIfNotContainProposalID<ProposalType>;
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
@@ -386,16 +466,17 @@ spec aptos_framework::voting {
     }
 
     spec get_proposal_expiration_secs<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): u64 {
         include AbortsIfNotContainProposalID<ProposalType>;
-        ensures result == spec_get_proposal_expiration_secs<ProposalType>(voting_forum_address, proposal_id);
+        ensures result
+            == spec_get_proposal_expiration_secs<ProposalType>(
+                voting_forum_address, proposal_id
+            );
     }
 
     spec get_resolution_time_secs<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): u64 {
         include AbortsIfNotContainProposalID<ProposalType>;
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
@@ -404,8 +485,7 @@ spec aptos_framework::voting {
     }
 
     spec get_execution_hash<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): vector<u8> {
         include AbortsIfNotContainProposalID<ProposalType>;
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
@@ -414,8 +494,7 @@ spec aptos_framework::voting {
     }
 
     spec get_min_vote_threshold<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): u128 {
         include AbortsIfNotContainProposalID<ProposalType>;
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
@@ -424,8 +503,7 @@ spec aptos_framework::voting {
     }
 
     spec get_early_resolution_vote_threshold<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): Option<u128> {
         include AbortsIfNotContainProposalID<ProposalType>;
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
@@ -434,8 +512,7 @@ spec aptos_framework::voting {
     }
 
     spec get_proposal_metadata<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): SimpleMap<String, vector<u8>> {
         include AbortsIfNotContainProposalID<ProposalType>;
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
@@ -444,9 +521,7 @@ spec aptos_framework::voting {
     }
 
     spec get_proposal_metadata_value<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
-        metadata_key: String,
+        voting_forum_address: address, proposal_id: u64, metadata_key: String,
     ): vector<u8> {
         include AbortsIfNotContainProposalID<ProposalType>;
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
@@ -455,10 +530,9 @@ spec aptos_framework::voting {
         ensures result == simple_map::spec_get(proposal.metadata, metadata_key);
     }
 
-    spec get_votes<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
-    ): (u128, u128) {
+    spec get_votes<ProposalType: store>(voting_forum_address: address, proposal_id: u64,): (
+        u128, u128
+    ) {
         include AbortsIfNotContainProposalID<ProposalType>;
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
         let proposal = table::spec_get(voting_forum.proposals, proposal_id);
@@ -466,10 +540,7 @@ spec aptos_framework::voting {
         ensures result_2 == proposal.no_votes;
     }
 
-    spec is_resolved<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
-    ): bool {
+    spec is_resolved<ProposalType: store>(voting_forum_address: address, proposal_id: u64,): bool {
         include AbortsIfNotContainProposalID<ProposalType>;
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
         let proposal = table::spec_get(voting_forum.proposals, proposal_id);
@@ -485,18 +556,23 @@ spec aptos_framework::voting {
     }
 
     spec is_multi_step_proposal_in_execution<ProposalType: store>(
-        voting_forum_address: address,
-        proposal_id: u64,
+        voting_forum_address: address, proposal_id: u64,
     ): bool {
         include AbortsIfNotContainProposalID<ProposalType>;
         let voting_forum = global<VotingForum<ProposalType>>(voting_forum_address);
-        let proposal = table::spec_get(voting_forum.proposals,proposal_id);
-        aborts_if !std::string::spec_internal_check_utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
+        let proposal = table::spec_get(voting_forum.proposals, proposal_id);
+        aborts_if !std::string::spec_internal_check_utf8(
+            IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY
+        );
 
-        let execution_key = std::string::spec_utf8(IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY);
-        aborts_if !simple_map::spec_contains_key(proposal.metadata,execution_key);
+        let execution_key = std::string::spec_utf8(
+            IS_MULTI_STEP_PROPOSAL_IN_EXECUTION_KEY
+        );
+        aborts_if !simple_map::spec_contains_key(proposal.metadata, execution_key);
 
-        let is_multi_step_in_execution_key = simple_map::spec_get(proposal.metadata,execution_key);
+        let is_multi_step_in_execution_key = simple_map::spec_get(
+            proposal.metadata, execution_key
+        );
         aborts_if !from_bcs::deserializable<bool>(is_multi_step_in_execution_key);
 
         ensures result == from_bcs::deserialize<bool>(is_multi_step_in_execution_key);

--- a/aptos-move/framework/aptos-framework/tests/aptos_coin_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/aptos_coin_tests.move
@@ -6,13 +6,14 @@ module aptos_framework::aptos_coin_tests {
     use aptos_framework::primary_fungible_store;
     use aptos_framework::object::{Self, Object};
 
-    public fun mint_apt_fa_to_for_test<T: key>(store: Object<T>, amount: u64) {
+    public fun mint_apt_fa_to_for_test<T: key>(
+        store: Object<T>, amount: u64
+    ) {
         fungible_asset::deposit(store, aptos_coin::mint_apt_fa_for_test(amount));
     }
 
     public fun mint_apt_fa_to_primary_fungible_store_for_test(
-        owner: address,
-        amount: u64,
+        owner: address, amount: u64,
     ) {
         primary_fungible_store::deposit(owner, aptos_coin::mint_apt_fa_for_test(amount));
     }
@@ -26,9 +27,9 @@ module aptos_framework::aptos_coin_tests {
         assert!(
             primary_fungible_store::balance(
                 @aptos_framework,
-                object::address_to_object<Metadata>(@aptos_fungible_asset)
+                object::address_to_object<Metadata>(@aptos_fungible_asset),
             ) == 100,
-            0
+            0,
         );
         coin::destroy_mint_cap(mint_cap);
         coin::destroy_burn_cap(burn_cap);
@@ -42,7 +43,8 @@ module aptos_framework::aptos_coin_tests {
         mint_apt_fa_to_primary_fungible_store_for_test(@aptos_framework, 100);
         let metadata = object::address_to_object<Metadata>(@aptos_fungible_asset);
         assert!(primary_fungible_store::balance(@aptos_framework, metadata) == 100, 0);
-        let store_addr = primary_fungible_store::primary_store_address(@aptos_framework, metadata);
+        let store_addr =
+            primary_fungible_store::primary_store_address(@aptos_framework, metadata);
         mint_apt_fa_to_for_test(object::address_to_object<FungibleStore>(store_addr), 100);
         assert!(primary_fungible_store::balance(@aptos_framework, metadata) == 200, 0);
     }

--- a/aptos-move/framework/aptos-framework/tests/deflation_token.move
+++ b/aptos-move/framework/aptos-framework/tests/deflation_token.move
@@ -58,7 +58,11 @@ module 0xcafe::deflation_token {
     use aptos_framework::fungible_asset::{Metadata, TestToken};
 
     #[test(creator = @0xcafe)]
-    #[expected_failure(major_status = 4037, location = aptos_framework::dispatchable_fungible_asset)]
+    #[
+        expected_failure(
+            major_status = 4037, location = aptos_framework::dispatchable_fungible_asset
+        )
+    ]
     fun test_self_reentrancy(creator: &signer,) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);

--- a/aptos-move/framework/aptos-framework/tests/deflation_token.move
+++ b/aptos-move/framework/aptos-framework/tests/deflation_token.move
@@ -13,17 +13,20 @@ module 0xcafe::deflation_token {
         burn_ref: BurnRef,
     }
 
-    public fun initialize(account: &signer, constructor_ref: &ConstructorRef) {
+    public fun initialize(
+        account: &signer, constructor_ref: &ConstructorRef
+    ) {
         let burn_ref = fungible_asset::generate_burn_ref(constructor_ref);
 
         assert!(signer::address_of(account) == @0xcafe, 1);
         move_to<BurnStore>(account, BurnStore { burn_ref });
 
-        let withdraw = function_info::new_function_info(
-            account,
-            string::utf8(b"deflation_token"),
-            string::utf8(b"withdraw"),
-        );
+        let withdraw =
+            function_info::new_function_info(
+                account,
+                string::utf8(b"deflation_token"),
+                string::utf8(b"withdraw"),
+            );
 
         dispatchable_fungible_asset::register_dispatch_functions(
             constructor_ref,
@@ -41,7 +44,9 @@ module 0xcafe::deflation_token {
         // For every withdraw, we burn 10% from the store.
         let burn_amount = amount / 10;
         if (burn_amount > 0) {
-            fungible_asset::burn_from(&borrow_global<BurnStore>(@0xcafe).burn_ref, store, burn_amount);
+            fungible_asset::burn_from(
+                &borrow_global<BurnStore>(@0xcafe).burn_ref, store, burn_amount
+            );
         };
 
         fungible_asset::withdraw_with_ref(transfer_ref, store, amount)
@@ -53,10 +58,8 @@ module 0xcafe::deflation_token {
     use aptos_framework::fungible_asset::{Metadata, TestToken};
 
     #[test(creator = @0xcafe)]
-    #[expected_failure(major_status=4037, location=aptos_framework::dispatchable_fungible_asset)]
-    fun test_self_reentrancy(
-        creator: &signer,
-    ) {
+    #[expected_failure(major_status = 4037, location = aptos_framework::dispatchable_fungible_asset)]
+    fun test_self_reentrancy(creator: &signer,) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);
         let metadata = object::convert<TestToken, Metadata>(token_object);

--- a/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
@@ -12,9 +12,7 @@ module 0xcafe::deflation_token_tests {
     use std::signer;
 
     #[test(creator = @0xcafe, aaron = @0xface)]
-    fun test_deflation_e2e_basic_flow(
-        creator: &signer, aaron: &signer,
-    ) {
+    fun test_deflation_e2e_basic_flow(creator: &signer, aaron: &signer,) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);
         let metadata = object::convert<TestToken, Metadata>(token_object);
@@ -59,7 +57,11 @@ module 0xcafe::deflation_token_tests {
     }
 
     #[test(creator = @0xcafe, aaron = @0xface)]
-    #[expected_failure(abort_code = 0x70002, location = aptos_framework::dispatchable_fungible_asset)]
+    #[
+        expected_failure(
+            abort_code = 0x70002, location = aptos_framework::dispatchable_fungible_asset
+        )
+    ]
     fun test_deflation_assert_min_deposit(
         creator: &signer, aaron: &signer,
     ) {
@@ -107,9 +109,7 @@ module 0xcafe::deflation_token_tests {
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     #[expected_failure(abort_code = 0x1001C, location = aptos_framework::fungible_asset)]
-    fun test_deflation_fa_withdraw(
-        creator: &signer, aaron: &signer,
-    ) {
+    fun test_deflation_fa_withdraw(creator: &signer, aaron: &signer,) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);
         let metadata = object::convert<TestToken, Metadata>(token_object);
@@ -299,9 +299,7 @@ module 0xcafe::deflation_token_tests {
     }
 
     #[test(creator = @0xcafe, aaron = @0xface)]
-    fun test_basic_flow_primary_fa(
-        creator: &signer, aaron: &signer,
-    ) {
+    fun test_basic_flow_primary_fa(creator: &signer, aaron: &signer,) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint_ref, transfer_ref, burn_ref) =
             primary_fungible_store::init_test_metadata_with_primary_store_enabled(
@@ -351,9 +349,7 @@ module 0xcafe::deflation_token_tests {
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     #[expected_failure(abort_code = 0x50003, location = aptos_framework::fungible_asset)]
-    fun test_deflation_set_frozen(
-        creator: &signer, aaron: &signer,
-    ) {
+    fun test_deflation_set_frozen(creator: &signer, aaron: &signer,) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, transfer_ref, _, _) = fungible_asset::init_test_metadata(&creator_ref);
         let metadata = object::convert<TestToken, Metadata>(token_object);
@@ -385,9 +381,7 @@ module 0xcafe::deflation_token_tests {
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     #[expected_failure(abort_code = 0x50008, location = aptos_framework::fungible_asset)]
-    fun test_deflation_wrong_withdraw(
-        creator: &signer, aaron: &signer,
-    ) {
+    fun test_deflation_wrong_withdraw(creator: &signer, aaron: &signer,) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         fungible_asset::init_test_metadata(&creator_ref);
         let metadata = object::convert<TestToken, Metadata>(token_object);

--- a/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
@@ -13,8 +13,7 @@ module 0xcafe::deflation_token_tests {
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     fun test_deflation_e2e_basic_flow(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);
@@ -52,7 +51,9 @@ module 0xcafe::deflation_token_tests {
         assert!(fungible_asset::balance(creator_store) == 73, 42);
         assert!(fungible_asset::balance(aaron_store) == 25, 42);
 
-        dispatchable_fungible_asset::transfer_assert_minimum_deposit(creator, creator_store, aaron_store, 10, 10);
+        dispatchable_fungible_asset::transfer_assert_minimum_deposit(
+            creator, creator_store, aaron_store, 10, 10
+        );
         assert!(fungible_asset::balance(creator_store) == 62, 42);
         assert!(fungible_asset::balance(aaron_store) == 35, 42);
     }
@@ -60,8 +61,7 @@ module 0xcafe::deflation_token_tests {
     #[test(creator = @0xcafe, aaron = @0xface)]
     #[expected_failure(abort_code = 0x70002, location = aptos_framework::dispatchable_fungible_asset)]
     fun test_deflation_assert_min_deposit(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);
@@ -78,14 +78,14 @@ module 0xcafe::deflation_token_tests {
         assert!(fungible_asset::supply(metadata) == option::some(100), 2);
         dispatchable_fungible_asset::deposit(creator_store, fa);
 
-        dispatchable_fungible_asset::transfer_assert_minimum_deposit(creator, creator_store, aaron_store, 10, 11);
+        dispatchable_fungible_asset::transfer_assert_minimum_deposit(
+            creator, creator_store, aaron_store, 10, 11
+        );
     }
 
     #[test(creator = @0xcafe)]
     #[expected_failure(abort_code = 0x1001C, location = aptos_framework::fungible_asset)]
-    fun test_deflation_fa_deposit(
-        creator: &signer,
-    ) {
+    fun test_deflation_fa_deposit(creator: &signer,) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);
         let metadata = object::convert<TestToken, Metadata>(token_object);
@@ -108,8 +108,7 @@ module 0xcafe::deflation_token_tests {
     #[test(creator = @0xcafe, aaron = @0xface)]
     #[expected_failure(abort_code = 0x1001C, location = aptos_framework::fungible_asset)]
     fun test_deflation_fa_withdraw(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);
@@ -134,143 +133,136 @@ module 0xcafe::deflation_token_tests {
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     #[expected_failure(abort_code = 0x8001D, location = aptos_framework::fungible_asset)]
-    fun test_double_init(
-        creator: &signer,
-    ) {
+    fun test_double_init(creator: &signer,) {
         let (creator_ref, _) = fungible_asset::create_test_token(creator);
         let (_, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);
         deflation_token::initialize(creator, &creator_ref);
 
-        let withdraw = function_info::new_function_info(
-            creator,
-            string::utf8(b"deflation_token"),
-            string::utf8(b"withdraw"),
-        );
+        let withdraw =
+            function_info::new_function_info(
+                creator,
+                string::utf8(b"deflation_token"),
+                string::utf8(b"withdraw"),
+            );
 
         // Re-registering the overload function should yield an error
         dispatchable_fungible_asset::register_dispatch_functions(
             &creator_ref,
             option::some(withdraw),
             option::none(),
-            option::none()
+            option::none(),
         );
     }
 
     #[test(creator = @0xcafe)]
     #[expected_failure(abort_code = 0x10019, location = aptos_framework::fungible_asset)]
-    fun test_register_bad_withdraw(
-        creator: &signer,
-    ) {
+    fun test_register_bad_withdraw(creator: &signer,) {
         let (creator_ref, _) = fungible_asset::create_test_token(creator);
 
-        let withdraw = function_info::new_function_info(
-            creator,
-            string::utf8(b"deflation_token"),
-            string::utf8(b"initialize"),
-        );
+        let withdraw =
+            function_info::new_function_info(
+                creator,
+                string::utf8(b"deflation_token"),
+                string::utf8(b"initialize"),
+            );
 
         // Change the deposit and withdraw function. Should give a type mismatch error.
         dispatchable_fungible_asset::register_dispatch_functions(
             &creator_ref,
             option::some(withdraw),
             option::none(),
-            option::none()
+            option::none(),
         );
     }
 
     #[test(creator = @0xcafe)]
     #[expected_failure(abort_code = 0x1001A, location = aptos_framework::fungible_asset)]
-    fun test_register_bad_deposit(
-        creator: &signer,
-    ) {
+    fun test_register_bad_deposit(creator: &signer,) {
         let (creator_ref, _) = fungible_asset::create_test_token(creator);
 
-        let withdraw = function_info::new_function_info(
-            creator,
-            string::utf8(b"deflation_token"),
-            string::utf8(b"withdraw"),
-        );
+        let withdraw =
+            function_info::new_function_info(
+                creator,
+                string::utf8(b"deflation_token"),
+                string::utf8(b"withdraw"),
+            );
 
         // Change the deposit and withdraw function. Should give a type mismatch error.
         dispatchable_fungible_asset::register_dispatch_functions(
             &creator_ref,
             option::some(withdraw),
             option::some(withdraw),
-            option::none()
+            option::none(),
         );
     }
 
     #[test(creator = @0xcafe)]
     #[expected_failure(abort_code = 0x1001B, location = aptos_framework::fungible_asset)]
-    fun test_register_bad_value(
-        creator: &signer,
-    ) {
+    fun test_register_bad_value(creator: &signer,) {
         let (creator_ref, _) = fungible_asset::create_test_token(creator);
 
-        let withdraw = function_info::new_function_info(
-            creator,
-            string::utf8(b"deflation_token"),
-            string::utf8(b"withdraw"),
-        );
+        let withdraw =
+            function_info::new_function_info(
+                creator,
+                string::utf8(b"deflation_token"),
+                string::utf8(b"withdraw"),
+            );
 
         // Change the deposit and withdraw function. Should give a type mismatch error.
         dispatchable_fungible_asset::register_dispatch_functions(
             &creator_ref,
             option::some(withdraw),
             option::none(),
-            option::some(withdraw)
+            option::some(withdraw),
         );
     }
 
     #[test(creator = @0xcafe, aaron = @0xface)]
-    #[expected_failure(major_status=1081, location = aptos_framework::function_info)]
+    #[expected_failure(major_status = 1081, location = aptos_framework::function_info)]
     fun test_register_bad_withdraw_non_exist(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) {
         let (creator_ref, _) = fungible_asset::create_test_token(creator);
 
-        let withdraw = function_info::new_function_info(
-            aaron,
-            string::utf8(b"deflation_token"),
-            string::utf8(b"withdraw"),
-        );
+        let withdraw =
+            function_info::new_function_info(
+                aaron,
+                string::utf8(b"deflation_token"),
+                string::utf8(b"withdraw"),
+            );
 
         // Change the deposit and withdraw function. Should give a type mismatch error.
         dispatchable_fungible_asset::register_dispatch_functions(
             &creator_ref,
             option::some(withdraw),
             option::none(),
-            option::none()
+            option::none(),
         );
     }
 
     #[test(creator = @0xcafe)]
-    #[expected_failure(abort_code=2, location = aptos_framework::function_info)]
-    fun test_register_bad_withdraw_non_exist_2(
-        creator: &signer,
-    ) {
+    #[expected_failure(abort_code = 2, location = aptos_framework::function_info)]
+    fun test_register_bad_withdraw_non_exist_2(creator: &signer,) {
         let (creator_ref, _) = fungible_asset::create_test_token(creator);
 
-        let withdraw = function_info::new_function_info(
-            creator,
-            string::utf8(b"deflation_token"),
-            string::utf8(b"withdraw2"),
-        );
+        let withdraw =
+            function_info::new_function_info(
+                creator,
+                string::utf8(b"deflation_token"),
+                string::utf8(b"withdraw2"),
+            );
 
         // Change the deposit and withdraw function. Should give a type mismatch error.
         dispatchable_fungible_asset::register_dispatch_functions(
             &creator_ref,
             option::some(withdraw),
             option::none(),
-            option::none()
+            option::none(),
         );
     }
 
     #[test(creator = @0xcafe)]
-    fun test_calling_overloadable_api_on_regular_fa(
-        creator: &signer,
-    ) {
+    fun test_calling_overloadable_api_on_regular_fa(creator: &signer,) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);
         let metadata = object::convert<TestToken, Metadata>(token_object);
@@ -286,34 +278,35 @@ module 0xcafe::deflation_token_tests {
     }
 
     #[test(creator = @0xcafe)]
-    #[expected_failure(abort_code=0x6001E, location = aptos_framework::fungible_asset)]
-    fun test_register_on_non_metadata_object(
-        creator: &signer,
-    ) {
+    #[expected_failure(abort_code = 0x6001E, location = aptos_framework::fungible_asset)]
+    fun test_register_on_non_metadata_object(creator: &signer,) {
         account::create_account_for_test(signer::address_of(creator));
         let creator_ref = object::create_named_object(creator, b"TEST");
-         let withdraw = function_info::new_function_info(
-            creator,
-            string::utf8(b"deflation_token"),
-            string::utf8(b"withdraw"),
-        );
+        let withdraw =
+            function_info::new_function_info(
+                creator,
+                string::utf8(b"deflation_token"),
+                string::utf8(b"withdraw"),
+            );
 
         // Change the deposit and withdraw function. Should give a type mismatch error.
         dispatchable_fungible_asset::register_dispatch_functions(
             &creator_ref,
             option::some(withdraw),
             option::none(),
-            option::none()
+            option::none(),
         );
     }
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     fun test_basic_flow_primary_fa(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
-        let (mint_ref, transfer_ref, burn_ref) = primary_fungible_store::init_test_metadata_with_primary_store_enabled(&creator_ref);
+        let (mint_ref, transfer_ref, burn_ref) =
+            primary_fungible_store::init_test_metadata_with_primary_store_enabled(
+                &creator_ref
+            );
         let metadata = object::convert<TestToken, Metadata>(token_object);
 
         deflation_token::initialize(creator, &creator_ref);
@@ -334,7 +327,8 @@ module 0xcafe::deflation_token_tests {
 
         primary_fungible_store::set_frozen_flag(&transfer_ref, aaron_address, true);
         assert!(primary_fungible_store::is_frozen(aaron_address, metadata), 5);
-        let fa = primary_fungible_store::withdraw_with_ref(&transfer_ref, aaron_address, 30);
+        let fa =
+            primary_fungible_store::withdraw_with_ref(&transfer_ref, aaron_address, 30);
 
         assert!(primary_fungible_store::balance(creator_address, metadata) == 22, 3);
         assert!(primary_fungible_store::balance(aaron_address, metadata) == 39, 4);
@@ -342,7 +336,9 @@ module 0xcafe::deflation_token_tests {
         primary_fungible_store::deposit_with_ref(&transfer_ref, aaron_address, fa);
 
         assert!(primary_fungible_store::balance(aaron_address, metadata) == 69, 4);
-        primary_fungible_store::transfer_with_ref(&transfer_ref, aaron_address, creator_address, 20);
+        primary_fungible_store::transfer_with_ref(
+            &transfer_ref, aaron_address, creator_address, 20
+        );
 
         assert!(primary_fungible_store::balance(creator_address, metadata) == 42, 3);
         assert!(primary_fungible_store::balance(aaron_address, metadata) == 49, 4);
@@ -356,8 +352,7 @@ module 0xcafe::deflation_token_tests {
     #[test(creator = @0xcafe, aaron = @0xface)]
     #[expected_failure(abort_code = 0x50003, location = aptos_framework::fungible_asset)]
     fun test_deflation_set_frozen(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, transfer_ref, _, _) = fungible_asset::init_test_metadata(&creator_ref);
@@ -391,8 +386,7 @@ module 0xcafe::deflation_token_tests {
     #[test(creator = @0xcafe, aaron = @0xface)]
     #[expected_failure(abort_code = 0x50008, location = aptos_framework::fungible_asset)]
     fun test_deflation_wrong_withdraw(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         fungible_asset::init_test_metadata(&creator_ref);

--- a/aptos-move/framework/aptos-framework/tests/delegation_pool_integration_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/delegation_pool_integration_tests.move
@@ -80,7 +80,9 @@ module aptos_framework::delegation_pool_integration_tests {
         );
         reconfiguration::initialize_for_test(aptos_framework);
         features::change_feature_flags_for_testing(
-            aptos_framework, vector[DELEGATION_POOLS, MODULE_EVENT], vector[]
+            aptos_framework,
+            vector[DELEGATION_POOLS, MODULE_EVENT],
+            vector[],
         );
     }
 
@@ -595,7 +597,8 @@ module aptos_framework::delegation_pool_integration_tests {
 
         // Receive back all coins with an extra 1 for rewards.
         assert!(
-            coin::balance<AptosCoin>(signer::address_of(validator)) == 100100000000, 2
+            coin::balance<AptosCoin>(signer::address_of(validator)) == 100100000000,
+            2,
         );
         stake::assert_validator_state(validator_address, 0, 0, 0, 0, 0);
     }
@@ -810,7 +813,14 @@ module aptos_framework::delegation_pool_integration_tests {
         mint_and_add_stake(validator_1, 51 * ONE_APT);
     }
 
-    #[test(aptos_framework = @0x1, validator_1 = @0x123, validator_2 = @0x234, validator_3 = @0x345)]
+    #[
+        test(
+            aptos_framework = @0x1,
+            validator_1 = @0x123,
+            validator_2 = @0x234,
+            validator_3 = @0x345
+        )
+    ]
     public entry fun test_multiple_validators_join_and_leave(
         aptos_framework: &signer,
         validator_1: &signer,
@@ -861,7 +871,10 @@ module aptos_framework::delegation_pool_integration_tests {
         let pk_1b_bytes = bls12381::public_key_to_bytes(&pk_1b);
         let pop_1b_bytes = bls12381::proof_of_possession_to_bytes(&pop_1b);
         stake::rotate_consensus_key(
-            validator_1, validator_1_address, pk_1b_bytes, pop_1b_bytes
+            validator_1,
+            validator_1_address,
+            pk_1b_bytes,
+            pop_1b_bytes,
         );
         stake::leave_validator_set(validator_2, validator_2_address);
         stake::join_validator_set(validator_3, validator_3_address);
@@ -887,7 +900,7 @@ module aptos_framework::delegation_pool_integration_tests {
         stake::assert_validator_state(validator_1_address, 101 * ONE_APT, 0, 0, 0, 0);
         assert!(
             stake::get_validator_state(validator_2_address) == VALIDATOR_STATUS_INACTIVE,
-            9
+            9,
         );
         // The validator index of validator 2 stays the same but this doesn't matter as the next time they rejoin the
         // validator set, their index will get set correctly.
@@ -944,7 +957,8 @@ module aptos_framework::delegation_pool_integration_tests {
         stake::assert_validator_state(pool_address, 0, 101 * ONE_APT, 0, 0, 0);
         dp::withdraw(validator, pool_address, 101 * ONE_APT);
         assert!(
-            coin::balance<AptosCoin>(signer::address_of(validator)) == 101 * ONE_APT, 1
+            coin::balance<AptosCoin>(signer::address_of(validator)) == 101 * ONE_APT,
+            1,
         );
         stake::assert_validator_state(pool_address, 0, 0, 0, 0, 0);
 
@@ -1023,7 +1037,16 @@ module aptos_framework::delegation_pool_integration_tests {
         stake::leave_validator_set(validator, validator_address);
     }
 
-    #[test(aptos_framework = @aptos_framework, validator_1 = @aptos_framework, validator_2 = @0x2, validator_3 = @0x3, validator_4 = @0x4, validator_5 = @0x5)]
+    #[
+        test(
+            aptos_framework = @aptos_framework,
+            validator_1 = @aptos_framework,
+            validator_2 = @0x2,
+            validator_3 = @0x3,
+            validator_4 = @0x4,
+            validator_5 = @0x5
+        )
+    ]
     public entry fun test_staking_validator_index(
         aptos_framework: &signer,
         validator_1: &signer,

--- a/aptos-move/framework/aptos-framework/tests/delegation_pool_integration_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/delegation_pool_integration_tests.move
@@ -45,7 +45,7 @@ module aptos_framework::delegation_pool_integration_tests {
             true,
             1,
             100,
-            1000000
+            1000000,
         );
     }
 
@@ -76,16 +76,20 @@ module aptos_framework::delegation_pool_integration_tests {
             allow_validator_set_change,
             rewards_rate_numerator,
             rewards_rate_denominator,
-            voting_power_increase_limit
+            voting_power_increase_limit,
         );
         reconfiguration::initialize_for_test(aptos_framework);
-        features::change_feature_flags_for_testing(aptos_framework, vector[DELEGATION_POOLS, MODULE_EVENT], vector[]);
+        features::change_feature_flags_for_testing(
+            aptos_framework, vector[DELEGATION_POOLS, MODULE_EVENT], vector[]
+        );
     }
 
     #[test_only]
     public fun mint_and_add_stake(account: &signer, amount: u64) {
         stake::mint(account, amount);
-        dp::add_stake(account, dp::get_owned_pool_address(signer::address_of(account)), amount);
+        dp::add_stake(
+            account, dp::get_owned_pool_address(signer::address_of(account)), amount
+        );
     }
 
     #[test_only]
@@ -122,7 +126,10 @@ module aptos_framework::delegation_pool_integration_tests {
     }
 
     #[test_only]
-    public fun generate_identity(): (bls12381::SecretKey, bls12381::PublicKey, bls12381::ProofOfPossession) {
+    public fun generate_identity()
+        : (
+        bls12381::SecretKey, bls12381::PublicKey, bls12381::ProofOfPossession
+    ) {
         let (sk, pkpop) = bls12381::generate_keys();
         let pop = bls12381::generate_proof_of_possession(&sk);
         let unvalidated_pk = bls12381::public_key_with_pop_to_normal(&pkpop);
@@ -132,8 +139,7 @@ module aptos_framework::delegation_pool_integration_tests {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x10007, location = aptos_framework::stake)]
     public entry fun test_inactive_validator_can_add_stake_if_exceeding_max_allowed(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -158,7 +164,7 @@ module aptos_framework::delegation_pool_integration_tests {
             true,
             1,
             10,
-            100000
+            100000,
         );
         // Have one validator join the set to ensure the validator set is not empty when main validator joins.
         let (_sk_1, pk_1, pop_1) = generate_identity();
@@ -175,8 +181,7 @@ module aptos_framework::delegation_pool_integration_tests {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x10007, location = aptos_framework::stake)]
     public entry fun test_active_validator_cannot_add_stake_if_exceeding_max_allowed(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test(aptos_framework);
         // Validator joins validator set and waits for epoch end so it's in the validator set.
@@ -190,8 +195,7 @@ module aptos_framework::delegation_pool_integration_tests {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x10007, location = aptos_framework::stake)]
     public entry fun test_active_validator_with_pending_inactive_stake_cannot_add_stake_if_exceeding_max_allowed(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test(aptos_framework);
         // Validator joins validator set and waits for epoch end so it's in the validator set.
@@ -221,7 +225,9 @@ module aptos_framework::delegation_pool_integration_tests {
         initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, true, true);
 
         // Leave validator set so validator is in pending_inactive state.
-        stake::leave_validator_set(validator_1, dp::get_owned_pool_address(signer::address_of(validator_1)));
+        stake::leave_validator_set(
+            validator_1, dp::get_owned_pool_address(signer::address_of(validator_1))
+        );
 
         // Add 9900 APT + 1 more. Total stake is 50 (active) + 50 (pending_inactive) + 9900 APT + 1 > 10000 so still exceeding max.
         mint_and_add_stake(validator_1, 9900 * ONE_APT + 1);
@@ -229,8 +235,7 @@ module aptos_framework::delegation_pool_integration_tests {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_end_to_end(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -302,7 +307,7 @@ module aptos_framework::delegation_pool_integration_tests {
             true,
             1,
             10,
-            50
+            50,
         );
         let (_sk_1, pk_1, pop_1) = generate_identity();
         let (_sk_2, pk_2, pop_2) = generate_identity();
@@ -310,12 +315,16 @@ module aptos_framework::delegation_pool_integration_tests {
         initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, false, false);
 
         // Validator 1 needs to be in the set so validator 2's added stake counts against the limit.
-        stake::join_validator_set(validator_1, dp::get_owned_pool_address(signer::address_of(validator_1)));
+        stake::join_validator_set(
+            validator_1, dp::get_owned_pool_address(signer::address_of(validator_1))
+        );
         end_epoch();
 
         // Validator 2 joins the validator set but their stake would lead to exceeding the voting power increase limit.
         // Therefore, this should fail.
-        stake::join_validator_set(validator_2, dp::get_owned_pool_address(signer::address_of(validator_2)));
+        stake::join_validator_set(
+            validator_2, dp::get_owned_pool_address(signer::address_of(validator_2))
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, validator_1 = @0x123, validator_2 = @0x234)]
@@ -332,7 +341,7 @@ module aptos_framework::delegation_pool_integration_tests {
             true,
             1,
             10,
-            10000
+            10000,
         );
         // Need 1 validator to be in the active validator set so joining limit works.
         let (_sk_1, pk_1, pop_1) = generate_identity();
@@ -341,9 +350,14 @@ module aptos_framework::delegation_pool_integration_tests {
         initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, false, false);
 
         // Add more stake while still pending_active.
-        let validator_2_address = dp::get_owned_pool_address(signer::address_of(validator_2));
+        let validator_2_address =
+            dp::get_owned_pool_address(signer::address_of(validator_2));
         stake::join_validator_set(validator_2, validator_2_address);
-        assert!(stake::get_validator_state(validator_2_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 0);
+        assert!(
+            stake::get_validator_state(validator_2_address)
+                == VALIDATOR_STATUS_PENDING_ACTIVE,
+            0,
+        );
         mint_and_add_stake(validator_2, 100 * ONE_APT);
         stake::assert_validator_state(validator_2_address, 200 * ONE_APT, 0, 0, 0, 0);
     }
@@ -364,7 +378,7 @@ module aptos_framework::delegation_pool_integration_tests {
             true,
             1,
             10,
-            100
+            100,
         );
         // Need 1 validator to be in the active validator set so joining limit works.
         let (_sk_1, pk_1, pop_1) = generate_identity();
@@ -381,26 +395,29 @@ module aptos_framework::delegation_pool_integration_tests {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_pending_active_validator_leaves_validator_set(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test(aptos_framework);
         // Validator joins but epoch hasn't ended, so the validator is still pending_active.
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, false);
         let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
-        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 0);
+        assert!(
+            stake::get_validator_state(validator_address) == VALIDATOR_STATUS_PENDING_ACTIVE,
+            0,
+        );
 
         // Leave the validator set immediately.
         stake::leave_validator_set(validator, validator_address);
-        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_INACTIVE, 1);
+        assert!(
+            stake::get_validator_state(validator_address) == VALIDATOR_STATUS_INACTIVE, 1
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000D, location = aptos_framework::stake)]
     public entry fun test_active_validator_cannot_add_more_stake_than_limit_in_multiple_epochs(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         // Only 50% voting power increase is allowed in each epoch.
         initialize_for_test_custom(
@@ -411,7 +428,7 @@ module aptos_framework::delegation_pool_integration_tests {
             true,
             1,
             10,
-            50
+            50,
         );
         // Add initial stake and join the validator set.
         let (_sk, pk, pop) = generate_identity();
@@ -430,8 +447,7 @@ module aptos_framework::delegation_pool_integration_tests {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000D, location = aptos_framework::stake)]
     public entry fun test_active_validator_cannot_add_more_stake_than_limit(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         // Only 50% voting power increase is allowed in each epoch.
         initialize_for_test_custom(
@@ -442,7 +458,7 @@ module aptos_framework::delegation_pool_integration_tests {
             true,
             1,
             10,
-            50
+            50,
         );
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
@@ -453,8 +469,7 @@ module aptos_framework::delegation_pool_integration_tests {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_unlock_partial_stake(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         // Reward rate = 10%.
         initialize_for_test_custom(
@@ -465,45 +480,62 @@ module aptos_framework::delegation_pool_integration_tests {
             true,
             1,
             10,
-            100
+            100,
         );
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
 
         // Unlock half of the coins.
         let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
-        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 1);
+        assert!(
+            stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 1
+        );
         dp::unlock(validator, validator_address, 50 * ONE_APT);
-        stake::assert_validator_state(validator_address, 50 * ONE_APT, 0, 0, 50 * ONE_APT, 0);
+        stake::assert_validator_state(
+            validator_address, 50 * ONE_APT, 0, 0, 50 * ONE_APT, 0
+        );
 
         // Enough time has passed so the current lockup cycle should have ended.
         // 50 coins should have unlocked while the remaining 51 (50 + rewards) should stay locked for another cycle.
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
         end_epoch();
-        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 2);
+        assert!(
+            stake::get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 2
+        );
         // Validator received rewards in both active and pending inactive.
-        stake::assert_validator_state(validator_address, 55 * ONE_APT, 55 * ONE_APT, 0, 0, 0);
-        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 3);
+        stake::assert_validator_state(
+            validator_address, 55 * ONE_APT, 55 * ONE_APT, 0, 0, 0
+        );
+        assert!(
+            stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 3
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_can_withdraw_all_stake_and_rewards_at_once(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, true, true);
         let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
-        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 0);
+        assert!(
+            stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 0
+        );
 
         // One more epoch passes to generate rewards.
         end_epoch();
-        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 1);
+        assert!(
+            stake::get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 1
+        );
         stake::assert_validator_state(validator_address, 101 * ONE_APT, 0, 0, 0, 0);
 
         // Unlock all coins while still having a lockup.
-        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS - EPOCH_DURATION, 2);
+        assert!(
+            stake::get_remaining_lockup_secs(validator_address)
+                == LOCKUP_CYCLE_SECONDS - EPOCH_DURATION,
+            2,
+        );
         dp::unlock(validator, validator_address, 101 * ONE_APT);
         stake::assert_validator_state(validator_address, 0, 0, 0, 101 * ONE_APT, 0);
 
@@ -512,7 +544,9 @@ module aptos_framework::delegation_pool_integration_tests {
         end_epoch();
         // Validator should not be removed from the validator set since their 100 coins in pending_inactive state should
         // still count toward voting power.
-        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 3);
+        assert!(
+            stake::get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 3
+        );
         stake::assert_validator_state(validator_address, 0, 0, 0, 10201000000, 0);
 
         // Enough time has passed so the current lockup cycle should have ended. Funds are now fully unlocked.
@@ -520,14 +554,15 @@ module aptos_framework::delegation_pool_integration_tests {
         end_epoch();
         stake::assert_validator_state(validator_address, 0, 10303010000, 0, 0, 0);
         // Validator has been kicked out of the validator set as their stake is 0 now.
-        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_INACTIVE, 4);
+        assert!(
+            stake::get_validator_state(validator_address) == VALIDATOR_STATUS_INACTIVE, 4
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x10006, location = aptos_framework::delegation_pool)]
     public entry fun test_active_validator_unlocking_more_than_available_stake_should_cap(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -540,8 +575,7 @@ module aptos_framework::delegation_pool_integration_tests {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_withdraw_should_cap_by_inactive_stake(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test(aptos_framework);
         // Initial balance = 900 (idle) + 100 (staked) = 1000.
@@ -560,14 +594,15 @@ module aptos_framework::delegation_pool_integration_tests {
         dp::withdraw(validator, validator_address, 200 * ONE_APT);
 
         // Receive back all coins with an extra 1 for rewards.
-        assert!(coin::balance<AptosCoin>(signer::address_of(validator)) == 100100000000, 2);
+        assert!(
+            coin::balance<AptosCoin>(signer::address_of(validator)) == 100100000000, 2
+        );
         stake::assert_validator_state(validator_address, 0, 0, 0, 0, 0);
     }
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_can_reactivate_pending_inactive_stake(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -576,7 +611,9 @@ module aptos_framework::delegation_pool_integration_tests {
         // Validator unlocks stake, which gets moved into pending_inactive.
         let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
         dp::unlock(validator, validator_address, 50 * ONE_APT);
-        stake::assert_validator_state(validator_address, 50 * ONE_APT, 0, 0, 50 * ONE_APT, 0);
+        stake::assert_validator_state(
+            validator_address, 50 * ONE_APT, 0, 0, 50 * ONE_APT, 0
+        );
 
         // Validator can reactivate pending_inactive stake.
         dp::reactivate_stake(validator, validator_address, 50 * ONE_APT);
@@ -585,8 +622,7 @@ module aptos_framework::delegation_pool_integration_tests {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_reactivate_more_than_available_pending_inactive_stake_should_cap(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -595,15 +631,16 @@ module aptos_framework::delegation_pool_integration_tests {
         // Validator tries to reactivate more than available pending_inactive stake, which should limit to 50.
         let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
         dp::unlock(validator, validator_address, 50 * ONE_APT);
-        stake::assert_validator_state(validator_address, 50 * ONE_APT, 0, 0, 50 * ONE_APT, 0);
+        stake::assert_validator_state(
+            validator_address, 50 * ONE_APT, 0, 0, 50 * ONE_APT, 0
+        );
         dp::reactivate_stake(validator, validator_address, 51 * ONE_APT);
         stake::assert_validator_state(validator_address, 100 * ONE_APT, 0, 0, 0, 0);
     }
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_having_insufficient_remaining_stake_after_withdrawal_gets_kicked(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -611,17 +648,25 @@ module aptos_framework::delegation_pool_integration_tests {
 
         // Unlock enough coins that the remaining is not enough to meet the min required.
         let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
-        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 1);
+        assert!(
+            stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 1
+        );
         dp::unlock(validator, validator_address, 50 * ONE_APT);
-        stake::assert_validator_state(validator_address, 50 * ONE_APT, 0, 0, 50 * ONE_APT, 0);
+        stake::assert_validator_state(
+            validator_address, 50 * ONE_APT, 0, 0, 50 * ONE_APT, 0
+        );
 
         // Enough time has passed so the current lockup cycle should have ended.
         // 50 coins should have unlocked while the remaining 51 (50 + rewards) is not enough so the validator is kicked
         // from the validator set.
-        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 2);
+        assert!(
+            stake::get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 2
+        );
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
         end_epoch();
-        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_INACTIVE, 2);
+        assert!(
+            stake::get_validator_state(validator_address) == VALIDATOR_STATUS_INACTIVE, 2
+        );
         stake::assert_validator_state(validator_address, 5050000000, 5050000000, 0, 0, 0);
         // Lockup is no longer renewed since the validator is no longer a part of the validator set.
         assert!(stake::get_remaining_lockup_secs(validator_address) == 0, 3);
@@ -642,18 +687,30 @@ module aptos_framework::delegation_pool_integration_tests {
 
         // Leave the validator set while still having a lockup.
         let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
-        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 0);
+        assert!(
+            stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 0
+        );
         stake::leave_validator_set(validator, validator_address);
         // Validator is in pending_inactive state but is technically still part of the validator set.
-        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_PENDING_INACTIVE, 2);
+        assert!(
+            stake::get_validator_state(validator_address)
+                == VALIDATOR_STATUS_PENDING_INACTIVE,
+            2,
+        );
         stake::assert_validator_state(validator_address, 100 * ONE_APT, 0, 0, 0, 1);
         end_epoch();
 
         // Epoch has ended so validator is no longer part of the validator set.
-        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_INACTIVE, 3);
+        assert!(
+            stake::get_validator_state(validator_address) == VALIDATOR_STATUS_INACTIVE, 3
+        );
         // However, their stake, including rewards, should still subject to the existing lockup.
         stake::assert_validator_state(validator_address, 101 * ONE_APT, 0, 0, 0, 1);
-        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS - EPOCH_DURATION, 4);
+        assert!(
+            stake::get_remaining_lockup_secs(validator_address)
+                == LOCKUP_CYCLE_SECONDS - EPOCH_DURATION,
+            4,
+        );
 
         // If they try to unlock, their stake is moved to pending_inactive and would only be withdrawable after the
         // lockup has expired.
@@ -673,7 +730,13 @@ module aptos_framework::delegation_pool_integration_tests {
         // pending_inactive stake should not be inactivated
         stake::assert_validator_state(validator_address, 5100000001, 0, 0, 4999999999, 1);
         // delegator's stake should be in sync with states reported by stake pool
-        dp::assert_delegation(signer::address_of(validator), validator_address, 5100000001, 0, 4999999999);
+        dp::assert_delegation(
+            signer::address_of(validator),
+            validator_address,
+            5100000001,
+            0,
+            4999999999,
+        );
 
         dp::withdraw(validator, validator_address, 4999999999);
         stake::assert_validator_state(validator_address, 5100000001, 0, 0, 0, 1);
@@ -694,7 +757,9 @@ module aptos_framework::delegation_pool_integration_tests {
 
         // Leave the validator set while still having a lockup.
         let validator_address = dp::get_owned_pool_address(signer::address_of(validator));
-        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 0);
+        assert!(
+            stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 0
+        );
         stake::leave_validator_set(validator, validator_address);
         end_epoch();
 
@@ -706,8 +771,12 @@ module aptos_framework::delegation_pool_integration_tests {
         // renewed.
         stake::join_validator_set(validator, validator_address);
         end_epoch();
-        assert!(stake::get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 2);
-        assert!(stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 2);
+        assert!(
+            stake::get_validator_state(validator_address) == VALIDATOR_STATUS_ACTIVE, 2
+        );
+        assert!(
+            stake::get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 2
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, validator_1 = @0x123, validator_2 = @0x234)]
@@ -725,7 +794,7 @@ module aptos_framework::delegation_pool_integration_tests {
             true,
             1,
             10,
-            50
+            50,
         );
         let (_sk_1, pk_1, pop_1) = generate_identity();
         let (_sk_2, pk_2, pop_2) = generate_identity();
@@ -734,7 +803,9 @@ module aptos_framework::delegation_pool_integration_tests {
         initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, true, true);
 
         // Validator 1 leaves the validator set. Epoch has not ended so they're still pending_inactive.
-        stake::leave_validator_set(validator_1, dp::get_owned_pool_address(signer::address_of(validator_1)));
+        stake::leave_validator_set(
+            validator_1, dp::get_owned_pool_address(signer::address_of(validator_1))
+        );
         // Validator 1 adds more stake. This should not succeed as it should not count as a voting power increase.
         mint_and_add_stake(validator_1, 51 * ONE_APT);
     }
@@ -754,7 +825,7 @@ module aptos_framework::delegation_pool_integration_tests {
             true,
             1,
             100,
-            100
+            100,
         );
         let (_sk_1, pk_1, pop_1) = generate_identity();
         let (_sk_2, pk_2, pop_2) = generate_identity();
@@ -763,16 +834,23 @@ module aptos_framework::delegation_pool_integration_tests {
         initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, false, false);
         initialize_test_validator(&pk_3, &pop_3, validator_3, 100 * ONE_APT, false, false);
 
-        let validator_1_address = dp::get_owned_pool_address(signer::address_of(validator_1));
-        let validator_2_address = dp::get_owned_pool_address(signer::address_of(validator_2));
-        let validator_3_address = dp::get_owned_pool_address(signer::address_of(validator_3));
+        let validator_1_address =
+            dp::get_owned_pool_address(signer::address_of(validator_1));
+        let validator_2_address =
+            dp::get_owned_pool_address(signer::address_of(validator_2));
+        let validator_3_address =
+            dp::get_owned_pool_address(signer::address_of(validator_3));
 
         // Validator 1 and 2 join the validator set.
         stake::join_validator_set(validator_2, validator_2_address);
         stake::join_validator_set(validator_1, validator_1_address);
         end_epoch();
-        assert!(stake::get_validator_state(validator_1_address) == VALIDATOR_STATUS_ACTIVE, 0);
-        assert!(stake::get_validator_state(validator_2_address) == VALIDATOR_STATUS_ACTIVE, 1);
+        assert!(
+            stake::get_validator_state(validator_1_address) == VALIDATOR_STATUS_ACTIVE, 0
+        );
+        assert!(
+            stake::get_validator_state(validator_2_address) == VALIDATOR_STATUS_ACTIVE, 1
+        );
 
         // Validator indices is the reverse order of the joining order.
         stake::assert_validator_state(validator_1_address, 100 * ONE_APT, 0, 0, 0, 0);
@@ -782,37 +860,56 @@ module aptos_framework::delegation_pool_integration_tests {
         let (_sk_1b, pk_1b, pop_1b) = generate_identity();
         let pk_1b_bytes = bls12381::public_key_to_bytes(&pk_1b);
         let pop_1b_bytes = bls12381::proof_of_possession_to_bytes(&pop_1b);
-        stake::rotate_consensus_key(validator_1, validator_1_address, pk_1b_bytes, pop_1b_bytes);
+        stake::rotate_consensus_key(
+            validator_1, validator_1_address, pk_1b_bytes, pop_1b_bytes
+        );
         stake::leave_validator_set(validator_2, validator_2_address);
         stake::join_validator_set(validator_3, validator_3_address);
         // Validator 2 is not effectively removed until next epoch.
-        assert!(stake::get_validator_state(validator_2_address) == VALIDATOR_STATUS_PENDING_INACTIVE, 6);
+        assert!(
+            stake::get_validator_state(validator_2_address)
+                == VALIDATOR_STATUS_PENDING_INACTIVE,
+            6,
+        );
 
         // Validator 3 is not effectively added until next epoch.
-        assert!(stake::get_validator_state(validator_3_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 7);
+        assert!(
+            stake::get_validator_state(validator_3_address)
+                == VALIDATOR_STATUS_PENDING_ACTIVE,
+            7,
+        );
 
         // Changes applied after new epoch
         end_epoch();
-        assert!(stake::get_validator_state(validator_1_address) == VALIDATOR_STATUS_ACTIVE, 8);
+        assert!(
+            stake::get_validator_state(validator_1_address) == VALIDATOR_STATUS_ACTIVE, 8
+        );
         stake::assert_validator_state(validator_1_address, 101 * ONE_APT, 0, 0, 0, 0);
-        assert!(stake::get_validator_state(validator_2_address) == VALIDATOR_STATUS_INACTIVE, 9);
+        assert!(
+            stake::get_validator_state(validator_2_address) == VALIDATOR_STATUS_INACTIVE,
+            9
+        );
         // The validator index of validator 2 stays the same but this doesn't matter as the next time they rejoin the
         // validator set, their index will get set correctly.
         stake::assert_validator_state(validator_2_address, 101 * ONE_APT, 0, 0, 0, 1);
-        assert!(stake::get_validator_state(validator_3_address) == VALIDATOR_STATUS_ACTIVE, 10);
+        assert!(
+            stake::get_validator_state(validator_3_address) == VALIDATOR_STATUS_ACTIVE, 10
+        );
         stake::assert_validator_state(validator_3_address, 100 * ONE_APT, 0, 0, 0, 1);
 
         // Validators without enough stake will be removed.
         dp::unlock(validator_1, validator_1_address, 50 * ONE_APT);
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS);
         end_epoch();
-        assert!(stake::get_validator_state(validator_1_address) == VALIDATOR_STATUS_INACTIVE, 11);
+        assert!(
+            stake::get_validator_state(validator_1_address) == VALIDATOR_STATUS_INACTIVE,
+            11,
+        );
     }
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_delegated_staking_with_owner_cap(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test_custom(
             aptos_framework,
@@ -822,7 +919,7 @@ module aptos_framework::delegation_pool_integration_tests {
             true,
             1,
             100,
-            100
+            100,
         );
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 0, false, false);
@@ -846,7 +943,9 @@ module aptos_framework::delegation_pool_integration_tests {
         // Withdraw stake + rewards.
         stake::assert_validator_state(pool_address, 0, 101 * ONE_APT, 0, 0, 0);
         dp::withdraw(validator, pool_address, 101 * ONE_APT);
-        assert!(coin::balance<AptosCoin>(signer::address_of(validator)) == 101 * ONE_APT, 1);
+        assert!(
+            coin::balance<AptosCoin>(signer::address_of(validator)) == 101 * ONE_APT, 1
+        );
         stake::assert_validator_state(pool_address, 0, 0, 0, 0, 0);
 
         // Operator can separately rotate consensus key.
@@ -859,7 +958,8 @@ module aptos_framework::delegation_pool_integration_tests {
 
         // Operator can update network and fullnode addresses.
         stake::update_network_and_fullnode_addresses(validator, pool_address, b"1", b"2");
-        let (_, network_addresses, fullnode_addresses) = stake::get_validator_config(pool_address);
+        let (_, network_addresses, fullnode_addresses) =
+            stake::get_validator_config(pool_address);
         assert!(network_addresses == b"1", 3);
         assert!(fullnode_addresses == b"2", 4);
     }
@@ -867,8 +967,7 @@ module aptos_framework::delegation_pool_integration_tests {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000A, location = aptos_framework::stake)]
     public entry fun test_validator_cannot_join_post_genesis(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test_custom(
             aptos_framework,
@@ -878,7 +977,7 @@ module aptos_framework::delegation_pool_integration_tests {
             false,
             1,
             100,
-            100
+            100,
         );
 
         // Joining the validator set should fail as post genesis validator set change is not allowed.
@@ -889,8 +988,7 @@ module aptos_framework::delegation_pool_integration_tests {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000E, location = aptos_framework::stake)]
     public entry fun test_invalid_pool_address(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
@@ -901,8 +999,7 @@ module aptos_framework::delegation_pool_integration_tests {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000A, location = aptos_framework::stake)]
     public entry fun test_validator_cannot_leave_post_genesis(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test_custom(
             aptos_framework,
@@ -912,7 +1009,7 @@ module aptos_framework::delegation_pool_integration_tests {
             false,
             1,
             100,
-            100
+            100,
         );
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100 * ONE_APT, false, false);
@@ -926,14 +1023,7 @@ module aptos_framework::delegation_pool_integration_tests {
         stake::leave_validator_set(validator, validator_address);
     }
 
-    #[test(
-        aptos_framework = @aptos_framework,
-        validator_1 = @aptos_framework,
-        validator_2 = @0x2,
-        validator_3 = @0x3,
-        validator_4 = @0x4,
-        validator_5 = @0x5
-    )]
+    #[test(aptos_framework = @aptos_framework, validator_1 = @aptos_framework, validator_2 = @0x2, validator_3 = @0x3, validator_4 = @0x4, validator_5 = @0x5)]
     public entry fun test_staking_validator_index(
         aptos_framework: &signer,
         validator_1: &signer,
@@ -1002,8 +1092,7 @@ module aptos_framework::delegation_pool_integration_tests {
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000B, location = aptos_framework::stake)]
     public entry fun test_invalid_config(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test_custom(
             aptos_framework,
@@ -1013,7 +1102,7 @@ module aptos_framework::delegation_pool_integration_tests {
             true,
             1,
             100,
-            100
+            100,
         );
 
         // Call initialize_stake_owner, which only initializes the stake pool but not validator config.
@@ -1030,8 +1119,7 @@ module aptos_framework::delegation_pool_integration_tests {
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_valid_config(
-        aptos_framework: &signer,
-        validator: &signer,
+        aptos_framework: &signer, validator: &signer,
     ) {
         initialize_for_test_custom(
             aptos_framework,
@@ -1041,7 +1129,7 @@ module aptos_framework::delegation_pool_integration_tests {
             true,
             1,
             100,
-            100
+            100,
         );
 
         // Call initialize_stake_owner, which only initializes the stake pool but not validator config.
@@ -1055,7 +1143,9 @@ module aptos_framework::delegation_pool_integration_tests {
         let (_sk_new, pk_new, pop_new) = generate_identity();
         let pk_new_bytes = bls12381::public_key_to_bytes(&pk_new);
         let pop_new_bytes = bls12381::proof_of_possession_to_bytes(&pop_new);
-        stake::rotate_consensus_key(validator, validator_address, pk_new_bytes, pop_new_bytes);
+        stake::rotate_consensus_key(
+            validator, validator_address, pk_new_bytes, pop_new_bytes
+        );
 
         // Join the validator set with enough stake. This now wouldn't fail since the validator config already exists.
         stake::join_validator_set(validator, validator_address);
@@ -1074,8 +1164,13 @@ module aptos_framework::delegation_pool_integration_tests {
         initialize_test_validator(&pk_2, &pop_2, validator_2, 100 * ONE_APT, true, true);
 
         // Remove validator 1 from the active validator set. Only validator 2 remains.
-        let validator_to_remove = dp::get_owned_pool_address(signer::address_of(validator_1));
+        let validator_to_remove =
+            dp::get_owned_pool_address(signer::address_of(validator_1));
         stake::remove_validators(aptos_framework, &vector[validator_to_remove]);
-        assert!(stake::get_validator_state(validator_to_remove) == VALIDATOR_STATUS_PENDING_INACTIVE, 1);
+        assert!(
+            stake::get_validator_state(validator_to_remove)
+                == VALIDATOR_STATUS_PENDING_INACTIVE,
+            1,
+        );
     }
 }

--- a/aptos-move/framework/aptos-framework/tests/function_info_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/function_info_tests.move
@@ -30,8 +30,14 @@ module aptos_framework::function_info_tests {
     fun test_func_type_eq() {
         let m = string::utf8(b"function_info_tests_helpers");
         let m2 = string::utf8(b"function_info_tests");
-        let lhs = function_info::new_function_info_from_address(@aptos_framework, m2, string::utf8(b"lhs"));
-        let rhs = function_info::new_function_info_from_address(@0xcafe, m, string::utf8(b"rhs"));
+        let lhs =
+            function_info::new_function_info_from_address(
+                @aptos_framework, m2, string::utf8(b"lhs")
+            );
+        let rhs =
+            function_info::new_function_info_from_address(
+                @0xcafe, m, string::utf8(b"rhs")
+            );
         assert!(function_info::check_dispatch_type_compatibility(&lhs, &rhs), 0x1);
     }
 
@@ -39,8 +45,14 @@ module aptos_framework::function_info_tests {
     fun test_func_type_eq_generic() {
         let m = string::utf8(b"function_info_tests_helpers");
         let m2 = string::utf8(b"function_info_tests");
-        let lhs = function_info::new_function_info_from_address(@aptos_framework, m2, string::utf8(b"lhs_generic"));
-        let rhs = function_info::new_function_info_from_address(@0xcafe, m, string::utf8(b"rhs_generic"));
+        let lhs =
+            function_info::new_function_info_from_address(
+                @aptos_framework, m2, string::utf8(b"lhs_generic")
+            );
+        let rhs =
+            function_info::new_function_info_from_address(
+                @0xcafe, m, string::utf8(b"rhs_generic")
+            );
         assert!(function_info::check_dispatch_type_compatibility(&lhs, &rhs), 0x1);
     }
 
@@ -48,8 +60,14 @@ module aptos_framework::function_info_tests {
     #[expected_failure(abort_code = 0x2, location = aptos_framework::function_info)]
     fun test_func_type_eq_reject_same_module() {
         let m2 = string::utf8(b"function_info_tests");
-        let lhs = function_info::new_function_info_from_address(@aptos_framework, m2, string::utf8(b"lhs"));
-        let rhs = function_info::new_function_info_from_address(@aptos_framework, m2, string::utf8(b"rhs"));
+        let lhs =
+            function_info::new_function_info_from_address(
+                @aptos_framework, m2, string::utf8(b"lhs")
+            );
+        let rhs =
+            function_info::new_function_info_from_address(
+                @aptos_framework, m2, string::utf8(b"rhs")
+            );
         assert!(function_info::check_dispatch_type_compatibility(&lhs, &rhs), 0x1);
     }
 
@@ -58,8 +76,14 @@ module aptos_framework::function_info_tests {
     fun test_func_type_bad_lhs() {
         let m = string::utf8(b"function_info_tests_helpers");
         let m2 = string::utf8(b"function_info_tests");
-        let lhs = function_info::new_function_info_from_address(@aptos_framework, m2, string::utf8(b"lhs"));
-        let rhs = function_info::new_function_info_from_address(@0xcafe, m, string::utf8(b"rhs"));
+        let lhs =
+            function_info::new_function_info_from_address(
+                @aptos_framework, m2, string::utf8(b"lhs")
+            );
+        let rhs =
+            function_info::new_function_info_from_address(
+                @0xcafe, m, string::utf8(b"rhs")
+            );
 
         // rhs has less than one arguments.
         assert!(function_info::check_dispatch_type_compatibility(&rhs, &lhs), 0x42);
@@ -70,8 +94,14 @@ module aptos_framework::function_info_tests {
     fun test_func_type_neq() {
         let m = string::utf8(b"function_info_tests_helpers");
         let m2 = string::utf8(b"function_info_tests");
-        let lhs = function_info::new_function_info_from_address(@aptos_framework, m2, string::utf8(b"lhs"));
-        let rhs = function_info::new_function_info_from_address(@0xcafe, m, string::utf8(b"rhs2"));
+        let lhs =
+            function_info::new_function_info_from_address(
+                @aptos_framework, m2, string::utf8(b"lhs")
+            );
+        let rhs =
+            function_info::new_function_info_from_address(
+                @0xcafe, m, string::utf8(b"rhs2")
+            );
         assert!(function_info::check_dispatch_type_compatibility(&lhs, &rhs), 0x42);
     }
 
@@ -80,8 +110,14 @@ module aptos_framework::function_info_tests {
     fun test_func_type_neq_generic() {
         let m = string::utf8(b"function_info_tests_helpers");
         let m2 = string::utf8(b"function_info_tests");
-        let lhs = function_info::new_function_info_from_address(@aptos_framework, m2, string::utf8(b"lhs_generic"));
-        let rhs = function_info::new_function_info_from_address(@0xcafe, m, string::utf8(b"rhs"));
+        let lhs =
+            function_info::new_function_info_from_address(
+                @aptos_framework, m2, string::utf8(b"lhs_generic")
+            );
+        let rhs =
+            function_info::new_function_info_from_address(
+                @0xcafe, m, string::utf8(b"rhs")
+            );
         assert!(function_info::check_dispatch_type_compatibility(&lhs, &rhs), 0x42);
     }
 
@@ -91,8 +127,14 @@ module aptos_framework::function_info_tests {
         let m = string::utf8(b"function_info_tests_helpers");
         let m2 = string::utf8(b"function_info_tests");
 
-        let lhs = function_info::new_function_info_from_address(@aptos_framework, m2, string::utf8(b"lhs"));
-        let rhs = function_info::new_function_info_from_address(@0xcafe, m, string::utf8(b"rhs3"));
+        let lhs =
+            function_info::new_function_info_from_address(
+                @aptos_framework, m2, string::utf8(b"lhs")
+            );
+        let rhs =
+            function_info::new_function_info_from_address(
+                @0xcafe, m, string::utf8(b"rhs3")
+            );
 
         // rhs has less than one arguments.
         assert!(function_info::check_dispatch_type_compatibility(&rhs, &lhs), 0x42);

--- a/aptos-move/framework/aptos-framework/tests/native_disaptch_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/native_disaptch_token_tests.move
@@ -4,10 +4,8 @@ module aptos_framework::native_dispatch_token_tests {
     use 0xcafe::native_dispatch_token;
 
     #[test(creator = @0xcafe)]
-    #[expected_failure(abort_code=0x10019, location=aptos_framework::fungible_asset)]
-    fun test_native_dispatch_token(
-        creator: &signer,
-    ) {
+    #[expected_failure(abort_code = 0x10019, location = aptos_framework::fungible_asset)]
+    fun test_native_dispatch_token(creator: &signer,) {
         let (creator_ref, _) = fungible_asset::create_test_token(creator);
         fungible_asset::init_test_metadata(&creator_ref);
 

--- a/aptos-move/framework/aptos-framework/tests/native_dispatch_token.move
+++ b/aptos-move/framework/aptos-framework/tests/native_dispatch_token.move
@@ -9,13 +9,16 @@ module 0xcafe::native_dispatch_token {
     use std::signer;
     use std::string;
 
-    public fun initialize(account: &signer, constructor_ref: &ConstructorRef) {
+    public fun initialize(
+        account: &signer, constructor_ref: &ConstructorRef
+    ) {
         assert!(signer::address_of(account) == @0xcafe, 1);
-        let withdraw = function_info::new_function_info(
-            account,
-            string::utf8(b"native_dispatch_token"),
-            string::utf8(b"withdraw"),
-        );
+        let withdraw =
+            function_info::new_function_info(
+                account,
+                string::utf8(b"native_dispatch_token"),
+                string::utf8(b"withdraw"),
+            );
 
         dispatchable_fungible_asset::register_dispatch_functions(
             constructor_ref,
@@ -26,8 +29,6 @@ module 0xcafe::native_dispatch_token {
     }
 
     public native fun withdraw<T: key>(
-        store: Object<T>,
-        _amount: u64,
-        transfer_ref: &TransferRef,
+        store: Object<T>, _amount: u64, transfer_ref: &TransferRef,
     ): FungibleAsset;
 }

--- a/aptos-move/framework/aptos-framework/tests/nil_op_token.move
+++ b/aptos-move/framework/aptos-framework/tests/nil_op_token.move
@@ -9,13 +9,16 @@ module 0xcafe::nil_op_token {
     use std::signer;
     use std::string;
 
-    public fun initialize(account: &signer, constructor_ref: &ConstructorRef) {
+    public fun initialize(
+        account: &signer, constructor_ref: &ConstructorRef
+    ) {
         assert!(signer::address_of(account) == @0xcafe, 1);
-        let withdraw = function_info::new_function_info(
-            account,
-            string::utf8(b"nil_op_token"),
-            string::utf8(b"withdraw"),
-        );
+        let withdraw =
+            function_info::new_function_info(
+                account,
+                string::utf8(b"nil_op_token"),
+                string::utf8(b"withdraw"),
+            );
 
         dispatchable_fungible_asset::register_dispatch_functions(
             constructor_ref,

--- a/aptos-move/framework/aptos-framework/tests/nil_op_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/nil_op_token_tests.move
@@ -7,7 +7,11 @@ module aptos_framework::nil_op_token_tests {
     use std::option;
 
     #[test(creator = @0xcafe)]
-    #[expected_failure(abort_code = 0x70002, location = aptos_framework::dispatchable_fungible_asset)]
+    #[
+        expected_failure(
+            abort_code = 0x70002, location = aptos_framework::dispatchable_fungible_asset
+        )
+    ]
     fun test_nil_op_token(creator: &signer,) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);

--- a/aptos-move/framework/aptos-framework/tests/nil_op_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/nil_op_token_tests.move
@@ -7,10 +7,8 @@ module aptos_framework::nil_op_token_tests {
     use std::option;
 
     #[test(creator = @0xcafe)]
-    #[expected_failure(abort_code=0x70002, location=aptos_framework::dispatchable_fungible_asset)]
-    fun test_nil_op_token(
-        creator: &signer,
-    ) {
+    #[expected_failure(abort_code = 0x70002, location = aptos_framework::dispatchable_fungible_asset)]
+    fun test_nil_op_token(creator: &signer,) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);
         let metadata = object::convert<TestToken, Metadata>(token_object);

--- a/aptos-move/framework/aptos-framework/tests/permissioned_token.move
+++ b/aptos-move/framework/aptos-framework/tests/permissioned_token.move
@@ -17,15 +17,18 @@ module 0xcafe::permissioned_token {
         allowed_sender: vector<address>,
     }
 
-    public fun initialize(account: &signer, constructor_ref: &ConstructorRef, allowed_sender: vector<address>) {
+    public fun initialize(
+        account: &signer, constructor_ref: &ConstructorRef, allowed_sender: vector<address>
+    ) {
         assert!(signer::address_of(account) == @0xcafe, 1);
         move_to<AllowlistStore>(account, AllowlistStore { allowed_sender });
 
-        let withdraw = function_info::new_function_info(
-            account,
-            string::utf8(b"permissioned_token"),
-            string::utf8(b"withdraw"),
-        );
+        let withdraw =
+            function_info::new_function_info(
+                account,
+                string::utf8(b"permissioned_token"),
+                string::utf8(b"withdraw"),
+            );
 
         dispatchable_fungible_asset::register_dispatch_functions(
             constructor_ref,
@@ -38,7 +41,7 @@ module 0xcafe::permissioned_token {
     public fun add_to_allow_list(account: &signer, new_address: address) acquires AllowlistStore {
         assert!(signer::address_of(account) == @0xcafe, 1);
         let allowed_sender = borrow_global_mut<AllowlistStore>(@0xcafe);
-        if(!vector::contains(&allowed_sender.allowed_sender, &new_address)) {
+        if (!vector::contains(&allowed_sender.allowed_sender, &new_address)) {
             vector::push_back(&mut allowed_sender.allowed_sender, new_address);
         }
     }
@@ -48,10 +51,13 @@ module 0xcafe::permissioned_token {
         amount: u64,
         transfer_ref: &TransferRef,
     ): FungibleAsset acquires AllowlistStore {
-        assert!(vector::contains(
-            &borrow_global<AllowlistStore>(@0xcafe).allowed_sender,
-            &object::object_address(&store)
-        ), EWITHDRAW_NOT_ALLOWED);
+        assert!(
+            vector::contains(
+                &borrow_global<AllowlistStore>(@0xcafe).allowed_sender,
+                &object::object_address(&store),
+            ),
+            EWITHDRAW_NOT_ALLOWED,
+        );
 
         fungible_asset::withdraw_with_ref(transfer_ref, store, amount)
     }

--- a/aptos-move/framework/aptos-framework/tests/permissioned_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/permissioned_token_tests.move
@@ -8,8 +8,7 @@ module 0xcafe::permissioned_token_tests {
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     fun test_permissioned_e2e_basic_flow(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);
@@ -19,8 +18,7 @@ module 0xcafe::permissioned_token_tests {
         let aaron_store = fungible_asset::create_test_store(aaron, metadata);
         let allowed_sender = vector[
             object::object_address(&creator_store),
-            object::object_address(&aaron_store),
-        ];
+            object::object_address(&aaron_store),];
 
         permissioned_token::initialize(creator, &creator_ref, allowed_sender);
 
@@ -43,8 +41,7 @@ module 0xcafe::permissioned_token_tests {
     #[test(creator = @0xcafe, aaron = @0xface)]
     #[expected_failure(abort_code = 1, location = 0xcafe::permissioned_token)]
     fun test_permissioned_disallowed_sender(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);
@@ -52,9 +49,7 @@ module 0xcafe::permissioned_token_tests {
 
         let creator_store = fungible_asset::create_test_store(creator, metadata);
         let aaron_store = fungible_asset::create_test_store(aaron, metadata);
-        let allowed_sender = vector[
-            object::object_address(&creator_store),
-        ];
+        let allowed_sender = vector[object::object_address(&creator_store),];
 
         permissioned_token::initialize(creator, &creator_ref, allowed_sender);
 
@@ -77,8 +72,7 @@ module 0xcafe::permissioned_token_tests {
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     fun test_permissioned_update_disallowed_sender(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);
@@ -86,9 +80,7 @@ module 0xcafe::permissioned_token_tests {
 
         let creator_store = fungible_asset::create_test_store(creator, metadata);
         let aaron_store = fungible_asset::create_test_store(aaron, metadata);
-        let allowed_sender = vector[
-            object::object_address(&creator_store),
-        ];
+        let allowed_sender = vector[object::object_address(&creator_store),];
 
         permissioned_token::initialize(creator, &creator_ref, allowed_sender);
 
@@ -103,7 +95,9 @@ module 0xcafe::permissioned_token_tests {
         assert!(fungible_asset::supply(metadata) == option::some(100), 3);
         dispatchable_fungible_asset::deposit(aaron_store, fa);
 
-        permissioned_token::add_to_allow_list(creator, object::object_address(&aaron_store));
+        permissioned_token::add_to_allow_list(
+            creator, object::object_address(&aaron_store)
+        );
         // aaron_store is now allowed to perform withdraw
         let fa = dispatchable_fungible_asset::withdraw(aaron, aaron_store, 1);
         dispatchable_fungible_asset::deposit(creator_store, fa);

--- a/aptos-move/framework/aptos-framework/tests/permissioned_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/permissioned_token_tests.move
@@ -18,7 +18,8 @@ module 0xcafe::permissioned_token_tests {
         let aaron_store = fungible_asset::create_test_store(aaron, metadata);
         let allowed_sender = vector[
             object::object_address(&creator_store),
-            object::object_address(&aaron_store),];
+            object::object_address(&aaron_store),
+        ];
 
         permissioned_token::initialize(creator, &creator_ref, allowed_sender);
 

--- a/aptos-move/framework/aptos-framework/tests/reentrant_token.move
+++ b/aptos-move/framework/aptos-framework/tests/reentrant_token.move
@@ -9,19 +9,22 @@ module 0xcafe::reentrant_token {
     use std::signer;
     use std::string;
 
-    public fun initialize(account: &signer, constructor_ref: &ConstructorRef) {
+    public fun initialize(
+        account: &signer, constructor_ref: &ConstructorRef
+    ) {
         assert!(signer::address_of(account) == @0xcafe, 1);
-        let deposit = function_info::new_function_info(
-            account,
-            string::utf8(b"reentrant_token"),
-            string::utf8(b"deposit"),
-        );
+        let deposit =
+            function_info::new_function_info(
+                account,
+                string::utf8(b"reentrant_token"),
+                string::utf8(b"deposit"),
+            );
 
         dispatchable_fungible_asset::register_dispatch_functions(
             constructor_ref,
             option::none(),
             option::some(deposit),
-            option::none()
+            option::none(),
         );
     }
 

--- a/aptos-move/framework/aptos-framework/tests/reentrant_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/reentrant_token_tests.move
@@ -7,7 +7,11 @@ module 0xcafe::reentrant_token_tests {
     use std::option;
 
     #[test(creator = @0xcafe)]
-    #[expected_failure(major_status = 4037, location = aptos_framework::dispatchable_fungible_asset)]
+    #[
+        expected_failure(
+            major_status = 4037, location = aptos_framework::dispatchable_fungible_asset
+        )
+    ]
     fun test_reentrant_deposit(creator: &signer,) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);

--- a/aptos-move/framework/aptos-framework/tests/reentrant_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/reentrant_token_tests.move
@@ -7,10 +7,8 @@ module 0xcafe::reentrant_token_tests {
     use std::option;
 
     #[test(creator = @0xcafe)]
-    #[expected_failure(major_status=4037, location=aptos_framework::dispatchable_fungible_asset)]
-    fun test_reentrant_deposit(
-        creator: &signer,
-    ) {
+    #[expected_failure(major_status = 4037, location = aptos_framework::dispatchable_fungible_asset)]
+    fun test_reentrant_deposit(creator: &signer,) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);
         let metadata = object::convert<TestToken, Metadata>(token_object);

--- a/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token.move
+++ b/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token.move
@@ -9,26 +9,30 @@ module 0xcafe::simple_token {
     use std::signer;
     use std::string;
 
-    public fun initialize(account: &signer, constructor_ref: &ConstructorRef) {
+    public fun initialize(
+        account: &signer, constructor_ref: &ConstructorRef
+    ) {
         assert!(signer::address_of(account) == @0xcafe, 1);
 
-        let withdraw = function_info::new_function_info(
-            account,
-            string::utf8(b"simple_token"),
-            string::utf8(b"withdraw"),
-        );
+        let withdraw =
+            function_info::new_function_info(
+                account,
+                string::utf8(b"simple_token"),
+                string::utf8(b"withdraw"),
+            );
 
-        let deposit = function_info::new_function_info(
-            account,
-            string::utf8(b"simple_token"),
-            string::utf8(b"deposit"),
-        );
+        let deposit =
+            function_info::new_function_info(
+                account,
+                string::utf8(b"simple_token"),
+                string::utf8(b"deposit"),
+            );
 
         dispatchable_fungible_asset::register_dispatch_functions(
             constructor_ref,
             option::some(withdraw),
             option::some(deposit),
-            option::none()
+            option::none(),
         );
     }
 

--- a/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_fa_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_fa_tests.move
@@ -1,9 +1,27 @@
 #[test_only]
 module aptos_framework::simple_token_fa_tests {
     use aptos_framework::fungible_asset::{
-        amount, balance, burn, destroy_zero, extract, create_test_token, init_test_metadata,
-        supply, create_store, create_test_store, remove_store, deposit_with_ref, mint, mint_to, merge,
-        set_frozen_flag, is_frozen, transfer_with_ref, upgrade_to_concurrent, Metadata, TestToken
+        amount,
+        balance,
+        burn,
+        destroy_zero,
+        extract,
+        create_test_token,
+        init_test_metadata,
+        supply,
+        create_store,
+        create_test_store,
+        remove_store,
+        deposit_with_ref,
+        mint,
+        mint_to,
+        merge,
+        set_frozen_flag,
+        is_frozen,
+        transfer_with_ref,
+        upgrade_to_concurrent,
+        Metadata,
+        TestToken
     };
     use aptos_framework::object;
     use 0xcafe::simple_token;
@@ -24,11 +42,11 @@ module aptos_framework::simple_token_fa_tests {
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     fun test_transfer_with_ref(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) {
         let (creator_ref, test_token) = create_test_token(creator);
-        let (mint_ref, transfer_ref, _burn_ref, _mutate_metadata_ref) = init_test_metadata(&creator_ref);
+        let (mint_ref, transfer_ref, _burn_ref, _mutate_metadata_ref) =
+            init_test_metadata(&creator_ref);
         let metadata = object::convert<TestToken, Metadata>(test_token);
         simple_token::initialize(creator, &creator_ref);
 
@@ -49,7 +67,8 @@ module aptos_framework::simple_token_fa_tests {
     #[test(creator = @0xcafe)]
     fun test_merge_and_exact(creator: &signer) {
         let (creator_ref, _test_token) = create_test_token(creator);
-        let (mint_ref, _transfer_ref, burn_ref, _mutate_metadata_ref) = init_test_metadata(&creator_ref);
+        let (mint_ref, _transfer_ref, burn_ref, _mutate_metadata_ref) =
+            init_test_metadata(&creator_ref);
         simple_token::initialize(creator, &creator_ref);
 
         let fa = mint(&mint_ref, 100);
@@ -58,22 +77,21 @@ module aptos_framework::simple_token_fa_tests {
         assert!(amount(&cash) == 80, 2);
         let more_cash = extract(&mut fa, 20);
         destroy_zero(fa);
-        merge(&mut cash,
-         more_cash);
+        merge(&mut cash, more_cash);
         assert!(amount(&cash) == 100, 3);
         burn(&burn_ref, cash);
     }
 
     #[test(fx = @aptos_framework, creator = @0xcafe)]
     fun test_fungible_asset_upgrade(
-        fx: &signer,
-        creator: &signer
+        fx: &signer, creator: &signer
     ) {
         let feature = features::get_concurrent_fungible_assets_feature();
         features::change_feature_flags_for_testing(fx, vector[], vector[feature]);
 
         let (creator_ref, token_object) = create_test_token(creator);
-        let (mint_ref, transfer_ref, _burn_ref, _mutate_metadata_ref) = init_test_metadata(&creator_ref);
+        let (mint_ref, transfer_ref, _burn_ref, _mutate_metadata_ref) =
+            init_test_metadata(&creator_ref);
         let test_token = object::convert<TestToken, Metadata>(token_object);
         simple_token::initialize(creator, &creator_ref);
 
@@ -97,11 +115,10 @@ module aptos_framework::simple_token_fa_tests {
 
     #[test(creator = @0xcafe)]
     #[expected_failure(abort_code = 0x50003, location = aptos_framework::fungible_asset)]
-    fun test_mint_to_frozen(
-        creator: &signer
-    ) {
+    fun test_mint_to_frozen(creator: &signer) {
         let (creator_ref, test_token) = create_test_token(creator);
-        let (mint_ref, transfer_ref, _burn_ref, _mutate_metadata_ref) = init_test_metadata(&creator_ref);
+        let (mint_ref, transfer_ref, _burn_ref, _mutate_metadata_ref) =
+            init_test_metadata(&creator_ref);
         let metadata = object::convert<TestToken, Metadata>(test_token);
         simple_token::initialize(creator, &creator_ref);
 

--- a/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_fa_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_fa_tests.move
@@ -41,9 +41,7 @@ module aptos_framework::simple_token_fa_tests {
     }
 
     #[test(creator = @0xcafe, aaron = @0xface)]
-    fun test_transfer_with_ref(
-        creator: &signer, aaron: &signer,
-    ) {
+    fun test_transfer_with_ref(creator: &signer, aaron: &signer,) {
         let (creator_ref, test_token) = create_test_token(creator);
         let (mint_ref, transfer_ref, _burn_ref, _mutate_metadata_ref) =
             init_test_metadata(&creator_ref);
@@ -83,9 +81,7 @@ module aptos_framework::simple_token_fa_tests {
     }
 
     #[test(fx = @aptos_framework, creator = @0xcafe)]
-    fun test_fungible_asset_upgrade(
-        fx: &signer, creator: &signer
-    ) {
+    fun test_fungible_asset_upgrade(fx: &signer, creator: &signer) {
         let feature = features::get_concurrent_fungible_assets_feature();
         features::change_feature_flags_for_testing(fx, vector[], vector[feature]);
 

--- a/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_pfs_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_pfs_tests.move
@@ -2,9 +2,21 @@
 module aptos_framework::simple_token_pfs_tests {
     use aptos_framework::fungible_asset::{create_test_token};
     use aptos_framework::primary_fungible_store::{
-        balance, burn, deposit, mint, primary_store, transfer, transfer_assert_minimum_deposit,
-        withdraw, init_test_metadata_with_primary_store_enabled, is_frozen, set_frozen_flag,
-        transfer_with_ref, deposit_with_ref, withdraw_with_ref, primary_store_exists,
+        balance,
+        burn,
+        deposit,
+        mint,
+        primary_store,
+        transfer,
+        transfer_assert_minimum_deposit,
+        withdraw,
+        init_test_metadata_with_primary_store_enabled,
+        is_frozen,
+        set_frozen_flag,
+        transfer_with_ref,
+        deposit_with_ref,
+        withdraw_with_ref,
+        primary_store_exists,
         ensure_primary_store_exists
     };
     use aptos_framework::object;
@@ -14,11 +26,11 @@ module aptos_framework::simple_token_pfs_tests {
     // Copied from primary_fungible_store tests.
     #[test(user_1 = @0xcafe, user_2 = @0xface)]
     fun test_transfer_to_burnt_store(
-        user_1: &signer,
-        user_2: &signer,
+        user_1: &signer, user_2: &signer,
     ) {
         let (creator_ref, metadata) = create_test_token(user_1);
-        let (mint_ref, _, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
+        let (mint_ref, _, _) =
+            init_test_metadata_with_primary_store_enabled(&creator_ref);
         simple_token::initialize(user_1, &creator_ref);
 
         let user_1_address = signer::address_of(user_1);
@@ -40,11 +52,11 @@ module aptos_framework::simple_token_pfs_tests {
 
     #[test(user_1 = @0xcafe, user_2 = @0xface)]
     fun test_withdraw_from_burnt_store(
-        user_1: &signer,
-        user_2: &signer,
+        user_1: &signer, user_2: &signer,
     ) {
         let (creator_ref, metadata) = create_test_token(user_1);
-        let (mint_ref, _, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
+        let (mint_ref, _, _) =
+            init_test_metadata_with_primary_store_enabled(&creator_ref);
         simple_token::initialize(user_1, &creator_ref);
 
         let user_1_address = signer::address_of(user_1);
@@ -83,11 +95,11 @@ module aptos_framework::simple_token_pfs_tests {
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     fun test_basic_flow(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) {
         let (creator_ref, metadata) = create_test_token(creator);
-        let (mint_ref, transfer_ref, burn_ref) = init_test_metadata_with_primary_store_enabled(&creator_ref);
+        let (mint_ref, transfer_ref, burn_ref) =
+            init_test_metadata_with_primary_store_enabled(&creator_ref);
         simple_token::initialize(creator, &creator_ref);
 
         let creator_address = signer::address_of(creator);
@@ -113,11 +125,11 @@ module aptos_framework::simple_token_pfs_tests {
 
     #[test(creator = @0xcafe, aaron = @0xface)]
     fun test_basic_flow_with_min_balance(
-        creator: &signer,
-        aaron: &signer,
+        creator: &signer, aaron: &signer,
     ) {
         let (creator_ref, metadata) = create_test_token(creator);
-        let (mint_ref, _transfer_ref, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
+        let (mint_ref, _transfer_ref, _) =
+            init_test_metadata_with_primary_store_enabled(&creator_ref);
         simple_token::initialize(creator, &creator_ref);
 
         let creator_address = signer::address_of(creator);

--- a/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_pfs_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_pfs_tests.move
@@ -25,9 +25,7 @@ module aptos_framework::simple_token_pfs_tests {
 
     // Copied from primary_fungible_store tests.
     #[test(user_1 = @0xcafe, user_2 = @0xface)]
-    fun test_transfer_to_burnt_store(
-        user_1: &signer, user_2: &signer,
-    ) {
+    fun test_transfer_to_burnt_store(user_1: &signer, user_2: &signer,) {
         let (creator_ref, metadata) = create_test_token(user_1);
         let (mint_ref, _, _) =
             init_test_metadata_with_primary_store_enabled(&creator_ref);
@@ -94,9 +92,7 @@ module aptos_framework::simple_token_pfs_tests {
     }
 
     #[test(creator = @0xcafe, aaron = @0xface)]
-    fun test_basic_flow(
-        creator: &signer, aaron: &signer,
-    ) {
+    fun test_basic_flow(creator: &signer, aaron: &signer,) {
         let (creator_ref, metadata) = create_test_token(creator);
         let (mint_ref, transfer_ref, burn_ref) =
             init_test_metadata_with_primary_store_enabled(&creator_ref);

--- a/aptos-move/framework/aptos-framework/tests/ten_x_token.move
+++ b/aptos-move/framework/aptos-framework/tests/ten_x_token.move
@@ -10,27 +10,30 @@ module 0xcafe::ten_x_token {
     use std::signer;
     use std::string;
 
-    public fun initialize(account: &signer, constructor_ref: &ConstructorRef) {
+    public fun initialize(
+        account: &signer, constructor_ref: &ConstructorRef
+    ) {
         assert!(signer::address_of(account) == @0xcafe, 1);
-        let balance_value = function_info::new_function_info(
-            account,
-            string::utf8(b"ten_x_token"),
-            string::utf8(b"derived_balance"),
-        );
-        let supply_value = function_info::new_function_info(
-            account,
-            string::utf8(b"ten_x_token"),
-            string::utf8(b"derived_supply"),
-        );
+        let balance_value =
+            function_info::new_function_info(
+                account,
+                string::utf8(b"ten_x_token"),
+                string::utf8(b"derived_balance"),
+            );
+        let supply_value =
+            function_info::new_function_info(
+                account,
+                string::utf8(b"ten_x_token"),
+                string::utf8(b"derived_supply"),
+            );
         dispatchable_fungible_asset::register_dispatch_functions(
             constructor_ref,
             option::none(),
             option::none(),
-            option::some(balance_value)
+            option::some(balance_value),
         );
         dispatchable_fungible_asset::register_derive_supply_dispatch_function(
-            constructor_ref,
-            option::some(supply_value)
+            constructor_ref, option::some(supply_value)
         );
     }
 
@@ -41,8 +44,10 @@ module 0xcafe::ten_x_token {
 
     public fun derived_supply<T: key>(metadata: Object<T>): Option<u128> {
         // Derived supply is 10x.
-        if(option::is_some(&fungible_asset::supply(metadata))) {
-            return option::some(option::extract(&mut fungible_asset::supply(metadata)) * 10)
+        if (option::is_some(&fungible_asset::supply(metadata))) {
+            return option::some(
+                option::extract(&mut fungible_asset::supply(metadata)) * 10
+            )
         };
         option::none()
     }

--- a/aptos-move/framework/aptos-framework/tests/ten_x_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/ten_x_token_tests.move
@@ -7,9 +7,7 @@ module aptos_framework::ten_x_token_tests {
     use std::option;
 
     #[test(creator = @0xcafe)]
-    fun test_ten_x(
-        creator: &signer,
-    ) {
+    fun test_ten_x(creator: &signer,) {
         let (creator_ref, token_object) = fungible_asset::create_test_token(creator);
         let (mint, _, _, _) = fungible_asset::init_test_metadata(&creator_ref);
         let metadata = object::convert<TestToken, Metadata>(token_object);
@@ -19,7 +17,9 @@ module aptos_framework::ten_x_token_tests {
         ten_x_token::initialize(creator, &creator_ref);
 
         assert!(fungible_asset::supply(metadata) == option::some(0), 1);
-        assert!(dispatchable_fungible_asset::derived_supply(metadata) == option::some(0), 2);
+        assert!(
+            dispatchable_fungible_asset::derived_supply(metadata) == option::some(0), 2
+        );
         // Mint
         let fa = fungible_asset::mint(&mint, 100);
         assert!(fungible_asset::supply(metadata) == option::some(100), 3);
@@ -30,6 +30,8 @@ module aptos_framework::ten_x_token_tests {
         assert!(dispatchable_fungible_asset::derived_balance(creator_store) == 1000, 4);
 
         // The derived supply is 10x
-        assert!(dispatchable_fungible_asset::derived_supply(metadata) == option::some(1000), 5);
+        assert!(
+            dispatchable_fungible_asset::derived_supply(metadata) == option::some(1000), 5
+        );
     }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/any.move
+++ b/aptos-move/framework/aptos-stdlib/sources/any.move
@@ -29,15 +29,15 @@ module aptos_std::any {
     /// Pack a value into the `Any` representation. Because Any can be stored and dropped, this is
     /// also required from `T`.
     public fun pack<T: drop + store>(x: T): Any {
-        Any {
-            type_name: type_info::type_name<T>(),
-            data: to_bytes(&x)
-        }
+        Any { type_name: type_info::type_name<T>(), data: to_bytes(&x) }
     }
 
     /// Unpack a value from the `Any` representation. This aborts if the value has not the expected type `T`.
     public fun unpack<T>(x: Any): T {
-        assert!(type_info::type_name<T>() == x.type_name, error::invalid_argument(ETYPE_MISMATCH));
+        assert!(
+            type_info::type_name<T>() == x.type_name,
+            error::invalid_argument(ETYPE_MISMATCH),
+        );
         from_bytes<T>(x.data)
     }
 
@@ -47,7 +47,9 @@ module aptos_std::any {
     }
 
     #[test_only]
-    struct S has store, drop { x: u64 }
+    struct S has store, drop {
+        x: u64
+    }
 
     #[test]
     fun test_any() {

--- a/aptos-move/framework/aptos-stdlib/sources/any.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/any.spec.move
@@ -8,10 +8,8 @@ spec aptos_std::any {
         use std::bcs;
         use aptos_std::from_bcs;
         aborts_if false;
-        ensures result == Any {
-            type_name: type_info::type_name<T>(),
-            data: bcs::serialize<T>(x)
-        };
+        ensures result
+            == Any { type_name: type_info::type_name<T>(), data: bcs::serialize<T>(x) };
         ensures [abstract] from_bcs::deserializable<T>(result.data);
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/capability.move
+++ b/aptos-move/framework/aptos-stdlib/sources/capability.move
@@ -108,58 +108,73 @@ module aptos_std::capability {
     /// they own the `Feature` type parameter.
     public fun create<Feature>(owner: &signer, _feature_witness: &Feature) {
         let addr = signer::address_of(owner);
-        assert!(!exists<CapState<Feature>>(addr), error::already_exists(ECAPABILITY_ALREADY_EXISTS));
+        assert!(
+            !exists<CapState<Feature>>(addr),
+            error::already_exists(ECAPABILITY_ALREADY_EXISTS),
+        );
         move_to<CapState<Feature>>(owner, CapState { delegates: vector::empty() });
     }
 
     /// Acquires a capability token. Only the owner of the capability class, or an authorized delegate,
     /// can succeed with this operation. A caller must pass a witness that they own the `Feature` type
     /// parameter.
-    public fun acquire<Feature>(requester: &signer, _feature_witness: &Feature): Cap<Feature>
-    acquires CapState, CapDelegateState {
+    public fun acquire<Feature>(
+        requester: &signer, _feature_witness: &Feature
+    ): Cap<Feature> acquires CapState, CapDelegateState {
         Cap<Feature> { root: validate_acquire<Feature>(requester) }
     }
 
     /// Acquires a linear capability token. It is up to the module which owns `Feature` to decide
     /// whether to expose a linear or non-linear capability.
-    public fun acquire_linear<Feature>(requester: &signer, _feature_witness: &Feature): LinearCap<Feature>
-    acquires CapState, CapDelegateState {
+    public fun acquire_linear<Feature>(
+        requester: &signer, _feature_witness: &Feature
+    ): LinearCap<Feature> acquires CapState, CapDelegateState {
         LinearCap<Feature> { root: validate_acquire<Feature>(requester) }
     }
 
     /// Helper to validate an acquire. Returns the root address of the capability.
-    fun validate_acquire<Feature>(requester: &signer): address
-    acquires CapState, CapDelegateState {
+    fun validate_acquire<Feature>(requester: &signer): address acquires CapState, CapDelegateState {
         let addr = signer::address_of(requester);
         if (exists<CapDelegateState<Feature>>(addr)) {
             let root_addr = borrow_global<CapDelegateState<Feature>>(addr).root;
             // double check that requester is actually registered as a delegate
             assert!(exists<CapState<Feature>>(root_addr), error::invalid_state(EDELEGATE));
-            assert!(vector::contains(&borrow_global<CapState<Feature>>(root_addr).delegates, &addr),
-                error::invalid_state(EDELEGATE));
+            assert!(
+                vector::contains(
+                    &borrow_global<CapState<Feature>>(root_addr).delegates, &addr
+                ),
+                error::invalid_state(EDELEGATE),
+            );
             root_addr
         } else {
-            assert!(exists<CapState<Feature>>(addr), error::not_found(ECAPABILITY_NOT_FOUND));
+            assert!(
+                exists<CapState<Feature>>(addr), error::not_found(ECAPABILITY_NOT_FOUND)
+            );
             addr
         }
     }
 
     /// Returns the root address associated with the given capability token. Only the owner
     /// of the feature can do this.
-    public fun root_addr<Feature>(cap: Cap<Feature>, _feature_witness: &Feature): address {
+    public fun root_addr<Feature>(
+        cap: Cap<Feature>, _feature_witness: &Feature
+    ): address {
         cap.root
     }
 
     /// Returns the root address associated with the given linear capability token.
-    public fun linear_root_addr<Feature>(cap: LinearCap<Feature>, _feature_witness: &Feature): address {
+    public fun linear_root_addr<Feature>(
+        cap: LinearCap<Feature>, _feature_witness: &Feature
+    ): address {
         cap.root
     }
 
     /// Registers a delegation relation. If the relation already exists, this function does
     /// nothing.
     // TODO: explore whether this should be idempotent like now or abort
-    public fun delegate<Feature>(cap: Cap<Feature>, _feature_witness: &Feature, to: &signer)
-    acquires CapState {
+    public fun delegate<Feature>(
+        cap: Cap<Feature>, _feature_witness: &Feature, to: &signer
+    ) acquires CapState {
         let addr = signer::address_of(to);
         if (exists<CapDelegateState<Feature>>(addr)) return;
         move_to(to, CapDelegateState<Feature> { root: cap.root });
@@ -168,12 +183,14 @@ module aptos_std::capability {
 
     /// Revokes a delegation relation. If no relation exists, this function does nothing.
     // TODO: explore whether this should be idempotent like now or abort
-    public fun revoke<Feature>(cap: Cap<Feature>, _feature_witness: &Feature, from: address)
-    acquires CapState, CapDelegateState
-    {
+    public fun revoke<Feature>(
+        cap: Cap<Feature>, _feature_witness: &Feature, from: address
+    ) acquires CapState, CapDelegateState {
         if (!exists<CapDelegateState<Feature>>(from)) return;
         let CapDelegateState { root: _root } = move_from<CapDelegateState<Feature>>(from);
-        remove_element(&mut borrow_global_mut<CapState<Feature>>(cap.root).delegates, &from);
+        remove_element(
+            &mut borrow_global_mut<CapState<Feature>>(cap.root).delegates, &from
+        );
     }
 
     /// Helper to remove an element from a vector.

--- a/aptos-move/framework/aptos-stdlib/sources/capability.move
+++ b/aptos-move/framework/aptos-stdlib/sources/capability.move
@@ -141,14 +141,16 @@ module aptos_std::capability {
             assert!(exists<CapState<Feature>>(root_addr), error::invalid_state(EDELEGATE));
             assert!(
                 vector::contains(
-                    &borrow_global<CapState<Feature>>(root_addr).delegates, &addr
+                    &borrow_global<CapState<Feature>>(root_addr).delegates,
+                    &addr,
                 ),
                 error::invalid_state(EDELEGATE),
             );
             root_addr
         } else {
             assert!(
-                exists<CapState<Feature>>(addr), error::not_found(ECAPABILITY_NOT_FOUND)
+                exists<CapState<Feature>>(addr),
+                error::not_found(ECAPABILITY_NOT_FOUND),
             );
             addr
         }
@@ -189,7 +191,8 @@ module aptos_std::capability {
         if (!exists<CapDelegateState<Feature>>(from)) return;
         let CapDelegateState { root: _root } = move_from<CapDelegateState<Feature>>(from);
         remove_element(
-            &mut borrow_global_mut<CapState<Feature>>(cap.root).delegates, &from
+            &mut borrow_global_mut<CapState<Feature>>(cap.root).delegates,
+            &from,
         );
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/capability.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/capability.spec.move
@@ -24,31 +24,40 @@ spec aptos_std::capability {
         let addr = signer::address_of(requester);
         let root_addr = global<CapDelegateState<Feature>>(addr).root;
         include AcquireSchema<Feature>;
-        ensures spec_has_delegate_cap<Feature>(addr) ==> result.root == root_addr;
-        ensures !spec_has_delegate_cap<Feature>(addr) ==> result.root == addr;
+        ensures spec_has_delegate_cap<Feature>(addr) ==>
+            result.root == root_addr;
+        ensures !spec_has_delegate_cap<Feature>(addr) ==>
+            result.root == addr;
     }
 
     spec acquire_linear<Feature>(requester: &signer, _feature_witness: &Feature): LinearCap<Feature> {
         let addr = signer::address_of(requester);
         let root_addr = global<CapDelegateState<Feature>>(addr).root;
         include AcquireSchema<Feature>;
-        ensures spec_has_delegate_cap<Feature>(addr) ==> result.root == root_addr;
-        ensures !spec_has_delegate_cap<Feature>(addr) ==> result.root == addr;
+        ensures spec_has_delegate_cap<Feature>(addr) ==>
+            result.root == root_addr;
+        ensures !spec_has_delegate_cap<Feature>(addr) ==>
+            result.root == addr;
     }
 
     spec schema AcquireSchema<Feature> {
         addr: address;
         root_addr: address;
-        aborts_if spec_has_delegate_cap<Feature>(addr) && !spec_has_cap<Feature>(root_addr);
-        aborts_if spec_has_delegate_cap<Feature>(addr) && !vector::spec_contains(spec_delegates<Feature>(root_addr), addr);
+        aborts_if spec_has_delegate_cap<Feature>(addr) && !spec_has_cap<Feature>(
+            root_addr
+        );
+        aborts_if spec_has_delegate_cap<Feature>(addr)
+            && !vector::spec_contains(spec_delegates<Feature>(root_addr), addr);
         aborts_if !spec_has_delegate_cap<Feature>(addr) && !spec_has_cap<Feature>(addr);
     }
 
     spec delegate<Feature>(cap: Cap<Feature>, _feature_witness: &Feature, to: &signer) {
         let addr = signer::address_of(to);
         ensures spec_has_delegate_cap<Feature>(addr);
-        ensures !old(spec_has_delegate_cap<Feature>(addr)) ==> global<CapDelegateState<Feature>>(addr).root == cap.root;
-        ensures !old(spec_has_delegate_cap<Feature>(addr)) ==> vector::spec_contains(spec_delegates<Feature>(cap.root), addr);
+        ensures !old(spec_has_delegate_cap<Feature>(addr)) ==>
+            global<CapDelegateState<Feature>>(addr).root == cap.root;
+        ensures !old(spec_has_delegate_cap<Feature>(addr)) ==>
+            vector::spec_contains(spec_delegates<Feature>(cap.root), addr);
     }
 
     spec revoke<Feature>(cap: Cap<Feature>, _feature_witness: &Feature, from: address) {

--- a/aptos-move/framework/aptos-stdlib/sources/comparator.move
+++ b/aptos-move/framework/aptos-stdlib/sources/comparator.move
@@ -138,29 +138,13 @@ module aptos_std::comparator {
         vector::push_back(&mut value0_1, 5);
         vector::push_back(&mut value0_1, 1);
 
-        let base = Complex {
-            value0: value0_0,
-            value1: 13,
-            value2: 41,
-        };
+        let base = Complex { value0: value0_0, value1: 13, value2: 41, };
 
-        let other_0 = Complex {
-            value0: value0_1,
-            value1: 13,
-            value2: 41,
-        };
+        let other_0 = Complex { value0: value0_1, value1: 13, value2: 41, };
 
-        let other_1 = Complex {
-            value0: copy value0_0,
-            value1: 14,
-            value2: 41,
-        };
+        let other_1 = Complex { value0: copy value0_0, value1: 14, value2: 41, };
 
-        let other_2 = Complex {
-            value0: value0_0,
-            value1: 13,
-            value2: 42,
-        };
+        let other_2 = Complex { value0: value0_0, value1: 13, value2: 42, };
 
         assert!(is_equal(&compare(&base, &base)), 0);
         assert!(is_smaller_than(&compare(&base, &other_0)), 1);

--- a/aptos-move/framework/aptos-stdlib/sources/comparator.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/comparator.spec.move
@@ -48,21 +48,23 @@ spec aptos_std::comparator {
         ensures (result.inner == SMALLER) ==>
             (
                 (
-                    exists i: u64 where i < left_length: (i < right_length)
-                    && (left[i] < right[i])
-                    && (forall j: u64 where j < i: left[j] == right[j])
+                    exists i: u64 where i < left_length:
+                        (i < right_length)
+                            && (left[i] < right[i])
+                            && (forall j: u64 where j < i: left[j] == right[j])
                 )
-                || (left_length < right_length)
+                    || (left_length < right_length)
             );
 
         ensures (result.inner == GREATER) ==>
             (
                 (
-                    exists i: u64 where i < left_length: (i < right_length)
-                    && (left[i] > right[i])
-                    && (forall j: u64 where j < i: left[j] == right[j])
+                    exists i: u64 where i < left_length:
+                        (i < right_length)
+                            && (left[i] > right[i])
+                            && (forall j: u64 where j < i: left[j] == right[j])
                 )
-                || (left_length > right_length)
+                    || (left_length > right_length)
             );
 
         ensures [abstract] result == spec_compare_u8_vector(left, right);

--- a/aptos-move/framework/aptos-stdlib/sources/comparator.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/comparator.spec.move
@@ -1,6 +1,8 @@
 spec aptos_std::comparator {
     spec Result {
-        invariant inner == EQUAL || inner == SMALLER || inner == GREATER;
+        invariant inner == EQUAL
+            || inner == SMALLER
+            || inner == GREATER;
     }
 
     spec is_equal(result: &Result): bool {
@@ -37,28 +39,31 @@ spec aptos_std::comparator {
         let left_length = len(left);
         let right_length = len(right);
 
-        ensures (result.inner == EQUAL) ==> (
-            (left_length == right_length) &&
-                (forall i: u64 where i < left_length: left[i] == right[i])
-        );
+        ensures (result.inner == EQUAL) ==>
+            (
+                (left_length == right_length)
+                    && (forall i: u64 where i < left_length: left[i] == right[i])
+            );
 
-        ensures (result.inner == SMALLER) ==> (
-            (exists i: u64 where i < left_length:
-                (i < right_length) &&
-                    (left[i] < right[i]) &&
-                    (forall j: u64 where j < i: left[j] == right[j])
-            ) ||
-                (left_length < right_length)
-        );
+        ensures (result.inner == SMALLER) ==>
+            (
+                (
+                    exists i: u64 where i < left_length: (i < right_length)
+                    && (left[i] < right[i])
+                    && (forall j: u64 where j < i: left[j] == right[j])
+                )
+                || (left_length < right_length)
+            );
 
-        ensures (result.inner == GREATER) ==> (
-            (exists i: u64 where i < left_length:
-                (i < right_length) &&
-                    (left[i] > right[i]) &&
-                    (forall j: u64 where j < i: left[j] == right[j])
-            ) ||
-                (left_length > right_length)
-        );
+        ensures (result.inner == GREATER) ==>
+            (
+                (
+                    exists i: u64 where i < left_length: (i < right_length)
+                    && (left[i] > right[i])
+                    && (forall j: u64 where j < i: left[j] == right[j])
+                )
+                || (left_length > right_length)
+            );
 
         ensures [abstract] result == spec_compare_u8_vector(left, right);
     }

--- a/aptos-move/framework/aptos-stdlib/sources/copyable_any.move
+++ b/aptos-move/framework/aptos-stdlib/sources/copyable_any.move
@@ -17,15 +17,15 @@ module aptos_std::copyable_any {
     /// Pack a value into the `Any` representation. Because Any can be stored, dropped, and copied this is
     /// also required from `T`.
     public fun pack<T: drop + store + copy>(x: T): Any {
-        Any {
-            type_name: type_info::type_name<T>(),
-            data: bcs::to_bytes(&x)
-        }
+        Any { type_name: type_info::type_name<T>(), data: bcs::to_bytes(&x) }
     }
 
     /// Unpack a value from the `Any` representation. This aborts if the value has not the expected type `T`.
     public fun unpack<T>(x: Any): T {
-        assert!(type_info::type_name<T>() == x.type_name, error::invalid_argument(ETYPE_MISMATCH));
+        assert!(
+            type_info::type_name<T>() == x.type_name,
+            error::invalid_argument(ETYPE_MISMATCH),
+        );
         from_bytes<T>(x.data)
     }
 
@@ -35,7 +35,9 @@ module aptos_std::copyable_any {
     }
 
     #[test_only]
-    struct S has store, drop, copy { x: u64 }
+    struct S has store, drop, copy {
+        x: u64
+    }
 
     #[test]
     fun test_any() {

--- a/aptos-move/framework/aptos-stdlib/sources/copyable_any.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/copyable_any.spec.move
@@ -9,10 +9,8 @@ spec aptos_std::copyable_any {
         use aptos_std::from_bcs;
         aborts_if false;
         pragma opaque;
-        ensures result == Any {
-            type_name: type_info::type_name<T>(),
-            data: bcs::serialize<T>(x)
-        };
+        ensures result
+            == Any { type_name: type_info::type_name<T>(), data: bcs::serialize<T>(x) };
         ensures [abstract] from_bcs::deserializable<T>(result.data);
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381.move
@@ -86,9 +86,7 @@ module aptos_std::bls12381 {
     /// Creates a new public key from a sequence of bytes.
     public fun public_key_from_bytes(bytes: vector<u8>): Option<PublicKey> {
         if (validate_pubkey_internal(bytes)) {
-            option::some(PublicKey {
-                bytes
-            })
+            option::some(PublicKey { bytes })
         } else {
             option::none<PublicKey>()
         }
@@ -101,9 +99,7 @@ module aptos_std::bls12381 {
 
     /// Creates a new proof-of-possession (PoP) which can be later used to create a PublicKeyWithPoP struct,
     public fun proof_of_possession_from_bytes(bytes: vector<u8>): ProofOfPossession {
-        ProofOfPossession {
-            bytes
-        }
+        ProofOfPossession { bytes }
     }
 
     /// Serializes the signature into 96 bytes.
@@ -112,11 +108,11 @@ module aptos_std::bls12381 {
     }
 
     /// Creates a PoP'd public key from a normal public key and a corresponding proof-of-possession.
-    public fun public_key_from_bytes_with_pop(pk_bytes: vector<u8>, pop: &ProofOfPossession): Option<PublicKeyWithPoP> {
+    public fun public_key_from_bytes_with_pop(
+        pk_bytes: vector<u8>, pop: &ProofOfPossession
+    ): Option<PublicKeyWithPoP> {
         if (verify_proof_of_possession_internal(pk_bytes, pop.bytes)) {
-            option::some(PublicKeyWithPoP {
-                bytes: pk_bytes
-            })
+            option::some(PublicKeyWithPoP { bytes: pk_bytes })
         } else {
             option::none<PublicKeyWithPoP>()
         }
@@ -124,9 +120,7 @@ module aptos_std::bls12381 {
 
     /// Creates a normal public key from a PoP'd public key.
     public fun public_key_with_pop_to_normal(pkpop: &PublicKeyWithPoP): PublicKey {
-        PublicKey {
-            bytes: pkpop.bytes
-        }
+        PublicKey { bytes: pkpop.bytes }
     }
 
     /// Serializes a PoP'd public key into 48 bytes.
@@ -137,9 +131,7 @@ module aptos_std::bls12381 {
     /// Creates a new signature from a sequence of bytes. Does not check the signature for prime-order subgroup
     /// membership since that is done implicitly during verification.
     public fun signature_from_bytes(bytes: vector<u8>): Signature {
-        Signature {
-            bytes
-        }
+        Signature { bytes }
     }
 
     /// Serializes the signature into 96 bytes.
@@ -161,9 +153,7 @@ module aptos_std::bls12381 {
         let (bytes, success) = aggregate_pubkeys_internal(public_keys);
         assert!(success, std::error::invalid_argument(EZERO_PUBKEYS));
 
-        AggrPublicKeysWithPoP {
-            bytes
-        }
+        AggrPublicKeysWithPoP { bytes }
     }
 
     /// Serializes an aggregate public key into 48 bytes.
@@ -174,13 +164,12 @@ module aptos_std::bls12381 {
     /// Aggregates the input signatures into an aggregate-or-multi-signature structure, which can be later verified via
     /// `verify_aggregate_signature` or `verify_multisignature`. Returns `None` if zero signatures are given as input
     /// or if some of the signatures are not valid group elements.
-    public fun aggregate_signatures(signatures: vector<Signature>): Option<AggrOrMultiSignature> {
+    public fun aggregate_signatures(signatures: vector<Signature>)
+        : Option<AggrOrMultiSignature> {
         let (bytes, success) = aggregate_signatures_internal(signatures);
         if (success) {
             option::some(
-                AggrOrMultiSignature {
-                    bytes
-                }
+                AggrOrMultiSignature { bytes },
             )
         } else {
             option::none<AggrOrMultiSignature>()
@@ -188,22 +177,26 @@ module aptos_std::bls12381 {
     }
 
     /// Serializes an aggregate-or-multi-signature into 96 bytes.
-    public fun aggr_or_multi_signature_to_bytes(sig: &AggrOrMultiSignature): vector<u8> {
+    public fun aggr_or_multi_signature_to_bytes(
+        sig: &AggrOrMultiSignature
+    ): vector<u8> {
         sig.bytes
     }
 
     /// Deserializes an aggregate-or-multi-signature from 96 bytes.
     public fun aggr_or_multi_signature_from_bytes(bytes: vector<u8>): AggrOrMultiSignature {
-        assert!(std::vector::length(&bytes) == SIGNATURE_SIZE, std::error::invalid_argument(EWRONG_SIZE));
+        assert!(
+            std::vector::length(&bytes) == SIGNATURE_SIZE,
+            std::error::invalid_argument(EWRONG_SIZE),
+        );
 
-        AggrOrMultiSignature {
-            bytes
-        }
+        AggrOrMultiSignature { bytes }
     }
 
-
     /// Checks that the group element that defines an aggregate-or-multi-signature is in the prime-order subgroup.
-    public fun aggr_or_multi_signature_subgroup_check(signature: &AggrOrMultiSignature): bool {
+    public fun aggr_or_multi_signature_subgroup_check(
+        signature: &AggrOrMultiSignature
+    ): bool {
         signature_subgroup_check_internal(signature.bytes)
     }
 
@@ -227,18 +220,14 @@ module aptos_std::bls12381 {
 
     /// Verifies a normal, non-aggregated signature.
     public fun verify_normal_signature(
-        signature: &Signature,
-        public_key: &PublicKey,
-        message: vector<u8>
+        signature: &Signature, public_key: &PublicKey, message: vector<u8>
     ): bool {
         verify_normal_signature_internal(signature.bytes, public_key.bytes, message)
     }
 
     /// Verifies a signature share in the multisignature share or an aggregate signature share.
     public fun verify_signature_share(
-        signature_share: &Signature,
-        public_key: &PublicKeyWithPoP,
-        message: vector<u8>
+        signature_share: &Signature, public_key: &PublicKeyWithPoP, message: vector<u8>
     ): bool {
         verify_signature_share_internal(signature_share.bytes, public_key.bytes, message)
     }
@@ -247,26 +236,24 @@ module aptos_std::bls12381 {
     /// Generates a BLS key-pair: a secret key with its corresponding public key.
     public fun generate_keys(): (SecretKey, PublicKeyWithPoP) {
         let (sk_bytes, pk_bytes) = generate_keys_internal();
-        let sk = SecretKey {
-            bytes: sk_bytes
-        };
-        let pkpop = PublicKeyWithPoP {
-            bytes: pk_bytes
-        };
+        let sk = SecretKey { bytes: sk_bytes };
+        let pkpop = PublicKeyWithPoP { bytes: pk_bytes };
         (sk, pkpop)
     }
 
     #[test_only]
     /// Generates a BLS signature for a message with a signing key.
-    public fun sign_arbitrary_bytes(signing_key: &SecretKey, message: vector<u8>): Signature {
-        Signature {
-            bytes: sign_internal(signing_key.bytes, message)
-        }
+    public fun sign_arbitrary_bytes(
+        signing_key: &SecretKey, message: vector<u8>
+    ): Signature {
+        Signature { bytes: sign_internal(signing_key.bytes, message) }
     }
 
     #[test_only]
     /// Generates a multi-signature for a message with multiple signing keys.
-    public fun multi_sign_arbitrary_bytes(signing_keys: &vector<SecretKey>, message: vector<u8>): AggrOrMultiSignature {
+    public fun multi_sign_arbitrary_bytes(
+        signing_keys: &vector<SecretKey>, message: vector<u8>
+    ): AggrOrMultiSignature {
         let n = std::vector::length(signing_keys);
         let sigs = vector[];
         let i: u64 = 0;
@@ -281,14 +268,24 @@ module aptos_std::bls12381 {
 
     #[test_only]
     /// Generates an aggregated signature over all messages in messages, where signing_keys[i] signs messages[i].
-    public fun aggr_sign_arbitrary_bytes(signing_keys: &vector<SecretKey>, messages: &vector<vector<u8>>): AggrOrMultiSignature {
+    public fun aggr_sign_arbitrary_bytes(
+        signing_keys: &vector<SecretKey>, messages: &vector<vector<u8>>
+    ): AggrOrMultiSignature {
         let signing_key_count = std::vector::length(signing_keys);
         let message_count = std::vector::length(messages);
-        assert!(signing_key_count == message_count, invalid_argument(E_NUM_SIGNERS_MUST_EQ_NUM_MESSAGES));
+        assert!(
+            signing_key_count == message_count,
+            invalid_argument(E_NUM_SIGNERS_MUST_EQ_NUM_MESSAGES),
+        );
         let sigs = vector[];
         let i: u64 = 0;
         while (i < signing_key_count) {
-            let sig = sign_arbitrary_bytes(std::vector::borrow(signing_keys, i), *std::vector::borrow(messages, i));
+            let sig =
+                sign_arbitrary_bytes(
+                    std::vector::borrow(signing_keys, i), *std::vector::borrow(
+                        messages, i
+                    )
+                );
             std::vector::push_back(&mut sigs, sig);
             i = i + 1;
         };
@@ -308,58 +305,43 @@ module aptos_std::bls12381 {
     #[test_only]
     /// Returns a mauled copy of a normal signature.
     public fun maul_signature(sig: &Signature): Signature {
-        Signature {
-            bytes: maul_bytes(&signature_to_bytes(sig))
-        }
+        Signature { bytes: maul_bytes(&signature_to_bytes(sig)) }
     }
 
     #[test_only]
     /// Returns a mauled copy of an aggregated signature or a multi-signature.
     public fun maul_aggr_or_multi_signature(sig: &AggrOrMultiSignature): AggrOrMultiSignature {
-        AggrOrMultiSignature {
-            bytes: maul_bytes(&aggr_or_multi_signature_to_bytes(sig))
-        }
+        AggrOrMultiSignature { bytes: maul_bytes(&aggr_or_multi_signature_to_bytes(sig)) }
     }
 
     #[test_only]
     /// Returns a mauled copy of a normal public key.
     public fun maul_public_key(pk: &PublicKey): PublicKey {
-        PublicKey {
-            bytes: maul_bytes(&public_key_to_bytes(pk))
-        }
+        PublicKey { bytes: maul_bytes(&public_key_to_bytes(pk)) }
     }
 
     #[test_only]
     /// Returns a mauled copy of a PoP'd public key.
     public fun maul_public_key_with_pop(pk: &PublicKeyWithPoP): PublicKeyWithPoP {
-        PublicKeyWithPoP {
-            bytes: maul_bytes(&public_key_with_pop_to_bytes(pk))
-        }
+        PublicKeyWithPoP { bytes: maul_bytes(&public_key_with_pop_to_bytes(pk)) }
     }
 
     #[test_only]
     /// Returns a mauled copy of an aggregated public key.
     public fun maul_aggregated_public_key(pk: &AggrPublicKeysWithPoP): AggrPublicKeysWithPoP {
-        AggrPublicKeysWithPoP {
-            bytes: maul_bytes(&aggregate_pubkey_to_bytes(pk))
-        }
+        AggrPublicKeysWithPoP { bytes: maul_bytes(&aggregate_pubkey_to_bytes(pk)) }
     }
 
     #[test_only]
     /// Returns a mauled copy of a proof-of-possession.
     public fun maul_proof_of_possession(pop: &ProofOfPossession): ProofOfPossession {
-        ProofOfPossession {
-            bytes: maul_bytes(&proof_of_possession_to_bytes(pop))
-        }
+        ProofOfPossession { bytes: maul_bytes(&proof_of_possession_to_bytes(pop)) }
     }
-
 
     #[test_only]
     /// Generates a proof-of-possession (PoP) for the public key associated with the secret key `sk`.
     public fun generate_proof_of_possession(sk: &SecretKey): ProofOfPossession {
-        ProofOfPossession {
-            bytes: generate_proof_of_possession_internal(sk.bytes)
-        }
+        ProofOfPossession { bytes: generate_proof_of_possession_internal(sk.bytes) }
     }
 
     //
@@ -372,8 +354,9 @@ module aptos_std::bls12381 {
     /// Given a vector of serialized public keys, combines them into an aggregated public key, returning `(bytes, true)`,
     /// where `bytes` store the serialized public key.
     /// Aborts if no public keys are given as input.
-    native fun aggregate_pubkeys_internal(public_keys: vector<PublicKeyWithPoP>): (vector<u8>, bool);
-
+    native fun aggregate_pubkeys_internal(public_keys: vector<PublicKeyWithPoP>): (
+        vector<u8>, bool
+    );
 
     /// CRYPTOGRAPHY WARNING: This function can be safely called without verifying that the input signatures are elements
     /// of the prime-order subgroup of the BLS12-381 curve.
@@ -427,9 +410,7 @@ module aptos_std::bls12381 {
     /// Returns `false` otherwise.
     /// Does not abort.
     native fun verify_multisignature_internal(
-        multisignature: vector<u8>,
-        agg_public_key: vector<u8>,
-        message: vector<u8>
+        multisignature: vector<u8>, agg_public_key: vector<u8>, message: vector<u8>
     ): bool;
 
     /// CRYPTOGRAPHY WARNING: This function WILL check that the public key is a prime-order point, in order to prevent
@@ -440,9 +421,7 @@ module aptos_std::bls12381 {
     /// Returns `false` otherwise.
     /// Does not abort.
     native fun verify_normal_signature_internal(
-        signature: vector<u8>,
-        public_key: vector<u8>,
-        message: vector<u8>
+        signature: vector<u8>, public_key: vector<u8>, message: vector<u8>
     ): bool;
 
     /// Return `true` if the bytes in `public_key` are a valid bls12381 public key (as per `validate_pubkey`)
@@ -450,8 +429,7 @@ module aptos_std::bls12381 {
     /// Return `false` otherwise.
     /// Does not abort.
     native fun verify_proof_of_possession_internal(
-        public_key: vector<u8>,
-        proof_of_possesion: vector<u8>
+        public_key: vector<u8>, proof_of_possesion: vector<u8>
     ): bool;
 
     /// CRYPTOGRAPHY WARNING: Assumes the public key has a valid proof-of-possesion (PoP). This prevents rogue-key
@@ -461,9 +439,7 @@ module aptos_std::bls12381 {
     /// Returns `false` otherwise, similar to `verify_multisignature`.
     /// Does not abort.
     native fun verify_signature_share_internal(
-        signature_share: vector<u8>,
-        public_key: vector<u8>,
-        message: vector<u8>
+        signature_share: vector<u8>, public_key: vector<u8>, message: vector<u8>
     ): bool;
 
     #[test_only]
@@ -502,17 +478,36 @@ module aptos_std::bls12381 {
     fun get_random_pk_with_pop(): PublicKeyWithPoP {
         assert!(validate_pubkey_internal(RANDOM_PK), 1);
 
-        PublicKeyWithPoP {
-            bytes: RANDOM_PK
-        }
+        PublicKeyWithPoP { bytes: RANDOM_PK }
     }
 
     #[test]
     fun test_pubkey_validation() {
         // test low order points (in group for PK)
-        assert!(option::is_none(&public_key_from_bytes(x"ae3cd9403b69c20a0d455fd860e977fe6ee7140a7f091f26c860f2caccd3e0a7a7365798ac10df776675b3a67db8faa0")), 1);
-        assert!(option::is_none(&public_key_from_bytes(x"928d4862a40439a67fd76a9c7560e2ff159e770dcf688ff7b2dd165792541c88ee76c82eb77dd6e9e72c89cbf1a56a68")), 1);
-        assert!(option::is_some(&public_key_from_bytes(x"b3e4921277221e01ed71284be5e3045292b26c7f465a6fcdba53ee47edd39ec5160da3b229a73c75671024dcb36de091")), 1);
+        assert!(
+            option::is_none(
+                &public_key_from_bytes(
+                    x"ae3cd9403b69c20a0d455fd860e977fe6ee7140a7f091f26c860f2caccd3e0a7a7365798ac10df776675b3a67db8faa0",
+                ),
+            ),
+            1,
+        );
+        assert!(
+            option::is_none(
+                &public_key_from_bytes(
+                    x"928d4862a40439a67fd76a9c7560e2ff159e770dcf688ff7b2dd165792541c88ee76c82eb77dd6e9e72c89cbf1a56a68",
+                ),
+            ),
+            1,
+        );
+        assert!(
+            option::is_some(
+                &public_key_from_bytes(
+                    x"b3e4921277221e01ed71284be5e3045292b26c7f465a6fcdba53ee47edd39ec5160da3b229a73c75671024dcb36de091",
+                ),
+            ),
+            1,
+        );
     }
 
     #[test]
@@ -528,21 +523,39 @@ module aptos_std::bls12381 {
         // Second, try some test-cases generated by running the following command in `crates/aptos-crypto`:
         //  $ cargo test -- sample_aggregate_pk_and_multisig --nocapture --include-ignored
         let pks = vector[
-            PublicKeyWithPoP { bytes: x"92e201a806af246f805f460fbdc6fc90dd16a18d6accc236e85d3578671d6f6690dde22134d19596c58ce9d63252410a" },
-            PublicKeyWithPoP { bytes: x"ab9df801c6f96ade1c0490c938c87d5bcc2e52ccb8768e1b5d14197c5e8bfa562783b96711b702dda411a1a9f08ebbfa" },
-            PublicKeyWithPoP { bytes: x"b698c932cf7097d99c17bd6e9c9dc4eeba84278c621700a8f80ec726b1daa11e3ab55fc045b4dbadefbeef05c4182494" },
-            PublicKeyWithPoP { bytes: x"934706a8b876d47a996d427e1526ce52c952d5ec0858d49cd262efb785b62b1972d06270b0a7adda1addc98433ad1843" },
-            PublicKeyWithPoP { bytes: x"a4cd352daad3a0651c1998dfbaa7a748e08d248a54347544bfedd51a197e016bb6008e9b8e45a744e1a030cc3b27d2da" },
-        ];
+            PublicKeyWithPoP {
+                bytes: x"92e201a806af246f805f460fbdc6fc90dd16a18d6accc236e85d3578671d6f6690dde22134d19596c58ce9d63252410a"
+            },
+            PublicKeyWithPoP {
+                bytes: x"ab9df801c6f96ade1c0490c938c87d5bcc2e52ccb8768e1b5d14197c5e8bfa562783b96711b702dda411a1a9f08ebbfa"
+            },
+            PublicKeyWithPoP {
+                bytes: x"b698c932cf7097d99c17bd6e9c9dc4eeba84278c621700a8f80ec726b1daa11e3ab55fc045b4dbadefbeef05c4182494"
+            },
+            PublicKeyWithPoP {
+                bytes: x"934706a8b876d47a996d427e1526ce52c952d5ec0858d49cd262efb785b62b1972d06270b0a7adda1addc98433ad1843"
+            },
+            PublicKeyWithPoP {
+                bytes: x"a4cd352daad3a0651c1998dfbaa7a748e08d248a54347544bfedd51a197e016bb6008e9b8e45a744e1a030cc3b27d2da"
+            },];
 
         // agg_pks[i] = \sum_{j <= i}  pk[j]
         let agg_pks = vector[
-            AggrPublicKeysWithPoP { bytes: x"92e201a806af246f805f460fbdc6fc90dd16a18d6accc236e85d3578671d6f6690dde22134d19596c58ce9d63252410a" },
-            AggrPublicKeysWithPoP { bytes: x"b79ad47abb441d7eda9b220a626df2e4e4910738c5f777947f0213398ecafae044ec0c20d552d1348347e9abfcf3eca1" },
-            AggrPublicKeysWithPoP { bytes: x"b5f5eb6153ab5388a1a76343d714e4a2dcf224c5d0722d1e8e90c6bcead05c573fffe986460bd4000645a655bf52bc60" },
-            AggrPublicKeysWithPoP { bytes: x"b922006ec14c183572a8864c31dc6632dccffa9f9c86411796f8b1b5a93a2457762c8e2f5ef0a2303506c4bca9a4e0bf" },
-            AggrPublicKeysWithPoP { bytes: x"b53df1cfee2168f59e5792e710bf22928dc0553e6531dae5c7656c0a66fc12cb82fbb04863938c953dc901a5a79cc0f3" },
-        ];
+            AggrPublicKeysWithPoP {
+                bytes: x"92e201a806af246f805f460fbdc6fc90dd16a18d6accc236e85d3578671d6f6690dde22134d19596c58ce9d63252410a"
+            },
+            AggrPublicKeysWithPoP {
+                bytes: x"b79ad47abb441d7eda9b220a626df2e4e4910738c5f777947f0213398ecafae044ec0c20d552d1348347e9abfcf3eca1"
+            },
+            AggrPublicKeysWithPoP {
+                bytes: x"b5f5eb6153ab5388a1a76343d714e4a2dcf224c5d0722d1e8e90c6bcead05c573fffe986460bd4000645a655bf52bc60"
+            },
+            AggrPublicKeysWithPoP {
+                bytes: x"b922006ec14c183572a8864c31dc6632dccffa9f9c86411796f8b1b5a93a2457762c8e2f5ef0a2303506c4bca9a4e0bf"
+            },
+            AggrPublicKeysWithPoP {
+                bytes: x"b53df1cfee2168f59e5792e710bf22928dc0553e6531dae5c7656c0a66fc12cb82fbb04863938c953dc901a5a79cc0f3"
+            },];
 
         let i = 0;
         let accum_pk = std::vector::empty<PublicKeyWithPoP>();
@@ -577,21 +590,39 @@ module aptos_std::bls12381 {
 
         // Signatures of each signer i
         let sigs = vector[
-            signature_from_bytes(x"a55ac2d64b4c1d141b15d876d3e54ad1eea07ee488e8287cce7cdf3eec551458ab5795ab196f8c112590346f7bc7c97e0053cd5be0f9bd74b93a87cd44458e98d125d6d5c6950ea5e62666beb34422ead79121f8cb0815dae41a986688d03eaf"),
-            signature_from_bytes(x"90a639a44491191c46379a843266c293de3a46197714ead2ad3886233dd5c2b608b6437fa32fbf9d218b20f1cbfa7970182663beb9c148e2e9412b148e16abf283ffa51b8a536c0e55d61b2e5c849edc49f636c0ef07cb99f125cbcf602e22bb"),
-            signature_from_bytes(x"9527d81aa15863ef3a3bf96bea6d58157d5063a93a6d0eb9d8b4f4bbda3b31142ec4586cb519da2cd7600941283d1bad061b5439703fd584295b44037a969876962ae1897dcc7cadf909d06faae213c4fef8e015dfb33ec109af02ab0c3f6833"),
-            signature_from_bytes(x"a54d264f5cab9654b1744232c4650c42b29adf2b19bd00bbdaf4a4d792ee4dfd40a1fe1b067f298bcfd8ae4fdc8250660a2848bd4a80d96585afccec5c6cfa617033dd7913c9acfdf98a72467e8a5155d4cad589a72d6665be7cb410aebc0068"),
-            signature_from_bytes(x"8d22876bdf73e6ad36ed98546018f6258cd47e45904b87c071e774a6ef4b07cac323258cb920b2fe2b07cca1f2b24bcb0a3194ec76f32edb92391ed2c39e1ada8919f8ea755c5e39873d33ff3a8f4fba21b1261c1ddb9d1688c2b40b77e355d1"),
-        ];
+            signature_from_bytes(
+                x"a55ac2d64b4c1d141b15d876d3e54ad1eea07ee488e8287cce7cdf3eec551458ab5795ab196f8c112590346f7bc7c97e0053cd5be0f9bd74b93a87cd44458e98d125d6d5c6950ea5e62666beb34422ead79121f8cb0815dae41a986688d03eaf",
+            ),
+            signature_from_bytes(
+                x"90a639a44491191c46379a843266c293de3a46197714ead2ad3886233dd5c2b608b6437fa32fbf9d218b20f1cbfa7970182663beb9c148e2e9412b148e16abf283ffa51b8a536c0e55d61b2e5c849edc49f636c0ef07cb99f125cbcf602e22bb",
+            ),
+            signature_from_bytes(
+                x"9527d81aa15863ef3a3bf96bea6d58157d5063a93a6d0eb9d8b4f4bbda3b31142ec4586cb519da2cd7600941283d1bad061b5439703fd584295b44037a969876962ae1897dcc7cadf909d06faae213c4fef8e015dfb33ec109af02ab0c3f6833",
+            ),
+            signature_from_bytes(
+                x"a54d264f5cab9654b1744232c4650c42b29adf2b19bd00bbdaf4a4d792ee4dfd40a1fe1b067f298bcfd8ae4fdc8250660a2848bd4a80d96585afccec5c6cfa617033dd7913c9acfdf98a72467e8a5155d4cad589a72d6665be7cb410aebc0068",
+            ),
+            signature_from_bytes(
+                x"8d22876bdf73e6ad36ed98546018f6258cd47e45904b87c071e774a6ef4b07cac323258cb920b2fe2b07cca1f2b24bcb0a3194ec76f32edb92391ed2c39e1ada8919f8ea755c5e39873d33ff3a8f4fba21b1261c1ddb9d1688c2b40b77e355d1",
+            ),];
 
         // multisigs[i] is a signature on "Hello, Aptoverse!" from signers 1 through i (inclusive)
         let multisigs = vector[
-            AggrOrMultiSignature { bytes: x"a55ac2d64b4c1d141b15d876d3e54ad1eea07ee488e8287cce7cdf3eec551458ab5795ab196f8c112590346f7bc7c97e0053cd5be0f9bd74b93a87cd44458e98d125d6d5c6950ea5e62666beb34422ead79121f8cb0815dae41a986688d03eaf" },
-            AggrOrMultiSignature { bytes: x"8f1949a06b95c3cb62898d861f889350c0d2cb740da513bfa195aa0ab8fa006ea2efe004a7bbbd9bb363637a279aed20132efd0846f520e7ee0e8ed847a1c6969bb986ad2239bcc9af561b6c2aa6d3016e1c722146471f1e28313de189fe7ebc" },
-            AggrOrMultiSignature { bytes: x"ab5ad42bb8f350f8a6b4ae897946a05dbe8f2b22db4f6c37eff6ff737aebd6c5d75bd1abdfc99345ac8ec38b9a449700026f98647752e1c99f69bb132340f063b8a989728e0a3d82a753740bf63e5d8f51e413ebd9a36f6acbe1407a00c4b3e7" },
-            AggrOrMultiSignature { bytes: x"ae307a0d055d3ba55ad6ec7094adef27ed821bdcf735fb509ab2c20b80952732394bc67ea1fd8c26ea963540df7448f8102509f7b8c694e4d75f30a43c455f251b6b3fd8b580b9228ffeeb9039834927aacefccd3069bef4b847180d036971cf" },
-            AggrOrMultiSignature { bytes: x"8284e4e3983f29cb45020c3e2d89066df2eae533a01cb6ca2c4d466b5e02dd22467f59640aa120db2b9cc49e931415c3097e3d54ff977fd9067b5bc6cfa1c885d9d8821aef20c028999a1d97e783ae049d8fa3d0bbac36ce4ca8e10e551d3461" },
-        ];
+            AggrOrMultiSignature {
+                bytes: x"a55ac2d64b4c1d141b15d876d3e54ad1eea07ee488e8287cce7cdf3eec551458ab5795ab196f8c112590346f7bc7c97e0053cd5be0f9bd74b93a87cd44458e98d125d6d5c6950ea5e62666beb34422ead79121f8cb0815dae41a986688d03eaf"
+            },
+            AggrOrMultiSignature {
+                bytes: x"8f1949a06b95c3cb62898d861f889350c0d2cb740da513bfa195aa0ab8fa006ea2efe004a7bbbd9bb363637a279aed20132efd0846f520e7ee0e8ed847a1c6969bb986ad2239bcc9af561b6c2aa6d3016e1c722146471f1e28313de189fe7ebc"
+            },
+            AggrOrMultiSignature {
+                bytes: x"ab5ad42bb8f350f8a6b4ae897946a05dbe8f2b22db4f6c37eff6ff737aebd6c5d75bd1abdfc99345ac8ec38b9a449700026f98647752e1c99f69bb132340f063b8a989728e0a3d82a753740bf63e5d8f51e413ebd9a36f6acbe1407a00c4b3e7"
+            },
+            AggrOrMultiSignature {
+                bytes: x"ae307a0d055d3ba55ad6ec7094adef27ed821bdcf735fb509ab2c20b80952732394bc67ea1fd8c26ea963540df7448f8102509f7b8c694e4d75f30a43c455f251b6b3fd8b580b9228ffeeb9039834927aacefccd3069bef4b847180d036971cf"
+            },
+            AggrOrMultiSignature {
+                bytes: x"8284e4e3983f29cb45020c3e2d89066df2eae533a01cb6ca2c4d466b5e02dd22467f59640aa120db2b9cc49e931415c3097e3d54ff977fd9067b5bc6cfa1c885d9d8821aef20c028999a1d97e783ae049d8fa3d0bbac36ce4ca8e10e551d3461"
+            },];
 
         let i = 0;
         let accum_sigs = std::vector::empty<Signature>();
@@ -618,30 +649,57 @@ module aptos_std::bls12381 {
         // Second, try some test-cases generated by running the following command in `crates/aptos-crypto`:
         //  $ cargo test -- sample_aggregate_pk_and_multisig --nocapture --include-ignored
         let pks = vector[
-            PublicKeyWithPoP { bytes: x"92e201a806af246f805f460fbdc6fc90dd16a18d6accc236e85d3578671d6f6690dde22134d19596c58ce9d63252410a" },
-            PublicKeyWithPoP { bytes: x"ab9df801c6f96ade1c0490c938c87d5bcc2e52ccb8768e1b5d14197c5e8bfa562783b96711b702dda411a1a9f08ebbfa" },
-            PublicKeyWithPoP { bytes: x"b698c932cf7097d99c17bd6e9c9dc4eeba84278c621700a8f80ec726b1daa11e3ab55fc045b4dbadefbeef05c4182494" },
-            PublicKeyWithPoP { bytes: x"934706a8b876d47a996d427e1526ce52c952d5ec0858d49cd262efb785b62b1972d06270b0a7adda1addc98433ad1843" },
-            PublicKeyWithPoP { bytes: x"a4cd352daad3a0651c1998dfbaa7a748e08d248a54347544bfedd51a197e016bb6008e9b8e45a744e1a030cc3b27d2da" },
-        ];
+            PublicKeyWithPoP {
+                bytes: x"92e201a806af246f805f460fbdc6fc90dd16a18d6accc236e85d3578671d6f6690dde22134d19596c58ce9d63252410a"
+            },
+            PublicKeyWithPoP {
+                bytes: x"ab9df801c6f96ade1c0490c938c87d5bcc2e52ccb8768e1b5d14197c5e8bfa562783b96711b702dda411a1a9f08ebbfa"
+            },
+            PublicKeyWithPoP {
+                bytes: x"b698c932cf7097d99c17bd6e9c9dc4eeba84278c621700a8f80ec726b1daa11e3ab55fc045b4dbadefbeef05c4182494"
+            },
+            PublicKeyWithPoP {
+                bytes: x"934706a8b876d47a996d427e1526ce52c952d5ec0858d49cd262efb785b62b1972d06270b0a7adda1addc98433ad1843"
+            },
+            PublicKeyWithPoP {
+                bytes: x"a4cd352daad3a0651c1998dfbaa7a748e08d248a54347544bfedd51a197e016bb6008e9b8e45a744e1a030cc3b27d2da"
+            },];
 
         // agg_pks[i] = \sum_{j <= i}  pk[j]
         let agg_pks = vector[
-            AggrPublicKeysWithPoP { bytes: x"92e201a806af246f805f460fbdc6fc90dd16a18d6accc236e85d3578671d6f6690dde22134d19596c58ce9d63252410a" },
-            AggrPublicKeysWithPoP { bytes: x"b79ad47abb441d7eda9b220a626df2e4e4910738c5f777947f0213398ecafae044ec0c20d552d1348347e9abfcf3eca1" },
-            AggrPublicKeysWithPoP { bytes: x"b5f5eb6153ab5388a1a76343d714e4a2dcf224c5d0722d1e8e90c6bcead05c573fffe986460bd4000645a655bf52bc60" },
-            AggrPublicKeysWithPoP { bytes: x"b922006ec14c183572a8864c31dc6632dccffa9f9c86411796f8b1b5a93a2457762c8e2f5ef0a2303506c4bca9a4e0bf" },
-            AggrPublicKeysWithPoP { bytes: x"b53df1cfee2168f59e5792e710bf22928dc0553e6531dae5c7656c0a66fc12cb82fbb04863938c953dc901a5a79cc0f3" },
-        ];
+            AggrPublicKeysWithPoP {
+                bytes: x"92e201a806af246f805f460fbdc6fc90dd16a18d6accc236e85d3578671d6f6690dde22134d19596c58ce9d63252410a"
+            },
+            AggrPublicKeysWithPoP {
+                bytes: x"b79ad47abb441d7eda9b220a626df2e4e4910738c5f777947f0213398ecafae044ec0c20d552d1348347e9abfcf3eca1"
+            },
+            AggrPublicKeysWithPoP {
+                bytes: x"b5f5eb6153ab5388a1a76343d714e4a2dcf224c5d0722d1e8e90c6bcead05c573fffe986460bd4000645a655bf52bc60"
+            },
+            AggrPublicKeysWithPoP {
+                bytes: x"b922006ec14c183572a8864c31dc6632dccffa9f9c86411796f8b1b5a93a2457762c8e2f5ef0a2303506c4bca9a4e0bf"
+            },
+            AggrPublicKeysWithPoP {
+                bytes: x"b53df1cfee2168f59e5792e710bf22928dc0553e6531dae5c7656c0a66fc12cb82fbb04863938c953dc901a5a79cc0f3"
+            },];
 
         // multisigs[i] is a signature on "Hello, Aptoverse!" under agg_pks[i]
         let multisigs = vector[
-            AggrOrMultiSignature { bytes: x"ade45c67bff09ae57e0575feb0be870f2d351ce078e8033d847615099366da1299c69497027b77badb226ff1708543cd062597030c3f1553e0aef6c17e7af5dd0de63c1e4f1f9da68c966ea6c1dcade2cdc646bd5e8bcd4773931021ec5be3fd" },
-            AggrOrMultiSignature { bytes: x"964af3d83436f6a9a382f34590c0c14e4454dc1de536af205319ce1ed417b87a2374863d5df7b7d5ed900cf91dffa7a105d3f308831d698c0d74fb2259d4813434fb86425db0ded664ae8f85d02ec1d31734910317d4155cbf69017735900d4d" },
-            AggrOrMultiSignature { bytes: x"b523a31813e771e55aa0fc99a48db716ecc1085f9899ccadb64e759ecb481a2fb1cdcc0b266f036695f941361de773081729311f6a1bca9d47393f5359c8c87dc34a91f5dae335590aacbff974076ad1f910dd81750553a72ccbcad3c8cc0f07" },
-            AggrOrMultiSignature { bytes: x"a945f61699df58617d37530a85e67bd1181349678b89293951ed29d1fb7588b5c12ebb7917dfc9d674f3f4fde4d062740b85a5f4927f5a4f0091e46e1ac6e41bbd650a74dd49e91445339d741e3b10bdeb9bc8bba46833e0011ff91fa5c77bd2" },
-            AggrOrMultiSignature { bytes: x"b627b2cfd8ae59dcf5e58cc6c230ae369985fd096e1bc3be38da5deafcbed7d939f07cccc75383539940c56c6b6453db193f563f5b6e4fe54915afd9e1baea40a297fa7eda74abbdcd4cc5c667d6db3b9bd265782f7693798894400f2beb4637" },
-        ];
+            AggrOrMultiSignature {
+                bytes: x"ade45c67bff09ae57e0575feb0be870f2d351ce078e8033d847615099366da1299c69497027b77badb226ff1708543cd062597030c3f1553e0aef6c17e7af5dd0de63c1e4f1f9da68c966ea6c1dcade2cdc646bd5e8bcd4773931021ec5be3fd"
+            },
+            AggrOrMultiSignature {
+                bytes: x"964af3d83436f6a9a382f34590c0c14e4454dc1de536af205319ce1ed417b87a2374863d5df7b7d5ed900cf91dffa7a105d3f308831d698c0d74fb2259d4813434fb86425db0ded664ae8f85d02ec1d31734910317d4155cbf69017735900d4d"
+            },
+            AggrOrMultiSignature {
+                bytes: x"b523a31813e771e55aa0fc99a48db716ecc1085f9899ccadb64e759ecb481a2fb1cdcc0b266f036695f941361de773081729311f6a1bca9d47393f5359c8c87dc34a91f5dae335590aacbff974076ad1f910dd81750553a72ccbcad3c8cc0f07"
+            },
+            AggrOrMultiSignature {
+                bytes: x"a945f61699df58617d37530a85e67bd1181349678b89293951ed29d1fb7588b5c12ebb7917dfc9d674f3f4fde4d062740b85a5f4927f5a4f0091e46e1ac6e41bbd650a74dd49e91445339d741e3b10bdeb9bc8bba46833e0011ff91fa5c77bd2"
+            },
+            AggrOrMultiSignature {
+                bytes: x"b627b2cfd8ae59dcf5e58cc6c230ae369985fd096e1bc3be38da5deafcbed7d939f07cccc75383539940c56c6b6453db193f563f5b6e4fe54915afd9e1baea40a297fa7eda74abbdcd4cc5c667d6db3b9bd265782f7693798894400f2beb4637"
+            },];
 
         let i = 0;
         let accum_pk = std::vector::empty<PublicKeyWithPoP>();
@@ -652,7 +710,12 @@ module aptos_std::bls12381 {
 
             assert!(apk == *std::vector::borrow(&agg_pks, i), 1);
 
-            assert!(verify_multisignature(std::vector::borrow(&multisigs, i), &apk, b"Hello, Aptoverse!"), 1);
+            assert!(
+                verify_multisignature(
+                    std::vector::borrow(&multisigs, i), &apk, b"Hello, Aptoverse!"
+                ),
+                1,
+            );
 
             i = i + 1;
         };
@@ -681,8 +744,18 @@ module aptos_std::bls12381 {
 
             // Test signature verification.
             assert!(verify_multisignature(&multisig, &aggr_pk, msg), 1);
-            assert!(!verify_multisignature(&maul_aggr_or_multi_signature(&multisig), &aggr_pk, msg), 1);
-            assert!(!verify_multisignature(&multisig, &maul_aggregated_public_key(&aggr_pk), msg), 1);
+            assert!(
+                !verify_multisignature(
+                    &maul_aggr_or_multi_signature(&multisig), &aggr_pk, msg
+                ),
+                1,
+            );
+            assert!(
+                !verify_multisignature(
+                    &multisig, &maul_aggregated_public_key(&aggr_pk), msg
+                ),
+                1,
+            );
             assert!(!verify_multisignature(&multisig, &aggr_pk, maul_bytes(&msg)), 1);
 
             // Also test signature aggregation.
@@ -694,9 +767,14 @@ module aptos_std::bls12381 {
                 std::vector::push_back(&mut signatures, sig);
                 i = i + 1;
             };
-            let aggregated_signature = option::extract(&mut aggregate_signatures(signatures));
+            let aggregated_signature =
+                option::extract(&mut aggregate_signatures(signatures));
             assert!(aggr_or_multi_signature_subgroup_check(&aggregated_signature), 1);
-            assert!(aggr_or_multi_signature_to_bytes(&aggregated_signature) == aggr_or_multi_signature_to_bytes(&multisig), 1);
+            assert!(
+                aggr_or_multi_signature_to_bytes(&aggregated_signature)
+                    == aggr_or_multi_signature_to_bytes(&multisig),
+                1,
+            );
 
             signer_count = signer_count + 1;
         }
@@ -704,38 +782,57 @@ module aptos_std::bls12381 {
 
     #[test]
     fun test_verify_aggsig() {
-        assert!(aggr_or_multi_signature_to_bytes(&aggr_or_multi_signature_from_bytes(RANDOM_SIGNATURE)) == RANDOM_SIGNATURE, 1);
+        assert!(
+            aggr_or_multi_signature_to_bytes(
+                &aggr_or_multi_signature_from_bytes(RANDOM_SIGNATURE)
+            ) == RANDOM_SIGNATURE,
+            1,
+        );
 
         // First, make sure verification returns None when no inputs are given or |pks| != |msgs|
-        assert!(verify_aggregate_signature(&get_random_aggsig(), vector[], vector[]) == false, 1);
+        assert!(
+            verify_aggregate_signature(&get_random_aggsig(), vector[], vector[]) == false,
+            1,
+        );
 
-        assert!(verify_aggregate_signature(
-            &get_random_aggsig(),
-            vector[ get_random_pk_with_pop() ],
-            vector[]) == false, 1);
+        assert!(
+            verify_aggregate_signature(
+                &get_random_aggsig(),
+                vector[get_random_pk_with_pop()],
+                vector[],
+            ) == false,
+            1,
+        );
 
-        assert!(verify_aggregate_signature(
-            &get_random_aggsig(),
-            vector[],
-            vector[ x"ab" ]) == false, 1);
+        assert!(
+            verify_aggregate_signature(
+                &get_random_aggsig(),
+                vector[],
+                vector[x"ab"],
+            ) == false,
+            1,
+        );
 
-        assert!(verify_aggregate_signature(
-            &get_random_aggsig(),
-            vector[ get_random_pk_with_pop() ],
-            vector[
-                x"cd", x"ef"
-            ]) == false, 1);
+        assert!(
+            verify_aggregate_signature(
+                &get_random_aggsig(),
+                vector[get_random_pk_with_pop()],
+                vector[x"cd", x"ef"],
+            ) == false,
+            1,
+        );
 
-        assert!(verify_aggregate_signature(
-            &get_random_aggsig(),
-            vector[
-                get_random_pk_with_pop(),
-                get_random_pk_with_pop(),
-                get_random_pk_with_pop(),
-            ],
-            vector[
-                x"cd", x"ef"
-            ]) == false, 1);
+        assert!(
+            verify_aggregate_signature(
+                &get_random_aggsig(),
+                vector[
+                    get_random_pk_with_pop(),
+                    get_random_pk_with_pop(),
+                    get_random_pk_with_pop(),],
+                vector[x"cd", x"ef"],
+            ) == false,
+            1,
+        );
 
         // Second, try some test-cases generated by running the following command in `crates/aptos-crypto`:
         //  $ cargo test -- bls12381_sample_aggregate_pk_and_aggsig --nocapture --ignored
@@ -746,26 +843,43 @@ module aptos_std::bls12381 {
             x"48656c6c6f2c204170746f73203221",
             x"48656c6c6f2c204170746f73203321",
             x"48656c6c6f2c204170746f73203421",
-            x"48656c6c6f2c204170746f73203521",
-        ];
+            x"48656c6c6f2c204170746f73203521",];
 
         // Public key of signer i
         let pks = vector[
-            PublicKeyWithPoP { bytes: x"b93d6aabb2b83e52f4b8bda43c24ea920bbced87a03ffc80f8f70c814a8b3f5d69fbb4e579ca76ee008d61365747dbc6" },
-            PublicKeyWithPoP { bytes: x"b45648ceae3a983bcb816a96db599b5aef3b688c5753fa20ce36ac7a4f2c9ed792ab20af6604e85e42dab746398bb82c" },
-            PublicKeyWithPoP { bytes: x"b3e4921277221e01ed71284be5e3045292b26c7f465a6fcdba53ee47edd39ec5160da3b229a73c75671024dcb36de091" },
-            PublicKeyWithPoP { bytes: x"8463b8671c9775a7dbd98bf76d3deba90b5a90535fc87dc8c13506bb5c7bbd99be4d257e60c548140e1e30b107ff5822" },
-            PublicKeyWithPoP { bytes: x"a79e3d0e9d04587a3b27d05efe5717da05fd93485dc47978c866dc70a01695c2efd247d1dd843a011a4b6b24079d7384" },
-        ];
+            PublicKeyWithPoP {
+                bytes: x"b93d6aabb2b83e52f4b8bda43c24ea920bbced87a03ffc80f8f70c814a8b3f5d69fbb4e579ca76ee008d61365747dbc6"
+            },
+            PublicKeyWithPoP {
+                bytes: x"b45648ceae3a983bcb816a96db599b5aef3b688c5753fa20ce36ac7a4f2c9ed792ab20af6604e85e42dab746398bb82c"
+            },
+            PublicKeyWithPoP {
+                bytes: x"b3e4921277221e01ed71284be5e3045292b26c7f465a6fcdba53ee47edd39ec5160da3b229a73c75671024dcb36de091"
+            },
+            PublicKeyWithPoP {
+                bytes: x"8463b8671c9775a7dbd98bf76d3deba90b5a90535fc87dc8c13506bb5c7bbd99be4d257e60c548140e1e30b107ff5822"
+            },
+            PublicKeyWithPoP {
+                bytes: x"a79e3d0e9d04587a3b27d05efe5717da05fd93485dc47978c866dc70a01695c2efd247d1dd843a011a4b6b24079d7384"
+            },];
 
         // aggsigs[i] = \sum_{j <= i}  sigs[j], where sigs[j] is a signature on msgs[j] under pks[j]
         let aggsigs = vector[
-            AggrOrMultiSignature { bytes: x"a2bc8bdebe6215ba74b5b53c5ed2aa0c68221a4adf868989ccdcfb62bb0eecc6537def9ee686a7960169c5917d25e5220177ed1c5e95ecfd68c09694062e76efcb00759beac874e4f9a715fd144210883bf9bb272f156b0a1fa15d0e9460f01f" },
-            AggrOrMultiSignature { bytes: x"a523aa3c3f1f1074d968ffecf017c7b93ae5243006bf0abd2e45c036ddbec99302984b650ebe5ba306cda4071d281ba50a99ef0e66c3957fab94163296f9d673fc58a36de4276f82bfb1d9180b591df93b5c2804d40dd68cf0f72cd92f86442e" },
-            AggrOrMultiSignature { bytes: x"abed10f464de74769121fc09715e59a3ac96a5054a43a9d43cc890a2d4d332614c74c7fb4cceef6d25f85c65dee337330f062f89f23fec9ecf7ce3193fbba2c886630d753be6a4513a4634428904b767af2f230c5cadbcb53a451dd9c7d977f6" },
-            AggrOrMultiSignature { bytes: x"8362871631ba822742a31209fa4abce6dc94b741ac4725995459da2951324b51efbbf6bc3ab4681e547ebfbadd80e0360dc078c04188198f0acea26c12645ace9107a4a23cf8db46abc7a402637f16a0477c72569fc9966fe804ef4dc0e5e758" },
-            AggrOrMultiSignature { bytes: x"a44d967935fbe63a763ce2dd2b16981f967ecd31e20d3266eef5517530cdc233c8a18273b6d9fd7f61dd39178826e3f115df4e7b304f2de17373a95ea0c9a14293dcfd6f0ef416e06fa23f6a3c850d638e4d8f97ab4562ef55d49a96a50baa13" },
-        ];
+            AggrOrMultiSignature {
+                bytes: x"a2bc8bdebe6215ba74b5b53c5ed2aa0c68221a4adf868989ccdcfb62bb0eecc6537def9ee686a7960169c5917d25e5220177ed1c5e95ecfd68c09694062e76efcb00759beac874e4f9a715fd144210883bf9bb272f156b0a1fa15d0e9460f01f"
+            },
+            AggrOrMultiSignature {
+                bytes: x"a523aa3c3f1f1074d968ffecf017c7b93ae5243006bf0abd2e45c036ddbec99302984b650ebe5ba306cda4071d281ba50a99ef0e66c3957fab94163296f9d673fc58a36de4276f82bfb1d9180b591df93b5c2804d40dd68cf0f72cd92f86442e"
+            },
+            AggrOrMultiSignature {
+                bytes: x"abed10f464de74769121fc09715e59a3ac96a5054a43a9d43cc890a2d4d332614c74c7fb4cceef6d25f85c65dee337330f062f89f23fec9ecf7ce3193fbba2c886630d753be6a4513a4634428904b767af2f230c5cadbcb53a451dd9c7d977f6"
+            },
+            AggrOrMultiSignature {
+                bytes: x"8362871631ba822742a31209fa4abce6dc94b741ac4725995459da2951324b51efbbf6bc3ab4681e547ebfbadd80e0360dc078c04188198f0acea26c12645ace9107a4a23cf8db46abc7a402637f16a0477c72569fc9966fe804ef4dc0e5e758"
+            },
+            AggrOrMultiSignature {
+                bytes: x"a44d967935fbe63a763ce2dd2b16981f967ecd31e20d3266eef5517530cdc233c8a18273b6d9fd7f61dd39178826e3f115df4e7b304f2de17373a95ea0c9a14293dcfd6f0ef416e06fa23f6a3c850d638e4d8f97ab4562ef55d49a96a50baa13"
+            },];
 
         let i = 0;
         let msg_subset = std::vector::empty<vector<u8>>();
@@ -796,13 +910,17 @@ module aptos_std::bls12381 {
                 let (sk, pk) = generate_keys();
                 std::vector::push_back(&mut signing_keys, sk);
                 std::vector::push_back(&mut public_keys, pk);
-                let msg: vector<u8> = vector[104, 101, 108, 108, 111, 32, 97, 112, 116, 111, 115, 32, 117, 115, 101, 114, 32, 48+(i as u8)]; //"hello aptos user {i}"
+                let msg: vector<u8> = vector[
+                    104, 101, 108, 108, 111, 32, 97, 112, 116, 111, 115, 32, 117, 115, 101,
+                    114, 32, 48 + (i as u8)]; //"hello aptos user {i}"
                 std::vector::push_back(&mut messages, msg);
                 i = i + 1;
             };
 
             // Maul messages and public keys.
-            let mauled_public_keys = vector[maul_public_key_with_pop(std::vector::borrow(&public_keys, 0))];
+            let mauled_public_keys = vector[maul_public_key_with_pop(
+                    std::vector::borrow(&public_keys, 0)
+                )];
             let mauled_messages = vector[maul_bytes(std::vector::borrow(&messages, 0))];
             let i = 1;
             while (i < signer_count) {
@@ -818,9 +936,18 @@ module aptos_std::bls12381 {
 
             // Test signature verification.
             assert!(verify_aggregate_signature(&aggrsig, public_keys, messages), 1);
-            assert!(!verify_aggregate_signature(&maul_aggr_or_multi_signature(&aggrsig), public_keys, messages), 1);
-            assert!(!verify_aggregate_signature(&aggrsig, mauled_public_keys, messages), 1);
-            assert!(!verify_aggregate_signature(&aggrsig, public_keys, mauled_messages), 1);
+            assert!(
+                !verify_aggregate_signature(
+                    &maul_aggr_or_multi_signature(&aggrsig), public_keys, messages
+                ),
+                1,
+            );
+            assert!(
+                !verify_aggregate_signature(&aggrsig, mauled_public_keys, messages), 1
+            );
+            assert!(
+                !verify_aggregate_signature(&aggrsig, public_keys, mauled_messages), 1
+            );
 
             // Also test signature aggregation.
             let signatures = vector[];
@@ -833,7 +960,11 @@ module aptos_std::bls12381 {
                 i = i + 1;
             };
             let aggrsig_another = option::extract(&mut aggregate_signatures(signatures));
-            assert!(aggr_or_multi_signature_to_bytes(&aggrsig_another) == aggr_or_multi_signature_to_bytes(&aggrsig), 1);
+            assert!(
+                aggr_or_multi_signature_to_bytes(&aggrsig_another)
+                    == aggr_or_multi_signature_to_bytes(&aggrsig),
+                1,
+            );
 
             signer_count = signer_count + 1;
         }
@@ -850,39 +981,54 @@ module aptos_std::bls12381 {
         let message = b"Hello Aptos!";
 
         // First, test signatures that verify
-        let ok = verify_normal_signature(
-            &signature_from_bytes(x"b01ce4632e94d8c611736e96aa2ad8e0528a02f927a81a92db8047b002a8c71dc2d6bfb94729d0973790c10b6ece446817e4b7543afd7ca9a17c75de301ae835d66231c26a003f11ae26802b98d90869a9e73788c38739f7ac9d52659e1f7cf7"),
-            &option::extract(&mut public_key_from_bytes(x"94209a296b739577cb076d3bfb1ca8ee936f29b69b7dae436118c4dd1cc26fd43dcd16249476a006b8b949bf022a7858")),
-            message,
-        );
+        let ok =
+            verify_normal_signature(
+                &signature_from_bytes(
+                    x"b01ce4632e94d8c611736e96aa2ad8e0528a02f927a81a92db8047b002a8c71dc2d6bfb94729d0973790c10b6ece446817e4b7543afd7ca9a17c75de301ae835d66231c26a003f11ae26802b98d90869a9e73788c38739f7ac9d52659e1f7cf7",
+                ),
+                &option::extract(
+                    &mut public_key_from_bytes(
+                        x"94209a296b739577cb076d3bfb1ca8ee936f29b69b7dae436118c4dd1cc26fd43dcd16249476a006b8b949bf022a7858",
+                    ),
+                ),
+                message,
+            );
         assert!(ok == true, 1);
 
-        let pk = option::extract(&mut public_key_from_bytes(x"94209a296b739577cb076d3bfb1ca8ee936f29b69b7dae436118c4dd1cc26fd43dcd16249476a006b8b949bf022a7858"));
+        let pk =
+            option::extract(
+                &mut public_key_from_bytes(
+                    x"94209a296b739577cb076d3bfb1ca8ee936f29b69b7dae436118c4dd1cc26fd43dcd16249476a006b8b949bf022a7858",
+                ),
+            );
         let pk_with_pop = PublicKeyWithPoP { bytes: pk.bytes };
 
-        let ok = verify_signature_share(
-            &signature_from_bytes(x"b01ce4632e94d8c611736e96aa2ad8e0528a02f927a81a92db8047b002a8c71dc2d6bfb94729d0973790c10b6ece446817e4b7543afd7ca9a17c75de301ae835d66231c26a003f11ae26802b98d90869a9e73788c38739f7ac9d52659e1f7cf7"),
-            &pk_with_pop,
-            message,
-        );
+        let ok =
+            verify_signature_share(
+                &signature_from_bytes(
+                    x"b01ce4632e94d8c611736e96aa2ad8e0528a02f927a81a92db8047b002a8c71dc2d6bfb94729d0973790c10b6ece446817e4b7543afd7ca9a17c75de301ae835d66231c26a003f11ae26802b98d90869a9e73788c38739f7ac9d52659e1f7cf7",
+                ),
+                &pk_with_pop,
+                message,
+            );
         assert!(ok == true, 1);
 
         // Second, test signatures that do NOT verify
         let sigs = vector[
-            Signature { bytes: x"a01ce4632e94d8c611736e96aa2ad8e0528a02f927a81a92db8047b002a8c71dc2d6bfb94729d0973790c10b6ece446817e4b7543afd7ca9a17c75de301ae835d66231c26a003f11ae26802b98d90869a9e73788c38739f7ac9d52659e1f7cf7" },
-            Signature { bytes: x"b01ce4632e94d8c611736e96aa2ad8e0528a02f927a81a92db8047b002a8c71dc2d6bfb94729d0973790c10b6ece446817e4b7543afd7ca9a17c75de301ae835d66231c26a003f11ae26802b98d90869a9e73788c38739f7ac9d52659e1f7cf7" },
-            Signature { bytes: x"b01ce4632e94d8c611736e96aa2ad8e0528a02f927a81a92db8047b002a8c71dc2d6bfb94729d0973790c10b6ece446817e4b7543afd7ca9a17c75de301ae835d66231c26a003f11ae26802b98d90869a9e73788c38739f7ac9d52659e1f7cf7" },
-        ];
+            Signature {
+                bytes: x"a01ce4632e94d8c611736e96aa2ad8e0528a02f927a81a92db8047b002a8c71dc2d6bfb94729d0973790c10b6ece446817e4b7543afd7ca9a17c75de301ae835d66231c26a003f11ae26802b98d90869a9e73788c38739f7ac9d52659e1f7cf7"
+            },
+            Signature {
+                bytes: x"b01ce4632e94d8c611736e96aa2ad8e0528a02f927a81a92db8047b002a8c71dc2d6bfb94729d0973790c10b6ece446817e4b7543afd7ca9a17c75de301ae835d66231c26a003f11ae26802b98d90869a9e73788c38739f7ac9d52659e1f7cf7"
+            },
+            Signature {
+                bytes: x"b01ce4632e94d8c611736e96aa2ad8e0528a02f927a81a92db8047b002a8c71dc2d6bfb94729d0973790c10b6ece446817e4b7543afd7ca9a17c75de301ae835d66231c26a003f11ae26802b98d90869a9e73788c38739f7ac9d52659e1f7cf7"
+            },];
         let pks = vector[
             x"94209a296b739577cb076d3bfb1ca8ee936f29b69b7dae436118c4dd1cc26fd43dcd16249476a006b8b949bf022a7858",
             x"ae4851bb9e7782027437ed0e2c026dd63b77a972ddf4bd9f72bcc218e327986568317e3aa9f679c697a2cb7cebf992f3",
-            x"82ed7bb5528303a2e306775040a7309e0bd597b70d9949d8c6198a01a7be0b00079320ebfeaf7bbd5bfe86809940d252",
-        ];
-        let messages = vector[
-            b"Hello Aptos!",
-            b"Hello Aptos!",
-            b"Bello Aptos!",
-        ];
+            x"82ed7bb5528303a2e306775040a7309e0bd597b70d9949d8c6198a01a7be0b00079320ebfeaf7bbd5bfe86809940d252",];
+        let messages = vector[b"Hello Aptos!", b"Hello Aptos!", b"Bello Aptos!",];
 
         let i = 0;
         while (i < std::vector::length(&pks)) {
@@ -899,11 +1045,12 @@ module aptos_std::bls12381 {
             );
             assert!(notok == false, 1);
 
-            let notok = verify_signature_share(
-                sig,
-                &PublicKeyWithPoP { bytes: pk.bytes },
-                msg,
-            );
+            let notok =
+                verify_signature_share(
+                    sig,
+                    &PublicKeyWithPoP { bytes: pk.bytes },
+                    msg,
+                );
             assert!(notok == false, 1);
 
             i = i + 1;
@@ -939,37 +1086,56 @@ module aptos_std::bls12381 {
             x"8843843c76d167c02842a214c21277bad0bfd83da467cb5cf2d3ee67b2dcc7221b9fafa6d430400164012580e0c34d27",
             x"a23b524d4308d46e43ee8cbbf57f3e1c20c47061ad9c3f915212334ea6532451dd5c01d3d3ada6bea10fe180b2c3b450",
             x"a2aaa3eae1df3fc36365491afa1da5181acbb03801afd1430f04bb3b3eb18036f8b756b3508e4caee04beff50d455d1c",
-            x"84985b7e983dbdaddfca1f0b7dad9660bb39fff660e329acec15f69ac48c75dfa5d2df9f0dc320e4e7b7658166e0ac1c",
-        ];
+            x"84985b7e983dbdaddfca1f0b7dad9660bb39fff660e329acec15f69ac48c75dfa5d2df9f0dc320e4e7b7658166e0ac1c",];
 
         let pops = vector[
-            proof_of_possession_from_bytes(x"ab42afff92510034bf1232a37a0d31bc8abfc17e7ead9170d2d100f6cf6c75ccdcfedbd31699a112b4464a06fd636f3f190595863677d660b4c5d922268ace421f9e86e3a054946ee34ce29e1f88c1a10f27587cf5ec528d65ba7c0dc4863364"),
-            proof_of_possession_from_bytes(x"a6da5f2bc17df70ce664cff3e3a3e09d17162e47e652032b9fedc0c772fd5a533583242cba12095602e422e579c5284b1735009332dbdd23430bbcf61cc506ae37e41ff9a1fc78f0bc0d99b6bc7bf74c8f567dfb59079a035842bdc5fa3a0464"),
-            proof_of_possession_from_bytes(x"b8eef236595e2eab34d3c1abdab65971f5cfa1988c731ef62bd63c9a9ad3dfc9259f4f183bfffbc8375a38ba62e1c41a11173209705996ce889859bcbb3ddd7faa3c4ea3d8778f30a9ff814fdcfea1fb163d745c54dfb4dcc5a8cee092ee0070"),
-            proof_of_possession_from_bytes(x"a03a12fab68ad59d85c15dd1528560eff2c89250070ad0654ba260fda4334da179811d2ecdaca57693f80e9ce977d62011e3b1ee7bb4f7e0eb9b349468dd758f10fc35d54e0d0b8536ca713a77a301944392a5c192b6adf2a79ae2b38912dc98"),
-            proof_of_possession_from_bytes(x"8899b294f3c066e6dfb59bc0843265a1ccd6afc8f0f38a074d45ded8799c39d25ee0376cd6d6153b0d4d2ff8655e578b140254f1287b9e9df4e2aecc5b049d8556a4ab07f574df68e46348fd78e5298b7913377cf5bb3cf4796bfc755902bfdd"),
-        ];
+            proof_of_possession_from_bytes(
+                x"ab42afff92510034bf1232a37a0d31bc8abfc17e7ead9170d2d100f6cf6c75ccdcfedbd31699a112b4464a06fd636f3f190595863677d660b4c5d922268ace421f9e86e3a054946ee34ce29e1f88c1a10f27587cf5ec528d65ba7c0dc4863364",
+            ),
+            proof_of_possession_from_bytes(
+                x"a6da5f2bc17df70ce664cff3e3a3e09d17162e47e652032b9fedc0c772fd5a533583242cba12095602e422e579c5284b1735009332dbdd23430bbcf61cc506ae37e41ff9a1fc78f0bc0d99b6bc7bf74c8f567dfb59079a035842bdc5fa3a0464",
+            ),
+            proof_of_possession_from_bytes(
+                x"b8eef236595e2eab34d3c1abdab65971f5cfa1988c731ef62bd63c9a9ad3dfc9259f4f183bfffbc8375a38ba62e1c41a11173209705996ce889859bcbb3ddd7faa3c4ea3d8778f30a9ff814fdcfea1fb163d745c54dfb4dcc5a8cee092ee0070",
+            ),
+            proof_of_possession_from_bytes(
+                x"a03a12fab68ad59d85c15dd1528560eff2c89250070ad0654ba260fda4334da179811d2ecdaca57693f80e9ce977d62011e3b1ee7bb4f7e0eb9b349468dd758f10fc35d54e0d0b8536ca713a77a301944392a5c192b6adf2a79ae2b38912dc98",
+            ),
+            proof_of_possession_from_bytes(
+                x"8899b294f3c066e6dfb59bc0843265a1ccd6afc8f0f38a074d45ded8799c39d25ee0376cd6d6153b0d4d2ff8655e578b140254f1287b9e9df4e2aecc5b049d8556a4ab07f574df68e46348fd78e5298b7913377cf5bb3cf4796bfc755902bfdd",
+            ),];
 
         assert!(std::vector::length(&pks) == std::vector::length(&pops), 1);
 
         let i = 0;
         while (i < std::vector::length(&pks)) {
-            let opt_pk = public_key_from_bytes_with_pop(*std::vector::borrow(&pks, i), std::vector::borrow(&pops, i));
+            let opt_pk =
+                public_key_from_bytes_with_pop(
+                    *std::vector::borrow(&pks, i), std::vector::borrow(&pops, i)
+                );
             assert!(option::is_some(&opt_pk), 1);
 
             i = i + 1;
         };
 
         // assert first PK's PoP does not verify against modifed PK' = 0xa0 | PK[1:]
-        let opt_pk = public_key_from_bytes_with_pop(
-            x"a08864c91ae7a9998b3f5ee71f447840864e56d79838e4785ff5126c51480198df3d972e1e0348c6da80d396983e42d7",
-            &proof_of_possession_from_bytes(x"ab42afff92510034bf1232a37a0d31bc8abfc17e7ead9170d2d100f6cf6c75ccdcfedbd31699a112b4464a06fd636f3f190595863677d660b4c5d922268ace421f9e86e3a054946ee34ce29e1f88c1a10f27587cf5ec528d65ba7c0dc4863364"));
+        let opt_pk =
+            public_key_from_bytes_with_pop(
+                x"a08864c91ae7a9998b3f5ee71f447840864e56d79838e4785ff5126c51480198df3d972e1e0348c6da80d396983e42d7",
+                &proof_of_possession_from_bytes(
+                    x"ab42afff92510034bf1232a37a0d31bc8abfc17e7ead9170d2d100f6cf6c75ccdcfedbd31699a112b4464a06fd636f3f190595863677d660b4c5d922268ace421f9e86e3a054946ee34ce29e1f88c1a10f27587cf5ec528d65ba7c0dc4863364",
+                ),
+            );
         assert!(option::is_none(&opt_pk), 1);
 
         // assert first PK's PoP does not verify if modifed as pop' = 0xb0 | pop[1:]
-        let opt_pk = public_key_from_bytes_with_pop(
-            x"808864c91ae7a9998b3f5ee71f447840864e56d79838e4785ff5126c51480198df3d972e1e0348c6da80d396983e42d7",
-            &proof_of_possession_from_bytes(x"bb42afff92510034bf1232a37a0d31bc8abfc17e7ead9170d2d100f6cf6c75ccdcfedbd31699a112b4464a06fd636f3f190595863677d660b4c5d922268ace421f9e86e3a054946ee34ce29e1f88c1a10f27587cf5ec528d65ba7c0dc4863364"));
+        let opt_pk =
+            public_key_from_bytes_with_pop(
+                x"808864c91ae7a9998b3f5ee71f447840864e56d79838e4785ff5126c51480198df3d972e1e0348c6da80d396983e42d7",
+                &proof_of_possession_from_bytes(
+                    x"bb42afff92510034bf1232a37a0d31bc8abfc17e7ead9170d2d100f6cf6c75ccdcfedbd31699a112b4464a06fd636f3f190595863677d660b4c5d922268ace421f9e86e3a054946ee34ce29e1f88c1a10f27587cf5ec528d65ba7c0dc4863364",
+                ),
+            );
         assert!(option::is_none(&opt_pk), 1);
     }
 
@@ -979,7 +1145,15 @@ module aptos_std::bls12381 {
         let pk_bytes = public_key_with_pop_to_bytes(&pk);
         let pop = generate_proof_of_possession(&sk);
         assert!(option::is_some(&public_key_from_bytes_with_pop(pk_bytes, &pop)), 1);
-        assert!(option::is_none(&public_key_from_bytes_with_pop(pk_bytes, &maul_proof_of_possession(&pop))), 1);
-        assert!(option::is_none(&public_key_from_bytes_with_pop(maul_bytes(&pk_bytes), &pop)), 1);
+        assert!(
+            option::is_none(
+                &public_key_from_bytes_with_pop(pk_bytes, &maul_proof_of_possession(&pop))
+            ),
+            1,
+        );
+        assert!(
+            option::is_none(&public_key_from_bytes_with_pop(maul_bytes(&pk_bytes), &pop)),
+            1,
+        );
     }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381.move
@@ -168,9 +168,7 @@ module aptos_std::bls12381 {
         : Option<AggrOrMultiSignature> {
         let (bytes, success) = aggregate_signatures_internal(signatures);
         if (success) {
-            option::some(
-                AggrOrMultiSignature { bytes },
-            )
+            option::some(AggrOrMultiSignature { bytes })
         } else {
             option::none<AggrOrMultiSignature>()
         }
@@ -282,9 +280,8 @@ module aptos_std::bls12381 {
         while (i < signing_key_count) {
             let sig =
                 sign_arbitrary_bytes(
-                    std::vector::borrow(signing_keys, i), *std::vector::borrow(
-                        messages, i
-                    )
+                    std::vector::borrow(signing_keys, i),
+                    *std::vector::borrow(messages, i),
                 );
             std::vector::push_back(&mut sigs, sig);
             i = i + 1;
@@ -537,7 +534,8 @@ module aptos_std::bls12381 {
             },
             PublicKeyWithPoP {
                 bytes: x"a4cd352daad3a0651c1998dfbaa7a748e08d248a54347544bfedd51a197e016bb6008e9b8e45a744e1a030cc3b27d2da"
-            },];
+            },
+        ];
 
         // agg_pks[i] = \sum_{j <= i}  pk[j]
         let agg_pks = vector[
@@ -555,7 +553,8 @@ module aptos_std::bls12381 {
             },
             AggrPublicKeysWithPoP {
                 bytes: x"b53df1cfee2168f59e5792e710bf22928dc0553e6531dae5c7656c0a66fc12cb82fbb04863938c953dc901a5a79cc0f3"
-            },];
+            },
+        ];
 
         let i = 0;
         let accum_pk = std::vector::empty<PublicKeyWithPoP>();
@@ -604,7 +603,8 @@ module aptos_std::bls12381 {
             ),
             signature_from_bytes(
                 x"8d22876bdf73e6ad36ed98546018f6258cd47e45904b87c071e774a6ef4b07cac323258cb920b2fe2b07cca1f2b24bcb0a3194ec76f32edb92391ed2c39e1ada8919f8ea755c5e39873d33ff3a8f4fba21b1261c1ddb9d1688c2b40b77e355d1",
-            ),];
+            ),
+        ];
 
         // multisigs[i] is a signature on "Hello, Aptoverse!" from signers 1 through i (inclusive)
         let multisigs = vector[
@@ -622,7 +622,8 @@ module aptos_std::bls12381 {
             },
             AggrOrMultiSignature {
                 bytes: x"8284e4e3983f29cb45020c3e2d89066df2eae533a01cb6ca2c4d466b5e02dd22467f59640aa120db2b9cc49e931415c3097e3d54ff977fd9067b5bc6cfa1c885d9d8821aef20c028999a1d97e783ae049d8fa3d0bbac36ce4ca8e10e551d3461"
-            },];
+            },
+        ];
 
         let i = 0;
         let accum_sigs = std::vector::empty<Signature>();
@@ -663,7 +664,8 @@ module aptos_std::bls12381 {
             },
             PublicKeyWithPoP {
                 bytes: x"a4cd352daad3a0651c1998dfbaa7a748e08d248a54347544bfedd51a197e016bb6008e9b8e45a744e1a030cc3b27d2da"
-            },];
+            },
+        ];
 
         // agg_pks[i] = \sum_{j <= i}  pk[j]
         let agg_pks = vector[
@@ -681,7 +683,8 @@ module aptos_std::bls12381 {
             },
             AggrPublicKeysWithPoP {
                 bytes: x"b53df1cfee2168f59e5792e710bf22928dc0553e6531dae5c7656c0a66fc12cb82fbb04863938c953dc901a5a79cc0f3"
-            },];
+            },
+        ];
 
         // multisigs[i] is a signature on "Hello, Aptoverse!" under agg_pks[i]
         let multisigs = vector[
@@ -699,7 +702,8 @@ module aptos_std::bls12381 {
             },
             AggrOrMultiSignature {
                 bytes: x"b627b2cfd8ae59dcf5e58cc6c230ae369985fd096e1bc3be38da5deafcbed7d939f07cccc75383539940c56c6b6453db193f563f5b6e4fe54915afd9e1baea40a297fa7eda74abbdcd4cc5c667d6db3b9bd265782f7693798894400f2beb4637"
-            },];
+            },
+        ];
 
         let i = 0;
         let accum_pk = std::vector::empty<PublicKeyWithPoP>();
@@ -712,7 +716,9 @@ module aptos_std::bls12381 {
 
             assert!(
                 verify_multisignature(
-                    std::vector::borrow(&multisigs, i), &apk, b"Hello, Aptoverse!"
+                    std::vector::borrow(&multisigs, i),
+                    &apk,
+                    b"Hello, Aptoverse!",
                 ),
                 1,
             );
@@ -828,7 +834,8 @@ module aptos_std::bls12381 {
                 vector[
                     get_random_pk_with_pop(),
                     get_random_pk_with_pop(),
-                    get_random_pk_with_pop(),],
+                    get_random_pk_with_pop(),
+                ],
                 vector[x"cd", x"ef"],
             ) == false,
             1,
@@ -843,7 +850,8 @@ module aptos_std::bls12381 {
             x"48656c6c6f2c204170746f73203221",
             x"48656c6c6f2c204170746f73203321",
             x"48656c6c6f2c204170746f73203421",
-            x"48656c6c6f2c204170746f73203521",];
+            x"48656c6c6f2c204170746f73203521",
+        ];
 
         // Public key of signer i
         let pks = vector[
@@ -861,7 +869,8 @@ module aptos_std::bls12381 {
             },
             PublicKeyWithPoP {
                 bytes: x"a79e3d0e9d04587a3b27d05efe5717da05fd93485dc47978c866dc70a01695c2efd247d1dd843a011a4b6b24079d7384"
-            },];
+            },
+        ];
 
         // aggsigs[i] = \sum_{j <= i}  sigs[j], where sigs[j] is a signature on msgs[j] under pks[j]
         let aggsigs = vector[
@@ -879,7 +888,8 @@ module aptos_std::bls12381 {
             },
             AggrOrMultiSignature {
                 bytes: x"a44d967935fbe63a763ce2dd2b16981f967ecd31e20d3266eef5517530cdc233c8a18273b6d9fd7f61dd39178826e3f115df4e7b304f2de17373a95ea0c9a14293dcfd6f0ef416e06fa23f6a3c850d638e4d8f97ab4562ef55d49a96a50baa13"
-            },];
+            },
+        ];
 
         let i = 0;
         let msg_subset = std::vector::empty<vector<u8>>();
@@ -912,15 +922,16 @@ module aptos_std::bls12381 {
                 std::vector::push_back(&mut public_keys, pk);
                 let msg: vector<u8> = vector[
                     104, 101, 108, 108, 111, 32, 97, 112, 116, 111, 115, 32, 117, 115, 101,
-                    114, 32, 48 + (i as u8)]; //"hello aptos user {i}"
+                    114, 32, 48 + (i as u8)
+                ]; //"hello aptos user {i}"
                 std::vector::push_back(&mut messages, msg);
                 i = i + 1;
             };
 
             // Maul messages and public keys.
             let mauled_public_keys = vector[maul_public_key_with_pop(
-                    std::vector::borrow(&public_keys, 0)
-                )];
+                std::vector::borrow(&public_keys, 0)
+            )];
             let mauled_messages = vector[maul_bytes(std::vector::borrow(&messages, 0))];
             let i = 1;
             while (i < signer_count) {
@@ -943,10 +954,12 @@ module aptos_std::bls12381 {
                 1,
             );
             assert!(
-                !verify_aggregate_signature(&aggrsig, mauled_public_keys, messages), 1
+                !verify_aggregate_signature(&aggrsig, mauled_public_keys, messages),
+                1,
             );
             assert!(
-                !verify_aggregate_signature(&aggrsig, public_keys, mauled_messages), 1
+                !verify_aggregate_signature(&aggrsig, public_keys, mauled_messages),
+                1,
             );
 
             // Also test signature aggregation.
@@ -1023,11 +1036,13 @@ module aptos_std::bls12381 {
             },
             Signature {
                 bytes: x"b01ce4632e94d8c611736e96aa2ad8e0528a02f927a81a92db8047b002a8c71dc2d6bfb94729d0973790c10b6ece446817e4b7543afd7ca9a17c75de301ae835d66231c26a003f11ae26802b98d90869a9e73788c38739f7ac9d52659e1f7cf7"
-            },];
+            },
+        ];
         let pks = vector[
             x"94209a296b739577cb076d3bfb1ca8ee936f29b69b7dae436118c4dd1cc26fd43dcd16249476a006b8b949bf022a7858",
             x"ae4851bb9e7782027437ed0e2c026dd63b77a972ddf4bd9f72bcc218e327986568317e3aa9f679c697a2cb7cebf992f3",
-            x"82ed7bb5528303a2e306775040a7309e0bd597b70d9949d8c6198a01a7be0b00079320ebfeaf7bbd5bfe86809940d252",];
+            x"82ed7bb5528303a2e306775040a7309e0bd597b70d9949d8c6198a01a7be0b00079320ebfeaf7bbd5bfe86809940d252",
+        ];
         let messages = vector[b"Hello Aptos!", b"Hello Aptos!", b"Bello Aptos!",];
 
         let i = 0;
@@ -1086,7 +1101,8 @@ module aptos_std::bls12381 {
             x"8843843c76d167c02842a214c21277bad0bfd83da467cb5cf2d3ee67b2dcc7221b9fafa6d430400164012580e0c34d27",
             x"a23b524d4308d46e43ee8cbbf57f3e1c20c47061ad9c3f915212334ea6532451dd5c01d3d3ada6bea10fe180b2c3b450",
             x"a2aaa3eae1df3fc36365491afa1da5181acbb03801afd1430f04bb3b3eb18036f8b756b3508e4caee04beff50d455d1c",
-            x"84985b7e983dbdaddfca1f0b7dad9660bb39fff660e329acec15f69ac48c75dfa5d2df9f0dc320e4e7b7658166e0ac1c",];
+            x"84985b7e983dbdaddfca1f0b7dad9660bb39fff660e329acec15f69ac48c75dfa5d2df9f0dc320e4e7b7658166e0ac1c",
+        ];
 
         let pops = vector[
             proof_of_possession_from_bytes(
@@ -1103,7 +1119,8 @@ module aptos_std::bls12381 {
             ),
             proof_of_possession_from_bytes(
                 x"8899b294f3c066e6dfb59bc0843265a1ccd6afc8f0f38a074d45ded8799c39d25ee0376cd6d6153b0d4d2ff8655e578b140254f1287b9e9df4e2aecc5b049d8556a4ab07f574df68e46348fd78e5298b7913377cf5bb3cf4796bfc755902bfdd",
-            ),];
+            ),
+        ];
 
         assert!(std::vector::length(&pks) == std::vector::length(&pops), 1);
 
@@ -1111,7 +1128,8 @@ module aptos_std::bls12381 {
         while (i < std::vector::length(&pks)) {
             let opt_pk =
                 public_key_from_bytes_with_pop(
-                    *std::vector::borrow(&pks, i), std::vector::borrow(&pops, i)
+                    *std::vector::borrow(&pks, i),
+                    std::vector::borrow(&pops, i),
                 );
             assert!(option::is_some(&opt_pk), 1);
 
@@ -1147,7 +1165,7 @@ module aptos_std::bls12381 {
         assert!(option::is_some(&public_key_from_bytes_with_pop(pk_bytes, &pop)), 1);
         assert!(
             option::is_none(
-                &public_key_from_bytes_with_pop(pk_bytes, &maul_proof_of_possession(&pop))
+                &public_key_from_bytes_with_pop(pk_bytes, &maul_proof_of_possession(&pop)),
             ),
             1,
         );

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381.spec.move
@@ -2,15 +2,25 @@ spec aptos_std::bls12381 {
 
     spec public_key_from_bytes {
         aborts_if false;
-        ensures spec_validate_pubkey_internal(bytes) ==> (std::option::spec_is_some(result) && std::option::spec_borrow(result).bytes == bytes);
-        ensures !spec_validate_pubkey_internal(bytes) ==> std::option::spec_is_none(result);
+        ensures spec_validate_pubkey_internal(bytes) ==>
+            (
+                std::option::spec_is_some(result)
+                    && std::option::spec_borrow(result).bytes == bytes
+            );
+        ensures !spec_validate_pubkey_internal(bytes) ==>
+            std::option::spec_is_none(result);
     }
 
     spec public_key_from_bytes_with_pop {
         pragma opaque;
         aborts_if false;
-        ensures spec_verify_proof_of_possession_internal(pk_bytes, pop.bytes) ==> (std::option::spec_is_some(result) && std::option::spec_borrow(result).bytes == pk_bytes);
-        ensures !spec_verify_proof_of_possession_internal(pk_bytes, pop.bytes) ==> std::option::spec_is_none(result);
+        ensures spec_verify_proof_of_possession_internal(pk_bytes, pop.bytes) ==>
+            (
+                std::option::spec_is_some(result)
+                    && std::option::spec_borrow(result).bytes == pk_bytes
+            );
+        ensures !spec_verify_proof_of_possession_internal(pk_bytes, pop.bytes) ==>
+            std::option::spec_is_none(result);
         ensures [abstract] result == spec_public_key_from_bytes_with_pop(pk_bytes, pop);
     }
 
@@ -32,7 +42,11 @@ spec aptos_std::bls12381 {
         aborts_if false;
         let bytes = spec_aggregate_signatures_internal_1(signatures);
         let success = spec_aggregate_signatures_internal_2(signatures);
-        ensures success ==> (std::option::spec_is_some(result) && std::option::spec_borrow(result).bytes == bytes);
+        ensures success ==>
+            (
+                std::option::spec_is_some(result)
+                    && std::option::spec_borrow(result).bytes == bytes
+            );
         ensures !success ==> std::option::spec_is_none(result);
     }
 
@@ -67,59 +81,79 @@ spec aptos_std::bls12381 {
 
     spec verify_aggregate_signature {
         aborts_if false;
-        ensures result == spec_verify_aggregate_signature_internal(aggr_sig.bytes, public_keys, messages);
+        ensures result
+            == spec_verify_aggregate_signature_internal(
+                aggr_sig.bytes, public_keys, messages
+            );
     }
 
     spec verify_aggregate_signature_internal {
         pragma opaque;
         aborts_if [abstract] false;
-        ensures result == spec_verify_aggregate_signature_internal(aggsig, public_keys, messages);
+        ensures result
+            == spec_verify_aggregate_signature_internal(aggsig, public_keys, messages);
     }
 
     spec verify_multisignature {
         aborts_if false;
-        ensures result == spec_verify_multisignature_internal(multisig.bytes, aggr_public_key.bytes, message);
+        ensures result
+            == spec_verify_multisignature_internal(
+                multisig.bytes, aggr_public_key.bytes, message
+            );
     }
 
     spec verify_multisignature_internal {
         pragma opaque;
         aborts_if [abstract] false;
-        ensures result == spec_verify_multisignature_internal(multisignature, agg_public_key, message);
+        ensures result
+            == spec_verify_multisignature_internal(
+                multisignature, agg_public_key, message
+            );
     }
 
     spec verify_normal_signature {
         aborts_if false;
-        ensures result == spec_verify_normal_signature_internal(signature.bytes, public_key.bytes, message);
+        ensures result
+            == spec_verify_normal_signature_internal(
+                signature.bytes, public_key.bytes, message
+            );
     }
 
     spec verify_normal_signature_internal {
         pragma opaque;
         aborts_if [abstract] false;
-        ensures result == spec_verify_normal_signature_internal(signature, public_key, message);
+        ensures result
+            == spec_verify_normal_signature_internal(signature, public_key, message);
     }
 
     spec verify_proof_of_possession_internal {
         pragma opaque;
         aborts_if [abstract] false;
-        ensures result == spec_verify_proof_of_possession_internal(public_key, proof_of_possesion);
+        ensures result
+            == spec_verify_proof_of_possession_internal(public_key, proof_of_possesion);
     }
 
     spec verify_signature_share {
         aborts_if false;
-        ensures result == spec_verify_signature_share_internal(signature_share.bytes, public_key.bytes, message);
+        ensures result
+            == spec_verify_signature_share_internal(
+                signature_share.bytes, public_key.bytes, message
+            );
     }
 
     spec verify_signature_share_internal {
         pragma opaque;
         aborts_if [abstract] false;
-        ensures result == spec_verify_signature_share_internal(signature_share, public_key, message);
+        ensures result
+            == spec_verify_signature_share_internal(signature_share, public_key, message);
     }
 
     /// # Helper functions
 
     spec fun spec_aggregate_pubkeys_internal_1(public_keys: vector<PublicKeyWithPoP>): vector<u8>;
 
-    spec fun spec_public_key_from_bytes_with_pop(pk_bytes: vector<u8>, pop: ProofOfPossession): Option<PublicKeyWithPoP>;
+    spec fun spec_public_key_from_bytes_with_pop(pk_bytes: vector<u8>, pop: ProofOfPossession): Option<
+        PublicKeyWithPoP>;
 
     spec fun spec_aggregate_pubkeys_internal_2(public_keys: vector<PublicKeyWithPoP>): bool;
 
@@ -138,27 +172,19 @@ spec aptos_std::bls12381 {
     ): bool;
 
     spec fun spec_verify_multisignature_internal(
-        multisignature: vector<u8>,
-        agg_public_key: vector<u8>,
-        message: vector<u8>
+        multisignature: vector<u8>, agg_public_key: vector<u8>, message: vector<u8>
     ): bool;
 
     spec fun spec_verify_normal_signature_internal(
-        signature: vector<u8>,
-        public_key: vector<u8>,
-        message: vector<u8>
+        signature: vector<u8>, public_key: vector<u8>, message: vector<u8>
     ): bool;
 
     spec fun spec_verify_proof_of_possession_internal(
-        public_key: vector<u8>,
-        proof_of_possesion: vector<u8>
+        public_key: vector<u8>, proof_of_possesion: vector<u8>
     ): bool;
 
     spec fun spec_verify_signature_share_internal(
-        signature_share: vector<u8>,
-        public_key: vector<u8>,
-        message: vector<u8>
+        signature_share: vector<u8>, public_key: vector<u8>, message: vector<u8>
     ): bool;
-
 
 }

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381_algebra.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381_algebra.move
@@ -285,7 +285,7 @@ module aptos_std::bls12381_algebra {
         let val_minus_7 = neg(&val_7);
         assert!(
             FQ12_VAL_7_NEG_SERIALIZED == serialize<Fq12, FormatFq12LscLsb>(&val_minus_7),
-            1
+            1,
         );
 
         // Addition.
@@ -315,7 +315,8 @@ module aptos_std::bls12381_algebra {
 
         // Downcasting.
         assert!(
-            eq(&zero<Gt>(), &std::option::extract(&mut downcast<Fq12, Gt>(&val_1))), 1
+            eq(&zero<Gt>(), &std::option::extract(&mut downcast<Fq12, Gt>(&val_1))),
+            1,
         );
     }
 
@@ -350,7 +351,7 @@ module aptos_std::bls12381_algebra {
         // Serialization/deserialization.
         assert!(
             G1_GENERATOR_SERIALIZED_UNCOMP == serialize<G1, FormatG1Uncompr>(&generator),
-            1
+            1,
         );
         assert!(
             G1_GENERATOR_SERIALIZED_COMP == serialize<G1, FormatG1Compr>(&generator), 1
@@ -606,7 +607,7 @@ module aptos_std::bls12381_algebra {
         );
         assert!(
             G2_GENERATOR_SERIALIZED_UNCOMP == serialize<G2, FormatG2Uncompr>(&generator),
-            1
+            1,
         );
         let generator_from_uncomp =
             std::option::extract(
@@ -960,7 +961,7 @@ module aptos_std::bls12381_algebra {
         assert!(
             std::option::is_none(
                 &deserialize<Fr, FormatFrLsb>(
-                    &x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73"
+                    &x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73",
                 ),
             ),
             1,
@@ -968,7 +969,7 @@ module aptos_std::bls12381_algebra {
         assert!(
             std::option::is_none(
                 &deserialize<Fr, FormatFrMsb>(
-                    &x"73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
+                    &x"73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001",
                 ),
             ),
             1,
@@ -978,7 +979,7 @@ module aptos_std::bls12381_algebra {
         assert!(
             std::option::is_none(
                 &deserialize<Fr, FormatFrLsb>(
-                    &x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed7300"
+                    &x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed7300",
                 ),
             ),
             1,
@@ -986,7 +987,7 @@ module aptos_std::bls12381_algebra {
         assert!(
             std::option::is_none(
                 &deserialize<Fr, FormatFrMsb>(
-                    &x"0073eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
+                    &x"0073eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001",
                 ),
             ),
             1,
@@ -1078,7 +1079,8 @@ module aptos_std::bls12381_algebra {
         // Efficient API.
         let m =
             multi_pairing<G1, G2, Gt>(
-                &vector[p0_a0, p1_a1, p2_a2], &vector[q0_b0, q1_b1, q2_b2]
+                &vector[p0_a0, p1_a1, p2_a2],
+                &vector[q0_b0, q1_b1, q2_b2],
             );
         assert!(eq(&n, &m), 1);
     }

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381_algebra.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381_algebra.move
@@ -273,14 +273,20 @@ module aptos_std::bls12381_algebra {
         assert!(FQ12_VAL_0_SERIALIZED == serialize<Fq12, FormatFq12LscLsb>(&val_0), 1);
         assert!(FQ12_VAL_1_SERIALIZED == serialize<Fq12, FormatFq12LscLsb>(&val_1), 1);
         let val_7 = from_u64<Fq12>(7);
-        let val_7_another = std::option::extract(&mut deserialize<Fq12, FormatFq12LscLsb>(&FQ12_VAL_7_SERIALIZED));
+        let val_7_another =
+            std::option::extract(
+                &mut deserialize<Fq12, FormatFq12LscLsb>(&FQ12_VAL_7_SERIALIZED)
+            );
         assert!(eq(&val_7, &val_7_another), 1);
         assert!(FQ12_VAL_7_SERIALIZED == serialize<Fq12, FormatFq12LscLsb>(&val_7), 1);
         assert!(std::option::is_none(&deserialize<Fq12, FormatFq12LscLsb>(&x"ffff")), 1);
 
         // Negation.
         let val_minus_7 = neg(&val_7);
-        assert!(FQ12_VAL_7_NEG_SERIALIZED == serialize<Fq12, FormatFq12LscLsb>(&val_minus_7), 1);
+        assert!(
+            FQ12_VAL_7_NEG_SERIALIZED == serialize<Fq12, FormatFq12LscLsb>(&val_minus_7),
+            1
+        );
 
         // Addition.
         let val_9 = from_u64<Fq12>(9);
@@ -308,7 +314,9 @@ module aptos_std::bls12381_algebra {
         assert!(eq(&mul(&val_x, &val_x), &sqr(&val_x)), 1);
 
         // Downcasting.
-        assert!(eq(&zero<Gt>(), &std::option::extract(&mut downcast<Fq12, Gt>(&val_1))), 1);
+        assert!(
+            eq(&zero<Gt>(), &std::option::extract(&mut downcast<Fq12, Gt>(&val_1))), 1
+        );
     }
 
     #[test_only]
@@ -340,58 +348,154 @@ module aptos_std::bls12381_algebra {
         let generator = one<G1>();
 
         // Serialization/deserialization.
-        assert!(G1_GENERATOR_SERIALIZED_UNCOMP == serialize<G1, FormatG1Uncompr>(&generator), 1);
-        assert!(G1_GENERATOR_SERIALIZED_COMP == serialize<G1, FormatG1Compr>(&generator), 1);
-        let generator_from_comp = std::option::extract(&mut deserialize<G1, FormatG1Compr>(&G1_GENERATOR_SERIALIZED_COMP
-        ));
-        let generator_from_uncomp = std::option::extract(&mut deserialize<G1, FormatG1Uncompr>(&G1_GENERATOR_SERIALIZED_UNCOMP
-        ));
+        assert!(
+            G1_GENERATOR_SERIALIZED_UNCOMP == serialize<G1, FormatG1Uncompr>(&generator),
+            1
+        );
+        assert!(
+            G1_GENERATOR_SERIALIZED_COMP == serialize<G1, FormatG1Compr>(&generator), 1
+        );
+        let generator_from_comp =
+            std::option::extract(
+                &mut deserialize<G1, FormatG1Compr>(&G1_GENERATOR_SERIALIZED_COMP)
+            );
+        let generator_from_uncomp =
+            std::option::extract(
+                &mut deserialize<G1, FormatG1Uncompr>(&G1_GENERATOR_SERIALIZED_UNCOMP)
+            );
         assert!(eq(&generator, &generator_from_comp), 1);
         assert!(eq(&generator, &generator_from_uncomp), 1);
 
         // Deserialization should fail if given a byte array of correct size but the value is not a member.
-        assert!(std::option::is_none(&deserialize<Fq12, FormatFq12LscLsb>(&x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<Fq12, FormatFq12LscLsb>(
+                    &x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given a byte array of wrong size.
-        assert!(std::option::is_none(&deserialize<Fq12, FormatFq12LscLsb>(&x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<Fq12, FormatFq12LscLsb>(
+                    &x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                ),
+            ),
+            1,
+        );
 
         assert!(
-            G1_INF_SERIALIZED_UNCOMP == serialize<G1, FormatG1Uncompr>(&point_at_infinity), 1);
-        assert!(G1_INF_SERIALIZED_COMP == serialize<G1, FormatG1Compr>(&point_at_infinity), 1);
-        let inf_from_uncomp = std::option::extract(&mut deserialize<G1, FormatG1Uncompr>(&G1_INF_SERIALIZED_UNCOMP
-        ));
-        let inf_from_comp = std::option::extract(&mut deserialize<G1, FormatG1Compr>(&G1_INF_SERIALIZED_COMP
-        ));
+            G1_INF_SERIALIZED_UNCOMP == serialize<G1, FormatG1Uncompr>(&point_at_infinity),
+            1,
+        );
+        assert!(
+            G1_INF_SERIALIZED_COMP == serialize<G1, FormatG1Compr>(&point_at_infinity), 1
+        );
+        let inf_from_uncomp =
+            std::option::extract(
+                &mut deserialize<G1, FormatG1Uncompr>(&G1_INF_SERIALIZED_UNCOMP)
+            );
+        let inf_from_comp =
+            std::option::extract(
+                &mut deserialize<G1, FormatG1Compr>(&G1_INF_SERIALIZED_COMP)
+            );
         assert!(eq(&point_at_infinity, &inf_from_comp), 1);
         assert!(eq(&point_at_infinity, &inf_from_uncomp), 1);
 
-        let point_7g_from_uncomp = std::option::extract(&mut deserialize<G1, FormatG1Uncompr>(&G1_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP
-        ));
-        let point_7g_from_comp = std::option::extract(&mut deserialize<G1, FormatG1Compr>(&G1_GENERATOR_MUL_BY_7_SERIALIZED_COMP
-        ));
+        let point_7g_from_uncomp =
+            std::option::extract(
+                &mut deserialize<G1, FormatG1Uncompr>(
+                    &G1_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP
+                ),
+            );
+        let point_7g_from_comp =
+            std::option::extract(
+                &mut deserialize<G1, FormatG1Compr>(
+                    &G1_GENERATOR_MUL_BY_7_SERIALIZED_COMP
+                ),
+            );
         assert!(eq(&point_7g_from_comp, &point_7g_from_uncomp), 1);
 
         // Deserialization should fail if given a point on the curve but off its prime-order subgroup, e.g., `(0,2)`.
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002")), 1);
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Compr>(&x"800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002",
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Compr>(
+                    &x"800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given a valid point in (Fq,Fq) but not on the curve.
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"8959e137e0719bf872abb08411010f437a8955bd42f5ba20fca64361af58ce188b1adb96ef229698bb7860b79e24ba12000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"8959e137e0719bf872abb08411010f437a8955bd42f5ba20fca64361af58ce188b1adb96ef229698bb7860b79e24ba12000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given an invalid point (x not in Fq).
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa76e9853b35f5c9b2002d9e5833fd8f9ab4cd3934a4722a06f6055bfca720c91629811e2ecae7f0cf301b6d07898a90f")), 1);
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Compr>(&x"9fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa76e9853b35f5c9b2002d9e5833fd8f9ab4cd3934a4722a06f6055bfca720c91629811e2ecae7f0cf301b6d07898a90f",
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Compr>(
+                    &x"9fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given a byte array of wrong size.
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab")), 1);
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Compr>(&x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab",
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Compr>(
+                    &x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab",
+                ),
+            ),
+            1,
+        );
 
         // Scalar multiplication.
         let scalar_7 = from_u64<Fr>(7);
         let point_7g_calc = scalar_mul(&generator, &scalar_7);
         assert!(eq(&point_7g_calc, &point_7g_from_comp), 1);
-        assert!(G1_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP == serialize<G1, FormatG1Uncompr>(&point_7g_calc), 1);
-        assert!(G1_GENERATOR_MUL_BY_7_SERIALIZED_COMP == serialize<G1, FormatG1Compr>( &point_7g_calc), 1);
+        assert!(
+            G1_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP
+                == serialize<G1, FormatG1Uncompr>(&point_7g_calc),
+            1,
+        );
+        assert!(
+            G1_GENERATOR_MUL_BY_7_SERIALIZED_COMP
+                == serialize<G1, FormatG1Compr>(&point_7g_calc),
+            1,
+        );
 
         // Multi-scalar multiplication.
         let num_entries = 1;
@@ -422,8 +526,16 @@ module aptos_std::bls12381_algebra {
 
         // Negation.
         let point_minus_7g_calc = neg(&point_7g_calc);
-        assert!(G1_GENERATOR_MUL_BY_7_NEG_SERIALIZED_COMP == serialize<G1, FormatG1Compr>(&point_minus_7g_calc), 1);
-        assert!(G1_GENERATOR_MUL_BY_7_NEG_SERIALIZED_UNCOMP == serialize<G1, FormatG1Uncompr>(&point_minus_7g_calc), 1);
+        assert!(
+            G1_GENERATOR_MUL_BY_7_NEG_SERIALIZED_COMP
+                == serialize<G1, FormatG1Compr>(&point_minus_7g_calc),
+            1,
+        );
+        assert!(
+            G1_GENERATOR_MUL_BY_7_NEG_SERIALIZED_UNCOMP
+                == serialize<G1, FormatG1Uncompr>(&point_minus_7g_calc),
+            1,
+        );
 
         // Addition.
         let scalar_9 = from_u64<Fr>(9);
@@ -437,11 +549,28 @@ module aptos_std::bls12381_algebra {
 
         // Hash-to-group using suite `BLS12381G1_XMD:SHA-256_SSWU_RO_`.
         // Test vectors source: https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-bls12381g1_xmdsha-256_sswu_
-        let actual = hash_to<G1, HashG1XmdSha256SswuRo>(&b"QUUX-V01-CS02-with-BLS12381G1_XMD:SHA-256_SSWU_RO_", &b"");
-        let expected = std::option::extract(&mut deserialize<G1, FormatG1Uncompr>(&x"052926add2207b76ca4fa57a8734416c8dc95e24501772c814278700eed6d1e4e8cf62d9c09db0fac349612b759e79a108ba738453bfed09cb546dbb0783dbb3a5f1f566ed67bb6be0e8c67e2e81a4cc68ee29813bb7994998f3eae0c9c6a265"));
+        let actual =
+            hash_to<G1, HashG1XmdSha256SswuRo>(
+                &b"QUUX-V01-CS02-with-BLS12381G1_XMD:SHA-256_SSWU_RO_", &b""
+            );
+        let expected =
+            std::option::extract(
+                &mut deserialize<G1, FormatG1Uncompr>(
+                    &x"052926add2207b76ca4fa57a8734416c8dc95e24501772c814278700eed6d1e4e8cf62d9c09db0fac349612b759e79a108ba738453bfed09cb546dbb0783dbb3a5f1f566ed67bb6be0e8c67e2e81a4cc68ee29813bb7994998f3eae0c9c6a265",
+                ),
+            );
         assert!(eq(&expected, &actual), 1);
-        let actual = hash_to<G1, HashG1XmdSha256SswuRo>(&b"QUUX-V01-CS02-with-BLS12381G1_XMD:SHA-256_SSWU_RO_", &b"abcdef0123456789");
-        let expected = std::option::extract(&mut deserialize<G1, FormatG1Uncompr>(&x"11e0b079dea29a68f0383ee94fed1b940995272407e3bb916bbf268c263ddd57a6a27200a784cbc248e84f357ce82d9803a87ae2caf14e8ee52e51fa2ed8eefe80f02457004ba4d486d6aa1f517c0889501dc7413753f9599b099ebcbbd2d709"));
+        let actual =
+            hash_to<G1, HashG1XmdSha256SswuRo>(
+                &b"QUUX-V01-CS02-with-BLS12381G1_XMD:SHA-256_SSWU_RO_",
+                &b"abcdef0123456789",
+            );
+        let expected =
+            std::option::extract(
+                &mut deserialize<G1, FormatG1Uncompr>(
+                    &x"11e0b079dea29a68f0383ee94fed1b940995272407e3bb916bbf268c263ddd57a6a27200a784cbc248e84f357ce82d9803a87ae2caf14e8ee52e51fa2ed8eefe80f02457004ba4d486d6aa1f517c0889501dc7413753f9599b099ebcbbd2d709",
+                ),
+            );
         assert!(eq(&expected, &actual), 1);
     }
 
@@ -472,47 +601,132 @@ module aptos_std::bls12381_algebra {
         let generator = one<G2>();
 
         // Serialization/deserialization.
-        assert!(G2_GENERATOR_SERIALIZED_COMP == serialize<G2, FormatG2Compr>(&generator), 1);
-        assert!(G2_GENERATOR_SERIALIZED_UNCOMP == serialize<G2, FormatG2Uncompr>(&generator), 1);
-        let generator_from_uncomp = std::option::extract(&mut deserialize<G2, FormatG2Uncompr>(&G2_GENERATOR_SERIALIZED_UNCOMP
-        ));
-        let generator_from_comp = std::option::extract(&mut deserialize<G2, FormatG2Compr>(&G2_GENERATOR_SERIALIZED_COMP
-        ));
+        assert!(
+            G2_GENERATOR_SERIALIZED_COMP == serialize<G2, FormatG2Compr>(&generator), 1
+        );
+        assert!(
+            G2_GENERATOR_SERIALIZED_UNCOMP == serialize<G2, FormatG2Uncompr>(&generator),
+            1
+        );
+        let generator_from_uncomp =
+            std::option::extract(
+                &mut deserialize<G2, FormatG2Uncompr>(&G2_GENERATOR_SERIALIZED_UNCOMP)
+            );
+        let generator_from_comp =
+            std::option::extract(
+                &mut deserialize<G2, FormatG2Compr>(&G2_GENERATOR_SERIALIZED_COMP)
+            );
         assert!(eq(&generator, &generator_from_comp), 1);
         assert!(eq(&generator, &generator_from_uncomp), 1);
-        assert!(G2_INF_SERIALIZED_UNCOMP == serialize<G2, FormatG2Uncompr>(&point_at_infinity), 1);
-        assert!(G2_INF_SERIALIZED_COMP == serialize<G2, FormatG2Compr>(&point_at_infinity), 1);
-        let inf_from_uncomp = std::option::extract(&mut deserialize<G2, FormatG2Uncompr>(&G2_INF_SERIALIZED_UNCOMP));
-        let inf_from_comp = std::option::extract(&mut deserialize<G2, FormatG2Compr>(&G2_INF_SERIALIZED_COMP));
+        assert!(
+            G2_INF_SERIALIZED_UNCOMP == serialize<G2, FormatG2Uncompr>(&point_at_infinity),
+            1,
+        );
+        assert!(
+            G2_INF_SERIALIZED_COMP == serialize<G2, FormatG2Compr>(&point_at_infinity), 1
+        );
+        let inf_from_uncomp =
+            std::option::extract(
+                &mut deserialize<G2, FormatG2Uncompr>(&G2_INF_SERIALIZED_UNCOMP)
+            );
+        let inf_from_comp =
+            std::option::extract(
+                &mut deserialize<G2, FormatG2Compr>(&G2_INF_SERIALIZED_COMP)
+            );
         assert!(eq(&point_at_infinity, &inf_from_comp), 1);
         assert!(eq(&point_at_infinity, &inf_from_uncomp), 1);
-        let point_7g_from_uncomp = std::option::extract(&mut deserialize<G2, FormatG2Uncompr>(&G2_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP
-        ));
-        let point_7g_from_comp = std::option::extract(&mut deserialize<G2, FormatG2Compr>(&G2_GENERATOR_MUL_BY_7_SERIALIZED_COMP
-        ));
+        let point_7g_from_uncomp =
+            std::option::extract(
+                &mut deserialize<G2, FormatG2Uncompr>(
+                    &G2_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP
+                ),
+            );
+        let point_7g_from_comp =
+            std::option::extract(
+                &mut deserialize<G2, FormatG2Compr>(
+                    &G2_GENERATOR_MUL_BY_7_SERIALIZED_COMP
+                ),
+            );
         assert!(eq(&point_7g_from_comp, &point_7g_from_uncomp), 1);
 
         // Deserialization should fail if given a point on the curve but not in the prime-order subgroup.
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"f037d4ccd5ee751eba1c1fd4c7edbb76d2b04c3a1f3f554827cf37c3acbc2dbb7cdb320a2727c2462d6c55ca1f637707b96eeebc622c1dbe7c56c34f93887c8751b42bd04f29253a82251c192ef27ece373993b663f4360505299c5bd18c890ddd862a6308796bf47e2265073c1f7d81afd69f9497fc1403e2e97a866129b43b672295229c21116d4a99f3e5c2ae720a31f181dbed8a93e15f909c20cf69d11a8879adbbe6890740def19814e6d4ed23fb0dcbd79291655caf48b466ac9cae04")), 1);
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Compr>(&x"f037d4ccd5ee751eba1c1fd4c7edbb76d2b04c3a1f3f554827cf37c3acbc2dbb7cdb320a2727c2462d6c55ca1f637707b96eeebc622c1dbe7c56c34f93887c8751b42bd04f29253a82251c192ef27ece373993b663f4360505299c5bd18c890d")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"f037d4ccd5ee751eba1c1fd4c7edbb76d2b04c3a1f3f554827cf37c3acbc2dbb7cdb320a2727c2462d6c55ca1f637707b96eeebc622c1dbe7c56c34f93887c8751b42bd04f29253a82251c192ef27ece373993b663f4360505299c5bd18c890ddd862a6308796bf47e2265073c1f7d81afd69f9497fc1403e2e97a866129b43b672295229c21116d4a99f3e5c2ae720a31f181dbed8a93e15f909c20cf69d11a8879adbbe6890740def19814e6d4ed23fb0dcbd79291655caf48b466ac9cae04",
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Compr>(
+                    &x"f037d4ccd5ee751eba1c1fd4c7edbb76d2b04c3a1f3f554827cf37c3acbc2dbb7cdb320a2727c2462d6c55ca1f637707b96eeebc622c1dbe7c56c34f93887c8751b42bd04f29253a82251c192ef27ece373993b663f4360505299c5bd18c890d",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given a valid point in (Fq2,Fq2) but not on the curve.
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"f037d4ccd5ee751eba1c1fd4c7edbb76d2b04c3a1f3f554827cf37c3acbc2dbb7cdb320a2727c2462d6c55ca1f637707b96eeebc622c1dbe7c56c34f93887c8751b42bd04f29253a82251c192ef27ece373993b663f4360505299c5bd18c890d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"f037d4ccd5ee751eba1c1fd4c7edbb76d2b04c3a1f3f554827cf37c3acbc2dbb7cdb320a2727c2462d6c55ca1f637707b96eeebc622c1dbe7c56c34f93887c8751b42bd04f29253a82251c192ef27ece373993b663f4360505299c5bd18c890d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given an invalid point (x not in Fq2).
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdd862a6308796bf47e2265073c1f7d81afd69f9497fc1403e2e97a866129b43b672295229c21116d4a99f3e5c2ae720a31f181dbed8a93e15f909c20cf69d11a8879adbbe6890740def19814e6d4ed23fb0dcbd79291655caf48b466ac9cae04")), 1);
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Compr>(&x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdd862a6308796bf47e2265073c1f7d81afd69f9497fc1403e2e97a866129b43b672295229c21116d4a99f3e5c2ae720a31f181dbed8a93e15f909c20cf69d11a8879adbbe6890740def19814e6d4ed23fb0dcbd79291655caf48b466ac9cae04",
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Compr>(
+                    &x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given a byte array of wrong size.
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab")), 1);
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Compr>(&x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab",
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Compr>(
+                    &x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab",
+                ),
+            ),
+            1,
+        );
 
         // Scalar multiplication.
         let scalar_7 = from_u64<Fr>(7);
         let point_7g_calc = scalar_mul(&generator, &scalar_7);
         assert!(eq(&point_7g_calc, &point_7g_from_comp), 1);
-        assert!(G2_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP == serialize<G2, FormatG2Uncompr>(&point_7g_calc), 1);
-        assert!(G2_GENERATOR_MUL_BY_7_SERIALIZED_COMP == serialize<G2, FormatG2Compr>(&point_7g_calc), 1);
+        assert!(
+            G2_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP
+                == serialize<G2, FormatG2Uncompr>(&point_7g_calc),
+            1,
+        );
+        assert!(
+            G2_GENERATOR_MUL_BY_7_SERIALIZED_COMP
+                == serialize<G2, FormatG2Compr>(&point_7g_calc),
+            1,
+        );
 
         // Multi-scalar multiplication.
         let num_entries = 1;
@@ -543,8 +757,16 @@ module aptos_std::bls12381_algebra {
 
         // Negation.
         let point_minus_7g_calc = neg(&point_7g_calc);
-        assert!(G2_GENERATOR_MUL_BY_7_NEG_SERIALIZED_COMP == serialize<G2, FormatG2Compr>(&point_minus_7g_calc), 1);
-        assert!(G2_GENERATOR_MUL_BY_7_NEG_SERIALIZED_UNCOMP == serialize<G2, FormatG2Uncompr>(&point_minus_7g_calc), 1);
+        assert!(
+            G2_GENERATOR_MUL_BY_7_NEG_SERIALIZED_COMP
+                == serialize<G2, FormatG2Compr>(&point_minus_7g_calc),
+            1,
+        );
+        assert!(
+            G2_GENERATOR_MUL_BY_7_NEG_SERIALIZED_UNCOMP
+                == serialize<G2, FormatG2Uncompr>(&point_minus_7g_calc),
+            1,
+        );
 
         // Addition.
         let scalar_9 = from_u64<Fr>(9);
@@ -558,11 +780,28 @@ module aptos_std::bls12381_algebra {
 
         // Hash-to-group using suite `BLS12381G2_XMD:SHA-256_SSWU_RO_`.
         // Test vectors source: https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-16.html#name-bls12381g2_xmdsha-256_sswu_
-        let actual = hash_to<G2, HashG2XmdSha256SswuRo>(&b"QUUX-V01-CS02-with-BLS12381G2_XMD:SHA-256_SSWU_RO_", &b"");
-        let expected = std::option::extract(&mut deserialize<G2, FormatG2Uncompr>(&x"05cb8437535e20ecffaef7752baddf98034139c38452458baeefab379ba13dff5bf5dd71b72418717047f5b0f37da03d0141ebfbdca40eb85b87142e130ab689c673cf60f1a3e98d69335266f30d9b8d4ac44c1038e9dcdd5393faf5c41fb78a12424ac32561493f3fe3c260708a12b7c620e7be00099a974e259ddc7d1f6395c3c811cdd19f1e8dbf3e9ecfdcbab8d60503921d7f6a12805e72940b963c0cf3471c7b2a524950ca195d11062ee75ec076daf2d4bc358c4b190c0c98064fdd92"));
+        let actual =
+            hash_to<G2, HashG2XmdSha256SswuRo>(
+                &b"QUUX-V01-CS02-with-BLS12381G2_XMD:SHA-256_SSWU_RO_", &b""
+            );
+        let expected =
+            std::option::extract(
+                &mut deserialize<G2, FormatG2Uncompr>(
+                    &x"05cb8437535e20ecffaef7752baddf98034139c38452458baeefab379ba13dff5bf5dd71b72418717047f5b0f37da03d0141ebfbdca40eb85b87142e130ab689c673cf60f1a3e98d69335266f30d9b8d4ac44c1038e9dcdd5393faf5c41fb78a12424ac32561493f3fe3c260708a12b7c620e7be00099a974e259ddc7d1f6395c3c811cdd19f1e8dbf3e9ecfdcbab8d60503921d7f6a12805e72940b963c0cf3471c7b2a524950ca195d11062ee75ec076daf2d4bc358c4b190c0c98064fdd92",
+                ),
+            );
         assert!(eq(&expected, &actual), 1);
-        let actual = hash_to<G2, HashG2XmdSha256SswuRo>(&b"QUUX-V01-CS02-with-BLS12381G2_XMD:SHA-256_SSWU_RO_", &b"abcdef0123456789");
-        let expected = std::option::extract(&mut deserialize<G2, FormatG2Uncompr>(&x"190d119345b94fbd15497bcba94ecf7db2cbfd1e1fe7da034d26cbba169fb3968288b3fafb265f9ebd380512a71c3f2c121982811d2491fde9ba7ed31ef9ca474f0e1501297f68c298e9f4c0028add35aea8bb83d53c08cfc007c1e005723cd00bb5e7572275c567462d91807de765611490205a941a5a6af3b1691bfe596c31225d3aabdf15faff860cb4ef17c7c3be05571a0f8d3c08d094576981f4a3b8eda0a8e771fcdcc8ecceaf1356a6acf17574518acb506e435b639353c2e14827c8"));
+        let actual =
+            hash_to<G2, HashG2XmdSha256SswuRo>(
+                &b"QUUX-V01-CS02-with-BLS12381G2_XMD:SHA-256_SSWU_RO_",
+                &b"abcdef0123456789",
+            );
+        let expected =
+            std::option::extract(
+                &mut deserialize<G2, FormatG2Uncompr>(
+                    &x"190d119345b94fbd15497bcba94ecf7db2cbfd1e1fe7da034d26cbba169fb3968288b3fafb265f9ebd380512a71c3f2c121982811d2491fde9ba7ed31ef9ca474f0e1501297f68c298e9f4c0028add35aea8bb83d53c08cfc007c1e005723cd00bb5e7572275c567462d91807de765611490205a941a5a6af3b1691bfe596c31225d3aabdf15faff860cb4ef17c7c3be05571a0f8d3c08d094576981f4a3b8eda0a8e771fcdcc8ecceaf1356a6acf17574518acb506e435b639353c2e14827c8",
+                ),
+            );
         assert!(eq(&expected, &actual), 1);
     }
 
@@ -586,30 +825,55 @@ module aptos_std::bls12381_algebra {
 
         // Serialization/deserialization.
         assert!(GT_GENERATOR_SERIALIZED == serialize<Gt, FormatGt>(&generator), 1);
-        let generator_from_deser = std::option::extract(&mut deserialize<Gt, FormatGt>(&GT_GENERATOR_SERIALIZED));
+        let generator_from_deser =
+            std::option::extract(&mut deserialize<Gt, FormatGt>(&GT_GENERATOR_SERIALIZED));
         assert!(eq(&generator, &generator_from_deser), 1);
         assert!(FQ12_ONE_SERIALIZED == serialize<Gt, FormatGt>(&identity), 1);
-        let identity_from_deser = std::option::extract(&mut deserialize<Gt, FormatGt>(&FQ12_ONE_SERIALIZED));
+        let identity_from_deser =
+            std::option::extract(&mut deserialize<Gt, FormatGt>(&FQ12_ONE_SERIALIZED));
         assert!(eq(&identity, &identity_from_deser), 1);
-        let element_7g_from_deser = std::option::extract(&mut deserialize<Gt, FormatGt>(&GT_GENERATOR_MUL_BY_7_SERIALIZED
-        ));
+        let element_7g_from_deser =
+            std::option::extract(
+                &mut deserialize<Gt, FormatGt>(&GT_GENERATOR_MUL_BY_7_SERIALIZED)
+            );
         assert!(std::option::is_none(&deserialize<Gt, FormatGt>(&x"ffff")), 1);
 
         // Deserialization should fail if given an element in Fq12 but not in the prime-order subgroup.
-        assert!(std::option::is_none(&deserialize<Gt, FormatGt>(&x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<Gt, FormatGt>(
+                    &x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given a byte array of wrong size.
-        assert!(std::option::is_none(&deserialize<Gt, FormatGt>(&x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<Gt, FormatGt>(
+                    &x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab",
+                ),
+            ),
+            1,
+        );
 
         // Element scalar multiplication.
         let scalar_7 = from_u64<Fr>(7);
         let element_7g_calc = scalar_mul(&generator, &scalar_7);
         assert!(eq(&element_7g_calc, &element_7g_from_deser), 1);
-        assert!(GT_GENERATOR_MUL_BY_7_SERIALIZED == serialize<Gt, FormatGt>(&element_7g_calc), 1);
+        assert!(
+            GT_GENERATOR_MUL_BY_7_SERIALIZED == serialize<Gt, FormatGt>(&element_7g_calc),
+            1,
+        );
 
         // Element negation.
         let element_minus_7g_calc = neg(&element_7g_calc);
-        assert!(GT_GENERATOR_MUL_BY_7_NEG_SERIALIZED == serialize<Gt, FormatGt>(&element_minus_7g_calc), 1);
+        assert!(
+            GT_GENERATOR_MUL_BY_7_NEG_SERIALIZED
+                == serialize<Gt, FormatGt>(&element_minus_7g_calc),
+            1,
+        );
 
         // Element addition.
         let scalar_9 = from_u64<Fr>(9);
@@ -627,7 +891,33 @@ module aptos_std::bls12381_algebra {
     }
 
     #[test_only]
-    use aptos_std::crypto_algebra::{zero, one, from_u64, eq, deserialize, serialize, neg, add, sub, mul, div, inv, rand_insecure, sqr, order, scalar_mul, multi_scalar_mul, double, hash_to, upcast, enable_cryptography_algebra_natives, pairing, multi_pairing, downcast, Element};
+    use aptos_std::crypto_algebra::{
+        zero,
+        one,
+        from_u64,
+        eq,
+        deserialize,
+        serialize,
+        neg,
+        add,
+        sub,
+        mul,
+        div,
+        inv,
+        rand_insecure,
+        sqr,
+        order,
+        scalar_mul,
+        multi_scalar_mul,
+        double,
+        hash_to,
+        upcast,
+        enable_cryptography_algebra_natives,
+        pairing,
+        multi_pairing,
+        downcast,
+        Element
+    };
 
     #[test_only]
     const FR_VAL_0_SERIALIZED_LSB: vector<u8> = x"0000000000000000000000000000000000000000000000000000000000000000";
@@ -653,26 +943,62 @@ module aptos_std::bls12381_algebra {
         assert!(FR_VAL_0_SERIALIZED_LSB == serialize<Fr, FormatFrLsb>(&val_0), 1);
         assert!(FR_VAL_1_SERIALIZED_LSB == serialize<Fr, FormatFrLsb>(&val_1), 1);
         let val_7 = from_u64<Fr>(7);
-        let val_7_2nd = std::option::extract(&mut deserialize<Fr, FormatFrLsb>(&FR_VAL_7_SERIALIZED_LSB));
-        let val_7_3rd = std::option::extract(&mut deserialize<Fr, FormatFrMsb>(&FR_VAL_7_SERIALIZED_MSB));
+        let val_7_2nd =
+            std::option::extract(
+                &mut deserialize<Fr, FormatFrLsb>(&FR_VAL_7_SERIALIZED_LSB)
+            );
+        let val_7_3rd =
+            std::option::extract(
+                &mut deserialize<Fr, FormatFrMsb>(&FR_VAL_7_SERIALIZED_MSB)
+            );
         assert!(eq(&val_7, &val_7_2nd), 1);
         assert!(eq(&val_7, &val_7_3rd), 1);
         assert!(FR_VAL_7_SERIALIZED_LSB == serialize<Fr, FormatFrLsb>(&val_7), 1);
         assert!(FR_VAL_7_SERIALIZED_MSB == serialize<Fr, FormatFrMsb>(&val_7), 1);
 
         // Deserialization should fail if given a byte array of right size but the value is not a member.
-        assert!(std::option::is_none(&deserialize<Fr, FormatFrLsb>(&x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73")), 1);
-        assert!(std::option::is_none(&deserialize<Fr, FormatFrMsb>(&x"73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<Fr, FormatFrLsb>(
+                    &x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73"
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<Fr, FormatFrMsb>(
+                    &x"73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given a byte array of wrong size.
-        assert!(std::option::is_none(&deserialize<Fr, FormatFrLsb>(&x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed7300")), 1);
-        assert!(std::option::is_none(&deserialize<Fr, FormatFrMsb>(&x"0073eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<Fr, FormatFrLsb>(
+                    &x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed7300"
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<Fr, FormatFrMsb>(
+                    &x"0073eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
+                ),
+            ),
+            1,
+        );
         assert!(std::option::is_none(&deserialize<Fr, FormatFrLsb>(&x"ffff")), 1);
         assert!(std::option::is_none(&deserialize<Fr, FormatFrMsb>(&x"ffff")), 1);
 
         // Negation.
         let val_minus_7 = neg(&val_7);
-        assert!(FR_VAL_7_NEG_SERIALIZED_LSB == serialize<Fr, FormatFrLsb>(&val_minus_7), 1);
+        assert!(
+            FR_VAL_7_NEG_SERIALIZED_LSB == serialize<Fr, FormatFrLsb>(&val_minus_7), 1
+        );
 
         // Addition.
         let val_9 = from_u64<Fr>(9);
@@ -709,8 +1035,10 @@ module aptos_std::bls12381_algebra {
         let element_q = rand_insecure<G2>();
         let a = rand_insecure<Fr>();
         let b = rand_insecure<Fr>();
-        let gt_element = pairing<G1, G2,Gt>(&scalar_mul(&element_p, &a), &scalar_mul(&element_q, &b));
-        let gt_element_another = scalar_mul(&pairing<G1, G2,Gt>(&element_p, &element_q), &mul(&a, &b));
+        let gt_element =
+            pairing<G1, G2, Gt>(&scalar_mul(&element_p, &a), &scalar_mul(&element_q, &b));
+        let gt_element_another =
+            scalar_mul(&pairing<G1, G2, Gt>(&element_p, &element_q), &mul(&a, &b));
         assert!(eq(&gt_element, &gt_element_another), 1);
     }
 
@@ -739,16 +1067,19 @@ module aptos_std::bls12381_algebra {
         let q2_b2 = scalar_mul(&element_q2, &b2);
 
         // Naive method.
-        let n0 = pairing<G1, G2,Gt>(&p0_a0, &q0_b0);
-        let n1 = pairing<G1, G2,Gt>(&p1_a1, &q1_b1);
-        let n2 = pairing<G1, G2,Gt>(&p2_a2, &q2_b2);
+        let n0 = pairing<G1, G2, Gt>(&p0_a0, &q0_b0);
+        let n1 = pairing<G1, G2, Gt>(&p1_a1, &q1_b1);
+        let n2 = pairing<G1, G2, Gt>(&p2_a2, &q2_b2);
         let n = zero<Gt>();
         n = add(&n, &n0);
         n = add(&n, &n1);
         n = add(&n, &n2);
 
         // Efficient API.
-        let m = multi_pairing<G1, G2, Gt>(&vector[p0_a0, p1_a1, p2_a2], &vector[q0_b0, q1_b1, q2_b2]);
+        let m =
+            multi_pairing<G1, G2, Gt>(
+                &vector[p0_a0, p1_a1, p2_a2], &vector[q0_b0, q1_b1, q2_b2]
+            );
         assert!(eq(&n, &m), 1);
     }
 
@@ -763,7 +1094,9 @@ module aptos_std::bls12381_algebra {
 
     #[test(fx = @std)]
     #[expected_failure(abort_code = 0x010002, location = aptos_std::crypto_algebra)]
-    fun test_multi_scalar_mul_should_abort_when_sizes_mismatch(fx: signer) {
+    fun test_multi_scalar_mul_should_abort_when_sizes_mismatch(
+        fx: signer
+    ) {
         enable_cryptography_algebra_natives(&fx);
         let elements = vector[rand_insecure<G1>()];
         let scalars = vector[rand_insecure<Fr>(), rand_insecure<Fr>()];

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/bn254_algebra.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/bn254_algebra.move
@@ -280,7 +280,7 @@ module std::bn254_algebra {
         let val_minus_7 = neg(&val_7);
         assert!(
             FQ12_VAL_7_NEG_SERIALIZED == serialize<Fq12, FormatFq12LscLsb>(&val_minus_7),
-            1
+            1,
         );
 
         // Addition.
@@ -310,7 +310,8 @@ module std::bn254_algebra {
 
         // Downcasting.
         assert!(
-            eq(&zero<Gt>(), &std::option::extract(&mut downcast<Fq12, Gt>(&val_1))), 1
+            eq(&zero<Gt>(), &std::option::extract(&mut downcast<Fq12, Gt>(&val_1))),
+            1,
         );
         // upcasting
         assert!(eq(&val_1, &upcast<Gt, Fq12>(&zero<Gt>())), 1);
@@ -347,7 +348,7 @@ module std::bn254_algebra {
         // Serialization/deserialization.
         assert!(
             G1_GENERATOR_SERIALIZED_UNCOMP == serialize<G1, FormatG1Uncompr>(&generator),
-            1
+            1,
         );
         assert!(
             G1_GENERATOR_SERIALIZED_COMP == serialize<G1, FormatG1Compr>(&generator), 1
@@ -577,7 +578,7 @@ module std::bn254_algebra {
         );
         assert!(
             G2_GENERATOR_SERIALIZED_UNCOMP == serialize<G2, FormatG2Uncompr>(&generator),
-            1
+            1,
         );
         let generator_from_uncomp =
             std::option::extract(
@@ -904,7 +905,7 @@ module std::bn254_algebra {
         assert!(
             std::option::is_none(
                 &deserialize<Fr, FormatFrLsb>(
-                    &x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73"
+                    &x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73",
                 ),
             ),
             1,
@@ -912,7 +913,7 @@ module std::bn254_algebra {
         assert!(
             std::option::is_none(
                 &deserialize<Fr, FormatFrMsb>(
-                    &x"73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
+                    &x"73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001",
                 ),
             ),
             1,
@@ -922,7 +923,7 @@ module std::bn254_algebra {
         assert!(
             std::option::is_none(
                 &deserialize<Fr, FormatFrLsb>(
-                    &x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed7300"
+                    &x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed7300",
                 ),
             ),
             1,
@@ -930,7 +931,7 @@ module std::bn254_algebra {
         assert!(
             std::option::is_none(
                 &deserialize<Fr, FormatFrMsb>(
-                    &x"0073eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
+                    &x"0073eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001",
                 ),
             ),
             1,
@@ -1013,7 +1014,7 @@ module std::bn254_algebra {
         assert!(
             std::option::is_none(
                 &deserialize<Fq, FormatFqLsb>(
-                    &x"47fd7cd8168c203c8dca7168916a81975d588181b64550b829a031e1724e6430"
+                    &x"47fd7cd8168c203c8dca7168916a81975d588181b64550b829a031e1724e6430",
                 ),
             ),
             1,
@@ -1021,7 +1022,7 @@ module std::bn254_algebra {
         assert!(
             std::option::is_none(
                 &deserialize<Fq, FormatFqMsb>(
-                    &x"30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
+                    &x"30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47",
                 ),
             ),
             1,
@@ -1031,7 +1032,7 @@ module std::bn254_algebra {
         assert!(
             std::option::is_none(
                 &deserialize<Fq, FormatFqLsb>(
-                    &x"46fd7cd8168c203c8dca7168916a81975d588181b64550b829a031e1724e643000"
+                    &x"46fd7cd8168c203c8dca7168916a81975d588181b64550b829a031e1724e643000",
                 ),
             ),
             1,
@@ -1039,7 +1040,7 @@ module std::bn254_algebra {
         assert!(
             std::option::is_none(
                 &deserialize<Fq, FormatFqMsb>(
-                    &x"30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd4600"
+                    &x"30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd4600",
                 ),
             ),
             1,
@@ -1131,7 +1132,8 @@ module std::bn254_algebra {
         // Efficient API.
         let m =
             multi_pairing<G1, G2, Gt>(
-                &vector[p0_a0, p1_a1, p2_a2], &vector[q0_b0, q1_b1, q2_b2]
+                &vector[p0_a0, p1_a1, p2_a2],
+                &vector[q0_b0, q1_b1, q2_b2],
             );
         assert!(eq(&n, &m), 1);
     }

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/bn254_algebra.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/bn254_algebra.move
@@ -102,6 +102,7 @@ module std::bn254_algebra {
     /// The field can downcast to `Gt` if it's an element of the multiplicative subgroup `Gt` of `Fq12`
     /// with a prime order $r$ = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001.
     struct Fq12 {}
+
     /// A serialization scheme for `Fq12` elements,
     /// where an element $(c_0+c_1\cdot w)$ is represented by a byte array `b[]` of size 384,
     /// which is a concatenation of its coefficients serialized, with the least significant coefficient (LSC) coming first.
@@ -243,7 +244,6 @@ module std::bn254_algebra {
         elements
     }
 
-
     #[test_only]
     const FQ12_VAL_0_SERIALIZED: vector<u8> = x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
     #[test_only]
@@ -254,7 +254,6 @@ module std::bn254_algebra {
     const FQ12_VAL_7_NEG_SERIALIZED: vector<u8> = x"40fd7cd8168c203c8dca7168916a81975d588181b64550b829a031e1724e643000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
     #[test_only]
     const Q12_SERIALIZED: vector<u8> = x"21f186cad2e2d4c1dbaf8a066b0ebf41f734e3f859b1c523a6c1f4d457413fdbe3cd44add090135d3ae519acc30ee3bdb6bfac6573b767e975b18a77d53cdcddebf3672c74da9d1409d51b2b2db7ff000d59e3aa7cf09220159f925c86b65459ca6558c4eaa703bf45d85030ff85cc6a879c7e2c4034f7045faf20e4d3dcfffac5eb6634c3e7b939b69b2be70bdf6b9a4680297839b4e3a48cd746bd4d0ea82749ffb7e71bd9b3fb10aa684d71e6adab1250b1d8604d91b51c76c256a50b60ddba2f52b6cc853ac926c6ea86d09d400b2f2330e5c8e92e38905ba50a50c9e11cd979c284bf1327ccdc051a6da1a4a7eac5cec16757a27a1a2311bedd108a9b21ac0814269e7523a5dd3a1f5f4767ffe504a6cb3994fb0ec98d5cd5da00b9cb1188a85f2aa871ecb8a0f9d64141f1ccd2699c138e0ef9ac4d8d6a692b29db0f38b60eb08426ab46109fbab9a5221bb44dd338aafebcc4e6c10dd933597f3ff44ba41d04e82871447f3a759cfa9397c22c0c77f13618dfb65adc8aacf008";
-
 
     #[test(fx = @std)]
     fun test_fq12(fx: signer) {
@@ -269,14 +268,20 @@ module std::bn254_algebra {
         assert!(FQ12_VAL_0_SERIALIZED == serialize<Fq12, FormatFq12LscLsb>(&val_0), 1);
         assert!(FQ12_VAL_1_SERIALIZED == serialize<Fq12, FormatFq12LscLsb>(&val_1), 1);
         let val_7 = from_u64<Fq12>(7);
-        let val_7_another = std::option::extract(&mut deserialize<Fq12, FormatFq12LscLsb>(&FQ12_VAL_7_SERIALIZED));
+        let val_7_another =
+            std::option::extract(
+                &mut deserialize<Fq12, FormatFq12LscLsb>(&FQ12_VAL_7_SERIALIZED)
+            );
         assert!(eq(&val_7, &val_7_another), 1);
         assert!(FQ12_VAL_7_SERIALIZED == serialize<Fq12, FormatFq12LscLsb>(&val_7), 1);
         assert!(std::option::is_none(&deserialize<Fq12, FormatFq12LscLsb>(&x"ffff")), 1);
 
         // Negation.
         let val_minus_7 = neg(&val_7);
-        assert!(FQ12_VAL_7_NEG_SERIALIZED == serialize<Fq12, FormatFq12LscLsb>(&val_minus_7), 1);
+        assert!(
+            FQ12_VAL_7_NEG_SERIALIZED == serialize<Fq12, FormatFq12LscLsb>(&val_minus_7),
+            1
+        );
 
         // Addition.
         let val_9 = from_u64<Fq12>(9);
@@ -304,7 +309,9 @@ module std::bn254_algebra {
         assert!(eq(&mul(&val_x, &val_x), &sqr(&val_x)), 1);
 
         // Downcasting.
-        assert!(eq(&zero<Gt>(), &std::option::extract(&mut downcast<Fq12, Gt>(&val_1))), 1);
+        assert!(
+            eq(&zero<Gt>(), &std::option::extract(&mut downcast<Fq12, Gt>(&val_1))), 1
+        );
         // upcasting
         assert!(eq(&val_1, &upcast<Gt, Fq12>(&zero<Gt>())), 1);
     }
@@ -338,56 +345,154 @@ module std::bn254_algebra {
         let generator = one<G1>();
 
         // Serialization/deserialization.
-        assert!(G1_GENERATOR_SERIALIZED_UNCOMP == serialize<G1, FormatG1Uncompr>(&generator), 1);
-        assert!(G1_GENERATOR_SERIALIZED_COMP == serialize<G1, FormatG1Compr>(&generator), 1);
-        let generator_from_comp = std::option::extract(&mut deserialize<G1, FormatG1Compr>(&G1_GENERATOR_SERIALIZED_COMP));
-        let generator_from_uncomp = std::option::extract(&mut deserialize<G1, FormatG1Uncompr>(&G1_GENERATOR_SERIALIZED_UNCOMP));
+        assert!(
+            G1_GENERATOR_SERIALIZED_UNCOMP == serialize<G1, FormatG1Uncompr>(&generator),
+            1
+        );
+        assert!(
+            G1_GENERATOR_SERIALIZED_COMP == serialize<G1, FormatG1Compr>(&generator), 1
+        );
+        let generator_from_comp =
+            std::option::extract(
+                &mut deserialize<G1, FormatG1Compr>(&G1_GENERATOR_SERIALIZED_COMP)
+            );
+        let generator_from_uncomp =
+            std::option::extract(
+                &mut deserialize<G1, FormatG1Uncompr>(&G1_GENERATOR_SERIALIZED_UNCOMP)
+            );
         assert!(eq(&generator, &generator_from_comp), 1);
         assert!(eq(&generator, &generator_from_uncomp), 1);
 
         // Deserialization should fail if given a byte array of correct size but the value is not a member.
-        assert!(std::option::is_none(&deserialize<Fq12, FormatFq12LscLsb>(&x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<Fq12, FormatFq12LscLsb>(
+                    &x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given a byte array of wrong size.
-        assert!(std::option::is_none(&deserialize<Fq12, FormatFq12LscLsb>(&x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<Fq12, FormatFq12LscLsb>(
+                    &x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                ),
+            ),
+            1,
+        );
 
         assert!(
-            G1_INF_SERIALIZED_UNCOMP == serialize<G1, FormatG1Uncompr>(&point_at_infinity), 1);
-        assert!(G1_INF_SERIALIZED_COMP == serialize<G1, FormatG1Compr>(&point_at_infinity), 1);
-        let inf_from_uncomp = std::option::extract(&mut deserialize<G1, FormatG1Uncompr>(&G1_INF_SERIALIZED_UNCOMP
-        ));
-        let inf_from_comp = std::option::extract(&mut deserialize<G1, FormatG1Compr>(&G1_INF_SERIALIZED_COMP
-        ));
+            G1_INF_SERIALIZED_UNCOMP == serialize<G1, FormatG1Uncompr>(&point_at_infinity),
+            1,
+        );
+        assert!(
+            G1_INF_SERIALIZED_COMP == serialize<G1, FormatG1Compr>(&point_at_infinity), 1
+        );
+        let inf_from_uncomp =
+            std::option::extract(
+                &mut deserialize<G1, FormatG1Uncompr>(&G1_INF_SERIALIZED_UNCOMP)
+            );
+        let inf_from_comp =
+            std::option::extract(
+                &mut deserialize<G1, FormatG1Compr>(&G1_INF_SERIALIZED_COMP)
+            );
         assert!(eq(&point_at_infinity, &inf_from_comp), 1);
         assert!(eq(&point_at_infinity, &inf_from_uncomp), 1);
 
-        let point_7g_from_uncomp = std::option::extract(&mut deserialize<G1, FormatG1Uncompr>(&G1_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP
-        ));
-        let point_7g_from_comp = std::option::extract(&mut deserialize<G1, FormatG1Compr>(&G1_GENERATOR_MUL_BY_7_SERIALIZED_COMP
-        ));
+        let point_7g_from_uncomp =
+            std::option::extract(
+                &mut deserialize<G1, FormatG1Uncompr>(
+                    &G1_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP
+                ),
+            );
+        let point_7g_from_comp =
+            std::option::extract(
+                &mut deserialize<G1, FormatG1Compr>(
+                    &G1_GENERATOR_MUL_BY_7_SERIALIZED_COMP
+                ),
+            );
         assert!(eq(&point_7g_from_comp, &point_7g_from_uncomp), 1);
 
         // Deserialization should fail if given a point on the curve but off its prime-order subgroup, e.g., `(0,2)`.
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002")), 1);
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Compr>(&x"800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002",
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Compr>(
+                    &x"800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given a valid point in (Fq,Fq) but not on the curve.
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"8959e137e0719bf872abb08411010f437a8955bd42f5ba20fca64361af58ce188b1adb96ef229698bb7860b79e24ba12000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"8959e137e0719bf872abb08411010f437a8955bd42f5ba20fca64361af58ce188b1adb96ef229698bb7860b79e24ba12000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given an invalid point (x not in Fq).
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa76e9853b35f5c9b2002d9e5833fd8f9ab4cd3934a4722a06f6055bfca720c91629811e2ecae7f0cf301b6d07898a90f")), 1);
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Compr>(&x"9fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa76e9853b35f5c9b2002d9e5833fd8f9ab4cd3934a4722a06f6055bfca720c91629811e2ecae7f0cf301b6d07898a90f",
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Compr>(
+                    &x"9fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given a byte array of wrong size.
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab")), 1);
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Compr>(&x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab",
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Compr>(
+                    &x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab",
+                ),
+            ),
+            1,
+        );
 
         // Scalar multiplication.
         let scalar_7 = from_u64<Fr>(7);
         let point_7g_calc = scalar_mul(&generator, &scalar_7);
         assert!(eq(&point_7g_calc, &point_7g_from_comp), 1);
-        assert!(G1_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP == serialize<G1, FormatG1Uncompr>(&point_7g_calc), 1);
-        assert!(G1_GENERATOR_MUL_BY_7_SERIALIZED_COMP == serialize<G1, FormatG1Compr>( &point_7g_calc), 1);
+        assert!(
+            G1_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP
+                == serialize<G1, FormatG1Uncompr>(&point_7g_calc),
+            1,
+        );
+        assert!(
+            G1_GENERATOR_MUL_BY_7_SERIALIZED_COMP
+                == serialize<G1, FormatG1Compr>(&point_7g_calc),
+            1,
+        );
 
         // Multi-scalar multiplication.
         let num_entries = 1;
@@ -418,8 +523,16 @@ module std::bn254_algebra {
 
         // Negation.
         let point_minus_7g_calc = neg(&point_7g_calc);
-        assert!(G1_GENERATOR_MUL_BY_7_NEG_SERIALIZED_COMP == serialize<G1, FormatG1Compr>(&point_minus_7g_calc), 1);
-        assert!(G1_GENERATOR_MUL_BY_7_NEG_SERIALIZED_UNCOMP == serialize<G1, FormatG1Uncompr>(&point_minus_7g_calc), 1);
+        assert!(
+            G1_GENERATOR_MUL_BY_7_NEG_SERIALIZED_COMP
+                == serialize<G1, FormatG1Compr>(&point_minus_7g_calc),
+            1,
+        );
+        assert!(
+            G1_GENERATOR_MUL_BY_7_NEG_SERIALIZED_UNCOMP
+                == serialize<G1, FormatG1Uncompr>(&point_minus_7g_calc),
+            1,
+        );
 
         // Addition.
         let scalar_9 = from_u64<Fr>(9);
@@ -459,47 +572,132 @@ module std::bn254_algebra {
         let generator = one<G2>();
 
         // Serialization/deserialization.
-        assert!(G2_GENERATOR_SERIALIZED_COMP == serialize<G2, FormatG2Compr>(&generator), 1);
-        assert!(G2_GENERATOR_SERIALIZED_UNCOMP == serialize<G2, FormatG2Uncompr>(&generator), 1);
-        let generator_from_uncomp = std::option::extract(&mut deserialize<G2, FormatG2Uncompr>(&G2_GENERATOR_SERIALIZED_UNCOMP
-        ));
-        let generator_from_comp = std::option::extract(&mut deserialize<G2, FormatG2Compr>(&G2_GENERATOR_SERIALIZED_COMP
-        ));
+        assert!(
+            G2_GENERATOR_SERIALIZED_COMP == serialize<G2, FormatG2Compr>(&generator), 1
+        );
+        assert!(
+            G2_GENERATOR_SERIALIZED_UNCOMP == serialize<G2, FormatG2Uncompr>(&generator),
+            1
+        );
+        let generator_from_uncomp =
+            std::option::extract(
+                &mut deserialize<G2, FormatG2Uncompr>(&G2_GENERATOR_SERIALIZED_UNCOMP)
+            );
+        let generator_from_comp =
+            std::option::extract(
+                &mut deserialize<G2, FormatG2Compr>(&G2_GENERATOR_SERIALIZED_COMP)
+            );
         assert!(eq(&generator, &generator_from_comp), 1);
         assert!(eq(&generator, &generator_from_uncomp), 1);
-        assert!(G2_INF_SERIALIZED_UNCOMP == serialize<G2, FormatG2Uncompr>(&point_at_infinity), 1);
-        assert!(G2_INF_SERIALIZED_COMP == serialize<G2, FormatG2Compr>(&point_at_infinity), 1);
-        let inf_from_uncomp = std::option::extract(&mut deserialize<G2, FormatG2Uncompr>(&G2_INF_SERIALIZED_UNCOMP));
-        let inf_from_comp = std::option::extract(&mut deserialize<G2, FormatG2Compr>(&G2_INF_SERIALIZED_COMP));
+        assert!(
+            G2_INF_SERIALIZED_UNCOMP == serialize<G2, FormatG2Uncompr>(&point_at_infinity),
+            1,
+        );
+        assert!(
+            G2_INF_SERIALIZED_COMP == serialize<G2, FormatG2Compr>(&point_at_infinity), 1
+        );
+        let inf_from_uncomp =
+            std::option::extract(
+                &mut deserialize<G2, FormatG2Uncompr>(&G2_INF_SERIALIZED_UNCOMP)
+            );
+        let inf_from_comp =
+            std::option::extract(
+                &mut deserialize<G2, FormatG2Compr>(&G2_INF_SERIALIZED_COMP)
+            );
         assert!(eq(&point_at_infinity, &inf_from_comp), 1);
         assert!(eq(&point_at_infinity, &inf_from_uncomp), 1);
-        let point_7g_from_uncomp = std::option::extract(&mut deserialize<G2, FormatG2Uncompr>(&G2_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP
-        ));
-        let point_7g_from_comp = std::option::extract(&mut deserialize<G2, FormatG2Compr>(&G2_GENERATOR_MUL_BY_7_SERIALIZED_COMP
-        ));
+        let point_7g_from_uncomp =
+            std::option::extract(
+                &mut deserialize<G2, FormatG2Uncompr>(
+                    &G2_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP
+                ),
+            );
+        let point_7g_from_comp =
+            std::option::extract(
+                &mut deserialize<G2, FormatG2Compr>(
+                    &G2_GENERATOR_MUL_BY_7_SERIALIZED_COMP
+                ),
+            );
         assert!(eq(&point_7g_from_comp, &point_7g_from_uncomp), 1);
 
         // Deserialization should fail if given a point on the curve but not in the prime-order subgroup.
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"f037d4ccd5ee751eba1c1fd4c7edbb76d2b04c3a1f3f554827cf37c3acbc2dbb7cdb320a2727c2462d6c55ca1f637707b96eeebc622c1dbe7c56c34f93887c8751b42bd04f29253a82251c192ef27ece373993b663f4360505299c5bd18c890ddd862a6308796bf47e2265073c1f7d81afd69f9497fc1403e2e97a866129b43b672295229c21116d4a99f3e5c2ae720a31f181dbed8a93e15f909c20cf69d11a8879adbbe6890740def19814e6d4ed23fb0dcbd79291655caf48b466ac9cae04")), 1);
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Compr>(&x"f037d4ccd5ee751eba1c1fd4c7edbb76d2b04c3a1f3f554827cf37c3acbc2dbb7cdb320a2727c2462d6c55ca1f637707b96eeebc622c1dbe7c56c34f93887c8751b42bd04f29253a82251c192ef27ece373993b663f4360505299c5bd18c890d")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"f037d4ccd5ee751eba1c1fd4c7edbb76d2b04c3a1f3f554827cf37c3acbc2dbb7cdb320a2727c2462d6c55ca1f637707b96eeebc622c1dbe7c56c34f93887c8751b42bd04f29253a82251c192ef27ece373993b663f4360505299c5bd18c890ddd862a6308796bf47e2265073c1f7d81afd69f9497fc1403e2e97a866129b43b672295229c21116d4a99f3e5c2ae720a31f181dbed8a93e15f909c20cf69d11a8879adbbe6890740def19814e6d4ed23fb0dcbd79291655caf48b466ac9cae04",
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Compr>(
+                    &x"f037d4ccd5ee751eba1c1fd4c7edbb76d2b04c3a1f3f554827cf37c3acbc2dbb7cdb320a2727c2462d6c55ca1f637707b96eeebc622c1dbe7c56c34f93887c8751b42bd04f29253a82251c192ef27ece373993b663f4360505299c5bd18c890d",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given a valid point in (Fq2,Fq2) but not on the curve.
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"f037d4ccd5ee751eba1c1fd4c7edbb76d2b04c3a1f3f554827cf37c3acbc2dbb7cdb320a2727c2462d6c55ca1f637707b96eeebc622c1dbe7c56c34f93887c8751b42bd04f29253a82251c192ef27ece373993b663f4360505299c5bd18c890d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"f037d4ccd5ee751eba1c1fd4c7edbb76d2b04c3a1f3f554827cf37c3acbc2dbb7cdb320a2727c2462d6c55ca1f637707b96eeebc622c1dbe7c56c34f93887c8751b42bd04f29253a82251c192ef27ece373993b663f4360505299c5bd18c890d000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given an invalid point (x not in Fq2).
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdd862a6308796bf47e2265073c1f7d81afd69f9497fc1403e2e97a866129b43b672295229c21116d4a99f3e5c2ae720a31f181dbed8a93e15f909c20cf69d11a8879adbbe6890740def19814e6d4ed23fb0dcbd79291655caf48b466ac9cae04")), 1);
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Compr>(&x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffdd862a6308796bf47e2265073c1f7d81afd69f9497fc1403e2e97a866129b43b672295229c21116d4a99f3e5c2ae720a31f181dbed8a93e15f909c20cf69d11a8879adbbe6890740def19814e6d4ed23fb0dcbd79291655caf48b466ac9cae04",
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Compr>(
+                    &x"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given a byte array of wrong size.
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Uncompr>(&x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab")), 1);
-        assert!(std::option::is_none(&deserialize<G1, FormatG1Compr>(&x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Uncompr>(
+                    &x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab",
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<G1, FormatG1Compr>(
+                    &x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab",
+                ),
+            ),
+            1,
+        );
 
         // Scalar multiplication.
         let scalar_7 = from_u64<Fr>(7);
         let point_7g_calc = scalar_mul(&generator, &scalar_7);
         assert!(eq(&point_7g_calc, &point_7g_from_comp), 1);
-        assert!(G2_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP == serialize<G2, FormatG2Uncompr>(&point_7g_calc), 1);
-        assert!(G2_GENERATOR_MUL_BY_7_SERIALIZED_COMP == serialize<G2, FormatG2Compr>(&point_7g_calc), 1);
+        assert!(
+            G2_GENERATOR_MUL_BY_7_SERIALIZED_UNCOMP
+                == serialize<G2, FormatG2Uncompr>(&point_7g_calc),
+            1,
+        );
+        assert!(
+            G2_GENERATOR_MUL_BY_7_SERIALIZED_COMP
+                == serialize<G2, FormatG2Compr>(&point_7g_calc),
+            1,
+        );
 
         // Multi-scalar multiplication.
         let num_entries = 1;
@@ -530,8 +728,16 @@ module std::bn254_algebra {
 
         // Negation.
         let point_minus_7g_calc = neg(&point_7g_calc);
-        assert!(G2_GENERATOR_MUL_BY_7_NEG_SERIALIZED_COMP == serialize<G2, FormatG2Compr>(&point_minus_7g_calc), 1);
-        assert!(G2_GENERATOR_MUL_BY_7_NEG_SERIALIZED_UNCOMP == serialize<G2, FormatG2Uncompr>(&point_minus_7g_calc), 1);
+        assert!(
+            G2_GENERATOR_MUL_BY_7_NEG_SERIALIZED_COMP
+                == serialize<G2, FormatG2Compr>(&point_minus_7g_calc),
+            1,
+        );
+        assert!(
+            G2_GENERATOR_MUL_BY_7_NEG_SERIALIZED_UNCOMP
+                == serialize<G2, FormatG2Uncompr>(&point_minus_7g_calc),
+            1,
+        );
 
         // Addition.
         let scalar_9 = from_u64<Fr>(9);
@@ -553,7 +759,6 @@ module std::bn254_algebra {
     #[test_only]
     const GT_GENERATOR_MUL_BY_7_NEG_SERIALIZED: vector<u8> = x"533a587534641b568125fb273eac723c789a347eba9fcfd58d93742b3a0b782fd61bbf6202e04b8a33b6c60150fc62a071cb9ac9749a79031fd0dbb6dd8a1f2bcf1eb450bdf58fd3d124b2e0aaf878d11e96af3051631145a4bf0530b5d19d08bfe2d515530b9059525b2826587f7bf1f146bfd0e91e84411c7722abb7a8c418b20b1660b41e6949beff93b2b36303e74804df3335ab5bd85bfd7959d6fd3101d0bf6f681eb809c9a6c3544db7f81444e5c4fbdd0a31e920616ae08a2ab5f51e88f6308f10c56da66be273c4b965fe8cc3e98bac609df5d796893c81a26616269879cf565c3bffac84c82858791ee4bca82d598c9c33893ed433f01a58943629eb007acdb5ea95a826017a51397a755327bda8178dd3f3bfc1ff78e3cbb9bc1cfdd5ecec24ef619a93578388bb52fa2e1ec0a878214f1fb91dcb1df48678c11887ee59c0ad74956770d6f6eb8f454afd23324c436335ab3f23333627fe0b1c2e8ebad423205893bcef3ed527608e3a8123ffbbf1c04164118e3b0e49bdac4205";
 
-
     #[test(fx = @std)]
     fun test_gt(fx: signer) {
         enable_cryptography_algebra_natives(&fx);
@@ -565,30 +770,55 @@ module std::bn254_algebra {
 
         // Serialization/deserialization.
         assert!(GT_GENERATOR_SERIALIZED == serialize<Gt, FormatGt>(&generator), 1);
-        let generator_from_deser = std::option::extract(&mut deserialize<Gt, FormatGt>(&GT_GENERATOR_SERIALIZED));
+        let generator_from_deser =
+            std::option::extract(&mut deserialize<Gt, FormatGt>(&GT_GENERATOR_SERIALIZED));
         assert!(eq(&generator, &generator_from_deser), 1);
         assert!(FQ12_ONE_SERIALIZED == serialize<Gt, FormatGt>(&identity), 1);
-        let identity_from_deser = std::option::extract(&mut deserialize<Gt, FormatGt>(&FQ12_ONE_SERIALIZED));
+        let identity_from_deser =
+            std::option::extract(&mut deserialize<Gt, FormatGt>(&FQ12_ONE_SERIALIZED));
         assert!(eq(&identity, &identity_from_deser), 1);
-        let element_7g_from_deser = std::option::extract(&mut deserialize<Gt, FormatGt>(&GT_GENERATOR_MUL_BY_7_SERIALIZED
-        ));
+        let element_7g_from_deser =
+            std::option::extract(
+                &mut deserialize<Gt, FormatGt>(&GT_GENERATOR_MUL_BY_7_SERIALIZED)
+            );
         assert!(std::option::is_none(&deserialize<Gt, FormatGt>(&x"ffff")), 1);
 
         // Deserialization should fail if given an element in Fq12 but not in the prime-order subgroup.
-        assert!(std::option::is_none(&deserialize<Gt, FormatGt>(&x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<Gt, FormatGt>(
+                    &x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given a byte array of wrong size.
-        assert!(std::option::is_none(&deserialize<Gt, FormatGt>(&x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<Gt, FormatGt>(
+                    &x"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ab",
+                ),
+            ),
+            1,
+        );
 
         // Element scalar multiplication.
         let scalar_7 = from_u64<Fr>(7);
         let element_7g_calc = scalar_mul(&generator, &scalar_7);
         assert!(eq(&element_7g_calc, &element_7g_from_deser), 1);
-        assert!(GT_GENERATOR_MUL_BY_7_SERIALIZED == serialize<Gt, FormatGt>(&element_7g_calc), 1);
+        assert!(
+            GT_GENERATOR_MUL_BY_7_SERIALIZED == serialize<Gt, FormatGt>(&element_7g_calc),
+            1,
+        );
 
         // Element negation.
         let element_minus_7g_calc = neg(&element_7g_calc);
-        assert!(GT_GENERATOR_MUL_BY_7_NEG_SERIALIZED == serialize<Gt, FormatGt>(&element_minus_7g_calc), 1);
+        assert!(
+            GT_GENERATOR_MUL_BY_7_NEG_SERIALIZED
+                == serialize<Gt, FormatGt>(&element_minus_7g_calc),
+            1,
+        );
 
         // Element addition.
         let scalar_9 = from_u64<Fr>(9);
@@ -606,7 +836,32 @@ module std::bn254_algebra {
     }
 
     #[test_only]
-    use aptos_std::crypto_algebra::{zero, one, from_u64, eq, deserialize, serialize, neg, add, sub, mul, div, inv, rand_insecure, sqr, order, scalar_mul, multi_scalar_mul, double, upcast, enable_cryptography_algebra_natives, pairing, multi_pairing, downcast, Element};
+    use aptos_std::crypto_algebra::{
+        zero,
+        one,
+        from_u64,
+        eq,
+        deserialize,
+        serialize,
+        neg,
+        add,
+        sub,
+        mul,
+        div,
+        inv,
+        rand_insecure,
+        sqr,
+        order,
+        scalar_mul,
+        multi_scalar_mul,
+        double,
+        upcast,
+        enable_cryptography_algebra_natives,
+        pairing,
+        multi_pairing,
+        downcast,
+        Element
+    };
 
     #[test_only]
     const FR_VAL_0_SERIALIZED_LSB: vector<u8> = x"0000000000000000000000000000000000000000000000000000000000000000";
@@ -632,26 +887,62 @@ module std::bn254_algebra {
         assert!(FR_VAL_0_SERIALIZED_LSB == serialize<Fr, FormatFrLsb>(&val_0), 1);
         assert!(FR_VAL_1_SERIALIZED_LSB == serialize<Fr, FormatFrLsb>(&val_1), 1);
         let val_7 = from_u64<Fr>(7);
-        let val_7_2nd = std::option::extract(&mut deserialize<Fr, FormatFrLsb>(&FR_VAL_7_SERIALIZED_LSB));
-        let val_7_3rd = std::option::extract(&mut deserialize<Fr, FormatFrMsb>(&FR_VAL_7_SERIALIZED_MSB));
+        let val_7_2nd =
+            std::option::extract(
+                &mut deserialize<Fr, FormatFrLsb>(&FR_VAL_7_SERIALIZED_LSB)
+            );
+        let val_7_3rd =
+            std::option::extract(
+                &mut deserialize<Fr, FormatFrMsb>(&FR_VAL_7_SERIALIZED_MSB)
+            );
         assert!(eq(&val_7, &val_7_2nd), 1);
         assert!(eq(&val_7, &val_7_3rd), 1);
         assert!(FR_VAL_7_SERIALIZED_LSB == serialize<Fr, FormatFrLsb>(&val_7), 1);
         assert!(FR_VAL_7_SERIALIZED_MSB == serialize<Fr, FormatFrMsb>(&val_7), 1);
 
         // Deserialization should fail if given a byte array of right size but the value is not a member.
-        assert!(std::option::is_none(&deserialize<Fr, FormatFrLsb>(&x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73")), 1);
-        assert!(std::option::is_none(&deserialize<Fr, FormatFrMsb>(&x"73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<Fr, FormatFrLsb>(
+                    &x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed73"
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<Fr, FormatFrMsb>(
+                    &x"73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given a byte array of wrong size.
-        assert!(std::option::is_none(&deserialize<Fr, FormatFrLsb>(&x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed7300")), 1);
-        assert!(std::option::is_none(&deserialize<Fr, FormatFrMsb>(&x"0073eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<Fr, FormatFrLsb>(
+                    &x"01000000fffffffffe5bfeff02a4bd5305d8a10908d83933487d9d2953a7ed7300"
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<Fr, FormatFrMsb>(
+                    &x"0073eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001"
+                ),
+            ),
+            1,
+        );
         assert!(std::option::is_none(&deserialize<Fr, FormatFrLsb>(&x"ffff")), 1);
         assert!(std::option::is_none(&deserialize<Fr, FormatFrMsb>(&x"ffff")), 1);
 
         // Negation.
         let val_minus_7 = neg(&val_7);
-        assert!(FR_VAL_7_NEG_SERIALIZED_LSB == serialize<Fr, FormatFrLsb>(&val_minus_7), 1);
+        assert!(
+            FR_VAL_7_NEG_SERIALIZED_LSB == serialize<Fr, FormatFrLsb>(&val_minus_7), 1
+        );
 
         // Addition.
         let val_9 = from_u64<Fr>(9);
@@ -705,26 +996,62 @@ module std::bn254_algebra {
         assert!(FQ_VAL_0_SERIALIZED_LSB == serialize<Fq, FormatFqLsb>(&val_0), 1);
         assert!(FQ_VAL_1_SERIALIZED_LSB == serialize<Fq, FormatFqLsb>(&val_1), 1);
         let val_7 = from_u64<Fq>(7);
-        let val_7_2nd = std::option::extract(&mut deserialize<Fq, FormatFqLsb>(&FQ_VAL_7_SERIALIZED_LSB));
-        let val_7_3rd = std::option::extract(&mut deserialize<Fq, FormatFqMsb>(&FQ_VAL_7_SERIALIZED_MSB));
+        let val_7_2nd =
+            std::option::extract(
+                &mut deserialize<Fq, FormatFqLsb>(&FQ_VAL_7_SERIALIZED_LSB)
+            );
+        let val_7_3rd =
+            std::option::extract(
+                &mut deserialize<Fq, FormatFqMsb>(&FQ_VAL_7_SERIALIZED_MSB)
+            );
         assert!(eq(&val_7, &val_7_2nd), 1);
         assert!(eq(&val_7, &val_7_3rd), 1);
         assert!(FQ_VAL_7_SERIALIZED_LSB == serialize<Fq, FormatFqLsb>(&val_7), 1);
         assert!(FQ_VAL_7_SERIALIZED_MSB == serialize<Fq, FormatFqMsb>(&val_7), 1);
 
         // Deserialization should fail if given a byte array of right size but the value is not a member.
-        assert!(std::option::is_none(&deserialize<Fq, FormatFqLsb>(&x"47fd7cd8168c203c8dca7168916a81975d588181b64550b829a031e1724e6430")), 1);
-        assert!(std::option::is_none(&deserialize<Fq, FormatFqMsb>(&x"30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<Fq, FormatFqLsb>(
+                    &x"47fd7cd8168c203c8dca7168916a81975d588181b64550b829a031e1724e6430"
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<Fq, FormatFqMsb>(
+                    &x"30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
+                ),
+            ),
+            1,
+        );
 
         // Deserialization should fail if given a byte array of wrong size.
-        assert!(std::option::is_none(&deserialize<Fq, FormatFqLsb>(&x"46fd7cd8168c203c8dca7168916a81975d588181b64550b829a031e1724e643000")), 1);
-        assert!(std::option::is_none(&deserialize<Fq, FormatFqMsb>(&x"30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd4600")), 1);
+        assert!(
+            std::option::is_none(
+                &deserialize<Fq, FormatFqLsb>(
+                    &x"46fd7cd8168c203c8dca7168916a81975d588181b64550b829a031e1724e643000"
+                ),
+            ),
+            1,
+        );
+        assert!(
+            std::option::is_none(
+                &deserialize<Fq, FormatFqMsb>(
+                    &x"30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd4600"
+                ),
+            ),
+            1,
+        );
         assert!(std::option::is_none(&deserialize<Fq, FormatFqLsb>(&x"ffff")), 1);
         assert!(std::option::is_none(&deserialize<Fq, FormatFqMsb>(&x"ffff")), 1);
 
         // Negation.
         let val_minus_7 = neg(&val_7);
-        assert!(FQ_VAL_7_NEG_SERIALIZED_LSB == serialize<Fq, FormatFqLsb>(&val_minus_7), 1);
+        assert!(
+            FQ_VAL_7_NEG_SERIALIZED_LSB == serialize<Fq, FormatFqLsb>(&val_minus_7), 1
+        );
 
         // Addition.
         let val_9 = from_u64<Fq>(9);
@@ -761,8 +1088,10 @@ module std::bn254_algebra {
         let element_q = rand_insecure<G2>();
         let a = rand_insecure<Fr>();
         let b = rand_insecure<Fr>();
-        let gt_element = pairing<G1, G2,Gt>(&scalar_mul(&element_p, &a), &scalar_mul(&element_q, &b));
-        let gt_element_another = scalar_mul(&pairing<G1, G2,Gt>(&element_p, &element_q), &mul(&a, &b));
+        let gt_element =
+            pairing<G1, G2, Gt>(&scalar_mul(&element_p, &a), &scalar_mul(&element_q, &b));
+        let gt_element_another =
+            scalar_mul(&pairing<G1, G2, Gt>(&element_p, &element_q), &mul(&a, &b));
         assert!(eq(&gt_element, &gt_element_another), 1);
     }
 
@@ -791,16 +1120,19 @@ module std::bn254_algebra {
         let q2_b2 = scalar_mul(&element_q2, &b2);
 
         // Naive method.
-        let n0 = pairing<G1, G2,Gt>(&p0_a0, &q0_b0);
-        let n1 = pairing<G1, G2,Gt>(&p1_a1, &q1_b1);
-        let n2 = pairing<G1, G2,Gt>(&p2_a2, &q2_b2);
+        let n0 = pairing<G1, G2, Gt>(&p0_a0, &q0_b0);
+        let n1 = pairing<G1, G2, Gt>(&p1_a1, &q1_b1);
+        let n2 = pairing<G1, G2, Gt>(&p2_a2, &q2_b2);
         let n = zero<Gt>();
         n = add(&n, &n0);
         n = add(&n, &n1);
         n = add(&n, &n2);
 
         // Efficient API.
-        let m = multi_pairing<G1, G2, Gt>(&vector[p0_a0, p1_a1, p2_a2], &vector[q0_b0, q1_b1, q2_b2]);
+        let m =
+            multi_pairing<G1, G2, Gt>(
+                &vector[p0_a0, p1_a1, p2_a2], &vector[q0_b0, q1_b1, q2_b2]
+            );
         assert!(eq(&n, &m), 1);
     }
 
@@ -815,7 +1147,9 @@ module std::bn254_algebra {
 
     #[test(fx = @std)]
     #[expected_failure(abort_code = 0x010002, location = aptos_std::crypto_algebra)]
-    fun test_multi_scalar_mul_should_abort_when_sizes_mismatch(fx: signer) {
+    fun test_multi_scalar_mul_should_abort_when_sizes_mismatch(
+        fx: signer
+    ) {
         enable_cryptography_algebra_natives(&fx);
         let elements = vector[rand_insecure<G1>()];
         let scalars = vector[rand_insecure<Fr>(), rand_insecure<Fr>()];
@@ -851,5 +1185,4 @@ module std::bn254_algebra {
     //
     // (Tests end here.)
     //
-
 }

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/crypto_algebra.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/crypto_algebra.move
@@ -61,57 +61,43 @@ module aptos_std::crypto_algebra {
     /// Convert a u64 to an element of a structure `S`.
     public fun from_u64<S>(value: u64): Element<S> {
         abort_unless_cryptography_algebra_natives_enabled();
-        Element<S> {
-            handle: from_u64_internal<S>(value)
-        }
+        Element<S> { handle: from_u64_internal<S>(value) }
     }
 
     /// Return the additive identity of field `S`, or the identity of group `S`.
     public fun zero<S>(): Element<S> {
         abort_unless_cryptography_algebra_natives_enabled();
-        Element<S> {
-            handle: zero_internal<S>()
-        }
+        Element<S> { handle: zero_internal<S>() }
     }
 
     /// Return the multiplicative identity of field `S`, or a fixed generator of group `S`.
     public fun one<S>(): Element<S> {
         abort_unless_cryptography_algebra_natives_enabled();
-        Element<S> {
-            handle: one_internal<S>()
-        }
+        Element<S> { handle: one_internal<S>() }
     }
 
     /// Compute `-x` for an element `x` of a structure `S`.
     public fun neg<S>(x: &Element<S>): Element<S> {
         abort_unless_cryptography_algebra_natives_enabled();
-        Element<S> {
-            handle: neg_internal<S>(x.handle)
-        }
+        Element<S> { handle: neg_internal<S>(x.handle) }
     }
 
     /// Compute `x + y` for elements `x` and `y` of structure `S`.
     public fun add<S>(x: &Element<S>, y: &Element<S>): Element<S> {
         abort_unless_cryptography_algebra_natives_enabled();
-        Element<S> {
-            handle: add_internal<S>(x.handle, y.handle)
-        }
+        Element<S> { handle: add_internal<S>(x.handle, y.handle) }
     }
 
     /// Compute `x - y` for elements `x` and `y` of a structure `S`.
     public fun sub<S>(x: &Element<S>, y: &Element<S>): Element<S> {
         abort_unless_cryptography_algebra_natives_enabled();
-        Element<S> {
-            handle: sub_internal<S>(x.handle, y.handle)
-        }
+        Element<S> { handle: sub_internal<S>(x.handle, y.handle) }
     }
 
     /// Compute `x * y` for elements `x` and `y` of a structure `S`.
     public fun mul<S>(x: &Element<S>, y: &Element<S>): Element<S> {
         abort_unless_cryptography_algebra_natives_enabled();
-        Element<S> {
-            handle: mul_internal<S>(x.handle, y.handle)
-        }
+        Element<S> { handle: mul_internal<S>(x.handle, y.handle) }
     }
 
     /// Try computing `x / y` for elements `x` and `y` of a structure `S`.
@@ -122,17 +108,13 @@ module aptos_std::crypto_algebra {
         let (succ, handle) = div_internal<S>(x.handle, y.handle);
         if (succ) {
             some(Element<S> { handle })
-        } else {
-            none()
-        }
+        } else { none() }
     }
 
     /// Compute `x^2` for an element `x` of a structure `S`. Faster and cheaper than `mul(x, x)`.
     public fun sqr<S>(x: &Element<S>): Element<S> {
         abort_unless_cryptography_algebra_natives_enabled();
-        Element<S> {
-            handle: sqr_internal<S>(x.handle)
-        }
+        Element<S> { handle: sqr_internal<S>(x.handle) }
     }
 
     /// Try computing `x^(-1)` for an element `x` of a structure `S`.
@@ -144,17 +126,13 @@ module aptos_std::crypto_algebra {
         if (succeeded) {
             let scalar = Element<S> { handle };
             some(scalar)
-        } else {
-            none()
-        }
+        } else { none() }
     }
 
     /// Compute `2*P` for an element `P` of a structure `S`. Faster and cheaper than `add(P, P)`.
     public fun double<S>(element_p: &Element<S>): Element<S> {
         abort_unless_cryptography_algebra_natives_enabled();
-        Element<S> {
-            handle: double_internal<S>(element_p.handle)
-        }
+        Element<S> { handle: double_internal<S>(element_p.handle) }
     }
 
     /// Compute `k[0]*P[0]+...+k[n-1]*P[n-1]`, where
@@ -162,7 +140,9 @@ module aptos_std::crypto_algebra {
     /// `k[]` are `n` elements of the scalarfield `S` of group `G` represented by parameter `scalars`.
     ///
     /// Abort with code `std::error::invalid_argument(E_NON_EQUAL_LENGTHS)` if the sizes of `elements` and `scalars` do not match.
-    public fun multi_scalar_mul<G, S>(elements: &vector<Element<G>>, scalars: &vector<Element<S>>): Element<G> {
+    public fun multi_scalar_mul<G, S>(
+        elements: &vector<Element<G>>, scalars: &vector<Element<S>>
+    ): Element<G> {
         let element_handles = handles_from_elements(elements);
         let scalar_handles = handles_from_elements(scalars);
         Element<G> {
@@ -171,7 +151,9 @@ module aptos_std::crypto_algebra {
     }
 
     /// Compute `k*P`, where `P` is an element of a group `G` and `k` is an element of the scalar field `S` associated to the group `G`.
-    public fun scalar_mul<G, S>(element_p: &Element<G>, scalar_k: &Element<S>): Element<G> {
+    public fun scalar_mul<G, S>(
+        element_p: &Element<G>, scalar_k: &Element<S>
+    ): Element<G> {
         abort_unless_cryptography_algebra_natives_enabled();
         Element<G> {
             handle: scalar_mul_internal<G, S>(element_p.handle, scalar_k.handle)
@@ -187,21 +169,24 @@ module aptos_std::crypto_algebra {
     ///
     /// NOTE: we are viewing the target group `Gt` of the pairing as an additive group,
     /// rather than a multiplicative one (which is typically the case).
-    public fun multi_pairing<G1,G2,Gt>(g1_elements: &vector<Element<G1>>, g2_elements: &vector<Element<G2>>): Element<Gt> {
+    public fun multi_pairing<G1, G2, Gt>(
+        g1_elements: &vector<Element<G1>>,
+        g2_elements: &vector<Element<G2>>
+    ): Element<Gt> {
         abort_unless_cryptography_algebra_natives_enabled();
         let g1_handles = handles_from_elements(g1_elements);
         let g2_handles = handles_from_elements(g2_elements);
-        Element<Gt> {
-            handle: multi_pairing_internal<G1,G2,Gt>(g1_handles, g2_handles)
-        }
+        Element<Gt> { handle: multi_pairing_internal<G1, G2, Gt>(g1_handles, g2_handles) }
     }
 
     /// Compute the pairing function (a.k.a., bilinear map) on a `G1` element and a `G2` element.
     /// Return an element in the target group `Gt`.
-    public fun pairing<G1,G2,Gt>(element_1: &Element<G1>, element_2: &Element<G2>): Element<Gt> {
+    public fun pairing<G1, G2, Gt>(
+        element_1: &Element<G1>, element_2: &Element<G2>
+    ): Element<Gt> {
         abort_unless_cryptography_algebra_natives_enabled();
         Element<Gt> {
-            handle: pairing_internal<G1,G2,Gt>(element_1.handle, element_2.handle)
+            handle: pairing_internal<G1, G2, Gt>(element_1.handle, element_2.handle)
         }
     }
 
@@ -212,9 +197,7 @@ module aptos_std::crypto_algebra {
         let (succeeded, handle) = deserialize_internal<S, F>(bytes);
         if (succeeded) {
             some(Element<S> { handle })
-        } else {
-            none()
-        }
+        } else { none() }
     }
 
     /// Serialize an element of an algebraic structure `S` to a byte array using a given serialization format `F`.
@@ -230,25 +213,21 @@ module aptos_std::crypto_algebra {
     }
 
     /// Cast an element of a structure `S` to a parent structure `L`.
-    public fun upcast<S,L>(element: &Element<S>): Element<L> {
+    public fun upcast<S, L>(element: &Element<S>): Element<L> {
         abort_unless_cryptography_algebra_natives_enabled();
-        Element<L> {
-            handle: upcast_internal<S,L>(element.handle)
-        }
+        Element<L> { handle: upcast_internal<S, L>(element.handle) }
     }
 
     /// Try casting an element `x` of a structure `L` to a sub-structure `S`.
     /// Return none if `x` is not a member of `S`.
     ///
     /// NOTE: Membership check in `S` is performed inside, which can be expensive, depending on the structures `L` and `S`.
-    public fun downcast<L,S>(element_x: &Element<L>): Option<Element<S>> {
+    public fun downcast<L, S>(element_x: &Element<L>): Option<Element<S>> {
         abort_unless_cryptography_algebra_natives_enabled();
-        let (succ, new_handle) = downcast_internal<L,S>(element_x.handle);
+        let (succ, new_handle) = downcast_internal<L, S>(element_x.handle);
         if (succ) {
             some(Element<S> { handle: new_handle })
-        } else {
-            none()
-        }
+        } else { none() }
     }
 
     /// Hash an arbitrary-length byte array `msg` into structure `S` with a domain separation tag `dst`
@@ -257,18 +236,14 @@ module aptos_std::crypto_algebra {
     /// NOTE: some hashing methods do not accept a `dst` and will abort if a non-empty one is provided.
     public fun hash_to<S, H>(dst: &vector<u8>, msg: &vector<u8>): Element<S> {
         abort_unless_cryptography_algebra_natives_enabled();
-        Element {
-            handle: hash_to_internal<S, H>(dst, msg)
-        }
+        Element { handle: hash_to_internal<S, H>(dst, msg) }
     }
 
     #[test_only]
     /// Generate a random element of an algebraic structure `S`.
     public fun rand_insecure<S>(): Element<S> {
         abort_unless_cryptography_algebra_natives_enabled();
-        Element<S> {
-            handle: rand_insecure_internal<S>()
-        }
+        Element<S> { handle: rand_insecure_internal<S>() }
     }
 
     //
@@ -283,7 +258,9 @@ module aptos_std::crypto_algebra {
 
     #[test_only]
     public fun enable_cryptography_algebra_natives(fx: &signer) {
-        std::features::change_feature_flags_for_testing(fx, vector[std::features::get_cryptography_algebra_natives_feature()], vector[]);
+        std::features::change_feature_flags_for_testing(
+            fx, vector[std::features::get_cryptography_algebra_natives_feature()], vector[]
+        );
     }
 
     fun handles_from_elements<S>(elements: &vector<Element<S>>): vector<u64> {
@@ -291,13 +268,15 @@ module aptos_std::crypto_algebra {
         let element_handles = std::vector::empty();
         let i = 0;
         while ({
-            spec {
-                invariant len(element_handles) == i;
-                invariant forall k in 0..i: element_handles[k] == elements[k].handle;
-            };
-            i < num_elements
-        }) {
-            std::vector::push_back(&mut element_handles, std::vector::borrow(elements, i).handle);
+                spec {
+                    invariant len(element_handles) == i;
+                    invariant forall k in 0..i: element_handles[k] == elements[k].handle;
+                };
+                i < num_elements
+            }) {
+            std::vector::push_back(
+                &mut element_handles, std::vector::borrow(elements, i).handle
+            );
             i = i + 1;
         };
         element_handles
@@ -312,7 +291,7 @@ module aptos_std::crypto_algebra {
     native fun deserialize_internal<S, F>(bytes: &vector<u8>): (bool, u64);
     native fun div_internal<F>(handle_1: u64, handle_2: u64): (bool, u64);
     native fun double_internal<G>(element_handle: u64): u64;
-    native fun downcast_internal<L,S>(handle: u64): (bool, u64);
+    native fun downcast_internal<L, S>(handle: u64): (bool, u64);
     native fun from_u64_internal<S>(value: u64): u64;
     native fun eq_internal<S>(handle_1: u64, handle_2: u64): bool;
     native fun hash_to_internal<S, H>(dst: &vector<u8>, bytes: &vector<u8>): u64;
@@ -320,17 +299,19 @@ module aptos_std::crypto_algebra {
     #[test_only]
     native fun rand_insecure_internal<S>(): u64;
     native fun mul_internal<F>(handle_1: u64, handle_2: u64): u64;
-    native fun multi_pairing_internal<G1,G2,Gt>(g1_handles: vector<u64>, g2_handles: vector<u64>): u64;
-    native fun multi_scalar_mul_internal<G, S>(element_handles: vector<u64>, scalar_handles: vector<u64>): u64;
+    native fun multi_pairing_internal<G1, G2, Gt>(g1_handles: vector<u64>, g2_handles: vector<u64>): u64;
+    native fun multi_scalar_mul_internal<G, S>(
+        element_handles: vector<u64>, scalar_handles: vector<u64>
+    ): u64;
     native fun neg_internal<F>(handle: u64): u64;
     native fun one_internal<S>(): u64;
     native fun order_internal<G>(): vector<u8>;
-    native fun pairing_internal<G1,G2,Gt>(g1_handle: u64, g2_handle: u64): u64;
+    native fun pairing_internal<G1, G2, Gt>(g1_handle: u64, g2_handle: u64): u64;
     native fun scalar_mul_internal<G, S>(element_handle: u64, scalar_handle: u64): u64;
     native fun serialize_internal<S, F>(handle: u64): vector<u8>;
     native fun sqr_internal<G>(handle: u64): u64;
     native fun sub_internal<G>(handle_1: u64, handle_2: u64): u64;
-    native fun upcast_internal<S,L>(handle: u64): u64;
+    native fun upcast_internal<S, L>(handle: u64): u64;
     native fun zero_internal<S>(): u64;
 
     //
@@ -343,7 +324,9 @@ module aptos_std::crypto_algebra {
 
     #[test(fx = @std)]
     #[expected_failure(abort_code = 0x0c0001, location = Self)]
-    fun test_generic_operation_should_abort_with_unsupported_structures(fx: signer) {
+    fun test_generic_operation_should_abort_with_unsupported_structures(
+        fx: signer
+    ) {
         enable_cryptography_algebra_natives(&fx);
         let _ = order<MysteriousGroup>();
     }

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/crypto_algebra.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/crypto_algebra.move
@@ -141,7 +141,8 @@ module aptos_std::crypto_algebra {
     ///
     /// Abort with code `std::error::invalid_argument(E_NON_EQUAL_LENGTHS)` if the sizes of `elements` and `scalars` do not match.
     public fun multi_scalar_mul<G, S>(
-        elements: &vector<Element<G>>, scalars: &vector<Element<S>>
+        elements: &vector<Element<G>>,
+        scalars: &vector<Element<S>>
     ): Element<G> {
         let element_handles = handles_from_elements(elements);
         let scalar_handles = handles_from_elements(scalars);
@@ -176,7 +177,9 @@ module aptos_std::crypto_algebra {
         abort_unless_cryptography_algebra_natives_enabled();
         let g1_handles = handles_from_elements(g1_elements);
         let g2_handles = handles_from_elements(g2_elements);
-        Element<Gt> { handle: multi_pairing_internal<G1, G2, Gt>(g1_handles, g2_handles) }
+        Element<Gt> {
+            handle: multi_pairing_internal<G1, G2, Gt>(g1_handles, g2_handles)
+        }
     }
 
     /// Compute the pairing function (a.k.a., bilinear map) on a `G1` element and a `G2` element.
@@ -259,7 +262,9 @@ module aptos_std::crypto_algebra {
     #[test_only]
     public fun enable_cryptography_algebra_natives(fx: &signer) {
         std::features::change_feature_flags_for_testing(
-            fx, vector[std::features::get_cryptography_algebra_natives_feature()], vector[]
+            fx,
+            vector[std::features::get_cryptography_algebra_natives_feature()],
+            vector[],
         );
     }
 
@@ -268,12 +273,12 @@ module aptos_std::crypto_algebra {
         let element_handles = std::vector::empty();
         let i = 0;
         while ({
-                spec {
-                    invariant len(element_handles) == i;
-                    invariant forall k in 0..i: element_handles[k] == elements[k].handle;
-                };
-                i < num_elements
-            }) {
+            spec {
+                invariant len(element_handles) == i;
+                invariant forall k in 0..i: element_handles[k] == elements[k].handle;
+            };
+            i < num_elements
+        }) {
             std::vector::push_back(
                 &mut element_handles, std::vector::borrow(elements, i).handle
             );

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/crypto_algebra.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/crypto_algebra.spec.move
@@ -21,7 +21,7 @@ spec aptos_std::crypto_algebra {
         pragma opaque;
     }
 
-    spec downcast_internal<L,S>(handle: u64): (bool, u64) {
+    spec downcast_internal<L, S>(handle: u64): (bool, u64) {
         pragma opaque;
     }
 
@@ -45,11 +45,13 @@ spec aptos_std::crypto_algebra {
         pragma opaque;
     }
 
-    spec multi_pairing_internal<G1,G2,Gt>(g1_handles: vector<u64>, g2_handles: vector<u64>): u64 {
+    spec multi_pairing_internal<G1, G2, Gt>(g1_handles: vector<u64>, g2_handles: vector<u64>): u64 {
         pragma opaque;
     }
 
-    spec multi_scalar_mul_internal<G, S>(element_handles: vector<u64>, scalar_handles: vector<u64>): u64 {
+    spec multi_scalar_mul_internal<G, S>(
+        element_handles: vector<u64>, scalar_handles: vector<u64>
+    ): u64 {
         pragma opaque;
     }
 
@@ -65,7 +67,7 @@ spec aptos_std::crypto_algebra {
         pragma opaque;
     }
 
-    spec pairing_internal<G1,G2,Gt>(g1_handle: u64, g2_handle: u64): u64 {
+    spec pairing_internal<G1, G2, Gt>(g1_handle: u64, g2_handle: u64): u64 {
         pragma opaque;
     }
 
@@ -85,12 +87,11 @@ spec aptos_std::crypto_algebra {
         pragma opaque;
     }
 
-    spec upcast_internal<S,L>(handle: u64): u64 {
+    spec upcast_internal<S, L>(handle: u64): u64 {
         pragma opaque;
     }
 
     spec zero_internal<S>(): u64 {
         pragma opaque;
     }
-
 }

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ed25519.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ed25519.move
@@ -71,16 +71,18 @@ module aptos_std::ed25519 {
 
     /// Parses the input 32 bytes as an *unvalidated* Ed25519 public key.
     public fun new_unvalidated_public_key_from_bytes(bytes: vector<u8>): UnvalidatedPublicKey {
-        assert!(std::vector::length(&bytes) == PUBLIC_KEY_NUM_BYTES, std::error::invalid_argument(E_WRONG_PUBKEY_SIZE));
+        assert!(
+            std::vector::length(&bytes) == PUBLIC_KEY_NUM_BYTES,
+            std::error::invalid_argument(E_WRONG_PUBKEY_SIZE),
+        );
         UnvalidatedPublicKey { bytes }
     }
 
     /// Parses the input 32 bytes as a *validated* Ed25519 public key.
-    public fun new_validated_public_key_from_bytes(bytes: vector<u8>): Option<ValidatedPublicKey> {
+    public fun new_validated_public_key_from_bytes(bytes: vector<u8>)
+        : Option<ValidatedPublicKey> {
         if (public_key_validate_internal(bytes)) {
-            option::some(ValidatedPublicKey {
-                bytes
-            })
+            option::some(ValidatedPublicKey { bytes })
         } else {
             option::none<ValidatedPublicKey>()
         }
@@ -88,22 +90,21 @@ module aptos_std::ed25519 {
 
     /// Parses the input 64 bytes as a purported Ed25519 signature.
     public fun new_signature_from_bytes(bytes: vector<u8>): Signature {
-        assert!(std::vector::length(&bytes) == SIGNATURE_NUM_BYTES, std::error::invalid_argument(E_WRONG_SIGNATURE_SIZE));
+        assert!(
+            std::vector::length(&bytes) == SIGNATURE_NUM_BYTES,
+            std::error::invalid_argument(E_WRONG_SIGNATURE_SIZE),
+        );
         Signature { bytes }
     }
 
     /// Converts a ValidatedPublicKey to an UnvalidatedPublicKey, which can be used in the strict verification APIs.
     public fun public_key_to_unvalidated(pk: &ValidatedPublicKey): UnvalidatedPublicKey {
-        UnvalidatedPublicKey {
-            bytes: pk.bytes
-        }
+        UnvalidatedPublicKey { bytes: pk.bytes }
     }
 
     /// Moves a ValidatedPublicKey into an UnvalidatedPublicKey, which can be used in the strict verification APIs.
     public fun public_key_into_unvalidated(pk: ValidatedPublicKey): UnvalidatedPublicKey {
-        UnvalidatedPublicKey {
-            bytes: pk.bytes
-        }
+        UnvalidatedPublicKey { bytes: pk.bytes }
     }
 
     /// Serializes an UnvalidatedPublicKey struct to 32-bytes.
@@ -130,39 +131,39 @@ module aptos_std::ed25519 {
     /// Verifies a purported Ed25519 `signature` under an *unvalidated* `public_key` on the specified `message`.
     /// This call will validate the public key by checking it is NOT in the small subgroup.
     public fun signature_verify_strict(
-        signature: &Signature,
-        public_key: &UnvalidatedPublicKey,
-        message: vector<u8>
+        signature: &Signature, public_key: &UnvalidatedPublicKey, message: vector<u8>
     ): bool {
         signature_verify_strict_internal(signature.bytes, public_key.bytes, message)
     }
 
     /// This function is used to verify a signature on any BCS-serializable type T. For now, it is used to verify the
     /// proof of private key ownership when rotating authentication keys.
-    public fun signature_verify_strict_t<T: drop>(signature: &Signature, public_key: &UnvalidatedPublicKey, data: T): bool {
-        let encoded = SignedMessage {
-            type_info: type_info::type_of<T>(),
-            inner: data,
-        };
+    public fun signature_verify_strict_t<T: drop>(
+        signature: &Signature, public_key: &UnvalidatedPublicKey, data: T
+    ): bool {
+        let encoded = SignedMessage { type_info: type_info::type_of<T>(), inner: data, };
 
-        signature_verify_strict_internal(signature.bytes, public_key.bytes, bcs::to_bytes(&encoded))
+        signature_verify_strict_internal(
+            signature.bytes, public_key.bytes, bcs::to_bytes(&encoded)
+        )
     }
 
     /// Helper method to construct a SignedMessage struct.
     public fun new_signed_message<T: drop>(data: T): SignedMessage<T> {
-        SignedMessage {
-            type_info: type_info::type_of<T>(),
-            inner: data,
-        }
+        SignedMessage { type_info: type_info::type_of<T>(), inner: data, }
     }
 
     /// Derives the Aptos-specific authentication key of the given Ed25519 public key.
-    public fun unvalidated_public_key_to_authentication_key(pk: &UnvalidatedPublicKey): vector<u8> {
+    public fun unvalidated_public_key_to_authentication_key(
+        pk: &UnvalidatedPublicKey
+    ): vector<u8> {
         public_key_bytes_to_authentication_key(pk.bytes)
     }
 
     /// Derives the Aptos-specific authentication key of the given Ed25519 public key.
-    public fun validated_public_key_to_authentication_key(pk: &ValidatedPublicKey): vector<u8> {
+    public fun validated_public_key_to_authentication_key(
+        pk: &ValidatedPublicKey
+    ): vector<u8> {
         public_key_bytes_to_authentication_key(pk.bytes)
     }
 
@@ -176,30 +177,22 @@ module aptos_std::ed25519 {
     /// Generates an Ed25519 key pair.
     public fun generate_keys(): (SecretKey, ValidatedPublicKey) {
         let (sk_bytes, pk_bytes) = generate_keys_internal();
-        let sk = SecretKey {
-            bytes: sk_bytes
-        };
-        let pk = ValidatedPublicKey {
-            bytes: pk_bytes
-        };
-        (sk,pk)
+        let sk = SecretKey { bytes: sk_bytes };
+        let pk = ValidatedPublicKey { bytes: pk_bytes };
+        (sk, pk)
     }
 
     #[test_only]
     /// Generates an Ed25519 signature for a given byte array using a given signing key.
     public fun sign_arbitrary_bytes(sk: &SecretKey, msg: vector<u8>): Signature {
-        Signature {
-            bytes: sign_internal(sk.bytes, msg)
-        }
+        Signature { bytes: sign_internal(sk.bytes, msg) }
     }
 
     #[test_only]
     /// Generates an Ed25519 signature for given structured data using a given signing key.
-    public fun sign_struct<T:drop>(sk: &SecretKey, data: T): Signature {
+    public fun sign_struct<T: drop>(sk: &SecretKey, data: T): Signature {
         let encoded = new_signed_message(data);
-        Signature {
-            bytes: sign_internal(sk.bytes, bcs::to_bytes(&encoded))
-        }
+        Signature { bytes: sign_internal(sk.bytes, bcs::to_bytes(&encoded)) }
     }
 
     //
@@ -218,9 +211,7 @@ module aptos_std::ed25519 {
     /// - `signature` does not pass points-on-curve or not-in-small-subgroup checks,
     /// - the signature on `message` does not verify.
     native fun signature_verify_strict_internal(
-        signature: vector<u8>,
-        public_key: vector<u8>,
-        message: vector<u8>
+        signature: vector<u8>, public_key: vector<u8>, message: vector<u8>
     ): bool;
 
     #[test_only]
@@ -250,13 +241,10 @@ module aptos_std::ed25519 {
         let sig1 = sign_arbitrary_bytes(&sk, msg1);
         assert!(signature_verify_strict(&sig1, &pk, msg1), std::error::invalid_state(1));
 
-        let msg2 = TestMessage {
-            title: b"Some Title",
-            content: b"That is it.",
-        };
+        let msg2 = TestMessage { title: b"Some Title", content: b"That is it.", };
         let sig2 = sign_struct(&sk, copy msg2);
-        assert!(signature_verify_strict_t(&sig2, &pk, copy msg2), std::error::invalid_state(2));
+        assert!(
+            signature_verify_strict_t(&sig2, &pk, copy msg2), std::error::invalid_state(2)
+        );
     }
-
-
 }

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ed25519.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ed25519.move
@@ -244,7 +244,8 @@ module aptos_std::ed25519 {
         let msg2 = TestMessage { title: b"Some Title", content: b"That is it.", };
         let sig2 = sign_struct(&sk, copy msg2);
         assert!(
-            signature_verify_strict_t(&sig2, &pk, copy msg2), std::error::invalid_state(2)
+            signature_verify_strict_t(&sig2, &pk, copy msg2),
+            std::error::invalid_state(2),
         );
     }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ed25519.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ed25519.spec.move
@@ -8,6 +8,7 @@ spec aptos_std::ed25519 {
         include NewUnvalidatedPublicKeyFromBytesAbortsIf;
         ensures result == UnvalidatedPublicKey { bytes };
     }
+
     spec schema NewUnvalidatedPublicKeyFromBytesAbortsIf {
         bytes: vector<u8>;
         aborts_if len(bytes) != PUBLIC_KEY_NUM_BYTES;
@@ -16,14 +17,17 @@ spec aptos_std::ed25519 {
     spec new_validated_public_key_from_bytes(bytes: vector<u8>): Option<ValidatedPublicKey> {
         aborts_if false;
         let cond = spec_public_key_validate_internal(bytes);
-        ensures cond ==> result == option::spec_some(ValidatedPublicKey{bytes});
-        ensures !cond ==> result == option::spec_none<ValidatedPublicKey>();
+        ensures cond ==>
+            result == option::spec_some(ValidatedPublicKey { bytes });
+        ensures !cond ==>
+            result == option::spec_none<ValidatedPublicKey>();
     }
 
     spec new_signature_from_bytes(bytes: vector<u8>): Signature {
         include NewSignatureFromBytesAbortsIf;
         ensures result == Signature { bytes };
     }
+
     spec schema NewSignatureFromBytesAbortsIf {
         bytes: vector<u8>;
         aborts_if len(bytes) != SIGNATURE_NUM_BYTES;
@@ -34,7 +38,6 @@ spec aptos_std::ed25519 {
         aborts_if false;
         ensures [abstract] result == spec_public_key_bytes_to_authentication_key(pk_bytes);
     }
-
 
     // ----------------
     // Native functions
@@ -47,34 +50,29 @@ spec aptos_std::ed25519 {
     }
 
     spec signature_verify_strict_internal(
-        signature: vector<u8>,
-        public_key: vector<u8>,
-        message: vector<u8>)
-    : bool {
+        signature: vector<u8>, public_key: vector<u8>, message: vector<u8>
+    ): bool {
         pragma opaque;
         aborts_if false;
-        ensures result == spec_signature_verify_strict_internal(signature, public_key, message);
+        ensures result
+            == spec_signature_verify_strict_internal(signature, public_key, message);
     }
 
     /// # Helper functions
 
     spec fun spec_signature_verify_strict_internal(
-        signature: vector<u8>,
-        public_key: vector<u8>,
-        message: vector<u8>
+        signature: vector<u8>, public_key: vector<u8>, message: vector<u8>
     ): bool;
 
     spec fun spec_public_key_validate_internal(bytes: vector<u8>): bool;
 
     spec fun spec_public_key_bytes_to_authentication_key(pk_bytes: vector<u8>): vector<u8>;
 
-    spec fun spec_signature_verify_strict_t<T>(signature: Signature, public_key: UnvalidatedPublicKey, data: T): bool {
-        let encoded = SignedMessage<T> {
-            type_info: type_info::type_of<T>(),
-            inner: data,
-        };
+    spec fun spec_signature_verify_strict_t<T>(
+        signature: Signature, public_key: UnvalidatedPublicKey, data: T
+    ): bool {
+        let encoded = SignedMessage<T> { type_info: type_info::type_of<T>(), inner: data, };
         let message = bcs::serialize(encoded);
         spec_signature_verify_strict_internal(signature.bytes, public_key.bytes, message)
     }
-
 }

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/multi_ed25519.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/multi_ed25519.move
@@ -143,8 +143,8 @@ module aptos_std::multi_ed25519 {
         : Option<ValidatedPublicKey> {
         // Note that `public_key_validate_internal` will check that `vector::length(&bytes) / INDIVIDUAL_PUBLIC_KEY_NUM_BYTES <= MAX_NUMBER_OF_PUBLIC_KEYS`.
         if (vector::length(&bytes) % INDIVIDUAL_PUBLIC_KEY_NUM_BYTES == THRESHOLD_SIZE_BYTES && public_key_validate_internal(
-                bytes
-            )) {
+            bytes
+        )) {
             option::some(ValidatedPublicKey { bytes })
         } else {
             option::none<ValidatedPublicKey>()
@@ -372,7 +372,9 @@ module aptos_std::multi_ed25519 {
     #[test(fx = @std)]
     fun bugfix_validated_pk_from_zero_subpks(fx: signer) {
         features::change_feature_flags_for_testing(
-            &fx, vector[features::multi_ed25519_pk_validate_v2_feature()], vector[]
+            &fx,
+            vector[features::multi_ed25519_pk_validate_v2_feature()],
+            vector[],
         );
         let bytes = vector<u8>[1u8];
         assert!(vector::length(&bytes) == 1, 1);
@@ -392,7 +394,9 @@ module aptos_std::multi_ed25519 {
     #[test(fx = @std)]
     fun test_validated_pk_without_threshold_byte(fx: signer) {
         features::change_feature_flags_for_testing(
-            &fx, vector[features::multi_ed25519_pk_validate_v2_feature()], vector[]
+            &fx,
+            vector[features::multi_ed25519_pk_validate_v2_feature()],
+            vector[],
         );
 
         let (_, subpk) = ed25519::generate_keys();
@@ -413,11 +417,14 @@ module aptos_std::multi_ed25519 {
     #[test(fx = @std)]
     fun test_validated_pk_from_small_order_subpk(fx: signer) {
         features::change_feature_flags_for_testing(
-            &fx, vector[features::multi_ed25519_pk_validate_v2_feature()], vector[]
+            &fx,
+            vector[features::multi_ed25519_pk_validate_v2_feature()],
+            vector[],
         );
         let torsion_point_with_threshold_1 = vector<u8>[
             1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 1,];
+            0, 0, 0, 0, 0, 0, 1,
+        ];
 
         assert!(
             option::extract(&mut check_and_get_threshold(torsion_point_with_threshold_1))

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/multi_ed25519.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/multi_ed25519.move
@@ -90,30 +90,25 @@ module aptos_std::multi_ed25519 {
 
     #[test_only]
     public fun generate_keys(threshold: u8, n: u8): (SecretKey, ValidatedPublicKey) {
-        assert!(1 <= threshold && threshold <= n, error::invalid_argument(E_INVALID_THRESHOLD_OR_NUMBER_OF_SIGNERS));
+        assert!(
+            1 <= threshold && threshold <= n,
+            error::invalid_argument(E_INVALID_THRESHOLD_OR_NUMBER_OF_SIGNERS),
+        );
         let (sk_bytes, pk_bytes) = generate_keys_internal(threshold, n);
-        let sk = SecretKey {
-            bytes: sk_bytes
-        };
-        let pk = ValidatedPublicKey {
-            bytes: pk_bytes
-        };
+        let sk = SecretKey { bytes: sk_bytes };
+        let pk = ValidatedPublicKey { bytes: pk_bytes };
         (sk, pk)
     }
 
     #[test_only]
-    public fun sign_arbitrary_bytes(sk: &SecretKey, msg: vector<u8>) : Signature {
-        Signature {
-            bytes: sign_internal(sk.bytes, msg)
-        }
+    public fun sign_arbitrary_bytes(sk: &SecretKey, msg: vector<u8>): Signature {
+        Signature { bytes: sign_internal(sk.bytes, msg) }
     }
 
     #[test_only]
-    public fun sign_struct<T: drop>(sk: &SecretKey, data: T) : Signature {
+    public fun sign_struct<T: drop>(sk: &SecretKey, data: T): Signature {
         let encoded = ed25519::new_signed_message(data);
-        Signature {
-            bytes: sign_internal(sk.bytes, bcs::to_bytes(&encoded)),
-        }
+        Signature { bytes: sign_internal(sk.bytes, bcs::to_bytes(&encoded)), }
     }
 
     /// Parses the input 32 bytes as an *unvalidated* MultiEd25519 public key.
@@ -130,36 +125,41 @@ module aptos_std::multi_ed25519 {
         let len = vector::length(&bytes);
         let num_sub_pks = len / INDIVIDUAL_PUBLIC_KEY_NUM_BYTES;
 
-        assert!(num_sub_pks <= MAX_NUMBER_OF_PUBLIC_KEYS, error::invalid_argument(E_WRONG_PUBKEY_SIZE));
-        assert!(len % INDIVIDUAL_PUBLIC_KEY_NUM_BYTES == THRESHOLD_SIZE_BYTES, error::invalid_argument(E_WRONG_PUBKEY_SIZE));
+        assert!(
+            num_sub_pks <= MAX_NUMBER_OF_PUBLIC_KEYS,
+            error::invalid_argument(E_WRONG_PUBKEY_SIZE),
+        );
+        assert!(
+            len % INDIVIDUAL_PUBLIC_KEY_NUM_BYTES == THRESHOLD_SIZE_BYTES,
+            error::invalid_argument(E_WRONG_PUBKEY_SIZE),
+        );
         UnvalidatedPublicKey { bytes }
     }
 
     /// DEPRECATED: Use `new_validated_public_key_from_bytes_v2` instead. See `public_key_validate_internal` comments.
     ///
     /// (Incorrectly) parses the input bytes as a *validated* MultiEd25519 public key.
-    public fun new_validated_public_key_from_bytes(bytes: vector<u8>): Option<ValidatedPublicKey> {
+    public fun new_validated_public_key_from_bytes(bytes: vector<u8>)
+        : Option<ValidatedPublicKey> {
         // Note that `public_key_validate_internal` will check that `vector::length(&bytes) / INDIVIDUAL_PUBLIC_KEY_NUM_BYTES <= MAX_NUMBER_OF_PUBLIC_KEYS`.
-        if (vector::length(&bytes) % INDIVIDUAL_PUBLIC_KEY_NUM_BYTES == THRESHOLD_SIZE_BYTES &&
-            public_key_validate_internal(bytes)) {
-            option::some(ValidatedPublicKey {
+        if (vector::length(&bytes) % INDIVIDUAL_PUBLIC_KEY_NUM_BYTES == THRESHOLD_SIZE_BYTES && public_key_validate_internal(
                 bytes
-            })
+            )) {
+            option::some(ValidatedPublicKey { bytes })
         } else {
             option::none<ValidatedPublicKey>()
         }
     }
 
     /// Parses the input bytes as a *validated* MultiEd25519 public key (see `public_key_validate_internal_v2`).
-    public fun new_validated_public_key_from_bytes_v2(bytes: vector<u8>): Option<ValidatedPublicKey> {
+    public fun new_validated_public_key_from_bytes_v2(bytes: vector<u8>)
+        : Option<ValidatedPublicKey> {
         if (!features::multi_ed25519_pk_validate_v2_enabled()) {
             abort(error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE))
         };
 
         if (public_key_validate_v2_internal(bytes)) {
-            option::some(ValidatedPublicKey {
-                bytes
-            })
+            option::some(ValidatedPublicKey { bytes })
         } else {
             option::none<ValidatedPublicKey>()
         }
@@ -167,22 +167,21 @@ module aptos_std::multi_ed25519 {
 
     /// Parses the input bytes as a purported MultiEd25519 multi-signature.
     public fun new_signature_from_bytes(bytes: vector<u8>): Signature {
-        assert!(vector::length(&bytes) % INDIVIDUAL_SIGNATURE_NUM_BYTES == BITMAP_NUM_OF_BYTES, error::invalid_argument(E_WRONG_SIGNATURE_SIZE));
+        assert!(
+            vector::length(&bytes) % INDIVIDUAL_SIGNATURE_NUM_BYTES == BITMAP_NUM_OF_BYTES,
+            error::invalid_argument(E_WRONG_SIGNATURE_SIZE),
+        );
         Signature { bytes }
     }
 
     /// Converts a ValidatedPublicKey to an UnvalidatedPublicKey, which can be used in the strict verification APIs.
     public fun public_key_to_unvalidated(pk: &ValidatedPublicKey): UnvalidatedPublicKey {
-        UnvalidatedPublicKey {
-            bytes: pk.bytes
-        }
+        UnvalidatedPublicKey { bytes: pk.bytes }
     }
 
     /// Moves a ValidatedPublicKey into an UnvalidatedPublicKey, which can be used in the strict verification APIs.
     public fun public_key_into_unvalidated(pk: ValidatedPublicKey): UnvalidatedPublicKey {
-        UnvalidatedPublicKey {
-            bytes: pk.bytes
-        }
+        UnvalidatedPublicKey { bytes: pk.bytes }
     }
 
     /// Serializes an UnvalidatedPublicKey struct to 32-bytes.
@@ -217,23 +216,27 @@ module aptos_std::multi_ed25519 {
     /// Verifies a purported MultiEd25519 `multisignature` under an *unvalidated* `public_key` on the specified `message`.
     /// This call will validate the public key by checking it is NOT in the small subgroup.
     public fun signature_verify_strict(
-        multisignature: &Signature,
-        public_key: &UnvalidatedPublicKey,
-        message: vector<u8>
+        multisignature: &Signature, public_key: &UnvalidatedPublicKey, message: vector<u8>
     ): bool {
         signature_verify_strict_internal(multisignature.bytes, public_key.bytes, message)
     }
 
     /// This function is used to verify a multi-signature on any BCS-serializable type T. For now, it is used to verify the
     /// proof of private key ownership when rotating authentication keys.
-    public fun signature_verify_strict_t<T: drop>(multisignature: &Signature, public_key: &UnvalidatedPublicKey, data: T): bool {
+    public fun signature_verify_strict_t<T: drop>(
+        multisignature: &Signature, public_key: &UnvalidatedPublicKey, data: T
+    ): bool {
         let encoded = ed25519::new_signed_message(data);
 
-        signature_verify_strict_internal(multisignature.bytes, public_key.bytes, bcs::to_bytes(&encoded))
+        signature_verify_strict_internal(
+            multisignature.bytes, public_key.bytes, bcs::to_bytes(&encoded)
+        )
     }
 
     /// Derives the Aptos-specific authentication key of the given Ed25519 public key.
-    public fun unvalidated_public_key_to_authentication_key(pk: &UnvalidatedPublicKey): vector<u8> {
+    public fun unvalidated_public_key_to_authentication_key(
+        pk: &UnvalidatedPublicKey
+    ): vector<u8> {
         public_key_bytes_to_authentication_key(pk.bytes)
     }
 
@@ -243,7 +246,9 @@ module aptos_std::multi_ed25519 {
     ///
     /// We provide this API as a cheaper alternative to calling `public_key_validate` and then `validated_public_key_num_sub_pks`
     /// when the input `pk` is known to be valid.
-    public fun unvalidated_public_key_num_sub_pks(pk: &UnvalidatedPublicKey): u8 {
+    public fun unvalidated_public_key_num_sub_pks(
+        pk: &UnvalidatedPublicKey
+    ): u8 {
         let len = vector::length(&pk.bytes);
 
         ((len / INDIVIDUAL_PUBLIC_KEY_NUM_BYTES) as u8)
@@ -256,7 +261,9 @@ module aptos_std::multi_ed25519 {
     }
 
     /// Derives the Aptos-specific authentication key of the given Ed25519 public key.
-    public fun validated_public_key_to_authentication_key(pk: &ValidatedPublicKey): vector<u8> {
+    public fun validated_public_key_to_authentication_key(
+        pk: &ValidatedPublicKey
+    ): vector<u8> {
         public_key_bytes_to_authentication_key(pk.bytes)
     }
 
@@ -289,7 +296,9 @@ module aptos_std::multi_ed25519 {
         let num_of_keys = len / INDIVIDUAL_PUBLIC_KEY_NUM_BYTES;
         let threshold_byte = *vector::borrow(&bytes, len - 1);
 
-        if (num_of_keys == 0 || num_of_keys > MAX_NUMBER_OF_PUBLIC_KEYS || threshold_num_of_bytes != 1) {
+        if (num_of_keys == 0
+            || num_of_keys > MAX_NUMBER_OF_PUBLIC_KEYS
+            || threshold_num_of_bytes != 1) {
             return option::none<u8>()
         } else if (threshold_byte == 0 || threshold_byte > (num_of_keys as u8)) {
             return option::none<u8>()
@@ -335,13 +344,11 @@ module aptos_std::multi_ed25519 {
     /// - The signatures in `multisignature` do not all pass points-on-curve or not-in-small-subgroup checks,
     /// - the `multisignature` on `message` does not verify.
     native fun signature_verify_strict_internal(
-        multisignature: vector<u8>,
-        public_key: vector<u8>,
-        message: vector<u8>
+        multisignature: vector<u8>, public_key: vector<u8>, message: vector<u8>
     ): bool;
 
     #[test_only]
-    native fun generate_keys_internal(threshold: u8, n: u8): (vector<u8>,vector<u8>);
+    native fun generate_keys_internal(threshold: u8, n: u8): (vector<u8>, vector<u8>);
 
     #[test_only]
     native fun sign_internal(sk: vector<u8>, message: vector<u8>): vector<u8>;
@@ -362,10 +369,11 @@ module aptos_std::multi_ed25519 {
         *first_sig_byte = *first_sig_byte ^ 0xff;
     }
 
-
     #[test(fx = @std)]
     fun bugfix_validated_pk_from_zero_subpks(fx: signer) {
-        features::change_feature_flags_for_testing(&fx, vector[ features::multi_ed25519_pk_validate_v2_feature()], vector[]);
+        features::change_feature_flags_for_testing(
+            &fx, vector[features::multi_ed25519_pk_validate_v2_feature()], vector[]
+        );
         let bytes = vector<u8>[1u8];
         assert!(vector::length(&bytes) == 1, 1);
 
@@ -373,8 +381,8 @@ module aptos_std::multi_ed25519 {
         // This would ideally NOT succeed, but it currently does. Regardless, such invalid PKs will be safely dismissed
         // during signature verification.
         let some = new_validated_public_key_from_bytes(bytes);
-        assert!(option::is_none(&check_and_get_threshold(bytes)), 1);   // ground truth
-        assert!(option::is_some(&some), 2);                             // incorrect
+        assert!(option::is_none(&check_and_get_threshold(bytes)), 1); // ground truth
+        assert!(option::is_some(&some), 2); // incorrect
 
         // In contrast, the v2 API will fail deserializing, as it should.
         let none = new_validated_public_key_from_bytes_v2(bytes);
@@ -383,7 +391,9 @@ module aptos_std::multi_ed25519 {
 
     #[test(fx = @std)]
     fun test_validated_pk_without_threshold_byte(fx: signer) {
-        features::change_feature_flags_for_testing(&fx, vector[ features::multi_ed25519_pk_validate_v2_feature()], vector[]);
+        features::change_feature_flags_for_testing(
+            &fx, vector[features::multi_ed25519_pk_validate_v2_feature()], vector[]
+        );
 
         let (_, subpk) = ed25519::generate_keys();
         let bytes = ed25519::validated_public_key_to_bytes(&subpk);
@@ -392,23 +402,28 @@ module aptos_std::multi_ed25519 {
         // Try deserializing a MultiEd25519 `ValidatedPublicKey` with 1 Ed25519 sub-PKs but no threshold byte, which
         // will not succeed,
         let none = new_validated_public_key_from_bytes(bytes);
-        assert!(option::is_none(&check_and_get_threshold(bytes)), 1);   // ground truth
-        assert!(option::is_none(&none), 2);                             // correct
+        assert!(option::is_none(&check_and_get_threshold(bytes)), 1); // ground truth
+        assert!(option::is_none(&none), 2); // correct
 
         // Similarly, the v2 API will also fail deserializing.
         let none = new_validated_public_key_from_bytes_v2(bytes);
-        assert!(option::is_none(&none), 3);                             // also correct
+        assert!(option::is_none(&none), 3); // also correct
     }
 
     #[test(fx = @std)]
     fun test_validated_pk_from_small_order_subpk(fx: signer) {
-        features::change_feature_flags_for_testing(&fx, vector[ features::multi_ed25519_pk_validate_v2_feature()], vector[]);
+        features::change_feature_flags_for_testing(
+            &fx, vector[features::multi_ed25519_pk_validate_v2_feature()], vector[]
+        );
         let torsion_point_with_threshold_1 = vector<u8>[
-            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 1,
-        ];
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 1,];
 
-        assert!(option::extract(&mut check_and_get_threshold(torsion_point_with_threshold_1)) == 1, 1);
+        assert!(
+            option::extract(&mut check_and_get_threshold(torsion_point_with_threshold_1))
+                == 1,
+            1,
+        );
 
         // Try deserializing a MultiEd25519 `ValidatedPublicKey` with 1 Ed25519 sub-PKs and 1 threshold byte, as it should,
         // except the sub-PK is of small order. This should not succeed,
@@ -437,17 +452,17 @@ module aptos_std::multi_ed25519 {
             assert!(public_key_validate_v2_internal(pk.bytes), 3);
 
             let upk = public_key_into_unvalidated(pk);
-            assert!(option::extract(&mut unvalidated_public_key_threshold(&upk)) == threshold, 4);
+            assert!(
+                option::extract(&mut unvalidated_public_key_threshold(&upk)) == threshold,
+                4,
+            );
             assert!(unvalidated_public_key_num_sub_pks(&upk) == group_size, 5);
 
             let msg1 = b"Hello Aptos!";
             let sig1 = sign_arbitrary_bytes(&sk, msg1);
             assert!(signature_verify_strict(&sig1, &upk, msg1), 6);
 
-            let obj2 = TestMessage {
-                foo: b"Hello Move!",
-                bar: 64,
-            };
+            let obj2 = TestMessage { foo: b"Hello Move!", bar: 64, };
             let sig2 = sign_struct(&sk, copy obj2);
             assert!(signature_verify_strict_t(&sig2, &upk, copy obj2), 7);
 
@@ -457,7 +472,7 @@ module aptos_std::multi_ed25519 {
 
     #[test]
     fun test_threshold_not_met_rejection() {
-        let (sk,pk) = generate_keys(4, 5);
+        let (sk, pk) = generate_keys(4, 5);
         assert!(validated_public_key_threshold(&pk) == 4, 1);
         assert!(validated_public_key_num_sub_pks(&pk) == 5, 2);
         assert!(public_key_validate_v2_internal(pk.bytes), 3);
@@ -471,10 +486,7 @@ module aptos_std::multi_ed25519 {
         maul_first_signature(&mut sig1);
         assert!(!signature_verify_strict(&sig1, &upk, msg1), 6);
 
-        let obj2 = TestMessage {
-            foo: b"Hello Move!",
-            bar: 64,
-        };
+        let obj2 = TestMessage { foo: b"Hello Move!", bar: 64, };
         let sig2 = sign_struct(&sk, copy obj2);
         maul_first_signature(&mut sig2);
         assert!(!signature_verify_strict_t(&sig2, &upk, copy obj2), 7);

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/multi_ed25519.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/multi_ed25519.spec.move
@@ -8,6 +8,7 @@ spec aptos_std::multi_ed25519 {
         include NewUnvalidatedPublicKeyFromBytesAbortsIf;
         ensures result == UnvalidatedPublicKey { bytes };
     }
+
     spec schema NewUnvalidatedPublicKeyFromBytesAbortsIf {
         bytes: vector<u8>;
         let length = len(bytes);
@@ -19,20 +20,25 @@ spec aptos_std::multi_ed25519 {
         aborts_if false;
         let cond = len(bytes) % INDIVIDUAL_PUBLIC_KEY_NUM_BYTES == THRESHOLD_SIZE_BYTES
             && spec_public_key_validate_internal(bytes);
-        ensures cond ==> result == option::spec_some(ValidatedPublicKey{bytes});
-        ensures !cond ==> result == option::spec_none<ValidatedPublicKey>();
+        ensures cond ==>
+            result == option::spec_some(ValidatedPublicKey { bytes });
+        ensures !cond ==>
+            result == option::spec_none<ValidatedPublicKey>();
     }
 
     spec new_validated_public_key_from_bytes_v2(bytes: vector<u8>): Option<ValidatedPublicKey> {
         let cond = spec_public_key_validate_v2_internal(bytes);
-        ensures cond ==> result == option::spec_some(ValidatedPublicKey{bytes});
-        ensures !cond ==> result == option::spec_none<ValidatedPublicKey>();
+        ensures cond ==>
+            result == option::spec_some(ValidatedPublicKey { bytes });
+        ensures !cond ==>
+            result == option::spec_none<ValidatedPublicKey>();
     }
 
     spec new_signature_from_bytes(bytes: vector<u8>): Signature {
         include NewSignatureFromBytesAbortsIf;
         ensures result == Signature { bytes };
     }
+
     spec schema NewSignatureFromBytesAbortsIf {
         bytes: vector<u8>;
         aborts_if len(bytes) % INDIVIDUAL_SIGNATURE_NUM_BYTES != BITMAP_NUM_OF_BYTES;
@@ -83,7 +89,8 @@ spec aptos_std::multi_ed25519 {
     spec public_key_validate_internal(bytes: vector<u8>): bool {
         pragma opaque;
         aborts_if false;
-        ensures (len(bytes) / INDIVIDUAL_PUBLIC_KEY_NUM_BYTES > MAX_NUMBER_OF_PUBLIC_KEYS) ==> (result == false);
+        ensures (len(bytes) / INDIVIDUAL_PUBLIC_KEY_NUM_BYTES > MAX_NUMBER_OF_PUBLIC_KEYS) ==>
+             (result == false);
         ensures result == spec_public_key_validate_internal(bytes);
     }
 
@@ -93,13 +100,12 @@ spec aptos_std::multi_ed25519 {
     }
 
     spec signature_verify_strict_internal(
-        multisignature: vector<u8>,
-        public_key: vector<u8>,
-        message: vector<u8>
+        multisignature: vector<u8>, public_key: vector<u8>, message: vector<u8>
     ): bool {
         pragma opaque;
         aborts_if false;
-        ensures result == spec_signature_verify_strict_internal(multisignature, public_key, message);
+        ensures result
+            == spec_signature_verify_strict_internal(multisignature, public_key, message);
     }
 
     /// # Helper functions
@@ -112,7 +118,9 @@ spec aptos_std::multi_ed25519 {
             let threshold_num_of_bytes = len % INDIVIDUAL_PUBLIC_KEY_NUM_BYTES;
             let num_of_keys = len / INDIVIDUAL_PUBLIC_KEY_NUM_BYTES;
             let threshold_byte = bytes[len - 1];
-            if (num_of_keys == 0 || num_of_keys > MAX_NUMBER_OF_PUBLIC_KEYS || len % INDIVIDUAL_PUBLIC_KEY_NUM_BYTES != 1) {
+            if (num_of_keys == 0
+                || num_of_keys > MAX_NUMBER_OF_PUBLIC_KEYS
+                || len % INDIVIDUAL_PUBLIC_KEY_NUM_BYTES != 1) {
                 option::none<u8>()
             } else if (threshold_byte == 0 || threshold_byte > (num_of_keys as u8)) {
                 option::none<u8>()
@@ -123,9 +131,7 @@ spec aptos_std::multi_ed25519 {
     }
 
     spec fun spec_signature_verify_strict_internal(
-        multisignature: vector<u8>,
-        public_key: vector<u8>,
-        message: vector<u8>
+        multisignature: vector<u8>, public_key: vector<u8>, message: vector<u8>
     ): bool;
 
     spec fun spec_public_key_validate_internal(bytes: vector<u8>): bool;
@@ -134,7 +140,9 @@ spec aptos_std::multi_ed25519 {
 
     spec fun spec_public_key_bytes_to_authentication_key(pk_bytes: vector<u8>): vector<u8>;
 
-    spec fun spec_signature_verify_strict_t<T>(signature: Signature, public_key: UnvalidatedPublicKey, data: T): bool {
+    spec fun spec_signature_verify_strict_t<T>(
+        signature: Signature, public_key: UnvalidatedPublicKey, data: T
+    ): bool {
         let encoded = ed25519::new_signed_message<T>(data);
         let message = bcs::serialize(encoded);
         spec_signature_verify_strict_internal(signature.bytes, public_key.bytes, message)

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255.move
@@ -122,16 +122,12 @@ module aptos_std::ristretto255 {
 
     /// Returns the identity point as a CompressedRistretto.
     public fun point_identity(): RistrettoPoint {
-        RistrettoPoint {
-            handle: point_identity_internal()
-        }
+        RistrettoPoint { handle: point_identity_internal() }
     }
 
     /// Returns the basepoint (generator) of the Ristretto255 group as a compressed point
     public fun basepoint_compressed(): CompressedRistretto {
-        CompressedRistretto {
-            data: BASE_POINT
-        }
+        CompressedRistretto { data: BASE_POINT }
     }
 
     /// Returns the hash-to-point result of serializing the basepoint of the Ristretto255 group.
@@ -145,26 +141,20 @@ module aptos_std::ristretto255 {
     public fun basepoint(): RistrettoPoint {
         let (handle, _) = point_decompress_internal(BASE_POINT);
 
-        RistrettoPoint {
-            handle
-        }
+        RistrettoPoint { handle }
     }
 
     /// Multiplies the basepoint (generator) of the Ristretto255 group by a scalar and returns the result.
     /// This call is much faster than `point_mul(&basepoint(), &some_scalar)` because of precomputation tables.
     public fun basepoint_mul(a: &Scalar): RistrettoPoint {
-        RistrettoPoint {
-            handle: basepoint_mul_internal(a.data)
-        }
+        RistrettoPoint { handle: basepoint_mul_internal(a.data) }
     }
 
     /// Creates a new CompressedRistretto point from a sequence of 32 bytes. If those bytes do not represent a valid
     /// point, returns None.
     public fun new_compressed_point_from_bytes(bytes: vector<u8>): Option<CompressedRistretto> {
         if (point_is_canonical_internal(bytes)) {
-            std::option::some(CompressedRistretto {
-                data: bytes
-            })
+            std::option::some(CompressedRistretto { data: bytes })
         } else {
             std::option::none<CompressedRistretto>()
         }
@@ -195,18 +185,16 @@ module aptos_std::ristretto255 {
 
     /// Hashes the input to a uniformly-at-random RistrettoPoint via SHA2-512.
     public fun new_point_from_sha2_512(sha2_512_input: vector<u8>): RistrettoPoint {
-        RistrettoPoint {
-            handle: new_point_from_sha512_internal(sha2_512_input)
-        }
+        RistrettoPoint { handle: new_point_from_sha512_internal(sha2_512_input) }
     }
 
     /// Samples a uniformly-at-random RistrettoPoint given a sequence of 64 uniformly-at-random bytes. This function
     /// can be used to build a collision-resistant hash function that maps 64-byte messages to RistrettoPoint's.
     public fun new_point_from_64_uniform_bytes(bytes: vector<u8>): Option<RistrettoPoint> {
         if (std::vector::length(&bytes) == 64) {
-            std::option::some(RistrettoPoint {
-                handle: new_point_from_64_uniform_bytes_internal(bytes)
-            })
+            std::option::some(
+                RistrettoPoint { handle: new_point_from_64_uniform_bytes_internal(bytes) }
+            )
         } else {
             std::option::none<RistrettoPoint>()
         }
@@ -222,20 +210,16 @@ module aptos_std::ristretto255 {
 
     /// Clones a RistrettoPoint.
     public fun point_clone(point: &RistrettoPoint): RistrettoPoint {
-        if(!features::bulletproofs_enabled()) {
+        if (!features::bulletproofs_enabled()) {
             abort(std::error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE))
         };
 
-        RistrettoPoint {
-            handle: point_clone_internal(point.handle)
-        }
+        RistrettoPoint { handle: point_clone_internal(point.handle) }
     }
 
     /// Compresses a RistrettoPoint to a CompressedRistretto which can be put in storage.
     public fun point_compress(point: &RistrettoPoint): CompressedRistretto {
-        CompressedRistretto {
-            data: point_compress_internal(point)
-        }
+        CompressedRistretto { data: point_compress_internal(point) }
     }
 
     /// Returns the sequence of bytes representin this Ristretto point.
@@ -247,9 +231,7 @@ module aptos_std::ristretto255 {
 
     /// Returns a * point.
     public fun point_mul(point: &RistrettoPoint, a: &Scalar): RistrettoPoint {
-        RistrettoPoint {
-            handle: point_mul_internal(point, a.data, false)
-        }
+        RistrettoPoint { handle: point_mul_internal(point, a.data, false) }
     }
 
     /// Sets a *= point and returns 'a'.
@@ -259,43 +241,41 @@ module aptos_std::ristretto255 {
     }
 
     /// Returns (a * a_base + b * base_point), where base_point is the Ristretto basepoint encoded in `BASE_POINT`.
-    public fun basepoint_double_mul(a: &Scalar, a_base: &RistrettoPoint, b: &Scalar): RistrettoPoint {
-        RistrettoPoint {
-            handle: basepoint_double_mul_internal(a.data, a_base, b.data)
-        }
+    public fun basepoint_double_mul(
+        a: &Scalar, a_base: &RistrettoPoint, b: &Scalar
+    ): RistrettoPoint {
+        RistrettoPoint { handle: basepoint_double_mul_internal(a.data, a_base, b.data) }
     }
 
     /// Returns a + b
     public fun point_add(a: &RistrettoPoint, b: &RistrettoPoint): RistrettoPoint {
-        RistrettoPoint {
-            handle: point_add_internal(a, b, false)
-        }
+        RistrettoPoint { handle: point_add_internal(a, b, false) }
     }
 
     /// Sets a += b and returns 'a'.
-    public fun point_add_assign(a: &mut RistrettoPoint, b: &RistrettoPoint): &mut RistrettoPoint {
+    public fun point_add_assign(
+        a: &mut RistrettoPoint, b: &RistrettoPoint
+    ): &mut RistrettoPoint {
         point_add_internal(a, b, true);
         a
     }
 
     /// Returns a - b
     public fun point_sub(a: &RistrettoPoint, b: &RistrettoPoint): RistrettoPoint {
-        RistrettoPoint {
-            handle: point_sub_internal(a, b, false)
-        }
+        RistrettoPoint { handle: point_sub_internal(a, b, false) }
     }
 
     /// Sets a -= b and returns 'a'.
-    public fun point_sub_assign(a: &mut RistrettoPoint, b: &RistrettoPoint): &mut RistrettoPoint {
+    public fun point_sub_assign(
+        a: &mut RistrettoPoint, b: &RistrettoPoint
+    ): &mut RistrettoPoint {
         point_sub_internal(a, b, true);
         a
     }
 
     /// Returns -a
     public fun point_neg(a: &RistrettoPoint): RistrettoPoint {
-        RistrettoPoint {
-            handle: point_neg_internal(a, false)
-        }
+        RistrettoPoint { handle: point_neg_internal(a, false) }
     }
 
     /// Sets a = -a, and returns 'a'.
@@ -309,22 +289,35 @@ module aptos_std::ristretto255 {
 
     /// Computes a double-scalar multiplication, returning a_1 p_1 + a_2 p_2
     /// This function is much faster than computing each a_i p_i using `point_mul` and adding up the results using `point_add`.
-    public fun double_scalar_mul(scalar1: &Scalar, point1: &RistrettoPoint, scalar2: &Scalar, point2: &RistrettoPoint): RistrettoPoint {
-        if(!features::bulletproofs_enabled()) {
+    public fun double_scalar_mul(
+        scalar1: &Scalar, point1: &RistrettoPoint, scalar2: &Scalar, point2: &RistrettoPoint
+    ): RistrettoPoint {
+        if (!features::bulletproofs_enabled()) {
             abort(std::error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE))
         };
 
         RistrettoPoint {
-            handle: double_scalar_mul_internal(point1.handle, point2.handle, scalar1.data, scalar2.data)
+            handle: double_scalar_mul_internal(
+                point1.handle, point2.handle, scalar1.data, scalar2.data
+            )
         }
     }
 
     /// Computes a multi-scalar multiplication, returning a_1 p_1 + a_2 p_2 + ... + a_n p_n.
     /// This function is much faster than computing each a_i p_i using `point_mul` and adding up the results using `point_add`.
-    public fun multi_scalar_mul(points: &vector<RistrettoPoint>, scalars: &vector<Scalar>): RistrettoPoint {
-        assert!(!std::vector::is_empty(points), std::error::invalid_argument(E_ZERO_POINTS));
-        assert!(!std::vector::is_empty(scalars), std::error::invalid_argument(E_ZERO_SCALARS));
-        assert!(std::vector::length(points) == std::vector::length(scalars), std::error::invalid_argument(E_DIFFERENT_NUM_POINTS_AND_SCALARS));
+    public fun multi_scalar_mul(
+        points: &vector<RistrettoPoint>, scalars: &vector<Scalar>
+    ): RistrettoPoint {
+        assert!(
+            !std::vector::is_empty(points), std::error::invalid_argument(E_ZERO_POINTS)
+        );
+        assert!(
+            !std::vector::is_empty(scalars), std::error::invalid_argument(E_ZERO_SCALARS)
+        );
+        assert!(
+            std::vector::length(points) == std::vector::length(scalars),
+            std::error::invalid_argument(E_DIFFERENT_NUM_POINTS_AND_SCALARS),
+        );
 
         RistrettoPoint {
             handle: multi_scalar_mul_internal<RistrettoPoint, Scalar>(points, scalars)
@@ -339,9 +332,7 @@ module aptos_std::ristretto255 {
     /// Otherwise, returns None.
     public fun new_scalar_from_bytes(bytes: vector<u8>): Option<Scalar> {
         if (scalar_is_canonical_internal(bytes)) {
-            std::option::some(Scalar {
-                data: bytes
-            })
+            std::option::some(Scalar { data: bytes })
         } else {
             std::option::none<Scalar>()
         }
@@ -356,9 +347,7 @@ module aptos_std::ristretto255 {
 
     /// Hashes the input to a uniformly-at-random Scalar via SHA2-512
     public fun new_scalar_from_sha2_512(sha2_512_input: vector<u8>): Scalar {
-        Scalar {
-            data: scalar_from_sha512_internal(sha2_512_input)
-        }
+        Scalar { data: scalar_from_sha512_internal(sha2_512_input) }
     }
 
     /// Creates a Scalar from an u8.
@@ -372,31 +361,25 @@ module aptos_std::ristretto255 {
 
     /// Creates a Scalar from an u32.
     public fun new_scalar_from_u32(four_bytes: u32): Scalar {
-        Scalar {
-            data: scalar_from_u64_internal((four_bytes as u64))
-        }
+        Scalar { data: scalar_from_u64_internal((four_bytes as u64)) }
     }
 
     /// Creates a Scalar from an u64.
     public fun new_scalar_from_u64(eight_bytes: u64): Scalar {
-        Scalar {
-            data: scalar_from_u64_internal(eight_bytes)
-        }
+        Scalar { data: scalar_from_u64_internal(eight_bytes) }
     }
 
     /// Creates a Scalar from an u128.
     public fun new_scalar_from_u128(sixteen_bytes: u128): Scalar {
-        Scalar {
-            data: scalar_from_u128_internal(sixteen_bytes)
-        }
+        Scalar { data: scalar_from_u128_internal(sixteen_bytes) }
     }
 
     /// Creates a Scalar from 32 bytes by reducing the little-endian-encoded number in those bytes modulo $\ell$.
     public fun new_scalar_reduced_from_32_bytes(bytes: vector<u8>): Option<Scalar> {
         if (std::vector::length(&bytes) == 32) {
-            std::option::some(Scalar {
-                data: scalar_reduced_from_32_bytes_internal(bytes)
-            })
+            std::option::some(
+                Scalar { data: scalar_reduced_from_32_bytes_internal(bytes) }
+            )
         } else {
             std::option::none()
         }
@@ -406,9 +389,9 @@ module aptos_std::ristretto255 {
     /// in those bytes modulo $\ell$.
     public fun new_scalar_uniform_from_64_bytes(bytes: vector<u8>): Option<Scalar> {
         if (std::vector::length(&bytes) == 64) {
-            std::option::some(Scalar {
-                data: scalar_uniform_from_64_bytes_internal(bytes)
-            })
+            std::option::some(
+                Scalar { data: scalar_uniform_from_64_bytes_internal(bytes) }
+            )
         } else {
             std::option::none()
         }
@@ -449,17 +432,13 @@ module aptos_std::ristretto255 {
         if (scalar_is_zero(s)) {
             std::option::none<Scalar>()
         } else {
-            std::option::some(Scalar {
-                data: scalar_invert_internal(s.data)
-            })
+            std::option::some(Scalar { data: scalar_invert_internal(s.data) })
         }
     }
 
     /// Returns the product of the two scalars.
     public fun scalar_mul(a: &Scalar, b: &Scalar): Scalar {
-        Scalar {
-            data: scalar_mul_internal(a.data, b.data)
-        }
+        Scalar { data: scalar_mul_internal(a.data, b.data) }
     }
 
     /// Computes the product of 'a' and 'b' and assigns the result to 'a'.
@@ -471,9 +450,7 @@ module aptos_std::ristretto255 {
 
     /// Returns the sum of the two scalars.
     public fun scalar_add(a: &Scalar, b: &Scalar): Scalar {
-        Scalar {
-            data: scalar_add_internal(a.data, b.data)
-        }
+        Scalar { data: scalar_add_internal(a.data, b.data) }
     }
 
     /// Computes the sum of 'a' and 'b' and assigns the result to 'a'
@@ -485,9 +462,7 @@ module aptos_std::ristretto255 {
 
     /// Returns the difference of the two scalars.
     public fun scalar_sub(a: &Scalar, b: &Scalar): Scalar {
-        Scalar {
-            data: scalar_sub_internal(a.data, b.data)
-        }
+        Scalar { data: scalar_sub_internal(a.data, b.data) }
     }
 
     /// Subtracts 'b' from 'a' and assigns the result to 'a'.
@@ -499,9 +474,7 @@ module aptos_std::ristretto255 {
 
     /// Returns the negation of 'a': i.e., $(0 - a) \mod \ell$.
     public fun scalar_neg(a: &Scalar): Scalar {
-        Scalar {
-            data: scalar_neg_internal(a.data)
-        }
+        Scalar { data: scalar_neg_internal(a.data) }
     }
 
     /// Replaces 'a' by its negation.
@@ -538,7 +511,9 @@ module aptos_std::ristretto255 {
 
     native fun basepoint_mul_internal(a: vector<u8>): u64;
 
-    native fun basepoint_double_mul_internal(a: vector<u8>, some_point: &RistrettoPoint, b: vector<u8>): u64;
+    native fun basepoint_double_mul_internal(
+        a: vector<u8>, some_point: &RistrettoPoint, b: vector<u8>
+    ): u64;
 
     native fun point_add_internal(a: &RistrettoPoint, b: &RistrettoPoint, in_place: bool): u64;
 
@@ -546,7 +521,9 @@ module aptos_std::ristretto255 {
 
     native fun point_neg_internal(a: &RistrettoPoint, in_place: bool): u64;
 
-    native fun double_scalar_mul_internal(point1: u64, point2: u64, scalar1: vector<u8>, scalar2: vector<u8>): u64;
+    native fun double_scalar_mul_internal(
+        point1: u64, point2: u64, scalar1: vector<u8>, scalar2: vector<u8>
+    ): u64;
 
     /// The generic arguments are needed to deal with some Move VM peculiarities which prevent us from borrowing the
     /// points (or scalars) inside a &vector in Rust.
@@ -590,9 +567,7 @@ module aptos_std::ristretto255 {
 
     #[test_only]
     public fun random_scalar(): Scalar {
-        Scalar {
-            data: random_scalar_internal()
-        }
+        Scalar { data: random_scalar_internal() }
     }
 
     #[test_only]
@@ -732,8 +707,8 @@ module aptos_std::ristretto255 {
         assert!(ag.handle == 1, 1);
         assert!(p.handle == 2, 1);
 
-        assert!(!point_equals(&g, &ag), 1);     // make sure input g remains unmodifed
-        assert!(point_equals(&p, &ag), 1);   // make sure output a*g is correct
+        assert!(!point_equals(&g, &ag), 1); // make sure input g remains unmodifed
+        assert!(point_equals(&p, &ag), 1); // make sure output a*g is correct
     }
 
     #[test]
@@ -782,9 +757,9 @@ module aptos_std::ristretto255 {
         assert!(a_plus_b.handle == 2, 1);
         assert!(result.handle == 3, 1);
 
-        assert!(!point_equals(&a, &result), 1);     // make sure input a remains unmodifed
-        assert!(!point_equals(&b, &result), 1);     // make sure input b remains unmodifed
-        assert!(point_equals(&a_plus_b, &result), 1);   // make sure output a+b is correct
+        assert!(!point_equals(&a, &result), 1); // make sure input a remains unmodifed
+        assert!(!point_equals(&b, &result), 1); // make sure input b remains unmodifed
+        assert!(point_equals(&a_plus_b, &result), 1); // make sure output a+b is correct
     }
 
     #[test]
@@ -808,7 +783,9 @@ module aptos_std::ristretto255 {
     }
 
     #[test_only]
-    fun test_point_add_assign_internal(before_a_gap: u64, before_b_gap: u64) {
+    fun test_point_add_assign_internal(
+        before_a_gap: u64, before_b_gap: u64
+    ) {
         // create extra RistrettoPoints here, so as to generate different PointStore layouts inside the native Rust implementation
         let c = before_a_gap;
         while (c > 0) {
@@ -875,9 +852,9 @@ module aptos_std::ristretto255 {
         assert!(a_plus_b.handle == 2, 1);
         assert!(result.handle == 3, 1);
 
-        assert!(!point_equals(&a_plus_b, &result), 1);     // make sure input a_plus_b remains unmodifed
-        assert!(!point_equals(&b, &result), 1);     // make sure input b remains unmodifed
-        assert!(point_equals(&a, &result), 1);   // make sure output 'a+b-b' is correct
+        assert!(!point_equals(&a_plus_b, &result), 1); // make sure input a_plus_b remains unmodifed
+        assert!(!point_equals(&b, &result), 1); // make sure input b remains unmodifed
+        assert!(point_equals(&a, &result), 1); // make sure output 'a+b-b' is correct
     }
 
     #[test]
@@ -907,9 +884,16 @@ module aptos_std::ristretto255 {
 
     #[test(fx = @std)]
     fun test_basepoint_double_mul(fx: signer) {
-        features::change_feature_flags_for_testing(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
+        features::change_feature_flags_for_testing(
+            &fx, vector[features::get_bulletproofs_feature()], vector[]
+        );
 
-        let expected = option::extract(&mut new_point_from_bytes(x"be5d615d8b8f996723cdc6e1895b8b6d312cc75d1ffb0259873b99396a38c05a"));
+        let expected =
+            option::extract(
+                &mut new_point_from_bytes(
+                    x"be5d615d8b8f996723cdc6e1895b8b6d312cc75d1ffb0259873b99396a38c05a"
+                ),
+            );
 
         let a = Scalar { data: A_SCALAR };
         let a_point = option::extract(&mut new_point_from_bytes(A_POINT));
@@ -925,37 +909,36 @@ module aptos_std::ristretto255 {
     #[test]
     #[expected_failure]
     fun test_multi_scalar_mul_aborts_empty_scalars() {
-        multi_scalar_mul(&vector[ basepoint() ], &vector[]);
+        multi_scalar_mul(&vector[basepoint()], &vector[]);
     }
 
     #[test]
     #[expected_failure]
     fun test_multi_scalar_mul_aborts_empty_points() {
-        multi_scalar_mul(&vector[ ], &vector[ Scalar { data: A_SCALAR } ]);
+        multi_scalar_mul(&vector[], &vector[Scalar { data: A_SCALAR }]);
     }
 
     #[test]
     #[expected_failure]
     fun test_multi_scalar_mul_aborts_empty_all() {
-        multi_scalar_mul(&vector[ ], &vector[ ]);
+        multi_scalar_mul(&vector[], &vector[]);
     }
 
     #[test]
     #[expected_failure]
     fun test_multi_scalar_mul_aborts_different_sizes() {
-        multi_scalar_mul(&vector[ basepoint() ], &vector[ Scalar { data: A_SCALAR }, Scalar { data: B_SCALAR }  ]);
+        multi_scalar_mul(
+            &vector[basepoint()],
+            &vector[Scalar { data: A_SCALAR }, Scalar { data: B_SCALAR }],
+        );
     }
 
     #[test]
     fun test_multi_scalar_mul_single() {
         // Test single exp
-        let points = vector[
-            basepoint(),
-        ];
+        let points = vector[basepoint(),];
 
-        let scalars = vector[
-            Scalar { data: A_SCALAR },
-        ];
+        let scalars = vector[Scalar { data: A_SCALAR },];
 
         let result = multi_scalar_mul(&points, &scalars);
         let expected = std::option::extract(&mut new_point_from_bytes(A_TIMES_BASE_POINT));
@@ -966,21 +949,17 @@ module aptos_std::ristretto255 {
     #[test]
     fun test_multi_scalar_mul_double() {
         // Test double exp
-        let points = vector[
-            basepoint(),
-            basepoint(),
-        ];
+        let points = vector[basepoint(), basepoint(),];
 
-        let scalars = vector[
-            Scalar { data: A_SCALAR },
-            Scalar { data: B_SCALAR },
-        ];
+        let scalars = vector[Scalar { data: A_SCALAR }, Scalar { data: B_SCALAR },];
 
         let result = multi_scalar_mul(&points, &scalars);
-        let expected = basepoint_double_mul(
-            std::vector::borrow(&scalars, 0),
-            &basepoint(),
-            std::vector::borrow(&scalars, 1));
+        let expected =
+            basepoint_double_mul(
+                std::vector::borrow(&scalars, 0),
+                &basepoint(),
+                std::vector::borrow(&scalars, 1),
+            );
 
         assert!(point_equals(&result, &expected), 1);
     }
@@ -992,18 +971,21 @@ module aptos_std::ristretto255 {
             new_scalar_from_sha2_512(b"2"),
             new_scalar_from_sha2_512(b"3"),
             new_scalar_from_sha2_512(b"4"),
-            new_scalar_from_sha2_512(b"5"),
-        ];
+            new_scalar_from_sha2_512(b"5"),];
 
         let points = vector[
             new_point_from_sha2_512(b"1"),
             new_point_from_sha2_512(b"2"),
             new_point_from_sha2_512(b"3"),
             new_point_from_sha2_512(b"4"),
-            new_point_from_sha2_512(b"5"),
-        ];
+            new_point_from_sha2_512(b"5"),];
 
-        let expected = std::option::extract(&mut new_point_from_bytes(x"c4a98fbe6bd0f315a0c150858aec8508be397443093e955ef982e299c1318928"));
+        let expected =
+            std::option::extract(
+                &mut new_point_from_bytes(
+                    x"c4a98fbe6bd0f315a0c150858aec8508be397443093e955ef982e299c1318928"
+                ),
+            );
         let result = multi_scalar_mul(&points, &scalars);
 
         assert!(point_equals(&expected, &result), 1);
@@ -1012,15 +994,26 @@ module aptos_std::ristretto255 {
     #[test]
     fun test_new_point_from_sha2_512() {
         let msg = b"To really appreciate architecture, you may even need to commit a murder";
-        let expected = option::extract(&mut new_point_from_bytes(x"baaa91eb43e5e2f12ffc96347e14bc458fdb1772b2232b08977ee61ea9f84e31"));
+        let expected =
+            option::extract(
+                &mut new_point_from_bytes(
+                    x"baaa91eb43e5e2f12ffc96347e14bc458fdb1772b2232b08977ee61ea9f84e31"
+                ),
+            );
 
         assert!(point_equals(&expected, &new_point_from_sha2_512(msg)), 1);
     }
 
     #[test]
     fun test_new_point_from_64_uniform_bytes() {
-        let bytes_64 = x"baaa91eb43e5e2f12ffc96347e14bc458fdb1772b2232b08977ee61ea9f84e31e87feda199d72b83de4f5b2d45d34805c57019c6c59c42cb70ee3d19aa996f75";
-        let expected = option::extract(&mut new_point_from_bytes(x"4a8e429f906478654232d7ae180ad60854754944ac67f38e20d8fa79e4b7d71e"));
+        let bytes_64 =
+            x"baaa91eb43e5e2f12ffc96347e14bc458fdb1772b2232b08977ee61ea9f84e31e87feda199d72b83de4f5b2d45d34805c57019c6c59c42cb70ee3d19aa996f75";
+        let expected =
+            option::extract(
+                &mut new_point_from_bytes(
+                    x"4a8e429f906478654232d7ae180ad60854754944ac67f38e20d8fa79e4b7d71e"
+                ),
+            );
 
         let point = option::extract(&mut new_point_from_64_uniform_bytes(bytes_64));
         assert!(point_equals(&expected, &point), 1);
@@ -1039,7 +1032,12 @@ module aptos_std::ristretto255 {
         assert!(scalar_equals(&new_scalar_from_u128(2u128), &two), 1);
 
         // Test (0 - 1) % order = order - 1
-        assert!(scalar_equals(&scalar_sub(&scalar_zero(), &scalar_one()), &Scalar { data: L_MINUS_ONE }), 1);
+        assert!(
+            scalar_equals(
+                &scalar_sub(&scalar_zero(), &scalar_one()), &Scalar { data: L_MINUS_ONE }
+            ),
+            1,
+        );
     }
 
     #[test]
@@ -1049,10 +1047,24 @@ module aptos_std::ristretto255 {
         assert!(std::option::is_none(&new_scalar_from_bytes(x"00")), 1);
 
         // 32 zero bytes are canonical
-        assert!(std::option::is_some(&new_scalar_from_bytes(x"0000000000000000000000000000000000000000000000000000000000000000")), 1);
+        assert!(
+            std::option::is_some(
+                &new_scalar_from_bytes(
+                    x"0000000000000000000000000000000000000000000000000000000000000000"
+                ),
+            ),
+            1,
+        );
 
         // Non-canonical because unreduced
-        assert!(std::option::is_none(&new_scalar_from_bytes(x"1010101010101010101010101010101010101010101010101010101010101010")), 1);
+        assert!(
+            std::option::is_none(
+                &new_scalar_from_bytes(
+                    x"1010101010101010101010101010101010101010101010101010101010101010"
+                ),
+            ),
+            1,
+        );
 
         // Canonical because \ell - 1
         assert!(std::option::is_some(&new_scalar_from_bytes(L_MINUS_ONE)), 1);
@@ -1067,8 +1079,11 @@ module aptos_std::ristretto255 {
         assert!(std::option::is_none(&new_scalar_from_bytes(L_PLUS_TWO)), 1);
 
         // Non-canonical because high bit is set
-        let non_canonical_highbit = vector[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128];
-        let non_canonical_highbit_hex = x"0000000000000000000000000000000000000000000000000000000000000080";
+        let non_canonical_highbit = vector[
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 128];
+        let non_canonical_highbit_hex =
+            x"0000000000000000000000000000000000000000000000000000000000000080";
         assert!(non_canonical_highbit == non_canonical_highbit_hex, 1);
         assert!(std::option::is_none(&new_scalar_from_bytes(non_canonical_highbit)), 1);
     }
@@ -1121,21 +1136,33 @@ module aptos_std::ristretto255 {
     fun test_scalar_from_sha2_512() {
         // Test a specific message hashes correctly to the field
         let str: vector<u8> = vector[];
-        std::vector::append(&mut str, b"To really appreciate architecture, you may even need to commit a murder.");
-        std::vector::append(&mut str, b"While the programs used for The Manhattan Transcripts are of the most extreme");
-        std::vector::append(&mut str, b"nature, they also parallel the most common formula plot: the archetype of");
-        std::vector::append(&mut str, b"murder. Other phantasms were occasionally used to underline the fact that");
-        std::vector::append(&mut str, b"perhaps all architecture, rather than being about functional standards, is");
+        std::vector::append(
+            &mut str,
+            b"To really appreciate architecture, you may even need to commit a murder.",
+        );
+        std::vector::append(
+            &mut str,
+            b"While the programs used for The Manhattan Transcripts are of the most extreme",
+        );
+        std::vector::append(
+            &mut str,
+            b"nature, they also parallel the most common formula plot: the archetype of",
+        );
+        std::vector::append(
+            &mut str,
+            b"murder. Other phantasms were occasionally used to underline the fact that",
+        );
+        std::vector::append(
+            &mut str,
+            b"perhaps all architecture, rather than being about functional standards, is",
+        );
         std::vector::append(&mut str, b"about love and death.");
 
         let s = new_scalar_from_sha2_512(str);
 
         let expected: vector<u8> = vector[
-            21, 88, 208, 252, 63, 122, 210, 152,
-            154, 38, 15, 23, 16, 167, 80, 150,
-            192, 221, 77, 226, 62, 25, 224, 148,
-            239, 48, 176, 10, 185, 69, 168, 11
-        ];
+            21, 88, 208, 252, 63, 122, 210, 152, 154, 38, 15, 23, 16, 167, 80, 150, 192,
+            221, 77, 226, 62, 25, 224, 148, 239, 48, 176, 10, 185, 69, 168, 11];
 
         assert!(s.data == expected, 1)
     }
@@ -1199,7 +1226,13 @@ module aptos_std::ristretto255 {
         assert!(scalar_equals(&scalar_mul(&x, &y), &x_times_y), 1);
 
         // A * B
-        assert!(scalar_equals(&scalar_mul(&Scalar { data: A_SCALAR }, &Scalar { data: B_SCALAR }), &Scalar { data: A_TIMES_B_SCALAR }), 1);
+        assert!(
+            scalar_equals(
+                &scalar_mul(&Scalar { data: A_SCALAR }, &Scalar { data: B_SCALAR }),
+                &Scalar { data: A_TIMES_B_SCALAR },
+            ),
+            1,
+        );
     }
 
     #[test]
@@ -1224,14 +1257,22 @@ module aptos_std::ristretto255 {
         assert!(scalar_equals(&scalar_add(&scalar_one(), &scalar_one()), &two), 1);
 
         // A + B
-        assert!(scalar_equals(&scalar_add(&Scalar { data: A_SCALAR }, &Scalar { data: B_SCALAR }), &Scalar { data: A_PLUS_B_SCALAR }), 1);
+        assert!(
+            scalar_equals(
+                &scalar_add(&Scalar { data: A_SCALAR }, &Scalar { data: B_SCALAR }),
+                &Scalar { data: A_PLUS_B_SCALAR },
+            ),
+            1,
+        );
     }
 
     #[test]
     fun test_scalar_sub() {
         // Subtraction reduces: 0 - 1 = \ell - 1
         let ell_minus_one = Scalar { data: L_MINUS_ONE };
-        assert!(scalar_equals(&scalar_sub(&scalar_zero(), &scalar_one()), &ell_minus_one), 1);
+        assert!(
+            scalar_equals(&scalar_sub(&scalar_zero(), &scalar_one()), &ell_minus_one), 1
+        );
 
         // 2 - 1 = 1
         let two = Scalar { data: TWO_SCALAR };
@@ -1250,7 +1291,10 @@ module aptos_std::ristretto255 {
         assert!(scalar_equals(&s, &two), 1);
 
         // Reducing the all 1's bit vector yields $(2^256 - 1) \mod \ell$
-        let biggest = std::option::extract(&mut new_scalar_reduced_from_32_bytes(NON_CANONICAL_ALL_ONES));
+        let biggest =
+            std::option::extract(
+                &mut new_scalar_reduced_from_32_bytes(NON_CANONICAL_ALL_ONES)
+            );
         assert!(scalar_equals(&biggest, &Scalar { data: REDUCED_2_256_MINUS_1_SCALAR }), 1);
     }
 
@@ -1262,7 +1306,10 @@ module aptos_std::ristretto255 {
         std::vector::append(&mut x_plus_2_to_256_times_x, X_SCALAR);
         std::vector::append(&mut x_plus_2_to_256_times_x, X_SCALAR);
 
-        let reduced = std::option::extract(&mut new_scalar_uniform_from_64_bytes(x_plus_2_to_256_times_x));
+        let reduced =
+            std::option::extract(
+                &mut new_scalar_uniform_from_64_bytes(x_plus_2_to_256_times_x)
+            );
         let expected = Scalar { data: REDUCED_X_PLUS_2_TO_256_TIMES_X_SCALAR };
         assert!(scalar_equals(&reduced, &expected), 1)
     }
@@ -1298,7 +1345,7 @@ module aptos_std::ristretto255 {
     }
 
     #[test]
-    #[expected_failure(abort_code=0x090004, location=Self)]
+    #[expected_failure(abort_code = 0x090004, location = Self)]
     fun test_num_points_limit_exceeded() {
         let limit = 10001;
         let i = 0;

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255.move
@@ -290,7 +290,10 @@ module aptos_std::ristretto255 {
     /// Computes a double-scalar multiplication, returning a_1 p_1 + a_2 p_2
     /// This function is much faster than computing each a_i p_i using `point_mul` and adding up the results using `point_add`.
     public fun double_scalar_mul(
-        scalar1: &Scalar, point1: &RistrettoPoint, scalar2: &Scalar, point2: &RistrettoPoint
+        scalar1: &Scalar,
+        point1: &RistrettoPoint,
+        scalar2: &Scalar,
+        point2: &RistrettoPoint
     ): RistrettoPoint {
         if (!features::bulletproofs_enabled()) {
             abort(std::error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE))
@@ -298,7 +301,10 @@ module aptos_std::ristretto255 {
 
         RistrettoPoint {
             handle: double_scalar_mul_internal(
-                point1.handle, point2.handle, scalar1.data, scalar2.data
+                point1.handle,
+                point2.handle,
+                scalar1.data,
+                scalar2.data,
             )
         }
     }
@@ -312,7 +318,8 @@ module aptos_std::ristretto255 {
             !std::vector::is_empty(points), std::error::invalid_argument(E_ZERO_POINTS)
         );
         assert!(
-            !std::vector::is_empty(scalars), std::error::invalid_argument(E_ZERO_SCALARS)
+            !std::vector::is_empty(scalars),
+            std::error::invalid_argument(E_ZERO_SCALARS),
         );
         assert!(
             std::vector::length(points) == std::vector::length(scalars),
@@ -885,7 +892,9 @@ module aptos_std::ristretto255 {
     #[test(fx = @std)]
     fun test_basepoint_double_mul(fx: signer) {
         features::change_feature_flags_for_testing(
-            &fx, vector[features::get_bulletproofs_feature()], vector[]
+            &fx,
+            vector[features::get_bulletproofs_feature()],
+            vector[],
         );
 
         let expected =
@@ -971,14 +980,16 @@ module aptos_std::ristretto255 {
             new_scalar_from_sha2_512(b"2"),
             new_scalar_from_sha2_512(b"3"),
             new_scalar_from_sha2_512(b"4"),
-            new_scalar_from_sha2_512(b"5"),];
+            new_scalar_from_sha2_512(b"5"),
+        ];
 
         let points = vector[
             new_point_from_sha2_512(b"1"),
             new_point_from_sha2_512(b"2"),
             new_point_from_sha2_512(b"3"),
             new_point_from_sha2_512(b"4"),
-            new_point_from_sha2_512(b"5"),];
+            new_point_from_sha2_512(b"5"),
+        ];
 
         let expected =
             std::option::extract(
@@ -1034,7 +1045,8 @@ module aptos_std::ristretto255 {
         // Test (0 - 1) % order = order - 1
         assert!(
             scalar_equals(
-                &scalar_sub(&scalar_zero(), &scalar_one()), &Scalar { data: L_MINUS_ONE }
+                &scalar_sub(&scalar_zero(), &scalar_one()),
+                &Scalar { data: L_MINUS_ONE },
             ),
             1,
         );
@@ -1081,7 +1093,8 @@ module aptos_std::ristretto255 {
         // Non-canonical because high bit is set
         let non_canonical_highbit = vector[
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 128];
+            0, 0, 0, 0, 0, 128
+        ];
         let non_canonical_highbit_hex =
             x"0000000000000000000000000000000000000000000000000000000000000080";
         assert!(non_canonical_highbit == non_canonical_highbit_hex, 1);
@@ -1162,7 +1175,8 @@ module aptos_std::ristretto255 {
 
         let expected: vector<u8> = vector[
             21, 88, 208, 252, 63, 122, 210, 152, 154, 38, 15, 23, 16, 167, 80, 150, 192,
-            221, 77, 226, 62, 25, 224, 148, 239, 48, 176, 10, 185, 69, 168, 11];
+            221, 77, 226, 62, 25, 224, 148, 239, 48, 176, 10, 185, 69, 168, 11
+        ];
 
         assert!(s.data == expected, 1)
     }
@@ -1271,7 +1285,8 @@ module aptos_std::ristretto255 {
         // Subtraction reduces: 0 - 1 = \ell - 1
         let ell_minus_one = Scalar { data: L_MINUS_ONE };
         assert!(
-            scalar_equals(&scalar_sub(&scalar_zero(), &scalar_one()), &ell_minus_one), 1
+            scalar_equals(&scalar_sub(&scalar_zero(), &scalar_one()), &ell_minus_one),
+            1,
         );
 
         // 2 - 1 = 1

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255.spec.move
@@ -130,9 +130,13 @@ spec aptos_std::ristretto255 {
 
     spec new_scalar_from_bytes {
         aborts_if false;
-        ensures spec_scalar_is_canonical_internal(bytes) ==> (std::option::spec_is_some(result)
-            && std::option::spec_borrow(result).data == bytes);
-        ensures !spec_scalar_is_canonical_internal(bytes) ==> std::option::spec_is_none(result);
+        ensures spec_scalar_is_canonical_internal(bytes) ==>
+            (
+                std::option::spec_is_some(result)
+                    && std::option::spec_borrow(result).data == bytes
+            );
+        ensures !spec_scalar_is_canonical_internal(bytes) ==>
+            std::option::spec_is_none(result);
     }
 
     spec scalar_from_sha512_internal {
@@ -168,13 +172,19 @@ spec aptos_std::ristretto255 {
     }
 
     spec new_scalar_reduced_from_32_bytes {
-        ensures len(bytes) != 32 ==> std::option::spec_is_none(result);
-        ensures len(bytes) == 32 ==> std::option::spec_borrow(result).data == spec_scalar_reduced_from_32_bytes_internal(bytes);
+        ensures len(bytes) != 32 ==>
+            std::option::spec_is_none(result);
+        ensures len(bytes) == 32 ==>
+            std::option::spec_borrow(result).data
+                == spec_scalar_reduced_from_32_bytes_internal(bytes);
     }
 
     spec new_scalar_uniform_from_64_bytes {
-        ensures len(bytes) != 64 ==> std::option::spec_is_none(result);
-        ensures len(bytes) == 64 ==> std::option::spec_borrow(result).data == spec_scalar_uniform_from_64_bytes_internal(bytes);
+        ensures len(bytes) != 64 ==>
+            std::option::spec_is_none(result);
+        ensures len(bytes) == 64 ==>
+            std::option::spec_borrow(result).data
+                == spec_scalar_uniform_from_64_bytes_internal(bytes);
     }
 
     spec scalar_zero {
@@ -200,8 +210,14 @@ spec aptos_std::ristretto255 {
 
     spec scalar_invert {
         aborts_if false;
-        ensures spec_scalar_is_zero(s) ==> std::option::spec_is_none(result);
-        ensures !spec_scalar_is_zero(s) ==> (std::option::spec_is_some(result) && std::option::spec_borrow(result).data == spec_scalar_invert_internal(s.data));
+        ensures spec_scalar_is_zero(s) ==>
+            std::option::spec_is_none(result);
+        ensures !spec_scalar_is_zero(s) ==>
+            (
+                std::option::spec_is_some(result)
+                    && std::option::spec_borrow(result).data
+                        == spec_scalar_invert_internal(s.data)
+            );
     }
 
     spec scalar_mul_internal {
@@ -286,7 +302,9 @@ spec aptos_std::ristretto255 {
 
     spec fun spec_point_is_canonical_internal(bytes: vector<u8>): bool;
 
-    spec fun spec_double_scalar_mul_internal(point1: u64, point2: u64, scalar1: vector<u8>, scalar2: vector<u8>): u64;
+    spec fun spec_double_scalar_mul_internal(
+        point1: u64, point2: u64, scalar1: vector<u8>, scalar2: vector<u8>
+    ): u64;
 
     spec fun spec_multi_scalar_mul_internal<P, S>(points: vector<P>, scalars: vector<S>): u64;
 

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_bulletproofs.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_bulletproofs.move
@@ -14,7 +14,7 @@ module aptos_std::ristretto255_bulletproofs {
     //
 
     /// The maximum range supported by the Bulletproofs library is $[0, 2^{64})$.
-    const MAX_RANGE_BITS : u64 = 64;
+    const MAX_RANGE_BITS: u64 = 64;
 
     //
     // Error codes
@@ -54,9 +54,7 @@ module aptos_std::ristretto255_bulletproofs {
     /// Deserializes a range proof from a sequence of bytes. The serialization format is the same as the format in
     /// the zkcrypto's `bulletproofs` library (https://docs.rs/bulletproofs/4.0.0/bulletproofs/struct.RangeProof.html#method.from_bytes).
     public fun range_proof_from_bytes(bytes: vector<u8>): RangeProof {
-        RangeProof {
-            bytes
-        }
+        RangeProof { bytes }
     }
 
     /// Returns the byte-representation of a range proof.
@@ -71,15 +69,21 @@ module aptos_std::ristretto255_bulletproofs {
     ///
     /// WARNING: The DST check is VERY important for security as it prevents proofs computed for one application
     /// (a.k.a., a _domain_) with `dst_1` from verifying in a different application with `dst_2 != dst_1`.
-    public fun verify_range_proof_pedersen(com: &pedersen::Commitment, proof: &RangeProof, num_bits: u64, dst: vector<u8>): bool {
-        assert!(features::bulletproofs_enabled(), error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE));
+    public fun verify_range_proof_pedersen(
+        com: &pedersen::Commitment, proof: &RangeProof, num_bits: u64, dst: vector<u8>
+    ): bool {
+        assert!(
+            features::bulletproofs_enabled(),
+            error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE),
+        );
 
         verify_range_proof_internal(
             ristretto255::point_to_bytes(&pedersen::commitment_as_compressed_point(com)),
-            &ristretto255::basepoint(), &ristretto255::hash_to_point_base(),
+            &ristretto255::basepoint(),
+            &ristretto255::hash_to_point_base(),
             proof.bytes,
             num_bits,
-            dst
+            dst,
         )
     }
 
@@ -87,15 +91,24 @@ module aptos_std::ristretto255_bulletproofs {
     /// for some randomness `r`) satisfies `v` in `[0, 2^num_bits)`. Only works for `num_bits` in `{8, 16, 32, 64}`.
     public fun verify_range_proof(
         com: &RistrettoPoint,
-        val_base: &RistrettoPoint, rand_base: &RistrettoPoint,
-        proof: &RangeProof, num_bits: u64, dst: vector<u8>): bool
-    {
-        assert!(features::bulletproofs_enabled(), error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE));
+        val_base: &RistrettoPoint,
+        rand_base: &RistrettoPoint,
+        proof: &RangeProof,
+        num_bits: u64,
+        dst: vector<u8>
+    ): bool {
+        assert!(
+            features::bulletproofs_enabled(),
+            error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE),
+        );
 
         verify_range_proof_internal(
             ristretto255::point_to_bytes(&ristretto255::point_compress(com)),
-            val_base, rand_base,
-            proof.bytes, num_bits, dst
+            val_base,
+            rand_base,
+            proof.bytes,
+            num_bits,
+            dst,
         )
     }
 
@@ -103,15 +116,22 @@ module aptos_std::ristretto255_bulletproofs {
     /// Computes a range proof for the Pedersen commitment to 'val' with randomness 'r', under the default Bulletproofs
     /// commitment key; see `pedersen::new_commitment_for_bulletproof`. Returns the said commitment too.
     ///  Only works for `num_bits` in `{8, 16, 32, 64}`.
-    public fun prove_range_pedersen(val: &Scalar, r: &Scalar, num_bits: u64, dst: vector<u8>): (RangeProof, pedersen::Commitment) {
-        let (bytes, compressed_comm) = prove_range_internal(scalar_to_bytes(val), scalar_to_bytes(r), num_bits, dst, &ristretto255::basepoint(), &ristretto255::hash_to_point_base());
+    public fun prove_range_pedersen(
+        val: &Scalar, r: &Scalar, num_bits: u64, dst: vector<u8>
+    ): (RangeProof, pedersen::Commitment) {
+        let (bytes, compressed_comm) =
+            prove_range_internal(
+                scalar_to_bytes(val),
+                scalar_to_bytes(r),
+                num_bits,
+                dst,
+                &ristretto255::basepoint(),
+                &ristretto255::hash_to_point_base(),
+            );
         let point = ristretto255::new_compressed_point_from_bytes(compressed_comm);
         let point = &std::option::extract(&mut point);
 
-        (
-            RangeProof { bytes },
-            pedersen::commitment_from_compressed(point)
-        )
+        (RangeProof { bytes }, pedersen::commitment_from_compressed(point))
     }
 
     //
@@ -127,7 +147,8 @@ module aptos_std::ristretto255_bulletproofs {
         rand_base: &RistrettoPoint,
         proof: vector<u8>,
         num_bits: u64,
-        dst: vector<u8>): bool;
+        dst: vector<u8>
+    ): bool;
 
     #[test_only]
     /// Returns a tuple consisting of (1) a range proof for 'val' committed with randomness 'r' under the default Bulletproofs
@@ -141,7 +162,8 @@ module aptos_std::ristretto255_bulletproofs {
         num_bits: u64,
         dst: vector<u8>,
         val_base: &RistrettoPoint,
-        rand_base: &RistrettoPoint): (vector<u8>, vector<u8>);
+        rand_base: &RistrettoPoint
+    ): (vector<u8>, vector<u8>);
 
     //
     // Testing
@@ -153,7 +175,7 @@ module aptos_std::ristretto255_bulletproofs {
     #[test_only]
     const A_DST: vector<u8> = b"AptosBulletproofs";
     #[test_only]
-    const A_VALUE: vector<u8> = x"870c2fa1b2e9ac45000000000000000000000000000000000000000000000000";  // i.e., 5020644638028926087u64
+    const A_VALUE: vector<u8> = x"870c2fa1b2e9ac45000000000000000000000000000000000000000000000000"; // i.e., 5020644638028926087u64
     #[test_only]
     const A_BLINDER: vector<u8> = x"e7c7b42b75503bfc7b1932783786d227ebf88f79da752b68f6b865a9c179640c";
     // Pedersen commitment to A_VALUE with randomness A_BLINDER
@@ -166,20 +188,30 @@ module aptos_std::ristretto255_bulletproofs {
     #[test(fx = @std)]
     #[expected_failure(abort_code = 0x010003, location = Self)]
     fun test_unsupported_ranges(fx: signer) {
-        features::change_feature_flags_for_testing(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
+        features::change_feature_flags_for_testing(
+            &fx, vector[features::get_bulletproofs_feature()], vector[]
+        );
 
         let comm = ristretto255::new_point_from_bytes(A_COMM);
         let comm = std::option::extract(&mut comm);
         let comm = pedersen::commitment_from_point(comm);
 
-        assert!(verify_range_proof_pedersen(
-            &comm,
-            &range_proof_from_bytes(A_RANGE_PROOF_PEDERSEN), 10, A_DST), 1);
+        assert!(
+            verify_range_proof_pedersen(
+                &comm,
+                &range_proof_from_bytes(A_RANGE_PROOF_PEDERSEN),
+                10,
+                A_DST,
+            ),
+            1,
+        );
     }
 
     #[test(fx = @std)]
     fun test_prover(fx: signer) {
-        features::change_feature_flags_for_testing(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
+        features::change_feature_flags_for_testing(
+            &fx, vector[features::get_bulletproofs_feature()], vector[]
+        );
 
         let v = ristretto255::new_scalar_from_u64(59);
         let r = ristretto255::new_scalar_from_bytes(A_BLINDER);
@@ -197,14 +229,17 @@ module aptos_std::ristretto255_bulletproofs {
     #[test(fx = @std)]
     #[expected_failure(abort_code = 0x010001, location = Self)]
     fun test_empty_range_proof(fx: signer) {
-        features::change_feature_flags_for_testing(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
-
-        let proof = &range_proof_from_bytes(vector[ ]);
-        let num_bits = 64;
-        let com = pedersen::new_commitment_for_bulletproof(
-            &ristretto255::scalar_one(),
-            &ristretto255::new_scalar_from_sha2_512(b"hello random world")
+        features::change_feature_flags_for_testing(
+            &fx, vector[features::get_bulletproofs_feature()], vector[]
         );
+
+        let proof = &range_proof_from_bytes(vector[]);
+        let num_bits = 64;
+        let com =
+            pedersen::new_commitment_for_bulletproof(
+                &ristretto255::scalar_one(),
+                &ristretto255::new_scalar_from_sha2_512(b"hello random world"),
+            );
 
         // This will fail with error::invalid_argument(E_DESERIALIZE_RANGE_PROOF)
         verify_range_proof_pedersen(&com, proof, num_bits, A_DST);
@@ -212,7 +247,9 @@ module aptos_std::ristretto255_bulletproofs {
 
     #[test(fx = @std)]
     fun test_valid_range_proof_verifies_against_comm(fx: signer) {
-        features::change_feature_flags_for_testing(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
+        features::change_feature_flags_for_testing(
+            &fx, vector[features::get_bulletproofs_feature()], vector[]
+        );
 
         let value = ristretto255::new_scalar_from_bytes(A_VALUE);
         let value = std::option::extract(&mut value);
@@ -222,17 +259,26 @@ module aptos_std::ristretto255_bulletproofs {
 
         let comm = pedersen::new_commitment_for_bulletproof(&value, &blinder);
 
-        let expected_comm = std::option::extract(&mut ristretto255::new_point_from_bytes(A_COMM));
+        let expected_comm =
+            std::option::extract(&mut ristretto255::new_point_from_bytes(A_COMM));
         assert!(point_equals(pedersen::commitment_as_point(&comm), &expected_comm), 1);
 
-        assert!(verify_range_proof_pedersen(
-            &comm,
-            &range_proof_from_bytes(A_RANGE_PROOF_PEDERSEN), MAX_RANGE_BITS, A_DST), 1);
+        assert!(
+            verify_range_proof_pedersen(
+                &comm,
+                &range_proof_from_bytes(A_RANGE_PROOF_PEDERSEN),
+                MAX_RANGE_BITS,
+                A_DST,
+            ),
+            1,
+        );
     }
 
     #[test(fx = @std)]
     fun test_invalid_range_proof_fails_verification(fx: signer) {
-        features::change_feature_flags_for_testing(&fx, vector[ features::get_bulletproofs_feature() ], vector[]);
+        features::change_feature_flags_for_testing(
+            &fx, vector[features::get_bulletproofs_feature()], vector[]
+        );
 
         let comm = ristretto255::new_point_from_bytes(A_COMM);
         let comm = std::option::extract(&mut comm);
@@ -246,8 +292,14 @@ module aptos_std::ristretto255_bulletproofs {
         let byte = std::vector::borrow_mut(&mut range_proof_invalid, pos);
         *byte = *byte + 1;
 
-        assert!(verify_range_proof_pedersen(
-            &comm,
-            &range_proof_from_bytes(range_proof_invalid), MAX_RANGE_BITS, A_DST) == false, 1);
+        assert!(
+            verify_range_proof_pedersen(
+                &comm,
+                &range_proof_from_bytes(range_proof_invalid),
+                MAX_RANGE_BITS,
+                A_DST,
+            ) == false,
+            1,
+        );
     }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_bulletproofs.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_bulletproofs.move
@@ -189,7 +189,9 @@ module aptos_std::ristretto255_bulletproofs {
     #[expected_failure(abort_code = 0x010003, location = Self)]
     fun test_unsupported_ranges(fx: signer) {
         features::change_feature_flags_for_testing(
-            &fx, vector[features::get_bulletproofs_feature()], vector[]
+            &fx,
+            vector[features::get_bulletproofs_feature()],
+            vector[],
         );
 
         let comm = ristretto255::new_point_from_bytes(A_COMM);
@@ -210,7 +212,9 @@ module aptos_std::ristretto255_bulletproofs {
     #[test(fx = @std)]
     fun test_prover(fx: signer) {
         features::change_feature_flags_for_testing(
-            &fx, vector[features::get_bulletproofs_feature()], vector[]
+            &fx,
+            vector[features::get_bulletproofs_feature()],
+            vector[],
         );
 
         let v = ristretto255::new_scalar_from_u64(59);
@@ -230,7 +234,9 @@ module aptos_std::ristretto255_bulletproofs {
     #[expected_failure(abort_code = 0x010001, location = Self)]
     fun test_empty_range_proof(fx: signer) {
         features::change_feature_flags_for_testing(
-            &fx, vector[features::get_bulletproofs_feature()], vector[]
+            &fx,
+            vector[features::get_bulletproofs_feature()],
+            vector[],
         );
 
         let proof = &range_proof_from_bytes(vector[]);
@@ -248,7 +254,9 @@ module aptos_std::ristretto255_bulletproofs {
     #[test(fx = @std)]
     fun test_valid_range_proof_verifies_against_comm(fx: signer) {
         features::change_feature_flags_for_testing(
-            &fx, vector[features::get_bulletproofs_feature()], vector[]
+            &fx,
+            vector[features::get_bulletproofs_feature()],
+            vector[],
         );
 
         let value = ristretto255::new_scalar_from_bytes(A_VALUE);
@@ -277,7 +285,9 @@ module aptos_std::ristretto255_bulletproofs {
     #[test(fx = @std)]
     fun test_invalid_range_proof_fails_verification(fx: signer) {
         features::change_feature_flags_for_testing(
-            &fx, vector[features::get_bulletproofs_feature()], vector[]
+            &fx,
+            vector[features::get_bulletproofs_feature()],
+            vector[],
         );
 
         let comm = ristretto255::new_point_from_bytes(A_COMM);

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_elgamal.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_elgamal.move
@@ -83,7 +83,7 @@ module aptos_std::ristretto255_elgamal {
         let right_point = ristretto255::new_point_from_bytes(bytes_right);
 
         if (std::option::is_some<RistrettoPoint>(&mut left_point)
-                && std::option::is_some<RistrettoPoint>(&mut right_point)) {
+            && std::option::is_some<RistrettoPoint>(&mut right_point)) {
             std::option::some<Ciphertext>(
                 Ciphertext {
                     left: std::option::extract<RistrettoPoint>(&mut left_point),

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_elgamal.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_elgamal.move
@@ -9,7 +9,13 @@
 /// are the randomness of the ciphertexts.
 
 module aptos_std::ristretto255_elgamal {
-    use aptos_std::ristretto255::{Self, RistrettoPoint, Scalar, CompressedRistretto, point_compress};
+    use aptos_std::ristretto255::{
+        Self,
+        RistrettoPoint,
+        Scalar,
+        CompressedRistretto,
+        point_compress
+    };
     use std::option::Option;
     use std::vector;
 
@@ -19,8 +25,8 @@ module aptos_std::ristretto255_elgamal {
 
     /// An ElGamal ciphertext.
     struct Ciphertext has drop {
-        left: RistrettoPoint,   // v * G + r * Y
-        right: RistrettoPoint,  // r * G
+        left: RistrettoPoint, // v * G + r * Y
+        right: RistrettoPoint, // r * G
     }
 
     /// A compressed ElGamal ciphertext.
@@ -42,9 +48,7 @@ module aptos_std::ristretto255_elgamal {
     public fun new_pubkey_from_bytes(bytes: vector<u8>): Option<CompressedPubkey> {
         let point = ristretto255::new_compressed_point_from_bytes(bytes);
         if (std::option::is_some(&mut point)) {
-            let pk = CompressedPubkey {
-                point: std::option::extract(&mut point)
-            };
+            let pk = CompressedPubkey { point: std::option::extract(&mut point) };
             std::option::some(pk)
         } else {
             std::option::none<CompressedPubkey>()
@@ -69,7 +73,7 @@ module aptos_std::ristretto255_elgamal {
     /// Creates a new ciphertext from two serialized Ristretto255 points: the first 32 bytes store `r * G` while the
     /// next 32 bytes store `v * G + r * Y`, where `Y` is the public key.
     public fun new_ciphertext_from_bytes(bytes: vector<u8>): Option<Ciphertext> {
-        if(vector::length(&bytes) != 64) {
+        if (vector::length(&bytes) != 64) {
             return std::option::none<Ciphertext>()
         };
 
@@ -78,11 +82,14 @@ module aptos_std::ristretto255_elgamal {
         let left_point = ristretto255::new_point_from_bytes(bytes);
         let right_point = ristretto255::new_point_from_bytes(bytes_right);
 
-        if (std::option::is_some<RistrettoPoint>(&mut left_point) && std::option::is_some<RistrettoPoint>(&mut right_point)) {
-            std::option::some<Ciphertext>(Ciphertext {
-                left: std::option::extract<RistrettoPoint>(&mut left_point),
-                right: std::option::extract<RistrettoPoint>(&mut right_point)
-            })
+        if (std::option::is_some<RistrettoPoint>(&mut left_point)
+                && std::option::is_some<RistrettoPoint>(&mut right_point)) {
+            std::option::some<Ciphertext>(
+                Ciphertext {
+                    left: std::option::extract<RistrettoPoint>(&mut left_point),
+                    right: std::option::extract<RistrettoPoint>(&mut right_point)
+                },
+            )
         } else {
             std::option::none<Ciphertext>()
         }
@@ -98,25 +105,25 @@ module aptos_std::ristretto255_elgamal {
     }
 
     /// Moves a pair of Ristretto points into an ElGamal ciphertext.
-    public fun ciphertext_from_points(left: RistrettoPoint, right: RistrettoPoint): Ciphertext {
-        Ciphertext {
-            left,
-            right,
-        }
+    public fun ciphertext_from_points(
+        left: RistrettoPoint, right: RistrettoPoint
+    ): Ciphertext {
+        Ciphertext { left, right, }
     }
 
     /// Moves a pair of `CompressedRistretto` points into an ElGamal ciphertext.
-    public fun ciphertext_from_compressed_points(left: CompressedRistretto, right: CompressedRistretto): CompressedCiphertext {
-        CompressedCiphertext {
-            left,
-            right,
-        }
+    public fun ciphertext_from_compressed_points(
+        left: CompressedRistretto, right: CompressedRistretto
+    ): CompressedCiphertext {
+        CompressedCiphertext { left, right, }
     }
 
     /// Given a ciphertext `ct`, serializes that ciphertext into bytes.
     public fun ciphertext_to_bytes(ct: &Ciphertext): vector<u8> {
-        let bytes_left = ristretto255::point_to_bytes(&ristretto255::point_compress(&ct.left));
-        let bytes_right = ristretto255::point_to_bytes(&ristretto255::point_compress(&ct.right));
+        let bytes_left =
+            ristretto255::point_to_bytes(&ristretto255::point_compress(&ct.left));
+        let bytes_right =
+            ristretto255::point_to_bytes(&ristretto255::point_compress(&ct.right));
         let bytes = vector::empty<u8>();
         vector::append<u8>(&mut bytes, bytes_left);
         vector::append<u8>(&mut bytes, bytes_right);
@@ -160,7 +167,9 @@ module aptos_std::ristretto255_elgamal {
     }
 
     /// Like `ciphertext_add` but assigns `lhs = lhs + rhs`.
-    public fun ciphertext_add_assign(lhs: &mut Ciphertext, rhs: &Ciphertext) {
+    public fun ciphertext_add_assign(
+        lhs: &mut Ciphertext, rhs: &Ciphertext
+    ) {
         ristretto255::point_add_assign(&mut lhs.left, &rhs.left);
         ristretto255::point_add_assign(&mut lhs.right, &rhs.right);
     }
@@ -175,7 +184,9 @@ module aptos_std::ristretto255_elgamal {
     }
 
     /// Like `ciphertext_add` but assigns `lhs = lhs - rhs`.
-    public fun ciphertext_sub_assign(lhs: &mut Ciphertext, rhs: &Ciphertext) {
+    public fun ciphertext_sub_assign(
+        lhs: &mut Ciphertext, rhs: &Ciphertext
+    ) {
         ristretto255::point_sub_assign(&mut lhs.left, &rhs.left);
         ristretto255::point_sub_assign(&mut lhs.right, &rhs.right);
     }
@@ -190,8 +201,8 @@ module aptos_std::ristretto255_elgamal {
 
     /// Returns true if the two ciphertexts are identical: i.e., same value and same randomness.
     public fun ciphertext_equals(lhs: &Ciphertext, rhs: &Ciphertext): bool {
-        ristretto255::point_equals(&lhs.left, &rhs.left) &&
-        ristretto255::point_equals(&lhs.right, &rhs.right)
+        ristretto255::point_equals(&lhs.left, &rhs.left)
+            && ristretto255::point_equals(&lhs.right, &rhs.right)
     }
 
     /// Returns the `RistrettoPoint` in the ciphertext which contains the encrypted value in the exponent.
@@ -207,15 +218,15 @@ module aptos_std::ristretto255_elgamal {
     /// Given an ElGamal secret key `sk`, returns the corresponding ElGamal public key as `sk * G`.
     public fun pubkey_from_secret_key(sk: &Scalar): CompressedPubkey {
         let point = ristretto255::basepoint_mul(sk);
-        CompressedPubkey {
-            point: point_compress(&point)
-        }
+        CompressedPubkey { point: point_compress(&point) }
     }
 
     #[test_only]
     /// Returns a ciphertext (v * point + r * pubkey, r * point) where `point` is *any* Ristretto255 point,
     /// `pubkey` is the public key and `r` is the randomness.
-    public fun new_ciphertext(v: &Scalar, point: &RistrettoPoint, r: &Scalar, pubkey: &CompressedPubkey): Ciphertext {
+    public fun new_ciphertext(
+        v: &Scalar, point: &RistrettoPoint, r: &Scalar, pubkey: &CompressedPubkey
+    ): Ciphertext {
         Ciphertext {
             left: ristretto255::double_scalar_mul(v, point, r, &pubkey_to_point(pubkey)),
             right: ristretto255::point_mul(point, r),
@@ -225,7 +236,9 @@ module aptos_std::ristretto255_elgamal {
     #[test_only]
     /// Returns a ciphertext (v * basepoint + r * pubkey, r * basepoint) where `basepoint` is the Ristretto255 basepoint
     /// `pubkey` is the public key and `r` is the randomness.
-    public fun new_ciphertext_with_basepoint(v: &Scalar, r: &Scalar, pubkey: &CompressedPubkey): Ciphertext {
+    public fun new_ciphertext_with_basepoint(
+        v: &Scalar, r: &Scalar, pubkey: &CompressedPubkey
+    ): Ciphertext {
         Ciphertext {
             left: ristretto255::basepoint_double_mul(r, &pubkey_to_point(pubkey), v),
             right: ristretto255::basepoint_mul(r),

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_elgamal.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_elgamal.spec.move
@@ -1,2 +1,1 @@
-spec aptos_std::ristretto255_elgamal {
-}
+spec aptos_std::ristretto255_elgamal {}

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_pedersen.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_pedersen.move
@@ -153,7 +153,7 @@ module aptos_std::ristretto255_pedersen {
         std::option::extract(
             &mut ristretto255::new_point_from_bytes(
                 BULLETPROOF_DEFAULT_PEDERSEN_RAND_BASE
-            )
+            ),
         )
     }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_pedersen.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_pedersen.move
@@ -4,7 +4,13 @@
 /// A Pedersen commitment to a value `v` under _commitment key_ `(g, h)` is `v * g + r * h`, for a random scalar `r`.
 
 module aptos_std::ristretto255_pedersen {
-    use aptos_std::ristretto255::{Self, RistrettoPoint, Scalar, CompressedRistretto, point_compress};
+    use aptos_std::ristretto255::{
+        Self,
+        RistrettoPoint,
+        Scalar,
+        CompressedRistretto,
+        point_compress
+    };
     use std::option::Option;
 
     //
@@ -13,7 +19,7 @@ module aptos_std::ristretto255_pedersen {
 
     /// The default Pedersen randomness base `h` used in our underlying Bulletproofs library.
     /// This is obtained by hashing the compressed Ristretto255 basepoint using SHA3-512 (not SHA2-512).
-    const BULLETPROOF_DEFAULT_PEDERSEN_RAND_BASE : vector<u8> = x"8c9240b456a9e6dc65c377a1048d745f94a08cdb7f44cbcd7b46f34048871134";
+    const BULLETPROOF_DEFAULT_PEDERSEN_RAND_BASE: vector<u8> = x"8c9240b456a9e6dc65c377a1048d745f94a08cdb7f44cbcd7b46f34048871134";
 
     //
     // Structs
@@ -32,9 +38,7 @@ module aptos_std::ristretto255_pedersen {
     public fun new_commitment_from_bytes(bytes: vector<u8>): Option<Commitment> {
         let point = ristretto255::new_point_from_bytes(bytes);
         if (std::option::is_some(&mut point)) {
-            let comm = Commitment {
-                point: std::option::extract(&mut point)
-            };
+            let comm = Commitment { point: std::option::extract(&mut point) };
             std::option::some(comm)
         } else {
             std::option::none<Commitment>()
@@ -48,74 +52,67 @@ module aptos_std::ristretto255_pedersen {
 
     /// Moves a Ristretto point into a Pedersen commitment.
     public fun commitment_from_point(point: RistrettoPoint): Commitment {
-        Commitment {
-            point
-        }
+        Commitment { point }
     }
 
     /// Deserializes a commitment from a compressed Ristretto point.
     public fun commitment_from_compressed(point: &CompressedRistretto): Commitment {
-        Commitment {
-            point: ristretto255::point_decompress(point)
-        }
+        Commitment { point: ristretto255::point_decompress(point) }
     }
 
     /// Returns a commitment `v * val_base + r * rand_base` where `(val_base, rand_base)` is the commitment key.
-    public fun new_commitment(v: &Scalar, val_base: &RistrettoPoint, r: &Scalar, rand_base: &RistrettoPoint): Commitment {
-        Commitment {
-            point: ristretto255::double_scalar_mul(v, val_base, r, rand_base)
-        }
+    public fun new_commitment(
+        v: &Scalar, val_base: &RistrettoPoint, r: &Scalar, rand_base: &RistrettoPoint
+    ): Commitment {
+        Commitment { point: ristretto255::double_scalar_mul(v, val_base, r, rand_base) }
     }
 
     /// Returns a commitment `v * G + r * rand_base` where `G` is the Ristretto255 basepoint.
-    public fun new_commitment_with_basepoint(v: &Scalar, r: &Scalar, rand_base: &RistrettoPoint): Commitment {
-        Commitment {
-            point: ristretto255::basepoint_double_mul(r, rand_base, v)
-        }
+    public fun new_commitment_with_basepoint(
+        v: &Scalar, r: &Scalar, rand_base: &RistrettoPoint
+    ): Commitment {
+        Commitment { point: ristretto255::basepoint_double_mul(r, rand_base, v) }
     }
 
     /// Returns a commitment `v * G + r * H` where `G` is the Ristretto255 basepoint and `H` is the default randomness
     /// base used in the Bulletproofs library (i.e., `BULLETPROOF_DEFAULT_PEDERSEN_RAND_BASE`).
     public fun new_commitment_for_bulletproof(v: &Scalar, r: &Scalar): Commitment {
-        let rand_base = ristretto255::new_point_from_bytes(BULLETPROOF_DEFAULT_PEDERSEN_RAND_BASE);
+        let rand_base =
+            ristretto255::new_point_from_bytes(BULLETPROOF_DEFAULT_PEDERSEN_RAND_BASE);
         let rand_base = std::option::extract(&mut rand_base);
 
-        Commitment {
-            point: ristretto255::basepoint_double_mul(r, &rand_base, v)
-        }
+        Commitment { point: ristretto255::basepoint_double_mul(r, &rand_base, v) }
     }
 
     /// Homomorphically combines two commitments `lhs` and `rhs` as `lhs + rhs`.
     /// Useful for re-randomizing the commitment or updating the committed value.
     public fun commitment_add(lhs: &Commitment, rhs: &Commitment): Commitment {
-        Commitment {
-            point: ristretto255::point_add(&lhs.point, &rhs.point)
-        }
+        Commitment { point: ristretto255::point_add(&lhs.point, &rhs.point) }
     }
 
     /// Like `commitment_add` but assigns `lhs = lhs + rhs`.
-    public fun commitment_add_assign(lhs: &mut Commitment, rhs: &Commitment) {
+    public fun commitment_add_assign(
+        lhs: &mut Commitment, rhs: &Commitment
+    ) {
         ristretto255::point_add_assign(&mut lhs.point, &rhs.point);
     }
 
     /// Homomorphically combines two commitments `lhs` and `rhs` as `lhs - rhs`.
     /// Useful for re-randomizing the commitment or updating the committed value.
     public fun commitment_sub(lhs: &Commitment, rhs: &Commitment): Commitment {
-        Commitment {
-            point: ristretto255::point_sub(&lhs.point, &rhs.point)
-        }
+        Commitment { point: ristretto255::point_sub(&lhs.point, &rhs.point) }
     }
 
     /// Like `commitment_add` but assigns `lhs = lhs - rhs`.
-    public fun commitment_sub_assign(lhs: &mut Commitment, rhs: &Commitment) {
+    public fun commitment_sub_assign(
+        lhs: &mut Commitment, rhs: &Commitment
+    ) {
         ristretto255::point_sub_assign(&mut lhs.point, &rhs.point);
     }
 
     /// Creates a copy of this commitment.
     public fun commitment_clone(c: &Commitment): Commitment {
-        Commitment {
-            point: ristretto255::point_clone(&c.point)
-        }
+        Commitment { point: ristretto255::point_clone(&c.point) }
     }
 
     /// Returns true if the two commitments are identical: i.e., same value and same randomness.
@@ -153,6 +150,10 @@ module aptos_std::ristretto255_pedersen {
     /// Bulletproof has a default choice for `g` and `h` and this function returns the default `h` as used in the
     /// Bulletproofs Move module.
     public fun randomness_base_for_bulletproof(): RistrettoPoint {
-        std::option::extract(&mut ristretto255::new_point_from_bytes(BULLETPROOF_DEFAULT_PEDERSEN_RAND_BASE))
+        std::option::extract(
+            &mut ristretto255::new_point_from_bytes(
+                BULLETPROOF_DEFAULT_PEDERSEN_RAND_BASE
+            )
+        )
     }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_pedersen.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255_pedersen.spec.move
@@ -1,2 +1,1 @@
-spec aptos_std::ristretto255_pedersen {
-}
+spec aptos_std::ristretto255_pedersen {}

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/secp256k1.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/secp256k1.move
@@ -4,7 +4,7 @@ module aptos_std::secp256k1 {
     use std::option::Option;
 
     /// An error occurred while deserializing, for example due to wrong input size.
-    const E_DESERIALIZE: u64 = 1;   // This code must be the same, if ever returned from the native Rust implementation.
+    const E_DESERIALIZE: u64 = 1; // This code must be the same, if ever returned from the native Rust implementation.
 
     /// The size of a secp256k1-based ECDSA public key, in bytes.
     const RAW_PUBLIC_KEY_NUM_BYTES: u64 = 64;
@@ -25,13 +25,19 @@ module aptos_std::secp256k1 {
 
     /// Constructs an ECDSASignature struct from the given 64 bytes.
     public fun ecdsa_signature_from_bytes(bytes: vector<u8>): ECDSASignature {
-        assert!(std::vector::length(&bytes) == SIGNATURE_NUM_BYTES, std::error::invalid_argument(E_DESERIALIZE));
+        assert!(
+            std::vector::length(&bytes) == SIGNATURE_NUM_BYTES,
+            std::error::invalid_argument(E_DESERIALIZE),
+        );
         ECDSASignature { bytes }
     }
 
     /// Constructs an ECDSARawPublicKey struct, given a 64-byte raw representation.
     public fun ecdsa_raw_public_key_from_64_bytes(bytes: vector<u8>): ECDSARawPublicKey {
-        assert!(std::vector::length(&bytes) == RAW_PUBLIC_KEY_NUM_BYTES, std::error::invalid_argument(E_DESERIALIZE));
+        assert!(
+            std::vector::length(&bytes) == RAW_PUBLIC_KEY_NUM_BYTES,
+            std::error::invalid_argument(E_DESERIALIZE),
+        );
         ECDSARawPublicKey { bytes }
     }
 
@@ -71,9 +77,7 @@ module aptos_std::secp256k1 {
     /// Returns `(public_key, true)` if `signature` verifies on `message` under the recovered `public_key`
     /// and returns `([], false)` otherwise.
     native fun ecdsa_recover_internal(
-        message: vector<u8>,
-        recovery_id: u8,
-        signature: vector<u8>
+        message: vector<u8>, recovery_id: u8, signature: vector<u8>
     ): (vector<u8>, bool);
 
     //
@@ -85,30 +89,47 @@ module aptos_std::secp256k1 {
     fun test_ecdsa_recover() {
         use std::hash;
 
-        let pk = ecdsa_recover(
-            hash::sha2_256(b"test aptos secp256k1"),
-            0,
-            &ECDSASignature { bytes: x"f7ad936da03f948c14c542020e3c5f4e02aaacd1f20427c11aa6e2fbf8776477646bba0e1a37f9e7c777c423a1d2849baafd7ff6a9930814a43c3f80d59db56f" },
-        );
+        let pk =
+            ecdsa_recover(
+                hash::sha2_256(b"test aptos secp256k1"),
+                0,
+                &ECDSASignature {
+                    bytes: x"f7ad936da03f948c14c542020e3c5f4e02aaacd1f20427c11aa6e2fbf8776477646bba0e1a37f9e7c777c423a1d2849baafd7ff6a9930814a43c3f80d59db56f"
+                },
+            );
         assert!(std::option::is_some(&pk), 1);
-        assert!(std::option::extract(&mut pk).bytes == x"4646ae5047316b4230d0086c8acec687f00b1cd9d1dc634f6cb358ac0a9a8ffffe77b4dd0a4bfb95851f3b7355c781dd60f8418fc8a65d14907aff47c903a559", 1);
+        assert!(
+            std::option::extract(&mut pk).bytes
+                == x"4646ae5047316b4230d0086c8acec687f00b1cd9d1dc634f6cb358ac0a9a8ffffe77b4dd0a4bfb95851f3b7355c781dd60f8418fc8a65d14907aff47c903a559",
+            1,
+        );
 
         // Flipped bits; Signature stays valid
-        let pk = ecdsa_recover(
-            hash::sha2_256(b"test aptos secp256k1"),
-            0,
-            // NOTE: A '7' was flipped to an 'f' here
-            &ECDSASignature { bytes: x"f7ad936da03f948c14c542020e3c5f4e02aaacd1f20427c11aa6e2fbf8776477646bba0e1a37f9e7c7f7c423a1d2849baafd7ff6a9930814a43c3f80d59db56f" },
-        );
+        let pk =
+            ecdsa_recover(
+                hash::sha2_256(b"test aptos secp256k1"),
+                0,
+                // NOTE: A '7' was flipped to an 'f' here
+                &ECDSASignature {
+                    bytes: x"f7ad936da03f948c14c542020e3c5f4e02aaacd1f20427c11aa6e2fbf8776477646bba0e1a37f9e7c7f7c423a1d2849baafd7ff6a9930814a43c3f80d59db56f"
+                },
+            );
         assert!(std::option::is_some(&pk), 1);
-        assert!(std::option::extract(&mut pk).bytes != x"4646ae5047316b4230d0086c8acec687f00b1cd9d1dc634f6cb358ac0a9a8ffffe77b4dd0a4bfb95851f3b7355c781dd60f8418fc8a65d14907aff47c903a559", 1);
+        assert!(
+            std::option::extract(&mut pk).bytes
+                != x"4646ae5047316b4230d0086c8acec687f00b1cd9d1dc634f6cb358ac0a9a8ffffe77b4dd0a4bfb95851f3b7355c781dd60f8418fc8a65d14907aff47c903a559",
+            1,
+        );
 
         // Flipped bits; Signature becomes invalid
-        let pk = ecdsa_recover(
-            hash::sha2_256(b"test aptos secp256k1"),
-            0,
-            &ECDSASignature { bytes: x"ffad936da03f948c14c542020e3c5f4e02aaacd1f20427c11aa6e2fbf8776477646bba0e1a37f9e7c7f7c423a1d2849baafd7ff6a9930814a43c3f80d59db56f" },
-        );
+        let pk =
+            ecdsa_recover(
+                hash::sha2_256(b"test aptos secp256k1"),
+                0,
+                &ECDSASignature {
+                    bytes: x"ffad936da03f948c14c542020e3c5f4e02aaacd1f20427c11aa6e2fbf8776477646bba0e1a37f9e7c7f7c423a1d2849baafd7ff6a9930814a43c3f80d59db56f"
+                },
+            );
         assert!(std::option::is_none(&pk), 1);
     }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/secp256k1.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/secp256k1.spec.move
@@ -19,31 +19,47 @@ spec aptos_std::secp256k1 {
         ensures result == sig.bytes;
     }
 
-    spec ecdsa_recover(
-        message: vector<u8>,
-        recovery_id: u8,
-        signature: &ECDSASignature,
-    ): Option<ECDSARawPublicKey> {
-        aborts_if ecdsa_recover_internal_abort_condition(message, recovery_id, signature.bytes);
-        let pk = spec_ecdsa_recover_internal_result_1(message, recovery_id, signature.bytes);
-        let success = spec_ecdsa_recover_internal_result_2(message, recovery_id, signature.bytes);
-        ensures success ==> result == std::option::spec_some(ecdsa_raw_public_key_from_64_bytes(pk));
-        ensures !success ==> result == std::option::spec_none<ECDSARawPublicKey>();
+    spec ecdsa_recover(message: vector<u8>, recovery_id: u8, signature: &ECDSASignature,): Option<
+        ECDSARawPublicKey> {
+        aborts_if ecdsa_recover_internal_abort_condition(
+            message, recovery_id, signature.bytes
+        );
+        let pk = spec_ecdsa_recover_internal_result_1(
+            message, recovery_id, signature.bytes
+        );
+        let success = spec_ecdsa_recover_internal_result_2(
+            message, recovery_id, signature.bytes
+        );
+        ensures success ==>
+            result == std::option::spec_some(ecdsa_raw_public_key_from_64_bytes(pk));
+        ensures !success ==>
+            result == std::option::spec_none<ECDSARawPublicKey>();
     }
 
-    spec ecdsa_recover_internal(
-        message: vector<u8>,
-        recovery_id: u8,
-        signature: vector<u8>
-    ): (vector<u8>, bool) {
+    spec ecdsa_recover_internal(message: vector<u8>, recovery_id: u8, signature: vector<u8>): (
+        vector<u8>, bool
+    ) {
         pragma opaque;
         aborts_if ecdsa_recover_internal_abort_condition(message, recovery_id, signature);
-        ensures result_1 == spec_ecdsa_recover_internal_result_1(message, recovery_id, signature);
-        ensures result_2 == spec_ecdsa_recover_internal_result_2(message, recovery_id, signature);
-        ensures len(result_1) == if (result_2) { RAW_PUBLIC_KEY_NUM_BYTES } else { 0 };
+        ensures result_1
+            == spec_ecdsa_recover_internal_result_1(message, recovery_id, signature);
+        ensures result_2
+            == spec_ecdsa_recover_internal_result_2(message, recovery_id, signature);
+        ensures len(result_1)
+            == if (result_2) {
+                RAW_PUBLIC_KEY_NUM_BYTES
+            } else { 0 };
     }
 
-    spec fun ecdsa_recover_internal_abort_condition(message: vector<u8>, recovery_id: u8, signature: vector<u8>): bool;
-    spec fun spec_ecdsa_recover_internal_result_1(message: vector<u8>, recovery_id: u8, signature: vector<u8>): vector<u8>;
-    spec fun spec_ecdsa_recover_internal_result_2(message: vector<u8>, recovery_id: u8, signature: vector<u8>): bool;
+    spec fun ecdsa_recover_internal_abort_condition(
+        message: vector<u8>, recovery_id: u8, signature: vector<u8>
+    ): bool;
+
+    spec fun spec_ecdsa_recover_internal_result_1(
+        message: vector<u8>, recovery_id: u8, signature: vector<u8>
+    ): vector<u8>;
+
+    spec fun spec_ecdsa_recover_internal_result_2(
+        message: vector<u8>, recovery_id: u8, signature: vector<u8>
+    ): bool;
 }

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.move
@@ -61,7 +61,8 @@ module aptos_std::big_vector {
     public fun borrow<T>(v: &BigVector<T>, i: u64): &T {
         assert!(i < length(v), error::invalid_argument(EINDEX_OUT_OF_BOUNDS));
         vector::borrow(
-            table_with_length::borrow(&v.buckets, i / v.bucket_size), i % v.bucket_size
+            table_with_length::borrow(&v.buckets, i / v.bucket_size),
+            i % v.bucket_size,
         )
     }
 
@@ -146,12 +147,12 @@ module aptos_std::big_vector {
         v.end_index = v.end_index - 1;
         move cur_bucket;
         while ({
-                spec {
-                    invariant cur_bucket_index <= num_buckets;
-                    invariant table_with_length::spec_len(v.buckets) == num_buckets;
-                };
-                (cur_bucket_index < num_buckets)
-            }) {
+            spec {
+                invariant cur_bucket_index <= num_buckets;
+                invariant table_with_length::spec_len(v.buckets) == num_buckets;
+            };
+            (cur_bucket_index < num_buckets)
+        }) {
             // remove one element from the start of current vector
             let cur_bucket =
                 table_with_length::borrow_mut(&mut v.buckets, cur_bucket_index);
@@ -203,7 +204,8 @@ module aptos_std::big_vector {
     /// for v.
     public fun swap<T>(v: &mut BigVector<T>, i: u64, j: u64) {
         assert!(
-            i < length(v) && j < length(v), error::invalid_argument(EINDEX_OUT_OF_BOUNDS)
+            i < length(v) && j < length(v),
+            error::invalid_argument(EINDEX_OUT_OF_BOUNDS),
         );
         let i_bucket_index = i / v.bucket_size;
         let j_bucket_index = j / v.bucket_size;

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.move
@@ -26,11 +26,7 @@ module aptos_std::big_vector {
     /// Create an empty vector.
     public(friend) fun empty<T: store>(bucket_size: u64): BigVector<T> {
         assert!(bucket_size > 0, error::invalid_argument(EZERO_BUCKET_SIZE));
-        BigVector {
-            buckets: table_with_length::new(),
-            end_index: 0,
-            bucket_size,
-        }
+        BigVector { buckets: table_with_length::new(), end_index: 0, bucket_size, }
     }
 
     /// Create a vector of length 1 containing the passed in element.
@@ -64,20 +60,27 @@ module aptos_std::big_vector {
     /// Aborts if `i` is out of bounds.
     public fun borrow<T>(v: &BigVector<T>, i: u64): &T {
         assert!(i < length(v), error::invalid_argument(EINDEX_OUT_OF_BOUNDS));
-        vector::borrow(table_with_length::borrow(&v.buckets, i / v.bucket_size), i % v.bucket_size)
+        vector::borrow(
+            table_with_length::borrow(&v.buckets, i / v.bucket_size), i % v.bucket_size
+        )
     }
 
     /// Return a mutable reference to the `i`th element in the vector `v`.
     /// Aborts if `i` is out of bounds.
     public fun borrow_mut<T>(v: &mut BigVector<T>, i: u64): &mut T {
         assert!(i < length(v), error::invalid_argument(EINDEX_OUT_OF_BOUNDS));
-        vector::borrow_mut(table_with_length::borrow_mut(&mut v.buckets, i / v.bucket_size), i % v.bucket_size)
+        vector::borrow_mut(
+            table_with_length::borrow_mut(&mut v.buckets, i / v.bucket_size),
+            i % v.bucket_size,
+        )
     }
 
     /// Empty and destroy the other vector, and push each of the elements in the other vector onto the lhs vector in the
     /// same order as they occurred in other.
     /// Disclaimer: This function is costly. Use it at your own discretion.
-    public fun append<T: store>(lhs: &mut BigVector<T>, other: BigVector<T>) {
+    public fun append<T: store>(
+        lhs: &mut BigVector<T>, other: BigVector<T>
+    ) {
         let other_len = length(&other);
         let half_other_len = other_len / 2;
         let i = 0;
@@ -98,9 +101,13 @@ module aptos_std::big_vector {
         let num_buckets = table_with_length::length(&v.buckets);
         if (v.end_index == num_buckets * v.bucket_size) {
             table_with_length::add(&mut v.buckets, num_buckets, vector::empty());
-            vector::push_back(table_with_length::borrow_mut(&mut v.buckets, num_buckets), val);
+            vector::push_back(
+                table_with_length::borrow_mut(&mut v.buckets, num_buckets), val
+            );
         } else {
-            vector::push_back(table_with_length::borrow_mut(&mut v.buckets, num_buckets - 1), val);
+            vector::push_back(
+                table_with_length::borrow_mut(&mut v.buckets, num_buckets - 1), val
+            );
         };
         v.end_index = v.end_index + 1;
     }
@@ -116,7 +123,9 @@ module aptos_std::big_vector {
         // Shrink the table if the last vector is empty.
         if (vector::is_empty(last_bucket)) {
             move last_bucket;
-            vector::destroy_empty(table_with_length::remove(&mut v.buckets, num_buckets - 1));
+            vector::destroy_empty(
+                table_with_length::remove(&mut v.buckets, num_buckets - 1)
+            );
         };
         v.end_index = v.end_index - 1;
         val
@@ -130,23 +139,27 @@ module aptos_std::big_vector {
         assert!(i < len, error::invalid_argument(EINDEX_OUT_OF_BOUNDS));
         let num_buckets = table_with_length::length(&v.buckets);
         let cur_bucket_index = i / v.bucket_size + 1;
-        let cur_bucket = table_with_length::borrow_mut(&mut v.buckets, cur_bucket_index - 1);
+        let cur_bucket = table_with_length::borrow_mut(
+            &mut v.buckets, cur_bucket_index - 1
+        );
         let res = vector::remove(cur_bucket, i % v.bucket_size);
         v.end_index = v.end_index - 1;
         move cur_bucket;
         while ({
-            spec {
-                invariant cur_bucket_index <= num_buckets;
-                invariant table_with_length::spec_len(v.buckets) == num_buckets;
-            };
-            (cur_bucket_index < num_buckets)
-        }) {
+                spec {
+                    invariant cur_bucket_index <= num_buckets;
+                    invariant table_with_length::spec_len(v.buckets) == num_buckets;
+                };
+                (cur_bucket_index < num_buckets)
+            }) {
             // remove one element from the start of current vector
-            let cur_bucket = table_with_length::borrow_mut(&mut v.buckets, cur_bucket_index);
+            let cur_bucket =
+                table_with_length::borrow_mut(&mut v.buckets, cur_bucket_index);
             let t = vector::remove(cur_bucket, 0);
             move cur_bucket;
             // and put it at the end of the last one
-            let prev_bucket = table_with_length::borrow_mut(&mut v.buckets, cur_bucket_index - 1);
+            let prev_bucket =
+                table_with_length::borrow_mut(&mut v.buckets, cur_bucket_index - 1);
             vector::push_back(prev_bucket, t);
             cur_bucket_index = cur_bucket_index + 1;
         };
@@ -158,7 +171,9 @@ module aptos_std::big_vector {
         let last_bucket = table_with_length::borrow_mut(&mut v.buckets, num_buckets - 1);
         if (vector::is_empty(last_bucket)) {
             move last_bucket;
-            vector::destroy_empty(table_with_length::remove(&mut v.buckets, num_buckets - 1));
+            vector::destroy_empty(
+                table_with_length::remove(&mut v.buckets, num_buckets - 1)
+            );
         };
 
         res
@@ -187,13 +202,19 @@ module aptos_std::big_vector {
     /// Swap the elements at the i'th and j'th indices in the vector v. Will abort if either of i or j are out of bounds
     /// for v.
     public fun swap<T>(v: &mut BigVector<T>, i: u64, j: u64) {
-        assert!(i < length(v) && j < length(v), error::invalid_argument(EINDEX_OUT_OF_BOUNDS));
+        assert!(
+            i < length(v) && j < length(v), error::invalid_argument(EINDEX_OUT_OF_BOUNDS)
+        );
         let i_bucket_index = i / v.bucket_size;
         let j_bucket_index = j / v.bucket_size;
         let i_vector_index = i % v.bucket_size;
         let j_vector_index = j % v.bucket_size;
         if (i_bucket_index == j_bucket_index) {
-            vector::swap(table_with_length::borrow_mut(&mut v.buckets, i_bucket_index), i_vector_index, j_vector_index);
+            vector::swap(
+                table_with_length::borrow_mut(&mut v.buckets, i_bucket_index),
+                i_vector_index,
+                j_vector_index,
+            );
             return
         };
         // If i and j are in different buckets, take the buckets out first for easy mutation.
@@ -224,14 +245,19 @@ module aptos_std::big_vector {
         let num_buckets_left = num_buckets;
 
         while (num_buckets_left > 0) {
-            let pop_bucket = table_with_length::remove(&mut v.buckets, num_buckets_left - 1);
-            vector::for_each_reverse(pop_bucket, |val| {
-                vector::push_back(&mut push_bucket, val);
-                if (vector::length(&push_bucket) == v.bucket_size) {
-                    vector::push_back(&mut new_buckets, push_bucket);
-                    push_bucket = vector[];
-                };
-            });
+            let pop_bucket = table_with_length::remove(
+                &mut v.buckets, num_buckets_left - 1
+            );
+            vector::for_each_reverse(
+                pop_bucket,
+                |val| {
+                    vector::push_back(&mut push_bucket, val);
+                    if (vector::length(&push_bucket) == v.bucket_size) {
+                        vector::push_back(&mut new_buckets, push_bucket);
+                        push_bucket = vector[];
+                    };
+                },
+            );
             num_buckets_left = num_buckets_left - 1;
         };
 

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.spec.move
@@ -11,30 +11,45 @@ spec aptos_std::big_vector {
 
         // ensure all buckets except last has `bucket_size`
         invariant spec_table_len(buckets) == 0
-            || (forall i in 0..spec_table_len(buckets)-1: len(table_with_length::spec_get(buckets, i)) == bucket_size);
+            || (
+                forall i in 0..spec_table_len(buckets) - 1: len(
+                    table_with_length::spec_get(buckets, i)
+                ) == bucket_size
+            );
         // ensure last bucket doesn't have more than `bucket_size` elements
         invariant spec_table_len(buckets) == 0
-            || len(table_with_length::spec_get(buckets, spec_table_len(buckets) -1 )) <= bucket_size;
+            || len(table_with_length::spec_get(buckets, spec_table_len(buckets) - 1))
+                <= bucket_size;
         // ensure each table entry exists due to a bad spec in `Table::spec_get`
         invariant forall i in 0..spec_table_len(buckets): spec_table_contains(buckets, i);
         // ensure correct number of buckets
         invariant spec_table_len(buckets) == (end_index + bucket_size - 1) / bucket_size;
         // ensure bucket lengths add up to `end_index`
-        invariant (spec_table_len(buckets) == 0 && end_index == 0)
-            || (spec_table_len(buckets) != 0 && ((spec_table_len(buckets) - 1) * bucket_size) + (len(table_with_length::spec_get(buckets, spec_table_len(buckets) - 1))) == end_index);
+        invariant (spec_table_len(buckets) == 0
+                && end_index == 0)
+            || (
+                spec_table_len(buckets) != 0
+                && ((spec_table_len(buckets) - 1) * bucket_size)
+                    + (
+                        len(
+                            table_with_length::spec_get(
+                                buckets, spec_table_len(buckets) - 1
+                            ),
+                        )
+                    ) == end_index
+            );
         // ensures that no out-of-bound buckets exist
-        invariant forall i: u64 where i >= spec_table_len(buckets):  {
+        invariant forall i: u64 where i >= spec_table_len(buckets): {
             !spec_table_contains(buckets, i)
         };
         // ensures that all buckets exist
-        invariant forall i: u64 where i < spec_table_len(buckets):  {
+        invariant forall i: u64 where i < spec_table_len(buckets): {
             spec_table_contains(buckets, i)
         };
         // ensures that the last bucket is non-empty
         invariant spec_table_len(buckets) == 0
             || (len(table_with_length::spec_get(buckets, spec_table_len(buckets) - 1)) > 0);
     }
-
 
     // -----------------------
     // Function specifications
@@ -71,8 +86,8 @@ spec aptos_std::big_vector {
         include PushbackAbortsIf<T>;
         ensures length(v) == length(old(v)) + 1;
         ensures v.end_index == old(v.end_index) + 1;
-        ensures spec_at(v, v.end_index-1) == val;
-        ensures forall i in 0..v.end_index-1: spec_at(v, i) == spec_at(old(v), i);
+        ensures spec_at(v, v.end_index - 1) == val;
+        ensures forall i in 0..v.end_index - 1: spec_at(v, i) == spec_at(old(v), i);
         ensures v.bucket_size == old(v).bucket_size;
     }
 
@@ -86,7 +101,7 @@ spec aptos_std::big_vector {
     spec pop_back<T>(v: &mut BigVector<T>): T {
         aborts_if is_empty(v);
         ensures length(v) == length(old(v)) - 1;
-        ensures result == old(spec_at(v, v.end_index-1));
+        ensures result == old(spec_at(v, v.end_index - 1));
         ensures forall i in 0..v.end_index: spec_at(v, i) == spec_at(old(v), i);
     }
 
@@ -103,25 +118,24 @@ spec aptos_std::big_vector {
         ensures length(v) == length(old(v));
         ensures spec_at(v, i) == spec_at(old(v), j);
         ensures spec_at(v, j) == spec_at(old(v), i);
-        ensures forall idx in 0..length(v)
-            where idx != i && idx != j:
-            spec_at(v, idx) == spec_at(old(v), idx);
+        ensures forall idx in 0..length(v) where idx != i && idx != j: spec_at(v, idx)
+            == spec_at(old(v), idx);
     }
 
     spec append<T: store>(lhs: &mut BigVector<T>, other: BigVector<T>) {
-        pragma verify=false;
+        pragma verify = false;
     }
 
     spec remove<T>(v: &mut BigVector<T>, i: u64): T {
-        pragma verify=false;
+        pragma verify = false;
     }
 
     spec reverse<T>(v: &mut BigVector<T>) {
-        pragma verify=false;
+        pragma verify = false;
     }
 
     spec index_of<T>(v: &BigVector<T>, val: &T): (bool, u64) {
-        pragma verify=false;
+        pragma verify = false;
     }
 
     // ---------------------

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/big_vector.spec.move
@@ -12,9 +12,8 @@ spec aptos_std::big_vector {
         // ensure all buckets except last has `bucket_size`
         invariant spec_table_len(buckets) == 0
             || (
-                forall i in 0..spec_table_len(buckets) - 1: len(
-                    table_with_length::spec_get(buckets, i)
-                ) == bucket_size
+                forall i in 0..spec_table_len(buckets) - 1:
+                    len(table_with_length::spec_get(buckets, i)) == bucket_size
             );
         // ensure last bucket doesn't have more than `bucket_size` elements
         invariant spec_table_len(buckets) == 0
@@ -26,26 +25,24 @@ spec aptos_std::big_vector {
         invariant spec_table_len(buckets) == (end_index + bucket_size - 1) / bucket_size;
         // ensure bucket lengths add up to `end_index`
         invariant (spec_table_len(buckets) == 0
-                && end_index == 0)
+            && end_index == 0)
             || (
                 spec_table_len(buckets) != 0
-                && ((spec_table_len(buckets) - 1) * bucket_size)
-                    + (
-                        len(
-                            table_with_length::spec_get(
-                                buckets, spec_table_len(buckets) - 1
-                            ),
-                        )
-                    ) == end_index
+                    && ((spec_table_len(buckets) - 1) * bucket_size)
+                        + (
+                            len(
+                                table_with_length::spec_get(
+                                    buckets, spec_table_len(buckets) - 1
+                                ),
+                            )
+                        ) == end_index
             );
         // ensures that no out-of-bound buckets exist
-        invariant forall i: u64 where i >= spec_table_len(buckets): {
-            !spec_table_contains(buckets, i)
-        };
+        invariant forall i: u64 where i >= spec_table_len(buckets):
+            { !spec_table_contains(buckets, i) };
         // ensures that all buckets exist
-        invariant forall i: u64 where i < spec_table_len(buckets): {
-            spec_table_contains(buckets, i)
-        };
+        invariant forall i: u64 where i < spec_table_len(buckets):
+            { spec_table_contains(buckets, i) };
         // ensures that the last bucket is non-empty
         invariant spec_table_len(buckets) == 0
             || (len(table_with_length::spec_get(buckets, spec_table_len(buckets) - 1)) > 0);
@@ -118,8 +115,8 @@ spec aptos_std::big_vector {
         ensures length(v) == length(old(v));
         ensures spec_at(v, i) == spec_at(old(v), j);
         ensures spec_at(v, j) == spec_at(old(v), i);
-        ensures forall idx in 0..length(v) where idx != i && idx != j: spec_at(v, idx)
-            == spec_at(old(v), idx);
+        ensures forall idx in 0..length(v) where idx != i && idx != j:
+            spec_at(v, idx) == spec_at(old(v), idx);
     }
 
     spec append<T: store>(lhs: &mut BigVector<T>, other: BigVector<T>) {

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
@@ -179,10 +179,13 @@ module aptos_std::smart_table {
     public fun add_all<K, V>(
         table: &mut SmartTable<K, V>, keys: vector<K>, values: vector<V>
     ) {
-        vector::zip(keys, values,
+        vector::zip(
+            keys,
+            values,
             |key, value| {
                 add(table, key, value);
-            });
+            },
+        );
     }
 
     inline fun unzip_entries<K: copy, V: copy>(entries: &vector<Entry<K, V>>)
@@ -264,8 +267,9 @@ module aptos_std::smart_table {
         let keys = vector[];
         if (num_keys_to_get == 0)
             return (
-                keys, option::some(starting_bucket_index),
-                option::some(starting_vector_index)
+                keys, option::some(starting_bucket_index), option::some(
+                    starting_vector_index
+                )
             );
         for (bucket_index in starting_bucket_index..num_buckets) {
             bucket_ref = table_with_length::borrow(buckets_ref, bucket_index);
@@ -643,9 +647,11 @@ module aptos_std::smart_table {
     public fun smart_table_add_all_test() {
         let table: SmartTable<u64, u64> = new_with_config(1, 100, 2);
         assert!(length(&table) == 0, 0);
-        add_all(&mut table,
+        add_all(
+            &mut table,
             vector[1, 2, 3, 4, 5, 6, 7],
-            vector[1, 2, 3, 4, 5, 6, 7],);
+            vector[1, 2, 3, 4, 5, 6, 7],
+        );
         assert!(length(&table) == 7, 1);
         let i = 1;
         while (i < 8) {
@@ -734,7 +740,7 @@ module aptos_std::smart_table {
             );
             vector::append(&mut keys, returned_keys);
             if (starting_bucket_index_r == option::none()
-                    || starting_vector_index_r == option::none())
+                || starting_vector_index_r == option::none())
             break;
             starting_bucket_index = option::destroy_some(starting_bucket_index_r);
             starting_vector_index = option::destroy_some(starting_vector_index_r);

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.move
@@ -66,11 +66,12 @@ module aptos_std::smart_table {
     /// `target_bucket_size`: The target number of entries per bucket, though not guaranteed. 0 means not set and will
     /// dynamically assgined by the contract code.
     public fun new_with_config<K: copy + drop + store, V: store>(
-        num_initial_buckets: u64,
-        split_load_threshold: u8,
-        target_bucket_size: u64
+        num_initial_buckets: u64, split_load_threshold: u8, target_bucket_size: u64
     ): SmartTable<K, V> {
-        assert!(split_load_threshold <= 100, error::invalid_argument(EINVALID_LOAD_THRESHOLD_PERCENT));
+        assert!(
+            split_load_threshold <= 100,
+            error::invalid_argument(EINVALID_LOAD_THRESHOLD_PERCENT),
+        );
         let buckets = table_with_length::new();
         table_with_length::add(&mut buckets, 0, vector::empty());
         let table = SmartTable {
@@ -79,7 +80,10 @@ module aptos_std::smart_table {
             level: 0,
             size: 0,
             // The default split load threshold is 75%.
-            split_load_threshold: if (split_load_threshold == 0) { 75 } else { split_load_threshold },
+            split_load_threshold: if (split_load_threshold == 0) { 75 }
+            else {
+                split_load_threshold
+            },
             target_bucket_size,
         };
         // The default number of initial buckets is 2.
@@ -102,7 +106,14 @@ module aptos_std::smart_table {
             vector::destroy_empty(table_with_length::remove(&mut table.buckets, i));
             i = i + 1;
         };
-        let SmartTable { buckets, num_buckets: _, level: _, size: _, split_load_threshold: _, target_bucket_size: _ } = table;
+        let SmartTable {
+            buckets,
+            num_buckets: _,
+            level: _,
+            size: _,
+            split_load_threshold: _,
+            target_bucket_size: _
+        } = table;
         table_with_length::destroy_empty(buckets);
     }
 
@@ -135,15 +146,26 @@ module aptos_std::smart_table {
         let index = bucket_index(table.level, table.num_buckets, hash);
         let bucket = table_with_length::borrow_mut(&mut table.buckets, index);
         // We set a per-bucket limit here with a upper bound (10000) that nobody should normally reach.
-        assert!(vector::length(bucket) <= 10000, error::permission_denied(EEXCEED_MAX_BUCKET_SIZE));
-        assert!(vector::all(bucket, | entry | {
-            let e: &Entry<K, V> = entry;
-            &e.key != &key
-        }), error::invalid_argument(EALREADY_EXIST));
+        assert!(
+            vector::length(bucket) <= 10000,
+            error::permission_denied(EEXCEED_MAX_BUCKET_SIZE),
+        );
+        assert!(
+            vector::all(
+                bucket,
+                |entry| {
+                    let e: &Entry<K, V> = entry;
+                    &e.key != &key
+                },
+            ),
+            error::invalid_argument(EALREADY_EXIST),
+        );
         let e = Entry { hash, key, value };
         if (table.target_bucket_size == 0) {
             let estimated_entry_size = max(size_of_val(&e), 1);
-            table.target_bucket_size = max(1024 /* free_write_quota */ / estimated_entry_size, 1);
+            table.target_bucket_size = max(
+                1024 /* free_write_quota */ / estimated_entry_size, 1
+            );
         };
         vector::push_back(bucket, e);
         table.size = table.size + 1;
@@ -154,18 +176,27 @@ module aptos_std::smart_table {
     }
 
     /// Add multiple key/value pairs to the smart table. The keys must not already exist.
-    public fun add_all<K, V>(table: &mut SmartTable<K, V>, keys: vector<K>, values: vector<V>) {
-        vector::zip(keys, values, |key, value| { add(table, key, value); });
+    public fun add_all<K, V>(
+        table: &mut SmartTable<K, V>, keys: vector<K>, values: vector<V>
+    ) {
+        vector::zip(keys, values,
+            |key, value| {
+                add(table, key, value);
+            });
     }
 
-    inline fun unzip_entries<K: copy, V: copy>(entries: &vector<Entry<K, V>>): (vector<K>, vector<V>) {
+    inline fun unzip_entries<K: copy, V: copy>(entries: &vector<Entry<K, V>>)
+        : (vector<K>, vector<V>) {
         let keys = vector[];
         let values = vector[];
-        vector::for_each_ref(entries, |e|{
-            let entry: &Entry<K, V> = e;
-            vector::push_back(&mut keys, entry.key);
-            vector::push_back(&mut values, entry.value);
-        });
+        vector::for_each_ref(
+            entries,
+            |e| {
+                let entry: &Entry<K, V> = e;
+                vector::push_back(&mut keys, entry.key);
+                vector::push_back(&mut values, entry.value);
+            },
+        );
         (keys, values)
     }
 
@@ -178,7 +209,8 @@ module aptos_std::smart_table {
         let i = 0;
         let res = simple_map::new<K, V>();
         while (i < table.num_buckets) {
-            let (keys, values) = unzip_entries(table_with_length::borrow(&table.buckets, i));
+            let (keys, values) =
+                unzip_entries(table_with_length::borrow(&table.buckets, i));
             simple_map::add_all(&mut res, keys, values);
             i = i + 1;
         };
@@ -214,11 +246,7 @@ module aptos_std::smart_table {
         starting_bucket_index: u64,
         starting_vector_index: u64,
         num_keys_to_get: u64,
-    ): (
-        vector<K>,
-        Option<u64>,
-        Option<u64>,
-    ) {
+    ): (vector<K>, Option<u64>, Option<u64>,) {
         let num_buckets = table_ref.num_buckets;
         let buckets_ref = &table_ref.buckets;
         assert!(starting_bucket_index < num_buckets, EINVALID_BUCKET_INDEX);
@@ -231,11 +259,14 @@ module aptos_std::smart_table {
             // starting iteration at the beginning of an empty bucket since buckets are never
             // destroyed, only emptied.
             starting_vector_index < bucket_length || starting_vector_index == 0,
-            EINVALID_VECTOR_INDEX
+            EINVALID_VECTOR_INDEX,
         );
         let keys = vector[];
-        if (num_keys_to_get == 0) return
-            (keys, option::some(starting_bucket_index), option::some(starting_vector_index));
+        if (num_keys_to_get == 0)
+            return (
+                keys, option::some(starting_bucket_index),
+                option::some(starting_vector_index)
+            );
         for (bucket_index in starting_bucket_index..num_buckets) {
             bucket_ref = table_with_length::borrow(buckets_ref, bucket_index);
             bucket_length = vector::length(bucket_ref);
@@ -265,7 +296,7 @@ module aptos_std::smart_table {
     fun split_one_bucket<K, V>(table: &mut SmartTable<K, V>) {
         let new_bucket_index = table.num_buckets;
         // the next bucket to split is num_bucket without the most significant bit.
-        let to_split = new_bucket_index ^ (1 << table.level);
+        let to_split = new_bucket_index ^(1 << table.level);
         table.num_buckets = new_bucket_index + 1;
         // if the whole level is splitted once, bump the level.
         if (to_split + 1 == 1 << table.level) {
@@ -273,10 +304,13 @@ module aptos_std::smart_table {
         };
         let old_bucket = table_with_length::borrow_mut(&mut table.buckets, to_split);
         // partition the bucket, [0..p) stays in old bucket, [p..len) goes to new bucket
-        let p = vector::partition(old_bucket, |e| {
-            let entry: &Entry<K, V> = e; // Explicit type to satisfy compiler
-            bucket_index(table.level, table.num_buckets, entry.hash) != new_bucket_index
-        });
+        let p = vector::partition(
+            old_bucket,
+            |e| {
+                let entry: &Entry<K, V> = e; // Explicit type to satisfy compiler
+                bucket_index(table.level, table.num_buckets, entry.hash) != new_bucket_index
+            },
+        );
         let new_bucket = vector::trim_reverse(old_bucket, p);
         table_with_length::add(&mut table.buckets, new_bucket_index, new_bucket);
     }
@@ -298,7 +332,9 @@ module aptos_std::smart_table {
     /// Acquire an immutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
     public fun borrow<K: drop, V>(table: &SmartTable<K, V>, key: K): &V {
-        let index = bucket_index(table.level, table.num_buckets, sip_hash_from_value(&key));
+        let index = bucket_index(
+            table.level, table.num_buckets, sip_hash_from_value(&key)
+        );
         let bucket = table_with_length::borrow(&table.buckets, index);
         let i = 0;
         let len = vector::length(bucket);
@@ -314,7 +350,9 @@ module aptos_std::smart_table {
 
     /// Acquire an immutable reference to the value which `key` maps to.
     /// Returns specified default value if there is no entry for `key`.
-    public fun borrow_with_default<K: copy + drop, V>(table: &SmartTable<K, V>, key: K, default: &V): &V {
+    public fun borrow_with_default<K: copy + drop, V>(
+        table: &SmartTable<K, V>, key: K, default: &V
+    ): &V {
         if (!contains(table, copy key)) {
             default
         } else {
@@ -325,7 +363,9 @@ module aptos_std::smart_table {
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
     public fun borrow_mut<K: drop, V>(table: &mut SmartTable<K, V>, key: K): &mut V {
-        let index = bucket_index(table.level, table.num_buckets, sip_hash_from_value(&key));
+        let index = bucket_index(
+            table.level, table.num_buckets, sip_hash_from_value(&key)
+        );
         let bucket = table_with_length::borrow_mut(&mut table.buckets, index);
         let i = 0;
         let len = vector::length(bucket);
@@ -357,16 +397,21 @@ module aptos_std::smart_table {
         let hash = sip_hash_from_value(&key);
         let index = bucket_index(table.level, table.num_buckets, hash);
         let bucket = table_with_length::borrow(&table.buckets, index);
-        vector::any(bucket, | entry | {
-            let e: &Entry<K, V> = entry;
-            e.hash == hash && &e.key == &key
-        })
+        vector::any(
+            bucket,
+            |entry| {
+                let e: &Entry<K, V> = entry;
+                e.hash == hash && &e.key == &key
+            },
+        )
     }
 
     /// Remove from `table` and return the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
     public fun remove<K: copy + drop, V>(table: &mut SmartTable<K, V>, key: K): V {
-        let index = bucket_index(table.level, table.num_buckets, sip_hash_from_value(&key));
+        let index = bucket_index(
+            table.level, table.num_buckets, sip_hash_from_value(&key)
+        );
         let bucket = table_with_length::borrow_mut(&mut table.buckets, index);
         let i = 0;
         let len = vector::length(bucket);
@@ -384,7 +429,9 @@ module aptos_std::smart_table {
 
     /// Insert the pair (`key`, `value`) if there is no entry for `key`.
     /// update the value of the entry for `key` to `value` otherwise
-    public fun upsert<K: copy + drop, V: drop>(table: &mut SmartTable<K, V>, key: K, value: V) {
+    public fun upsert<K: copy + drop, V: drop>(
+        table: &mut SmartTable<K, V>, key: K, value: V
+    ) {
         if (!contains(table, copy key)) {
             add(table, copy key, value)
         } else {
@@ -404,45 +451,59 @@ module aptos_std::smart_table {
     }
 
     /// Update `split_load_threshold`.
-    public fun update_split_load_threshold<K, V>(table: &mut SmartTable<K, V>, split_load_threshold: u8) {
+    public fun update_split_load_threshold<K, V>(
+        table: &mut SmartTable<K, V>, split_load_threshold: u8
+    ) {
         assert!(
             split_load_threshold <= 100 && split_load_threshold > 0,
-            error::invalid_argument(EINVALID_LOAD_THRESHOLD_PERCENT)
+            error::invalid_argument(EINVALID_LOAD_THRESHOLD_PERCENT),
         );
         table.split_load_threshold = split_load_threshold;
     }
 
     /// Update `target_bucket_size`.
-    public fun update_target_bucket_size<K, V>(table: &mut SmartTable<K, V>, target_bucket_size: u64) {
-        assert!(target_bucket_size > 0, error::invalid_argument(EINVALID_TARGET_BUCKET_SIZE));
+    public fun update_target_bucket_size<K, V>(
+        table: &mut SmartTable<K, V>, target_bucket_size: u64
+    ) {
+        assert!(
+            target_bucket_size > 0, error::invalid_argument(EINVALID_TARGET_BUCKET_SIZE)
+        );
         table.target_bucket_size = target_bucket_size;
     }
 
     /// Apply the function to a reference of each key-value pair in the table.
-    public inline fun for_each_ref<K, V>(table: &SmartTable<K, V>, f: |&K, &V|) {
+    public inline fun for_each_ref<K, V>(
+        table: &SmartTable<K, V>, f: |&K, &V|
+    ) {
         let i = 0;
         while (i < aptos_std::smart_table::num_buckets(table)) {
             vector::for_each_ref(
-                aptos_std::table_with_length::borrow(aptos_std::smart_table::borrow_buckets(table), i),
+                aptos_std::table_with_length::borrow(
+                    aptos_std::smart_table::borrow_buckets(table), i
+                ),
                 |elem| {
                     let (key, value) = aptos_std::smart_table::borrow_kv(elem);
                     f(key, value)
-                }
+                },
             );
             i = i + 1;
         }
     }
 
     /// Apply the function to a mutable reference of each key-value pair in the table.
-    public inline fun for_each_mut<K, V>(table: &mut SmartTable<K, V>, f: |&K, &mut V|) {
+    public inline fun for_each_mut<K, V>(
+        table: &mut SmartTable<K, V>, f: |&K, &mut V|
+    ) {
         let i = 0;
         while (i < aptos_std::smart_table::num_buckets(table)) {
             vector::for_each_mut(
-                table_with_length::borrow_mut(aptos_std::smart_table::borrow_buckets_mut(table), i),
+                table_with_length::borrow_mut(
+                    aptos_std::smart_table::borrow_buckets_mut(table), i
+                ),
                 |elem| {
                     let (key, value) = aptos_std::smart_table::borrow_kv_mut(elem);
                     f(key, value)
-                }
+                },
             );
             i = i + 1;
         };
@@ -450,8 +511,7 @@ module aptos_std::smart_table {
 
     /// Map the function over the references of key-value pairs in the table without modifying it.
     public inline fun map_ref<K: copy + drop + store, V1, V2: store>(
-        table: &SmartTable<K, V1>,
-        f: |&V1|V2
+        table: &SmartTable<K, V1>, f: |&V1| V2
     ): SmartTable<K, V2> {
         let new_table = new<K, V2>();
         for_each_ref(table, |key, value| add(&mut new_table, *key, f(value)));
@@ -461,15 +521,20 @@ module aptos_std::smart_table {
     /// Return true if any key-value pair in the table satisfies the predicate.
     public inline fun any<K, V>(
         table: &SmartTable<K, V>,
-        p: |&K, &V|bool
+        p: |&K, &V| bool
     ): bool {
         let found = false;
         let i = 0;
         while (i < aptos_std::smart_table::num_buckets(table)) {
-            found = vector::any(table_with_length::borrow(aptos_std::smart_table::borrow_buckets(table), i), |elem| {
-                let (key, value) = aptos_std::smart_table::borrow_kv(elem);
-                p(key, value)
-            });
+            found = vector::any(
+                table_with_length::borrow(
+                    aptos_std::smart_table::borrow_buckets(table), i
+                ),
+                |elem| {
+                    let (key, value) = aptos_std::smart_table::borrow_kv(elem);
+                    p(key, value)
+                },
+            );
             if (found) break;
             i = i + 1;
         };
@@ -489,14 +554,15 @@ module aptos_std::smart_table {
         table.num_buckets
     }
 
-    public fun borrow_buckets<K, V>(table: &SmartTable<K, V>): &TableWithLength<u64, vector<Entry<K, V>>> {
+    public fun borrow_buckets<K, V>(table: &SmartTable<K, V>)
+        : &TableWithLength<u64, vector<Entry<K, V>>> {
         &table.buckets
     }
 
-    public fun borrow_buckets_mut<K, V>(table: &mut SmartTable<K, V>): &mut TableWithLength<u64, vector<Entry<K, V>>> {
+    public fun borrow_buckets_mut<K, V>(table: &mut SmartTable<K, V>)
+        : &mut TableWithLength<u64, vector<Entry<K, V>>> {
         &mut table.buckets
     }
-
 
     #[test]
     fun smart_table_test() {
@@ -577,7 +643,9 @@ module aptos_std::smart_table {
     public fun smart_table_add_all_test() {
         let table: SmartTable<u64, u64> = new_with_config(1, 100, 2);
         assert!(length(&table) == 0, 0);
-        add_all(&mut table, vector[1, 2, 3, 4, 5, 6, 7], vector[1, 2, 3, 4, 5, 6, 7]);
+        add_all(&mut table,
+            vector[1, 2, 3, 4, 5, 6, 7],
+            vector[1, 2, 3, 4, 5, 6, 7],);
         assert!(length(&table) == 7, 1);
         let i = 1;
         while (i < 8) {
@@ -632,12 +700,13 @@ module aptos_std::smart_table {
         assert!(vector::is_empty(&keys), 0);
         let starting_bucket_index = 0;
         let starting_vector_index = 0;
-        let (keys, starting_bucket_index_r, starting_vector_index_r) = keys_paginated(
-            &table,
-            starting_bucket_index,
-            starting_vector_index,
-            0
-        );
+        let (keys, starting_bucket_index_r, starting_vector_index_r) =
+            keys_paginated(
+                &table,
+                starting_bucket_index,
+                starting_vector_index,
+                0,
+            );
         assert!(starting_bucket_index_r == option::some(starting_bucket_index), 0);
         assert!(starting_vector_index_r == option::some(starting_vector_index), 0);
         assert!(vector::is_empty(&keys), 0);
@@ -648,9 +717,12 @@ module aptos_std::smart_table {
         };
         let keys = keys(&table);
         assert!(vector::length(&keys) == vector::length(&expected_keys), 0);
-        vector::for_each_ref(&keys, |e_ref| {
-            assert!(vector::contains(&expected_keys, e_ref), 0);
-        });
+        vector::for_each_ref(
+            &keys,
+            |e_ref| {
+                assert!(vector::contains(&expected_keys, e_ref), 0);
+            },
+        );
         let keys = vector[];
         let starting_bucket_index = 0;
         let starting_vector_index = 0;
@@ -658,28 +730,29 @@ module aptos_std::smart_table {
         vector::length(&returned_keys); // To eliminate erroneous compiler "unused" warning
         loop {
             (returned_keys, starting_bucket_index_r, starting_vector_index_r) = keys_paginated(
-                &table,
-                starting_bucket_index,
-                starting_vector_index,
-                15
+                &table, starting_bucket_index, starting_vector_index, 15
             );
             vector::append(&mut keys, returned_keys);
-            if (
-                starting_bucket_index_r == option::none() ||
-                starting_vector_index_r == option::none()
-            ) break;
+            if (starting_bucket_index_r == option::none()
+                    || starting_vector_index_r == option::none())
+            break;
             starting_bucket_index = option::destroy_some(starting_bucket_index_r);
             starting_vector_index = option::destroy_some(starting_vector_index_r);
         };
         assert!(vector::length(&keys) == vector::length(&expected_keys), 0);
-        vector::for_each_ref(&keys, |e_ref| {
-            assert!(vector::contains(&expected_keys, e_ref), 0);
-        });
+        vector::for_each_ref(
+            &keys,
+            |e_ref| {
+                assert!(vector::contains(&expected_keys, e_ref), 0);
+            },
+        );
         destroy(table);
         table = new();
         add(&mut table, 1, 0);
         add(&mut table, 2, 0);
-        (keys, starting_bucket_index_r, starting_vector_index_r) = keys_paginated(&table, 0, 0, 1);
+        (keys, starting_bucket_index_r, starting_vector_index_r) = keys_paginated(
+            &table, 0, 0, 1
+        );
         (returned_keys, starting_bucket_index_r, starting_vector_index_r) = keys_paginated(
             &table,
             option::destroy_some(starting_bucket_index_r),
@@ -690,7 +763,9 @@ module aptos_std::smart_table {
         assert!(keys == vector[1, 2] || keys == vector[2, 1], 0);
         assert!(starting_bucket_index_r == option::none(), 0);
         assert!(starting_vector_index_r == option::none(), 0);
-        (keys, starting_bucket_index_r, starting_vector_index_r) = keys_paginated(&table, 0, 0, 0);
+        (keys, starting_bucket_index_r, starting_vector_index_r) = keys_paginated(
+            &table, 0, 0, 0
+        );
         assert!(keys == vector[], 0);
         assert!(starting_bucket_index_r == option::some(0), 0);
         assert!(starting_vector_index_r == option::some(0), 0);
@@ -708,9 +783,12 @@ module aptos_std::smart_table {
         let (keys, starting_bucket_index_r, starting_vector_index_r) =
             keys_paginated(&table, 0, 0, 5); // Both indices 0.
         assert!(vector::length(&keys) == 5, 0);
-        vector::for_each_ref(&keys, |e_ref| {
-            assert!(vector::contains(&expected_keys, e_ref), 0);
-        });
+        vector::for_each_ref(
+            &keys,
+            |e_ref| {
+                assert!(vector::contains(&expected_keys, e_ref), 0);
+            },
+        );
         let starting_bucket_index = option::destroy_some(starting_bucket_index_r);
         let starting_vector_index = option::destroy_some(starting_vector_index_r);
         (keys, starting_bucket_index_r, starting_vector_index_r) = keys_paginated(
@@ -729,9 +807,12 @@ module aptos_std::smart_table {
             50,
         );
         assert!(vector::length(&keys) == 50, 0);
-        vector::for_each_ref(&keys, |e_ref| {
-            assert!(vector::contains(&expected_keys, e_ref), 0);
-        });
+        vector::for_each_ref(
+            &keys,
+            |e_ref| {
+                assert!(vector::contains(&expected_keys, e_ref), 0);
+            },
+        );
         let starting_bucket_index = option::destroy_some(starting_bucket_index_r);
         assert!(starting_bucket_index > 0, 0);
         assert!(option::is_some(&starting_vector_index_r), 0);
@@ -742,9 +823,12 @@ module aptos_std::smart_table {
             50,
         );
         assert!(vector::length(&keys) == 50, 0);
-        vector::for_each_ref(&keys, |e_ref| {
-            assert!(vector::contains(&expected_keys, e_ref), 0);
-        });
+        vector::for_each_ref(
+            &keys,
+            |e_ref| {
+                assert!(vector::contains(&expected_keys, e_ref), 0);
+            },
+        );
         assert!(option::is_some(&starting_bucket_index_r), 0);
         assert!(option::is_some(&starting_vector_index_r), 0);
         destroy(table);

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_table.spec.move
@@ -15,10 +15,12 @@ spec aptos_std::smart_table {
             map_spec_set = spec_set,
             map_spec_del = spec_remove,
             map_spec_len = spec_len,
-        map_spec_has_key = spec_contains;
+            map_spec_has_key = spec_contains;
     }
 
-    spec new_with_config<K: copy + drop + store, V: store>(num_initial_buckets: u64, split_load_threshold: u8, target_bucket_size: u64): SmartTable<K, V> {
+    spec new_with_config<K: copy + drop + store, V: store>(
+        num_initial_buckets: u64, split_load_threshold: u8, target_bucket_size: u64
+    ): SmartTable<K, V> {
         pragma verify = false;
     }
 
@@ -46,9 +48,7 @@ spec aptos_std::smart_table {
         pragma verify = false;
     }
 
-    spec to_simple_map<K: store + copy + drop, V: store + copy>(
-    table: &SmartTable<K, V>,
-    ): SimpleMap<K, V> {
+    spec to_simple_map<K: store + copy + drop, V: store + copy>(table: &SmartTable<K, V>,): SimpleMap<K, V> {
         pragma verify = false;
     }
 
@@ -61,11 +61,7 @@ spec aptos_std::smart_table {
         starting_bucket_index: u64,
         starting_vector_index: u64,
         num_keys_to_get: u64,
-    ): (
-        vector<K>,
-        Option<u64>,
-        Option<u64>,
-    ) {
+    ): (vector<K>, Option<u64>, Option<u64>,) {
         pragma verify = false;
     }
 
@@ -73,7 +69,9 @@ spec aptos_std::smart_table {
         pragma verify = false;
     }
 
-    spec update_split_load_threshold<K, V>(table: &mut SmartTable<K, V>, split_load_threshold: u8) {
+    spec update_split_load_threshold<K, V>(
+        table: &mut SmartTable<K, V>, split_load_threshold: u8
+    ) {
         pragma verify = false;
     }
 
@@ -103,8 +101,12 @@ spec aptos_std::smart_table {
 
     // Specification functions for tables
     spec native fun spec_len<K, V>(t: SmartTable<K, V>): num;
+
     spec native fun spec_contains<K, V>(t: SmartTable<K, V>, k: K): bool;
+
     spec native fun spec_set<K, V>(t: SmartTable<K, V>, k: K, v: V): SmartTable<K, V>;
+
     spec native fun spec_remove<K, V>(t: SmartTable<K, V>, k: K): SmartTable<K, V>;
+
     spec native fun spec_get<K, V>(t: SmartTable<K, V>, k: K): V;
 }

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.move
@@ -50,7 +50,9 @@ module aptos_std::smart_vector {
 
     /// Create an empty vector with customized config.
     /// When inline_capacity = 0, SmartVector degrades to a wrapper of BigVector.
-    public fun empty_with_config<T: store>(inline_capacity: u64, bucket_size: u64): SmartVector<T> {
+    public fun empty_with_config<T: store>(
+        inline_capacity: u64, bucket_size: u64
+    ): SmartVector<T> {
         assert!(bucket_size > 0, error::invalid_argument(EZERO_BUCKET_SIZE));
         SmartVector {
             inline_vec: vector[],
@@ -117,7 +119,9 @@ module aptos_std::smart_vector {
     /// Empty and destroy the other vector, and push each of the Ts in the other vector onto the lhs vector in the
     /// same order as they occurred in other.
     /// Disclaimer: This function may be costly. Use it at your own discretion.
-    public fun append<T: store>(lhs: &mut SmartVector<T>, other: SmartVector<T>) {
+    public fun append<T: store>(
+        lhs: &mut SmartVector<T>, other: SmartVector<T>
+    ) {
         let other_len = length(&other);
         let half_other_len = other_len / 2;
         let i = 0;
@@ -134,7 +138,10 @@ module aptos_std::smart_vector {
 
     /// Add multiple values to the vector at once.
     public fun add_all<T: store>(v: &mut SmartVector<T>, vals: vector<T>) {
-        vector::for_each(vals, |val| { push_back(v, val); })
+        vector::for_each(vals,
+            |val| {
+                push_back(v, val);
+            })
     }
 
     /// Convert a smart vector to a native vector, which is supposed to be called mostly by view functions to get an
@@ -155,21 +162,23 @@ module aptos_std::smart_vector {
         let len = length(v);
         let inline_len = vector::length(&v.inline_vec);
         if (len == inline_len) {
-            let bucket_size = if (option::is_some(&v.inline_capacity)) {
-                if (len < *option::borrow(&v.inline_capacity)) {
-                    vector::push_back(&mut v.inline_vec, val);
-                    return
+            let bucket_size =
+                if (option::is_some(&v.inline_capacity)) {
+                    if (len < *option::borrow(&v.inline_capacity)) {
+                        vector::push_back(&mut v.inline_vec, val);
+                        return
+                    };
+                    *option::borrow(&v.bucket_size)
+                } else {
+                    let val_size = size_of_val(&val);
+                    if (val_size * (inline_len + 1) < 150 /* magic number */) {
+                        vector::push_back(&mut v.inline_vec, val);
+                        return
+                    };
+                    let estimated_avg_size =
+                        max((size_of_val(&v.inline_vec) + val_size) / (inline_len + 1), 1);
+                    max(1024 /* free_write_quota */ / estimated_avg_size, 1)
                 };
-                *option::borrow(&v.bucket_size)
-            } else {
-                let val_size = size_of_val(&val);
-                if (val_size * (inline_len + 1) < 150 /* magic number */) {
-                    vector::push_back(&mut v.inline_vec, val);
-                    return
-                };
-                let estimated_avg_size = max((size_of_val(&v.inline_vec) + val_size) / (inline_len + 1), 1);
-                max(1024 /* free_write_quota */ / estimated_avg_size, 1)
-            };
             option::fill(&mut v.big_vec, big_vector::empty(bucket_size));
         };
         big_vector::push_back(option::borrow_mut(&mut v.big_vec), val);
@@ -259,7 +268,9 @@ module aptos_std::smart_vector {
         assert!(j < len, error::invalid_argument(EINDEX_OUT_OF_BOUNDS));
         let inline_len = vector::length(&v.inline_vec);
         if (i >= inline_len) {
-            big_vector::swap(option::borrow_mut(&mut v.big_vec), i - inline_len, j - inline_len);
+            big_vector::swap(
+                option::borrow_mut(&mut v.big_vec), i - inline_len, j - inline_len
+            );
         } else if (j < inline_len) {
             vector::swap(&mut v.inline_vec, i, j);
         } else {
@@ -332,11 +343,11 @@ module aptos_std::smart_vector {
 
     /// Return the length of the vector.
     public fun length<T>(v: &SmartVector<T>): u64 {
-        vector::length(&v.inline_vec) + if (option::is_none(&v.big_vec)) {
-            0
-        } else {
-            big_vector::length(option::borrow(&v.big_vec))
-        }
+        vector::length(&v.inline_vec)
+            + if (option::is_none(&v.big_vec)) { 0 }
+            else {
+                big_vector::length(option::borrow(&v.big_vec))
+            }
     }
 
     /// Return `true` if the vector `v` has no Ts and `false` otherwise.
@@ -391,7 +402,9 @@ module aptos_std::smart_vector {
     }
 
     /// Apply the function to a mutable reference of each T in the vector with its index.
-    public inline fun enumerate_mut<T>(v: &mut SmartVector<T>, f: |u64, &mut T|) {
+    public inline fun enumerate_mut<T>(
+        v: &mut SmartVector<T>, f: |u64, &mut T|
+    ) {
         let i = 0;
         let len = length(v);
         while (i < len) {
@@ -405,7 +418,7 @@ module aptos_std::smart_vector {
     public inline fun fold<Accumulator, T: store>(
         v: SmartVector<T>,
         init: Accumulator,
-        f: |Accumulator, T|Accumulator
+        f: |Accumulator, T| Accumulator
     ): Accumulator {
         let accu = init;
         aptos_std::smart_vector::for_each(v, |elem| accu = f(accu, elem));
@@ -417,7 +430,7 @@ module aptos_std::smart_vector {
     public inline fun foldr<Accumulator, T>(
         v: SmartVector<T>,
         init: Accumulator,
-        f: |T, Accumulator|Accumulator
+        f: |T, Accumulator| Accumulator
     ): Accumulator {
         let accu = init;
         aptos_std::smart_vector::for_each_reverse(v, |elem| accu = f(elem, accu));
@@ -427,18 +440,18 @@ module aptos_std::smart_vector {
     /// Map the function over the references of the Ts of the vector, producing a new vector without modifying the
     /// original vector.
     public inline fun map_ref<T1, T2: store>(
-        v: &SmartVector<T1>,
-        f: |&T1|T2
+        v: &SmartVector<T1>, f: |&T1| T2
     ): SmartVector<T2> {
         let result = aptos_std::smart_vector::new<T2>();
-        aptos_std::smart_vector::for_each_ref(v, |elem| aptos_std::smart_vector::push_back(&mut result, f(elem)));
+        aptos_std::smart_vector::for_each_ref(
+            v, |elem| aptos_std::smart_vector::push_back(&mut result, f(elem))
+        );
         result
     }
 
     /// Map the function over the Ts of the vector, producing a new vector.
     public inline fun map<T1: store, T2: store>(
-        v: SmartVector<T1>,
-        f: |T1|T2
+        v: SmartVector<T1>, f: |T1| T2
     ): SmartVector<T2> {
         let result = aptos_std::smart_vector::new<T2>();
         aptos_std::smart_vector::for_each(v, |elem| push_back(&mut result, f(elem)));
@@ -447,17 +460,21 @@ module aptos_std::smart_vector {
 
     /// Filter the vector using the boolean function, removing all Ts for which `p(e)` is not true.
     public inline fun filter<T: store + drop>(
-        v: SmartVector<T>,
-        p: |&T|bool
+        v: SmartVector<T>, p: |&T| bool
     ): SmartVector<T> {
         let result = aptos_std::smart_vector::new<T>();
-        aptos_std::smart_vector::for_each(v, |elem| {
-            if (p(&elem)) aptos_std::smart_vector::push_back(&mut result, elem);
-        });
+        aptos_std::smart_vector::for_each(
+            v,
+            |elem| {
+                if (p(&elem)) aptos_std::smart_vector::push_back(&mut result, elem);
+            },
+        );
         result
     }
 
-    public inline fun zip<T1: store, T2: store>(v1: SmartVector<T1>, v2: SmartVector<T2>, f: |T1, T2|) {
+    public inline fun zip<T1: store, T2: store>(
+        v1: SmartVector<T1>, v2: SmartVector<T2>, f: |T1, T2|
+    ) {
         // We need to reverse the vectors to consume it efficiently
         aptos_std::smart_vector::reverse(&mut v1);
         aptos_std::smart_vector::reverse(&mut v2);
@@ -476,7 +493,10 @@ module aptos_std::smart_vector {
         // due to how inline functions work.
         assert!(len == aptos_std::smart_vector::length(&v2), 0x20005);
         while (len > 0) {
-            f(aptos_std::smart_vector::pop_back(&mut v1), aptos_std::smart_vector::pop_back(&mut v2));
+            f(
+                aptos_std::smart_vector::pop_back(&mut v1),
+                aptos_std::smart_vector::pop_back(&mut v2),
+            );
             len = len - 1;
         };
         aptos_std::smart_vector::destroy_empty(v1);
@@ -496,7 +516,10 @@ module aptos_std::smart_vector {
         assert!(len == aptos_std::smart_vector::length(v2), 0x20005);
         let i = 0;
         while (i < len) {
-            f(aptos_std::smart_vector::borrow(v1, i), aptos_std::smart_vector::borrow(v2, i));
+            f(
+                aptos_std::smart_vector::borrow(v1, i),
+                aptos_std::smart_vector::borrow(v2, i),
+            );
             i = i + 1
         }
     }
@@ -514,7 +537,10 @@ module aptos_std::smart_vector {
         // due to how inline functions work.
         assert!(len == aptos_std::smart_vector::length(v2), 0x20005);
         while (i < len) {
-            f(aptos_std::smart_vector::borrow_mut(v1, i), aptos_std::smart_vector::borrow_mut(v2, i));
+            f(
+                aptos_std::smart_vector::borrow_mut(v1, i),
+                aptos_std::smart_vector::borrow_mut(v2, i),
+            );
             i = i + 1
         }
     }
@@ -523,11 +549,14 @@ module aptos_std::smart_vector {
     public inline fun zip_map<T1: store, T2: store, NewT: store>(
         v1: SmartVector<T1>,
         v2: SmartVector<T2>,
-        f: |T1, T2|NewT
+        f: |T1, T2| NewT
     ): SmartVector<NewT> {
         // We can't use the constant ESMART_VECTORS_LENGTH_MISMATCH here as all calling code would then need to define it
         // due to how inline functions work.
-        assert!(aptos_std::smart_vector::length(&v1) == aptos_std::smart_vector::length(&v2), 0x20005);
+        assert!(
+            aptos_std::smart_vector::length(&v1) == aptos_std::smart_vector::length(&v2),
+            0x20005,
+        );
 
         let result = aptos_std::smart_vector::new<NewT>();
         aptos_std::smart_vector::zip(v1, v2, |e1, e2| push_back(&mut result, f(e1, e2)));
@@ -539,14 +568,19 @@ module aptos_std::smart_vector {
     public inline fun zip_map_ref<T1, T2, NewT: store>(
         v1: &SmartVector<T1>,
         v2: &SmartVector<T2>,
-        f: |&T1, &T2|NewT
+        f: |&T1, &T2| NewT
     ): SmartVector<NewT> {
         // We can't use the constant ESMART_VECTORS_LENGTH_MISMATCH here as all calling code would then need to define it
         // due to how inline functions work.
-        assert!(aptos_std::smart_vector::length(v1) == aptos_std::smart_vector::length(v2), 0x20005);
+        assert!(
+            aptos_std::smart_vector::length(v1) == aptos_std::smart_vector::length(v2),
+            0x20005,
+        );
 
         let result = aptos_std::smart_vector::new<NewT>();
-        aptos_std::smart_vector::zip_ref(v1, v2, |e1, e2| push_back(&mut result, f(e1, e2)));
+        aptos_std::smart_vector::zip_ref(
+            v1, v2, |e1, e2| push_back(&mut result, f(e1, e2))
+        );
         result
     }
 
@@ -689,11 +723,12 @@ module aptos_std::smart_vector {
         let len = length(&v);
         while (i + 1 < len) {
             assert!(
-                *big_vector::borrow(option::borrow(&v.big_vec), i) == *big_vector::borrow(
-                    option::borrow(&v.big_vec),
-                    i + 1
-                ) + 1,
-                0
+                *big_vector::borrow(option::borrow(&v.big_vec), i)
+                    == *big_vector::borrow(
+                        option::borrow(&v.big_vec),
+                        i + 1,
+                    ) + 1,
+                0,
             );
             i = i + 1;
         };

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.move
@@ -138,10 +138,11 @@ module aptos_std::smart_vector {
 
     /// Add multiple values to the vector at once.
     public fun add_all<T: store>(v: &mut SmartVector<T>, vals: vector<T>) {
-        vector::for_each(vals,
-            |val| {
+        vector::for_each(
+            vals, |val| {
                 push_back(v, val);
-            })
+            }
+        )
     }
 
     /// Convert a smart vector to a native vector, which is supposed to be called mostly by view functions to get an
@@ -269,7 +270,9 @@ module aptos_std::smart_vector {
         let inline_len = vector::length(&v.inline_vec);
         if (i >= inline_len) {
             big_vector::swap(
-                option::borrow_mut(&mut v.big_vec), i - inline_len, j - inline_len
+                option::borrow_mut(&mut v.big_vec),
+                i - inline_len,
+                j - inline_len,
             );
         } else if (j < inline_len) {
             vector::swap(&mut v.inline_vec, i, j);
@@ -444,7 +447,8 @@ module aptos_std::smart_vector {
     ): SmartVector<T2> {
         let result = aptos_std::smart_vector::new<T2>();
         aptos_std::smart_vector::for_each_ref(
-            v, |elem| aptos_std::smart_vector::push_back(&mut result, f(elem))
+            v,
+            |elem| aptos_std::smart_vector::push_back(&mut result, f(elem)),
         );
         result
     }

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.spec.move
@@ -8,12 +8,16 @@ spec aptos_std::smart_vector {
         invariant option::is_none(inline_capacity)
             || (len(inline_vec) <= option::borrow(inline_capacity));
         // both `inline_capacity` and `bucket_size` should either exist or shouldn't exist at all.
-        invariant (option::is_none(inline_capacity) && option::is_none(bucket_size))
-            || (option::is_some(inline_capacity) && option::is_some(bucket_size));
+        invariant (option::is_none(inline_capacity)
+                && option::is_none(bucket_size))
+            || (option::is_some(inline_capacity)
+                && option::is_some(bucket_size));
     }
 
     spec length {
-        aborts_if option::is_some(v.big_vec) && len(v.inline_vec) + big_vector::length(option::spec_borrow(v.big_vec)) > MAX_U64;
+        aborts_if option::is_some(v.big_vec)
+            && len(v.inline_vec) + big_vector::length(option::spec_borrow(v.big_vec))
+                > MAX_U64;
     }
 
     spec empty {
@@ -26,15 +30,16 @@ spec aptos_std::smart_vector {
 
     spec destroy_empty {
         aborts_if !(is_empty(v));
-        aborts_if len(v.inline_vec) != 0
-            || option::is_some(v.big_vec);
+        aborts_if len(v.inline_vec) != 0 || option::is_some(v.big_vec);
     }
 
     spec borrow {
         aborts_if i >= length(v);
-        aborts_if option::is_some(v.big_vec) && (
-            (len(v.inline_vec) + big_vector::length<T>(option::borrow(v.big_vec))) > MAX_U64
-        );
+        aborts_if option::is_some(v.big_vec)
+            && (
+                (len(v.inline_vec) + big_vector::length<T>(option::borrow(v.big_vec)))
+                    > MAX_U64
+            );
     }
 
     spec push_back<T: store>(v: &mut SmartVector<T>, val: T) {
@@ -65,13 +70,14 @@ spec aptos_std::smart_vector {
 
         pragma verify_duration_estimate = 120; // TODO: set because of timeout (property proved)
 
-        aborts_if  option::is_some(v.big_vec)
-            &&
-            (table_with_length::spec_len(option::borrow(v.big_vec).buckets) == 0);
+        aborts_if option::is_some(v.big_vec)
+            && (table_with_length::spec_len(option::borrow(v.big_vec).buckets) == 0);
         aborts_if is_empty(v);
-        aborts_if option::is_some(v.big_vec) && (
-            (len(v.inline_vec) + big_vector::length<T>(option::borrow(v.big_vec))) > MAX_U64
-        );
+        aborts_if option::is_some(v.big_vec)
+            && (
+                (len(v.inline_vec) + big_vector::length<T>(option::borrow(v.big_vec)))
+                    > MAX_U64
+            );
 
         ensures length(v) == length(old(v)) - 1;
     }
@@ -79,9 +85,11 @@ spec aptos_std::smart_vector {
     spec swap_remove {
         pragma verify = false; // TODO: set because of timeout
         aborts_if i >= length(v);
-        aborts_if option::is_some(v.big_vec) && (
-            (len(v.inline_vec) + big_vector::length<T>(option::borrow(v.big_vec))) > MAX_U64
-        );
+        aborts_if option::is_some(v.big_vec)
+            && (
+                (len(v.inline_vec) + big_vector::length<T>(option::borrow(v.big_vec)))
+                    > MAX_U64
+            );
         ensures length(v) == length(old(v)) - 1;
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/smart_vector.spec.move
@@ -9,7 +9,7 @@ spec aptos_std::smart_vector {
             || (len(inline_vec) <= option::borrow(inline_capacity));
         // both `inline_capacity` and `bucket_size` should either exist or shouldn't exist at all.
         invariant (option::is_none(inline_capacity)
-                && option::is_none(bucket_size))
+            && option::is_none(bucket_size))
             || (option::is_some(inline_capacity)
                 && option::is_some(bucket_size));
     }

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/tests/smart_table_test.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/tests/smart_table_test.move
@@ -17,9 +17,10 @@ module aptos_std::smart_table_test {
     public fun smart_table_for_each_ref_test() {
         let t = make_smart_table();
         let s = 0;
-        smart_table::for_each_ref(&t, |x, y| {
-            s = s + *x + *y;
-        });
+        smart_table::for_each_ref(&t,
+            |x, y| {
+                s = s + *x + *y;
+            });
         assert!(s == 9900, 0);
         smart_table::destroy(t);
     }
@@ -27,13 +28,19 @@ module aptos_std::smart_table_test {
     #[test]
     public fun smart_table_for_each_mut_test() {
         let t = make_smart_table();
-        smart_table::for_each_mut(&mut t, |_key, val| {
-            let val: &mut u64 = val;
-            *val = *val + 1
-        });
-        smart_table::for_each_ref(&t, |key, val| {
-            assert!(*key + 1 == *val, *key);
-        });
+        smart_table::for_each_mut(
+            &mut t,
+            |_key, val| {
+                let val: &mut u64 = val;
+                *val = *val + 1
+            },
+        );
+        smart_table::for_each_ref(
+            &t,
+            |key, val| {
+                assert!(*key + 1 == *val, *key);
+            }
+        );
         smart_table::destroy(t);
     }
 
@@ -41,9 +48,12 @@ module aptos_std::smart_table_test {
     public fun smart_table_test_map_ref_test() {
         let t = make_smart_table();
         let r = smart_table::map_ref(&t, |val| *val + 1);
-        smart_table::for_each_ref(&r, |key, val| {
-            assert!(*key + 1 == *val, *key);
-        });
+        smart_table::for_each_ref(
+            &r,
+            |key, val| {
+                assert!(*key + 1 == *val, *key);
+            }
+        );
         smart_table::destroy(t);
         smart_table::destroy(r);
     }

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/tests/smart_table_test.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/tests/smart_table_test.move
@@ -17,10 +17,11 @@ module aptos_std::smart_table_test {
     public fun smart_table_for_each_ref_test() {
         let t = make_smart_table();
         let s = 0;
-        smart_table::for_each_ref(&t,
-            |x, y| {
+        smart_table::for_each_ref(
+            &t, |x, y| {
                 s = s + *x + *y;
-            });
+            }
+        );
         assert!(s == 9900, 0);
         smart_table::destroy(t);
     }
@@ -39,7 +40,7 @@ module aptos_std::smart_table_test {
             &t,
             |key, val| {
                 assert!(*key + 1 == *val, *key);
-            }
+            },
         );
         smart_table::destroy(t);
     }
@@ -52,7 +53,7 @@ module aptos_std::smart_table_test {
             &r,
             |key, val| {
                 assert!(*key + 1 == *val, *key);
-            }
+            },
         );
         smart_table::destroy(t);
         smart_table::destroy(r);

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/tests/smart_vector_test.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/tests/smart_vector_test.move
@@ -23,7 +23,7 @@ module aptos_std::smart_vector_test {
             |x| {
                 assert!(i + 1 == x, 0);
                 i = i + 1;
-            }
+            },
         );
     }
 
@@ -36,7 +36,7 @@ module aptos_std::smart_vector_test {
             |x| {
                 assert!(i == 100 - x, 0);
                 i = i + 1;
-            }
+            },
         );
     }
 
@@ -44,10 +44,9 @@ module aptos_std::smart_vector_test {
     fun smart_vector_for_each_ref_test() {
         let v = make_smart_vector(100);
         let s = 0;
-        V::for_each_ref(&v,
-            |x| {
-                s = s + *x;
-            });
+        V::for_each_ref(&v, |x| {
+            s = s + *x;
+        });
         assert!(s == 5050, 0);
         V::destroy(v);
     }
@@ -68,10 +67,11 @@ module aptos_std::smart_vector_test {
     #[test]
     fun smart_vector_enumerate_ref_test() {
         let v = make_smart_vector(100);
-        V::enumerate_ref(&v,
-            |i, x| {
+        V::enumerate_ref(
+            &v, |i, x| {
                 assert!(i + 1 == *x, 0);
-            });
+            }
+        );
         V::destroy(v);
     }
 
@@ -145,7 +145,7 @@ module aptos_std::smart_vector_test {
             &filtered_v,
             |i, x| {
                 assert!((i + 1) * 10 == *x, 0);
-            }
+            },
         );
         V::destroy(filtered_v);
     }

--- a/aptos-move/framework/aptos-stdlib/sources/data_structures/tests/smart_vector_test.move
+++ b/aptos-move/framework/aptos-stdlib/sources/data_structures/tests/smart_vector_test.move
@@ -18,29 +18,36 @@ module aptos_std::smart_vector_test {
     fun smart_vector_for_each_test() {
         let v = make_smart_vector(100);
         let i = 0;
-        V::for_each(v, |x| {
-            assert!(i + 1 == x, 0);
-            i = i + 1;
-        });
+        V::for_each(
+            v,
+            |x| {
+                assert!(i + 1 == x, 0);
+                i = i + 1;
+            }
+        );
     }
 
     #[test]
     fun smart_vector_for_each_reverse_test() {
         let v = make_smart_vector(100);
         let i = 0;
-        V::for_each_reverse(v, |x| {
-            assert!(i == 100 - x, 0);
-            i = i + 1;
-        });
+        V::for_each_reverse(
+            v,
+            |x| {
+                assert!(i == 100 - x, 0);
+                i = i + 1;
+            }
+        );
     }
 
     #[test]
     fun smart_vector_for_each_ref_test() {
         let v = make_smart_vector(100);
         let s = 0;
-        V::for_each_ref(&v, |x| {
-            s = s + *x;
-        });
+        V::for_each_ref(&v,
+            |x| {
+                s = s + *x;
+            });
         assert!(s == 5050, 0);
         V::destroy(v);
     }
@@ -48,46 +55,53 @@ module aptos_std::smart_vector_test {
     #[test]
     fun smart_vector_for_each_mut_test() {
         let v = make_smart_vector(100);
-        V::for_each_mut(&mut v, |x| {
-            let x: &mut u64 = x;
-            *x = *x + 1;
-        });
-        assert!(V::fold(v, 0, |s, x| {
-            s + x
-        }) == 5150, 0);
+        V::for_each_mut(
+            &mut v,
+            |x| {
+                let x: &mut u64 = x;
+                *x = *x + 1;
+            },
+        );
+        assert!(V::fold(v, 0, |s, x| { s + x }) == 5150, 0);
     }
 
     #[test]
     fun smart_vector_enumerate_ref_test() {
         let v = make_smart_vector(100);
-        V::enumerate_ref(&v, |i, x| {
-            assert!(i + 1 == *x, 0);
-        });
+        V::enumerate_ref(&v,
+            |i, x| {
+                assert!(i + 1 == *x, 0);
+            });
         V::destroy(v);
     }
 
     #[test]
     fun smart_vector_enumerate_mut_test() {
         let v = make_smart_vector(100);
-        V::enumerate_mut(&mut v, |i, x| {
-            let x: &mut u64 = x;
-            assert!(i + 1 == *x, 0);
-            *x = *x + 1;
-        });
-        assert!(V::fold(v, 0, |s, x| {
-            s + x
-        }) == 5150, 0);
+        V::enumerate_mut(
+            &mut v,
+            |i, x| {
+                let x: &mut u64 = x;
+                assert!(i + 1 == *x, 0);
+                *x = *x + 1;
+            },
+        );
+        assert!(V::fold(v, 0, |s, x| { s + x }) == 5150, 0);
     }
 
     #[test]
     fun smart_vector_fold_test() {
         let v = make_smart_vector(100);
         let i = 0;
-        let sum = V::fold(v, 0, |s, x| {
-            assert!(i + 1 == x, 0);
-            i = i + 1;
-            s + x
-        });
+        let sum = V::fold(
+            v,
+            0,
+            |s, x| {
+                assert!(i + 1 == x, 0);
+                i = i + 1;
+                s + x
+            },
+        );
         assert!(sum == 5050, 0);
     }
 
@@ -95,11 +109,15 @@ module aptos_std::smart_vector_test {
     fun smart_vector_for_foldr_test() {
         let v = make_smart_vector(100);
         let i = 0;
-        let sum = V::foldr(v, 0, |x, s| {
-            assert!(i == 100 - x, i);
-            i = i + 1;
-            s + x
-        });
+        let sum = V::foldr(
+            v,
+            0,
+            |x, s| {
+                assert!(i == 100 - x, i);
+                i = i + 1;
+                s + x
+            },
+        );
         assert!(sum == 5050, 0);
     }
 
@@ -107,31 +125,28 @@ module aptos_std::smart_vector_test {
     fun smart_vector_map_test() {
         let v = make_smart_vector(100);
         let mapped_v = V::map(v, |x| { x * 2 });
-        let sum = V::fold(mapped_v, 0, |s, x| {
-            s + x
-        });
+        let sum = V::fold(mapped_v, 0, |s, x| { s + x });
         assert!(sum == 10100, 0);
     }
 
     #[test]
     fun smart_vector_map_ref_test() {
         let v = make_smart_vector(100);
-        let mapped_v = V::map_ref(&v, |x|  *x * 2);
-        assert!(V::fold(v, 0, |s, x| {
-            s + x
-        }) == 5050, 0);
-        assert!(V::fold(mapped_v, 0, |s, x| {
-            s + x
-        }) == 10100, 0);
+        let mapped_v = V::map_ref(&v, |x| *x * 2);
+        assert!(V::fold(v, 0, |s, x| { s + x }) == 5050, 0);
+        assert!(V::fold(mapped_v, 0, |s, x| { s + x }) == 10100, 0);
     }
 
     #[test]
     fun smart_vector_filter_test() {
         let v = make_smart_vector(100);
         let filtered_v = V::filter(v, |x| *x % 10 == 0);
-        V::enumerate_ref(&filtered_v, |i, x| {
-            assert!((i + 1) * 10 == *x, 0);
-        });
+        V::enumerate_ref(
+            &filtered_v,
+            |i, x| {
+                assert!((i + 1) * 10 == *x, 0);
+            }
+        );
         V::destroy(filtered_v);
     }
 
@@ -140,11 +155,15 @@ module aptos_std::smart_vector_test {
         let v1 = make_smart_vector(100);
         let v2 = make_smart_vector(100);
         let s = 0;
-        V::zip(v1, v2, |e1, e2| {
-            let e1: u64 = e1;
-            let e2: u64 = e2;
-            s = s + e1 / e2
-        });
+        V::zip(
+            v1,
+            v2,
+            |e1, e2| {
+                let e1: u64 = e1;
+                let e2: u64 = e2;
+                s = s + e1 / e2
+            },
+        );
         assert!(s == 100, 0);
     }
 
@@ -155,11 +174,15 @@ module aptos_std::smart_vector_test {
         let v1 = make_smart_vector(100);
         let v2 = make_smart_vector(99);
         let s = 0;
-        V::zip(v1, v2, |e1, e2| {
-            let e1: u64 = e1;
-            let e2: u64 = e2;
-            s = s + e1 / e2
-        });
+        V::zip(
+            v1,
+            v2,
+            |e1, e2| {
+                let e1: u64 = e1;
+                let e2: u64 = e2;
+                s = s + e1 / e2
+            },
+        );
     }
 
     #[test]
@@ -189,12 +212,16 @@ module aptos_std::smart_vector_test {
     fun smart_vector_test_zip_mut() {
         let v1 = make_smart_vector(100);
         let v2 = make_smart_vector(100);
-        V::zip_mut(&mut v1, &mut v2, |e1, e2| {
-            let e1: &mut u64 = e1;
-            let e2: &mut u64 = e2;
-            *e1 = *e1 + 1;
-            *e2 = *e2 - 1;
-        });
+        V::zip_mut(
+            &mut v1,
+            &mut v2,
+            |e1, e2| {
+                let e1: &mut u64 = e1;
+                let e2: &mut u64 = e2;
+                *e1 = *e1 + 1;
+                *e2 = *e2 - 1;
+            },
+        );
         V::zip_ref(&v1, &v2, |e1, e2| assert!(*e1 == *e2 + 2, 0));
         V::destroy(v1);
         V::destroy(v2);

--- a/aptos-move/framework/aptos-stdlib/sources/debug.move
+++ b/aptos-move/framework/aptos-stdlib/sources/debug.move
@@ -22,10 +22,18 @@ module aptos_std::debug {
 
     #[test_only]
     struct Foo has drop {}
+
     #[test_only]
-    struct Bar has drop { x: u128, y: Foo, z: bool }
+    struct Bar has drop {
+        x: u128,
+        y: Foo,
+        z: bool
+    }
+
     #[test_only]
-    struct Box<T> has drop { x: T }
+    struct Box<T> has drop {
+        x: T
+    }
 
     #[test_only]
     struct GenericStruct<phantom T> has drop {
@@ -63,7 +71,7 @@ module aptos_std::debug {
     }
 
     #[test]
-    public fun test()  {
+    public fun test() {
         let x = 42;
         assert_equal(&x, b"42");
 
@@ -77,17 +85,25 @@ module aptos_std::debug {
         assert_equal(&foo, b"0x1::debug::Foo {\n  dummy_field: false\n}");
 
         let bar = Bar { x: 404, y: Foo {}, z: true };
-        assert_equal(&bar, b"0x1::debug::Bar {\n  x: 404,\n  y: 0x1::debug::Foo {\n    dummy_field: false\n  },\n  z: true\n}");
+        assert_equal(
+            &bar,
+            b"0x1::debug::Bar {\n  x: 404,\n  y: 0x1::debug::Foo {\n    dummy_field: false\n  },\n  z: true\n}",
+        );
 
         let box = Box { x: Foo {} };
-        assert_equal(&box, b"0x1::debug::Box<0x1::debug::Foo> {\n  x: 0x1::debug::Foo {\n    dummy_field: false\n  }\n}");
+        assert_equal(
+            &box,
+            b"0x1::debug::Box<0x1::debug::Foo> {\n  x: 0x1::debug::Foo {\n    dummy_field: false\n  }\n}",
+        );
     }
 
     #[test]
     fun test_print_string() {
         let str_bytes = b"Hello, sane Move debugging!";
 
-        assert_equal(&str_bytes, b"0x48656c6c6f2c2073616e65204d6f766520646562756767696e6721");
+        assert_equal(
+            &str_bytes, b"0x48656c6c6f2c2073616e65204d6f766520646562756767696e6721"
+        );
 
         let str = std::string::utf8(str_bytes);
         assert_equal(&str, b"\"Hello, sane Move debugging!\"");
@@ -100,7 +116,6 @@ module aptos_std::debug {
         let str = std::string::utf8(str_bytes);
         assert_equal(&str, b"\"Can you say \\\"Hel\\\\lo\\\"?\"");
     }
-
 
     #[test_only]
     use std::features;
@@ -121,8 +136,13 @@ module aptos_std::debug {
         let u128 = 340282366920938463463374607431768211455u128;
         assert_equal(&u128, b"340282366920938463463374607431768211455");
 
-        let u256 = 115792089237316195423570985008687907853269984665640564039457584007913129639935u256;
-        assert_equal(&u256, b"115792089237316195423570985008687907853269984665640564039457584007913129639935");
+        let u256 =
+
+                115792089237316195423570985008687907853269984665640564039457584007913129639935u256;
+        assert_equal(
+            &u256,
+            b"115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        );
 
         let bool = false;
         assert_equal(&bool, b"false");
@@ -139,8 +159,8 @@ module aptos_std::debug {
         }
     }
 
-    const MSG_1 : vector<u8> = b"abcdef";
-    const MSG_2 : vector<u8> = b"123456";
+    const MSG_1: vector<u8> = b"abcdef";
+    const MSG_2: vector<u8> = b"123456";
 
     #[test]
     fun test_print_struct() {
@@ -150,13 +170,12 @@ module aptos_std::debug {
             msgs: vector[MSG_1, MSG_2],
         };
 
-        assert_equal(&obj, b"0x1::debug::TestInner {\n  val: 100,\n  vec: [ 200, 400 ],\n  msgs: [\n    0x616263646566,\n    0x313233343536\n  ]\n}");
+        assert_equal(
+            &obj,
+            b"0x1::debug::TestInner {\n  val: 100,\n  vec: [ 200, 400 ],\n  msgs: [\n    0x616263646566,\n    0x313233343536\n  ]\n}",
+        );
 
-        let obj = TestInner {
-            val: 10,
-            vec: vector[],
-            msgs: vector[],
-        };
+        let obj = TestInner { val: 10, vec: vector[], msgs: vector[], };
 
         assert_equal(&obj, b"0x1::debug::TestInner {\n  val: 10,\n  vec: [],\n  msgs: []\n}");
     }
@@ -199,12 +218,14 @@ module aptos_std::debug {
                 msgs: vector[x"00ff", x"abcd"],
             },
             TestInner {
-                val: 8u128 ,
+                val: 8u128,
                 vec: vector[128u128, 129u128],
                 msgs: vector[x"0000"],
-            }
-        ];
-        assert_equal(&v, b"[\n  0x1::debug::TestInner {\n    val: 4,\n    vec: [ 127, 128 ],\n    msgs: [\n      0x00ff,\n      0xabcd\n    ]\n  },\n  0x1::debug::TestInner {\n    val: 8,\n    vec: [ 128, 129 ],\n    msgs: [\n      0x0000\n    ]\n  }\n]");
+            }];
+        assert_equal(
+            &v,
+            b"[\n  0x1::debug::TestInner {\n    val: 4,\n    vec: [ 127, 128 ],\n    msgs: [\n      0x00ff,\n      0xabcd\n    ]\n  },\n  0x1::debug::TestInner {\n    val: 8,\n    vec: [ 128, 129 ],\n    msgs: [\n      0x0000\n    ]\n  }\n]",
+        );
     }
 
     #[test(s1 = @0x123, s2 = @0x456)]
@@ -241,14 +262,14 @@ module aptos_std::debug {
         let v = vector[
             vector[
                 TestInner { val: 4u128, vec: vector[127u128, 128u128], msgs: vector[] },
-                TestInner { val: 8u128 , vec: vector[128u128, 129u128], msgs: vector[] }
-            ],
+                TestInner { val: 8u128, vec: vector[128u128, 129u128], msgs: vector[] }],
             vector[
                 TestInner { val: 4u128, vec: vector[127u128, 128u128], msgs: vector[] },
-                TestInner { val: 8u128 , vec: vector[128u128, 129u128], msgs: vector[] }
-            ]
-        ];
-        assert_equal(&v, b"[\n  [\n    0x1::debug::TestInner {\n      val: 4,\n      vec: [ 127, 128 ],\n      msgs: []\n    },\n    0x1::debug::TestInner {\n      val: 8,\n      vec: [ 128, 129 ],\n      msgs: []\n    }\n  ],\n  [\n    0x1::debug::TestInner {\n      val: 4,\n      vec: [ 127, 128 ],\n      msgs: []\n    },\n    0x1::debug::TestInner {\n      val: 8,\n      vec: [ 128, 129 ],\n      msgs: []\n    }\n  ]\n]");
+                TestInner { val: 8u128, vec: vector[128u128, 129u128], msgs: vector[] }]];
+        assert_equal(
+            &v,
+            b"[\n  [\n    0x1::debug::TestInner {\n      val: 4,\n      vec: [ 127, 128 ],\n      msgs: []\n    },\n    0x1::debug::TestInner {\n      val: 8,\n      vec: [ 128, 129 ],\n      msgs: []\n    }\n  ],\n  [\n    0x1::debug::TestInner {\n      val: 4,\n      vec: [ 127, 128 ],\n      msgs: []\n    },\n    0x1::debug::TestInner {\n      val: 8,\n      vec: [ 128, 129 ],\n      msgs: []\n    }\n  ]\n]",
+        );
     }
 
     #[test]
@@ -260,18 +281,18 @@ module aptos_std::debug {
             name: std::string::utf8(b"He\"llo"),
             vec: vector[
                 TestInner { val: 1, vec: vector[130u128, 131u128], msgs: vector[] },
-                TestInner { val: 2, vec: vector[132u128, 133u128], msgs: vector[] }
-            ],
+                TestInner { val: 2, vec: vector[132u128, 133u128], msgs: vector[] }],
         };
 
-        assert_equal(&obj, b"0x1::debug::TestStruct {\n  addr: @0x1,\n  number: 255,\n  bytes: 0xc0ffee,\n  name: \"He\\\"llo\",\n  vec: [\n    0x1::debug::TestInner {\n      val: 1,\n      vec: [ 130, 131 ],\n      msgs: []\n    },\n    0x1::debug::TestInner {\n      val: 2,\n      vec: [ 132, 133 ],\n      msgs: []\n    }\n  ]\n}");
+        assert_equal(
+            &obj,
+            b"0x1::debug::TestStruct {\n  addr: @0x1,\n  number: 255,\n  bytes: 0xc0ffee,\n  name: \"He\\\"llo\",\n  vec: [\n    0x1::debug::TestInner {\n      val: 1,\n      vec: [ 130, 131 ],\n      msgs: []\n    },\n    0x1::debug::TestInner {\n      val: 2,\n      vec: [ 132, 133 ],\n      msgs: []\n    }\n  ]\n}",
+        );
     }
 
     #[test]
     fun test_print_generic_struct() {
-        let obj = GenericStruct<Foo> {
-            val: 60u64,
-        };
+        let obj = GenericStruct<Foo> { val: 60u64, };
 
         assert_equal(&obj, b"0x1::debug::GenericStruct<0x1::debug::Foo> {\n  val: 60\n}");
     }

--- a/aptos-move/framework/aptos-stdlib/sources/debug.move
+++ b/aptos-move/framework/aptos-stdlib/sources/debug.move
@@ -217,11 +217,8 @@ module aptos_std::debug {
                 vec: vector[127u128, 128u128],
                 msgs: vector[x"00ff", x"abcd"],
             },
-            TestInner {
-                val: 8u128,
-                vec: vector[128u128, 129u128],
-                msgs: vector[x"0000"],
-            }];
+            TestInner { val: 8u128, vec: vector[128u128, 129u128], msgs: vector[x"0000"], }
+        ];
         assert_equal(
             &v,
             b"[\n  0x1::debug::TestInner {\n    val: 4,\n    vec: [ 127, 128 ],\n    msgs: [\n      0x00ff,\n      0xabcd\n    ]\n  },\n  0x1::debug::TestInner {\n    val: 8,\n    vec: [ 128, 129 ],\n    msgs: [\n      0x0000\n    ]\n  }\n]",
@@ -262,10 +259,13 @@ module aptos_std::debug {
         let v = vector[
             vector[
                 TestInner { val: 4u128, vec: vector[127u128, 128u128], msgs: vector[] },
-                TestInner { val: 8u128, vec: vector[128u128, 129u128], msgs: vector[] }],
+                TestInner { val: 8u128, vec: vector[128u128, 129u128], msgs: vector[] }
+            ],
             vector[
                 TestInner { val: 4u128, vec: vector[127u128, 128u128], msgs: vector[] },
-                TestInner { val: 8u128, vec: vector[128u128, 129u128], msgs: vector[] }]];
+                TestInner { val: 8u128, vec: vector[128u128, 129u128], msgs: vector[] }
+            ]
+        ];
         assert_equal(
             &v,
             b"[\n  [\n    0x1::debug::TestInner {\n      val: 4,\n      vec: [ 127, 128 ],\n      msgs: []\n    },\n    0x1::debug::TestInner {\n      val: 8,\n      vec: [ 128, 129 ],\n      msgs: []\n    }\n  ],\n  [\n    0x1::debug::TestInner {\n      val: 4,\n      vec: [ 127, 128 ],\n      msgs: []\n    },\n    0x1::debug::TestInner {\n      val: 8,\n      vec: [ 128, 129 ],\n      msgs: []\n    }\n  ]\n]",
@@ -281,7 +281,8 @@ module aptos_std::debug {
             name: std::string::utf8(b"He\"llo"),
             vec: vector[
                 TestInner { val: 1, vec: vector[130u128, 131u128], msgs: vector[] },
-                TestInner { val: 2, vec: vector[132u128, 133u128], msgs: vector[] }],
+                TestInner { val: 2, vec: vector[132u128, 133u128], msgs: vector[] }
+            ],
         };
 
         assert_equal(

--- a/aptos-move/framework/aptos-stdlib/sources/fixed_point64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/fixed_point64.move
@@ -444,7 +444,9 @@ module aptos_std::fixed_point64 {
         // 9/7 - 1/3 = 20/21
         let expected_result = create_from_rational(20, 21);
         assert_approx_the_same(
-            (get_raw_value(result) as u256), (get_raw_value(expected_result) as u256), 16
+            (get_raw_value(result) as u256),
+            (get_raw_value(expected_result) as u256),
+            16,
         );
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/fixed_point64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/fixed_point64.move
@@ -12,7 +12,9 @@ module aptos_std::fixed_point64 {
     /// floating-point has less than 16 decimal digits of precision, so
     /// be careful about using floating-point to convert these values to
     /// decimal.
-    struct FixedPoint64 has copy, drop, store { value: u128 }
+    struct FixedPoint64 has copy, drop, store {
+        value: u128
+    }
 
     const MAX_U128: u256 = 340282366920938463463374607431768211455;
 
@@ -36,6 +38,7 @@ module aptos_std::fixed_point64 {
         assert!(x_raw >= y_raw, ENEGATIVE_RESULT);
         create_from_raw_value(x_raw - y_raw)
     }
+
     spec sub {
         pragma opaque;
         aborts_if x.value < y.value with ENEGATIVE_RESULT;
@@ -50,6 +53,7 @@ module aptos_std::fixed_point64 {
         assert!(result <= MAX_U128, ERATIO_OUT_OF_RANGE);
         create_from_raw_value((result as u128))
     }
+
     spec add {
         pragma opaque;
         aborts_if (x.value as u256) + (y.value as u256) > MAX_U128 with ERATIO_OUT_OF_RANGE;
@@ -71,16 +75,19 @@ module aptos_std::fixed_point64 {
         assert!(product <= MAX_U128, EMULTIPLICATION);
         (product as u128)
     }
+
     spec multiply_u128 {
         pragma opaque;
         include MultiplyAbortsIf;
         ensures result == spec_multiply_u128(val, multiplier);
     }
+
     spec schema MultiplyAbortsIf {
         val: num;
         multiplier: FixedPoint64;
         aborts_if spec_multiply_u128(val, multiplier) > MAX_U128 with EMULTIPLICATION;
     }
+
     spec fun spec_multiply_u128(val: num, multiplier: FixedPoint64): num {
         (val * multiplier.value) >> 64
     }
@@ -101,17 +108,20 @@ module aptos_std::fixed_point64 {
         // with an arithmetic error.
         (quotient as u128)
     }
+
     spec divide_u128 {
         pragma opaque;
         include DivideAbortsIf;
         ensures result == spec_divide_u128(val, divisor);
     }
+
     spec schema DivideAbortsIf {
         val: num;
         divisor: FixedPoint64;
         aborts_if divisor.value == 0 with EDIVISION_BY_ZERO;
         aborts_if spec_divide_u128(val, divisor) > MAX_U128 with EDIVISION;
     }
+
     spec fun spec_divide_u128(val: num, divisor: FixedPoint64): num {
         (val << 64) / divisor.value
     }
@@ -139,30 +149,34 @@ module aptos_std::fixed_point64 {
         assert!(quotient <= MAX_U128, ERATIO_OUT_OF_RANGE);
         FixedPoint64 { value: (quotient as u128) }
     }
+
     spec create_from_rational {
         pragma opaque;
         pragma verify_duration_estimate = 1000; // TODO: set because of timeout (property proved).
         include CreateFromRationalAbortsIf;
         ensures result == spec_create_from_rational(numerator, denominator);
     }
+
     spec schema CreateFromRationalAbortsIf {
         numerator: u128;
         denominator: u128;
-        let scaled_numerator = (numerator as u256)<< 64;
+        let scaled_numerator = (numerator as u256) << 64;
         let scaled_denominator = (denominator as u256);
         let quotient = scaled_numerator / scaled_denominator;
         aborts_if scaled_denominator == 0 with EDENOMINATOR;
         aborts_if quotient == 0 && scaled_numerator != 0 with ERATIO_OUT_OF_RANGE;
         aborts_if quotient > MAX_U128 with ERATIO_OUT_OF_RANGE;
     }
+
     spec fun spec_create_from_rational(numerator: num, denominator: num): FixedPoint64 {
-        FixedPoint64{value: (numerator << 128) / (denominator << 64)}
+        FixedPoint64 { value: (numerator << 128) / (denominator << 64) }
     }
 
     /// Create a fixedpoint value from a raw value.
     public fun create_from_raw_value(value: u128): FixedPoint64 {
         FixedPoint64 { value }
     }
+
     spec create_from_raw_value {
         pragma opaque;
         aborts_if false;
@@ -183,55 +197,49 @@ module aptos_std::fixed_point64 {
 
     /// Returns the smaller of the two FixedPoint64 numbers.
     public fun min(num1: FixedPoint64, num2: FixedPoint64): FixedPoint64 {
-        if (num1.value < num2.value) {
-            num1
-        } else {
-            num2
-        }
+        if (num1.value < num2.value) { num1 }
+        else { num2 }
     }
+
     spec min {
         pragma opaque;
         aborts_if false;
         ensures result == spec_min(num1, num2);
     }
+
     spec fun spec_min(num1: FixedPoint64, num2: FixedPoint64): FixedPoint64 {
-        if (num1.value < num2.value) {
-            num1
-        } else {
-            num2
-        }
+        if (num1.value < num2.value) { num1 }
+        else { num2 }
     }
 
     /// Returns the larger of the two FixedPoint64 numbers.
     public fun max(num1: FixedPoint64, num2: FixedPoint64): FixedPoint64 {
-        if (num1.value > num2.value) {
-            num1
-        } else {
-            num2
-        }
+        if (num1.value > num2.value) { num1 }
+        else { num2 }
     }
+
     spec max {
         pragma opaque;
         aborts_if false;
         ensures result == spec_max(num1, num2);
     }
+
     spec fun spec_max(num1: FixedPoint64, num2: FixedPoint64): FixedPoint64 {
-        if (num1.value > num2.value) {
-            num1
-        } else {
-            num2
-        }
+        if (num1.value > num2.value) { num1 }
+        else { num2 }
     }
 
     /// Returns true if num1 <= num2
     public fun less_or_equal(num1: FixedPoint64, num2: FixedPoint64): bool {
         num1.value <= num2.value
     }
+
     spec less_or_equal {
         pragma opaque;
         aborts_if false;
         ensures result == spec_less_or_equal(num1, num2);
     }
+
     spec fun spec_less_or_equal(num1: FixedPoint64, num2: FixedPoint64): bool {
         num1.value <= num2.value
     }
@@ -240,11 +248,13 @@ module aptos_std::fixed_point64 {
     public fun less(num1: FixedPoint64, num2: FixedPoint64): bool {
         num1.value < num2.value
     }
+
     spec less {
         pragma opaque;
         aborts_if false;
         ensures result == spec_less(num1, num2);
     }
+
     spec fun spec_less(num1: FixedPoint64, num2: FixedPoint64): bool {
         num1.value < num2.value
     }
@@ -253,11 +263,13 @@ module aptos_std::fixed_point64 {
     public fun greater_or_equal(num1: FixedPoint64, num2: FixedPoint64): bool {
         num1.value >= num2.value
     }
+
     spec greater_or_equal {
         pragma opaque;
         aborts_if false;
         ensures result == spec_greater_or_equal(num1, num2);
     }
+
     spec fun spec_greater_or_equal(num1: FixedPoint64, num2: FixedPoint64): bool {
         num1.value >= num2.value
     }
@@ -266,11 +278,13 @@ module aptos_std::fixed_point64 {
     public fun greater(num1: FixedPoint64, num2: FixedPoint64): bool {
         num1.value > num2.value
     }
+
     spec greater {
         pragma opaque;
         aborts_if false;
         ensures result == spec_greater(num1, num2);
     }
+
     spec fun spec_greater(num1: FixedPoint64, num2: FixedPoint64): bool {
         num1.value > num2.value
     }
@@ -279,28 +293,34 @@ module aptos_std::fixed_point64 {
     public fun equal(num1: FixedPoint64, num2: FixedPoint64): bool {
         num1.value == num2.value
     }
+
     spec equal {
         pragma opaque;
         aborts_if false;
         ensures result == spec_equal(num1, num2);
     }
+
     spec fun spec_equal(num1: FixedPoint64, num2: FixedPoint64): bool {
         num1.value == num2.value
     }
 
     /// Returns true if num1 almost equals to num2, which means abs(num1-num2) <= precision
-    public fun almost_equal(num1: FixedPoint64, num2: FixedPoint64, precision: FixedPoint64): bool {
+    public fun almost_equal(
+        num1: FixedPoint64, num2: FixedPoint64, precision: FixedPoint64
+    ): bool {
         if (num1.value > num2.value) {
             (num1.value - num2.value <= precision.value)
         } else {
             (num2.value - num1.value <= precision.value)
         }
     }
+
     spec almost_equal {
         pragma opaque;
         aborts_if false;
         ensures result == spec_almost_equal(num1, num2, precision);
     }
+
     spec fun spec_almost_equal(num1: FixedPoint64, num2: FixedPoint64, precision: FixedPoint64): bool {
         if (num1.value > num2.value) {
             (num1.value - num2.value <= precision.value)
@@ -308,35 +328,41 @@ module aptos_std::fixed_point64 {
             (num2.value - num1.value <= precision.value)
         }
     }
+
     /// Create a fixedpoint value from a u128 value.
     public fun create_from_u128(val: u128): FixedPoint64 {
         let value = (val as u256) << 64;
         assert!(value <= MAX_U128, ERATIO_OUT_OF_RANGE);
-        FixedPoint64 {value: (value as u128)}
+        FixedPoint64 { value: (value as u128) }
     }
+
     spec create_from_u128 {
         pragma opaque;
         include CreateFromU64AbortsIf;
         ensures result == spec_create_from_u128(val);
     }
+
     spec schema CreateFromU64AbortsIf {
         val: num;
         let scaled_value = (val as u256) << 64;
         aborts_if scaled_value > MAX_U128;
     }
+
     spec fun spec_create_from_u128(val: num): FixedPoint64 {
-        FixedPoint64 {value: val << 64}
+        FixedPoint64 { value: val << 64 }
     }
 
     /// Returns the largest integer less than or equal to a given number.
     public fun floor(num: FixedPoint64): u128 {
         num.value >> 64
     }
+
     spec floor {
         pragma opaque;
         aborts_if false;
         ensures result == spec_floor(num);
     }
+
     spec fun spec_floor(val: FixedPoint64): u128 {
         let fractional = val.value % (1 << 64);
         if (fractional == 0) {
@@ -355,6 +381,7 @@ module aptos_std::fixed_point64 {
         let val = ((floored_num as u256) + (1 << 64));
         (val >> 64 as u128)
     }
+
     spec ceil {
         // TODO: set because of timeout (property proved).
         pragma verify_duration_estimate = 1000;
@@ -362,6 +389,7 @@ module aptos_std::fixed_point64 {
         aborts_if false;
         ensures result == spec_ceil(num);
     }
+
     spec fun spec_ceil(val: FixedPoint64): u128 {
         let fractional = val.value % (1 << 64);
         let one = 1 << 64;
@@ -382,11 +410,13 @@ module aptos_std::fixed_point64 {
             ceil(num)
         }
     }
+
     spec round {
         pragma opaque;
         aborts_if false;
         ensures result == spec_round(num);
     }
+
     spec fun spec_round(val: FixedPoint64): u128 {
         let fractional = val.value % (1 << 64);
         let boundary = (1 << 64) / 2;
@@ -413,7 +443,9 @@ module aptos_std::fixed_point64 {
         let result = sub(x, y);
         // 9/7 - 1/3 = 20/21
         let expected_result = create_from_rational(20, 21);
-        assert_approx_the_same((get_raw_value(result) as u256), (get_raw_value(expected_result) as u256), 16);
+        assert_approx_the_same(
+            (get_raw_value(result) as u256), (get_raw_value(expected_result) as u256), 16
+        );
     }
 
     #[test]

--- a/aptos-move/framework/aptos-stdlib/sources/from_bcs.move
+++ b/aptos-move/framework/aptos-stdlib/sources/from_bcs.move
@@ -68,14 +68,14 @@ module aptos_std::from_bcs {
     friend aptos_std::any;
     friend aptos_std::copyable_any;
 
-
     #[test_only]
     use std::bcs;
 
     #[test]
     fun test_address() {
         let addr = @0x01;
-        let addr_vec = x"0000000000000000000000000000000000000000000000000000000000000001";
+        let addr_vec =
+            x"0000000000000000000000000000000000000000000000000000000000000001";
         let addr_out = to_address(addr_vec);
         let addr_vec_out = bcs::to_bytes(&addr_out);
         assert!(addr == addr_out, 0);

--- a/aptos-move/framework/aptos-stdlib/sources/from_bcs.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/from_bcs.spec.move
@@ -15,11 +15,15 @@ spec aptos_std::from_bcs {
         //    (deserialize<T>(b1) == deserialize<T>(b2) ==> b1 == b2);
 
         // If the input are equal, the result of deserialize should be equal too
-        axiom<T> forall b1: vector<u8>, b2: vector<u8>:
-            ( b1 == b2 ==> deserializable<T>(b1) == deserializable<T>(b2) );
+        axiom<T> forall b1: vector<u8> , b2: vector<u8> : (
+            b1 == b2 ==>
+            deserializable<T>(b1) == deserializable<T>(b2)
+        );
 
-        axiom<T> forall b1: vector<u8>, b2: vector<u8>:
-            ( b1 == b2 ==> deserialize<T>(b1) == deserialize<T>(b2) );
+        axiom<T> forall b1: vector<u8> , b2: vector<u8> : (
+            b1 == b2 ==>
+            deserialize<T>(b1) == deserialize<T>(b2)
+        );
 
         // `deserialize` is an inverse function of `bcs::serialize`.
         // TODO: disabled because this generic axiom causes a timeout.
@@ -29,7 +33,6 @@ spec aptos_std::from_bcs {
         // TODO: disabled because this generic axiom causes a timeout.
         // axiom<T> forall v: T: deserializable<T>(bcs::serialize(v));
     }
-
 
     // -----------------------
     // Function specifications

--- a/aptos-move/framework/aptos-stdlib/sources/from_bcs.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/from_bcs.spec.move
@@ -15,15 +15,13 @@ spec aptos_std::from_bcs {
         //    (deserialize<T>(b1) == deserialize<T>(b2) ==> b1 == b2);
 
         // If the input are equal, the result of deserialize should be equal too
-        axiom<T> forall b1: vector<u8> , b2: vector<u8> : (
-            b1 == b2 ==>
-            deserializable<T>(b1) == deserializable<T>(b2)
-        );
+        axiom<T> forall b1: vector<u8> , b2: vector<u8> :
+            (b1 == b2 ==>
+                deserializable<T>(b1) == deserializable<T>(b2));
 
-        axiom<T> forall b1: vector<u8> , b2: vector<u8> : (
-            b1 == b2 ==>
-            deserialize<T>(b1) == deserialize<T>(b2)
-        );
+        axiom<T> forall b1: vector<u8> , b2: vector<u8> :
+            (b1 == b2 ==>
+                deserialize<T>(b1) == deserialize<T>(b2));
 
         // `deserialize` is an inverse function of `bcs::serialize`.
         // TODO: disabled because this generic axiom causes a timeout.

--- a/aptos-move/framework/aptos-stdlib/sources/hash.move
+++ b/aptos-move/framework/aptos-stdlib/sources/hash.move
@@ -36,7 +36,7 @@ module aptos_std::aptos_hash {
 
     /// Returns the SHA2-512 hash of `bytes`.
     public fun sha2_512(bytes: vector<u8>): vector<u8> {
-        if(!features::sha_512_and_ripemd_160_enabled()) {
+        if (!features::sha_512_and_ripemd_160_enabled()) {
             abort(std::error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE))
         };
 
@@ -45,20 +45,19 @@ module aptos_std::aptos_hash {
 
     /// Returns the SHA3-512 hash of `bytes`.
     public fun sha3_512(bytes: vector<u8>): vector<u8> {
-        if(!features::sha_512_and_ripemd_160_enabled()) {
+        if (!features::sha_512_and_ripemd_160_enabled()) {
             abort(std::error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE))
         };
 
         sha3_512_internal(bytes)
     }
 
-
     /// Returns the RIPEMD-160 hash of `bytes`.
     ///
     /// WARNING: Only 80-bit security is provided by this function. This means an adversary who can compute roughly 2^80
     /// hashes will, with high probability, find a collision x_1 != x_2 such that RIPEMD-160(x_1) = RIPEMD-160(x_2).
     public fun ripemd160(bytes: vector<u8>): vector<u8> {
-        if(!features::sha_512_and_ripemd_160_enabled()) {
+        if (!features::sha_512_and_ripemd_160_enabled()) {
             abort(std::error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE))
         };
 
@@ -67,7 +66,7 @@ module aptos_std::aptos_hash {
 
     /// Returns the BLAKE2B-256 hash of `bytes`.
     public fun blake2b_256(bytes: vector<u8>): vector<u8> {
-        if(!features::blake2b_256_enabled()) {
+        if (!features::blake2b_256_enabled()) {
             abort(std::error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE))
         };
 
@@ -80,7 +79,6 @@ module aptos_std::aptos_hash {
 
     /// Returns the SHA2-512 hash of `bytes`.
     native fun sha2_512_internal(bytes: vector<u8>): vector<u8>;
-
 
     /// Returns the SHA3-512 hash of `bytes`.
     native fun sha3_512_internal(bytes: vector<u8>): vector<u8>;
@@ -100,15 +98,11 @@ module aptos_std::aptos_hash {
 
     #[test]
     fun keccak256_test() {
-        let inputs = vector[
-            b"testing",
-            b"",
-        ];
+        let inputs = vector[b"testing", b"",];
 
         let outputs = vector[
             x"5f16f4c7f149ac4f9510d9cf8cf384038ad348b3bcdc01915f95de12df9d1b02",
-            x"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
-        ];
+            x"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",];
 
         let i = 0;
         while (i < std::vector::length(&inputs)) {
@@ -125,18 +119,16 @@ module aptos_std::aptos_hash {
     #[test(fx = @aptos_std)]
     fun sha2_512_test(fx: signer) {
         // We need to enable the feature in order for the native call to be allowed.
-        features::change_feature_flags_for_testing(&fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]);
+        features::change_feature_flags_for_testing(
+            &fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]
+        );
 
-        let inputs = vector[
-        b"testing",
-        b"",
-        ];
+        let inputs = vector[b"testing", b"",];
 
         // From https://emn178.github.io/online-tools/sha512.html
         let outputs = vector[
-        x"521b9ccefbcd14d179e7a1bb877752870a6d620938b28a66a107eac6e6805b9d0989f45b5730508041aa5e710847d439ea74cd312c9355f1f2dae08d40e41d50",
-        x"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
-        ];
+            x"521b9ccefbcd14d179e7a1bb877752870a6d620938b28a66a107eac6e6805b9d0989f45b5730508041aa5e710847d439ea74cd312c9355f1f2dae08d40e41d50",
+            x"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",];
 
         let i = 0;
         while (i < std::vector::length(&inputs)) {
@@ -153,17 +145,15 @@ module aptos_std::aptos_hash {
     #[test(fx = @aptos_std)]
     fun sha3_512_test(fx: signer) {
         // We need to enable the feature in order for the native call to be allowed.
-        features::change_feature_flags_for_testing(&fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]);
-        let inputs = vector[
-        b"testing",
-        b"",
-        ];
+        features::change_feature_flags_for_testing(
+            &fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]
+        );
+        let inputs = vector[b"testing", b"",];
 
         // From https://emn178.github.io/online-tools/sha3_512.html
         let outputs = vector[
-        x"881c7d6ba98678bcd96e253086c4048c3ea15306d0d13ff48341c6285ee71102a47b6f16e20e4d65c0c3d677be689dfda6d326695609cbadfafa1800e9eb7fc1",
-        x"a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26",
-        ];
+            x"881c7d6ba98678bcd96e253086c4048c3ea15306d0d13ff48341c6285ee71102a47b6f16e20e4d65c0c3d677be689dfda6d326695609cbadfafa1800e9eb7fc1",
+            x"a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26",];
 
         let i = 0;
         while (i < std::vector::length(&inputs)) {
@@ -180,17 +170,15 @@ module aptos_std::aptos_hash {
     #[test(fx = @aptos_std)]
     fun ripemd160_test(fx: signer) {
         // We need to enable the feature in order for the native call to be allowed.
-        features::change_feature_flags_for_testing(&fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]);
-        let inputs = vector[
-        b"testing",
-        b"",
-        ];
+        features::change_feature_flags_for_testing(
+            &fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]
+        );
+        let inputs = vector[b"testing", b"",];
 
         // From https://www.browserling.com/tools/ripemd160-hash
         let outputs = vector[
-        x"b89ba156b40bed29a5965684b7d244c49a3a769b",
-        x"9c1185a5c5e9fc54612808977ee8f548b2258d31",
-        ];
+            x"b89ba156b40bed29a5965684b7d244c49a3a769b",
+            x"9c1185a5c5e9fc54612808977ee8f548b2258d31",];
 
         let i = 0;
         while (i < std::vector::length(&inputs)) {
@@ -208,7 +196,9 @@ module aptos_std::aptos_hash {
     #[expected_failure(abort_code = 196609, location = Self)]
     fun blake2b_256_aborts(fx: signer) {
         // We disable the feature to make sure the `blake2b_256` call aborts
-        features::change_feature_flags_for_testing(&fx, vector[], vector[features::get_blake2b_256_feature()]);
+        features::change_feature_flags_for_testing(
+            &fx, vector[], vector[features::get_blake2b_256_feature()]
+        );
 
         blake2b_256(b"This will abort");
     }
@@ -216,11 +206,13 @@ module aptos_std::aptos_hash {
     #[test(fx = @aptos_std)]
     fun blake2b_256_test(fx: signer) {
         // We need to enable the feature in order for the native call to be allowed.
-        features::change_feature_flags_for_testing(&fx, vector[features::get_blake2b_256_feature()], vector[]);
+        features::change_feature_flags_for_testing(
+            &fx, vector[features::get_blake2b_256_feature()], vector[]
+        );
         let inputs = vector[
-        b"",
-        b"testing",
-        b"testing again", // empty message doesn't yield an output on the online generator
+            b"",
+            b"testing",
+            b"testing again", // empty message doesn't yield an output on the online generator
         ];
 
         // From https://www.toolkitbay.com/tkb/tool/BLAKE2b_256
@@ -234,10 +226,9 @@ module aptos_std::aptos_hash {
         //   print(hashlib.blake2b(b'', digest_size=32).hexdigest());
         // ```
         let outputs = vector[
-        x"0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
-        x"99397ff32ae348b8b6536d5c213f343d7e9fdeaa10e8a23a9f90ab21a1658565",
-        x"1deab5a4eb7481453ca9b29e1f7c4be8ba44de4faeeafdf173b310cbaecfc84c",
-        ];
+            x"0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
+            x"99397ff32ae348b8b6536d5c213f343d7e9fdeaa10e8a23a9f90ab21a1658565",
+            x"1deab5a4eb7481453ca9b29e1f7c4be8ba44de4faeeafdf173b310cbaecfc84c",];
 
         let i = 0;
         while (i < std::vector::length(&inputs)) {

--- a/aptos-move/framework/aptos-stdlib/sources/hash.move
+++ b/aptos-move/framework/aptos-stdlib/sources/hash.move
@@ -102,7 +102,8 @@ module aptos_std::aptos_hash {
 
         let outputs = vector[
             x"5f16f4c7f149ac4f9510d9cf8cf384038ad348b3bcdc01915f95de12df9d1b02",
-            x"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",];
+            x"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        ];
 
         let i = 0;
         while (i < std::vector::length(&inputs)) {
@@ -120,7 +121,9 @@ module aptos_std::aptos_hash {
     fun sha2_512_test(fx: signer) {
         // We need to enable the feature in order for the native call to be allowed.
         features::change_feature_flags_for_testing(
-            &fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]
+            &fx,
+            vector[features::get_sha_512_and_ripemd_160_feature()],
+            vector[],
         );
 
         let inputs = vector[b"testing", b"",];
@@ -128,7 +131,8 @@ module aptos_std::aptos_hash {
         // From https://emn178.github.io/online-tools/sha512.html
         let outputs = vector[
             x"521b9ccefbcd14d179e7a1bb877752870a6d620938b28a66a107eac6e6805b9d0989f45b5730508041aa5e710847d439ea74cd312c9355f1f2dae08d40e41d50",
-            x"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",];
+            x"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+        ];
 
         let i = 0;
         while (i < std::vector::length(&inputs)) {
@@ -146,14 +150,17 @@ module aptos_std::aptos_hash {
     fun sha3_512_test(fx: signer) {
         // We need to enable the feature in order for the native call to be allowed.
         features::change_feature_flags_for_testing(
-            &fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]
+            &fx,
+            vector[features::get_sha_512_and_ripemd_160_feature()],
+            vector[],
         );
         let inputs = vector[b"testing", b"",];
 
         // From https://emn178.github.io/online-tools/sha3_512.html
         let outputs = vector[
             x"881c7d6ba98678bcd96e253086c4048c3ea15306d0d13ff48341c6285ee71102a47b6f16e20e4d65c0c3d677be689dfda6d326695609cbadfafa1800e9eb7fc1",
-            x"a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26",];
+            x"a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26",
+        ];
 
         let i = 0;
         while (i < std::vector::length(&inputs)) {
@@ -171,14 +178,17 @@ module aptos_std::aptos_hash {
     fun ripemd160_test(fx: signer) {
         // We need to enable the feature in order for the native call to be allowed.
         features::change_feature_flags_for_testing(
-            &fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]
+            &fx,
+            vector[features::get_sha_512_and_ripemd_160_feature()],
+            vector[],
         );
         let inputs = vector[b"testing", b"",];
 
         // From https://www.browserling.com/tools/ripemd160-hash
         let outputs = vector[
             x"b89ba156b40bed29a5965684b7d244c49a3a769b",
-            x"9c1185a5c5e9fc54612808977ee8f548b2258d31",];
+            x"9c1185a5c5e9fc54612808977ee8f548b2258d31",
+        ];
 
         let i = 0;
         while (i < std::vector::length(&inputs)) {
@@ -197,7 +207,9 @@ module aptos_std::aptos_hash {
     fun blake2b_256_aborts(fx: signer) {
         // We disable the feature to make sure the `blake2b_256` call aborts
         features::change_feature_flags_for_testing(
-            &fx, vector[], vector[features::get_blake2b_256_feature()]
+            &fx,
+            vector[],
+            vector[features::get_blake2b_256_feature()],
         );
 
         blake2b_256(b"This will abort");
@@ -207,7 +219,9 @@ module aptos_std::aptos_hash {
     fun blake2b_256_test(fx: signer) {
         // We need to enable the feature in order for the native call to be allowed.
         features::change_feature_flags_for_testing(
-            &fx, vector[features::get_blake2b_256_feature()], vector[]
+            &fx,
+            vector[features::get_blake2b_256_feature()],
+            vector[],
         );
         let inputs = vector[
             b"",
@@ -228,7 +242,8 @@ module aptos_std::aptos_hash {
         let outputs = vector[
             x"0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8",
             x"99397ff32ae348b8b6536d5c213f343d7e9fdeaa10e8a23a9f90ab21a1658565",
-            x"1deab5a4eb7481453ca9b29e1f7c4be8ba44de4faeeafdf173b310cbaecfc84c",];
+            x"1deab5a4eb7481453ca9b29e1f7c4be8ba44de4faeeafdf173b310cbaecfc84c",
+        ];
 
         let i = 0;
         while (i < std::vector::length(&inputs)) {

--- a/aptos-move/framework/aptos-stdlib/sources/hash.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/hash.spec.move
@@ -5,28 +5,33 @@ spec aptos_std::aptos_hash {
 
         /// `spec_keccak256` is an injective function.
         fun spec_keccak256(bytes: vector<u8>): vector<u8>;
-        axiom forall b1: vector<u8>, b2: vector<u8>:
-            (spec_keccak256(b1) == spec_keccak256(b2) ==> b1 == b2);
+        axiom forall b1: vector<u8> , b2: vector<u8> : (
+            spec_keccak256(b1) == spec_keccak256(b2) ==> b1 == b2
+        );
 
         /// `spec_sha2_512_internal` is an injective function.
         fun spec_sha2_512_internal(bytes: vector<u8>): vector<u8>;
-        axiom forall b1: vector<u8>, b2: vector<u8>:
-            (spec_sha2_512_internal(b1) == spec_sha2_512_internal(b2) ==> b1 == b2);
+        axiom forall b1: vector<u8> , b2: vector<u8> : (
+            spec_sha2_512_internal(b1) == spec_sha2_512_internal(b2) ==> b1 == b2
+        );
 
         /// `spec_sha3_512_internal` is an injective function.
         fun spec_sha3_512_internal(bytes: vector<u8>): vector<u8>;
-        axiom forall b1: vector<u8>, b2: vector<u8>:
-            (spec_sha3_512_internal(b1) == spec_sha3_512_internal(b2) ==> b1 == b2);
+        axiom forall b1: vector<u8> , b2: vector<u8> : (
+            spec_sha3_512_internal(b1) == spec_sha3_512_internal(b2) ==> b1 == b2
+        );
 
         /// `spec_ripemd160_internal` is an injective function.
         fun spec_ripemd160_internal(bytes: vector<u8>): vector<u8>;
-        axiom forall b1: vector<u8>, b2: vector<u8>:
-            (spec_ripemd160_internal(b1) == spec_ripemd160_internal(b2) ==> b1 == b2);
+        axiom forall b1: vector<u8> , b2: vector<u8> : (
+            spec_ripemd160_internal(b1) == spec_ripemd160_internal(b2) ==> b1 == b2
+        );
 
         /// `spec_blake2b_256_internal` is an injective function.
         fun spec_blake2b_256_internal(bytes: vector<u8>): vector<u8>;
-        axiom forall b1: vector<u8>, b2: vector<u8>:
-            (spec_blake2b_256_internal(b1) == spec_blake2b_256_internal(b2) ==> b1 == b2);
+        axiom forall b1: vector<u8> , b2: vector<u8> : (
+            spec_blake2b_256_internal(b1) == spec_blake2b_256_internal(b2) ==> b1 == b2
+        );
     }
 
     spec sip_hash(bytes: vector<u8>): u64 {
@@ -93,5 +98,4 @@ spec aptos_std::aptos_hash {
         aborts_if !features::spec_is_enabled(features::BLAKE2B_256_NATIVE);
         ensures result == spec_blake2b_256_internal(bytes);
     }
-
 }

--- a/aptos-move/framework/aptos-stdlib/sources/hash.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/hash.spec.move
@@ -5,33 +5,28 @@ spec aptos_std::aptos_hash {
 
         /// `spec_keccak256` is an injective function.
         fun spec_keccak256(bytes: vector<u8>): vector<u8>;
-        axiom forall b1: vector<u8> , b2: vector<u8> : (
-            spec_keccak256(b1) == spec_keccak256(b2) ==> b1 == b2
-        );
+        axiom forall b1: vector<u8> , b2: vector<u8> :
+            (spec_keccak256(b1) == spec_keccak256(b2) ==> b1 == b2);
 
         /// `spec_sha2_512_internal` is an injective function.
         fun spec_sha2_512_internal(bytes: vector<u8>): vector<u8>;
-        axiom forall b1: vector<u8> , b2: vector<u8> : (
-            spec_sha2_512_internal(b1) == spec_sha2_512_internal(b2) ==> b1 == b2
-        );
+        axiom forall b1: vector<u8> , b2: vector<u8> :
+            (spec_sha2_512_internal(b1) == spec_sha2_512_internal(b2) ==> b1 == b2);
 
         /// `spec_sha3_512_internal` is an injective function.
         fun spec_sha3_512_internal(bytes: vector<u8>): vector<u8>;
-        axiom forall b1: vector<u8> , b2: vector<u8> : (
-            spec_sha3_512_internal(b1) == spec_sha3_512_internal(b2) ==> b1 == b2
-        );
+        axiom forall b1: vector<u8> , b2: vector<u8> :
+            (spec_sha3_512_internal(b1) == spec_sha3_512_internal(b2) ==> b1 == b2);
 
         /// `spec_ripemd160_internal` is an injective function.
         fun spec_ripemd160_internal(bytes: vector<u8>): vector<u8>;
-        axiom forall b1: vector<u8> , b2: vector<u8> : (
-            spec_ripemd160_internal(b1) == spec_ripemd160_internal(b2) ==> b1 == b2
-        );
+        axiom forall b1: vector<u8> , b2: vector<u8> :
+            (spec_ripemd160_internal(b1) == spec_ripemd160_internal(b2) ==> b1 == b2);
 
         /// `spec_blake2b_256_internal` is an injective function.
         fun spec_blake2b_256_internal(bytes: vector<u8>): vector<u8>;
-        axiom forall b1: vector<u8> , b2: vector<u8> : (
-            spec_blake2b_256_internal(b1) == spec_blake2b_256_internal(b2) ==> b1 == b2
-        );
+        axiom forall b1: vector<u8> , b2: vector<u8> :
+            (spec_blake2b_256_internal(b1) == spec_blake2b_256_internal(b2) ==> b1 == b2);
     }
 
     spec sip_hash(bytes: vector<u8>): u64 {

--- a/aptos-move/framework/aptos-stdlib/sources/math128.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math128.move
@@ -53,9 +53,8 @@ module aptos_std::math128 {
 
     /// Return the value of n raised to power e
     public fun pow(n: u128, e: u128): u128 {
-        if (e == 0) {
-            1
-        } else {
+        if (e == 0) { 1 }
+        else {
             let p = 1;
             while (e > 1) {
                 if (e % 2 == 1) {
@@ -101,10 +100,13 @@ module aptos_std::math128 {
             x = (x * x) >> 32;
             // x is now in [1, 4)
             // if x in [2, 4) then log x = 1 + log (x / 2)
-            if (x >= (2 << 32)) { frac = frac + delta; x = x >> 1; };
+            if (x >= (2 << 32)) {
+                frac = frac + delta;
+                x = x >> 1;
+            };
             delta = delta >> 1;
         };
-        fixed_point32::create_from_raw_value (((integer_part as u64) << 32) + frac)
+        fixed_point32::create_from_raw_value(((integer_part as u64) << 32) + frac)
     }
 
     // Return log2(x) as FixedPoint64
@@ -124,10 +126,13 @@ module aptos_std::math128 {
             x = (x * x) >> 63;
             // x is now in [1, 4)
             // if x in [2, 4) then log x = 1 + log (x / 2)
-            if (x >= (2 << 63)) { frac = frac + delta; x = x >> 1; };
+            if (x >= (2 << 63)) {
+                frac = frac + delta;
+                x = x >> 1;
+            };
             delta = delta >> 1;
         };
-        fixed_point64::create_from_raw_value (((integer_part as u128) << 64) + frac)
+        fixed_point64::create_from_raw_value(((integer_part as u128) << 64) + frac)
     }
 
     /// Returns square root of x, precisely floor(sqrt(x))
@@ -157,8 +162,7 @@ module aptos_std::math128 {
             // Inline functions cannot take constants, as then every module using it needs the constant
             assert!(y != 0, std::error::invalid_argument(4));
             0
-        }
-        else (x - 1) / y + 1
+        } else (x - 1) / y + 1
     }
 
     #[test]
@@ -170,7 +174,11 @@ module aptos_std::math128 {
         assert!(ceil_div(13, 3) == 5, 0);
 
         // No overflow
-        assert!(ceil_div((((1u256<<128) - 9) as u128), 11) == 30934760629176223951215873402888019223, 0);
+        assert!(
+            ceil_div((((1u256 << 128) - 9) as u128), 11)
+                == 30934760629176223951215873402888019223,
+            0,
+        );
     }
 
     #[test]
@@ -234,10 +242,10 @@ module aptos_std::math128 {
 
     #[test]
     public entry fun test_mul_div() {
-        let tmp: u128 = 1<<127;
-        assert!(mul_div(tmp,tmp,tmp) == tmp, 0);
+        let tmp: u128 = 1 << 127;
+        assert!(mul_div(tmp, tmp, tmp) == tmp, 0);
 
-        assert!(mul_div(tmp,5,5) == tmp, 0);
+        assert!(mul_div(tmp, 5, 5) == tmp, 0);
         // Note that ordering other way is imprecise.
         assert!((tmp / 5) * 5 != tmp, 0);
     }
@@ -252,12 +260,12 @@ module aptos_std::math128 {
     public entry fun test_floor_log2() {
         let idx: u8 = 0;
         while (idx < 128) {
-            assert!(floor_log2(1<<idx) == idx, 0);
+            assert!(floor_log2(1 << idx) == idx, 0);
             idx = idx + 1;
         };
         idx = 1;
         while (idx <= 128) {
-            assert!(floor_log2((((1u256<<idx) - 1) as u128)) == idx - 1, 0);
+            assert!(floor_log2((((1u256 << idx) - 1) as u128)) == idx - 1, 0);
             idx = idx + 1;
         };
     }
@@ -266,22 +274,25 @@ module aptos_std::math128 {
     public entry fun test_log2() {
         let idx: u8 = 0;
         while (idx < 128) {
-            let res = log2(1<<idx);
+            let res = log2(1 << idx);
             assert!(fixed_point32::get_raw_value(res) == (idx as u64) << 32, 0);
             idx = idx + 1;
         };
         idx = 10;
         while (idx <= 128) {
-            let res = log2((((1u256<<idx) - 1) as u128));
+            let res = log2((((1u256 << idx) - 1) as u128));
             // idx + log2 (1 - 1/2^idx) = idx + ln (1-1/2^idx)/ln2
             // Use 3rd order taylor to approximate expected result
             let expected = (idx as u128) << 32;
-            let taylor1 = ((1 << 32) / ((1u256<<idx)) as u128);
+            let taylor1 = ((1 << 32) / ((1u256 << idx)) as u128);
             let taylor2 = (taylor1 * taylor1) >> 32;
             let taylor3 = (taylor2 * taylor1) >> 32;
-            let expected = expected - ((taylor1 + taylor2 / 2 + taylor3 / 3) << 32) / 2977044472;
+            let expected = expected
+                - ((taylor1 + taylor2 / 2 + taylor3 / 3) << 32) / 2977044472;
             // verify it matches to 8 significant digits
-            assert_approx_the_same((fixed_point32::get_raw_value(res) as u128), expected, 8);
+            assert_approx_the_same(
+                (fixed_point32::get_raw_value(res) as u128), expected, 8
+            );
             idx = idx + 1;
         };
     }
@@ -290,23 +301,28 @@ module aptos_std::math128 {
     public entry fun test_log2_64() {
         let idx: u8 = 0;
         while (idx < 128) {
-            let res = log2_64(1<<idx);
+            let res = log2_64(1 << idx);
             assert!(fixed_point64::get_raw_value(res) == (idx as u128) << 64, 0);
             idx = idx + 1;
         };
         idx = 10;
         while (idx <= 128) {
-            let res = log2_64((((1u256<<idx) - 1) as u128));
+            let res = log2_64((((1u256 << idx) - 1) as u128));
             // idx + log2 (1 - 1/2^idx) = idx + ln (1-1/2^idx)/ln2
             // Use 3rd order taylor to approximate expected result
             let expected = (idx as u256) << 64;
-            let taylor1 = (1 << 64) / ((1u256<<idx));
+            let taylor1 = (1 << 64) / ((1u256 << idx));
             let taylor2 = (taylor1 * taylor1) >> 64;
             let taylor3 = (taylor2 * taylor1) >> 64;
             let taylor4 = (taylor3 * taylor1) >> 64;
-            let expected = expected - ((taylor1 + taylor2 / 2 + taylor3 / 3 + taylor4 / 4) << 64) / 12786308645202655660;
+            let expected =
+                expected
+                    - ((taylor1 + taylor2 / 2 + taylor3 / 3 + taylor4 / 4) << 64)
+                        / 12786308645202655660;
             // verify it matches to 8 significant digits
-            assert_approx_the_same(fixed_point64::get_raw_value(res), (expected as u128), 14);
+            assert_approx_the_same(
+                fixed_point64::get_raw_value(res), (expected as u128), 14
+            );
             idx = idx + 1;
         };
     }
@@ -322,8 +338,8 @@ module aptos_std::math128 {
         let result = sqrt(256);
         assert!(result == 16, 0);
 
-        let result = sqrt(1<<126);
-        assert!(result == 1<<63, 0);
+        let result = sqrt(1 << 126);
+        assert!(result == 1 << 63, 0);
 
         let result = sqrt((((1u256 << 128) - 1) as u128));
         assert!(result == (1u128 << 64) - 1, 0);

--- a/aptos-move/framework/aptos-stdlib/sources/math128.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math128.spec.move
@@ -21,7 +21,7 @@ spec aptos_std::math128 {
     spec clamp(x: u128, lower: u128, upper: u128): u128 {
         requires (lower <= upper);
         aborts_if false;
-        ensures (lower <=x && x <= upper) ==> result == x;
+        ensures (lower <= x && x <= upper) ==> result == x;
         ensures (x < lower) ==> result == lower;
         ensures (upper < x) ==> result == upper;
     }
@@ -39,22 +39,20 @@ spec aptos_std::math128 {
         pragma opaque;
         aborts_if [abstract] x == 0;
         ensures [abstract] spec_pow(2, result) <= x;
-        ensures [abstract] x < spec_pow(2, result+1);
+        ensures [abstract] x < spec_pow(2, result + 1);
     }
 
     spec sqrt(x: u128): u128 {
         pragma opaque;
         aborts_if [abstract] false;
         ensures [abstract] x > 0 ==> result * result <= x;
-        ensures [abstract] x > 0 ==> x < (result+1) * (result+1);
+        ensures [abstract] x > 0 ==> x < (result + 1) * (result + 1);
     }
 
     spec fun spec_pow(n: u128, e: u128): u128 {
-        if (e == 0) {
-            1
-        }
+        if (e == 0) { 1 }
         else {
-            n * spec_pow(n, e-1)
+            n * spec_pow(n, e - 1)
         }
     }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/math64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math64.move
@@ -51,9 +51,8 @@ module aptos_std::math64 {
 
     /// Return the value of n raised to power e
     public fun pow(n: u64, e: u64): u64 {
-        if (e == 0) {
-            1
-        } else {
+        if (e == 0) { 1 }
+        else {
             let p = 1;
             while (e > 1) {
                 if (e % 2 == 1) {
@@ -86,11 +85,13 @@ module aptos_std::math64 {
     public fun log2(x: u64): FixedPoint32 {
         let integer_part = floor_log2(x);
         // Normalize x to [1, 2) in fixed point 32.
-        let y = (if (x >= 1 << 32) {
-            x >> (integer_part - 32)
-        } else {
-            x << (32 - integer_part)
-        } as u128);
+        let y = (
+            if (x >= 1 << 32) {
+                x >> (integer_part - 32)
+            } else {
+                x << (32 - integer_part)
+            } as u128
+        );
         let frac = 0;
         let delta = 1 << 31;
         while (delta != 0) {
@@ -99,10 +100,13 @@ module aptos_std::math64 {
             y = (y * y) >> 32;
             // x is now in [1, 4)
             // if x in [2, 4) then log x = 1 + log (x / 2)
-            if (y >= (2 << 32)) { frac = frac + delta; y = y >> 1; };
+            if (y >= (2 << 32)) {
+                frac = frac + delta;
+                y = y >> 1;
+            };
             delta = delta >> 1;
         };
-        fixed_point32::create_from_raw_value (((integer_part as u64) << 32) + frac)
+        fixed_point32::create_from_raw_value(((integer_part as u64) << 32) + frac)
     }
 
     /// Returns square root of x, precisely floor(sqrt(x))
@@ -131,8 +135,7 @@ module aptos_std::math64 {
             // Inline functions cannot take constants, as then every module using it needs the constant
             assert!(y != 0, std::error::invalid_argument(4));
             0
-        }
-        else (x - 1) / y + 1
+        } else (x - 1) / y + 1
     }
 
     #[test]
@@ -144,7 +147,7 @@ module aptos_std::math64 {
         assert!(ceil_div(13, 3) == 5, 0);
 
         // No overflow
-        assert!(ceil_div((((1u128<<64) - 9) as u64), 11) == 1676976733973595601, 0);
+        assert!(ceil_div((((1u128 << 64) - 9) as u64), 11) == 1676976733973595601, 0);
     }
 
     #[test]
@@ -214,10 +217,10 @@ module aptos_std::math64 {
 
     #[test]
     public entry fun test_mul_div() {
-        let tmp: u64 = 1<<63;
-        assert!(mul_div(tmp,tmp,tmp) == tmp, 0);
+        let tmp: u64 = 1 << 63;
+        assert!(mul_div(tmp, tmp, tmp) == tmp, 0);
 
-        assert!(mul_div(tmp,5,5) == tmp, 0);
+        assert!(mul_div(tmp, 5, 5) == tmp, 0);
         // Note that ordering other way is imprecise.
         assert!((tmp / 5) * 5 != tmp, 0);
     }
@@ -232,12 +235,12 @@ module aptos_std::math64 {
     public entry fun test_floor_lg2() {
         let idx: u8 = 0;
         while (idx < 64) {
-            assert!(floor_log2(1<<idx) == idx, 0);
+            assert!(floor_log2(1 << idx) == idx, 0);
             idx = idx + 1;
         };
         idx = 1;
         while (idx <= 64) {
-            assert!(floor_log2((((1u128<<idx) - 1) as u64)) == idx - 1, 0);
+            assert!(floor_log2((((1u128 << idx) - 1) as u64)) == idx - 1, 0);
             idx = idx + 1;
         };
     }
@@ -246,22 +249,25 @@ module aptos_std::math64 {
     public entry fun test_log2() {
         let idx: u8 = 0;
         while (idx < 64) {
-            let res = log2(1<<idx);
+            let res = log2(1 << idx);
             assert!(fixed_point32::get_raw_value(res) == (idx as u64) << 32, 0);
             idx = idx + 1;
         };
         idx = 10;
         while (idx <= 64) {
-            let res = log2((((1u128<<idx) - 1) as u64));
+            let res = log2((((1u128 << idx) - 1) as u64));
             // idx + log2 (1 - 1/2^idx) = idx + ln (1-1/2^idx)/ln2
             // Use 3rd order taylor to approximate expected result
             let expected = (idx as u128) << 32;
-            let taylor1 = ((1 << 32) / ((1u256<<idx)) as u128);
+            let taylor1 = ((1 << 32) / ((1u256 << idx)) as u128);
             let taylor2 = (taylor1 * taylor1) >> 32;
             let taylor3 = (taylor2 * taylor1) >> 32;
-            let expected = expected - ((taylor1 + taylor2 / 2 + taylor3 / 3) << 32) / 2977044472;
+            let expected = expected
+                - ((taylor1 + taylor2 / 2 + taylor3 / 3) << 32) / 2977044472;
             // verify it matches to 8 significant digits
-            assert_approx_the_same((fixed_point32::get_raw_value(res) as u128), expected, 8);
+            assert_approx_the_same(
+                (fixed_point32::get_raw_value(res) as u128), expected, 8
+            );
             idx = idx + 1;
         };
     }
@@ -277,8 +283,8 @@ module aptos_std::math64 {
         let result = sqrt(256);
         assert!(result == 16, 0);
 
-        let result = sqrt(1<<62);
-        assert!(result == 1<<31, 0);
+        let result = sqrt(1 << 62);
+        assert!(result == 1 << 31, 0);
 
         let result = sqrt((((1u128 << 64) - 1) as u64));
         assert!(result == (1u64 << 32) - 1, 0);

--- a/aptos-move/framework/aptos-stdlib/sources/math64.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math64.spec.move
@@ -21,7 +21,7 @@ spec aptos_std::math64 {
     spec clamp(x: u64, lower: u64, upper: u64): u64 {
         requires (lower <= upper);
         aborts_if false;
-        ensures (lower <=x && x <= upper) ==> result == x;
+        ensures (lower <= x && x <= upper) ==> result == x;
         ensures (x < lower) ==> result == lower;
         ensures (upper < x) ==> result == upper;
     }
@@ -39,22 +39,20 @@ spec aptos_std::math64 {
         pragma opaque;
         aborts_if [abstract] x == 0;
         ensures [abstract] spec_pow(2, result) <= x;
-        ensures [abstract] x < spec_pow(2, result+1);
+        ensures [abstract] x < spec_pow(2, result + 1);
     }
 
     spec sqrt(x: u64): u64 {
         pragma opaque;
         aborts_if [abstract] false;
         ensures [abstract] x > 0 ==> result * result <= x;
-        ensures [abstract] x > 0 ==> x < (result+1) * (result+1);
+        ensures [abstract] x > 0 ==> x < (result + 1) * (result + 1);
     }
 
     spec fun spec_pow(n: u64, e: u64): u64 {
-        if (e == 0) {
-            1
-        }
+        if (e == 0) { 1 }
         else {
-            n * spec_pow(n, e-1)
+            n * spec_pow(n, e - 1)
         }
     }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/math_fixed.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math_fixed.move
@@ -9,8 +9,8 @@ module aptos_std::math_fixed {
     const EOVERFLOW_EXP: u64 = 1;
 
     /// Natural log 2 in 32 bit fixed point
-    const LN2: u128 = 2977044472;  // ln(2) in fixed 32 representation
-    const LN2_X_32: u64 = 32 * 2977044472;  // 32 * ln(2) in fixed 32 representation
+    const LN2: u128 = 2977044472; // ln(2) in fixed 32 representation
+    const LN2_X_32: u64 = 32 * 2977044472; // 32 * ln(2) in fixed 32 representation
 
     /// Square root of fixed point number
     public fun sqrt(x: FixedPoint32): FixedPoint32 {
@@ -48,7 +48,7 @@ module aptos_std::math_fixed {
         let a = fixed_point32::get_raw_value(x);
         let b = fixed_point32::get_raw_value(y);
         let c = fixed_point32::get_raw_value(z);
-        fixed_point32::create_from_raw_value (math64::mul_div(a, b, c))
+        fixed_point32::create_from_raw_value(math64::mul_div(a, b, c))
     }
 
     // Calculate e^x where x and the result are fixed point numbers
@@ -64,7 +64,7 @@ module aptos_std::math_fixed {
         let exponent = remainder / bigfactor;
         let x = remainder % bigfactor;
         // 2^(remainder / ln2) = (2^(1/4999))^exponent * exp(x / 2^32)
-        let roottwo = 4295562865;  // fixed point representation of 2^(1/4999)
+        let roottwo = 4295562865; // fixed point representation of 2^(1/4999)
         // This has an error of 5000 / 4 10^9 roughly 6 digits of precission
         let power = pow_raw(roottwo, exponent);
         let eps_correction = 1241009291;
@@ -99,7 +99,9 @@ module aptos_std::math_fixed {
         assert!(fixed_point32::get_raw_value(result) == fixed_base, 0);
 
         let result = sqrt(fixed_point32::create_from_u64(2));
-        assert_approx_the_same((fixed_point32::get_raw_value(result) as u128), 6074001000, 9);
+        assert_approx_the_same(
+            (fixed_point32::get_raw_value(result) as u128), 6074001000, 9
+        );
     }
 
     #[test]
@@ -109,11 +111,11 @@ module aptos_std::math_fixed {
         assert!(result == fixed_base, 0);
 
         let result = exp_raw(fixed_base);
-        let e = 11674931554;  // e in 32 bit fixed point
+        let e = 11674931554; // e in 32 bit fixed point
         assert_approx_the_same(result, e, 9);
 
         let result = exp_raw(10 * fixed_base);
-        let exp10 = 94602950235157;  // e^10 in 32 bit fixed point
+        let exp10 = 94602950235157; // e^10 in 32 bit fixed point
         assert_approx_the_same(result, exp10, 9);
     }
 
@@ -121,7 +123,7 @@ module aptos_std::math_fixed {
     public entry fun test_pow() {
         // We use the case of exp
         let result = pow_raw(4295562865, 4999);
-        assert_approx_the_same(result,  1 << 33, 6);
+        assert_approx_the_same(result, 1 << 33, 6);
     }
 
     #[test_only]

--- a/aptos-move/framework/aptos-stdlib/sources/math_fixed64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math_fixed64.move
@@ -9,7 +9,7 @@ module aptos_std::math_fixed64 {
     const EOVERFLOW_EXP: u64 = 1;
 
     /// Natural log 2 in 32 bit fixed point
-    const LN2: u256 = 12786308645202655660;  // ln(2) in fixed 64 representation
+    const LN2: u256 = 12786308645202655660; // ln(2) in fixed 64 representation
 
     /// Square root of fixed point number
     public fun sqrt(x: FixedPoint64): FixedPoint64 {
@@ -49,7 +49,7 @@ module aptos_std::math_fixed64 {
         let a = fixed_point64::get_raw_value(x);
         let b = fixed_point64::get_raw_value(y);
         let c = fixed_point64::get_raw_value(z);
-        fixed_point64::create_from_raw_value (math128::mul_div(a, b, c))
+        fixed_point64::create_from_raw_value(math128::mul_div(a, b, c))
     }
 
     // Calculate e^x where x and the result are fixed point numbers
@@ -65,7 +65,7 @@ module aptos_std::math_fixed64 {
         let exponent = remainder / bigfactor;
         let x = remainder % bigfactor;
         // 2^(remainder / ln2) = (2^(1/580))^exponent * exp(x / 2^64)
-        let roottwo = 18468802611690918839;  // fixed point representation of 2^(1/580)
+        let roottwo = 18468802611690918839; // fixed point representation of 2^(1/580)
         // 2^(1/580) = roottwo(1 - eps), so the number we seek is roottwo^exponent (1 - eps * exponent)
         let power = pow_raw(roottwo, (exponent as u128));
         let eps_correction = 219071715585908898;
@@ -78,7 +78,8 @@ module aptos_std::math_fixed64 {
         let taylor4 = (taylor3 * x) >> 64;
         let taylor5 = (taylor4 * x) >> 64;
         let taylor6 = (taylor5 * x) >> 64;
-        (power << shift) + taylor1 + taylor2 / 2 + taylor3 / 6 + taylor4 / 24 + taylor5 / 120 + taylor6 / 720
+        (power << shift) + taylor1 + taylor2 / 2 + taylor3 / 6 + taylor4 / 24
+            + taylor5 / 120 + taylor6 / 720
     }
 
     // Calculate x to the power of n, where x and the result are fixed point numbers.
@@ -102,7 +103,9 @@ module aptos_std::math_fixed64 {
         assert!(fixed_point64::get_raw_value(result) == fixed_base, 0);
 
         let result = sqrt(fixed_point64::create_from_u128(2));
-        assert_approx_the_same((fixed_point64::get_raw_value(result) as u256), 26087635650665564424, 16);
+        assert_approx_the_same(
+            (fixed_point64::get_raw_value(result) as u256), 26087635650665564424, 16
+        );
     }
 
     #[test]
@@ -112,11 +115,11 @@ module aptos_std::math_fixed64 {
         assert!(result == fixed_base, 0);
 
         let result = exp_raw(fixed_base);
-        let e = 50143449209799256682;  // e in 32 bit fixed point
+        let e = 50143449209799256682; // e in 32 bit fixed point
         assert_approx_the_same(result, e, 16);
 
         let result = exp_raw(10 * fixed_base);
-        let exp10 = 406316577365116946489258;  // e^10 in 32 bit fixed point
+        let exp10 = 406316577365116946489258; // e^10 in 32 bit fixed point
         assert_approx_the_same(result, exp10, 16);
     }
 
@@ -124,7 +127,7 @@ module aptos_std::math_fixed64 {
     public entry fun test_pow() {
         // We use the case of exp
         let result = pow_raw(18468802611690918839, 580);
-        assert_approx_the_same(result,  1 << 65, 16);
+        assert_approx_the_same(result, 1 << 65, 16);
     }
 
     #[test_only]

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64.move
@@ -60,7 +60,9 @@ module aptos_std::pool_u64 {
     }
 
     /// Create a new pool with custom `scaling_factor`.
-    public fun create_with_scaling_factor(shareholders_limit: u64, scaling_factor: u64): Pool {
+    public fun create_with_scaling_factor(
+        shareholders_limit: u64, scaling_factor: u64
+    ): Pool {
         Pool {
             shareholders_limit,
             total_coins: 0,
@@ -103,9 +105,7 @@ module aptos_std::pool_u64 {
     public fun shares(pool: &Pool, shareholder: address): u64 {
         if (contains(pool, shareholder)) {
             *simple_map::borrow(&pool.shares, &shareholder)
-        } else {
-            0
-        }
+        } else { 0 }
     }
 
     /// Return the balance in coins of `shareholder` in `pool.`
@@ -130,12 +130,20 @@ module aptos_std::pool_u64 {
     }
 
     /// Allow an existing or new shareholder to add their coins to the pool in exchange for new shares.
-    public fun buy_in(pool: &mut Pool, shareholder: address, coins_amount: u64): u64 {
+    public fun buy_in(
+        pool: &mut Pool, shareholder: address, coins_amount: u64
+    ): u64 {
         if (coins_amount == 0) return 0;
 
         let new_shares = amount_to_shares(pool, coins_amount);
-        assert!(MAX_U64 - pool.total_coins >= coins_amount, error::invalid_argument(EPOOL_TOTAL_COINS_OVERFLOW));
-        assert!(MAX_U64 - pool.total_shares >= new_shares, error::invalid_argument(EPOOL_TOTAL_COINS_OVERFLOW));
+        assert!(
+            MAX_U64 - pool.total_coins >= coins_amount,
+            error::invalid_argument(EPOOL_TOTAL_COINS_OVERFLOW),
+        );
+        assert!(
+            MAX_U64 - pool.total_shares >= new_shares,
+            error::invalid_argument(EPOOL_TOTAL_COINS_OVERFLOW),
+        );
 
         pool.total_coins = pool.total_coins + coins_amount;
         pool.total_shares = pool.total_shares + new_shares;
@@ -145,11 +153,16 @@ module aptos_std::pool_u64 {
 
     /// Add the number of shares directly for `shareholder` in `pool`.
     /// This would dilute other shareholders if the pool's balance of coins didn't change.
-    fun add_shares(pool: &mut Pool, shareholder: address, new_shares: u64): u64 {
+    fun add_shares(
+        pool: &mut Pool, shareholder: address, new_shares: u64
+    ): u64 {
         if (contains(pool, shareholder)) {
             let existing_shares = simple_map::borrow_mut(&mut pool.shares, &shareholder);
             let current_shares = *existing_shares;
-            assert!(MAX_U64 - current_shares >= new_shares, error::invalid_argument(ESHAREHOLDER_SHARES_OVERFLOW));
+            assert!(
+                MAX_U64 - current_shares >= new_shares,
+                error::invalid_argument(ESHAREHOLDER_SHARES_OVERFLOW),
+            );
 
             *existing_shares = current_shares + new_shares;
             *existing_shares
@@ -168,9 +181,16 @@ module aptos_std::pool_u64 {
     }
 
     /// Allow `shareholder` to redeem their shares in `pool` for coins.
-    public fun redeem_shares(pool: &mut Pool, shareholder: address, shares_to_redeem: u64): u64 {
-        assert!(contains(pool, shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
-        assert!(shares(pool, shareholder) >= shares_to_redeem, error::invalid_argument(EINSUFFICIENT_SHARES));
+    public fun redeem_shares(
+        pool: &mut Pool, shareholder: address, shares_to_redeem: u64
+    ): u64 {
+        assert!(
+            contains(pool, shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND)
+        );
+        assert!(
+            shares(pool, shareholder) >= shares_to_redeem,
+            error::invalid_argument(EINSUFFICIENT_SHARES),
+        );
 
         if (shares_to_redeem == 0) return 0;
 
@@ -189,8 +209,13 @@ module aptos_std::pool_u64 {
         shareholder_2: address,
         shares_to_transfer: u64,
     ) {
-        assert!(contains(pool, shareholder_1), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
-        assert!(shares(pool, shareholder_1) >= shares_to_transfer, error::invalid_argument(EINSUFFICIENT_SHARES));
+        assert!(
+            contains(pool, shareholder_1), error::invalid_argument(ESHAREHOLDER_NOT_FOUND)
+        );
+        assert!(
+            shares(pool, shareholder_1) >= shares_to_transfer,
+            error::invalid_argument(EINSUFFICIENT_SHARES),
+        );
         if (shares_to_transfer == 0) return;
 
         deduct_shares(pool, shareholder_1, shares_to_transfer);
@@ -198,9 +223,16 @@ module aptos_std::pool_u64 {
     }
 
     /// Directly deduct `shareholder`'s number of shares in `pool` and return the number of remaining shares.
-    fun deduct_shares(pool: &mut Pool, shareholder: address, num_shares: u64): u64 {
-        assert!(contains(pool, shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
-        assert!(shares(pool, shareholder) >= num_shares, error::invalid_argument(EINSUFFICIENT_SHARES));
+    fun deduct_shares(
+        pool: &mut Pool, shareholder: address, num_shares: u64
+    ): u64 {
+        assert!(
+            contains(pool, shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND)
+        );
+        assert!(
+            shares(pool, shareholder) >= num_shares,
+            error::invalid_argument(EINSUFFICIENT_SHARES),
+        );
 
         let existing_shares = simple_map::borrow_mut(&mut pool.shares, &shareholder);
         *existing_shares = *existing_shares - num_shares;
@@ -208,7 +240,9 @@ module aptos_std::pool_u64 {
         // Remove the shareholder completely if they have no shares left.
         let remaining_shares = *existing_shares;
         if (remaining_shares == 0) {
-            let (_, shareholder_index) = vector::index_of(&pool.shareholders, &shareholder);
+            let (_, shareholder_index) = vector::index_of(
+                &pool.shareholders, &shareholder
+            );
             vector::remove(&mut pool.shareholders, shareholder_index);
             simple_map::remove(&mut pool.shares, &shareholder);
         };
@@ -224,7 +258,9 @@ module aptos_std::pool_u64 {
 
     /// Return the number of new shares `coins_amount` can buy in `pool` with a custom total coins number.
     /// `amount` needs to big enough to avoid rounding number.
-    public fun amount_to_shares_with_total_coins(pool: &Pool, coins_amount: u64, total_coins: u64): u64 {
+    public fun amount_to_shares_with_total_coins(
+        pool: &Pool, coins_amount: u64, total_coins: u64
+    ): u64 {
         // No shares yet so amount is worth the same number of shares.
         if (pool.total_coins == 0 || pool.total_shares == 0) {
             // Multiply by scaling factor to minimize rounding errors during internal calculations for buy ins/redeems.
@@ -246,11 +282,12 @@ module aptos_std::pool_u64 {
 
     /// Return the number of coins `shares` are worth in `pool` with a custom total coins number.
     /// `shares` needs to big enough to avoid rounding number.
-    public fun shares_to_amount_with_total_coins(pool: &Pool, shares: u64, total_coins: u64): u64 {
+    public fun shares_to_amount_with_total_coins(
+        pool: &Pool, shares: u64, total_coins: u64
+    ): u64 {
         // No shares or coins yet so shares are worthless.
-        if (pool.total_coins == 0 || pool.total_shares == 0) {
-            0
-        } else {
+        if (pool.total_coins == 0 || pool.total_shares == 0) { 0 }
+        else {
             // Shares price = total_coins / total existing shares.
             // Shares worth = shares * shares price = shares * total_coins / total existing shares.
             // We rearrange the calc and do multiplication first to avoid rounding errors.
@@ -318,7 +355,9 @@ module aptos_std::pool_u64 {
         let expected_value_per_500_shares = 500 * 8000 / all_shares;
         assert!(redeem_shares(&mut pool, @1, 500) == expected_value_per_500_shares, 14);
         assert!(redeem_shares(&mut pool, @1, 500) == expected_value_per_500_shares, 15);
-        assert!(redeem_shares(&mut pool, @2, 2000) == expected_value_per_500_shares * 4, 16);
+        assert!(
+            redeem_shares(&mut pool, @2, 2000) == expected_value_per_500_shares * 4, 16
+        );
 
         // Due to a very small rounding error of 1, shareholder 3 actually has 1 more coin.
         let shareholder_3_balance = expected_value_per_500_shares * 6 / 5 + 1;

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64.move
@@ -210,7 +210,8 @@ module aptos_std::pool_u64 {
         shares_to_transfer: u64,
     ) {
         assert!(
-            contains(pool, shareholder_1), error::invalid_argument(ESHAREHOLDER_NOT_FOUND)
+            contains(pool, shareholder_1),
+            error::invalid_argument(ESHAREHOLDER_NOT_FOUND),
         );
         assert!(
             shares(pool, shareholder_1) >= shares_to_transfer,
@@ -356,7 +357,8 @@ module aptos_std::pool_u64 {
         assert!(redeem_shares(&mut pool, @1, 500) == expected_value_per_500_shares, 14);
         assert!(redeem_shares(&mut pool, @1, 500) == expected_value_per_500_shares, 15);
         assert!(
-            redeem_shares(&mut pool, @2, 2000) == expected_value_per_500_shares * 4, 16
+            redeem_shares(&mut pool, @2, 2000) == expected_value_per_500_shares * 4,
+            16,
         );
 
         // Due to a very small rounding error of 1, shareholder 3 actually has 1 more coin.

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64.spec.move
@@ -6,6 +6,7 @@ spec aptos_std::pool_u64 {
         // TODO: Disabled due to the issue with the data invariant verification
         pragma verify = false;
     }
+
     // -----------------
     // Struct invariants
     // -----------------
@@ -13,14 +14,15 @@ spec aptos_std::pool_u64 {
     // The invariants of the struct Pool.
     spec Pool {
         // `shares` contains the key `addr` if and only if `shareholders` contains `addr.
-        invariant forall addr: address:
-            (simple_map::spec_contains_key(shares, addr) == vector::spec_contains(shareholders, addr));
+        invariant forall addr: address: (
+            simple_map::spec_contains_key(shares, addr)
+                == vector::spec_contains(shareholders, addr)
+        );
 
         // `shareholders` does not contain duplicates.
-        invariant forall i in 0..len(shareholders), j in 0..len(shareholders):
-            shareholders[i] == shareholders[j] ==> i == j;
+        invariant forall i in 0..len(shareholders), j in 0..len(shareholders): shareholders[i] ==
+             shareholders[j] ==> i == j;
     }
-
 
     // -----------------------
     // Function specifications
@@ -38,10 +40,7 @@ spec aptos_std::pool_u64 {
     spec fun spec_shares(pool: Pool, shareholder: address): u64 {
         if (simple_map::spec_contains_key(pool.shares, shareholder)) {
             simple_map::spec_get(pool.shares, shareholder)
-        }
-        else {
-            0
-        }
+        } else { 0 }
     }
 
     spec shares(pool: &Pool, shareholder: address): u64 {
@@ -52,16 +51,24 @@ spec aptos_std::pool_u64 {
     spec balance(pool: &Pool, shareholder: address): u64 {
         let shares = spec_shares(pool, shareholder);
         let total_coins = pool.total_coins;
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0 && (shares * total_coins) / pool.total_shares > MAX_U64;
-        ensures result == spec_shares_to_amount_with_total_coins(pool, shares, total_coins);
+        aborts_if pool.total_coins > 0
+            && pool.total_shares > 0
+            && (shares * total_coins) / pool.total_shares > MAX_U64;
+        ensures result == spec_shares_to_amount_with_total_coins(
+            pool, shares, total_coins
+        );
     }
 
     spec buy_in(pool: &mut Pool, shareholder: address, coins_amount: u64): u64 {
-        let new_shares = spec_amount_to_shares_with_total_coins(pool, coins_amount, pool.total_coins);
+        let new_shares = spec_amount_to_shares_with_total_coins(
+            pool, coins_amount, pool.total_coins
+        );
         aborts_if pool.total_coins + coins_amount > MAX_U64;
         aborts_if pool.total_shares + new_shares > MAX_U64;
-        include coins_amount > 0 ==> AddSharesAbortsIf { new_shares: new_shares };
-        include coins_amount > 0 ==> AddSharesEnsures { new_shares: new_shares };
+        include coins_amount > 0 ==>
+            AddSharesAbortsIf { new_shares: new_shares };
+        include coins_amount > 0 ==>
+            AddSharesEnsures { new_shares: new_shares };
         ensures pool.total_coins == old(pool.total_coins) + coins_amount;
         ensures pool.total_shares == old(pool.total_shares) + new_shares;
         ensures result == new_shares;
@@ -72,9 +79,14 @@ spec aptos_std::pool_u64 {
         include AddSharesEnsures;
 
         let key_exists = simple_map::spec_contains_key(pool.shares, shareholder);
-        ensures result == if (key_exists) { simple_map::spec_get(pool.shares, shareholder) }
-        else { new_shares };
+        ensures result
+            == if (key_exists) {
+                simple_map::spec_get(pool.shares, shareholder)
+            } else {
+                new_shares
+            };
     }
+
     spec schema AddSharesAbortsIf {
         pool: Pool;
         shareholder: address;
@@ -84,8 +96,11 @@ spec aptos_std::pool_u64 {
         let current_shares = simple_map::spec_get(pool.shares, shareholder);
 
         aborts_if key_exists && current_shares + new_shares > MAX_U64;
-        aborts_if !key_exists && new_shares > 0 && len(pool.shareholders) >= pool.shareholders_limit;
+        aborts_if !key_exists
+            && new_shares > 0
+            && len(pool.shareholders) >= pool.shareholders_limit;
     }
+
     spec schema AddSharesEnsures {
         pool: Pool;
         shareholder: address;
@@ -95,41 +110,50 @@ spec aptos_std::pool_u64 {
         let current_shares = simple_map::spec_get(pool.shares, shareholder);
 
         ensures key_exists ==>
-            pool.shares == simple_map::spec_set(old(pool.shares), shareholder, current_shares + new_shares);
+            pool.shares
+                == simple_map::spec_set(
+                    old(pool.shares), shareholder, current_shares + new_shares
+                );
         ensures (!key_exists && new_shares > 0) ==>
             pool.shares == simple_map::spec_set(old(pool.shares), shareholder, new_shares);
         ensures (!key_exists && new_shares > 0) ==>
             vector::eq_push_back(pool.shareholders, old(pool.shareholders), shareholder);
     }
 
-    spec fun spec_amount_to_shares_with_total_coins(pool: Pool, coins_amount: u64, total_coins: u64): u64 {
+    spec fun spec_amount_to_shares_with_total_coins(
+        pool: Pool, coins_amount: u64, total_coins: u64
+    ): u64 {
         if (pool.total_coins == 0 || pool.total_shares == 0) {
             coins_amount * pool.scaling_factor
-        }
-        else {
+        } else {
             (coins_amount * pool.total_shares) / total_coins
         }
     }
 
     spec amount_to_shares_with_total_coins(pool: &Pool, coins_amount: u64, total_coins: u64): u64 {
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0
+        aborts_if pool.total_coins > 0
+            && pool.total_shares > 0
             && (coins_amount * pool.total_shares) / total_coins > MAX_U64;
         aborts_if (pool.total_coins == 0 || pool.total_shares == 0)
             && coins_amount * pool.scaling_factor > MAX_U64;
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0 && total_coins == 0;
-        ensures result == spec_amount_to_shares_with_total_coins(pool, coins_amount, total_coins);
+        aborts_if pool.total_coins > 0
+            && pool.total_shares > 0
+            && total_coins == 0;
+        ensures result
+            == spec_amount_to_shares_with_total_coins(pool, coins_amount, total_coins);
     }
 
     spec shares_to_amount_with_total_coins(pool: &Pool, shares: u64, total_coins: u64): u64 {
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0
+        aborts_if pool.total_coins > 0
+            && pool.total_shares > 0
             && (shares * total_coins) / pool.total_shares > MAX_U64;
-        ensures result == spec_shares_to_amount_with_total_coins(pool, shares, total_coins);
+        ensures result == spec_shares_to_amount_with_total_coins(
+            pool, shares, total_coins
+        );
     }
 
     spec fun spec_shares_to_amount_with_total_coins(pool: Pool, shares: u64, total_coins: u64): u64 {
-        if (pool.total_coins == 0 || pool.total_shares == 0) {
-            0
-        }
+        if (pool.total_coins == 0 || pool.total_shares == 0) { 0 }
         else {
             (shares * total_coins) / pool.total_shares
         }
@@ -142,14 +166,17 @@ spec aptos_std::pool_u64 {
     }
 
     spec redeem_shares(pool: &mut Pool, shareholder: address, shares_to_redeem: u64): u64 {
-        let redeemed_coins = spec_shares_to_amount_with_total_coins(pool, shares_to_redeem, pool.total_coins);
+        let redeemed_coins = spec_shares_to_amount_with_total_coins(
+            pool, shares_to_redeem, pool.total_coins
+        );
         aborts_if !spec_contains(pool, shareholder);
         aborts_if spec_shares(pool, shareholder) < shares_to_redeem;
         aborts_if pool.total_coins < redeemed_coins;
         aborts_if pool.total_shares < shares_to_redeem;
         ensures pool.total_coins == old(pool.total_coins) - redeemed_coins;
         ensures pool.total_shares == old(pool.total_shares) - shares_to_redeem;
-        include shares_to_redeem > 0 ==> DeductSharesEnsures { num_shares: shares_to_redeem };
+        include shares_to_redeem > 0 ==>
+            DeductSharesEnsures { num_shares: shares_to_redeem };
         ensures result == redeemed_coins;
     }
 
@@ -171,16 +198,21 @@ spec aptos_std::pool_u64 {
 
         include DeductSharesEnsures;
         let remaining_shares = simple_map::spec_get(pool.shares, shareholder) - num_shares;
-        ensures remaining_shares > 0 ==> result == simple_map::spec_get(pool.shares, shareholder);
+        ensures remaining_shares > 0 ==>
+            result == simple_map::spec_get(pool.shares, shareholder);
         ensures remaining_shares == 0 ==> result == 0;
     }
+
     spec schema DeductSharesEnsures {
         pool: Pool;
         shareholder: address;
         num_shares: u64;
         let remaining_shares = simple_map::spec_get(pool.shares, shareholder) - num_shares;
-        ensures remaining_shares > 0 ==> simple_map::spec_get(pool.shares, shareholder) == remaining_shares;
-        ensures remaining_shares == 0 ==> !simple_map::spec_contains_key(pool.shares, shareholder);
-        ensures remaining_shares == 0 ==> !vector::spec_contains(pool.shareholders, shareholder);
+        ensures remaining_shares > 0 ==>
+            simple_map::spec_get(pool.shares, shareholder) == remaining_shares;
+        ensures remaining_shares == 0 ==>
+            !simple_map::spec_contains_key(pool.shares, shareholder);
+        ensures remaining_shares == 0 ==>
+            !vector::spec_contains(pool.shareholders, shareholder);
     }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64.spec.move
@@ -14,14 +14,15 @@ spec aptos_std::pool_u64 {
     // The invariants of the struct Pool.
     spec Pool {
         // `shares` contains the key `addr` if and only if `shareholders` contains `addr.
-        invariant forall addr: address: (
-            simple_map::spec_contains_key(shares, addr)
-                == vector::spec_contains(shareholders, addr)
-        );
+        invariant forall addr: address:
+            (
+                simple_map::spec_contains_key(shares, addr)
+                    == vector::spec_contains(shareholders, addr)
+            );
 
         // `shareholders` does not contain duplicates.
-        invariant forall i in 0..len(shareholders), j in 0..len(shareholders): shareholders[i] ==
-             shareholders[j] ==> i == j;
+        invariant forall i in 0..len(shareholders), j in 0..len(shareholders):
+            shareholders[i] == shareholders[j] ==> i == j;
     }
 
     // -----------------------

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.move
@@ -188,7 +188,8 @@ module aptos_std::pool_u64_unbound {
         shares_to_transfer: u128,
     ) {
         assert!(
-            contains(pool, shareholder_1), error::invalid_argument(ESHAREHOLDER_NOT_FOUND)
+            contains(pool, shareholder_1),
+            error::invalid_argument(ESHAREHOLDER_NOT_FOUND),
         );
         assert!(
             shares(pool, shareholder_1) >= shares_to_transfer,
@@ -245,7 +246,10 @@ module aptos_std::pool_u64_unbound {
             // New number of shares = new_amount / shares_price = new_amount * existing_shares / total_amount.
             // We rearrange the calc and do multiplication first to avoid rounding errors.
             multiply_then_divide(
-                pool, to_u128(coins_amount), pool.total_shares, to_u128(total_coins)
+                pool,
+                to_u128(coins_amount),
+                pool.total_shares,
+                to_u128(total_coins),
             )
         }
     }
@@ -269,7 +273,10 @@ module aptos_std::pool_u64_unbound {
             // We rearrange the calc and do multiplication first to avoid rounding errors.
             (
                 multiply_then_divide(
-                    pool, shares, to_u128(total_coins), pool.total_shares
+                    pool,
+                    shares,
+                    to_u128(total_coins),
+                    pool.total_shares,
                 ) as u64
             )
         }

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.move
@@ -71,12 +71,7 @@ module aptos_std::pool_u64_unbound {
     /// Destroy an empty pool. This will fail if the pool has any balance of coins.
     public fun destroy_empty(pool: Pool) {
         assert!(pool.total_coins == 0, error::invalid_state(EPOOL_IS_NOT_EMPTY));
-        let Pool {
-            total_coins: _,
-            total_shares: _,
-            shares,
-            scaling_factor: _,
-        } = pool;
+        let Pool { total_coins: _, total_shares: _, shares, scaling_factor: _, } = pool;
         table::destroy_empty<address, u128>(shares);
     }
 
@@ -99,9 +94,7 @@ module aptos_std::pool_u64_unbound {
     public fun shares(pool: &Pool, shareholder: address): u128 {
         if (contains(pool, shareholder)) {
             *table::borrow(&pool.shares, shareholder)
-        } else {
-            0
-        }
+        } else { 0 }
     }
 
     /// Return the balance in coins of `shareholder` in `pool.`
@@ -121,12 +114,20 @@ module aptos_std::pool_u64_unbound {
     }
 
     /// Allow an existing or new shareholder to add their coins to the pool in exchange for new shares.
-    public fun buy_in(pool: &mut Pool, shareholder: address, coins_amount: u64): u128 {
+    public fun buy_in(
+        pool: &mut Pool, shareholder: address, coins_amount: u64
+    ): u128 {
         if (coins_amount == 0) return 0;
 
         let new_shares = amount_to_shares(pool, coins_amount);
-        assert!(MAX_U64 - pool.total_coins >= coins_amount, error::invalid_argument(EPOOL_TOTAL_COINS_OVERFLOW));
-        assert!(MAX_U128 - pool.total_shares >= new_shares, error::invalid_argument(EPOOL_TOTAL_SHARES_OVERFLOW));
+        assert!(
+            MAX_U64 - pool.total_coins >= coins_amount,
+            error::invalid_argument(EPOOL_TOTAL_COINS_OVERFLOW),
+        );
+        assert!(
+            MAX_U128 - pool.total_shares >= new_shares,
+            error::invalid_argument(EPOOL_TOTAL_SHARES_OVERFLOW),
+        );
 
         pool.total_coins = pool.total_coins + coins_amount;
         pool.total_shares = pool.total_shares + new_shares;
@@ -136,11 +137,16 @@ module aptos_std::pool_u64_unbound {
 
     /// Add the number of shares directly for `shareholder` in `pool`.
     /// This would dilute other shareholders if the pool's balance of coins didn't change.
-    fun add_shares(pool: &mut Pool, shareholder: address, new_shares: u128): u128 {
+    fun add_shares(
+        pool: &mut Pool, shareholder: address, new_shares: u128
+    ): u128 {
         if (contains(pool, shareholder)) {
             let existing_shares = table::borrow_mut(&mut pool.shares, shareholder);
             let current_shares = *existing_shares;
-            assert!(MAX_U128 - current_shares >= new_shares, error::invalid_argument(ESHAREHOLDER_SHARES_OVERFLOW));
+            assert!(
+                MAX_U128 - current_shares >= new_shares,
+                error::invalid_argument(ESHAREHOLDER_SHARES_OVERFLOW),
+            );
 
             *existing_shares = current_shares + new_shares;
             *existing_shares
@@ -153,9 +159,16 @@ module aptos_std::pool_u64_unbound {
     }
 
     /// Allow `shareholder` to redeem their shares in `pool` for coins.
-    public fun redeem_shares(pool: &mut Pool, shareholder: address, shares_to_redeem: u128): u64 {
-        assert!(contains(pool, shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
-        assert!(shares(pool, shareholder) >= shares_to_redeem, error::invalid_argument(EINSUFFICIENT_SHARES));
+    public fun redeem_shares(
+        pool: &mut Pool, shareholder: address, shares_to_redeem: u128
+    ): u64 {
+        assert!(
+            contains(pool, shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND)
+        );
+        assert!(
+            shares(pool, shareholder) >= shares_to_redeem,
+            error::invalid_argument(EINSUFFICIENT_SHARES),
+        );
 
         if (shares_to_redeem == 0) return 0;
 
@@ -174,8 +187,13 @@ module aptos_std::pool_u64_unbound {
         shareholder_2: address,
         shares_to_transfer: u128,
     ) {
-        assert!(contains(pool, shareholder_1), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
-        assert!(shares(pool, shareholder_1) >= shares_to_transfer, error::invalid_argument(EINSUFFICIENT_SHARES));
+        assert!(
+            contains(pool, shareholder_1), error::invalid_argument(ESHAREHOLDER_NOT_FOUND)
+        );
+        assert!(
+            shares(pool, shareholder_1) >= shares_to_transfer,
+            error::invalid_argument(EINSUFFICIENT_SHARES),
+        );
         if (shares_to_transfer == 0) return;
 
         deduct_shares(pool, shareholder_1, shares_to_transfer);
@@ -183,9 +201,16 @@ module aptos_std::pool_u64_unbound {
     }
 
     /// Directly deduct `shareholder`'s number of shares in `pool` and return the number of remaining shares.
-    fun deduct_shares(pool: &mut Pool, shareholder: address, num_shares: u128): u128 {
-        assert!(contains(pool, shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
-        assert!(shares(pool, shareholder) >= num_shares, error::invalid_argument(EINSUFFICIENT_SHARES));
+    fun deduct_shares(
+        pool: &mut Pool, shareholder: address, num_shares: u128
+    ): u128 {
+        assert!(
+            contains(pool, shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND)
+        );
+        assert!(
+            shares(pool, shareholder) >= num_shares,
+            error::invalid_argument(EINSUFFICIENT_SHARES),
+        );
 
         let existing_shares = table::borrow_mut(&mut pool.shares, shareholder);
         *existing_shares = *existing_shares - num_shares;
@@ -207,7 +232,9 @@ module aptos_std::pool_u64_unbound {
 
     /// Return the number of new shares `coins_amount` can buy in `pool` with a custom total coins number.
     /// `amount` needs to big enough to avoid rounding number.
-    public fun amount_to_shares_with_total_coins(pool: &Pool, coins_amount: u64, total_coins: u64): u128 {
+    public fun amount_to_shares_with_total_coins(
+        pool: &Pool, coins_amount: u64, total_coins: u64
+    ): u128 {
         // No shares yet so amount is worth the same number of shares.
         if (pool.total_coins == 0 || pool.total_shares == 0) {
             // Multiply by scaling factor to minimize rounding errors during internal calculations for buy ins/redeems.
@@ -217,7 +244,9 @@ module aptos_std::pool_u64_unbound {
             // Shares price = total_coins / total existing shares.
             // New number of shares = new_amount / shares_price = new_amount * existing_shares / total_amount.
             // We rearrange the calc and do multiplication first to avoid rounding errors.
-            multiply_then_divide(pool, to_u128(coins_amount), pool.total_shares, to_u128(total_coins))
+            multiply_then_divide(
+                pool, to_u128(coins_amount), pool.total_shares, to_u128(total_coins)
+            )
         }
     }
 
@@ -229,15 +258,20 @@ module aptos_std::pool_u64_unbound {
 
     /// Return the number of coins `shares` are worth in `pool` with a custom total coins number.
     /// `shares` needs to big enough to avoid rounding number.
-    public fun shares_to_amount_with_total_coins(pool: &Pool, shares: u128, total_coins: u64): u64 {
+    public fun shares_to_amount_with_total_coins(
+        pool: &Pool, shares: u128, total_coins: u64
+    ): u64 {
         // No shares or coins yet so shares are worthless.
-        if (pool.total_coins == 0 || pool.total_shares == 0) {
-            0
-        } else {
+        if (pool.total_coins == 0 || pool.total_shares == 0) { 0 }
+        else {
             // Shares price = total_coins / total existing shares.
             // Shares worth = shares * shares price = shares * total_coins / total existing shares.
             // We rearrange the calc and do multiplication first to avoid rounding errors.
-            (multiply_then_divide(pool, shares, to_u128(total_coins), pool.total_shares) as u64)
+            (
+                multiply_then_divide(
+                    pool, shares, to_u128(total_coins), pool.total_shares
+                ) as u64
+            )
         }
     }
 
@@ -248,14 +282,15 @@ module aptos_std::pool_u64_unbound {
         total_coins: u64,
         total_shares: u128,
     ): u64 {
-        if (pool.total_coins == 0 || total_shares == 0) {
-            0
-        } else {
+        if (pool.total_coins == 0 || total_shares == 0) { 0 }
+        else {
             (multiply_then_divide(pool, shares, to_u128(total_coins), total_shares) as u64)
         }
     }
 
-    public fun multiply_then_divide(_pool: &Pool, x: u128, y: u128, z: u128): u128 {
+    public fun multiply_then_divide(
+        _pool: &Pool, x: u128, y: u128, z: u128
+    ): u128 {
         let result = (to_u256(x) * to_u256(y)) / to_u256(z);
         (result as u128)
     }

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.spec.move
@@ -7,8 +7,9 @@ spec aptos_std::pool_u64_unbound {
     // -----------------------
 
     spec Pool {
-        invariant forall addr: address: table::spec_contains(shares, addr) ==>
-            (table::spec_get(shares, addr) > 0);
+        invariant forall addr: address:
+            table::spec_contains(shares, addr) ==>
+                (table::spec_get(shares, addr) > 0);
     }
 
     spec fun spec_contains(pool: Pool, shareholder: address): bool {
@@ -181,33 +182,33 @@ spec aptos_std::pool_u64_unbound {
             (spec_contains(pool, shareholder_2));
         ensures (
             shareholder_1 != shareholder_2
-            && shares_to_transfer > 0
-            && !spec_contains(old(pool), shareholder_2)
+                && shares_to_transfer > 0
+                && !spec_contains(old(pool), shareholder_2)
         ) ==>
             (
                 spec_contains(pool, shareholder_2)
-                && spec_shares(pool, shareholder_2) == shares_to_transfer
+                    && spec_shares(pool, shareholder_2) == shares_to_transfer
             );
         ensures (
             shareholder_1 != shareholder_2
-            && shares_to_transfer > 0
-            && spec_contains(old(pool), shareholder_2)
+                && shares_to_transfer > 0
+                && spec_contains(old(pool), shareholder_2)
         ) ==>
             (
                 spec_contains(pool, shareholder_2)
-                && spec_shares(pool, shareholder_2)
-                    == spec_shares(old(pool), shareholder_2) + shares_to_transfer
+                    && spec_shares(pool, shareholder_2)
+                        == spec_shares(old(pool), shareholder_2) + shares_to_transfer
             );
         ensures (
             (shareholder_1 != shareholder_2)
-            && (spec_shares(old(pool), shareholder_1) > shares_to_transfer)
+                && (spec_shares(old(pool), shareholder_1) > shares_to_transfer)
         ) ==>
             (
                 spec_contains(pool, shareholder_1)
-                && (
-                    spec_shares(pool, shareholder_1)
-                        == spec_shares(old(pool), shareholder_1) - shares_to_transfer
-                )
+                    && (
+                        spec_shares(pool, shareholder_1)
+                            == spec_shares(old(pool), shareholder_1) - shares_to_transfer
+                    )
             );
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.spec.move
@@ -7,8 +7,8 @@ spec aptos_std::pool_u64_unbound {
     // -----------------------
 
     spec Pool {
-        invariant forall addr: address:
-            table::spec_contains(shares, addr) ==> (table::spec_get(shares, addr) > 0);
+        invariant forall addr: address: table::spec_contains(shares, addr) ==>
+            (table::spec_get(shares, addr) > 0);
     }
 
     spec fun spec_contains(pool: Pool, shareholder: address): bool {
@@ -23,10 +23,7 @@ spec aptos_std::pool_u64_unbound {
     spec fun spec_shares(pool: Pool, shareholder: address): u64 {
         if (spec_contains(pool, shareholder)) {
             table::spec_get(pool.shares, shareholder)
-        }
-        else {
-            0
-        }
+        } else { 0 }
     }
 
     spec shares(pool: &Pool, shareholder: address): u128 {
@@ -37,16 +34,24 @@ spec aptos_std::pool_u64_unbound {
     spec balance(pool: &Pool, shareholder: address): u64 {
         let shares = spec_shares(pool, shareholder);
         let total_coins = pool.total_coins;
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0 && (shares * total_coins) / pool.total_shares > MAX_U64;
-        ensures result == spec_shares_to_amount_with_total_coins(pool, shares, total_coins);
+        aborts_if pool.total_coins > 0
+            && pool.total_shares > 0
+            && (shares * total_coins) / pool.total_shares > MAX_U64;
+        ensures result == spec_shares_to_amount_with_total_coins(
+            pool, shares, total_coins
+        );
     }
 
     spec buy_in(pool: &mut Pool, shareholder: address, coins_amount: u64): u128 {
-        let new_shares = spec_amount_to_shares_with_total_coins(pool, coins_amount, pool.total_coins);
+        let new_shares = spec_amount_to_shares_with_total_coins(
+            pool, coins_amount, pool.total_coins
+        );
         aborts_if pool.total_coins + coins_amount > MAX_U64;
         aborts_if pool.total_shares + new_shares > MAX_U128;
-        include coins_amount > 0 ==> AddSharesAbortsIf { new_shares: new_shares };
-        include coins_amount > 0 ==> AddSharesEnsures { new_shares: new_shares };
+        include coins_amount > 0 ==>
+            AddSharesAbortsIf { new_shares: new_shares };
+        include coins_amount > 0 ==>
+            AddSharesEnsures { new_shares: new_shares };
         ensures pool.total_coins == old(pool.total_coins) + coins_amount;
         ensures pool.total_shares == old(pool.total_shares) + new_shares;
         ensures result == new_shares;
@@ -57,9 +62,14 @@ spec aptos_std::pool_u64_unbound {
         include AddSharesEnsures;
 
         let key_exists = table::spec_contains(pool.shares, shareholder);
-        ensures result == if (key_exists) { table::spec_get(pool.shares, shareholder) }
-        else { new_shares };
+        ensures result
+            == if (key_exists) {
+                table::spec_get(pool.shares, shareholder)
+            } else {
+                new_shares
+            };
     }
+
     spec schema AddSharesAbortsIf {
         pool: Pool;
         shareholder: address;
@@ -70,6 +80,7 @@ spec aptos_std::pool_u64_unbound {
 
         aborts_if key_exists && current_shares + new_shares > MAX_U128;
     }
+
     spec schema AddSharesEnsures {
         pool: Pool;
         shareholder: address;
@@ -79,39 +90,48 @@ spec aptos_std::pool_u64_unbound {
         let current_shares = table::spec_get(pool.shares, shareholder);
 
         ensures key_exists ==>
-            pool.shares == table::spec_set(old(pool.shares), shareholder, current_shares + new_shares);
+            pool.shares
+                == table::spec_set(
+                    old(pool.shares), shareholder, current_shares + new_shares
+                );
         ensures (!key_exists && new_shares > 0) ==>
             pool.shares == table::spec_set(old(pool.shares), shareholder, new_shares);
     }
 
-    spec fun spec_amount_to_shares_with_total_coins(pool: Pool, coins_amount: u64, total_coins: u64): u128 {
+    spec fun spec_amount_to_shares_with_total_coins(
+        pool: Pool, coins_amount: u64, total_coins: u64
+    ): u128 {
         if (pool.total_coins == 0 || pool.total_shares == 0) {
             coins_amount * pool.scaling_factor
-        }
-        else {
+        } else {
             (coins_amount * pool.total_shares) / total_coins
         }
     }
 
     spec amount_to_shares_with_total_coins(pool: &Pool, coins_amount: u64, total_coins: u64): u128 {
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0
+        aborts_if pool.total_coins > 0
+            && pool.total_shares > 0
             && (coins_amount * pool.total_shares) / total_coins > MAX_U128;
         aborts_if (pool.total_coins == 0 || pool.total_shares == 0)
             && coins_amount * pool.scaling_factor > MAX_U128;
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0 && total_coins == 0;
-        ensures result == spec_amount_to_shares_with_total_coins(pool, coins_amount, total_coins);
+        aborts_if pool.total_coins > 0
+            && pool.total_shares > 0
+            && total_coins == 0;
+        ensures result
+            == spec_amount_to_shares_with_total_coins(pool, coins_amount, total_coins);
     }
 
     spec shares_to_amount_with_total_coins(pool: &Pool, shares: u128, total_coins: u64): u64 {
-        aborts_if pool.total_coins > 0 && pool.total_shares > 0
+        aborts_if pool.total_coins > 0
+            && pool.total_shares > 0
             && (shares * total_coins) / pool.total_shares > MAX_U64;
-        ensures result == spec_shares_to_amount_with_total_coins(pool, shares, total_coins);
+        ensures result == spec_shares_to_amount_with_total_coins(
+            pool, shares, total_coins
+        );
     }
 
     spec fun spec_shares_to_amount_with_total_coins(pool: Pool, shares: u128, total_coins: u64): u64 {
-        if (pool.total_coins == 0 || pool.total_shares == 0) {
-            0
-        }
+        if (pool.total_coins == 0 || pool.total_shares == 0) { 0 }
         else {
             (shares * total_coins) / pool.total_shares
         }
@@ -124,38 +144,71 @@ spec aptos_std::pool_u64_unbound {
     }
 
     spec redeem_shares(pool: &mut Pool, shareholder: address, shares_to_redeem: u128): u64 {
-        let redeemed_coins = spec_shares_to_amount_with_total_coins(pool, shares_to_redeem, pool.total_coins);
+        let redeemed_coins = spec_shares_to_amount_with_total_coins(
+            pool, shares_to_redeem, pool.total_coins
+        );
         aborts_if !spec_contains(pool, shareholder);
         aborts_if spec_shares(pool, shareholder) < shares_to_redeem;
         aborts_if pool.total_coins < redeemed_coins;
         aborts_if pool.total_shares < shares_to_redeem;
         ensures pool.total_coins == old(pool.total_coins) - redeemed_coins;
         ensures pool.total_shares == old(pool.total_shares) - shares_to_redeem;
-        include shares_to_redeem > 0 ==> DeductSharesEnsures { num_shares: shares_to_redeem };
+        include shares_to_redeem > 0 ==>
+            DeductSharesEnsures { num_shares: shares_to_redeem };
         ensures result == redeemed_coins;
     }
 
     spec transfer_shares(
-    pool: &mut Pool,
-    shareholder_1: address,
-    shareholder_2: address,
-    shares_to_transfer: u128
+        pool: &mut Pool,
+        shareholder_1: address,
+        shareholder_2: address,
+        shares_to_transfer: u128
     ) {
-        aborts_if (shareholder_1 != shareholder_2) && shares_to_transfer > 0 && spec_contains(pool, shareholder_2) &&
-            (spec_shares(pool, shareholder_2) + shares_to_transfer > MAX_U128);
+        aborts_if (shareholder_1 != shareholder_2)
+            && shares_to_transfer > 0
+            && spec_contains(pool, shareholder_2)
+            && (spec_shares(pool, shareholder_2) + shares_to_transfer > MAX_U128);
         aborts_if !spec_contains(pool, shareholder_1);
         aborts_if spec_shares(pool, shareholder_1) < shares_to_transfer;
-        ensures shareholder_1 == shareholder_2 ==> spec_shares(old(pool), shareholder_1) == spec_shares(pool, shareholder_1);
-        ensures ((shareholder_1 != shareholder_2) && (spec_shares(old(pool), shareholder_1) == shares_to_transfer)) ==>
+        ensures shareholder_1 == shareholder_2 ==>
+            spec_shares(old(pool), shareholder_1) == spec_shares(pool, shareholder_1);
+        ensures (
+            (shareholder_1 != shareholder_2)
+                && (spec_shares(old(pool), shareholder_1) == shares_to_transfer)
+        ) ==>
             !spec_contains(pool, shareholder_1);
         ensures (shareholder_1 != shareholder_2 && shares_to_transfer > 0) ==>
             (spec_contains(pool, shareholder_2));
-        ensures (shareholder_1 != shareholder_2 && shares_to_transfer > 0 && !spec_contains(old(pool), shareholder_2)) ==>
-            (spec_contains(pool, shareholder_2) && spec_shares(pool, shareholder_2) == shares_to_transfer);
-        ensures (shareholder_1 != shareholder_2 && shares_to_transfer > 0 && spec_contains(old(pool), shareholder_2)) ==>
-            (spec_contains(pool, shareholder_2) && spec_shares(pool, shareholder_2) == spec_shares(old(pool), shareholder_2) + shares_to_transfer);
-        ensures ((shareholder_1 != shareholder_2) && (spec_shares(old(pool), shareholder_1) > shares_to_transfer)) ==>
-            (spec_contains(pool, shareholder_1) && (spec_shares(pool, shareholder_1) == spec_shares(old(pool), shareholder_1) - shares_to_transfer));
+        ensures (
+            shareholder_1 != shareholder_2
+            && shares_to_transfer > 0
+            && !spec_contains(old(pool), shareholder_2)
+        ) ==>
+            (
+                spec_contains(pool, shareholder_2)
+                && spec_shares(pool, shareholder_2) == shares_to_transfer
+            );
+        ensures (
+            shareholder_1 != shareholder_2
+            && shares_to_transfer > 0
+            && spec_contains(old(pool), shareholder_2)
+        ) ==>
+            (
+                spec_contains(pool, shareholder_2)
+                && spec_shares(pool, shareholder_2)
+                    == spec_shares(old(pool), shareholder_2) + shares_to_transfer
+            );
+        ensures (
+            (shareholder_1 != shareholder_2)
+            && (spec_shares(old(pool), shareholder_1) > shares_to_transfer)
+        ) ==>
+            (
+                spec_contains(pool, shareholder_1)
+                && (
+                    spec_shares(pool, shareholder_1)
+                        == spec_shares(old(pool), shareholder_1) - shares_to_transfer
+                )
+            );
     }
 
     spec deduct_shares(pool: &mut Pool, shareholder: address, num_shares: u128): u128 {
@@ -164,16 +217,20 @@ spec aptos_std::pool_u64_unbound {
 
         include DeductSharesEnsures;
         let remaining_shares = table::spec_get(pool.shares, shareholder) - num_shares;
-        ensures remaining_shares > 0 ==> result == table::spec_get(pool.shares, shareholder);
+        ensures remaining_shares > 0 ==>
+            result == table::spec_get(pool.shares, shareholder);
         ensures remaining_shares == 0 ==> result == 0;
     }
+
     spec schema DeductSharesEnsures {
         pool: Pool;
         shareholder: address;
         num_shares: u64;
         let remaining_shares = table::spec_get(pool.shares, shareholder) - num_shares;
-        ensures remaining_shares > 0 ==> table::spec_get(pool.shares, shareholder) == remaining_shares;
-        ensures remaining_shares == 0 ==> !table::spec_contains(pool.shares, shareholder);
+        ensures remaining_shares > 0 ==>
+            table::spec_get(pool.shares, shareholder) == remaining_shares;
+        ensures remaining_shares == 0 ==>
+            !table::spec_contains(pool.shares, shareholder);
     }
 
     spec to_u128(num: u64): u128 {

--- a/aptos-move/framework/aptos-stdlib/sources/simple_map.move
+++ b/aptos-move/framework/aptos-stdlib/sources/simple_map.move
@@ -29,15 +29,12 @@ module aptos_std::simple_map {
 
     /// Create an empty SimpleMap.
     public fun new<Key: store, Value: store>(): SimpleMap<Key, Value> {
-        SimpleMap {
-            data: vector::empty(),
-        }
+        SimpleMap { data: vector::empty(), }
     }
 
     /// Create a SimpleMap from a vector of keys and values. The keys must be unique.
     public fun new_from<Key: store, Value: store>(
-        keys: vector<Key>,
-        values: vector<Value>,
+        keys: vector<Key>, values: vector<Value>,
     ): SimpleMap<Key, Value> {
         let map = new();
         add_all(&mut map, keys, values);
@@ -79,7 +76,9 @@ module aptos_std::simple_map {
         option::is_some(&maybe_idx)
     }
 
-    public fun destroy_empty<Key: store, Value: store>(map: SimpleMap<Key, Value>) {
+    public fun destroy_empty<Key: store, Value: store>(
+        map: SimpleMap<Key, Value>
+    ) {
         let SimpleMap { data } = map;
         vector::destroy_empty(data);
     }
@@ -102,9 +101,12 @@ module aptos_std::simple_map {
         keys: vector<Key>,
         values: vector<Value>,
     ) {
-        vector::zip(keys, values, |key, value| {
-            add(map, key, value);
-        });
+        vector::zip(
+            keys, values,
+            |key, value| {
+                add(map, key, value);
+            }
+        );
     }
 
     /// Insert key/value pair or update an existing key to a new value
@@ -132,32 +134,42 @@ module aptos_std::simple_map {
 
     /// Return all keys in the map. This requires keys to be copyable.
     public fun keys<Key: copy, Value>(map: &SimpleMap<Key, Value>): vector<Key> {
-        vector::map_ref(&map.data, |e| {
-            let e: &Element<Key, Value> = e;
-            e.key
-        })
+        vector::map_ref(
+            &map.data,
+            |e| {
+                let e: &Element<Key, Value> = e;
+                e.key
+            },
+        )
     }
 
     /// Return all values in the map. This requires values to be copyable.
     public fun values<Key, Value: copy>(map: &SimpleMap<Key, Value>): vector<Value> {
-        vector::map_ref(&map.data, |e| {
-            let e: &Element<Key, Value> = e;
-            e.value
-        })
+        vector::map_ref(
+            &map.data,
+            |e| {
+                let e: &Element<Key, Value> = e;
+                e.value
+            },
+        )
     }
 
     /// Transform the map into two vectors with the keys and values respectively
     /// Primarily used to destroy a map
     public fun to_vec_pair<Key: store, Value: store>(
-        map: SimpleMap<Key, Value>): (vector<Key>, vector<Value>) {
+        map: SimpleMap<Key, Value>
+    ): (vector<Key>, vector<Value>) {
         let keys: vector<Key> = vector::empty();
         let values: vector<Value> = vector::empty();
         let SimpleMap { data } = map;
-        vector::for_each(data, |e| {
-            let Element { key, value } = e;
-            vector::push_back(&mut keys, key);
-            vector::push_back(&mut values, value);
-        });
+        vector::for_each(
+            data,
+            |e| {
+                let Element { key, value } = e;
+                vector::push_back(&mut keys, key);
+                vector::push_back(&mut values, value);
+            },
+        );
         (keys, values)
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/simple_map.move
+++ b/aptos-move/framework/aptos-stdlib/sources/simple_map.move
@@ -102,10 +102,11 @@ module aptos_std::simple_map {
         values: vector<Value>,
     ) {
         vector::zip(
-            keys, values,
+            keys,
+            values,
             |key, value| {
                 add(map, key, value);
-            }
+            },
         );
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/simple_map.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/simple_map.spec.move
@@ -57,15 +57,15 @@ spec aptos_std::simple_map {
     }
 
     spec find {
-        pragma verify=false;
+        pragma verify = false;
     }
 
     spec keys {
-        pragma verify=false;
+        pragma verify = false;
     }
 
     spec values {
-        pragma verify=false;
+        pragma verify = false;
     }
 
     spec new<Key: store, Value: store>(): SimpleMap<Key, Value> {
@@ -76,49 +76,60 @@ spec aptos_std::simple_map {
         ensures [abstract] forall k: Key: !spec_contains_key(result, k);
     }
 
-    spec new_from<Key: store, Value: store>(
-    keys: vector<Key>,
-    values: vector<Value>,
-    ): SimpleMap<Key, Value> {
+    spec new_from<Key: store, Value: store>(keys: vector<Key>, values: vector<Value>,): SimpleMap<Key, Value> {
         pragma intrinsic;
         pragma opaque;
         aborts_if [abstract] false;
         ensures [abstract] spec_len(result) == len(keys);
-        ensures [abstract] forall k: Key: spec_contains_key(result, k) <==> vector::spec_contains(keys, k);
-        ensures [abstract] forall i in 0..len(keys):
-            spec_get(result, vector::borrow(keys, i)) == vector::borrow(values, i);
+        ensures [abstract] forall k: Key: spec_contains_key(result, k) <==>
+            vector::spec_contains(keys, k);
+        ensures [abstract] forall i in 0..len(keys): spec_get(
+            result, vector::borrow(keys, i)
+        ) == vector::borrow(values, i);
     }
 
-    spec to_vec_pair<Key: store, Value: store>(map: SimpleMap<Key, Value>): (vector<Key>, vector<Value>) {
+    spec to_vec_pair<Key: store, Value: store>(map: SimpleMap<Key, Value>): (
+        vector<Key>, vector<Value>
+    ) {
         pragma intrinsic;
         pragma opaque;
-        ensures [abstract]
-            forall k: Key: vector::spec_contains(result_1, k) <==>
-                spec_contains_key(map, k);
-        ensures [abstract] forall i in 0..len(result_1):
-            spec_get(map, vector::borrow(result_1, i)) == vector::borrow(result_2, i);
+        ensures [abstract] forall k: Key: vector::spec_contains(result_1, k) <==>
+            spec_contains_key(map, k);
+        ensures [abstract] forall i in 0..len(result_1): spec_get(
+            map, vector::borrow(result_1, i)
+        ) == vector::borrow(result_2, i);
     }
 
     spec upsert<Key: store, Value: store>(
-        map: &mut SimpleMap<Key, Value>,
-        key: Key,
-        value: Value
-        ): (std::option::Option<Key>, std::option::Option<Value>) {
+        map: &mut SimpleMap<Key, Value>, key: Key, value: Value): (
+        std::option::Option<Key>, std::option::Option<Value>
+    ) {
         pragma intrinsic;
         pragma opaque;
         aborts_if [abstract] false;
-        ensures [abstract] !spec_contains_key(old(map), key) ==> option::is_none(result_1);
-        ensures [abstract] !spec_contains_key(old(map), key) ==> option::is_none(result_2);
+        ensures [abstract]!spec_contains_key(old(map), key) ==>
+            option::is_none(result_1);
+        ensures [abstract]!spec_contains_key(old(map), key) ==>
+            option::is_none(result_2);
         ensures [abstract] spec_contains_key(map, key);
         ensures [abstract] spec_get(map, key) == value;
-        ensures [abstract] spec_contains_key(old(map), key) ==> ((option::is_some(result_1)) && (option::spec_borrow(result_1) == key));
-        ensures [abstract] spec_contains_key(old(map), key) ==> ((option::is_some(result_2)) && (option::spec_borrow(result_2) == spec_get(old(map), key)));
+        ensures [abstract] spec_contains_key(old(map), key) ==>
+            ((option::is_some(result_1)) && (option::spec_borrow(result_1) == key));
+        ensures [abstract] spec_contains_key(old(map), key) ==>
+            (
+                (option::is_some(result_2))
+                    && (option::spec_borrow(result_2) == spec_get(old(map), key))
+            );
     }
 
     // Specification functions for tables
     spec native fun spec_len<K, V>(t: SimpleMap<K, V>): num;
+
     spec native fun spec_contains_key<K, V>(t: SimpleMap<K, V>, k: K): bool;
+
     spec native fun spec_set<K, V>(t: SimpleMap<K, V>, k: K, v: V): SimpleMap<K, V>;
+
     spec native fun spec_remove<K, V>(t: SimpleMap<K, V>, k: K): SimpleMap<K, V>;
+
     spec native fun spec_get<K, V>(t: SimpleMap<K, V>, k: K): V;
 }

--- a/aptos-move/framework/aptos-stdlib/sources/simple_map.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/simple_map.spec.move
@@ -81,11 +81,12 @@ spec aptos_std::simple_map {
         pragma opaque;
         aborts_if [abstract] false;
         ensures [abstract] spec_len(result) == len(keys);
-        ensures [abstract] forall k: Key: spec_contains_key(result, k) <==>
-            vector::spec_contains(keys, k);
-        ensures [abstract] forall i in 0..len(keys): spec_get(
-            result, vector::borrow(keys, i)
-        ) == vector::borrow(values, i);
+        ensures [abstract] forall k: Key:
+            spec_contains_key(result, k) <==>
+                vector::spec_contains(keys, k);
+        ensures [abstract] forall i in 0..len(keys):
+            spec_get(result, vector::borrow(keys, i))
+                == vector::borrow(values, i);
     }
 
     spec to_vec_pair<Key: store, Value: store>(map: SimpleMap<Key, Value>): (
@@ -93,11 +94,12 @@ spec aptos_std::simple_map {
     ) {
         pragma intrinsic;
         pragma opaque;
-        ensures [abstract] forall k: Key: vector::spec_contains(result_1, k) <==>
-            spec_contains_key(map, k);
-        ensures [abstract] forall i in 0..len(result_1): spec_get(
-            map, vector::borrow(result_1, i)
-        ) == vector::borrow(result_2, i);
+        ensures [abstract] forall k: Key:
+            vector::spec_contains(result_1, k) <==>
+                spec_contains_key(map, k);
+        ensures [abstract] forall i in 0..len(result_1):
+            spec_get(map, vector::borrow(result_1, i))
+                == vector::borrow(result_2, i);
     }
 
     spec upsert<Key: store, Value: store>(

--- a/aptos-move/framework/aptos-stdlib/sources/string_utils.move
+++ b/aptos-move/framework/aptos-stdlib/sources/string_utils.move
@@ -85,7 +85,7 @@ module aptos_std::string_utils {
         cons(a, list2(b, c))
     } inline fun list4<T0, T1, T2, T3>(a: T0, b: T1, c: T2, d: T3)
 
-        : Cons<T0, Cons<T1, Cons<T2, Cons<T3, NIL>>>> {
+    : Cons<T0, Cons<T1, Cons<T2, Cons<T3, NIL>>>> {
         cons(a, list3(b, c, d))
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/string_utils.move
+++ b/aptos-move/framework/aptos-stdlib/sources/string_utils.move
@@ -39,13 +39,20 @@ module aptos_std::string_utils {
     public fun format1<T0: drop>(fmt: &vector<u8>, a: T0): String {
         native_format_list(fmt, &list1(a))
     }
+
     public fun format2<T0: drop, T1: drop>(fmt: &vector<u8>, a: T0, b: T1): String {
         native_format_list(fmt, &list2(a, b))
     }
-    public fun format3<T0: drop, T1: drop, T2: drop>(fmt: &vector<u8>, a: T0, b: T1, c: T2): String {
+
+    public fun format3<T0: drop, T1: drop, T2: drop>(
+        fmt: &vector<u8>, a: T0, b: T1, c: T2
+    ): String {
         native_format_list(fmt, &list3(a, b, c))
     }
-    public fun format4<T0: drop, T1: drop, T2: drop, T3: drop>(fmt: &vector<u8>, a: T0, b: T1, c: T2, d: T3): String {
+
+    public fun format4<T0: drop, T1: drop, T2: drop, T3: drop>(
+        fmt: &vector<u8>, a: T0, b: T1, c: T2, d: T3
+    ): String {
         native_format_list(fmt, &list4(a, b, c, d))
     }
 
@@ -58,19 +65,38 @@ module aptos_std::string_utils {
     struct NIL has copy, drop, store {}
 
     // Create a pair of values.
-    fun cons<T, N>(car: T, cdr: N): Cons<T, N> { Cons { car, cdr } }
+    fun cons<T, N>(car: T, cdr: N): Cons<T, N> {
+        Cons { car, cdr }
+    }
 
     // Create a nil value.
-    fun nil(): NIL { NIL {} }
+    fun nil(): NIL {
+        NIL {}
+    }
 
     // Create a list of values.
-    inline fun list1<T0>(a: T0): Cons<T0, NIL> { cons(a, nil()) }
-    inline fun list2<T0, T1>(a: T0, b: T1): Cons<T0, Cons<T1, NIL>> { cons(a, list1(b)) }
-    inline fun list3<T0, T1, T2>(a: T0, b: T1, c: T2): Cons<T0, Cons<T1, Cons<T2, NIL>>> { cons(a, list2(b, c)) }
-    inline fun list4<T0, T1, T2, T3>(a: T0, b: T1, c: T2, d: T3): Cons<T0, Cons<T1, Cons<T2, Cons<T3, NIL>>>> { cons(a, list3(b, c, d)) }
+    inline fun list1<T0>(a: T0): Cons<T0, NIL> {
+        cons(a, nil())
+    } inline fun list2<T0, T1>(a: T0, b: T1): Cons<T0, Cons<T1, NIL>> {
+
+        cons(a, list1(b))
+    } inline fun list3<T0, T1, T2>(a: T0, b: T1, c: T2): Cons<T0, Cons<T1, Cons<T2, NIL>>> {
+
+        cons(a, list2(b, c))
+    } inline fun list4<T0, T1, T2, T3>(a: T0, b: T1, c: T2, d: T3)
+
+        : Cons<T0, Cons<T1, Cons<T2, Cons<T3, NIL>>>> {
+        cons(a, list3(b, c, d))
+    }
 
     // Native functions
-    native fun native_format<T>(s: &T, type_tag: bool, canonicalize: bool, single_line: bool, include_int_types: bool): String;
+    native fun native_format<T>(
+        s: &T,
+        type_tag: bool,
+        canonicalize: bool,
+        single_line: bool,
+        include_int_types: bool
+    ): String;
     native fun native_format_list<T>(fmt: &vector<u8>, val: &T): String;
 
     #[test]
@@ -79,7 +105,11 @@ module aptos_std::string_utils {
         assert!(to_string(&false) == std::string::utf8(b"false"), 2);
         assert!(to_string(&1u256) == std::string::utf8(b"1"), 3);
         assert!(to_string(&vector[1, 2, 3]) == std::string::utf8(b"[ 1, 2, 3 ]"), 4);
-        assert!(to_string(&cons(std::string::utf8(b"My string"),2)) == std::string::utf8(b"Cons { car: \"My string\", cdr: 2 }"), 5);
+        assert!(
+            to_string(&cons(std::string::utf8(b"My string"), 2))
+                == std::string::utf8(b"Cons { car: \"My string\", cdr: 2 }"),
+            5,
+        );
         assert!(to_string(&std::option::none<u64>()) == std::string::utf8(b"None"), 6);
         assert!(to_string(&std::option::some(1)) == std::string::utf8(b"Some(1)"), 7);
     }
@@ -118,14 +148,14 @@ module aptos_std::string_utils {
     #[test]
     #[expected_failure(abort_code = EARGS_MISMATCH)]
     fun test_format_list_not_valid_list() {
-        let l = cons(1, FakeCons { car: 2, cdr: cons(3, nil())});
+        let l = cons(1, FakeCons { car: 2, cdr: cons(3, nil()) });
         native_format_list(&b"a = {} b = {} c = {}", &l);
     }
 
     #[test]
     #[expected_failure(abort_code = EINVALID_FORMAT)]
     fun test_format_unclosed_braces() {
-        format3(&b"a = {} b = {} c = {", 1, 2 ,3);
+        format3(&b"a = {} b = {} c = {", 1, 2, 3);
     }
 
     #[test]

--- a/aptos-move/framework/aptos-stdlib/sources/string_utils.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/string_utils.spec.move
@@ -39,10 +39,19 @@ spec aptos_std::string_utils {
         ensures result == spec_native_format_list(fmt, list4(a, b, c, d));
     }
 
-    spec native_format<T>(s: &T, type_tag: bool, canonicalize: bool, single_line: bool, include_int_types: bool): String {
+    spec native_format<T>(
+        s: &T,
+        type_tag: bool,
+        canonicalize: bool,
+        single_line: bool,
+        include_int_types: bool
+    ): String {
         pragma opaque;
         aborts_if false;
-        ensures result == spec_native_format(s, type_tag, canonicalize, single_line, include_int_types);
+        ensures result
+            == spec_native_format(
+                s, type_tag, canonicalize, single_line, include_int_types
+            );
     }
 
     spec native_format_list<T>(fmt: &vector<u8>, val: &T): String {
@@ -51,7 +60,11 @@ spec aptos_std::string_utils {
         ensures result == spec_native_format_list(fmt, val);
     }
 
-    spec fun spec_native_format<T>(s: T, type_tag: bool, canonicalize: bool, single_line: bool, include_int_types: bool): String;
+    spec fun spec_native_format<T>(
+        s: T, type_tag: bool, canonicalize: bool, single_line: bool, include_int_types: bool
+    ): String;
+
     spec fun spec_native_format_list<T>(fmt: vector<u8>, val: T): String;
+
     spec fun args_mismatch_or_invalid_format<T>(fmt: vector<u8>, val: T): bool;
 }

--- a/aptos-move/framework/aptos-stdlib/sources/string_utils.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/string_utils.spec.move
@@ -50,7 +50,11 @@ spec aptos_std::string_utils {
         aborts_if false;
         ensures result
             == spec_native_format(
-                s, type_tag, canonicalize, single_line, include_int_types
+                s,
+                type_tag,
+                canonicalize,
+                single_line,
+                include_int_types,
             );
     }
 
@@ -61,7 +65,11 @@ spec aptos_std::string_utils {
     }
 
     spec fun spec_native_format<T>(
-        s: T, type_tag: bool, canonicalize: bool, single_line: bool, include_int_types: bool
+        s: T,
+        type_tag: bool,
+        canonicalize: bool,
+        single_line: bool,
+        include_int_types: bool
     ): String;
 
     spec fun spec_native_format_list<T>(fmt: vector<u8>, val: T): String;

--- a/aptos-move/framework/aptos-stdlib/sources/table.move
+++ b/aptos-move/framework/aptos-stdlib/sources/table.move
@@ -15,9 +15,7 @@ module aptos_std::table {
 
     /// Create a new Table.
     public fun new<K: copy + drop, V: store>(): Table<K, V> {
-        Table {
-            handle: new_table_handle<K, V>(),
-        }
+        Table { handle: new_table_handle<K, V>(), }
     }
 
     /// Add a new entry to the table. Aborts if an entry for this
@@ -35,7 +33,9 @@ module aptos_std::table {
 
     /// Acquire an immutable reference to the value which `key` maps to.
     /// Returns specified default value if there is no entry for `key`.
-    public fun borrow_with_default<K: copy + drop, V>(table: &Table<K, V>, key: K, default: &V): &V {
+    public fun borrow_with_default<K: copy + drop, V>(
+        table: &Table<K, V>, key: K, default: &V
+    ): &V {
         if (!contains(table, copy key)) {
             default
         } else {
@@ -51,7 +51,9 @@ module aptos_std::table {
 
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Insert the pair (`key`, `default`) first if there is no entry for `key`.
-    public fun borrow_mut_with_default<K: copy + drop, V: drop>(table: &mut Table<K, V>, key: K, default: V): &mut V {
+    public fun borrow_mut_with_default<K: copy + drop, V: drop>(
+        table: &mut Table<K, V>, key: K, default: V
+    ): &mut V {
         if (!contains(table, copy key)) {
             add(table, copy key, default)
         };
@@ -60,7 +62,9 @@ module aptos_std::table {
 
     /// Insert the pair (`key`, `value`) if there is no entry for `key`.
     /// update the value of the entry for `key` to `value` otherwise
-    public fun upsert<K: copy + drop, V: drop>(table: &mut Table<K, V>, key: K, value: V) {
+    public fun upsert<K: copy + drop, V: drop>(
+        table: &mut Table<K, V>, key: K, value: V
+    ) {
         if (!contains(table, copy key)) {
             add(table, copy key, value)
         } else {
@@ -121,7 +125,7 @@ module aptos_std::table {
         add(&mut t, key, 1);
         assert!(*borrow_with_default(&t, key, &12) == 1, error_code);
 
-        move_to(&account, TableHolder{ t });
+        move_to(&account, TableHolder { t });
     }
 
     // ======================================================================================================

--- a/aptos-move/framework/aptos-stdlib/sources/table.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/table.spec.move
@@ -17,7 +17,8 @@ spec aptos_std::table {
             map_spec_get = spec_get,
             map_spec_set = spec_set,
             map_spec_del = spec_remove,
-            map_spec_has_key = spec_contains;
+            map_spec_has_key =
+             spec_contains;
     }
 
     spec new {
@@ -58,7 +59,10 @@ spec aptos_std::table {
 
     // Specification functions for tables
     spec native fun spec_contains<K, V>(t: Table<K, V>, k: K): bool;
+
     spec native fun spec_remove<K, V>(t: Table<K, V>, k: K): Table<K, V>;
+
     spec native fun spec_set<K, V>(t: Table<K, V>, k: K, v: V): Table<K, V>;
+
     spec native fun spec_get<K, V>(t: Table<K, V>, k: K): V;
 }

--- a/aptos-move/framework/aptos-stdlib/sources/table_with_length.move
+++ b/aptos-move/framework/aptos-stdlib/sources/table_with_length.move
@@ -18,10 +18,7 @@ module aptos_std::table_with_length {
 
     /// Create a new Table.
     public fun new<K: copy + drop, V: store>(): TableWithLength<K, V> {
-        TableWithLength {
-            inner: table::new<K, V>(),
-            length: 0,
-        }
+        TableWithLength { inner: table::new<K, V>(), length: 0, }
     }
 
     /// Destroy a table. The table must be empty to succeed.
@@ -34,20 +31,26 @@ module aptos_std::table_with_length {
     /// Add a new entry to the table. Aborts if an entry for this
     /// key already exists. The entry itself is not stored in the
     /// table, and cannot be discovered from it.
-    public fun add<K: copy + drop, V>(table: &mut TableWithLength<K, V>, key: K, val: V) {
+    public fun add<K: copy + drop, V>(
+        table: &mut TableWithLength<K, V>, key: K, val: V
+    ) {
         table::add(&mut table.inner, key, val);
         table.length = table.length + 1;
     }
 
     /// Acquire an immutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun borrow<K: copy + drop, V>(table: &TableWithLength<K, V>, key: K): &V {
+    public fun borrow<K: copy + drop, V>(
+        table: &TableWithLength<K, V>, key: K
+    ): &V {
         table::borrow(&table.inner, key)
     }
 
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun borrow_mut<K: copy + drop, V>(table: &mut TableWithLength<K, V>, key: K): &mut V {
+    public fun borrow_mut<K: copy + drop, V>(
+        table: &mut TableWithLength<K, V>, key: K
+    ): &mut V {
         table::borrow_mut(&mut table.inner, key)
     }
 
@@ -63,7 +66,9 @@ module aptos_std::table_with_length {
 
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Insert the pair (`key`, `default`) first if there is no entry for `key`.
-    public fun borrow_mut_with_default<K: copy + drop, V: drop>(table: &mut TableWithLength<K, V>, key: K, default: V): &mut V {
+    public fun borrow_mut_with_default<K: copy + drop, V: drop>(
+        table: &mut TableWithLength<K, V>, key: K, default: V
+    ): &mut V {
         if (table::contains(&table.inner, key)) {
             table::borrow_mut(&mut table.inner, key)
         } else {
@@ -75,7 +80,9 @@ module aptos_std::table_with_length {
 
     /// Insert the pair (`key`, `value`) if there is no entry for `key`.
     /// update the value of the entry for `key` to `value` otherwise
-    public fun upsert<K: copy + drop, V: drop>(table: &mut TableWithLength<K, V>, key: K, value: V) {
+    public fun upsert<K: copy + drop, V: drop>(
+        table: &mut TableWithLength<K, V>, key: K, value: V
+    ) {
         if (!table::contains(&table.inner, key)) {
             add(table, copy key, value)
         } else {
@@ -86,14 +93,18 @@ module aptos_std::table_with_length {
 
     /// Remove from `table` and return the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
-    public fun remove<K: copy + drop, V>(table: &mut TableWithLength<K, V>, key: K): V {
+    public fun remove<K: copy + drop, V>(
+        table: &mut TableWithLength<K, V>, key: K
+    ): V {
         let val = table::remove(&mut table.inner, key);
         table.length = table.length - 1;
         val
     }
 
     /// Returns true iff `table` contains an entry for `key`.
-    public fun contains<K: copy + drop, V>(table: &TableWithLength<K, V>, key: K): bool {
+    public fun contains<K: copy + drop, V>(
+        table: &TableWithLength<K, V>, key: K
+    ): bool {
         table::contains(&table.inner, key)
     }
 
@@ -102,7 +113,7 @@ module aptos_std::table_with_length {
     public fun drop_unchecked<K: copy + drop, V>(table: TableWithLength<K, V>) {
         // Unpack table with length, dropping length count but not
         // inner table.
-        let TableWithLength{inner, length: _} = table;
+        let TableWithLength { inner, length: _ } = table;
         table::drop_unchecked(inner); // Drop inner table.
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/table_with_length.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/table_with_length.spec.move
@@ -70,8 +70,12 @@ spec aptos_std::table_with_length {
 
     // Specification functions for tables
     spec native fun spec_len<K, V>(t: TableWithLength<K, V>): num;
+
     spec native fun spec_contains<K, V>(t: TableWithLength<K, V>, k: K): bool;
+
     spec native fun spec_set<K, V>(t: TableWithLength<K, V>, k: K, v: V): TableWithLength<K, V>;
+
     spec native fun spec_remove<K, V>(t: TableWithLength<K, V>, k: K): TableWithLength<K, V>;
+
     spec native fun spec_get<K, V>(t: TableWithLength<K, V>, k: K): V;
 }

--- a/aptos-move/framework/aptos-stdlib/sources/type_info.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.move
@@ -85,13 +85,18 @@ module aptos_std::type_info {
         let type_info = type_of<Table<String, String>>();
         assert!(account_address(&type_info) == @aptos_std, 0);
         assert!(module_name(&type_info) == b"table", 1);
-        assert!(struct_name(&type_info) == b"Table<0x1::string::String, 0x1::string::String>", 2);
+        assert!(
+            struct_name(&type_info) == b"Table<0x1::string::String, 0x1::string::String>",
+            2,
+        );
     }
 
     #[test(fx = @std)]
     fun test_chain_id(fx: signer) {
         // We need to enable the feature in order for the native call to be allowed.
-        features::change_feature_flags_for_testing(&fx, vector[features::get_aptos_stdlib_chain_id_feature()], vector[]);
+        features::change_feature_flags_for_testing(
+            &fx, vector[features::get_aptos_stdlib_chain_id_feature()], vector[]
+        );
 
         // The testing environment chain ID is 4u8.
         assert!(chain_id() == 4u8, 1);
@@ -99,8 +104,6 @@ module aptos_std::type_info {
 
     #[test]
     fun test_type_name() {
-
-
         assert!(type_name<bool>() == string::utf8(b"bool"), 0);
         assert!(type_name<u8>() == string::utf8(b"u8"), 1);
         assert!(type_name<u64>() == string::utf8(b"u64"), 2);
@@ -111,17 +114,21 @@ module aptos_std::type_info {
         // vector
         assert!(type_name<vector<u8>>() == string::utf8(b"vector<u8>"), 6);
         assert!(type_name<vector<vector<u8>>>() == string::utf8(b"vector<vector<u8>>"), 7);
-        assert!(type_name<vector<vector<TypeInfo>>>() == string::utf8(b"vector<vector<0x1::type_info::TypeInfo>>"), 8);
-
+        assert!(
+            type_name<vector<vector<TypeInfo>>>()
+                == string::utf8(b"vector<vector<0x1::type_info::TypeInfo>>"),
+            8,
+        );
 
         // struct
         assert!(type_name<TypeInfo>() == string::utf8(b"0x1::type_info::TypeInfo"), 9);
-        assert!(type_name<
-            Table<
-                TypeInfo,
-                Table<u8, vector<TypeInfo>>
-            >
-        >() == string::utf8(b"0x1::table::Table<0x1::type_info::TypeInfo, 0x1::table::Table<u8, vector<0x1::type_info::TypeInfo>>>"), 10);
+        assert!(
+            type_name<Table<TypeInfo, Table<u8, vector<TypeInfo>>>>()
+                == string::utf8(
+                    b"0x1::table::Table<0x1::type_info::TypeInfo, 0x1::table::Table<u8, vector<0x1::type_info::TypeInfo>>>",
+                ),
+            10,
+        );
     }
 
     #[verify_only]
@@ -149,6 +156,7 @@ module aptos_std::type_info {
             assert struct_name == type_of<T>().struct_name;
         };
     }
+
     spec verify_type_of_generic {
         aborts_if !spec_is_struct<T>();
     }
@@ -182,9 +190,7 @@ module aptos_std::type_info {
 
     #[test(account = @0x0)]
     /// Ensure valid returns across native types and nesting schemas.
-    fun test_size_of_val(
-        account: &signer
-    ) {
+    fun test_size_of_val(account: &signer) {
         assert!(size_of_val(&false) == 1, 0); // Bool takes 1 byte.
         assert!(size_of_val<u8>(&0) == 1, 0); // u8 takes 1 byte.
         assert!(size_of_val<u64>(&0) == 8, 0); // u64 takes 8 bytes.
@@ -193,12 +199,12 @@ module aptos_std::type_info {
         assert!(size_of_val(&@0x0) == 32, 0);
         assert!(size_of_val(account) == 32, 0); // Signer is an address.
         // Assert custom type without fields has size 1.
-        assert!(size_of_val(&CustomType{}) == 1, 0);
+        assert!(size_of_val(&CustomType {}) == 1, 0);
         // Declare a simple struct with a 1-byte field.
-        let simple_struct = SimpleStruct{field: 0};
+        let simple_struct = SimpleStruct { field: 0 };
         // Assert size is indicated as 1 byte.
         assert!(size_of_val(&simple_struct) == 1, 0);
-        let complex_struct = ComplexStruct<u128>{
+        let complex_struct = ComplexStruct<u128> {
             field_1: false,
             field_2: 0,
             field_3: 0,
@@ -209,7 +215,7 @@ module aptos_std::type_info {
         // Assert size is bytewise sum of components.
         assert!(size_of_val(&complex_struct) == (1 + 1 + 8 + 16 + 1 + 16), 0);
         // Declare a struct with two boolean values.
-        let two_bools = TwoBools{bool_1: false, bool_2: false};
+        let two_bools = TwoBools { bool_1: false, bool_2: false };
         // Assert size is two bytes.
         assert!(size_of_val(&two_bools) == 2, 0);
         // Declare an empty vector of element type u64.
@@ -309,12 +315,12 @@ module aptos_std::type_info {
         // Repeat for custom struct.
         let vector_complex = vector::empty<ComplexStruct<address>>();
         // Declare a null element.
-        let null_element = ComplexStruct{
+        let null_element = ComplexStruct {
             field_1: false,
             field_2: 0,
             field_3: 0,
             field_4: 0,
-            field_5: SimpleStruct{field: 0},
+            field_5: SimpleStruct { field: 0 },
             field_6: @0x0
         };
         element_size = size_of_val(&null_element); // Get element size.
@@ -326,25 +332,32 @@ module aptos_std::type_info {
             vector::push_back(&mut vector_complex, copy null_element);
             i = i + 1; // Increment counter.
         };
-        assert!( // Vector base size is still 1 byte.
-            size_of_val(&vector_complex) - element_size * i == base_size_1, 0);
+        assert!(// Vector base size is still 1 byte.
+            size_of_val(&vector_complex) - element_size * i == base_size_1,
+            0,
+        );
         // Add another element, exceeding the cutoff.
         vector::push_back(&mut vector_complex, null_element);
         i = i + 1; // Increment counter.
-        assert!( // Vector base size is now 2 bytes.
-            size_of_val(&vector_complex) - element_size * i == base_size_2, 0);
+        assert!(// Vector base size is now 2 bytes.
+            size_of_val(&vector_complex) - element_size * i == base_size_2,
+            0,
+        );
         while (i < n_elems_cutoff_2) { // Iterate until second cutoff:
             // Add an element.
             vector::push_back(&mut vector_complex, copy null_element);
             i = i + 1; // Increment counter.
         };
-        assert!( // Vector base size is still 2 bytes.
-            size_of_val(&vector_complex) - element_size * i == base_size_2, 0);
+        assert!(// Vector base size is still 2 bytes.
+            size_of_val(&vector_complex) - element_size * i == base_size_2,
+            0,
+        );
         // Add another element, exceeding the cutoff.
         vector::push_back(&mut vector_complex, null_element);
         i = i + 1; // Increment counter.
-        assert!( // Vector base size is now 3 bytes.
-            size_of_val(&vector_complex) - element_size * i == base_size_3, 0);
+        assert!(// Vector base size is now 3 bytes.
+            size_of_val(&vector_complex) - element_size * i == base_size_3,
+            0,
+        );
     }
-
 }

--- a/aptos-move/framework/aptos-stdlib/sources/type_info.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.move
@@ -95,7 +95,9 @@ module aptos_std::type_info {
     fun test_chain_id(fx: signer) {
         // We need to enable the feature in order for the native call to be allowed.
         features::change_feature_flags_for_testing(
-            &fx, vector[features::get_aptos_stdlib_chain_id_feature()], vector[]
+            &fx,
+            vector[features::get_aptos_stdlib_chain_id_feature()],
+            vector[],
         );
 
         // The testing environment chain ID is 4u8.

--- a/aptos-move/framework/aptos-stdlib/tests/fixedpoint64_tests.move
+++ b/aptos-move/framework/aptos-stdlib/tests/fixedpoint64_tests.move
@@ -116,10 +116,10 @@ module aptos_std::fixed_point64_tests {
         let two = fixed_point64::create_from_rational(2, 1);
         let smaller_number1 = fixed_point64::min(one, two);
         let val1 = fixed_point64::get_raw_value(smaller_number1);
-        assert!(val1 == POW2_64, 0);  // 0x1.00000000
+        assert!(val1 == POW2_64, 0); // 0x1.00000000
         let smaller_number2 = fixed_point64::min(two, one);
         let val2 = fixed_point64::get_raw_value(smaller_number2);
-        assert!(val2 == POW2_64, 0);  // 0x1.00000000
+        assert!(val2 == POW2_64, 0); // 0x1.00000000
     }
 
     #[test]
@@ -129,9 +129,9 @@ module aptos_std::fixed_point64_tests {
         let larger_number1 = fixed_point64::max(one, two);
         let larger_number2 = fixed_point64::max(two, one);
         let val1 = fixed_point64::get_raw_value(larger_number1);
-        assert!(val1 == 2 * POW2_64, 0);  // 0x2.00000000
+        assert!(val1 == 2 * POW2_64, 0); // 0x2.00000000
         let val2 = fixed_point64::get_raw_value(larger_number2);
-        assert!(val2 == 2 * POW2_64, 0);  // 0x2.00000000
+        assert!(val2 == 2 * POW2_64, 0); // 0x2.00000000
     }
 
     #[test]

--- a/aptos-move/framework/aptos-stdlib/tests/math64_tests.move
+++ b/aptos-move/framework/aptos-stdlib/tests/math64_tests.move
@@ -4,18 +4,18 @@ module aptos_std::math64_tests {
 
     #[test]
     fun test_nested_mul_div() {
-       let a = math64::mul_div(1, 1, 1);
-       assert!(math64::mul_div(1, a, 1) == 1, 0);
+        let a = math64::mul_div(1, 1, 1);
+        assert!(math64::mul_div(1, a, 1) == 1, 0);
     }
 
     #[test]
     fun test_nested_mul_div2() {
-	assert!(math64::mul_div(1, math64::mul_div(1, 1, 1),1) == 1, 0);
+        assert!(math64::mul_div(1, math64::mul_div(1, 1, 1), 1) == 1, 0);
     }
 
     #[test]
     fun test_nested_mul_div3() {
-        let a = math64::mul_div(1, math64::mul_div(1, 1, 1),1);
+        let a = math64::mul_div(1, math64::mul_div(1, 1, 1), 1);
         assert!(a == 1, 0);
     }
 }

--- a/aptos-move/framework/aptos-token-objects/sources/aptos_token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/aptos_token.move
@@ -896,9 +896,7 @@ module aptos_token_objects::aptos_token {
 
     #[test(creator = @0x123, noncreator = @0x456)]
     #[expected_failure(abort_code = 0x50003, location = Self)]
-    fun test_set_uri_non_creator(
-        creator: &signer, noncreator: &signer,
-    ) acquires AptosCollection, AptosToken {
+    fun test_set_uri_non_creator(creator: &signer, noncreator: &signer,) acquires AptosCollection, AptosToken {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
 
@@ -937,9 +935,7 @@ module aptos_token_objects::aptos_token {
 
     #[test(creator = @0x123, noncreator = @0x456)]
     #[expected_failure(abort_code = 0x50003, location = Self)]
-    fun test_burn_non_creator(
-        creator: &signer, noncreator: &signer,
-    ) acquires AptosCollection, AptosToken {
+    fun test_burn_non_creator(creator: &signer, noncreator: &signer,) acquires AptosCollection, AptosToken {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
 

--- a/aptos-move/framework/aptos-token-objects/sources/aptos_token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/aptos_token.move
@@ -103,7 +103,7 @@ module aptos_token_objects::aptos_token {
             tokens_burnable_by_creator,
             tokens_freezable_by_creator,
             royalty_numerator,
-            royalty_denominator
+            royalty_denominator,
         );
     }
 
@@ -126,28 +126,37 @@ module aptos_token_objects::aptos_token {
         royalty_denominator: u64,
     ): Object<AptosCollection> {
         let creator_addr = signer::address_of(creator);
-        let royalty = royalty::create(royalty_numerator, royalty_denominator, creator_addr);
-        let constructor_ref = collection::create_fixed_collection(
-            creator,
-            description,
-            max_supply,
-            name,
-            option::some(royalty),
-            uri,
+        let royalty = royalty::create(
+            royalty_numerator, royalty_denominator, creator_addr
         );
+        let constructor_ref =
+            collection::create_fixed_collection(
+                creator,
+                description,
+                max_supply,
+                name,
+                option::some(royalty),
+                uri,
+            );
 
         let object_signer = object::generate_signer(&constructor_ref);
-        let mutator_ref = if (mutable_description || mutable_uri) {
-            option::some(collection::generate_mutator_ref(&constructor_ref))
-        } else {
-            option::none()
-        };
+        let mutator_ref =
+            if (mutable_description || mutable_uri) {
+                option::some(collection::generate_mutator_ref(&constructor_ref))
+            } else {
+                option::none()
+            };
 
-        let royalty_mutator_ref = if (mutable_royalty) {
-            option::some(royalty::generate_mutator_ref(object::generate_extend_ref(&constructor_ref)))
-        } else {
-            option::none()
-        };
+        let royalty_mutator_ref =
+            if (mutable_royalty) {
+                option::some(
+                    royalty::generate_mutator_ref(
+                        object::generate_extend_ref(&constructor_ref)
+                    ),
+                )
+            } else {
+                option::none()
+            };
 
         let aptos_collection = AptosCollection {
             mutator_ref,
@@ -176,7 +185,16 @@ module aptos_token_objects::aptos_token {
         property_types: vector<String>,
         property_values: vector<vector<u8>>,
     ) acquires AptosCollection, AptosToken {
-        mint_token_object(creator, collection, description, name, uri, property_keys, property_types, property_values);
+        mint_token_object(
+            creator,
+            collection,
+            description,
+            name,
+            uri,
+            property_keys,
+            property_types,
+            property_values,
+        );
     }
 
     /// Mint a token into an existing collection, and retrieve the object / address of the token.
@@ -190,16 +208,17 @@ module aptos_token_objects::aptos_token {
         property_types: vector<String>,
         property_values: vector<vector<u8>>,
     ): Object<AptosToken> acquires AptosCollection, AptosToken {
-        let constructor_ref = mint_internal(
-            creator,
-            collection,
-            description,
-            name,
-            uri,
-            property_keys,
-            property_types,
-            property_values,
-        );
+        let constructor_ref =
+            mint_internal(
+                creator,
+                collection,
+                description,
+                name,
+                uri,
+                property_keys,
+                property_types,
+                property_values,
+            );
 
         let collection = collection_object(creator, &collection);
 
@@ -236,7 +255,7 @@ module aptos_token_objects::aptos_token {
             property_keys,
             property_types,
             property_values,
-            soul_bound_to
+            soul_bound_to,
         );
     }
 
@@ -252,16 +271,17 @@ module aptos_token_objects::aptos_token {
         property_values: vector<vector<u8>>,
         soul_bound_to: address,
     ): Object<AptosToken> acquires AptosCollection {
-        let constructor_ref = mint_internal(
-            creator,
-            collection,
-            description,
-            name,
-            uri,
-            property_keys,
-            property_types,
-            property_values,
-        );
+        let constructor_ref =
+            mint_internal(
+                creator,
+                collection,
+                description,
+                name,
+                uri,
+                property_keys,
+                property_types,
+                property_values,
+            );
 
         let transfer_ref = object::generate_transfer_ref(&constructor_ref);
         let linear_transfer_ref = object::generate_linear_transfer_ref(&transfer_ref);
@@ -281,28 +301,29 @@ module aptos_token_objects::aptos_token {
         property_types: vector<String>,
         property_values: vector<vector<u8>>,
     ): ConstructorRef acquires AptosCollection {
-        let constructor_ref = token::create(creator, collection, description, name, option::none(), uri);
+        let constructor_ref =
+            token::create(creator, collection, description, name, option::none(), uri);
 
         let object_signer = object::generate_signer(&constructor_ref);
 
         let collection_obj = collection_object(creator, &collection);
         let collection = borrow_collection(&collection_obj);
 
-        let mutator_ref = if (
-            collection.mutable_token_description
+        let mutator_ref =
+            if (collection.mutable_token_description
                 || collection.mutable_token_name
-                || collection.mutable_token_uri
-        ) {
-            option::some(token::generate_mutator_ref(&constructor_ref))
-        } else {
-            option::none()
-        };
+                || collection.mutable_token_uri) {
+                option::some(token::generate_mutator_ref(&constructor_ref))
+            } else {
+                option::none()
+            };
 
-        let burn_ref = if (collection.tokens_burnable_by_creator) {
-            option::some(token::generate_burn_ref(&constructor_ref))
-        } else {
-            option::none()
-        };
+        let burn_ref =
+            if (collection.tokens_burnable_by_creator) {
+                option::some(token::generate_burn_ref(&constructor_ref))
+            } else {
+                option::none()
+            };
 
         let aptos_token = AptosToken {
             burn_ref,
@@ -312,7 +333,8 @@ module aptos_token_objects::aptos_token {
         };
         move_to(&object_signer, aptos_token);
 
-        let properties = property_map::prepare_input(property_keys, property_types, property_values);
+        let properties =
+            property_map::prepare_input(property_keys, property_types, property_values);
         property_map::init(&constructor_ref, properties);
 
         constructor_ref
@@ -362,7 +384,9 @@ module aptos_token_objects::aptos_token {
 
     // Token mutators
 
-    inline fun authorized_borrow<T: key>(token: &Object<T>, creator: &signer): &AptosToken {
+    inline fun authorized_borrow<T: key>(
+        token: &Object<T>, creator: &signer
+    ): &AptosToken {
         let token_address = object::object_address(token);
         assert!(
             exists<AptosToken>(token_address),
@@ -384,17 +408,15 @@ module aptos_token_objects::aptos_token {
         );
         move aptos_token;
         let aptos_token = move_from<AptosToken>(object::object_address(&token));
-        let AptosToken {
-            burn_ref,
-            transfer_ref: _,
-            mutator_ref: _,
-            property_mutator_ref,
-        } = aptos_token;
+        let AptosToken { burn_ref, transfer_ref: _, mutator_ref: _, property_mutator_ref, } =
+            aptos_token;
         property_map::burn(property_mutator_ref);
         token::burn(option::extract(&mut burn_ref));
     }
 
-    public entry fun freeze_transfer<T: key>(creator: &signer, token: Object<T>) acquires AptosCollection, AptosToken {
+    public entry fun freeze_transfer<T: key>(
+        creator: &signer, token: Object<T>
+    ) acquires AptosCollection, AptosToken {
         let aptos_token = authorized_borrow(&token, creator);
         assert!(
             are_collection_tokens_freezable(token::collection_object(token))
@@ -405,8 +427,7 @@ module aptos_token_objects::aptos_token {
     }
 
     public entry fun unfreeze_transfer<T: key>(
-        creator: &signer,
-        token: Object<T>
+        creator: &signer, token: Object<T>
     ) acquires AptosCollection, AptosToken {
         let aptos_token = authorized_borrow(&token, creator);
         assert!(
@@ -535,7 +556,8 @@ module aptos_token_objects::aptos_token {
     // Collection accessors
 
     inline fun collection_object(creator: &signer, name: &String): Object<AptosCollection> {
-        let collection_addr = collection::create_collection_address(&signer::address_of(creator), name);
+        let collection_addr =
+            collection::create_collection_address(&signer::address_of(creator), name);
         object::address_to_object<AptosCollection>(collection_addr)
     }
 
@@ -560,9 +582,7 @@ module aptos_token_objects::aptos_token {
         option::is_some(&borrow_collection(&collection).royalty_mutator_ref)
     }
 
-    public fun is_mutable_collection_uri<T: key>(
-        collection: Object<T>,
-    ): bool acquires AptosCollection {
+    public fun is_mutable_collection_uri<T: key>(collection: Object<T>,): bool acquires AptosCollection {
         borrow_collection(&collection).mutable_uri
     }
 
@@ -604,7 +624,9 @@ module aptos_token_objects::aptos_token {
 
     // Collection mutators
 
-    inline fun authorized_borrow_collection<T: key>(collection: &Object<T>, creator: &signer): &AptosCollection {
+    inline fun authorized_borrow_collection<T: key>(
+        collection: &Object<T>, creator: &signer
+    ): &AptosCollection {
         let collection_address = object::object_address(collection);
         assert!(
             exists<AptosCollection>(collection_address),
@@ -627,7 +649,9 @@ module aptos_token_objects::aptos_token {
             aptos_collection.mutable_description,
             error::permission_denied(EFIELD_NOT_MUTABLE),
         );
-        collection::set_description(option::borrow(&aptos_collection.mutator_ref), description);
+        collection::set_description(
+            option::borrow(&aptos_collection.mutator_ref), description
+        );
     }
 
     public fun set_collection_royalties<T: key>(
@@ -650,7 +674,8 @@ module aptos_token_objects::aptos_token {
         royalty_denominator: u64,
         payee_address: address,
     ) acquires AptosCollection {
-        let royalty = royalty::create(royalty_numerator, royalty_denominator, payee_address);
+        let royalty =
+            royalty::create(royalty_numerator, royalty_denominator, payee_address);
         set_collection_royalties(creator, collection, royalty);
     }
 
@@ -698,17 +723,18 @@ module aptos_token_objects::aptos_token {
         let creator_addr = signer::address_of(creator);
         account::create_account_for_test(creator_addr);
 
-        let token = mint_soul_bound_token_object(
-            creator,
-            collection_name,
-            string::utf8(b""),
-            token_name,
-            string::utf8(b""),
-            vector[],
-            vector[],
-            vector[],
-            signer::address_of(bob),
-        );
+        let token =
+            mint_soul_bound_token_object(
+                creator,
+                collection_name,
+                string::utf8(b""),
+                token_name,
+                string::utf8(b""),
+                vector[],
+                vector[],
+                vector[],
+                signer::address_of(bob),
+            );
 
         object::transfer(bob, token, @0x345);
     }
@@ -789,8 +815,7 @@ module aptos_token_objects::aptos_token {
     #[test(creator = @0x123, noncreator = @0x456)]
     #[expected_failure(abort_code = 0x50003, location = Self)]
     fun test_set_description_non_creator(
-        creator: &signer,
-        noncreator: &signer,
+        creator: &signer, noncreator: &signer,
     ) acquires AptosCollection, AptosToken {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
@@ -831,8 +856,7 @@ module aptos_token_objects::aptos_token {
     #[test(creator = @0x123, noncreator = @0x456)]
     #[expected_failure(abort_code = 0x50003, location = Self)]
     fun test_set_name_non_creator(
-        creator: &signer,
-        noncreator: &signer,
+        creator: &signer, noncreator: &signer,
     ) acquires AptosCollection, AptosToken {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
@@ -873,8 +897,7 @@ module aptos_token_objects::aptos_token {
     #[test(creator = @0x123, noncreator = @0x456)]
     #[expected_failure(abort_code = 0x50003, location = Self)]
     fun test_set_uri_non_creator(
-        creator: &signer,
-        noncreator: &signer,
+        creator: &signer, noncreator: &signer,
     ) acquires AptosCollection, AptosToken {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
@@ -915,8 +938,7 @@ module aptos_token_objects::aptos_token {
     #[test(creator = @0x123, noncreator = @0x456)]
     #[expected_failure(abort_code = 0x50003, location = Self)]
     fun test_burn_non_creator(
-        creator: &signer,
-        noncreator: &signer,
+        creator: &signer, noncreator: &signer,
     ) acquires AptosCollection, AptosToken {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
@@ -948,8 +970,7 @@ module aptos_token_objects::aptos_token {
     #[test(creator = @0x123, noncreator = @0x456)]
     #[expected_failure(abort_code = 0x50003, location = Self)]
     fun test_set_collection_description_non_creator(
-        creator: &signer,
-        noncreator: &signer,
+        creator: &signer, noncreator: &signer,
     ) acquires AptosCollection {
         let collection_name = string::utf8(b"collection name");
         let collection = create_collection_helper(creator, collection_name, true);
@@ -977,8 +998,7 @@ module aptos_token_objects::aptos_token {
     #[test(creator = @0x123, noncreator = @0x456)]
     #[expected_failure(abort_code = 0x50003, location = Self)]
     fun test_set_collection_uri_non_creator(
-        creator: &signer,
-        noncreator: &signer,
+        creator: &signer, noncreator: &signer,
     ) acquires AptosCollection {
         let collection_name = string::utf8(b"collection name");
         let collection = create_collection_helper(creator, collection_name, true);
@@ -994,7 +1014,7 @@ module aptos_token_objects::aptos_token {
 
         create_collection_helper(creator, collection_name, true);
         let token = mint_helper(creator, collection_name, token_name);
-        add_property(creator, token, property_name, property_type, vector [ 0x08 ]);
+        add_property(creator, token, property_name, property_type, vector[0x08]);
 
         assert!(property_map::read_u8(&token, &property_name) == 0x8, 0);
     }
@@ -1021,7 +1041,7 @@ module aptos_token_objects::aptos_token {
 
         create_collection_helper(creator, collection_name, true);
         let token = mint_helper(creator, collection_name, token_name);
-        update_property(creator, token, property_name, property_type, vector [ 0x00 ]);
+        update_property(creator, token, property_name, property_type, vector[0x00]);
 
         assert!(!property_map::read_bool(&token, &property_name), 0);
     }

--- a/aptos-move/framework/aptos-token-objects/sources/collection.move
+++ b/aptos-move/framework/aptos-token-objects/sources/collection.move
@@ -271,9 +271,17 @@ module aptos_token_objects::collection {
         uri: String,
         supply: Option<Supply>,
     ): ConstructorRef {
-        assert!(string::length(&name) <= MAX_COLLECTION_NAME_LENGTH, error::out_of_range(ECOLLECTION_NAME_TOO_LONG));
-        assert!(string::length(&uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
-        assert!(string::length(&description) <= MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
+        assert!(
+            string::length(&name) <= MAX_COLLECTION_NAME_LENGTH,
+            error::out_of_range(ECOLLECTION_NAME_TOO_LONG),
+        );
+        assert!(
+            string::length(&uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG)
+        );
+        assert!(
+            string::length(&description) <= MAX_DESCRIPTION_LENGTH,
+            error::out_of_range(EDESCRIPTION_TOO_LONG),
+        );
 
         let object_signer = object::generate_signer(&constructor_ref);
 
@@ -309,14 +317,16 @@ module aptos_token_objects::collection {
 
     /// Named objects are derived from a seed, the collection's seed is its name.
     public fun create_collection_seed(name: &String): vector<u8> {
-        assert!(string::length(name) <= MAX_COLLECTION_NAME_LENGTH, error::out_of_range(ECOLLECTION_NAME_TOO_LONG));
+        assert!(
+            string::length(name) <= MAX_COLLECTION_NAME_LENGTH,
+            error::out_of_range(ECOLLECTION_NAME_TOO_LONG),
+        );
         *string::bytes(name)
     }
 
     /// Called by token on mint to increment supply if there's an appropriate Supply struct.
     public(friend) fun increment_supply(
-        collection: &Object<Collection>,
-        token: address,
+        collection: &Object<Collection>, token: address,
     ): Option<AggregatorSnapshot<u64>> acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
         let collection_addr = object::object_address(collection);
         if (exists<ConcurrentSupply>(collection_addr)) {
@@ -351,11 +361,9 @@ module aptos_token_objects::collection {
                     },
                 );
             };
-            event::emit_event(&mut supply.mint_events,
-                MintEvent {
-                    index: supply.total_minted,
-                    token,
-                },
+            event::emit_event(
+                &mut supply.mint_events,
+                MintEvent { index: supply.total_minted, token, },
             );
             option::some(aggregator_v2::create_snapshot<u64>(supply.total_minted))
         } else if (exists<UnlimitedSupply>(collection_addr)) {
@@ -373,10 +381,7 @@ module aptos_token_objects::collection {
             };
             event::emit_event(
                 &mut supply.mint_events,
-                MintEvent {
-                    index: supply.total_minted,
-                    token,
-                },
+                MintEvent { index: supply.total_minted, token, },
             );
             option::some(aggregator_v2::create_snapshot<u64>(supply.total_minted))
         } else {
@@ -419,10 +424,7 @@ module aptos_token_objects::collection {
             };
             event::emit_event(
                 &mut supply.burn_events,
-                BurnEvent {
-                    index: *option::borrow(&index),
-                    token,
-                },
+                BurnEvent { index: *option::borrow(&index), token, },
             );
         } else if (exists<UnlimitedSupply>(collection_addr)) {
             let supply = borrow_global_mut<UnlimitedSupply>(collection_addr);
@@ -439,10 +441,7 @@ module aptos_token_objects::collection {
             };
             event::emit_event(
                 &mut supply.burn_events,
-                BurnEvent {
-                    index: *option::borrow(&index),
-                    token,
-                },
+                BurnEvent { index: *option::borrow(&index), token, },
             );
         }
     }
@@ -453,45 +452,42 @@ module aptos_token_objects::collection {
         MutatorRef { self: object::object_address(&object) }
     }
 
-    public fun upgrade_to_concurrent(
-        ref: &ExtendRef,
-    ) acquires FixedSupply, UnlimitedSupply {
+    public fun upgrade_to_concurrent(ref: &ExtendRef,) acquires FixedSupply, UnlimitedSupply {
         let metadata_object_address = object::address_from_extend_ref(ref);
         let metadata_object_signer = object::generate_signer_for_extending(ref);
 
-        let (supply, current_supply, total_minted, burn_events, mint_events) = if (exists<FixedSupply>(
-            metadata_object_address
-        )) {
-            let FixedSupply {
-                current_supply,
-                max_supply,
-                total_minted,
-                burn_events,
-                mint_events,
-            } = move_from<FixedSupply>(metadata_object_address);
+        let (supply, current_supply, total_minted, burn_events, mint_events) =
+            if (exists<FixedSupply>(metadata_object_address)) {
+                let FixedSupply {
+                    current_supply,
+                    max_supply,
+                    total_minted,
+                    burn_events,
+                    mint_events,
+                } = move_from<FixedSupply>(metadata_object_address);
 
-            let supply = ConcurrentSupply {
-                current_supply: aggregator_v2::create_aggregator(max_supply),
-                total_minted: aggregator_v2::create_unbounded_aggregator(),
-            };
-            (supply, current_supply, total_minted, burn_events, mint_events)
-        } else if (exists<UnlimitedSupply>(metadata_object_address)) {
-            let UnlimitedSupply {
-                current_supply,
-                total_minted,
-                burn_events,
-                mint_events,
-            } = move_from<UnlimitedSupply>(metadata_object_address);
+                let supply = ConcurrentSupply {
+                    current_supply: aggregator_v2::create_aggregator(max_supply),
+                    total_minted: aggregator_v2::create_unbounded_aggregator(),
+                };
+                (supply, current_supply, total_minted, burn_events, mint_events)
+            } else if (exists<UnlimitedSupply>(metadata_object_address)) {
+                let UnlimitedSupply {
+                    current_supply,
+                    total_minted,
+                    burn_events,
+                    mint_events,
+                } = move_from<UnlimitedSupply>(metadata_object_address);
 
-            let supply = ConcurrentSupply {
-                current_supply: aggregator_v2::create_unbounded_aggregator(),
-                total_minted: aggregator_v2::create_unbounded_aggregator(),
+                let supply = ConcurrentSupply {
+                    current_supply: aggregator_v2::create_unbounded_aggregator(),
+                    total_minted: aggregator_v2::create_unbounded_aggregator(),
+                };
+                (supply, current_supply, total_minted, burn_events, mint_events)
+            } else {
+                // untracked collection is already concurrent, and other variants too.
+                abort error::invalid_argument(EALREADY_CONCURRENT)
             };
-            (supply, current_supply, total_minted, burn_events, mint_events)
-        } else {
-            // untracked collection is already concurrent, and other variants too.
-            abort error::invalid_argument(EALREADY_CONCURRENT)
-        };
 
         // update current state:
         aggregator_v2::add(&mut supply.current_supply, current_supply);
@@ -522,9 +518,7 @@ module aptos_token_objects::collection {
     ///
     /// Note: Calling this method from transaction that also mints/burns, prevents
     /// it from being parallelized.
-    public fun count<T: key>(
-        collection: Object<T>
-    ): Option<u64> acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
+    public fun count<T: key>(collection: Object<T>): Option<u64> acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
         let collection_address = object::object_address(&collection);
         check_collection_exists(collection_address);
 
@@ -576,27 +570,39 @@ module aptos_token_objects::collection {
     ///
     /// After changing the collection's name, to create tokens - only call functions that accept the collection object as an argument.
     public fun set_name(mutator_ref: &MutatorRef, name: String) acquires Collection {
-        assert!(string::length(&name) <= MAX_COLLECTION_NAME_LENGTH, error::out_of_range(ECOLLECTION_NAME_TOO_LONG));
+        assert!(
+            string::length(&name) <= MAX_COLLECTION_NAME_LENGTH,
+            error::out_of_range(ECOLLECTION_NAME_TOO_LONG),
+        );
         let collection = borrow_mut(mutator_ref);
-        event::emit(Mutation {
-            mutated_field_name: string::utf8(b"name") ,
-            collection: object::address_to_object(mutator_ref.self),
-            old_value: collection.name,
-            new_value: name,
-        });
+        event::emit(
+            Mutation {
+                mutated_field_name: string::utf8(b"name"),
+                collection: object::address_to_object(mutator_ref.self),
+                old_value: collection.name,
+                new_value: name,
+            },
+        );
         collection.name = name;
     }
 
-    public fun set_description(mutator_ref: &MutatorRef, description: String) acquires Collection {
-        assert!(string::length(&description) <= MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
+    public fun set_description(
+        mutator_ref: &MutatorRef, description: String
+    ) acquires Collection {
+        assert!(
+            string::length(&description) <= MAX_DESCRIPTION_LENGTH,
+            error::out_of_range(EDESCRIPTION_TOO_LONG),
+        );
         let collection = borrow_mut(mutator_ref);
         if (std::features::module_event_migration_enabled()) {
-            event::emit(Mutation {
-                mutated_field_name: string::utf8(b"description"),
-                collection: object::address_to_object(mutator_ref.self),
-                old_value: collection.description,
-                new_value: description,
-            });
+            event::emit(
+                Mutation {
+                    mutated_field_name: string::utf8(b"description"),
+                    collection: object::address_to_object(mutator_ref.self),
+                    old_value: collection.description,
+                    new_value: description,
+                },
+            );
         };
         collection.description = description;
         event::emit_event(
@@ -606,15 +612,19 @@ module aptos_token_objects::collection {
     }
 
     public fun set_uri(mutator_ref: &MutatorRef, uri: String) acquires Collection {
-        assert!(string::length(&uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
+        assert!(
+            string::length(&uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG)
+        );
         let collection = borrow_mut(mutator_ref);
         if (std::features::module_event_migration_enabled()) {
-            event::emit(Mutation {
-                mutated_field_name: string::utf8(b"uri"),
-                collection: object::address_to_object(mutator_ref.self),
-                old_value: collection.uri,
-                new_value: uri,
-            });
+            event::emit(
+                Mutation {
+                    mutated_field_name: string::utf8(b"uri"),
+                    collection: object::address_to_object(mutator_ref.self),
+                    old_value: collection.uri,
+                    new_value: uri,
+                },
+            );
         };
         collection.uri = uri;
         event::emit_event(
@@ -650,38 +660,42 @@ module aptos_token_objects::collection {
             abort error::invalid_argument(ENO_MAX_SUPPLY_IN_COLLECTION)
         };
 
-        event::emit(SetMaxSupply { collection, old_max_supply, new_max_supply: max_supply });
+        event::emit(
+            SetMaxSupply { collection, old_max_supply, new_max_supply: max_supply }
+        );
     }
 
     // Tests
 
     #[test_only]
-    fun downgrade_from_concurrent_for_test(
-        ref: &ExtendRef,
-    ) acquires ConcurrentSupply {
+    fun downgrade_from_concurrent_for_test(ref: &ExtendRef,) acquires ConcurrentSupply {
         let metadata_object_address = object::address_from_extend_ref(ref);
         let metadata_object_signer = object::generate_signer_for_extending(ref);
 
-        let ConcurrentSupply {
-            current_supply,
-            total_minted,
-        } = move_from<ConcurrentSupply>(metadata_object_address);
+        let ConcurrentSupply { current_supply, total_minted, } =
+            move_from<ConcurrentSupply>(metadata_object_address);
 
         if (aggregator_v2::max_value(&current_supply) == MAX_U64) {
-            move_to(&metadata_object_signer, UnlimitedSupply {
-                current_supply: aggregator_v2::read(&current_supply),
-                total_minted: aggregator_v2::read(&total_minted),
-                burn_events: object::new_event_handle(&metadata_object_signer),
-                mint_events: object::new_event_handle(&metadata_object_signer),
-            });
+            move_to(
+                &metadata_object_signer,
+                UnlimitedSupply {
+                    current_supply: aggregator_v2::read(&current_supply),
+                    total_minted: aggregator_v2::read(&total_minted),
+                    burn_events: object::new_event_handle(&metadata_object_signer),
+                    mint_events: object::new_event_handle(&metadata_object_signer),
+                },
+            );
         } else {
-            move_to(&metadata_object_signer, FixedSupply {
-                current_supply: aggregator_v2::read(&current_supply),
-                max_supply: aggregator_v2::max_value(&current_supply),
-                total_minted: aggregator_v2::read(&total_minted),
-                burn_events: object::new_event_handle(&metadata_object_signer),
-                mint_events: object::new_event_handle(&metadata_object_signer),
-            });
+            move_to(
+                &metadata_object_signer,
+                FixedSupply {
+                    current_supply: aggregator_v2::read(&current_supply),
+                    max_supply: aggregator_v2::max_value(&current_supply),
+                    total_minted: aggregator_v2::read(&total_minted),
+                    burn_events: object::new_event_handle(&metadata_object_signer),
+                    mint_events: object::new_event_handle(&metadata_object_signer),
+                },
+            );
         }
     }
 
@@ -689,63 +703,111 @@ module aptos_token_objects::collection {
     fun test_create_mint_burn_for_unlimited(creator: &signer) acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
         let creator_address = signer::address_of(creator);
         let name = string::utf8(b"collection name");
-        let constructor_ref = create_unlimited_collection(creator, string::utf8(b""), name, option::none(), string::utf8(b""));
+        let constructor_ref =
+            create_unlimited_collection(
+                creator,
+                string::utf8(b""),
+                name,
+                option::none(),
+                string::utf8(b""),
+            );
         downgrade_from_concurrent_for_test(&object::generate_extend_ref(&constructor_ref));
 
         let collection_address = create_collection_address(&creator_address, &name);
         let collection = object::address_to_object<Collection>(collection_address);
         assert!(count(collection) == option::some(0), 0);
-        let cid = aggregator_v2::read_snapshot(&option::destroy_some(increment_supply(&collection, creator_address)));
+        let cid =
+            aggregator_v2::read_snapshot(
+                &option::destroy_some(increment_supply(&collection, creator_address))
+            );
         assert!(count(collection) == option::some(1), 0);
-        assert!(event::counter(&borrow_global<UnlimitedSupply>(collection_address).mint_events) == 1, 0);
+        assert!(
+            event::counter(
+                &borrow_global<UnlimitedSupply>(collection_address).mint_events
+            ) == 1,
+            0,
+        );
         decrement_supply(&collection, creator_address, option::some(cid), creator_address);
         assert!(count(collection) == option::some(0), 0);
-        assert!(event::counter(&borrow_global<UnlimitedSupply>(collection_address).burn_events) == 1, 0);
+        assert!(
+            event::counter(
+                &borrow_global<UnlimitedSupply>(collection_address).burn_events
+            ) == 1,
+            0,
+        );
     }
 
     #[test(creator = @0x123)]
     fun test_create_mint_burn_for_fixed(creator: &signer) acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
         let creator_address = signer::address_of(creator);
         let name = string::utf8(b"collection name");
-        let constructor_ref = create_fixed_collection(creator, string::utf8(b""), 1, name, option::none(), string::utf8(b""));
+        let constructor_ref =
+            create_fixed_collection(
+                creator,
+                string::utf8(b""),
+                1,
+                name,
+                option::none(),
+                string::utf8(b""),
+            );
         downgrade_from_concurrent_for_test(&object::generate_extend_ref(&constructor_ref));
 
         let collection_address = create_collection_address(&creator_address, &name);
         let collection = object::address_to_object<Collection>(collection_address);
         assert!(count(collection) == option::some(0), 0);
-        let cid = aggregator_v2::read_snapshot(&option::destroy_some(increment_supply(&collection, creator_address)));
+        let cid =
+            aggregator_v2::read_snapshot(
+                &option::destroy_some(increment_supply(&collection, creator_address))
+            );
         assert!(count(collection) == option::some(1), 0);
-        assert!(event::counter(&borrow_global<FixedSupply>(collection_address).mint_events) == 1, 0);
+        assert!(
+            event::counter(&borrow_global<FixedSupply>(collection_address).mint_events) ==
+            1,
+            0,
+        );
         decrement_supply(&collection, creator_address, option::some(cid), creator_address);
         assert!(count(collection) == option::some(0), 0);
-        assert!(event::counter(&borrow_global<FixedSupply>(collection_address).burn_events) == 1, 0);
+        assert!(
+            event::counter(&borrow_global<FixedSupply>(collection_address).burn_events) ==
+            1,
+            0,
+        );
     }
 
     #[test(creator = @0x123)]
-    fun test_create_mint_burn_for_concurrent(
-        creator: &signer
-    ) acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
+    fun test_create_mint_burn_for_concurrent(creator: &signer) acquires FixedSupply, UnlimitedSupply, ConcurrentSupply {
         let creator_address = signer::address_of(creator);
         let name = string::utf8(b"collection name");
-        create_fixed_collection(creator, string::utf8(b""), 1, name, option::none(), string::utf8(b""));
+        create_fixed_collection(
+            creator,
+            string::utf8(b""),
+            1,
+            name,
+            option::none(),
+            string::utf8(b""),
+        );
         let collection_address = create_collection_address(&creator_address, &name);
         let collection = object::address_to_object<Collection>(collection_address);
         assert!(count(collection) == option::some(0), 0);
         let cid = increment_supply(&collection, creator_address);
-        event::was_event_emitted<Mint>(&Mint {
-            collection: collection_address,
-            index: aggregator_v2::create_snapshot(0),
-            token: creator_address,
-        });
+        event::was_event_emitted<Mint>(
+            &Mint {
+                collection: collection_address,
+                index: aggregator_v2::create_snapshot(0),
+                token: creator_address,
+            },
+        );
         assert!(cid == option::some(aggregator_v2::create_snapshot(1)), 1);
         assert!(count(collection) == option::some(1), 0);
         decrement_supply(&collection, creator_address, option::some(1), creator_address);
-        event::was_event_emitted<Burn>(&Burn {
-            collection: collection_address,
-            index: 1,
-            token: creator_address,
-            previous_owner: creator_address,
-        });
+        event::was_event_emitted<Burn>(
+            &Burn {
+                collection: collection_address,
+                index: 1,
+                token: creator_address,
+                previous_owner: creator_address,
+            },
+        );
         assert!(count(collection) == option::some(0), 0);
     }
 
@@ -756,9 +818,10 @@ module aptos_token_objects::collection {
         let collection_name = string::utf8(b"collection name");
         create_collection_helper(creator, collection_name);
 
-        let collection = object::address_to_object<Collection>(
-            create_collection_address(&creator_address, &collection_name),
-        );
+        let collection =
+            object::address_to_object<Collection>(
+                create_collection_address(&creator_address, &collection_name)
+            );
         assert!(object::owner(collection) == creator_address, 1);
         object::transfer(creator, collection, signer::address_of(trader));
     }
@@ -776,28 +839,32 @@ module aptos_token_objects::collection {
         let collection_name = string::utf8(b"collection name");
         let constructor_ref = create_collection_helper(creator, collection_name);
         let mutator_ref = generate_mutator_ref(&constructor_ref);
-        let collection = object::address_to_object<Collection>(
-            create_collection_address(&signer::address_of(creator), &collection_name),
-        );
+        let collection =
+            object::address_to_object<Collection>(
+                create_collection_address(&signer::address_of(creator), &collection_name),
+            );
         let new_collection_name = string::utf8(b"new collection name");
         assert!(new_collection_name != name(collection), 0);
         set_name(&mutator_ref, new_collection_name);
         assert!(new_collection_name == name(collection), 1);
-        event::was_event_emitted(&Mutation {
-            mutated_field_name: string::utf8(b"name"),
-            collection,
-            old_value: collection_name,
-            new_value: new_collection_name,
-        });
+        event::was_event_emitted(
+            &Mutation {
+                mutated_field_name: string::utf8(b"name"),
+                collection,
+                old_value: collection_name,
+                new_value: new_collection_name,
+            },
+        );
     }
 
     #[test(creator = @0x123)]
     entry fun test_set_description(creator: &signer) acquires Collection {
         let collection_name = string::utf8(b"collection name");
         let constructor_ref = create_collection_helper(creator, collection_name);
-        let collection = object::address_to_object<Collection>(
-            create_collection_address(&signer::address_of(creator), &collection_name),
-        );
+        let collection =
+            object::address_to_object<Collection>(
+                create_collection_address(&signer::address_of(creator), &collection_name),
+            );
         let mutator_ref = generate_mutator_ref(&constructor_ref);
         let description = string::utf8(b"no fail");
         assert!(description != description(collection), 0);
@@ -810,9 +877,10 @@ module aptos_token_objects::collection {
         let collection_name = string::utf8(b"collection name");
         let constructor_ref = create_collection_helper(creator, collection_name);
         let mutator_ref = generate_mutator_ref(&constructor_ref);
-        let collection = object::address_to_object<Collection>(
-            create_collection_address(&signer::address_of(creator), &collection_name),
-        );
+        let collection =
+            object::address_to_object<Collection>(
+                create_collection_address(&signer::address_of(creator), &collection_name),
+            );
         let uri = string::utf8(b"no fail");
         assert!(uri != uri(collection), 0);
         set_uri(&mutator_ref, uri);
@@ -823,21 +891,25 @@ module aptos_token_objects::collection {
     entry fun test_set_max_supply_concurrent(creator: &signer) acquires ConcurrentSupply, FixedSupply {
         let collection_name = string::utf8(b"collection name");
         let max_supply = 100;
-        let constructor_ref = create_fixed_collection_helper(creator, collection_name, max_supply);
+        let constructor_ref =
+            create_fixed_collection_helper(creator, collection_name, max_supply);
         let mutator_ref = generate_mutator_ref(&constructor_ref);
 
         let new_max_supply = 200;
         set_max_supply(&mutator_ref, new_max_supply);
 
-        let collection_address = create_collection_address(&signer::address_of(creator), &collection_name);
+        let collection_address =
+            create_collection_address(&signer::address_of(creator), &collection_name);
         let supply = borrow_global<ConcurrentSupply>(collection_address);
         assert!(aggregator_v2::max_value(&supply.current_supply) == new_max_supply, 0);
 
-        event::was_event_emitted<SetMaxSupply>(&SetMaxSupply {
-            collection: object::address_to_object<Collection>(collection_address),
-            old_max_supply: max_supply,
-            new_max_supply,
-        });
+        event::was_event_emitted<SetMaxSupply>(
+            &SetMaxSupply {
+                collection: object::address_to_object<Collection>(collection_address),
+                old_max_supply: max_supply,
+                new_max_supply,
+            },
+        );
     }
 
     #[test(creator = @0x123)]
@@ -846,8 +918,10 @@ module aptos_token_objects::collection {
     ) acquires ConcurrentSupply, FixedSupply, UnlimitedSupply {
         let collection_name = string::utf8(b"collection name");
         let max_supply = 10;
-        let constructor_ref = create_fixed_collection_helper(creator, collection_name, max_supply);
-        let collection = object::object_from_constructor_ref<Collection>(&constructor_ref);
+        let constructor_ref =
+            create_fixed_collection_helper(creator, collection_name, max_supply);
+        let collection =
+            object::object_from_constructor_ref<Collection>(&constructor_ref);
         let token_signer = create_token(creator);
 
         let current_supply = 5;
@@ -860,15 +934,21 @@ module aptos_token_objects::collection {
         let mutator_ref = generate_mutator_ref(&constructor_ref);
         set_max_supply(&mutator_ref, current_supply);
 
-        let collection_address = create_collection_address(&signer::address_of(creator), &collection_name);
+        let collection_address =
+            create_collection_address(&signer::address_of(creator), &collection_name);
         let supply = borrow_global<ConcurrentSupply>(collection_address);
-        assert!(aggregator_v2::max_value(&supply.current_supply) == current_supply, EINVALID_MAX_SUPPLY);
+        assert!(
+            aggregator_v2::max_value(&supply.current_supply) == current_supply,
+            EINVALID_MAX_SUPPLY,
+        );
 
-        event::was_event_emitted<SetMaxSupply>(&SetMaxSupply {
-            collection: object::address_to_object<Collection>(collection_address),
-            old_max_supply: current_supply,
-            new_max_supply: current_supply,
-        });
+        event::was_event_emitted<SetMaxSupply>(
+            &SetMaxSupply {
+                collection: object::address_to_object<Collection>(collection_address),
+                old_max_supply: current_supply,
+                new_max_supply: current_supply,
+            },
+        );
     }
 
     #[test(creator = @0x123)]
@@ -885,10 +965,12 @@ module aptos_token_objects::collection {
     entry fun test_set_max_supply_too_low_fixed_supply(creator: &signer) acquires ConcurrentSupply, FixedSupply, UnlimitedSupply {
         let max_supply = 3;
         let collection_name = string::utf8(b"Low Supply Collection");
-        let constructor_ref = create_fixed_collection_helper(creator, collection_name, max_supply);
+        let constructor_ref =
+            create_fixed_collection_helper(creator, collection_name, max_supply);
         downgrade_from_concurrent_for_test(&object::generate_extend_ref(&constructor_ref));
 
-        let collection = object::object_from_constructor_ref<Collection>(&constructor_ref);
+        let collection =
+            object::object_from_constructor_ref<Collection>(&constructor_ref);
         let token_signer = create_token(creator);
 
         let i = 0;
@@ -904,11 +986,15 @@ module aptos_token_objects::collection {
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 0x20009, location = aptos_token_objects::collection)]
-    entry fun test_set_max_supply_too_low_concurrent_supply(creator: &signer) acquires ConcurrentSupply, FixedSupply, UnlimitedSupply {
+    entry fun test_set_max_supply_too_low_concurrent_supply(
+        creator: &signer
+    ) acquires ConcurrentSupply, FixedSupply, UnlimitedSupply {
         let collection_name = string::utf8(b"Low Supply Collection");
         let max_supply = 3;
-        let constructor_ref = create_fixed_collection_helper(creator, collection_name, max_supply);
-        let collection = object::object_from_constructor_ref<Collection>(&constructor_ref);
+        let constructor_ref =
+            create_fixed_collection_helper(creator, collection_name, max_supply);
+        let collection =
+            object::object_from_constructor_ref<Collection>(&constructor_ref);
         let token_signer = create_token(creator);
 
         let i = 0;
@@ -934,7 +1020,9 @@ module aptos_token_objects::collection {
     }
 
     #[test_only]
-    fun create_fixed_collection_helper(creator: &signer, name: String, max_supply: u64): ConstructorRef {
+    fun create_fixed_collection_helper(
+        creator: &signer, name: String, max_supply: u64
+    ): ConstructorRef {
         create_fixed_collection(
             creator,
             string::utf8(b"description"),

--- a/aptos-move/framework/aptos-token-objects/sources/property_map.move
+++ b/aptos-move/framework/aptos-token-objects/sources/property_map.move
@@ -483,7 +483,10 @@ module aptos_token_objects::property_map {
             bcs::to_bytes<bool>(&false),
         );
         update(
-            &mutator, &string::utf8(b"u8"), string::utf8(b"u8"), bcs::to_bytes<u8>(&0x21)
+            &mutator,
+            &string::utf8(b"u8"),
+            string::utf8(b"u8"),
+            bcs::to_bytes<u8>(&0x21),
         );
         update(
             &mutator,
@@ -625,13 +628,15 @@ module aptos_token_objects::property_map {
                     b"u32"
                 ), string::utf8(b"u64"), string::utf8(b"u128"), string::utf8(b"u256"), string::utf8(
                     b"vector<u8>"
-                ), string::utf8(b"0x1::string::String"),],
+                ), string::utf8(b"0x1::string::String"),
+            ],
             vector[
                 string::utf8(b"bool"), string::utf8(b"u8"), string::utf8(b"u16"), string::utf8(
                     b"u32"
                 ), string::utf8(b"u64"), string::utf8(b"u128"), string::utf8(b"u256"), string::utf8(
                     b"vector<u8>"
-                ), string::utf8(b"0x1::string::String"),],
+                ), string::utf8(b"0x1::string::String"),
+            ],
             vector[
                 bcs::to_bytes<bool>(&true), bcs::to_bytes<u8>(&0x12), bcs::to_bytes<u16>(
                     &0x1234
@@ -641,7 +646,8 @@ module aptos_token_objects::property_map {
                     &0x1234567812345678123456781234567812345678123456781234567812345678
                 ), bcs::to_bytes<vector<u8>>(&vector[0x01]), bcs::to_bytes<String>(
                     &string::utf8(b"a")
-                ),],
+                ),
+            ],
         )
     }
 

--- a/aptos-move/framework/aptos-token-objects/sources/property_map.move
+++ b/aptos-move/framework/aptos-token-objects/sources/property_map.move
@@ -88,9 +88,17 @@ module aptos_token_objects::property_map {
         values: vector<vector<u8>>,
     ): PropertyMap {
         let length = vector::length(&keys);
-        assert!(length <= MAX_PROPERTY_MAP_SIZE, error::invalid_argument(ETOO_MANY_PROPERTIES));
-        assert!(length == vector::length(&values), error::invalid_argument(EKEY_VALUE_COUNT_MISMATCH));
-        assert!(length == vector::length(&types), error::invalid_argument(EKEY_TYPE_COUNT_MISMATCH));
+        assert!(
+            length <= MAX_PROPERTY_MAP_SIZE, error::invalid_argument(ETOO_MANY_PROPERTIES)
+        );
+        assert!(
+            length == vector::length(&values),
+            error::invalid_argument(EKEY_VALUE_COUNT_MISMATCH),
+        );
+        assert!(
+            length == vector::length(&types),
+            error::invalid_argument(EKEY_TYPE_COUNT_MISMATCH),
+        );
 
         let container = simple_map::create<String, PropertyValue>();
         while (!vector::is_empty(&keys)) {
@@ -135,34 +143,26 @@ module aptos_token_objects::property_map {
         } else if (type == STRING) {
             string::utf8(b"0x1::string::String")
         } else {
-            abort (error::invalid_argument(ETYPE_INVALID))
+            abort(error::invalid_argument(ETYPE_INVALID))
         }
     }
 
     /// Maps the `String` representation of types to `u8`
     inline fun to_internal_type(type: String): u8 {
-        if (type == string::utf8(b"bool")) {
-            BOOL
-        } else if (type == string::utf8(b"u8")) {
-            U8
-        } else if (type == string::utf8(b"u16")) {
-            U16
-        } else if (type == string::utf8(b"u32")) {
-            U32
-        } else if (type == string::utf8(b"u64")) {
-            U64
-        } else if (type == string::utf8(b"u128")) {
-            U128
-        } else if (type == string::utf8(b"u256")) {
-            U256
-        } else if (type == string::utf8(b"address")) {
+        if (type == string::utf8(b"bool")) { BOOL }
+        else if (type == string::utf8(b"u8")) { U8 }
+        else if (type == string::utf8(b"u16")) { U16 }
+        else if (type == string::utf8(b"u32")) { U32 }
+        else if (type == string::utf8(b"u64")) { U64 }
+        else if (type == string::utf8(b"u128")) { U128 }
+        else if (type == string::utf8(b"u256")) { U256 }
+        else if (type == string::utf8(b"address")) {
             ADDRESS
         } else if (type == string::utf8(b"vector<u8>")) {
             BYTE_VECTOR
-        } else if (type == string::utf8(b"0x1::string::String")) {
-            STRING
-        } else {
-            abort (error::invalid_argument(ETYPE_INVALID))
+        } else if (type == string::utf8(b"0x1::string::String")) { STRING }
+        else {
+            abort(error::invalid_argument(ETYPE_INVALID))
         }
     }
 
@@ -195,7 +195,7 @@ module aptos_token_objects::property_map {
         } else if (type == STRING) {
             from_bcs::to_string(value);
         } else {
-            abort (error::invalid_argument(ETYPE_MISMATCH))
+            abort(error::invalid_argument(ETYPE_MISMATCH))
         };
     }
 
@@ -297,7 +297,9 @@ module aptos_token_objects::property_map {
 
     // Mutators
     /// Add a property, already bcs encoded as a `vector<u8>`
-    public fun add(ref: &MutatorRef, key: String, type: String, value: vector<u8>) acquires PropertyMap {
+    public fun add(
+        ref: &MutatorRef, key: String, type: String, value: vector<u8>
+    ) acquires PropertyMap {
         let new_type = to_internal_type(type);
         validate_type(new_type, value);
         add_internal(ref, key, new_type, value);
@@ -309,26 +311,34 @@ module aptos_token_objects::property_map {
         add_internal(ref, key, type, bcs::to_bytes(&value));
     }
 
-    inline fun add_internal(ref: &MutatorRef, key: String, type: u8, value: vector<u8>) acquires PropertyMap {
+    inline fun add_internal(
+        ref: &MutatorRef, key: String, type: u8, value: vector<u8>
+    ) acquires PropertyMap {
         assert_exists(ref.self);
         let property_map = borrow_global_mut<PropertyMap>(ref.self);
         simple_map::add(&mut property_map.inner, key, PropertyValue { type, value });
     }
 
     /// Updates a property in place already bcs encoded
-    public fun update(ref: &MutatorRef, key: &String, type: String, value: vector<u8>) acquires PropertyMap {
+    public fun update(
+        ref: &MutatorRef, key: &String, type: String, value: vector<u8>
+    ) acquires PropertyMap {
         let new_type = to_internal_type(type);
         validate_type(new_type, value);
         update_internal(ref, key, new_type, value);
     }
 
     /// Updates a property in place that is not already bcs encoded
-    public fun update_typed<T: drop>(ref: &MutatorRef, key: &String, value: T) acquires PropertyMap {
+    public fun update_typed<T: drop>(
+        ref: &MutatorRef, key: &String, value: T
+    ) acquires PropertyMap {
         let type = type_info_to_internal_type<T>();
         update_internal(ref, key, type, bcs::to_bytes(&value));
     }
 
-    inline fun update_internal(ref: &MutatorRef, key: &String, type: u8, value: vector<u8>) acquires PropertyMap {
+    inline fun update_internal(
+        ref: &MutatorRef, key: &String, type: u8, value: vector<u8>
+    ) acquires PropertyMap {
         assert_exists(ref.self);
         let property_map = borrow_global_mut<PropertyMap>(ref.self);
         let old_value = simple_map::borrow_mut(&mut property_map.inner, key);
@@ -346,7 +356,8 @@ module aptos_token_objects::property_map {
     #[test(creator = @0x123)]
     fun test_end_to_end(creator: &signer) acquires PropertyMap {
         let constructor_ref = object::create_named_object(creator, b"");
-        let object = object::object_from_constructor_ref<object::ObjectCore>(&constructor_ref);
+        let object =
+            object::object_from_constructor_ref<object::ObjectCore>(&constructor_ref);
 
         let input = end_to_end_input();
         init(&constructor_ref, input);
@@ -386,34 +397,56 @@ module aptos_token_objects::property_map {
 
         assert!(length(&object) == 0, 31);
 
-        add(&mutator, string::utf8(b"bool"), string::utf8(b"bool"), bcs::to_bytes<bool>(&true));
+        add(
+            &mutator,
+            string::utf8(b"bool"),
+            string::utf8(b"bool"),
+            bcs::to_bytes<bool>(&true),
+        );
         add(&mutator, string::utf8(b"u8"), string::utf8(b"u8"), bcs::to_bytes<u8>(&0x12));
-        add(&mutator, string::utf8(b"u16"), string::utf8(b"u16"), bcs::to_bytes<u16>(&0x1234));
-        add(&mutator, string::utf8(b"u32"), string::utf8(b"u32"), bcs::to_bytes<u32>(&0x12345678));
-        add(&mutator, string::utf8(b"u64"), string::utf8(b"u64"), bcs::to_bytes<u64>(&0x1234567812345678));
+        add(
+            &mutator,
+            string::utf8(b"u16"),
+            string::utf8(b"u16"),
+            bcs::to_bytes<u16>(&0x1234),
+        );
+        add(
+            &mutator,
+            string::utf8(b"u32"),
+            string::utf8(b"u32"),
+            bcs::to_bytes<u32>(&0x12345678),
+        );
+        add(
+            &mutator,
+            string::utf8(b"u64"),
+            string::utf8(b"u64"),
+            bcs::to_bytes<u64>(&0x1234567812345678),
+        );
         add(
             &mutator,
             string::utf8(b"u128"),
             string::utf8(b"u128"),
-            bcs::to_bytes<u128>(&0x12345678123456781234567812345678)
+            bcs::to_bytes<u128>(&0x12345678123456781234567812345678),
         );
         add(
             &mutator,
             string::utf8(b"u256"),
             string::utf8(b"u256"),
-            bcs::to_bytes<u256>(&0x1234567812345678123456781234567812345678123456781234567812345678)
+            bcs::to_bytes<u256>(
+                &0x1234567812345678123456781234567812345678123456781234567812345678
+            ),
         );
         add(
             &mutator,
             string::utf8(b"vector<u8>"),
             string::utf8(b"vector<u8>"),
-            bcs::to_bytes<vector<u8>>(&vector[0x01])
+            bcs::to_bytes<vector<u8>>(&vector[0x01]),
         );
         add(
             &mutator,
             string::utf8(b"0x1::string::String"),
             string::utf8(b"0x1::string::String"),
-            bcs::to_bytes<String>(&string::utf8(b"a"))
+            bcs::to_bytes<String>(&string::utf8(b"a")),
         );
 
         assert!(read_bool(&object, &string::utf8(b"bool")), 32);
@@ -421,37 +454,78 @@ module aptos_token_objects::property_map {
         assert!(read_u16(&object, &string::utf8(b"u16")) == 0x1234, 34);
         assert!(read_u32(&object, &string::utf8(b"u32")) == 0x12345678, 35);
         assert!(read_u64(&object, &string::utf8(b"u64")) == 0x1234567812345678, 36);
-        assert!(read_u128(&object, &string::utf8(b"u128")) == 0x12345678123456781234567812345678, 37);
+        assert!(
+            read_u128(&object, &string::utf8(b"u128")) ==
+            0x12345678123456781234567812345678,
+            37,
+        );
         assert!(
             read_u256(
                 &object,
-                &string::utf8(b"u256")
+                &string::utf8(b"u256"),
             ) == 0x1234567812345678123456781234567812345678123456781234567812345678,
-            38
+            38,
         );
         assert!(read_bytes(&object, &string::utf8(b"vector<u8>")) == vector[0x01], 39);
-        assert!(read_string(&object, &string::utf8(b"0x1::string::String")) == string::utf8(b"a"), 40);
+        assert!(
+            read_string(&object, &string::utf8(b"0x1::string::String")) == string::utf8(
+                b"a"
+            ),
+            40,
+        );
 
         assert!(length(&object) == 9, 41);
 
-        update(&mutator, &string::utf8(b"bool"), string::utf8(b"bool"), bcs::to_bytes<bool>(&false));
-        update(&mutator, &string::utf8(b"u8"), string::utf8(b"u8"), bcs::to_bytes<u8>(&0x21));
-        update(&mutator, &string::utf8(b"u16"), string::utf8(b"u16"), bcs::to_bytes<u16>(&0x22));
-        update(&mutator, &string::utf8(b"u32"), string::utf8(b"u32"), bcs::to_bytes<u32>(&0x23));
-        update(&mutator, &string::utf8(b"u64"), string::utf8(b"u64"), bcs::to_bytes<u64>(&0x24));
-        update(&mutator, &string::utf8(b"u128"), string::utf8(b"u128"), bcs::to_bytes<u128>(&0x25));
-        update(&mutator, &string::utf8(b"u256"), string::utf8(b"u256"), bcs::to_bytes<u256>(&0x26));
+        update(
+            &mutator,
+            &string::utf8(b"bool"),
+            string::utf8(b"bool"),
+            bcs::to_bytes<bool>(&false),
+        );
+        update(
+            &mutator, &string::utf8(b"u8"), string::utf8(b"u8"), bcs::to_bytes<u8>(&0x21)
+        );
+        update(
+            &mutator,
+            &string::utf8(b"u16"),
+            string::utf8(b"u16"),
+            bcs::to_bytes<u16>(&0x22),
+        );
+        update(
+            &mutator,
+            &string::utf8(b"u32"),
+            string::utf8(b"u32"),
+            bcs::to_bytes<u32>(&0x23),
+        );
+        update(
+            &mutator,
+            &string::utf8(b"u64"),
+            string::utf8(b"u64"),
+            bcs::to_bytes<u64>(&0x24),
+        );
+        update(
+            &mutator,
+            &string::utf8(b"u128"),
+            string::utf8(b"u128"),
+            bcs::to_bytes<u128>(&0x25),
+        );
+        update(
+            &mutator,
+            &string::utf8(b"u256"),
+            string::utf8(b"u256"),
+            bcs::to_bytes<u256>(&0x26),
+        );
         update(
             &mutator,
             &string::utf8(b"vector<u8>"),
             string::utf8(b"vector<u8>"),
-            bcs::to_bytes<vector<u8>>(&vector[0x02])
+            bcs::to_bytes<vector<u8>>(&vector[0x02]),
         );
         update(
             &mutator,
             &string::utf8(b"0x1::string::String"),
             string::utf8(b"0x1::string::String"),
-            bcs::to_bytes<String>(&string::utf8(b"ha"))
+            bcs::to_bytes<String>(&string::utf8(b"ha")),
         );
 
         assert!(!read_bool(&object, &string::utf8(b"bool")), 10);
@@ -462,11 +536,17 @@ module aptos_token_objects::property_map {
         assert!(read_u128(&object, &string::utf8(b"u128")) == 0x25, 15);
         assert!(read_u256(&object, &string::utf8(b"u256")) == 0x26, 16);
         assert!(read_bytes(&object, &string::utf8(b"vector<u8>")) == vector[0x02], 17);
-        assert!(read_string(&object, &string::utf8(b"0x1::string::String")) == string::utf8(b"ha"), 18);
+        assert!(
+            read_string(&object, &string::utf8(b"0x1::string::String"))
+                == string::utf8(b"ha"),
+            18,
+        );
     }
 
     #[test_only]
-    fun test_end_to_end_update_typed(mutator: &MutatorRef, object: &Object<object::ObjectCore>) acquires PropertyMap {
+    fun test_end_to_end_update_typed(
+        mutator: &MutatorRef, object: &Object<object::ObjectCore>
+    ) acquires PropertyMap {
         update_typed<bool>(mutator, &string::utf8(b"bool"), false);
         update_typed<u8>(mutator, &string::utf8(b"u8"), 0x21);
         update_typed<u16>(mutator, &string::utf8(b"u16"), 0x22);
@@ -475,7 +555,9 @@ module aptos_token_objects::property_map {
         update_typed<u128>(mutator, &string::utf8(b"u128"), 0x25);
         update_typed<u256>(mutator, &string::utf8(b"u256"), 0x26);
         update_typed<vector<u8>>(mutator, &string::utf8(b"vector<u8>"), vector[0x02]);
-        update_typed<String>(mutator, &string::utf8(b"0x1::string::String"), string::utf8(b"ha"));
+        update_typed<String>(
+            mutator, &string::utf8(b"0x1::string::String"), string::utf8(b"ha")
+        );
 
         assert!(!read_bool(object, &string::utf8(b"bool")), 10);
         assert!(read_u8(object, &string::utf8(b"u8")) == 0x21, 11);
@@ -485,11 +567,18 @@ module aptos_token_objects::property_map {
         assert!(read_u128(object, &string::utf8(b"u128")) == 0x25, 15);
         assert!(read_u256(object, &string::utf8(b"u256")) == 0x26, 16);
         assert!(read_bytes(object, &string::utf8(b"vector<u8>")) == vector[0x02], 17);
-        assert!(read_string(object, &string::utf8(b"0x1::string::String")) == string::utf8(b"ha"), 18);
+        assert!(
+            read_string(object, &string::utf8(b"0x1::string::String")) == string::utf8(
+                b"ha"
+            ),
+            18,
+        );
     }
 
     #[test_only]
-    fun test_end_to_end_add_typed(mutator: &MutatorRef, object: &Object<object::ObjectCore>) acquires PropertyMap {
+    fun test_end_to_end_add_typed(
+        mutator: &MutatorRef, object: &Object<object::ObjectCore>
+    ) acquires PropertyMap {
         add_typed<bool>(mutator, string::utf8(b"bool"), false);
         add_typed<u8>(mutator, string::utf8(b"u8"), 0x21);
         add_typed<u16>(mutator, string::utf8(b"u16"), 0x22);
@@ -498,7 +587,9 @@ module aptos_token_objects::property_map {
         add_typed<u128>(mutator, string::utf8(b"u128"), 0x25);
         add_typed<u256>(mutator, string::utf8(b"u256"), 0x26);
         add_typed<vector<u8>>(mutator, string::utf8(b"vector<u8>"), vector[0x02]);
-        add_typed<String>(mutator, string::utf8(b"0x1::string::String"), string::utf8(b"ha"));
+        add_typed<String>(
+            mutator, string::utf8(b"0x1::string::String"), string::utf8(b"ha")
+        );
 
         assert!(!read_bool(object, &string::utf8(b"bool")), 21);
         assert!(read_u8(object, &string::utf8(b"u8")) == 0x21, 22);
@@ -508,7 +599,12 @@ module aptos_token_objects::property_map {
         assert!(read_u128(object, &string::utf8(b"u128")) == 0x25, 26);
         assert!(read_u256(object, &string::utf8(b"u256")) == 0x26, 27);
         assert!(read_bytes(object, &string::utf8(b"vector<u8>")) == vector[0x02], 28);
-        assert!(read_string(object, &string::utf8(b"0x1::string::String")) == string::utf8(b"ha"), 29);
+        assert!(
+            read_string(object, &string::utf8(b"0x1::string::String")) == string::utf8(
+                b"ha"
+            ),
+            29,
+        );
     }
 
     #[test(creator = @0x123)]
@@ -525,38 +621,27 @@ module aptos_token_objects::property_map {
     fun end_to_end_input(): PropertyMap {
         prepare_input(
             vector[
-                string::utf8(b"bool"),
-                string::utf8(b"u8"),
-                string::utf8(b"u16"),
-                string::utf8(b"u32"),
-                string::utf8(b"u64"),
-                string::utf8(b"u128"),
-                string::utf8(b"u256"),
-                string::utf8(b"vector<u8>"),
-                string::utf8(b"0x1::string::String"),
-            ],
+                string::utf8(b"bool"), string::utf8(b"u8"), string::utf8(b"u16"), string::utf8(
+                    b"u32"
+                ), string::utf8(b"u64"), string::utf8(b"u128"), string::utf8(b"u256"), string::utf8(
+                    b"vector<u8>"
+                ), string::utf8(b"0x1::string::String"),],
             vector[
-                string::utf8(b"bool"),
-                string::utf8(b"u8"),
-                string::utf8(b"u16"),
-                string::utf8(b"u32"),
-                string::utf8(b"u64"),
-                string::utf8(b"u128"),
-                string::utf8(b"u256"),
-                string::utf8(b"vector<u8>"),
-                string::utf8(b"0x1::string::String"),
-            ],
+                string::utf8(b"bool"), string::utf8(b"u8"), string::utf8(b"u16"), string::utf8(
+                    b"u32"
+                ), string::utf8(b"u64"), string::utf8(b"u128"), string::utf8(b"u256"), string::utf8(
+                    b"vector<u8>"
+                ), string::utf8(b"0x1::string::String"),],
             vector[
-                bcs::to_bytes<bool>(&true),
-                bcs::to_bytes<u8>(&0x12),
-                bcs::to_bytes<u16>(&0x1234),
-                bcs::to_bytes<u32>(&0x12345678),
-                bcs::to_bytes<u64>(&0x1234567812345678),
-                bcs::to_bytes<u128>(&0x12345678123456781234567812345678),
-                bcs::to_bytes<u256>(&0x1234567812345678123456781234567812345678123456781234567812345678),
-                bcs::to_bytes<vector<u8>>(&vector[0x01]),
-                bcs::to_bytes<String>(&string::utf8(b"a")),
-            ],
+                bcs::to_bytes<bool>(&true), bcs::to_bytes<u8>(&0x12), bcs::to_bytes<u16>(
+                    &0x1234
+                ), bcs::to_bytes<u32>(&0x12345678), bcs::to_bytes<u64>(
+                    &0x1234567812345678
+                ), bcs::to_bytes<u128>(&0x12345678123456781234567812345678), bcs::to_bytes<u256>(
+                    &0x1234567812345678123456781234567812345678123456781234567812345678
+                ), bcs::to_bytes<vector<u8>>(&vector[0x01]), bcs::to_bytes<String>(
+                    &string::utf8(b"a")
+                ),],
         )
     }
 
@@ -565,11 +650,12 @@ module aptos_token_objects::property_map {
     fun test_invalid_init(creator: &signer) {
         let constructor_ref = object::create_named_object(creator, b"");
 
-        let input = prepare_input(
-            vector[string::utf8(b"bool")],
-            vector[string::utf8(b"u16")],
-            vector[bcs::to_bytes<bool>(&true)],
-        );
+        let input =
+            prepare_input(
+                vector[string::utf8(b"bool")],
+                vector[string::utf8(b"u16")],
+                vector[bcs::to_bytes<bool>(&true)],
+            );
         init(&constructor_ref, input);
     }
 
@@ -578,11 +664,12 @@ module aptos_token_objects::property_map {
     fun test_init_wrong_values(creator: &signer) {
         let constructor_ref = object::create_named_object(creator, b"");
 
-        let input = prepare_input(
-            vector[string::utf8(b"bool"), string::utf8(b"u8")],
-            vector[string::utf8(b"bool"), string::utf8(b"u8")],
-            vector[bcs::to_bytes<bool>(&true)],
-        );
+        let input =
+            prepare_input(
+                vector[string::utf8(b"bool"), string::utf8(b"u8")],
+                vector[string::utf8(b"bool"), string::utf8(b"u8")],
+                vector[bcs::to_bytes<bool>(&true)],
+            );
         init(&constructor_ref, input);
     }
 
@@ -591,11 +678,12 @@ module aptos_token_objects::property_map {
     fun test_init_wrong_types(creator: &signer) {
         let constructor_ref = object::create_named_object(creator, b"");
 
-        let input = prepare_input(
-            vector[string::utf8(b"bool"), string::utf8(b"u8")],
-            vector[string::utf8(b"bool")],
-            vector[bcs::to_bytes<bool>(&true), bcs::to_bytes<u8>(&0x2)],
-        );
+        let input =
+            prepare_input(
+                vector[string::utf8(b"bool"), string::utf8(b"u8")],
+                vector[string::utf8(b"bool")],
+                vector[bcs::to_bytes<bool>(&true), bcs::to_bytes<u8>(&0x2)],
+            );
         init(&constructor_ref, input);
     }
 
@@ -604,15 +692,21 @@ module aptos_token_objects::property_map {
     fun test_invalid_add(creator: &signer) acquires PropertyMap {
         let constructor_ref = object::create_named_object(creator, b"");
 
-        let input = prepare_input(
-            vector[string::utf8(b"bool")],
-            vector[string::utf8(b"bool")],
-            vector[bcs::to_bytes<bool>(&true)],
-        );
+        let input =
+            prepare_input(
+                vector[string::utf8(b"bool")],
+                vector[string::utf8(b"bool")],
+                vector[bcs::to_bytes<bool>(&true)],
+            );
         init(&constructor_ref, input);
         let mutator = generate_mutator_ref(&constructor_ref);
 
-        update(&mutator, &string::utf8(b"u16"), string::utf8(b"bool"), bcs::to_bytes<u16>(&0x1234));
+        update(
+            &mutator,
+            &string::utf8(b"u16"),
+            string::utf8(b"bool"),
+            bcs::to_bytes<u16>(&0x1234),
+        );
     }
 
     #[test(creator = @0x123)]
@@ -620,28 +714,36 @@ module aptos_token_objects::property_map {
     fun test_invalid_update(creator: &signer) acquires PropertyMap {
         let constructor_ref = object::create_named_object(creator, b"");
 
-        let input = prepare_input(
-            vector[string::utf8(b"bool")],
-            vector[string::utf8(b"bool")],
-            vector[bcs::to_bytes<bool>(&true)],
-        );
+        let input =
+            prepare_input(
+                vector[string::utf8(b"bool")],
+                vector[string::utf8(b"bool")],
+                vector[bcs::to_bytes<bool>(&true)],
+            );
         init(&constructor_ref, input);
         let mutator = generate_mutator_ref(&constructor_ref);
 
-        update(&mutator, &string::utf8(b"bool"), string::utf8(b"bool"), bcs::to_bytes<u16>(&0x1234));
+        update(
+            &mutator,
+            &string::utf8(b"bool"),
+            string::utf8(b"bool"),
+            bcs::to_bytes<u16>(&0x1234),
+        );
     }
 
     #[test(creator = @0x123)]
     #[expected_failure(abort_code = 0x10006, location = Self)]
     fun test_invalid_read(creator: &signer) acquires PropertyMap {
         let constructor_ref = object::create_named_object(creator, b"");
-        let object = object::object_from_constructor_ref<object::ObjectCore>(&constructor_ref);
+        let object =
+            object::object_from_constructor_ref<object::ObjectCore>(&constructor_ref);
 
-        let input = prepare_input(
-            vector[string::utf8(b"bool")],
-            vector[string::utf8(b"bool")],
-            vector[bcs::to_bytes<bool>(&true)],
-        );
+        let input =
+            prepare_input(
+                vector[string::utf8(b"bool")],
+                vector[string::utf8(b"bool")],
+                vector[bcs::to_bytes<bool>(&true)],
+            );
         init(&constructor_ref, input);
         read_u8(&object, &string::utf8(b"bool"));
     }
@@ -652,16 +754,25 @@ module aptos_token_objects::property_map {
         assert!(read_u16(&object, &string::utf8(b"u16")) == 0x1234, 2);
         assert!(read_u32(&object, &string::utf8(b"u32")) == 0x12345678, 3);
         assert!(read_u64(&object, &string::utf8(b"u64")) == 0x1234567812345678, 4);
-        assert!(read_u128(&object, &string::utf8(b"u128")) == 0x12345678123456781234567812345678, 5);
+        assert!(
+            read_u128(&object, &string::utf8(b"u128")) ==
+            0x12345678123456781234567812345678,
+            5,
+        );
         assert!(
             read_u256(
                 &object,
-                &string::utf8(b"u256")
+                &string::utf8(b"u256"),
             ) == 0x1234567812345678123456781234567812345678123456781234567812345678,
-            6
+            6,
         );
         assert!(read_bytes(&object, &string::utf8(b"vector<u8>")) == vector[0x01], 7);
-        assert!(read_string(&object, &string::utf8(b"0x1::string::String")) == string::utf8(b"a"), 8);
+        assert!(
+            read_string(&object, &string::utf8(b"0x1::string::String")) == string::utf8(
+                b"a"
+            ),
+            8,
+        );
 
         assert!(length(&object) == 9, 9);
     }

--- a/aptos-move/framework/aptos-token-objects/sources/royalty.move
+++ b/aptos-move/framework/aptos-token-objects/sources/royalty.move
@@ -51,7 +51,9 @@ module aptos_token_objects::royalty {
     }
 
     /// Creates a new royalty, verifying that it is a valid percentage
-    public fun create(numerator: u64, denominator: u64, payee_address: address): Royalty {
+    public fun create(
+        numerator: u64, denominator: u64, payee_address: address
+    ): Royalty {
         assert!(denominator != 0, error::out_of_range(EROYALTY_DENOMINATOR_IS_ZERO));
         assert!(numerator <= denominator, error::out_of_range(EROYALTY_EXCEEDS_MAXIMUM));
 
@@ -96,14 +98,16 @@ module aptos_token_objects::royalty {
     #[test(creator = @0x123)]
     fun test_none(creator: &signer) acquires Royalty {
         let constructor_ref = object::create_named_object(creator, b"");
-        let object = object::object_from_constructor_ref<object::ObjectCore>(&constructor_ref);
+        let object =
+            object::object_from_constructor_ref<object::ObjectCore>(&constructor_ref);
         assert!(option::none() == get(object), 0);
     }
 
     #[test(creator = @0x123)]
     fun test_init_and_update(creator: &signer) acquires Royalty {
         let constructor_ref = object::create_named_object(creator, b"");
-        let object = object::object_from_constructor_ref<object::ObjectCore>(&constructor_ref);
+        let object =
+            object::object_from_constructor_ref<object::ObjectCore>(&constructor_ref);
         let init_royalty = create(1, 2, @0x123);
         init(&constructor_ref, init_royalty);
         assert!(option::some(init_royalty) == get(object), 0);
@@ -111,7 +115,8 @@ module aptos_token_objects::royalty {
         assert!(denominator(&init_royalty) == 2, 2);
         assert!(payee_address(&init_royalty) == @0x123, 3);
 
-        let mutator_ref = generate_mutator_ref(object::generate_extend_ref(&constructor_ref));
+        let mutator_ref =
+            generate_mutator_ref(object::generate_extend_ref(&constructor_ref));
         let update_royalty = create(2, 5, @0x456);
         update(&mutator_ref, update_royalty);
         assert!(option::some(update_royalty) == get(object), 4);
@@ -123,10 +128,12 @@ module aptos_token_objects::royalty {
     #[test(creator = @0x123)]
     fun test_update_only(creator: &signer) acquires Royalty {
         let constructor_ref = object::create_named_object(creator, b"");
-        let object = object::object_from_constructor_ref<object::ObjectCore>(&constructor_ref);
+        let object =
+            object::object_from_constructor_ref<object::ObjectCore>(&constructor_ref);
         assert!(option::none() == get(object), 0);
 
-        let mutator_ref = generate_mutator_ref(object::generate_extend_ref(&constructor_ref));
+        let mutator_ref =
+            generate_mutator_ref(object::generate_extend_ref(&constructor_ref));
         let update_royalty = create(1, 5, @0x123);
         update(&mutator_ref, update_royalty);
         assert!(option::some(update_royalty) == get(object), 1);

--- a/aptos-move/framework/aptos-token-objects/sources/token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/token.move
@@ -127,7 +127,8 @@ module aptos_token_objects::token {
         uri: String,
     ) {
         let creator_address = signer::address_of(creator);
-        let collection_addr = collection::create_collection_address(&creator_address, &collection_name);
+        let collection_addr =
+            collection::create_collection_address(&creator_address, &collection_name);
         let collection = object::address_to_object<Collection>(collection_addr);
 
         create_common_with_collection(
@@ -138,7 +139,7 @@ module aptos_token_objects::token {
             name_prefix,
             name_with_index_suffix,
             royalty,
-            uri
+            uri,
         )
     }
 
@@ -154,43 +155,56 @@ module aptos_token_objects::token {
         royalty: Option<Royalty>,
         uri: String,
     ) {
-        assert!(collection::creator(collection) == signer::address_of(creator), error::unauthenticated(ENOT_CREATOR));
+        assert!(
+            collection::creator(collection) == signer::address_of(creator),
+            error::unauthenticated(ENOT_CREATOR),
+        );
 
         if (option::is_some(&name_with_index_suffix)) {
             // Be conservative, as we don't know what length the index will be, and assume worst case (20 chars in MAX_U64)
             assert!(
-                string::length(&name_prefix) + 20 + string::length(
-                    option::borrow(&name_with_index_suffix)
-                ) <= MAX_TOKEN_NAME_LENGTH,
-                error::out_of_range(ETOKEN_NAME_TOO_LONG)
+                string::length(&name_prefix) + 20
+                    + string::length(option::borrow(&name_with_index_suffix)) <= MAX_TOKEN_NAME_LENGTH,
+                error::out_of_range(ETOKEN_NAME_TOO_LONG),
             );
         } else {
-            assert!(string::length(&name_prefix) <= MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
+            assert!(
+                string::length(&name_prefix) <= MAX_TOKEN_NAME_LENGTH,
+                error::out_of_range(ETOKEN_NAME_TOO_LONG),
+            );
         };
-        assert!(string::length(&description) <= MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
-        assert!(string::length(&uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
+        assert!(
+            string::length(&description) <= MAX_DESCRIPTION_LENGTH,
+            error::out_of_range(EDESCRIPTION_TOO_LONG),
+        );
+        assert!(
+            string::length(&uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG)
+        );
 
         let object_signer = object::generate_signer(constructor_ref);
 
-        let index = option::destroy_with_default(
-            collection::increment_supply(&collection, signer::address_of(&object_signer)),
-            aggregator_v2::create_snapshot<u64>(0)
-        );
+        let index =
+            option::destroy_with_default(
+                collection::increment_supply(
+                    &collection, signer::address_of(&object_signer)
+                ),
+                aggregator_v2::create_snapshot<u64>(0),
+            );
 
         // If create_numbered_token called us, add index to the name.
-        let name = if (option::is_some(&name_with_index_suffix)) {
-            aggregator_v2::derive_string_concat(name_prefix, &index, option::extract(&mut name_with_index_suffix))
-        } else {
-            aggregator_v2::create_derived_string(name_prefix)
-        };
+        let name =
+            if (option::is_some(&name_with_index_suffix)) {
+                aggregator_v2::derive_string_concat(
+                    name_prefix, &index, option::extract(&mut name_with_index_suffix)
+                )
+            } else {
+                aggregator_v2::create_derived_string(name_prefix)
+            };
 
         let deprecated_index = 0;
         let deprecated_name = string::utf8(b"");
 
-        let token_concurrent = TokenIdentifiers {
-            index,
-            name,
-        };
+        let token_concurrent = TokenIdentifiers { index, name, };
         move_to(&object_signer, token_concurrent);
 
         let token = Token {
@@ -230,7 +244,7 @@ module aptos_token_objects::token {
             name,
             option::none(),
             royalty,
-            uri
+            uri,
         );
         constructor_ref
     }
@@ -255,7 +269,7 @@ module aptos_token_objects::token {
             name,
             option::none(),
             royalty,
-            uri
+            uri,
         );
         constructor_ref
     }
@@ -287,7 +301,7 @@ module aptos_token_objects::token {
             name_with_index_prefix,
             option::some(name_with_index_suffix),
             royalty,
-            uri
+            uri,
         );
         constructor_ref
     }
@@ -316,7 +330,7 @@ module aptos_token_objects::token {
             name_with_index_prefix,
             option::some(name_with_index_suffix),
             royalty,
-            uri
+            uri,
         );
         constructor_ref
     }
@@ -342,7 +356,7 @@ module aptos_token_objects::token {
             name,
             option::none(),
             royalty,
-            uri
+            uri,
         );
         constructor_ref
     }
@@ -368,7 +382,7 @@ module aptos_token_objects::token {
             name,
             option::none(),
             royalty,
-            uri
+            uri,
         );
         constructor_ref
     }
@@ -385,9 +399,20 @@ module aptos_token_objects::token {
         royalty: Option<Royalty>,
         uri: String,
     ): ConstructorRef {
-        let seed = create_token_name_with_seed(&collection::name(collection), &name, &seed);
+        let seed = create_token_name_with_seed(
+            &collection::name(collection), &name, &seed
+        );
         let constructor_ref = object::create_named_object(creator, seed);
-        create_common_with_collection(creator, &constructor_ref, collection, description, name, option::none(), royalty, uri);
+        create_common_with_collection(
+            creator,
+            &constructor_ref,
+            collection,
+            description,
+            name,
+            option::none(),
+            royalty,
+            uri,
+        );
         constructor_ref
     }
 
@@ -413,34 +438,46 @@ module aptos_token_objects::token {
             name,
             option::none(),
             royalty,
-            uri
+            uri,
         );
         constructor_ref
     }
 
     /// Generates the token's address based upon the creator's address, the collection's name and the token's name.
-    public fun create_token_address(creator: &address, collection: &String, name: &String): address {
+    public fun create_token_address(
+        creator: &address, collection: &String, name: &String
+    ): address {
         object::create_object_address(creator, create_token_seed(collection, name))
     }
 
     #[view]
     /// Generates the token's address based upon the creator's address, the collection object and the token's name and seed.
-    public fun create_token_address_with_seed(creator: address, collection: String, name: String, seed: String): address {
+    public fun create_token_address_with_seed(
+        creator: address, collection: String, name: String, seed: String
+    ): address {
         let seed = create_token_name_with_seed(&collection, &name, &seed);
         object::create_object_address(&creator, seed)
     }
 
     /// Named objects are derived from a seed, the token's seed is its name appended to the collection's name.
     public fun create_token_seed(collection: &String, name: &String): vector<u8> {
-        assert!(string::length(name) <= MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
+        assert!(
+            string::length(name) <= MAX_TOKEN_NAME_LENGTH,
+            error::out_of_range(ETOKEN_NAME_TOO_LONG),
+        );
         let seed = *string::bytes(collection);
         vector::append(&mut seed, b"::");
         vector::append(&mut seed, *string::bytes(name));
         seed
     }
 
-    public fun create_token_name_with_seed(collection: &String, name: &String, seed: &String): vector<u8> {
-        assert!(string::length(seed) <= MAX_TOKEN_SEED_LENGTH, error::out_of_range(ESEED_TOO_LONG));
+    public fun create_token_name_with_seed(
+        collection: &String, name: &String, seed: &String
+    ): vector<u8> {
+        assert!(
+            string::length(seed) <= MAX_TOKEN_SEED_LENGTH,
+            error::out_of_range(ESEED_TOO_LONG),
+        );
         let seeds = create_token_seed(collection, name);
         vector::append(&mut seeds, *string::bytes(seed));
         seeds
@@ -454,13 +491,14 @@ module aptos_token_objects::token {
 
     /// Creates a BurnRef, which gates the ability to burn the given token.
     public fun generate_burn_ref(ref: &ConstructorRef): BurnRef {
-        let (inner, self) = if (object::can_generate_delete_ref(ref)) {
-            let delete_ref = object::generate_delete_ref(ref);
-            (option::some(delete_ref), option::none())
-        } else {
-            let addr = object::address_from_constructor_ref(ref);
-            (option::none(), option::some(addr))
-        };
+        let (inner, self) =
+            if (object::can_generate_delete_ref(ref)) {
+                let delete_ref = object::generate_delete_ref(ref);
+                (option::some(delete_ref), option::none())
+            } else {
+                let addr = object::address_from_constructor_ref(ref);
+                (option::none(), option::some(addr))
+            };
         BurnRef { self, inner }
     }
 
@@ -523,7 +561,9 @@ module aptos_token_objects::token {
     public fun name<T: key>(token: Object<T>): String acquires Token, TokenIdentifiers {
         let token_address = object::object_address(&token);
         if (exists<TokenIdentifiers>(token_address)) {
-            aggregator_v2::read_derived_string(&borrow_global<TokenIdentifiers>(token_address).name)
+            aggregator_v2::read_derived_string(
+                &borrow_global<TokenIdentifiers>(token_address).name
+            )
         } else {
             borrow(&token).name
         }
@@ -543,8 +583,10 @@ module aptos_token_objects::token {
         } else {
             let creator = creator(token);
             let collection_name = collection_name(token);
-            let collection_address = collection::create_collection_address(&creator, &collection_name);
-            let collection = object::address_to_object<collection::Collection>(collection_address);
+            let collection_address =
+                collection::create_collection_address(&creator, &collection_name);
+            let collection =
+                object::address_to_object<collection::Collection>(collection_address);
             royalty::get(collection)
         }
     }
@@ -568,7 +610,9 @@ module aptos_token_objects::token {
     public fun index<T: key>(token: Object<T>): u64 acquires Token, TokenIdentifiers {
         let token_address = object::object_address(&token);
         if (exists<TokenIdentifiers>(token_address)) {
-            aggregator_v2::read_snapshot(&borrow_global<TokenIdentifiers>(token_address).index)
+            aggregator_v2::read_snapshot(
+                &borrow_global<TokenIdentifiers>(token_address).index
+            )
         } else {
             borrow(&token).index
         }
@@ -585,17 +629,20 @@ module aptos_token_objects::token {
     }
 
     public fun burn(burn_ref: BurnRef) acquires Token, TokenIdentifiers {
-        let (addr, previous_owner) = if (option::is_some(&burn_ref.inner)) {
-            let delete_ref = option::extract(&mut burn_ref.inner);
-            let addr = object::address_from_delete_ref(&delete_ref);
-            let previous_owner = object::owner(object::address_to_object<Token>(addr));
-            object::delete(delete_ref);
-            (addr, previous_owner)
-        } else {
-            let addr = option::extract(&mut burn_ref.self);
-            let previous_owner = object::owner(object::address_to_object<Token>(addr));
-            (addr, previous_owner)
-        };
+        let (addr, previous_owner) =
+            if (option::is_some(&burn_ref.inner)) {
+                let delete_ref = option::extract(&mut burn_ref.inner);
+                let addr = object::address_from_delete_ref(&delete_ref);
+                let previous_owner =
+                    object::owner(object::address_to_object<Token>(addr));
+                object::delete(delete_ref);
+                (addr, previous_owner)
+            } else {
+                let addr = option::extract(&mut burn_ref.self);
+                let previous_owner =
+                    object::owner(object::address_to_object<Token>(addr));
+                (addr, previous_owner)
+            };
 
         if (royalty::exists_at(addr)) {
             royalty::delete(addr)
@@ -610,30 +657,38 @@ module aptos_token_objects::token {
             mutation_events,
         } = move_from<Token>(addr);
 
-        let index = if (exists<TokenIdentifiers>(addr)) {
-            let TokenIdentifiers {
-                index,
-                name: _,
-            } = move_from<TokenIdentifiers>(addr);
-            aggregator_v2::read_snapshot(&index)
-        } else {
-            deprecated_index
-        };
+        let index =
+            if (exists<TokenIdentifiers>(addr)) {
+                let TokenIdentifiers { index, name: _, } =
+                    move_from<TokenIdentifiers>(addr);
+                aggregator_v2::read_snapshot(&index)
+            } else {
+                deprecated_index
+            };
 
         event::destroy_handle(mutation_events);
-        collection::decrement_supply(&collection, addr, option::some(index), previous_owner);
+        collection::decrement_supply(
+            &collection, addr, option::some(index), previous_owner
+        );
     }
 
-    public fun set_description(mutator_ref: &MutatorRef, description: String) acquires Token {
-        assert!(string::length(&description) <= MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
+    public fun set_description(
+        mutator_ref: &MutatorRef, description: String
+    ) acquires Token {
+        assert!(
+            string::length(&description) <= MAX_DESCRIPTION_LENGTH,
+            error::out_of_range(EDESCRIPTION_TOO_LONG),
+        );
         let token = borrow_mut(mutator_ref);
         if (std::features::module_event_migration_enabled()) {
-            event::emit(Mutation {
-                token_address: mutator_ref.self,
-                mutated_field_name: string::utf8(b"description"),
-                old_value: token.description,
-                new_value: description
-            })
+            event::emit(
+                Mutation {
+                    token_address: mutator_ref.self,
+                    mutated_field_name: string::utf8(b"description"),
+                    old_value: token.description,
+                    new_value: description
+                },
+            )
         };
         event::emit_event(
             &mut token.mutation_events,
@@ -647,28 +702,35 @@ module aptos_token_objects::token {
     }
 
     public fun set_name(mutator_ref: &MutatorRef, name: String) acquires Token, TokenIdentifiers {
-        assert!(string::length(&name) <= MAX_TOKEN_NAME_LENGTH, error::out_of_range(ETOKEN_NAME_TOO_LONG));
+        assert!(
+            string::length(&name) <= MAX_TOKEN_NAME_LENGTH,
+            error::out_of_range(ETOKEN_NAME_TOO_LONG),
+        );
 
         let token = borrow_mut(mutator_ref);
 
-        let old_name = if (exists<TokenIdentifiers>(mutator_ref.self)) {
-            let token_concurrent = borrow_global_mut<TokenIdentifiers>(mutator_ref.self);
-            let old_name = aggregator_v2::read_derived_string(&token_concurrent.name);
-            token_concurrent.name = aggregator_v2::create_derived_string(name);
-            old_name
-        } else {
-            let old_name = token.name;
-            token.name = name;
-            old_name
-        };
+        let old_name =
+            if (exists<TokenIdentifiers>(mutator_ref.self)) {
+                let token_concurrent =
+                    borrow_global_mut<TokenIdentifiers>(mutator_ref.self);
+                let old_name = aggregator_v2::read_derived_string(&token_concurrent.name);
+                token_concurrent.name = aggregator_v2::create_derived_string(name);
+                old_name
+            } else {
+                let old_name = token.name;
+                token.name = name;
+                old_name
+            };
 
         if (std::features::module_event_migration_enabled()) {
-            event::emit(Mutation {
-                token_address: mutator_ref.self,
-                mutated_field_name: string::utf8(b"name"),
-                old_value: old_name,
-                new_value: name
-            })
+            event::emit(
+                Mutation {
+                    token_address: mutator_ref.self,
+                    mutated_field_name: string::utf8(b"name"),
+                    old_value: old_name,
+                    new_value: name
+                },
+            )
         };
         event::emit_event(
             &mut token.mutation_events,
@@ -681,15 +743,19 @@ module aptos_token_objects::token {
     }
 
     public fun set_uri(mutator_ref: &MutatorRef, uri: String) acquires Token {
-        assert!(string::length(&uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
+        assert!(
+            string::length(&uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG)
+        );
         let token = borrow_mut(mutator_ref);
         if (std::features::module_event_migration_enabled()) {
-            event::emit(Mutation {
-                token_address: mutator_ref.self,
-                mutated_field_name: string::utf8(b"uri"),
-                old_value: token.uri,
-                new_value: uri,
-            })
+            event::emit(
+                Mutation {
+                    token_address: mutator_ref.self,
+                    mutated_field_name: string::utf8(b"uri"),
+                    old_value: token.uri,
+                    new_value: uri,
+                },
+            )
         };
         event::emit_event(
             &mut token.mutation_events,
@@ -711,7 +777,8 @@ module aptos_token_objects::token {
         create_token_helper(creator, collection_name, token_name);
 
         let creator_address = signer::address_of(creator);
-        let token_addr = create_token_address(&creator_address, &collection_name, &token_name);
+        let token_addr =
+            create_token_address(&creator_address, &collection_name, &token_name);
         let token = object::address_to_object<Token>(token_addr);
         assert!(object::owner(token) == creator_address, 1);
         object::transfer(creator, token, signer::address_of(trader));
@@ -724,46 +791,76 @@ module aptos_token_objects::token {
     #[test(creator = @0x123, trader = @0x456)]
     #[expected_failure(abort_code = 0x40002, location = aptos_token_objects::token)]
     fun test_create_token_non_creator(creator: &signer, trader: &signer) {
-        let constructor_ref = &create_fixed_collection(creator, string::utf8(b"collection name"), 5);
-        let collection = get_collection_from_ref(&object::generate_extend_ref(constructor_ref));
+        let constructor_ref =
+            &create_fixed_collection(creator, string::utf8(b"collection name"), 5);
+        let collection =
+            get_collection_from_ref(&object::generate_extend_ref(constructor_ref));
         create_token(
-            trader, collection, string::utf8(b"token description"), string::utf8(b"token name"),
-            option::some(royalty::create(25, 10000, signer::address_of(creator))), string::utf8(b"uri"),
+            trader,
+            collection,
+            string::utf8(b"token description"),
+            string::utf8(b"token name"),
+            option::some(royalty::create(25, 10000, signer::address_of(creator))),
+            string::utf8(b"uri"),
         );
     }
 
     #[test(creator = @0x123, trader = @0x456)]
     #[expected_failure(abort_code = 0x40002, location = aptos_token_objects::token)]
-    fun test_create_named_token_non_creator(creator: &signer, trader: &signer) {
-        let constructor_ref = &create_fixed_collection(creator, string::utf8(b"collection name"), 5);
-        let collection = get_collection_from_ref(&object::generate_extend_ref(constructor_ref));
-        create_token_with_collection_helper(trader, collection, string::utf8(b"token name"));
+    fun test_create_named_token_non_creator(
+        creator: &signer, trader: &signer
+    ) {
+        let constructor_ref =
+            &create_fixed_collection(creator, string::utf8(b"collection name"), 5);
+        let collection =
+            get_collection_from_ref(&object::generate_extend_ref(constructor_ref));
+        create_token_with_collection_helper(
+            trader, collection, string::utf8(b"token name")
+        );
     }
 
     #[test(creator = @0x123, trader = @0x456)]
     #[expected_failure(abort_code = 0x40002, location = aptos_token_objects::token)]
-    fun test_create_named_token_object_non_creator(creator: &signer, trader: &signer) {
-        let constructor_ref = &create_fixed_collection(creator, string::utf8(b"collection name"), 5);
-        let collection = get_collection_from_ref(&object::generate_extend_ref(constructor_ref));
+    fun test_create_named_token_object_non_creator(
+        creator: &signer, trader: &signer
+    ) {
+        let constructor_ref =
+            &create_fixed_collection(creator, string::utf8(b"collection name"), 5);
+        let collection =
+            get_collection_from_ref(&object::generate_extend_ref(constructor_ref));
         create_named_token_object(
-            trader, collection, string::utf8(b"token description"), string::utf8(b"token name"),
-            option::some(royalty::create(25, 10000, signer::address_of(creator))), string::utf8(b"uri"),
+            trader,
+            collection,
+            string::utf8(b"token description"),
+            string::utf8(b"token name"),
+            option::some(royalty::create(25, 10000, signer::address_of(creator))),
+            string::utf8(b"uri"),
         );
     }
 
     #[test(creator = @0x123, trader = @0x456)]
     #[expected_failure(abort_code = 0x40002, location = aptos_token_objects::token)]
-    fun test_create_named_token_from_seed_non_creator(creator: &signer, trader: &signer) {
-        let constructor_ref = &create_fixed_collection(creator, string::utf8(b"collection name"), 5);
-        let collection = get_collection_from_ref(&object::generate_extend_ref(constructor_ref));
+    fun test_create_named_token_from_seed_non_creator(
+        creator: &signer, trader: &signer
+    ) {
+        let constructor_ref =
+            &create_fixed_collection(creator, string::utf8(b"collection name"), 5);
+        let collection =
+            get_collection_from_ref(&object::generate_extend_ref(constructor_ref));
         create_named_token_object(
-            trader, collection, string::utf8(b"token description"), string::utf8(b"token name"),
-            option::some(royalty::create(25, 10000, signer::address_of(creator))), string::utf8(b"uri"),
+            trader,
+            collection,
+            string::utf8(b"token description"),
+            string::utf8(b"token name"),
+            option::some(royalty::create(25, 10000, signer::address_of(creator))),
+            string::utf8(b"uri"),
         );
     }
 
     #[test(creator = @0x123, trader = @0x456)]
-    fun test_create_and_transfer_token_with_seed(creator: &signer, trader: &signer) acquires Token {
+    fun test_create_and_transfer_token_with_seed(
+        creator: &signer, trader: &signer
+    ) acquires Token {
         let collection_name = string::utf8(b"collection name");
         let token_name = string::utf8(b"token name");
 
@@ -774,7 +871,10 @@ module aptos_token_objects::token {
 
         let creator_address = signer::address_of(creator);
         // Calculate the token address with collection, token name and seed.
-        let token_addr = create_token_address_with_seed(creator_address, collection_name, token_name, seed);
+        let token_addr =
+            create_token_address_with_seed(
+                creator_address, collection_name, token_name, seed
+            );
         let token = object::address_to_object<Token>(token_addr);
         assert!(object::owner(token) == creator_address, 1);
         object::transfer(creator, token, signer::address_of(trader));
@@ -791,16 +891,18 @@ module aptos_token_objects::token {
 
         let creator_address = signer::address_of(creator);
         let expected_royalty = royalty::create(10, 1000, creator_address);
-        let constructor_ref = collection::create_fixed_collection(
-            creator,
-            string::utf8(b"collection description"),
-            5,
-            collection_name,
-            option::some(expected_royalty),
-            string::utf8(b"collection uri"),
-        );
+        let constructor_ref =
+            collection::create_fixed_collection(
+                creator,
+                string::utf8(b"collection description"),
+                5,
+                collection_name,
+                option::some(expected_royalty),
+                string::utf8(b"collection uri"),
+            );
 
-        let collection = object::object_from_constructor_ref<Collection>(&constructor_ref);
+        let collection =
+            object::object_from_constructor_ref<Collection>(&constructor_ref);
         create_named_token_object(
             creator,
             collection,
@@ -810,7 +912,8 @@ module aptos_token_objects::token {
             string::utf8(b"token uri"),
         );
 
-        let token_addr = create_token_address(&creator_address, &collection_name, &token_name);
+        let token_addr =
+            create_token_address(&creator_address, &collection_name, &token_name);
         let token = object::address_to_object<Token>(token_addr);
         assert!(option::some(expected_royalty) == royalty(token), 0);
     }
@@ -838,7 +941,8 @@ module aptos_token_objects::token {
         );
 
         let creator_address = signer::address_of(creator);
-        let token_addr = create_token_address(&creator_address, &collection_name, &token_name);
+        let token_addr =
+            create_token_address(&creator_address, &collection_name, &token_name);
         let token = object::address_to_object<Token>(token_addr);
         assert!(option::none() == royalty(token), 0);
     }
@@ -871,10 +975,14 @@ module aptos_token_objects::token {
         let token_name = string::utf8(b"token name");
 
         create_collection_helper(creator, collection_name, 1);
-        let mutator_ref = create_token_with_mutation_ref(creator, collection_name, token_name);
-        let token = object::address_to_object<Token>(
-            create_token_address(&signer::address_of(creator), &collection_name, &token_name),
-        );
+        let mutator_ref =
+            create_token_with_mutation_ref(creator, collection_name, token_name);
+        let token =
+            object::address_to_object<Token>(
+                create_token_address(
+                    &signer::address_of(creator), &collection_name, &token_name
+                ),
+            );
 
         let description = string::utf8(b"no fail");
         assert!(description != description(token), 0);
@@ -888,10 +996,14 @@ module aptos_token_objects::token {
         let token_name = string::utf8(b"token name");
 
         create_collection_helper(creator, collection_name, 1);
-        let mutator_ref = create_token_with_mutation_ref(creator, collection_name, token_name);
-        let token = object::address_to_object<Token>(
-            create_token_address(&signer::address_of(creator), &collection_name, &token_name),
-        );
+        let mutator_ref =
+            create_token_with_mutation_ref(creator, collection_name, token_name);
+        let token =
+            object::address_to_object<Token>(
+                create_token_address(
+                    &signer::address_of(creator), &collection_name, &token_name
+                ),
+            );
 
         let name = string::utf8(b"no fail");
         assert!(name != name(token), 0);
@@ -905,10 +1017,14 @@ module aptos_token_objects::token {
         let token_name = string::utf8(b"token name");
 
         create_collection_helper(creator, collection_name, 1);
-        let mutator_ref = create_token_with_mutation_ref(creator, collection_name, token_name);
-        let token = object::address_to_object<Token>(
-            create_token_address(&signer::address_of(creator), &collection_name, &token_name),
-        );
+        let mutator_ref =
+            create_token_with_mutation_ref(creator, collection_name, token_name);
+        let token =
+            object::address_to_object<Token>(
+                create_token_address(
+                    &signer::address_of(creator), &collection_name, &token_name
+                ),
+            );
 
         let uri = string::utf8(b"no fail");
         assert!(uri != uri(token), 0);
@@ -922,14 +1038,15 @@ module aptos_token_objects::token {
         let token_name = string::utf8(b"token name");
 
         create_collection_helper(creator, collection_name, 1);
-        let constructor_ref = create_named_token(
-            creator,
-            collection_name,
-            string::utf8(b"token description"),
-            token_name,
-            option::none(),
-            string::utf8(b"token uri"),
-        );
+        let constructor_ref =
+            create_named_token(
+                creator,
+                collection_name,
+                string::utf8(b"token description"),
+                token_name,
+                option::none(),
+                string::utf8(b"token uri"),
+            );
         let burn_ref = generate_burn_ref(&constructor_ref);
         let token_addr = object::address_from_constructor_ref(&constructor_ref);
         assert!(exists<Token>(token_addr), 0);
@@ -945,14 +1062,15 @@ module aptos_token_objects::token {
         let token_name = string::utf8(b"token name");
 
         create_collection_helper(creator, collection_name, 1);
-        let constructor_ref = create_named_token(
-            creator,
-            collection_name,
-            string::utf8(b"token description"),
-            token_name,
-            option::some(royalty::create(1, 1, signer::address_of(creator))),
-            string::utf8(b"token uri"),
-        );
+        let constructor_ref =
+            create_named_token(
+                creator,
+                collection_name,
+                string::utf8(b"token description"),
+                token_name,
+                option::some(royalty::create(1, 1, signer::address_of(creator))),
+                string::utf8(b"token uri"),
+            );
         let burn_ref = generate_burn_ref(&constructor_ref);
         let token_addr = object::address_from_constructor_ref(&constructor_ref);
         assert!(exists<Token>(token_addr), 0);
@@ -972,14 +1090,15 @@ module aptos_token_objects::token {
 
         create_collection_helper(creator, collection_name, 1);
         account::create_account_for_test(signer::address_of(creator));
-        let constructor_ref = create_from_account(
-            creator,
-            collection_name,
-            string::utf8(b"token description"),
-            token_name,
-            option::none(),
-            string::utf8(b"token uri"),
-        );
+        let constructor_ref =
+            create_from_account(
+                creator,
+                collection_name,
+                string::utf8(b"token description"),
+                token_name,
+                option::none(),
+                string::utf8(b"token uri"),
+            );
         let burn_ref = generate_burn_ref(&constructor_ref);
         let token_addr = object::address_from_constructor_ref(&constructor_ref);
         assert!(exists<Token>(token_addr), 0);
@@ -998,14 +1117,15 @@ module aptos_token_objects::token {
         let extend_ref = create_collection_helper(creator, collection_name, 1);
         let collection = get_collection_from_ref(&extend_ref);
         account::create_account_for_test(signer::address_of(creator));
-        let constructor_ref = create_token(
-            creator,
-            collection,
-            string::utf8(b"token description"),
-            token_name,
-            option::none(),
-            string::utf8(b"token uri"),
-        );
+        let constructor_ref =
+            create_token(
+                creator,
+                collection,
+                string::utf8(b"token description"),
+                token_name,
+                option::none(),
+                string::utf8(b"token uri"),
+            );
         let burn_ref = generate_burn_ref(&constructor_ref);
         let token_addr = object::address_from_constructor_ref(&constructor_ref);
         assert!(exists<Token>(token_addr), 0);
@@ -1026,7 +1146,11 @@ module aptos_token_objects::token {
         assert!(token_1_name == std::string::utf8(b"token name1"), 1);
 
         let token_2_ref = create_numbered_token_helper(creator, collection, token_name);
-        assert!(name(object::object_from_constructor_ref<Token>(&token_2_ref)) == std::string::utf8(b"token name2"), 1);
+        assert!(
+            name(object::object_from_constructor_ref<Token>(&token_2_ref))
+                == std::string::utf8(b"token name2"),
+            1,
+        );
         assert!(vector::length(&event::emitted_events<collection::Mint>()) == 2, 0);
 
         let burn_ref = generate_burn_ref(&token_2_ref);
@@ -1043,7 +1167,8 @@ module aptos_token_objects::token {
         let token_name = string::utf8(b"token name");
 
         let constructor_ref = &create_fixed_collection(creator, collection_name, 5);
-        let collection = get_collection_from_ref(&object::generate_extend_ref(constructor_ref));
+        let collection =
+            get_collection_from_ref(&object::generate_extend_ref(constructor_ref));
         let mutator_ref = collection::generate_mutator_ref(constructor_ref);
 
         create_token_with_collection_helper(creator, collection, token_name);
@@ -1054,13 +1179,19 @@ module aptos_token_objects::token {
     }
 
     #[test_only]
-    fun create_collection_helper(creator: &signer, collection_name: String, max_supply: u64): ExtendRef {
-        let constructor_ref = create_fixed_collection(creator, collection_name, max_supply);
+    fun create_collection_helper(
+        creator: &signer, collection_name: String, max_supply: u64
+    ): ExtendRef {
+        let constructor_ref = create_fixed_collection(
+            creator, collection_name, max_supply
+        );
         object::generate_extend_ref(&constructor_ref)
     }
 
     #[test_only]
-    fun create_fixed_collection(creator: &signer, collection_name: String, max_supply: u64): ConstructorRef {
+    fun create_fixed_collection(
+        creator: &signer, collection_name: String, max_supply: u64
+    ): ConstructorRef {
         collection::create_fixed_collection(
             creator,
             string::utf8(b"collection description"),
@@ -1072,7 +1203,9 @@ module aptos_token_objects::token {
     }
 
     #[test_only]
-    fun create_token_helper(creator: &signer, collection_name: String, token_name: String): ConstructorRef {
+    fun create_token_helper(
+        creator: &signer, collection_name: String, token_name: String
+    ): ConstructorRef {
         create_named_token(
             creator,
             collection_name,
@@ -1084,7 +1217,9 @@ module aptos_token_objects::token {
     }
 
     #[test_only]
-    fun create_token_with_collection_helper(creator: &signer, collection: Object<Collection>, token_name: String): ConstructorRef {
+    fun create_token_with_collection_helper(
+        creator: &signer, collection: Object<Collection>, token_name: String
+    ): ConstructorRef {
         create_named_token_object(
             creator,
             collection,
@@ -1096,7 +1231,9 @@ module aptos_token_objects::token {
     }
 
     #[test_only]
-    fun create_token_object_with_seed_helper(creator: &signer, collection: Object<Collection>, token_name: String, seed: String): ConstructorRef {
+    fun create_token_object_with_seed_helper(
+        creator: &signer, collection: Object<Collection>, token_name: String, seed: String
+    ): ConstructorRef {
         create_named_token_from_seed(
             creator,
             collection,
@@ -1109,7 +1246,9 @@ module aptos_token_objects::token {
     }
 
     #[test_only]
-    fun create_numbered_token_helper(creator: &signer, collection: Object<Collection>, token_prefix: String): ConstructorRef {
+    fun create_numbered_token_helper(
+        creator: &signer, collection: Object<Collection>, token_prefix: String
+    ): ConstructorRef {
         create_numbered_token_object(
             creator,
             collection,
@@ -1133,7 +1272,8 @@ module aptos_token_objects::token {
 
     #[test_only]
     fun get_collection_from_ref(extend_ref: &ExtendRef): Object<Collection> {
-        let collection_address = signer::address_of(&object::generate_signer_for_extending(extend_ref));
+        let collection_address =
+            signer::address_of(&object::generate_signer_for_extending(extend_ref));
         object::address_to_object<Collection>(collection_address)
     }
 }

--- a/aptos-move/framework/aptos-token-objects/sources/token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/token.move
@@ -164,7 +164,8 @@ module aptos_token_objects::token {
             // Be conservative, as we don't know what length the index will be, and assume worst case (20 chars in MAX_U64)
             assert!(
                 string::length(&name_prefix) + 20
-                    + string::length(option::borrow(&name_with_index_suffix)) <= MAX_TOKEN_NAME_LENGTH,
+                    + string::length(option::borrow(&name_with_index_suffix))
+                    <= MAX_TOKEN_NAME_LENGTH,
                 error::out_of_range(ETOKEN_NAME_TOO_LONG),
             );
         } else {
@@ -873,7 +874,10 @@ module aptos_token_objects::token {
         // Calculate the token address with collection, token name and seed.
         let token_addr =
             create_token_address_with_seed(
-                creator_address, collection_name, token_name, seed
+                creator_address,
+                collection_name,
+                token_name,
+                seed,
             );
         let token = object::address_to_object<Token>(token_addr);
         assert!(object::owner(token) == creator_address, 1);

--- a/aptos-move/framework/aptos-token/sources/property_map.move
+++ b/aptos-move/framework/aptos-token/sources/property_map.move
@@ -234,9 +234,7 @@ module aptos_token::property_map {
         property.type
     }
 
-    public fun remove(
-        map: &mut PropertyMap, key: &String
-    ): (String, PropertyValue) {
+    public fun remove(map: &mut PropertyMap, key: &String): (String, PropertyValue) {
         let found = contains_key(map, key);
         assert!(found, error::not_found(EPROPERTY_NOT_EXIST));
         simple_map::remove(&mut map.map, key)
@@ -281,9 +279,7 @@ module aptos_token::property_map {
         *property_val = value;
     }
 
-    public fun create_property_value_raw(
-        value: vector<u8>, type: String
-    ): PropertyValue {
+    public fun create_property_value_raw(value: vector<u8>, type: String): PropertyValue {
         PropertyValue { value, type, }
     }
 
@@ -385,8 +381,8 @@ module aptos_token::property_map {
     fun test_read_value_with_type() {
         let keys = vector<String>[utf8(b"attack"), utf8(b"mutable")];
         let values = vector<vector<u8>>[bcs::to_bytes<u8>(&10), bcs::to_bytes<bool>(
-                &false
-            )];
+            &false
+        )];
         let types = vector<String>[utf8(b"u8"), utf8(b"bool")];
         let plist = new(keys, values, types);
         assert!(!read_bool(&plist, &utf8(b"mutable")), 1);
@@ -407,8 +403,8 @@ module aptos_token::property_map {
         let data1: address = @0xcafe;
         let data2: bool = false;
         let pvs = vector<PropertyValue>[create_property_value(&data1), create_property_value(
-                &data2
-            )];
+            &data2
+        )];
         let keys = vector<String>[string::utf8(b"addr"), string::utf8(b"flag")];
         let pm = new_with_key_and_property_value(keys, pvs);
         assert!(length(&pm) == 2, 1);

--- a/aptos-move/framework/aptos-token/sources/property_map.move
+++ b/aptos-move/framework/aptos-token/sources/property_map.move
@@ -18,7 +18,6 @@ module aptos_token::property_map {
     const MAX_PROPERTY_MAP_SIZE: u64 = 1000;
     const MAX_PROPERTY_NAME_LENGTH: u64 = 128;
 
-
     //
     // Errors.
     //
@@ -43,7 +42,6 @@ module aptos_token::property_map {
     /// The name (key) of the property is too long
     const EPROPERTY_MAP_NAME_TOO_LONG: u64 = 7;
 
-
     //
     // Structs
     //
@@ -63,20 +61,35 @@ module aptos_token::property_map {
         types: vector<String>
     ): PropertyMap {
         let length = vector::length(&keys);
-        assert!(length <= MAX_PROPERTY_MAP_SIZE, error::invalid_argument(EPROPERTY_NUMBER_EXCEED_LIMIT));
-        assert!(length == vector::length(&values), error::invalid_argument(EKEY_COUNT_NOT_MATCH_VALUE_COUNT));
-        assert!(length == vector::length(&types), error::invalid_argument(EKEY_COUNT_NOT_MATCH_TYPE_COUNT));
+        assert!(
+            length <= MAX_PROPERTY_MAP_SIZE,
+            error::invalid_argument(EPROPERTY_NUMBER_EXCEED_LIMIT),
+        );
+        assert!(
+            length == vector::length(&values),
+            error::invalid_argument(EKEY_COUNT_NOT_MATCH_VALUE_COUNT),
+        );
+        assert!(
+            length == vector::length(&types),
+            error::invalid_argument(EKEY_COUNT_NOT_MATCH_TYPE_COUNT),
+        );
 
         let properties = empty();
 
         let i = 0;
         while (i < length) {
             let key = *vector::borrow(&keys, i);
-            assert!(string::length(&key) <= MAX_PROPERTY_NAME_LENGTH, error::invalid_argument(EPROPERTY_MAP_NAME_TOO_LONG));
+            assert!(
+                string::length(&key) <= MAX_PROPERTY_NAME_LENGTH,
+                error::invalid_argument(EPROPERTY_MAP_NAME_TOO_LONG),
+            );
             simple_map::add(
                 &mut properties.map,
                 key,
-                PropertyValue { value: *vector::borrow(&values, i), type: *vector::borrow(&types, i) }
+                PropertyValue {
+                    value: *vector::borrow(&values, i),
+                    type: *vector::borrow(&types, i)
+                },
             );
             i = i + 1;
         };
@@ -85,12 +98,17 @@ module aptos_token::property_map {
 
     /// Create property map directly from key and property value
     public fun new_with_key_and_property_value(
-        keys: vector<String>,
-        values: vector<PropertyValue>
+        keys: vector<String>, values: vector<PropertyValue>
     ): PropertyMap {
         let length = vector::length(&keys);
-        assert!(length <= MAX_PROPERTY_MAP_SIZE, error::invalid_argument(EPROPERTY_NUMBER_EXCEED_LIMIT));
-        assert!(length == vector::length(&values), error::invalid_argument(EKEY_COUNT_NOT_MATCH_VALUE_COUNT));
+        assert!(
+            length <= MAX_PROPERTY_MAP_SIZE,
+            error::invalid_argument(EPROPERTY_NUMBER_EXCEED_LIMIT),
+        );
+        assert!(
+            length == vector::length(&values),
+            error::invalid_argument(EKEY_COUNT_NOT_MATCH_VALUE_COUNT),
+        );
 
         let properties = empty();
 
@@ -98,7 +116,10 @@ module aptos_token::property_map {
         while (i < length) {
             let key = *vector::borrow(&keys, i);
             let val = *vector::borrow(&values, i);
-            assert!(string::length(&key) <= MAX_PROPERTY_NAME_LENGTH, error::invalid_argument(EPROPERTY_MAP_NAME_TOO_LONG));
+            assert!(
+                string::length(&key) <= MAX_PROPERTY_NAME_LENGTH,
+                error::invalid_argument(EPROPERTY_MAP_NAME_TOO_LONG),
+            );
             add(&mut properties, key, val);
             i = i + 1;
         };
@@ -106,18 +127,24 @@ module aptos_token::property_map {
     }
 
     public fun empty(): PropertyMap {
-        PropertyMap {
-            map: simple_map::create<String, PropertyValue>(),
-        }
+        PropertyMap { map: simple_map::create<String, PropertyValue>(), }
     }
 
     public fun contains_key(map: &PropertyMap, key: &String): bool {
         simple_map::contains_key(&map.map, key)
     }
 
-    public fun add(map: &mut PropertyMap, key: String, value: PropertyValue) {
-        assert!(string::length(&key) <= MAX_PROPERTY_NAME_LENGTH, error::invalid_argument(EPROPERTY_MAP_NAME_TOO_LONG));
-        assert!(simple_map::length(&map.map) < MAX_PROPERTY_MAP_SIZE, error::invalid_state(EPROPERTY_NUMBER_EXCEED_LIMIT));
+    public fun add(
+        map: &mut PropertyMap, key: String, value: PropertyValue
+    ) {
+        assert!(
+            string::length(&key) <= MAX_PROPERTY_NAME_LENGTH,
+            error::invalid_argument(EPROPERTY_MAP_NAME_TOO_LONG),
+        );
+        assert!(
+            simple_map::length(&map.map) < MAX_PROPERTY_MAP_SIZE,
+            error::invalid_state(EPROPERTY_NUMBER_EXCEED_LIMIT),
+        );
         simple_map::add(&mut map.map, key, value);
     }
 
@@ -138,23 +165,32 @@ module aptos_token::property_map {
 
     /// Return the types of all properties in the property map in the order they are added.
     public fun types(map: &PropertyMap): vector<String> {
-        vector::map_ref(&simple_map::values(&map.map), |v| {
-            let v: &PropertyValue = v;
-            v.type
-        })
+        vector::map_ref(
+            &simple_map::values(&map.map),
+            |v| {
+                let v: &PropertyValue = v;
+                v.type
+            },
+        )
     }
 
     /// Return the values of all properties in the property map in the order they are added.
     public fun values(map: &PropertyMap): vector<vector<u8>> {
-        vector::map_ref(&simple_map::values(&map.map), |v| {
-            let v: &PropertyValue = v;
-            v.value
-        })
+        vector::map_ref(
+            &simple_map::values(&map.map),
+            |v| {
+                let v: &PropertyValue = v;
+                v.value
+            },
+        )
     }
 
     public fun read_string(map: &PropertyMap, key: &String): String {
         let prop = borrow(map, key);
-        assert!(prop.type == string::utf8(b"0x1::string::String"), error::invalid_state(ETYPE_NOT_MATCH));
+        assert!(
+            prop.type == string::utf8(b"0x1::string::String"),
+            error::invalid_state(ETYPE_NOT_MATCH),
+        );
         from_bcs::to_string(prop.value)
     }
 
@@ -172,7 +208,9 @@ module aptos_token::property_map {
 
     public fun read_address(map: &PropertyMap, key: &String): address {
         let prop = borrow(map, key);
-        assert!(prop.type == string::utf8(b"address"), error::invalid_state(ETYPE_NOT_MATCH));
+        assert!(
+            prop.type == string::utf8(b"address"), error::invalid_state(ETYPE_NOT_MATCH)
+        );
         from_bcs::to_address(prop.value)
     }
 
@@ -197,8 +235,7 @@ module aptos_token::property_map {
     }
 
     public fun remove(
-        map: &mut PropertyMap,
-        key: &String
+        map: &mut PropertyMap, key: &String
     ): (String, PropertyValue) {
         let found = contains_key(map, key);
         assert!(found, error::not_found(EPROPERTY_NOT_EXIST));
@@ -216,7 +253,9 @@ module aptos_token::property_map {
         let key_len = vector::length(&keys);
         let val_len = vector::length(&values);
         let typ_len = vector::length(&types);
-        assert!(key_len == val_len, error::invalid_state(EKEY_COUNT_NOT_MATCH_VALUE_COUNT));
+        assert!(
+            key_len == val_len, error::invalid_state(EKEY_COUNT_NOT_MATCH_VALUE_COUNT)
+        );
         assert!(key_len == typ_len, error::invalid_state(EKEY_COUNT_NOT_MATCH_TYPE_COUNT));
 
         let i = 0;
@@ -236,35 +275,27 @@ module aptos_token::property_map {
     }
 
     public fun update_property_value(
-        map: &mut PropertyMap,
-        key: &String,
-        value: PropertyValue
+        map: &mut PropertyMap, key: &String, value: PropertyValue
     ) {
         let property_val = simple_map::borrow_mut(&mut map.map, key);
         *property_val = value;
     }
 
     public fun create_property_value_raw(
-        value: vector<u8>,
-        type: String
+        value: vector<u8>, type: String
     ): PropertyValue {
-        PropertyValue {
-            value,
-            type,
-        }
+        PropertyValue { value, type, }
     }
 
     /// create a property value from generic type data
     public fun create_property_value<T: copy>(data: &T): PropertyValue {
         let name = type_name<T>();
-        if (
-            name == string::utf8(b"bool") ||
-                name == string::utf8(b"u8") ||
-                name == string::utf8(b"u64") ||
-                name == string::utf8(b"u128") ||
-                name == string::utf8(b"address") ||
-                name == string::utf8(b"0x1::string::String")
-        ) {
+        if (name == string::utf8(b"bool")
+            || name == string::utf8(b"u8")
+            || name == string::utf8(b"u64")
+            || name == string::utf8(b"u128")
+            || name == string::utf8(b"address")
+            || name == string::utf8(b"0x1::string::String")) {
             create_property_value_raw(bcs::to_bytes<T>(data), name)
         } else {
             create_property_value_raw(bcs::to_bytes<T>(data), string::utf8(b"vector<u8>"))
@@ -276,17 +307,17 @@ module aptos_token::property_map {
 
     #[test_only]
     fun test_keys(): vector<String> {
-        vector[ utf8(b"attack"), utf8(b"durability"), utf8(b"type") ]
+        vector[utf8(b"attack"), utf8(b"durability"), utf8(b"type")]
     }
 
     #[test_only]
     fun test_values(): vector<vector<u8>> {
-        vector[ b"10", b"5", b"weapon" ]
+        vector[b"10", b"5", b"weapon"]
     }
 
     #[test_only]
     fun test_types(): vector<String> {
-        vector[ utf8(b"integer"), utf8(b"integer"), utf8(b"String") ]
+        vector[utf8(b"integer"), utf8(b"integer"), utf8(b"String")]
     }
 
     #[test_only]
@@ -298,14 +329,11 @@ module aptos_token::property_map {
     fun test_add_property(): PropertyMap {
         let properties = create_property_list();
         add(
-            &mut properties, utf8(b"level"),
-            PropertyValue {
-                value: b"1",
-                type: utf8(b"integer")
-            });
-        assert!(
-            borrow(&properties, &utf8(b"level")).value == b"1",
-            EPROPERTY_NOT_EXIST);
+            &mut properties,
+            utf8(b"level"),
+            PropertyValue { value: b"1", type: utf8(b"integer") },
+        );
+        assert!(borrow(&properties, &utf8(b"level")).value == b"1", EPROPERTY_NOT_EXIST);
         properties
     }
 
@@ -327,10 +355,14 @@ module aptos_token::property_map {
     #[test]
     fun test_update_property(): PropertyMap {
         let properties = create_property_list();
-        update_property_value(&mut properties, &utf8(b"attack"), PropertyValue { value: b"7", type: utf8(b"integer") });
+        update_property_value(
+            &mut properties,
+            &utf8(b"attack"),
+            PropertyValue { value: b"7", type: utf8(b"integer") },
+        );
         assert!(
             borrow(&properties, &utf8(b"attack")).value == b"7",
-            1
+            1,
         );
         properties
     }
@@ -346,17 +378,16 @@ module aptos_token::property_map {
 
     #[test_only]
     public fun test_create_property_value(type: String, value: vector<u8>): PropertyValue {
-        PropertyValue {
-            type,
-            value
-        }
+        PropertyValue { type, value }
     }
 
     #[test]
     fun test_read_value_with_type() {
-        let keys = vector<String>[ utf8(b"attack"), utf8(b"mutable")];
-        let values = vector<vector<u8>>[ bcs::to_bytes<u8>(&10), bcs::to_bytes<bool>(&false) ];
-        let types = vector<String>[ utf8(b"u8"), utf8(b"bool")];
+        let keys = vector<String>[utf8(b"attack"), utf8(b"mutable")];
+        let values = vector<vector<u8>>[bcs::to_bytes<u8>(&10), bcs::to_bytes<bool>(
+                &false
+            )];
+        let types = vector<String>[utf8(b"u8"), utf8(b"bool")];
         let plist = new(keys, values, types);
         assert!(!read_bool(&plist, &utf8(b"mutable")), 1);
         assert!(read_u8(&plist, &utf8(b"attack")) == 10, 1);
@@ -375,7 +406,9 @@ module aptos_token::property_map {
     fun test_create_property_map_from_key_value_pairs() {
         let data1: address = @0xcafe;
         let data2: bool = false;
-        let pvs = vector<PropertyValue>[create_property_value(&data1), create_property_value(&data2)];
+        let pvs = vector<PropertyValue>[create_property_value(&data1), create_property_value(
+                &data2
+            )];
         let keys = vector<String>[string::utf8(b"addr"), string::utf8(b"flag")];
         let pm = new_with_key_and_property_value(keys, pvs);
         assert!(length(&pm) == 2, 1);

--- a/aptos-move/framework/aptos-token/sources/property_map.spec.move
+++ b/aptos-move/framework/aptos-token/sources/property_map.spec.move
@@ -4,14 +4,10 @@ spec aptos_token::property_map {
         pragma aborts_if_is_strict;
 
         let MAX_PROPERTY_MAP_SIZE = 1000;
-        let MAX_PROPERTY_NAME_LENGTH  = 128;
+        let MAX_PROPERTY_NAME_LENGTH = 128;
     }
 
-    spec new (
-        keys: vector<String>,
-        values: vector<vector<u8>>,
-        types: vector<String>
-    ): PropertyMap {
+    spec new(keys: vector<String>, values: vector<vector<u8>>, types: vector<String>): PropertyMap {
         // TODO: Can't handle abort in loop.
         pragma aborts_if_is_partial;
         let length = len(keys);
@@ -21,10 +17,7 @@ spec aptos_token::property_map {
         aborts_if !(length == vector::length(types));
     }
 
-    spec new_with_key_and_property_value (
-        keys: vector<String>,
-        values: vector<PropertyValue>
-    ): PropertyMap {
+    spec new_with_key_and_property_value(keys: vector<String>, values: vector<PropertyValue>): PropertyMap {
         // TODO: Can't handle abort in loop.
         pragma aborts_if_is_partial;
         let length = vector::length(keys);
@@ -85,7 +78,7 @@ spec aptos_token::property_map {
     }
 
     spec fun spec_utf8(bytes: vector<u8>): String {
-        String{bytes}
+        String { bytes }
     }
 
     spec read_u8(map: &PropertyMap, key: &String): u8 {
@@ -156,14 +149,11 @@ spec aptos_token::property_map {
         aborts_if false;
     }
 
-    spec remove (
-        map: &mut PropertyMap,
-        key: &String
-    ): (String, PropertyValue) {
+    spec remove(map: &mut PropertyMap, key: &String): (String, PropertyValue) {
         aborts_if !simple_map::spec_contains_key(map.map, key);
     }
 
-    spec update_property_map (
+    spec update_property_map(
         map: &mut PropertyMap,
         keys: vector<String>,
         values: vector<vector<u8>>,
@@ -178,18 +168,11 @@ spec aptos_token::property_map {
         aborts_if !(key_len == typ_len);
     }
 
-    spec update_property_value (
-        map: &mut PropertyMap,
-        key: &String,
-        value: PropertyValue
-    ) {
+    spec update_property_value(map: &mut PropertyMap, key: &String, value: PropertyValue) {
         aborts_if !simple_map::spec_contains_key(map.map, key);
     }
 
-    spec create_property_value_raw (
-        value: vector<u8>,
-        type: String
-    ): PropertyValue {
+    spec create_property_value_raw(value: vector<u8>, type: String): PropertyValue {
         aborts_if false;
     }
 
@@ -200,37 +183,36 @@ spec aptos_token::property_map {
         let name = type_name<T>();
         aborts_if !string::spec_internal_check_utf8(b"bool");
 
-        aborts_if name != spec_utf8(b"bool") &&
-            !string::spec_internal_check_utf8(b"u8");
+        aborts_if name != spec_utf8(b"bool") && !string::spec_internal_check_utf8(b"u8");
 
-        aborts_if name != spec_utf8(b"bool") &&
-            name != spec_utf8(b"u8") &&
-            !string::spec_internal_check_utf8(b"u64");
+        aborts_if name != spec_utf8(b"bool")
+            && name != spec_utf8(b"u8")
+            && !string::spec_internal_check_utf8(b"u64");
 
-        aborts_if name != spec_utf8(b"bool") &&
-            name != spec_utf8(b"u8") &&
-            name != spec_utf8(b"u64") &&
-            !string::spec_internal_check_utf8(b"u128");
+        aborts_if name != spec_utf8(b"bool")
+            && name != spec_utf8(b"u8")
+            && name != spec_utf8(b"u64")
+            && !string::spec_internal_check_utf8(b"u128");
 
-        aborts_if name != spec_utf8(b"bool") &&
-            name != spec_utf8(b"u8") &&
-            name != spec_utf8(b"u64") &&
-            name != spec_utf8(b"u128") &&
-            !string::spec_internal_check_utf8(b"address");
+        aborts_if name != spec_utf8(b"bool")
+            && name != spec_utf8(b"u8")
+            && name != spec_utf8(b"u64")
+            && name != spec_utf8(b"u128")
+            && !string::spec_internal_check_utf8(b"address");
 
-        aborts_if name != spec_utf8(b"bool") &&
-            name != spec_utf8(b"u8") &&
-            name != spec_utf8(b"u64") &&
-            name != spec_utf8(b"u128") &&
-            name != spec_utf8(b"address") &&
-            !string::spec_internal_check_utf8(b"0x1::string::String");
+        aborts_if name != spec_utf8(b"bool")
+            && name != spec_utf8(b"u8")
+            && name != spec_utf8(b"u64")
+            && name != spec_utf8(b"u128")
+            && name != spec_utf8(b"address")
+            && !string::spec_internal_check_utf8(b"0x1::string::String");
 
-        aborts_if name != spec_utf8(b"bool") &&
-            name != spec_utf8(b"u8") &&
-            name != spec_utf8(b"u64") &&
-            name != spec_utf8(b"u128") &&
-            name != spec_utf8(b"address") &&
-            name != spec_utf8(b"0x1::string::String") &&
-            !string::spec_internal_check_utf8(b"vector<u8>");
+        aborts_if name != spec_utf8(b"bool")
+            && name != spec_utf8(b"u8")
+            && name != spec_utf8(b"u64")
+            && name != spec_utf8(b"u128")
+            && name != spec_utf8(b"address")
+            && name != spec_utf8(b"0x1::string::String")
+            && !string::spec_internal_check_utf8(b"vector<u8>");
     }
 }

--- a/aptos-move/framework/aptos-token/sources/token.move
+++ b/aptos-move/framework/aptos-token/sources/token.move
@@ -142,7 +142,6 @@ module aptos_token::token {
     /// Token Properties count doesn't match
     const ETOKEN_PROPERTIES_COUNT_NOT_MATCH: u64 = 37;
 
-
     /// Withdraw capability doesn't have sufficient amount
     const EINSUFFICIENT_WITHDRAW_CAPABILITY_AMOUNT: u64 = 38;
 
@@ -420,7 +419,7 @@ module aptos_token::token {
             description,
             uri,
             maximum,
-            mutate_setting
+            mutate_setting,
         );
     }
 
@@ -442,26 +441,25 @@ module aptos_token::token {
         property_types: vector<String>
     ) acquires Collections, TokenStore {
         let token_mut_config = create_token_mutability_config(&mutate_setting);
-        let tokendata_id = create_tokendata(
-            account,
-            collection,
-            name,
-            description,
-            maximum,
-            uri,
-            royalty_payee_address,
-            royalty_points_denominator,
-            royalty_points_numerator,
-            token_mut_config,
-            property_keys,
-            property_values,
-            property_types
-        );
+        let tokendata_id =
+            create_tokendata(
+                account,
+                collection,
+                name,
+                description,
+                maximum,
+                uri,
+                royalty_payee_address,
+                royalty_points_denominator,
+                royalty_points_numerator,
+                token_mut_config,
+                property_keys,
+                property_values,
+                property_types,
+            );
 
         mint_token(
-            account,
-            tokendata_id,
-            balance,
+            account, tokendata_id, balance
         );
     }
 
@@ -479,11 +477,12 @@ module aptos_token::token {
             name,
         );
         // only creator of the tokendata can mint more tokens for now
-        assert!(token_data_id.creator == signer::address_of(account), error::permission_denied(ENO_MINT_CAPABILITY));
+        assert!(
+            token_data_id.creator == signer::address_of(account),
+            error::permission_denied(ENO_MINT_CAPABILITY),
+        );
         mint_token(
-            account,
-            token_data_id,
-            amount,
+            account, token_data_id, amount
         );
     }
 
@@ -502,14 +501,19 @@ module aptos_token::token {
         values: vector<vector<u8>>,
         types: vector<String>,
     ) acquires Collections, TokenStore {
-        assert!(signer::address_of(account) == creator, error::not_found(ENO_MUTATE_CAPABILITY));
-        let i = 0;
-        let token_id = create_token_id_raw(
-            creator,
-            collection_name,
-            token_name,
-            token_property_version,
+        assert!(
+            signer::address_of(account) == creator, error::not_found(
+                ENO_MUTATE_CAPABILITY
+            )
         );
+        let i = 0;
+        let token_id =
+            create_token_id_raw(
+                creator,
+                collection_name,
+                token_name,
+                token_property_version,
+            );
         // give a new property_version for each token
         while (i < amount) {
             mutate_one_token(account, token_owner, token_id, keys, values, types);
@@ -530,7 +534,8 @@ module aptos_token::token {
         property_version: u64,
         amount: u64,
     ) acquires TokenStore {
-        let token_id = create_token_id_raw(creators_address, collection, name, property_version);
+        let token_id =
+            create_token_id_raw(creators_address, collection, name, property_version);
         direct_transfer(sender, receiver, token_id, amount);
     }
 
@@ -553,7 +558,10 @@ module aptos_token::token {
         to: address,
         amount: u64,
     ) acquires TokenStore {
-        let token_id = create_token_id_raw(creator, collection_name, token_name, token_property_version);
+        let token_id =
+            create_token_id_raw(
+                creator, collection_name, token_name, token_property_version
+            );
         transfer(from, token_id, to, amount);
     }
 
@@ -569,7 +577,8 @@ module aptos_token::token {
     ) acquires Collections, TokenStore {
         let creator_address = signer::address_of(creator);
         assert!(amount > 0, error::invalid_argument(ENO_BURN_TOKEN_WITH_ZERO_AMOUNT));
-        let token_id = create_token_id_raw(creator_address, collection, name, property_version);
+        let token_id =
+            create_token_id_raw(creator_address, collection, name, property_version);
         let creator_addr = token_id.token_data_id.creator;
         assert!(
             exists<Collections>(creator_addr),
@@ -582,29 +591,38 @@ module aptos_token::token {
             error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
         );
 
-        let token_data = table::borrow_mut(
-            &mut collections.token_data,
-            token_id.token_data_id,
-        );
+        let token_data =
+            table::borrow_mut(
+                &mut collections.token_data,
+                token_id.token_data_id,
+            );
 
         // The property should be explicitly set in the property_map for creator to burn the token
         assert!(
-            property_map::contains_key(&token_data.default_properties, &string::utf8(BURNABLE_BY_CREATOR)),
-            error::permission_denied(ECREATOR_CANNOT_BURN_TOKEN)
+            property_map::contains_key(
+                &token_data.default_properties, &string::utf8(BURNABLE_BY_CREATOR)
+            ),
+            error::permission_denied(ECREATOR_CANNOT_BURN_TOKEN),
         );
 
-        let burn_by_creator_flag = property_map::read_bool(&token_data.default_properties, &string::utf8(BURNABLE_BY_CREATOR));
-        assert!(burn_by_creator_flag, error::permission_denied(ECREATOR_CANNOT_BURN_TOKEN));
+        let burn_by_creator_flag =
+            property_map::read_bool(
+                &token_data.default_properties, &string::utf8(BURNABLE_BY_CREATOR)
+            );
+        assert!(
+            burn_by_creator_flag, error::permission_denied(ECREATOR_CANNOT_BURN_TOKEN)
+        );
 
         // Burn the tokens.
-        let Token { id: _, amount: burned_amount, token_properties: _ } = withdraw_with_event_internal(owner, token_id, amount);
+        let Token { id: _, amount: burned_amount, token_properties: _ } =
+            withdraw_with_event_internal(owner, token_id, amount);
         let token_store = borrow_global_mut<TokenStore>(owner);
         if (std::features::module_event_migration_enabled()) {
             event::emit(BurnToken { id: token_id, amount: burned_amount });
         };
         event::emit_event<BurnTokenEvent>(
             &mut token_store.burn_events,
-            BurnTokenEvent { id: token_id, amount: burned_amount }
+            BurnTokenEvent { id: token_id, amount: burned_amount },
         );
 
         if (token_data.maximum > 0) {
@@ -612,18 +630,25 @@ module aptos_token::token {
 
             // Delete the token_data if supply drops to 0.
             if (token_data.supply == 0) {
-                destroy_token_data(table::remove(&mut collections.token_data, token_id.token_data_id));
+                destroy_token_data(
+                    table::remove(&mut collections.token_data, token_id.token_data_id)
+                );
 
                 // update the collection supply
-                let collection_data = table::borrow_mut(
-                    &mut collections.collection_data,
-                    token_id.token_data_id.collection
-                );
+                let collection_data =
+                    table::borrow_mut(
+                        &mut collections.collection_data,
+                        token_id.token_data_id.collection,
+                    );
                 if (collection_data.maximum > 0) {
                     collection_data.supply = collection_data.supply - 1;
                     // delete the collection data if the collection supply equals 0
                     if (collection_data.supply == 0) {
-                        destroy_collection_data(table::remove(&mut collections.collection_data, collection_data.name));
+                        destroy_collection_data(
+                            table::remove(
+                                &mut collections.collection_data, collection_data.name
+                            ),
+                        );
                     };
                 };
             };
@@ -640,7 +665,8 @@ module aptos_token::token {
         amount: u64
     ) acquires Collections, TokenStore {
         assert!(amount > 0, error::invalid_argument(ENO_BURN_TOKEN_WITH_ZERO_AMOUNT));
-        let token_id = create_token_id_raw(creators_address, collection, name, property_version);
+        let token_id =
+            create_token_id_raw(creators_address, collection, name, property_version);
         let creator_addr = token_id.token_data_id.creator;
         assert!(
             exists<Collections>(creator_addr),
@@ -653,34 +679,42 @@ module aptos_token::token {
             error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
         );
 
-        let token_data = table::borrow_mut(
-            &mut collections.token_data,
-            token_id.token_data_id,
-        );
+        let token_data =
+            table::borrow_mut(
+                &mut collections.token_data,
+                token_id.token_data_id,
+            );
 
         assert!(
-            property_map::contains_key(&token_data.default_properties, &string::utf8(BURNABLE_BY_OWNER)),
-            error::permission_denied(EOWNER_CANNOT_BURN_TOKEN)
+            property_map::contains_key(
+                &token_data.default_properties, &string::utf8(BURNABLE_BY_OWNER)
+            ),
+            error::permission_denied(EOWNER_CANNOT_BURN_TOKEN),
         );
-        let burn_by_owner_flag = property_map::read_bool(&token_data.default_properties, &string::utf8(BURNABLE_BY_OWNER));
+        let burn_by_owner_flag =
+            property_map::read_bool(
+                &token_data.default_properties, &string::utf8(BURNABLE_BY_OWNER)
+            );
         assert!(burn_by_owner_flag, error::permission_denied(EOWNER_CANNOT_BURN_TOKEN));
 
         // Burn the tokens.
-        let Token { id: _, amount: burned_amount, token_properties: _ } = withdraw_token(owner, token_id, amount);
+        let Token { id: _, amount: burned_amount, token_properties: _ } =
+            withdraw_token(owner, token_id, amount);
         let token_store = borrow_global_mut<TokenStore>(signer::address_of(owner));
         if (std::features::module_event_migration_enabled()) {
             event::emit(BurnToken { id: token_id, amount: burned_amount });
         };
         event::emit_event<BurnTokenEvent>(
             &mut token_store.burn_events,
-            BurnTokenEvent { id: token_id, amount: burned_amount }
+            BurnTokenEvent { id: token_id, amount: burned_amount },
         );
 
         // Decrease the supply correspondingly by the amount of tokens burned.
-        let token_data = table::borrow_mut(
-            &mut collections.token_data,
-            token_id.token_data_id,
-        );
+        let token_data =
+            table::borrow_mut(
+                &mut collections.token_data,
+                token_id.token_data_id,
+            );
 
         // only update the supply if we tracking the supply and maximal
         // maximal == 0 is reserved for unlimited token and collection with no tracking info.
@@ -689,20 +723,27 @@ module aptos_token::token {
 
             // Delete the token_data if supply drops to 0.
             if (token_data.supply == 0) {
-                destroy_token_data(table::remove(&mut collections.token_data, token_id.token_data_id));
-
-                // update the collection supply
-                let collection_data = table::borrow_mut(
-                    &mut collections.collection_data,
-                    token_id.token_data_id.collection
+                destroy_token_data(
+                    table::remove(&mut collections.token_data, token_id.token_data_id)
                 );
 
+                // update the collection supply
+                let collection_data =
+                    table::borrow_mut(
+                        &mut collections.collection_data,
+                        token_id.token_data_id.collection,
+                    );
+
                 // only update and check the supply for unlimited collection
-                if (collection_data.maximum > 0){
+                if (collection_data.maximum > 0) {
                     collection_data.supply = collection_data.supply - 1;
                     // delete the collection data if the collection supply equals 0
                     if (collection_data.supply == 0) {
-                        destroy_collection_data(table::remove(&mut collections.collection_data, collection_data.name));
+                        destroy_collection_data(
+                            table::remove(
+                                &mut collections.collection_data, collection_data.name
+                            ),
+                        );
                     };
                 };
             };
@@ -714,71 +755,141 @@ module aptos_token::token {
     //
 
     // Functions for mutating CollectionData fields
-    public fun mutate_collection_description(creator: &signer, collection_name: String, description: String) acquires Collections {
+    public fun mutate_collection_description(
+        creator: &signer, collection_name: String, description: String
+    ) acquires Collections {
         let creator_address = signer::address_of(creator);
         assert_collection_exists(creator_address, collection_name);
-        let collection_data = table::borrow_mut(&mut borrow_global_mut<Collections>(creator_address).collection_data, collection_name);
-        assert!(collection_data.mutability_config.description, error::permission_denied(EFIELD_NOT_MUTABLE));
-        token_event_store::emit_collection_description_mutate_event(creator, collection_name, collection_data.description, description);
+        let collection_data =
+            table::borrow_mut(
+                &mut borrow_global_mut<Collections>(creator_address).collection_data,
+                collection_name,
+            );
+        assert!(
+            collection_data.mutability_config.description,
+            error::permission_denied(EFIELD_NOT_MUTABLE),
+        );
+        token_event_store::emit_collection_description_mutate_event(
+            creator, collection_name, collection_data.description, description
+        );
         collection_data.description = description;
     }
 
-    public fun mutate_collection_uri(creator: &signer, collection_name: String, uri: String) acquires Collections {
-        assert!(string::length(&uri) <= MAX_URI_LENGTH, error::invalid_argument(EURI_TOO_LONG));
+    public fun mutate_collection_uri(
+        creator: &signer, collection_name: String, uri: String
+    ) acquires Collections {
+        assert!(
+            string::length(&uri) <= MAX_URI_LENGTH, error::invalid_argument(EURI_TOO_LONG)
+        );
         let creator_address = signer::address_of(creator);
         assert_collection_exists(creator_address, collection_name);
-        let collection_data = table::borrow_mut(&mut borrow_global_mut<Collections>(creator_address).collection_data, collection_name);
-        assert!(collection_data.mutability_config.uri, error::permission_denied(EFIELD_NOT_MUTABLE));
-        token_event_store::emit_collection_uri_mutate_event(creator, collection_name, collection_data.uri , uri);
+        let collection_data =
+            table::borrow_mut(
+                &mut borrow_global_mut<Collections>(creator_address).collection_data,
+                collection_name,
+            );
+        assert!(
+            collection_data.mutability_config.uri,
+            error::permission_denied(EFIELD_NOT_MUTABLE),
+        );
+        token_event_store::emit_collection_uri_mutate_event(
+            creator, collection_name, collection_data.uri, uri
+        );
         collection_data.uri = uri;
     }
 
-    public fun mutate_collection_maximum(creator: &signer, collection_name: String, maximum: u64) acquires Collections {
+    public fun mutate_collection_maximum(
+        creator: &signer, collection_name: String, maximum: u64
+    ) acquires Collections {
         let creator_address = signer::address_of(creator);
         assert_collection_exists(creator_address, collection_name);
-        let collection_data = table::borrow_mut(&mut borrow_global_mut<Collections>(creator_address).collection_data, collection_name);
+        let collection_data =
+            table::borrow_mut(
+                &mut borrow_global_mut<Collections>(creator_address).collection_data,
+                collection_name,
+            );
         // cannot change maximum from 0 and cannot change maximum to 0
-        assert!(collection_data.maximum != 0 && maximum != 0, error::invalid_argument(EINVALID_MAXIMUM));
-        assert!(maximum >= collection_data.supply, error::invalid_argument(EINVALID_MAXIMUM));
-        assert!(collection_data.mutability_config.maximum, error::permission_denied(EFIELD_NOT_MUTABLE));
-        token_event_store::emit_collection_maximum_mutate_event(creator, collection_name, collection_data.maximum, maximum);
+        assert!(
+            collection_data.maximum != 0 && maximum != 0,
+            error::invalid_argument(EINVALID_MAXIMUM),
+        );
+        assert!(
+            maximum >= collection_data.supply, error::invalid_argument(EINVALID_MAXIMUM)
+        );
+        assert!(
+            collection_data.mutability_config.maximum,
+            error::permission_denied(EFIELD_NOT_MUTABLE),
+        );
+        token_event_store::emit_collection_maximum_mutate_event(
+            creator, collection_name, collection_data.maximum, maximum
+        );
         collection_data.maximum = maximum;
     }
 
     // Functions for mutating TokenData fields
-    public fun mutate_tokendata_maximum(creator: &signer, token_data_id: TokenDataId, maximum: u64) acquires Collections {
+    public fun mutate_tokendata_maximum(
+        creator: &signer, token_data_id: TokenDataId, maximum: u64
+    ) acquires Collections {
         assert_tokendata_exists(creator, token_data_id);
-        let all_token_data = &mut borrow_global_mut<Collections>(token_data_id.creator).token_data;
+        let all_token_data =
+            &mut borrow_global_mut<Collections>(token_data_id.creator).token_data;
         let token_data = table::borrow_mut(all_token_data, token_data_id);
         // cannot change maximum from 0 and cannot change maximum to 0
-        assert!(token_data.maximum != 0 && maximum != 0, error::invalid_argument(EINVALID_MAXIMUM));
+        assert!(
+            token_data.maximum != 0 && maximum != 0,
+            error::invalid_argument(EINVALID_MAXIMUM),
+        );
         assert!(maximum >= token_data.supply, error::invalid_argument(EINVALID_MAXIMUM));
-        assert!(token_data.mutability_config.maximum, error::permission_denied(EFIELD_NOT_MUTABLE));
-        token_event_store::emit_token_maximum_mutate_event(creator, token_data_id.collection, token_data_id.name, token_data.maximum, maximum);
+        assert!(
+            token_data.mutability_config.maximum,
+            error::permission_denied(EFIELD_NOT_MUTABLE),
+        );
+        token_event_store::emit_token_maximum_mutate_event(
+            creator,
+            token_data_id.collection,
+            token_data_id.name,
+            token_data.maximum,
+            maximum,
+        );
         token_data.maximum = maximum;
     }
 
     public fun mutate_tokendata_uri(
-        creator: &signer,
-        token_data_id: TokenDataId,
-        uri: String
+        creator: &signer, token_data_id: TokenDataId, uri: String
     ) acquires Collections {
-        assert!(string::length(&uri) <= MAX_URI_LENGTH, error::invalid_argument(EURI_TOO_LONG));
+        assert!(
+            string::length(&uri) <= MAX_URI_LENGTH, error::invalid_argument(EURI_TOO_LONG)
+        );
         assert_tokendata_exists(creator, token_data_id);
 
-        let all_token_data = &mut borrow_global_mut<Collections>(token_data_id.creator).token_data;
+        let all_token_data =
+            &mut borrow_global_mut<Collections>(token_data_id.creator).token_data;
         let token_data = table::borrow_mut(all_token_data, token_data_id);
-        assert!(token_data.mutability_config.uri, error::permission_denied(EFIELD_NOT_MUTABLE));
-        token_event_store::emit_token_uri_mutate_event(creator, token_data_id.collection, token_data_id.name, token_data.uri ,uri);
+        assert!(
+            token_data.mutability_config.uri, error::permission_denied(EFIELD_NOT_MUTABLE)
+        );
+        token_event_store::emit_token_uri_mutate_event(
+            creator,
+            token_data_id.collection,
+            token_data_id.name,
+            token_data.uri,
+            uri,
+        );
         token_data.uri = uri;
     }
 
-    public fun mutate_tokendata_royalty(creator: &signer, token_data_id: TokenDataId, royalty: Royalty) acquires Collections {
+    public fun mutate_tokendata_royalty(
+        creator: &signer, token_data_id: TokenDataId, royalty: Royalty
+    ) acquires Collections {
         assert_tokendata_exists(creator, token_data_id);
 
-        let all_token_data = &mut borrow_global_mut<Collections>(token_data_id.creator).token_data;
+        let all_token_data =
+            &mut borrow_global_mut<Collections>(token_data_id.creator).token_data;
         let token_data = table::borrow_mut(all_token_data, token_data_id);
-        assert!(token_data.mutability_config.royalty, error::permission_denied(EFIELD_NOT_MUTABLE));
+        assert!(
+            token_data.mutability_config.royalty,
+            error::permission_denied(EFIELD_NOT_MUTABLE),
+        );
 
         token_event_store::emit_token_royalty_mutate_event(
             creator,
@@ -789,18 +900,30 @@ module aptos_token::token {
             token_data.royalty.payee_address,
             royalty.royalty_points_numerator,
             royalty.royalty_points_denominator,
-            royalty.payee_address
+            royalty.payee_address,
         );
         token_data.royalty = royalty;
     }
 
-    public fun mutate_tokendata_description(creator: &signer, token_data_id: TokenDataId, description: String) acquires Collections {
+    public fun mutate_tokendata_description(
+        creator: &signer, token_data_id: TokenDataId, description: String
+    ) acquires Collections {
         assert_tokendata_exists(creator, token_data_id);
 
-        let all_token_data = &mut borrow_global_mut<Collections>(token_data_id.creator).token_data;
+        let all_token_data =
+            &mut borrow_global_mut<Collections>(token_data_id.creator).token_data;
         let token_data = table::borrow_mut(all_token_data, token_data_id);
-        assert!(token_data.mutability_config.description, error::permission_denied(EFIELD_NOT_MUTABLE));
-        token_event_store::emit_token_descrition_mutate_event(creator, token_data_id.collection, token_data_id.name, token_data.description, description);
+        assert!(
+            token_data.mutability_config.description,
+            error::permission_denied(EFIELD_NOT_MUTABLE),
+        );
+        token_event_store::emit_token_descrition_mutate_event(
+            creator,
+            token_data_id.collection,
+            token_data_id.name,
+            token_data.description,
+            description,
+        );
         token_data.description = description;
     }
 
@@ -816,34 +939,57 @@ module aptos_token::token {
         let key_len = vector::length(&keys);
         let val_len = vector::length(&values);
         let typ_len = vector::length(&types);
-        assert!(key_len == val_len, error::invalid_state(ETOKEN_PROPERTIES_COUNT_NOT_MATCH));
-        assert!(key_len == typ_len, error::invalid_state(ETOKEN_PROPERTIES_COUNT_NOT_MATCH));
+        assert!(
+            key_len == val_len, error::invalid_state(ETOKEN_PROPERTIES_COUNT_NOT_MATCH)
+        );
+        assert!(
+            key_len == typ_len, error::invalid_state(ETOKEN_PROPERTIES_COUNT_NOT_MATCH)
+        );
 
-        let all_token_data = &mut borrow_global_mut<Collections>(token_data_id.creator).token_data;
+        let all_token_data =
+            &mut borrow_global_mut<Collections>(token_data_id.creator).token_data;
         let token_data = table::borrow_mut(all_token_data, token_data_id);
-        assert!(token_data.mutability_config.properties, error::permission_denied(EFIELD_NOT_MUTABLE));
+        assert!(
+            token_data.mutability_config.properties,
+            error::permission_denied(EFIELD_NOT_MUTABLE),
+        );
         let i: u64 = 0;
         let old_values: vector<Option<PropertyValue>> = vector::empty();
         let new_values: vector<PropertyValue> = vector::empty();
         assert_non_standard_reserved_property(&keys);
-        while (i < vector::length(&keys)){
+        while (i < vector::length(&keys)) {
             let key = vector::borrow(&keys, i);
-            let old_pv = if (property_map::contains_key(&token_data.default_properties, key)) {
-                option::some(*property_map::borrow(&token_data.default_properties, key))
-            } else {
-                option::none<PropertyValue>()
-            };
+            let old_pv =
+                if (property_map::contains_key(&token_data.default_properties, key)) {
+                    option::some(
+                        *property_map::borrow(&token_data.default_properties, key)
+                    )
+                } else {
+                    option::none<PropertyValue>()
+                };
             vector::push_back(&mut old_values, old_pv);
-            let new_pv = property_map::create_property_value_raw(*vector::borrow(&values, i), *vector::borrow(&types, i));
+            let new_pv =
+                property_map::create_property_value_raw(
+                    *vector::borrow(&values, i), *vector::borrow(&types, i)
+                );
             vector::push_back(&mut new_values, new_pv);
             if (option::is_some(&old_pv)) {
-                property_map::update_property_value(&mut token_data.default_properties, key, new_pv);
+                property_map::update_property_value(
+                    &mut token_data.default_properties, key, new_pv
+                );
             } else {
                 property_map::add(&mut token_data.default_properties, *key, new_pv);
             };
             i = i + 1;
         };
-        token_event_store::emit_default_property_mutate_event(creator, token_data_id.collection, token_data_id.name, keys, old_values, new_values);
+        token_event_store::emit_default_property_mutate_event(
+            creator,
+            token_data_id.collection,
+            token_data_id.name,
+            keys,
+            old_values,
+            new_values,
+        );
     }
 
     /// Mutate the token_properties of one token.
@@ -856,25 +1002,36 @@ module aptos_token::token {
         types: vector<String>,
     ): TokenId acquires Collections, TokenStore {
         let creator = token_id.token_data_id.creator;
-        assert!(signer::address_of(account) == creator, error::permission_denied(ENO_MUTATE_CAPABILITY));
+        assert!(
+            signer::address_of(account) == creator,
+            error::permission_denied(ENO_MUTATE_CAPABILITY),
+        );
         // validate if the properties is mutable
-        assert!(exists<Collections>(creator), error::not_found(ECOLLECTIONS_NOT_PUBLISHED));
-        let all_token_data = &mut borrow_global_mut<Collections>(
-            creator
-        ).token_data;
+        assert!(
+            exists<Collections>(creator), error::not_found(ECOLLECTIONS_NOT_PUBLISHED)
+        );
+        let all_token_data = &mut borrow_global_mut<Collections>(creator).token_data;
 
-        assert!(table::contains(all_token_data, token_id.token_data_id), error::not_found(ETOKEN_DATA_NOT_PUBLISHED));
+        assert!(
+            table::contains(all_token_data, token_id.token_data_id),
+            error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
+        );
         let token_data = table::borrow_mut(all_token_data, token_id.token_data_id);
 
         // if default property is mutatable, token property is alwasy mutable
         // we only need to check TOKEN_PROPERTY_MUTABLE when default property is immutable
         if (!token_data.mutability_config.properties) {
             assert!(
-                property_map::contains_key(&token_data.default_properties, &string::utf8(TOKEN_PROPERTY_MUTABLE)),
-                error::permission_denied(EFIELD_NOT_MUTABLE)
+                property_map::contains_key(
+                    &token_data.default_properties, &string::utf8(TOKEN_PROPERTY_MUTABLE)
+                ),
+                error::permission_denied(EFIELD_NOT_MUTABLE),
             );
 
-            let token_prop_mutable = property_map::read_bool(&token_data.default_properties, &string::utf8(TOKEN_PROPERTY_MUTABLE));
+            let token_prop_mutable =
+                property_map::read_bool(
+                    &token_data.default_properties, &string::utf8(TOKEN_PROPERTY_MUTABLE)
+                );
             assert!(token_prop_mutable, error::permission_denied(EFIELD_NOT_MUTABLE));
         };
 
@@ -883,7 +1040,8 @@ module aptos_token::token {
             let token = withdraw_with_event_internal(token_owner, token_id, 1);
             // give a new property_version for each token
             let cur_property_version = token_data.largest_property_version + 1;
-            let new_token_id = create_token_id(token_id.token_data_id, cur_property_version);
+            let new_token_id =
+                create_token_id(token_id.token_data_id, cur_property_version);
             let new_token = Token {
                 id: new_token_id,
                 amount: 1,
@@ -892,13 +1050,15 @@ module aptos_token::token {
             direct_deposit(token_owner, new_token);
             update_token_property_internal(token_owner, new_token_id, keys, values, types);
             if (std::features::module_event_migration_enabled()) {
-                event::emit(MutateTokenPropertyMap {
-                    old_id: token_id,
-                    new_id: new_token_id,
-                    keys,
-                    values,
-                    types
-                });
+                event::emit(
+                    MutateTokenPropertyMap {
+                        old_id: token_id,
+                        new_id: new_token_id,
+                        keys,
+                        values,
+                        types
+                    },
+                );
             };
             event::emit_event<MutateTokenPropertyMapEvent>(
                 &mut borrow_global_mut<TokenStore>(token_owner).mutate_token_property_events,
@@ -919,13 +1079,15 @@ module aptos_token::token {
             // only 1 copy for the token with property verion bigger than 0
             update_token_property_internal(token_owner, token_id, keys, values, types);
             if (std::features::module_event_migration_enabled()) {
-                event::emit(MutateTokenPropertyMap {
-                    old_id: token_id,
-                    new_id: token_id,
-                    keys,
-                    values,
-                    types
-                });
+                event::emit(
+                    MutateTokenPropertyMap {
+                        old_id: token_id,
+                        new_id: token_id,
+                        keys,
+                        values,
+                        types
+                    },
+                );
             };
             event::emit_event<MutateTokenPropertyMapEvent>(
                 &mut borrow_global_mut<TokenStore>(token_owner).mutate_token_property_events,
@@ -941,9 +1103,19 @@ module aptos_token::token {
         }
     }
 
-    public fun create_royalty(royalty_points_numerator: u64, royalty_points_denominator: u64, payee_address: address): Royalty {
-        assert!(royalty_points_numerator <= royalty_points_denominator, error::invalid_argument(EINVALID_ROYALTY_NUMERATOR_DENOMINATOR));
-        assert!(account::exists_at(payee_address), error::invalid_argument(EROYALTY_PAYEE_ACCOUNT_DOES_NOT_EXIST));
+    public fun create_royalty(
+        royalty_points_numerator: u64,
+        royalty_points_denominator: u64,
+        payee_address: address
+    ): Royalty {
+        assert!(
+            royalty_points_numerator <= royalty_points_denominator,
+            error::invalid_argument(EINVALID_ROYALTY_NUMERATOR_DENOMINATOR),
+        );
+        assert!(
+            account::exists_at(payee_address),
+            error::invalid_argument(EROYALTY_PAYEE_ACCOUNT_DOES_NOT_EXIST),
+        );
         Royalty {
             royalty_points_numerator,
             royalty_points_denominator,
@@ -959,9 +1131,13 @@ module aptos_token::token {
     }
 
     /// direct deposit if user opt in direct transfer
-    public fun direct_deposit_with_opt_in(account_addr: address, token: Token) acquires TokenStore {
+    public fun direct_deposit_with_opt_in(
+        account_addr: address, token: Token
+    ) acquires TokenStore {
         let opt_in_transfer = borrow_global<TokenStore>(account_addr).direct_transfer;
-        assert!(opt_in_transfer, error::permission_denied(EUSER_NOT_OPT_IN_DIRECT_TRANSFER));
+        assert!(
+            opt_in_transfer, error::permission_denied(EUSER_NOT_OPT_IN_DIRECT_TRANSFER)
+        );
         direct_deposit(account_addr, token);
     }
 
@@ -985,21 +1161,30 @@ module aptos_token::token {
                     deposit_events: account::new_event_handle<DepositEvent>(account),
                     withdraw_events: account::new_event_handle<WithdrawEvent>(account),
                     burn_events: account::new_event_handle<BurnTokenEvent>(account),
-                    mutate_token_property_events: account::new_event_handle<MutateTokenPropertyMapEvent>(account),
+                    mutate_token_property_events: account::new_event_handle<
+                        MutateTokenPropertyMapEvent>(account),
                 },
             );
         }
     }
 
     public fun merge(dst_token: &mut Token, source_token: Token) {
-        assert!(&dst_token.id == &source_token.id, error::invalid_argument(EINVALID_TOKEN_MERGE));
+        assert!(
+            &dst_token.id == &source_token.id,
+            error::invalid_argument(EINVALID_TOKEN_MERGE),
+        );
         dst_token.amount = dst_token.amount + source_token.amount;
         let Token { id: _, amount: _, token_properties: _ } = source_token;
     }
 
     public fun split(dst_token: &mut Token, amount: u64): Token {
-        assert!(dst_token.id.property_version == 0, error::invalid_state(ENFT_NOT_SPLITABLE));
-        assert!(dst_token.amount > amount, error::invalid_argument(ETOKEN_SPLIT_AMOUNT_LARGER_OR_EQUAL_TO_TOKEN_AMOUNT));
+        assert!(
+            dst_token.id.property_version == 0, error::invalid_state(ENFT_NOT_SPLITABLE)
+        );
+        assert!(
+            dst_token.amount > amount,
+            error::invalid_argument(ETOKEN_SPLIT_AMOUNT_LARGER_OR_EQUAL_TO_TOKEN_AMOUNT),
+        );
         assert!(amount > 0, error::invalid_argument(ETOKEN_CANNOT_HAVE_ZERO_AMOUNT));
         dst_token.amount = dst_token.amount - amount;
         Token {
@@ -1021,11 +1206,12 @@ module aptos_token::token {
         amount: u64,
     ) acquires TokenStore {
         let opt_in_transfer = borrow_global<TokenStore>(to).direct_transfer;
-        assert!(opt_in_transfer, error::permission_denied(EUSER_NOT_OPT_IN_DIRECT_TRANSFER));
+        assert!(
+            opt_in_transfer, error::permission_denied(EUSER_NOT_OPT_IN_DIRECT_TRANSFER)
+        );
         let token = withdraw_token(from, id, amount);
         direct_deposit(to, token);
     }
-
 
     /// Token owner can create this one-time withdraw capability with an expiration time
     public fun create_withdraw_capability(
@@ -1047,7 +1233,10 @@ module aptos_token::token {
         withdraw_proof: WithdrawCapability,
     ): Token acquires TokenStore {
         // verify the delegation hasn't expired yet
-        assert!(timestamp::now_seconds() <= withdraw_proof.expiration_sec, error::invalid_argument(EWITHDRAW_PROOF_EXPIRES));
+        assert!(
+            timestamp::now_seconds() <= withdraw_proof.expiration_sec,
+            error::invalid_argument(EWITHDRAW_PROOF_EXPIRES),
+        );
 
         withdraw_with_event_internal(
             withdraw_proof.token_owner,
@@ -1058,26 +1247,32 @@ module aptos_token::token {
 
     /// Withdraw the token with a capability.
     public fun partial_withdraw_with_capability(
-        withdraw_proof: WithdrawCapability,
-        withdraw_amount: u64,
+        withdraw_proof: WithdrawCapability, withdraw_amount: u64,
     ): (Token, Option<WithdrawCapability>) acquires TokenStore {
         // verify the delegation hasn't expired yet
-        assert!(timestamp::now_seconds() <= withdraw_proof.expiration_sec, error::invalid_argument(EWITHDRAW_PROOF_EXPIRES));
+        assert!(
+            timestamp::now_seconds() <= withdraw_proof.expiration_sec,
+            error::invalid_argument(EWITHDRAW_PROOF_EXPIRES),
+        );
 
-        assert!(withdraw_amount <= withdraw_proof.amount, error::invalid_argument(EINSUFFICIENT_WITHDRAW_CAPABILITY_AMOUNT));
+        assert!(
+            withdraw_amount <= withdraw_proof.amount,
+            error::invalid_argument(EINSUFFICIENT_WITHDRAW_CAPABILITY_AMOUNT),
+        );
 
-        let res: Option<WithdrawCapability> = if (withdraw_amount == withdraw_proof.amount) {
-            option::none<WithdrawCapability>()
-        } else {
-            option::some(
-                WithdrawCapability {
-                    token_owner: withdraw_proof.token_owner,
-                    token_id: withdraw_proof.token_id,
-                    amount: withdraw_proof.amount - withdraw_amount,
-                    expiration_sec: withdraw_proof.expiration_sec,
-                }
-            )
-        };
+        let res: Option<WithdrawCapability> =
+            if (withdraw_amount == withdraw_proof.amount) {
+                option::none<WithdrawCapability>()
+            } else {
+                option::some(
+                    WithdrawCapability {
+                        token_owner: withdraw_proof.token_owner,
+                        token_id: withdraw_proof.token_id,
+                        amount: withdraw_proof.amount - withdraw_amount,
+                        expiration_sec: withdraw_proof.expiration_sec,
+                    },
+                )
+            };
 
         (
             withdraw_with_event_internal(
@@ -1108,8 +1303,13 @@ module aptos_token::token {
         maximum: u64,
         mutate_setting: vector<bool>
     ) acquires Collections {
-        assert!(string::length(&name) <= MAX_COLLECTION_NAME_LENGTH, error::invalid_argument(ECOLLECTION_NAME_TOO_LONG));
-        assert!(string::length(&uri) <= MAX_URI_LENGTH, error::invalid_argument(EURI_TOO_LONG));
+        assert!(
+            string::length(&name) <= MAX_COLLECTION_NAME_LENGTH,
+            error::invalid_argument(ECOLLECTION_NAME_TOO_LONG),
+        );
+        assert!(
+            string::length(&uri) <= MAX_URI_LENGTH, error::invalid_argument(EURI_TOO_LONG)
+        );
         let account_addr = signer::address_of(creator);
         if (!exists<Collections>(account_addr)) {
             move_to(
@@ -1117,14 +1317,17 @@ module aptos_token::token {
                 Collections {
                     collection_data: table::new(),
                     token_data: table::new(),
-                    create_collection_events: account::new_event_handle<CreateCollectionEvent>(creator),
-                    create_token_data_events: account::new_event_handle<CreateTokenDataEvent>(creator),
+                    create_collection_events: account::new_event_handle<
+                        CreateCollectionEvent>(creator),
+                    create_token_data_events: account::new_event_handle<
+                        CreateTokenDataEvent>(creator),
                     mint_token_events: account::new_event_handle<MintTokenEvent>(creator),
                 },
             )
         };
 
-        let collection_data = &mut borrow_global_mut<Collections>(account_addr).collection_data;
+        let collection_data =
+            &mut borrow_global_mut<Collections>(account_addr).collection_data;
 
         assert!(
             !table::contains(collection_data, name),
@@ -1151,7 +1354,7 @@ module aptos_token::token {
                     uri,
                     description,
                     maximum,
-                }
+                },
             );
         };
         event::emit_event<CreateCollectionEvent>(
@@ -1162,7 +1365,7 @@ module aptos_token::token {
                 uri,
                 description,
                 maximum,
-            }
+            },
         );
     }
 
@@ -1176,7 +1379,9 @@ module aptos_token::token {
         table::contains(collection_data, name)
     }
 
-    public fun check_tokendata_exists(creator: address, collection_name: String, token_name: String): bool acquires Collections {
+    public fun check_tokendata_exists(
+        creator: address, collection_name: String, token_name: String
+    ): bool acquires Collections {
         assert!(
             exists<Collections>(creator),
             error::not_found(ECOLLECTIONS_NOT_PUBLISHED),
@@ -1202,10 +1407,21 @@ module aptos_token::token {
         property_values: vector<vector<u8>>,
         property_types: vector<String>
     ): TokenDataId acquires Collections {
-        assert!(string::length(&name) <= MAX_NFT_NAME_LENGTH, error::invalid_argument(ENFT_NAME_TOO_LONG));
-        assert!(string::length(&collection) <= MAX_COLLECTION_NAME_LENGTH, error::invalid_argument(ECOLLECTION_NAME_TOO_LONG));
-        assert!(string::length(&uri) <= MAX_URI_LENGTH, error::invalid_argument(EURI_TOO_LONG));
-        assert!(royalty_points_numerator <= royalty_points_denominator, error::invalid_argument(EINVALID_ROYALTY_NUMERATOR_DENOMINATOR));
+        assert!(
+            string::length(&name) <= MAX_NFT_NAME_LENGTH,
+            error::invalid_argument(ENFT_NAME_TOO_LONG),
+        );
+        assert!(
+            string::length(&collection) <= MAX_COLLECTION_NAME_LENGTH,
+            error::invalid_argument(ECOLLECTION_NAME_TOO_LONG),
+        );
+        assert!(
+            string::length(&uri) <= MAX_URI_LENGTH, error::invalid_argument(EURI_TOO_LONG)
+        );
+        assert!(
+            royalty_points_numerator <= royalty_points_denominator,
+            error::invalid_argument(EINVALID_ROYALTY_NUMERATOR_DENOMINATOR),
+        );
 
         let account_addr = signer::address_of(account);
         assert!(
@@ -1225,7 +1441,8 @@ module aptos_token::token {
             error::already_exists(ETOKEN_DATA_ALREADY_EXISTS),
         );
 
-        let collection = table::borrow_mut(&mut collections.collection_data, token_data_id.collection);
+        let collection =
+            table::borrow_mut(&mut collections.collection_data, token_data_id.collection);
 
         // if collection maximum == 0, user don't want to enforce supply constraint.
         // we don't track supply to make token creation parallelizable
@@ -1242,10 +1459,14 @@ module aptos_token::token {
             largest_property_version: 0,
             supply: 0,
             uri,
-            royalty: create_royalty(royalty_points_numerator, royalty_points_denominator, royalty_payee_address),
+            royalty: create_royalty(
+                royalty_points_numerator, royalty_points_denominator, royalty_payee_address
+            ),
             name,
             description,
-            default_properties: property_map::new(property_keys, property_values, property_types),
+            default_properties: property_map::new(
+                property_keys, property_values, property_types
+            ),
             mutability_config: token_mutate_config,
         };
 
@@ -1265,7 +1486,7 @@ module aptos_token::token {
                     property_keys,
                     property_values,
                     property_types,
-                }
+                },
             );
         };
 
@@ -1290,9 +1511,15 @@ module aptos_token::token {
     }
 
     /// return the number of distinct token_data_id created under this collection
-    public fun get_collection_supply(creator_address: address, collection_name: String): Option<u64> acquires Collections {
+    public fun get_collection_supply(
+        creator_address: address, collection_name: String
+    ): Option<u64> acquires Collections {
         assert_collection_exists(creator_address, collection_name);
-        let collection_data = table::borrow_mut(&mut borrow_global_mut<Collections>(creator_address).collection_data, collection_name);
+        let collection_data =
+            table::borrow_mut(
+                &mut borrow_global_mut<Collections>(creator_address).collection_data,
+                collection_name,
+            );
 
         if (collection_data.maximum > 0) {
             option::some(collection_data.supply)
@@ -1301,29 +1528,55 @@ module aptos_token::token {
         }
     }
 
-    public fun get_collection_description(creator_address: address, collection_name: String): String acquires Collections {
+    public fun get_collection_description(
+        creator_address: address, collection_name: String
+    ): String acquires Collections {
         assert_collection_exists(creator_address, collection_name);
-        let collection_data = table::borrow_mut(&mut borrow_global_mut<Collections>(creator_address).collection_data, collection_name);
+        let collection_data =
+            table::borrow_mut(
+                &mut borrow_global_mut<Collections>(creator_address).collection_data,
+                collection_name,
+            );
         collection_data.description
     }
 
-    public fun get_collection_uri(creator_address: address, collection_name: String): String acquires Collections {
+    public fun get_collection_uri(
+        creator_address: address, collection_name: String
+    ): String acquires Collections {
         assert_collection_exists(creator_address, collection_name);
-        let collection_data = table::borrow_mut(&mut borrow_global_mut<Collections>(creator_address).collection_data, collection_name);
+        let collection_data =
+            table::borrow_mut(
+                &mut borrow_global_mut<Collections>(creator_address).collection_data,
+                collection_name,
+            );
         collection_data.uri
     }
 
-    public fun get_collection_maximum(creator_address: address, collection_name: String): u64 acquires Collections {
+    public fun get_collection_maximum(
+        creator_address: address, collection_name: String
+    ): u64 acquires Collections {
         assert_collection_exists(creator_address, collection_name);
-        let collection_data = table::borrow_mut(&mut borrow_global_mut<Collections>(creator_address).collection_data, collection_name);
+        let collection_data =
+            table::borrow_mut(
+                &mut borrow_global_mut<Collections>(creator_address).collection_data,
+                collection_name,
+            );
         collection_data.maximum
     }
 
     /// return the number of distinct token_id created under this TokenData
-    public fun get_token_supply(creator_address: address, token_data_id: TokenDataId): Option<u64> acquires Collections {
-        assert!(exists<Collections>(creator_address), error::not_found(ECOLLECTIONS_NOT_PUBLISHED));
+    public fun get_token_supply(
+        creator_address: address, token_data_id: TokenDataId
+    ): Option<u64> acquires Collections {
+        assert!(
+            exists<Collections>(creator_address),
+            error::not_found(ECOLLECTIONS_NOT_PUBLISHED),
+        );
         let all_token_data = &borrow_global<Collections>(creator_address).token_data;
-        assert!(table::contains(all_token_data, token_data_id), error::not_found(ETOKEN_DATA_NOT_PUBLISHED));
+        assert!(
+            table::contains(all_token_data, token_data_id),
+            error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
+        );
         let token_data = table::borrow(all_token_data, token_data_id);
 
         if (token_data.maximum > 0) {
@@ -1334,10 +1587,18 @@ module aptos_token::token {
     }
 
     /// return the largest_property_version of this TokenData
-    public fun get_tokendata_largest_property_version(creator_address: address, token_data_id: TokenDataId): u64 acquires Collections {
-        assert!(exists<Collections>(creator_address), error::not_found(ECOLLECTIONS_NOT_PUBLISHED));
+    public fun get_tokendata_largest_property_version(
+        creator_address: address, token_data_id: TokenDataId
+    ): u64 acquires Collections {
+        assert!(
+            exists<Collections>(creator_address),
+            error::not_found(ECOLLECTIONS_NOT_PUBLISHED),
+        );
         let all_token_data = &borrow_global<Collections>(creator_address).token_data;
-        assert!(table::contains(all_token_data, token_data_id), error::not_found(ETOKEN_DATA_NOT_PUBLISHED));
+        assert!(
+            table::contains(all_token_data, token_data_id),
+            error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
+        );
         table::borrow(all_token_data, token_data_id).largest_property_version
     }
 
@@ -1354,7 +1615,9 @@ module aptos_token::token {
         borrow_global<TokenStore>(receiver).direct_transfer
     }
 
-    public fun create_token_mutability_config(mutate_setting: &vector<bool>): TokenMutabilityConfig {
+    public fun create_token_mutability_config(
+        mutate_setting: &vector<bool>
+    ): TokenMutabilityConfig {
         TokenMutabilityConfig {
             maximum: *vector::borrow(mutate_setting, TOKEN_MAX_MUTABLE_IND),
             uri: *vector::borrow(mutate_setting, TOKEN_URI_MUTABLE_IND),
@@ -1364,9 +1627,13 @@ module aptos_token::token {
         }
     }
 
-    public fun create_collection_mutability_config(mutate_setting: &vector<bool>): CollectionMutabilityConfig {
+    public fun create_collection_mutability_config(
+        mutate_setting: &vector<bool>
+    ): CollectionMutabilityConfig {
         CollectionMutabilityConfig {
-            description: *vector::borrow(mutate_setting, COLLECTION_DESCRIPTION_MUTABLE_IND),
+            description: *vector::borrow(
+                mutate_setting, COLLECTION_DESCRIPTION_MUTABLE_IND
+            ),
             uri: *vector::borrow(mutate_setting, COLLECTION_URI_MUTABLE_IND),
             maximum: *vector::borrow(mutate_setting, COLLECTION_MAX_MUTABLE_IND),
         }
@@ -1377,14 +1644,23 @@ module aptos_token::token {
         token_data_id: TokenDataId,
         amount: u64,
     ): TokenId acquires Collections, TokenStore {
-        assert!(token_data_id.creator == signer::address_of(account), error::permission_denied(ENO_MINT_CAPABILITY));
+        assert!(
+            token_data_id.creator == signer::address_of(account),
+            error::permission_denied(ENO_MINT_CAPABILITY),
+        );
         let creator_addr = token_data_id.creator;
         let all_token_data = &mut borrow_global_mut<Collections>(creator_addr).token_data;
-        assert!(table::contains(all_token_data, token_data_id), error::not_found(ETOKEN_DATA_NOT_PUBLISHED));
+        assert!(
+            table::contains(all_token_data, token_data_id),
+            error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
+        );
         let token_data = table::borrow_mut(all_token_data, token_data_id);
 
         if (token_data.maximum > 0) {
-            assert!(token_data.supply + amount <= token_data.maximum, error::invalid_argument(EMINT_WOULD_EXCEED_TOKEN_MAXIMUM));
+            assert!(
+                token_data.supply + amount <= token_data.maximum,
+                error::invalid_argument(EMINT_WOULD_EXCEED_TOKEN_MAXIMUM),
+            );
             token_data.supply = token_data.supply + amount;
         };
 
@@ -1395,18 +1671,16 @@ module aptos_token::token {
         };
         event::emit_event<MintTokenEvent>(
             &mut borrow_global_mut<Collections>(creator_addr).mint_token_events,
-            MintTokenEvent {
-                id: token_data_id,
-                amount,
-            }
+            MintTokenEvent { id: token_data_id, amount, },
         );
 
-        deposit_token(account,
+        deposit_token(
+            account,
             Token {
                 id: token_id,
                 amount,
                 token_properties: property_map::empty(), // same as default properties no need to store
-            }
+            },
         );
 
         token_id
@@ -1419,18 +1693,31 @@ module aptos_token::token {
         token_data_id: TokenDataId,
         amount: u64,
     ) acquires Collections, TokenStore {
-        assert!(exists<TokenStore>(receiver), error::not_found(ETOKEN_STORE_NOT_PUBLISHED));
+        assert!(
+            exists<TokenStore>(receiver), error::not_found(ETOKEN_STORE_NOT_PUBLISHED)
+        );
         let opt_in_transfer = borrow_global<TokenStore>(receiver).direct_transfer;
-        assert!(opt_in_transfer, error::permission_denied(EUSER_NOT_OPT_IN_DIRECT_TRANSFER));
+        assert!(
+            opt_in_transfer, error::permission_denied(EUSER_NOT_OPT_IN_DIRECT_TRANSFER)
+        );
 
-        assert!(token_data_id.creator == signer::address_of(account), error::permission_denied(ENO_MINT_CAPABILITY));
+        assert!(
+            token_data_id.creator == signer::address_of(account),
+            error::permission_denied(ENO_MINT_CAPABILITY),
+        );
         let creator_addr = token_data_id.creator;
         let all_token_data = &mut borrow_global_mut<Collections>(creator_addr).token_data;
-        assert!(table::contains(all_token_data, token_data_id), error::not_found(ETOKEN_DATA_NOT_PUBLISHED));
+        assert!(
+            table::contains(all_token_data, token_data_id),
+            error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
+        );
         let token_data = table::borrow_mut(all_token_data, token_data_id);
 
         if (token_data.maximum > 0) {
-            assert!(token_data.supply + amount <= token_data.maximum, error::invalid_argument(EMINT_WOULD_EXCEED_TOKEN_MAXIMUM));
+            assert!(
+                token_data.supply + amount <= token_data.maximum,
+                error::invalid_argument(EMINT_WOULD_EXCEED_TOKEN_MAXIMUM),
+            );
             token_data.supply = token_data.supply + amount;
         };
 
@@ -1442,26 +1729,23 @@ module aptos_token::token {
         };
         event::emit_event<MintTokenEvent>(
             &mut borrow_global_mut<Collections>(creator_addr).mint_token_events,
-            MintTokenEvent {
-                id: token_data_id,
-                amount,
-            }
+            MintTokenEvent { id: token_data_id, amount, },
         );
 
-        direct_deposit(receiver,
+        direct_deposit(
+            receiver,
             Token {
                 id: token_id,
                 amount,
                 token_properties: property_map::empty(), // same as default properties no need to store
-            }
+            },
         );
     }
 
-    public fun create_token_id(token_data_id: TokenDataId, property_version: u64): TokenId {
-        TokenId {
-            token_data_id,
-            property_version,
-        }
+    public fun create_token_id(
+        token_data_id: TokenDataId, property_version: u64
+    ): TokenId {
+        TokenId { token_data_id, property_version, }
     }
 
     public fun create_token_data_id(
@@ -1469,8 +1753,14 @@ module aptos_token::token {
         collection: String,
         name: String,
     ): TokenDataId {
-        assert!(string::length(&collection) <= MAX_COLLECTION_NAME_LENGTH, error::invalid_argument(ECOLLECTION_NAME_TOO_LONG));
-        assert!(string::length(&name) <= MAX_NFT_NAME_LENGTH, error::invalid_argument(ENFT_NAME_TOO_LONG));
+        assert!(
+            string::length(&collection) <= MAX_COLLECTION_NAME_LENGTH,
+            error::invalid_argument(ECOLLECTION_NAME_TOO_LONG),
+        );
+        assert!(
+            string::length(&name) <= MAX_NFT_NAME_LENGTH,
+            error::invalid_argument(ENFT_NAME_TOO_LONG),
+        );
         TokenDataId { creator, collection, name }
     }
 
@@ -1493,9 +1783,7 @@ module aptos_token::token {
         let token_store = borrow_global<TokenStore>(owner);
         if (table::contains(&token_store.tokens, id)) {
             table::borrow(&token_store.tokens, id).amount
-        } else {
-            0
-        }
+        } else { 0 }
     }
 
     public fun has_token_store(owner: address): bool {
@@ -1534,11 +1822,7 @@ module aptos_token::token {
     }
 
     public fun get_token_data_id_fields(token_data_id: &TokenDataId): (address, String, String) {
-        (
-            token_data_id.creator,
-            token_data_id.collection,
-            token_data_id.name,
-        )
+        (token_data_id.creator, token_data_id.collection, token_data_id.name,)
     }
 
     /// return a copy of the token property map.
@@ -1550,7 +1834,10 @@ module aptos_token::token {
         if (token_id.property_version == 0) {
             let creator_addr = token_id.token_data_id.creator;
             let all_token_data = &borrow_global<Collections>(creator_addr).token_data;
-            assert!(table::contains(all_token_data, token_id.token_data_id), error::not_found(ETOKEN_DATA_NOT_PUBLISHED));
+            assert!(
+                table::contains(all_token_data, token_id.token_data_id),
+                error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
+            );
             let token_data = table::borrow(all_token_data, token_id.token_data_id);
             token_data.default_properties
         } else {
@@ -1561,18 +1848,31 @@ module aptos_token::token {
 
     public fun get_tokendata_maximum(token_data_id: TokenDataId): u64 acquires Collections {
         let creator_address = token_data_id.creator;
-        assert!(exists<Collections>(creator_address), error::not_found(ECOLLECTIONS_NOT_PUBLISHED));
+        assert!(
+            exists<Collections>(creator_address),
+            error::not_found(ECOLLECTIONS_NOT_PUBLISHED),
+        );
         let all_token_data = &borrow_global<Collections>(creator_address).token_data;
-        assert!(table::contains(all_token_data, token_data_id), error::not_found(ETOKEN_DATA_NOT_PUBLISHED));
+        assert!(
+            table::contains(all_token_data, token_data_id),
+            error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
+        );
 
         let token_data = table::borrow(all_token_data, token_data_id);
         token_data.maximum
     }
 
-    public fun get_tokendata_uri(creator: address, token_data_id: TokenDataId): String acquires Collections {
-        assert!(exists<Collections>(creator), error::not_found(ECOLLECTIONS_NOT_PUBLISHED));
+    public fun get_tokendata_uri(
+        creator: address, token_data_id: TokenDataId
+    ): String acquires Collections {
+        assert!(
+            exists<Collections>(creator), error::not_found(ECOLLECTIONS_NOT_PUBLISHED)
+        );
         let all_token_data = &borrow_global<Collections>(creator).token_data;
-        assert!(table::contains(all_token_data, token_data_id), error::not_found(ETOKEN_DATA_NOT_PUBLISHED));
+        assert!(
+            table::contains(all_token_data, token_data_id),
+            error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
+        );
 
         let token_data = table::borrow(all_token_data, token_data_id);
         token_data.uri
@@ -1580,9 +1880,15 @@ module aptos_token::token {
 
     public fun get_tokendata_description(token_data_id: TokenDataId): String acquires Collections {
         let creator_address = token_data_id.creator;
-        assert!(exists<Collections>(creator_address), error::not_found(ECOLLECTIONS_NOT_PUBLISHED));
+        assert!(
+            exists<Collections>(creator_address),
+            error::not_found(ECOLLECTIONS_NOT_PUBLISHED),
+        );
         let all_token_data = &borrow_global<Collections>(creator_address).token_data;
-        assert!(table::contains(all_token_data, token_data_id), error::not_found(ETOKEN_DATA_NOT_PUBLISHED));
+        assert!(
+            table::contains(all_token_data, token_data_id),
+            error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
+        );
 
         let token_data = table::borrow(all_token_data, token_data_id);
         token_data.description
@@ -1590,9 +1896,15 @@ module aptos_token::token {
 
     public fun get_tokendata_royalty(token_data_id: TokenDataId): Royalty acquires Collections {
         let creator_address = token_data_id.creator;
-        assert!(exists<Collections>(creator_address), error::not_found(ECOLLECTIONS_NOT_PUBLISHED));
+        assert!(
+            exists<Collections>(creator_address),
+            error::not_found(ECOLLECTIONS_NOT_PUBLISHED),
+        );
         let all_token_data = &borrow_global<Collections>(creator_address).token_data;
-        assert!(table::contains(all_token_data, token_data_id), error::not_found(ETOKEN_DATA_NOT_PUBLISHED));
+        assert!(
+            table::contains(all_token_data, token_data_id),
+            error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
+        );
 
         let token_data = table::borrow(all_token_data, token_data_id);
         token_data.royalty
@@ -1604,21 +1916,33 @@ module aptos_token::token {
     }
 
     /// return the mutation setting of the token
-    public fun get_tokendata_mutability_config(token_data_id: TokenDataId): TokenMutabilityConfig acquires Collections {
+    public fun get_tokendata_mutability_config(token_data_id: TokenDataId)
+        : TokenMutabilityConfig acquires Collections {
         let creator_addr = token_data_id.creator;
-        assert!(exists<Collections>(creator_addr), error::not_found(ECOLLECTIONS_NOT_PUBLISHED));
+        assert!(
+            exists<Collections>(creator_addr), error::not_found(
+                ECOLLECTIONS_NOT_PUBLISHED
+            )
+        );
         let all_token_data = &borrow_global<Collections>(creator_addr).token_data;
-        assert!(table::contains(all_token_data, token_data_id), error::not_found(ETOKEN_DATA_NOT_PUBLISHED));
+        assert!(
+            table::contains(all_token_data, token_data_id),
+            error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
+        );
         table::borrow(all_token_data, token_data_id).mutability_config
     }
 
     /// return if the token's maximum is mutable
-    public fun get_token_mutability_maximum(config: &TokenMutabilityConfig): bool {
+    public fun get_token_mutability_maximum(
+        config: &TokenMutabilityConfig
+    ): bool {
         config.maximum
     }
 
     /// return if the token royalty is mutable with a token mutability config
-    public fun get_token_mutability_royalty(config: &TokenMutabilityConfig): bool {
+    public fun get_token_mutability_royalty(
+        config: &TokenMutabilityConfig
+    ): bool {
         config.royalty
     }
 
@@ -1628,38 +1952,53 @@ module aptos_token::token {
     }
 
     /// return if the token description is mutable with a token mutability config
-    public fun get_token_mutability_description(config: &TokenMutabilityConfig): bool {
+    public fun get_token_mutability_description(
+        config: &TokenMutabilityConfig
+    ): bool {
         config.description
     }
 
     /// return if the tokendata's default properties is mutable with a token mutability config
-    public fun get_token_mutability_default_properties(config: &TokenMutabilityConfig): bool {
+    public fun get_token_mutability_default_properties(
+        config: &TokenMutabilityConfig
+    ): bool {
         config.properties
     }
 
     #[view]
     /// return the collection mutation setting
     public fun get_collection_mutability_config(
-        creator: address,
-        collection_name: String
+        creator: address, collection_name: String
     ): CollectionMutabilityConfig acquires Collections {
-        assert!(exists<Collections>(creator), error::not_found(ECOLLECTIONS_NOT_PUBLISHED));
+        assert!(
+            exists<Collections>(creator), error::not_found(ECOLLECTIONS_NOT_PUBLISHED)
+        );
         let all_collection_data = &borrow_global<Collections>(creator).collection_data;
-        assert!(table::contains(all_collection_data, collection_name), error::not_found(ECOLLECTION_NOT_PUBLISHED));
+        assert!(
+            table::contains(all_collection_data, collection_name),
+            error::not_found(ECOLLECTION_NOT_PUBLISHED),
+        );
         table::borrow(all_collection_data, collection_name).mutability_config
     }
 
     /// return if the collection description is mutable with a collection mutability config
-    public fun get_collection_mutability_description(config: &CollectionMutabilityConfig): bool {
+    public fun get_collection_mutability_description(
+        config: &CollectionMutabilityConfig
+    ): bool {
         config.description
     }
 
     /// return if the collection uri is mutable with a collection mutability config
-    public fun get_collection_mutability_uri(config: &CollectionMutabilityConfig): bool {
+    public fun get_collection_mutability_uri(
+        config: &CollectionMutabilityConfig
+    ): bool {
         config.uri
     }
+
     /// return if the collection maximum is mutable with collection mutability config
-    public fun get_collection_mutability_maximum(config: &CollectionMutabilityConfig): bool {
+    public fun get_collection_mutability_maximum(
+        config: &CollectionMutabilityConfig
+    ): bool {
         config.maximum
     }
 
@@ -1699,7 +2038,10 @@ module aptos_token::token {
         // It does not make sense to withdraw 0 tokens.
         assert!(amount > 0, error::invalid_argument(EWITHDRAW_ZERO));
         // Make sure the account has sufficient tokens to withdraw.
-        assert!(balance_of(account_addr, id) >= amount, error::invalid_argument(EINSUFFICIENT_BALANCE));
+        assert!(
+            balance_of(account_addr, id) >= amount,
+            error::invalid_argument(EINSUFFICIENT_BALANCE),
+        );
 
         assert!(
             exists<TokenStore>(account_addr),
@@ -1712,7 +2054,7 @@ module aptos_token::token {
         };
         event::emit_event<WithdrawEvent>(
             &mut token_store.withdraw_events,
-            WithdrawEvent { id, amount }
+            WithdrawEvent { id, amount },
         );
         let tokens = &mut borrow_global_mut<TokenStore>(account_addr).tokens;
         assert!(
@@ -1737,7 +2079,9 @@ module aptos_token::token {
         types: vector<String>,
     ) acquires TokenStore {
         let tokens = &mut borrow_global_mut<TokenStore>(token_owner).tokens;
-        assert!(table::contains(tokens, token_id), error::not_found(ENO_TOKEN_IN_TOKEN_STORE));
+        assert!(
+            table::contains(tokens, token_id), error::not_found(ENO_TOKEN_IN_TOKEN_STORE)
+        );
 
         let value = &mut table::borrow_mut(tokens, token_id).token_properties;
         assert_non_standard_reserved_property(&keys);
@@ -1770,51 +2114,78 @@ module aptos_token::token {
         };
     }
 
-    fun assert_collection_exists(creator_address: address, collection_name: String) acquires Collections {
-        assert!(exists<Collections>(creator_address), error::not_found(ECOLLECTIONS_NOT_PUBLISHED));
-        let all_collection_data = &borrow_global<Collections>(creator_address).collection_data;
-        assert!(table::contains(all_collection_data, collection_name), error::not_found(ECOLLECTION_NOT_PUBLISHED));
+    fun assert_collection_exists(
+        creator_address: address, collection_name: String
+    ) acquires Collections {
+        assert!(
+            exists<Collections>(creator_address),
+            error::not_found(ECOLLECTIONS_NOT_PUBLISHED),
+        );
+        let all_collection_data =
+            &borrow_global<Collections>(creator_address).collection_data;
+        assert!(
+            table::contains(all_collection_data, collection_name),
+            error::not_found(ECOLLECTION_NOT_PUBLISHED),
+        );
     }
 
-    fun assert_tokendata_exists(creator: &signer, token_data_id: TokenDataId) acquires Collections {
+    fun assert_tokendata_exists(
+        creator: &signer, token_data_id: TokenDataId
+    ) acquires Collections {
         let creator_addr = token_data_id.creator;
-        assert!(signer::address_of(creator) == creator_addr, error::permission_denied(ENO_MUTATE_CAPABILITY));
-        assert!(exists<Collections>(creator_addr), error::not_found(ECOLLECTIONS_NOT_PUBLISHED));
+        assert!(
+            signer::address_of(creator) == creator_addr,
+            error::permission_denied(ENO_MUTATE_CAPABILITY),
+        );
+        assert!(
+            exists<Collections>(creator_addr), error::not_found(
+                ECOLLECTIONS_NOT_PUBLISHED
+            )
+        );
         let all_token_data = &mut borrow_global_mut<Collections>(creator_addr).token_data;
-        assert!(table::contains(all_token_data, token_data_id), error::not_found(ETOKEN_DATA_NOT_PUBLISHED));
+        assert!(
+            table::contains(all_token_data, token_data_id),
+            error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
+        );
     }
 
     fun assert_non_standard_reserved_property(keys: &vector<String>) {
-        vector::for_each_ref(keys, |key| {
-            let key: &String = key;
-            let length = string::length(key);
-            if (length >= 6) {
-                let prefix = string::sub_string(&*key, 0, 6);
-                assert!(prefix != string::utf8(b"TOKEN_"), error::permission_denied(EPROPERTY_RESERVED_BY_STANDARD));
-            };
-        });
+        vector::for_each_ref(
+            keys,
+            |key| {
+                let key: &String = key;
+                let length = string::length(key);
+                if (length >= 6) {
+                    let prefix = string::sub_string(&*key, 0, 6);
+                    assert!(
+                        prefix != string::utf8(b"TOKEN_"),
+                        error::permission_denied(EPROPERTY_RESERVED_BY_STANDARD),
+                    );
+                };
+            },
+        );
     }
 
     // ****************** TEST-ONLY FUNCTIONS **************
 
     #[test(creator = @0x1, owner = @0x2)]
     public fun create_withdraw_deposit_token(
-        creator: signer,
-        owner: signer
+        creator: signer, owner: signer
     ) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(&creator));
         account::create_account_for_test(signer::address_of(&owner));
-        let token_id = create_collection_and_token(
-            &creator,
-            1,
-            1,
-            1,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                &creator,
+                1,
+                1,
+                1,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, false],
+            );
 
         let token = withdraw_token(&creator, token_id, 1);
         deposit_token(&owner, token);
@@ -1822,22 +2193,22 @@ module aptos_token::token {
 
     #[test(creator = @0xCC, owner = @0xCB)]
     public fun create_withdraw_deposit(
-        creator: signer,
-        owner: signer
+        creator: signer, owner: signer
     ) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(&creator));
         account::create_account_for_test(signer::address_of(&owner));
-        let token_id = create_collection_and_token(
-            &creator,
-            2,
-            5,
-            5,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                &creator,
+                2,
+                5,
+                5,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, false],
+            );
 
         let token_0 = withdraw_token(&creator, token_id, 1);
         let token_1 = withdraw_token(&creator, token_id, 1);
@@ -1852,21 +2223,26 @@ module aptos_token::token {
     public entry fun test_collection_maximum(creator: signer) acquires Collections, TokenStore {
         use std::bcs;
         account::create_account_for_test(signer::address_of(&creator));
-        let token_id = create_collection_and_token(
-            &creator,
-            2,
-            2,
-            1,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, false],
-        );
-        let default_keys = vector<String>[ string::utf8(b"attack"), string::utf8(b"num_of_use") ];
-        let default_vals = vector<vector<u8>>[ bcs::to_bytes<u64>(&10), bcs::to_bytes<u64>(&5) ];
-        let default_types = vector<String>[ string::utf8(b"u64"), string::utf8(b"u64") ];
-        let mutate_setting = vector<bool>[ false, false, false, false, false, false ];
+        let token_id =
+            create_collection_and_token(
+                &creator,
+                2,
+                2,
+                1,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, false],
+            );
+        let default_keys = vector<String>[string::utf8(b"attack"), string::utf8(
+                b"num_of_use"
+            )];
+        let default_vals = vector<vector<u8>>[bcs::to_bytes<u64>(&10), bcs::to_bytes<u64>(
+                &5
+            )];
+        let default_types = vector<String>[string::utf8(b"u64"), string::utf8(b"u64")];
+        let mutate_setting = vector<bool>[false, false, false, false, false, false];
         create_token_script(
             &creator,
             token_id.token_data_id.collection,
@@ -1887,22 +2263,22 @@ module aptos_token::token {
 
     #[test(creator = @0xFA, owner = @0xAF)]
     public entry fun direct_transfer_test(
-        creator: signer,
-        owner: signer,
+        creator: signer, owner: signer,
     ) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(&creator));
         account::create_account_for_test(signer::address_of(&owner));
-        let token_id = create_collection_and_token(
-            &creator,
-            2,
-            2,
-            2,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                &creator,
+                2,
+                2,
+                2,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, false],
+            );
         assert!(balance_of(signer::address_of(&owner), token_id) == 0, 1);
 
         direct_transfer(&creator, &owner, token_id, 1);
@@ -1944,12 +2320,27 @@ module aptos_token::token {
             string::utf8(b"Collection: Hello, World"),
             string::utf8(b"https://aptos.dev"),
             collection_max,
-            mutate_setting
+            mutate_setting,
         );
 
-        let default_keys = if (vector::length<String>(&property_keys) == 0) { vector<String>[string::utf8(b"attack"), string::utf8(b"num_of_use")] } else { property_keys };
-        let default_vals = if (vector::length<vector<u8>>(&property_values) == 0) { vector<vector<u8>>[bcs::to_bytes<u64>(&10), bcs::to_bytes<u64>(&5)] } else { property_values };
-        let default_types = if (vector::length<String>(&property_types) == 0) { vector<String>[string::utf8(b"u64"), string::utf8(b"u64")] } else { property_types };
+        let default_keys =
+            if (vector::length<String>(&property_keys) == 0) {
+                vector<String>[string::utf8(b"attack"), string::utf8(b"num_of_use")]
+            } else {
+                property_keys
+            };
+        let default_vals =
+            if (vector::length<vector<u8>>(&property_values) == 0) {
+                vector<vector<u8>>[bcs::to_bytes<u64>(&10), bcs::to_bytes<u64>(&5)]
+            } else {
+                property_values
+            };
+        let default_types =
+            if (vector::length<String>(&property_types) == 0) {
+                vector<String>[string::utf8(b"u64"), string::utf8(b"u64")]
+            } else {
+                property_types
+            };
         let mutate_setting = token_mutate_setting;
         create_token_script(
             creator,
@@ -1967,7 +2358,9 @@ module aptos_token::token {
             default_vals,
             default_types,
         );
-        create_token_id_raw(signer::address_of(creator), get_collection_name(), get_token_name(), 0)
+        create_token_id_raw(
+            signer::address_of(creator), get_collection_name(), get_token_name(), 0
+        )
     }
 
     #[test(creator = @0xFF)]
@@ -2003,15 +2396,15 @@ module aptos_token::token {
             vector<bool>[false, false, false],
             vector<bool>[false, false, false, false, false],
         );
-        let token_data_id = create_token_data_id(
-            signer::address_of(creator),
-            get_collection_name(),
-            get_token_name());
+        let token_data_id =
+            create_token_data_id(
+                signer::address_of(creator),
+                get_collection_name(),
+                get_token_name(),
+            );
 
         let token_id = mint_token(
-            creator,
-            token_data_id,
-            1,
+            creator, token_data_id, 1
         );
 
         assert!(balance_of(signer::address_of(creator), token_id) == 3, 1);
@@ -2023,28 +2416,31 @@ module aptos_token::token {
         account::create_account_for_test(signer::address_of(creator));
 
         // token owner mutate the token property
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[string::utf8(TOKEN_PROPERTY_MUTABLE)],
-            vector<vector<u8>>[bcs::to_bytes<bool>(&true)],
-            vector<String>[string::utf8(b"bool")],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[string::utf8(TOKEN_PROPERTY_MUTABLE)],
+                vector<vector<u8>>[bcs::to_bytes<bool>(&true)],
+                vector<String>[string::utf8(b"bool")],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, false],
+            );
         assert!(token_id.property_version == 0, 1);
         // only be able to mutate the attributed defined when creating the token
         let new_keys = vector<String>[
-            string::utf8(b"attack"), string::utf8(b"num_of_use"), string::utf8(b"new_attribute")
-        ];
+            string::utf8(b"attack"),
+            string::utf8(b"num_of_use"),
+            string::utf8(b"new_attribute")];
         let new_vals = vector<vector<u8>>[
-            bcs::to_bytes<u64>(&1), bcs::to_bytes<u64>(&1), bcs::to_bytes<u64>(&1)
-        ];
-        let new_types = vector<String>[
-            string::utf8(b"u64"), string::utf8(b"u64"), string::utf8(b"u64")
-        ];
+            bcs::to_bytes<u64>(&1),
+            bcs::to_bytes<u64>(&1),
+            bcs::to_bytes<u64>(&1)];
+        let new_types = vector<String>[string::utf8(b"u64"), string::utf8(b"u64"), string::utf8(
+                b"u64"
+            )];
 
         mutate_token_properties(
             creator,
@@ -2061,43 +2457,41 @@ module aptos_token::token {
     }
 
     #[test(creator = @0xAF, owner = @0xBB)]
-    fun test_get_property_map_should_not_update_source_value(creator: &signer) acquires Collections, TokenStore {
+    fun test_get_property_map_should_not_update_source_value(
+        creator: &signer
+    ) acquires Collections, TokenStore {
         use std::bcs;
         account::create_account_for_test(signer::address_of(creator));
 
         // token owner mutate the token property
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, true],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, true],
+            );
         assert!(token_id.property_version == 0, 1);
         // only be able to mutate the attributed defined when creating the token
-        let new_keys = vector<String>[
-            string::utf8(b"attack"), string::utf8(b"num_of_use")
-        ];
-        let new_vals = vector<vector<u8>>[
-            bcs::to_bytes<u64>(&1), bcs::to_bytes<u64>(&1)
-        ];
-        let new_types = vector<String>[
-            string::utf8(b"u64"), string::utf8(b"u64")
-        ];
+        let new_keys = vector<String>[string::utf8(b"attack"), string::utf8(b"num_of_use")];
+        let new_vals = vector<vector<u8>>[bcs::to_bytes<u64>(&1), bcs::to_bytes<u64>(&1)];
+        let new_types = vector<String>[string::utf8(b"u64"), string::utf8(b"u64")];
         let pm = get_property_map(signer::address_of(creator), token_id);
         assert!(property_map::length(&pm) == 2, 1);
-        let new_token_id = mutate_one_token(
-            creator,
-            signer::address_of(creator),
-            token_id,
-            new_keys,
-            new_vals,
-            new_types,
-        );
+        let new_token_id =
+            mutate_one_token(
+                creator,
+                signer::address_of(creator),
+                token_id,
+                new_keys,
+                new_vals,
+                new_types,
+            );
         let updated_pm = get_property_map(signer::address_of(creator), new_token_id);
         assert!(property_map::length(&updated_pm) == 2, 1);
         property_map::update_property_value(
@@ -2115,99 +2509,116 @@ module aptos_token::token {
     fun test_withdraw_with_proof(creator: &signer, framework: &signer): Token acquires TokenStore, Collections {
         timestamp::set_time_has_started_for_testing(framework);
         account::create_account_for_test(signer::address_of(creator));
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, false],
+            );
 
         timestamp::update_global_time_for_test(1000000);
 
         // provide the proof to the account
-        let cap = create_withdraw_capability(
-            creator, // ask user to provide address to avoid ambiguity from rotated keys
-            token_id,
-            1,
-            2000000,
-        );
+        let cap =
+            create_withdraw_capability(
+                creator, // ask user to provide address to avoid ambiguity from rotated keys
+                token_id,
+                1,
+                2000000,
+            );
 
         withdraw_with_capability(cap)
     }
 
     #[test(creator = @0xcafe, another_creator = @0xde)]
     fun test_burn_token_from_both_limited_and_unlimited(
-        creator: &signer,
-        another_creator: &signer,
-    )acquires Collections, TokenStore {
+        creator: &signer, another_creator: &signer,
+    ) acquires Collections, TokenStore {
         // create limited token and collection
         use std::bcs;
         account::create_account_for_test(signer::address_of(creator));
         account::create_account_for_test(signer::address_of(another_creator));
 
         // token owner mutate the token property
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[string::utf8(BURNABLE_BY_CREATOR)],
-            vector<vector<u8>>[bcs::to_bytes<bool>(&true)],
-            vector<String>[string::utf8(b"bool")],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[string::utf8(BURNABLE_BY_CREATOR)],
+                vector<vector<u8>>[bcs::to_bytes<bool>(&true)],
+                vector<String>[string::utf8(b"bool")],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, false],
+            );
         // burn token from limited token
         let creator_addr = signer::address_of(creator);
         let pre_amount = &mut get_token_supply(creator_addr, token_id.token_data_id);
-        burn_by_creator(creator, creator_addr, get_collection_name(), get_token_name(), 0, 1);
+        burn_by_creator(
+            creator,
+            creator_addr,
+            get_collection_name(),
+            get_token_name(),
+            0,
+            1,
+        );
         let aft_amount = &mut get_token_supply(creator_addr, token_id.token_data_id);
-        assert!((option::extract<u64>(pre_amount) - option::extract<u64>(aft_amount)) == 1, 1);
+        assert!(
+            (option::extract<u64>(pre_amount) - option::extract<u64>(aft_amount)) == 1, 1
+        );
 
         // create unlimited token and collection
         let new_addr = signer::address_of(another_creator);
-        let new_token_id = create_collection_and_token(
-            another_creator,
-            2,
-            0,
-            0,
-            vector<String>[string::utf8(BURNABLE_BY_OWNER)],
-            vector<vector<u8>>[bcs::to_bytes<bool>(&true)],
-            vector<String>[string::utf8(b"bool")],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, false],
-        );
+        let new_token_id =
+            create_collection_and_token(
+                another_creator,
+                2,
+                0,
+                0,
+                vector<String>[string::utf8(BURNABLE_BY_OWNER)],
+                vector<vector<u8>>[bcs::to_bytes<bool>(&true)],
+                vector<String>[string::utf8(b"bool")],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, false],
+            );
         let pre = balance_of(new_addr, new_token_id);
         // burn token from unlimited token and collection
-        burn(another_creator, new_addr, get_collection_name(), get_token_name(), 0, 1);
+        burn(another_creator,
+            new_addr,
+            get_collection_name(),
+            get_token_name(),
+            0,
+            1,);
         let aft = balance_of(new_addr, new_token_id);
         assert!(pre - aft == 1, 1);
     }
 
     #[test(creator = @0xcafe, owner = @0xafe)]
     fun test_mint_token_to_different_address(
-        creator: &signer,
-        owner: &signer,
-    )acquires Collections, TokenStore {
+        creator: &signer, owner: &signer,
+    ) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(creator));
         account::create_account_for_test(signer::address_of(owner));
         // token owner mutate the token property
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, false],
+            );
         let owner_addr = signer::address_of(owner);
         opt_in_direct_transfer(owner, true);
         mint_token_to(creator, owner_addr, token_id.token_data_id, 1);
@@ -2217,23 +2628,23 @@ module aptos_token::token {
     #[test(creator = @0xcafe, owner = @0xafe)]
     #[expected_failure(abort_code = 327696, location = Self)]
     fun test_opt_in_direct_transfer_fail(
-        creator: &signer,
-        owner: &signer,
+        creator: &signer, owner: &signer,
     ) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(creator));
         account::create_account_for_test(signer::address_of(owner));
         // token owner mutate the token property
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, false],
+            );
         let owner_addr = signer::address_of(owner);
         initialize_token_store(owner);
         transfer(creator, token_id, owner_addr, 1);
@@ -2242,108 +2653,139 @@ module aptos_token::token {
     #[test(creator = @0xcafe, owner = @0xafe)]
     #[expected_failure(abort_code = 327696, location = Self)]
     fun test_opt_in_direct_deposit_fail(
-        creator: &signer,
-        owner: &signer,
+        creator: &signer, owner: &signer,
     ) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(creator));
         account::create_account_for_test(signer::address_of(owner));
 
         // token owner mutate the token property
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, false],
+            );
         let owner_addr = signer::address_of(owner);
         let token = withdraw_token(creator, token_id, 2);
         initialize_token_store(owner);
         direct_deposit_with_opt_in(owner_addr, token);
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, false],
+            );
         opt_in_direct_transfer(owner, true);
         initialize_token_store(owner);
         transfer(creator, token_id, signer::address_of(owner), 2);
-        burn_by_creator(creator, signer::address_of(owner), get_collection_name(), get_token_name(), 0, 1);
+        burn_by_creator(
+            creator,
+            signer::address_of(owner),
+            get_collection_name(),
+            get_token_name(),
+            0,
+            1,
+        );
     }
 
     #[test(creator = @0xcafe, owner = @0x456)]
     #[expected_failure(abort_code = 327710, location = Self)]
     fun test_burn_token_by_owner_without_burnable_config(
-        creator: &signer,
-        owner: &signer,
-    )acquires Collections, TokenStore {
+        creator: &signer, owner: &signer,
+    ) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(creator));
         account::create_account_for_test(signer::address_of(owner));
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, false],
+            );
 
         opt_in_direct_transfer(owner, true);
         initialize_token_store(owner);
         transfer(creator, token_id, signer::address_of(owner), 2);
 
-        burn(owner, signer::address_of(creator), get_collection_name(), get_token_name(), 0, 1);
+        burn(
+            owner,
+            signer::address_of(creator),
+            get_collection_name(),
+            get_token_name(),
+            0,
+            1,
+        );
     }
 
     #[test(creator = @0xcafe, owner = @0x456)]
     fun test_burn_token_by_owner_and_creator(
-        creator: &signer,
-        owner: &signer,
+        creator: &signer, owner: &signer,
     ) acquires TokenStore, Collections {
         use std::bcs;
         account::create_account_for_test(signer::address_of(creator));
         account::create_account_for_test(signer::address_of(owner));
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[string::utf8(BURNABLE_BY_CREATOR), string::utf8(BURNABLE_BY_OWNER)],
-            vector<vector<u8>>[bcs::to_bytes<bool>(&true), bcs::to_bytes<bool>(&true)],
-            vector<String>[string::utf8(b"bool"), string::utf8(b"bool")],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[string::utf8(BURNABLE_BY_CREATOR), string::utf8(
+                        BURNABLE_BY_OWNER
+                    )],
+                vector<vector<u8>>[bcs::to_bytes<bool>(&true), bcs::to_bytes<bool>(&true)],
+                vector<String>[string::utf8(b"bool"), string::utf8(b"bool")],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, false],
+            );
         opt_in_direct_transfer(owner, true);
         initialize_token_store(owner);
         transfer(creator, token_id, signer::address_of(owner), 2);
-        burn_by_creator(creator, signer::address_of(owner), get_collection_name(), get_token_name(), 0, 1);
-        burn(owner, signer::address_of(creator), get_collection_name(), get_token_name(), 0, 1);
+        burn_by_creator(
+            creator,
+            signer::address_of(owner),
+            get_collection_name(),
+            get_token_name(),
+            0,
+            1,
+        );
+        burn(
+            owner,
+            signer::address_of(creator),
+            get_collection_name(),
+            get_token_name(),
+            0,
+            1,
+        );
         assert!(balance_of(signer::address_of(owner), token_id) == 0, 1);
 
         // The corresponding token_data and collection_data should be deleted
         let collections = borrow_global<Collections>(signer::address_of(creator));
-        assert!(!table::contains(&collections.collection_data, token_id.token_data_id.name), 1);
+        assert!(
+            !table::contains(&collections.collection_data, token_id.token_data_id.name), 1
+        );
         assert!(!table::contains(&collections.token_data, token_id.token_data_id), 1);
     }
 
     #[test(creator = @0xcafe)]
-    fun test_mutate_collection_description(
-        creator: &signer,
-    ) acquires Collections, TokenStore {
+    fun test_mutate_collection_description(creator: &signer,) acquires Collections, TokenStore {
         let creator_address = signer::address_of(creator);
         account::create_account_for_test(creator_address);
         create_collection_and_token(
@@ -2361,13 +2803,13 @@ module aptos_token::token {
         let description = string::utf8(b"test");
         let collection_name = get_collection_name();
         mutate_collection_description(creator, collection_name, description);
-        assert!(get_collection_description(creator_address, collection_name) == description, 1);
+        assert!(
+            get_collection_description(creator_address, collection_name) == description, 1
+        );
     }
 
     #[test(creator = @0xcafe)]
-    fun test_mutate_collection_uri(
-        creator: &signer,
-    ) acquires Collections, TokenStore {
+    fun test_mutate_collection_uri(creator: &signer,) acquires Collections, TokenStore {
         let creator_address = signer::address_of(creator);
         account::create_account_for_test(creator_address);
         create_collection_and_token(
@@ -2389,9 +2831,7 @@ module aptos_token::token {
     }
 
     #[test(creator = @0xcafe)]
-    fun test_mutate_collection_maximum(
-        creator: &signer,
-    ) acquires Collections, TokenStore {
+    fun test_mutate_collection_maximum(creator: &signer,) acquires Collections, TokenStore {
         let creator_address = signer::address_of(creator);
         account::create_account_for_test(creator_address);
         create_collection_and_token(
@@ -2412,34 +2852,27 @@ module aptos_token::token {
     }
 
     #[test(creator = @0xcafe, owner = @0x456)]
-    fun test_mutate_default_token_properties(
-        creator: &signer,
-    ) acquires Collections, TokenStore {
+    fun test_mutate_default_token_properties(creator: &signer,) acquires Collections, TokenStore {
         use std::bcs;
         account::create_account_for_test(signer::address_of(creator));
 
         // token owner mutate the token property
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, true],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, true],
+            );
         assert!(token_id.property_version == 0, 1);
-        let new_keys = vector<String>[
-            string::utf8(b"attack"), string::utf8(b"num_of_use")
-        ];
-        let new_vals = vector<vector<u8>>[
-            bcs::to_bytes<u64>(&1), bcs::to_bytes<u64>(&1)
-        ];
-        let new_types = vector<String>[
-            string::utf8(b"u64"), string::utf8(b"u64")
-        ];
+        let new_keys = vector<String>[string::utf8(b"attack"), string::utf8(b"num_of_use")];
+        let new_vals = vector<vector<u8>>[bcs::to_bytes<u64>(&1), bcs::to_bytes<u64>(&1)];
+        let new_types = vector<String>[string::utf8(b"u64"), string::utf8(b"u64")];
 
         mutate_tokendata_property(
             creator,
@@ -2449,89 +2882,91 @@ module aptos_token::token {
             new_types,
         );
 
-        let all_token_data = &borrow_global<Collections>(signer::address_of(creator)).token_data;
+        let all_token_data =
+            &borrow_global<Collections>(signer::address_of(creator)).token_data;
         assert!(table::contains(all_token_data, token_id.token_data_id), 1);
-        let props = &table::borrow(all_token_data, token_id.token_data_id).default_properties;
+        let props =
+            &table::borrow(all_token_data, token_id.token_data_id).default_properties;
         assert!(property_map::read_u64(props, &string::utf8(b"attack")) == 1, 1);
     }
 
     #[test(creator = @0xcafe)]
-    fun test_mutate_tokendata_maximum(
-        creator: &signer,
-    ) acquires Collections, TokenStore {
+    fun test_mutate_tokendata_maximum(creator: &signer,) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(creator));
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[true, false, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[true, false, false, false, false],
+            );
         mutate_tokendata_maximum(creator, token_id.token_data_id, 10);
         assert!(get_tokendata_maximum(token_id.token_data_id) == 10, 1);
     }
 
     #[test(creator = @0xcafe)]
     #[expected_failure(abort_code = 65572, location = Self)]
-    fun test_mutate_tokendata_maximum_from_zero(
-        creator: &signer,
-    ) acquires Collections, TokenStore {
+    fun test_mutate_tokendata_maximum_from_zero(creator: &signer,) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(creator));
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[true, false, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[true, false, false, false, false],
+            );
         mutate_tokendata_maximum(creator, token_id.token_data_id, 0);
     }
 
     #[test(creator = @0xcafe)]
-    fun test_mutate_tokendata_uri(
-        creator: &signer,
-    ) acquires Collections, TokenStore {
+    fun test_mutate_tokendata_uri(creator: &signer,) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(creator));
         // token owner mutate the token property
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, true, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, true, false, false, false],
+            );
         mutate_tokendata_uri(creator, token_id.token_data_id, string::utf8(b""));
-        assert!(get_tokendata_uri(signer::address_of(creator), token_id.token_data_id) == string::utf8(b""), 1);
+        assert!(
+            get_tokendata_uri(signer::address_of(creator), token_id.token_data_id)
+                == string::utf8(b""),
+            1,
+        );
     }
 
     #[test(creator = @0xcafe)]
-    fun test_mutate_tokendata_royalty(
-        creator: &signer,
-    ) acquires Collections, TokenStore {
+    fun test_mutate_tokendata_royalty(creator: &signer,) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(creator));
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, true, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, true, false, false],
+            );
 
         let royalty = create_royalty(1, 3, signer::address_of(creator));
         mutate_tokendata_royalty(creator, token_id.token_data_id, royalty);
@@ -2539,21 +2974,20 @@ module aptos_token::token {
     }
 
     #[test(creator = @0xcafe)]
-    fun test_mutate_tokendata_description(
-        creator: &signer,
-    ) acquires Collections, TokenStore {
+    fun test_mutate_tokendata_description(creator: &signer,) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(creator));
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, true, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, true, false],
+            );
 
         let description = string::utf8(b"test");
         mutate_tokendata_description(creator, token_id.token_data_id, description);
@@ -2567,27 +3001,22 @@ module aptos_token::token {
         account::create_account_for_test(signer::address_of(owner));
 
         // token owner mutate the token property
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, true],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, true],
+            );
         assert!(token_id.property_version == 0, 1);
-        let new_keys = vector<String>[
-        string::utf8(b"attack"), string::utf8(b"num_of_use")
-        ];
-        let new_vals = vector<vector<u8>>[
-        bcs::to_bytes<u64>(&1), bcs::to_bytes<u64>(&1)
-        ];
-        let new_types = vector<String>[
-        string::utf8(b"u64"), string::utf8(b"u64")
-        ];
+        let new_keys = vector<String>[string::utf8(b"attack"), string::utf8(b"num_of_use")];
+        let new_vals = vector<vector<u8>>[bcs::to_bytes<u64>(&1), bcs::to_bytes<u64>(&1)];
+        let new_types = vector<String>[string::utf8(b"u64"), string::utf8(b"u64")];
 
         mutate_token_properties(
             creator,
@@ -2603,7 +3032,10 @@ module aptos_token::token {
         );
 
         // should have two new property_version from the orignal two tokens
-        let largest_property_version = get_tokendata_largest_property_version(signer::address_of(creator), token_id.token_data_id);
+        let largest_property_version =
+            get_tokendata_largest_property_version(
+                signer::address_of(creator), token_id.token_data_id
+            );
         assert!(largest_property_version == 2, largest_property_version);
 
         let new_id_1 = create_token_id(token_id.token_data_id, 1);
@@ -2614,10 +3046,14 @@ module aptos_token::token {
         assert!(balance_of(signer::address_of(creator), new_id_2) == 1, 1);
         assert!(balance_of(signer::address_of(creator), token_id) == 0, 1);
 
-        let creator_props = &borrow_global<TokenStore>(signer::address_of(creator)).tokens;
+        let creator_props =
+            &borrow_global<TokenStore>(signer::address_of(creator)).tokens;
         let token = table::borrow(creator_props, new_id_1);
 
-        assert!(property_map::length(&token.token_properties) == 2, property_map::length(&token.token_properties));
+        assert!(
+            property_map::length(&token.token_properties) == 2,
+            property_map::length(&token.token_properties),
+        );
         // mutate token with property_version > 0 should not generate new property_version
         mutate_token_properties(
             creator,
@@ -2629,7 +3065,7 @@ module aptos_token::token {
             1,
             new_keys,
             new_vals,
-            new_types
+            new_types,
         );
         assert!(balance_of(signer::address_of(creator), new_id_3) == 0, 1);
         // transfer token with property_version > 0 also transfer the token properties
@@ -2638,14 +3074,15 @@ module aptos_token::token {
         let props = &borrow_global<TokenStore>(signer::address_of(owner)).tokens;
         assert!(table::contains(props, new_id_1), 1);
         let token = table::borrow(props, new_id_1);
-        assert!(property_map::length(&token.token_properties) == 2, property_map::length(&token.token_properties));
+        assert!(
+            property_map::length(&token.token_properties) == 2,
+            property_map::length(&token.token_properties),
+        );
     }
 
     #[test(creator = @0xcafe)]
     #[expected_failure(abort_code = 65569, location = Self)]
-    fun test_no_zero_balance_token_deposit(
-        creator: &signer,
-    ) acquires Collections, TokenStore {
+    fun test_no_zero_balance_token_deposit(creator: &signer,) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(creator));
         // token owner mutate the token property
         create_collection_and_token(
@@ -2663,71 +3100,67 @@ module aptos_token::token {
 
     #[test(creator = @0xcafe)]
     #[expected_failure(abort_code = 65548, location = Self)]
-    fun test_split_out_zero_token(
-        creator: &signer,
-    ) acquires Collections, TokenStore {
+    fun test_split_out_zero_token(creator: &signer,) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(creator));
         // token owner mutate the token property
-        let token_id = create_collection_and_token(
-            creator,
-            1,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, true, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                1,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, true, false, false, false],
+            );
         let token = withdraw_token(creator, token_id, 1);
         let split_token = split(&mut token, 1);
-        let Token {
-            id: _,
-            amount: _,
-            token_properties: _,
-        } = split_token;
-        let Token {
-            id: _,
-            amount: _,
-            token_properties: _,
-        } = token;
+        let Token { id: _, amount: _, token_properties: _, } = split_token;
+        let Token { id: _, amount: _, token_properties: _, } = token;
     }
 
     #[test]
     #[expected_failure(abort_code = 65570, location = Self)]
-    public fun test_enter_illegal_royalty(){
+    public fun test_enter_illegal_royalty() {
         create_royalty(101, 100, @0xcafe);
     }
 
     #[test(framework = @0x1, creator = @0xcafe)]
-    fun test_partial_withdraw_with_proof(creator: &signer, framework: &signer): Token acquires TokenStore, Collections {
+    fun test_partial_withdraw_with_proof(
+        creator: &signer, framework: &signer
+    ): Token acquires TokenStore, Collections {
         timestamp::set_time_has_started_for_testing(framework);
         account::create_account_for_test(signer::address_of(creator));
-        let token_id = create_collection_and_token(
-            creator,
-            4,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, false],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                4,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, false],
+            );
 
         timestamp::update_global_time_for_test(1000000);
 
         // provide the proof to the account
-        let cap = create_withdraw_capability(
-            creator, // ask user to provide address to avoid ambiguity from rotated keys
-            token_id,
-            3,
-            2000000,
-        );
+        let cap =
+            create_withdraw_capability(
+                creator, // ask user to provide address to avoid ambiguity from rotated keys
+                token_id,
+                3,
+                2000000,
+            );
 
         let (token, capability) = partial_withdraw_with_capability(cap, 1);
         assert!(option::borrow<WithdrawCapability>(&capability).amount == 2, 1);
-        let (token_1, cap) = partial_withdraw_with_capability(option::extract(&mut capability), 2);
+        let (token_1, cap) =
+            partial_withdraw_with_capability(option::extract(&mut capability), 2);
         assert!(option::is_none(&cap), 1);
         merge(&mut token, token_1);
         token
@@ -2758,17 +3191,18 @@ module aptos_token::token {
         account::create_account_for_test(signer::address_of(creator));
 
         // token owner mutate the token property
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[],
-            vector<vector<u8>>[],
-            vector<String>[],
-            vector<bool>[false, false, false],
-            vector<bool>[false, false, false, false, true],
-        );
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[],
+                vector<vector<u8>>[],
+                vector<String>[],
+                vector<bool>[false, false, false],
+                vector<bool>[false, false, false, false, true],
+            );
 
         get_tokendata_mutability_config(token_id.token_data_id);
     }
@@ -2776,32 +3210,26 @@ module aptos_token::token {
     #[test(creator = @0xcafe, owner = @0x456)]
     #[expected_failure(abort_code = 327720, location = Self)]
     fun test_fail_to_add_burn_flag(
-        creator: &signer,
-        owner: &signer,
+        creator: &signer, owner: &signer,
     ) acquires TokenStore, Collections {
         use std::bcs;
         account::create_account_for_test(signer::address_of(creator));
         account::create_account_for_test(signer::address_of(owner));
-        let token_id = create_collection_and_token(
-            creator,
-            2,
-            4,
-            4,
-            vector<String>[string::utf8(BURNABLE_BY_OWNER)],
-            vector<vector<u8>>[bcs::to_bytes<bool>(&true)],
-            vector<String>[string::utf8(b"bool")],
-            vector<bool>[false, false, false],
-            vector<bool>[true, true, true, true, true],
-        );
-        let new_keys = vector<String>[
-            string::utf8(BURNABLE_BY_CREATOR),
-        ];
-        let new_vals = vector<vector<u8>>[
-            bcs::to_bytes<bool>(&true),
-        ];
-        let new_types = vector<String>[
-            string::utf8(b"bool"),
-        ];
+        let token_id =
+            create_collection_and_token(
+                creator,
+                2,
+                4,
+                4,
+                vector<String>[string::utf8(BURNABLE_BY_OWNER)],
+                vector<vector<u8>>[bcs::to_bytes<bool>(&true)],
+                vector<String>[string::utf8(b"bool")],
+                vector<bool>[false, false, false],
+                vector<bool>[true, true, true, true, true],
+            );
+        let new_keys = vector<String>[string::utf8(BURNABLE_BY_CREATOR),];
+        let new_vals = vector<vector<u8>>[bcs::to_bytes<bool>(&true),];
+        let new_types = vector<String>[string::utf8(b"bool"),];
         mutate_tokendata_property(
             creator,
             token_id.token_data_id,

--- a/aptos-move/framework/aptos-token/sources/token.move
+++ b/aptos-move/framework/aptos-token/sources/token.move
@@ -458,9 +458,7 @@ module aptos_token::token {
                 property_types,
             );
 
-        mint_token(
-            account, tokendata_id, balance
-        );
+        mint_token(account, tokendata_id, balance);
     }
 
     /// Mint more token from an existing token_data. Mint only adds more token to property_version 0
@@ -481,9 +479,7 @@ module aptos_token::token {
             token_data_id.creator == signer::address_of(account),
             error::permission_denied(ENO_MINT_CAPABILITY),
         );
-        mint_token(
-            account, token_data_id, amount
-        );
+        mint_token(account, token_data_id, amount);
     }
 
     /// mutate the token property and save the new property in TokenStore
@@ -502,9 +498,8 @@ module aptos_token::token {
         types: vector<String>,
     ) acquires Collections, TokenStore {
         assert!(
-            signer::address_of(account) == creator, error::not_found(
-                ENO_MUTATE_CAPABILITY
-            )
+            signer::address_of(account) == creator,
+            error::not_found(ENO_MUTATE_CAPABILITY),
         );
         let i = 0;
         let token_id =
@@ -560,7 +555,10 @@ module aptos_token::token {
     ) acquires TokenStore {
         let token_id =
             create_token_id_raw(
-                creator, collection_name, token_name, token_property_version
+                creator,
+                collection_name,
+                token_name,
+                token_property_version,
             );
         transfer(from, token_id, to, amount);
     }
@@ -770,7 +768,10 @@ module aptos_token::token {
             error::permission_denied(EFIELD_NOT_MUTABLE),
         );
         token_event_store::emit_collection_description_mutate_event(
-            creator, collection_name, collection_data.description, description
+            creator,
+            collection_name,
+            collection_data.description,
+            description,
         );
         collection_data.description = description;
     }
@@ -821,7 +822,10 @@ module aptos_token::token {
             error::permission_denied(EFIELD_NOT_MUTABLE),
         );
         token_event_store::emit_collection_maximum_mutate_event(
-            creator, collection_name, collection_data.maximum, maximum
+            creator,
+            collection_name,
+            collection_data.maximum,
+            maximum,
         );
         collection_data.maximum = maximum;
     }
@@ -866,7 +870,8 @@ module aptos_token::token {
             &mut borrow_global_mut<Collections>(token_data_id.creator).token_data;
         let token_data = table::borrow_mut(all_token_data, token_data_id);
         assert!(
-            token_data.mutability_config.uri, error::permission_denied(EFIELD_NOT_MUTABLE)
+            token_data.mutability_config.uri,
+            error::permission_denied(EFIELD_NOT_MUTABLE),
         );
         token_event_store::emit_token_uri_mutate_event(
             creator,
@@ -970,7 +975,8 @@ module aptos_token::token {
             vector::push_back(&mut old_values, old_pv);
             let new_pv =
                 property_map::create_property_value_raw(
-                    *vector::borrow(&values, i), *vector::borrow(&types, i)
+                    *vector::borrow(&values, i),
+                    *vector::borrow(&types, i),
                 );
             vector::push_back(&mut new_values, new_pv);
             if (option::is_some(&old_pv)) {
@@ -1008,7 +1014,8 @@ module aptos_token::token {
         );
         // validate if the properties is mutable
         assert!(
-            exists<Collections>(creator), error::not_found(ECOLLECTIONS_NOT_PUBLISHED)
+            exists<Collections>(creator),
+            error::not_found(ECOLLECTIONS_NOT_PUBLISHED),
         );
         let all_token_data = &mut borrow_global_mut<Collections>(creator).token_data;
 
@@ -1023,14 +1030,16 @@ module aptos_token::token {
         if (!token_data.mutability_config.properties) {
             assert!(
                 property_map::contains_key(
-                    &token_data.default_properties, &string::utf8(TOKEN_PROPERTY_MUTABLE)
+                    &token_data.default_properties,
+                    &string::utf8(TOKEN_PROPERTY_MUTABLE),
                 ),
                 error::permission_denied(EFIELD_NOT_MUTABLE),
             );
 
             let token_prop_mutable =
                 property_map::read_bool(
-                    &token_data.default_properties, &string::utf8(TOKEN_PROPERTY_MUTABLE)
+                    &token_data.default_properties,
+                    &string::utf8(TOKEN_PROPERTY_MUTABLE),
                 );
             assert!(token_prop_mutable, error::permission_denied(EFIELD_NOT_MUTABLE));
         };
@@ -1460,7 +1469,9 @@ module aptos_token::token {
             supply: 0,
             uri,
             royalty: create_royalty(
-                royalty_points_numerator, royalty_points_denominator, royalty_payee_address
+                royalty_points_numerator,
+                royalty_points_denominator,
+                royalty_payee_address,
             ),
             name,
             description,
@@ -1694,7 +1705,8 @@ module aptos_token::token {
         amount: u64,
     ) acquires Collections, TokenStore {
         assert!(
-            exists<TokenStore>(receiver), error::not_found(ETOKEN_STORE_NOT_PUBLISHED)
+            exists<TokenStore>(receiver),
+            error::not_found(ETOKEN_STORE_NOT_PUBLISHED),
         );
         let opt_in_transfer = borrow_global<TokenStore>(receiver).direct_transfer;
         assert!(
@@ -1866,7 +1878,8 @@ module aptos_token::token {
         creator: address, token_data_id: TokenDataId
     ): String acquires Collections {
         assert!(
-            exists<Collections>(creator), error::not_found(ECOLLECTIONS_NOT_PUBLISHED)
+            exists<Collections>(creator),
+            error::not_found(ECOLLECTIONS_NOT_PUBLISHED),
         );
         let all_token_data = &borrow_global<Collections>(creator).token_data;
         assert!(
@@ -1920,9 +1933,8 @@ module aptos_token::token {
         : TokenMutabilityConfig acquires Collections {
         let creator_addr = token_data_id.creator;
         assert!(
-            exists<Collections>(creator_addr), error::not_found(
-                ECOLLECTIONS_NOT_PUBLISHED
-            )
+            exists<Collections>(creator_addr),
+            error::not_found(ECOLLECTIONS_NOT_PUBLISHED),
         );
         let all_token_data = &borrow_global<Collections>(creator_addr).token_data;
         assert!(
@@ -1971,7 +1983,8 @@ module aptos_token::token {
         creator: address, collection_name: String
     ): CollectionMutabilityConfig acquires Collections {
         assert!(
-            exists<Collections>(creator), error::not_found(ECOLLECTIONS_NOT_PUBLISHED)
+            exists<Collections>(creator),
+            error::not_found(ECOLLECTIONS_NOT_PUBLISHED),
         );
         let all_collection_data = &borrow_global<Collections>(creator).collection_data;
         assert!(
@@ -2138,9 +2151,8 @@ module aptos_token::token {
             error::permission_denied(ENO_MUTATE_CAPABILITY),
         );
         assert!(
-            exists<Collections>(creator_addr), error::not_found(
-                ECOLLECTIONS_NOT_PUBLISHED
-            )
+            exists<Collections>(creator_addr),
+            error::not_found(ECOLLECTIONS_NOT_PUBLISHED),
         );
         let all_token_data = &mut borrow_global_mut<Collections>(creator_addr).token_data;
         assert!(
@@ -2192,9 +2204,7 @@ module aptos_token::token {
     }
 
     #[test(creator = @0xCC, owner = @0xCB)]
-    public fun create_withdraw_deposit(
-        creator: signer, owner: signer
-    ) acquires Collections, TokenStore {
+    public fun create_withdraw_deposit(creator: signer, owner: signer) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(&creator));
         account::create_account_for_test(signer::address_of(&owner));
         let token_id =
@@ -2236,11 +2246,11 @@ module aptos_token::token {
                 vector<bool>[false, false, false, false, false],
             );
         let default_keys = vector<String>[string::utf8(b"attack"), string::utf8(
-                b"num_of_use"
-            )];
+            b"num_of_use"
+        )];
         let default_vals = vector<vector<u8>>[bcs::to_bytes<u64>(&10), bcs::to_bytes<u64>(
-                &5
-            )];
+            &5
+        )];
         let default_types = vector<String>[string::utf8(b"u64"), string::utf8(b"u64")];
         let mutate_setting = vector<bool>[false, false, false, false, false, false];
         create_token_script(
@@ -2262,9 +2272,7 @@ module aptos_token::token {
     }
 
     #[test(creator = @0xFA, owner = @0xAF)]
-    public entry fun direct_transfer_test(
-        creator: signer, owner: signer,
-    ) acquires Collections, TokenStore {
+    public entry fun direct_transfer_test(creator: signer, owner: signer,) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(&creator));
         account::create_account_for_test(signer::address_of(&owner));
         let token_id =
@@ -2359,7 +2367,10 @@ module aptos_token::token {
             default_types,
         );
         create_token_id_raw(
-            signer::address_of(creator), get_collection_name(), get_token_name(), 0
+            signer::address_of(creator),
+            get_collection_name(),
+            get_token_name(),
+            0,
         )
     }
 
@@ -2403,9 +2414,7 @@ module aptos_token::token {
                 get_token_name(),
             );
 
-        let token_id = mint_token(
-            creator, token_data_id, 1
-        );
+        let token_id = mint_token(creator, token_data_id, 1);
 
         assert!(balance_of(signer::address_of(creator), token_id) == 3, 1);
     }
@@ -2433,14 +2442,16 @@ module aptos_token::token {
         let new_keys = vector<String>[
             string::utf8(b"attack"),
             string::utf8(b"num_of_use"),
-            string::utf8(b"new_attribute")];
+            string::utf8(b"new_attribute")
+        ];
         let new_vals = vector<vector<u8>>[
             bcs::to_bytes<u64>(&1),
             bcs::to_bytes<u64>(&1),
-            bcs::to_bytes<u64>(&1)];
+            bcs::to_bytes<u64>(&1)
+        ];
         let new_types = vector<String>[string::utf8(b"u64"), string::utf8(b"u64"), string::utf8(
-                b"u64"
-            )];
+            b"u64"
+        )];
 
         mutate_token_properties(
             creator,
@@ -2571,7 +2582,8 @@ module aptos_token::token {
         );
         let aft_amount = &mut get_token_supply(creator_addr, token_id.token_data_id);
         assert!(
-            (option::extract<u64>(pre_amount) - option::extract<u64>(aft_amount)) == 1, 1
+            (option::extract<u64>(pre_amount) - option::extract<u64>(aft_amount)) == 1,
+            1,
         );
 
         // create unlimited token and collection
@@ -2590,12 +2602,14 @@ module aptos_token::token {
             );
         let pre = balance_of(new_addr, new_token_id);
         // burn token from unlimited token and collection
-        burn(another_creator,
+        burn(
+            another_creator,
             new_addr,
             get_collection_name(),
             get_token_name(),
             0,
-            1,);
+            1,
+        );
         let aft = balance_of(new_addr, new_token_id);
         assert!(pre - aft == 1, 1);
     }
@@ -2747,9 +2761,10 @@ module aptos_token::token {
                 2,
                 4,
                 4,
-                vector<String>[string::utf8(BURNABLE_BY_CREATOR), string::utf8(
-                        BURNABLE_BY_OWNER
-                    )],
+                vector<String>[
+                    string::utf8(BURNABLE_BY_CREATOR),
+                    string::utf8(BURNABLE_BY_OWNER)
+                ],
                 vector<vector<u8>>[bcs::to_bytes<bool>(&true), bcs::to_bytes<bool>(&true)],
                 vector<String>[string::utf8(b"bool"), string::utf8(b"bool")],
                 vector<bool>[false, false, false],
@@ -2779,7 +2794,8 @@ module aptos_token::token {
         // The corresponding token_data and collection_data should be deleted
         let collections = borrow_global<Collections>(signer::address_of(creator));
         assert!(
-            !table::contains(&collections.collection_data, token_id.token_data_id.name), 1
+            !table::contains(&collections.collection_data, token_id.token_data_id.name),
+            1,
         );
         assert!(!table::contains(&collections.token_data, token_id.token_data_id), 1);
     }
@@ -3209,9 +3225,7 @@ module aptos_token::token {
 
     #[test(creator = @0xcafe, owner = @0x456)]
     #[expected_failure(abort_code = 327720, location = Self)]
-    fun test_fail_to_add_burn_flag(
-        creator: &signer, owner: &signer,
-    ) acquires TokenStore, Collections {
+    fun test_fail_to_add_burn_flag(creator: &signer, owner: &signer,) acquires TokenStore, Collections {
         use std::bcs;
         account::create_account_for_test(signer::address_of(creator));
         account::create_account_for_test(signer::address_of(owner));

--- a/aptos-move/framework/aptos-token/sources/token.spec.move
+++ b/aptos-move/framework/aptos-token/sources/token.spec.move
@@ -192,7 +192,8 @@ spec aptos_token::token {
         aborts_if !exists<Collections>(creator_addr);
         aborts_if !table::spec_contains(collections.token_data, token_id.token_data_id);
         aborts_if !simple_map::spec_contains_key(
-            token_data.default_properties.map, std::string::spec_utf8(BURNABLE_BY_CREATOR)
+            token_data.default_properties.map,
+            std::string::spec_utf8(BURNABLE_BY_CREATOR),
         );
     }
 

--- a/aptos-move/framework/aptos-token/sources/token.spec.move
+++ b/aptos-move/framework/aptos-token/sources/token.spec.move
@@ -6,7 +6,7 @@ spec aptos_token::token {
 
     /// The length of the name is up to MAX_COLLECTION_NAME_LENGTH;
     /// The length of the uri is up to MAX_URI_LENGTH;
-    spec create_collection_script (
+    spec create_collection_script(
         creator: &signer,
         name: String,
         description: String,
@@ -56,10 +56,7 @@ spec aptos_token::token {
         include CreateTokenMutabilityConfigAbortsIf;
     }
 
-    spec fun spec_create_tokendata(
-        creator: address,
-        collection: String,
-        name: String): TokenDataId {
+    spec fun spec_create_tokendata(creator: address, collection: String, name: String): TokenDataId {
         TokenDataId { creator, collection, name }
     }
 
@@ -84,15 +81,13 @@ spec aptos_token::token {
         let token_data = table::spec_get(all_token_data, token_data_id);
         aborts_if token_data_id.creator != signer::address_of(account);
 
-        include CreateTokenDataIdAbortsIf{
-        creator: token_data_address,
-        collection: collection,
-        name: name
+        include CreateTokenDataIdAbortsIf {
+            creator: token_data_address,
+            collection: collection,
+            name: name
         };
 
-        include MintTokenAbortsIf {
-        token_data_id: token_data_id
-        };
+        include MintTokenAbortsIf { token_data_id: token_data_id };
     }
 
     /// The signer is creator.
@@ -119,7 +114,7 @@ spec aptos_token::token {
         };
     }
 
-    spec direct_transfer_script (
+    spec direct_transfer_script(
         sender: &signer,
         receiver: &signer,
         creators_address: address,
@@ -130,7 +125,7 @@ spec aptos_token::token {
     ) {
         // TODO: Unknown error message in direct_transfer function.
         pragma aborts_if_is_partial;
-        include CreateTokenDataIdAbortsIf{
+        include CreateTokenDataIdAbortsIf {
             creator: creators_address,
             collection: collection,
             name: name
@@ -143,11 +138,15 @@ spec aptos_token::token {
         let addr = signer::address_of(account);
         let account_addr = global<account::Account>(addr);
         aborts_if !exists<TokenStore>(addr) && !exists<account::Account>(addr);
-        aborts_if !exists<TokenStore>(addr) && account_addr.guid_creation_num + 4 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if !exists<TokenStore>(addr)
+            && account_addr.guid_creation_num + 4 >= account::MAX_GUID_CREATION_NUM;
         aborts_if !exists<TokenStore>(addr) && account_addr.guid_creation_num + 4 > MAX_U64;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account_addr.guid_creation_num + 9 > account::MAX_GUID_CREATION_NUM;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account_addr.guid_creation_num + 9 > MAX_U64;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && !exists<account::Account>(addr);
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account_addr.guid_creation_num + 9 > account::MAX_GUID_CREATION_NUM;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account_addr.guid_creation_num + 9 > MAX_U64;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && !exists<account::Account>(addr);
     }
 
     spec transfer_with_opt_in(
@@ -161,7 +160,7 @@ spec aptos_token::token {
     ) {
         //TODO: Abort condition is complex because of transfer function.
         pragma aborts_if_is_partial;
-        include CreateTokenDataIdAbortsIf{
+        include CreateTokenDataIdAbortsIf {
             creator: creator,
             collection: collection_name,
             name: token_name
@@ -180,7 +179,9 @@ spec aptos_token::token {
         //TODO: Abort condition is complex because of the read_bool in the property_map module.
         pragma aborts_if_is_partial;
         let creator_address = signer::address_of(creator);
-        let token_id = spec_create_token_id_raw(creator_address, collection, name, property_version);
+        let token_id = spec_create_token_id_raw(
+            creator_address, collection, name, property_version
+        );
         let creator_addr = token_id.token_data_id.creator;
         let collections = borrow_global_mut<Collections>(creator_address);
         let token_data = table::spec_get(
@@ -190,7 +191,9 @@ spec aptos_token::token {
         aborts_if amount <= 0;
         aborts_if !exists<Collections>(creator_addr);
         aborts_if !table::spec_contains(collections.token_data, token_id.token_data_id);
-        aborts_if !simple_map::spec_contains_key(token_data.default_properties.map, std::string::spec_utf8(BURNABLE_BY_CREATOR));
+        aborts_if !simple_map::spec_contains_key(
+            token_data.default_properties.map, std::string::spec_utf8(BURNABLE_BY_CREATOR)
+        );
     }
 
     /// The token_data_id should exist in token_data.
@@ -205,66 +208,74 @@ spec aptos_token::token {
         use aptos_std::simple_map;
         //TODO: Abort condition is complex because of the read_bool in the property_map module.
         pragma aborts_if_is_partial;
-        let token_id = spec_create_token_id_raw(creators_address, collection, name, property_version);
+        let token_id = spec_create_token_id_raw(
+            creators_address, collection, name, property_version
+        );
         let creator_addr = token_id.token_data_id.creator;
         let collections = borrow_global_mut<Collections>(creator_addr);
         let token_data = table::spec_get(
             collections.token_data,
             token_id.token_data_id,
         );
-        include CreateTokenDataIdAbortsIf {
-        creator: creators_address
-        };
+        include CreateTokenDataIdAbortsIf { creator: creators_address };
         aborts_if amount <= 0;
         aborts_if !exists<Collections>(creator_addr);
         aborts_if !table::spec_contains(collections.token_data, token_id.token_data_id);
-        aborts_if !simple_map::spec_contains_key(token_data.default_properties.map, std::string::spec_utf8(BURNABLE_BY_OWNER));
+        aborts_if !simple_map::spec_contains_key(
+            token_data.default_properties.map, std::string::spec_utf8(BURNABLE_BY_OWNER)
+        );
         aborts_if !string::spec_internal_check_utf8(BURNABLE_BY_OWNER);
 
     }
 
     spec fun spec_create_token_id_raw(
-        creator: address,
-        collection: String,
-        name: String,
-        property_version: u64,
+        creator: address, collection: String, name: String, property_version: u64,
     ): TokenId {
         let token_data_id = TokenDataId { creator, collection, name };
-        TokenId {
-            token_data_id,
-            property_version
-        }
+        TokenId { token_data_id, property_version }
     }
 
     /// The description of Collection is mutable.
-    spec mutate_collection_description(creator: &signer, collection_name: String, description: String) {
+    spec mutate_collection_description(
+        creator: &signer, collection_name: String, description: String
+    ) {
         let addr = signer::address_of(creator);
         let account = global<account::Account>(addr);
-        let collection_data = table::spec_get(global<Collections>(addr).collection_data, collection_name);
+        let collection_data = table::spec_get(
+            global<Collections>(addr).collection_data, collection_name
+        );
         include AssertCollectionExistsAbortsIf {
             creator_address: addr,
             collection_name: collection_name
         };
         aborts_if !collection_data.mutability_config.description;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && !exists<account::Account>(addr);
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account.guid_creation_num + 9 > MAX_U64;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && !exists<account::Account>(addr);
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account.guid_creation_num + 9 > MAX_U64;
     }
 
     /// The uri of Collection is mutable.
     spec mutate_collection_uri(creator: &signer, collection_name: String, uri: String) {
         let addr = signer::address_of(creator);
         let account = global<account::Account>(addr);
-        let collection_data = table::spec_get(global<Collections>(addr).collection_data, collection_name);
+        let collection_data = table::spec_get(
+            global<Collections>(addr).collection_data, collection_name
+        );
         aborts_if len(uri.bytes) > MAX_URI_LENGTH;
         include AssertCollectionExistsAbortsIf {
             creator_address: addr,
             collection_name: collection_name
         };
         aborts_if !collection_data.mutability_config.uri;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && !exists<account::Account>(addr);
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account.guid_creation_num + 9 > MAX_U64;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && !exists<account::Account>(addr);
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account.guid_creation_num + 9 > MAX_U64;
     }
 
     /// Cannot change maximum from 0 and cannot change maximum to 0.
@@ -273,7 +284,9 @@ spec aptos_token::token {
     spec mutate_collection_maximum(creator: &signer, collection_name: String, maximum: u64) {
         let addr = signer::address_of(creator);
         let account = global<account::Account>(addr);
-        let collection_data = table::spec_get(global<Collections>(addr).collection_data, collection_name);
+        let collection_data = table::spec_get(
+            global<Collections>(addr).collection_data, collection_name
+        );
         include AssertCollectionExistsAbortsIf {
             creator_address: addr,
             collection_name: collection_name
@@ -281,9 +294,12 @@ spec aptos_token::token {
         aborts_if collection_data.maximum == 0 || maximum == 0;
         aborts_if maximum < collection_data.supply;
         aborts_if !collection_data.mutability_config.maximum;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && !exists<account::Account>(addr);
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account.guid_creation_num + 9 > MAX_U64;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && !exists<account::Account>(addr);
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account.guid_creation_num + 9 > MAX_U64;
     }
 
     /// Cannot change maximum from 0 and cannot change maximum to 0.
@@ -298,19 +314,18 @@ spec aptos_token::token {
         aborts_if token_data.maximum == 0 || maximum == 0;
         aborts_if maximum < token_data.supply;
         aborts_if !token_data.mutability_config.maximum;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && !exists<account::Account>(addr);
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account.guid_creation_num + 9 > MAX_U64;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && !exists<account::Account>(addr);
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account.guid_creation_num + 9 > MAX_U64;
     }
 
     /// The length of uri should less than MAX_URI_LENGTH.
     /// The  creator of token_data_id should exist in Collections.
     /// The token uri is mutable
-    spec mutate_tokendata_uri(
-        creator: &signer,
-        token_data_id: TokenDataId,
-        uri: String
-    ) {
+    spec mutate_tokendata_uri(creator: &signer, token_data_id: TokenDataId, uri: String) {
         let addr = signer::address_of(creator);
         let account = global<account::Account>(addr);
         let all_token_data = global<Collections>(token_data_id.creator).token_data;
@@ -318,35 +333,48 @@ spec aptos_token::token {
         include AssertTokendataExistsAbortsIf;
         aborts_if len(uri.bytes) > MAX_URI_LENGTH;
         aborts_if !token_data.mutability_config.uri;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && !exists<account::Account>(addr);
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account.guid_creation_num + 9 > MAX_U64;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && !exists<account::Account>(addr);
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account.guid_creation_num + 9 > MAX_U64;
     }
 
-   /// The token royalty is mutable
-    spec mutate_tokendata_royalty(creator: &signer, token_data_id: TokenDataId, royalty: Royalty) {
+    /// The token royalty is mutable
+    spec mutate_tokendata_royalty(
+        creator: &signer, token_data_id: TokenDataId, royalty: Royalty
+    ) {
         include AssertTokendataExistsAbortsIf;
         let addr = signer::address_of(creator);
         let account = global<account::Account>(addr);
         let all_token_data = global<Collections>(token_data_id.creator).token_data;
         let token_data = table::spec_get(all_token_data, token_data_id);
         aborts_if !token_data.mutability_config.royalty;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && !exists<account::Account>(addr);
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account.guid_creation_num + 9 > MAX_U64;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && !exists<account::Account>(addr);
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account.guid_creation_num + 9 > MAX_U64;
     }
 
     /// The token description is mutable
-    spec mutate_tokendata_description(creator: &signer, token_data_id: TokenDataId, description: String) {
+    spec mutate_tokendata_description(
+        creator: &signer, token_data_id: TokenDataId, description: String
+    ) {
         include AssertTokendataExistsAbortsIf;
         let addr = signer::address_of(creator);
         let account = global<account::Account>(addr);
         let all_token_data = global<Collections>(token_data_id.creator).token_data;
         let token_data = table::spec_get(all_token_data, token_data_id);
         aborts_if !token_data.mutability_config.description;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && !exists<account::Account>(addr);
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
-        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr) && account.guid_creation_num + 9 > MAX_U64;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && !exists<account::Account>(addr);
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if !exists<token_event_store::TokenEventStoreV1>(addr)
+            && account.guid_creation_num + 9 > MAX_U64;
     }
 
     /// The property map is mutable
@@ -388,10 +416,18 @@ spec aptos_token::token {
         aborts_if addr != creator;
         aborts_if !exists<Collections>(creator);
         aborts_if !table::spec_contains(all_token_data, token_id.token_data_id);
-        aborts_if !token_data.mutability_config.properties && !simple_map::spec_contains_key(token_data.default_properties.map, std::string::spec_utf8(TOKEN_PROPERTY_MUTABLE));
+        aborts_if !token_data.mutability_config.properties
+            && !simple_map::spec_contains_key(
+                token_data.default_properties.map,
+                std::string::spec_utf8(TOKEN_PROPERTY_MUTABLE),
+            );
     }
 
-    spec create_royalty(royalty_points_numerator: u64, royalty_points_denominator: u64, payee_address: address): Royalty {
+    spec create_royalty(
+        royalty_points_numerator: u64,
+        royalty_points_denominator: u64,
+        payee_address: address
+    ): Royalty {
         include CreateRoyaltyAbortsIf;
     }
 
@@ -409,7 +445,8 @@ spec aptos_token::token {
         pragma verify = false;
         pragma aborts_if_is_partial;
         let account_addr = signer::address_of(account);
-        include !exists<TokenStore>(account_addr) ==> InitializeTokenStore;
+        include !exists<TokenStore>(account_addr) ==>
+            InitializeTokenStore;
         let token_id = token.id;
         let token_amount = token.amount;
         include DirectDepositAbortsIf;
@@ -428,10 +465,7 @@ spec aptos_token::token {
     /// Cannot withdraw 0 tokens.
     /// Make sure the account has sufficient tokens to withdraw.
     spec direct_transfer(
-        sender: &signer,
-        receiver: &signer,
-        token_id: TokenId,
-        amount: u64,
+        sender: &signer, receiver: &signer, token_id: TokenId, amount: u64,
     ) {
         //TODO: Unable to get thef value of token.
         pragma verify = false;
@@ -447,7 +481,8 @@ spec aptos_token::token {
         let addr = signer::address_of(account);
         let account_addr = global<account::Account>(addr);
         aborts_if !exists<TokenStore>(addr) && !exists<account::Account>(addr);
-        aborts_if !exists<TokenStore>(addr) && account_addr.guid_creation_num + 4 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if !exists<TokenStore>(addr)
+            && account_addr.guid_creation_num + 4 >= account::MAX_GUID_CREATION_NUM;
         aborts_if !exists<TokenStore>(addr) && account_addr.guid_creation_num + 4 > MAX_U64;
     }
 
@@ -463,10 +498,7 @@ spec aptos_token::token {
     }
 
     spec transfer(
-        from: &signer,
-        id: TokenId,
-        to: address,
-        amount: u64,
+        from: &signer, id: TokenId, to: address, amount: u64,
     ) {
         let opt_in_transfer = global<TokenStore>(to).direct_transfer;
         let account_addr = signer::address_of(from);
@@ -476,27 +508,27 @@ spec aptos_token::token {
         include WithdrawWithEventInternalAbortsIf;
     }
 
-    spec withdraw_with_capability(
-        withdraw_proof: WithdrawCapability,
-    ): Token {
+    spec withdraw_with_capability(withdraw_proof: WithdrawCapability,): Token {
         let now_seconds = global<timestamp::CurrentTimeMicroseconds>(@aptos_framework).microseconds;
         aborts_if !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
-        aborts_if now_seconds / timestamp::MICRO_CONVERSION_FACTOR > withdraw_proof.expiration_sec;
-        include WithdrawWithEventInternalAbortsIf{
-        account_addr: withdraw_proof.token_owner,
-        id: withdraw_proof.token_id,
-        amount: withdraw_proof.amount};
+        aborts_if now_seconds / timestamp::MICRO_CONVERSION_FACTOR
+            > withdraw_proof.expiration_sec;
+        include WithdrawWithEventInternalAbortsIf {
+            account_addr: withdraw_proof.token_owner,
+            id: withdraw_proof.token_id,
+            amount: withdraw_proof.amount
+        };
     }
 
     spec partial_withdraw_with_capability(
-        withdraw_proof: WithdrawCapability,
-        withdraw_amount: u64,
+        withdraw_proof: WithdrawCapability, withdraw_amount: u64,
     ): (Token, Option<WithdrawCapability>) {
         let now_seconds = global<timestamp::CurrentTimeMicroseconds>(@aptos_framework).microseconds;
         aborts_if !exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
-        aborts_if now_seconds / timestamp::MICRO_CONVERSION_FACTOR > withdraw_proof.expiration_sec;
+        aborts_if now_seconds / timestamp::MICRO_CONVERSION_FACTOR
+            > withdraw_proof.expiration_sec;
         aborts_if withdraw_amount > withdraw_proof.amount;
-        include WithdrawWithEventInternalAbortsIf{
+        include WithdrawWithEventInternalAbortsIf {
             account_addr: withdraw_proof.token_owner,
             id: withdraw_proof.token_id,
             amount: withdraw_amount
@@ -505,11 +537,7 @@ spec aptos_token::token {
 
     /// Cannot withdraw 0 tokens.
     /// Make sure the account has sufficient tokens to withdraw.
-    spec withdraw_token(
-        account: &signer,
-        id: TokenId,
-        amount: u64,
-    ): Token {
+    spec withdraw_token(account: &signer, id: TokenId, amount: u64,): Token {
         let account_addr = signer::address_of(account);
         include WithdrawWithEventInternalAbortsIf;
     }
@@ -594,7 +622,9 @@ spec aptos_token::token {
         let account_addr = signer::address_of(account);
         let collections = global<Collections>(account_addr);
         let token_data_id = spec_create_token_data_id(account_addr, collection, name);
-        let Collection = table::spec_get(collections.collection_data, token_data_id.collection);
+        let Collection = table::spec_get(
+            collections.collection_data, token_data_id.collection
+        );
         let length = len(property_keys);
         aborts_if len(name.bytes) > MAX_NFT_NAME_LENGTH;
         aborts_if len(collection.bytes) > MAX_COLLECTION_NAME_LENGTH;
@@ -610,19 +640,13 @@ spec aptos_token::token {
         aborts_if table::spec_contains(collections.token_data, token_data_id);
         aborts_if Collection.maximum > 0 && Collection.supply + 1 > MAX_U64;
         aborts_if Collection.maximum > 0 && Collection.maximum < Collection.supply + 1;
-        include CreateRoyaltyAbortsIf {
-            payee_address: royalty_payee_address
-        };
+        include CreateRoyaltyAbortsIf { payee_address: royalty_payee_address };
         aborts_if length > property_map::MAX_PROPERTY_MAP_SIZE;
         aborts_if length != len(property_values);
         aborts_if length != len(property_types);
     }
 
-    spec fun spec_create_token_data_id(
-        creator: address,
-        collection: String,
-        name: String,
-    ): TokenDataId {
+    spec fun spec_create_token_data_id(creator: address, collection: String, name: String,): TokenDataId {
         TokenDataId { creator, collection, name }
     }
 
@@ -648,7 +672,9 @@ spec aptos_token::token {
         aborts_if !table::spec_contains(all_token_data, token_data_id);
     }
 
-    spec get_tokendata_largest_property_version(creator_address: address, token_data_id: TokenDataId): u64 {
+    spec get_tokendata_largest_property_version(
+        creator_address: address, token_data_id: TokenDataId
+    ): u64 {
         aborts_if !exists<Collections>(creator_address);
         let all_token_data = global<Collections>(creator_address).token_data;
         aborts_if !table::spec_contains(all_token_data, token_data_id);
@@ -656,18 +682,28 @@ spec aptos_token::token {
 
     /// The length of 'mutate_setting' should more than five.
     /// The mutate_setting shuold have a value.
-    spec create_token_mutability_config(mutate_setting: &vector<bool>): TokenMutabilityConfig  {
+    spec create_token_mutability_config(mutate_setting: &vector<bool>): TokenMutabilityConfig {
         include CreateTokenMutabilityConfigAbortsIf;
     }
 
     spec schema CreateTokenMutabilityConfigAbortsIf {
         mutate_setting: vector<bool>;
         aborts_if len(mutate_setting) < 5;
-        aborts_if !vector::spec_contains(mutate_setting, mutate_setting[TOKEN_MAX_MUTABLE_IND]);
-        aborts_if !vector::spec_contains(mutate_setting, mutate_setting[TOKEN_URI_MUTABLE_IND]);
-        aborts_if !vector::spec_contains(mutate_setting, mutate_setting[TOKEN_ROYALTY_MUTABLE_IND]);
-        aborts_if !vector::spec_contains(mutate_setting, mutate_setting[TOKEN_DESCRIPTION_MUTABLE_IND]);
-        aborts_if !vector::spec_contains(mutate_setting, mutate_setting[TOKEN_PROPERTY_MUTABLE_IND]);
+        aborts_if !vector::spec_contains(
+            mutate_setting, mutate_setting[TOKEN_MAX_MUTABLE_IND]
+        );
+        aborts_if !vector::spec_contains(
+            mutate_setting, mutate_setting[TOKEN_URI_MUTABLE_IND]
+        );
+        aborts_if !vector::spec_contains(
+            mutate_setting, mutate_setting[TOKEN_ROYALTY_MUTABLE_IND]
+        );
+        aborts_if !vector::spec_contains(
+            mutate_setting, mutate_setting[TOKEN_DESCRIPTION_MUTABLE_IND]
+        );
+        aborts_if !vector::spec_contains(
+            mutate_setting, mutate_setting[TOKEN_PROPERTY_MUTABLE_IND]
+        );
     }
 
     spec create_collection_mutability_config {
@@ -677,19 +713,21 @@ spec aptos_token::token {
     spec schema CreateCollectionMutabilityConfigAbortsIf {
         mutate_setting: vector<bool>;
         aborts_if len(mutate_setting) < 3;
-        aborts_if !vector::spec_contains(mutate_setting, mutate_setting[COLLECTION_DESCRIPTION_MUTABLE_IND]);
-        aborts_if !vector::spec_contains(mutate_setting, mutate_setting[COLLECTION_URI_MUTABLE_IND]);
-        aborts_if !vector::spec_contains(mutate_setting, mutate_setting[COLLECTION_MAX_MUTABLE_IND]);
+        aborts_if !vector::spec_contains(
+            mutate_setting, mutate_setting[COLLECTION_DESCRIPTION_MUTABLE_IND]
+        );
+        aborts_if !vector::spec_contains(
+            mutate_setting, mutate_setting[COLLECTION_URI_MUTABLE_IND]
+        );
+        aborts_if !vector::spec_contains(
+            mutate_setting, mutate_setting[COLLECTION_MAX_MUTABLE_IND]
+        );
     }
 
     /// The creator of the TokenDataId is signer.
     /// The token_data_id should exist in the creator's collections..
     /// The sum of supply and the amount of mint Token is less than maximum.
-    spec mint_token(
-        account: &signer,
-        token_data_id: TokenDataId,
-        amount: u64,
-    ): TokenId {
+    spec mint_token(account: &signer, token_data_id: TokenDataId, amount: u64,): TokenId {
         //TODO: Cannot get the value of Token for deposit_token function.
         // pragma aborts_if_is_partial;
         pragma verify = false;
@@ -730,10 +768,7 @@ spec aptos_token::token {
     }
 
     spec mint_token_to(
-        account: &signer,
-        receiver: address,
-        token_data_id: TokenDataId,
-        amount: u64,
+        account: &signer, receiver: address, token_data_id: TokenDataId, amount: u64,
     ) {
         let addr = signer::address_of(account);
         let opt_in_transfer = global<TokenStore>(receiver).direct_transfer;
@@ -759,11 +794,7 @@ spec aptos_token::token {
 
     /// The length of collection should less than MAX_COLLECTION_NAME_LENGTH
     /// The length of name should less than MAX_NFT_NAME_LENGTH
-    spec create_token_data_id(
-        creator: address,
-        collection: String,
-        name: String,
-    ): TokenDataId {
+    spec create_token_data_id(creator: address, collection: String, name: String,): TokenDataId {
         include CreateTokenDataIdAbortsIf;
     }
 
@@ -778,37 +809,29 @@ spec aptos_token::token {
     /// The length of collection should less than MAX_COLLECTION_NAME_LENGTH
     /// The length of name should less than MAX_NFT_NAME_LENGTH
     spec create_token_id_raw(
-        creator: address,
-        collection: String,
-        name: String,
-        property_version: u64,
+        creator: address, collection: String, name: String, property_version: u64,
     ): TokenId {
         include CreateTokenDataIdAbortsIf;
     }
 
     spec fun spec_balance_of(owner: address, id: TokenId): u64 {
         let token_store = borrow_global<TokenStore>(owner);
-        if (!exists<TokenStore>(owner)) {
-            0
-        }
+        if (!exists<TokenStore>(owner)) { 0 }
         else if (table::spec_contains(token_store.tokens, id)) {
             table::spec_get(token_store.tokens, id).amount
-        } else {
-            0
-        }
+        } else { 0 }
     }
 
     spec get_royalty(token_id: TokenId): Royalty {
-        include GetTokendataRoyaltyAbortsIf {
-            token_data_id: token_id.token_data_id
-        };
+        include GetTokendataRoyaltyAbortsIf { token_data_id: token_id.token_data_id };
     }
 
     spec get_property_map(owner: address, token_id: TokenId): PropertyMap {
         let creator_addr = token_id.token_data_id.creator;
         let all_token_data = global<Collections>(creator_addr).token_data;
         aborts_if spec_balance_of(owner, token_id) <= 0;
-        aborts_if token_id.property_version == 0 && !table::spec_contains(all_token_data, token_id.token_data_id);
+        aborts_if token_id.property_version == 0
+            && !table::spec_contains(all_token_data, token_id.token_data_id);
         aborts_if token_id.property_version == 0 && !exists<Collections>(creator_addr);
     }
 
@@ -851,20 +874,13 @@ spec aptos_token::token {
         aborts_if !table::spec_contains(all_token_data, token_data_id);
     }
 
-    spec get_collection_mutability_config(
-        creator: address,
-        collection_name: String
-    ): CollectionMutabilityConfig {
+    spec get_collection_mutability_config(creator: address, collection_name: String): CollectionMutabilityConfig {
         let all_collection_data = global<Collections>(creator).collection_data;
         aborts_if !exists<Collections>(creator);
         aborts_if !table::spec_contains(all_collection_data, collection_name);
     }
 
-    spec withdraw_with_event_internal(
-        account_addr: address,
-        id: TokenId,
-        amount: u64,
-    ): Token {
+    spec withdraw_with_event_internal(account_addr: address, id: TokenId, amount: u64,): Token {
         include WithdrawWithEventInternalAbortsIf;
     }
 
@@ -879,7 +895,7 @@ spec aptos_token::token {
         aborts_if !table::spec_contains(tokens, id);
     }
 
-    spec update_token_property_internal (
+    spec update_token_property_internal(
         token_owner: address,
         token_id: TokenId,
         keys: vector<String>,

--- a/aptos-move/framework/aptos-token/sources/token_coin_swap.move
+++ b/aptos-move/framework/aptos-token/sources/token_coin_swap.move
@@ -79,8 +79,7 @@ module aptos_token::token_coin_swap {
     }
 
     public fun does_listing_exist<CoinType>(
-        _token_owner: address,
-        _token_id: TokenId
+        _token_owner: address, _token_id: TokenId
     ): bool {
         abort error::invalid_argument(EDEPRECATED_MODULE)
     }
@@ -135,18 +134,14 @@ module aptos_token::token_coin_swap {
 
     /// Private function for withdraw tokens from an escrow stored in token owner address
     fun withdraw_token_from_escrow_internal(
-        _token_owner_addr: address,
-        _token_id: TokenId,
-        _amount: u64
+        _token_owner_addr: address, _token_id: TokenId, _amount: u64
     ): Token {
         abort error::invalid_argument(EDEPRECATED_MODULE)
     }
 
     /// Withdraw tokens from the token escrow. It needs a signer to authorize
     public fun withdraw_token_from_escrow(
-        _token_owner: &signer,
-        _token_id: TokenId,
-        _amount: u64
+        _token_owner: &signer, _token_id: TokenId, _amount: u64
     ): Token {
         abort error::invalid_argument(EDEPRECATED_MODULE)
     }

--- a/aptos-move/framework/aptos-token/sources/token_event_store.move
+++ b/aptos-move/framework/aptos-token/sources/token_event_store.move
@@ -212,25 +212,39 @@ module aptos_token::token_event_store {
         extension: Option<Any>,
     }
 
-    fun initialize_token_event_store(acct: &signer){
+    fun initialize_token_event_store(acct: &signer) {
         if (!exists<TokenEventStoreV1>(signer::address_of(acct))) {
-            move_to(acct, TokenEventStoreV1 {
-                collection_uri_mutate_events: account::new_event_handle<CollectionUriMutateEvent>(acct),
-                collection_maximum_mutate_events: account::new_event_handle<CollectionMaxiumMutateEvent>(acct),
-                collection_description_mutate_events: account::new_event_handle<CollectionDescriptionMutateEvent>(acct),
-                opt_in_events: account::new_event_handle<OptInTransferEvent>(acct),
-                uri_mutate_events: account::new_event_handle<UriMutationEvent>(acct),
-                default_property_mutate_events: account::new_event_handle<DefaultPropertyMutateEvent>(acct),
-                description_mutate_events: account::new_event_handle<DescriptionMutateEvent>(acct),
-                royalty_mutate_events: account::new_event_handle<RoyaltyMutateEvent>(acct),
-                maximum_mutate_events: account::new_event_handle<MaxiumMutateEvent>(acct),
-                extension: option::none<Any>(),
-            });
+            move_to(
+                acct,
+                TokenEventStoreV1 {
+                    collection_uri_mutate_events: account::new_event_handle<
+                        CollectionUriMutateEvent>(acct),
+                    collection_maximum_mutate_events: account::new_event_handle<
+                        CollectionMaxiumMutateEvent>(acct),
+                    collection_description_mutate_events: account::new_event_handle<
+                        CollectionDescriptionMutateEvent>(acct),
+                    opt_in_events: account::new_event_handle<OptInTransferEvent>(acct),
+                    uri_mutate_events: account::new_event_handle<UriMutationEvent>(acct),
+                    default_property_mutate_events: account::new_event_handle<
+                        DefaultPropertyMutateEvent>(acct),
+                    description_mutate_events: account::new_event_handle<
+                        DescriptionMutateEvent>(acct),
+                    royalty_mutate_events: account::new_event_handle<RoyaltyMutateEvent>(
+                        acct
+                    ),
+                    maximum_mutate_events: account::new_event_handle<MaxiumMutateEvent>(
+                        acct
+                    ),
+                    extension: option::none<Any>(),
+                },
+            );
         };
     }
 
     /// Emit the collection uri mutation event
-    public(friend) fun emit_collection_uri_mutate_event(creator: &signer, collection: String, old_uri: String, new_uri: String) acquires TokenEventStoreV1 {
+    public(friend) fun emit_collection_uri_mutate_event(
+        creator: &signer, collection: String, old_uri: String, new_uri: String
+    ) acquires TokenEventStoreV1 {
         let event = CollectionUriMutateEvent {
             creator_addr: signer::address_of(creator),
             collection_name: collection,
@@ -238,7 +252,8 @@ module aptos_token::token_event_store {
             new_uri,
         };
         initialize_token_event_store(creator);
-        let token_event_store = borrow_global_mut<TokenEventStoreV1>(signer::address_of(creator));
+        let token_event_store =
+            borrow_global_mut<TokenEventStoreV1>(signer::address_of(creator));
         if (std::features::module_event_migration_enabled()) {
             event::emit(
                 CollectionUriMutate {
@@ -246,7 +261,7 @@ module aptos_token::token_event_store {
                     collection_name: collection,
                     old_uri,
                     new_uri,
-                }
+                },
             );
         };
         event::emit_event<CollectionUriMutateEvent>(
@@ -256,7 +271,12 @@ module aptos_token::token_event_store {
     }
 
     /// Emit the collection description mutation event
-    public(friend) fun emit_collection_description_mutate_event(creator: &signer, collection: String, old_description: String, new_description: String) acquires TokenEventStoreV1 {
+    public(friend) fun emit_collection_description_mutate_event(
+        creator: &signer,
+        collection: String,
+        old_description: String,
+        new_description: String
+    ) acquires TokenEventStoreV1 {
         let event = CollectionDescriptionMutateEvent {
             creator_addr: signer::address_of(creator),
             collection_name: collection,
@@ -264,7 +284,8 @@ module aptos_token::token_event_store {
             new_description,
         };
         initialize_token_event_store(creator);
-        let token_event_store = borrow_global_mut<TokenEventStoreV1>(signer::address_of(creator));
+        let token_event_store =
+            borrow_global_mut<TokenEventStoreV1>(signer::address_of(creator));
         if (std::features::module_event_migration_enabled()) {
             event::emit(
                 CollectionDescriptionMutate {
@@ -272,7 +293,7 @@ module aptos_token::token_event_store {
                     collection_name: collection,
                     old_description,
                     new_description,
-                }
+                },
             );
         };
         event::emit_event<CollectionDescriptionMutateEvent>(
@@ -282,7 +303,9 @@ module aptos_token::token_event_store {
     }
 
     /// Emit the collection maximum mutation event
-    public(friend) fun emit_collection_maximum_mutate_event(creator: &signer, collection: String, old_maximum: u64, new_maximum: u64) acquires TokenEventStoreV1 {
+    public(friend) fun emit_collection_maximum_mutate_event(
+        creator: &signer, collection: String, old_maximum: u64, new_maximum: u64
+    ) acquires TokenEventStoreV1 {
         let event = CollectionMaxiumMutateEvent {
             creator_addr: signer::address_of(creator),
             collection_name: collection,
@@ -290,7 +313,8 @@ module aptos_token::token_event_store {
             new_maximum,
         };
         initialize_token_event_store(creator);
-        let token_event_store = borrow_global_mut<TokenEventStoreV1>(signer::address_of(creator));
+        let token_event_store =
+            borrow_global_mut<TokenEventStoreV1>(signer::address_of(creator));
         if (std::features::module_event_migration_enabled()) {
             event::emit(
                 CollectionMaxiumMutate {
@@ -298,7 +322,7 @@ module aptos_token::token_event_store {
                     collection_name: collection,
                     old_maximum,
                     new_maximum,
-                }
+                },
             );
         };
         event::emit_event<CollectionMaxiumMutateEvent>(
@@ -308,18 +332,17 @@ module aptos_token::token_event_store {
     }
 
     /// Emit the direct opt-in event
-    public(friend) fun emit_token_opt_in_event(account: &signer, opt_in: bool) acquires TokenEventStoreV1 {
-        let opt_in_event = OptInTransferEvent {
-          opt_in,
-        };
+    public(friend) fun emit_token_opt_in_event(
+        account: &signer, opt_in: bool
+    ) acquires TokenEventStoreV1 {
+        let opt_in_event = OptInTransferEvent { opt_in, };
         initialize_token_event_store(account);
-        let token_event_store = borrow_global_mut<TokenEventStoreV1>(signer::address_of(account));
+        let token_event_store =
+            borrow_global_mut<TokenEventStoreV1>(signer::address_of(account));
         if (std::features::module_event_migration_enabled()) {
             event::emit(
-                OptInTransfer {
-                    account_address: signer::address_of(account),
-                    opt_in,
-                });
+                OptInTransfer { account_address: signer::address_of(account), opt_in, },
+            );
         };
         event::emit_event<OptInTransferEvent>(
             &mut token_event_store.opt_in_events,
@@ -349,13 +372,8 @@ module aptos_token::token_event_store {
         let token_event_store = borrow_global_mut<TokenEventStoreV1>(creator_addr);
         if (std::features::module_event_migration_enabled()) {
             event::emit(
-                UriMutation {
-                    creator: creator_addr,
-                    collection,
-                    token,
-                    old_uri,
-                    new_uri,
-                });
+                UriMutation { creator: creator_addr, collection, token, old_uri, new_uri, },
+            );
         };
         event::emit_event<UriMutationEvent>(
             &mut token_event_store.uri_mutate_events,
@@ -394,7 +412,8 @@ module aptos_token::token_event_store {
                     keys,
                     old_values,
                     new_values,
-                });
+                },
+            );
         };
         event::emit_event<DefaultPropertyMutateEvent>(
             &mut token_event_store.default_property_mutate_events,
@@ -430,7 +449,8 @@ module aptos_token::token_event_store {
                     token,
                     old_description,
                     new_description,
-                });
+                },
+            );
         };
         event::emit_event<DescriptionMutateEvent>(
             &mut token_event_store.description_mutate_events,
@@ -477,7 +497,8 @@ module aptos_token::token_event_store {
                     new_royalty_numerator,
                     new_royalty_denominator,
                     new_royalty_payee_addr,
-                });
+                },
+            );
         };
         event::emit_event<RoyaltyMutateEvent>(
             &mut token_event_store.royalty_mutate_events,
@@ -504,7 +525,7 @@ module aptos_token::token_event_store {
         };
 
         initialize_token_event_store(creator);
-        let token_event_store =  borrow_global_mut<TokenEventStoreV1>(creator_addr);
+        let token_event_store = borrow_global_mut<TokenEventStoreV1>(creator_addr);
         if (std::features::module_event_migration_enabled()) {
             event::emit(
                 MaximumMutate {
@@ -513,7 +534,8 @@ module aptos_token::token_event_store {
                     token,
                     old_maximum,
                     new_maximum,
-                });
+                },
+            );
         };
         event::emit_event<MaxiumMutateEvent>(
             &mut token_event_store.maximum_mutate_events,

--- a/aptos-move/framework/aptos-token/sources/token_event_store.spec.move
+++ b/aptos-move/framework/aptos-token/sources/token_event_store.spec.move
@@ -7,7 +7,7 @@ spec aptos_token::token_event_store {
     spec initialize_token_event_store(acct: &signer) {
         pragma verify = true;
         let addr = signer::address_of(acct);
-        include InitializeTokenEventStoreAbortsIf {creator : acct};
+        include InitializeTokenEventStoreAbortsIf { creator: acct };
     }
 
     /// Adjust the overflow value according to the
@@ -18,8 +18,10 @@ spec aptos_token::token_event_store {
         let addr = signer::address_of(creator);
         let account = global<Account>(addr);
         aborts_if !exists<TokenEventStoreV1>(addr) && !exists<Account>(addr);
-        aborts_if !exists<TokenEventStoreV1>(addr) && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
-        aborts_if !exists<TokenEventStoreV1>(addr) && account.guid_creation_num + 9 > MAX_U64;
+        aborts_if !exists<TokenEventStoreV1>(addr)
+            && account.guid_creation_num + 9 >= account::MAX_GUID_CREATION_NUM;
+        aborts_if !exists<TokenEventStoreV1>(addr) && account.guid_creation_num + 9
+            > MAX_U64;
     }
 
     spec schema TokenEventStoreAbortsIf {
@@ -32,20 +34,29 @@ spec aptos_token::token_event_store {
         aborts_if account.guid_creation_num + 9 > MAX_U64;
     }
 
-    spec emit_collection_uri_mutate_event(creator: &signer, collection: String, old_uri: String, new_uri: String) {
+    spec emit_collection_uri_mutate_event(
+        creator: &signer, collection: String, old_uri: String, new_uri: String
+    ) {
         include InitializeTokenEventStoreAbortsIf;
     }
 
-    spec emit_collection_description_mutate_event(creator: &signer, collection: String, old_description: String, new_description: String) {
+    spec emit_collection_description_mutate_event(
+        creator: &signer,
+        collection: String,
+        old_description: String,
+        new_description: String
+    ) {
         include InitializeTokenEventStoreAbortsIf;
     }
 
-    spec emit_collection_maximum_mutate_event(creator: &signer, collection: String, old_maximum: u64, new_maximum: u64) {
+    spec emit_collection_maximum_mutate_event(
+        creator: &signer, collection: String, old_maximum: u64, new_maximum: u64
+    ) {
         include InitializeTokenEventStoreAbortsIf;
     }
 
     spec emit_token_opt_in_event(account: &signer, opt_in: bool) {
-        include InitializeTokenEventStoreAbortsIf {creator : account};
+        include InitializeTokenEventStoreAbortsIf { creator: account };
     }
 
     spec emit_token_uri_mutate_event(

--- a/aptos-move/framework/aptos-token/sources/token_transfers.move
+++ b/aptos-move/framework/aptos-token/sources/token_transfers.move
@@ -76,17 +76,16 @@ module aptos_token::token_transfers {
             PendingClaims {
                 pending_claims: table::new<TokenOfferId, Token>(),
                 offer_events: account::new_event_handle<TokenOfferEvent>(account),
-                cancel_offer_events: account::new_event_handle<TokenCancelOfferEvent>(account),
+                cancel_offer_events: account::new_event_handle<TokenCancelOfferEvent>(
+                    account
+                ),
                 claim_events: account::new_event_handle<TokenClaimEvent>(account),
-            }
+            },
         )
     }
 
     fun create_token_offer_id(to_addr: address, token_id: TokenId): TokenOfferId {
-        TokenOfferId {
-            to_addr,
-            token_id
-        }
+        TokenOfferId { to_addr, token_id }
     }
 
     public entry fun offer_script(
@@ -98,7 +97,8 @@ module aptos_token::token_transfers {
         property_version: u64,
         amount: u64,
     ) acquires PendingClaims {
-        let token_id = token::create_token_id_raw(creator, collection, name, property_version);
+        let token_id =
+            token::create_token_id_raw(creator, collection, name, property_version);
         offer(&sender, receiver, token_id, amount);
     }
 
@@ -126,20 +126,12 @@ module aptos_token::token_transfers {
 
         if (std::features::module_event_migration_enabled()) {
             event::emit(
-                TokenOffer {
-                    to_address: receiver,
-                    token_id,
-                    amount,
-                }
+                TokenOffer { to_address: receiver, token_id, amount, },
             )
         };
         event::emit_event<TokenOfferEvent>(
             &mut borrow_global_mut<PendingClaims>(sender_addr).offer_events,
-            TokenOfferEvent {
-                to_address: receiver,
-                token_id,
-                amount,
-            },
+            TokenOfferEvent { to_address: receiver, token_id, amount, },
         );
     }
 
@@ -151,7 +143,8 @@ module aptos_token::token_transfers {
         name: String,
         property_version: u64,
     ) acquires PendingClaims {
-        let token_id = token::create_token_id_raw(creator, collection, name, property_version);
+        let token_id =
+            token::create_token_id_raw(creator, collection, name, property_version);
         claim(&receiver, sender, token_id);
     }
 
@@ -161,30 +154,24 @@ module aptos_token::token_transfers {
         token_id: TokenId,
     ) acquires PendingClaims {
         assert!(exists<PendingClaims>(sender), ETOKEN_OFFER_NOT_EXIST);
-        let pending_claims =
-            &mut borrow_global_mut<PendingClaims>(sender).pending_claims;
+        let pending_claims = &mut borrow_global_mut<PendingClaims>(sender).pending_claims;
         let token_offer_id = create_token_offer_id(signer::address_of(receiver), token_id);
-        assert!(table::contains(pending_claims, token_offer_id), error::not_found(ETOKEN_OFFER_NOT_EXIST));
+        assert!(
+            table::contains(pending_claims, token_offer_id),
+            error::not_found(ETOKEN_OFFER_NOT_EXIST),
+        );
         let tokens = table::remove(pending_claims, token_offer_id);
         let amount = token::get_token_amount(&tokens);
         token::deposit_token(receiver, tokens);
 
         if (std::features::module_event_migration_enabled()) {
             event::emit(
-                TokenClaim {
-                    to_address: signer::address_of(receiver),
-                    token_id,
-                    amount,
-                }
+                TokenClaim { to_address: signer::address_of(receiver), token_id, amount, },
             )
         };
         event::emit_event<TokenClaimEvent>(
             &mut borrow_global_mut<PendingClaims>(sender).claim_events,
-            TokenClaimEvent {
-                to_address: signer::address_of(receiver),
-                token_id,
-                amount,
-            },
+            TokenClaimEvent { to_address: signer::address_of(receiver), token_id, amount, },
         );
     }
 
@@ -196,7 +183,8 @@ module aptos_token::token_transfers {
         name: String,
         property_version: u64,
     ) acquires PendingClaims {
-        let token_id = token::create_token_id_raw(creator, collection, name, property_version);
+        let token_id =
+            token::create_token_id_raw(creator, collection, name, property_version);
         cancel_offer(&sender, receiver, token_id);
     }
 
@@ -217,20 +205,12 @@ module aptos_token::token_transfers {
 
         if (std::features::module_event_migration_enabled()) {
             event::emit(
-                TokenCancelOffer {
-                    to_address: receiver,
-                    token_id,
-                    amount,
-                },
+                TokenCancelOffer { to_address: receiver, token_id, amount, },
             )
         };
         event::emit_event<TokenCancelOfferEvent>(
             &mut borrow_global_mut<PendingClaims>(sender_addr).cancel_offer_events,
-            TokenCancelOfferEvent {
-                to_address: receiver,
-                token_id,
-                amount,
-            },
+            TokenCancelOfferEvent { to_address: receiver, token_id, amount, },
         );
     }
 
@@ -243,7 +223,6 @@ module aptos_token::token_transfers {
         aptos_framework::account::create_account_for_test(owner_addr);
         offer(&creator, owner_addr, token_id, 1);
         claim(&owner, creator_addr, token_id);
-
 
         offer(&owner, creator_addr, token_id, 1);
         cancel_offer(&owner, creator_addr, token_id);
@@ -298,9 +277,13 @@ module aptos_token::token_transfers {
         );
 
         let token_mutation_setting = vector<bool>[false, false, false, false, true];
-        let default_keys = vector<String>[string::utf8(b"attack"), string::utf8(b"num_of_use")];
+        let default_keys = vector<String>[string::utf8(b"attack"), string::utf8(
+                b"num_of_use"
+            )];
         let default_vals = vector<vector<u8>>[b"10", b"5"];
-        let default_types = vector<String>[string::utf8(b"integer"), string::utf8(b"integer")];
+        let default_types = vector<String>[string::utf8(b"integer"), string::utf8(
+                b"integer"
+            )];
         token::create_token_script(
             creator,
             collection_name,
@@ -321,7 +304,7 @@ module aptos_token::token_transfers {
             signer::address_of(creator),
             collection_name,
             string::utf8(b"Token: Hello, Token"),
-            0
+            0,
         )
     }
 }

--- a/aptos-move/framework/aptos-token/sources/token_transfers.move
+++ b/aptos-move/framework/aptos-token/sources/token_transfers.move
@@ -278,12 +278,12 @@ module aptos_token::token_transfers {
 
         let token_mutation_setting = vector<bool>[false, false, false, false, true];
         let default_keys = vector<String>[string::utf8(b"attack"), string::utf8(
-                b"num_of_use"
-            )];
+            b"num_of_use"
+        )];
         let default_vals = vector<vector<u8>>[b"10", b"5"];
         let default_types = vector<String>[string::utf8(b"integer"), string::utf8(
-                b"integer"
-            )];
+            b"integer"
+        )];
         token::create_token_script(
             creator,
             collection_name,

--- a/aptos-move/framework/aptos-token/sources/token_transfers.spec.move
+++ b/aptos-move/framework/aptos-token/sources/token_transfers.spec.move
@@ -33,24 +33,24 @@ spec aptos_token::token_transfers {
         name: String,
         property_version: u64,
         amount: u64,
-    ){
+    ) {
         pragma verify = false;
-        let token_id = token::create_token_id_raw(creator, collection, name, property_version);
+        let token_id = token::create_token_id_raw(
+            creator, collection, name, property_version
+        );
     }
 
     spec offer(
-        sender: &signer,
-        receiver: address,
-        token_id: TokenId,
-        amount: u64,
-    ){
-        use aptos_token::token::{TokenStore,Self};
+        sender: &signer, receiver: address, token_id: TokenId, amount: u64,
+    ) {
+        use aptos_token::token::{TokenStore, Self};
 
         // TODO: Can't get the return from `withdraw_token`.
         pragma verify = false;
 
         let sender_addr = signer::address_of(sender);
-        include !exists<PendingClaims>(sender_addr) ==> InitializeTokenTransfersAbortsIf{account : sender};
+        include !exists<PendingClaims>(sender_addr) ==>
+            InitializeTokenTransfersAbortsIf { account: sender };
         let pending_claims = global<PendingClaims>(sender_addr).pending_claims;
         let token_offer_id = create_token_offer_id(receiver, token_id);
 
@@ -64,22 +64,19 @@ spec aptos_token::token_transfers {
         let a = table::spec_contains(pending_claims, token_offer_id);
         let dst_token = table::spec_get(pending_claims, token_offer_id);
 
-        aborts_if dst_token.amount + spce_get(signer::address_of(sender), token_id, amount) > MAX_U64;
+        aborts_if dst_token.amount + spce_get(
+            signer::address_of(sender), token_id, amount
+        ) > MAX_U64;
     }
 
     /// Get the amount from sender token
-    spec fun spce_get(
-        account_addr: address,
-        id: TokenId,
-        amount: u64
-    ): u64 {
+    spec fun spce_get(account_addr: address, id: TokenId, amount: u64): u64 {
         use aptos_token::token::{TokenStore};
         use aptos_std::table::{Self};
         let tokens = global<TokenStore>(account_addr).tokens;
         let balance = table::spec_get(tokens, id).amount;
-        if (balance > amount) {
-            amount
-        } else {
+        if (balance > amount) { amount }
+        else {
             table::spec_get(tokens, id).amount
         }
     }
@@ -91,20 +88,22 @@ spec aptos_token::token_transfers {
         collection: String,
         name: String,
         property_version: u64,
-    ){
+    ) {
         use aptos_token::token::{TokenStore};
 
         // TODO: deposit_token has pending issues
         pragma aborts_if_is_partial;
 
-        let token_id = token::create_token_id_raw(creator, collection, name, property_version);
+        let token_id = token::create_token_id_raw(
+            creator, collection, name, property_version
+        );
         aborts_if !exists<PendingClaims>(sender);
         let pending_claims = global<PendingClaims>(sender).pending_claims;
         let token_offer_id = create_token_offer_id(signer::address_of(receiver), token_id);
         aborts_if !table::spec_contains(pending_claims, token_offer_id);
         let tokens = table::spec_get(pending_claims, token_offer_id);
 
-        include token::InitializeTokenStore{account: receiver };
+        include token::InitializeTokenStore { account: receiver };
 
         let account_addr = signer::address_of(receiver);
         let token = tokens;
@@ -115,11 +114,7 @@ spec aptos_token::token_transfers {
 
     }
 
-    spec claim(
-        receiver: &signer,
-        sender: address,
-        token_id: TokenId,
-    ){
+    spec claim(receiver: &signer, sender: address, token_id: TokenId,) {
         use aptos_token::token::{TokenStore};
         // TODO: deposit_token has pending issues
         pragma aborts_if_is_partial;
@@ -130,7 +125,7 @@ spec aptos_token::token_transfers {
         aborts_if !table::spec_contains(pending_claims, token_offer_id);
         let tokens = table::spec_get(pending_claims, token_offer_id);
 
-        include token::InitializeTokenStore{account: receiver };
+        include token::InitializeTokenStore { account: receiver };
 
         let account_addr = signer::address_of(receiver);
         let token = tokens;
@@ -147,13 +142,15 @@ spec aptos_token::token_transfers {
         collection: String,
         name: String,
         property_version: u64,
-    ){
+    ) {
         use aptos_token::token::{TokenStore};
 
         // TODO: deposit_token has pending issues.
         pragma aborts_if_is_partial;
 
-        let token_id = token::create_token_id_raw(creator, collection, name, property_version);
+        let token_id = token::create_token_id_raw(
+            creator, collection, name, property_version
+        );
 
         let sender_addr = signer::address_of(sender);
         aborts_if !exists<PendingClaims>(sender_addr);
@@ -161,7 +158,7 @@ spec aptos_token::token_transfers {
         let token_offer_id = create_token_offer_id(receiver, token_id);
         aborts_if !table::spec_contains(pending_claims, token_offer_id);
 
-        include token::InitializeTokenStore{account: sender };
+        include token::InitializeTokenStore { account: sender };
         let dst_token = table::spec_get(pending_claims, token_offer_id);
 
         let account_addr = sender_addr;
@@ -172,11 +169,7 @@ spec aptos_token::token_transfers {
         aborts_if token.amount <= 0;
     }
 
-    spec cancel_offer(
-        sender: &signer,
-        receiver: address,
-        token_id: TokenId,
-    ){
+    spec cancel_offer(sender: &signer, receiver: address, token_id: TokenId,) {
         use aptos_token::token::{TokenStore};
 
         // TODO: deposit_token has pending issues.
@@ -188,7 +181,7 @@ spec aptos_token::token_transfers {
         let token_offer_id = create_token_offer_id(receiver, token_id);
         aborts_if !table::spec_contains(pending_claims, token_offer_id);
 
-        include token::InitializeTokenStore{account: sender };
+        include token::InitializeTokenStore { account: sender };
         let dst_token = table::spec_get(pending_claims, token_offer_id);
 
         let account_addr = sender_addr;

--- a/aptos-move/framework/move-stdlib/sources/acl.move
+++ b/aptos-move/framework/move-stdlib/sources/acl.move
@@ -18,12 +18,14 @@ module std::acl {
 
     /// Return an empty ACL.
     public fun empty(): ACL {
-        ACL{ list: vector::empty<address>() }
+        ACL { list: vector::empty<address>() }
     }
 
     /// Add the address to the ACL.
     public fun add(acl: &mut ACL, addr: address) {
-        assert!(!vector::contains(&mut acl.list, &addr), error::invalid_argument(ECONTAIN));
+        assert!(
+            !vector::contains(&mut acl.list, &addr), error::invalid_argument(ECONTAIN)
+        );
         vector::push_back(&mut acl.list, addr);
     }
 

--- a/aptos-move/framework/move-stdlib/sources/acl.spec.move
+++ b/aptos-move/framework/move-stdlib/sources/acl.spec.move
@@ -1,6 +1,7 @@
 spec std::acl {
     spec ACL {
-        invariant forall i in 0..len(list), j in 0..len(list): list[i] == list[j] ==> i == j;
+        invariant forall i in 0..len(list), j in 0..len(list):
+            list[i] == list[j] ==> i == j;
     }
 
     spec fun spec_contains(acl: ACL, addr: address): bool {

--- a/aptos-move/framework/move-stdlib/sources/bit_vector.move
+++ b/aptos-move/framework/move-stdlib/sources/bit_vector.move
@@ -25,12 +25,12 @@ module std::bit_vector {
         let counter = 0;
         let bit_field = vector::empty();
         while ({
-                spec {
-                    invariant counter <= length;
-                    invariant len(bit_field) == counter;
-                };
-                (counter < length)
-            }) {
+            spec {
+                invariant counter <= length;
+                invariant len(bit_field) == counter;
+            };
+            (counter < length)
+        }) {
             vector::push_back(&mut bit_field, false);
             counter = counter + 1;
         };
@@ -94,10 +94,12 @@ module std::bit_vector {
     /// bitvector's length the bitvector will be zeroed out.
     public fun shift_left(bitvector: &mut BitVector, amount: u64) {
         if (amount >= bitvector.length) {
-            vector::for_each_mut(&mut bitvector.bit_field,
+            vector::for_each_mut(
+                &mut bitvector.bit_field,
                 |elem| {
                     *elem = false;
-                });
+                },
+            );
         } else {
             let i = amount;
 
@@ -162,17 +164,17 @@ module std::bit_vector {
 
         // Find the greatest index in the vector such that all indices less than it are set.
         while ({
-                spec {
-                    invariant index >= start_index;
-                    invariant index == start_index || is_index_set(bitvector, index - 1);
-                    invariant index == start_index
-                        || index - 1 < vector::length(bitvector.bit_field);
-                    invariant forall j in start_index..index: is_index_set(bitvector, j);
-                    invariant forall j in start_index..index: j
-                        < vector::length(bitvector.bit_field);
-                };
-                index < bitvector.length
-            }) {
+            spec {
+                invariant index >= start_index;
+                invariant index == start_index || is_index_set(bitvector, index - 1);
+                invariant index == start_index
+                    || index - 1 < vector::length(bitvector.bit_field);
+                invariant forall j in start_index..index: is_index_set(bitvector, j);
+                invariant forall j in start_index..index:
+                    j < vector::length(bitvector.bit_field);
+            };
+            index < bitvector.length
+        }) {
             if (!is_index_set(bitvector, index)) break;
             index = index + 1;
         };
@@ -198,14 +200,14 @@ module std::bit_vector {
             let len = vector::length(&bitvector.bit_field);
             let i = 0;
             while ({
-                    spec {
-                        invariant len == bitvector.length;
-                        invariant forall k in 0..i: !bitvector.bit_field[k];
-                        invariant forall k in i..bitvector.length: bitvector.bit_field[k]
-                            == old(bitvector).bit_field[k];
-                    };
-                    i < len
-                }) {
+                spec {
+                    invariant len == bitvector.length;
+                    invariant forall k in 0..i: !bitvector.bit_field[k];
+                    invariant forall k in i..bitvector.length:
+                        bitvector.bit_field[k] == old(bitvector).bit_field[k];
+                };
+                i < len
+            }) {
                 let elem = vector::borrow_mut(&mut bitvector.bit_field, i);
                 *elem = false;
                 i = i + 1;
@@ -214,19 +216,18 @@ module std::bit_vector {
             let i = amount;
 
             while ({
-                    spec {
-                        invariant i >= amount;
-                        invariant bitvector.length == old(bitvector).length;
-                        invariant forall j in amount..i: old(bitvector).bit_field[j]
-                            == bitvector.bit_field[j - amount];
-                        invariant forall j in (i - amount)..bitvector.length: old(
-                            bitvector
-                        ).bit_field[j] == bitvector.bit_field[j];
-                        invariant forall k in 0..i - amount: bitvector.bit_field[k]
-                            == old(bitvector).bit_field[k + amount];
-                    };
-                    i < bitvector.length
-                }) {
+                spec {
+                    invariant i >= amount;
+                    invariant bitvector.length == old(bitvector).length;
+                    invariant forall j in amount..i:
+                        old(bitvector).bit_field[j] == bitvector.bit_field[j - amount];
+                    invariant forall j in (i - amount)..bitvector.length:
+                        old(bitvector).bit_field[j] == bitvector.bit_field[j];
+                    invariant forall k in 0..i - amount:
+                        bitvector.bit_field[k] == old(bitvector).bit_field[k + amount];
+                };
+                i < bitvector.length
+            }) {
                 if (is_index_set(bitvector, i)) set(bitvector, i - amount)
                 else unset(bitvector, i - amount);
                 i = i + 1;
@@ -235,14 +236,15 @@ module std::bit_vector {
             i = bitvector.length - amount;
 
             while ({
-                    spec {
-                        invariant forall j in bitvector.length - amount..i: !bitvector.bit_field[j];
-                        invariant forall k in 0..bitvector.length - amount: bitvector.bit_field[k] ==
-                             old(bitvector).bit_field[k + amount];
-                        invariant i >= bitvector.length - amount;
-                    };
-                    i < bitvector.length
-                }) {
+                spec {
+                    invariant forall j in bitvector.length - amount..i:
+                        !bitvector.bit_field[j];
+                    invariant forall k in 0..bitvector.length - amount:
+                        bitvector.bit_field[k] == old(bitvector).bit_field[k + amount];
+                    invariant i >= bitvector.length - amount;
+                };
+                i < bitvector.length
+            }) {
                 unset(bitvector, i);
                 i = i + 1;
             }
@@ -255,12 +257,13 @@ module std::bit_vector {
             (forall k in 0..bitvector.length: !bitvector.bit_field[k]);
         ensures amount < bitvector.length ==>
             (
-                forall i in bitvector.length - amount..bitvector.length: !bitvector.bit_field[i]
+                forall i in bitvector.length - amount..bitvector.length:
+                    !bitvector.bit_field[i]
             );
         ensures amount < bitvector.length ==>
             (
-                forall i in 0..bitvector.length - amount: bitvector.bit_field[i]
-                    == old(bitvector).bit_field[i + amount]
+                forall i in 0..bitvector.length - amount:
+                    bitvector.bit_field[i] == old(bitvector).bit_field[i + amount]
             );
     }
 }

--- a/aptos-move/framework/move-stdlib/sources/bit_vector.move
+++ b/aptos-move/framework/move-stdlib/sources/bit_vector.move
@@ -24,11 +24,13 @@ module std::bit_vector {
         assert!(length < MAX_SIZE, ELENGTH);
         let counter = 0;
         let bit_field = vector::empty();
-        while ({spec {
-            invariant counter <= length;
-            invariant len(bit_field) == counter;
-        };
-            (counter < length)}) {
+        while ({
+                spec {
+                    invariant counter <= length;
+                    invariant len(bit_field) == counter;
+                };
+                (counter < length)
+            }) {
             vector::push_back(&mut bit_field, false);
             counter = counter + 1;
         };
@@ -37,16 +39,15 @@ module std::bit_vector {
             assert len(bit_field) == length;
         };
 
-        BitVector {
-            length,
-            bit_field,
-        }
+        BitVector { length, bit_field, }
     }
+
     spec new {
         include NewAbortsIf;
         ensures result.length == length;
         ensures len(result.bit_field) == length;
     }
+
     spec schema NewAbortsIf {
         length: u64;
         aborts_if length <= 0 with ELENGTH;
@@ -59,10 +60,12 @@ module std::bit_vector {
         let x = vector::borrow_mut(&mut bitvector.bit_field, bit_index);
         *x = true;
     }
+
     spec set {
         include SetAbortsIf;
         ensures bitvector.bit_field[bit_index];
     }
+
     spec schema SetAbortsIf {
         bitvector: BitVector;
         bit_index: u64;
@@ -75,10 +78,12 @@ module std::bit_vector {
         let x = vector::borrow_mut(&mut bitvector.bit_field, bit_index);
         *x = false;
     }
+
     spec unset {
         include UnsetAbortsIf;
         ensures !bitvector.bit_field[bit_index];
     }
+
     spec schema UnsetAbortsIf {
         bitvector: BitVector;
         bit_index: u64;
@@ -89,9 +94,10 @@ module std::bit_vector {
     /// bitvector's length the bitvector will be zeroed out.
     public fun shift_left(bitvector: &mut BitVector, amount: u64) {
         if (amount >= bitvector.length) {
-            vector::for_each_mut(&mut bitvector.bit_field, |elem| {
-                *elem = false;
-            });
+            vector::for_each_mut(&mut bitvector.bit_field,
+                |elem| {
+                    *elem = false;
+                });
         } else {
             let i = amount;
 
@@ -109,6 +115,7 @@ module std::bit_vector {
             };
         }
     }
+
     spec shift_left {
         // TODO: set to false because data invariant cannot be proved with inline function. Will remove it once inline is supported
         pragma verify = false;
@@ -120,19 +127,21 @@ module std::bit_vector {
         assert!(bit_index < vector::length(&bitvector.bit_field), EINDEX);
         *vector::borrow(&bitvector.bit_field, bit_index)
     }
+
     spec is_index_set {
         include IsIndexSetAbortsIf;
         ensures result == bitvector.bit_field[bit_index];
     }
+
     spec schema IsIndexSetAbortsIf {
         bitvector: BitVector;
         bit_index: u64;
         aborts_if bit_index >= length(bitvector) with EINDEX;
     }
+
     spec fun spec_is_index_set(bitvector: BitVector, bit_index: u64): bool {
-        if (bit_index >= length(bitvector)) {
-            false
-        } else {
+        if (bit_index >= length(bitvector)) { false }
+        else {
             bitvector.bit_field[bit_index]
         }
     }
@@ -145,21 +154,25 @@ module std::bit_vector {
     /// Returns the length of the longest sequence of set bits starting at (and
     /// including) `start_index` in the `bitvector`. If there is no such
     /// sequence, then `0` is returned.
-    public fun longest_set_sequence_starting_at(bitvector: &BitVector, start_index: u64): u64 {
+    public fun longest_set_sequence_starting_at(
+        bitvector: &BitVector, start_index: u64
+    ): u64 {
         assert!(start_index < bitvector.length, EINDEX);
         let index = start_index;
 
         // Find the greatest index in the vector such that all indices less than it are set.
         while ({
-            spec {
-                invariant index >= start_index;
-                invariant index == start_index || is_index_set(bitvector, index - 1);
-                invariant index == start_index || index - 1 < vector::length(bitvector.bit_field);
-                invariant forall j in start_index..index: is_index_set(bitvector, j);
-                invariant forall j in start_index..index: j < vector::length(bitvector.bit_field);
-            };
-            index < bitvector.length
-        }) {
+                spec {
+                    invariant index >= start_index;
+                    invariant index == start_index || is_index_set(bitvector, index - 1);
+                    invariant index == start_index
+                        || index - 1 < vector::length(bitvector.bit_field);
+                    invariant forall j in start_index..index: is_index_set(bitvector, j);
+                    invariant forall j in start_index..index: j
+                        < vector::length(bitvector.bit_field);
+                };
+                index < bitvector.length
+            }) {
             if (!is_index_set(bitvector, index)) break;
             index = index + 1;
         };
@@ -178,18 +191,21 @@ module std::bit_vector {
     }
 
     #[verify_only]
-    public fun shift_left_for_verification_only(bitvector: &mut BitVector, amount: u64) {
+    public fun shift_left_for_verification_only(
+        bitvector: &mut BitVector, amount: u64
+    ) {
         if (amount >= bitvector.length) {
             let len = vector::length(&bitvector.bit_field);
             let i = 0;
             while ({
-                spec {
-                    invariant len == bitvector.length;
-                    invariant forall k in 0..i: !bitvector.bit_field[k];
-                    invariant forall k in i..bitvector.length: bitvector.bit_field[k] == old(bitvector).bit_field[k];
-                };
-                i < len
-            }) {
+                    spec {
+                        invariant len == bitvector.length;
+                        invariant forall k in 0..i: !bitvector.bit_field[k];
+                        invariant forall k in i..bitvector.length: bitvector.bit_field[k]
+                            == old(bitvector).bit_field[k];
+                    };
+                    i < len
+                }) {
                 let elem = vector::borrow_mut(&mut bitvector.bit_field, i);
                 *elem = false;
                 i = i + 1;
@@ -198,42 +214,53 @@ module std::bit_vector {
             let i = amount;
 
             while ({
-                spec {
-                    invariant i >= amount;
-                    invariant bitvector.length == old(bitvector).length;
-                    invariant forall j in amount..i: old(bitvector).bit_field[j] == bitvector.bit_field[j - amount];
-                    invariant forall j in (i-amount)..bitvector.length : old(bitvector).bit_field[j] == bitvector.bit_field[j];
-                    invariant forall k in 0..i-amount: bitvector.bit_field[k] == old(bitvector).bit_field[k + amount];
-                };
-                i < bitvector.length
-            }) {
+                    spec {
+                        invariant i >= amount;
+                        invariant bitvector.length == old(bitvector).length;
+                        invariant forall j in amount..i: old(bitvector).bit_field[j]
+                            == bitvector.bit_field[j - amount];
+                        invariant forall j in (i - amount)..bitvector.length: old(
+                            bitvector
+                        ).bit_field[j] == bitvector.bit_field[j];
+                        invariant forall k in 0..i - amount: bitvector.bit_field[k]
+                            == old(bitvector).bit_field[k + amount];
+                    };
+                    i < bitvector.length
+                }) {
                 if (is_index_set(bitvector, i)) set(bitvector, i - amount)
                 else unset(bitvector, i - amount);
                 i = i + 1;
             };
 
-
             i = bitvector.length - amount;
 
             while ({
-                spec {
-                    invariant forall j in bitvector.length - amount..i: !bitvector.bit_field[j];
-                    invariant forall k in 0..bitvector.length - amount: bitvector.bit_field[k] == old(bitvector).bit_field[k + amount];
-                    invariant i >= bitvector.length - amount;
-                };
-                i < bitvector.length
-            }) {
+                    spec {
+                        invariant forall j in bitvector.length - amount..i: !bitvector.bit_field[j];
+                        invariant forall k in 0..bitvector.length - amount: bitvector.bit_field[k] ==
+                             old(bitvector).bit_field[k + amount];
+                        invariant i >= bitvector.length - amount;
+                    };
+                    i < bitvector.length
+                }) {
                 unset(bitvector, i);
                 i = i + 1;
             }
         }
     }
+
     spec shift_left_for_verification_only {
         aborts_if false;
-        ensures amount >= bitvector.length ==> (forall k in 0..bitvector.length: !bitvector.bit_field[k]);
+        ensures amount >= bitvector.length ==>
+            (forall k in 0..bitvector.length: !bitvector.bit_field[k]);
         ensures amount < bitvector.length ==>
-            (forall i in bitvector.length - amount..bitvector.length: !bitvector.bit_field[i]);
+            (
+                forall i in bitvector.length - amount..bitvector.length: !bitvector.bit_field[i]
+            );
         ensures amount < bitvector.length ==>
-            (forall i in 0..bitvector.length - amount: bitvector.bit_field[i] == old(bitvector).bit_field[i + amount]);
+            (
+                forall i in 0..bitvector.length - amount: bitvector.bit_field[i]
+                    == old(bitvector).bit_field[i + amount]
+            );
     }
 }

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -58,7 +58,9 @@ module std::features {
     /// Lifetime: transient
     const SHA_512_AND_RIPEMD_160_NATIVES: u64 = 3;
 
-    public fun get_sha_512_and_ripemd_160_feature(): u64 { SHA_512_AND_RIPEMD_160_NATIVES }
+    public fun get_sha_512_and_ripemd_160_feature(): u64 {
+        SHA_512_AND_RIPEMD_160_NATIVES
+    }
 
     public fun sha_512_and_ripemd_160_enabled(): bool acquires Features {
         is_enabled(SHA_512_AND_RIPEMD_160_NATIVES)
@@ -69,7 +71,9 @@ module std::features {
     /// Lifetime: transient
     const APTOS_STD_CHAIN_ID_NATIVES: u64 = 4;
 
-    public fun get_aptos_stdlib_chain_id_feature(): u64 { APTOS_STD_CHAIN_ID_NATIVES }
+    public fun get_aptos_stdlib_chain_id_feature(): u64 {
+        APTOS_STD_CHAIN_ID_NATIVES
+    }
 
     public fun aptos_stdlib_chain_id_enabled(): bool acquires Features {
         is_enabled(APTOS_STD_CHAIN_ID_NATIVES)
@@ -79,7 +83,9 @@ module std::features {
     /// Lifetime: transient
     const VM_BINARY_FORMAT_V6: u64 = 5;
 
-    public fun get_vm_binary_format_v6(): u64 { VM_BINARY_FORMAT_V6 }
+    public fun get_vm_binary_format_v6(): u64 {
+        VM_BINARY_FORMAT_V6
+    }
 
     public fun allow_vm_binary_format_v6(): bool acquires Features {
         is_enabled(VM_BINARY_FORMAT_V6)
@@ -89,7 +95,9 @@ module std::features {
     /// Lifetime: transient
     const COLLECT_AND_DISTRIBUTE_GAS_FEES: u64 = 6;
 
-    public fun get_collect_and_distribute_gas_fees_feature(): u64 { COLLECT_AND_DISTRIBUTE_GAS_FEES }
+    public fun get_collect_and_distribute_gas_fees_feature(): u64 {
+        COLLECT_AND_DISTRIBUTE_GAS_FEES
+    }
 
     public fun collect_and_distribute_gas_fees(): bool acquires Features {
         is_enabled(COLLECT_AND_DISTRIBUTE_GAS_FEES)
@@ -100,7 +108,9 @@ module std::features {
     /// Lifetime: transient
     const MULTI_ED25519_PK_VALIDATE_V2_NATIVES: u64 = 7;
 
-    public fun multi_ed25519_pk_validate_v2_feature(): u64 { MULTI_ED25519_PK_VALIDATE_V2_NATIVES }
+    public fun multi_ed25519_pk_validate_v2_feature(): u64 {
+        MULTI_ED25519_PK_VALIDATE_V2_NATIVES
+    }
 
     public fun multi_ed25519_pk_validate_v2_enabled(): bool acquires Features {
         is_enabled(MULTI_ED25519_PK_VALIDATE_V2_NATIVES)
@@ -111,7 +121,9 @@ module std::features {
     /// Lifetime: transient
     const BLAKE2B_256_NATIVE: u64 = 8;
 
-    public fun get_blake2b_256_feature(): u64 { BLAKE2B_256_NATIVE }
+    public fun get_blake2b_256_feature(): u64 {
+        BLAKE2B_256_NATIVE
+    }
 
     public fun blake2b_256_enabled(): bool acquires Features {
         is_enabled(BLAKE2B_256_NATIVE)
@@ -121,7 +133,9 @@ module std::features {
     /// This is needed because of new attributes for structs and a change in storage representation.
     const RESOURCE_GROUPS: u64 = 9;
 
-    public fun get_resource_groups_feature(): u64 { RESOURCE_GROUPS }
+    public fun get_resource_groups_feature(): u64 {
+        RESOURCE_GROUPS
+    }
 
     public fun resource_groups_enabled(): bool acquires Features {
         is_enabled(RESOURCE_GROUPS)
@@ -130,7 +144,9 @@ module std::features {
     /// Whether multisig accounts (different from accounts with multi-ed25519 auth keys) are enabled.
     const MULTISIG_ACCOUNTS: u64 = 10;
 
-    public fun get_multisig_accounts_feature(): u64 { MULTISIG_ACCOUNTS }
+    public fun get_multisig_accounts_feature(): u64 {
+        MULTISIG_ACCOUNTS
+    }
 
     public fun multisig_accounts_enabled(): bool acquires Features {
         is_enabled(MULTISIG_ACCOUNTS)
@@ -140,7 +156,9 @@ module std::features {
     /// Lifetime: transient
     const DELEGATION_POOLS: u64 = 11;
 
-    public fun get_delegation_pools_feature(): u64 { DELEGATION_POOLS }
+    public fun get_delegation_pools_feature(): u64 {
+        DELEGATION_POOLS
+    }
 
     public fun delegation_pools_enabled(): bool acquires Features {
         is_enabled(DELEGATION_POOLS)
@@ -151,7 +169,9 @@ module std::features {
     /// Lifetime: transient
     const CRYPTOGRAPHY_ALGEBRA_NATIVES: u64 = 12;
 
-    public fun get_cryptography_algebra_natives_feature(): u64 { CRYPTOGRAPHY_ALGEBRA_NATIVES }
+    public fun get_cryptography_algebra_natives_feature(): u64 {
+        CRYPTOGRAPHY_ALGEBRA_NATIVES
+    }
 
     public fun cryptography_algebra_enabled(): bool acquires Features {
         is_enabled(CRYPTOGRAPHY_ALGEBRA_NATIVES)
@@ -162,12 +182,13 @@ module std::features {
     /// Lifetime: transient
     const BLS12_381_STRUCTURES: u64 = 13;
 
-    public fun get_bls12_381_strutures_feature(): u64 { BLS12_381_STRUCTURES }
+    public fun get_bls12_381_strutures_feature(): u64 {
+        BLS12_381_STRUCTURES
+    }
 
     public fun bls12_381_structures_enabled(): bool acquires Features {
         is_enabled(BLS12_381_STRUCTURES)
     }
-
 
     /// Whether native_public_key_validate aborts when a public key of the wrong length is given
     /// Lifetime: ephemeral
@@ -182,7 +203,9 @@ module std::features {
     /// Lifetime: transient
     const PERIODICAL_REWARD_RATE_DECREASE: u64 = 16;
 
-    public fun get_periodical_reward_rate_decrease_feature(): u64 { PERIODICAL_REWARD_RATE_DECREASE }
+    public fun get_periodical_reward_rate_decrease_feature(): u64 {
+        PERIODICAL_REWARD_RATE_DECREASE
+    }
 
     public fun periodical_reward_rate_decrease_enabled(): bool acquires Features {
         is_enabled(PERIODICAL_REWARD_RATE_DECREASE)
@@ -192,7 +215,9 @@ module std::features {
     /// Lifetime: transient
     const PARTIAL_GOVERNANCE_VOTING: u64 = 17;
 
-    public fun get_partial_governance_voting(): u64 { PARTIAL_GOVERNANCE_VOTING }
+    public fun get_partial_governance_voting(): u64 {
+        PARTIAL_GOVERNANCE_VOTING
+    }
 
     public fun partial_governance_voting_enabled(): bool acquires Features {
         is_enabled(PARTIAL_GOVERNANCE_VOTING)
@@ -206,7 +231,9 @@ module std::features {
     /// Lifetime: transient
     const DELEGATION_POOL_PARTIAL_GOVERNANCE_VOTING: u64 = 21;
 
-    public fun get_delegation_pool_partial_governance_voting(): u64 { DELEGATION_POOL_PARTIAL_GOVERNANCE_VOTING }
+    public fun get_delegation_pool_partial_governance_voting(): u64 {
+        DELEGATION_POOL_PARTIAL_GOVERNANCE_VOTING
+    }
 
     public fun delegation_pool_partial_governance_voting_enabled(): bool acquires Features {
         is_enabled(DELEGATION_POOL_PARTIAL_GOVERNANCE_VOTING)
@@ -226,7 +253,7 @@ module std::features {
 
     public fun get_auids(): u64 {
         error::invalid_argument(EFEATURE_CANNOT_BE_DISABLED)
-     }
+    }
 
     public fun auids_enabled(): bool {
         true
@@ -237,7 +264,9 @@ module std::features {
     /// Lifetime: transient
     const BULLETPROOFS_NATIVES: u64 = 24;
 
-    public fun get_bulletproofs_feature(): u64 { BULLETPROOFS_NATIVES }
+    public fun get_bulletproofs_feature(): u64 {
+        BULLETPROOFS_NATIVES
+    }
 
     public fun bulletproofs_enabled(): bool acquires Features {
         is_enabled(BULLETPROOFS_NATIVES)
@@ -247,7 +276,9 @@ module std::features {
     /// Lifetime: transient
     const SIGNER_NATIVE_FORMAT_FIX: u64 = 25;
 
-    public fun get_signer_native_format_fix_feature(): u64 { SIGNER_NATIVE_FORMAT_FIX }
+    public fun get_signer_native_format_fix_feature(): u64 {
+        SIGNER_NATIVE_FORMAT_FIX
+    }
 
     public fun signer_native_format_fix_enabled(): bool acquires Features {
         is_enabled(SIGNER_NATIVE_FORMAT_FIX)
@@ -258,7 +289,9 @@ module std::features {
     /// Lifetime: transient
     const MODULE_EVENT: u64 = 26;
 
-    public fun get_module_event_feature(): u64 { MODULE_EVENT }
+    public fun get_module_event_feature(): u64 {
+        MODULE_EVENT
+    }
 
     public fun module_event_enabled(): bool acquires Features {
         is_enabled(MODULE_EVENT)
@@ -296,7 +329,9 @@ module std::features {
     /// Lifetime: transient
     const SPONSORED_AUTOMATIC_ACCOUNT_CREATION: u64 = 34;
 
-    public fun get_sponsored_automatic_account_creation(): u64 { SPONSORED_AUTOMATIC_ACCOUNT_CREATION }
+    public fun get_sponsored_automatic_account_creation(): u64 {
+        SPONSORED_AUTOMATIC_ACCOUNT_CREATION
+    }
 
     public fun sponsored_automatic_account_creation_enabled(): bool acquires Features {
         is_enabled(SPONSORED_AUTOMATIC_ACCOUNT_CREATION)
@@ -328,7 +363,9 @@ module std::features {
     /// Lifetime: transient
     const OPERATOR_BENEFICIARY_CHANGE: u64 = 39;
 
-    public fun get_operator_beneficiary_change_feature(): u64 { OPERATOR_BENEFICIARY_CHANGE }
+    public fun get_operator_beneficiary_change_feature(): u64 {
+        OPERATOR_BENEFICIARY_CHANGE
+    }
 
     public fun operator_beneficiary_change_enabled(): bool acquires Features {
         is_enabled(OPERATOR_BENEFICIARY_CHANGE)
@@ -342,7 +379,9 @@ module std::features {
     /// Lifetime: transient
     const COMMISSION_CHANGE_DELEGATION_POOL: u64 = 42;
 
-    public fun get_commission_change_delegation_pool_feature(): u64 { COMMISSION_CHANGE_DELEGATION_POOL }
+    public fun get_commission_change_delegation_pool_feature(): u64 {
+        COMMISSION_CHANGE_DELEGATION_POOL
+    }
 
     public fun commission_change_delegation_pool_enabled(): bool acquires Features {
         is_enabled(COMMISSION_CHANGE_DELEGATION_POOL)
@@ -353,7 +392,9 @@ module std::features {
     /// Lifetime: transient
     const BN254_STRUCTURES: u64 = 43;
 
-    public fun get_bn254_strutures_feature(): u64 { BN254_STRUCTURES }
+    public fun get_bn254_strutures_feature(): u64 {
+        BN254_STRUCTURES
+    }
 
     public fun bn254_structures_enabled(): bool acquires Features {
         is_enabled(BN254_STRUCTURES)
@@ -362,7 +403,9 @@ module std::features {
     /// Deprecated by `aptos_framework::randomness_config::RandomnessConfig`.
     const RECONFIGURE_WITH_DKG: u64 = 45;
 
-    public fun get_reconfigure_with_dkg_feature(): u64 { RECONFIGURE_WITH_DKG }
+    public fun get_reconfigure_with_dkg_feature(): u64 {
+        RECONFIGURE_WITH_DKG
+    }
 
     public fun reconfigure_with_dkg_enabled(): bool acquires Features {
         is_enabled(RECONFIGURE_WITH_DKG)
@@ -373,7 +416,9 @@ module std::features {
     /// Lifetime: transient
     const KEYLESS_ACCOUNTS: u64 = 46;
 
-    public fun get_keyless_accounts_feature(): u64 { KEYLESS_ACCOUNTS }
+    public fun get_keyless_accounts_feature(): u64 {
+        KEYLESS_ACCOUNTS
+    }
 
     public fun keyless_accounts_enabled(): bool acquires Features {
         is_enabled(KEYLESS_ACCOUNTS)
@@ -384,7 +429,9 @@ module std::features {
     /// Lifetime: transient
     const KEYLESS_BUT_ZKLESS_ACCOUNTS: u64 = 47;
 
-    public fun get_keyless_but_zkless_accounts_feature(): u64 { KEYLESS_BUT_ZKLESS_ACCOUNTS }
+    public fun get_keyless_but_zkless_accounts_feature(): u64 {
+        KEYLESS_BUT_ZKLESS_ACCOUNTS
+    }
 
     public fun keyless_but_zkless_accounts_feature_enabled(): bool acquires Features {
         is_enabled(KEYLESS_BUT_ZKLESS_ACCOUNTS)
@@ -393,7 +440,9 @@ module std::features {
     /// Deprecated by `aptos_framework::jwk_consensus_config::JWKConsensusConfig`.
     const JWK_CONSENSUS: u64 = 49;
 
-    public fun get_jwk_consensus_feature(): u64 { JWK_CONSENSUS }
+    public fun get_jwk_consensus_feature(): u64 {
+        JWK_CONSENSUS
+    }
 
     public fun jwk_consensus_enabled(): bool acquires Features {
         is_enabled(JWK_CONSENSUS)
@@ -404,7 +453,9 @@ module std::features {
     /// Lifetime: transient
     const CONCURRENT_FUNGIBLE_ASSETS: u64 = 50;
 
-    public fun get_concurrent_fungible_assets_feature(): u64 { CONCURRENT_FUNGIBLE_ASSETS }
+    public fun get_concurrent_fungible_assets_feature(): u64 {
+        CONCURRENT_FUNGIBLE_ASSETS
+    }
 
     public fun concurrent_fungible_assets_enabled(): bool acquires Features {
         is_enabled(CONCURRENT_FUNGIBLE_ASSETS)
@@ -420,7 +471,9 @@ module std::features {
     /// Whether checking the maximum object nesting is enabled.
     const MAX_OBJECT_NESTING_CHECK: u64 = 53;
 
-    public fun get_max_object_nesting_check_feature(): u64 { MAX_OBJECT_NESTING_CHECK }
+    public fun get_max_object_nesting_check_feature(): u64 {
+        MAX_OBJECT_NESTING_CHECK
+    }
 
     public fun max_object_nesting_check_enabled(): bool acquires Features {
         is_enabled(MAX_OBJECT_NESTING_CHECK)
@@ -431,7 +484,9 @@ module std::features {
     /// Lifetime: transient
     const KEYLESS_ACCOUNTS_WITH_PASSKEYS: u64 = 54;
 
-    public fun get_keyless_accounts_with_passkeys_feature(): u64 { KEYLESS_ACCOUNTS_WITH_PASSKEYS }
+    public fun get_keyless_accounts_with_passkeys_feature(): u64 {
+        KEYLESS_ACCOUNTS_WITH_PASSKEYS
+    }
 
     public fun keyless_accounts_with_passkeys_feature_enabled(): bool acquires Features {
         is_enabled(KEYLESS_ACCOUNTS_WITH_PASSKEYS)
@@ -442,7 +497,9 @@ module std::features {
     /// Lifetime: transient
     const MULTISIG_V2_ENHANCEMENT: u64 = 55;
 
-    public fun get_multisig_v2_enhancement_feature(): u64 { MULTISIG_V2_ENHANCEMENT }
+    public fun get_multisig_v2_enhancement_feature(): u64 {
+        MULTISIG_V2_ENHANCEMENT
+    }
 
     public fun multisig_v2_enhancement_feature_enabled(): bool acquires Features {
         is_enabled(MULTISIG_V2_ENHANCEMENT)
@@ -452,7 +509,9 @@ module std::features {
     /// Lifetime: transient
     const DELEGATION_POOL_ALLOWLISTING: u64 = 56;
 
-    public fun get_delegation_pool_allowlisting_feature(): u64 { DELEGATION_POOL_ALLOWLISTING }
+    public fun get_delegation_pool_allowlisting_feature(): u64 {
+        DELEGATION_POOL_ALLOWLISTING
+    }
 
     public fun delegation_pool_allowlisting_enabled(): bool acquires Features {
         is_enabled(DELEGATION_POOL_ALLOWLISTING)
@@ -463,7 +522,9 @@ module std::features {
     /// Lifetime: transient
     const MODULE_EVENT_MIGRATION: u64 = 57;
 
-    public fun get_module_event_migration_feature(): u64 { MODULE_EVENT_MIGRATION }
+    public fun get_module_event_migration_feature(): u64 {
+        MODULE_EVENT_MIGRATION
+    }
 
     public fun module_event_migration_enabled(): bool acquires Features {
         is_enabled(MODULE_EVENT_MIGRATION)
@@ -475,7 +536,9 @@ module std::features {
     /// Lifetime: transient
     const TRANSACTION_CONTEXT_EXTENSION: u64 = 59;
 
-    public fun get_transaction_context_extension_feature(): u64 { TRANSACTION_CONTEXT_EXTENSION }
+    public fun get_transaction_context_extension_feature(): u64 {
+        TRANSACTION_CONTEXT_EXTENSION
+    }
 
     public fun transaction_context_extension_enabled(): bool acquires Features {
         is_enabled(TRANSACTION_CONTEXT_EXTENSION)
@@ -486,7 +549,9 @@ module std::features {
     /// Lifetime: transient
     const COIN_TO_FUNGIBLE_ASSET_MIGRATION: u64 = 60;
 
-    public fun get_coin_to_fungible_asset_migration_feature(): u64 { COIN_TO_FUNGIBLE_ASSET_MIGRATION }
+    public fun get_coin_to_fungible_asset_migration_feature(): u64 {
+        COIN_TO_FUNGIBLE_ASSET_MIGRATION
+    }
 
     public fun coin_to_fungible_asset_migration_feature_enabled(): bool acquires Features {
         is_enabled(COIN_TO_FUNGIBLE_ASSET_MIGRATION)
@@ -495,8 +560,7 @@ module std::features {
     const PRIMARY_APT_FUNGIBLE_STORE_AT_USER_ADDRESS: u64 = 61;
 
     #[deprecated]
-    public fun get_primary_apt_fungible_store_at_user_address_feature(
-    ): u64 {
+    public fun get_primary_apt_fungible_store_at_user_address_feature(): u64 {
         abort error::invalid_argument(EINVALID_FEATURE)
     }
 
@@ -514,7 +578,9 @@ module std::features {
     /// Whether we use more efficient native implementation of computing object derived address
     const OBJECT_NATIVE_DERIVED_ADDRESS: u64 = 62;
 
-    public fun get_object_native_derived_address_feature(): u64 { OBJECT_NATIVE_DERIVED_ADDRESS }
+    public fun get_object_native_derived_address_feature(): u64 {
+        OBJECT_NATIVE_DERIVED_ADDRESS
+    }
 
     public fun object_native_derived_address_enabled(): bool acquires Features {
         is_enabled(OBJECT_NATIVE_DERIVED_ADDRESS)
@@ -525,7 +591,9 @@ module std::features {
     /// Lifetime: transient
     const DISPATCHABLE_FUNGIBLE_ASSET: u64 = 63;
 
-    public fun get_dispatchable_fungible_asset_feature(): u64 { DISPATCHABLE_FUNGIBLE_ASSET }
+    public fun get_dispatchable_fungible_asset_feature(): u64 {
+        DISPATCHABLE_FUNGIBLE_ASSET
+    }
 
     public fun dispatchable_fungible_asset_enabled(): bool acquires Features {
         is_enabled(DISPATCHABLE_FUNGIBLE_ASSET)
@@ -534,7 +602,9 @@ module std::features {
     /// Lifetime: transient
     const NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE: u64 = 64;
 
-    public fun get_new_accounts_default_to_fa_apt_store_feature(): u64 { NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE }
+    public fun get_new_accounts_default_to_fa_apt_store_feature(): u64 {
+        NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE
+    }
 
     public fun new_accounts_default_to_fa_apt_store_enabled(): bool acquires Features {
         is_enabled(NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE)
@@ -543,7 +613,9 @@ module std::features {
     /// Lifetime: transient
     const OPERATIONS_DEFAULT_TO_FA_APT_STORE: u64 = 65;
 
-    public fun get_operations_default_to_fa_apt_store_feature(): u64 { OPERATIONS_DEFAULT_TO_FA_APT_STORE }
+    public fun get_operations_default_to_fa_apt_store_feature(): u64 {
+        OPERATIONS_DEFAULT_TO_FA_APT_STORE
+    }
 
     public fun operations_default_to_fa_apt_store_enabled(): bool acquires Features {
         is_enabled(OPERATIONS_DEFAULT_TO_FA_APT_STORE)
@@ -554,7 +626,9 @@ module std::features {
     /// Lifetime: transient
     const CONCURRENT_FUNGIBLE_BALANCE: u64 = 67;
 
-    public fun get_concurrent_fungible_balance_feature(): u64 { CONCURRENT_FUNGIBLE_BALANCE }
+    public fun get_concurrent_fungible_balance_feature(): u64 {
+        CONCURRENT_FUNGIBLE_BALANCE
+    }
 
     public fun concurrent_fungible_balance_enabled(): bool acquires Features {
         is_enabled(CONCURRENT_FUNGIBLE_BALANCE)
@@ -564,7 +638,9 @@ module std::features {
     /// Lifetime: transient
     const DEFAULT_TO_CONCURRENT_FUNGIBLE_BALANCE: u64 = 68;
 
-    public fun get_default_to_concurrent_fungible_balance_feature(): u64 { DEFAULT_TO_CONCURRENT_FUNGIBLE_BALANCE }
+    public fun get_default_to_concurrent_fungible_balance_feature(): u64 {
+        DEFAULT_TO_CONCURRENT_FUNGIBLE_BALANCE
+    }
 
     public fun default_to_concurrent_fungible_balance_enabled(): bool acquires Features {
         is_enabled(DEFAULT_TO_CONCURRENT_FUNGIBLE_BALANCE)
@@ -576,7 +652,9 @@ module std::features {
     /// Lifetime: transient
     const ABORT_IF_MULTISIG_PAYLOAD_MISMATCH: u64 = 70;
 
-    public fun get_abort_if_multisig_payload_mismatch_feature(): u64 { ABORT_IF_MULTISIG_PAYLOAD_MISMATCH }
+    public fun get_abort_if_multisig_payload_mismatch_feature(): u64 {
+        ABORT_IF_MULTISIG_PAYLOAD_MISMATCH
+    }
 
     public fun abort_if_multisig_payload_mismatch_enabled(): bool acquires Features {
         is_enabled(ABORT_IF_MULTISIG_PAYLOAD_MISMATCH)
@@ -604,45 +682,60 @@ module std::features {
     /// Genesis/tests should use `change_feature_flags_internal()` for feature vec initialization.
     ///
     /// Governance proposals should use `change_feature_flags_for_next_epoch()` to enable/disable features.
-    public fun change_feature_flags(_framework: &signer, _enable: vector<u64>, _disable: vector<u64>) {
-        abort (error::invalid_state(EAPI_DISABLED))
+    public fun change_feature_flags(
+        _framework: &signer, _enable: vector<u64>, _disable: vector<u64>
+    ) {
+        abort(error::invalid_state(EAPI_DISABLED))
     }
 
     /// Update feature flags directly. Only used in genesis/tests.
-    fun change_feature_flags_internal(framework: &signer, enable: vector<u64>, disable: vector<u64>) acquires Features {
-        assert!(signer::address_of(framework) == @std, error::permission_denied(EFRAMEWORK_SIGNER_NEEDED));
+    fun change_feature_flags_internal(
+        framework: &signer, enable: vector<u64>, disable: vector<u64>
+    ) acquires Features {
+        assert!(
+            signer::address_of(framework) == @std,
+            error::permission_denied(EFRAMEWORK_SIGNER_NEEDED),
+        );
         if (!exists<Features>(@std)) {
             move_to<Features>(framework, Features { features: vector[] })
         };
         let features = &mut borrow_global_mut<Features>(@std).features;
-        vector::for_each_ref(&enable, |feature| {
-            set(features, *feature, true);
-        });
-        vector::for_each_ref(&disable, |feature| {
-            set(features, *feature, false);
-        });
+        vector::for_each_ref(
+            &enable,
+            |feature| {
+                set(features, *feature, true);
+            }
+        );
+        vector::for_each_ref(
+            &disable,
+            |feature| {
+                set(features, *feature, false);
+            }
+        );
     }
 
     /// Enable and disable features for the next epoch.
     public fun change_feature_flags_for_next_epoch(
-        framework: &signer,
-        enable: vector<u64>,
-        disable: vector<u64>
+        framework: &signer, enable: vector<u64>, disable: vector<u64>
     ) acquires PendingFeatures, Features {
-        assert!(signer::address_of(framework) == @std, error::permission_denied(EFRAMEWORK_SIGNER_NEEDED));
+        assert!(
+            signer::address_of(framework) == @std,
+            error::permission_denied(EFRAMEWORK_SIGNER_NEEDED),
+        );
 
         // Figure out the baseline feature vec that the diff will be applied to.
-        let new_feature_vec = if (exists<PendingFeatures>(@std)) {
-            // If there is a buffered feature vec, use it as the baseline.
-            let PendingFeatures { features } = move_from<PendingFeatures>(@std);
-            features
-        } else if (exists<Features>(@std)) {
-            // Otherwise, use the currently effective feature flag vec as the baseline, if it exists.
-            borrow_global<Features>(@std).features
-        } else {
-            // Otherwise, use an empty feature vec.
-            vector[]
-        };
+        let new_feature_vec =
+            if (exists<PendingFeatures>(@std)) {
+                // If there is a buffered feature vec, use it as the baseline.
+                let PendingFeatures { features } = move_from<PendingFeatures>(@std);
+                features
+            } else if (exists<Features>(@std)) {
+                // Otherwise, use the currently effective feature flag vec as the baseline, if it exists.
+                borrow_global<Features>(@std).features
+            } else {
+                // Otherwise, use an empty feature vec.
+                vector[]
+            };
 
         // Apply the diff and save it to the buffer.
         apply_diff(&mut new_feature_vec, enable, disable);
@@ -668,38 +761,43 @@ module std::features {
     #[view]
     /// Check whether the feature is enabled.
     public fun is_enabled(feature: u64): bool acquires Features {
-        exists<Features>(@std) &&
-            contains(&borrow_global<Features>(@std).features, feature)
+        exists<Features>(@std) && contains(
+            &borrow_global<Features>(@std).features, feature
+        )
     }
 
     /// Helper to include or exclude a feature flag.
     fun set(features: &mut vector<u8>, feature: u64, include: bool) {
         let byte_index = feature / 8;
         let bit_mask = 1 << ((feature % 8) as u8);
-        while (vector::length(features) <= byte_index) {
-            vector::push_back(features, 0)
-        };
+        while (vector::length(features) <= byte_index) { vector::push_back(features, 0) };
         let entry = vector::borrow_mut(features, byte_index);
-        if (include)
-            *entry = *entry | bit_mask
-        else
-            *entry = *entry & (0xff ^ bit_mask)
+        if (include) *entry = *entry | bit_mask else *entry = *entry & (0xff ^ bit_mask)
     }
 
     /// Helper to check whether a feature flag is enabled.
     fun contains(features: &vector<u8>, feature: u64): bool {
         let byte_index = feature / 8;
         let bit_mask = 1 << ((feature % 8) as u8);
-        byte_index < vector::length(features) && (*vector::borrow(features, byte_index) & bit_mask) != 0
+        byte_index < vector::length(features)
+            && (*vector::borrow(features, byte_index) & bit_mask) != 0
     }
 
-    fun apply_diff(features: &mut vector<u8>, enable: vector<u64>, disable: vector<u64>) {
-        vector::for_each(enable, |feature| {
-            set(features, feature, true);
-        });
-        vector::for_each(disable, |feature| {
-            set(features, feature, false);
-        });
+    fun apply_diff(
+        features: &mut vector<u8>, enable: vector<u64>, disable: vector<u64>
+    ) {
+        vector::for_each(
+            enable,
+            |feature| {
+                set(features, feature, true);
+            }
+        );
+        vector::for_each(
+            disable,
+            |feature| {
+                set(features, feature, false);
+            }
+        );
     }
 
     fun ensure_framework_signer(account: &signer) {
@@ -709,18 +807,14 @@ module std::features {
 
     #[verify_only]
     public fun change_feature_flags_for_verification(
-        framework: &signer,
-        enable: vector<u64>,
-        disable: vector<u64>
+        framework: &signer, enable: vector<u64>, disable: vector<u64>
     ) acquires Features {
         change_feature_flags_internal(framework, enable, disable)
     }
 
     #[test_only]
     public fun change_feature_flags_for_testing(
-        framework: &signer,
-        enable: vector<u64>,
-        disable: vector<u64>
+        framework: &signer, enable: vector<u64>, disable: vector<u64>
     ) acquires Features {
         change_feature_flags_internal(framework, enable, disable)
     }

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -704,13 +704,13 @@ module std::features {
             &enable,
             |feature| {
                 set(features, *feature, true);
-            }
+            },
         );
         vector::for_each_ref(
             &disable,
             |feature| {
                 set(features, *feature, false);
-            }
+            },
         );
     }
 
@@ -790,13 +790,13 @@ module std::features {
             enable,
             |feature| {
                 set(features, feature, true);
-            }
+            },
         );
         vector::for_each(
             disable,
             |feature| {
                 set(features, feature, false);
-            }
+            },
         );
     }
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
@@ -1,36 +1,37 @@
 /// Maintains feature flags.
 spec std::features {
     spec Features {
-        pragma bv=b"0";
+        pragma bv = b"0";
     }
 
     spec PendingFeatures {
-        pragma bv=b"0";
+        pragma bv = b"0";
     }
 
     spec set(features: &mut vector<u8>, feature: u64, include: bool) {
-        pragma bv=b"0";
+        pragma bv = b"0";
         aborts_if false;
         ensures feature / 8 < len(features);
         ensures include == spec_contains(features, feature);
     }
 
-
     spec apply_diff(features: &mut vector<u8>, enable: vector<u64>, disable: vector<u64>) {
         aborts_if [abstract] false; // TODO(#12011)
         ensures [abstract] forall i in disable: !spec_contains(features, i);
-        ensures [abstract] forall i in enable: !vector::spec_contains(disable, i)
-            ==> spec_contains(features, i);
+        ensures [abstract] forall i in enable: !vector::spec_contains(disable, i) ==>
+            spec_contains(features, i);
         pragma opaque;
     }
 
     spec contains(features: &vector<u8>, feature: u64): bool {
-        pragma bv=b"0";
+        pragma bv = b"0";
         aborts_if false;
         ensures result == spec_contains(features, feature);
     }
 
-    spec change_feature_flags_for_next_epoch(framework: &signer, enable: vector<u64>, disable: vector<u64>) {
+    spec change_feature_flags_for_next_epoch(
+        framework: &signer, enable: vector<u64>, disable: vector<u64>
+    ) {
         aborts_if signer::address_of(framework) != @std;
         // TODO(tengzhang): add functional spec
         // TODO(#12526): undo declaring opaque once fixed
@@ -40,11 +41,15 @@ spec std::features {
     }
 
     spec fun spec_contains(features: vector<u8>, feature: u64): bool {
-        ((int2bv((((1 as u8) << ((feature % (8 as u64)) as u64)) as u8)) as u8) & features[feature/8] as u8) > (0 as u8)
-            && (feature / 8) < len(features)
+        (
+            (int2bv((((1 as u8) << ((feature % (8 as u64)) as u64)) as u8)) as u8)
+                & features[feature / 8] as u8
+        ) > (0 as u8) && (feature / 8) < len(features)
     }
 
-    spec change_feature_flags_internal(framework: &signer, enable: vector<u64>, disable: vector<u64>) {
+    spec change_feature_flags_internal(
+        framework: &signer, enable: vector<u64>, disable: vector<u64>
+    ) {
         pragma opaque;
         modifies global<Features>(@std);
         aborts_if signer::address_of(framework) != @std;
@@ -110,7 +115,8 @@ spec std::features {
         requires @std == signer::address_of(framework);
         let features_pending = global<PendingFeatures>(@std).features;
         let post features_std = global<Features>(@std).features;
-        ensures exists<PendingFeatures>(@std) ==> features_std == features_pending;
+        ensures exists<PendingFeatures>(@std) ==>
+            features_std == features_pending;
         aborts_if false;
     }
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
@@ -18,8 +18,9 @@ spec std::features {
     spec apply_diff(features: &mut vector<u8>, enable: vector<u64>, disable: vector<u64>) {
         aborts_if [abstract] false; // TODO(#12011)
         ensures [abstract] forall i in disable: !spec_contains(features, i);
-        ensures [abstract] forall i in enable: !vector::spec_contains(disable, i) ==>
-            spec_contains(features, i);
+        ensures [abstract] forall i in enable:
+            !vector::spec_contains(disable, i) ==>
+                spec_contains(features, i);
         pragma opaque;
     }
 

--- a/aptos-move/framework/move-stdlib/sources/error.move
+++ b/aptos-move/framework/move-stdlib/sources/error.move
@@ -21,68 +21,104 @@
 /// error codes here are a bit richer than HTTP codes.
 module std::error {
 
-  /// Caller specified an invalid argument (http: 400)
-  const INVALID_ARGUMENT: u64 = 0x1;
+    /// Caller specified an invalid argument (http: 400)
+    const INVALID_ARGUMENT: u64 = 0x1;
 
-  /// An input or result of a computation is out of range (http: 400)
-  const OUT_OF_RANGE: u64 = 0x2;
+    /// An input or result of a computation is out of range (http: 400)
+    const OUT_OF_RANGE: u64 = 0x2;
 
-  /// The system is not in a state where the operation can be performed (http: 400)
-  const INVALID_STATE: u64 = 0x3;
+    /// The system is not in a state where the operation can be performed (http: 400)
+    const INVALID_STATE: u64 = 0x3;
 
-  /// Request not authenticated due to missing, invalid, or expired auth token (http: 401)
-  const UNAUTHENTICATED: u64 = 0x4;
+    /// Request not authenticated due to missing, invalid, or expired auth token (http: 401)
+    const UNAUTHENTICATED: u64 = 0x4;
 
-  /// client does not have sufficient permission (http: 403)
-  const PERMISSION_DENIED: u64 = 0x5;
+    /// client does not have sufficient permission (http: 403)
+    const PERMISSION_DENIED: u64 = 0x5;
 
-  /// A specified resource is not found (http: 404)
-  const NOT_FOUND: u64 = 0x6;
+    /// A specified resource is not found (http: 404)
+    const NOT_FOUND: u64 = 0x6;
 
-  /// Concurrency conflict, such as read-modify-write conflict (http: 409)
-  const ABORTED: u64 = 0x7;
+    /// Concurrency conflict, such as read-modify-write conflict (http: 409)
+    const ABORTED: u64 = 0x7;
 
-  /// The resource that a client tried to create already exists (http: 409)
-  const ALREADY_EXISTS: u64 = 0x8;
+    /// The resource that a client tried to create already exists (http: 409)
+    const ALREADY_EXISTS: u64 = 0x8;
 
-  /// Out of gas or other forms of quota (http: 429)
-  const RESOURCE_EXHAUSTED: u64 = 0x9;
+    /// Out of gas or other forms of quota (http: 429)
+    const RESOURCE_EXHAUSTED: u64 = 0x9;
 
-  /// Request cancelled by the client (http: 499)
-  const CANCELLED: u64 = 0xA;
+    /// Request cancelled by the client (http: 499)
+    const CANCELLED: u64 = 0xA;
 
-  /// Internal error (http: 500)
-  const INTERNAL: u64 = 0xB;
+    /// Internal error (http: 500)
+    const INTERNAL: u64 = 0xB;
 
-  /// Feature not implemented (http: 501)
-  const NOT_IMPLEMENTED: u64 = 0xC;
+    /// Feature not implemented (http: 501)
+    const NOT_IMPLEMENTED: u64 = 0xC;
 
-  /// The service is currently unavailable. Indicates that a retry could solve the issue (http: 503)
-  const UNAVAILABLE: u64 = 0xD;
+    /// The service is currently unavailable. Indicates that a retry could solve the issue (http: 503)
+    const UNAVAILABLE: u64 = 0xD;
 
-  /// Construct a canonical error code from a category and a reason.
-  public fun canonical(category: u64, reason: u64): u64 {
-    (category << 16) + reason
-  }
-  spec canonical {
-    pragma opaque = true;
-    let shl_res = category << 16;
-    ensures [concrete] result == shl_res + reason;
-    aborts_if [abstract] false;
-    ensures [abstract] result == category;
-  }
+    /// Construct a canonical error code from a category and a reason.
+    public fun canonical(category: u64, reason: u64): u64 {
+        (category << 16) + reason
+    }
 
-  /// Functions to construct a canonical error code of the given category.
-  public fun invalid_argument(r: u64): u64 {  canonical(INVALID_ARGUMENT, r) }
-  public fun out_of_range(r: u64): u64 {  canonical(OUT_OF_RANGE, r) }
-  public fun invalid_state(r: u64): u64 {  canonical(INVALID_STATE, r) }
-  public fun unauthenticated(r: u64): u64 { canonical(UNAUTHENTICATED, r) }
-  public fun permission_denied(r: u64): u64 { canonical(PERMISSION_DENIED, r) }
-  public fun not_found(r: u64): u64 { canonical(NOT_FOUND, r) }
-  public fun aborted(r: u64): u64 { canonical(ABORTED, r) }
-  public fun already_exists(r: u64): u64 { canonical(ALREADY_EXISTS, r) }
-  public fun resource_exhausted(r: u64): u64 {  canonical(RESOURCE_EXHAUSTED, r) }
-  public fun internal(r: u64): u64 {  canonical(INTERNAL, r) }
-  public fun not_implemented(r: u64): u64 {  canonical(NOT_IMPLEMENTED, r) }
-  public fun unavailable(r: u64): u64 { canonical(UNAVAILABLE, r) }
+    spec canonical {
+        pragma opaque = true;
+        let shl_res = category << 16;
+        ensures [concrete] result == shl_res + reason;
+        aborts_if [abstract] false;
+        ensures [abstract] result == category;
+    }
+
+    /// Functions to construct a canonical error code of the given category.
+    public fun invalid_argument(r: u64): u64 {
+        canonical(INVALID_ARGUMENT, r)
+    }
+
+    public fun out_of_range(r: u64): u64 {
+        canonical(OUT_OF_RANGE, r)
+    }
+
+    public fun invalid_state(r: u64): u64 {
+        canonical(INVALID_STATE, r)
+    }
+
+    public fun unauthenticated(r: u64): u64 {
+        canonical(UNAUTHENTICATED, r)
+    }
+
+    public fun permission_denied(r: u64): u64 {
+        canonical(PERMISSION_DENIED, r)
+    }
+
+    public fun not_found(r: u64): u64 {
+        canonical(NOT_FOUND, r)
+    }
+
+    public fun aborted(r: u64): u64 {
+        canonical(ABORTED, r)
+    }
+
+    public fun already_exists(r: u64): u64 {
+        canonical(ALREADY_EXISTS, r)
+    }
+
+    public fun resource_exhausted(r: u64): u64 {
+        canonical(RESOURCE_EXHAUSTED, r)
+    }
+
+    public fun internal(r: u64): u64 {
+        canonical(INTERNAL, r)
+    }
+
+    public fun not_implemented(r: u64): u64 {
+        canonical(NOT_IMPLEMENTED, r)
+    }
+
+    public fun unavailable(r: u64): u64 {
+        canonical(UNAVAILABLE, r)
+    }
 }

--- a/aptos-move/framework/move-stdlib/sources/fixed_point32.move
+++ b/aptos-move/framework/move-stdlib/sources/fixed_point32.move
@@ -12,7 +12,9 @@ module std::fixed_point32 {
     /// floating-point has less than 16 decimal digits of precision, so
     /// be careful about using floating-point to convert these values to
     /// decimal.
-    struct FixedPoint32 has copy, drop, store { value: u64 }
+    struct FixedPoint32 has copy, drop, store {
+        value: u64
+    }
 
     const MAX_U64: u128 = 18446744073709551615;
 
@@ -42,16 +44,19 @@ module std::fixed_point32 {
         assert!(product <= MAX_U64, EMULTIPLICATION);
         (product as u64)
     }
+
     spec multiply_u64 {
         pragma opaque;
         include MultiplyAbortsIf;
         ensures result == spec_multiply_u64(val, multiplier);
     }
+
     spec schema MultiplyAbortsIf {
         val: num;
         multiplier: FixedPoint32;
         aborts_if spec_multiply_u64(val, multiplier) > MAX_U64 with EMULTIPLICATION;
     }
+
     spec fun spec_multiply_u64(val: num, multiplier: FixedPoint32): num {
         (val * multiplier.value) >> 32
     }
@@ -72,17 +77,20 @@ module std::fixed_point32 {
         // with an arithmetic error.
         (quotient as u64)
     }
+
     spec divide_u64 {
         pragma opaque;
         include DivideAbortsIf;
         ensures result == spec_divide_u64(val, divisor);
     }
+
     spec schema DivideAbortsIf {
         val: num;
         divisor: FixedPoint32;
         aborts_if divisor.value == 0 with EDIVISION_BY_ZERO;
         aborts_if spec_divide_u64(val, divisor) > MAX_U64 with EDIVISION;
     }
+
     spec fun spec_divide_u64(val: num, divisor: FixedPoint32): num {
         (val << 32) / divisor.value
     }
@@ -112,29 +120,33 @@ module std::fixed_point32 {
         assert!(quotient <= MAX_U64, ERATIO_OUT_OF_RANGE);
         FixedPoint32 { value: (quotient as u64) }
     }
+
     spec create_from_rational {
         pragma opaque;
         include CreateFromRationalAbortsIf;
         ensures result == spec_create_from_rational(numerator, denominator);
     }
+
     spec schema CreateFromRationalAbortsIf {
         numerator: u64;
         denominator: u64;
-        let scaled_numerator = (numerator as u128)<< 64;
+        let scaled_numerator = (numerator as u128) << 64;
         let scaled_denominator = (denominator as u128) << 32;
         let quotient = scaled_numerator / scaled_denominator;
         aborts_if scaled_denominator == 0 with EDENOMINATOR;
         aborts_if quotient == 0 && scaled_numerator != 0 with ERATIO_OUT_OF_RANGE;
         aborts_if quotient > MAX_U64 with ERATIO_OUT_OF_RANGE;
     }
+
     spec fun spec_create_from_rational(numerator: num, denominator: num): FixedPoint32 {
-        FixedPoint32{value: (numerator << 64) / (denominator << 32)}
+        FixedPoint32 { value: (numerator << 64) / (denominator << 32) }
     }
 
     /// Create a fixedpoint value from a raw value.
     public fun create_from_raw_value(value: u64): FixedPoint32 {
         FixedPoint32 { value }
     }
+
     spec create_from_raw_value {
         pragma opaque;
         aborts_if false;
@@ -155,75 +167,72 @@ module std::fixed_point32 {
 
     /// Returns the smaller of the two FixedPoint32 numbers.
     public fun min(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
-        if (num1.value < num2.value) {
-            num1
-        } else {
-            num2
-        }
+        if (num1.value < num2.value) { num1 }
+        else { num2 }
     }
+
     spec min {
         pragma opaque;
         aborts_if false;
         ensures result == spec_min(num1, num2);
     }
+
     spec fun spec_min(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
-        if (num1.value < num2.value) {
-            num1
-        } else {
-            num2
-        }
+        if (num1.value < num2.value) { num1 }
+        else { num2 }
     }
 
     /// Returns the larger of the two FixedPoint32 numbers.
     public fun max(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
-        if (num1.value > num2.value) {
-            num1
-        } else {
-            num2
-        }
+        if (num1.value > num2.value) { num1 }
+        else { num2 }
     }
+
     spec max {
         pragma opaque;
         aborts_if false;
         ensures result == spec_max(num1, num2);
     }
+
     spec fun spec_max(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
-        if (num1.value > num2.value) {
-            num1
-        } else {
-            num2
-        }
+        if (num1.value > num2.value) { num1 }
+        else { num2 }
     }
 
     /// Create a fixedpoint value from a u64 value.
     public fun create_from_u64(val: u64): FixedPoint32 {
         let value = (val as u128) << 32;
         assert!(value <= MAX_U64, ERATIO_OUT_OF_RANGE);
-        FixedPoint32 {value: (value as u64)}
+        FixedPoint32 { value: (value as u64) }
     }
+
     spec create_from_u64 {
         pragma opaque;
         include CreateFromU64AbortsIf;
         ensures result == spec_create_from_u64(val);
     }
+
     spec schema CreateFromU64AbortsIf {
         val: num;
         let scaled_value = (val as u128) << 32;
         aborts_if scaled_value > MAX_U64;
     }
+
     spec fun spec_create_from_u64(val: num): FixedPoint32 {
-        FixedPoint32 {value: val << 32}
+        FixedPoint32 { value: val << 32 }
     }
 
     /// Returns the largest integer less than or equal to a given number.
     public fun floor(num: FixedPoint32): u64 {
         num.value >> 32
     }
+
     spec floor {
         pragma opaque;
         aborts_if false;
         ensures result == spec_floor(num);
     }
+
     spec fun spec_floor(val: FixedPoint32): u64 {
         let fractional = val.value % (1 << 32);
         if (fractional == 0) {
@@ -242,12 +251,14 @@ module std::fixed_point32 {
         let val = ((floored_num as u128) + (1 << 32));
         (val >> 32 as u64)
     }
+
     spec ceil {
         pragma verify_duration_estimate = 120;
         pragma opaque;
         aborts_if false;
         ensures result == spec_ceil(num);
     }
+
     spec fun spec_ceil(val: FixedPoint32): u64 {
         let fractional = val.value % (1 << 32);
         let one = 1 << 32;
@@ -268,12 +279,14 @@ module std::fixed_point32 {
             ceil(num)
         }
     }
+
     spec round {
         pragma verify_duration_estimate = 120;
         pragma opaque;
         aborts_if false;
         ensures result == spec_round(num);
     }
+
     spec fun spec_round(val: FixedPoint32): u64 {
         let fractional = val.value % (1 << 32);
         let boundary = (1 << 32) / 2;

--- a/aptos-move/framework/move-stdlib/sources/option.move
+++ b/aptos-move/framework/move-stdlib/sources/option.move
@@ -7,6 +7,7 @@ module std::option {
     struct Option<Element> has copy, drop, store {
         vec: vector<Element>
     }
+
     spec Option {
         /// The size of vector is always less than equal to 1
         /// because it's 0 for "none" or 1 for "some".
@@ -26,26 +27,30 @@ module std::option {
     public fun none<Element>(): Option<Element> {
         Option { vec: vector::empty() }
     }
+
     spec none {
         pragma opaque;
         aborts_if false;
         ensures result == spec_none<Element>();
     }
+
     spec fun spec_none<Element>(): Option<Element> {
-        Option{ vec: vec() }
+        Option { vec: vec() }
     }
 
     /// Return an `Option` containing `e`
     public fun some<Element>(e: Element): Option<Element> {
         Option { vec: vector::singleton(e) }
     }
+
     spec some {
         pragma opaque;
         aborts_if false;
         ensures result == spec_some(e);
     }
+
     spec fun spec_some<Element>(e: Element): Option<Element> {
-        Option{ vec: vec(e) }
+        Option { vec: vec(e) }
     }
 
     public fun from_vec<Element>(vec: vector<Element>): Option<Element> {
@@ -61,11 +66,13 @@ module std::option {
     public fun is_none<Element>(t: &Option<Element>): bool {
         vector::is_empty(&t.vec)
     }
+
     spec is_none {
         pragma opaque;
         aborts_if false;
         ensures result == spec_is_none(t);
     }
+
     spec fun spec_is_none<Element>(t: Option<Element>): bool {
         vector::is_empty(t.vec)
     }
@@ -74,11 +81,13 @@ module std::option {
     public fun is_some<Element>(t: &Option<Element>): bool {
         !vector::is_empty(&t.vec)
     }
+
     spec is_some {
         pragma opaque;
         aborts_if false;
         ensures result == spec_is_some(t);
     }
+
     spec fun spec_is_some<Element>(t: Option<Element>): bool {
         !vector::is_empty(t.vec)
     }
@@ -88,11 +97,13 @@ module std::option {
     public fun contains<Element>(t: &Option<Element>, e_ref: &Element): bool {
         vector::contains(&t.vec, e_ref)
     }
+
     spec contains {
         pragma opaque;
         aborts_if false;
         ensures result == spec_contains(t, e_ref);
     }
+
     spec fun spec_contains<Element>(t: Option<Element>, e: Element): bool {
         is_some(t) && borrow(t) == e
     }
@@ -103,22 +114,26 @@ module std::option {
         assert!(is_some(t), EOPTION_NOT_SET);
         vector::borrow(&t.vec, 0)
     }
+
     spec borrow {
         pragma opaque;
         include AbortsIfNone<Element>;
         ensures result == spec_borrow(t);
     }
+
     spec fun spec_borrow<Element>(t: Option<Element>): Element {
         t.vec[0]
     }
 
     /// Return a reference to the value inside `t` if it holds one
     /// Return `default_ref` if `t` does not hold a value
-    public fun borrow_with_default<Element>(t: &Option<Element>, default_ref: &Element): &Element {
+    public fun borrow_with_default<Element>(
+        t: &Option<Element>, default_ref: &Element
+    ): &Element {
         let vec_ref = &t.vec;
-        if (vector::is_empty(vec_ref)) default_ref
-        else vector::borrow(vec_ref, 0)
+        if (vector::is_empty(vec_ref)) default_ref else vector::borrow(vec_ref, 0)
     }
+
     spec borrow_with_default {
         pragma opaque;
         aborts_if false;
@@ -128,13 +143,12 @@ module std::option {
     /// Return the value inside `t` if it holds one
     /// Return `default` if `t` does not hold a value
     public fun get_with_default<Element: copy + drop>(
-        t: &Option<Element>,
-        default: Element,
+        t: &Option<Element>, default: Element,
     ): Element {
         let vec_ref = &t.vec;
-        if (vector::is_empty(vec_ref)) default
-        else *vector::borrow(vec_ref, 0)
+        if (vector::is_empty(vec_ref)) default else *vector::borrow(vec_ref, 0)
     }
+
     spec get_with_default {
         pragma opaque;
         aborts_if false;
@@ -145,9 +159,10 @@ module std::option {
     /// Aborts if `t` already holds a value
     public fun fill<Element>(t: &mut Option<Element>, e: Element) {
         let vec_ref = &mut t.vec;
-        if (vector::is_empty(vec_ref)) vector::push_back(vec_ref, e)
-        else abort EOPTION_IS_SET
+        if (vector::is_empty(vec_ref)) vector::push_back(vec_ref, e) else
+            abort EOPTION_IS_SET
     }
+
     spec fill {
         pragma opaque;
         aborts_if spec_is_some(t) with EOPTION_IS_SET;
@@ -161,6 +176,7 @@ module std::option {
         assert!(is_some(t), EOPTION_NOT_SET);
         vector::pop_back(&mut t.vec)
     }
+
     spec extract {
         pragma opaque;
         include AbortsIfNone<Element>;
@@ -174,6 +190,7 @@ module std::option {
         assert!(is_some(t), EOPTION_NOT_SET);
         vector::borrow_mut(&mut t.vec, 0)
     }
+
     spec borrow_mut {
         include AbortsIfNone<Element>;
         ensures result == spec_borrow(t);
@@ -189,6 +206,7 @@ module std::option {
         vector::push_back(vec_ref, e);
         old_value
     }
+
     spec swap {
         pragma opaque;
         include AbortsIfNone<Element>;
@@ -202,11 +220,12 @@ module std::option {
     /// Different from swap(), swap_or_fill() allows for `t` not holding a value.
     public fun swap_or_fill<Element>(t: &mut Option<Element>, e: Element): Option<Element> {
         let vec_ref = &mut t.vec;
-        let old_value = if (vector::is_empty(vec_ref)) none()
-            else some(vector::pop_back(vec_ref));
+        let old_value =
+            if (vector::is_empty(vec_ref)) none() else some(vector::pop_back(vec_ref));
         vector::push_back(vec_ref, e);
         old_value
     }
+
     spec swap_or_fill {
         pragma opaque;
         aborts_if false;
@@ -215,11 +234,13 @@ module std::option {
     }
 
     /// Destroys `t.` If `t` holds a value, return it. Returns `default` otherwise
-    public fun destroy_with_default<Element: drop>(t: Option<Element>, default: Element): Element {
+    public fun destroy_with_default<Element: drop>(
+        t: Option<Element>, default: Element
+    ): Element {
         let Option { vec } = t;
-        if (vector::is_empty(&mut vec)) default
-        else vector::pop_back(&mut vec)
+        if (vector::is_empty(&mut vec)) default else vector::pop_back(&mut vec)
     }
+
     spec destroy_with_default {
         pragma opaque;
         aborts_if false;
@@ -235,6 +256,7 @@ module std::option {
         vector::destroy_empty(vec);
         elem
     }
+
     spec destroy_some {
         pragma opaque;
         include AbortsIfNone<Element>;
@@ -248,6 +270,7 @@ module std::option {
         let Option { vec } = t;
         vector::destroy_empty(vec)
     }
+
     spec destroy_none {
         pragma opaque;
         aborts_if spec_is_some(t) with EOPTION_IS_SET;
@@ -259,11 +282,13 @@ module std::option {
         let Option { vec } = t;
         vec
     }
+
     spec to_vec {
         pragma opaque;
         aborts_if false;
         ensures result == t.vec;
     }
+
     /// Apply the function to the optional element, consuming it. Does nothing if no value present.
     public inline fun for_each<Element>(o: Option<Element>, f: |Element|) {
         if (is_some(&o)) {
@@ -274,14 +299,18 @@ module std::option {
     }
 
     /// Apply the function to the optional element reference. Does nothing if no value present.
-    public inline fun for_each_ref<Element>(o: &Option<Element>, f: |&Element|) {
+    public inline fun for_each_ref<Element>(
+        o: &Option<Element>, f: |&Element|
+    ) {
         if (is_some(o)) {
             f(borrow(o))
         }
     }
 
     /// Apply the function to the optional element reference. Does nothing if no value present.
-    public inline fun for_each_mut<Element>(o: &mut Option<Element>, f: |&mut Element|) {
+    public inline fun for_each_mut<Element>(
+        o: &mut Option<Element>, f: |&mut Element|
+    ) {
         if (is_some(o)) {
             f(borrow_mut(o))
         }
@@ -291,7 +320,7 @@ module std::option {
     public inline fun fold<Accumulator, Element>(
         o: Option<Element>,
         init: Accumulator,
-        f: |Accumulator,Element|Accumulator
+        f: |Accumulator, Element| Accumulator
     ): Accumulator {
         if (is_some(&o)) {
             f(init, destroy_some(o))
@@ -302,7 +331,9 @@ module std::option {
     }
 
     /// Maps the content of an option.
-    public inline fun map<Element, OtherElement>(o: Option<Element>, f: |Element|OtherElement): Option<OtherElement> {
+    public inline fun map<Element, OtherElement>(
+        o: Option<Element>, f: |Element| OtherElement
+    ): Option<OtherElement> {
         if (is_some(&o)) {
             some(f(destroy_some(o)))
         } else {
@@ -313,25 +344,23 @@ module std::option {
 
     /// Maps the content of an option without destroying the original option.
     public inline fun map_ref<Element, OtherElement>(
-        o: &Option<Element>, f: |&Element|OtherElement): Option<OtherElement> {
+        o: &Option<Element>, f: |&Element| OtherElement
+    ): Option<OtherElement> {
         if (is_some(o)) {
             some(f(borrow(o)))
-        } else {
-            none()
-        }
+        } else { none() }
     }
 
     /// Filters the content of an option
-    public inline fun filter<Element:drop>(o: Option<Element>, f: |&Element|bool): Option<Element> {
-        if (is_some(&o) && f(borrow(&o))) {
-            o
-        } else {
-            none()
-        }
+    public inline fun filter<Element: drop>(
+        o: Option<Element>, f: |&Element| bool
+    ): Option<Element> {
+        if (is_some(&o) && f(borrow(&o))) { o }
+        else { none() }
     }
 
     /// Returns true if the option contains an element which satisfies predicate.
-    public inline fun any<Element>(o: &Option<Element>, p: |&Element|bool): bool {
+    public inline fun any<Element>(o: &Option<Element>, p: |&Element| bool): bool {
         is_some(o) && p(borrow(o))
     }
 

--- a/aptos-move/framework/move-stdlib/sources/string.move
+++ b/aptos-move/framework/move-stdlib/sources/string.move
@@ -17,13 +17,13 @@ module std::string {
     /// Creates a new string from a sequence of bytes. Aborts if the bytes do not represent valid utf8.
     public fun utf8(bytes: vector<u8>): String {
         assert!(internal_check_utf8(&bytes), EINVALID_UTF8);
-        String{bytes}
+        String { bytes }
     }
 
     /// Tries to create a new string from a sequence of bytes.
     public fun try_utf8(bytes: vector<u8>): Option<String> {
         if (internal_check_utf8(&bytes)) {
-            option::some(String{bytes})
+            option::some(String { bytes })
         } else {
             option::none()
         }
@@ -58,7 +58,10 @@ module std::string {
     /// boundary.
     public fun insert(s: &mut String, at: u64, o: String) {
         let bytes = &s.bytes;
-        assert!(at <= vector::length(bytes) && internal_is_char_boundary(bytes, at), EINVALID_INDEX);
+        assert!(
+            at <= vector::length(bytes) && internal_is_char_boundary(bytes, at),
+            EINVALID_INDEX,
+        );
         let l = length(s);
         let front = sub_string(s, 0, at);
         let end = sub_string(s, at, l);
@@ -74,8 +77,11 @@ module std::string {
         let bytes = &s.bytes;
         let l = vector::length(bytes);
         assert!(
-            j <= l && i <= j && internal_is_char_boundary(bytes, i) && internal_is_char_boundary(bytes, j),
-            EINVALID_INDEX
+            j <= l
+            && i <= j
+            && internal_is_char_boundary(bytes, i)
+            && internal_is_char_boundary(bytes, j),
+            EINVALID_INDEX,
         );
         String { bytes: internal_sub_string(bytes, i, j) }
     }

--- a/aptos-move/framework/move-stdlib/sources/string.move
+++ b/aptos-move/framework/move-stdlib/sources/string.move
@@ -78,9 +78,9 @@ module std::string {
         let l = vector::length(bytes);
         assert!(
             j <= l
-            && i <= j
-            && internal_is_char_boundary(bytes, i)
-            && internal_is_char_boundary(bytes, j),
+                && i <= j
+                && internal_is_char_boundary(bytes, i)
+                && internal_is_char_boundary(bytes, j),
             EINVALID_INDEX,
         );
         String { bytes: internal_sub_string(bytes, i, j) }

--- a/aptos-move/framework/move-stdlib/sources/string.spec.move
+++ b/aptos-move/framework/move-stdlib/sources/string.spec.move
@@ -10,18 +10,21 @@ spec std::string {
         aborts_if [abstract] false;
         ensures [abstract] result == spec_internal_is_char_boundary(v, i);
     }
+
     spec internal_sub_string(v: &vector<u8>, i: u64, j: u64): vector<u8> {
         pragma opaque;
         aborts_if [abstract] false;
         ensures [abstract] result == spec_internal_sub_string(v, i, j);
     }
+
     spec internal_index_of(v: &vector<u8>, r: &vector<u8>): u64 {
         pragma opaque;
         aborts_if [abstract] false;
         ensures [abstract] result == spec_internal_index_of(v, r);
     }
+
     spec fun spec_utf8(bytes: vector<u8>): String {
-        String{bytes}
+        String { bytes }
     }
 
     spec module {

--- a/aptos-move/framework/move-stdlib/sources/vector.move
+++ b/aptos-move/framework/move-stdlib/sources/vector.move
@@ -67,6 +67,7 @@ module std::vector {
         push_back(&mut v, e);
         v
     }
+
     spec singleton {
         aborts_if false;
         ensures result == vec(e);
@@ -83,7 +84,9 @@ module std::vector {
     }
 
     /// Reverses the order of the elements [left, right) in the vector `v` in place.
-    public fun reverse_slice<Element>(v: &mut vector<Element>, left: u64, right: u64) {
+    public fun reverse_slice<Element>(
+        v: &mut vector<Element>, left: u64, right: u64
+    ) {
         assert!(left <= right, EINVALID_RANGE);
         if (left == right) return;
         right = right - 1;
@@ -93,24 +96,31 @@ module std::vector {
             right = right - 1;
         }
     }
+
     spec reverse_slice {
         pragma intrinsic = true;
     }
 
     /// Pushes all of the elements of the `other` vector into the `lhs` vector.
-    public fun append<Element>(lhs: &mut vector<Element>, other: vector<Element>) {
+    public fun append<Element>(
+        lhs: &mut vector<Element>, other: vector<Element>
+    ) {
         reverse(&mut other);
         reverse_append(lhs, other);
     }
+
     spec append {
         pragma intrinsic = true;
     }
+
     spec is_empty {
         pragma intrinsic = true;
     }
 
     /// Pushes all of the elements of the `other` vector into the `lhs` vector.
-    public fun reverse_append<Element>(lhs: &mut vector<Element>, other: vector<Element>) {
+    public fun reverse_append<Element>(
+        lhs: &mut vector<Element>, other: vector<Element>
+    ) {
         let len = length(&other);
         while (len > 0) {
             push_back(lhs, pop_back(&mut other));
@@ -118,6 +128,7 @@ module std::vector {
         };
         destroy_empty(other);
     }
+
     spec reverse_append {
         pragma intrinsic = true;
     }
@@ -128,12 +139,15 @@ module std::vector {
         reverse(&mut res);
         res
     }
+
     spec trim {
         pragma intrinsic = true;
     }
 
     /// Trim a vector to a smaller size, returning the evicted elements in reverse order
-    public fun trim_reverse<Element>(v: &mut vector<Element>, new_len: u64): vector<Element> {
+    public fun trim_reverse<Element>(
+        v: &mut vector<Element>, new_len: u64
+    ): vector<Element> {
         let len = length(v);
         assert!(new_len <= len, EINDEX_OUT_OF_BOUNDS);
         let result = empty();
@@ -143,10 +157,10 @@ module std::vector {
         };
         result
     }
+
     spec trim_reverse {
         pragma intrinsic = true;
     }
-
 
     /// Return `true` if the vector `v` has no elements and `false` otherwise.
     public fun is_empty<Element>(v: &vector<Element>): bool {
@@ -163,6 +177,7 @@ module std::vector {
         };
         false
     }
+
     spec contains {
         pragma intrinsic = true;
     }
@@ -178,6 +193,7 @@ module std::vector {
         };
         (false, 0)
     }
+
     spec index_of {
         pragma intrinsic = true;
     }
@@ -185,7 +201,7 @@ module std::vector {
     /// Return `(true, i)` if there's an element that matches the predicate. If there are multiple elements that match
     /// the predicate, only the index of the first one is returned.
     /// Otherwise, returns `(false, 0)`.
-    public inline fun find<Element>(v: &vector<Element>, f: |&Element|bool): (bool, u64) {
+    public inline fun find<Element>(v: &vector<Element>, f: |&Element| bool): (bool, u64) {
         let find = false;
         let found_index = 0;
         let i = 0;
@@ -204,7 +220,9 @@ module std::vector {
 
     /// Insert a new element at position 0 <= i <= length, using O(length - i) time.
     /// Aborts if out of bounds.
-    public fun insert<Element>(v: &mut vector<Element>, i: u64, e: Element) {
+    public fun insert<Element>(
+        v: &mut vector<Element>, i: u64, e: Element
+    ) {
         let len = length(v);
         assert!(i <= len, EINDEX_OUT_OF_BOUNDS);
         push_back(v, e);
@@ -213,6 +231,7 @@ module std::vector {
             i = i + 1;
         };
     }
+
     spec insert {
         pragma intrinsic = true;
     }
@@ -226,9 +245,13 @@ module std::vector {
         if (i >= len) abort EINDEX_OUT_OF_BOUNDS;
 
         len = len - 1;
-        while (i < len) swap(v, i, { i = i + 1; i });
+        while (i < len) swap(v, i, {
+                i = i + 1;
+                i
+            });
         pop_back(v)
     }
+
     spec remove {
         pragma intrinsic = true;
     }
@@ -239,16 +262,19 @@ module std::vector {
     /// This returns an empty vector if the value isn't present in the vector.
     /// Note that this cannot return an option as option uses vector and there'd be a circular dependency between option
     /// and vector.
-    public fun remove_value<Element>(v: &mut vector<Element>, val: &Element): vector<Element> {
+    public fun remove_value<Element>(
+        v: &mut vector<Element>, val: &Element
+    ): vector<Element> {
         // This doesn't cost a O(2N) run time as index_of scans from left to right and stops when the element is found,
         // while remove would continue from the identified index to the end of the vector.
         let (found, index) = index_of(v, val);
         if (found) {
             vector[remove(v, index)]
         } else {
-           vector[]
+            vector[]
         }
     }
+
     spec remove_value {
         pragma intrinsic = true;
     }
@@ -262,6 +288,7 @@ module std::vector {
         swap(v, i, last_idx);
         pop_back(v)
     }
+
     spec swap_remove {
         pragma intrinsic = true;
     }
@@ -273,7 +300,9 @@ module std::vector {
     }
 
     /// Apply the function to each element in the vector, consuming it.
-    public inline fun for_each_reverse<Element>(v: vector<Element>, f: |Element|) {
+    public inline fun for_each_reverse<Element>(
+        v: vector<Element>, f: |Element|
+    ) {
         let len = length(&v);
         while (len > 0) {
             f(pop_back(&mut v));
@@ -283,7 +312,9 @@ module std::vector {
     }
 
     /// Apply the function to a reference of each element in the vector.
-    public inline fun for_each_ref<Element>(v: &vector<Element>, f: |&Element|) {
+    public inline fun for_each_ref<Element>(
+        v: &vector<Element>, f: |&Element|
+    ) {
         let i = 0;
         let len = length(v);
         while (i < len) {
@@ -293,7 +324,9 @@ module std::vector {
     }
 
     /// Apply the function to each pair of elements in the two given vectors, consuming them.
-    public inline fun zip<Element1, Element2>(v1: vector<Element1>, v2: vector<Element2>, f: |Element1, Element2|) {
+    public inline fun zip<Element1, Element2>(
+        v1: vector<Element1>, v2: vector<Element2>, f: |Element1, Element2|
+    ) {
         // We need to reverse the vectors to consume it efficiently
         reverse(&mut v1);
         reverse(&mut v2);
@@ -338,7 +371,9 @@ module std::vector {
     }
 
     /// Apply the function to a reference of each element in the vector with its index.
-    public inline fun enumerate_ref<Element>(v: &vector<Element>, f: |u64, &Element|) {
+    public inline fun enumerate_ref<Element>(
+        v: &vector<Element>, f: |u64, &Element|
+    ) {
         let i = 0;
         let len = length(v);
         while (i < len) {
@@ -348,7 +383,9 @@ module std::vector {
     }
 
     /// Apply the function to a mutable reference to each element in the vector.
-    public inline fun for_each_mut<Element>(v: &mut vector<Element>, f: |&mut Element|) {
+    public inline fun for_each_mut<Element>(
+        v: &mut vector<Element>, f: |&mut Element|
+    ) {
         let i = 0;
         let len = length(v);
         while (i < len) {
@@ -376,7 +413,9 @@ module std::vector {
     }
 
     /// Apply the function to a mutable reference of each element in the vector with its index.
-    public inline fun enumerate_mut<Element>(v: &mut vector<Element>, f: |u64, &mut Element|) {
+    public inline fun enumerate_mut<Element>(
+        v: &mut vector<Element>, f: |u64, &mut Element|
+    ) {
         let i = 0;
         let len = length(v);
         while (i < len) {
@@ -390,7 +429,7 @@ module std::vector {
     public inline fun fold<Accumulator, Element>(
         v: vector<Element>,
         init: Accumulator,
-        f: |Accumulator,Element|Accumulator
+        f: |Accumulator, Element| Accumulator
     ): Accumulator {
         let accu = init;
         for_each(v, |elem| accu = f(accu, elem));
@@ -402,7 +441,7 @@ module std::vector {
     public inline fun foldr<Accumulator, Element>(
         v: vector<Element>,
         init: Accumulator,
-        f: |Element, Accumulator|Accumulator
+        f: |Element, Accumulator| Accumulator
     ): Accumulator {
         let accu = init;
         for_each_reverse(v, |elem| accu = f(elem, accu));
@@ -412,8 +451,7 @@ module std::vector {
     /// Map the function over the references of the elements of the vector, producing a new vector without modifying the
     /// original vector.
     public inline fun map_ref<Element, NewElement>(
-        v: &vector<Element>,
-        f: |&Element|NewElement
+        v: &vector<Element>, f: |&Element| NewElement
     ): vector<NewElement> {
         let result = vector<NewElement>[];
         for_each_ref(v, |elem| push_back(&mut result, f(elem)));
@@ -425,7 +463,7 @@ module std::vector {
     public inline fun zip_map_ref<Element1, Element2, NewElement>(
         v1: &vector<Element1>,
         v2: &vector<Element2>,
-        f: |&Element1, &Element2|NewElement
+        f: |&Element1, &Element2| NewElement
     ): vector<NewElement> {
         // We can't use the constant EVECTORS_LENGTH_MISMATCH here as all calling code would then need to define it
         // due to how inline functions work.
@@ -438,8 +476,7 @@ module std::vector {
 
     /// Map the function over the elements of the vector, producing a new vector.
     public inline fun map<Element, NewElement>(
-        v: vector<Element>,
-        f: |Element|NewElement
+        v: vector<Element>, f: |Element| NewElement
     ): vector<NewElement> {
         let result = vector<NewElement>[];
         for_each(v, |elem| push_back(&mut result, f(elem)));
@@ -450,7 +487,7 @@ module std::vector {
     public inline fun zip_map<Element1, Element2, NewElement>(
         v1: vector<Element1>,
         v2: vector<Element2>,
-        f: |Element1, Element2|NewElement
+        f: |Element1, Element2| NewElement
     ): vector<NewElement> {
         // We can't use the constant EVECTORS_LENGTH_MISMATCH here as all calling code would then need to define it
         // due to how inline functions work.
@@ -462,14 +499,16 @@ module std::vector {
     }
 
     /// Filter the vector using the boolean function, removing all elements for which `p(e)` is not true.
-    public inline fun filter<Element:drop>(
-        v: vector<Element>,
-        p: |&Element|bool
+    public inline fun filter<Element: drop>(
+        v: vector<Element>, p: |&Element| bool
     ): vector<Element> {
         let result = vector<Element>[];
-        for_each(v, |elem| {
-            if (p(&elem)) push_back(&mut result, elem);
-        });
+        for_each(
+            v,
+            |elem| {
+                if (p(&elem)) push_back(&mut result, elem);
+            }
+        );
         result
     }
 
@@ -477,8 +516,7 @@ module std::vector {
     /// Preserves the relative order of the elements for which pred is true,
     /// BUT NOT for the elements for which pred is false.
     public inline fun partition<Element>(
-        v: &mut vector<Element>,
-        pred: |&Element|bool
+        v: &mut vector<Element>, pred: |&Element| bool
     ): u64 {
         let i = 0;
         let len = length(v);
@@ -501,12 +539,12 @@ module std::vector {
     /// rotate(&mut [1, 2, 3, 4, 5], 2) -> [3, 4, 5, 1, 2] in place, returns the split point
     /// ie. 3 in the example above
     public fun rotate<Element>(
-        v: &mut vector<Element>,
-        rot: u64
+        v: &mut vector<Element>, rot: u64
     ): u64 {
         let len = length(v);
         rotate_slice(v, 0, rot, len)
     }
+
     spec rotate {
         pragma intrinsic = true;
     }
@@ -524,6 +562,7 @@ module std::vector {
         reverse_slice(v, left, right);
         left + (right - rot)
     }
+
     spec rotate_slice {
         pragma intrinsic = true;
     }
@@ -531,8 +570,7 @@ module std::vector {
     /// Partition the array based on a predicate p, this routine is stable and thus
     /// preserves the relative order of the elements in the two partitions.
     public inline fun stable_partition<Element>(
-        v: &mut vector<Element>,
-        p: |&Element|bool
+        v: &mut vector<Element>, p: |&Element| bool
     ): u64 {
         let len = length(v);
         let t = empty();
@@ -554,16 +592,13 @@ module std::vector {
 
     /// Return true if any element in the vector satisfies the predicate.
     public inline fun any<Element>(
-        v: &vector<Element>,
-        p: |&Element|bool
+        v: &vector<Element>, p: |&Element| bool
     ): bool {
         let result = false;
         let i = 0;
         while (i < length(v)) {
             result = p(borrow(v, i));
-            if (result) {
-                break
-            };
+            if (result) { break };
             i = i + 1
         };
         result
@@ -571,16 +606,13 @@ module std::vector {
 
     /// Return true if all elements in the vector satisfy the predicate.
     public inline fun all<Element>(
-        v: &vector<Element>,
-        p: |&Element|bool
+        v: &vector<Element>, p: |&Element| bool
     ): bool {
         let result = true;
         let i = 0;
         while (i < length(v)) {
             result = p(borrow(v, i));
-            if (!result) {
-                break
-            };
+            if (!result) { break };
             i = i + 1
         };
         result
@@ -589,8 +621,7 @@ module std::vector {
     /// Destroy a vector, just a wrapper around for_each_reverse with a descriptive name
     /// when used in the context of destroying a vector.
     public inline fun destroy<Element>(
-        v: vector<Element>,
-        d: |Element|
+        v: vector<Element>, d: |Element|
     ) {
         for_each_reverse(v, |e| d(e))
     }
@@ -611,9 +642,7 @@ module std::vector {
     }
 
     public fun slice<Element: copy>(
-        v: &vector<Element>,
-        start: u64,
-        end: u64
+        v: &vector<Element>, start: u64, end: u64
     ): vector<Element> {
         assert!(start <= end && end <= length(v), EINVALID_SLICE_RANGE);
 
@@ -635,29 +664,28 @@ module std::vector {
     spec module {
         /// Check if `v1` is equal to the result of adding `e` at the end of `v2`
         fun eq_push_back<Element>(v1: vector<Element>, v2: vector<Element>, e: Element): bool {
-            len(v1) == len(v2) + 1 &&
-            v1[len(v1)-1] == e &&
-            v1[0..len(v1)-1] == v2[0..len(v2)]
+            len(v1) == len(v2) + 1
+                && v1[len(v1) - 1] == e
+                && v1[0..len(v1) - 1] == v2[0..len(v2)]
         }
 
         /// Check if `v` is equal to the result of concatenating `v1` and `v2`
         fun eq_append<Element>(v: vector<Element>, v1: vector<Element>, v2: vector<Element>): bool {
-            len(v) == len(v1) + len(v2) &&
-            v[0..len(v1)] == v1 &&
-            v[len(v1)..len(v)] == v2
+            len(v) == len(v1) + len(v2)
+                && v[0..len(v1)] == v1
+                && v[len(v1)..len(v)] == v2
         }
 
         /// Check `v1` is equal to the result of removing the first element of `v2`
         fun eq_pop_front<Element>(v1: vector<Element>, v2: vector<Element>): bool {
-            len(v1) + 1 == len(v2) &&
-            v1 == v2[1..len(v2)]
+            len(v1) + 1 == len(v2) && v1 == v2[1..len(v2)]
         }
 
         /// Check that `v1` is equal to the result of removing the element at index `i` from `v2`.
         fun eq_remove_elem_at_index<Element>(i: u64, v1: vector<Element>, v2: vector<Element>): bool {
-            len(v1) + 1 == len(v2) &&
-            v1[0..i] == v2[0..i] &&
-            v1[i..len(v1)] == v2[i + 1..len(v2)]
+            len(v1) + 1 == len(v2)
+                && v1[0..i] == v2[0..i]
+                && v1[i..len(v1)] == v2[i + 1..len(v2)]
         }
 
         /// Check if `v` contains `e`.
@@ -665,5 +693,4 @@ module std::vector {
             exists x in v: x == e
         }
     }
-
 }

--- a/aptos-move/framework/move-stdlib/sources/vector.move
+++ b/aptos-move/framework/move-stdlib/sources/vector.move
@@ -201,7 +201,9 @@ module std::vector {
     /// Return `(true, i)` if there's an element that matches the predicate. If there are multiple elements that match
     /// the predicate, only the index of the first one is returned.
     /// Otherwise, returns `(false, 0)`.
-    public inline fun find<Element>(v: &vector<Element>, f: |&Element| bool): (bool, u64) {
+    public inline fun find<Element>(
+        v: &vector<Element>, f: |&Element| bool
+    ): (bool, u64) {
         let find = false;
         let found_index = 0;
         let i = 0;
@@ -245,10 +247,12 @@ module std::vector {
         if (i >= len) abort EINDEX_OUT_OF_BOUNDS;
 
         len = len - 1;
-        while (i < len) swap(v, i, {
+        while (i < len) swap(
+            v, i, {
                 i = i + 1;
                 i
-            });
+            }
+        );
         pop_back(v)
     }
 
@@ -507,7 +511,7 @@ module std::vector {
             v,
             |elem| {
                 if (p(&elem)) push_back(&mut result, elem);
-            }
+            },
         );
         result
     }
@@ -538,9 +542,7 @@ module std::vector {
 
     /// rotate(&mut [1, 2, 3, 4, 5], 2) -> [3, 4, 5, 1, 2] in place, returns the split point
     /// ie. 3 in the example above
-    public fun rotate<Element>(
-        v: &mut vector<Element>, rot: u64
-    ): u64 {
+    public fun rotate<Element>(v: &mut vector<Element>, rot: u64): u64 {
         let len = length(v);
         rotate_slice(v, 0, rot, len)
     }
@@ -620,9 +622,7 @@ module std::vector {
 
     /// Destroy a vector, just a wrapper around for_each_reverse with a descriptive name
     /// when used in the context of destroying a vector.
-    public inline fun destroy<Element>(
-        v: vector<Element>, d: |Element|
-    ) {
+    public inline fun destroy<Element>(v: vector<Element>, d: |Element|) {
         for_each_reverse(v, |e| d(e))
     }
 

--- a/aptos-move/framework/move-stdlib/tests/bcs_tests.move
+++ b/aptos-move/framework/move-stdlib/tests/bcs_tests.move
@@ -2,13 +2,33 @@
 module std::bcs_tests {
     use std::bcs;
 
-    struct Box<T> has copy, drop, store { x: T }
-    struct Box3<T> has copy, drop, store { x: Box<Box<T>> }
-    struct Box7<T> has copy, drop, store { x: Box3<Box3<T>> }
-    struct Box15<T> has copy, drop, store { x: Box7<Box7<T>> }
-    struct Box31<T> has copy, drop, store { x: Box15<Box15<T>> }
-    struct Box63<T> has copy, drop, store { x: Box31<Box31<T>> }
-    struct Box127<T> has copy, drop, store { x: Box63<Box63<T>> }
+    struct Box<T> has copy, drop, store {
+        x: T
+    }
+
+    struct Box3<T> has copy, drop, store {
+        x: Box<Box<T>>
+    }
+
+    struct Box7<T> has copy, drop, store {
+        x: Box3<Box3<T>>
+    }
+
+    struct Box15<T> has copy, drop, store {
+        x: Box7<Box7<T>>
+    }
+
+    struct Box31<T> has copy, drop, store {
+        x: Box15<Box15<T>>
+    }
+
+    struct Box63<T> has copy, drop, store {
+        x: Box31<Box31<T>>
+    }
+
+    struct Box127<T> has copy, drop, store {
+        x: Box63<Box63<T>>
+    }
 
     /* Deactivated because of address size dependency
     #[test]

--- a/aptos-move/framework/move-stdlib/tests/bit_vector_tests.move
+++ b/aptos-move/framework/move-stdlib/tests/bit_vector_tests.move
@@ -105,7 +105,9 @@ module std::bit_vector_tests {
         };
         assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 0) == 20, 0);
         assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 20) == 0, 0);
-        assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 21) == 100 - 21, 0);
+        assert!(
+            bit_vector::longest_set_sequence_starting_at(&bitvector, 21) == 100 - 21, 0
+        );
     }
 
     #[test]
@@ -123,7 +125,7 @@ module std::bit_vector_tests {
         while (i > 0) {
             assert!(bit_vector::is_index_set(&bitvector, i), 0);
             bit_vector::shift_left(&mut bitvector, 1);
-            assert!(!bit_vector::is_index_set(&bitvector,  i), 1);
+            assert!(!bit_vector::is_index_set(&bitvector, i), 1);
             i = i - 1;
         };
     }
@@ -142,7 +144,7 @@ module std::bit_vector_tests {
         assert!(!bit_vector::is_index_set(&bitvector, 201), 2);
 
         // Make sure this shift clears all the bits
-        bit_vector::shift_left(&mut bitvector, bitlen  - 1);
+        bit_vector::shift_left(&mut bitvector, bitlen - 1);
 
         let i = 0;
         while (i < bitlen) {
@@ -197,7 +199,7 @@ module std::bit_vector_tests {
         bit_vector::shift_left(&mut bitvector, bitlen - 1);
         i = bitlen - 1;
         while (i > 0) {
-            assert!(!bit_vector::is_index_set(&bitvector,  i), 1);
+            assert!(!bit_vector::is_index_set(&bitvector, i), 1);
             i = i - 1;
         };
     }

--- a/aptos-move/framework/move-stdlib/tests/bit_vector_tests.move
+++ b/aptos-move/framework/move-stdlib/tests/bit_vector_tests.move
@@ -106,7 +106,8 @@ module std::bit_vector_tests {
         assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 0) == 20, 0);
         assert!(bit_vector::longest_set_sequence_starting_at(&bitvector, 20) == 0, 0);
         assert!(
-            bit_vector::longest_set_sequence_starting_at(&bitvector, 21) == 100 - 21, 0
+            bit_vector::longest_set_sequence_starting_at(&bitvector, 21) == 100 - 21,
+            0,
         );
     }
 

--- a/aptos-move/framework/move-stdlib/tests/fixedpoint32_tests.move
+++ b/aptos-move/framework/move-stdlib/tests/fixedpoint32_tests.move
@@ -102,7 +102,10 @@ module std::fixed_point32_tests {
     #[test]
     fun create_from_rational_max_numerator_denominator() {
         // Test creating a 1.0 fraction from the maximum u64 value.
-        let f = fixed_point32::create_from_rational(18446744073709551615, 18446744073709551615);
+        let f =
+            fixed_point32::create_from_rational(
+                18446744073709551615, 18446744073709551615
+            );
         let one = fixed_point32::get_raw_value(f);
         assert!(one == 4294967296, 0); // 0x1.00000000
     }
@@ -113,10 +116,10 @@ module std::fixed_point32_tests {
         let two = fixed_point32::create_from_rational(2, 1);
         let smaller_number1 = fixed_point32::min(one, two);
         let val1 = fixed_point32::get_raw_value(smaller_number1);
-        assert!(val1 == 4294967296, 0);  // 0x1.00000000
+        assert!(val1 == 4294967296, 0); // 0x1.00000000
         let smaller_number2 = fixed_point32::min(two, one);
         let val2 = fixed_point32::get_raw_value(smaller_number2);
-        assert!(val2 == 4294967296, 0);  // 0x1.00000000
+        assert!(val2 == 4294967296, 0); // 0x1.00000000
     }
 
     #[test]
@@ -126,9 +129,9 @@ module std::fixed_point32_tests {
         let larger_number1 = fixed_point32::max(one, two);
         let larger_number2 = fixed_point32::max(two, one);
         let val1 = fixed_point32::get_raw_value(larger_number1);
-        assert!(val1 == 8589934592, 0);  // 0x2.00000000
+        assert!(val1 == 8589934592, 0); // 0x2.00000000
         let val2 = fixed_point32::get_raw_value(larger_number2);
-        assert!(val2 == 8589934592, 0);  // 0x2.00000000
+        assert!(val2 == 8589934592, 0); // 0x2.00000000
     }
 
     #[test]

--- a/aptos-move/framework/move-stdlib/tests/hash_tests.move
+++ b/aptos-move/framework/move-stdlib/tests/hash_tests.move
@@ -5,14 +5,16 @@ module std::hash_tests {
     #[test]
     fun sha2_256_expected_hash() {
         let input = x"616263";
-        let expected_output = x"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+        let expected_output =
+            x"ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
         assert!(hash::sha2_256(input) == expected_output, 0);
     }
 
     #[test]
     fun sha3_256_expected_hash() {
         let input = x"616263";
-        let expected_output = x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
+        let expected_output =
+            x"3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532";
         assert!(hash::sha3_256(input) == expected_output, 0);
     }
 }

--- a/aptos-move/framework/move-stdlib/tests/option_tests.move
+++ b/aptos-move/framework/move-stdlib/tests/option_tests.move
@@ -226,6 +226,4 @@ module std::option_tests {
         let r = option::any(&option::some(1), |e| *e == 1);
         assert!(r, 0);
     }
-
-
 }

--- a/aptos-move/framework/move-stdlib/tests/vector_tests.move
+++ b/aptos-move/framework/move-stdlib/tests/vector_tests.move
@@ -3,8 +3,10 @@ module std::vector_tests {
     use std::vector as V;
     use std::vector;
 
-    struct R has store { }
+    struct R has store {}
+
     struct Droppable has drop {}
+
     struct NotDroppable {}
 
     #[test]
@@ -106,6 +108,7 @@ module std::vector_tests {
             assert!(&V::trim(&mut v, 0) == &vector[1, 2], 3);
         };
     }
+
     #[test]
     #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
     fun test_trim_fail() {
@@ -612,10 +615,9 @@ module std::vector_tests {
 
         test_natives_with_type<vector<u8>>(V::empty(), V::empty());
 
-        test_natives_with_type<Droppable>(Droppable{}, Droppable{});
+        test_natives_with_type<Droppable>(Droppable {}, Droppable {});
         (NotDroppable {}, NotDroppable {}) = test_natives_with_type<NotDroppable>(
-            NotDroppable {},
-            NotDroppable {}
+            NotDroppable {}, NotDroppable {}
         );
     }
 
@@ -623,9 +625,10 @@ module std::vector_tests {
     fun test_for_each() {
         let v = vector[1, 2, 3];
         let s = 0;
-        V::for_each(v, |e| {
-            s = s + e;
-        });
+        V::for_each(v,
+            |e| {
+                s = s + e;
+            });
         assert!(s == 6, 0)
     }
 
@@ -653,10 +656,13 @@ module std::vector_tests {
         let v = vector[1, 2, 3];
         let i_s = 0;
         let s = 0;
-        V::enumerate_ref(&v, |i, e| {
-            i_s = i_s + i;
-            s = s + *e;
-        });
+        V::enumerate_ref(
+            &v,
+            |i, e| {
+                i_s = i_s + i;
+                s = s + *e;
+            }
+        );
         assert!(i_s == 3, 0);
         assert!(s == 6, 0);
     }
@@ -673,7 +679,11 @@ module std::vector_tests {
     fun test_for_each_mut() {
         let v = vector[1, 2, 3];
         let s = 2;
-        V::for_each_mut(&mut v, |e| { *e = s; s = s + 1 });
+        V::for_each_mut(&mut v,
+            |e| {
+                *e = s;
+                s = s + 1
+            });
         assert!(v == vector[2, 3, 4], 0)
     }
 
@@ -700,12 +710,16 @@ module std::vector_tests {
     fun test_zip_mut() {
         let v1 = vector[1, 2, 3];
         let v2 = vector[10, 20, 30];
-        V::zip_mut(&mut v1, &mut v2, |e1, e2| {
-            let e1: &mut u64 = e1;
-            let e2: &mut u64 = e2;
-            *e1 = *e1 + 1;
-            *e2 = *e2 + 10;
-        });
+        V::zip_mut(
+            &mut v1,
+            &mut v2,
+            |e1, e2| {
+                let e1: &mut u64 = e1;
+                let e2: &mut u64 = e2;
+                *e1 = *e1 + 1;
+                *e2 = *e2 + 10;
+            },
+        );
         assert!(v1 == vector[2, 3, 4], 0);
         assert!(v2 == vector[20, 30, 40], 0);
     }
@@ -759,11 +773,14 @@ module std::vector_tests {
         let v = vector[1, 2, 3];
         let i_s = 0;
         let s = 2;
-        V::enumerate_mut(&mut v, |i, e| {
-            i_s = i_s + i;
-            *e = s;
-            s = s + 1
-        });
+        V::enumerate_mut(
+            &mut v,
+            |i, e| {
+                i_s = i_s + i;
+                *e = s;
+                s = s + 1
+            },
+        );
         assert!(i_s == 3, 0);
         assert!(v == vector[2, 3, 4], 0);
     }
@@ -772,7 +789,7 @@ module std::vector_tests {
     fun test_fold() {
         let v = vector[1, 2, 3];
         let s = V::fold(v, 0, |r, e| r + e);
-        assert!(s == 6 , 0)
+        assert!(s == 6, 0)
     }
 
     #[test]
@@ -796,21 +813,21 @@ module std::vector_tests {
     fun test_map() {
         let v = vector[1, 2, 3];
         let s = V::map(v, |x| x + 1);
-        assert!(s == vector[2, 3, 4] , 0)
+        assert!(s == vector[2, 3, 4], 0)
     }
 
     #[test]
     fun test_map_ref() {
         let v = vector[1, 2, 3];
         let s = V::map_ref(&v, |x| *x + 1);
-        assert!(s == vector[2, 3, 4] , 0)
+        assert!(s == vector[2, 3, 4], 0)
     }
 
     #[test]
     fun test_filter() {
         let v = vector[1, 2, 3];
         let s = V::filter(v, |x| *x % 2 == 0);
-        assert!(s == vector[2] , 0)
+        assert!(s == vector[2], 0)
     }
 
     #[test]
@@ -857,7 +874,7 @@ module std::vector_tests {
 
     #[test]
     fun test_stable_partition() {
-        let v:vector<u64> = vector[1, 2, 3, 4, 5];
+        let v: vector<u64> = vector[1, 2, 3, 4, 5];
 
         assert!(vector::stable_partition(&mut v, |n| *n % 2 == 0) == 2, 0);
         assert!(&v == &vector[2, 4, 1, 3, 5], 1);
@@ -871,21 +888,21 @@ module std::vector_tests {
 
     #[test]
     fun test_insert() {
-        let v:vector<u64> = vector[1, 2, 3, 4, 5];
+        let v: vector<u64> = vector[1, 2, 3, 4, 5];
 
-        vector::insert(&mut v,2, 6);
+        vector::insert(&mut v, 2, 6);
         assert!(&v == &vector[1, 2, 6, 3, 4, 5], 1);
 
-        vector::insert(&mut v,6, 7);
+        vector::insert(&mut v, 6, 7);
         assert!(&v == &vector[1, 2, 6, 3, 4, 5, 7], 1);
     }
 
     #[test]
     #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
     fun test_insert_out_of_bounds() {
-        let v:vector<u64> = vector[1, 2, 3, 4, 5];
+        let v: vector<u64> = vector[1, 2, 3, 4, 5];
 
-        vector::insert(&mut v,6, 6);
+        vector::insert(&mut v, 6, 6);
     }
 
     #[test]
@@ -952,6 +969,9 @@ module std::vector_tests {
     #[test]
     fun test_destroy() {
         let v = vector[MoveOnly {}];
-        vector::destroy(v, |m| { let MoveOnly {} = m; })
+        vector::destroy(v,
+            |m| {
+                let MoveOnly {} = m;
+            })
     }
 }

--- a/aptos-move/framework/move-stdlib/tests/vector_tests.move
+++ b/aptos-move/framework/move-stdlib/tests/vector_tests.move
@@ -625,10 +625,9 @@ module std::vector_tests {
     fun test_for_each() {
         let v = vector[1, 2, 3];
         let s = 0;
-        V::for_each(v,
-            |e| {
-                s = s + e;
-            });
+        V::for_each(v, |e| {
+            s = s + e;
+        });
         assert!(s == 6, 0)
     }
 
@@ -661,7 +660,7 @@ module std::vector_tests {
             |i, e| {
                 i_s = i_s + i;
                 s = s + *e;
-            }
+            },
         );
         assert!(i_s == 3, 0);
         assert!(s == 6, 0);
@@ -679,11 +678,13 @@ module std::vector_tests {
     fun test_for_each_mut() {
         let v = vector[1, 2, 3];
         let s = 2;
-        V::for_each_mut(&mut v,
+        V::for_each_mut(
+            &mut v,
             |e| {
                 *e = s;
                 s = s + 1
-            });
+            },
+        );
         assert!(v == vector[2, 3, 4], 0)
     }
 
@@ -969,9 +970,10 @@ module std::vector_tests {
     #[test]
     fun test_destroy() {
         let v = vector[MoveOnly {}];
-        vector::destroy(v,
-            |m| {
+        vector::destroy(
+            v, |m| {
                 let MoveOnly {} = m;
-            })
+            }
+        )
     }
 }


### PR DESCRIPTION
## Description
This PR shows the result after applying the newest [movefmt v1.0.3](https://github.com/movebit/movefmt/tree/develop) to the framework code using the default option:
```
max_width = 90
indent_size = 4
hard_tabs = false
tab_spaces = 4
emit_mode = "NewFiles"
verbose = "Normal"
prefer_one_line_for_short_branch_blk = true
```