### PR TITLE
[Consensus Observer] Add simple unit tests.

### DIFF
--- a/consensus/src/consensus_observer/network_message.rs
+++ b/consensus/src/consensus_observer/network_message.rs
@@ -65,17 +65,13 @@ impl Display for ConsensusObserverMessage {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ConsensusObserverMessage::Request(request) => {
-                write!(f, "ConsensusObserverRequest: {}", request.get_content())
+                write!(f, "ConsensusObserverRequest: {}", request)
             },
             ConsensusObserverMessage::Response(response) => {
-                write!(f, "ConsensusObserverResponse: {}", response.get_content())
+                write!(f, "ConsensusObserverResponse: {}", response)
             },
             ConsensusObserverMessage::DirectSend(direct_send) => {
-                write!(
-                    f,
-                    "ConsensusObserverDirectSend: {}",
-                    direct_send.get_content()
-                )
+                write!(f, "ConsensusObserverDirectSend: {}", direct_send)
             },
         }
     }
@@ -96,10 +92,11 @@ impl ConsensusObserverRequest {
             ConsensusObserverRequest::Unsubscribe => "unsubscribe",
         }
     }
+}
 
-    /// Returns the message content for the request. This is useful for debugging.
-    pub fn get_content(&self) -> String {
-        self.get_label().into()
+impl Display for ConsensusObserverRequest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.get_label())
     }
 }
 
@@ -118,10 +115,11 @@ impl ConsensusObserverResponse {
             ConsensusObserverResponse::UnsubscribeAck => "unsubscribe_ack",
         }
     }
+}
 
-    /// Returns the message content for the response. This is useful for debugging.
-    pub fn get_content(&self) -> String {
-        self.get_label().into()
+impl Display for ConsensusObserverResponse {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.get_label())
     }
 }
 
@@ -142,18 +140,20 @@ impl ConsensusObserverDirectSend {
             ConsensusObserverDirectSend::BlockPayload(_) => "block_payload",
         }
     }
+}
 
-    /// Returns the message content for the direct send. This is useful for debugging.
-    pub fn get_content(&self) -> String {
+impl Display for ConsensusObserverDirectSend {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ConsensusObserverDirectSend::OrderedBlock(ordered_block) => {
-                format!("OrderedBlock: {}", ordered_block.proof_block_info())
+                write!(f, "OrderedBlock: {}", ordered_block.proof_block_info())
             },
             ConsensusObserverDirectSend::CommitDecision(commit_decision) => {
-                format!("CommitDecision: {}", commit_decision.proof_block_info())
+                write!(f, "CommitDecision: {}", commit_decision.proof_block_info())
             },
             ConsensusObserverDirectSend::BlockPayload(block_payload) => {
-                format!(
+                write!(
+                    f,
                     "BlockPayload: {}. Number of transactions: {}, limit: {:?}, proofs: {:?}",
                     block_payload.block,
                     block_payload.transaction_payload.transactions().len(),

--- a/consensus/src/consensus_observer/network_message.rs
+++ b/consensus/src/consensus_observer/network_message.rs
@@ -608,10 +608,11 @@ impl BlockPayload {
         }
 
         // Verify that there are no transactions remaining
-        if transactions_iter.next().is_some() {
+        let remaining_transactions = transactions_iter.as_slice();
+        if !remaining_transactions.is_empty() {
             return Err(Error::InvalidMessageError(format!(
                 "Failed to verify payload transactions! Transactions remaining: {:?}. Expected: 0",
-                transactions_iter.as_slice().len()
+                remaining_transactions.len()
             )));
         }
 
@@ -671,11 +672,632 @@ fn reconstruct_and_verify_batch(
     let expected_digest = expected_batch_info.digest();
     if batch_digest != *expected_digest {
         return Err(Error::InvalidMessageError(format!(
-            "The reconstructed inline batch digest does not match the expected digest!\
+            "The reconstructed batch digest does not match the expected digest!\
              Batch: {:?}, Expected digest: {:?}, Reconstructed digest: {:?}",
             expected_batch_info, expected_digest, batch_digest
         )));
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use aptos_bitvec::BitVec;
+    use aptos_consensus_types::{
+        block::Block,
+        block_data::{BlockData, BlockType},
+        common::{Author, ProofWithData, ProofWithDataWithTxnLimit},
+        proof_of_store::BatchId,
+        quorum_cert::QuorumCert,
+    };
+    use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
+    use aptos_types::{
+        aggregate_signature::AggregateSignature,
+        chain_id::ChainId,
+        ledger_info::LedgerInfo,
+        transaction::{RawTransaction, Script, TransactionPayload},
+        validator_signer::ValidatorSigner,
+        validator_verifier::{ValidatorConsensusInfo, ValidatorVerifier},
+        PeerId,
+    };
+    use claims::assert_matches;
+    use move_core_types::account_address::AccountAddress;
+
+    #[test]
+    fn test_verify_against_ordered_payload_mempool() {
+        // Create an empty transaction payload
+        let transaction_payload = BlockTransactionPayload::new_in_quorum_store(vec![], vec![]);
+
+        // Create a direct mempool payload
+        let ordered_payload = Payload::DirectMempool(vec![]);
+
+        // Verify the transaction payload and ensure it fails (mempool payloads are not supported)
+        let error = transaction_payload
+            .verify_against_ordered_payload(&ordered_payload)
+            .unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+    }
+
+    #[test]
+    fn test_verify_against_ordered_payload_in_qs() {
+        // Create an empty transaction payload with no proofs
+        let proofs = vec![];
+        let transaction_payload =
+            BlockTransactionPayload::new_in_quorum_store(vec![], proofs.clone());
+
+        // Create a quorum store payload with a single proof
+        let batch_info = create_batch_info();
+        let proof_with_data = ProofWithData::new(vec![ProofOfStore::new(
+            batch_info,
+            AggregateSignature::empty(),
+        )]);
+        let ordered_payload = Payload::InQuorumStore(proof_with_data);
+
+        // Verify the transaction payload and ensure it fails (the batch infos don't match)
+        let error = transaction_payload
+            .verify_against_ordered_payload(&ordered_payload)
+            .unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+
+        // Create a quorum store payload with no proofs
+        let proof_with_data = ProofWithData::new(proofs);
+        let ordered_payload = Payload::InQuorumStore(proof_with_data);
+
+        // Verify the transaction payload and ensure it passes
+        transaction_payload
+            .verify_against_ordered_payload(&ordered_payload)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_verify_against_ordered_payload_in_qs_limit() {
+        // Create an empty transaction payload with no proofs
+        let proofs = vec![];
+        let transaction_limit = Some(10);
+        let transaction_payload = BlockTransactionPayload::new_in_quorum_store_with_limit(
+            vec![],
+            proofs.clone(),
+            transaction_limit,
+        );
+
+        // Create a quorum store payload with a single proof
+        let batch_info = create_batch_info();
+        let proof_with_data = ProofWithDataWithTxnLimit::new(
+            ProofWithData::new(vec![ProofOfStore::new(
+                batch_info,
+                AggregateSignature::empty(),
+            )]),
+            transaction_limit,
+        );
+        let ordered_payload = Payload::InQuorumStoreWithLimit(proof_with_data);
+
+        // Verify the transaction payload and ensure it fails (the batch infos don't match)
+        let error = transaction_payload
+            .verify_against_ordered_payload(&ordered_payload)
+            .unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+
+        // Create a quorum store payload with no proofs and no transaction limit
+        let proof_with_data =
+            ProofWithDataWithTxnLimit::new(ProofWithData::new(proofs.clone()), None);
+        let ordered_payload = Payload::InQuorumStoreWithLimit(proof_with_data);
+
+        // Verify the transaction payload and ensure it fails (the transaction limit doesn't match)
+        let error = transaction_payload
+            .verify_against_ordered_payload(&ordered_payload)
+            .unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+
+        // Create a quorum store payload with no proofs and the correct limit
+        let proof_with_data =
+            ProofWithDataWithTxnLimit::new(ProofWithData::new(proofs), transaction_limit);
+        let ordered_payload = Payload::InQuorumStoreWithLimit(proof_with_data);
+
+        // Verify the transaction payload and ensure it passes
+        transaction_payload
+            .verify_against_ordered_payload(&ordered_payload)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_verify_against_ordered_payload_in_qs_hybrid() {
+        // Create an empty transaction payload with no proofs and no inline batches
+        let proofs = vec![];
+        let transaction_limit = Some(100);
+        let inline_batches = vec![];
+        let transaction_payload = BlockTransactionPayload::new_quorum_store_inline_hybrid(
+            vec![],
+            proofs.clone(),
+            transaction_limit,
+            inline_batches.clone(),
+        );
+
+        // Create a quorum store payload with a single proof
+        let inline_batches = vec![];
+        let batch_info = create_batch_info();
+        let proof_with_data = ProofWithData::new(vec![ProofOfStore::new(
+            batch_info,
+            AggregateSignature::empty(),
+        )]);
+        let ordered_payload = Payload::QuorumStoreInlineHybrid(
+            inline_batches.clone(),
+            proof_with_data,
+            transaction_limit,
+        );
+
+        // Verify the transaction payload and ensure it fails (the batch infos don't match)
+        let error = transaction_payload
+            .verify_against_ordered_payload(&ordered_payload)
+            .unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+
+        // Create a quorum store payload with no transaction limit
+        let proof_with_data = ProofWithData::new(vec![]);
+        let ordered_payload =
+            Payload::QuorumStoreInlineHybrid(inline_batches.clone(), proof_with_data, None);
+
+        // Verify the transaction payload and ensure it fails (the transaction limit doesn't match)
+        let error = transaction_payload
+            .verify_against_ordered_payload(&ordered_payload)
+            .unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+
+        // Create a quorum store payload with a single inline batch
+        let proof_with_data = ProofWithData::new(vec![]);
+        let ordered_payload = Payload::QuorumStoreInlineHybrid(
+            vec![(create_batch_info(), vec![])],
+            proof_with_data,
+            transaction_limit,
+        );
+
+        // Verify the transaction payload and ensure it fails (the inline batches don't match)
+        let error = transaction_payload
+            .verify_against_ordered_payload(&ordered_payload)
+            .unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+
+        // Create an empty quorum store payload
+        let proof_with_data = ProofWithData::new(vec![]);
+        let ordered_payload =
+            Payload::QuorumStoreInlineHybrid(vec![], proof_with_data, transaction_limit);
+
+        // Verify the transaction payload and ensure it passes
+        transaction_payload
+            .verify_against_ordered_payload(&ordered_payload)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_verify_commit_proof() {
+        // Create a ledger info with an empty signature set
+        let current_epoch = 0;
+        let ledger_info = create_empty_ledger_info(current_epoch);
+
+        // Create an epoch state for the current epoch (with an empty verifier)
+        let epoch_state = EpochState::new(current_epoch, ValidatorVerifier::new(vec![]));
+
+        // Create a commit decision message with the ledger info
+        let commit_decision = CommitDecision::new(ledger_info);
+
+        // Verify the commit proof and ensure it passes
+        commit_decision.verify_commit_proof(&epoch_state).unwrap();
+
+        // Create an epoch state for the current epoch (with a non-empty verifier)
+        let validator_signer = ValidatorSigner::random(None);
+        let validator_consensus_info = ValidatorConsensusInfo::new(
+            validator_signer.author(),
+            validator_signer.public_key(),
+            100,
+        );
+        let validator_verifier = ValidatorVerifier::new(vec![validator_consensus_info]);
+        let epoch_state = EpochState::new(current_epoch, validator_verifier.clone());
+
+        // Verify the commit proof and ensure it fails (the signature set is insufficient)
+        let error = commit_decision
+            .verify_commit_proof(&epoch_state)
+            .unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+    }
+
+    #[test]
+    fn test_verify_ordered_blocks() {
+        // Create an ordered block with no internal blocks
+        let current_epoch = 0;
+        let ordered_block = OrderedBlock::new(vec![], create_empty_ledger_info(current_epoch));
+
+        // Verify the ordered blocks and ensure it fails (there are no internal blocks)
+        let error = ordered_block.verify_ordered_blocks().unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+
+        // Create a pipelined block with a random block ID
+        let block_id = HashValue::random();
+        let block_info = create_block_info(current_epoch, block_id);
+        let pipelined_block = create_pipelined_block(block_info.clone());
+
+        // Create an ordered block with the pipelined block and random proof
+        let ordered_block = OrderedBlock::new(
+            vec![pipelined_block.clone()],
+            create_empty_ledger_info(current_epoch),
+        );
+
+        // Verify the ordered blocks and ensure it fails (the block IDs don't match)
+        let error = ordered_block.verify_ordered_blocks().unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+
+        // Create an ordered block proof with the same block ID
+        let ordered_proof = LedgerInfoWithSignatures::new(
+            LedgerInfo::new(block_info, HashValue::random()),
+            AggregateSignature::empty(),
+        );
+
+        // Create an ordered block with the correct proof
+        let ordered_block = OrderedBlock::new(vec![pipelined_block], ordered_proof);
+
+        // Verify the ordered block and ensure it passes
+        ordered_block.verify_ordered_blocks().unwrap();
+    }
+
+    #[test]
+    fn test_verify_ordered_blocks_chained() {
+        // Create multiple pipelined blocks not chained together
+        let current_epoch = 0;
+        let mut pipelined_blocks = vec![];
+        for _ in 0..3 {
+            // Create the pipelined block
+            let block_id = HashValue::random();
+            let block_info = create_block_info(current_epoch, block_id);
+            let pipelined_block = create_pipelined_block(block_info);
+
+            // Add the pipelined block to the list
+            pipelined_blocks.push(pipelined_block);
+        }
+
+        // Create an ordered block proof with the same block ID as the last pipelined block
+        let last_block_info = pipelined_blocks.last().unwrap().block_info().clone();
+        let ordered_proof = LedgerInfoWithSignatures::new(
+            LedgerInfo::new(last_block_info, HashValue::random()),
+            AggregateSignature::empty(),
+        );
+
+        // Create an ordered block with the pipelined blocks and proof
+        let ordered_block = OrderedBlock::new(pipelined_blocks, ordered_proof);
+
+        // Verify the ordered block and ensure it fails (the blocks are not chained)
+        let error = ordered_block.verify_ordered_blocks().unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+
+        // Create multiple pipelined blocks that are chained together
+        let mut pipelined_blocks = vec![];
+        let mut expected_parent_id = None;
+        for _ in 0..5 {
+            // Create the pipelined block
+            let block_id = HashValue::random();
+            let block_info = create_block_info(current_epoch, block_id);
+            let pipelined_block = create_pipelined_block_with_parent(
+                block_info,
+                expected_parent_id.unwrap_or_default(),
+            );
+
+            // Add the pipelined block to the list
+            pipelined_blocks.push(pipelined_block);
+
+            // Update the expected parent ID
+            expected_parent_id = Some(block_id);
+        }
+
+        // Create an ordered block proof with the same block ID as the last pipelined block
+        let last_block_info = pipelined_blocks.last().unwrap().block_info().clone();
+        let ordered_proof = LedgerInfoWithSignatures::new(
+            LedgerInfo::new(last_block_info, HashValue::random()),
+            AggregateSignature::empty(),
+        );
+
+        // Create an ordered block with the pipelined blocks and proof
+        let ordered_block = OrderedBlock::new(pipelined_blocks, ordered_proof);
+
+        // Verify the ordered block and ensure it passes
+        ordered_block.verify_ordered_blocks().unwrap();
+    }
+
+    #[test]
+    fn test_verify_ordered_proof() {
+        // Create a ledger info with an empty signature set
+        let current_epoch = 100;
+        let ledger_info = create_empty_ledger_info(current_epoch);
+
+        // Create an epoch state for the current epoch (with an empty verifier)
+        let epoch_state = EpochState::new(current_epoch, ValidatorVerifier::new(vec![]));
+
+        // Create an ordered block message with an empty block and ordered proof
+        let ordered_block = OrderedBlock::new(vec![], ledger_info);
+
+        // Verify the ordered proof and ensure it passes
+        ordered_block.verify_ordered_proof(&epoch_state).unwrap();
+
+        // Create an epoch state for the current epoch (with a non-empty verifier)
+        let validator_signer = ValidatorSigner::random(None);
+        let validator_consensus_info = ValidatorConsensusInfo::new(
+            validator_signer.author(),
+            validator_signer.public_key(),
+            100,
+        );
+        let validator_verifier = ValidatorVerifier::new(vec![validator_consensus_info]);
+        let epoch_state = EpochState::new(current_epoch, validator_verifier.clone());
+
+        // Verify the ordered proof and ensure it fails (the signature set is insufficient)
+        let error = ordered_block
+            .verify_ordered_proof(&epoch_state)
+            .unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+    }
+
+    #[test]
+    fn test_verify_payload_digests() {
+        // Create multiple signed transactions
+        let num_signed_transactions = 10;
+        let mut signed_transactions = create_signed_transactions(num_signed_transactions);
+
+        // Create multiple batch proofs with random digests
+        let num_batches = num_signed_transactions - 1;
+        let mut proofs = vec![];
+        for _ in 0..num_batches {
+            let batch_info = create_batch_info_with_digest(HashValue::random(), 1);
+            let proof = ProofOfStore::new(batch_info, AggregateSignature::empty());
+            proofs.push(proof);
+        }
+
+        // Create a single inline batch with a random digest
+        let inline_batch = create_batch_info_with_digest(HashValue::random(), 1);
+        let inline_batches = vec![inline_batch];
+
+        // Create a block payload (with the transactions, proofs and inline batches)
+        let block_payload = create_block_payload(&signed_transactions, &proofs, &inline_batches);
+
+        // Verify the block payload digests and ensure it fails (the batch digests don't match)
+        let error = block_payload.verify_payload_digests().unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+
+        // Create multiple batch proofs with the correct digests
+        let mut proofs = vec![];
+        for transaction in &signed_transactions[0..num_batches] {
+            let batch_payload = BatchPayload::new(PeerId::ZERO, vec![transaction.clone()]);
+            let batch_info = create_batch_info_with_digest(batch_payload.hash(), 1);
+            let proof = ProofOfStore::new(batch_info, AggregateSignature::empty());
+            proofs.push(proof);
+        }
+
+        // Create a block payload (with the transactions, correct proofs and inline batches)
+        let block_payload = create_block_payload(&signed_transactions, &proofs, &inline_batches);
+
+        // Verify the block payload digests and ensure it fails (the inline batch digests don't match)
+        let error = block_payload.verify_payload_digests().unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+
+        // Create a single inline batch with the correct digest
+        let inline_batch_payload = BatchPayload::new(PeerId::ZERO, vec![signed_transactions
+            .last()
+            .unwrap()
+            .clone()]);
+        let inline_batch_info = create_batch_info_with_digest(inline_batch_payload.hash(), 1);
+        let inline_batches = vec![inline_batch_info];
+
+        // Create a block payload (with the transactions, correct proofs and correct inline batches)
+        let block_payload = create_block_payload(&signed_transactions, &proofs, &inline_batches);
+
+        // Verify the block payload digests and ensure it passes
+        block_payload.verify_payload_digests().unwrap();
+
+        // Create a block payload (with too many transactions)
+        signed_transactions.append(&mut create_signed_transactions(1));
+        let block_payload = create_block_payload(&signed_transactions, &proofs, &inline_batches);
+
+        // Verify the block payload digests and ensure it fails (there are too many transactions)
+        let error = block_payload.verify_payload_digests().unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+
+        // Create a block payload (with too few transactions)
+        for _ in 0..3 {
+            signed_transactions.pop();
+        }
+        let block_payload = create_block_payload(&signed_transactions, &proofs, &inline_batches);
+
+        // Verify the block payload digests and ensure it fails (there are too few transactions)
+        let error = block_payload.verify_payload_digests().unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+    }
+
+    #[test]
+    fn test_verify_payload_signatures() {
+        // Create multiple batch info proofs (with empty signatures)
+        let mut proofs = vec![];
+        for _ in 0..3 {
+            let batch_info = create_batch_info();
+            let proof = ProofOfStore::new(batch_info, AggregateSignature::empty());
+            proofs.push(proof);
+        }
+
+        // Create a transaction payload (with the proofs)
+        let transaction_payload = BlockTransactionPayload::new_quorum_store_inline_hybrid(
+            vec![],
+            proofs.clone(),
+            None,
+            vec![],
+        );
+
+        // Create a block payload
+        let current_epoch = 50;
+        let block_info = create_block_info(current_epoch, HashValue::random());
+        let block_payload = BlockPayload::new(block_info, transaction_payload);
+
+        // Create an epoch state for the current epoch (with an empty verifier)
+        let epoch_state = EpochState::new(current_epoch, ValidatorVerifier::new(vec![]));
+
+        // Verify the block payload signatures and ensure it passes
+        block_payload
+            .verify_payload_signatures(&epoch_state)
+            .unwrap();
+
+        // Create an epoch state for the current epoch (with a non-empty verifier)
+        let validator_signer = ValidatorSigner::random(None);
+        let validator_consensus_info = ValidatorConsensusInfo::new(
+            validator_signer.author(),
+            validator_signer.public_key(),
+            100,
+        );
+        let validator_verifier = ValidatorVerifier::new(vec![validator_consensus_info]);
+        let epoch_state = EpochState::new(current_epoch, validator_verifier.clone());
+
+        // Verify the block payload signatures and ensure it fails (the signature set is insufficient)
+        let error = block_payload
+            .verify_payload_signatures(&epoch_state)
+            .unwrap_err();
+        assert_matches!(error, Error::InvalidMessageError(_));
+    }
+
+    /// Creates and returns a new batch info with random data
+    fn create_batch_info() -> BatchInfo {
+        create_batch_info_with_digest(HashValue::random(), 0)
+    }
+
+    /// Creates and returns a new batch info with the specified digest
+    fn create_batch_info_with_digest(digest: HashValue, num_transactions: u64) -> BatchInfo {
+        BatchInfo::new(
+            PeerId::ZERO,
+            BatchId::new(0),
+            10,
+            1,
+            digest,
+            num_transactions,
+            1,
+            0,
+        )
+    }
+
+    /// Creates and returns a new block with the given block info
+    fn create_block(block_info: BlockInfo) -> Block {
+        let block_data = BlockData::new_for_testing(
+            block_info.epoch(),
+            block_info.round(),
+            block_info.timestamp_usecs(),
+            QuorumCert::dummy(),
+            BlockType::Genesis,
+        );
+        Block::new_for_testing(block_info.id(), block_data, None)
+    }
+
+    /// Creates and returns a new ordered block with the given block ID
+    fn create_block_info(epoch: u64, block_id: HashValue) -> BlockInfo {
+        BlockInfo::new(epoch, 0, block_id, HashValue::random(), 0, 0, None)
+    }
+
+    /// Creates and returns a hybrid quorum store payload using the given data
+    fn create_block_payload(
+        signed_transactions: &[SignedTransaction],
+        proofs: &[ProofOfStore],
+        inline_batches: &[BatchInfo],
+    ) -> BlockPayload {
+        // Create the transaction payload
+        let transaction_payload = BlockTransactionPayload::new_quorum_store_inline_hybrid(
+            signed_transactions.to_vec(),
+            proofs.to_vec(),
+            None,
+            inline_batches.to_vec(),
+        );
+
+        // Create the block payload
+        BlockPayload::new(
+            create_block_info(0, HashValue::random()),
+            transaction_payload,
+        )
+    }
+
+    /// Creates and returns a new ledger info with an empty signature set
+    fn create_empty_ledger_info(epoch: u64) -> LedgerInfoWithSignatures {
+        LedgerInfoWithSignatures::new(
+            LedgerInfo::new(BlockInfo::random_with_epoch(epoch, 0), HashValue::random()),
+            AggregateSignature::empty(),
+        )
+    }
+
+    /// Creates and returns a new pipelined block with the given block info
+    fn create_pipelined_block(block_info: BlockInfo) -> Arc<PipelinedBlock> {
+        let block_data = BlockData::new_for_testing(
+            block_info.epoch(),
+            block_info.round(),
+            block_info.timestamp_usecs(),
+            QuorumCert::dummy(),
+            BlockType::Genesis,
+        );
+        let block = Block::new_for_testing(block_info.id(), block_data, None);
+        Arc::new(PipelinedBlock::new_ordered(block))
+    }
+
+    /// Creates and returns a new pipelined block with the given block info and parent ID
+    fn create_pipelined_block_with_parent(
+        block_info: BlockInfo,
+        parent_block_id: HashValue,
+    ) -> Arc<PipelinedBlock> {
+        // Create the block type
+        let block_type = BlockType::DAGBlock {
+            author: Author::random(),
+            failed_authors: vec![],
+            validator_txns: vec![],
+            payload: Payload::DirectMempool(vec![]),
+            node_digests: vec![],
+            parent_block_id,
+            parents_bitvec: BitVec::with_num_bits(0),
+        };
+
+        // Create the block data
+        let block_data = BlockData::new_for_testing(
+            block_info.epoch(),
+            block_info.round(),
+            block_info.timestamp_usecs(),
+            QuorumCert::dummy(),
+            block_type,
+        );
+
+        // Create the pipelined block
+        let block = Block::new_for_testing(block_info.id(), block_data, None);
+        Arc::new(PipelinedBlock::new_ordered(block))
+    }
+
+    /// Creates a returns multiple signed transactions
+    fn create_signed_transactions(num_transactions: usize) -> Vec<SignedTransaction> {
+        // Create a random sender and keypair
+        let private_key = Ed25519PrivateKey::generate_for_testing();
+        let public_key = private_key.public_key();
+        let sender = AccountAddress::random();
+
+        // Create multiple signed transactions
+        let mut transactions = vec![];
+        for i in 0..num_transactions {
+            // Create the raw transaction
+            let transaction_payload =
+                TransactionPayload::Script(Script::new(vec![], vec![], vec![]));
+            let raw_transaction = RawTransaction::new(
+                sender,
+                i as u64,
+                transaction_payload,
+                0,
+                0,
+                0,
+                ChainId::new(10),
+            );
+
+            // Create the signed transaction
+            let signed_transaction = SignedTransaction::new(
+                raw_transaction.clone(),
+                public_key.clone(),
+                private_key.sign(&raw_transaction).unwrap(),
+            );
+
+            // Save the signed transaction
+            transactions.push(signed_transaction)
+        }
+
+        transactions
+    }
 }


### PR DESCRIPTION
## Description
This PR adds several simple unit tests to consensus observer. Specifically, it offers the following commits:
1. Clean up the display implementation.
2. Add simple unit tests for network message verification.
3. Add a missing unit test for the block payload store.

Nothing should logically change.

## Testing Plan
New and existing test infrastructure.