### PR TITLE
[release builder] fix handling of next execution hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4811,9 +4811,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.5"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2d0cfb2a7388d34f590e76686704c494ed7aaceed62ee1ba35cbf363abc2a5"
+checksum = "fec134f64e2bc57411226dfc4e52dec859ddfc7e711fc5e07b612584f000e4aa"
 dependencies = [
  "flate2",
  "futures-core",
@@ -5114,7 +5114,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body 1.0.0",
  "http-body-util",
  "hyper 1.4.1",
  "hyper-util",
@@ -5164,7 +5164,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body 1.0.0",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -6824,12 +6824,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
 dependencies = [
- "darling_core 0.20.10",
- "darling_macro 0.20.10",
+ "darling_core 0.20.9",
+ "darling_macro 0.20.9",
 ]
 
 [[package]]
@@ -6848,9 +6848,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
 dependencies = [
  "fnv",
  "ident_case",
@@ -6873,11 +6873,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
 dependencies = [
- "darling_core 0.20.10",
+ "darling_core 0.20.9",
  "quote",
  "syn 2.0.48",
 ]
@@ -7037,7 +7037,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
 dependencies = [
- "darling 0.20.10",
+ "darling 0.20.9",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -8297,14 +8297,14 @@ dependencies = [
  "hyper 1.4.1",
  "jsonwebtoken 9.3.0",
  "once_cell",
- "prost 0.13.1",
- "prost-types 0.13.1",
+ "prost 0.13.2",
+ "prost-types 0.13.2",
  "reqwest 0.12.5",
  "secret-vault-value",
  "serde",
  "serde_json",
  "tokio",
- "tonic 0.12.1",
+ "tonic 0.12.2",
  "tower",
  "tower-layer",
  "tower-util",
@@ -8735,9 +8735,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -9069,9 +9069,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -9086,7 +9086,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -9184,9 +9184,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.6",
+ "h2 0.4.5",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body 1.0.0",
  "httparse",
  "httpdate",
  "itoa",
@@ -9229,16 +9229,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.2"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
  "rustls 0.23.7",
- "rustls-native-certs 0.7.0",
+ "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -9285,15 +9285,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body 1.0.0",
  "hyper 1.4.1",
  "pin-project-lite",
  "socket2 0.5.5",
@@ -10107,9 +10107,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -10351,9 +10351,9 @@ dependencies = [
 
 [[package]]
 name = "lz4"
-version = "1.26.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958b4caa893816eea05507c20cfe47574a43d9a697138a7872990bba8a0ece68"
+checksum = "d6eab492fe7f8651add23237ea56dbf11b3c4ff762ab83d40a47f11433421f91"
 dependencies = [
  "libc",
  "lz4-sys",
@@ -10361,9 +10361,9 @@ dependencies = [
 
 [[package]]
 name = "lz4-sys"
-version = "1.10.0"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109de74d5d2353660401699a4174a4ff23fcc649caf553df71933c7fb45ad868"
+checksum = "e9764018d143cc854c9f17f0b907de70f14393b1f502da6375dce70f00514eb3"
 dependencies = [
  "cc",
  "libc",
@@ -10433,9 +10433,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
@@ -12257,9 +12257,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "52.2.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e977b9066b4d3b03555c22bdc442f3fadebd96a39111249113087d0edb2691cd"
+checksum = "0f22ba0d95db56dde8685e3fadcb915cdaadda31ab8abbe3ff7f0ad1ef333267"
 dependencies = [
  "ahash 0.8.11",
  "bytes",
@@ -12279,9 +12279,9 @@ dependencies = [
 
 [[package]]
 name = "parquet_derive"
-version = "52.2.0"
+version = "52.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e57262f900bc3e93755be67e0fc4e2fcdae416b563472528e413c6e0a52ee81"
+checksum = "cbfe02f8b63a15a78398db242f9b1d2dcc201319075ea6222c7108ffd48b23c0"
 dependencies = [
  "parquet",
  "proc-macro2",
@@ -12820,7 +12820,7 @@ name = "poem-openapi-derive"
 version = "5.0.2"
 source = "git+https://github.com/poem-web/poem.git?rev=809b2816d3504beeba140fef3fdfe9432d654c5b#809b2816d3504beeba140fef3fdfe9432d654c5b"
 dependencies = [
- "darling 0.20.10",
+ "darling 0.20.9",
  "http 1.1.0",
  "indexmap 2.2.5",
  "mime",
@@ -13359,12 +13359,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13db3d3fde688c61e2446b4d843bc27a7e8af269a69440c0308021dc92333cc"
+checksum = "3b2ecbe40f08db5c006b5764a2645f7f3f141ce756412ac9e1dd6087e6d32995"
 dependencies = [
  "bytes",
- "prost-derive 0.13.1",
+ "prost-derive 0.13.2",
 ]
 
 [[package]]
@@ -13395,9 +13395,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
+checksum = "acf0c195eebb4af52c752bec4f52f645da98b6e92077a04110c7f349477ae5ac"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
@@ -13426,11 +13426,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee5168b05f49d4b0ca581206eb14a7b22fafd963efe729ac48eb03266e25cc2"
+checksum = "60caa6738c7369b940c3d49246a8d1749323674c65cb13010134f5c9bad5b519"
 dependencies = [
- "prost 0.13.1",
+ "prost 0.13.2",
 ]
 
 [[package]]
@@ -13576,9 +13576,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22d8e7369034b9a7132bc2008cac12f2013c8132b45e0554e6e20e2617f2156"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
 dependencies = [
  "bytes",
  "pin-project-lite",
@@ -13594,9 +13594,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba92fb39ec7ad06ca2582c0ca834dfeadcaf06ddfc8e635c80aa7e1c05315fdd"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -13974,10 +13974,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body 1.0.0",
  "http-body-util",
  "hyper 1.4.1",
- "hyper-rustls 0.27.2",
+ "hyper-rustls 0.27.3",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -14409,6 +14409,19 @@ name = "rustls-native-certs"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.1",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 2.1.1",
@@ -14916,7 +14929,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
 dependencies = [
- "darling 0.20.10",
+ "darling 0.20.9",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
@@ -15965,18 +15978,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16338,9 +16351,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
 dependencies = [
  "serde",
 ]
@@ -16448,25 +16461,25 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38659f4a91aba8598d27821589f5db7dddd94601e7a01b1e485a50e5484c7401"
+checksum = "c6f6ba989e4b2c58ae83d862d3a3e27690b6e3ae630d0deb59f3697f32aa88ad"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.7.5",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.6",
+ "h2 0.4.5",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body 1.0.0",
  "http-body-util",
  "hyper 1.4.1",
  "hyper-timeout 0.5.1",
  "hyper-util",
  "percent-encoding",
  "pin-project 1.1.3",
- "prost 0.13.1",
+ "prost 0.13.2",
  "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.1",
  "socket2 0.5.5",
@@ -17054,9 +17067,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom 0.2.11",
  "serde",

--- a/aptos-move/aptos-release-builder/src/components/consensus_config.rs
+++ b/aptos-move/aptos-release-builder/src/components/consensus_config.rs
@@ -3,13 +3,16 @@
 
 use crate::{components::get_signer_arg, utils::*};
 use anyhow::Result;
+use aptos_crypto::HashValue;
+use aptos_framework::generate_blob_as_hex_string;
 use aptos_types::on_chain_config::OnChainConsensusConfig;
 use move_model::{code_writer::CodeWriter, emit, emitln, model::Loc};
 
 pub fn generate_consensus_upgrade_proposal(
     consensus_config: &OnChainConsensusConfig,
     is_testnet: bool,
-    next_execution_hash: Vec<u8>,
+    next_execution_hash: Option<HashValue>,
+    is_multi_step: bool,
 ) -> Result<Vec<(String, String)>> {
     let signer_arg = get_signer_arg(is_testnet, &next_execution_hash);
     let mut result = vec![];
@@ -23,7 +26,8 @@ pub fn generate_consensus_upgrade_proposal(
     let proposal = generate_governance_proposal(
         &writer,
         is_testnet,
-        next_execution_hash.clone(),
+        next_execution_hash,
+        is_multi_step,
         &["aptos_framework::consensus_config"],
         |writer| {
             let consensus_config_blob = bcs::to_bytes(consensus_config).unwrap();

--- a/aptos-move/aptos-release-builder/src/components/execution_config.rs
+++ b/aptos-move/aptos-release-builder/src/components/execution_config.rs
@@ -3,13 +3,16 @@
 
 use crate::{components::get_signer_arg, utils::*};
 use anyhow::Result;
+use aptos_crypto::HashValue;
+use aptos_framework::generate_blob_as_hex_string;
 use aptos_types::on_chain_config::OnChainExecutionConfig;
 use move_model::{code_writer::CodeWriter, emit, emitln, model::Loc};
 
 pub fn generate_execution_config_upgrade_proposal(
     execution_config: &OnChainExecutionConfig,
     is_testnet: bool,
-    next_execution_hash: Vec<u8>,
+    next_execution_hash: Option<HashValue>,
+    is_multi_step: bool,
 ) -> Result<Vec<(String, String)>> {
     let signer_arg = get_signer_arg(is_testnet, &next_execution_hash);
     let mut result = vec![];
@@ -23,7 +26,8 @@ pub fn generate_execution_config_upgrade_proposal(
     let proposal = generate_governance_proposal(
         &writer,
         is_testnet,
-        next_execution_hash.clone(),
+        next_execution_hash,
+        is_multi_step,
         &["aptos_framework::execution_config"],
         |writer| {
             let execution_config_blob = bcs::to_bytes(execution_config).unwrap();

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -3,6 +3,7 @@
 
 use crate::{components::get_signer_arg, utils::*};
 use anyhow::Result;
+use aptos_crypto::HashValue;
 use aptos_types::on_chain_config::{FeatureFlag as AptosFeatureFlag, Features as AptosFeatures};
 use move_model::{code_writer::CodeWriter, emit, emitln, model::Loc};
 use serde::{Deserialize, Serialize};
@@ -153,7 +154,8 @@ fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
 pub fn generate_feature_upgrade_proposal(
     features: &Features,
     is_testnet: bool,
-    next_execution_hash: Vec<u8>,
+    next_execution_hash: Option<HashValue>,
+    is_multi_step: bool,
 ) -> Result<Vec<(String, String)>> {
     let signer_arg = get_signer_arg(is_testnet, &next_execution_hash);
     let mut result = vec![];
@@ -182,7 +184,8 @@ pub fn generate_feature_upgrade_proposal(
     let proposal = generate_governance_proposal(
         &writer,
         is_testnet,
-        next_execution_hash.clone(),
+        next_execution_hash,
+        is_multi_step,
         &["std::features"],
         |writer| {
             emit!(writer, "let enabled_blob: vector<u64> = ");

--- a/aptos-move/aptos-release-builder/src/components/gas.rs
+++ b/aptos-move/aptos-release-builder/src/components/gas.rs
@@ -3,6 +3,8 @@
 
 use crate::{components::get_signer_arg, utils::*};
 use anyhow::Result;
+use aptos_crypto::HashValue;
+use aptos_framework::generate_blob_as_hex_string;
 use aptos_types::on_chain_config::{DiffItem, GasScheduleV2};
 use move_model::{code_writer::CodeWriter, emit, emitln, model::Loc};
 use sha3::{Digest, Sha3_512};
@@ -79,7 +81,8 @@ pub fn generate_gas_upgrade_proposal(
     old_gas_schedule: Option<&GasScheduleV2>,
     new_gas_schedule: &GasScheduleV2,
     is_testnet: bool,
-    next_execution_hash: Vec<u8>,
+    next_execution_hash: Option<HashValue>,
+    is_multi_step: bool,
 ) -> Result<Vec<(String, String)>> {
     let signer_arg = get_signer_arg(is_testnet, &next_execution_hash);
     let mut result = vec![];
@@ -114,7 +117,8 @@ pub fn generate_gas_upgrade_proposal(
     let proposal = generate_governance_proposal(
         &writer,
         is_testnet,
-        next_execution_hash.clone(),
+        next_execution_hash,
+        is_multi_step,
         &["aptos_framework::gas_schedule"],
         |writer| {
             let gas_schedule_blob = bcs::to_bytes(new_gas_schedule).unwrap();

--- a/aptos-move/aptos-release-builder/src/components/jwk_consensus_config.rs
+++ b/aptos-move/aptos-release-builder/src/components/jwk_consensus_config.rs
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{components::get_signer_arg, utils::generate_governance_proposal};
+use aptos_crypto::HashValue;
 use aptos_types::on_chain_config::OnChainJWKConsensusConfig;
 use move_model::{code_writer::CodeWriter, emitln, model::Loc};
 
 pub fn generate_jwk_consensus_config_update_proposal(
     config: &OnChainJWKConsensusConfig,
     is_testnet: bool,
-    next_execution_hash: Vec<u8>,
+    next_execution_hash: Option<HashValue>,
+    is_multi_step: bool,
 ) -> anyhow::Result<Vec<(String, String)>> {
     let signer_arg = get_signer_arg(is_testnet, &next_execution_hash);
     let mut result = vec![];
@@ -18,7 +20,8 @@ pub fn generate_jwk_consensus_config_update_proposal(
     let proposal = generate_governance_proposal(
         &writer,
         is_testnet,
-        next_execution_hash.clone(),
+        next_execution_hash,
+        is_multi_step,
         &["aptos_framework::jwk_consensus_config", "std::string::utf8"],
         |writer| {
             match config {

--- a/aptos-move/aptos-release-builder/src/components/mod.rs
+++ b/aptos-move/aptos-release-builder/src/components/mod.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail, Context, Result};
 use aptos::governance::GenerateExecutionHash;
+use aptos_crypto::HashValue;
 use aptos_gas_schedule::LATEST_GAS_FEATURE_VERSION;
 use aptos_infallible::duration_since_epoch;
 use aptos_rest_client::Client;
@@ -233,8 +234,9 @@ impl ReleaseEntry {
                         if is_multi_step {
                             get_execution_hash(result)
                         } else {
-                            "".to_owned().into_bytes()
+                            None
                         },
+                        is_multi_step,
                     )
                     .unwrap(),
                 );
@@ -281,8 +283,9 @@ impl ReleaseEntry {
                         if is_multi_step {
                             get_execution_hash(result)
                         } else {
-                            "".to_owned().into_bytes()
+                            None
                         },
+                        is_multi_step,
                     )?);
                 }
             },
@@ -294,8 +297,9 @@ impl ReleaseEntry {
                         if is_multi_step {
                             get_execution_hash(result)
                         } else {
-                            "".to_owned().into_bytes()
+                            None
                         },
+                        is_multi_step,
                     )?);
                 }
             },
@@ -322,8 +326,9 @@ impl ReleaseEntry {
                         if is_multi_step {
                             get_execution_hash(result)
                         } else {
-                            "".to_owned().into_bytes()
+                            None
                         },
+                        is_multi_step,
                     )?);
                 }
             },
@@ -335,8 +340,9 @@ impl ReleaseEntry {
                         if is_multi_step {
                             get_execution_hash(result)
                         } else {
-                            "".to_owned().into_bytes()
+                            None
                         },
+                        is_multi_step,
                     )?);
                 }
             },
@@ -349,8 +355,9 @@ impl ReleaseEntry {
                             if is_multi_step {
                                 get_execution_hash(result)
                             } else {
-                                "".to_owned().into_bytes()
+                                None
                             },
+                            is_multi_step,
                         )?,
                     );
                 }
@@ -362,8 +369,9 @@ impl ReleaseEntry {
                     if is_multi_step {
                         get_execution_hash(result)
                     } else {
-                        "".to_owned().into_bytes()
+                        None
                     },
+                    is_multi_step,
                 )?);
             },
             ReleaseEntry::RawScript(script_path) => {
@@ -415,8 +423,9 @@ impl ReleaseEntry {
                         if is_multi_step {
                             get_execution_hash(result)
                         } else {
-                            "".to_owned().into_bytes()
+                            None
                         },
+                        is_multi_step,
                     )?,
                 );
             },
@@ -428,8 +437,9 @@ impl ReleaseEntry {
                         if is_multi_step {
                             get_execution_hash(result)
                         } else {
-                            "".to_owned().into_bytes()
+                            None
                         },
+                        is_multi_step,
                     )?,
                 );
             },
@@ -753,9 +763,9 @@ impl Default for ReleaseConfig {
                             transaction_shuffler_type:
                                 TransactionShufflerType::DeprecatedSenderAwareV1(32),
                         })),
-                        ReleaseEntry::RawScript(PathBuf::from(
-                            "data/proposals/empty_multi_step.move",
-                        )),
+                        //ReleaseEntry::RawScript(PathBuf::from(
+                        //    "data/proposals/empty_multi_step.move",
+                        //)),
                     ],
                 },
             ],
@@ -763,9 +773,9 @@ impl Default for ReleaseConfig {
     }
 }
 
-pub fn get_execution_hash(result: &[(String, String)]) -> Vec<u8> {
+pub fn get_execution_hash(result: &[(String, String)]) -> Option<HashValue> {
     if result.is_empty() {
-        "vector::empty<u8>()".to_owned().into_bytes()
+        None
     } else {
         let temp_script_path = TempPath::new();
         temp_script_path.create_as_file().unwrap();
@@ -786,7 +796,7 @@ pub fn get_execution_hash(result: &[(String, String)]) -> Vec<u8> {
         }
         .generate_hash()
         .unwrap();
-        hash.to_vec()
+        Some(hash)
     }
 }
 
@@ -827,8 +837,8 @@ impl Default for ProposalMetadata {
     }
 }
 
-fn get_signer_arg(is_testnet: bool, next_execution_hash: &[u8]) -> &str {
-    if is_testnet && next_execution_hash.is_empty() {
+fn get_signer_arg(is_testnet: bool, next_execution_hash: &Option<HashValue>) -> &str {
+    if is_testnet && next_execution_hash.is_none() {
         "framework_signer"
     } else {
         "&framework_signer"

--- a/aptos-move/aptos-release-builder/src/components/oidc_providers.rs
+++ b/aptos-move/aptos-release-builder/src/components/oidc_providers.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{components::get_signer_arg, utils::generate_governance_proposal};
+use aptos_crypto::HashValue;
 use move_model::{code_writer::CodeWriter, emitln, model::Loc};
 use serde::{Deserialize, Serialize};
 
@@ -20,7 +21,8 @@ pub enum OidcProviderOp {
 pub fn generate_oidc_provider_ops_proposal(
     ops: &[OidcProviderOp],
     is_testnet: bool,
-    next_execution_hash: Vec<u8>,
+    next_execution_hash: Option<HashValue>,
+    is_multi_step: bool,
 ) -> anyhow::Result<Vec<(String, String)>> {
     let signer_arg = get_signer_arg(is_testnet, &next_execution_hash);
     let mut result = vec![];
@@ -30,7 +32,8 @@ pub fn generate_oidc_provider_ops_proposal(
     let proposal = generate_governance_proposal(
         &writer,
         is_testnet,
-        next_execution_hash.clone(),
+        next_execution_hash,
+        is_multi_step,
         &["aptos_framework::jwks"],
         |writer| {
             for op in ops {

--- a/aptos-move/aptos-release-builder/src/components/randomness_config.rs
+++ b/aptos-move/aptos-release-builder/src/components/randomness_config.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{components::get_signer_arg, utils::generate_governance_proposal};
+use aptos_crypto::HashValue;
 use aptos_types::on_chain_config::OnChainRandomnessConfig;
 use move_model::{code_writer::CodeWriter, emitln, model::Loc};
 use serde::{Deserialize, Serialize};
@@ -47,7 +48,8 @@ impl From<ReleaseFriendlyRandomnessConfig> for OnChainRandomnessConfig {
 pub fn generate_randomness_config_update_proposal(
     config: &ReleaseFriendlyRandomnessConfig,
     is_testnet: bool,
-    next_execution_hash: Vec<u8>,
+    next_execution_hash: Option<HashValue>,
+    is_multi_step: bool,
 ) -> anyhow::Result<Vec<(String, String)>> {
     let signer_arg = get_signer_arg(is_testnet, &next_execution_hash);
     let mut result = vec![];
@@ -57,7 +59,8 @@ pub fn generate_randomness_config_update_proposal(
     let proposal = generate_governance_proposal(
         &writer,
         is_testnet,
-        next_execution_hash.clone(),
+        next_execution_hash,
+        is_multi_step,
         &[
             "aptos_framework::randomness_config",
             "aptos_std::fixed_point64",

--- a/aptos-move/aptos-release-builder/src/components/transaction_fee.rs
+++ b/aptos-move/aptos-release-builder/src/components/transaction_fee.rs
@@ -3,13 +3,15 @@
 
 use crate::utils::*;
 use anyhow::Result;
+use aptos_crypto::HashValue;
 use move_model::{code_writer::CodeWriter, emitln, model::Loc};
 
 pub fn generate_fee_distribution_proposal(
     function_name: String,
     burn_percentage: u8,
     is_testnet: bool,
-    next_execution_hash: Vec<u8>,
+    next_execution_hash: Option<HashValue>,
+    is_multi_step: bool,
 ) -> Result<Vec<(String, String)>> {
     let mut result = vec![];
 
@@ -19,6 +21,7 @@ pub fn generate_fee_distribution_proposal(
         &writer,
         is_testnet,
         next_execution_hash,
+        is_multi_step,
         &["aptos_framework::transaction_fee"],
         |writer| {
             emitln!(
@@ -37,25 +40,29 @@ pub fn generate_fee_distribution_proposal(
 pub fn generate_proposal_to_initialize_fee_collection_and_distribution(
     burn_percentage: u8,
     is_testnet: bool,
-    next_execution_hash: Vec<u8>,
+    next_execution_hash: Option<HashValue>,
+    is_multi_step: bool,
 ) -> Result<Vec<(String, String)>> {
     generate_fee_distribution_proposal(
         "initialize_fee_collection_and_distribution".to_string(),
         burn_percentage,
         is_testnet,
         next_execution_hash,
+        is_multi_step,
     )
 }
 
 pub fn generate_proposal_to_upgrade_burn_percentage(
     burn_percentage: u8,
     is_testnet: bool,
-    next_execution_hash: Vec<u8>,
+    next_execution_hash: Option<HashValue>,
+    is_multi_step: bool,
 ) -> Result<Vec<(String, String)>> {
     generate_fee_distribution_proposal(
         "upgrade_burn_percentage".to_string(),
         burn_percentage,
         is_testnet,
         next_execution_hash,
+        is_multi_step,
     )
 }

--- a/aptos-move/aptos-release-builder/src/components/version.rs
+++ b/aptos-move/aptos-release-builder/src/components/version.rs
@@ -3,13 +3,15 @@
 
 use crate::{components::get_signer_arg, utils::*};
 use anyhow::Result;
+use aptos_crypto::HashValue;
 use aptos_types::on_chain_config::AptosVersion;
 use move_model::{code_writer::CodeWriter, emitln, model::Loc};
 
 pub fn generate_version_upgrade_proposal(
     version: &AptosVersion,
     is_testnet: bool,
-    next_execution_hash: Vec<u8>,
+    next_execution_hash: Option<HashValue>,
+    is_multi_step: bool,
 ) -> Result<Vec<(String, String)>> {
     let signer_arg = get_signer_arg(is_testnet, &next_execution_hash);
     let mut result = vec![];
@@ -19,7 +21,8 @@ pub fn generate_version_upgrade_proposal(
     let proposal = generate_governance_proposal(
         &writer,
         is_testnet,
-        next_execution_hash.clone(),
+        next_execution_hash,
+        is_multi_step,
         &["aptos_framework::version"],
         |writer| {
             emitln!(

--- a/aptos-move/aptos-release-builder/src/utils.rs
+++ b/aptos-move/aptos-release-builder/src/utils.rs
@@ -1,50 +1,16 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_crypto::HashValue;
+use aptos_framework::generate_next_execution_hash_blob;
 use move_core_types::account_address::AccountAddress;
-use move_model::{code_writer::CodeWriter, emit, emitln};
-
-pub(crate) fn generate_blob_as_hex_string(writer: &CodeWriter, data: &[u8]) {
-    emit!(writer, "x\"");
-    for b in data.iter() {
-        emit!(writer, "{:02x}", b);
-    }
-    emit!(writer, "\"");
-}
-
-pub(crate) fn generate_next_execution_hash_blob(
-    writer: &CodeWriter,
-    for_address: AccountAddress,
-    next_execution_hash: Vec<u8>,
-) {
-    if next_execution_hash == "vector::empty<u8>()".as_bytes() {
-        emitln!(
-                writer,
-                "let framework_signer = aptos_governance::resolve_multi_step_proposal(proposal_id, @{}, {});\n",
-                for_address,
-                "vector::empty<u8>()",
-            );
-    } else {
-        println!("{:?}", next_execution_hash);
-        emitln!(
-            writer,
-            "let framework_signer = aptos_governance::resolve_multi_step_proposal("
-        );
-        writer.indent();
-        emitln!(writer, "proposal_id,");
-        emitln!(writer, "@{},", for_address);
-        generate_blob_as_hex_string(writer, &next_execution_hash);
-        emit!(writer, ",");
-        writer.unindent();
-        emitln!(writer, ");");
-    }
-}
+use move_model::{code_writer::CodeWriter, emitln};
 
 pub(crate) fn generate_governance_proposal_header(
     writer: &CodeWriter,
     deps_names: &[&str],
     is_multi_step: bool,
-    next_execution_hash: Vec<u8>,
+    next_execution_hash: Option<HashValue>,
 ) {
     emitln!(writer, "script {");
     writer.indent();
@@ -53,15 +19,12 @@ pub(crate) fn generate_governance_proposal_header(
     for deps_name in deps_names {
         emitln!(writer, "use {};", deps_name);
     }
-    if next_execution_hash == "vector::empty<u8>()".as_bytes() {
-        emitln!(writer, "use std::vector;");
-    }
     emitln!(writer);
 
     emitln!(writer, "fun main(proposal_id: u64) {");
     writer.indent();
 
-    if is_multi_step && !next_execution_hash.is_empty() {
+    if is_multi_step {
         generate_next_execution_hash_blob(writer, AccountAddress::ONE, next_execution_hash);
     } else {
         emitln!(
@@ -106,27 +69,26 @@ pub(crate) fn finish_with_footer(writer: &CodeWriter) -> String {
 pub(crate) fn generate_governance_proposal<F>(
     writer: &CodeWriter,
     is_testnet: bool,
-    next_execution_hash: Vec<u8>,
+    next_execution_hash: Option<HashValue>,
+    is_multi_step: bool,
     deps_names: &[&str],
     body: F,
 ) -> String
 where
     F: FnOnce(&CodeWriter),
 {
-    if next_execution_hash.is_empty() {
-        if is_testnet {
-            generate_testnet_header(writer, deps_names);
-        } else {
-            generate_governance_proposal_header(
-                writer,
-                deps_names,
-                false,
-                "".to_owned().into_bytes(),
-            );
-        }
-    } else {
+    assert!(
+        is_multi_step || next_execution_hash.is_none(),
+        "only multi-step proposals can have a next execution hash"
+    );
+
+    if is_multi_step {
         generate_governance_proposal_header(writer, deps_names, true, next_execution_hash);
-    };
+    } else if is_testnet {
+        generate_testnet_header(writer, deps_names);
+    } else {
+        generate_governance_proposal_header(writer, deps_names, false, None);
+    }
 
     body(writer);
     finish_with_footer(writer)

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -1033,10 +1033,14 @@ impl CliCommand<()> for GenerateUpgradeProposal {
             // If we're generating a multi-step proposal
         } else {
             let next_execution_hash_bytes = hex::decode(next_execution_hash)?;
+            let next_execution_hash =
+                HashValue::from_slice(next_execution_hash_bytes).map_err(|_err| {
+                    CliError::CommandArgumentError("Invalid next execution hash".to_string())
+                })?;
             release.generate_script_proposal_multi_step(
                 account,
                 output,
-                next_execution_hash_bytes,
+                Some(next_execution_hash),
             )?;
         };
         Ok(())

--- a/testsuite/smoke-test/src/upgrade.rs
+++ b/testsuite/smoke-test/src/upgrade.rs
@@ -59,7 +59,7 @@ async fn test_upgrade_flow() {
     };
 
     let (_, update_gas_script) =
-        generate_gas_upgrade_proposal(None, &gas_schedule, true, "".to_owned().into_bytes())
+        generate_gas_upgrade_proposal(None, &gas_schedule, true, None, false)
             .unwrap()
             .pop()
             .unwrap();


### PR DESCRIPTION
## Description
Currently, the release builder represents the next execution hash as a raw byte array. This byte array is essentially an untagged union with 3 types of values:
1. A hash value
2. The empty array, meaning that we are not in multi-step mode
3. Byte representation of the string `"vector::empty<u8>()"`, meaning that we are in multi-step mode, but does not have a next execution hash (last step of the proposal)

This representation is extremely confusing and error-prone, resulting in a bug in the custom governance script generator that causes (3) to be treated as a regular hash value and emitted to the script, leading to a few incidents we've seen in the past.

This gets the issue fixed by switching it to a strongly typed representation. 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Other (release tooling)

## How Has This Been Tested?
Manually tested

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
