### PR TITLE
[Consensus Observer] Fix randomness_stall_recovery smoke test.

### DIFF
--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -106,8 +106,9 @@ impl ConfigOptimizer for ConsensusObserverConfig {
             },
             NodeType::PublicFullnode => {
                 if ENABLE_ON_PUBLIC_FULLNODES && !observer_manually_set {
-                    // Only enable the observer for PFNs
+                    // Enable both the observer and the publisher for PFNs
                     consensus_observer_config.observer_enabled = true;
+                    consensus_observer_config.publisher_enabled = true;
                     modified_config = true;
                 }
             },

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -195,7 +195,7 @@ pub fn start_consensus_observer(
     // Create the consensus observer
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let consensus_observer = ConsensusObserver::new(
-        node_config.consensus_observer,
+        node_config.clone(),
         consensus_observer_client,
         aptos_db.reader.clone(),
         execution_client,


### PR DESCRIPTION
## Description
This PR updates consensus observer to pass the `randomness_stall_recovery` smoke test. To do so, we: (i) update the smoke test to add the `randomness_override_seq_num` override; and (ii) update consensus observer to use the override when constructing `OnChainRandomnessConfig`.

Note: I'll remove the enablement of consensus observer before this lands. It's simply so that I can test the smoke test 😄 

## Testing Plan
Existing test infrastructure.