### PR TITLE
[Rosetta] Document design decisions and remaining code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3460,7 +3460,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
  "tokio",
  "url",
  "warp",

--- a/crates/aptos-rosetta/Cargo.toml
+++ b/crates/aptos-rosetta/Cargo.toml
@@ -35,7 +35,6 @@ once_cell = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
 warp = { workspace = true }

--- a/crates/aptos-rosetta/src/lib.rs
+++ b/crates/aptos-rosetta/src/lib.rs
@@ -114,6 +114,8 @@ pub async fn bootstrap_async(
     let handle = tokio::spawn(async move {
         // If it's Online mode, add the block cache
         let rest_client = rest_client.map(Arc::new);
+
+        // TODO: The BlockRetriever has no cache, and should probably be renamed from block_cache
         let block_cache = rest_client.as_ref().map(|rest_client| {
             Arc::new(BlockRetriever::new(
                 api_config.max_transactions_page_size,

--- a/crates/aptos-rosetta/src/lib.rs
+++ b/crates/aptos-rosetta/src/lib.rs
@@ -9,13 +9,12 @@ use crate::{
     block::BlockRetriever,
     common::{handle_request, with_context},
     error::{ApiError, ApiResult},
-    types::Store,
 };
 use aptos_config::config::ApiConfig;
-use aptos_logger::{debug, warn};
+use aptos_logger::debug;
 use aptos_types::{account_address::AccountAddress, chain_id::ChainId};
 use aptos_warp_webserver::{logger, Error, WebServer};
-use std::{collections::BTreeMap, convert::Infallible, sync::Arc};
+use std::{convert::Infallible, sync::Arc};
 use tokio::task::JoinHandle;
 use warp::{
     http::{HeaderValue, Method, StatusCode},
@@ -44,8 +43,6 @@ pub struct RosettaContext {
     pub chain_id: ChainId,
     /// Block index cache
     pub block_cache: Option<Arc<BlockRetriever>>,
-    pub owner_addresses: Vec<AccountAddress>,
-    pub pool_address_to_owner: BTreeMap<AccountAddress, AccountAddress>,
 }
 
 impl RosettaContext {
@@ -53,40 +50,11 @@ impl RosettaContext {
         rest_client: Option<Arc<aptos_rest_client::Client>>,
         chain_id: ChainId,
         block_cache: Option<Arc<BlockRetriever>>,
-        owner_addresses: Vec<AccountAddress>,
     ) -> Self {
-        let mut pool_address_to_owner = BTreeMap::new();
-        if let Some(ref rest_client) = rest_client {
-            // We have to now fill in all of the mappings of owner to pool address
-            for owner_address in owner_addresses.iter() {
-                if let Ok(store) = rest_client
-                    .get_account_resource_bcs::<Store>(
-                        *owner_address,
-                        "0x1::staking_contract::Store",
-                    )
-                    .await
-                {
-                    let store = store.into_inner();
-                    let pool_addresses: Vec<_> = store
-                        .staking_contracts
-                        .iter()
-                        .map(|(_, pool)| pool.pool_address)
-                        .collect();
-                    for pool_address in pool_addresses {
-                        pool_address_to_owner.insert(pool_address, *owner_address);
-                    }
-                } else {
-                    warn!("Did not find a pool for owner: {}", owner_address);
-                }
-            }
-        }
-
         RosettaContext {
             rest_client,
             chain_id,
             block_cache,
-            owner_addresses,
-            pool_address_to_owner,
         }
     }
 
@@ -112,18 +80,12 @@ pub fn bootstrap(
     chain_id: ChainId,
     api_config: ApiConfig,
     rest_client: Option<aptos_rest_client::Client>,
-    owner_addresses: Vec<AccountAddress>,
 ) -> anyhow::Result<tokio::runtime::Runtime> {
     let runtime = aptos_runtimes::spawn_named_runtime("rosetta".into(), None);
 
     debug!("Starting up Rosetta server with {:?}", api_config);
 
-    runtime.spawn(bootstrap_async(
-        chain_id,
-        api_config,
-        rest_client,
-        owner_addresses,
-    ));
+    runtime.spawn(bootstrap_async(chain_id, api_config, rest_client));
     Ok(runtime)
 }
 
@@ -132,7 +94,6 @@ pub async fn bootstrap_async(
     chain_id: ChainId,
     api_config: ApiConfig,
     rest_client: Option<aptos_rest_client::Client>,
-    owner_addresses: Vec<AccountAddress>,
 ) -> anyhow::Result<JoinHandle<()>> {
     debug!("Starting up Rosetta server with {:?}", api_config);
 
@@ -160,8 +121,7 @@ pub async fn bootstrap_async(
             ))
         });
 
-        let context =
-            RosettaContext::new(rest_client.clone(), chain_id, block_cache, owner_addresses).await;
+        let context = RosettaContext::new(rest_client.clone(), chain_id, block_cache).await;
         api.serve(routes(context)).await;
     });
     Ok(handle)

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -36,6 +36,7 @@ impl AccountIdentifier {
         str_to_account_address(self.address.as_str())
     }
 
+    /// Retrieve the pool address from an [`AccountIdentifier`], if it exists
     pub fn pool_address(&self) -> ApiResult<Option<AccountAddress>> {
         if let Some(sub_account) = &self.sub_account {
             if let Some(metadata) = &sub_account.metadata {
@@ -46,6 +47,7 @@ impl AccountIdentifier {
         Ok(None)
     }
 
+    /// Builds a normal account [`AccountIdentifier`] for a given address
     pub fn base_account(address: AccountAddress) -> Self {
         AccountIdentifier {
             address: to_hex_lower(&address),
@@ -53,6 +55,7 @@ impl AccountIdentifier {
         }
     }
 
+    /// Builds a stake account [`AccountIdentifier`] for a given address to retrieve stake balances
     pub fn total_stake_account(address: AccountAddress) -> Self {
         AccountIdentifier {
             address: to_hex_lower(&address),
@@ -60,6 +63,7 @@ impl AccountIdentifier {
         }
     }
 
+    /// Builds a pending active stake account [`AccountIdentifier`] for a given address to retrieve pending active stake balances
     pub fn pending_active_stake_account(address: AccountAddress) -> Self {
         AccountIdentifier {
             address: to_hex_lower(&address),
@@ -67,6 +71,7 @@ impl AccountIdentifier {
         }
     }
 
+    /// Builds a active stake account [`AccountIdentifier`] for a given address to retrieve active stake balances
     pub fn active_stake_account(address: AccountAddress) -> Self {
         AccountIdentifier {
             address: to_hex_lower(&address),
@@ -74,6 +79,7 @@ impl AccountIdentifier {
         }
     }
 
+    /// Builds a pending inactive stake account [`AccountIdentifier`] for a given address to retrieve pending inactive stake balances
     pub fn pending_inactive_stake_account(address: AccountAddress) -> Self {
         AccountIdentifier {
             address: to_hex_lower(&address),
@@ -81,6 +87,7 @@ impl AccountIdentifier {
         }
     }
 
+    /// Builds a inactive stake account [`AccountIdentifier`] for a given address to retrieve inactive stake balances
     pub fn inactive_stake_account(address: AccountAddress) -> Self {
         AccountIdentifier {
             address: to_hex_lower(&address),
@@ -88,6 +95,7 @@ impl AccountIdentifier {
         }
     }
 
+    /// Builds an operator stake account [`AccountIdentifier`] for a given address to retrieve operator stake balances
     pub fn operator_stake_account(
         address: AccountAddress,
         operator_address: AccountAddress,
@@ -98,6 +106,7 @@ impl AccountIdentifier {
         }
     }
 
+    /// Returns true if the account doesn't have a sub account
     pub fn is_base_account(&self) -> bool {
         self.sub_account.is_none()
     }
@@ -178,6 +187,7 @@ impl AccountIdentifier {
         }
     }
 
+    /// Retrieves the operator address if it has one in the sub-account
     pub fn operator_address(&self) -> ApiResult<AccountAddress> {
         if let Some(ref inner) = self.sub_account {
             inner.operator_address()
@@ -189,14 +199,16 @@ impl AccountIdentifier {
     }
 }
 
+/// Converts a string to an account address with error handling
 fn str_to_account_address(address: &str) -> Result<AccountAddress, ApiError> {
     AccountAddress::from_str(address)
         .map_err(|_| ApiError::InvalidInput(Some("Invalid account address".to_string())))
 }
 
-/// There are two types of SubAccountIdentifiers
+/// There are many types of SubAccountIdentifiers
 /// 1. `stake` which is the total stake
 /// 2. `stake-<operator>` which is the stake on the operator
+/// 3. And more for pool addresses and various stake types
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SubAccountIdentifier {
     /// Hex encoded AccountAddress beginning with 0x
@@ -356,7 +368,7 @@ impl SubAccountIdentifierMetadata {
     }
 }
 
-/// Identifier for a "block".  In aptos, we use a transaction model, so the index
+/// Identifier for a "block".  On Aptos, we use a transaction model, so the index
 /// represents multiple transactions in a "block" grouping of transactions
 ///
 /// [API Spec](https://www.rosetta-api.org/docs/models/BlockIdentifier.html)
@@ -364,7 +376,7 @@ impl SubAccountIdentifierMetadata {
 pub struct BlockIdentifier {
     /// Block index, which points to a txn at the beginning of a "block"
     pub index: u64,
-    /// Accumulator hash at the beginning of the block
+    /// A fake hash, that is actually `chain_id-block_height`
     pub hash: String,
 }
 

--- a/crates/aptos-rosetta/src/types/move_types.rs
+++ b/crates/aptos-rosetta/src/types/move_types.rs
@@ -39,7 +39,8 @@ pub const SWITCH_OPERATOR_WITH_SAME_COMMISSION_FUNCTION: &str =
     "switch_operator_with_same_commission";
 pub const UPDATE_VOTER_FUNCTION: &str = "update_voter";
 pub const UNLOCK_STAKE_FUNCTION: &str = "unlock_stake";
-// TODO fix the typo in function name. commision -> commission
+// TODO fix the typo in function name. commision -> commission (this has to be done on-chain first)
+// TODO: Handle update_commission and update_commision
 pub const UPDATE_COMMISSION_FUNCTION: &str = "update_commision";
 pub const DISTRIBUTE_STAKING_REWARDS_FUNCTION: &str = "distribute";
 
@@ -239,7 +240,7 @@ pub struct UndelegationEvent {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct WithdrawUndelegedEvent {
+pub struct WithdrawUndelegatedEvent {
     pub pool_address: AccountAddress,
     pub delegator_address: AccountAddress,
     pub amount_withdrawn: u64,

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -106,7 +106,7 @@ impl Amount {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BalanceExemption {}
 
-/// Representation of a Block for a blockchain.  For aptos it is the version
+/// Representation of a Block for a blockchain.
 ///
 /// [API Spec](https://www.rosetta-api.org/docs/models/Block.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -879,6 +879,7 @@ impl Transaction {
         server_context: &RosettaContext,
         txn: TransactionOnChainData,
     ) -> ApiResult<Transaction> {
+        // Parses the events, changesets, and metadata out of each transaction
         use aptos_types::transaction::Transaction::*;
         let (txn_type, maybe_user_txn, txn_info, events) = match &txn.transaction {
             UserTransaction(user_txn) => {
@@ -964,6 +965,8 @@ impl Transaction {
                 txn.gas_unit_price(),
             ));
         }
+
+        // TODO: Handle storage gas refund (though nothing currently in Rosetta refunds)
 
         Ok(Transaction {
             transaction_identifier: (&txn_info).into(),
@@ -1155,6 +1158,7 @@ fn parse_failed_operations_from_txn_payload(
     operations
 }
 
+/// Parses a 0x1::coin::transfer to a Withdraw and Deposit
 fn parse_transfer_from_txn_payload(
     payload: &EntryFunction,
     currency: Currency,
@@ -1294,6 +1298,7 @@ async fn parse_operations_from_write_set(
     }
 }
 
+/// Parses any account resource changes, in this case only create account is supported
 fn parse_account_resource_changes(
     version: u64,
     address: AccountAddress,
@@ -1530,6 +1535,7 @@ fn parse_stake_pool_resource_changes(
     Ok(operations)
 }
 
+/// Handles 0x1::staking_contract resource changes
 async fn parse_staking_contract_resource_changes(
     owner_address: AccountAddress,
     data: &[u8],
@@ -1682,6 +1688,7 @@ async fn parse_staking_contract_resource_changes(
     Ok(operations)
 }
 
+/// Parses 0x1::staking_contract commission updates
 async fn parse_update_commission(
     _owner_address: AccountAddress,
     data: &[u8],
@@ -1727,6 +1734,7 @@ async fn parse_update_commission(
     Ok(operations)
 }
 
+/// Parses delegation pool changes to resources
 async fn parse_delegation_pool_resource_changes(
     _owner_address: AccountAddress,
     _data: &[u8],
@@ -1748,7 +1756,7 @@ async fn parse_delegation_pool_resource_changes(
             struct_tag.name.as_str(),
         ) {
             (AccountAddress::ONE, DELEGATION_POOL_MODULE, WITHDRAW_STAKE_EVENT) => {
-                let event: WithdrawUndelegedEvent =
+                let event: WithdrawUndelegatedEvent =
                     if let Ok(event) = bcs::from_bytes(e.event_data()) {
                         event
                     } else {
@@ -1776,6 +1784,7 @@ async fn parse_delegation_pool_resource_changes(
     Ok(operations)
 }
 
+/// Parses coin store direct changes, for withdraws and deposits
 async fn parse_coinstore_changes(
     currency: Currency,
     version: u64,
@@ -1795,6 +1804,8 @@ async fn parse_coinstore_changes(
     };
 
     let mut operations = vec![];
+
+    // TODO: Handle Event V2 here for migration from Event V1
 
     // Skip if there is no currency that can be found
     let withdraw_amounts = get_amount_from_event(events, coin_store.withdraw_events().key());
@@ -1855,6 +1866,7 @@ fn get_fee_statement_from_event(events: &[ContractEvent]) -> Vec<FeeStatement> {
         .collect()
 }
 
+/// Filters events given a specific event key
 fn filter_events<F: Fn(&EventKey, &ContractEvent) -> Option<T>, T>(
     events: &[ContractEvent],
     event_key: &EventKey,
@@ -1904,8 +1916,10 @@ pub enum InternalOperation {
 
 impl InternalOperation {
     /// Pulls the [`InternalOperation`] from the set of [`Operation`]
+    /// TODO: this needs to be broken up
     pub fn extract(operations: &Vec<Operation>) -> ApiResult<InternalOperation> {
         match operations.len() {
+            // Single operation actions
             1 => {
                 if let Some(operation) = operations.first() {
                     match OperationType::from_str(&operation.operation_type) {
@@ -2150,7 +2164,9 @@ impl InternalOperation {
                     operations
                 ))))
             },
+            // Double operation actions (only coin transfer)
             2 => Ok(Self::Transfer(Transfer::extract_transfer(operations)?)),
+            // Anything else is not expected
             _ => Err(ApiError::InvalidOperations(Some(format!(
                 "Unrecognized operation combination {:?}",
                 operations

--- a/crates/aptos-rosetta/src/types/requests.rs
+++ b/crates/aptos-rosetta/src/types/requests.rs
@@ -58,7 +58,8 @@ pub struct AccountBalanceMetadata {
     pub operators: Option<Vec<AccountAddress>>,
     pub lockup_expiration_time_utc: U64,
 }
-/// Reqyest a block (version) on the account
+
+/// Request a block (version) on the account
 ///
 /// With neither value for PartialBlockIdentifier, get the latest version
 ///

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -113,7 +113,6 @@ async fn setup_test(
         Some(aptos_rest_client::Client::new(
             validator.rest_api_endpoint(),
         )),
-        cli.addresses(),
     )
     .await
     .unwrap();


### PR DESCRIPTION
## Description
Adds documentation for the Rosetta codebase around remaining design decisions.

Builds on top of https://github.com/aptos-labs/aptos-core/pull/14104

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [x] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Other (Rosetta)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
