### PR TITLE
[consensus] async proposal generation

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -1173,9 +1173,9 @@ pub static RAND_QUEUE_SIZE: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static CONSENSUS_PROPOSAL_PAYLOAD_AVAILABILITY: Lazy<IntGaugeVec> = Lazy::new(|| {
-    register_int_gauge_vec!(
-        "aptos_consensus_proposal_payload_availability",
+pub static CONSENSUS_PROPOSAL_PAYLOAD_AVAILABILITY: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_consensus_proposal_payload_availability_count",
         "The availability of proposal payload locally",
         &["status"]
     )

--- a/consensus/src/liveness/proposal_generator_test.rs
+++ b/consensus/src/liveness/proposal_generator_test.rs
@@ -30,7 +30,7 @@ fn empty_callback() -> BoxFuture<'static, ()> {
 async fn test_proposal_generation_empty_tree() {
     let signer = ValidatorSigner::random(None);
     let block_store = build_empty_tree();
-    let mut proposal_generator = ProposalGenerator::new(
+    let proposal_generator = ProposalGenerator::new(
         signer.author(),
         block_store.clone(),
         Arc::new(MockPayloadManager::new(None)),
@@ -49,13 +49,14 @@ async fn test_proposal_generation_empty_tree() {
         ValidatorTxnConfig::default_disabled(),
         true,
     );
-    let mut proposer_election =
-        UnequivocalProposerElection::new(Arc::new(RotatingProposer::new(vec![signer.author()], 1)));
+    let proposer_election = Arc::new(UnequivocalProposerElection::new(Arc::new(
+        RotatingProposer::new(vec![signer.author()], 1),
+    )));
     let genesis = block_store.ordered_root();
 
     // Generate proposals for an empty tree.
     let proposal_data = proposal_generator
-        .generate_proposal(1, &mut proposer_election, empty_callback())
+        .generate_proposal(1, proposer_election.clone(), empty_callback())
         .await
         .unwrap();
     let proposal = Block::new_proposal_from_block_data(proposal_data, &signer).unwrap();
@@ -66,7 +67,7 @@ async fn test_proposal_generation_empty_tree() {
 
     // Duplicate proposals on the same round are not allowed
     let proposal_err = proposal_generator
-        .generate_proposal(1, &mut proposer_election, empty_callback())
+        .generate_proposal(1, proposer_election.clone(), empty_callback())
         .await
         .err();
     assert!(proposal_err.is_some());
@@ -76,7 +77,7 @@ async fn test_proposal_generation_empty_tree() {
 async fn test_proposal_generation_parent() {
     let mut inserter = TreeInserter::default();
     let block_store = inserter.block_store();
-    let mut proposal_generator = ProposalGenerator::new(
+    let proposal_generator = ProposalGenerator::new(
         inserter.signer().author(),
         block_store.clone(),
         Arc::new(MockPayloadManager::new(None)),
@@ -95,9 +96,8 @@ async fn test_proposal_generation_parent() {
         ValidatorTxnConfig::default_disabled(),
         true,
     );
-    let mut proposer_election = UnequivocalProposerElection::new(Arc::new(RotatingProposer::new(
-        vec![inserter.signer().author()],
-        1,
+    let proposer_election = Arc::new(UnequivocalProposerElection::new(Arc::new(
+        RotatingProposer::new(vec![inserter.signer().author()], 1),
     )));
     let genesis = block_store.ordered_root();
     let a1 = inserter
@@ -108,7 +108,7 @@ async fn test_proposal_generation_parent() {
         .await;
 
     let original_res = proposal_generator
-        .generate_proposal(10, &mut proposer_election, empty_callback())
+        .generate_proposal(10, proposer_election.clone(), empty_callback())
         .await
         .unwrap();
     // With no certifications the parent is genesis
@@ -122,7 +122,7 @@ async fn test_proposal_generation_parent() {
     // Once a1 is certified, it should be the one to choose from
     inserter.insert_qc_for_block(a1.as_ref(), None);
     let a1_child_res = proposal_generator
-        .generate_proposal(11, &mut proposer_election, empty_callback())
+        .generate_proposal(11, proposer_election.clone(), empty_callback())
         .await
         .unwrap();
     assert_eq!(a1_child_res.parent_id(), a1.id());
@@ -137,7 +137,7 @@ async fn test_proposal_generation_parent() {
     // Once b1 is certified, it should be the one to choose from
     inserter.insert_qc_for_block(b1.as_ref(), None);
     let b1_child_res = proposal_generator
-        .generate_proposal(15, &mut proposer_election, empty_callback())
+        .generate_proposal(15, proposer_election.clone(), empty_callback())
         .await
         .unwrap();
     assert_eq!(b1_child_res.parent_id(), b1.id());
@@ -154,7 +154,7 @@ async fn test_proposal_generation_parent() {
 async fn test_old_proposal_generation() {
     let mut inserter = TreeInserter::default();
     let block_store = inserter.block_store();
-    let mut proposal_generator = ProposalGenerator::new(
+    let proposal_generator = ProposalGenerator::new(
         inserter.signer().author(),
         block_store.clone(),
         Arc::new(MockPayloadManager::new(None)),
@@ -173,9 +173,8 @@ async fn test_old_proposal_generation() {
         ValidatorTxnConfig::default_disabled(),
         true,
     );
-    let mut proposer_election = UnequivocalProposerElection::new(Arc::new(RotatingProposer::new(
-        vec![inserter.signer().author()],
-        1,
+    let proposer_election = Arc::new(UnequivocalProposerElection::new(Arc::new(
+        RotatingProposer::new(vec![inserter.signer().author()], 1),
     )));
     let genesis = block_store.ordered_root();
     let a1 = inserter
@@ -184,7 +183,7 @@ async fn test_old_proposal_generation() {
     inserter.insert_qc_for_block(a1.as_ref(), None);
 
     let proposal_err = proposal_generator
-        .generate_proposal(1, &mut proposer_election, empty_callback())
+        .generate_proposal(1, proposer_election.clone(), empty_callback())
         .await
         .err();
     assert!(proposal_err.is_some());
@@ -197,7 +196,7 @@ async fn test_correct_failed_authors() {
     let peer1 = Author::random();
     let peer2 = Author::random();
     let block_store = inserter.block_store();
-    let mut proposal_generator = ProposalGenerator::new(
+    let proposal_generator = ProposalGenerator::new(
         author,
         block_store.clone(),
         Arc::new(MockPayloadManager::new(None)),
@@ -216,14 +215,13 @@ async fn test_correct_failed_authors() {
         ValidatorTxnConfig::default_disabled(),
         true,
     );
-    let mut proposer_election = UnequivocalProposerElection::new(Arc::new(RotatingProposer::new(
-        vec![author, peer1, peer2],
-        1,
+    let proposer_election = Arc::new(UnequivocalProposerElection::new(Arc::new(
+        RotatingProposer::new(vec![author, peer1, peer2], 1),
     )));
     let genesis = block_store.ordered_root();
 
     let result = proposal_generator
-        .generate_proposal(6, &mut proposer_election, empty_callback())
+        .generate_proposal(6, proposer_election.clone(), empty_callback())
         .await
         .unwrap();
     // With no certifications the parent is genesis

--- a/consensus/src/liveness/round_state.rs
+++ b/consensus/src/liveness/round_state.rs
@@ -310,7 +310,7 @@ impl RoundState {
         }
     }
 
-    pub async fn process_delayed_qc_msg(
+    pub fn process_delayed_qc_msg(
         &mut self,
         validator_verifier: &ValidatorVerifier,
         msg: DelayedQcMsg,
@@ -322,11 +322,6 @@ impl RoundState {
 
     pub fn vote_sent(&self) -> Option<Vote> {
         self.vote_sent.clone()
-    }
-
-    /// Setup a longer timeout task for leader because it enters the round earlier.
-    pub fn setup_leader_timeout(&mut self) {
-        self.setup_timeout(2);
     }
 
     /// Setup the timeout task and return the duration of the current timeout

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -232,8 +232,8 @@ pub struct RoundManager {
     epoch_state: Arc<EpochState>,
     block_store: Arc<BlockStore>,
     round_state: RoundState,
-    proposer_election: UnequivocalProposerElection,
-    proposal_generator: ProposalGenerator,
+    proposer_election: Arc<UnequivocalProposerElection>,
+    proposal_generator: Arc<ProposalGenerator>,
     safety_rules: Arc<Mutex<MetricsSafetyRules>>,
     network: Arc<NetworkSender>,
     storage: Arc<dyn PersistentLivenessStorage>,
@@ -285,8 +285,8 @@ impl RoundManager {
             epoch_state,
             block_store,
             round_state,
-            proposer_election: UnequivocalProposerElection::new(proposer_election),
-            proposal_generator,
+            proposer_election: Arc::new(UnequivocalProposerElection::new(proposer_election)),
+            proposal_generator: Arc::new(proposal_generator),
             safety_rules,
             network,
             storage,
@@ -355,27 +355,69 @@ impl RoundManager {
             .proposer_election
             .is_valid_proposer(self.proposal_generator.author(), new_round_event.round)
         {
-            self.log_collected_vote_stats(&new_round_event);
-            self.round_state.setup_leader_timeout();
-            let proposal_msg = self.generate_proposal(new_round_event).await?;
-            #[cfg(feature = "failpoints")]
-            {
-                if self.check_whether_to_inject_reconfiguration_error() {
-                    Self::attempt_to_inject_reconfiguration_error(
-                        self.epoch_state.clone(),
-                        self.network.clone(),
-                        &proposal_msg,
-                    )
-                    .await?;
+            let epoch_state = self.epoch_state.clone();
+            let network = self.network.clone();
+            let sync_info = self.block_store.sync_info();
+            let proposal_generator = self.proposal_generator.clone();
+            let safety_rules = self.safety_rules.clone();
+            let proposer_election = self.proposer_election.clone();
+            tokio::spawn(async move {
+                if let Err(e) = Self::generate_and_send_proposal(
+                    epoch_state,
+                    new_round_event,
+                    network,
+                    sync_info,
+                    proposal_generator,
+                    safety_rules,
+                    proposer_election,
+                )
+                .await
+                {
+                    warn!("Error generating and sending proposal: {}", e);
                 }
-            }
-            self.network.broadcast_proposal(proposal_msg).await;
-            counters::PROPOSALS_COUNT.inc();
+            });
         }
         Ok(())
     }
 
-    fn log_collected_vote_stats(&self, new_round_event: &NewRoundEvent) {
+    async fn generate_and_send_proposal(
+        epoch_state: Arc<EpochState>,
+        new_round_event: NewRoundEvent,
+        network: Arc<NetworkSender>,
+        sync_info: SyncInfo,
+        proposal_generator: Arc<ProposalGenerator>,
+        safety_rules: Arc<Mutex<MetricsSafetyRules>>,
+        proposer_election: Arc<dyn ProposerElection + Send + Sync>,
+    ) -> anyhow::Result<()> {
+        let epoch = epoch_state.epoch;
+        Self::log_collected_vote_stats(epoch_state.clone(), &new_round_event);
+        let proposal_msg = Self::generate_proposal(
+            epoch,
+            new_round_event,
+            sync_info,
+            network.clone(),
+            proposal_generator,
+            safety_rules,
+            proposer_election,
+        )
+        .await?;
+        #[cfg(feature = "failpoints")]
+        {
+            if Self::check_whether_to_inject_reconfiguration_error() {
+                Self::attempt_to_inject_reconfiguration_error(
+                    epoch_state,
+                    network.clone(),
+                    &proposal_msg,
+                )
+                .await?;
+            }
+        };
+        network.broadcast_proposal(proposal_msg).await;
+        counters::PROPOSALS_COUNT.inc();
+        Ok(())
+    }
+
+    fn log_collected_vote_stats(epoch_state: Arc<EpochState>, new_round_event: &NewRoundEvent) {
         let prev_round_votes_for_li = new_round_event
             .prev_round_votes
             .iter()
@@ -384,7 +426,7 @@ impl RoundManager {
                     .signatures()
                     .keys()
                     .map(|author| {
-                        self.epoch_state
+                        epoch_state
                             .verifier
                             .get_voting_power(author)
                             .map(|voting_power| (voting_power as u128, 1))
@@ -413,7 +455,7 @@ impl RoundManager {
                 let (voting_power, votes): (Vec<_>, Vec<_>) = timeout_votes
                     .signers()
                     .map(|author| {
-                        self.epoch_state
+                        epoch_state
                             .verifier
                             .get_voting_power(author)
                             .map(|voting_power| (voting_power as u128, 1))
@@ -431,9 +473,9 @@ impl RoundManager {
         counters::PROPOSER_COLLECTED_TIMEOUT_VOTING_POWER.inc_by(timeout_voting_power as f64);
 
         info!(
-            epoch = self.epoch_state.epoch,
+            epoch = epoch_state.epoch,
             round = new_round_event.round,
-            total_voting_power = ?self.epoch_state.verifier.total_voting_power(),
+            total_voting_power = ?epoch_state.verifier.total_voting_power(),
             max_voting_power = ?max_voting_power,
             max_num_votes = max_num_votes,
             conflicting_voting_power = ?conflicting_voting_power,
@@ -444,31 +486,51 @@ impl RoundManager {
         );
     }
 
-    async fn generate_proposal(
-        &mut self,
+    #[cfg(feature = "fuzzing")]
+    async fn generate_proposal_for_test(
+        &self,
         new_round_event: NewRoundEvent,
     ) -> anyhow::Result<ProposalMsg> {
+        Self::generate_proposal(
+            self.epoch_state().epoch,
+            new_round_event,
+            self.block_store.sync_info(),
+            self.network.clone(),
+            self.proposal_generator.clone(),
+            self.safety_rules.clone(),
+            self.proposer_election.clone(),
+        )
+        .await
+    }
+
+    async fn generate_proposal(
+        epoch: u64,
+        new_round_event: NewRoundEvent,
+        sync_info: SyncInfo,
+        network: Arc<NetworkSender>,
+        proposal_generator: Arc<ProposalGenerator>,
+        safety_rules: Arc<Mutex<MetricsSafetyRules>>,
+        proposer_election: Arc<dyn ProposerElection + Send + Sync>,
+    ) -> anyhow::Result<ProposalMsg> {
         // Proposal generator will ensure that at most one proposal is generated per round
-        let sync_info = self.block_store.sync_info();
-        let sender = self.network.clone();
+        let callback_sync_info = sync_info.clone();
         let callback = async move {
-            sender.broadcast_sync_info(sync_info).await;
+            network.broadcast_sync_info(callback_sync_info).await;
         }
         .boxed();
 
-        let proposal = self
-            .proposal_generator
-            .generate_proposal(new_round_event.round, &mut self.proposer_election, callback)
+        let proposal = proposal_generator
+            .generate_proposal(new_round_event.round, proposer_election, callback)
             .await?;
-        let signature = self.safety_rules.lock().sign_proposal(&proposal)?;
+        let signature = safety_rules.lock().sign_proposal(&proposal)?;
         let signed_proposal =
             Block::new_proposal_from_block_data_and_signature(proposal, signature);
         observe_block(signed_proposal.timestamp_usecs(), BlockStage::SIGNED);
-        info!(self.new_log(LogEvent::Propose), "{}", signed_proposal);
-        Ok(ProposalMsg::new(
-            signed_proposal,
-            self.block_store.sync_info(),
-        ))
+        info!(
+            Self::new_log_with_round_epoch(LogEvent::Propose, new_round_event.round, epoch),
+            "{}", signed_proposal
+        );
+        Ok(ProposalMsg::new(signed_proposal, sync_info))
     }
 
     /// Process the proposal message:
@@ -529,8 +591,7 @@ impl RoundManager {
         let vote = msg.vote().clone();
         let vote_reception_result = self
             .round_state
-            .process_delayed_qc_msg(&self.epoch_state.verifier, msg)
-            .await;
+            .process_delayed_qc_msg(&self.epoch_state.verifier, msg);
         trace!(
             "Received delayed QC message and vote reception result is {:?}",
             vote_reception_result
@@ -660,7 +721,7 @@ impl RoundManager {
                 // Didn't vote in this round yet, generate a backup vote
                 let nil_block = self
                     .proposal_generator
-                    .generate_nil_block(round, &mut self.proposer_election)?;
+                    .generate_nil_block(round, self.proposer_election.clone())?;
                 info!(
                     self.new_log(LogEvent::VoteNIL),
                     "Planning to vote for a NIL block {}", nil_block
@@ -805,7 +866,7 @@ impl RoundManager {
             proposal.round(),
             proposal.quorum_cert().certified_block().round(),
             false,
-            &mut self.proposer_election,
+            self.proposer_election.clone(),
         );
         ensure!(
             proposal.block_data().failed_authors().map_or(false, |failed_authors| *failed_authors == expected_failed_authors),
@@ -1342,9 +1403,15 @@ impl RoundManager {
     }
 
     fn new_log(&self, event: LogEvent) -> LogSchema {
-        LogSchema::new(event)
-            .round(self.round_state.current_round())
-            .epoch(self.epoch_state.epoch)
+        Self::new_log_with_round_epoch(
+            event,
+            self.round_state().current_round(),
+            self.epoch_state().epoch,
+        )
+    }
+
+    fn new_log_with_round_epoch(event: LogEvent, round: Round, epoch: u64) -> LogSchema {
+        LogSchema::new(event).round(round).epoch(epoch)
     }
 
     /// Mainloop of processing messages.
@@ -1474,7 +1541,7 @@ impl RoundManager {
     }
 
     #[cfg(feature = "failpoints")]
-    fn check_whether_to_inject_reconfiguration_error(&self) -> bool {
+    fn check_whether_to_inject_reconfiguration_error() -> bool {
         fail_point!("consensus::inject_reconfiguration_error", |_| true);
         false
     }

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -58,10 +58,10 @@ use tokio::runtime::Runtime;
 
 // This generates a proposal for round 1
 pub fn generate_corpus_proposal() -> Vec<u8> {
-    let mut round_manager = create_node_for_fuzzing();
+    let round_manager = create_node_for_fuzzing();
     block_on(async {
         let proposal = round_manager
-            .generate_proposal(NewRoundEvent {
+            .generate_proposal_for_test(NewRoundEvent {
                 round: 1,
                 reason: NewRoundReason::QCReady,
                 timeout: std::time::Duration::new(5, 0),


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
 
This PR moves proposal generation to its own task so it does not block the round manager event loop. Proposal generation is heavy and blocking involving time sleeps. Moving it to an async task will allow RoundManager event loop to continue to process other events while proposal is generated. 

In addition, also removes the leader timeout step before the proposal. This is no longer needed because we now broadcast the votes to all nodes.