### PR TITLE
[aptos-vm] Allowing raw bytes for script argument

### DIFF
--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -275,9 +275,9 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
         let ret = match payload {
             Script(s) => {
                 let (code, ty_args, args) = s.into_inner();
-                let func_args = self.inner.view_script_arguments(&code, &args, &ty_args);
+                let script_args = self.inner.view_script_arguments(&code, &args, &ty_args);
 
-                let json_args = match func_args {
+                let json_args = match script_args {
                     Ok(values) => values
                         .into_iter()
                         .map(|v| MoveValue::try_from(v)?.json())

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -273,7 +273,6 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
     ) -> Result<TransactionPayload> {
         use aptos_types::transaction::TransactionPayload::*;
         let ret = match payload {
-            // TODO: Annotate the raw transaction argument using value annotator.
             Script(s) => {
                 let (code, ty_args, args) = s.into_inner();
                 let func_args = self.inner.view_script_arguments(&code, &args, &ty_args);

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -45,6 +45,7 @@ use move_core_types::{
     ident_str,
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
+    transaction_argument::convert_txn_args,
     value::{MoveStructLayout, MoveTypeLayout},
 };
 use serde_json::Value;
@@ -272,7 +273,27 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
     ) -> Result<TransactionPayload> {
         use aptos_types::transaction::TransactionPayload::*;
         let ret = match payload {
-            Script(s) => TransactionPayload::ScriptPayload(s.try_into()?),
+            // TODO: Annotate the raw transaction argument using value annotator.
+            Script(s) => {
+                let (code, ty_args, args) = s.into_inner();
+                let func_args = self.inner.view_script_arguments(&code, &args, &ty_args);
+
+                let json_args = match func_args {
+                    Ok(values) => values
+                        .into_iter()
+                        .map(|v| MoveValue::try_from(v)?.json())
+                        .collect::<Result<_>>()?,
+                    Err(_e) => convert_txn_args(&args)
+                        .into_iter()
+                        .map(|arg| HexEncodedBytes::from(arg).json())
+                        .collect::<Result<_>>()?,
+                };
+                TransactionPayload::ScriptPayload(ScriptPayload {
+                    code: MoveScriptBytecode::new(code).try_parse_abi(),
+                    type_arguments: ty_args.into_iter().map(|arg| arg.into()).collect(),
+                    arguments: json_args,
+                })
+            },
             EntryFunction(fun) => {
                 let (module, function, ty_args, args) = fun.into_inner();
                 let func_args = self

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -324,7 +324,7 @@ impl From<TransactionArgument> for MoveValue {
             TransactionArgument::Bool(v) => MoveValue::Bool(v),
             TransactionArgument::Address(v) => MoveValue::Address(v.into()),
             TransactionArgument::U8Vector(bytes) => MoveValue::Bytes(HexEncodedBytes(bytes)),
-            TransactionArgument::Raw(bytes) => MoveValue::Bytes(HexEncodedBytes(bytes)),
+            TransactionArgument::Serialized(bytes) => MoveValue::Bytes(HexEncodedBytes(bytes)),
         }
     }
 }

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -324,6 +324,7 @@ impl From<TransactionArgument> for MoveValue {
             TransactionArgument::Bool(v) => MoveValue::Bool(v),
             TransactionArgument::Address(v) => MoveValue::Address(v.into()),
             TransactionArgument::U8Vector(bytes) => MoveValue::Bytes(HexEncodedBytes(bytes)),
+            TransactionArgument::Raw(bytes) => MoveValue::Bytes(HexEncodedBytes(bytes)),
         }
     }
 }

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -15,5 +15,5 @@ proposals:
           git_hash: ~
       - FeatureFlag:
           enabled:
-            - raw_script_args
+            - allow_serialized_script_args
 

--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -13,3 +13,7 @@ proposals:
       - Framework:
           bytecode_version: 6
           git_hash: ~
+      - FeatureFlag:
+          enabled:
+            - raw_script_args
+

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -122,7 +122,7 @@ pub enum FeatureFlag {
     LimitVMTypeSize,
     AbortIfMultisigPayloadMismatch,
     DisallowUserNative,
-    RawScriptArgs,
+    AllowSerializedScriptArgs,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -319,7 +319,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
                 AptosFeatureFlag::ABORT_IF_MULTISIG_PAYLOAD_MISMATCH
             },
             FeatureFlag::DisallowUserNative => AptosFeatureFlag::DISALLOW_USER_NATIVES,
-            FeatureFlag::RawScriptArgs => AptosFeatureFlag::RAW_SCRIPT_ARGS,
+            FeatureFlag::AllowSerializedScriptArgs => AptosFeatureFlag::ALLOW_SERIALIZED_SCRIPT_ARGS,
         }
     }
 }
@@ -445,7 +445,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::AbortIfMultisigPayloadMismatch
             },
             AptosFeatureFlag::DISALLOW_USER_NATIVES => FeatureFlag::DisallowUserNative,
-            AptosFeatureFlag::RAW_SCRIPT_ARGS => FeatureFlag::RawScriptArgs,
+            AptosFeatureFlag::ALLOW_SERIALIZED_SCRIPT_ARGS => FeatureFlag::AllowSerializedScriptArgs,
         }
     }
 }

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -319,7 +319,9 @@ impl From<FeatureFlag> for AptosFeatureFlag {
                 AptosFeatureFlag::ABORT_IF_MULTISIG_PAYLOAD_MISMATCH
             },
             FeatureFlag::DisallowUserNative => AptosFeatureFlag::DISALLOW_USER_NATIVES,
-            FeatureFlag::AllowSerializedScriptArgs => AptosFeatureFlag::ALLOW_SERIALIZED_SCRIPT_ARGS,
+            FeatureFlag::AllowSerializedScriptArgs => {
+                AptosFeatureFlag::ALLOW_SERIALIZED_SCRIPT_ARGS
+            },
         }
     }
 }
@@ -445,7 +447,9 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::AbortIfMultisigPayloadMismatch
             },
             AptosFeatureFlag::DISALLOW_USER_NATIVES => FeatureFlag::DisallowUserNative,
-            AptosFeatureFlag::ALLOW_SERIALIZED_SCRIPT_ARGS => FeatureFlag::AllowSerializedScriptArgs,
+            AptosFeatureFlag::ALLOW_SERIALIZED_SCRIPT_ARGS => {
+                FeatureFlag::AllowSerializedScriptArgs
+            },
         }
     }
 }

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -122,6 +122,7 @@ pub enum FeatureFlag {
     LimitVMTypeSize,
     AbortIfMultisigPayloadMismatch,
     DisallowUserNative,
+    RawScriptArgs,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -318,6 +319,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
                 AptosFeatureFlag::ABORT_IF_MULTISIG_PAYLOAD_MISMATCH
             },
             FeatureFlag::DisallowUserNative => AptosFeatureFlag::DISALLOW_USER_NATIVES,
+            FeatureFlag::RawScriptArgs => AptosFeatureFlag::RAW_SCRIPT_ARGS,
         }
     }
 }
@@ -443,6 +445,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::AbortIfMultisigPayloadMismatch
             },
             AptosFeatureFlag::DISALLOW_USER_NATIVES => FeatureFlag::DisallowUserNative,
+            AptosFeatureFlag::RAW_SCRIPT_ARGS => FeatureFlag::RawScriptArgs,
         }
     }
 }

--- a/aptos-move/aptos-resource-viewer/src/lib.rs
+++ b/aptos-move/aptos-resource-viewer/src/lib.rs
@@ -15,8 +15,8 @@ use move_binary_format::CompiledModule;
 use move_core_types::{
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
-    value::{MoveTypeLayout, MoveValue},
     transaction_argument::TransactionArgument,
+    value::{MoveTypeLayout, MoveValue},
 };
 use move_resource_viewer::MoveValueAnnotator;
 pub use move_resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
@@ -87,8 +87,7 @@ impl<'a, S: StateView> AptosValueAnnotator<'a, S> {
         args: &[TransactionArgument],
         ty_args: &[TypeTag],
     ) -> anyhow::Result<Vec<AnnotatedMoveValue>> {
-        self.0
-            .view_script_arguments(script_bytes, args, ty_args)
+        self.0.view_script_arguments(script_bytes, args, ty_args)
     }
 
     pub fn view_fully_decorated_ty_layout(

--- a/aptos-move/aptos-resource-viewer/src/lib.rs
+++ b/aptos-move/aptos-resource-viewer/src/lib.rs
@@ -16,6 +16,7 @@ use move_core_types::{
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
     value::{MoveTypeLayout, MoveValue},
+    transaction_argument::TransactionArgument,
 };
 use move_resource_viewer::MoveValueAnnotator;
 pub use move_resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
@@ -78,6 +79,16 @@ impl<'a, S: StateView> AptosValueAnnotator<'a, S> {
     ) -> anyhow::Result<Vec<AnnotatedMoveValue>> {
         self.0
             .view_function_arguments(module, function, ty_args, args)
+    }
+
+    pub fn view_script_arguments(
+        &self,
+        script_bytes: &[u8],
+        args: &[TransactionArgument],
+        ty_args: &[TypeTag],
+    ) -> anyhow::Result<Vec<AnnotatedMoveValue>> {
+        self.0
+            .view_script_arguments(script_bytes, args, ty_args)
     }
 
     pub fn view_fully_decorated_ty_layout(

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -723,9 +723,9 @@ impl AptosVM {
             )?;
         }
 
-        if !self.features().is_enabled(FeatureFlag::RAW_SCRIPT_ARGS) {
+        if !self.features().is_enabled(FeatureFlag::ALLOW_SERIALIZED_SCRIPT_ARGS) {
             for arg in script.args() {
-                if let TransactionArgument::Raw(_) = arg {
+                if let TransactionArgument::Serialized(_) = arg {
                     return Err(PartialVMError::new(StatusCode::FEATURE_UNDER_GATING)
                         .finish(Location::Script)
                         .into_vm_status());

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -2617,6 +2617,19 @@ impl VMValidator for AptosVM {
             }
         }
 
+        if !self
+            .features()
+            .is_enabled(FeatureFlag::ALLOW_SERIALIZED_SCRIPT_ARGS)
+        {
+            if let TransactionPayload::Script(script) = transaction.payload() {
+                for arg in script.args() {
+                    if let TransactionArgument::Serialized(_) = arg {
+                        return VMValidatorResult::error(StatusCode::FEATURE_UNDER_GATING);
+                    }
+                }
+            }
+        }
+
         let txn = match transaction.check_signature() {
             Ok(t) => t,
             _ => {

--- a/aptos-move/e2e-move-tests/src/tests/script_with_object_param.data/pack/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/script_with_object_param.data/pack/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test"
+version = "0.0.0"
+
+[addresses]
+example_addr = "_"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }
+ManagedFungibleAsset =  { local = "../../../../../move-examples/fungible_asset/managed_fungible_asset" }

--- a/aptos-move/e2e-move-tests/src/tests/script_with_object_param.data/pack/sources/test.move
+++ b/aptos-move/e2e-move-tests/src/tests/script_with_object_param.data/pack/sources/test.move
@@ -1,0 +1,15 @@
+script {
+    use aptos_framework::fungible_asset::Metadata;
+    use aptos_framework::object::Object;
+    use example_addr::managed_fungible_asset::transfer_between_primary_stores;
+
+    fun main(
+        admin: &signer,
+        asset: Object<Metadata>,
+        from: vector<address>,
+        to: vector<address>,
+        amounts: vector<u64>,
+    ) {
+        transfer_between_primary_stores(admin, asset, from, to, amounts);
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/scripts.rs
+++ b/aptos-move/e2e-move-tests/src/tests/scripts.rs
@@ -88,10 +88,10 @@ fn test_script_with_object_parameter() {
 
     let code = package.extract_script_code().into_iter().next().unwrap();
     let script = Script::new(code, vec![], vec![
-        TransactionArgument::Raw(bcs::to_bytes(&metadata).unwrap()),
-        TransactionArgument::Raw(bcs::to_bytes(&vec![alice.address()]).unwrap()),
-        TransactionArgument::Raw(bcs::to_bytes(&vec![bob.address()]).unwrap()),
-        TransactionArgument::Raw(bcs::to_bytes(&vec![30u64]).unwrap()),
+        TransactionArgument::Serialized(bcs::to_bytes(&metadata).unwrap()),
+        TransactionArgument::Serialized(bcs::to_bytes(&vec![alice.address()]).unwrap()),
+        TransactionArgument::Serialized(bcs::to_bytes(&vec![bob.address()]).unwrap()),
+        TransactionArgument::Serialized(bcs::to_bytes(&vec![30u64]).unwrap()),
     ]);
 
     let txn = TransactionBuilder::new(alice.clone())
@@ -104,7 +104,7 @@ fn test_script_with_object_parameter() {
     let status = h.run(txn);
     assert_success!(status);
 
-    h.enable_features(vec![], vec![FeatureFlag::RAW_SCRIPT_ARGS]);
+    h.enable_features(vec![], vec![FeatureFlag::ALLOW_SERIALIZED_SCRIPT_ARGS]);
 
     let txn = TransactionBuilder::new(alice.clone())
         .script(script.clone())

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -608,8 +608,7 @@ TransactionArgument:
             SIZE: 32
     9:
       Raw:
-        NEWTYPE:
-          SEQ: U8
+        NEWTYPE: BYTES
 TransactionAuthenticator:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -606,6 +606,10 @@ TransactionArgument:
           TUPLEARRAY:
             CONTENT: U8
             SIZE: 32
+    9:
+      Raw:
+        NEWTYPE:
+          SEQ: U8
 TransactionAuthenticator:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -607,7 +607,7 @@ TransactionArgument:
             CONTENT: U8
             SIZE: 32
     9:
-      Raw:
+      Serialized:
         NEWTYPE: BYTES
 TransactionAuthenticator:
   ENUM:

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -538,6 +538,9 @@ TransactionArgument:
           TUPLEARRAY:
             CONTENT: U8
             SIZE: 32
+    9:
+      Serialized:
+        NEWTYPE: BYTES
 TransactionAuthenticator:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -937,6 +937,9 @@ TransactionArgument:
           TUPLEARRAY:
             CONTENT: U8
             SIZE: 32
+    9:
+      Serialized:
+        NEWTYPE: BYTES
 TransactionAuthenticator:
   ENUM:
     0:

--- a/third_party/move/move-core/types/src/transaction_argument.rs
+++ b/third_party/move/move-core/types/src/transaction_argument.rs
@@ -19,6 +19,7 @@ pub enum TransactionArgument {
     U16(u16),
     U32(u32),
     U256(u256::U256),
+    Raw(Vec<u8>),
 }
 
 impl fmt::Debug for TransactionArgument {
@@ -35,6 +36,7 @@ impl fmt::Debug for TransactionArgument {
             TransactionArgument::U16(value) => write!(f, "{{U16: {}}}", value),
             TransactionArgument::U32(value) => write!(f, "{{U32: {}}}", value),
             TransactionArgument::U256(value) => write!(f, "{{U256: {}}}", value),
+            TransactionArgument::Raw(value) => write!(f, "{{RAW_BYTES: {}}}", hex::encode(value)),
         }
     }
 }
@@ -51,6 +53,7 @@ impl From<TransactionArgument> for MoveValue {
             TransactionArgument::U16(i) => MoveValue::U16(i),
             TransactionArgument::U32(i) => MoveValue::U32(i),
             TransactionArgument::U256(i) => MoveValue::U256(i),
+            TransactionArgument::Raw(value) => MoveValue::vector_u8(value),
         }
     }
 }
@@ -90,9 +93,13 @@ impl TryFrom<MoveValue> for TransactionArgument {
 pub fn convert_txn_args(args: &[TransactionArgument]) -> Vec<Vec<u8>> {
     args.iter()
         .map(|arg| {
-            MoveValue::from(arg.clone())
-                .simple_serialize()
-                .expect("transaction arguments must serialize")
+            if let TransactionArgument::Raw(bytes) = arg {
+                bytes.clone()
+            } else {
+                MoveValue::from(arg.clone())
+                    .simple_serialize()
+                    .expect("transaction arguments must serialize")
+            }
         })
         .collect()
 }

--- a/third_party/move/move-core/types/src/transaction_argument.rs
+++ b/third_party/move/move-core/types/src/transaction_argument.rs
@@ -19,6 +19,7 @@ pub enum TransactionArgument {
     U16(u16),
     U32(u32),
     U256(u256::U256),
+    // Note: Gated by feature flag ALLOW_SERIALIZED_SCRIPT_ARGS
     Serialized(#[serde(with = "serde_bytes")] Vec<u8>),
 }
 

--- a/third_party/move/move-core/types/src/transaction_argument.rs
+++ b/third_party/move/move-core/types/src/transaction_argument.rs
@@ -36,7 +36,9 @@ impl fmt::Debug for TransactionArgument {
             TransactionArgument::U16(value) => write!(f, "{{U16: {}}}", value),
             TransactionArgument::U32(value) => write!(f, "{{U32: {}}}", value),
             TransactionArgument::U256(value) => write!(f, "{{U256: {}}}", value),
-            TransactionArgument::Serialized(value) => write!(f, "{{RAW_BYTES: {}}}", hex::encode(value)),
+            TransactionArgument::Serialized(value) => {
+                write!(f, "{{RAW_BYTES: {}}}", hex::encode(value))
+            },
         }
     }
 }

--- a/third_party/move/move-core/types/src/transaction_argument.rs
+++ b/third_party/move/move-core/types/src/transaction_argument.rs
@@ -19,7 +19,7 @@ pub enum TransactionArgument {
     U16(u16),
     U32(u32),
     U256(u256::U256),
-    Raw(#[serde(with = "serde_bytes")] Vec<u8>),
+    Serialized(#[serde(with = "serde_bytes")] Vec<u8>),
 }
 
 impl fmt::Debug for TransactionArgument {
@@ -36,7 +36,7 @@ impl fmt::Debug for TransactionArgument {
             TransactionArgument::U16(value) => write!(f, "{{U16: {}}}", value),
             TransactionArgument::U32(value) => write!(f, "{{U32: {}}}", value),
             TransactionArgument::U256(value) => write!(f, "{{U256: {}}}", value),
-            TransactionArgument::Raw(value) => write!(f, "{{RAW_BYTES: {}}}", hex::encode(value)),
+            TransactionArgument::Serialized(value) => write!(f, "{{RAW_BYTES: {}}}", hex::encode(value)),
         }
     }
 }
@@ -53,7 +53,7 @@ impl From<TransactionArgument> for MoveValue {
             TransactionArgument::U16(i) => MoveValue::U16(i),
             TransactionArgument::U32(i) => MoveValue::U32(i),
             TransactionArgument::U256(i) => MoveValue::U256(i),
-            TransactionArgument::Raw(value) => MoveValue::vector_u8(value),
+            TransactionArgument::Serialized(value) => MoveValue::vector_u8(value),
         }
     }
 }
@@ -93,7 +93,7 @@ impl TryFrom<MoveValue> for TransactionArgument {
 pub fn convert_txn_args(args: &[TransactionArgument]) -> Vec<Vec<u8>> {
     args.iter()
         .map(|arg| {
-            if let TransactionArgument::Raw(bytes) = arg {
+            if let TransactionArgument::Serialized(bytes) = arg {
                 bytes.clone()
             } else {
                 MoveValue::from(arg.clone())

--- a/third_party/move/move-core/types/src/transaction_argument.rs
+++ b/third_party/move/move-core/types/src/transaction_argument.rs
@@ -19,7 +19,7 @@ pub enum TransactionArgument {
     U16(u16),
     U32(u32),
     U256(u256::U256),
-    Raw(Vec<u8>),
+    Raw(#[serde(with = "serde_bytes")] Vec<u8>),
 }
 
 impl fmt::Debug for TransactionArgument {

--- a/third_party/move/tools/move-resource-viewer/src/lib.rs
+++ b/third_party/move/tools/move-resource-viewer/src/lib.rs
@@ -135,7 +135,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
         let args_bytes = convert_txn_args(args);
-        self.view_function_arguments_impl(&param_tys, ty_args, &args_bytes, &mut limit)
+        self.view_arguments_impl(&param_tys, ty_args, &args_bytes, &mut limit)
     }
 
     pub fn view_function_arguments(
@@ -147,10 +147,10 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
     ) -> anyhow::Result<Vec<AnnotatedMoveValue>> {
         let mut limit = Limiter::default();
         let param_tys = self.resolve_function_arguments(module, function, &mut limit)?;
-        self.view_function_arguments_impl(&param_tys, ty_args, args, &mut limit)
+        self.view_arguments_impl(&param_tys, ty_args, args, &mut limit)
     }
 
-    fn view_function_arguments_impl(
+    fn view_arguments_impl(
         &self,
         param_tys: &[FatType],
         ty_args: &[TypeTag],

--- a/third_party/move/tools/move-resource-viewer/src/lib.rs
+++ b/third_party/move/tools/move-resource-viewer/src/lib.rs
@@ -6,11 +6,12 @@ use crate::fat_type::{FatStructType, FatType, WrappedAbilitySet};
 use anyhow::{anyhow, bail};
 pub use limit::Limiter;
 use move_binary_format::{
-    access::ModuleAccess,
+    access::{ModuleAccess, ScriptAccess},
+    binary_views::BinaryIndexedView,
     errors::{Location, PartialVMError},
     file_format::{
-        Ability, AbilitySet, SignatureToken, StructDefinitionIndex, StructFieldInformation,
-        StructHandleIndex,
+        Ability, AbilitySet, CompiledScript, SignatureToken, StructDefinitionIndex,
+        StructFieldInformation, StructHandleIndex,
     },
     views::FunctionHandleView,
     CompiledModule,
@@ -20,6 +21,7 @@ use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
+    transaction_argument::{convert_txn_args, TransactionArgument},
     u256,
     value::{MoveStruct, MoveTypeLayout, MoveValue},
     vm_status::VMStatus,
@@ -115,6 +117,27 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         }
     }
 
+    pub fn view_script_arguments(
+        &self,
+        script_bytes: &[u8],
+        args: &[TransactionArgument],
+        ty_args: &[TypeTag],
+    ) -> anyhow::Result<Vec<AnnotatedMoveValue>> {
+        let mut limit = Limiter::default();
+        let compiled_script = CompiledScript::deserialize(script_bytes)
+            .map_err(|err| anyhow!("Failed to deserialzie script: {:?}", err))?;
+        let param_tys = compiled_script
+            .signature_at(compiled_script.parameters)
+            .0
+            .iter()
+            .map(|tok| {
+                self.resolve_signature(BinaryIndexedView::Script(&compiled_script), tok, &mut limit)
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let args_bytes = convert_txn_args(args);
+        self.view_function_arguments_impl(&param_tys, ty_args, &args_bytes, &mut limit)
+    }
+
     pub fn view_function_arguments(
         &self,
         module: &ModuleId,
@@ -123,9 +146,19 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         args: &[Vec<u8>],
     ) -> anyhow::Result<Vec<AnnotatedMoveValue>> {
         let mut limit = Limiter::default();
-        let types: Vec<FatType> = self
-            .resolve_function_arguments(module, function)?
-            .into_iter()
+        let param_tys = self.resolve_function_arguments(module, function, &mut limit)?;
+        self.view_function_arguments_impl(&param_tys, ty_args, args, &mut limit)
+    }
+
+    fn view_function_arguments_impl(
+        &self,
+        param_tys: &[FatType],
+        ty_args: &[TypeTag],
+        args: &[Vec<u8>],
+        limit: &mut Limiter,
+    ) -> anyhow::Result<Vec<AnnotatedMoveValue>> {
+        let types: Vec<&FatType> = param_tys
+            .iter()
             .filter(|t| match t {
                 FatType::Signer => false,
                 FatType::Reference(inner) => !matches!(&**inner, FatType::Signer),
@@ -157,11 +190,9 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             .iter()
             .enumerate()
             .map(|(i, ty)| {
-                ty.subst(&ty_args, &mut limit)
+                ty.subst(&ty_args, limit)
                     .map_err(anyhow::Error::from)
-                    .and_then(|fat_type| {
-                        self.view_value_by_fat_type(&fat_type, &args[i], &mut limit)
-                    })
+                    .and_then(|fat_type| self.view_value_by_fat_type(&fat_type, &args[i], limit))
             })
             .collect::<anyhow::Result<Vec<AnnotatedMoveValue>>>()
     }
@@ -170,8 +201,8 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         &self,
         module: &ModuleId,
         function: &IdentStr,
+        limit: &mut Limiter,
     ) -> anyhow::Result<Vec<FatType>> {
-        let mut limit = Limiter::default();
         let m = self.view_existing_module(module)?;
         let m = m.borrow();
         for def in m.function_defs.iter() {
@@ -182,7 +213,9 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                     .parameters()
                     .0
                     .iter()
-                    .map(|signature| self.resolve_signature(m, signature, &mut limit))
+                    .map(|signature| {
+                        self.resolve_signature(BinaryIndexedView::Module(m), signature, limit)
+                    })
                     .collect::<anyhow::Result<_>>();
             }
         }
@@ -281,7 +314,13 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
                 ty_args,
                 layout: defs
                     .iter()
-                    .map(|field_def| self.resolve_signature(module, &field_def.signature.0, limit))
+                    .map(|field_def| {
+                        self.resolve_signature(
+                            BinaryIndexedView::Module(module),
+                            &field_def.signature.0,
+                            limit,
+                        )
+                    })
                     .collect::<anyhow::Result<_>>()?,
             }),
             StructFieldInformation::DeclaredVariants(..) => Err(anyhow!(
@@ -292,7 +331,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
 
     fn resolve_signature(
         &self,
-        module: &CompiledModule,
+        module: BinaryIndexedView,
         sig: &SignatureToken,
         limit: &mut Limiter,
     ) -> anyhow::Result<FatType> {
@@ -335,7 +374,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
 
     fn resolve_struct_handle(
         &self,
-        module: &CompiledModule,
+        module: BinaryIndexedView,
         idx: StructHandleIndex,
         limit: &mut Limiter,
     ) -> anyhow::Result<FatStructType> {

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -87,7 +87,7 @@ pub enum FeatureFlag {
     LIMIT_VM_TYPE_SIZE = 69,
     ABORT_IF_MULTISIG_PAYLOAD_MISMATCH = 70,
     DISALLOW_USER_NATIVES = 71,
-    RAW_SCRIPT_ARGS = 72,
+    ALLOW_SERIALIZED_SCRIPT_ARGS = 72,
 }
 
 impl FeatureFlag {
@@ -155,7 +155,7 @@ impl FeatureFlag {
             FeatureFlag::LIMIT_VM_TYPE_SIZE,
             FeatureFlag::ABORT_IF_MULTISIG_PAYLOAD_MISMATCH,
             FeatureFlag::DISALLOW_USER_NATIVES,
-            FeatureFlag::RAW_SCRIPT_ARGS,
+            FeatureFlag::ALLOW_SERIALIZED_SCRIPT_ARGS,
         ]
     }
 }

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -87,6 +87,7 @@ pub enum FeatureFlag {
     LIMIT_VM_TYPE_SIZE = 69,
     ABORT_IF_MULTISIG_PAYLOAD_MISMATCH = 70,
     DISALLOW_USER_NATIVES = 71,
+    RAW_SCRIPT_ARGS = 72,
 }
 
 impl FeatureFlag {
@@ -154,6 +155,7 @@ impl FeatureFlag {
             FeatureFlag::LIMIT_VM_TYPE_SIZE,
             FeatureFlag::ABORT_IF_MULTISIG_PAYLOAD_MISMATCH,
             FeatureFlag::DISALLOW_USER_NATIVES,
+            FeatureFlag::RAW_SCRIPT_ARGS,
         ]
     }
 }


### PR DESCRIPTION
## Description

Script argument need to be updated so we can pass more complex arguments as we did for entry point functions.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Test implemented

## Key Areas to Review

- Compatibility: will this be a backward compatible change?
- Security: will this code cause new attack surfaces?

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
