### PR TITLE
account recovery db, more counters

### DIFF
--- a/keyless/pepper/common/src/account_recovery_db.rs
+++ b/keyless/pepper/common/src/account_recovery_db.rs
@@ -12,7 +12,14 @@ pub struct AccountRecoveryDbEntry {
     pub aud: String,
     pub uid_key: String,
     pub uid_val: String,
-    pub last_request_unix_ms: u64,
+
+    pub num_requests: Option<u64>,
+
+    /// First request time in unix milliseconds, but minus 1 quadrillion (10^15).
+    ///
+    /// See comments in function `update_account_recovery_db` for more context.
+    pub first_request_unix_ms_minus_1q: Option<i64>,
+    pub last_request_unix_ms: Option<u64>,
 }
 
 impl AccountRecoveryDbEntry {

--- a/keyless/pepper/example-client-rust/src/main.rs
+++ b/keyless/pepper/example-client-rust/src/main.rs
@@ -213,7 +213,7 @@ async fn main() {
     let docs: Vec<AccountRecoveryDbEntry> = db
         .fluent()
         .select()
-        .fields(paths!(AccountRecoveryDbEntry::{iss, aud, uid_key, uid_val, last_request_unix_ms}))
+        .fields(paths!(AccountRecoveryDbEntry::{iss, aud, uid_key, uid_val, last_request_unix_ms, first_request_unix_ms_minus_1q, num_requests}))
         .from("accounts")
         .filter(|q| {
             q.for_all([

--- a/keyless/pepper/service/src/lib.rs
+++ b/keyless/pepper/service/src/lib.rs
@@ -334,7 +334,7 @@ async fn update_account_recovery_db(input: &PepperInput) -> Result<(), Processin
             // better than using read-compute-write pattern that requires 2 RTTs.
             //
             // This strategy does not work directly:
-            // in firestore, the default value of a number field is 0, and we do not know a way to customize it.
+            // in firestore, the default value of a number field is 0, and we do not know a way to customize it for op 4.
             // The workaround here is apply an offset so 0 becomes a legitimate default value.
             // So we work with `first_request_unix_ms_minus_1q` instead,
             // which is defined as `first_request_unix_ms - 1_000_000_000_000_000`,

--- a/keyless/pepper/service/src/lib.rs
+++ b/keyless/pepper/service/src/lib.rs
@@ -28,7 +28,7 @@ use aptos_types::{
     keyless::{Configuration, IdCommitment, KeylessPublicKey, OpenIdSig},
     transaction::authenticator::{AnyPublicKey, AuthenticationKey, EphemeralPublicKey},
 };
-use firestore::{async_trait, paths};
+use firestore::{async_trait, paths, struct_path::path};
 use jsonwebtoken::{Algorithm::RS256, Validation};
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
@@ -83,6 +83,7 @@ impl HandlerTrait<PepperRequest, PepperResponse> for V0FetchHandler {
             derivation_path,
             false,
             None,
+            true,
         )
         .await?;
 
@@ -118,6 +119,7 @@ impl HandlerTrait<PepperRequest, SignatureResponse> for V0SignatureHandler {
             derivation_path,
             false,
             None,
+            false,
         )
         .await?;
 
@@ -137,6 +139,7 @@ async fn process_common(
     derivation_path: Option<String>,
     encrypts_pepper: bool,
     aud: Option<String>,
+    should_update_account_recovery_db: bool,
 ) -> Result<(Vec<u8>, Vec<u8>, AccountAddress), ProcessingFailure> {
     let config = Configuration::new_for_devnet();
 
@@ -243,7 +246,9 @@ async fn process_common(
             uid_key = input.uid_key.clone(),
             "PepperInput is available."
         );
-        update_account_recovery_db(&input).await?;
+        if should_update_account_recovery_db {
+            update_account_recovery_db(&input).await?;
+        }
     }
 
     let input_bytes = bcs::to_bytes(&input).unwrap();
@@ -310,21 +315,61 @@ async fn update_account_recovery_db(input: &PepperInput) -> Result<(), Processin
                 aud: input.aud.clone(),
                 uid_key: input.uid_key.clone(),
                 uid_val: input.uid_val.clone(),
-                last_request_unix_ms: duration_since_epoch().as_millis() as u64,
+                first_request_unix_ms_minus_1q: None,
+                last_request_unix_ms: None,
+                num_requests: None,
             };
             let doc_id = entry.document_id();
+            let now_unix_ms = duration_since_epoch().as_millis() as i64;
 
-            // Actual DB operation using fluent API.
-            let op_result = db.fluent()
+            // The update transactions use the following strategy.
+            // 1. If not exists, create the document for the user identifier `(iss, aud, uid_key, uid_val)`.
+            //    but leave counter/time fields unspecified.
+            // 2. `num_requests += 1`, assuming the default value is 0.
+            // 3. `last_request_unix_ms = max(last_request_unix_ms, now)`, assuming the default value is 0.
+            // 4. `first_request_unix_ms = min(first_request_unix_ms, now)`, assuming the default value is +inf.
+            //
+            // This strategy is preferred because all the operations can be made server-side,
+            // which means the txn should require only 1 RTT,
+            // better than using read-compute-write pattern that requires 2 RTTs.
+            //
+            // This strategy does not work directly:
+            // in firestore, the default value of a number field is 0, and we do not know a way to customize it.
+            // The workaround here is apply an offset so 0 becomes a legitimate default value.
+            // So we work with `first_request_unix_ms_minus_1q` instead,
+            // which is defined as `first_request_unix_ms - 1_000_000_000_000_000`,
+            // where 1_000_000_000_000_000 milliseconds is roughly 31710 years.
+
+            let mut txn = db
+                .begin_transaction()
+                .await
+                .map_err(|e| InternalError(format!("begin_transaction error: {e}")))?;
+            db.fluent()
                 .update()
-                .fields(paths!(AccountRecoveryDbEntry::{iss, aud, uid_key, uid_val, last_request_unix_ms}))
+                .fields(paths!(AccountRecoveryDbEntry::{iss, aud, uid_key, uid_val}))
                 .in_col("accounts")
                 .document_id(&doc_id)
-                .object(&entry)
-                .execute::<AccountRecoveryDbEntry>()
-                .await;
+                .object(&entry) // op 1
+                .transforms(|builder| {
+                    builder.fields([
+                        builder
+                            .field(path!(AccountRecoveryDbEntry::num_requests))
+                            .increment(1), // op 2
+                        builder
+                            .field(path!(AccountRecoveryDbEntry::last_request_unix_ms))
+                            .maximum(now_unix_ms), // op 3
+                        builder
+                            .field(path!(
+                                AccountRecoveryDbEntry::first_request_unix_ms_minus_1q
+                            ))
+                            .minimum(now_unix_ms - 1_000_000_000_000_000), // op 4
+                    ])
+                })
+                .add_to_transaction(&mut txn)
+                .map_err(|e| InternalError(format!("add_to_transaction error: {e}")))?;
+            let txn_result = txn.commit().await;
 
-            if let Err(e) = op_result {
+            if let Err(e) = txn_result {
                 warn!("ACCOUNT_RECOVERY_DB operation failed: {e}");
             }
             Ok(())


### PR DESCRIPTION
## Description

- In addition to last request time, now also track first request time and number of requests.
- Also avoid updating account recovery DB when it's a V0signature request.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Pepper service.

## How Has This Been Tested?
Local manual testing.

## Key Areas to Review
See comments in function `update_account_recovery_db` about the transaction details.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
