### PR TITLE
DB: ability to pre-commit

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/src/internal_indexer_db_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/src/internal_indexer_db_service.rs
@@ -82,12 +82,12 @@ impl InternalIndexerDBService {
             .state_sync_driver
             .bootstrapping_mode
             .is_fast_sync();
-        let mut main_db_synced_version = self.db_indexer.main_db_reader.get_synced_version()?;
+        let mut main_db_synced_version = self.db_indexer.main_db_reader.ensure_synced_version()?;
 
         // Wait till fast sync is done
         while fast_sync_enabled && main_db_synced_version == 0 {
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-            main_db_synced_version = self.db_indexer.main_db_reader.get_synced_version()?;
+            main_db_synced_version = self.db_indexer.main_db_reader.ensure_synced_version()?;
         }
 
         let start_version = self

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -166,7 +166,7 @@ pub fn run_benchmark<V>(
         ((0..pipeline_config.num_generator_workers).map(|_| transaction_generator_creator.create_transaction_generator()).collect::<Vec<_>>(), phase)
     });
 
-    let version = db.reader.get_synced_version().unwrap();
+    let version = db.reader.expect_synced_version();
 
     let (pipeline, block_sender) =
         Pipeline::new(executor, version, &pipeline_config, Some(num_blocks));
@@ -235,8 +235,7 @@ pub fn run_benchmark<V>(
     );
 
     if !pipeline_config.skip_commit {
-        let num_txns =
-            db.reader.get_synced_version().unwrap() - version - num_blocks_created as u64;
+        let num_txns = db.reader.expect_synced_version() - version - num_blocks_created as u64;
         overall_measuring.print_end("Overall", num_txns);
 
         if verify_sequence_numbers {
@@ -260,7 +259,7 @@ fn init_workload<V>(
 where
     V: TransactionBlockExecutor + 'static,
 {
-    let version = db.reader.get_synced_version().unwrap();
+    let version = db.reader.expect_synced_version();
     let (pipeline, block_sender) = Pipeline::<V>::new(
         BlockExecutor::new(db.clone()),
         version,

--- a/execution/executor/src/tests/chunk_executor_tests.rs
+++ b/execution/executor/src/tests/chunk_executor_tests.rs
@@ -106,7 +106,7 @@ fn test_executor_execute_or_apply_and_commit_chunk() {
         } = TestExecutor::new();
         execute_and_commit_chunks(chunks, ledger_info.clone(), &db, &executor);
 
-        let ledger_version = db.reader.get_synced_version().unwrap();
+        let ledger_version = db.reader.expect_synced_version();
         let output1 = db
             .reader
             .get_transaction_outputs(first_batch_start, first_batch_size, ledger_version)

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -783,7 +783,7 @@ proptest! {
 
             // get txn_infos from db
             let db = executor.db.reader.clone();
-            prop_assert_eq!(db.get_synced_version().unwrap(), ledger_version);
+            prop_assert_eq!(db.expect_synced_version(), ledger_version);
             let txn_list = db.get_transactions(1 /* start version */, ledger_version, ledger_version /* ledger version */, false /* fetch events */).unwrap();
             prop_assert_eq!(&block.inner_txns(), &txn_list.transactions[..num_input_txns as usize]);
             let txn_infos = txn_list.proof.transaction_infos;

--- a/execution/executor/tests/internal_indexer_test.rs
+++ b/execution/executor/tests/internal_indexer_test.rs
@@ -136,7 +136,7 @@ fn test_db_indexer_data() {
     use std::{thread, time::Duration};
     // create test db
     let (aptos_db, core_account) = create_test_db();
-    let total_version = aptos_db.get_synced_version().unwrap();
+    let total_version = aptos_db.expect_synced_version();
     assert_eq!(total_version, 11);
     let temp_path = TempPath::new();
     let mut node_config = aptos_config::config::NodeConfig::default();

--- a/peer-monitoring-service/server/src/tests.rs
+++ b/peer-monitoring-service/server/src/tests.rs
@@ -681,7 +681,7 @@ mod database_mock {
 
             fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures>;
 
-            fn get_synced_version(&self) -> Result<Version>;
+            fn get_synced_version(&self) -> Result<Option<Version>>;
 
             fn get_latest_ledger_info_version(&self) -> Result<Version>;
 

--- a/state-sync/aptos-data-client/src/latency_monitor.rs
+++ b/state-sync/aptos-data-client/src/latency_monitor.rs
@@ -67,7 +67,7 @@ impl LatencyMonitor {
             // Wait for the next round
             loop_ticker.next().await;
 
-            let highest_synced_version = match self.storage.get_synced_version() {
+            let highest_synced_version = match self.storage.ensure_synced_version() {
                 Ok(version) => version,
                 Err(error) => {
                     sample!(

--- a/state-sync/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/tests/bootstrapper.rs
@@ -1613,7 +1613,7 @@ fn create_bootstrapper(
         .returning(|| Ok(create_epoch_ending_ledger_info()));
     mock_database_reader
         .expect_get_synced_version()
-        .returning(|| Ok(0));
+        .returning(|| Ok(Some(0)));
 
     // Create the output fallback handler
     let time_service = time_service.unwrap_or_else(TimeService::mock);
@@ -1670,7 +1670,7 @@ fn create_bootstrapper_with_storage(
         .returning(move || Ok(epoch_ending_ledger_info.clone()));
     mock_database_reader
         .expect_get_synced_version()
-        .returning(move || Ok(latest_synced_version));
+        .returning(move || Ok(Some(latest_synced_version)));
 
     // Create the output fallback handler
     let output_fallback_handler =

--- a/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
+++ b/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
@@ -503,7 +503,7 @@ fn create_continuous_syncer(
     let mut mock_database_reader = create_mock_db_reader();
     mock_database_reader
         .expect_get_synced_version()
-        .returning(move || Ok(synced_version));
+        .returning(move || Ok(Some(synced_version)));
     mock_database_reader
         .expect_get_latest_epoch_state()
         .returning(move || Ok(create_epoch_state(current_epoch)));

--- a/state-sync/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-driver/src/tests/mocks.rs
@@ -82,7 +82,7 @@ pub fn create_mock_reader_writer_with_version(
     let mut reader = reader.unwrap_or_else(create_mock_db_reader);
     reader
         .expect_get_synced_version()
-        .returning(move || Ok(highest_synced_version));
+        .returning(move || Ok(Some(highest_synced_version)));
     reader
         .expect_get_latest_epoch_state()
         .returning(|| Ok(create_empty_epoch_state()));
@@ -235,7 +235,7 @@ mock! {
 
         fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures>;
 
-        fn get_synced_version(&self) -> Result<Version>;
+        fn get_synced_version(&self) -> Result<Option<Version>>;
 
         fn get_latest_ledger_info_version(&self) -> Result<Version>;
 

--- a/state-sync/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-driver/src/utils.rs
@@ -279,7 +279,7 @@ pub fn fetch_latest_synced_ledger_info(
 
 /// Fetches the latest synced version from the specified storage
 pub fn fetch_latest_synced_version(storage: Arc<dyn DbReader>) -> Result<Version, Error> {
-    storage.get_synced_version().map_err(|e| {
+    storage.ensure_synced_version().map_err(|e| {
         Error::StorageError(format!("Failed to get latest version from storage: {e:?}"))
     })
 }

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -288,7 +288,7 @@ mock! {
 
         fn get_latest_ledger_info(&self) -> aptos_storage_interface::Result<LedgerInfoWithSignatures>;
 
-        fn get_synced_version(&self) -> aptos_storage_interface::Result<Version>;
+        fn get_synced_version(&self) -> aptos_storage_interface::Result<Option<Version>>;
 
         fn get_latest_ledger_info_version(&self) -> aptos_storage_interface::Result<Version>;
 

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -119,7 +119,7 @@ impl RestoreHandler {
     }
 
     pub fn get_next_expected_transaction_version(&self) -> Result<Version> {
-        Ok(self.aptosdb.get_synced_version().map_or(0, |ver| ver + 1))
+        Ok(self.aptosdb.get_synced_version()?.map_or(0, |ver| ver + 1))
     }
 
     pub fn get_state_snapshot_before(

--- a/storage/aptosdb/src/db/fake_aptosdb.rs
+++ b/storage/aptosdb/src/db/fake_aptosdb.rs
@@ -236,7 +236,7 @@ impl FakeAptosDB {
             .current_version
             .map(|version| version + 1)
             .unwrap_or(0);
-        let num_transactions_in_db = self.get_synced_version().map_or(0, |v| v + 1);
+        let num_transactions_in_db = self.get_synced_version()?.map_or(0, |v| v + 1);
         ensure!(num_transactions_in_db == first_version && num_transactions_in_db == next_version_in_buffered_state,
             "The first version {} passed in, the next version in buffered state {} and the next version in db {} are inconsistent.",
             first_version,
@@ -667,7 +667,7 @@ impl DbReader for FakeAptosDB {
     fn get_block_timestamp(&self, version: Version) -> Result<u64> {
         gauged_api("get_block_timestamp", || {
             ensure!(
-                version <= self.get_synced_version()?,
+                version <= self.ensure_synced_version()?,
                 "version older than latest version"
             );
 
@@ -835,7 +835,7 @@ impl DbReader for FakeAptosDB {
         // This is because when we call save_transactions for the genesis block, we call [AptosDB::save_transactions]
         // where there is an expectation that the root of the SMTs are the same pointers. Here,
         // we get from the inner AptosDB which ensures that the pointers match when save_transactions is called.
-        if self.get_synced_version().unwrap_or_default() == 0 {
+        if self.ensure_synced_version().unwrap_or_default() == 0 {
             return self.inner.get_latest_executed_trees();
         }
 

--- a/storage/aptosdb/src/db/include/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_internal.rs
@@ -57,7 +57,8 @@ impl AptosDB {
                 state_merkle_db,
                 state_kv_db,
             ),
-            ledger_commit_lock: std::sync::Mutex::new(()),
+            pre_commit_lock: std::sync::Mutex::new(()),
+            commit_lock: std::sync::Mutex::new(()),
             indexer: None,
             skip_index_and_usage,
         }

--- a/storage/aptosdb/src/db/include/aptosdb_internal.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_internal.rs
@@ -115,7 +115,7 @@ impl AptosDB {
         rocksdb_config: RocksdbConfig,
     ) -> Result<()> {
         let indexer = Indexer::open(&db_root_path, rocksdb_config)?;
-        let ledger_next_version = self.get_synced_version().map_or(0, |v| v + 1);
+        let ledger_next_version = self.get_synced_version()?.map_or(0, |v| v + 1);
         info!(
             indexer_next_version = indexer.next_version(),
             ledger_next_version = ledger_next_version,
@@ -232,7 +232,7 @@ impl AptosDB {
             let (first_version, new_block_event) = self.event_store.get_event_by_key(
                 &new_block_event_key(),
                 block_height,
-                self.get_synced_version()?,
+                self.ensure_synced_version()?,
             )?;
             let new_block_event = bcs::from_bytes(new_block_event.event_data())?;
             Ok(BlockInfo::from_new_block_event(
@@ -254,7 +254,7 @@ impl AptosDB {
         &self,
         version: Version,
     ) -> Result<(u64 /* block_height */, BlockInfo)> {
-        let synced_version = self.get_synced_version()?;
+        let synced_version = self.ensure_synced_version()?;
         ensure!(
             version <= synced_version,
             "Requested version {version} > synced version {synced_version}",

--- a/storage/aptosdb/src/db/include/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_reader.rs
@@ -51,7 +51,7 @@ impl DbReader for AptosDB {
         })
     }
 
-    fn get_synced_version(&self) -> Result<Version> {
+    fn get_synced_version(&self) -> Result<Option<Version>> {
         gauged_api("get_synced_version", || {
             self.ledger_db.metadata_db().get_synced_version()
         })
@@ -545,7 +545,7 @@ impl DbReader for AptosDB {
                     u64::max_value(),
                     Order::Descending,
                     num_events as u64,
-                    self.get_synced_version().unwrap_or(0),
+                    self.get_synced_version()?.unwrap_or(0),
                 );
             }
 

--- a/storage/aptosdb/src/db/include/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_writer.rs
@@ -1,48 +1,41 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use itertools::Itertools;
+
 impl DbWriter for AptosDB {
-    /// `first_version` is the version of the first transaction in `txns_to_commit`.
-    /// When `ledger_info_with_sigs` is provided, verify that the transaction accumulator root hash
-    /// it carries is generated after the `txns_to_commit` are applied.
-    /// Note that even if `txns_to_commit` is empty, `first_version` is checked to be
-    /// `ledger_info_with_sigs.ledger_info.version + 1` if `ledger_info_with_sigs` is not `None`.
-    fn save_transactions(
+    fn pre_commit_ledger(
         &self,
         txns_to_commit: &[TransactionToCommit],
         first_version: Version,
         base_state_version: Option<Version>,
-        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
         sync_commit: bool,
         latest_in_memory_state: StateDelta,
         state_updates_until_last_checkpoint: Option<ShardedStateUpdates>,
         sharded_state_cache: Option<&ShardedStateCache>,
     ) -> Result<()> {
-        gauged_api("save_transactions", || {
-            // Executing and committing from more than one threads not allowed -- consensus and
-            // state sync must hand over to each other after all pending execution and committing
-            // complete.
+        gauged_api("pre_commit_ledger", || {
+            // Pre-committing and committing in concurrency is allowed but not pre-committing at the
+            // same time from multiple threads, the same for committing.
+            // Consensus and state sync must hand over to each other after all pending execution and
+            // committing complete.
             let _lock = self
-                .ledger_commit_lock
+                .pre_commit_lock
                 .try_lock()
                 .expect("Concurrent committing detected.");
+            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["pre_commit_ledger"]);
 
             latest_in_memory_state.current.log_generation("db_save");
 
-            // For reconfig suffix.
-            if ledger_info_with_sigs.is_none() && txns_to_commit.is_empty() {
-                return Ok(());
-            }
-
-            self.save_transactions_validation(
+            self.pre_commit_validation(
                 txns_to_commit,
                 first_version,
                 base_state_version,
-                ledger_info_with_sigs,
                 &latest_in_memory_state,
             )?;
+            let last_version = first_version + txns_to_commit.len() as u64 - 1;
 
-            let new_root_hash = self.calculate_and_commit_ledger_and_state_kv(
+            let _new_root_hash = self.calculate_and_commit_ledger_and_state_kv(
                 txns_to_commit,
                 first_version,
                 latest_in_memory_state.current.usage(),
@@ -53,9 +46,6 @@ impl DbWriter for AptosDB {
             let _timer = OTHER_TIMERS_SECONDS.timer_with(&["save_transactions__others"]);
             {
                 let mut buffered_state = self.state_store.buffered_state().lock();
-                let last_version = first_version + txns_to_commit.len() as u64 - 1;
-
-                self.commit_ledger_info(last_version, new_root_hash, ledger_info_with_sigs)?;
 
                 if !txns_to_commit.is_empty() {
                     let _timer = OTHER_TIMERS_SECONDS.timer_with(&["buffered_state___update"]);
@@ -66,10 +56,52 @@ impl DbWriter for AptosDB {
                     )?;
                 }
             }
-
-            self.post_commit(txns_to_commit, first_version, ledger_info_with_sigs)
+            self.ledger_db.metadata_db().set_pre_committed_version(last_version);
+            Ok(())
         })
     }
+
+    fn commit_ledger(
+        &self,
+        version: Version,
+        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        txns_to_commit: Option<&[TransactionToCommit]>,
+    ) -> Result<()> {
+        gauged_api("commit_ledger", || {
+            // Pre-committing and committing in concurrency is allowed but not pre-committing at the
+            // same time from multiple threads, the same for committing.
+            // Consensus and state sync must hand over to each other after all pending execution and
+            // committing complete.
+            let _lock = self
+                .commit_lock
+                .try_lock()
+                .expect("Concurrent committing detected.");
+            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["commit_ledger"]);
+
+            let old_committed_ver = self.get_and_check_commit_range(version, txns_to_commit)?;
+
+            let ledger_batch = SchemaBatch::new();
+            // Write down LedgerInfo if provided.
+            if let Some(li) = ledger_info_with_sigs {
+                self.check_and_put_ledger_info(version, li, &ledger_batch)?;
+            }
+            // Write down commit progress
+            ledger_batch.put::<DbMetadataSchema>(
+                &DbMetadataKey::OverallCommitProgress,
+                &DbMetadataValue::Version(version),
+            )?;
+            self.ledger_db.metadata_db().write_schemas(ledger_batch)?;
+
+            // Notify the pruners, invoke the indexer, and update in-memory ledger info.
+            self.post_commit(
+                old_committed_ver,
+                version,
+                ledger_info_with_sigs,
+                txns_to_commit,
+            )
+        })
+    }
+
 
     fn get_state_snapshot_receiver(
         &self,
@@ -200,68 +232,55 @@ impl DbWriter for AptosDB {
 }
 
 impl AptosDB {
-    fn save_transactions_validation(
+    fn pre_commit_validation(
         &self,
         txns_to_commit: &[TransactionToCommit],
         first_version: Version,
         base_state_version: Option<Version>,
-        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
         latest_in_memory_state: &StateDelta,
     ) -> Result<()> {
         let _timer = OTHER_TIMERS_SECONDS
             .with_label_values(&["save_transactions_validation"])
             .start_timer();
-        let buffered_state = self.state_store.buffered_state().lock();
-        ensure!(
-            base_state_version == buffered_state.current_state().base_version,
-            "base_state_version {:?} does not equal to the base_version {:?} in buffered state with current version {:?}",
-            base_state_version,
-            buffered_state.current_state().base_version,
-            buffered_state.current_state().current_version,
-        );
-
-        // Ensure the incoming committing requests are always consecutive and the version in
-        // buffered state is consistent with that in db.
-        let next_version_in_buffered_state = buffered_state
-            .current_state()
-            .current_version
-            .map(|version| version + 1)
-            .unwrap_or(0);
-        let num_transactions_in_db = self.get_synced_version().map_or(0, |v| v + 1);
-        ensure!(num_transactions_in_db == first_version && num_transactions_in_db == next_version_in_buffered_state,
-            "The first version {} passed in, the next version in buffered state {} and the next version in db {} are inconsistent.",
-            first_version,
-            next_version_in_buffered_state,
-            num_transactions_in_db,
-        );
 
         let num_txns = txns_to_commit.len() as u64;
-        // ledger_info_with_sigs could be None if we are doing state synchronization. In this case
-        // txns_to_commit should not be empty. Otherwise it is okay to commit empty blocks.
         ensure!(
-            ledger_info_with_sigs.is_some() || num_txns > 0,
-            "txns_to_commit is empty while ledger_info_with_sigs is None.",
+            num_txns > 0,
+            "txns_to_commit is empty, nothing to save.",
         );
-
         let last_version = first_version + num_txns - 1;
-
-        if let Some(x) = ledger_info_with_sigs {
-            let claimed_last_version = x.ledger_info().version();
-            ensure!(
-                claimed_last_version  == last_version,
-                "Transaction batch not applicable: first_version {}, num_txns {}, last_version_in_ledger_info {}",
-                first_version,
-                num_txns,
-                claimed_last_version,
-            );
-        }
-
         ensure!(
             Some(last_version) == latest_in_memory_state.current_version,
             "the last_version {:?} to commit doesn't match the current_version {:?} in latest_in_memory_state",
             last_version,
             latest_in_memory_state.current_version.expect("Must exist"),
         );
+
+        let num_transactions_in_db = self.get_synced_version().map_or(0, |v| v + 1);
+        {
+            let buffered_state = self.state_store.buffered_state().lock();
+            ensure!(
+                base_state_version == buffered_state.current_state().base_version,
+                "base_state_version {:?} does not equal to the base_version {:?} in buffered state with current version {:?}",
+                base_state_version,
+                buffered_state.current_state().base_version,
+                buffered_state.current_state().current_version,
+            );
+
+            // Ensure the incoming committing requests are always consecutive and the version in
+            // buffered state is consistent with that in db.
+            let next_version_in_buffered_state = buffered_state
+                .current_state()
+                .current_version
+                .map(|version| version + 1)
+                .unwrap_or(0);
+            ensure!(num_transactions_in_db == first_version && num_transactions_in_db == next_version_in_buffered_state,
+                "The first version {} passed in, the next version in buffered state {} and the next version in db {} are inconsistent.",
+                first_version,
+                next_version_in_buffered_state,
+                num_transactions_in_db,
+            );
+        }
 
         Ok(())
     }
@@ -566,82 +585,121 @@ impl AptosDB {
         self.ledger_db.transaction_info_db().write_schemas(batch)
     }
 
-    fn commit_ledger_info(
+    fn get_and_check_commit_range(
         &self,
-        last_version: Version,
-        new_root_hash: HashValue,
-        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
-    ) -> Result<()> {
-        let _timer = OTHER_TIMERS_SECONDS
-            .with_label_values(&["commit_ledger_info"])
-            .start_timer();
-
-        let ledger_batch = SchemaBatch::new();
-
-        // If expected ledger info is provided, verify result root hash and save the ledger info.
-        if let Some(x) = ledger_info_with_sigs {
-            let expected_root_hash = x.ledger_info().transaction_accumulator_hash();
+        version_to_commit: Version,
+        txns_to_commit: Option<&[TransactionToCommit]>
+    ) -> Result<Option<Version>> {
+        let old_committed_ver = self.ledger_db.metadata_db().get_synced_version_opt()?;
+        let pre_committed_ver = self.ledger_db.metadata_db().get_pre_committed_version();
+        ensure!(
+            old_committed_ver.is_none() || version_to_commit >= old_committed_ver.unwrap(),
+            "Version too old to commit. Committed: {:?}; Trying to commit with LI: {}",
+            old_committed_ver,
+            version_to_commit,
+        );
+        ensure!(
+            pre_committed_ver.is_some() && version_to_commit <= pre_committed_ver.unwrap(),
+            "Version too new to commit. Pre-committed: {:?}, Trying to commit with LI: {}",
+            pre_committed_ver,
+            version_to_commit,
+        );
+        if let Some(txns_to_commit) = txns_to_commit {
+            let expected_next_to_commit = old_committed_ver.map_or(0, |v| v + 1);
             ensure!(
-                new_root_hash == expected_root_hash,
-                "Root hash calculated doesn't match expected. {:?} vs {:?}",
-                new_root_hash,
-                expected_root_hash,
+                txns_to_commit.len() as u64 == version_to_commit + 1 - expected_next_to_commit,
+                "Bad commit range. to-commit: {}, committed: {:?}, Num txns: {}",
+                version_to_commit,
+                old_committed_ver,
+                txns_to_commit.len(),
             );
-            let current_epoch = self
-                .ledger_db
-                .metadata_db()
-                .get_latest_ledger_info_option()
-                .map_or(0, |li| li.ledger_info().next_block_epoch());
-            ensure!(
-                x.ledger_info().epoch() == current_epoch,
-                "Gap in epoch history. Trying to put in LedgerInfo in epoch: {}, current epoch: {}",
-                x.ledger_info().epoch(),
-                current_epoch,
-            );
-
-            self.ledger_db
-                .metadata_db()
-                .put_ledger_info(x, &ledger_batch)?;
         }
+        Ok(old_committed_ver)
+    }
 
-        ledger_batch.put::<DbMetadataSchema>(
-            &DbMetadataKey::OverallCommitProgress,
-            &DbMetadataValue::Version(last_version),
-        )?;
-        self.ledger_db.metadata_db().write_schemas(ledger_batch)
+    fn check_and_put_ledger_info(
+        &self,
+        version: Version,
+        ledger_info_with_sig: &LedgerInfoWithSignatures,
+        ledger_batch: &SchemaBatch
+    ) -> Result<(), AptosDbError> {
+        let ledger_info = ledger_info_with_sig.ledger_info();
+
+        // Verify the version.
+        ensure!(
+            ledger_info.version() == version,
+            "Version in LedgerInfo doesn't match last version. {:?} vs {:?}",
+            ledger_info.version(),
+            version,
+        );
+
+        // Verify the root hash.
+        let db_root_hash = self.ledger_db.transaction_accumulator_db().get_root_hash(version)?;
+        let li_root_hash = ledger_info_with_sig.ledger_info().transaction_accumulator_hash();
+        ensure!(
+            db_root_hash == li_root_hash,
+            "Root hash pre-committed doesn't match LedgerInfo. pre-commited: {:?} vs in LedgerInfo: {:?}",
+            db_root_hash,
+            li_root_hash,
+        );
+
+        // Verify epoch continuity.
+        let current_epoch = self
+            .ledger_db
+            .metadata_db()
+            .get_latest_ledger_info_option()
+            .map_or(0, |li| li.ledger_info().next_block_epoch());
+        ensure!(
+            ledger_info_with_sig.ledger_info().epoch() == current_epoch,
+            "Gap in epoch history. Trying to put in LedgerInfo in epoch: {}, current epoch: {}",
+            ledger_info_with_sig.ledger_info().epoch(),
+            current_epoch,
+        );
+
+        // Put write to batch.
+        self.ledger_db
+            .metadata_db()
+            .put_ledger_info(ledger_info_with_sig, ledger_batch)?;
+        Ok(())
     }
 
     fn post_commit(
         &self,
-        txns_to_commit: &[TransactionToCommit],
-        first_version: Version,
+        old_committed_version: Option<Version>,
+        version: Version,
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        txns_to_commit: Option<&[TransactionToCommit]>,
     ) -> Result<()> {
         // If commit succeeds and there are at least one transaction written to the storage, we
         // will inform the pruner thread to work.
-        let num_txns = txns_to_commit.len() as u64;
-        if num_txns > 0 {
-            let last_version = first_version + num_txns - 1;
+        if old_committed_version.is_none() || version > old_committed_version.unwrap() {
+            let first_version = old_committed_version.map_or(0, |v| v + 1);
+            let num_txns = version + 1 - first_version;
+
             COMMITTED_TXNS.inc_by(num_txns);
-            LATEST_TXN_VERSION.set(last_version as i64);
+            LATEST_TXN_VERSION.set(version as i64);
             // Activate the ledger pruner and state kv pruner.
             // Note the state merkle pruner is activated when state snapshots are persisted
             // in their async thread.
             self.ledger_pruner
-                .maybe_set_pruner_target_db_version(last_version);
+                .maybe_set_pruner_target_db_version(version);
             self.state_store
                 .state_kv_pruner
-                .maybe_set_pruner_target_db_version(last_version);
-        }
+                .maybe_set_pruner_target_db_version(version);
 
-        // Note: this must happen after txns have been saved to db because types can be newly
-        // created in this same chunk of transactions.
-        if let Some(indexer) = &self.indexer {
-            let _timer = OTHER_TIMERS_SECONDS
-                .with_label_values(&["indexer_index"])
-                .start_timer();
-            let write_sets: Vec<_> = txns_to_commit.iter().map(|txn| txn.write_set()).collect();
-            indexer.index(self.state_store.clone(), first_version, &write_sets)?;
+            // Note: this must happen after txns have been saved to db because types can be newly
+            // created in this same chunk of transactions.
+            if let Some(indexer) = &self.indexer {
+                let _timer = OTHER_TIMERS_SECONDS.timer_with(&["indexer_index"]);
+                if let Some(txns_to_commit) = txns_to_commit {
+                    let write_sets = txns_to_commit.iter().map(|txn| txn.write_set()).collect_vec();
+                    indexer.index(self.state_store.clone(), first_version, &write_sets)?;
+                } else {
+                    let write_sets: Vec<_> = self.ledger_db.write_set_db().get_write_set_iter(first_version, num_txns as usize)?.try_collect()?;
+                    let write_set_refs = write_sets.iter().collect_vec();
+                    indexer.index(self.state_store.clone(), first_version, &write_set_refs)?;
+                };
+            }
         }
 
         // Once everything is successfully persisted, update the latest in-memory ledger info.

--- a/storage/aptosdb/src/db/include/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_writer.rs
@@ -256,7 +256,7 @@ impl AptosDB {
             latest_in_memory_state.current_version.expect("Must exist"),
         );
 
-        let num_transactions_in_db = self.get_synced_version().map_or(0, |v| v + 1);
+        let num_transactions_in_db = self.get_synced_version()?.map_or(0, |v| v + 1);
         {
             let buffered_state = self.state_store.buffered_state().lock();
             ensure!(
@@ -590,7 +590,7 @@ impl AptosDB {
         version_to_commit: Version,
         txns_to_commit: Option<&[TransactionToCommit]>
     ) -> Result<Option<Version>> {
-        let old_committed_ver = self.ledger_db.metadata_db().get_synced_version_opt()?;
+        let old_committed_ver = self.ledger_db.metadata_db().get_synced_version()?;
         let pre_committed_ver = self.ledger_db.metadata_db().get_pre_committed_version();
         ensure!(
             old_committed_ver.is_none() || version_to_commit >= old_committed_ver.unwrap(),

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -97,7 +97,8 @@ pub struct AptosDB {
     pub(crate) transaction_store: Arc<TransactionStore>,
     ledger_pruner: LedgerPrunerManager,
     _rocksdb_property_reporter: RocksdbPropertyReporter,
-    ledger_commit_lock: std::sync::Mutex<()>,
+    pre_commit_lock: std::sync::Mutex<()>,
+    commit_lock: std::sync::Mutex<()>,
     indexer: Option<Indexer>,
     skip_index_and_usage: bool,
 }

--- a/storage/aptosdb/src/db_debugger/state_kv/get_value.rs
+++ b/storage/aptosdb/src/db_debugger/state_kv/get_value.rs
@@ -35,7 +35,10 @@ impl Cmd {
 
         let ledger_db = self.db_dir.open_ledger_db()?;
         let db = self.db_dir.open_state_kv_db()?;
-        let latest_version = ledger_db.metadata_db().get_synced_version()?;
+        let latest_version = ledger_db
+            .metadata_db()
+            .get_synced_version()?
+            .expect("DB is empty.");
         println!("latest version: {latest_version}");
         if self.version != Version::MAX && self.version > latest_version {
             println!(

--- a/storage/aptosdb/src/db_debugger/truncate/mod.rs
+++ b/storage/aptosdb/src/db_debugger/truncate/mod.rs
@@ -89,6 +89,7 @@ impl Cmd {
         let overall_version = ledger_db
             .metadata_db()
             .get_synced_version()
+            .expect("DB read failed.")
             .expect("Overall commit progress must exist.");
         let ledger_db_version = ledger_db
             .metadata_db()
@@ -274,7 +275,7 @@ mod test {
                 version += txns_to_commit.len() as u64;
             }
 
-            let db_version = db.get_synced_version().unwrap();
+            let db_version = db.expect_synced_version();
             prop_assert_eq!(db_version, version - 1);
 
             drop(db);
@@ -293,7 +294,7 @@ mod test {
             cmd.run().unwrap();
 
             let db = if input.1 { AptosDB::new_for_test_with_sharding(&tmp_dir, DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD) } else { AptosDB::new_for_test(&tmp_dir) };
-            let db_version = db.get_synced_version().unwrap();
+            let db_version = db.expect_synced_version();
             prop_assert!(db_version <= target_version);
             target_version = db_version;
 

--- a/storage/aptosdb/src/fast_sync_storage_wrapper.rs
+++ b/storage/aptosdb/src/fast_sync_storage_wrapper.rs
@@ -67,7 +67,7 @@ impl FastSyncStorageWrapper {
             && (db_main
                 .ledger_db
                 .metadata_db()
-                .get_synced_version()
+                .get_synced_version()?
                 .map_or(0, |v| v)
                 == 0)
         {

--- a/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
+++ b/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
@@ -88,13 +88,7 @@ impl LedgerMetadataDb {
         self.db.write_schemas(batch)
     }
 
-    pub(crate) fn get_synced_version(&self) -> Result<Version> {
-        get_progress(&self.db, &DbMetadataKey::OverallCommitProgress)?.ok_or(
-            AptosDbError::NotFound("No OverallCommitProgress in db.".to_string()),
-        )
-    }
-
-    pub(crate) fn get_synced_version_opt(&self) -> Result<Option<Version>> {
+    pub(crate) fn get_synced_version(&self) -> Result<Option<Version>> {
         get_progress(&self.db, &DbMetadataKey::OverallCommitProgress)
     }
 

--- a/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
+++ b/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
@@ -16,12 +16,20 @@ use anyhow::anyhow;
 use aptos_schemadb::{SchemaBatch, DB};
 use aptos_storage_interface::{block_info::BlockInfo, db_ensure as ensure, AptosDbError, Result};
 use aptos_types::{
-    account_config::NewBlockEvent, block_info::BlockHeight, contract_event::ContractEvent,
-    epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
-    state_store::state_storage_usage::StateStorageUsage, transaction::Version,
+    account_config::NewBlockEvent,
+    block_info::BlockHeight,
+    contract_event::ContractEvent,
+    epoch_state::EpochState,
+    ledger_info::LedgerInfoWithSignatures,
+    state_store::state_storage_usage::StateStorageUsage,
+    transaction::{AtomicVersion, Version},
 };
 use arc_swap::ArcSwap;
-use std::{ops::Deref, path::Path, sync::Arc};
+use std::{
+    ops::Deref,
+    path::Path,
+    sync::{atomic::Ordering, Arc},
+};
 
 fn get_latest_ledger_info_in_db_impl(db: &DB) -> Result<Option<LedgerInfoWithSignatures>> {
     let mut iter = db.iter::<LedgerInfoSchema>()?;
@@ -37,16 +45,23 @@ pub(crate) struct LedgerMetadataDb {
     /// cache it in memory in order to avoid reading DB and deserializing the object frequently. It
     /// should be updated every time new ledger info and signatures are persisted.
     latest_ledger_info: ArcSwap<Option<LedgerInfoWithSignatures>>,
+
+    next_pre_commit_version: AtomicVersion,
 }
 
 impl LedgerMetadataDb {
     pub(super) fn new(db: Arc<DB>) -> Self {
-        let ledger_info = get_latest_ledger_info_in_db_impl(&db)
-            .expect("Reading latest ledger info from DB should work.");
+        let latest_ledger_info = get_latest_ledger_info_in_db_impl(&db).expect("DB read failed.");
+        let latest_ledger_info = ArcSwap::from(Arc::new(latest_ledger_info));
+
+        let synced_version =
+            get_progress(&db, &DbMetadataKey::OverallCommitProgress).expect("DB read failed.");
+        let next_pre_commit_version = AtomicVersion::new(synced_version.map_or(0, |v| v + 1));
 
         Self {
             db,
-            latest_ledger_info: ArcSwap::from(Arc::new(ledger_info)),
+            latest_ledger_info,
+            next_pre_commit_version,
         }
     }
 
@@ -79,6 +94,24 @@ impl LedgerMetadataDb {
         )
     }
 
+    pub(crate) fn get_synced_version_opt(&self) -> Result<Option<Version>> {
+        get_progress(&self.db, &DbMetadataKey::OverallCommitProgress)
+    }
+
+    pub(crate) fn get_pre_committed_version(&self) -> Option<Version> {
+        let next_version = self.next_pre_commit_version.load(Ordering::Acquire);
+        if next_version == 0 {
+            None
+        } else {
+            Some(next_version - 1)
+        }
+    }
+
+    pub(crate) fn set_pre_committed_version(&self, version: Version) {
+        self.next_pre_commit_version
+            .store(version + 1, Ordering::Release);
+    }
+
     pub(crate) fn get_ledger_commit_progress(&self) -> Result<Version> {
         get_progress(&self.db, &DbMetadataKey::LedgerCommitProgress)?.ok_or(AptosDbError::NotFound(
             "No LedgerCommitProgress in db.".to_string(),
@@ -99,6 +132,12 @@ impl LedgerMetadataDb {
         let ledger_info_ptr = self.latest_ledger_info.load();
         let ledger_info: &Option<_> = ledger_info_ptr.deref();
         ledger_info.clone()
+    }
+
+    pub(crate) fn get_committed_version(&self) -> Option<Version> {
+        let ledger_info_ptr = self.latest_ledger_info.load();
+        let ledger_info: &Option<_> = ledger_info_ptr.deref();
+        ledger_info.as_ref().map(|li| li.ledger_info().version())
     }
 
     /// Returns the latest ledger info, or NOT_FOUND if it doesn't exist.

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -342,7 +342,10 @@ impl StateStore {
         crash_if_difference_is_too_large: bool,
     ) {
         let ledger_metadata_db = ledger_db.metadata_db();
-        if let Ok(overall_commit_progress) = ledger_metadata_db.get_synced_version() {
+        if let Some(overall_commit_progress) = ledger_metadata_db
+            .get_synced_version()
+            .expect("DB read failed.")
+        {
             info!(
                 overall_commit_progress = overall_commit_progress,
                 "Start syncing databases..."
@@ -440,7 +443,7 @@ impl StateStore {
         let num_transactions = state_db
             .ledger_db
             .metadata_db()
-            .get_synced_version()
+            .get_synced_version()?
             .map_or(0, |v| v + 1);
 
         let latest_snapshot_version = state_db

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -41,7 +41,7 @@ struct TestData {
 
 fn test_data_strategy() -> impl Strategy<Value = TestData> {
     let db = test_execution_with_storage_impl();
-    let latest_ver = db.get_synced_version().unwrap();
+    let latest_ver = db.expect_synced_version();
 
     let latest_epoch_state = db.get_latest_epoch_state().unwrap();
     let epoch_ending_lis = db

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -144,7 +144,7 @@ fn end_to_end() {
         assert_eq!(restore_ws, org_ws);
     }
 
-    assert_eq!(tgt_db.get_synced_version().unwrap(), target_version);
+    assert_eq!(tgt_db.expect_synced_version(), target_version);
     let recovered_transactions = tgt_db
         .get_transactions(
             0,

--- a/storage/indexer/src/db_indexer.rs
+++ b/storage/indexer/src/db_indexer.rs
@@ -347,7 +347,7 @@ impl DBIndexer {
     }
 
     fn get_num_of_transactions(&self, version: Version) -> Result<u64> {
-        let highest_version = self.main_db_reader.get_synced_version()?;
+        let highest_version = self.main_db_reader.ensure_synced_version()?;
         if version > highest_version {
             // In case main db is not synced yet or recreated
             return Ok(0);

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -519,11 +519,7 @@ pub trait DbWriter: Send + Sync {
         unimplemented!()
     }
 
-    /// Persist transactions. Called by the executor module when either syncing nodes or committing
-    /// blocks during normal operation.
-    /// See [`AptosDB::save_transactions`].
-    ///
-    /// [`AptosDB::save_transactions`]: ../aptosdb/struct.AptosDB.html#method.save_transactions
+    /// Persist transactions. Called by state sync to save verified transactions to the DB.
     fn save_transactions(
         &self,
         txns_to_commit: &[TransactionToCommit],
@@ -534,6 +530,67 @@ pub trait DbWriter: Send + Sync {
         latest_in_memory_state: StateDelta,
         state_updates_until_last_checkpoint: Option<ShardedStateUpdates>,
         sharded_state_cache: Option<&ShardedStateCache>,
+    ) -> Result<()> {
+        // For reconfig suffix.
+        if ledger_info_with_sigs.is_none() && txns_to_commit.is_empty() {
+            return Ok(());
+        }
+
+        if !txns_to_commit.is_empty() {
+            self.pre_commit_ledger(
+                txns_to_commit,
+                first_version,
+                base_state_version,
+                sync_commit,
+                latest_in_memory_state,
+                state_updates_until_last_checkpoint,
+                sharded_state_cache,
+            )?;
+        }
+        let version_to_commit = if let Some(ledger_info_with_sigs) = ledger_info_with_sigs {
+            ledger_info_with_sigs.ledger_info().version()
+        } else {
+            // here txns_to_commit is known to be non-empty
+            first_version + txns_to_commit.len() as u64 - 1
+        };
+        self.commit_ledger(
+            version_to_commit,
+            ledger_info_with_sigs,
+            Some(txns_to_commit),
+        )
+    }
+
+    /// Optimistically persist transactions to the ledger.
+    ///
+    /// Called by consensus to pre-commit blocks before execution result is agreed on by the
+    /// validators.
+    ///
+    ///   If these blocks are later confirmed to be included in the ledger, commit_ledger should be
+    ///       called with a `LedgerInfoWithSignatures`.
+    ///   If not, the consensus needs to panic, resulting in a reboot of the node where the DB will
+    ///       truncate the unconfirmed data.
+    fn pre_commit_ledger(
+        &self,
+        txns_to_commit: &[TransactionToCommit],
+        first_version: Version,
+        base_state_version: Option<Version>,
+        sync_commit: bool,
+        latest_in_memory_state: StateDelta,
+        state_updates_until_last_checkpoint: Option<ShardedStateUpdates>,
+        sharded_state_cache: Option<&ShardedStateCache>,
+    ) -> Result<()> {
+        unimplemented!()
+    }
+
+    /// Commit pre-committed transactions to the ledger.
+    ///
+    /// If a LedgerInfoWithSigs is provided, both the "synced version" and "committed version" will
+    /// advance, otherwise only the synced version will advance.
+    fn commit_ledger(
+        &self,
+        version: Version,
+        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        txns_to_commit: Option<&[TransactionToCommit]>,
     ) -> Result<()> {
         unimplemented!()
     }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

pre-commit puts speculative block data to the DB, and commit writes down
the LedgerInfo to make it viewable to the DbReader.

This is to be used in Consensus (aptos-executor::BlockExecutor) so that
data can be proactively put on disk while voting on the execution result
is still on going.

gonna be used by https://github.com/aptos-labs/aptos-core/pull/13604

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Validator Node


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

unit tests
