### PR TITLE
[move] Loader V2 API integration for MoveVM

### DIFF
--- a/aptos-move/aptos-release-builder/src/simulate.rs
+++ b/aptos-move/aptos-release-builder/src/simulate.rs
@@ -66,7 +66,10 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag},
     move_resource::MoveResource,
 };
-use move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage};
+use move_vm_runtime::{
+    module_traversal::{TraversalContext, TraversalStorage},
+    DummyCodeStorage,
+};
 use move_vm_types::{gas::UnmeteredGasMeter, resolver::ModuleResolver};
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
@@ -480,6 +483,7 @@ fn force_end_epoch(state_view: &SimulationStateView<impl StateView>) -> Result<(
         vec![bcs::to_bytes(&AccountAddress::ONE)?],
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
+        &DummyCodeStorage,
     )?;
     let (mut change_set, module_write_set) = sess.finish(&change_set_configs)?;
     change_set.try_materialize_aggregator_v1_delta_set(&resolver)?;

--- a/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
+++ b/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
@@ -12,7 +12,7 @@ use move_core_types::{account_address::AccountAddress, ident_str, identifier::Id
 use move_ir_compiler::Compiler;
 use move_vm_runtime::{
     module_traversal::*, move_vm::MoveVM, native_extensions::NativeContextExtensions,
-    native_functions::NativeFunction,
+    native_functions::NativeFunction, DummyCodeStorage,
 };
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::{
@@ -176,6 +176,8 @@ fn main() -> Result<()> {
             args,
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
+            &DummyCodeStorage,
         )?;
     } else {
         let module = Compiler::new(test_modules.iter().collect()).into_compiled_module(&src)?;
@@ -186,6 +188,7 @@ fn main() -> Result<()> {
             module_blob,
             *module.self_id().address(),
             &mut UnmeteredGasMeter,
+            &DummyCodeStorage,
         )?;
         let args: Vec<Vec<u8>> = vec![];
         let res = sess.execute_function_bypass_visibility(
@@ -195,6 +198,7 @@ fn main() -> Result<()> {
             args,
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
         )?;
         println!("{:?}", res);
     }

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -288,6 +288,8 @@ impl<'r, 'l> SessionExt<'r, 'l> {
             let (modules, resources) = account_changeset.into_inner();
 
             for (struct_tag, blob_op) in resources {
+                // TODO(George): Use ModuleStorage to resolve module metadata directly.
+                #[allow(deprecated)]
                 let resource_group_tag = runtime
                     .with_module_metadata(&struct_tag.module_id(), |md| {
                         get_resource_group_member_from_metadata(&struct_tag, md)

--- a/aptos-move/aptos-vm/src/move_vm_ext/warm_vm_cache.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/warm_vm_cache.rs
@@ -109,6 +109,7 @@ impl WarmVmCache {
         //
         // Loading up `0x1::account` should be sufficient as this is the most common module
         // used for prologue, epilogue and transfer functionality.
+        #[allow(deprecated)]
         let _ = vm.load_module(
             &ModuleId::new(CORE_CODE_ADDRESS, ident_str!("account").to_owned()),
             resolver,

--- a/aptos-move/aptos-vm/src/transaction_validation.rs
+++ b/aptos-move/aptos-vm/src/transaction_validation.rs
@@ -27,7 +27,9 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
     vm_status::{AbortLocation, StatusCode, VMStatus},
 };
-use move_vm_runtime::{logging::expect_no_verification_errors, module_traversal::TraversalContext};
+use move_vm_runtime::{
+    logging::expect_no_verification_errors, module_traversal::TraversalContext, DummyCodeStorage,
+};
 use move_vm_types::gas::UnmeteredGasMeter;
 use once_cell::sync::Lazy;
 
@@ -142,6 +144,7 @@ pub(crate) fn run_script_prologue(
             serialize_values(&args),
             &mut gas_meter,
             traversal_context,
+            &DummyCodeStorage,
         )
         .map(|_return_vals| ())
         .map_err(expect_no_verification_errors)
@@ -185,6 +188,7 @@ pub(crate) fn run_multisig_prologue(
             ]),
             &mut UnmeteredGasMeter,
             traversal_context,
+            &DummyCodeStorage,
         )
         .map(|_return_vals| ())
         .map_err(expect_no_verification_errors)
@@ -226,6 +230,7 @@ fn run_epilogue(
             serialize_values(&args),
             &mut UnmeteredGasMeter,
             traversal_context,
+            &DummyCodeStorage,
         )
     } else {
         // Regular tx, run the normal epilogue
@@ -246,6 +251,7 @@ fn run_epilogue(
             serialize_values(&args),
             &mut UnmeteredGasMeter,
             traversal_context,
+            &DummyCodeStorage,
         )
     }
     .map(|_return_vals| ())
@@ -274,6 +280,7 @@ fn emit_fee_statement(
             vec![bcs::to_bytes(&fee_statement).expect("Failed to serialize fee statement")],
             &mut UnmeteredGasMeter,
             traversal_context,
+            &DummyCodeStorage,
         )
         .map(|_return_vals| ())
 }

--- a/aptos-move/aptos-vm/src/validator_txns/dkg.rs
+++ b/aptos-move/aptos-vm/src/validator_txns/dkg.rs
@@ -25,7 +25,10 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
     vm_status::{AbortLocation, StatusCode, VMStatus},
 };
-use move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage};
+use move_vm_runtime::{
+    module_traversal::{TraversalContext, TraversalStorage},
+    DummyCodeStorage,
+};
 use move_vm_types::gas::UnmeteredGasMeter;
 
 #[derive(Debug)]
@@ -114,6 +117,7 @@ impl AptosVM {
                 serialize_values(&args),
                 &mut gas_meter,
                 &mut TraversalContext::new(&module_storage),
+                &DummyCodeStorage,
             )
             .map_err(|e| {
                 expect_only_successful_execution(e, FINISH_WITH_DKG_RESULT.as_str(), log_context)

--- a/aptos-move/aptos-vm/src/validator_txns/jwk.rs
+++ b/aptos-move/aptos-vm/src/validator_txns/jwk.rs
@@ -31,7 +31,10 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
     vm_status::{AbortLocation, StatusCode, VMStatus},
 };
-use move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage};
+use move_vm_runtime::{
+    module_traversal::{TraversalContext, TraversalStorage},
+    DummyCodeStorage,
+};
 use move_vm_types::gas::UnmeteredGasMeter;
 use std::collections::HashMap;
 
@@ -144,6 +147,7 @@ impl AptosVM {
                 serialize_values(&args),
                 &mut gas_meter,
                 &mut TraversalContext::new(&module_storage),
+                &DummyCodeStorage,
             )
             .map_err(|e| {
                 expect_only_successful_execution(e, UPSERT_INTO_OBSERVED_JWKS.as_str(), log_context)

--- a/aptos-move/aptos-vm/src/verifier/event_validation.rs
+++ b/aptos-move/aptos-vm/src/verifier/event_validation.rs
@@ -120,13 +120,16 @@ pub(crate) fn extract_event_metadata_from_module(
     session: &mut SessionExt,
     module_id: &ModuleId,
 ) -> VMResult<HashSet<String>> {
-    let metadata = session.load_module(module_id).map(|module| {
-        CompiledModule::deserialize_with_config(
-            &module,
-            &session.get_vm_config().deserializer_config,
-        )
-        .map(|module| aptos_framework::get_metadata_from_compiled_module(&module))
-    });
+    #[allow(deprecated)]
+    let metadata = session
+        .fetch_module_from_data_store(module_id)
+        .map(|module| {
+            CompiledModule::deserialize_with_config(
+                &module,
+                &session.get_vm_config().deserializer_config,
+            )
+            .map(|module| aptos_framework::get_metadata_from_compiled_module(&module))
+        });
 
     if let Ok(Ok(Some(metadata))) = metadata {
         extract_event_metadata(&metadata)

--- a/aptos-move/aptos-vm/src/verifier/randomness.rs
+++ b/aptos-move/aptos-vm/src/verifier/randomness.rs
@@ -11,6 +11,7 @@ pub(crate) fn get_randomness_annotation(
     session: &mut SessionExt,
     entry_fn: &EntryFunction,
 ) -> VMResult<Option<RandomnessAnnotation>> {
+    #[allow(deprecated)]
     let module = session
         .get_move_vm()
         .load_module(entry_fn.module(), resolver)?;

--- a/aptos-move/aptos-vm/src/verifier/resource_groups.rs
+++ b/aptos-move/aptos-vm/src/verifier/resource_groups.rs
@@ -150,12 +150,15 @@ pub(crate) fn extract_resource_group_metadata_from_module(
     BTreeMap<String, StructTag>,
     BTreeSet<String>,
 )> {
-    let module = session.load_module(module_id).map(|module| {
-        CompiledModule::deserialize_with_config(
-            &module,
-            &session.get_vm_config().deserializer_config,
-        )
-    });
+    #[allow(deprecated)]
+    let module = session
+        .fetch_module_from_data_store(module_id)
+        .map(|module| {
+            CompiledModule::deserialize_with_config(
+                &module,
+                &session.get_vm_config().deserializer_config,
+            )
+        });
     let (metadata, module) = if let Ok(Ok(module)) = module {
         (
             aptos_framework::get_metadata_from_compiled_module(&module),

--- a/aptos-move/framework/src/module_metadata.rs
+++ b/aptos-move/framework/src/module_metadata.rs
@@ -228,6 +228,8 @@ pub fn get_metadata_v0(md: &[Metadata]) -> Option<Arc<RuntimeModuleMetadataV1>> 
 
 /// Extract metadata from the VM, upgrading V0 to V1 representation as needed
 pub fn get_vm_metadata(vm: &MoveVM, module_id: &ModuleId) -> Option<Arc<RuntimeModuleMetadataV1>> {
+    // TODO(George): Use ModuleStorage to resolve module metadata directly.
+    #[allow(deprecated)]
     vm.with_module_metadata(module_id, get_metadata)
 }
 
@@ -236,6 +238,8 @@ pub fn get_vm_metadata_v0(
     vm: &MoveVM,
     module_id: &ModuleId,
 ) -> Option<Arc<RuntimeModuleMetadataV1>> {
+    // TODO(George): Use ModuleStorage to resolve module metadata directly.
+    #[allow(deprecated)]
     vm.with_module_metadata(module_id, get_metadata_v0)
 }
 

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -49,7 +49,10 @@ use move_core_types::{
     language_storage::{ModuleId, TypeTag},
     value::{serialize_values, MoveTypeLayout, MoveValue},
 };
-use move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage};
+use move_vm_runtime::{
+    module_traversal::{TraversalContext, TraversalStorage},
+    DummyCodeStorage,
+};
 use move_vm_types::gas::UnmeteredGasMeter;
 use once_cell::sync::Lazy;
 use rand::prelude::*;
@@ -382,6 +385,7 @@ fn exec_function(
             args,
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&storage),
+            &DummyCodeStorage,
         )
         .unwrap_or_else(|e| {
             panic!(
@@ -763,7 +767,7 @@ fn publish_package(session: &mut SessionExt, pack: &ReleasePackage) {
         .map(|(c, _)| c.to_vec())
         .collect::<Vec<_>>();
     session
-        .publish_module_bundle(code, addr, &mut UnmeteredGasMeter)
+        .publish_module_bundle(code, addr, &mut UnmeteredGasMeter, &DummyCodeStorage)
         .unwrap_or_else(|e| {
             panic!(
                 "Failure publishing package `{}`: {:?}",

--- a/third_party/move/extensions/async/move-async-vm/tests/testsuite.rs
+++ b/third_party/move/extensions/async/move-async-vm/tests/testsuite.rs
@@ -26,6 +26,7 @@ use move_core_types::{
     value::MoveTypeLayout,
 };
 use move_prover_test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives};
+use move_vm_runtime::DummyCodeStorage;
 use move_vm_test_utils::gas_schedule::GasStatus;
 use move_vm_types::resolver::{resource_size, ModuleResolver, ResourceResolver};
 use std::{
@@ -158,9 +159,12 @@ impl Harness {
                 }
             }
             self.log(format!("publishing {}", id));
-            session
-                .get_move_session()
-                .publish_module(cu.serialize(None), test_account(), gas)?
+            session.get_move_session().publish_module(
+                cu.serialize(None),
+                test_account(),
+                gas,
+                &DummyCodeStorage,
+            )?
         }
         Ok(())
     }

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
@@ -10,7 +10,7 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
     vm_status::StatusType,
 };
-use move_vm_runtime::{module_traversal::*, move_vm::MoveVM};
+use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, DummyCodeStorage};
 use move_vm_test_utils::{BlankStorage, InMemoryStorage};
 use move_vm_types::gas::UnmeteredGasMeter;
 
@@ -34,6 +34,7 @@ fn call_non_existent_module() {
             serialize_values(&vec![MoveValue::Signer(TEST_ADDR)]),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
         )
         .unwrap_err();
 
@@ -71,6 +72,7 @@ fn call_non_existent_function() {
             serialize_values(&vec![MoveValue::Signer(TEST_ADDR)]),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&storage),
+            &DummyCodeStorage,
         )
         .unwrap_err();
 

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -13,7 +13,7 @@ use move_core_types::{
     value::{serialize_values, MoveTypeLayout, MoveValue},
     vm_status::{StatusCode, StatusType},
 };
-use move_vm_runtime::{module_traversal::*, move_vm::MoveVM};
+use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, DummyCodeStorage};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::{
     gas::UnmeteredGasMeter,
@@ -103,6 +103,8 @@ fn test_malformed_resource() {
         vec![MoveValue::Signer(TEST_ADDR).simple_serialize().unwrap()],
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
+        &DummyCodeStorage,
+        &DummyCodeStorage,
     )
     .map(|_| ())
     .unwrap();
@@ -122,6 +124,8 @@ fn test_malformed_resource() {
             vec![MoveValue::Signer(TEST_ADDR).simple_serialize().unwrap()],
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
+            &DummyCodeStorage,
         )
         .map(|_| ())
         .unwrap();
@@ -150,6 +154,8 @@ fn test_malformed_resource() {
                 vec![MoveValue::Signer(TEST_ADDR).simple_serialize().unwrap()],
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
+                &DummyCodeStorage,
+                &DummyCodeStorage,
             )
             .map(|_| ())
             .unwrap_err();
@@ -191,6 +197,7 @@ fn test_malformed_module() {
             Vec::<Vec<u8>>::new(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
         )
         .unwrap();
     }
@@ -218,6 +225,7 @@ fn test_malformed_module() {
                 Vec::<Vec<u8>>::new(),
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
+                &DummyCodeStorage,
             )
             .unwrap_err();
         assert_eq!(err.status_type(), StatusType::InvariantViolation);
@@ -259,6 +267,7 @@ fn test_unverifiable_module() {
             Vec::<Vec<u8>>::new(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
         )
         .unwrap();
     }
@@ -285,6 +294,7 @@ fn test_unverifiable_module() {
                 Vec::<Vec<u8>>::new(),
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
+                &DummyCodeStorage,
             )
             .unwrap_err();
 
@@ -337,6 +347,7 @@ fn test_missing_module_dependency() {
             Vec::<Vec<u8>>::new(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
         )
         .unwrap();
     }
@@ -358,6 +369,7 @@ fn test_missing_module_dependency() {
                 Vec::<Vec<u8>>::new(),
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
+                &DummyCodeStorage,
             )
             .unwrap_err();
 
@@ -410,6 +422,7 @@ fn test_malformed_module_dependency() {
             Vec::<Vec<u8>>::new(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
         )
         .unwrap();
     }
@@ -437,6 +450,7 @@ fn test_malformed_module_dependency() {
                 Vec::<Vec<u8>>::new(),
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
+                &DummyCodeStorage,
             )
             .unwrap_err();
 
@@ -490,6 +504,7 @@ fn test_unverifiable_module_dependency() {
             Vec::<Vec<u8>>::new(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
         )
         .unwrap();
     }
@@ -517,6 +532,7 @@ fn test_unverifiable_module_dependency() {
                 Vec::<Vec<u8>>::new(),
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
+                &DummyCodeStorage,
             )
             .unwrap_err();
 
@@ -609,6 +625,7 @@ fn test_storage_returns_bogus_error_when_loading_module() {
                 Vec::<Vec<u8>>::new(),
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
+                &DummyCodeStorage,
             )
             .unwrap_err();
 
@@ -678,6 +695,7 @@ fn test_storage_returns_bogus_error_when_loading_resource() {
             Vec::<Vec<u8>>::new(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
         )
         .unwrap();
 
@@ -689,6 +707,7 @@ fn test_storage_returns_bogus_error_when_loading_resource() {
                 serialize_values(&vec![MoveValue::Signer(TEST_ADDR)]),
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
+                &DummyCodeStorage,
             )
             .unwrap_err();
 

--- a/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
@@ -7,7 +7,7 @@ use move_binary_format::{
     file_format_common::{IDENTIFIER_SIZE_MAX, VERSION_MAX},
 };
 use move_core_types::{account_address::AccountAddress, vm_status::StatusCode};
-use move_vm_runtime::{config::VMConfig, module_traversal::*, move_vm::MoveVM};
+use move_vm_runtime::{config::VMConfig, module_traversal::*, move_vm::MoveVM, DummyCodeStorage};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 
@@ -34,6 +34,7 @@ fn test_publish_module_with_custom_max_binary_format_version() {
             b_new.clone(),
             *m.self_id().address(),
             &mut UnmeteredGasMeter,
+            &DummyCodeStorage,
         )
         .unwrap();
 
@@ -41,6 +42,7 @@ fn test_publish_module_with_custom_max_binary_format_version() {
             b_old.clone(),
             *m.self_id().address(),
             &mut UnmeteredGasMeter,
+            &DummyCodeStorage,
         )
         .unwrap();
     }
@@ -68,6 +70,7 @@ fn test_publish_module_with_custom_max_binary_format_version() {
                 b_new.clone(),
                 *m.self_id().address(),
                 &mut UnmeteredGasMeter,
+                &DummyCodeStorage,
             )
             .unwrap_err()
             .major_status(),
@@ -78,6 +81,7 @@ fn test_publish_module_with_custom_max_binary_format_version() {
             b_old.clone(),
             *m.self_id().address(),
             &mut UnmeteredGasMeter,
+            &DummyCodeStorage,
         )
         .unwrap();
     }
@@ -110,6 +114,8 @@ fn test_run_script_with_custom_max_binary_format_version() {
             args.clone(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
+            &DummyCodeStorage,
         )
         .unwrap();
 
@@ -119,6 +125,8 @@ fn test_run_script_with_custom_max_binary_format_version() {
             args,
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
+            &DummyCodeStorage,
         )
         .unwrap();
     }
@@ -148,7 +156,9 @@ fn test_run_script_with_custom_max_binary_format_version() {
                 vec![],
                 args.clone(),
                 &mut UnmeteredGasMeter,
-                &mut TraversalContext::new(&traversal_storage)
+                &mut TraversalContext::new(&traversal_storage),
+                &DummyCodeStorage,
+                &DummyCodeStorage,
             )
             .unwrap_err()
             .major_status(),
@@ -161,6 +171,8 @@ fn test_run_script_with_custom_max_binary_format_version() {
             args,
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
+            &DummyCodeStorage,
         )
         .unwrap();
     }

--- a/third_party/move/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
@@ -13,7 +13,9 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
     vm_status::StatusCode,
 };
-use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, session::SerializedReturnValues};
+use move_vm_runtime::{
+    module_traversal::*, move_vm::MoveVM, session::SerializedReturnValues, DummyCodeStorage,
+};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 use std::convert::TryInto;
@@ -106,6 +108,7 @@ fn run(
             serialize_values(&vec![arg_val0]),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
         )
         .and_then(|ret_values| {
             let change_set = session.finish()?;

--- a/third_party/move/move-vm/integration-tests/src/tests/function_arg_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/function_arg_tests.rs
@@ -12,7 +12,7 @@ use move_core_types::{
     value::{MoveStruct, MoveValue},
     vm_status::StatusCode,
 };
-use move_vm_runtime::{module_traversal::*, move_vm::MoveVM};
+use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, DummyCodeStorage};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 
@@ -77,6 +77,7 @@ fn run(
         args,
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
+        &DummyCodeStorage,
     )?;
 
     Ok(())

--- a/third_party/move/move-vm/integration-tests/src/tests/instantiation_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/instantiation_tests.rs
@@ -14,7 +14,7 @@ use move_core_types::{
     language_storage::{StructTag, TypeTag},
     vm_status::StatusCode,
 };
-use move_vm_runtime::{config::VMConfig, move_vm::MoveVM};
+use move_vm_runtime::{config::VMConfig, move_vm::MoveVM, DummyCodeStorage};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 
@@ -118,7 +118,7 @@ fn instantiation_err() {
     cm.serialize(&mut mod_bytes).unwrap();
 
     session
-        .publish_module(mod_bytes, addr, &mut UnmeteredGasMeter)
+        .publish_module(mod_bytes, addr, &mut UnmeteredGasMeter, &DummyCodeStorage)
         .expect("Module must publish");
 
     let mut ty_arg = TypeTag::U128;
@@ -131,7 +131,7 @@ fn instantiation_err() {
         }));
     }
 
-    let res = session.load_function(&cm.self_id(), ident_str!("f"), &[ty_arg]);
+    let res = session.load_function(&DummyCodeStorage, &cm.self_id(), ident_str!("f"), &[ty_arg]);
     assert!(
         res.is_err(),
         "Instantiation must fail at load time when converting from type tag to type "

--- a/third_party/move/move-vm/integration-tests/src/tests/invariant_violation_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/invariant_violation_tests.rs
@@ -6,7 +6,7 @@ use move_binary_format::file_format::{
     SignatureToken::*,
 };
 use move_core_types::vm_status::StatusCode;
-use move_vm_runtime::{module_traversal::*, move_vm::MoveVM};
+use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, DummyCodeStorage};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 
@@ -86,6 +86,8 @@ fn merge_borrow_states_infinite_loop() {
             Vec::<Vec<u8>>::new(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
+            &DummyCodeStorage,
         )
         .unwrap_err();
 

--- a/third_party/move/move-vm/integration-tests/src/tests/leak_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/leak_tests.rs
@@ -4,7 +4,7 @@
 use move_binary_format::file_format::{
     Bytecode::*, CodeUnit, CompiledScript, Signature, SignatureIndex, SignatureToken::*,
 };
-use move_vm_runtime::{module_traversal::*, move_vm::MoveVM};
+use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, DummyCodeStorage};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 
@@ -61,6 +61,8 @@ fn leak_with_abort() {
             Vec::<Vec<u8>>::new(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
+            &DummyCodeStorage,
         );
     }
 

--- a/third_party/move/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/mutated_accounts_tests.rs
@@ -9,7 +9,7 @@ use move_core_types::{
     language_storage::ModuleId,
     value::{serialize_values, MoveValue},
 };
-use move_vm_runtime::{module_traversal::*, move_vm::MoveVM};
+use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, DummyCodeStorage};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 
@@ -60,13 +60,14 @@ fn mutated_accounts() {
         serialize_values(&vec![MoveValue::Signer(account1)]),
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
+        &DummyCodeStorage,
     )
     .unwrap();
 
     // The resource was published to "account1" and the sender's account
     // (TEST_ADDR) is assumed to be mutated as well (e.g., in a subsequent
     // transaction epilogue).
-    assert_eq!(sess.num_mutated_accounts(&TEST_ADDR), 2);
+    assert_eq!(sess.num_mutated_resources(&TEST_ADDR), 2);
 
     sess.execute_function_bypass_visibility(
         &module_id,
@@ -75,10 +76,11 @@ fn mutated_accounts() {
         serialize_values(&vec![MoveValue::Address(account1)]),
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
+        &DummyCodeStorage,
     )
     .unwrap();
 
-    assert_eq!(sess.num_mutated_accounts(&TEST_ADDR), 2);
+    assert_eq!(sess.num_mutated_resources(&TEST_ADDR), 2);
 
     sess.execute_function_bypass_visibility(
         &module_id,
@@ -87,9 +89,10 @@ fn mutated_accounts() {
         serialize_values(&vec![MoveValue::Address(account1)]),
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
+        &DummyCodeStorage,
     )
     .unwrap();
-    assert_eq!(sess.num_mutated_accounts(&TEST_ADDR), 2);
+    assert_eq!(sess.num_mutated_resources(&TEST_ADDR), 2);
 
     let changes = sess.finish().unwrap();
     storage.apply(changes).unwrap();
@@ -102,9 +105,10 @@ fn mutated_accounts() {
         serialize_values(&vec![MoveValue::Address(account1)]),
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
+        &DummyCodeStorage,
     )
     .unwrap();
 
     // Only the sender's account (TEST_ADDR) should have been modified.
-    assert_eq!(sess.num_mutated_accounts(&TEST_ADDR), 1);
+    assert_eq!(sess.num_mutated_resources(&TEST_ADDR), 1);
 }

--- a/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
@@ -9,6 +9,7 @@ use move_core_types::{
 };
 use move_vm_runtime::{
     config::VMConfig, module_traversal::*, move_vm::MoveVM, native_functions::NativeFunction,
+    DummyCodeStorage,
 };
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::{gas::UnmeteredGasMeter, natives::function::NativeResult};
@@ -73,11 +74,21 @@ fn test_publish_module_with_nested_loops() {
         });
 
         let mut sess = vm.new_session(&storage);
-        sess.publish_module(m_blob.clone(), TEST_ADDR, &mut UnmeteredGasMeter)
-            .unwrap();
+        sess.publish_module(
+            m_blob.clone(),
+            TEST_ADDR,
+            &mut UnmeteredGasMeter,
+            &DummyCodeStorage,
+        )
+        .unwrap();
 
         let func = sess
-            .load_function(&m.self_id(), &Identifier::new("foo").unwrap(), &[])
+            .load_function(
+                &DummyCodeStorage,
+                &m.self_id(),
+                &Identifier::new("foo").unwrap(),
+                &[],
+            )
             .unwrap();
         let err1 = sess
             .execute_entry_function(
@@ -85,13 +96,19 @@ fn test_publish_module_with_nested_loops() {
                 Vec::<Vec<u8>>::new(),
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
+                &DummyCodeStorage,
             )
             .unwrap_err();
 
         assert!(err1.exec_state().unwrap().stack_trace().is_empty());
 
         let func = sess
-            .load_function(&m.self_id(), &Identifier::new("foo2").unwrap(), &[])
+            .load_function(
+                &DummyCodeStorage,
+                &m.self_id(),
+                &Identifier::new("foo2").unwrap(),
+                &[],
+            )
             .unwrap();
         let err2 = sess
             .execute_entry_function(
@@ -99,6 +116,7 @@ fn test_publish_module_with_nested_loops() {
                 Vec::<Vec<u8>>::new(),
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
+                &DummyCodeStorage,
             )
             .unwrap_err();
 

--- a/third_party/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
@@ -4,7 +4,7 @@
 use crate::compiler::{as_module, as_script, compile_units};
 use move_bytecode_verifier::VerifierConfig;
 use move_core_types::account_address::AccountAddress;
-use move_vm_runtime::{config::VMConfig, module_traversal::*, move_vm::MoveVM};
+use move_vm_runtime::{config::VMConfig, module_traversal::*, move_vm::MoveVM, DummyCodeStorage};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 
@@ -53,8 +53,13 @@ fn test_publish_module_with_nested_loops() {
         );
 
         let mut sess = vm.new_session(&storage);
-        sess.publish_module(m_blob.clone(), TEST_ADDR, &mut UnmeteredGasMeter)
-            .unwrap();
+        sess.publish_module(
+            m_blob.clone(),
+            TEST_ADDR,
+            &mut UnmeteredGasMeter,
+            &DummyCodeStorage,
+        )
+        .unwrap();
     }
 
     // Should fail with max_loop_depth = 1
@@ -75,7 +80,7 @@ fn test_publish_module_with_nested_loops() {
         );
 
         let mut sess = vm.new_session(&storage);
-        sess.publish_module(m_blob, TEST_ADDR, &mut UnmeteredGasMeter)
+        sess.publish_module(m_blob, TEST_ADDR, &mut UnmeteredGasMeter, &DummyCodeStorage)
             .unwrap_err();
     }
 }
@@ -131,6 +136,8 @@ fn test_run_script_with_nested_loops() {
             args,
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
+            &DummyCodeStorage,
         )
         .unwrap();
     }
@@ -160,6 +167,8 @@ fn test_run_script_with_nested_loops() {
             args,
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
+            &DummyCodeStorage,
         )
         .unwrap_err();
     }

--- a/third_party/move/move-vm/integration-tests/src/tests/regression_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/regression_tests.rs
@@ -10,7 +10,7 @@ use move_core_types::{
     language_storage::{StructTag, TypeTag},
     vm_status::StatusCode,
 };
-use move_vm_runtime::{config::VMConfig, module_traversal::*, move_vm::MoveVM};
+use move_vm_runtime::{config::VMConfig, module_traversal::*, move_vm::MoveVM, DummyCodeStorage};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 use std::time::Instant;
@@ -138,6 +138,8 @@ fn script_large_ty() {
             Vec::<Vec<u8>>::new(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
+            &DummyCodeStorage,
         )
         .unwrap_err();
 

--- a/third_party/move/move-vm/integration-tests/src/tests/return_value_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/return_value_tests.rs
@@ -10,7 +10,9 @@ use move_core_types::{
     language_storage::{ModuleId, TypeTag},
     value::{MoveTypeLayout, MoveValue},
 };
-use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, session::SerializedReturnValues};
+use move_vm_runtime::{
+    module_traversal::*, move_vm::MoveVM, session::SerializedReturnValues, DummyCodeStorage,
+};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 
@@ -71,6 +73,7 @@ fn run(
         args,
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
+        &DummyCodeStorage,
     )?;
 
     Ok(return_values

--- a/third_party/move/move-vm/integration-tests/src/tests/runtime_reentrancy_check_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/runtime_reentrancy_check_tests.rs
@@ -8,7 +8,9 @@ use move_core_types::{
     account_address::AccountAddress, gas_algebra::GasQuantity, identifier::Identifier,
     language_storage::ModuleId, vm_status::StatusCode,
 };
-use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, native_functions::NativeFunction};
+use move_vm_runtime::{
+    module_traversal::*, move_vm::MoveVM, native_functions::NativeFunction, DummyCodeStorage,
+};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::{gas::UnmeteredGasMeter, natives::function::NativeResult};
 use smallvec::SmallVec;
@@ -170,7 +172,8 @@ fn runtime_reentrancy_check() {
             vec![],
             args.clone(),
             &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage)
+            &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
         )
         .unwrap_err()
         .major_status(),
@@ -189,6 +192,7 @@ fn runtime_reentrancy_check() {
         args.clone(),
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
+        &DummyCodeStorage,
     )
     .unwrap();
 
@@ -202,7 +206,8 @@ fn runtime_reentrancy_check() {
             vec![],
             args,
             &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage)
+            &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
         )
         .unwrap_err()
         .major_status(),

--- a/third_party/move/move-vm/integration-tests/src/tests/vm_arguments_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/vm_arguments_tests.rs
@@ -21,7 +21,7 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
     vm_status::{StatusCode, StatusType},
 };
-use move_vm_runtime::{module_traversal::*, move_vm::MoveVM};
+use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, DummyCodeStorage};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 
@@ -263,6 +263,8 @@ fn call_script_with_args_ty_args_signers(
             combine_signers_and_args(signers, non_signer_args),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
+            &DummyCodeStorage,
         )
         .map(|_| ())
 }
@@ -295,6 +297,7 @@ fn call_script_function_with_args_ty_args_signers(
         combine_signers_and_args(signers, non_signer_args),
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
+        &DummyCodeStorage,
     )?;
     Ok(())
 }
@@ -792,6 +795,7 @@ fn call_missing_item() {
             Vec::<Vec<u8>>::new(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
         )
         .err()
         .unwrap();
@@ -816,6 +820,7 @@ fn call_missing_item() {
             Vec::<Vec<u8>>::new(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
         )
         .err()
         .unwrap();

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -9,7 +9,7 @@ use crate::{
     module_traversal::TraversalContext,
     native_extensions::NativeContextExtensions,
     native_functions::NativeContext,
-    trace, LoadedFunction,
+    trace, LoadedFunction, ModuleStorage,
 };
 use fail::fail_point;
 use move_binary_format::{
@@ -89,6 +89,7 @@ impl Interpreter {
         args: Vec<Value>,
         data_store: &mut TransactionDataCache,
         module_store: &ModuleStorageAdapter,
+        module_storage: &impl ModuleStorage,
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext,
         extensions: &mut NativeContextExtensions,
@@ -105,6 +106,7 @@ impl Interpreter {
             loader,
             data_store,
             module_store,
+            module_storage,
             gas_meter,
             traversal_context,
             extensions,
@@ -124,6 +126,7 @@ impl Interpreter {
         loader: &Loader,
         data_store: &mut TransactionDataCache,
         module_store: &ModuleStorageAdapter,
+        module_storage: &impl ModuleStorage,
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext,
         extensions: &mut NativeContextExtensions,
@@ -149,12 +152,13 @@ impl Interpreter {
         self.access_control
             .enter_function(&current_frame, &current_frame.function)
             .map_err(|e| self.set_location(e))?;
+
         loop {
-            let resolver = current_frame.resolver(loader, module_store);
-            let exit_code =
-                current_frame //self
-                    .execute_code(&resolver, &mut self, data_store, module_store, gas_meter)
-                    .map_err(|err| self.attach_state_if_invariant_violation(err, &current_frame))?;
+            let resolver = current_frame.resolver(loader, module_store, module_storage);
+            let exit_code = current_frame
+                .execute_code(&resolver, &mut self, data_store, gas_meter)
+                .map_err(|err| self.attach_state_if_invariant_violation(err, &current_frame))?;
+
             match exit_code {
                 ExitCode::Return => {
                     let non_ref_vals = current_frame
@@ -224,7 +228,6 @@ impl Interpreter {
                             &mut current_frame,
                             &resolver,
                             data_store,
-                            module_store,
                             gas_meter,
                             traversal_context,
                             extensions,
@@ -278,7 +281,6 @@ impl Interpreter {
                             &mut current_frame,
                             &resolver,
                             data_store,
-                            module_store,
                             gas_meter,
                             traversal_context,
                             extensions,
@@ -424,7 +426,6 @@ impl Interpreter {
         current_frame: &mut Frame,
         resolver: &Resolver,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext,
         extensions: &mut NativeContextExtensions,
@@ -435,7 +436,6 @@ impl Interpreter {
             current_frame,
             resolver,
             data_store,
-            module_store,
             gas_meter,
             traversal_context,
             extensions,
@@ -464,7 +464,6 @@ impl Interpreter {
         current_frame: &mut Frame,
         resolver: &Resolver,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext,
         extensions: &mut NativeContextExtensions,
@@ -576,18 +575,22 @@ impl Interpreter {
             } => {
                 gas_meter.charge_native_function(cost, Option::<std::iter::Empty<&Value>>::None)?;
 
-                // Load the module that contains this function regardless of the traversal context.
-                //
-                // This is just a precautionary step to make sure that caching status of the VM will not alter execution
-                // result in case framework code forgot to use LoadFunction result to load the modules into cache
-                // and charge properly.
-                resolver
-                    .loader()
-                    .load_module(&module_name, data_store, module_store)
-                    .map_err(|_| {
-                        PartialVMError::new(StatusCode::FUNCTION_RESOLUTION_FAILURE)
-                            .with_message(format!("Module {} doesn't exist", module_name))
-                    })?;
+                // Note(George): when V2 loader fetches the function, the defining module is
+                // automatically loaded as well, and there is no need for preloading of a module
+                // into the cache like in V1 design.
+                if let Loader::V1(loader) = resolver.loader() {
+                    // Load the module that contains this function regardless of the traversal context.
+                    //
+                    // This is just a precautionary step to make sure that caching status of the VM will not alter execution
+                    // result in case framework code forgot to use LoadFunction result to load the modules into cache
+                    // and charge properly.
+                    loader
+                        .load_module(&module_name, data_store, resolver.module_store())
+                        .map_err(|_| {
+                            PartialVMError::new(StatusCode::FUNCTION_RESOLUTION_FAILURE)
+                                .with_message(format!("Module {} doesn't exist", module_name))
+                        })?;
+                }
                 let target_func = resolver.build_loaded_function_from_name_and_ty_args(
                     &module_name,
                     &func_name,
@@ -603,9 +606,7 @@ impl Interpreter {
                         ));
                 }
 
-                if resolver.loader().vm_config().disallow_dispatch_for_native
-                    && target_func.is_native()
-                {
+                if resolver.vm_config().disallow_dispatch_for_native && target_func.is_native() {
                     return Err(PartialVMError::new(StatusCode::RUNTIME_DISPATCH_ERROR)
                         .with_message("Invoking native function during dispatch".to_string()));
                 }
@@ -650,25 +651,32 @@ impl Interpreter {
                 resolver
                     .loader()
                     .check_dependencies_and_charge_gas(
-                        module_store,
+                        resolver.module_store(),
                         data_store,
                         gas_meter,
                         &mut traversal_context.visited,
                         traversal_context.referenced_modules,
                         [(arena_id.address(), arena_id.name())],
+                        resolver.module_storage(),
                     )
                     .map_err(|err| err
                         .to_partial()
                         .append_message_with_separator('.',
                             format!("Failed to charge transitive dependency for {}. Does this module exists?", module_name)
                         ))?;
-                resolver
-                    .loader()
-                    .load_module(&module_name, data_store, module_store)
-                    .map_err(|_| {
-                        PartialVMError::new(StatusCode::FUNCTION_RESOLUTION_FAILURE)
-                            .with_message(format!("Module {} doesn't exist", module_name))
-                    })?;
+
+                // Note(George): same as above, when V2 loader fetches the function, the module
+                // where it is defined automatically loaded from ModuleStorage as well. There is
+                // no resolution via ModuleStorageAdapter like in V1 design, and it will be soon
+                // removed.
+                if let Loader::V1(loader) = resolver.loader() {
+                    loader
+                        .load_module(&module_name, data_store, resolver.module_store())
+                        .map_err(|_| {
+                            PartialVMError::new(StatusCode::FUNCTION_RESOLUTION_FAILURE)
+                                .with_message(format!("Module {} doesn't exist", module_name))
+                        })?;
+                }
 
                 current_frame.pc += 1; // advance past the Call instruction in the caller
                 Ok(())
@@ -748,19 +756,27 @@ impl Interpreter {
 
     /// Loads a resource from the data store and return the number of bytes read from the storage.
     fn load_resource<'c>(
-        loader: &Loader,
+        resolver: &Resolver,
         data_store: &'c mut TransactionDataCache,
-        module_store: &'c ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
         addr: AccountAddress,
         ty: &Type,
     ) -> PartialVMResult<&'c mut GlobalValue> {
-        match data_store.load_resource(loader, addr, ty, module_store) {
+        match data_store.load_resource(
+            resolver.loader(),
+            resolver.module_storage(),
+            addr,
+            ty,
+            resolver.module_store(),
+        ) {
             Ok((gv, load_res)) => {
                 if let Some(bytes_loaded) = load_res {
                     gas_meter.charge_load_resource(
                         addr,
-                        TypeWithLoader { ty, loader },
+                        TypeWithLoader {
+                            ty,
+                            loader: resolver.loader(),
+                        },
                         gv.view(),
                         bytes_loaded,
                     )?;
@@ -776,23 +792,24 @@ impl Interpreter {
         &mut self,
         is_mut: bool,
         is_generic: bool,
-        loader: &Loader,
+        resolver: &Resolver,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
         addr: AccountAddress,
         ty: &Type,
     ) -> PartialVMResult<()> {
-        let res = Self::load_resource(loader, data_store, module_store, gas_meter, addr, ty)?
-            .borrow_global();
+        let res = Self::load_resource(resolver, data_store, gas_meter, addr, ty)?.borrow_global();
         gas_meter.charge_borrow_global(
             is_mut,
             is_generic,
-            TypeWithLoader { ty, loader },
+            TypeWithLoader {
+                ty,
+                loader: resolver.loader(),
+            },
             res.is_ok(),
         )?;
         self.check_access(
-            loader,
+            resolver.loader(),
             if is_mut {
                 AccessKind::Writes
             } else {
@@ -824,7 +841,7 @@ impl Interpreter {
                 )
             },
         };
-        let struct_name = &*loader.name_cache.idx_to_identifier(struct_idx);
+        let struct_name = &*loader.get_struct_name(struct_idx);
         if let Some(access) = AccessInstance::new(kind, struct_name, instance, addr) {
             self.access_control.check_access(access)?
         }
@@ -835,17 +852,23 @@ impl Interpreter {
     fn exists(
         &mut self,
         is_generic: bool,
-        loader: &Loader,
+        resolver: &Resolver,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
         addr: AccountAddress,
         ty: &Type,
     ) -> PartialVMResult<()> {
-        let gv = Self::load_resource(loader, data_store, module_store, gas_meter, addr, ty)?;
+        let gv = Self::load_resource(resolver, data_store, gas_meter, addr, ty)?;
         let exists = gv.exists()?;
-        gas_meter.charge_exists(is_generic, TypeWithLoader { ty, loader }, exists)?;
-        self.check_access(loader, AccessKind::Reads, ty, addr)?;
+        gas_meter.charge_exists(
+            is_generic,
+            TypeWithLoader {
+                ty,
+                loader: resolver.loader(),
+            },
+            exists,
+        )?;
+        self.check_access(resolver.loader(), AccessKind::Reads, ty, addr)?;
         self.operand_stack.push(Value::bool(exists))?;
         Ok(())
     }
@@ -854,34 +877,40 @@ impl Interpreter {
     fn move_from(
         &mut self,
         is_generic: bool,
-        loader: &Loader,
+        resolver: &Resolver,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
         addr: AccountAddress,
         ty: &Type,
     ) -> PartialVMResult<()> {
-        let resource =
-            match Self::load_resource(loader, data_store, module_store, gas_meter, addr, ty)?
-                .move_from()
-            {
-                Ok(resource) => {
-                    gas_meter.charge_move_from(
-                        is_generic,
-                        TypeWithLoader { ty, loader },
-                        Some(&resource),
-                    )?;
-                    self.check_access(loader, AccessKind::Writes, ty, addr)?;
-                    resource
-                },
-                Err(err) => {
-                    let val: Option<&Value> = None;
-                    gas_meter.charge_move_from(is_generic, TypeWithLoader { ty, loader }, val)?;
-                    return Err(
-                        err.with_message(format!("Failed to move resource from {:?}", addr))
-                    );
-                },
-            };
+        let resource = match Self::load_resource(resolver, data_store, gas_meter, addr, ty)?
+            .move_from()
+        {
+            Ok(resource) => {
+                gas_meter.charge_move_from(
+                    is_generic,
+                    TypeWithLoader {
+                        ty,
+                        loader: resolver.loader(),
+                    },
+                    Some(&resource),
+                )?;
+                self.check_access(resolver.loader(), AccessKind::Writes, ty, addr)?;
+                resource
+            },
+            Err(err) => {
+                let val: Option<&Value> = None;
+                gas_meter.charge_move_from(
+                    is_generic,
+                    TypeWithLoader {
+                        ty,
+                        loader: resolver.loader(),
+                    },
+                    val,
+                )?;
+                return Err(err.with_message(format!("Failed to move resource from {:?}", addr)));
+            },
+        };
         self.operand_stack.push(resource)?;
         Ok(())
     }
@@ -890,32 +919,37 @@ impl Interpreter {
     fn move_to(
         &mut self,
         is_generic: bool,
-        loader: &Loader,
+        resolver: &Resolver,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
         addr: AccountAddress,
         ty: &Type,
         resource: Value,
     ) -> PartialVMResult<()> {
-        let gv = Self::load_resource(loader, data_store, module_store, gas_meter, addr, ty)?;
+        let gv = Self::load_resource(resolver, data_store, gas_meter, addr, ty)?;
         // NOTE(Gas): To maintain backward compatibility, we need to charge gas after attempting
         //            the move_to operation.
         match gv.move_to(resource) {
             Ok(()) => {
                 gas_meter.charge_move_to(
                     is_generic,
-                    TypeWithLoader { ty, loader },
+                    TypeWithLoader {
+                        ty,
+                        loader: resolver.loader(),
+                    },
                     gv.view().unwrap(),
                     true,
                 )?;
-                self.check_access(loader, AccessKind::Writes, ty, addr)?;
+                self.check_access(resolver.loader(), AccessKind::Writes, ty, addr)?;
                 Ok(())
             },
             Err((err, resource)) => {
                 gas_meter.charge_move_to(
                     is_generic,
-                    TypeWithLoader { ty, loader },
+                    TypeWithLoader {
+                        ty,
+                        loader: resolver.loader(),
+                    },
                     &resource,
                     false,
                 )?;
@@ -1269,7 +1303,7 @@ impl CallStack {
 
 fn check_depth_of_type(resolver: &Resolver, ty: &Type) -> PartialVMResult<()> {
     // Start at 1 since we always call this right before we add a new node to the value's depth.
-    let max_depth = match resolver.loader().vm_config().max_value_nest_depth {
+    let max_depth = match resolver.vm_config().max_value_nest_depth {
         Some(max_depth) => max_depth,
         None => return Ok(()),
     };
@@ -1312,9 +1346,11 @@ fn check_depth_of_type_impl(
         },
         Type::Vector(ty) => check_depth_of_type_impl(resolver, ty, max_depth, check_depth!(1))?,
         Type::Struct { idx, .. } => {
-            let formula = resolver
-                .loader()
-                .calculate_depth_of_struct(*idx, resolver.module_store())?;
+            let formula = resolver.loader().calculate_depth_of_struct(
+                *idx,
+                resolver.module_store(),
+                resolver.module_storage(),
+            )?;
             check_depth!(formula.solve(&[]))
         },
         // NB: substitution must be performed before calling this function
@@ -1327,9 +1363,11 @@ fn check_depth_of_type_impl(
                     check_depth_of_type_impl(resolver, ty, max_depth, check_depth!(0))
                 })
                 .collect::<PartialVMResult<Vec<_>>>()?;
-            let formula = resolver
-                .loader()
-                .calculate_depth_of_struct(*idx, resolver.module_store())?;
+            let formula = resolver.loader().calculate_depth_of_struct(
+                *idx,
+                resolver.module_store(),
+                resolver.module_storage(),
+            )?;
             check_depth!(formula.solve(&ty_arg_depths))
         },
         Type::TyParam(_) => {
@@ -1562,10 +1600,9 @@ impl Frame {
         resolver: &Resolver,
         interpreter: &mut Interpreter,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
     ) -> VMResult<ExitCode> {
-        self.execute_code_impl(resolver, interpreter, data_store, module_store, gas_meter)
+        self.execute_code_impl(resolver, interpreter, data_store, gas_meter)
             .map_err(|e| {
                 let e = if cfg!(feature = "testing") || cfg!(feature = "stacktrace") {
                     e.with_exec_state(interpreter.get_internal_state())
@@ -2259,7 +2296,6 @@ impl Frame {
         resolver: &Resolver,
         interpreter: &mut Interpreter,
         data_store: &mut TransactionDataCache,
-        module_store: &ModuleStorageAdapter,
         gas_meter: &mut impl GasMeter,
     ) -> PartialVMResult<ExitCode> {
         use SimpleInstruction as S;
@@ -2407,7 +2443,7 @@ impl Frame {
                     Bytecode::MoveLoc(idx) => {
                         let local = self.locals.move_loc(
                             *idx as usize,
-                            resolver.loader().vm_config().check_invariant_in_swap_loc,
+                            resolver.vm_config().check_invariant_in_swap_loc,
                         )?;
                         gas_meter.charge_move_loc(&local)?;
 
@@ -2419,7 +2455,7 @@ impl Frame {
                         self.locals.store_loc(
                             *idx as usize,
                             value_to_store,
-                            resolver.loader().vm_config().check_invariant_in_swap_loc,
+                            resolver.vm_config().check_invariant_in_swap_loc,
                         )?;
                     },
                     Bytecode::Call(idx) => {
@@ -2891,14 +2927,7 @@ impl Frame {
                         let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
                         let ty = resolver.get_struct_ty(*sd_idx);
                         interpreter.borrow_global(
-                            is_mut,
-                            false,
-                            resolver.loader(),
-                            data_store,
-                            module_store,
-                            gas_meter,
-                            addr,
-                            &ty,
+                            is_mut, false, resolver, data_store, gas_meter, addr, &ty,
                         )?;
                     },
                     Bytecode::MutBorrowGlobalGeneric(si_idx)
@@ -2912,28 +2941,13 @@ impl Frame {
                         )?;
                         gas_meter.charge_create_ty(ty_count)?;
                         interpreter.borrow_global(
-                            is_mut,
-                            true,
-                            resolver.loader(),
-                            data_store,
-                            module_store,
-                            gas_meter,
-                            addr,
-                            ty,
+                            is_mut, true, resolver, data_store, gas_meter, addr, ty,
                         )?;
                     },
                     Bytecode::Exists(sd_idx) => {
                         let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
                         let ty = resolver.get_struct_ty(*sd_idx);
-                        interpreter.exists(
-                            false,
-                            resolver.loader(),
-                            data_store,
-                            module_store,
-                            gas_meter,
-                            addr,
-                            &ty,
-                        )?;
+                        interpreter.exists(false, resolver, data_store, gas_meter, addr, &ty)?;
                     },
                     Bytecode::ExistsGeneric(si_idx) => {
                         let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
@@ -2943,28 +2957,12 @@ impl Frame {
                             self.function.ty_args(),
                         )?;
                         gas_meter.charge_create_ty(ty_count)?;
-                        interpreter.exists(
-                            true,
-                            resolver.loader(),
-                            data_store,
-                            module_store,
-                            gas_meter,
-                            addr,
-                            ty,
-                        )?;
+                        interpreter.exists(true, resolver, data_store, gas_meter, addr, ty)?;
                     },
                     Bytecode::MoveFrom(sd_idx) => {
                         let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
                         let ty = resolver.get_struct_ty(*sd_idx);
-                        interpreter.move_from(
-                            false,
-                            resolver.loader(),
-                            data_store,
-                            module_store,
-                            gas_meter,
-                            addr,
-                            &ty,
-                        )?;
+                        interpreter.move_from(false, resolver, data_store, gas_meter, addr, &ty)?;
                     },
                     Bytecode::MoveFromGeneric(si_idx) => {
                         let addr = interpreter.operand_stack.pop_as::<AccountAddress>()?;
@@ -2974,15 +2972,7 @@ impl Frame {
                             self.function.ty_args(),
                         )?;
                         gas_meter.charge_create_ty(ty_count)?;
-                        interpreter.move_from(
-                            true,
-                            resolver.loader(),
-                            data_store,
-                            module_store,
-                            gas_meter,
-                            addr,
-                            ty,
-                        )?;
+                        interpreter.move_from(true, resolver, data_store, gas_meter, addr, ty)?;
                     },
                     Bytecode::MoveTo(sd_idx) => {
                         let resource = interpreter.operand_stack.pop()?;
@@ -2993,16 +2983,8 @@ impl Frame {
                             .read_ref()?
                             .value_as::<AccountAddress>()?;
                         let ty = resolver.get_struct_ty(*sd_idx);
-                        interpreter.move_to(
-                            false,
-                            resolver.loader(),
-                            data_store,
-                            module_store,
-                            gas_meter,
-                            addr,
-                            &ty,
-                            resource,
-                        )?;
+                        interpreter
+                            .move_to(false, resolver, data_store, gas_meter, addr, &ty, resource)?;
                     },
                     Bytecode::MoveToGeneric(si_idx) => {
                         let resource = interpreter.operand_stack.pop()?;
@@ -3018,16 +3000,8 @@ impl Frame {
                             self.function.ty_args(),
                         )?;
                         gas_meter.charge_create_ty(ty_count)?;
-                        interpreter.move_to(
-                            true,
-                            resolver.loader(),
-                            data_store,
-                            module_store,
-                            gas_meter,
-                            addr,
-                            ty,
-                            resource,
-                        )?;
+                        interpreter
+                            .move_to(true, resolver, data_store, gas_meter, addr, ty, resource)?;
                     },
                     Bytecode::FreezeRef => {
                         gas_meter.charge_simple_instr(S::FreezeRef)?;
@@ -3191,8 +3165,10 @@ impl Frame {
         &self,
         loader: &'a Loader,
         module_store: &'a ModuleStorageAdapter,
+        module_storage: &'a impl ModuleStorage,
     ) -> Resolver<'a> {
-        self.function.get_resolver(loader, module_store)
+        self.function
+            .get_resolver(loader, module_store, module_storage)
     }
 
     fn location(&self) -> Location {

--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -30,5 +30,9 @@ pub mod module_traversal;
 mod debug;
 
 mod access_control;
+mod storage;
 
 pub use loader::LoadedFunction;
+pub use storage::{
+    dummy::DummyCodeStorage, module_storage::ModuleStorage, script_storage::ScriptStorage,
+};

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -8,6 +8,7 @@ use crate::{
         Resolver, Script,
     },
     native_functions::{NativeFunction, NativeFunctions, UnboxedNativeFunction},
+    ModuleStorage,
 };
 use move_binary_format::{
     access::ModuleAccess,
@@ -144,13 +145,14 @@ impl LoadedFunction {
         &self,
         loader: &'a Loader,
         module_store: &'a ModuleStorageAdapter,
+        module_storage: &'a impl ModuleStorage,
     ) -> Resolver<'a> {
         match &self.owner {
             LoadedFunctionOwner::Module(module) => {
-                Resolver::for_module(loader, module_store, module.clone())
+                Resolver::for_module(loader, module_store, module_storage, module.clone())
             },
             LoadedFunctionOwner::Script(script) => {
-                Resolver::for_script(loader, module_store, script.clone())
+                Resolver::for_script(loader, module_store, module_storage, script.clone())
             },
         }
     }

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -2,7 +2,6 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::StructNameCache;
 use crate::{
     loader::{
         function::{Function, FunctionHandle, FunctionInstantiation},
@@ -10,6 +9,10 @@ use crate::{
         BinaryCache,
     },
     native_functions::NativeFunctions,
+    storage::{
+        struct_name_index_map::StructNameIndexMap,
+        struct_type_storage::{LoaderV1StructTypeStorage, StructTypeStorage},
+    },
 };
 use move_binary_format::{
     access::ModuleAccess,
@@ -110,16 +113,22 @@ impl ModuleStorageAdapter {
         id: ModuleId,
         module_size: usize,
         module: Arc<CompiledModule>,
-        name_cache: &StructNameCache,
+        struct_name_index_map: &StructNameIndexMap,
     ) -> VMResult<Arc<Module>> {
         if let Some(cached) = self.module_at(&id) {
             return Ok(cached);
         }
 
-        match Module::new(natives, module_size, module, self, name_cache) {
-            Ok(module) => Ok(self.modules.store_module(&id, module)),
-            Err((err, _)) => Err(err.finish(Location::Undefined)),
-        }
+        let struct_ty_storage = LoaderV1StructTypeStorage { module_store: self };
+        let module = Module::new(
+            natives,
+            module_size,
+            module,
+            &struct_ty_storage,
+            struct_name_index_map,
+        )
+        .map_err(|e| e.finish(Location::Undefined))?;
+        Ok(self.modules.store_module(&id, module))
     }
 
     pub(crate) fn has_module(&self, module_id: &ModuleId) -> bool {
@@ -281,9 +290,9 @@ impl Module {
         natives: &NativeFunctions,
         size: usize,
         module: Arc<CompiledModule>,
-        cache: &ModuleStorageAdapter,
-        name_cache: &StructNameCache,
-    ) -> Result<Self, (PartialVMError, Arc<CompiledModule>)> {
+        struct_ty_storage: &impl StructTypeStorage,
+        struct_name_index_map: &StructNameIndexMap,
+    ) -> PartialVMResult<Self> {
         let id = module.self_id();
 
         let mut structs = vec![];
@@ -312,16 +321,16 @@ impl Module {
                 let module_id = module.module_id_for_handle(module_handle);
 
                 if module_handle != module.self_handle() {
-                    cache
-                        .get_struct_type_by_identifier(struct_name, &module_id)?
+                    struct_ty_storage
+                        .fetch_struct_ty(&module_id, struct_name)?
                         .check_compatibility(struct_handle)?;
                 }
-                let name = StructIdentifier {
+                let struct_name = StructIdentifier {
                     module: module_id,
                     name: struct_name.to_owned(),
                 };
-                struct_idxs.push(name_cache.insert_or_get(name.clone()));
-                struct_names.push(name)
+                struct_idxs.push(struct_name_index_map.struct_name_to_idx(struct_name.clone()));
+                struct_names.push(struct_name)
             }
 
             // Build signature table
@@ -561,7 +570,7 @@ impl Module {
                 struct_map,
                 single_signature_token_map,
             }),
-            Err(err) => Err((err, module)),
+            Err(err) => Err(err),
         }
     }
 

--- a/third_party/move/move-vm/runtime/src/loader/script.rs
+++ b/third_party/move/move-vm/runtime/src/loader/script.rs
@@ -1,14 +1,15 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{
-    intern_type, BinaryCache, Function, FunctionHandle, FunctionInstantiation,
-    ModuleStorageAdapter, ScriptHash, StructNameCache,
+use super::{intern_type, BinaryCache, Function, FunctionHandle, FunctionInstantiation};
+use crate::{
+    loader::ScriptHash,
+    storage::{struct_name_index_map::StructNameIndexMap, struct_type_storage::StructTypeStorage},
 };
 use move_binary_format::{
     access::ScriptAccess,
     binary_views::BinaryIndexedView,
-    errors::{Location, PartialVMError, PartialVMResult, VMResult},
+    errors::{PartialVMError, PartialVMResult},
     file_format::{Bytecode, CompiledScript, FunctionDefinitionIndex, Signature, SignatureIndex},
 };
 use move_core_types::{identifier::Identifier, language_storage::ModuleId, vm_status::StatusCode};
@@ -42,21 +43,19 @@ pub struct Script {
 impl Script {
     pub(crate) fn new(
         script: Arc<CompiledScript>,
-        cache: &ModuleStorageAdapter,
-        name_cache: &StructNameCache,
-    ) -> VMResult<Self> {
+        struct_ty_storage: &impl StructTypeStorage,
+        struct_name_index_map: &StructNameIndexMap,
+    ) -> PartialVMResult<Self> {
         let mut struct_names = vec![];
         for struct_handle in script.struct_handles() {
             let struct_name = script.identifier_at(struct_handle.name);
             let module_handle = script.module_handle_at(struct_handle.module);
             let module_id = script.module_id_for_handle(module_handle);
-            cache
-                .get_struct_type_by_identifier(struct_name, &module_id)
-                .map_err(|err| err.finish(Location::Script))?
-                .check_compatibility(struct_handle)
-                .map_err(|err| err.finish(Location::Script))?;
 
-            struct_names.push(name_cache.insert_or_get(StructIdentifier {
+            struct_ty_storage
+                .fetch_struct_ty(&module_id, struct_name)?
+                .check_compatibility(struct_handle)?;
+            struct_names.push(struct_name_index_map.struct_name_to_idx(StructIdentifier {
                 module: module_id,
                 name: struct_name.to_owned(),
             }));
@@ -81,10 +80,11 @@ impl Script {
             let handle = function_refs[func_inst.handle.0 as usize].clone();
             let mut instantiation = vec![];
             for ty in &script.signature_at(func_inst.type_parameters).0 {
-                instantiation.push(
-                    intern_type(BinaryIndexedView::Script(&script), ty, &struct_names)
-                        .map_err(|e| e.finish(Location::Script))?,
-                );
+                instantiation.push(intern_type(
+                    BinaryIndexedView::Script(&script),
+                    ty,
+                    &struct_names,
+                )?);
             }
             function_instantiations.push(FunctionInstantiation {
                 handle,
@@ -99,8 +99,7 @@ impl Script {
             .0
             .iter()
             .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
-            .collect::<PartialVMResult<Vec<_>>>()
-            .map_err(|err| err.finish(Location::Undefined))?;
+            .collect::<PartialVMResult<Vec<_>>>()?;
         let locals = Signature(
             parameters
                 .0
@@ -113,8 +112,7 @@ impl Script {
             .0
             .iter()
             .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
-            .collect::<PartialVMResult<Vec<_>>>()
-            .map_err(|err| err.finish(Location::Undefined))?;
+            .collect::<PartialVMResult<Vec<_>>>()?;
         let ty_param_abilities = script.type_parameters.clone();
         // TODO: main does not have a name. Revisit.
         let name = Identifier::new("main").unwrap();
@@ -157,15 +155,13 @@ impl Script {
                                     "the type argument for vector-related bytecode \
                                                 expects one and only one signature token"
                                         .to_owned(),
-                                )
-                                .finish(Location::Script));
+                                ));
                             },
                             Some(sig_token) => sig_token,
                         };
                         single_signature_token_map.insert(
                             *si,
-                            intern_type(BinaryIndexedView::Script(&script), ty, &struct_names)
-                                .map_err(|e| e.finish(Location::Script))?,
+                            intern_type(BinaryIndexedView::Script(&script), ty, &struct_names)?,
                         );
                     }
                 },

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -5,7 +5,7 @@
 use crate::{
     data_cache::TransactionDataCache,
     interpreter::Interpreter,
-    loader::{Function, Resolver},
+    loader::{Function, Loader, Resolver},
     module_traversal::TraversalContext,
     native_extensions::NativeContextExtensions,
 };
@@ -134,14 +134,18 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
     pub fn exists_at(
         &mut self,
         address: AccountAddress,
-        type_: &Type,
+        ty: &Type,
     ) -> VMResult<(bool, Option<NumBytes>)> {
+        // TODO(Rati, George): propagate exists call the way to resolver, because we
+        //                     can implement the check more efficiently, without the
+        //                     need to actually load bytes.
         let (value, num_bytes) = self
             .data_store
             .load_resource(
                 self.resolver.loader(),
+                self.resolver.module_storage(),
                 address,
-                type_,
+                ty,
                 self.resolver.module_store(),
             )
             .map_err(|err| err.finish(Location::Undefined))?;
@@ -195,26 +199,34 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
 
     pub fn load_function(
         &mut self,
-        module: &ModuleId,
+        module_id: &ModuleId,
         function_name: &Identifier,
     ) -> PartialVMResult<Arc<Function>> {
-        // Load the module that contains this function regardless of the traversal context.
-        //
-        // This is just a precautionary step to make sure that caching status of the VM will not alter execution
-        // result in case framework code forgot to use LoadFunction result to load the modules into cache
-        // and charge properly.
-        self.resolver
-            .loader()
-            .load_module(module, self.data_store, self.resolver.module_store())
-            .map_err(|_| {
-                PartialVMError::new(StatusCode::FUNCTION_RESOLUTION_FAILURE)
-                    .with_message(format!("Module {} doesn't exist", module))
-            })?;
+        let (_, function) = match self.resolver.loader() {
+            Loader::V1(loader) => {
+                // Load the module that contains this function regardless of the traversal context.
+                //
+                // This is just a precautionary step to make sure that caching status of the VM will not alter execution
+                // result in case framework code forgot to use LoadFunction result to load the modules into cache
+                // and charge properly.
+                loader
+                    .load_module(module_id, self.data_store, self.resolver.module_store())
+                    .map_err(|_| {
+                        PartialVMError::new(StatusCode::FUNCTION_RESOLUTION_FAILURE)
+                            .with_message(format!("Module {} doesn't exist", module_id))
+                    })?;
 
-        let (_, function) = self
-            .resolver
-            .module_store()
-            .resolve_module_and_function_by_name(module, function_name)?;
+                self.resolver
+                    .module_store()
+                    .resolve_module_and_function_by_name(module_id, function_name)?
+            },
+            Loader::V2(loader) => loader.load_function_without_ty_args(
+                self.resolver.module_storage(),
+                module_id.address(),
+                module_id.name(),
+                function_name,
+            )?,
+        };
         Ok(function)
     }
 }

--- a/third_party/move/move-vm/runtime/src/runtime.rs
+++ b/third_party/move/move-vm/runtime/src/runtime.rs
@@ -11,6 +11,7 @@ use crate::{
     native_extensions::NativeContextExtensions,
     native_functions::{NativeFunction, NativeFunctions},
     session::SerializedReturnValues,
+    storage::{module_storage::ModuleStorage as ModuleStorageV2, script_storage::ScriptStorage},
 };
 use move_binary_format::{
     access::ModuleAccess,
@@ -70,6 +71,7 @@ impl VMRuntime {
         module_store: &ModuleStorageAdapter,
         _gas_meter: &mut impl GasMeter,
         compat: Compatibility,
+        module_storage: &impl ModuleStorageV2,
     ) -> VMResult<()> {
         // deserialize the modules. Perform bounds check. After this indexes can be
         // used with the `[]` operator
@@ -120,9 +122,12 @@ impl VMRuntime {
             let module_id = module.self_id();
 
             if data_store.exists_module(&module_id)? && compat.need_check_compat() {
-                let old_module_ref =
-                    self.loader
-                        .load_module(&module_id, data_store, module_store)?;
+                let old_module_ref = self.loader.load_module(
+                    &module_id,
+                    data_store,
+                    module_store,
+                    module_storage,
+                )?;
                 let old_module = old_module_ref.module();
                 if self.loader.vm_config().use_compatibility_checker_v2 {
                     compat
@@ -151,6 +156,7 @@ impl VMRuntime {
             &compiled_modules,
             data_store,
             module_store,
+            module_storage,
         )?;
 
         // NOTE: we want to (informally) argue that all modules pass the linking check before being
@@ -222,12 +228,13 @@ impl VMRuntime {
     fn deserialize_arg(
         &self,
         module_store: &ModuleStorageAdapter,
+        module_storage: &impl ModuleStorageV2,
         ty: &Type,
         arg: impl Borrow<[u8]>,
     ) -> PartialVMResult<Value> {
         let (layout, has_identifier_mappings) = match self
             .loader
-            .type_to_type_layout_with_identifier_mappings(ty, module_store)
+            .type_to_type_layout_with_identifier_mappings(ty, module_store, module_storage)
         {
             Ok(layout) => layout,
             Err(_err) => {
@@ -259,6 +266,7 @@ impl VMRuntime {
     fn deserialize_args(
         &self,
         module_store: &ModuleStorageAdapter,
+        module_storage: &impl ModuleStorageV2,
         param_tys: Vec<Type>,
         serialized_args: Vec<impl Borrow<[u8]>>,
     ) -> PartialVMResult<(Locals, Vec<Value>)> {
@@ -286,12 +294,12 @@ impl VMRuntime {
                 Type::MutableReference(inner_t) | Type::Reference(inner_t) => {
                     dummy_locals.store_loc(
                         idx,
-                        self.deserialize_arg(module_store, inner_t, arg_bytes)?,
+                        self.deserialize_arg(module_store, module_storage, inner_t, arg_bytes)?,
                         self.loader.vm_config().check_invariant_in_swap_loc,
                     )?;
                     dummy_locals.borrow_loc(idx)
                 },
-                _ => self.deserialize_arg(module_store, &ty, arg_bytes),
+                _ => self.deserialize_arg(module_store, module_storage, &ty, arg_bytes),
             })
             .collect::<PartialVMResult<Vec<_>>>()?;
         Ok((dummy_locals, deserialized_args))
@@ -300,6 +308,7 @@ impl VMRuntime {
     fn serialize_return_value(
         &self,
         module_store: &ModuleStorageAdapter,
+        module_storage: &impl ModuleStorageV2,
         ty: &Type,
         value: Value,
     ) -> PartialVMResult<(Vec<u8>, MoveTypeLayout)> {
@@ -314,7 +323,7 @@ impl VMRuntime {
 
         let (layout, has_identifier_mappings) = self
             .loader
-            .type_to_type_layout_with_identifier_mappings(ty, module_store)
+            .type_to_type_layout_with_identifier_mappings(ty, module_store, module_storage)
             .map_err(|_err| {
                 // TODO: Should we use `err` instead of mapping?
                 PartialVMError::new(StatusCode::VERIFICATION_ERROR).with_message(
@@ -341,6 +350,7 @@ impl VMRuntime {
     fn serialize_return_values(
         &self,
         module_store: &ModuleStorageAdapter,
+        module_storage: &impl ModuleStorageV2,
         return_types: &[Type],
         return_values: Vec<Value>,
     ) -> PartialVMResult<Vec<(Vec<u8>, MoveTypeLayout)>> {
@@ -359,7 +369,7 @@ impl VMRuntime {
         return_types
             .iter()
             .zip(return_values)
-            .map(|(ty, value)| self.serialize_return_value(module_store, ty, value))
+            .map(|(ty, value)| self.serialize_return_value(module_store, module_storage, ty, value))
             .collect()
     }
 
@@ -369,6 +379,7 @@ impl VMRuntime {
         serialized_args: Vec<impl Borrow<[u8]>>,
         data_store: &mut TransactionDataCache,
         module_store: &ModuleStorageAdapter,
+        module_storage: &impl ModuleStorageV2,
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext,
         extensions: &mut NativeContextExtensions,
@@ -391,7 +402,7 @@ impl VMRuntime {
             })
             .collect::<Vec<_>>();
         let (mut dummy_locals, deserialized_args) = self
-            .deserialize_args(module_store, param_tys, serialized_args)
+            .deserialize_args(module_store, module_storage, param_tys, serialized_args)
             .map_err(|e| e.finish(Location::Undefined))?;
         let return_tys = function
             .return_tys()
@@ -405,6 +416,7 @@ impl VMRuntime {
             deserialized_args,
             data_store,
             module_store,
+            module_storage,
             gas_meter,
             traversal_context,
             extensions,
@@ -412,7 +424,7 @@ impl VMRuntime {
         )?;
 
         let serialized_return_values = self
-            .serialize_return_values(module_store, &return_tys, return_values)
+            .serialize_return_values(module_store, module_storage, &return_tys, return_values)
             .map_err(|e| e.finish(Location::Undefined))?;
         let serialized_mut_ref_outputs = mut_ref_args
             .into_iter()
@@ -420,7 +432,8 @@ impl VMRuntime {
                 // serialize return values first in the case that a value points into this local
                 let local_val = dummy_locals
                     .move_loc(idx, self.loader.vm_config().check_invariant_in_swap_loc)?;
-                let (bytes, layout) = self.serialize_return_value(module_store, &ty, local_val)?;
+                let (bytes, layout) =
+                    self.serialize_return_value(module_store, module_storage, &ty, local_val)?;
                 Ok((idx as LocalIndex, bytes, layout))
             })
             .collect::<PartialVMResult<_>>()
@@ -444,12 +457,14 @@ impl VMRuntime {
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext,
         extensions: &mut NativeContextExtensions,
+        module_storage: &impl ModuleStorageV2,
     ) -> VMResult<SerializedReturnValues> {
         self.execute_function_impl(
             func,
             serialized_args,
             data_store,
             module_store,
+            module_storage,
             gas_meter,
             traversal_context,
             extensions,
@@ -466,16 +481,25 @@ impl VMRuntime {
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext,
         extensions: &mut NativeContextExtensions,
+        module_storage: &impl ModuleStorageV2,
+        script_storage: &impl ScriptStorage,
     ) -> VMResult<()> {
         // Load the script first, verify it, and then execute the entry-point main function.
-        let main = self
-            .loader
-            .load_script(script.borrow(), &ty_args, data_store, module_store)?;
+        let main = self.loader.load_script(
+            script.borrow(),
+            &ty_args,
+            data_store,
+            module_store,
+            module_storage,
+            script_storage,
+        )?;
+
         self.execute_function_impl(
             main,
             serialized_args,
             data_store,
             module_store,
+            module_storage,
             gas_meter,
             traversal_context,
             extensions,

--- a/third_party/move/move-vm/runtime/src/storage/dummy.rs
+++ b/third_party/move/move-vm/runtime/src/storage/dummy.rs
@@ -1,0 +1,124 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    loader::{Module, Script},
+    storage::{module_storage::ModuleStorage, script_storage::ScriptStorage, verifier::Verifier},
+};
+use move_binary_format::{
+    errors::{PartialVMError, PartialVMResult},
+    file_format::CompiledScript,
+    CompiledModule,
+};
+use move_core_types::{
+    account_address::AccountAddress, identifier::IdentStr, metadata::Metadata,
+    vm_status::StatusCode,
+};
+use std::sync::Arc;
+
+/// An error which is returned in case unimplemented code is reached. This is just a safety
+/// precaution to avoid panics in case we forget some gating.
+#[macro_export]
+macro_rules! unexpected_unimplemented_error {
+    () => {
+        Err(
+            PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                .with_message("New loader and code cache are not yet implemented".to_string()),
+        )
+    };
+}
+
+/// Dummy implementation of code storage (for modules and scripts), to be removed in the future.
+/// Used as a placeholder so that existing APIs can work, i.e., for now client side which has no
+/// script or module storage can be still connected to the new V2 APIs by using the dummy.
+pub struct DummyCodeStorage;
+
+impl ModuleStorage for DummyCodeStorage {
+    fn check_module_exists(
+        &self,
+        _address: &AccountAddress,
+        _module_name: &IdentStr,
+    ) -> PartialVMResult<bool> {
+        unexpected_unimplemented_error!()
+    }
+
+    fn fetch_module_size_in_bytes(
+        &self,
+        _address: &AccountAddress,
+        _module_name: &IdentStr,
+    ) -> PartialVMResult<usize> {
+        unexpected_unimplemented_error!()
+    }
+
+    fn fetch_module_metadata(
+        &self,
+        _address: &AccountAddress,
+        _module_name: &IdentStr,
+    ) -> PartialVMResult<&[Metadata]> {
+        unexpected_unimplemented_error!()
+    }
+
+    fn fetch_deserialized_module(
+        &self,
+        _address: &AccountAddress,
+        _module_name: &IdentStr,
+    ) -> PartialVMResult<Arc<CompiledModule>> {
+        unexpected_unimplemented_error!()
+    }
+
+    fn fetch_or_create_verified_module(
+        &self,
+        _address: &AccountAddress,
+        _module_name: &IdentStr,
+        _f: &dyn Fn(Arc<CompiledModule>) -> PartialVMResult<Module>,
+    ) -> PartialVMResult<Arc<Module>> {
+        unexpected_unimplemented_error!()
+    }
+}
+
+impl ScriptStorage for DummyCodeStorage {
+    fn fetch_deserialized_script(
+        &self,
+        _serialized_script: &[u8],
+    ) -> PartialVMResult<Arc<CompiledScript>> {
+        unexpected_unimplemented_error!()
+    }
+
+    fn fetch_or_create_verified_script(
+        &self,
+        _serialized_script: &[u8],
+        _f: &dyn Fn(Arc<CompiledScript>) -> PartialVMResult<Script>,
+    ) -> PartialVMResult<Arc<Script>> {
+        unexpected_unimplemented_error!()
+    }
+}
+
+/// Placeholder to use for now before an actual verifier is implemented.
+#[derive(Clone)]
+pub struct DummyVerifier;
+
+impl Verifier for DummyVerifier {
+    fn verify_script(&self, _script: &CompiledScript) -> PartialVMResult<()> {
+        unexpected_unimplemented_error!()
+    }
+
+    fn verify_script_with_dependencies<'a>(
+        &self,
+        _script: &CompiledScript,
+        _dependencies: impl IntoIterator<Item = &'a Module>,
+    ) -> PartialVMResult<()> {
+        unexpected_unimplemented_error!()
+    }
+
+    fn verify_module(&self, _module: &CompiledModule) -> PartialVMResult<()> {
+        unexpected_unimplemented_error!()
+    }
+
+    fn verify_module_with_dependencies<'a>(
+        &self,
+        _module: &CompiledModule,
+        _dependencies: impl IntoIterator<Item = &'a Module>,
+    ) -> PartialVMResult<()> {
+        unexpected_unimplemented_error!()
+    }
+}

--- a/third_party/move/move-vm/runtime/src/storage/loader.rs
+++ b/third_party/move/move-vm/runtime/src/storage/loader.rs
@@ -1,0 +1,375 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    config::VMConfig,
+    loader::{Function, LoadedFunctionOwner, Module, Script, TypeCache},
+    module_traversal::TraversalContext,
+    native_functions::NativeFunctions,
+    storage::{
+        module_storage::ModuleStorage, script_storage::ScriptStorage,
+        struct_name_index_map::StructNameIndexMap, struct_type_storage::LoaderV2StructTypeStorage,
+        verifier::Verifier,
+    },
+    unexpected_unimplemented_error, LoadedFunction,
+};
+use move_binary_format::{
+    access::{ModuleAccess, ScriptAccess},
+    errors::{Location, PartialVMError, PartialVMResult},
+    file_format::CompiledScript,
+    CompiledModule,
+};
+use move_core_types::{
+    account_address::AccountAddress, gas_algebra::NumBytes, identifier::IdentStr,
+    language_storage::TypeTag, vm_status::StatusCode,
+};
+use move_vm_types::{
+    gas::GasMeter,
+    loaded_data::runtime_types::{StructType, Type, TypeBuilder},
+};
+use parking_lot::RwLock;
+use std::{collections::BTreeMap, sync::Arc};
+use typed_arena::Arena;
+
+/// V2 implementation of loader, which is stateless - i.e., it does not contain
+/// module or script cache. Instead, module and script storages are passed to all
+/// APIs by reference.
+pub(crate) struct LoaderV2<V: Clone + Verifier> {
+    // Map to from struct names to indices, to save on unnecessary cloning and
+    // reduce memory consumption.
+    struct_name_index_map: StructNameIndexMap,
+    // Configuration of the VM, which own this loader. Contains information about
+    // enabled checks, etc.
+    vm_config: VMConfig,
+    // Verifier instance which runs passes when scripts or modules are loaded for
+    // the first time.
+    verifier: V,
+
+    // All registered native functions the loader is aware of. When loaded modules
+    // are constructed, existing native functions are inlined in the loaded module
+    // representation, so that the interpreter can call them directly.
+    natives: NativeFunctions,
+
+    // Local caches:
+    //   These caches are owned by this loader and are not affected by module
+    //   upgrades. When a new cache is added, the safety guarantees (i.e., why
+    //   it is safe for the loader to own this cache) MUST be documented.
+    // TODO(George): Revisit type cache implementation. For now re-use the existing
+    //               one to unblock upgradable module and script storage first.
+    ty_cache: RwLock<TypeCache>,
+}
+
+impl<V: Clone + Verifier> LoaderV2<V> {
+    pub(crate) fn vm_config(&self) -> &VMConfig {
+        &self.vm_config
+    }
+
+    pub(crate) fn ty_builder(&self) -> &TypeBuilder {
+        &self.vm_config.ty_builder
+    }
+
+    pub(crate) fn ty_cache(&self) -> &RwLock<TypeCache> {
+        &self.ty_cache
+    }
+
+    pub(crate) fn struct_name_index_map(&self) -> &StructNameIndexMap {
+        &self.struct_name_index_map
+    }
+
+    pub(crate) fn check_script_dependencies_and_check_gas(
+        &self,
+        module_storage: &impl ModuleStorage,
+        script_storage: &impl ScriptStorage,
+        gas_meter: &mut impl GasMeter,
+        traversal_context: &mut TraversalContext,
+        serialized_script: &[u8],
+    ) -> PartialVMResult<()> {
+        let compiled_script = script_storage.fetch_deserialized_script(serialized_script)?;
+        let compiled_script = traversal_context.referenced_scripts.alloc(compiled_script);
+
+        // TODO(Gas): Should we charge dependency gas for the script itself?
+        self.check_dependencies_and_charge_gas(
+            module_storage,
+            gas_meter,
+            &mut traversal_context.visited,
+            traversal_context.referenced_modules,
+            compiled_script.immediate_dependencies_iter(),
+        )?;
+
+        Ok(())
+    }
+
+    pub(crate) fn check_dependencies_and_charge_gas<'a, I>(
+        &self,
+        module_storage: &dyn ModuleStorage,
+        gas_meter: &mut impl GasMeter,
+        visited: &mut BTreeMap<(&'a AccountAddress, &'a IdentStr), ()>,
+        referenced_modules: &'a Arena<Arc<CompiledModule>>,
+        ids: I,
+    ) -> PartialVMResult<()>
+    where
+        I: IntoIterator<Item = (&'a AccountAddress, &'a IdentStr)>,
+        I::IntoIter: DoubleEndedIterator,
+    {
+        // Initialize the work list (stack) and the map of visited modules.
+        //
+        // TODO: Determine the reserved capacity based on the max number of dependencies allowed.
+        let mut stack = Vec::with_capacity(512);
+        push_next_ids_to_visit(&mut stack, visited, ids);
+
+        while let Some((addr, name)) = stack.pop() {
+            let size = module_storage.fetch_module_size_in_bytes(addr, name)?;
+            gas_meter.charge_dependency(false, addr, name, NumBytes::new(size as u64))?;
+
+            // Extend the lifetime of the module to the remainder of the function body
+            // by storing it in an arena.
+            //
+            // This is needed because we need to store references derived from it in the
+            // work list.
+            let compiled_module = module_storage.fetch_deserialized_module(addr, name)?;
+            let compiled_module = referenced_modules.alloc(compiled_module);
+
+            // Explore all dependencies and friends that have been visited yet.
+            let imm_deps_and_friends = compiled_module
+                .immediate_dependencies_iter()
+                .chain(compiled_module.immediate_friends_iter());
+            push_next_ids_to_visit(&mut stack, visited, imm_deps_and_friends);
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn load_script(
+        &self,
+        module_storage: &impl ModuleStorage,
+        script_storage: &impl ScriptStorage,
+        serialized_script: &[u8],
+        ty_args: &[TypeTag],
+    ) -> PartialVMResult<LoadedFunction> {
+        // Step 1: Load script. During the loading process, if script has not been previously
+        // cached, it will be verified.
+        let script = script_storage.fetch_or_create_verified_script(serialized_script, &|cs| {
+            self.build_script(module_storage, cs)
+        })?;
+
+        // Step 2: Load & verify types used as type arguments passed to this script. Note that
+        // arguments for scripts are verified on the client side.
+        let ty_args = ty_args
+            .iter()
+            .map(|ty| self.load_ty(module_storage, ty))
+            .collect::<PartialVMResult<Vec<_>>>()?;
+
+        let main = script.entry_point();
+        Type::verify_ty_arg_abilities(main.ty_param_abilities(), &ty_args)?;
+
+        Ok(LoadedFunction {
+            owner: LoadedFunctionOwner::Script(script),
+            ty_args,
+            function: main,
+        })
+    }
+
+    /// Returns a loaded & verified module corresponding to the specified name.
+    pub(crate) fn load_module(
+        &self,
+        module_storage: &dyn ModuleStorage,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+    ) -> PartialVMResult<Arc<Module>> {
+        module_storage.fetch_or_create_verified_module(address, module_name, &|cm| {
+            self.build_module(module_storage, cm)
+        })
+    }
+
+    /// Returns a function definition corresponding to the specified name. The module
+    /// containing the function is loaded.
+    pub(crate) fn load_function_without_ty_args(
+        &self,
+        module_storage: &dyn ModuleStorage,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+        function_name: &IdentStr,
+    ) -> PartialVMResult<(Arc<Module>, Arc<Function>)> {
+        let module = self.load_module(module_storage, address, module_name)?;
+        let function = module
+            .function_map
+            .get(function_name)
+            .and_then(|idx| module.function_defs.get(*idx))
+            .ok_or_else(|| {
+                PartialVMError::new(StatusCode::FUNCTION_RESOLUTION_FAILURE).with_message(format!(
+                    "Function {}::{}::{} does not exist",
+                    address, module_name, function_name
+                ))
+            })?
+            .clone();
+        Ok((module, function))
+    }
+
+    /// Returns a struct type corresponding to the specified name. The module
+    /// containing the struct is loaded.
+    pub(crate) fn load_struct_ty(
+        &self,
+        module_storage: &dyn ModuleStorage,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+        struct_name: &IdentStr,
+    ) -> PartialVMResult<Arc<StructType>> {
+        let module = self.load_module(module_storage, address, module_name)?;
+        Ok(module
+            .struct_map
+            .get(struct_name)
+            .and_then(|idx| module.structs.get(*idx))
+            .ok_or_else(|| {
+                PartialVMError::new(StatusCode::TYPE_RESOLUTION_FAILURE).with_message(format!(
+                    "Struct {}::{}::{} does not exist",
+                    address, module_name, struct_name
+                ))
+            })?
+            .definition_struct_type
+            .clone())
+    }
+
+    /// Returns a runtime type corresponding to the specified type tag (file format type
+    /// representation). In case struct types are transitively loaded, the module containing
+    /// the struct definition is also loaded.
+    pub(crate) fn load_ty(
+        &self,
+        module_storage: &impl ModuleStorage,
+        ty_tag: &TypeTag,
+    ) -> PartialVMResult<Type> {
+        // TODO(George): Loader V1 uses VMResults everywhere, but partial VM errors
+        //               seem better fit. Here we map error to VMError to reuse existing
+        //               type builder implementation, and then strip the location info.
+        self.ty_builder()
+            .create_ty(ty_tag, |st| {
+                self.load_struct_ty(
+                    module_storage,
+                    &st.address,
+                    st.module.as_ident_str(),
+                    st.name.as_ident_str(),
+                )
+                .map_err(|e| e.finish(Location::Undefined))
+            })
+            .map_err(|e| e.to_partial())
+    }
+
+    pub(crate) fn verify_modules_for_publication(
+        &self,
+        _module_storage: &impl ModuleStorage,
+        _published_modules: &[CompiledModule],
+    ) -> PartialVMResult<()> {
+        unexpected_unimplemented_error!()
+    }
+}
+
+impl<V: Clone + Verifier> Clone for LoaderV2<V> {
+    fn clone(&self) -> Self {
+        Self {
+            struct_name_index_map: self.struct_name_index_map().clone(),
+            vm_config: self.vm_config().clone(),
+            verifier: self.verifier.clone(),
+            natives: self.natives.clone(),
+            ty_cache: RwLock::new(self.ty_cache().read().clone()),
+        }
+    }
+}
+
+// Loader is the only structure that can create runtime representations of modules and
+// scripts. The following builder methods can be used to create these, or passed as
+// callbacks externally. These functions should remain private at all times.
+impl<V: Clone + Verifier> LoaderV2<V> {
+    /// Given loader's context, builds a new verified script instance.
+    fn build_script(
+        &self,
+        module_storage: &dyn ModuleStorage,
+        compiled_script: Arc<CompiledScript>,
+    ) -> PartialVMResult<Script> {
+        // Verify local properties of the script.
+        self.verifier.verify_script(compiled_script.as_ref())?;
+
+        // Fetch all dependencies of this script, and verify them as well.
+        let imm_dependencies = compiled_script
+            .immediate_dependencies_iter()
+            .map(|(addr, name)| {
+                module_storage.fetch_or_create_verified_module(addr, name, &|cm| {
+                    self.build_module(module_storage, cm)
+                })
+            })
+            .collect::<PartialVMResult<Vec<_>>>()?;
+
+        // Perform checks on script and its dependencies.
+        self.verifier.verify_script_with_dependencies(
+            compiled_script.as_ref(),
+            imm_dependencies.iter().map(|m| m.as_ref()),
+        )?;
+
+        let struct_ty_storage = LoaderV2StructTypeStorage {
+            loader: self,
+            module_storage,
+        };
+        Script::new(
+            compiled_script,
+            &struct_ty_storage,
+            self.struct_name_index_map(),
+        )
+    }
+
+    /// Given loader's context, builds a new verified module instance.
+    fn build_module(
+        &self,
+        module_storage: &dyn ModuleStorage,
+        compiled_module: Arc<CompiledModule>,
+    ) -> PartialVMResult<Module> {
+        // Verify local properties of the module.
+        self.verifier.verify_module(compiled_module.as_ref())?;
+
+        // Fetch all dependencies of this module, ensuring they are verified as well.
+        let f = |cm| self.build_module(module_storage, cm);
+        let imm_dependencies = compiled_module
+            .immediate_dependencies_iter()
+            .map(|(addr, name)| module_storage.fetch_or_create_verified_module(addr, name, &f))
+            .collect::<PartialVMResult<Vec<_>>>()?;
+
+        // Perform checks on the module with its immediate dependencies.
+        self.verifier.verify_module_with_dependencies(
+            compiled_module.as_ref(),
+            imm_dependencies.iter().map(|m| m.as_ref()),
+        )?;
+
+        let struct_ty_storage = LoaderV2StructTypeStorage {
+            loader: self,
+            module_storage,
+        };
+
+        // TODO(George): While we do not need size anymore, fetch the correct value just in case.
+        //               Once V1 API is no longer used, we can remove this.
+        let size = module_storage
+            .fetch_module_size_in_bytes(compiled_module.self_addr(), compiled_module.self_name())?;
+        Module::new(
+            &self.natives,
+            size,
+            compiled_module,
+            &struct_ty_storage,
+            self.struct_name_index_map(),
+        )
+    }
+}
+
+/// Given a list of addresses and module names, pushes them onto stack unless they have been
+/// already visited or if the address is special.
+#[inline]
+pub(crate) fn push_next_ids_to_visit<'a, I>(
+    stack: &mut Vec<(&'a AccountAddress, &'a IdentStr)>,
+    visited: &mut BTreeMap<(&'a AccountAddress, &'a IdentStr), ()>,
+    ids: I,
+) where
+    I: IntoIterator<Item = (&'a AccountAddress, &'a IdentStr)>,
+    I::IntoIter: DoubleEndedIterator,
+{
+    for (addr, name) in ids.into_iter().rev() {
+        // TODO: Allow the check of special addresses to be customized.
+        if !addr.is_special() && visited.insert((addr, name), ()).is_none() {
+            stack.push((addr, name));
+        }
+    }
+}

--- a/third_party/move/move-vm/runtime/src/storage/mod.rs
+++ b/third_party/move/move-vm/runtime/src/storage/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) mod loader;
+pub(crate) mod struct_name_index_map;
+pub(crate) mod struct_type_storage;
+
+// Note: these traits should be defined elsewhere, along with Script and Module types.
+//       We keep them here for now so that it is easier to land new changes.
+pub mod module_storage;
+pub mod script_storage;
+pub mod verifier;
+
+// TODO(George): Remove when we no longer need the dummy implementation.
+pub mod dummy;

--- a/third_party/move/move-vm/runtime/src/storage/module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/module_storage.rs
@@ -1,0 +1,56 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::loader::Module;
+use move_binary_format::{errors::PartialVMResult, CompiledModule};
+use move_core_types::{account_address::AccountAddress, identifier::IdentStr, metadata::Metadata};
+use std::sync::Arc;
+
+/// Represents module storage backend, abstracting away any caching behaviour. The
+/// clients can implement their own module storage to pass to the VM to resolve code.
+pub trait ModuleStorage {
+    /// Returns true if the module exists, and false otherwise. An error is returned
+    /// if there is a storage error.
+    fn check_module_exists(
+        &self,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+    ) -> PartialVMResult<bool>;
+
+    /// Returns the size of a module in bytes. An error is returned if the module does
+    /// not exist, or there is a storage error.
+    fn fetch_module_size_in_bytes(
+        &self,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+    ) -> PartialVMResult<usize>;
+
+    /// Returns the metadata in the module. An error is returned if the module does
+    /// not exist, or there is a storage error.
+    fn fetch_module_metadata(
+        &self,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+    ) -> PartialVMResult<&[Metadata]>;
+
+    /// Returns the deserialized module. There is no guarantees that the module has been
+    /// previously verified. An error is returned if:
+    ///   1. the module does not exist,
+    ///   2. the deserialization fails, or
+    ///   3. there is an error from the underlying storage, i.e., the DB.
+    fn fetch_deserialized_module(
+        &self,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+    ) -> PartialVMResult<Arc<CompiledModule>>;
+
+    /// Returns the verified module. In case the storage contains an unverified module in
+    /// its cache, the module is created using the passed callback. It is the responsibility
+    /// of the client to pass the callback which verifies all necessary module properties.
+    fn fetch_or_create_verified_module(
+        &self,
+        address: &AccountAddress,
+        module_name: &IdentStr,
+        f: &dyn Fn(Arc<CompiledModule>) -> PartialVMResult<Module>,
+    ) -> PartialVMResult<Arc<Module>>;
+}

--- a/third_party/move/move-vm/runtime/src/storage/script_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/script_storage.rs
@@ -1,0 +1,37 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::loader::Script;
+use move_binary_format::{errors::PartialVMResult, file_format::CompiledScript};
+use sha3::{Digest, Sha3_256};
+use std::sync::Arc;
+
+pub fn script_hash(serialized_script: &[u8]) -> [u8; 32] {
+    let mut sha3_256 = Sha3_256::new();
+    sha3_256.update(serialized_script);
+    sha3_256.finalize().into()
+}
+
+/// Represents storage which caches scripts, executed so far. The clients can
+/// implement this trait to ensure that even script dependency is upgraded, the
+/// correct script is still returned. Scripts are cached based on their hash.
+pub trait ScriptStorage {
+    /// Returns a deserialized script, either by directly deserializing it from the
+    /// provided bytes, or fetching it from the storage (if it has been cached). Note
+    /// that there are no guarantees that the returned script is verified. An error
+    /// is returned if the deserialization fails.
+    fn fetch_deserialized_script(
+        &self,
+        serialized_script: &[u8],
+    ) -> PartialVMResult<Arc<CompiledScript>>;
+
+    /// Returns a verified script, if it is cached. If not, the script is created using
+    /// the passed callback function. It is the responsibility of the client to ensure
+    /// that the callback verifies the script. An error is returned if script fails to
+    /// deserialize or verify.
+    fn fetch_or_create_verified_script(
+        &self,
+        serialized_script: &[u8],
+        f: &dyn Fn(Arc<CompiledScript>) -> PartialVMResult<Script>,
+    ) -> PartialVMResult<Arc<Script>>;
+}

--- a/third_party/move/move-vm/runtime/src/storage/struct_name_index_map.rs
+++ b/third_party/move/move-vm/runtime/src/storage/struct_name_index_map.rs
@@ -1,0 +1,97 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_vm_types::loaded_data::runtime_types::{StructIdentifier, StructNameIndex};
+use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
+use std::collections::BTreeMap;
+
+#[derive(Clone)]
+struct IndexMap<T: Clone + Ord> {
+    forward_map: BTreeMap<T, usize>,
+    backward_map: Vec<T>,
+}
+
+/// A data structure to cache struct identifiers (address, module name, struct name) and
+/// use indices instead, to save on the memory consumption and avoid unnecessary cloning.
+pub(crate) struct StructNameIndexMap(RwLock<IndexMap<StructIdentifier>>);
+
+impl StructNameIndexMap {
+    pub(crate) fn empty() -> Self {
+        Self(RwLock::new(IndexMap {
+            forward_map: BTreeMap::new(),
+            backward_map: vec![],
+        }))
+    }
+
+    pub(crate) fn struct_name_to_idx(&self, struct_name: StructIdentifier) -> StructNameIndex {
+        if let Some(idx) = self.0.read().forward_map.get(&struct_name) {
+            return StructNameIndex(*idx);
+        }
+        let mut index_map = self.0.write();
+        let idx = index_map.backward_map.len();
+        index_map.forward_map.insert(struct_name.clone(), idx);
+        index_map.backward_map.push(struct_name);
+        StructNameIndex(idx)
+    }
+
+    pub(crate) fn idx_to_struct_name(
+        &self,
+        idx: StructNameIndex,
+    ) -> MappedRwLockReadGuard<StructIdentifier> {
+        RwLockReadGuard::map(self.0.read(), |index_map| &index_map.backward_map[idx.0])
+    }
+}
+
+impl Clone for StructNameIndexMap {
+    fn clone(&self) -> Self {
+        Self(RwLock::new(self.0.read().clone()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use move_core_types::{
+        account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
+    };
+
+    fn make_struct_name(module_name: &str, struct_name: &str) -> StructIdentifier {
+        let module = ModuleId::new(AccountAddress::ONE, Identifier::new(module_name).unwrap());
+        let name = Identifier::new(struct_name).unwrap();
+        StructIdentifier { module, name }
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_index_map_must_contain_idx() {
+        let struct_name_idx_map = StructNameIndexMap::empty();
+        let _ = struct_name_idx_map.idx_to_struct_name(StructNameIndex(0));
+    }
+
+    #[test]
+    fn test_index_map() {
+        let struct_name_idx_map = StructNameIndexMap::empty();
+
+        // First-time access.
+
+        let foo = make_struct_name("foo", "Foo");
+        let foo_idx = struct_name_idx_map.struct_name_to_idx(foo.clone());
+        assert_eq!(foo_idx.0, 0);
+
+        let bar = make_struct_name("bar", "Bar");
+        let bar_idx = struct_name_idx_map.struct_name_to_idx(bar.clone());
+        assert_eq!(bar_idx.0, 1);
+
+        // Check that struct names actually correspond to indices.
+        let returned_foo = &*struct_name_idx_map.idx_to_struct_name(foo_idx);
+        assert_eq!(returned_foo, &foo);
+        let returned_bar = &*struct_name_idx_map.idx_to_struct_name(bar_idx);
+        assert_eq!(returned_bar, &bar);
+
+        // Re-check indices on second access.
+        let foo_idx = struct_name_idx_map.struct_name_to_idx(foo);
+        assert_eq!(foo_idx.0, 0);
+        let bar_idx = struct_name_idx_map.struct_name_to_idx(bar);
+        assert_eq!(bar_idx.0, 1);
+    }
+}

--- a/third_party/move/move-vm/runtime/src/storage/struct_type_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/struct_type_storage.rs
@@ -1,0 +1,57 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    loader::ModuleStorageAdapter,
+    storage::{loader::LoaderV2, verifier::Verifier},
+    ModuleStorage,
+};
+use move_binary_format::errors::PartialVMResult;
+use move_core_types::{identifier::IdentStr, language_storage::ModuleId};
+use move_vm_types::loaded_data::runtime_types::StructType;
+use std::sync::Arc;
+
+/// We use this trait so that we can fetch struct types differently for V1 and V2 loaders.
+pub(crate) trait StructTypeStorage {
+    /// Returns the struct type defined in the given module, for the specified name.
+    fn fetch_struct_ty(
+        &self,
+        module_id: &ModuleId,
+        struct_name: &IdentStr,
+    ) -> PartialVMResult<Arc<StructType>>;
+}
+
+pub(crate) struct LoaderV2StructTypeStorage<'a, V: Clone + Verifier> {
+    pub(crate) loader: &'a LoaderV2<V>,
+    pub(crate) module_storage: &'a dyn ModuleStorage,
+}
+
+impl<'a, V: Clone + Verifier> StructTypeStorage for LoaderV2StructTypeStorage<'a, V> {
+    fn fetch_struct_ty(
+        &self,
+        module_id: &ModuleId,
+        struct_name: &IdentStr,
+    ) -> PartialVMResult<Arc<StructType>> {
+        self.loader.load_struct_ty(
+            self.module_storage,
+            module_id.address(),
+            module_id.name(),
+            struct_name,
+        )
+    }
+}
+
+pub(crate) struct LoaderV1StructTypeStorage<'a> {
+    pub(crate) module_store: &'a ModuleStorageAdapter,
+}
+
+impl<'a> StructTypeStorage for LoaderV1StructTypeStorage<'a> {
+    fn fetch_struct_ty(
+        &self,
+        module_id: &ModuleId,
+        struct_name: &IdentStr,
+    ) -> PartialVMResult<Arc<StructType>> {
+        self.module_store
+            .get_struct_type_by_identifier(struct_name, module_id)
+    }
+}

--- a/third_party/move/move-vm/runtime/src/storage/verifier.rs
+++ b/third_party/move/move-vm/runtime/src/storage/verifier.rs
@@ -1,0 +1,30 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::loader::Module;
+use move_binary_format::{errors::PartialVMResult, file_format::CompiledScript, CompiledModule};
+
+/// Represents a verifier which is used for loaded modules and scripts. Clients
+/// can implement their own verification logic in addition to the bytecode verifier,
+/// and ensure that their passes are also running after.
+pub trait Verifier {
+    /// Runs a verification pass over a script.
+    fn verify_script(&self, unverified_script: &CompiledScript) -> PartialVMResult<()>;
+
+    /// Runs a verification pass over a verified script and its verified module dependencies.
+    fn verify_script_with_dependencies<'a>(
+        &self,
+        verified_script: &CompiledScript,
+        verified_imm_dependencies: impl IntoIterator<Item = &'a Module>,
+    ) -> PartialVMResult<()>;
+
+    /// Runs a verification pass over a module.
+    fn verify_module(&self, unverified_module: &CompiledModule) -> PartialVMResult<()>;
+
+    /// Runs a verification pass over a verified module and its verified immediate dependencies.
+    fn verify_module_with_dependencies<'a>(
+        &self,
+        verified_module: &CompiledModule,
+        verified_imm_dependencies: impl IntoIterator<Item = &'a Module>,
+    ) -> PartialVMResult<()>;
+}

--- a/third_party/move/testing-infra/test-generation/src/lib.rs
+++ b/third_party/move/testing-infra/test-generation/src/lib.rs
@@ -36,7 +36,7 @@ use move_core_types::{
     value::MoveValue,
     vm_status::{StatusCode, VMStatus},
 };
-use move_vm_runtime::{module_traversal::*, move_vm::MoveVM};
+use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, DummyCodeStorage};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas::UnmeteredGasMeter;
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -157,6 +157,7 @@ fn execute_function_in_module(
             args,
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
+            &DummyCodeStorage,
         )?;
 
         Ok(())

--- a/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -42,6 +42,7 @@ use move_vm_runtime::{
     module_traversal::*,
     move_vm::MoveVM,
     session::{SerializedReturnValues, Session},
+    DummyCodeStorage,
 };
 use move_vm_test_utils::{
     gas_schedule::{CostTable, Gas, GasStatus},
@@ -169,7 +170,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
                     let id = module.self_id();
                     let sender = *id.address();
                     session
-                        .publish_module(module_bytes, sender, gas_status)
+                        .publish_module(module_bytes, sender, gas_status, &DummyCodeStorage)
                         .unwrap();
                 }
                 Ok(())
@@ -220,6 +221,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
                 vec![module_bytes],
                 sender,
                 gas_status,
+                &DummyCodeStorage,
                 compat,
             )
         });
@@ -272,6 +274,8 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
                 args,
                 gas_status,
                 &mut TraversalContext::new(&traversal_storage),
+                &DummyCodeStorage,
+                &DummyCodeStorage,
             )
         })
         .map_err(|vm_error| {
@@ -323,6 +327,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
                     args,
                     gas_status,
                     &mut TraversalContext::new(&traversal_storage),
+                    &DummyCodeStorage,
                 )
             })
             .map_err(|vm_error| {

--- a/third_party/move/tools/move-unit-test/src/test_runner.rs
+++ b/third_party/move/tools/move-unit-test/src/test_runner.rs
@@ -26,6 +26,7 @@ use move_vm_runtime::{
     move_vm::MoveVM,
     native_extensions::NativeContextExtensions,
     native_functions::NativeFunctionTable,
+    DummyCodeStorage,
 };
 use move_vm_test_utils::{
     gas_schedule::{zero_cost_schedule, CostTable, Gas, GasCost, GasStatus},
@@ -282,6 +283,7 @@ impl SharedTestingConfig {
             serialize_values(test_info.arguments.iter()),
             &mut gas_meter,
             &mut TraversalContext::new(&storage),
+            &DummyCodeStorage,
         );
         let mut return_result = serialized_return_values_result.map(|res| {
             res.return_values


### PR DESCRIPTION
## Description

1. Versioning Loader into V1 and V2: this allows easier integration so that we can switch a flag and get the new behaviour.
2. New loader implementation draft:

- LoaderV2 does not store modules or scripts, instead the corresponding `ScriptStorage` and `ModuleStorage` are passed as references to loader APIs. This allows us to cache things on read.
- LoaderV2 still has type caches which keep track of depth formulas, etc. like the old loader: these do not change the behaviour with module upgrade, and it is fine to keep them IMO for simpler integration.

New data structures: 
1. LoaderV2 also has `V: Verifier` type param to make sure we can provide custom verifier when loading a module
2. Loading a module calls to `fetch_or_create_verified_module` - this function actually loads the transitive closure of dependencies, and this is an implementation detail of code cache (not here).
3. Because we do not want to leak data structures from Loader into code cache, the idea is to pass a function to `fetch_or_create_verified_module` that is just `f: &dyn Fn(Arc<CompiledModule>) -> PartialVMResult<Module>` and is passed by the loader. This way this function can capture struct name cache which maps struct names to identifiers, native functions, etc.

### Alternative design 

We can have a shared context which will be shared between loader & code cache: something like this:
```rust
pub struct LoaderContext<V: Verifier> {
    // Native functions can be also here, but type caches are kept in the loader.
    pub(crate) struct_name_index_map: StructNameIndexMap,
    phantom_data: PhantomData<V>,
}

impl<V: Verifier> LoaderContext<V> {
    pub fn build_module(
        &self,
        cm: Arc<CompiledModule>,
        module_storage: &impl ModuleStorage,
    ) -> PartialVMResult<Module> {
        V::verify_module(cm.as_ref())?;
        let imm_dependencies = cm
            .immediate_dependencies_iter()
            .map(|(addr, name)| module_storage.fetch_verified_module(addr, name))
            .collect::<PartialVMResult<Vec<_>>>()?;
        V::verify_module_with_dependencies(
            cm.as_ref(),
            imm_dependencies.iter().map(|m| m.module()),
        )?;
        // Must be a private constructor, so that one can create module only via the context.
        Module::new_v2(module_storage, &self.struct_name_index_map, cm)
    }
}
```

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
