### PR TITLE
[execution window] blocks support a window, along with block storage and sync

### DIFF
--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -213,8 +213,8 @@ impl BlockRetrievalResponse {
                     self.status == BlockRetrievalStatus::SucceededWithTarget
                         || !self
                             .blocks
-                            .last()
-                            .map_or(false, |block| retrieval_request.match_target_id(block.id())),
+                            .iter()
+                            .any(|block| retrieval_request.match_target_id(block.id())),
                     "target was found, but response is not marked as SucceededWithTarget",
                 );
                 ensure!(
@@ -237,9 +237,11 @@ impl BlockRetrievalResponse {
                 );
                 ensure!(
                     self.status == BlockRetrievalStatus::SucceededWithTarget
-                        || !self.blocks.last().map_or(false, |block| retrieval_request
-                            .is_window_start_block(block)),
-                    "target was found, but response is not marked as SucceededWithTarget",
+                        || !self.blocks.last().map_or(false, |block| {
+                            block.round() < retrieval_request.target_round()
+                                || retrieval_request.is_window_start_block(block)
+                        }),
+                    "smaller than target round or window start block was found, but response is not marked as SucceededWithTarget",
                 );
                 ensure!(
                     self.status != BlockRetrievalStatus::SucceededWithTarget

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -21,6 +21,30 @@ pub enum BlockRetrievalRequest {
     V2(BlockRetrievalRequestV2),
 }
 
+impl BlockRetrievalRequest {
+    pub fn new_with_target_round(block_id: HashValue, num_blocks: u64, target_round: u64) -> Self {
+        Self::V2(BlockRetrievalRequestV2 {
+            block_id,
+            num_blocks,
+            target_round,
+        })
+    }
+
+    pub fn block_id(&self) -> HashValue {
+        match self {
+            BlockRetrievalRequest::V1(req) => req.block_id,
+            BlockRetrievalRequest::V2(req) => req.block_id,
+        }
+    }
+
+    pub fn num_blocks(&self) -> u64 {
+        match self {
+            BlockRetrievalRequest::V1(req) => req.num_blocks,
+            BlockRetrievalRequest::V2(req) => req.num_blocks,
+        }
+    }
+}
+
 /// RPC to get a chain of block of the given length starting from the given block id.
 /// TODO @bchocho @hariria fix comment after all nodes upgrade to release with enum BlockRetrievalRequest (not struct)
 ///
@@ -81,7 +105,7 @@ impl fmt::Display for BlockRetrievalRequestV1 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "[BlockRetrievalRequest starting from id {} with {} blocks]",
+            "[BlockRetrievalRequestV1 starting from id {} with {} blocks]",
             self.block_id, self.num_blocks
         )
     }
@@ -129,6 +153,16 @@ impl BlockRetrievalRequestV2 {
     }
 }
 
+impl fmt::Display for BlockRetrievalRequestV2 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "[BlockRetrievalRequestV2 starting from id {} with {} blocks]",
+            self.block_id, self.num_blocks
+        )
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum BlockRetrievalStatus {
     // Successfully fill in the request.
@@ -161,28 +195,51 @@ impl BlockRetrievalResponse {
         &self.blocks
     }
 
-    /// TODO @bchocho @hariria change `retrieval_request` after all nodes upgrade to release with enum BlockRetrievalRequest (not struct)
+    /// TODO @bchocho @hariria deprecate `BlockRetrievalRequest::V1` after all nodes upgrade to release with enum BlockRetrievalRequest (not struct)
     pub fn verify(
         &self,
-        retrieval_request: BlockRetrievalRequestV1,
+        retrieval_request: BlockRetrievalRequest,
         sig_verifier: &ValidatorVerifier,
     ) -> anyhow::Result<()> {
-        ensure!(
-            self.status != BlockRetrievalStatus::Succeeded
-                || self.blocks.len() as u64 == retrieval_request.num_blocks(),
-            "not enough blocks returned, expect {}, get {}",
-            retrieval_request.num_blocks(),
-            self.blocks.len(),
-        );
-        ensure!(
-            self.status != BlockRetrievalStatus::SucceededWithTarget
-                || self
-                    .blocks
-                    .last()
-                    .map_or(false, |block| retrieval_request.match_target_id(block.id())),
-            "target not found in blocks returned, expect {:?}",
-            retrieval_request.target_block_id(),
-        );
+        match &retrieval_request {
+            BlockRetrievalRequest::V1(retrieval_request) => {
+                ensure!(
+                    self.status != BlockRetrievalStatus::Succeeded
+                        || self.blocks.len() as u64 == retrieval_request.num_blocks(),
+                    "not enough blocks returned, expect {}, get {}",
+                    retrieval_request.num_blocks(),
+                    self.blocks.len(),
+                );
+                ensure!(
+                    self.status != BlockRetrievalStatus::SucceededWithTarget
+                        || self
+                            .blocks
+                            .last()
+                            .map_or(false, |block| retrieval_request.match_target_id(block.id())),
+                    "target not found in blocks returned, expect {:?}",
+                    retrieval_request.target_block_id(),
+                );
+            },
+            BlockRetrievalRequest::V2(retrieval_request) => {
+                ensure!(
+                    self.status != BlockRetrievalStatus::Succeeded
+                        || self.blocks.len() as u64 == retrieval_request.num_blocks(),
+                    "not enough blocks returned, expect {}, get {}",
+                    retrieval_request.num_blocks(),
+                    self.blocks.len(),
+                );
+                ensure!(
+                    self.status != BlockRetrievalStatus::SucceededWithTarget
+                        || (!self.blocks.is_empty()
+                            && retrieval_request
+                                .match_target_round(self.blocks.last().unwrap().round())),
+                    "target not found in blocks returned, expected {:?}, got {:?}",
+                    retrieval_request.target_round(),
+                    self.blocks.iter().map(|b| b.round()).collect::<Vec<_>>(),
+                );
+            },
+        }
+
         self.blocks
             .iter()
             .try_fold(retrieval_request.block_id(), |expected_id, block| {

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -196,12 +196,7 @@ impl BlockRetrievalResponse {
         &self.blocks
     }
 
-    /// TODO @bchocho @hariria deprecate `BlockRetrievalRequest::V1` after all nodes upgrade to release with enum BlockRetrievalRequest (not struct)
-    pub fn verify(
-        &self,
-        retrieval_request: BlockRetrievalRequest,
-        sig_verifier: &ValidatorVerifier,
-    ) -> anyhow::Result<()> {
+    pub fn verify_inner(&self, retrieval_request: &BlockRetrievalRequest) -> anyhow::Result<()> {
         match &retrieval_request {
             BlockRetrievalRequest::V1(retrieval_request) => {
                 ensure!(
@@ -240,6 +235,17 @@ impl BlockRetrievalResponse {
                 );
             },
         }
+
+        Ok(())
+    }
+
+    /// TODO @bchocho @hariria deprecate `BlockRetrievalRequest::V1` after all nodes upgrade to release with enum BlockRetrievalRequest (not struct)
+    pub fn verify(
+        &self,
+        retrieval_request: BlockRetrievalRequest,
+        sig_verifier: &ValidatorVerifier,
+    ) -> anyhow::Result<()> {
+        self.verify_inner(&retrieval_request)?;
 
         self.blocks
             .iter()

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -238,7 +238,6 @@ impl BlockRetrievalResponse {
         Ok(())
     }
 
-    /// TODO @bchocho @hariria deprecate `BlockRetrievalRequest::V1` after all nodes upgrade to release with enum BlockRetrievalRequest (not struct)
     pub fn verify(
         &self,
         retrieval_request: BlockRetrievalRequest,

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -148,7 +148,8 @@ impl BlockRetrievalRequestV2 {
         self.target_round
     }
 
-    pub fn match_target_round(&self, round: u64) -> bool {
+    /// If there are gaps in the rounds, there might not be a block that stops exactly at the target
+    pub fn is_leq_target_round(&self, round: u64) -> bool {
         round <= self.target_round()
     }
 }
@@ -232,7 +233,7 @@ impl BlockRetrievalResponse {
                     self.status != BlockRetrievalStatus::SucceededWithTarget
                         || (!self.blocks.is_empty()
                             && retrieval_request
-                                .match_target_round(self.blocks.last().unwrap().round())),
+                                .is_leq_target_round(self.blocks.last().unwrap().round())),
                     "target not found in blocks returned, expected {:?}, got {:?}",
                     retrieval_request.target_round(),
                     self.blocks.iter().map(|b| b.round()).collect::<Vec<_>>(),

--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -11,7 +11,7 @@ use crate::{
     quorum_cert::QuorumCert,
     vote_proposal::VoteProposal,
 };
-use anyhow::{bail, Error};
+use anyhow::Error;
 use aptos_crypto::hash::{HashValue, ACCUMULATOR_PLACEHOLDER_HASH};
 use aptos_executor_types::{
     state_compute_result::StateComputeResult, ExecutorError, ExecutorResult,
@@ -146,27 +146,34 @@ impl OrderedBlockWindow {
     /// if the `PipelinedBlock` still exists
     ///      `upgraded_block` will be `Some(PipelinedBlock)`, and included in `blocks`
     /// else it will be `None`, and not included in `blocks`
-    pub fn blocks(&self) -> anyhow::Result<Vec<Block>> {
+    pub fn blocks(&self) -> Vec<Block> {
         let mut blocks: Vec<Block> = vec![];
         for (index, block) in self.blocks.iter().enumerate() {
             let upgraded_block = block.upgrade();
             if let Some(block) = upgraded_block {
                 blocks.push(block.block().clone())
             } else {
-                bail!(
+                // TODO @bchocho @hariria revisit if we want to panic or bail
+                panic!(
                     "Block {} not found during upgrade in OrderedBlockWindow::blocks()",
                     index
                 )
             }
         }
-        Ok(blocks)
+        blocks
     }
 
     pub fn pipelined_blocks(&self) -> Vec<Arc<PipelinedBlock>> {
         let mut blocks: Vec<Arc<PipelinedBlock>> = Vec::new();
-        for block in &self.blocks {
+        for (index, block) in self.blocks.iter().enumerate() {
             if let Some(block) = block.upgrade() {
                 blocks.push(block);
+            } else {
+                // TODO @bchocho @hariria revisit if we want to panic or bail
+                panic!(
+                    "Block {} not found during upgrade in OrderedBlockWindow::pipelined_blocks()",
+                    index
+                )
             }
         }
         blocks

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -867,4 +867,22 @@ impl BlockStore {
 
         (commit_root, Some(window_root))
     }
+
+    /// Helper function for testing commit_callback
+    /// User can provide a `window_size` to override the `BlockStore::window_size`
+    pub(crate) fn commit_callback(
+        &self,
+        block_id: HashValue,
+        block_round: Round,
+        commit_proof: WrappedLedgerInfo,
+        window_size: Option<u64>,
+    ) {
+        self.inner.write().commit_callback(
+            self.storage.clone(),
+            block_id,
+            block_round,
+            commit_proof,
+            window_size.or(self.window_size),
+        )
+    }
 }

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -207,7 +207,7 @@ impl BlockStore {
         ));
         assert_eq!(result.root_hash(), root_metadata.accu_hash);
 
-        let pipelined_root_block = match window_root_block {
+        let window_root = match window_root_block {
             None => {
                 PipelinedBlock::new(
                     *commit_root_block,
@@ -229,12 +229,12 @@ impl BlockStore {
         if let Some(pipeline_builder) = &pipeline_builder {
             let pipeline_fut =
                 pipeline_builder.build_root(result, root_commit_cert.ledger_info().clone());
-            pipelined_root_block.set_pipeline_futs(pipeline_fut);
+            window_root.set_pipeline_futs(pipeline_fut);
         }
 
         let tree = BlockTree::new(
             root_block_id,
-            pipelined_root_block,
+            window_root,
             root_qc,
             root_ordered_cert,
             root_commit_cert,
@@ -417,7 +417,7 @@ impl BlockStore {
             return Ok(existing_block);
         }
         ensure!(
-            self.inner.read().commit_root().round() < block.round(),
+            self.inner.read().ordered_root().round() < block.round(),
             "Block with old round"
         );
 

--- a/consensus/src/block_storage/block_store_test.rs
+++ b/consensus/src/block_storage/block_store_test.rs
@@ -6,7 +6,8 @@ use crate::{
     block_storage::{block_store::sync_manager::NeedFetchResult, BlockReader},
     pending_votes::{PendingVotes, VoteReceptionResult},
     test_utils::{
-        build_empty_tree, build_simple_tree, consensus_runtime, timed_block_on, TreeInserter,
+        build_default_empty_tree, build_simple_tree, consensus_runtime, timed_block_on,
+        TreeInserter,
     },
 };
 use aptos_consensus_types::{
@@ -121,7 +122,7 @@ proptest! {
             |key| Author::from_bytes(&key.public_key().to_bytes()[0..32]).unwrap()
         ).collect();
         let runtime = consensus_runtime();
-        let block_store = build_empty_tree();
+        let block_store = build_default_empty_tree();
         for block in blocks {
             if block.round() > 0 && authors.contains(&block.author().unwrap()) {
                 let known_parent = block_store.block_exists(block.parent_id());
@@ -154,6 +155,9 @@ proptest! {
 
 #[tokio::test]
 async fn test_block_store_prune() {
+    //       ╭--> A1--> A2--> A3
+    // Genesis--> B1--> B2
+    //             ╰--> C1
     let (blocks, block_store) = build_simple_tree().await;
     // Attempt to prune genesis block (should be no-op)
     assert_eq!(block_store.prune_tree(blocks[0].id()).len(), 0);
@@ -348,7 +352,7 @@ async fn test_insert_vote() {
 #[tokio::test]
 async fn test_illegal_timestamp() {
     let signer = ValidatorSigner::random(None);
-    let block_store = build_empty_tree();
+    let block_store = build_default_empty_tree();
     let genesis = block_store.ordered_root();
     let block_with_illegal_timestamp = Block::new_proposal(
         Payload::empty(false, true),

--- a/consensus/src/block_storage/block_tree.rs
+++ b/consensus/src/block_storage/block_tree.rs
@@ -8,10 +8,13 @@ use crate::{
     logging::{LogEvent, LogSchema},
     persistent_liveness_storage::PersistentLivenessStorage,
 };
-use anyhow::bail;
+use anyhow::{bail, ensure};
 use aptos_consensus_types::{
-    pipelined_block::PipelinedBlock, quorum_cert::QuorumCert,
-    timeout_2chain::TwoChainTimeoutCertificate, wrapped_ledger_info::WrappedLedgerInfo,
+    block::Block,
+    pipelined_block::{OrderedBlockWindow, PipelinedBlock},
+    quorum_cert::QuorumCert,
+    timeout_2chain::TwoChainTimeoutCertificate,
+    wrapped_ledger_info::WrappedLedgerInfo,
 };
 use aptos_crypto::HashValue;
 use aptos_logger::prelude::*;
@@ -75,6 +78,8 @@ pub struct BlockTree {
     ordered_root_id: HashValue,
     /// Commit Root id: this is the root of commit phase
     commit_root_id: HashValue,
+    /// Window Root id: this is the `parent_id` of the first item in the [`OrderedBlockWindow`](OrderedBlockWindow)
+    window_root_id: HashValue,
     /// A certified block id with highest round
     highest_certified_block_id: HashValue,
 
@@ -92,31 +97,30 @@ pub struct BlockTree {
     pruned_block_ids: VecDeque<HashValue>,
     /// Num pruned blocks to keep in memory.
     max_pruned_blocks_in_mem: usize,
-
     /// Round to Block index. We expect only one block per round.
     round_to_ids: BTreeMap<Round, HashValue>,
 }
 
 impl BlockTree {
     pub(super) fn new(
-        root: PipelinedBlock,
+        root_block_id: HashValue,
+        // TODO: need the certs?
+        window_root: PipelinedBlock,
         root_quorum_cert: QuorumCert,
         root_ordered_cert: WrappedLedgerInfo,
         root_commit_cert: WrappedLedgerInfo,
         max_pruned_blocks_in_mem: usize,
         highest_2chain_timeout_cert: Option<Arc<TwoChainTimeoutCertificate>>,
     ) -> Self {
-        assert_eq!(
-            root.id(),
-            root_ordered_cert.commit_info().id(),
-            "inconsistent root and ledger info"
-        );
-        let root_id = root.id();
+        assert_eq!(window_root.epoch(), root_ordered_cert.commit_info().epoch());
+        assert!(window_root.round() <= root_ordered_cert.commit_info().round());
+        let window_root_id = window_root.id();
 
+        // Build the tree from the window root block which is <= the commit root block.
         let mut id_to_block = HashMap::new();
         let mut round_to_ids = BTreeMap::new();
-        round_to_ids.insert(root.round(), root_id);
-        id_to_block.insert(root_id, LinkableBlock::new(root));
+        round_to_ids.insert(window_root.round(), window_root_id);
+        id_to_block.insert(window_root_id, LinkableBlock::new(window_root));
         counters::NUM_BLOCKS_IN_TREE.set(1);
 
         let root_quorum_cert = Arc::new(root_quorum_cert);
@@ -130,9 +134,10 @@ impl BlockTree {
 
         BlockTree {
             id_to_block,
-            ordered_root_id: root_id,
-            commit_root_id: root_id, // initially we set commit_root_id = root_id
-            highest_certified_block_id: root_id,
+            ordered_root_id: root_block_id,
+            commit_root_id: root_block_id, // initially we set commit_root_id = root_id
+            window_root_id,
+            highest_certified_block_id: root_block_id,
             highest_quorum_cert: Arc::clone(&root_quorum_cert),
             highest_ordered_cert: Arc::new(root_ordered_cert),
             highest_commit_cert: Arc::new(root_commit_cert),
@@ -170,6 +175,11 @@ impl BlockTree {
     fn linkable_root(&self) -> &LinkableBlock {
         self.get_linkable_block(&self.commit_root_id)
             .expect("Root must exist")
+    }
+
+    fn linkable_window_root(&self) -> &LinkableBlock {
+        self.get_linkable_block(&self.window_root_id)
+            .expect("Window root must exist")
     }
 
     fn remove_block(&mut self, block_id: HashValue) {
@@ -239,6 +249,86 @@ impl BlockTree {
         self.id_to_quorum_cert.get(block_id).cloned()
     }
 
+    pub(super) fn window_root(&self) -> Arc<PipelinedBlock> {
+        self.get_block(&self.window_root_id)
+            .expect("Window root not found")
+    }
+
+    // TODO: return an error when not enough blocks?
+    // TODO: how to know if the window is complete?
+    /// Retrieves a Window of Recent Blocks
+    ///
+    /// Returns an [`OrderedBlockWindow`](OrderedBlockWindow) containing the previous `window_size`
+    /// blocks, EXCLUDING the provided `current_block`. Returns an `OrderedBlockWindow` containing
+    /// the recent blocks in ascending order by round (oldest -> newest).
+    ///
+    /// # Parameters
+    /// - `current_block`: The reference block to base the window on.
+    /// - `window_size`: The number of recent blocks to include in the window, excluding the `current_block`.
+    ///
+    /// # Example
+    /// Given a `current_block` with `round: 30` and a `window_size` of 3:
+    ///
+    /// ```text
+    /// get_block_window(current_block, window_size)
+    /// // returns vec![
+    /// //     Block { BlockData { round: 28 } },
+    /// //     Block { BlockData { round: 29 } }
+    /// // ]
+    /// ```
+    ///
+    /// *Note*: The output vector in this example contains 2 blocks, not 3, as only blocks with rounds
+    /// preceding `current_block.round()` are included.
+    pub fn get_ordered_block_window(
+        &self,
+        block: &Block,
+        window_size: Option<u64>,
+    ) -> anyhow::Result<OrderedBlockWindow> {
+        // window_size is None only if execution pool is turned off
+        if window_size.is_none() {
+            return Ok(OrderedBlockWindow::empty());
+        }
+
+        // TODO Currently we do not check to see if the `block` provided exists in the `BlockTree`
+        // See `insert_block()` for more context.
+        //
+        // It's a little strange because you can call `get_block_window` with a recently pruned block,
+        // and it will return a seemingly valid OrderedBlockWindow... which is a bit unintuitive.
+        // Maybe rename this function or scope it to be non-public to not confuse people in the future.
+        // Revisit this later
+        let window_size = window_size.expect("Unexpected window size of None, assert window_size.is_none() invariant above was changed");
+        let round = block.round();
+        let window_start_round = (round + 1).saturating_sub(window_size);
+        let window_size = (round + 1) - window_start_round;
+        ensure!(window_size > 0, "window_size must be greater than 0");
+        if window_size == 1 {
+            return Ok(OrderedBlockWindow::empty());
+        }
+
+        let mut window = vec![];
+        let mut current_block = block.clone();
+        ensure!(!current_block.is_genesis_block());
+        loop {
+            // Break if my parent's block round is outside the window
+            if current_block.quorum_cert().certified_block().round() < window_start_round {
+                break;
+            }
+            if let Some(parent_block) = self.get_block(&current_block.parent_id()) {
+                current_block = parent_block.block().clone();
+                if current_block.is_genesis_block() {
+                    break;
+                }
+                window.push(parent_block);
+            } else {
+                bail!("Parent block not found for block {}", current_block.id());
+            }
+        }
+        // The window order is lower round -> higher round
+        window.reverse();
+        ensure!(window.len() < window_size as usize);
+        Ok(OrderedBlockWindow::new(window))
+    }
+
     pub(super) fn insert_block(
         &mut self,
         block: PipelinedBlock,
@@ -277,6 +367,12 @@ impl BlockTree {
         if new_commit_cert.commit_info().round() > self.highest_commit_cert.commit_info().round() {
             self.highest_commit_cert = Arc::new(new_commit_cert);
             self.update_commit_root(self.highest_commit_cert.commit_info().id());
+        } else {
+            warn!(
+                "Trying to update highest commit cert with lower round: {} <= {}",
+                new_commit_cert.commit_info().round(),
+                self.highest_commit_cert.commit_info().round()
+            );
         }
     }
 
@@ -336,20 +432,24 @@ impl BlockTree {
     /// B3--> B4, root = B3
     ///
     /// Note this function is read-only, use with process_pruned_blocks to do the actual prune.
-    pub(super) fn find_blocks_to_prune(&self, next_root_id: HashValue) -> VecDeque<HashValue> {
-        // Nothing to do if this is the commit root
-        if next_root_id == self.commit_root_id {
+    pub(super) fn find_blocks_to_prune(
+        &self,
+        next_window_root_id: HashValue,
+    ) -> VecDeque<HashValue> {
+        // Nothing to do if this is the window root
+        if next_window_root_id == self.window_root_id {
             return VecDeque::new();
         }
 
         let mut blocks_pruned = VecDeque::new();
-        let mut blocks_to_be_pruned = vec![self.linkable_root()];
+        let mut blocks_to_be_pruned = vec![self.linkable_window_root()];
+
         while let Some(block_to_remove) = blocks_to_be_pruned.pop() {
             block_to_remove.executed_block().abort_pipeline();
             // Add the children to the blocks to be pruned (if any), but stop when it reaches the
             // new root
             for child_id in block_to_remove.children() {
-                if next_root_id == *child_id {
+                if next_window_root_id == *child_id {
                     continue;
                 }
                 blocks_to_be_pruned.push(
@@ -371,6 +471,53 @@ impl BlockTree {
     pub(super) fn update_commit_root(&mut self, root_id: HashValue) {
         assert!(self.block_exists(&root_id));
         self.commit_root_id = root_id;
+    }
+
+    pub(super) fn update_window_root(&mut self, root_id: HashValue) {
+        assert!(
+            self.block_exists(&root_id),
+            "Block {} not found, previous window_root: {}",
+            root_id,
+            self.window_root_id
+        );
+        self.window_root_id = root_id;
+    }
+
+    /// `window_root` is the first block in the [OrderedBlockWindow](OrderedBlockWindow)
+    ///
+    /// ```text
+    ///                 block_window
+    ///                       ↓
+    ///              ┌──────────────────┐
+    ///  Genesis ──> │ A1 ──> A2 ──> A3 │ ──> A4
+    ///              └──────────────────┘
+    ///                 ↑                      ↑
+    ///            window_root          block_to_commit
+    /// ```
+    pub(super) fn find_window_root(
+        &self,
+        block_to_commit_id: HashValue,
+        window_size: Option<u64>,
+    ) -> HashValue {
+        // Window Size is None only if execution pool is off
+        if let Some(window_size) = window_size {
+            assert_ne!(window_size, 0, "Window size must be greater than 0");
+        }
+
+        // Try to get the block, then the ordered window, then the first block's parent ID
+        let block = self
+            .get_block(&block_to_commit_id)
+            .expect("Block not found");
+        let ordered_block_window = self
+            .get_ordered_block_window(block.block(), window_size)
+            .expect("Ordered block window not found");
+        let pipelined_blocks = ordered_block_window.pipelined_blocks();
+        let first_block = pipelined_blocks
+            .iter()
+            .chain(std::iter::once(&block))
+            .next()
+            .expect("Ordered block window not found");
+        first_block.id()
     }
 
     /// Process the data returned by the prune_tree, they're separated because caller might
@@ -455,6 +602,7 @@ impl BlockTree {
         blocks_to_commit: &[Arc<PipelinedBlock>],
         finality_proof: WrappedLedgerInfo,
         commit_decision: LedgerInfoWithSignatures,
+        window_size: Option<u64>,
     ) {
         let commit_proof = finality_proof
             .create_merged_with_executed_state(commit_decision)
@@ -465,7 +613,17 @@ impl BlockTree {
         let block_id = last_block.id();
         let block_round = last_block.round();
 
-        self.commit_callback(storage, block_id, block_round, commit_proof);
+        // TODO blocks_to_commit changed from being a single block to a vector of blocks after
+        // Zekun's pipeline commit. Make sure this is rebased correctly and the last block can
+        // be used here for find_window_root
+        //
+        // For posterity, since this calls commit_callback() I will be moving:
+        // 1. the update_window_root() call to the commit_callback() function so that others
+        // calling commit_callback instead of commit_callback_deprecated are updating the window root
+        // 2. storage.prune_tree() function to only the commit_callback() function instead of both
+        // commit_callback() and commit_callback_deprecated()
+
+        self.commit_callback(storage, block_id, block_round, commit_proof, window_size);
     }
 
     pub fn commit_callback(
@@ -474,6 +632,7 @@ impl BlockTree {
         block_id: HashValue,
         block_round: Round,
         commit_proof: WrappedLedgerInfo,
+        window_size: Option<u64>,
     ) {
         let current_round = self.commit_root().round();
         let committed_round = block_round;
@@ -484,13 +643,16 @@ impl BlockTree {
             block_id = block_id,
         );
 
-        let ids_to_remove = self.find_blocks_to_prune(block_id);
+        let window_root_id = self.find_window_root(block_id, window_size);
+        let ids_to_remove = self.find_blocks_to_prune(window_root_id);
+
         if let Err(e) = storage.prune_tree(ids_to_remove.clone().into_iter().collect()) {
             // it's fine to fail here, as long as the commit succeeds, the next restart will clean
             // up dangling blocks, and we need to prune the tree to keep the root consistent with
             // executor.
             warn!(error = ?e, "fail to delete block");
         }
+        self.update_window_root(window_root_id);
         self.process_pruned_blocks(ids_to_remove);
         self.update_highest_commit_cert(commit_proof);
     }

--- a/consensus/src/block_storage/block_tree.rs
+++ b/consensus/src/block_storage/block_tree.rs
@@ -7,6 +7,7 @@ use crate::{
     counters::update_counters_for_committed_blocks,
     logging::{LogEvent, LogSchema},
     persistent_liveness_storage::PersistentLivenessStorage,
+    util::calculate_window_start_round,
 };
 use anyhow::{bail, ensure};
 use aptos_consensus_types::{
@@ -304,8 +305,8 @@ impl BlockTree {
         // Maybe rename this function or scope it to be non-public to not confuse people in the future.
         // Revisit this later
         let round = block.round();
-        let window_start_round = (round + 1).saturating_sub(window_size);
-        let window_size = (round + 1) - window_start_round;
+        let window_start_round = calculate_window_start_round(round, window_size);
+        let window_size = round - window_start_round + 1;
         ensure!(window_size > 0, "window_size must be greater than 0");
         if window_size == 1 {
             return Ok(OrderedBlockWindow::empty());

--- a/consensus/src/block_storage/block_tree.rs
+++ b/consensus/src/block_storage/block_tree.rs
@@ -285,6 +285,10 @@ impl BlockTree {
         block: &Block,
         window_size: Option<u64>,
     ) -> anyhow::Result<OrderedBlockWindow> {
+        ensure!(
+            !block.is_genesis_block(),
+            "Genesis block does not have a block window",
+        );
         // Block round should never be less than the commit root round
         ensure!(
             block.round() >= self.commit_root().round(),

--- a/consensus/src/block_storage/block_tree.rs
+++ b/consensus/src/block_storage/block_tree.rs
@@ -311,9 +311,10 @@ impl BlockTree {
             return Ok(OrderedBlockWindow::empty());
         }
 
+        // genesis will never be inserted via insert_block
+        ensure!(!block.is_genesis_block());
         let mut window = vec![];
         let mut current_block = block.clone();
-        ensure!(!current_block.is_genesis_block());
 
         // Add each block to the window until you reach the start round
         while current_block.quorum_cert().certified_block().round() >= window_start_round {

--- a/consensus/src/block_storage/execution_pool/block_window_test.rs
+++ b/consensus/src/block_storage/execution_pool/block_window_test.rs
@@ -54,12 +54,11 @@ async fn test_execution_pool_block_window_3_no_commit() {
     assert_eq!(genesis_pipelined_block.parent_id(), HashValue::zero());
     let mut curr_pipelined_block = genesis_pipelined_block.clone();
 
-    // | blocks inserted | window_size | round | ordered_block_window block count |
-    // |-----------------|-------------|-------|----------------------------------|
-    // | 0               | 3           | 0     | 0                                |
+    // Getting the ordered block window for a genesis block should return an error
     let block = curr_pipelined_block.block();
-    let blocks = get_blocks_from_block_store_and_window(block_store.clone(), block, window_size);
-    assert_eq!(blocks.len(), 0);
+    assert!(block_store
+        .get_ordered_block_window(block, window_size)
+        .is_err());
 
     // | blocks inserted | window_size | round | ordered_block_window block count |
     // |-----------------|-------------|-------|----------------------------------|

--- a/consensus/src/block_storage/execution_pool/block_window_test.rs
+++ b/consensus/src/block_storage/execution_pool/block_window_test.rs
@@ -11,283 +11,22 @@
 //! This should not happen in production.
 
 use crate::{
-    block_storage::{BlockReader, BlockStore},
-    test_utils::TreeInserter,
+    block_storage::{
+        execution_pool::common::{
+            create_block_tree_no_forks, create_block_tree_no_forks_inner,
+            create_block_tree_with_forks, create_block_tree_with_forks_unordered_parents,
+            create_block_tree_with_forks_unordered_parents_and_nil_blocks,
+            get_blocks_from_block_store_and_window, DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM,
+        },
+        BlockReader,
+    },
+    test_utils::{build_custom_empty_tree, consensus_runtime, timed_block_on, TreeInserter},
 };
-use aptos_consensus_types::{
-    block::{block_test_utils::certificate_for_genesis, Block},
-    pipelined_block::PipelinedBlock,
-};
-use aptos_crypto::HashValue;
+use aptos_consensus_types::{block::block_test_utils, common::Author};
+use aptos_crypto::{HashValue, PrivateKey};
 use aptos_types::{block_info::Round, validator_signer::ValidatorSigner};
-use std::sync::Arc;
-
-const DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM: usize = 10;
-
-/// Helper function to get the [`OrderedBlockWindow`](aptos_consensus_types::pipelined_block::OrderedBlockWindow)
-/// from the `block_store`
-fn get_blocks_from_block_store_and_window(
-    block_store: Arc<BlockStore>,
-    block: &Block,
-    window_size: Option<u64>,
-) -> Vec<Block> {
-    let windowed_blocks = block_store
-        .inner
-        .read()
-        .get_ordered_block_window(block, window_size);
-    let ordered_block_window = windowed_blocks.unwrap();
-    ordered_block_window.blocks().unwrap().to_owned()
-}
-
-/// Helper function for getting `commit_root`, `window_root`
-/// NOTE: `block` is the reference block to base the window on
-fn get_roots(
-    block: &Block,
-    block_store: Arc<BlockStore>,
-    window_size: Option<u64>,
-) -> (Arc<PipelinedBlock>, Option<HashValue>) {
-    let block_store_inner_guard = block_store.inner.read();
-    let commit_root = block_store_inner_guard.commit_root();
-
-    let window_root = block_store_inner_guard.find_window_root(block.id(), window_size);
-
-    (commit_root, Some(window_root))
-}
-
-/// Helper function to create a block tree of size `N` with no forks
-/// ```text
-/// +--------------+       +---------+       +---------+       +---------+       +---------+
-/// | Genesis Block| ----> | Block 1 | ----> | Block 2 | ----> | Block 3 | ----> | Block 4 | --> ...
-/// +--------------+       +---------+       +---------+       +---------+       +---------+
-/// ```
-///
-/// NOTE: `num_blocks` includes the genesis block
-async fn create_block_tree_no_forks_inner<const N: usize>(
-    num_blocks: u64,
-    window_size: Option<u64>,
-    max_pruned_blocks_in_mem: usize,
-) -> (TreeInserter, Arc<BlockStore>, [Arc<PipelinedBlock>; N]) {
-    let validator_signer = ValidatorSigner::random(None);
-    let mut inserter =
-        TreeInserter::new_with_params(validator_signer, window_size, max_pruned_blocks_in_mem);
-    let block_store = inserter.block_store();
-
-    // Block Store is initialized with a genesis block
-    let genesis_pipelined_block = block_store
-        .get_block(block_store.ordered_root().id())
-        .unwrap();
-    assert!(genesis_pipelined_block.block().is_genesis_block());
-    assert_eq!(genesis_pipelined_block.parent_id(), HashValue::zero());
-    let mut cur_node = genesis_pipelined_block.clone();
-
-    // num_blocks + 1
-    let mut pipelined_blocks = Vec::with_capacity(num_blocks as usize);
-    pipelined_blocks.push(genesis_pipelined_block.clone());
-
-    // Adds `num_blocks` blocks to the block_store
-    for round in 1..num_blocks {
-        if round == 1 {
-            cur_node = inserter
-                .insert_block_with_qc(certificate_for_genesis(), &genesis_pipelined_block, round)
-                .await;
-        } else {
-            cur_node = inserter.insert_block(&cur_node, round, None).await;
-        }
-        pipelined_blocks.push(cur_node.clone());
-    }
-    let pipelined_blocks: [Arc<PipelinedBlock>; N] = pipelined_blocks
-        .try_into()
-        .expect("Unexpected error converting fixed size vector into fixed size array. Ensure the generic `N` is equal to `num_blocks`");
-
-    (inserter, block_store, pipelined_blocks)
-}
-
-/// Same as [`create_block_tree_no_forks_inner`](create_block_tree_no_forks_inner) defined above
-/// however ths includes a default for `max_pruned_blocks_in_mem` of 10
-async fn create_block_tree_no_forks<const N: usize>(
-    num_blocks: u64,
-    window_size: Option<u64>,
-) -> (TreeInserter, Arc<BlockStore>, [Arc<PipelinedBlock>; N]) {
-    create_block_tree_no_forks_inner(num_blocks, window_size, DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM)
-        .await
-}
-
-/// Create a block tree with forks. Similar to [`build_simple_tree`](crate::test_utils::build_simple_tree)
-/// Returns the following tree.
-///
-/// ```text
-///       ╭--> A1--> A2--> A3
-/// Genesis--> B1--> B2
-///             ╰--> C1
-/// ```
-///
-/// WARNING: Be wary of changing this function, it will affect consumers downstream
-async fn create_block_tree_with_forks(
-    window_size: Option<u64>,
-) -> (TreeInserter, Arc<BlockStore>, [Arc<PipelinedBlock>; 7]) {
-    let validator_signer = ValidatorSigner::random(None);
-    let mut inserter = TreeInserter::new_with_params(
-        validator_signer,
-        window_size,
-        DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM,
-    );
-    let block_store = inserter.block_store();
-    let genesis = block_store.ordered_root();
-    let genesis_block_id = genesis.id();
-    let genesis_block = block_store
-        .get_block(genesis_block_id)
-        .expect("genesis block must exist");
-    assert_eq!(genesis_block.parent_id(), HashValue::zero());
-
-    assert_eq!(block_store.len(), 1);
-    assert_eq!(block_store.child_links(), block_store.len() - 1);
-    assert!(block_store.block_exists(genesis_block.id()));
-
-    // a1 -> round 1
-    let a1_r1 = inserter
-        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 1)
-        .await;
-    let a2_r2 = inserter.insert_block(&a1_r1, 2, None).await;
-    let a3_r3 = inserter.insert_block(&a2_r2, 3, None).await;
-    let b1_r4 = inserter
-        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 4)
-        .await;
-    let b2_r5 = inserter.insert_block(&b1_r4, 5, None).await;
-    let c1_r6 = inserter.insert_block(&b1_r4, 6, None).await;
-
-    let pipelined_blocks: [Arc<PipelinedBlock>; 7] =
-        [genesis_block, a1_r1, a2_r2, a3_r3, b1_r4, b2_r5, c1_r6];
-
-    (inserter, block_store, pipelined_blocks)
-}
-
-/// Create a block tree with forks. Similar to [`create_block_tree_with_forks`](create_block_tree_with_forks)
-/// but blocks within a fork are not strictly sequentially increasing in round.
-///
-/// e.g., A1 = round 1, A2 = round 3, A3 = round 6
-///
-/// ```text
-///       ╭--> A1--> A2--> A3--> A4
-/// Genesis--> B1--> B2--> B3
-///             ╰--> C1
-///             ╰--> D1
-/// ```
-///
-/// WARNING: Be wary of changing this function, it will affect consumers downstream
-async fn create_block_tree_with_forks_unordered_parents(
-    window_size: Option<u64>,
-) -> (TreeInserter, Arc<BlockStore>, [Arc<PipelinedBlock>; 10]) {
-    let validator_signer = ValidatorSigner::random(None);
-    let mut inserter = TreeInserter::new_with_params(
-        validator_signer,
-        window_size,
-        DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM,
-    );
-    let block_store = inserter.block_store();
-    let genesis = block_store.ordered_root();
-    let genesis_block_id = genesis.id();
-    let genesis_block = block_store
-        .get_block(genesis_block_id)
-        .expect("genesis block must exist");
-    assert_eq!(genesis_block.parent_id(), HashValue::zero());
-
-    assert_eq!(block_store.len(), 1);
-    assert_eq!(block_store.child_links(), block_store.len() - 1);
-    assert!(block_store.block_exists(genesis_block.id()));
-
-    // a1 -> round 1
-    let a1_r1 = inserter
-        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 1)
-        .await;
-    let b1_r2 = inserter
-        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 2)
-        .await;
-    let a2_r3 = inserter.insert_block(&a1_r1, 3, None).await;
-    let b2_r4 = inserter.insert_block(&b1_r2, 4, None).await;
-    let b3_r5 = inserter.insert_block(&b2_r4, 5, None).await;
-    let a3_r6 = inserter.insert_block(&a2_r3, 6, None).await;
-    let c1_r7 = inserter.insert_block(&b1_r2, 7, None).await;
-    let d1_r8 = inserter.insert_block(&b1_r2, 8, None).await;
-    let a4_r9 = inserter
-        .insert_block(&a3_r6, 9, Some(genesis.block_info()))
-        .await;
-
-    let pipelined_blocks: [Arc<PipelinedBlock>; 10] = [
-        genesis_block,
-        a1_r1,
-        a2_r3,
-        a3_r6,
-        a4_r9,
-        b1_r2,
-        b2_r4,
-        b3_r5,
-        c1_r7,
-        d1_r8,
-    ];
-
-    (inserter, block_store, pipelined_blocks)
-}
-
-/// Same as [`create_block_tree_with_forks_unordered_parents`](create_block_tree_with_forks_unordered_parents)
-/// but makes `a4_r9` a nil block and `b2_r4` a nil block. This is to test that nil blocks have
-/// windows. See the test case below.
-async fn create_block_tree_with_forks_unordered_parents_and_nil_blocks(
-    window_size: Option<u64>,
-) -> (TreeInserter, Arc<BlockStore>, [Arc<PipelinedBlock>; 10]) {
-    let validator_signer = ValidatorSigner::random(None);
-    let mut inserter = TreeInserter::new_with_params(
-        validator_signer,
-        window_size,
-        DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM,
-    );
-    let block_store = inserter.block_store();
-    let genesis = block_store.ordered_root();
-    let genesis_block_id = genesis.id();
-    let genesis_block = block_store
-        .get_block(genesis_block_id)
-        .expect("genesis block must exist");
-    assert_eq!(genesis_block.parent_id(), HashValue::zero());
-
-    assert_eq!(block_store.len(), 1);
-    assert_eq!(block_store.child_links(), block_store.len() - 1);
-    assert!(block_store.block_exists(genesis_block.id()));
-
-    // a1 -> round 1
-    let a1_r1 = inserter
-        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 1)
-        .await;
-    let b1_r2 = inserter
-        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 2)
-        .await;
-    let a2_r3 = inserter.insert_block(&a1_r1, 3, None).await;
-
-    // Nil block
-    let b2_r4 = inserter.insert_nil_block(&b1_r2, 4, None).await;
-    let b3_r5 = inserter.insert_block(&b2_r4, 5, None).await;
-    let a3_r6 = inserter.insert_block(&a2_r3, 6, None).await;
-    let c1_r7 = inserter.insert_block(&b1_r2, 7, None).await;
-    let d1_r8 = inserter.insert_block(&b1_r2, 8, None).await;
-
-    // Nil block
-    let a4_r9 = inserter
-        .insert_nil_block(&a3_r6, 9, Some(genesis.block_info()))
-        .await;
-
-    let pipelined_blocks: [Arc<PipelinedBlock>; 10] = [
-        genesis_block,
-        a1_r1,
-        a2_r3,
-        a3_r6,
-        a4_r9,
-        b1_r2,
-        b2_r4,
-        b3_r5,
-        c1_r7,
-        d1_r8,
-    ];
-
-    (inserter, block_store, pipelined_blocks)
-}
+use proptest::{prop_assert, prop_assert_eq, proptest};
+use std::collections::HashSet;
 
 /// Check the following:
 /// 1. [`OrderedBlockWindow`](aptos_consensus_types::pipelined_block::OrderedBlockWindow)
@@ -305,6 +44,7 @@ async fn test_execution_pool_block_window_3_no_commit() {
         validator_signer,
         window_size,
         DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM,
+        None,
     );
     let block_store = inserter.block_store();
     let mut round: Round = 0;
@@ -508,10 +248,7 @@ async fn test_window_root_window_size_0_failure() {
 
     // Window size must be greater than 0, should panic
     let window_size = Some(0u64);
-    block_store
-        .inner
-        .read()
-        .find_window_root(genesis_block.id(), window_size);
+    block_store.find_window_root(genesis_block.id(), window_size);
 }
 
 #[tokio::test]
@@ -524,7 +261,7 @@ async fn test_window_root_no_forks() {
 
     // Genesis ──> A1 ──> ... ──> A4
     let [genesis_block, a1, a2, _, a4] = pipelined_blocks;
-    let (commit_root, window_root) = get_roots(a4.block(), block_store.clone(), window_size);
+    let (commit_root, window_root) = block_store.get_roots(a4.block(), window_size);
     let block_window =
         get_blocks_from_block_store_and_window(block_store.clone(), a4.block(), window_size);
 
@@ -541,7 +278,7 @@ async fn test_window_root_no_forks() {
 
     // Prune A2
     block_store.prune_tree(a2.id());
-    let (commit_root, window_root) = get_roots(a4.block(), block_store.clone(), window_size);
+    let (commit_root, window_root) = block_store.get_roots(a4.block(), window_size);
     let block_window =
         get_blocks_from_block_store_and_window(block_store.clone(), a4.block(), window_size);
 
@@ -565,7 +302,7 @@ async fn test_window_root_no_forks() {
 
     // Genesis ──> A1 ──> ... ──> A4
     let [genesis_block, _, a2, a3, a4] = pipelined_blocks;
-    let (commit_root, window_root) = get_roots(a4.block(), block_store.clone(), window_size);
+    let (commit_root, window_root) = block_store.get_roots(a4.block(), window_size);
     let block_window =
         get_blocks_from_block_store_and_window(block_store.clone(), a4.block(), window_size);
 
@@ -582,7 +319,7 @@ async fn test_window_root_no_forks() {
 
     // Prune A2
     block_store.prune_tree(a2.id());
-    let (commit_root, window_root) = get_roots(a4.block(), block_store.clone(), window_size);
+    let (commit_root, window_root) = block_store.get_roots(a4.block(), window_size);
     let block_window =
         get_blocks_from_block_store_and_window(block_store.clone(), a4.block(), window_size);
 
@@ -608,7 +345,7 @@ async fn test_window_root_with_forks() {
     //             ╰--> C1
     let (_, block_store, pipelined_blocks) = create_block_tree_with_forks(window_size).await;
     let [genesis_block, a1, _a2, a3, _b1, _b2, _c1] = pipelined_blocks;
-    let (commit_root, window_root) = get_roots(a3.block(), block_store.clone(), window_size);
+    let (commit_root, window_root) = block_store.get_roots(a3.block(), window_size);
     let block_window =
         get_blocks_from_block_store_and_window(block_store.clone(), a3.block(), window_size);
 
@@ -627,7 +364,7 @@ async fn test_window_root_with_forks() {
 
     // Prune A1
     block_store.prune_tree(a1.id());
-    let (commit_root, window_root) = get_roots(a3.block(), block_store.clone(), window_size);
+    let (commit_root, window_root) = block_store.get_roots(a3.block(), window_size);
     let block_window =
         get_blocks_from_block_store_and_window(block_store.clone(), a3.block(), window_size);
 
@@ -653,7 +390,7 @@ async fn test_window_root_with_forks() {
     let (_, block_store, pipelined_blocks) = create_block_tree_with_forks(window_size).await;
     let [genesis_block, _a1, _a2, _a3, b1, _b2, c1] = pipelined_blocks;
     let current_block = c1.block();
-    let (commit_root, window_root) = get_roots(current_block, block_store.clone(), window_size);
+    let (commit_root, window_root) = block_store.get_roots(current_block, window_size);
     let block_window =
         get_blocks_from_block_store_and_window(block_store.clone(), current_block, window_size);
 
@@ -669,7 +406,7 @@ async fn test_window_root_with_forks() {
 
     // Prune B1
     block_store.prune_tree(b1.id());
-    let (commit_root, window_root) = get_roots(c1.block(), block_store.clone(), window_size);
+    let (commit_root, window_root) = block_store.get_roots(c1.block(), window_size);
     let block_window =
         get_blocks_from_block_store_and_window(block_store.clone(), c1.block(), window_size);
 
@@ -698,7 +435,7 @@ async fn test_window_root_with_non_sequential_round_forks() {
     let [genesis_block, a1_r1, a2_r3, a3_r6, a4_r9, _b1_r2, _b2_r4, _b3_r5, _c1_r7, _d1_r8] =
         pipelined_blocks;
     let current_block = a4_r9.block();
-    let (commit_root, window_root) = get_roots(current_block, block_store.clone(), window_size);
+    let (commit_root, window_root) = block_store.get_roots(current_block, window_size);
     let block_window =
         get_blocks_from_block_store_and_window(block_store.clone(), current_block, window_size);
 
@@ -718,7 +455,7 @@ async fn test_window_root_with_non_sequential_round_forks() {
 
     // expand window size to 7
     let window_size = Some(7u64);
-    let (commit_root, window_root) = get_roots(current_block, block_store.clone(), window_size);
+    let (commit_root, window_root) = block_store.get_roots(current_block, window_size);
     let block_window =
         get_blocks_from_block_store_and_window(block_store.clone(), current_block, window_size);
 
@@ -741,7 +478,7 @@ async fn test_window_root_with_non_sequential_round_forks() {
 
     // Expand window_size to 100
     let window_size = Some(100u64);
-    let (commit_root, window_root) = get_roots(current_block, block_store.clone(), window_size);
+    let (commit_root, window_root) = block_store.get_roots(current_block, window_size);
     let block_window =
         get_blocks_from_block_store_and_window(block_store.clone(), current_block, window_size);
 
@@ -766,7 +503,7 @@ async fn test_window_root_with_non_sequential_round_forks() {
 
     // Prune a2
     block_store.prune_tree(a2_r3.id());
-    let (commit_root, window_root) = get_roots(current_block, block_store.clone(), window_size);
+    let (commit_root, window_root) = block_store.get_roots(current_block, window_size);
     let block_window =
         get_blocks_from_block_store_and_window(block_store.clone(), current_block, window_size);
 
@@ -806,7 +543,7 @@ async fn test_window_root_with_non_sequential_round_forks_and_nil_blocks() {
 
     // a4_r9 is the nil block
     let current_block = a4_r9.block();
-    let (commit_root, window_root) = get_roots(current_block, block_store.clone(), window_size);
+    let (commit_root, window_root) = block_store.get_roots(current_block, window_size);
     let block_window =
         get_blocks_from_block_store_and_window(block_store.clone(), current_block, window_size);
 
@@ -833,4 +570,78 @@ async fn test_window_root_with_non_sequential_round_forks_and_nil_blocks() {
     assert_eq!(block_window.get(1).unwrap().id(), b2_r4.id());
     assert!(b2_r4.block().is_nil_block());
     assert_eq!(block_window.len(), 2);
+}
+
+proptest! {
+    /// Test block window during block_store insertion
+    /// Inspired by [`test_block_store_insert`](crate::block_storage::block_store::block_store_test::test_block_store_insert)
+    #[test]
+    fn test_window_block_store_insert(
+        (private_keys, blocks) in block_test_utils::block_forest_and_its_keys(
+            10, // quorum size
+            50 // recursion depth
+        )
+    ){
+        let window_size = Some(3u64);
+        let authors: HashSet<Author> = private_keys.iter().map(
+            // match the signer_strategy in validator_signer.rs
+            |key| Author::from_bytes(&key.public_key().to_bytes()[0..32]).unwrap()
+        ).collect();
+        let runtime = consensus_runtime();
+        let block_store = build_custom_empty_tree(
+            window_size,
+            10usize, // max_pruned_blocks_in_mem
+            None
+        );
+        for block in blocks {
+            if block.round() > 0 && authors.contains(&block.author().unwrap()) {
+                let known_parent = block_store.block_exists(block.parent_id());
+                let certified_parent = block.quorum_cert().certified_block().id() == block.parent_id();
+                let verify_res = block.verify_well_formed();
+                let res = timed_block_on(&runtime, block_store.insert_block(block.clone()));
+                // assert_eq!(block.round(), 3);
+                if !certified_parent {
+                    prop_assert!(verify_res.is_err());
+                } else if !known_parent {
+                    // We cannot really bring blocks in this test because the block retrieval
+                    // functionality invokes event processing, which is not setup here.
+                    assert!(res.is_err());
+                }
+                else {
+                    // The parent must be present if we get to this line.
+                    let parent = block_store.get_block(block.parent_id()).unwrap();
+                    let ordered_block_window = get_blocks_from_block_store_and_window(block_store.clone(), &block, window_size);
+
+                    assert_eq!(block.round(), 3);
+
+                    // First block in the window must be the window root
+                    prop_assert_eq!(
+                        ordered_block_window.first().unwrap().id(),
+                        block_store.window_root().id(),
+                        "first block in ordered block window does not match window_root"
+                    );
+
+                    // TODO, in the beginning this shouldn't be true right?
+                    // There should be (window_size - 1) blocks in the window
+                    if let Some(window_size) = window_size {
+                        prop_assert_eq!(
+                            ordered_block_window.len() as u64,
+                            window_size - 1,
+                            "length of ordered block window is not (window_size - 1)"
+                        );
+                    }
+
+                    // TODO assertions on commit_root vs window_root positioning
+                    if block.round() <= parent.round() {
+                        prop_assert!(res.is_err());
+                    } else {
+                        let executed_block = res.unwrap();
+                        prop_assert_eq!(executed_block.block(),
+                             &block,
+                            "expected ok on block: {:#?}, got {:#?}", block, executed_block.block());
+                    }
+                }
+            }
+        }
+    }
 }

--- a/consensus/src/block_storage/execution_pool/common.rs
+++ b/consensus/src/block_storage/execution_pool/common.rs
@@ -1,0 +1,271 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    block_storage::{BlockReader, BlockStore},
+    test_utils::TreeInserter,
+};
+use aptos_consensus_types::{
+    block::{block_test_utils::certificate_for_genesis, Block},
+    pipelined_block::PipelinedBlock,
+};
+use aptos_crypto::HashValue;
+use aptos_types::validator_signer::ValidatorSigner;
+use std::sync::Arc;
+
+pub const DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM: usize = 10;
+
+/// Helper function to get the [`OrderedBlockWindow`](aptos_consensus_types::pipelined_block::OrderedBlockWindow)
+/// from the `block_store`
+pub fn get_blocks_from_block_store_and_window(
+    block_store: Arc<BlockStore>,
+    block: &Block,
+    window_size: Option<u64>,
+) -> Vec<Block> {
+    let windowed_blocks = block_store.get_ordered_block_window(block, window_size);
+    let ordered_block_window = windowed_blocks.expect("Expected valid OrderedBlockWindow");
+    ordered_block_window.blocks().to_owned()
+}
+
+/// Helper function to create a block tree of size `N` with no forks
+/// ```text
+/// +--------------+       +---------+       +---------+       +---------+       +---------+
+/// | Genesis Block| ----> | Block 1 | ----> | Block 2 | ----> | Block 3 | ----> | Block 4 | --> ...
+/// +--------------+       +---------+       +---------+       +---------+       +---------+
+/// ```
+///
+/// NOTE: `num_blocks` includes the genesis block
+pub async fn create_block_tree_no_forks_inner<const N: usize>(
+    num_blocks: u64,
+    window_size: Option<u64>,
+    max_pruned_blocks_in_mem: usize,
+) -> (TreeInserter, Arc<BlockStore>, [Arc<PipelinedBlock>; N]) {
+    let validator_signer = ValidatorSigner::random(None);
+    let mut inserter = TreeInserter::new_with_params(
+        validator_signer,
+        window_size,
+        max_pruned_blocks_in_mem,
+        None,
+    );
+    let block_store = inserter.block_store();
+
+    // Block Store is initialized with a genesis block
+    let genesis_pipelined_block = block_store
+        .get_block(block_store.ordered_root().id())
+        .expect("No genesis block found in BlockStore");
+    assert!(genesis_pipelined_block.block().is_genesis_block());
+    assert_eq!(genesis_pipelined_block.parent_id(), HashValue::zero());
+    let mut cur_node = genesis_pipelined_block.clone();
+
+    // num_blocks + 1
+    let mut pipelined_blocks = Vec::with_capacity(num_blocks as usize);
+    pipelined_blocks.push(genesis_pipelined_block.clone());
+
+    // Adds `num_blocks` blocks to the block_store
+    for round in 1..num_blocks {
+        if round == 1 {
+            cur_node = inserter
+                .insert_block_with_qc(certificate_for_genesis(), &genesis_pipelined_block, round)
+                .await;
+        } else {
+            cur_node = inserter.insert_block(&cur_node, round, None).await;
+        }
+        pipelined_blocks.push(cur_node.clone());
+    }
+    let pipelined_blocks: [Arc<PipelinedBlock>; N] = pipelined_blocks
+        .try_into()
+        .expect("Unexpected error converting fixed size vector into fixed size array. Ensure the generic `N` is equal to `num_blocks`");
+
+    (inserter, block_store, pipelined_blocks)
+}
+
+/// Same as [`create_block_tree_no_forks_inner`](create_block_tree_no_forks_inner) defined above
+/// however ths includes a default for `max_pruned_blocks_in_mem` of 10
+pub async fn create_block_tree_no_forks<const N: usize>(
+    num_blocks: u64,
+    window_size: Option<u64>,
+) -> (TreeInserter, Arc<BlockStore>, [Arc<PipelinedBlock>; N]) {
+    create_block_tree_no_forks_inner(num_blocks, window_size, DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM)
+        .await
+}
+
+/// Create a block tree with forks. Similar to [`build_simple_tree`](crate::test_utils::build_simple_tree)
+/// Returns the following tree.
+///
+/// ```text
+///       ╭--> A1--> A2--> A3
+/// Genesis--> B1--> B2
+///             ╰--> C1
+/// ```
+///
+/// WARNING: Be wary of changing this function, it will affect consumers downstream
+#[cfg(test)]
+pub async fn create_block_tree_with_forks(
+    window_size: Option<u64>,
+) -> (TreeInserter, Arc<BlockStore>, [Arc<PipelinedBlock>; 7]) {
+    let validator_signer = ValidatorSigner::random(None);
+    let mut inserter = TreeInserter::new_with_params(
+        validator_signer,
+        window_size,
+        DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM,
+        None,
+    );
+    let block_store = inserter.block_store();
+    let genesis = block_store.ordered_root();
+    let genesis_block_id = genesis.id();
+    let genesis_block = block_store
+        .get_block(genesis_block_id)
+        .expect("genesis block must exist");
+    assert_eq!(genesis_block.parent_id(), HashValue::zero());
+
+    assert_eq!(block_store.len(), 1);
+    assert_eq!(block_store.child_links(), block_store.len() - 1);
+    assert!(block_store.block_exists(genesis_block.id()));
+
+    // a1 -> round 1
+    let a1_r1 = inserter
+        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 1)
+        .await;
+    let a2_r2 = inserter.insert_block(&a1_r1, 2, None).await;
+    let a3_r3 = inserter.insert_block(&a2_r2, 3, None).await;
+    let b1_r4 = inserter
+        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 4)
+        .await;
+    let b2_r5 = inserter.insert_block(&b1_r4, 5, None).await;
+    let c1_r6 = inserter.insert_block(&b1_r4, 6, None).await;
+
+    let pipelined_blocks: [Arc<PipelinedBlock>; 7] =
+        [genesis_block, a1_r1, a2_r2, a3_r3, b1_r4, b2_r5, c1_r6];
+
+    (inserter, block_store, pipelined_blocks)
+}
+
+/// Create a block tree with forks. Similar to [`create_block_tree_with_forks`](create_block_tree_with_forks)
+/// but blocks within a fork are not strictly sequentially increasing in round.
+///
+/// e.g., A1 = round 1, A2 = round 3, A3 = round 6
+///
+/// ```text
+///       ╭--> A1--> A2--> A3--> A4
+/// Genesis--> B1--> B2--> B3
+///             ╰--> C1
+///             ╰--> D1
+/// ```
+///
+/// WARNING: Be wary of changing this function, it will affect consumers downstream
+pub async fn create_block_tree_with_forks_unordered_parents(
+    window_size: Option<u64>,
+) -> (TreeInserter, Arc<BlockStore>, [Arc<PipelinedBlock>; 10]) {
+    let validator_signer = ValidatorSigner::random(None);
+    let mut inserter = TreeInserter::new_with_params(
+        validator_signer,
+        window_size,
+        DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM,
+        None,
+    );
+    let block_store = inserter.block_store();
+    let genesis = block_store.ordered_root();
+    let genesis_block_id = genesis.id();
+    let genesis_block = block_store
+        .get_block(genesis_block_id)
+        .expect("genesis block must exist");
+    assert_eq!(genesis_block.parent_id(), HashValue::zero());
+
+    assert_eq!(block_store.len(), 1);
+    assert_eq!(block_store.child_links(), block_store.len() - 1);
+    assert!(block_store.block_exists(genesis_block.id()));
+
+    // a1 -> round 1
+    let a1_r1 = inserter
+        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 1)
+        .await;
+    let b1_r2 = inserter
+        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 2)
+        .await;
+    let a2_r3 = inserter.insert_block(&a1_r1, 3, None).await;
+    let b2_r4 = inserter.insert_block(&b1_r2, 4, None).await;
+    let b3_r5 = inserter.insert_block(&b2_r4, 5, None).await;
+    let a3_r6 = inserter.insert_block(&a2_r3, 6, None).await;
+    let c1_r7 = inserter.insert_block(&b1_r2, 7, None).await;
+    let d1_r8 = inserter.insert_block(&b1_r2, 8, None).await;
+    let a4_r9 = inserter
+        .insert_block(&a3_r6, 9, Some(genesis.block_info()))
+        .await;
+
+    let pipelined_blocks: [Arc<PipelinedBlock>; 10] = [
+        genesis_block,
+        a1_r1,
+        a2_r3,
+        a3_r6,
+        a4_r9,
+        b1_r2,
+        b2_r4,
+        b3_r5,
+        c1_r7,
+        d1_r8,
+    ];
+
+    (inserter, block_store, pipelined_blocks)
+}
+
+/// Same as [`create_block_tree_with_forks_unordered_parents`](create_block_tree_with_forks_unordered_parents)
+/// but makes `a4_r9` a nil block and `b2_r4` a nil block. This is to test that nil blocks have
+/// windows. See the test case below.
+pub async fn create_block_tree_with_forks_unordered_parents_and_nil_blocks(
+    window_size: Option<u64>,
+) -> (TreeInserter, Arc<BlockStore>, [Arc<PipelinedBlock>; 10]) {
+    let validator_signer = ValidatorSigner::random(None);
+    let mut inserter = TreeInserter::new_with_params(
+        validator_signer,
+        window_size,
+        DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM,
+        None,
+    );
+    let block_store = inserter.block_store();
+    let genesis = block_store.ordered_root();
+    let genesis_block_id = genesis.id();
+    let genesis_block = block_store
+        .get_block(genesis_block_id)
+        .expect("genesis block must exist");
+    assert_eq!(genesis_block.parent_id(), HashValue::zero());
+
+    assert_eq!(block_store.len(), 1);
+    assert_eq!(block_store.child_links(), block_store.len() - 1);
+    assert!(block_store.block_exists(genesis_block.id()));
+
+    // a1 -> round 1
+    let a1_r1 = inserter
+        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 1)
+        .await;
+    let b1_r2 = inserter
+        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 2)
+        .await;
+    let a2_r3 = inserter.insert_block(&a1_r1, 3, None).await;
+
+    // Nil block
+    let b2_r4 = inserter.insert_nil_block(&b1_r2, 4, None).await;
+    let b3_r5 = inserter.insert_block(&b2_r4, 5, None).await;
+    let a3_r6 = inserter.insert_block(&a2_r3, 6, None).await;
+    let c1_r7 = inserter.insert_block(&b1_r2, 7, None).await;
+    let d1_r8 = inserter.insert_block(&b1_r2, 8, None).await;
+
+    // Nil block
+    let a4_r9 = inserter
+        .insert_nil_block(&a3_r6, 9, Some(genesis.block_info()))
+        .await;
+
+    let pipelined_blocks: [Arc<PipelinedBlock>; 10] = [
+        genesis_block,
+        a1_r1,
+        a2_r3,
+        a3_r6,
+        a4_r9,
+        b1_r2,
+        b2_r4,
+        b3_r5,
+        c1_r7,
+        d1_r8,
+    ];
+
+    (inserter, block_store, pipelined_blocks)
+}

--- a/consensus/src/block_storage/execution_pool/common_test.rs
+++ b/consensus/src/block_storage/execution_pool/common_test.rs
@@ -217,12 +217,17 @@ pub async fn create_block_tree_with_forks_unordered_parents(
         .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 2)
         .await;
 
+    // NOTE: we are adding a1_r1 as the committed block here in insert_block
+    // This is important for setting the right QuorumCert for commit_callback in tests
     let a2_r3 = inserter
         .insert_block(&a1_r1, 3, Some(a1_r1.block_info()))
         .await;
 
     let b2_r4 = inserter.insert_block(&b1_r2, 4, None).await;
     let b3_r5 = inserter.insert_block(&b2_r4, 5, None).await;
+
+    // NOTE: we are adding a2_r3 as the committed block here in insert_block
+    // This is important for setting the right QuorumCert for commit_callback in tests
     let a3_r6 = inserter
         .insert_block(&a2_r3, 6, Some(a2_r3.block_info()))
         .await;

--- a/consensus/src/block_storage/execution_pool/mod.rs
+++ b/consensus/src/block_storage/execution_pool/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(test)]
-pub(crate) mod common;
+pub(crate) mod common_test;
 
 #[cfg(test)]
 mod block_window_test;

--- a/consensus/src/block_storage/execution_pool/mod.rs
+++ b/consensus/src/block_storage/execution_pool/mod.rs
@@ -1,0 +1,11 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+pub(crate) mod common;
+
+#[cfg(test)]
+mod block_window_test;
+
+#[cfg(test)]
+mod target_block_retrieval_test;

--- a/consensus/src/block_storage/execution_pool/target_block_retrieval_test.rs
+++ b/consensus/src/block_storage/execution_pool/target_block_retrieval_test.rs
@@ -1,0 +1,45 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::block_storage::{
+    block_store::sync_manager::TargetBlockRetrieval,
+    execution_pool::common::create_block_tree_with_forks_unordered_parents, BlockReader,
+    BlockStore,
+};
+
+#[tokio::test]
+async fn test_no_window_quorum_round_greater_than_commit_round() {
+    let window_size: Option<u64> = None;
+    let (_, block_store, pipelined_blocks) =
+        create_block_tree_with_forks_unordered_parents(window_size).await;
+    let [genesis_block, _a1_r1, _a2_r3, _a3_r6, a4_r9, _b1_r2, _b2_r4, _b3_r5, _c1_r7, _d1_r8] =
+        pipelined_blocks;
+
+    let commit_root = block_store.commit_root().id();
+    assert_eq!(commit_root, genesis_block.id());
+
+    // Use a4_r9 as an example of a quorum cert
+    let qc = a4_r9.quorum_cert().clone();
+    let qc_round = qc.certified_block().round();
+    let commit = qc.into_wrapped_ledger_info();
+    let commit_round = commit.commit_info().round();
+
+    assert_eq!(qc_round, 6);
+    assert_eq!(commit_round, 0);
+
+    let (payload, num_blocks) = BlockStore::generate_target_block_retrieval_payload_and_num_blocks(
+        &qc,
+        &commit,
+        window_size,
+    );
+
+    match payload {
+        TargetBlockRetrieval::TargetBlockId(id) => {
+            assert_eq!(id, genesis_block.id());
+            assert_eq!(num_blocks, 7);
+        },
+        TargetBlockRetrieval::TargetRound(_) => {
+            panic!("Should not be TargetRound variant")
+        },
+    }
+}

--- a/consensus/src/block_storage/execution_pool_test.rs
+++ b/consensus/src/block_storage/execution_pool_test.rs
@@ -1,0 +1,836 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for Execution Pool and their behaviors on the block_store
+//!
+//! Note: For the sake of testing, some functions use
+//! [`prune_tree`](BlockStore::prune_tree) to mimic some of the functionality present in
+//! [`commit_callback`](crate::block_storage::block_tree::BlockTree::commit_callback)
+//! however they are still different and should be treated as such. But this is why you may
+//! sometimes see the `window_root` behind the `commit_root`.
+//! This should not happen in production.
+
+use crate::{
+    block_storage::{BlockReader, BlockStore},
+    test_utils::TreeInserter,
+};
+use aptos_consensus_types::{
+    block::{block_test_utils::certificate_for_genesis, Block},
+    pipelined_block::PipelinedBlock,
+};
+use aptos_crypto::HashValue;
+use aptos_types::{block_info::Round, validator_signer::ValidatorSigner};
+use std::sync::Arc;
+
+const DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM: usize = 10;
+
+/// Helper function to get the [`OrderedBlockWindow`](aptos_consensus_types::pipelined_block::OrderedBlockWindow)
+/// from the `block_store`
+fn get_blocks_from_block_store_and_window(
+    block_store: Arc<BlockStore>,
+    block: &Block,
+    window_size: Option<u64>,
+) -> Vec<Block> {
+    let windowed_blocks = block_store
+        .inner
+        .read()
+        .get_ordered_block_window(block, window_size);
+    let ordered_block_window = windowed_blocks.unwrap();
+    ordered_block_window.blocks().unwrap().to_owned()
+}
+
+/// Helper function for getting `commit_root`, `window_root`
+/// NOTE: `block` is the reference block to base the window on
+fn get_roots(
+    block: &Block,
+    block_store: Arc<BlockStore>,
+    window_size: Option<u64>,
+) -> (Arc<PipelinedBlock>, Option<HashValue>) {
+    let block_store_inner_guard = block_store.inner.read();
+    let commit_root = block_store_inner_guard.commit_root();
+
+    let window_root = block_store_inner_guard.find_window_root(block.id(), window_size);
+
+    (commit_root, Some(window_root))
+}
+
+/// Helper function to create a block tree of size `N` with no forks
+/// ```text
+/// +--------------+       +---------+       +---------+       +---------+       +---------+
+/// | Genesis Block| ----> | Block 1 | ----> | Block 2 | ----> | Block 3 | ----> | Block 4 | --> ...
+/// +--------------+       +---------+       +---------+       +---------+       +---------+
+/// ```
+///
+/// NOTE: `num_blocks` includes the genesis block
+async fn create_block_tree_no_forks_inner<const N: usize>(
+    num_blocks: u64,
+    window_size: Option<u64>,
+    max_pruned_blocks_in_mem: usize,
+) -> (TreeInserter, Arc<BlockStore>, [Arc<PipelinedBlock>; N]) {
+    let validator_signer = ValidatorSigner::random(None);
+    let mut inserter =
+        TreeInserter::new_with_params(validator_signer, window_size, max_pruned_blocks_in_mem);
+    let block_store = inserter.block_store();
+
+    // Block Store is initialized with a genesis block
+    let genesis_pipelined_block = block_store
+        .get_block(block_store.ordered_root().id())
+        .unwrap();
+    assert!(genesis_pipelined_block.block().is_genesis_block());
+    assert_eq!(genesis_pipelined_block.parent_id(), HashValue::zero());
+    let mut cur_node = genesis_pipelined_block.clone();
+
+    // num_blocks + 1
+    let mut pipelined_blocks = Vec::with_capacity(num_blocks as usize);
+    pipelined_blocks.push(genesis_pipelined_block.clone());
+
+    // Adds `num_blocks` blocks to the block_store
+    for round in 1..num_blocks {
+        if round == 1 {
+            cur_node = inserter
+                .insert_block_with_qc(certificate_for_genesis(), &genesis_pipelined_block, round)
+                .await;
+        } else {
+            cur_node = inserter.insert_block(&cur_node, round, None).await;
+        }
+        pipelined_blocks.push(cur_node.clone());
+    }
+    let pipelined_blocks: [Arc<PipelinedBlock>; N] = pipelined_blocks
+        .try_into()
+        .expect("Unexpected error converting fixed size vector into fixed size array. Ensure the generic `N` is equal to `num_blocks`");
+
+    (inserter, block_store, pipelined_blocks)
+}
+
+/// Same as [`create_block_tree_no_forks_inner`](create_block_tree_no_forks_inner) defined above
+/// however ths includes a default for `max_pruned_blocks_in_mem` of 10
+async fn create_block_tree_no_forks<const N: usize>(
+    num_blocks: u64,
+    window_size: Option<u64>,
+) -> (TreeInserter, Arc<BlockStore>, [Arc<PipelinedBlock>; N]) {
+    create_block_tree_no_forks_inner(num_blocks, window_size, DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM)
+        .await
+}
+
+/// Create a block tree with forks. Similar to [`build_simple_tree`](crate::test_utils::build_simple_tree)
+/// Returns the following tree.
+///
+/// ```text
+///       ╭--> A1--> A2--> A3
+/// Genesis--> B1--> B2
+///             ╰--> C1
+/// ```
+///
+/// WARNING: Be wary of changing this function, it will affect consumers downstream
+async fn create_block_tree_with_forks(
+    window_size: Option<u64>,
+) -> (TreeInserter, Arc<BlockStore>, [Arc<PipelinedBlock>; 7]) {
+    let validator_signer = ValidatorSigner::random(None);
+    let mut inserter = TreeInserter::new_with_params(
+        validator_signer,
+        window_size,
+        DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM,
+    );
+    let block_store = inserter.block_store();
+    let genesis = block_store.ordered_root();
+    let genesis_block_id = genesis.id();
+    let genesis_block = block_store
+        .get_block(genesis_block_id)
+        .expect("genesis block must exist");
+    assert_eq!(genesis_block.parent_id(), HashValue::zero());
+
+    assert_eq!(block_store.len(), 1);
+    assert_eq!(block_store.child_links(), block_store.len() - 1);
+    assert!(block_store.block_exists(genesis_block.id()));
+
+    // a1 -> round 1
+    let a1_r1 = inserter
+        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 1)
+        .await;
+    let a2_r2 = inserter.insert_block(&a1_r1, 2, None).await;
+    let a3_r3 = inserter.insert_block(&a2_r2, 3, None).await;
+    let b1_r4 = inserter
+        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 4)
+        .await;
+    let b2_r5 = inserter.insert_block(&b1_r4, 5, None).await;
+    let c1_r6 = inserter.insert_block(&b1_r4, 6, None).await;
+
+    let pipelined_blocks: [Arc<PipelinedBlock>; 7] =
+        [genesis_block, a1_r1, a2_r2, a3_r3, b1_r4, b2_r5, c1_r6];
+
+    (inserter, block_store, pipelined_blocks)
+}
+
+/// Create a block tree with forks. Similar to [`create_block_tree_with_forks`](create_block_tree_with_forks)
+/// but blocks within a fork are not strictly sequentially increasing in round.
+///
+/// e.g., A1 = round 1, A2 = round 3, A3 = round 6
+///
+/// ```text
+///       ╭--> A1--> A2--> A3--> A4
+/// Genesis--> B1--> B2--> B3
+///             ╰--> C1
+///             ╰--> D1
+/// ```
+///
+/// WARNING: Be wary of changing this function, it will affect consumers downstream
+async fn create_block_tree_with_forks_unordered_parents(
+    window_size: Option<u64>,
+) -> (TreeInserter, Arc<BlockStore>, [Arc<PipelinedBlock>; 10]) {
+    let validator_signer = ValidatorSigner::random(None);
+    let mut inserter = TreeInserter::new_with_params(
+        validator_signer,
+        window_size,
+        DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM,
+    );
+    let block_store = inserter.block_store();
+    let genesis = block_store.ordered_root();
+    let genesis_block_id = genesis.id();
+    let genesis_block = block_store
+        .get_block(genesis_block_id)
+        .expect("genesis block must exist");
+    assert_eq!(genesis_block.parent_id(), HashValue::zero());
+
+    assert_eq!(block_store.len(), 1);
+    assert_eq!(block_store.child_links(), block_store.len() - 1);
+    assert!(block_store.block_exists(genesis_block.id()));
+
+    // a1 -> round 1
+    let a1_r1 = inserter
+        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 1)
+        .await;
+    let b1_r2 = inserter
+        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 2)
+        .await;
+    let a2_r3 = inserter.insert_block(&a1_r1, 3, None).await;
+    let b2_r4 = inserter.insert_block(&b1_r2, 4, None).await;
+    let b3_r5 = inserter.insert_block(&b2_r4, 5, None).await;
+    let a3_r6 = inserter.insert_block(&a2_r3, 6, None).await;
+    let c1_r7 = inserter.insert_block(&b1_r2, 7, None).await;
+    let d1_r8 = inserter.insert_block(&b1_r2, 8, None).await;
+    let a4_r9 = inserter
+        .insert_block(&a3_r6, 9, Some(genesis.block_info()))
+        .await;
+
+    let pipelined_blocks: [Arc<PipelinedBlock>; 10] = [
+        genesis_block,
+        a1_r1,
+        a2_r3,
+        a3_r6,
+        a4_r9,
+        b1_r2,
+        b2_r4,
+        b3_r5,
+        c1_r7,
+        d1_r8,
+    ];
+
+    (inserter, block_store, pipelined_blocks)
+}
+
+/// Same as [`create_block_tree_with_forks_unordered_parents`](create_block_tree_with_forks_unordered_parents)
+/// but makes `a4_r9` a nil block and `b2_r4` a nil block. This is to test that nil blocks have
+/// windows. See the test case below.
+async fn create_block_tree_with_forks_unordered_parents_and_nil_blocks(
+    window_size: Option<u64>,
+) -> (TreeInserter, Arc<BlockStore>, [Arc<PipelinedBlock>; 10]) {
+    let validator_signer = ValidatorSigner::random(None);
+    let mut inserter = TreeInserter::new_with_params(
+        validator_signer,
+        window_size,
+        DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM,
+    );
+    let block_store = inserter.block_store();
+    let genesis = block_store.ordered_root();
+    let genesis_block_id = genesis.id();
+    let genesis_block = block_store
+        .get_block(genesis_block_id)
+        .expect("genesis block must exist");
+    assert_eq!(genesis_block.parent_id(), HashValue::zero());
+
+    assert_eq!(block_store.len(), 1);
+    assert_eq!(block_store.child_links(), block_store.len() - 1);
+    assert!(block_store.block_exists(genesis_block.id()));
+
+    // a1 -> round 1
+    let a1_r1 = inserter
+        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 1)
+        .await;
+    let b1_r2 = inserter
+        .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 2)
+        .await;
+    let a2_r3 = inserter.insert_block(&a1_r1, 3, None).await;
+
+    // Nil block
+    let b2_r4 = inserter.insert_nil_block(&b1_r2, 4, None).await;
+    let b3_r5 = inserter.insert_block(&b2_r4, 5, None).await;
+    let a3_r6 = inserter.insert_block(&a2_r3, 6, None).await;
+    let c1_r7 = inserter.insert_block(&b1_r2, 7, None).await;
+    let d1_r8 = inserter.insert_block(&b1_r2, 8, None).await;
+
+    // Nil block
+    let a4_r9 = inserter
+        .insert_nil_block(&a3_r6, 9, Some(genesis.block_info()))
+        .await;
+
+    let pipelined_blocks: [Arc<PipelinedBlock>; 10] = [
+        genesis_block,
+        a1_r1,
+        a2_r3,
+        a3_r6,
+        a4_r9,
+        b1_r2,
+        b2_r4,
+        b3_r5,
+        c1_r7,
+        d1_r8,
+    ];
+
+    (inserter, block_store, pipelined_blocks)
+}
+
+/// Check the following:
+/// 1. [`OrderedBlockWindow`](aptos_consensus_types::pipelined_block::OrderedBlockWindow)
+///    has a length of at most (window_size - 1) blocks
+/// 2. [`OrderedBlockWindow`](aptos_consensus_types::pipelined_block::OrderedBlockWindow)
+///    excludes the current block.
+/// 3. Block rounds are in ascending order (oldest -> newest).
+/// 4. Confirm that the genesis block is not included in the
+///    [`OrderedBlockWindow`](aptos_consensus_types::pipelined_block::OrderedBlockWindow).
+#[tokio::test]
+async fn test_execution_pool_block_window_3_no_commit() {
+    let window_size: Option<u64> = Some(3);
+    let validator_signer = ValidatorSigner::random(None);
+    let mut inserter = TreeInserter::new_with_params(
+        validator_signer,
+        window_size,
+        DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM,
+    );
+    let block_store = inserter.block_store();
+    let mut round: Round = 0;
+
+    // Block Store is initialized with a genesis block
+    let genesis_pipelined_block = block_store
+        .get_block(block_store.ordered_root().id())
+        .unwrap();
+    assert_eq!(genesis_pipelined_block.block().round(), 0);
+    assert_eq!(genesis_pipelined_block.parent_id(), HashValue::zero());
+    let mut curr_pipelined_block = genesis_pipelined_block.clone();
+
+    // | blocks inserted | window_size | round | ordered_block_window block count |
+    // |-----------------|-------------|-------|----------------------------------|
+    // | 0               | 3           | 0     | 0                                |
+    let block = curr_pipelined_block.block();
+    let blocks = get_blocks_from_block_store_and_window(block_store.clone(), block, window_size);
+    assert_eq!(blocks.len(), 0);
+
+    // | blocks inserted | window_size | round | ordered_block_window block count |
+    // |-----------------|-------------|-------|----------------------------------|
+    // | 1               | 3           | 1     | 0                                |
+    round += 1;
+    curr_pipelined_block = inserter
+        .insert_block(&curr_pipelined_block, round, None)
+        .await;
+    let block = curr_pipelined_block.block();
+    let blocks = get_blocks_from_block_store_and_window(block_store.clone(), block, window_size);
+
+    // Confirm that the genesis block is NOT included in the OrderedBlockWindow
+    assert_eq!(blocks.len(), 0);
+    assert_eq!(round, 1);
+
+    // | blocks inserted | window_size | round | ordered_block_window block count |
+    // |-----------------|-------------|-------|----------------------------------|
+    // | 2               | 3           | 2     | 1                                |
+    round += 1;
+    curr_pipelined_block = inserter
+        .insert_block(&curr_pipelined_block, round, None)
+        .await;
+    let blocks = get_blocks_from_block_store_and_window(
+        block_store.clone(),
+        curr_pipelined_block.block(),
+        window_size,
+    );
+    assert_eq!(blocks.len(), 1);
+    assert_eq!(blocks.first().unwrap().round(), 1);
+    assert_eq!(round, 2);
+
+    // | blocks inserted | window_size | round | ordered_block_window block count |
+    // |-----------------|-------------|-------|----------------------------------|
+    // | 3               | 3           | 3     | 2                                |
+    round += 1;
+    curr_pipelined_block = inserter
+        .insert_block(&curr_pipelined_block, round, None)
+        .await;
+    let blocks = get_blocks_from_block_store_and_window(
+        block_store.clone(),
+        curr_pipelined_block.block(),
+        window_size,
+    );
+    assert_eq!(blocks.len(), 2);
+    assert_eq!(blocks.first().unwrap().round(), 1);
+    assert_eq!(blocks.get(1).unwrap().round(), 2);
+    assert_eq!(round, 3);
+
+    // | blocks inserted | window_size | round | ordered_block_window block count |
+    // |-----------------|-------------|-------|----------------------------------|
+    // | 4               | 3           | 4     | 2                                |
+    round += 1;
+    curr_pipelined_block = inserter
+        .insert_block(&curr_pipelined_block, round, None)
+        .await;
+    let blocks = get_blocks_from_block_store_and_window(
+        block_store.clone(),
+        curr_pipelined_block.block(),
+        window_size,
+    );
+
+    // Max should be 2, even if more blocks are added since Max(len(OrderedBlockWindow)) = window_size - 1
+    assert_eq!(blocks.len(), 2);
+    assert_eq!(blocks.first().unwrap().round(), 2);
+    assert_eq!(blocks.get(1).unwrap().round(), 3);
+    assert_eq!(round, 4);
+}
+
+#[tokio::test]
+async fn test_execution_pool_block_window_with_forks() {
+    let window_size = Some(3u64);
+
+    //       ╭--> A1--> A2--> A3
+    // Genesis--> B1--> B2
+    //             ╰--> C1
+    let (_, block_store, pipelined_blocks) = create_block_tree_with_forks(window_size).await;
+    let [_, a1, a2, a3, b1, _, c1] = pipelined_blocks;
+
+    let ordered_root_pipelined_block = block_store.ordered_root();
+    assert_eq!(ordered_root_pipelined_block.round(), 0);
+
+    //             ┌──────────┐
+    // Genesis ──> │ A1 -> A2 │ ──> A3
+    //             └──────────┘
+    let ordered_blocks =
+        get_blocks_from_block_store_and_window(block_store.clone(), a3.block(), window_size);
+    assert_eq!(ordered_blocks.len(), 2);
+    assert_eq!(ordered_blocks.first().unwrap().id(), a1.id());
+    assert_eq!(ordered_blocks.get(1).unwrap().id(), a2.id());
+
+    //             ┌────┐
+    // Genesis ──> │ B1 │ ──> C1
+    //             └────┘
+    let ordered_blocks =
+        get_blocks_from_block_store_and_window(block_store.clone(), c1.block(), window_size);
+    assert_eq!(ordered_blocks.len(), 1);
+    assert_eq!(ordered_blocks.first().unwrap().id(), b1.id());
+}
+
+#[tokio::test]
+async fn test_execution_pool_window_size_greater_than_block_store() {
+    // window size > block store size
+    const NUM_BLOCKS: usize = 4;
+    let window_size = Some(10u64);
+
+    // Genesis ──> A1 ──> A2 ──> A3
+    let (_, block_store, pipelined_blocks) =
+        create_block_tree_no_forks::<{ NUM_BLOCKS }>(NUM_BLOCKS as u64, window_size).await;
+    let [_, a1, a2, a3] = pipelined_blocks;
+
+    //            ┌───────────┐
+    // Genesis ─> │ A1 ──> A2 │ ──> A3
+    //            └───────────┘
+    let blocks =
+        get_blocks_from_block_store_and_window(block_store.clone(), a3.block(), window_size);
+
+    assert_eq!(blocks.len(), 2);
+    assert_eq!(blocks.first().unwrap().id(), a1.id());
+    assert_eq!(blocks.get(1).unwrap().id(), a2.id());
+}
+
+#[tokio::test]
+async fn test_execution_pool_block_window_with_pruning() {
+    const NUM_BLOCKS: usize = 5;
+    let window_size = Some(3u64);
+
+    // Genesis ──> A1 ──> ... ──> A4
+    let (_, block_store, pipelined_blocks) =
+        create_block_tree_no_forks::<{ NUM_BLOCKS }>(NUM_BLOCKS as u64, window_size).await;
+    let [_, _, a2, a3, a4] = pipelined_blocks;
+
+    // A2 ──> ... ──> A4
+    block_store.prune_tree(a2.id());
+    let ordered_root = block_store.ordered_root();
+    let commit_root = block_store.commit_root();
+    assert_eq!(ordered_root.round(), 2);
+    assert_eq!(commit_root.round(), 2);
+
+    // ┌───────────┐
+    // │ A2 ──> A3 │ ──> A4
+    // └───────────┘
+    let blocks =
+        get_blocks_from_block_store_and_window(block_store.clone(), a4.block(), window_size);
+    assert_eq!(blocks.len(), 2);
+    assert_eq!(blocks.first().unwrap().id(), a2.id());
+    assert_eq!(blocks.get(1).unwrap().id(), a3.id())
+}
+
+/// `get_block_window` on a block that has been pruned. Should panic if the
+/// `max_pruned_blocks_in_mem` is 0.
+#[should_panic]
+#[tokio::test]
+async fn test_execution_pool_block_window_with_pruning_failure() {
+    const NUM_BLOCKS: usize = 5;
+    let window_size = Some(3u64);
+
+    // No pruned blocks are not kept in the block store if this is set to 0
+    let max_pruned_blocks_in_mem: usize = 0;
+    let (_, block_store, pipelined_blocks) = create_block_tree_no_forks_inner::<{ NUM_BLOCKS }>(
+        NUM_BLOCKS as u64,
+        window_size,
+        max_pruned_blocks_in_mem,
+    )
+    .await;
+    let [_, _, a2, a3, _] = pipelined_blocks;
+
+    block_store.prune_tree(a3.id());
+
+    // a2 was pruned, no longer exists in the block_store
+    get_blocks_from_block_store_and_window(block_store.clone(), a2.block(), window_size);
+}
+
+#[should_panic]
+#[tokio::test]
+async fn test_window_root_window_size_0_failure() {
+    const NUM_BLOCKS: usize = 5;
+    let window_size = Some(1u64);
+    let (_, block_store, pipelined_blocks) =
+        create_block_tree_no_forks::<{ NUM_BLOCKS }>(NUM_BLOCKS as u64, window_size).await;
+
+    // Genesis ──> A1 ──> ... ──> A4
+    let [genesis_block, _, _, _, _] = pipelined_blocks;
+
+    // Window size must be greater than 0, should panic
+    let window_size = Some(0u64);
+    block_store
+        .inner
+        .read()
+        .find_window_root(genesis_block.id(), window_size);
+}
+
+#[tokio::test]
+async fn test_window_root_no_forks() {
+    // window_size > NUM_BLOCKS
+    const NUM_BLOCKS: usize = 5;
+    let window_size = Some(8u64);
+    let (_, block_store, pipelined_blocks) =
+        create_block_tree_no_forks::<{ NUM_BLOCKS }>(NUM_BLOCKS as u64, window_size).await;
+
+    // Genesis ──> A1 ──> ... ──> A4
+    let [genesis_block, a1, a2, _, a4] = pipelined_blocks;
+    let (commit_root, window_root) = get_roots(a4.block(), block_store.clone(), window_size);
+    let block_window =
+        get_blocks_from_block_store_and_window(block_store.clone(), a4.block(), window_size);
+
+    // commit_root      block_window
+    //      ↓                ↓
+    //              ┌──────────────────┐
+    //  Genesis ──> │ A1 ──> A2 ──> A3 │ ──> A4
+    //              └──────────────────┘
+    //                ↑
+    //           window_root
+    assert_eq!(commit_root.id(), genesis_block.id());
+    assert_eq!(window_root.expect("Window root not found"), a1.id());
+    assert_eq!(block_window.len(), 3);
+
+    // Prune A2
+    block_store.prune_tree(a2.id());
+    let (commit_root, window_root) = get_roots(a4.block(), block_store.clone(), window_size);
+    let block_window =
+        get_blocks_from_block_store_and_window(block_store.clone(), a4.block(), window_size);
+
+    //                   commit_root
+    //                        │
+    //              ┌──────── ↓ ───────┐
+    //  Genesis ──> │ A1 ──> A2 ──> A3 │ ──> A4
+    //              └──────────────────┘
+    //                ↑
+    //           window_root
+    assert_eq!(commit_root.id(), a2.id());
+    assert_eq!(window_root.expect("Window root not found"), a1.id());
+    assert_eq!(block_window.len(), 3);
+
+    // ----------------------------------------------------------------------------------------- //
+
+    // window_size < NUM_BLOCKS
+    let window_size = Some(2u64);
+    let (_, block_store, pipelined_blocks) =
+        create_block_tree_no_forks::<{ NUM_BLOCKS }>(NUM_BLOCKS as u64, window_size).await;
+
+    // Genesis ──> A1 ──> ... ──> A4
+    let [genesis_block, _, a2, a3, a4] = pipelined_blocks;
+    let (commit_root, window_root) = get_roots(a4.block(), block_store.clone(), window_size);
+    let block_window =
+        get_blocks_from_block_store_and_window(block_store.clone(), a4.block(), window_size);
+
+    // commit_root              block_window
+    //      ↓                       ↓
+    //                            ┌────┐
+    //  Genesis ──> A1 ──> A2 ──> │ A3 │ ──> A4
+    //                            └────┘
+    //                              ↑
+    //                         window_root
+    assert_eq!(commit_root.id(), genesis_block.id());
+    assert_eq!(window_root.expect("Window root not found"), a3.id());
+    assert_eq!(block_window.len(), 1);
+
+    // Prune A2
+    block_store.prune_tree(a2.id());
+    let (commit_root, window_root) = get_roots(a4.block(), block_store.clone(), window_size);
+    let block_window =
+        get_blocks_from_block_store_and_window(block_store.clone(), a4.block(), window_size);
+
+    //               commit_root  block_window
+    //                      ↓       ↓
+    //                            ┌────┐
+    //  Genesis ──> A1 ──> A2 ──> │ A3 │ ──> A4
+    //                            └────┘
+    //                              ↑
+    //                         window_root
+    assert_eq!(commit_root.id(), a2.id());
+    assert_eq!(window_root.expect("Window root not found"), a3.id());
+    assert_eq!(block_window.len(), 1);
+}
+
+#[tokio::test]
+async fn test_window_root_with_forks() {
+    // window_size > length of longest fork
+    let window_size = Some(8u64);
+
+    //       ╭--> A1--> A2--> A3
+    // Genesis--> B1--> B2
+    //             ╰--> C1
+    let (_, block_store, pipelined_blocks) = create_block_tree_with_forks(window_size).await;
+    let [genesis_block, a1, _a2, a3, _b1, _b2, _c1] = pipelined_blocks;
+    let (commit_root, window_root) = get_roots(a3.block(), block_store.clone(), window_size);
+    let block_window =
+        get_blocks_from_block_store_and_window(block_store.clone(), a3.block(), window_size);
+
+    // commit_root   block_window
+    //      ↓             ↓
+    //              ┌───────────┐
+    //  Genesis ──> │ A1 ──> A2 │ ──> A3
+    //              └───────────┘
+    //                ↑
+    //          window_root
+    // NOTE: Window root calculations are done in two places: `find_window_root` and `find_root`, update
+    // both if needed
+    assert_eq!(commit_root.id(), genesis_block.id());
+    assert_eq!(window_root.expect("Window root not found"), a1.id());
+    assert_eq!(block_window.len(), 2);
+
+    // Prune A1
+    block_store.prune_tree(a1.id());
+    let (commit_root, window_root) = get_roots(a3.block(), block_store.clone(), window_size);
+    let block_window =
+        get_blocks_from_block_store_and_window(block_store.clone(), a3.block(), window_size);
+
+    //   commit_root   block_window
+    //           └────┐   ↓
+    //              ┌ ↓ ────────┐
+    //  Genesis ──> │ A1 ──> A2 │ ──> A3
+    //              └───────────┘
+    //                ↑
+    //          window_root
+    assert_eq!(commit_root.id(), a1.id());
+    assert_eq!(window_root.expect("Window root not found"), a1.id());
+    assert_eq!(block_window.len(), 2);
+
+    // ----------------------------------------------------------------------------------------- //
+
+    // window_size < length of longest fork
+    let window_size = Some(1u64);
+
+    //       ╭--> A1--> A2--> A3
+    // Genesis--> B1--> B2
+    //             ╰--> C1
+    let (_, block_store, pipelined_blocks) = create_block_tree_with_forks(window_size).await;
+    let [genesis_block, _a1, _a2, _a3, b1, _b2, c1] = pipelined_blocks;
+    let current_block = c1.block();
+    let (commit_root, window_root) = get_roots(current_block, block_store.clone(), window_size);
+    let block_window =
+        get_blocks_from_block_store_and_window(block_store.clone(), current_block, window_size);
+
+    // commit_root
+    //      ↓
+    //  Genesis ──> B1 ──> C1
+    //                     ↑
+    //               window_root
+    assert_eq!(commit_root.id(), genesis_block.id());
+    assert_eq!(window_root.unwrap(), c1.id());
+    // This is zero length because OrderedBlockWindow consists of (window_size - 1) blocks
+    assert_eq!(block_window.len(), 0);
+
+    // Prune B1
+    block_store.prune_tree(b1.id());
+    let (commit_root, window_root) = get_roots(c1.block(), block_store.clone(), window_size);
+    let block_window =
+        get_blocks_from_block_store_and_window(block_store.clone(), c1.block(), window_size);
+
+    //          commit_root
+    //               ↓
+    //  Genesis ──> B1 ──> C1
+    //                     ↑
+    //               window_root
+    assert_eq!(commit_root.id(), b1.id());
+    assert_eq!(window_root.unwrap(), c1.id());
+    assert_eq!(block_window.len(), 0);
+}
+
+/// Checks `(block in window).round > current_block.round() - window_size`
+#[tokio::test]
+async fn test_window_root_with_non_sequential_round_forks() {
+    // window_size > length of longest fork
+    let window_size = Some(6u64);
+
+    //       ╭--> A1--> A2--> A3--> A4
+    // Genesis--> B1--> B2--> B3
+    //             ╰--> C1
+    //             ╰--> D1
+    let (_, block_store, pipelined_blocks) =
+        create_block_tree_with_forks_unordered_parents(window_size).await;
+    let [genesis_block, a1_r1, a2_r3, a3_r6, a4_r9, _b1_r2, _b2_r4, _b3_r5, _c1_r7, _d1_r8] =
+        pipelined_blocks;
+    let current_block = a4_r9.block();
+    let (commit_root, window_root) = get_roots(current_block, block_store.clone(), window_size);
+    let block_window =
+        get_blocks_from_block_store_and_window(block_store.clone(), current_block, window_size);
+
+    // commit_root              window_root
+    //      ↓                        ↓
+    //                            ┌────┐
+    //  Genesis ──> A1 ──> A2 ──> │ A3 │ ──> A4
+    //                            └────┘
+    //                               ↑
+    //                          block_window
+    //
+    // (block in window).round > current_block.round() - window_size
+    // 3 ≯ 9 - 6, thus block A2 is not included
+    assert_eq!(commit_root.id(), genesis_block.id());
+    assert_eq!(window_root.expect("Window root not found"), a3_r6.id());
+    assert_eq!(block_window.len(), 1);
+
+    // expand window size to 7
+    let window_size = Some(7u64);
+    let (commit_root, window_root) = get_roots(current_block, block_store.clone(), window_size);
+    let block_window =
+        get_blocks_from_block_store_and_window(block_store.clone(), current_block, window_size);
+
+    // commit_root          block_window
+    //      ↓                    ↓
+    //                     ┌───────────┐
+    //  Genesis ──> A1 ──> │ A2 ──> A3 │ ──> A4
+    //                     └───────────┘
+    //                       ↑
+    //                  window_root
+    //
+    // (block in window).round > current_block.round() - window_size
+    // 3 > 9 - 7, thus block A2 is included
+    assert_eq!(commit_root.id(), genesis_block.id());
+    assert_eq!(window_root.expect("Window root not found"), a2_r3.id());
+    assert_eq!(block_window.len(), 2);
+
+    // Prune A1
+    block_store.prune_tree(a1_r1.id());
+
+    // Expand window_size to 100
+    let window_size = Some(100u64);
+    let (commit_root, window_root) = get_roots(current_block, block_store.clone(), window_size);
+    let block_window =
+        get_blocks_from_block_store_and_window(block_store.clone(), current_block, window_size);
+
+    //      commit_root  block_window
+    //            └───┐       ↓
+    //              ┌ ↓ ────────────────┐
+    //  Genesis ──> │ A1 ──>  A2 ──> A3 │ ──> A4
+    //              └───────────────────┘
+    //                ↑
+    //          window_root
+    assert_eq!(commit_root.id(), a1_r1.id());
+    assert_eq!(window_root.expect("Window root not found"), a1_r1.id());
+    assert_eq!(block_window.len(), 3);
+
+    // ----------------------------------------------------------------------------------------- //
+
+    let (_, block_store, pipelined_blocks) =
+        create_block_tree_with_forks_unordered_parents(window_size).await;
+    let [_genesis_block, a1_r1, a2_r3, _a3_r6, a4_r9, _b1_r2, _b2_r4, _b3_r5, _c1_r7, _d1_r8] =
+        pipelined_blocks;
+    let current_block = a4_r9.block();
+
+    // Prune a2
+    block_store.prune_tree(a2_r3.id());
+    let (commit_root, window_root) = get_roots(current_block, block_store.clone(), window_size);
+    let block_window =
+        get_blocks_from_block_store_and_window(block_store.clone(), current_block, window_size);
+
+    //            commit_root  block_window
+    //                  └──────┐    ↓
+    //              ┌───────── ↓ ───────┐
+    //  Genesis ──> │ A1 ──>  A2 ──> A3 │ ──> A4
+    //              └───────────────────┘
+    //                ↑
+    //          window_root
+    assert_eq!(commit_root.id(), a2_r3.id());
+    assert_eq!(window_root.expect("Window root not found"), a1_r1.id());
+    assert_eq!(block_window.len(), 3);
+}
+
+/// Checks to make sure:
+/// 1. nil blocks can have a window
+/// 2. nil blocks can be in a window
+#[tokio::test]
+async fn test_window_root_with_non_sequential_round_forks_and_nil_blocks() {
+    // window_size > length of longest fork
+    let window_size = Some(6u64);
+
+    //                            nil_block
+    //                               ↓
+    //       ╭--> A1--> A2--> A3--> A4
+    // Genesis--> B1--> B2--> B3
+    //             │    ↑
+    //             │  nil_block
+    //             ╰--> C1
+    //             ╰--> D1
+    //
+    let (_, block_store, pipelined_blocks) =
+        create_block_tree_with_forks_unordered_parents_and_nil_blocks(window_size).await;
+    let [genesis_block, _a1_r1, _a2_r3, a3_r6, a4_r9, _b1_r2, _b2_r4, _b3_r5, _c1_r7, _d1_r8] =
+        pipelined_blocks;
+
+    // a4_r9 is the nil block
+    let current_block = a4_r9.block();
+    let (commit_root, window_root) = get_roots(current_block, block_store.clone(), window_size);
+    let block_window =
+        get_blocks_from_block_store_and_window(block_store.clone(), current_block, window_size);
+
+    assert_eq!(commit_root.id(), genesis_block.id());
+    assert_eq!(window_root.expect("Window root not found"), a3_r6.id());
+    assert_eq!(block_window.len(), 1);
+
+    // ----------------------------------------------------------------------------------------- //
+
+    let (_, block_store, pipelined_blocks) =
+        create_block_tree_with_forks_unordered_parents_and_nil_blocks(window_size).await;
+    let [_genesis_block, _a1_r1, _a2_r3, _a3_r6, _a4_r9, b1_r2, b2_r4, b3_r5, _c1_r7, _d1_r8] =
+        pipelined_blocks;
+
+    // Nil block is at b2_r4. Setting current block to b3_r5.
+    // Checking to make sure the nil block is included in the window
+    let current_block = b3_r5.block();
+    let block_window =
+        get_blocks_from_block_store_and_window(block_store.clone(), current_block, window_size);
+
+    assert_eq!(block_window.first().unwrap().id(), b1_r2.id());
+
+    // Nil block is included in OrderedBlockWindow
+    assert_eq!(block_window.get(1).unwrap().id(), b2_r4.id());
+    assert!(b2_r4.block().is_nil_block());
+    assert_eq!(block_window.len(), 2);
+}

--- a/consensus/src/block_storage/mod.rs
+++ b/consensus/src/block_storage/mod.rs
@@ -18,6 +18,7 @@ use std::{sync::Arc, time::Duration};
 
 mod block_store;
 mod block_tree;
+mod execution_pool;
 pub mod pending_blocks;
 pub mod tracing;
 

--- a/consensus/src/block_storage/pending_blocks.rs
+++ b/consensus/src/block_storage/pending_blocks.rs
@@ -33,14 +33,14 @@ impl PendingBlocks {
         self.blocks_by_hash.insert(block.id(), block.clone());
         self.blocks_by_round.insert(block.round(), block.clone());
         if let Some((target_block_retrieval_payload, tx)) = self.pending_request.take() {
-            let should_fulfill = match target_block_retrieval_payload {
+            let is_fulfilled = match target_block_retrieval_payload {
                 TargetBlockRetrieval::TargetBlockId(target_block_id) => {
                     target_block_id == block.id()
                 },
                 TargetBlockRetrieval::TargetRound(target_round) => target_round == block.round(),
             };
 
-            if should_fulfill {
+            if is_fulfilled {
                 info!(
                     "FulFill block request from incoming block: {:?}",
                     target_block_retrieval_payload

--- a/consensus/src/block_storage/pending_blocks.rs
+++ b/consensus/src/block_storage/pending_blocks.rs
@@ -1,7 +1,10 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::counters::BLOCK_RETRIEVAL_LOCAL_FULFILL_COUNT;
+use crate::{
+    block_storage::block_store::sync_manager::TargetBlockRetrieval,
+    counters::BLOCK_RETRIEVAL_LOCAL_FULFILL_COUNT,
+};
 use aptos_consensus_types::{block::Block, common::Round};
 use aptos_crypto::HashValue;
 use aptos_logger::info;
@@ -13,7 +16,7 @@ use std::collections::{BTreeMap, HashMap};
 pub struct PendingBlocks {
     blocks_by_hash: HashMap<HashValue, Block>,
     blocks_by_round: BTreeMap<Round, Block>,
-    pending_request: Option<(HashValue, oneshot::Sender<Block>)>,
+    pending_request: Option<(TargetBlockRetrieval, oneshot::Sender<Block>)>,
 }
 
 impl PendingBlocks {
@@ -29,25 +32,68 @@ impl PendingBlocks {
         info!("Pending block inserted: {}", block.id());
         self.blocks_by_hash.insert(block.id(), block.clone());
         self.blocks_by_round.insert(block.round(), block.clone());
-        if let Some((id, tx)) = self.pending_request.take() {
-            if id == block.id() {
-                info!("FulFill block request from incoming block: {}", id);
-                BLOCK_RETRIEVAL_LOCAL_FULFILL_COUNT.inc();
-                tx.send(block).ok();
-            } else {
-                self.pending_request = Some((id, tx));
+        if let Some((target_block_retrieval_payload, tx)) = self.pending_request.take() {
+            match target_block_retrieval_payload {
+                TargetBlockRetrieval::TargetBlockId(target_block_id) => {
+                    if target_block_id == block.id() {
+                        info!(
+                            "FulFill block request from incoming block: {}",
+                            target_block_id
+                        );
+                        BLOCK_RETRIEVAL_LOCAL_FULFILL_COUNT.inc();
+                        tx.send(block).ok();
+                    } else {
+                        self.pending_request = Some((target_block_retrieval_payload, tx));
+                    }
+                },
+                TargetBlockRetrieval::TargetRound(target_round) => {
+                    if target_round == block.round() {
+                        info!(
+                            "FulFill block request from incoming block for round: {}",
+                            target_round
+                        );
+                        BLOCK_RETRIEVAL_LOCAL_FULFILL_COUNT.inc();
+                        tx.send(block).ok();
+                    } else {
+                        self.pending_request = Some((target_block_retrieval_payload, tx));
+                    }
+                },
             }
         }
     }
 
-    pub fn insert_request(&mut self, block_id: HashValue, tx: oneshot::Sender<Block>) {
-        if let Some(block) = self.blocks_by_hash.get(&block_id) {
-            info!("FulFill block request from existing buffer: {}", block_id);
-            BLOCK_RETRIEVAL_LOCAL_FULFILL_COUNT.inc();
-            tx.send(block.clone()).ok();
-        } else {
-            info!("Insert block request for: {}", block_id);
-            self.pending_request = Some((block_id, tx));
+    pub fn insert_request(
+        &mut self,
+        target_block_retrieval_payload: TargetBlockRetrieval,
+        tx: oneshot::Sender<Block>,
+    ) {
+        match target_block_retrieval_payload {
+            TargetBlockRetrieval::TargetBlockId(target_block_id) => {
+                if let Some(block) = self.blocks_by_hash.get(&target_block_id) {
+                    info!(
+                        "FulFill block request from existing buffer: {}",
+                        target_block_id
+                    );
+                    BLOCK_RETRIEVAL_LOCAL_FULFILL_COUNT.inc();
+                    tx.send(block.clone()).ok();
+                } else {
+                    info!("Insert block request for: {}", target_block_id);
+                    self.pending_request = Some((target_block_retrieval_payload, tx));
+                }
+            },
+            TargetBlockRetrieval::TargetRound(target_round) => {
+                if let Some(block) = self.blocks_by_round.get(&target_round) {
+                    info!(
+                        "Fulfill block request from existing buffer: {}",
+                        target_round
+                    );
+                    BLOCK_RETRIEVAL_LOCAL_FULFILL_COUNT.inc();
+                    tx.send(block.clone()).ok();
+                } else {
+                    info!("Insert block request for: {}", target_round);
+                    self.pending_request = Some((target_block_retrieval_payload, tx));
+                }
+            },
         }
     }
 

--- a/consensus/src/block_storage/pending_blocks.rs
+++ b/consensus/src/block_storage/pending_blocks.rs
@@ -42,7 +42,7 @@ impl PendingBlocks {
 
             if is_fulfilled {
                 info!(
-                    "FulFill block request from incoming block: {:?}",
+                    "FulFill block request from incoming block: {}",
                     target_block_retrieval_payload
                 );
                 BLOCK_RETRIEVAL_LOCAL_FULFILL_COUNT.inc();

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -24,7 +24,7 @@ use crate::{
     pipeline::execution_client::TExecutionClient,
     util::calculate_window_start_round,
 };
-use anyhow::{anyhow, bail, Context};
+use anyhow::{anyhow, bail, ensure, Context};
 use aptos_consensus_types::{
     block::Block,
     block_retrieval::{
@@ -837,17 +837,17 @@ impl BlockRetriever {
         // Slightly different logic if using execution pool and not
         match target_block_retrieval_payload {
             TargetBlockRetrieval::TargetBlockId(target_block_id) => {
-                assert_eq!(
+                ensure!(
                     result_blocks
                         .last()
                         .expect("Expected at least a result_block")
-                        .id(),
-                    target_block_id
+                        .id()
+                        == target_block_id
                 );
             },
             TargetBlockRetrieval::TargetRound(target_round) => {
                 let last_block = result_blocks.last().expect("blocks are empty");
-                assert!(
+                ensure!(
                     last_block.round() == target_round || last_block.quorum_cert().certified_block().round() < target_round,
                     "Expecting in the retrieval response, last block should be == {} or its parent should be < {}, but got {} and parent {}",
                     target_round,

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -320,11 +320,10 @@ impl BlockStore {
                 )
             },
             Some(window_size) => {
-                let highest_commit_cert_round =
-                    highest_commit_cert.ledger_info().ledger_info().round();
-                // The next block to be executed is highest_commit_cert + 1.
-                let target_round =
-                    calculate_window_start_round(highest_commit_cert_round + 1, window_size);
+                let target_round = calculate_window_start_round(
+                    highest_commit_cert.ledger_info().ledger_info().round(),
+                    window_size,
+                );
                 let num_blocks = highest_quorum_cert.certified_block().round() - target_round + 1;
                 info!(
                     "[FastForwardSync] with window_size: {}, target_round: {}, num_blocks: {}",

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -396,14 +396,10 @@ impl BlockStore {
                     highest_commit_cert
                 );
                 BLOCKS_FETCHED_FROM_NETWORK_WHILE_FAST_FORWARD_SYNC.inc_by(1);
-                let target_block_retrieval_payload = match window_size {
-                    None => {
-                        TargetBlockRetrieval::TargetBlockId(highest_commit_certified_block.id())
-                    },
-                    Some(_) => {
-                        TargetBlockRetrieval::TargetRound(highest_commit_certified_block.round())
-                    },
-                };
+
+                // Only retrieving one block here, we can simply use TargetBlockRetrieval::TargetBlockId
+                let target_block_retrieval_payload =
+                    TargetBlockRetrieval::TargetBlockId(highest_commit_certified_block.id());
                 let mut additional_blocks = retriever
                     .retrieve_blocks_in_range(
                         highest_commit_certified_block.id(),
@@ -508,7 +504,6 @@ impl BlockStore {
         }
     }
 
-    /// TODO @bchocho @hariria deprecate later once BlockRetrievalRequest enum is released
     pub async fn process_block_retrieval_inner(
         &self,
         request: &BlockRetrievalRequest,

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -323,7 +323,8 @@ impl BlockStore {
                 let target_round = calculate_window_start_round(
                     highest_commit_cert.ledger_info().ledger_info().round(),
                     window_size,
-                );
+                )
+                .max(1); // Never retrieve genesis block
                 let num_blocks = highest_quorum_cert.certified_block().round() - target_round + 1;
                 info!(
                     "[FastForwardSync] with window_size: {}, target_round: {}, num_blocks: {}",

--- a/consensus/src/consensus_observer/network/observer_message.rs
+++ b/consensus/src/consensus_observer/network/observer_message.rs
@@ -1046,6 +1046,7 @@ mod test {
             BatchPointer, InlineBatch, OptBatches, OptQuorumStorePayload, PayloadExecutionLimit,
             ProofBatches,
         },
+        pipelined_block::OrderedBlockWindow,
         proof_of_store::BatchId,
         quorum_cert::QuorumCert,
     };
@@ -1947,7 +1948,10 @@ mod test {
             BlockType::Genesis,
         );
         let block = Block::new_for_testing(block_info.id(), block_data, None);
-        Arc::new(PipelinedBlock::new_ordered(block))
+        Arc::new(PipelinedBlock::new_ordered(
+            block,
+            OrderedBlockWindow::empty(),
+        ))
     }
 
     /// Creates and returns a new pipelined block with the given block info and parent ID
@@ -1977,7 +1981,10 @@ mod test {
 
         // Create the pipelined block
         let block = Block::new_for_testing(block_info.id(), block_data, None);
-        Arc::new(PipelinedBlock::new_ordered(block))
+        Arc::new(PipelinedBlock::new_ordered(
+            block,
+            OrderedBlockWindow::empty(),
+        ))
     }
 
     /// Creates a returns multiple signed transactions

--- a/consensus/src/consensus_observer/observer/active_state.rs
+++ b/consensus/src/consensus_observer/observer/active_state.rs
@@ -359,7 +359,7 @@ mod test {
     use aptos_consensus_types::{
         block::Block,
         block_data::{BlockData, BlockType},
-        pipelined_block::PipelinedBlock,
+        pipelined_block::{OrderedBlockWindow, PipelinedBlock},
         quorum_cert::QuorumCert,
     };
     use aptos_crypto::HashValue;
@@ -564,7 +564,10 @@ mod test {
                 BlockType::Genesis,
             );
             let block = Block::new_for_testing(block_info.id(), block_data, None);
-            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(block));
+            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(
+                block,
+                OrderedBlockWindow::empty(),
+            ));
 
             // Create an ordered block
             let blocks = vec![pipelined_block];
@@ -622,7 +625,10 @@ mod test {
             BlockType::Genesis,
         );
         let block = Block::new_for_testing(block_info.id(), block_data, None);
-        Arc::new(PipelinedBlock::new_ordered(block))
+        Arc::new(PipelinedBlock::new_ordered(
+            block,
+            OrderedBlockWindow::empty(),
+        ))
     }
 
     /// Creates and returns a reconfig notifier and listener

--- a/consensus/src/consensus_observer/observer/ordered_blocks.rs
+++ b/consensus/src/consensus_observer/observer/ordered_blocks.rs
@@ -212,7 +212,7 @@ mod test {
     use aptos_consensus_types::{
         block::Block,
         block_data::{BlockData, BlockType},
-        pipelined_block::PipelinedBlock,
+        pipelined_block::{OrderedBlockWindow, PipelinedBlock},
         quorum_cert::QuorumCert,
     };
     use aptos_crypto::HashValue;
@@ -718,7 +718,10 @@ mod test {
                 BlockType::Genesis,
             );
             let block = Block::new_for_testing(block_info.id(), block_data, None);
-            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(block));
+            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(
+                block,
+                OrderedBlockWindow::empty(),
+            ));
 
             // Create an ordered block
             let blocks = vec![pipelined_block];

--- a/consensus/src/consensus_observer/observer/payload_store.rs
+++ b/consensus/src/consensus_observer/observer/payload_store.rs
@@ -283,6 +283,7 @@ mod test {
         block::Block,
         block_data::{BlockData, BlockType},
         common::{Author, Payload, ProofWithData},
+        pipelined_block::OrderedBlockWindow,
         proof_of_store::{BatchId, BatchInfo, ProofOfStore},
         quorum_cert::QuorumCert,
     };
@@ -1131,7 +1132,10 @@ mod test {
                 block_type,
             );
             let block = Block::new_for_testing(block_info.id(), block_data, None);
-            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(block));
+            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(
+                block,
+                OrderedBlockWindow::empty(),
+            ));
 
             // Add the pipelined block to the list
             pipelined_blocks.push(pipelined_block.clone());

--- a/consensus/src/consensus_observer/observer/pending_blocks.rs
+++ b/consensus/src/consensus_observer/observer/pending_blocks.rs
@@ -241,7 +241,7 @@ mod test {
     use aptos_consensus_types::{
         block::Block,
         block_data::{BlockData, BlockType},
-        pipelined_block::PipelinedBlock,
+        pipelined_block::{OrderedBlockWindow, PipelinedBlock},
         quorum_cert::QuorumCert,
     };
     use aptos_crypto::HashValue;
@@ -965,7 +965,11 @@ mod test {
                 BlockType::Genesis,
             );
             let block = Block::new_for_testing(block_info.id(), block_data, None);
-            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(block));
+            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(
+                block,
+                // TODO revisit this, not sure how i would do this right now...
+                OrderedBlockWindow::empty(),
+            ));
 
             // Add the pipelined block to the list
             pipelined_blocks.push(pipelined_block);

--- a/consensus/src/consensus_observer/observer/pending_blocks.rs
+++ b/consensus/src/consensus_observer/observer/pending_blocks.rs
@@ -967,7 +967,7 @@ mod test {
             let block = Block::new_for_testing(block_info.id(), block_data, None);
             let pipelined_block = Arc::new(PipelinedBlock::new_ordered(
                 block,
-                // TODO revisit this, not sure how i would do this right now...
+                // TODO @bchocho @hariria revisit this, not sure how i would do this right now...
                 OrderedBlockWindow::empty(),
             ));
 

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -581,11 +581,13 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                             );
                             continue;
                         }
+                        // This should be OK. Wrapping BlockRetrievalRequestV1 in an IncomingBlockRetrievalRequest
+                        // instead of DeprecatedIncomingBlockRetrievalRequest
                         if let Err(e) = monitor!(
                             "process_block_retrieval",
                             block_store
-                                .process_block_retrieval(DeprecatedIncomingBlockRetrievalRequest {
-                                    req: v1,
+                                .process_block_retrieval(IncomingBlockRetrievalRequest {
+                                    req: BlockRetrievalRequest::V1(v1),
                                     protocol: request.protocol,
                                     response_sender: request.response_sender,
                                 })
@@ -605,7 +607,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                         if let Err(e) = monitor!(
                             "process_block_retrieval_v2",
                             block_store
-                                .process_block_retrieval_v2(IncomingBlockRetrievalRequest {
+                                .process_block_retrieval(IncomingBlockRetrievalRequest {
                                     req: BlockRetrievalRequest::V2(v2),
                                     protocol: request.protocol,
                                     response_sender: request.response_sender,
@@ -693,6 +695,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 .max_blocks_per_sending_request(onchain_consensus_config.quorum_store_enabled()),
             self.payload_manager.clone(),
             onchain_consensus_config.order_vote_enabled(),
+            onchain_consensus_config.window_size(),
             self.pending_blocks.clone(),
         );
         tokio::spawn(recovery_manager.start(recovery_manager_rx, close_rx));
@@ -801,7 +804,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         info!(
             epoch = epoch_state.epoch,
             validators = epoch_state.verifier.to_string(),
-            root_block = %recovery_data.root_block(),
+            root_block = %recovery_data.commit_root_block(),
             "Starting new epoch",
         );
 
@@ -855,7 +858,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 rand_config,
                 fast_rand_config.clone(),
                 rand_msg_rx,
-                recovery_data.root_block().round(),
+                recovery_data.commit_root_block().round(),
                 self.config.enable_pipeline,
             )
             .await;
@@ -879,6 +882,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             self.config.vote_back_pressure_limit,
             payload_manager,
             onchain_consensus_config.order_vote_enabled(),
+            onchain_consensus_config.window_size(),
             self.pending_blocks.clone(),
             maybe_pipeline_builder,
         ));
@@ -1336,7 +1340,10 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         fast_rand_config: Option<RandConfig>,
         rand_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingRandGenRequest>,
     ) {
-        match self.storage.start(consensus_config.order_vote_enabled()) {
+        match self.storage.start(
+            consensus_config.order_vote_enabled(),
+            consensus_config.window_size(),
+        ) {
             LivenessStorageData::FullRecoveryData(initial_data) => {
                 self.recovery_mode = false;
                 self.start_round_manager(
@@ -1740,16 +1747,22 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
         match request {
             // TODO @bchocho @hariria can remove after all nodes upgrade to release with enum BlockRetrievalRequest (not struct)
-            IncomingRpcRequest::DeprecatedBlockRetrieval(request) => {
+            IncomingRpcRequest::DeprecatedBlockRetrieval(
+                DeprecatedIncomingBlockRetrievalRequest {
+                    req,
+                    protocol,
+                    response_sender,
+                },
+            ) => {
                 if let Some(tx) = &self.block_retrieval_tx {
                     let incoming_block_retrieval_request = IncomingBlockRetrievalRequest {
-                        req: BlockRetrievalRequest::V1(request.req),
-                        protocol: request.protocol,
-                        response_sender: request.response_sender,
+                        req: BlockRetrievalRequest::V1(req),
+                        protocol,
+                        response_sender,
                     };
                     tx.push(peer_id, incoming_block_retrieval_request)
                 } else {
-                    error!("Round manager not started");
+                    error!("Round manager not started (in IncomingRpcRequest::DeprecatedBlockRetrieval)");
                     Ok(())
                 }
             },

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -581,8 +581,6 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                             );
                             continue;
                         }
-                        // This should be OK. Wrapping BlockRetrievalRequestV1 in an IncomingBlockRetrievalRequest
-                        // instead of DeprecatedIncomingBlockRetrievalRequest
                         if let Err(e) = monitor!(
                             "process_block_retrieval",
                             block_store

--- a/consensus/src/liveness/proposal_generator_test.rs
+++ b/consensus/src/liveness/proposal_generator_test.rs
@@ -12,7 +12,7 @@ use crate::{
         rotating_proposer_election::RotatingProposer,
         unequivocal_proposer_election::UnequivocalProposerElection,
     },
-    test_utils::{build_empty_tree, MockPayloadManager, TreeInserter},
+    test_utils::{build_default_empty_tree, MockPayloadManager, TreeInserter},
     util::mock_time_service::SimulatedTimeService,
 };
 use aptos_consensus_types::{
@@ -42,7 +42,7 @@ impl TOptQSPullParamsProvider for MockOptQSPayloadProvider {
 #[tokio::test]
 async fn test_proposal_generation_empty_tree() {
     let signer = ValidatorSigner::random(None);
-    let block_store = build_empty_tree();
+    let block_store = build_default_empty_tree();
     let proposal_generator = ProposalGenerator::new(
         signer.author(),
         block_store.clone(),

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -155,7 +155,6 @@ pub enum IncomingRpcRequest {
     DAGRequest(IncomingDAGRequest),
     CommitRequest(IncomingCommitRequest),
     RandGenRequest(IncomingRandGenRequest),
-    #[allow(dead_code)]
     BlockRetrieval(IncomingBlockRetrievalRequest),
 }
 

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -829,7 +829,12 @@ mod tests {
                     IncomingRpcRequest::DeprecatedBlockRetrieval(request) => {
                         request.response_sender.send(Ok(bytes)).unwrap()
                     },
-                    _ => panic!("unexpected message"),
+                    // TODO @bchocho @hariria fix after release, this is a sanity check to make sure
+                    // we're not making new BlockRetrievalRequest network requests anywhere
+                    IncomingRpcRequest::BlockRetrieval(_request) => {
+                        panic!("Unexpected IncomingRpcRequest::BlockRetrieval branch triggered")
+                    },
+                    request => panic!("test_rpc unexpected message {:?}", request),
                 }
             }
         };
@@ -842,8 +847,8 @@ mod tests {
                     peer,
                     Duration::from_secs(5),
                 )
-                .await
-                .unwrap();
+                .await;
+            let response = response.unwrap();
             assert_eq!(response.status(), BlockRetrievalStatus::IdNotFound);
         });
     }
@@ -880,6 +885,7 @@ mod tests {
             .push((peer_id, protocol_id), bad_msg)
             .unwrap();
 
+        // TODO @bchocho @hariria change in new release once new ConsensusMsg is available (ConsensusMsg::BlockRetrievalRequest)
         let liveness_check_msg = ConsensusMsg::DeprecatedBlockRetrievalRequest(Box::new(
             BlockRetrievalRequestV1::new(HashValue::random(), 1),
         ));

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -535,7 +535,10 @@ mod tests {
     };
     use aptos_config::network_id::{NetworkId, PeerNetworkId};
     use aptos_consensus_types::{
-        block_retrieval::{BlockRetrievalRequestV1, BlockRetrievalResponse, BlockRetrievalStatus},
+        block_retrieval::{
+            BlockRetrievalRequest, BlockRetrievalRequestV1, BlockRetrievalResponse,
+            BlockRetrievalStatus,
+        },
         common::Payload,
     };
     use aptos_crypto::HashValue;
@@ -831,8 +834,8 @@ mod tests {
                     },
                     // TODO @bchocho @hariria fix after release, this is a sanity check to make sure
                     // we're not making new BlockRetrievalRequest network requests anywhere
-                    IncomingRpcRequest::BlockRetrieval(_request) => {
-                        panic!("Unexpected IncomingRpcRequest::BlockRetrieval branch triggered")
+                    IncomingRpcRequest::BlockRetrieval(request) => {
+                        request.response_sender.send(Ok(bytes)).unwrap()
                     },
                     request => panic!("test_rpc unexpected message {:?}", request),
                 }
@@ -843,7 +846,7 @@ mod tests {
         timed_block_on(&runtime, async {
             let response = nodes[0]
                 .request_block(
-                    BlockRetrievalRequestV1::new(HashValue::zero(), 1),
+                    BlockRetrievalRequest::V1(BlockRetrievalRequestV1::new(HashValue::zero(), 1)),
                     peer,
                     Duration::from_secs(5),
                 )

--- a/consensus/src/persistent_liveness_storage.rs
+++ b/consensus/src/persistent_liveness_storage.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{consensusdb::ConsensusDB, epoch_manager::LivenessStorageData, error::DbError};
-use anyhow::{format_err, Context, Result};
+use anyhow::{ensure, format_err, Context, Result};
 use aptos_config::config::NodeConfig;
 use aptos_consensus_types::{
     block::Block, quorum_cert::QuorumCert, timeout_2chain::TwoChainTimeoutCertificate, vote::Vote,
@@ -16,7 +16,12 @@ use aptos_types::{
     block_info::Round, epoch_change::EpochChangeProof, ledger_info::LedgerInfoWithSignatures,
     proof::TransactionAccumulatorSummary, transaction::Version,
 };
-use std::{cmp::max, collections::HashSet, fmt::Debug, sync::Arc};
+use std::{
+    cmp::max,
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+    sync::Arc,
+};
 
 /// PersistentLivenessStorage is essential for maintaining liveness when a node crashes.  Specifically,
 /// upon a restart, a correct node will recover.  Even if all nodes crash, liveness is
@@ -37,7 +42,7 @@ pub trait PersistentLivenessStorage: Send + Sync {
     fn recover_from_ledger(&self) -> LedgerRecoveryData;
 
     /// Construct necessary data to start consensus.
-    fn start(&self, order_vote_enabled: bool) -> LivenessStorageData;
+    fn start(&self, order_vote_enabled: bool, window_size: Option<u64>) -> LivenessStorageData;
 
     /// Persist the highest 2chain timeout certificate for improved liveness - proof for other replicas
     /// to jump to this round
@@ -58,19 +63,20 @@ pub trait PersistentLivenessStorage: Send + Sync {
 }
 
 #[derive(Clone)]
-pub struct RootInfo(
-    pub Box<Block>,
-    pub QuorumCert,
-    pub WrappedLedgerInfo,
-    pub WrappedLedgerInfo,
-);
+pub struct RootInfo {
+    pub commit_root_block: Box<Block>,
+    pub window_root_block: Option<Box<Block>>,
+    pub quorum_cert: QuorumCert,
+    pub ordered_cert: WrappedLedgerInfo,
+    pub commit_cert: WrappedLedgerInfo,
+}
 
 impl Debug for RootInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "RootInfo: [block: {}, quorum_cert: {}, ordered_cert: {}, commit_cert: {}]",
-            self.0, self.1, self.2, self.3
+            "RootInfo: [commit_root_block: {}, window_root_block: {:?}, quorum_cert: {}, ordered_cert: {}, commit_cert: {}]",
+            self.commit_root_block, self.window_root_block, self.quorum_cert, self.ordered_cert, self.commit_cert,
         )
     }
 }
@@ -90,21 +96,120 @@ impl LedgerRecoveryData {
         self.storage_ledger.commit_info().round()
     }
 
-    /// Finds the root (last committed block) and returns the root block, the QC to the root block
-    /// and the ledger info for the root block, return an error if it can not be found.
-    ///
-    /// We guarantee that the block corresponding to the storage's latest ledger info always exists.
-    pub fn find_root(
+    pub fn find_root_with_window(
+        &self,
+        blocks: &mut Vec<Block>,
+        quorum_certs: &mut Vec<QuorumCert>,
+        order_vote_enabled: bool,
+        window_size: u64,
+    ) -> Result<RootInfo> {
+        // We start from the block that storage's latest ledger info, if storage has end-epoch
+        // LedgerInfo, we generate the virtual genesis block
+        let (latest_commit_id, latest_ledger_info_sig) =
+            if self.storage_ledger.ledger_info().ends_epoch() {
+                let genesis =
+                    Block::make_genesis_block_from_ledger_info(self.storage_ledger.ledger_info());
+                let genesis_qc = QuorumCert::certificate_for_genesis_from_ledger_info(
+                    self.storage_ledger.ledger_info(),
+                    genesis.id(),
+                );
+                let genesis_ledger_info = genesis_qc.ledger_info().clone();
+                let genesis_id = genesis.id();
+                blocks.push(genesis);
+                quorum_certs.push(genesis_qc);
+                (genesis_id, genesis_ledger_info)
+            } else {
+                (
+                    self.storage_ledger.ledger_info().consensus_block_id(),
+                    self.storage_ledger.clone(),
+                )
+            };
+
+        // sort by (epoch, round) to guarantee the topological order of parent <- child
+        blocks.sort_by_key(|b| (b.epoch(), b.round()));
+
+        let latest_commit_idx = blocks
+            .iter()
+            .position(|block| block.id() == latest_commit_id)
+            .ok_or_else(|| format_err!("unable to find root: {}", latest_commit_id))?;
+        let commit_block = blocks[latest_commit_idx].clone();
+        let root_quorum_cert = quorum_certs
+            .iter()
+            .find(|qc| qc.certified_block().id() == commit_block.id())
+            .ok_or_else(|| format_err!("No QC found for root: {}", commit_block.id()))?
+            .clone();
+
+        let (root_ordered_cert, root_commit_cert) = if order_vote_enabled {
+            // We are setting ordered_root same as commit_root. As every committed block is also ordered, this is fine.
+            // As the block store inserts all the fetched blocks and quorum certs and execute the blocks, the block store
+            // updates highest_ordered_cert accordingly.
+            let root_ordered_cert =
+                WrappedLedgerInfo::new(VoteData::dummy(), latest_ledger_info_sig.clone());
+            (root_ordered_cert.clone(), root_ordered_cert)
+        } else {
+            let root_ordered_cert = quorum_certs
+                .iter()
+                .find(|qc| qc.commit_info().id() == commit_block.id())
+                .ok_or_else(|| format_err!("No LI found for root: {}", latest_commit_id))?
+                .clone()
+                .into_wrapped_ledger_info();
+            let root_commit_cert = root_ordered_cert
+                .create_merged_with_executed_state(latest_ledger_info_sig)
+                .expect("Inconsistent commit proof and evaluation decision, cannot commit block");
+            (root_ordered_cert, root_commit_cert)
+        };
+
+        let window_start_round = blocks[latest_commit_idx]
+            .round()
+            .saturating_add(1)
+            .saturating_sub(window_size);
+        let mut id_to_blocks = HashMap::new();
+        blocks.iter().for_each(|block| {
+            id_to_blocks.insert(block.id(), block);
+        });
+
+        let mut curr_id = latest_commit_id;
+        let mut window_start_id = HashValue::zero();
+        while let Some(block) = id_to_blocks.get(&curr_id) {
+            if block.quorum_cert().certified_block().round() < window_start_round {
+                window_start_id = curr_id;
+                break;
+            }
+
+            window_start_id = curr_id;
+            curr_id = block.parent_id();
+        }
+        ensure!(
+            window_start_id != HashValue::zero(),
+            "Window start block not found"
+        );
+
+        let window_start_idx = blocks
+            .iter()
+            .position(|block| block.id() == window_start_id)
+            .ok_or_else(|| format_err!("unable to find root: {}", window_start_id))?;
+        let window_start_block = blocks.remove(window_start_idx);
+
+        info!(
+            "Commit block is {}, window block is {}",
+            commit_block, window_start_block
+        );
+
+        Ok(RootInfo {
+            commit_root_block: Box::new(commit_block),
+            window_root_block: Some(Box::new(window_start_block)),
+            quorum_cert: root_quorum_cert,
+            ordered_cert: root_ordered_cert,
+            commit_cert: root_commit_cert,
+        })
+    }
+
+    pub fn find_root_without_window(
         &self,
         blocks: &mut Vec<Block>,
         quorum_certs: &mut Vec<QuorumCert>,
         order_vote_enabled: bool,
     ) -> Result<RootInfo> {
-        info!(
-            "The last committed block id as recorded in storage: {}",
-            self.storage_ledger
-        );
-
         // We start from the block that storage's latest ledger info, if storage has end-epoch
         // LedgerInfo, we generate the virtual genesis block
         let (root_id, latest_ledger_info_sig) = if self.storage_ledger.ledger_info().ends_epoch() {
@@ -161,12 +266,37 @@ impl LedgerRecoveryData {
         };
         info!("Consensus root block is {}", root_block);
 
-        Ok(RootInfo(
-            Box::new(root_block),
-            root_quorum_cert,
-            root_ordered_cert,
-            root_commit_cert,
-        ))
+        Ok(RootInfo {
+            commit_root_block: Box::new(root_block),
+            window_root_block: None,
+            quorum_cert: root_quorum_cert,
+            ordered_cert: root_ordered_cert,
+            commit_cert: root_commit_cert,
+        })
+    }
+
+    /// Finds the root (last committed block) and returns the root block, the QC to the root block
+    /// and the ledger info for the root block, return an error if it can not be found.
+    ///
+    /// We guarantee that the block corresponding to the storage's latest ledger info always exists.
+    pub fn find_root(
+        &self,
+        blocks: &mut Vec<Block>,
+        quorum_certs: &mut Vec<QuorumCert>,
+        order_vote_enabled: bool,
+        window_size: Option<u64>,
+    ) -> Result<RootInfo> {
+        info!(
+            "The last committed block id as recorded in storage: {}",
+            self.storage_ledger
+        );
+
+        match window_size {
+            None => self.find_root_without_window(blocks, quorum_certs, order_vote_enabled),
+            Some(window_size) => {
+                self.find_root_with_window(blocks, quorum_certs, order_vote_enabled, window_size)
+            },
+        }
     }
 }
 
@@ -227,9 +357,15 @@ impl RecoveryData {
         mut quorum_certs: Vec<QuorumCert>,
         highest_2chain_timeout_cert: Option<TwoChainTimeoutCertificate>,
         order_vote_enabled: bool,
+        window_size: Option<u64>,
     ) -> Result<Self> {
         let root = ledger_recovery_data
-            .find_root(&mut blocks, &mut quorum_certs, order_vote_enabled)
+            .find_root(
+                &mut blocks,
+                &mut quorum_certs,
+                order_vote_enabled,
+                window_size,
+            )
             .with_context(|| {
                 // for better readability
                 blocks.sort_by_key(|block| block.round());
@@ -250,12 +386,29 @@ impl RecoveryData {
                 )
             })?;
 
-        let blocks_to_prune = Some(Self::find_blocks_to_prune(
-            root.0.id(),
-            &mut blocks,
-            &mut quorum_certs,
-        ));
-        let epoch = root.0.epoch();
+        // If execution pool is enabled, use the window_root, else use the commit_root
+        let (blocks_to_prune, epoch) = match &root.window_root_block {
+            None => {
+                let commit_root_id = root.commit_root_block.id();
+                let epoch = root.commit_root_block.epoch();
+                let blocks_to_prune = Some(Self::find_blocks_to_prune(
+                    commit_root_id,
+                    &mut blocks,
+                    &mut quorum_certs,
+                ));
+                (blocks_to_prune, epoch)
+            },
+            Some(window_root_block) => {
+                let window_start_id = window_root_block.id();
+                let epoch = window_root_block.epoch();
+                let blocks_to_prune = Some(Self::find_blocks_to_prune(
+                    window_start_id,
+                    &mut blocks,
+                    &mut quorum_certs,
+                ));
+                (blocks_to_prune, epoch)
+            },
+        };
         Ok(RecoveryData {
             last_vote: match last_vote {
                 Some(v) if v.epoch() == epoch => Some(v),
@@ -273,8 +426,8 @@ impl RecoveryData {
         })
     }
 
-    pub fn root_block(&self) -> &Block {
-        &self.root.0
+    pub fn commit_root_block(&self) -> &Block {
+        &self.root.commit_root_block
     }
 
     pub fn last_vote(&self) -> Option<Vote> {
@@ -371,7 +524,7 @@ impl PersistentLivenessStorage for StorageWriteProxy {
         LedgerRecoveryData::new(latest_ledger_info)
     }
 
-    fn start(&self, order_vote_enabled: bool) -> LivenessStorageData {
+    fn start(&self, order_vote_enabled: bool, window_size: Option<u64>) -> LivenessStorageData {
         info!("Start consensus recovery.");
         let raw_data = self
             .db
@@ -419,6 +572,7 @@ impl PersistentLivenessStorage for StorageWriteProxy {
             quorum_certs,
             highest_2chain_timeout_cert,
             order_vote_enabled,
+            window_size,
         ) {
             Ok(mut initial_data) => {
                 (self as &dyn PersistentLivenessStorage)

--- a/consensus/src/persistent_liveness_storage.rs
+++ b/consensus/src/persistent_liveness_storage.rs
@@ -163,16 +163,6 @@ impl LedgerRecoveryData {
             (root_ordered_cert, root_commit_cert)
         };
 
-        if commit_block.is_genesis_block() {
-            return Ok(RootInfo {
-                commit_root_block: Box::new(commit_block),
-                window_root_block: None,
-                quorum_cert: commit_block_quorum_cert,
-                ordered_cert: root_ordered_cert,
-                commit_cert: root_commit_cert,
-            });
-        }
-
         let window_start_round = calculate_window_start_round(commit_block.round(), window_size);
         let mut id_to_blocks = HashMap::new();
         blocks.iter().for_each(|block| {

--- a/consensus/src/persistent_liveness_storage.rs
+++ b/consensus/src/persistent_liveness_storage.rs
@@ -68,6 +68,7 @@ pub trait PersistentLivenessStorage: Send + Sync {
 #[derive(Clone)]
 pub struct RootInfo {
     pub commit_root_block: Box<Block>,
+    /// Genesis `window_root_block` will be None
     pub window_root_block: Option<Box<Block>>,
     pub quorum_cert: QuorumCert,
     pub ordered_cert: WrappedLedgerInfo,
@@ -136,7 +137,7 @@ impl LedgerRecoveryData {
             .position(|block| block.id() == latest_commit_id)
             .ok_or_else(|| format_err!("unable to find root: {}", latest_commit_id))?;
         let commit_block = blocks[latest_commit_idx].clone();
-        let root_quorum_cert = quorum_certs
+        let commit_block_quorum_cert = quorum_certs
             .iter()
             .find(|qc| qc.certified_block().id() == commit_block.id())
             .ok_or_else(|| format_err!("No QC found for root: {}", commit_block.id()))?
@@ -166,7 +167,7 @@ impl LedgerRecoveryData {
             return Ok(RootInfo {
                 commit_root_block: Box::new(commit_block),
                 window_root_block: None,
-                quorum_cert: root_quorum_cert,
+                quorum_cert: commit_block_quorum_cert,
                 ordered_cert: root_ordered_cert,
                 commit_cert: root_commit_cert,
             });
@@ -208,7 +209,7 @@ impl LedgerRecoveryData {
         Ok(RootInfo {
             commit_root_block: Box::new(commit_block),
             window_root_block: Some(Box::new(window_start_block)),
-            quorum_cert: root_quorum_cert,
+            quorum_cert: commit_block_quorum_cert,
             ordered_cert: root_ordered_cert,
             commit_cert: root_commit_cert,
         })

--- a/consensus/src/recovery_manager.rs
+++ b/consensus/src/recovery_manager.rs
@@ -35,6 +35,7 @@ pub struct RecoveryManager {
     max_blocks_to_request: u64,
     payload_manager: Arc<dyn TPayloadManager>,
     order_vote_enabled: bool,
+    window_size: Option<u64>,
     pending_blocks: Arc<Mutex<PendingBlocks>>,
 }
 
@@ -48,6 +49,7 @@ impl RecoveryManager {
         max_blocks_to_request: u64,
         payload_manager: Arc<dyn TPayloadManager>,
         order_vote_enabled: bool,
+        window_size: Option<u64>,
         pending_blocks: Arc<Mutex<PendingBlocks>>,
     ) -> Self {
         RecoveryManager {
@@ -59,6 +61,7 @@ impl RecoveryManager {
             max_blocks_to_request,
             payload_manager,
             order_vote_enabled,
+            window_size,
             pending_blocks,
         }
     }
@@ -106,6 +109,7 @@ impl RecoveryManager {
             self.execution_client.clone(),
             self.payload_manager.clone(),
             self.order_vote_enabled,
+            self.window_size,
         )
         .await?;
 

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -42,7 +42,7 @@ use aptos_types::{
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     on_chain_config::{
         OnChainConsensusConfig, OnChainJWKConsensusConfig, OnChainRandomnessConfig, ValidatorSet,
-        ValidatorTxnConfig,
+        ValidatorTxnConfig, DEFAULT_ENABLED_WINDOW_SIZE,
     },
     validator_info::ValidatorInfo,
     validator_signer::ValidatorSigner,
@@ -92,6 +92,7 @@ fn build_empty_store(
         10,
         Arc::from(DirectMempoolPayloadManager::new()),
         false,
+        DEFAULT_ENABLED_WINDOW_SIZE,
         Arc::new(Mutex::new(PendingBlocks::new())),
         None,
     ))

--- a/consensus/src/test_utils/mock_storage.rs
+++ b/consensus/src/test_utils/mock_storage.rs
@@ -19,7 +19,7 @@ use aptos_types::{
     aggregate_signature::AggregateSignature,
     epoch_change::EpochChangeProof,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-    on_chain_config::ValidatorSet,
+    on_chain_config::{ValidatorSet, DEFAULT_ENABLED_WINDOW_SIZE},
 };
 use std::{collections::HashMap, sync::Arc};
 
@@ -100,7 +100,11 @@ impl MockStorage {
         ))
     }
 
-    pub fn try_start(&self, order_vote_enabled: bool) -> Result<RecoveryData> {
+    pub fn try_start(
+        &self,
+        order_vote_enabled: bool,
+        window_size: Option<u64>,
+    ) -> Result<RecoveryData> {
         let ledger_recovery_data = self.get_ledger_recovery_data();
         let mut blocks: Vec<_> = self
             .shared_storage
@@ -131,19 +135,23 @@ impl MockStorage {
             quorum_certs,
             qc,
             order_vote_enabled,
+            window_size,
         )
     }
 
     pub fn verify_consistency(&self) -> Result<()> {
+        let order_vote_enabled = false;
+        let window_size = DEFAULT_ENABLED_WINDOW_SIZE;
         // TODO: Also test by setting order_vote_enabled to true
-        self.try_start(false).map(|_| ())
+        self.try_start(order_vote_enabled, window_size).map(|_| ())
     }
 
     pub fn start_for_testing(validator_set: ValidatorSet) -> (RecoveryData, Arc<Self>) {
         let shared_storage = Arc::new(MockSharedStorage::new(validator_set.clone()));
         let genesis_li = LedgerInfo::mock_genesis(Some(validator_set));
         let storage = Self::new_with_ledger_info(shared_storage, genesis_li);
-        let recovery_data = match storage.start(false) {
+        let window_size = DEFAULT_ENABLED_WINDOW_SIZE;
+        let recovery_data = match storage.start(false, window_size) {
             LivenessStorageData::FullRecoveryData(recovery_data) => recovery_data,
             _ => panic!("Mock storage should never fail constructing recovery data"),
         };
@@ -203,8 +211,8 @@ impl PersistentLivenessStorage for MockStorage {
         self.get_ledger_recovery_data()
     }
 
-    fn start(&self, order_vote_enabled: bool) -> LivenessStorageData {
-        match self.try_start(order_vote_enabled) {
+    fn start(&self, order_vote_enabled: bool, window_size: Option<u64>) -> LivenessStorageData {
+        match self.try_start(order_vote_enabled, window_size) {
             Ok(recovery_data) => LivenessStorageData::FullRecoveryData(recovery_data),
             Err(_) => LivenessStorageData::PartialRecoveryData(self.recover_from_ledger()),
         }
@@ -251,7 +259,7 @@ impl EmptyStorage {
 
     pub fn start_for_testing() -> (RecoveryData, Arc<Self>) {
         let storage = Arc::new(EmptyStorage::new());
-        let recovery_data = match storage.start(false) {
+        let recovery_data = match storage.start(false, DEFAULT_ENABLED_WINDOW_SIZE) {
             LivenessStorageData::FullRecoveryData(recovery_data) => recovery_data,
             _ => panic!("Mock storage should never fail constructing recovery data"),
         };
@@ -279,7 +287,7 @@ impl PersistentLivenessStorage for EmptyStorage {
         ))
     }
 
-    fn start(&self, order_vote_enabled: bool) -> LivenessStorageData {
+    fn start(&self, order_vote_enabled: bool, window_size: Option<u64>) -> LivenessStorageData {
         match RecoveryData::new(
             None,
             self.recover_from_ledger(),
@@ -288,6 +296,7 @@ impl PersistentLivenessStorage for EmptyStorage {
             vec![],
             None,
             order_vote_enabled,
+            window_size,
         ) {
             Ok(recovery_data) => LivenessStorageData::FullRecoveryData(recovery_data),
             Err(e) => {

--- a/consensus/src/test_utils/mod.rs
+++ b/consensus/src/test_utils/mod.rs
@@ -43,6 +43,7 @@ use aptos_infallible::Mutex;
 use aptos_types::{
     block_info::BlockInfo,
     chain_id::ChainId,
+    on_chain_config::DEFAULT_ENABLED_WINDOW_SIZE,
     transaction::{RawTransaction, Script, SignedTransaction, TransactionPayload},
 };
 pub use mock_payload_manager::MockPayloadManager;
@@ -74,9 +75,7 @@ pub async fn build_simple_tree() -> (Vec<Arc<PipelinedBlock>>, Arc<BlockStore>) 
         .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 1)
         .await;
     let a2 = inserter.insert_block(&a1, 2, None).await;
-    let a3 = inserter
-        .insert_block(&a2, 3, Some(genesis.block_info()))
-        .await;
+    let a3 = inserter.insert_block(&a2, 3, None).await;
     let b1 = inserter
         .insert_block_with_qc(certificate_for_genesis(), &genesis_block, 4)
         .await;
@@ -89,20 +88,38 @@ pub async fn build_simple_tree() -> (Vec<Arc<PipelinedBlock>>, Arc<BlockStore>) 
     (vec![genesis_block, a1, a2, a3, b1, b2, c1], block_store)
 }
 
-pub fn build_empty_tree() -> Arc<BlockStore> {
+fn build_empty_tree_inner(window_size: Option<u64>, max_pruned_blocks_in_mem: usize) -> BlockStore {
     let (initial_data, storage) = EmptyStorage::start_for_testing();
-    Arc::new(BlockStore::new(
+    BlockStore::new(
         storage,
         initial_data,
         Arc::new(DummyExecutionClient),
-        10, // max pruned blocks in mem
+        max_pruned_blocks_in_mem, // max pruned blocks in mem
         Arc::new(SimulatedTimeService::new()),
         10,
         Arc::from(DirectMempoolPayloadManager::new()),
         false,
+        window_size,
         Arc::new(Mutex::new(PendingBlocks::new())),
         None,
+    )
+}
+
+pub fn build_default_empty_tree() -> Arc<BlockStore> {
+    let window_size = DEFAULT_ENABLED_WINDOW_SIZE;
+    let max_pruned_blocks_in_mem: usize = 10;
+    Arc::new(build_empty_tree_inner(
+        window_size,
+        max_pruned_blocks_in_mem,
     ))
+}
+
+pub fn build_custom_empty_tree(
+    window_size: Option<u64>,
+    max_pruned_blocks_in_mem: usize,
+) -> Arc<BlockStore> {
+    let block_store = build_empty_tree_inner(window_size, max_pruned_blocks_in_mem);
+    Arc::new(block_store)
 }
 
 pub struct TreeInserter {
@@ -116,7 +133,19 @@ impl TreeInserter {
     }
 
     pub fn new(signer: ValidatorSigner) -> Self {
-        let block_store = build_empty_tree();
+        let block_store = build_default_empty_tree();
+        Self {
+            signer,
+            block_store,
+        }
+    }
+
+    pub fn new_with_params(
+        signer: ValidatorSigner,
+        window_size: Option<u64>,
+        max_pruned_blocks_in_mem: usize,
+    ) -> Self {
+        let block_store = build_custom_empty_tree(window_size, max_pruned_blocks_in_mem);
         Self {
             signer,
             block_store,
@@ -152,6 +181,17 @@ impl TreeInserter {
         self.insert_block_with_qc(parent_qc, parent, round).await
     }
 
+    pub async fn insert_nil_block(
+        &mut self,
+        parent: &PipelinedBlock,
+        round: Round,
+        committed_block: Option<BlockInfo>,
+    ) -> Arc<PipelinedBlock> {
+        // Node must carry a QC to its parent
+        let parent_qc = self.create_qc_for_block(parent, committed_block);
+        self.insert_nil_block_with_qc(parent_qc, round).await
+    }
+
     pub async fn insert_block_with_qc(
         &mut self,
         parent_qc: QuorumCert,
@@ -166,6 +206,17 @@ impl TreeInserter {
                 Payload::empty(false, true),
                 vec![],
             ))
+            .await
+            .unwrap()
+    }
+
+    pub async fn insert_nil_block_with_qc(
+        &mut self,
+        parent_qc: QuorumCert,
+        round: Round,
+    ) -> Arc<PipelinedBlock> {
+        self.block_store
+            .insert_block_with_qc(self.create_nil_block_with_qc(round, parent_qc, vec![]))
             .await
             .unwrap()
     }
@@ -206,6 +257,15 @@ impl TreeInserter {
             failed_authors,
         )
         .unwrap()
+    }
+
+    pub fn create_nil_block_with_qc(
+        &self,
+        round: Round,
+        quorum_cert: QuorumCert,
+        failed_authors: Vec<(Round, Author)>,
+    ) -> Block {
+        Block::new_nil(round, quorum_cert, failed_authors)
     }
 }
 

--- a/consensus/src/util/mod.rs
+++ b/consensus/src/util/mod.rs
@@ -25,10 +25,6 @@ pub fn is_vtxn_expected(
 }
 
 pub fn calculate_window_start_round(current_round: Round, window_size: u64) -> Round {
-    assert!(current_round > 0);
     assert!(window_size > 0);
-    (current_round + 1)
-        .saturating_sub(window_size)
-        // Window cannot start at genesis
-        .max(1)
+    (current_round + 1).saturating_sub(window_size)
 }

--- a/consensus/src/util/mod.rs
+++ b/consensus/src/util/mod.rs
@@ -2,6 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_consensus_types::common::Round;
 use aptos_types::{
     on_chain_config::{OnChainJWKConsensusConfig, OnChainRandomnessConfig},
     validator_txn::ValidatorTransaction,
@@ -21,4 +22,13 @@ pub fn is_vtxn_expected(
         ValidatorTransaction::DKGResult(_) => randomness_config.randomness_enabled(),
         ValidatorTransaction::ObservedJWKUpdate(_) => jwk_consensus_config.jwk_consensus_enabled(),
     }
+}
+
+pub fn calculate_window_start_round(current_round: Round, window_size: u64) -> Round {
+    assert!(current_round > 0);
+    assert!(window_size > 0);
+    (current_round + 1)
+        .saturating_sub(window_size)
+        // Window cannot start at genesis
+        .max(1)
 }

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -206,7 +206,7 @@ async fn test_onchain_config_change() {
                     alg: ConsensusAlgorithmConfig::Jolteon { main, .. },
                     ..
                 } => main,
-                _ => unimplemented!(),
+                _ => panic!("Other branches for OnChainConsensusConfig are not covered"),
             };
 
             let leader_reputation_type =

--- a/testsuite/smoke-test/src/execution_pool.rs
+++ b/testsuite/smoke-test/src/execution_pool.rs
@@ -1,0 +1,107 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    smoke_test_environment::SwarmBuilder,
+    utils::{update_consensus_config, MAX_CATCH_UP_WAIT_SECS},
+};
+use aptos::test::CliTestFramework;
+use aptos_forge::{LocalSwarm, NodeExt, Swarm, SwarmExt};
+use aptos_rest_client::Client;
+use aptos_types::on_chain_config::{
+    ConsensusAlgorithmConfig, OnChainConsensusConfig, ValidatorTxnConfig,
+};
+use move_core_types::language_storage::CORE_CODE_ADDRESS;
+use std::{sync::Arc, time::Duration};
+use tokio::task::JoinHandle;
+
+/// Checks the value of the `window_size` in the [`OnChainConsensusConfig`](OnChainConsensusConfig)
+pub async fn assert_on_chain_consensus_config_window_size(
+    swarm: &mut LocalSwarm,
+    expected_window_size: Option<usize>,
+) {
+    let rest_client = swarm.validators().next().unwrap().rest_client();
+    let current_consensus_config: OnChainConsensusConfig = bcs::from_bytes(
+        &rest_client
+            .get_account_resource_bcs::<Vec<u8>>(
+                CORE_CODE_ADDRESS,
+                "0x1::consensus_config::ConsensusConfig",
+            )
+            .await
+            .unwrap()
+            .into_inner(),
+    )
+    .unwrap();
+
+    match current_consensus_config {
+        OnChainConsensusConfig::V1(_)
+        | OnChainConsensusConfig::V2 { .. }
+        | OnChainConsensusConfig::V3 { .. } => {
+            panic!("Expected OnChainConsensusConfig::V4, but received a different version")
+        },
+        OnChainConsensusConfig::V4 { window_size, .. } => {
+            assert_eq!(window_size.map(|v| v as usize), expected_window_size)
+        },
+    }
+}
+
+async fn initialize_swarm_with_window() -> (
+    LocalSwarm,
+    CliTestFramework,
+    JoinHandle<anyhow::Result<()>>,
+    usize,
+    Client,
+) {
+    let (swarm, mut cli, _faucet) = SwarmBuilder::new_local(4)
+        .with_init_config(Arc::new(|_, conf, _| {
+            // reduce timeout, as we will have dead node during rounds
+            conf.consensus.round_initial_timeout_ms = 400;
+            conf.consensus.quorum_store_poll_time_ms = 100;
+            conf.api.failpoints_enabled = true;
+        }))
+        .with_init_genesis_config(Arc::new(|genesis_config| {
+            genesis_config.consensus_config = OnChainConsensusConfig::V4 {
+                alg: ConsensusAlgorithmConfig::default_for_genesis(),
+                vtxn: ValidatorTxnConfig::default_for_genesis(),
+                window_size: Some(4u64),
+            };
+        }))
+        .with_aptos()
+        .build_with_cli(0)
+        .await;
+
+    let root_cli_index = cli.add_account_with_address_to_cli(
+        swarm.root_key(),
+        swarm.chain_info().root_account().address(),
+    );
+
+    let rest_client = swarm.validators().next().unwrap().rest_client();
+
+    (swarm, cli, _faucet, root_cli_index, rest_client)
+}
+
+#[tokio::test]
+async fn test_window_size_onchain_config_change() {
+    let window_size = Some(4usize);
+    let (mut swarm, cli, _faucet, root_cli_index, ..) = initialize_swarm_with_window().await;
+
+    // Make sure that the current consensus config has a window size of 4
+    assert_on_chain_consensus_config_window_size(&mut swarm, window_size).await;
+
+    // Update consensus config with a different window_size
+    let window_size = Some(8usize);
+    let new_consensus_config = OnChainConsensusConfig::V4 {
+        alg: ConsensusAlgorithmConfig::default_for_genesis(),
+        vtxn: ValidatorTxnConfig::default_for_genesis(),
+        window_size: window_size.map(|v| v as u64),
+    };
+    update_consensus_config(&cli, root_cli_index, new_consensus_config).await;
+
+    swarm
+        .wait_for_all_nodes_to_catchup_to_next(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
+        .await
+        .unwrap();
+
+    // Make sure that the current consensus config has a window size of 8
+    assert_on_chain_consensus_config_window_size(&mut swarm, window_size).await;
+}

--- a/testsuite/smoke-test/src/lib.rs
+++ b/testsuite/smoke-test/src/lib.rs
@@ -69,4 +69,6 @@ mod utils;
 mod validator_txns;
 
 #[cfg(test)]
+mod execution_pool;
+#[cfg(test)]
 mod workspace_builder;

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -11,6 +11,7 @@ use std::collections::HashMap;
 /// Default Window Size for Execution Pool.
 /// This describes the number of blocks in the Execution Pool Window
 pub const DEFAULT_WINDOW_SIZE: Option<u64> = None;
+pub const DEFAULT_ENABLED_WINDOW_SIZE: Option<u64> = Some(1);
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub enum ConsensusAlgorithmConfig {

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -46,7 +46,7 @@ pub use self::{
     consensus_config::{
         AnchorElectionMode, ConsensusAlgorithmConfig, ConsensusConfigV1, DagConsensusConfigV1,
         LeaderReputationType, OnChainConsensusConfig, ProposerAndVoterConfig, ProposerElectionType,
-        ValidatorTxnConfig, DEFAULT_WINDOW_SIZE,
+        ValidatorTxnConfig, DEFAULT_ENABLED_WINDOW_SIZE, DEFAULT_WINDOW_SIZE,
     },
     execution_config::{
         BlockGasLimitType, ExecutionConfigV1, ExecutionConfigV2, ExecutionConfigV4,


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

The main purpose of this PR is to enhance block retrieval and pipeline execution by adding a window of blocks (`OrderedBlockWindow`) to the `PipelinedBlock`. It also refines the block retrieval mechanism by introducing `target_epoch_and_round` fields for better compatibility and logging improvements.

The recent changes in this PR are:

1. `consensus/consensus-types/src/block_retrieval.rs`:
    - Added `target_epoch_and_round` field and corresponding methods to `BlockRetrievalRequest`.
Updated `BlockRetrievalResponse` to use `target_epoch_and_round` instead of `target_block_id`.

2. `consensus/consensus-types/src/pipelined_block.rs`:
    - Introduced `OrderedBlockWindow` struct.
    - Added `block_window` field to `PipelinedBlock`.
    - Updated serialization and deserialization methods to include `block_window`.
    - Added logging for block creation.

## Test Plan

- Includes Unit Tests for testing the behavior of the `BlockStore` and `block_window` during pruning and other operations. 
- Includes swarm smoke tests for execution window for `OnChainConsensusConfig`

> Note: For testing, `BlockTree` exposes a `prune_tree` functionality which mimics some, but not all, of the behavior in `BlockTree::commit_callback`. To further illustrate the difference, I've provided a visual demonstrating the difference between the two in a happy path scenario. [Excalidraw available here](https://excalidraw.com/#json=4qgG1z2qZHQcg92UAR2J4,9lkwYpPA90UzM13XErqx8w)

![commit_callback](https://github.com/user-attachments/assets/705c2abc-ea9f-4b2d-8fa9-a7b1ddf995a1)

![Untitled-2024-02-01-1426](https://github.com/user-attachments/assets/bbd1e649-81de-4f59-88f7-359007d7e5c6)




## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
