### PR TITLE
[Compiler-v2][VM] add metadata check for script

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -126,6 +126,7 @@ pub enum FeatureFlag {
     UseCompatibilityCheckerV2,
     EnableEnumTypes,
     EnableResourceAccessControl,
+    RejectUnstableBytecodeForScript,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -331,6 +332,9 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::EnableEnumTypes => AptosFeatureFlag::ENABLE_ENUM_TYPES,
             FeatureFlag::EnableResourceAccessControl => {
                 AptosFeatureFlag::ENABLE_RESOURCE_ACCESS_CONTROL
+            }
+            FeatureFlag::RejectUnstableBytecodeForScript => {
+                AptosFeatureFlag::REJECT_UNSTABLE_BYTECODE_FOR_SCRIPT
             },
         }
     }
@@ -466,6 +470,9 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::ENABLE_ENUM_TYPES => FeatureFlag::EnableEnumTypes,
             AptosFeatureFlag::ENABLE_RESOURCE_ACCESS_CONTROL => {
                 FeatureFlag::EnableResourceAccessControl
+            }
+            AptosFeatureFlag::REJECT_UNSTABLE_BYTECODE_FOR_SCRIPT => {
+                FeatureFlag::RejectUnstableBytecodeForScript
             },
         }
     }

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -332,7 +332,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::EnableEnumTypes => AptosFeatureFlag::ENABLE_ENUM_TYPES,
             FeatureFlag::EnableResourceAccessControl => {
                 AptosFeatureFlag::ENABLE_RESOURCE_ACCESS_CONTROL
-            }
+            },
             FeatureFlag::RejectUnstableBytecodeForScript => {
                 AptosFeatureFlag::REJECT_UNSTABLE_BYTECODE_FOR_SCRIPT
             },
@@ -470,7 +470,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::ENABLE_ENUM_TYPES => FeatureFlag::EnableEnumTypes,
             AptosFeatureFlag::ENABLE_RESOURCE_ACCESS_CONTROL => {
                 FeatureFlag::EnableResourceAccessControl
-            }
+            },
             AptosFeatureFlag::REJECT_UNSTABLE_BYTECODE_FOR_SCRIPT => {
                 FeatureFlag::RejectUnstableBytecodeForScript
             },

--- a/aptos-move/aptos-vm/src/verifier/event_validation.rs
+++ b/aptos-move/aptos-vm/src/verifier/event_validation.rs
@@ -5,7 +5,6 @@ use crate::move_vm_ext::SessionExt;
 use aptos_framework::RuntimeModuleMetadataV1;
 use move_binary_format::{
     access::{ModuleAccess, ScriptAccess},
-    deserializer::DeserializerConfig,
     errors::{Location, PartialVMError, VMError, VMResult},
     file_format::{
         Bytecode, CompiledScript,
@@ -151,19 +150,7 @@ pub(crate) fn extract_event_metadata(
     Ok(event_structs)
 }
 
-pub(crate) fn verify_no_event_emission_in_script(
-    script_code: &[u8],
-    config: &DeserializerConfig,
-) -> VMResult<()> {
-    let script = match CompiledScript::deserialize_with_config(script_code, config) {
-        Ok(script) => script,
-        Err(err) => {
-            let msg = format!("[VM] deserializer for script returned error: {:?}", err);
-            return Err(PartialVMError::new(StatusCode::CODE_DESERIALIZATION_ERROR)
-                .with_message(msg)
-                .finish(Location::Script));
-        },
-    };
+pub(crate) fn verify_no_event_emission_in_compiled_script(script: &CompiledScript) -> VMResult<()> {
     for bc in &script.code().code {
         if let Bytecode::CallGeneric(index) = bc {
             let func_instantiation = &script.function_instantiation_at(*index);

--- a/aptos-move/e2e-move-tests/src/tests/metadata.rs
+++ b/aptos-move/e2e-move-tests/src/tests/metadata.rs
@@ -14,7 +14,7 @@ use aptos_package_builder::PackageBuilder;
 use aptos_types::{
     chain_id::ChainId,
     on_chain_config::{FeatureFlag, OnChainConfig},
-    transaction::TransactionStatus,
+    transaction::{Script, TransactionPayload, TransactionStatus},
 };
 use move_binary_format::CompiledModule;
 use move_core_types::{
@@ -267,6 +267,118 @@ fn test_compilation_metadata_internal(
             ),
         )
     }
+}
+
+fn test_compilation_metadata_script_internal(
+    mainnet_flag: bool,
+    v2_flag: bool,
+    feature_enabled: bool,
+) -> TransactionStatus {
+    let mut h = MoveHarness::new();
+    if feature_enabled {
+        h.enable_features(
+            vec![FeatureFlag::REJECT_UNSTABLE_BYTECODE_FOR_SCRIPT],
+            vec![],
+        );
+    } else {
+        h.enable_features(vec![], vec![
+            FeatureFlag::REJECT_UNSTABLE_BYTECODE_FOR_SCRIPT,
+        ]);
+    }
+    let account = h.new_account_at(AccountAddress::from_hex_literal("0xf00d").unwrap());
+    let mut builder = PackageBuilder::new("Package");
+    builder.add_source(
+        "m.move",
+        r#"
+        script {
+            fun main() { }
+        }
+        "#,
+    );
+    let path = builder.write_to_temp().unwrap();
+
+    let compiler_version = if v2_flag {
+        CompilerVersion::V2_0
+    } else {
+        CompilerVersion::V1
+    };
+    let package = build_package_with_compiler_version(
+        path.path().to_path_buf(),
+        BuildOptions::default(),
+        compiler_version,
+    )
+    .expect("building package must succeed");
+
+    let code = package.extract_script_code().into_iter().next().unwrap();
+
+    let script = TransactionPayload::Script(Script::new(code, vec![], vec![]));
+
+    if mainnet_flag {
+        h.set_resource(
+            CORE_CODE_ADDRESS,
+            ChainId::struct_tag(),
+            &ChainId::mainnet().id(),
+        );
+        h.run_transaction_payload_mainnet(&account, script)
+    } else {
+        h.run_transaction_payload(&account, script)
+    }
+}
+
+#[test]
+fn test_compilation_metadata_for_script() {
+    let mut enable_check = true;
+    // run compiler v2 code to mainnet
+    assert_vm_status!(
+        test_compilation_metadata_script_internal(true, true, enable_check),
+        StatusCode::UNSTABLE_BYTECODE_REJECTED
+    );
+    // run compiler v1 code to mainnet
+    assert_success!(test_compilation_metadata_script_internal(
+        true,
+        false,
+        enable_check
+    ));
+    // run compiler v2 code to test
+    assert_success!(test_compilation_metadata_script_internal(
+        false,
+        true,
+        enable_check
+    ));
+    // run compiler v1 code to test
+    assert_success!(test_compilation_metadata_script_internal(
+        false,
+        false,
+        enable_check
+    ));
+
+    enable_check = false;
+    // run compiler v2 code to mainnet
+    // success because the feature flag is turned off
+    assert_success!(test_compilation_metadata_script_internal(
+        true,
+        true,
+        enable_check
+    ),);
+    // run compiler v1 code to mainnet
+    assert_success!(test_compilation_metadata_script_internal(
+        true,
+        false,
+        enable_check
+    ));
+    // run compiler v2 code to test
+    // success because the feature flag is turned off
+    assert_success!(test_compilation_metadata_script_internal(
+        false,
+        true,
+        enable_check
+    ),);
+    // run compiler v1 code to test
+    assert_success!(test_compilation_metadata_script_internal(
+        false,
+        false,
+        enable_check
+    ));
 }
 
 #[test]

--- a/aptos-move/framework/src/module_metadata.rs
+++ b/aptos-move/framework/src/module_metadata.rs
@@ -312,6 +312,17 @@ pub fn get_compilation_metadata_from_compiled_module(
     }
 }
 
+/// Extract compilation metadata from a compiled script
+pub fn get_compilation_metadata_from_compiled_script(
+    module: &CompiledScript,
+) -> Option<CompilationMetadata> {
+    if let Some(data) = find_metadata_in_script(module, COMPILATION_METADATA_KEY) {
+        bcs::from_bytes::<CompilationMetadata>(&data.value).ok()
+    } else {
+        None
+    }
+}
+
 // This is mostly a copy paste of the existing function
 // get_metadata_from_compiled_module. In the API types there is a unifying trait for
 // modules and scripts called Bytecode that could help eliminate this duplication,

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -91,6 +91,7 @@ pub enum FeatureFlag {
     USE_COMPATIBILITY_CHECKER_V2 = 73,
     ENABLE_ENUM_TYPES = 74,
     ENABLE_RESOURCE_ACCESS_CONTROL = 75,
+    REJECT_UNSTABLE_BYTECODE_FOR_SCRIPT = 76,
 }
 
 impl FeatureFlag {
@@ -165,6 +166,7 @@ impl FeatureFlag {
             FeatureFlag::USE_COMPATIBILITY_CHECKER_V2,
             FeatureFlag::ENABLE_ENUM_TYPES,
             FeatureFlag::ENABLE_RESOURCE_ACCESS_CONTROL,
+            FeatureFlag::REJECT_UNSTABLE_BYTECODE_FOR_SCRIPT,
         ]
     }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR adds a check in the VM when running bytecode generated by an unstable compiler or containing unstable language feature on mainnet

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Added an e2e move test

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

1. logic of checking in the VM;
2. coverage in e2e move tests.


## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
