### PR TITLE
Haproxy update and fix

### DIFF
--- a/docker/compose/aptos-node/docker-compose-fullnode.yaml
+++ b/docker/compose/aptos-node/docker-compose-fullnode.yaml
@@ -4,7 +4,7 @@
 version: "3.8"
 services:
   haproxy:
-    image: haproxytech/haproxy-debian:2.2.29
+    image: haproxy:3.0.2
     volumes:
       - type: bind
         source: ./haproxy-fullnode.cfg

--- a/docker/compose/aptos-node/docker-compose-src.yaml
+++ b/docker/compose/aptos-node/docker-compose-src.yaml
@@ -4,7 +4,7 @@
 version: "3.8"
 services:
   haproxy:
-    image: haproxytech/haproxy-debian:2.2.29
+    image: haproxy:3.0.2
     volumes:
       - type: bind
         source: ./haproxy.cfg

--- a/docker/compose/aptos-node/docker-compose.yaml
+++ b/docker/compose/aptos-node/docker-compose.yaml
@@ -4,7 +4,7 @@
 version: "3.8"
 services:
   haproxy:
-    image: haproxytech/haproxy-debian:2.2.29
+    image: haproxy:3.0.2
     volumes:
       - type: bind
         source: ./haproxy.cfg

--- a/docker/compose/aptos-node/haproxy-fullnode.cfg
+++ b/docker/compose/aptos-node/haproxy-fullnode.cfg
@@ -12,7 +12,7 @@ global
     maxconnrate 300
 
     # Limit user privileges
-    user nobody
+    user haproxy
 
 ## Default settings
 defaults

--- a/docker/compose/aptos-node/haproxy.cfg
+++ b/docker/compose/aptos-node/haproxy.cfg
@@ -12,7 +12,7 @@ global
     maxconnrate 300
 
     # Limit user privileges
-    user nobody
+    user haproxy
 
 ## Default settings
 defaults

--- a/docker/compose/aptos-node/haproxy.cfg
+++ b/docker/compose/aptos-node/haproxy.cfg
@@ -126,7 +126,7 @@ backend validator-api
 ## Specify the stats frontend
 frontend stats
     mode http
-    bind :9101
+    bind :9102
     http-request use-service prometheus-exporter if { path /metrics }
     stats enable
     stats uri /stats


### PR DESCRIPTION
## Description
1. Update haproxy version for docker compose deployment method
2. Change user from nobody to haproxy, nobody causes an error on `haproxy:3.0.2`. If it's `haproxytech/haproxy-debian:3.0.2` it will work, but the latest Helm charts use `haproxy:3.0.2`.
3. Fix the metrics port, the current config was incorrectly changed to make aptos-node share a metrics port with haproxy. Metrics are randomly shuffled by aptos-node or haproxy for each request. 
It was incorrectly changed in the following commit
https://github.com/aptos-labs/aptos-core/commit/84ab6fa7a4060d21e6cb31eeadbb58da1cb88da9#diff-e14828a9d40dad356c6aa567c7e8fe99c86d368226a8cf348e172d0998f90053L169

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [X] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [X] Other (specify)

