### PR TITLE
[Target Determinator] Ignore the merge base out-of-date error.

### DIFF
--- a/devtools/aptos-cargo-cli/src/common.rs
+++ b/devtools/aptos-cargo-cli/src/common.rs
@@ -42,7 +42,7 @@ const IGNORED_DETERMINATOR_PATHS: [&str; 8] = [
 ];
 
 // The maximum number of days allowed since the merge-base commit for the branch
-const MAX_NUM_DAYS_SINCE_MERGE_BASE: u64 = 7;
+const MAX_NUM_DAYS_SINCE_MERGE_BASE: u64 = 1000;
 
 // The delimiter used to separate the package path and the package name.
 pub const PACKAGE_NAME_DELIMITER: &str = "#";


### PR DESCRIPTION
## Description
This PR updates the target determinator to ignore out-of-date merge base errors on the 1.17 release branch. It's the same fix as this: https://github.com/aptos-labs/aptos-core/pull/13939.

Going forward, I'll try to figure out how to avoid this problem so we don't run into it again...

## Testing Plan
Manual verification.
