### PR TITLE
keyless prover vk rotation zero downtime

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -9,6 +9,7 @@ use crate::{
     errors::{discarded_output, expect_only_successful_execution},
     gas::{check_gas, get_gas_parameters, make_prod_gas_meter, ProdGasMeter},
     keyless_validation,
+    keyless_validation::KeylessConfig,
     move_vm_ext::{
         session::user_transaction_sessions::{
             abort_hook::AbortHookSession,
@@ -81,8 +82,6 @@ use aptos_vm_types::{
     resolver::{ExecutorView, ResourceGroupView},
     storage::{change_set_configs::ChangeSetConfigs, StorageGasParameters},
 };
-use ark_bn254::Bn254;
-use ark_groth16::PreparedVerifyingKey;
 use claims::assert_err;
 use fail::fail_point;
 use move_binary_format::{
@@ -115,8 +114,6 @@ use std::{
     marker::Sync,
     sync::Arc,
 };
-use std::collections::HashMap;
-use crate::keyless_validation::KeylessConfig;
 
 static EXECUTION_CONCURRENCY_LEVEL: OnceCell<usize> = OnceCell::new();
 static NUM_EXECUTION_SHARD: OnceCell<usize> = OnceCell::new();

--- a/aptos-move/aptos-vm/src/keyless_validation.rs
+++ b/aptos-move/aptos-vm/src/keyless_validation.rs
@@ -233,16 +233,20 @@ pub(crate) fn validate_authenticators(
                 )?;
             },
             EphemeralCertificate::ZeroKnowledgeSigV2 { setup_id, zk_sig } => {
-                let pvk = keyless_config.pvks_by_setup.get(setup_id).or(default_pvk);
-                verify_zk_sig(
-                    &jwk,
-                    zk_sig,
-                    sig,
-                    pk,
-                    config,
-                    training_wheels_pk.as_ref(),
-                    pvk,
-                )?;
+                let pvk = keyless_config.pvks_by_setup.get(setup_id);
+                if pvk.is_some() {
+                    verify_zk_sig(
+                        &jwk,
+                        zk_sig,
+                        sig,
+                        pk,
+                        config,
+                        training_wheels_pk.as_ref(),
+                        pvk,
+                    )?;
+                } else {
+                    return Err(invalid_signature!("Unknown setup ID"));
+                }
             },
             EphemeralCertificate::OpenIdSig(openid_sig) => {
                 match jwk {

--- a/aptos-move/e2e-move-tests/src/tests/keyless_feature_gating.rs
+++ b/aptos-move/e2e-move-tests/src/tests/keyless_feature_gating.rs
@@ -242,7 +242,8 @@ fn spend_keyless_account(
     let esk = get_sample_esk();
 
     match &mut sig.cert {
-        EphemeralCertificate::ZeroKnowledgeSig(proof) => {
+        EphemeralCertificate::ZeroKnowledgeSig(proof)
+        | EphemeralCertificate::ZeroKnowledgeSigV2 { zk_sig: proof, .. } => {
             // Training wheels should be disabled.
             proof.training_wheels_signature = None;
             txn_and_zkp.proof = Some(proof.proof);

--- a/aptos-move/e2e-move-tests/src/tests/keyless_feature_gating.rs
+++ b/aptos-move/e2e-move-tests/src/tests/keyless_feature_gating.rs
@@ -8,7 +8,7 @@ use aptos_language_e2e_tests::account::{Account, AccountPublicKey, TransactionBu
 use aptos_types::{
     keyless::{
         test_utils::{
-            get_groth16_sig_and_pk_for_setup_1, get_sample_esk, get_sample_groth16_sig_and_pk,
+            get_groth16_sig_and_pk_for_upgraded_vk, get_sample_esk, get_sample_groth16_sig_and_pk,
             get_sample_iss, get_sample_jwk, get_sample_openid_sig_and_pk, get_upgraded_vk,
         },
         Configuration, EphemeralCertificate, Groth16VerificationKey, KeylessPublicKey,
@@ -96,7 +96,7 @@ fn test_rotate_vk() {
     assert_success!(output.status().clone());
 
     // New proof for old VK
-    let (new_sig, _) = get_groth16_sig_and_pk_for_setup_1();
+    let (new_sig, _) = get_groth16_sig_and_pk_for_upgraded_vk();
     let transaction =
         spend_keyless_account(&mut h, new_sig.clone(), &account, *recipient.address());
     let output = h.run_raw(transaction);

--- a/aptos-move/e2e-move-tests/src/tests/keyless_feature_gating.rs
+++ b/aptos-move/e2e-move-tests/src/tests/keyless_feature_gating.rs
@@ -8,7 +8,7 @@ use aptos_language_e2e_tests::account::{Account, AccountPublicKey, TransactionBu
 use aptos_types::{
     keyless::{
         test_utils::{
-            get_groth16_sig_and_pk_for_upgraded_vk, get_sample_esk, get_sample_groth16_sig_and_pk,
+            get_groth16_sig_and_pk_for_setup_1, get_sample_esk, get_sample_groth16_sig_and_pk,
             get_sample_iss, get_sample_jwk, get_sample_openid_sig_and_pk, get_upgraded_vk,
         },
         Configuration, EphemeralCertificate, Groth16VerificationKey, KeylessPublicKey,
@@ -96,7 +96,7 @@ fn test_rotate_vk() {
     assert_success!(output.status().clone());
 
     // New proof for old VK
-    let (new_sig, _) = get_groth16_sig_and_pk_for_upgraded_vk();
+    let (new_sig, _) = get_groth16_sig_and_pk_for_setup_1();
     let transaction =
         spend_keyless_account(&mut h, new_sig.clone(), &account, *recipient.address());
     let output = h.run_raw(transaction);

--- a/aptos-move/framework/aptos-framework/doc/keyless_account.md
+++ b/aptos-move/framework/aptos-framework/doc/keyless_account.md
@@ -9,9 +9,12 @@ This module is responsible for configuring keyless blockchain accounts which wer
 
 -  [Struct `Group`](#0x1_keyless_account_Group)
 -  [Resource `Groth16VerificationKey`](#0x1_keyless_account_Groth16VerificationKey)
+-  [Struct `SetupVKEntry`](#0x1_keyless_account_SetupVKEntry)
+-  [Resource `SetupsVKs`](#0x1_keyless_account_SetupsVKs)
 -  [Resource `Configuration`](#0x1_keyless_account_Configuration)
 -  [Constants](#@Constants_0)
 -  [Function `new_groth16_verification_key`](#0x1_keyless_account_new_groth16_verification_key)
+-  [Function `new_setup_vk_entry`](#0x1_keyless_account_new_setup_vk_entry)
 -  [Function `new_configuration`](#0x1_keyless_account_new_configuration)
 -  [Function `validate_groth16_vk`](#0x1_keyless_account_validate_groth16_vk)
 -  [Function `update_groth16_verification_key`](#0x1_keyless_account_update_groth16_verification_key)
@@ -21,6 +24,7 @@ This module is responsible for configuring keyless blockchain accounts which wer
 -  [Function `remove_all_override_auds`](#0x1_keyless_account_remove_all_override_auds)
 -  [Function `add_override_aud`](#0x1_keyless_account_add_override_aud)
 -  [Function `set_groth16_verification_key_for_next_epoch`](#0x1_keyless_account_set_groth16_verification_key_for_next_epoch)
+-  [Function `set_vk_map_for_next_epoch`](#0x1_keyless_account_set_vk_map_for_next_epoch)
 -  [Function `set_configuration_for_next_epoch`](#0x1_keyless_account_set_configuration_for_next_epoch)
 -  [Function `update_training_wheels_for_next_epoch`](#0x1_keyless_account_update_training_wheels_for_next_epoch)
 -  [Function `update_max_exp_horizon_for_next_epoch`](#0x1_keyless_account_update_max_exp_horizon_for_next_epoch)
@@ -75,7 +79,9 @@ This module is responsible for configuring keyless blockchain accounts which wer
 
 ## Resource `Groth16VerificationKey`
 
-The 288-byte Groth16 verification key (VK) for the ZK relation that implements keyless accounts
+The 288-byte Groth16 verification key (VK) for the ZK relation that implements keyless accounts.
+
+Deprecated by <code><a href="keyless_account.md#0x1_keyless_account_SetupsVKs">SetupsVKs</a></code>.
 
 
 <pre><code>#[resource_group_member(#[group = <a href="keyless_account.md#0x1_keyless_account_Group">0x1::keyless_account::Group</a>])]
@@ -119,6 +125,73 @@ The 288-byte Groth16 verification key (VK) for the ZK relation that implements k
 <dd>
  <code>\<b>forall</b> i \in {0, ..., \ell}, 64-byte serialization of gamma^{-1} * (beta * a_i + alpha * b_i + c_i) * H</code>, where
  <code>H</code> is the generator of <code>G1</code> and <code>\ell</code> is 1 for the ZK relation.
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_keyless_account_SetupVKEntry"></a>
+
+## Struct `SetupVKEntry`
+
+
+
+<pre><code><b>struct</b> <a href="keyless_account.md#0x1_keyless_account_SetupVKEntry">SetupVKEntry</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>setup_id: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>vk: <a href="keyless_account.md#0x1_keyless_account_Groth16VerificationKey">keyless_account::Groth16VerificationKey</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_keyless_account_SetupsVKs"></a>
+
+## Resource `SetupsVKs`
+
+Groth16 verification keys indexed by a setup ID.
+
+This is introduced to support zero-downtime VK rotation, where:
+0. a setup is done for a new circuit, yielding a new verification key (VK) and a new proving key (PK);
+1. the new VK is added to this collection;
+2. client-side proving intrastructures switch to the new PK;
+3. the old VK is removed from this collection.
+
+
+<pre><code><b>struct</b> <a href="keyless_account.md#0x1_keyless_account_SetupsVKs">SetupsVKs</a> <b>has</b> drop, store, key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>entries: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="keyless_account.md#0x1_keyless_account_SetupVKEntry">keyless_account::SetupVKEntry</a>&gt;</code>
+</dt>
+<dd>
+
 </dd>
 </dl>
 
@@ -260,6 +333,33 @@ The training wheels PK needs to be 32 bytes long.
         gamma_g2,
         delta_g2,
         gamma_abc_g1,
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_keyless_account_new_setup_vk_entry"></a>
+
+## Function `new_setup_vk_entry`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="keyless_account.md#0x1_keyless_account_new_setup_vk_entry">new_setup_vk_entry</a>(setup_id: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, vk: <a href="keyless_account.md#0x1_keyless_account_Groth16VerificationKey">keyless_account::Groth16VerificationKey</a>): <a href="keyless_account.md#0x1_keyless_account_SetupVKEntry">keyless_account::SetupVKEntry</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="keyless_account.md#0x1_keyless_account_new_setup_vk_entry">new_setup_vk_entry</a>(setup_id: String, vk: <a href="keyless_account.md#0x1_keyless_account_Groth16VerificationKey">Groth16VerificationKey</a>): <a href="keyless_account.md#0x1_keyless_account_SetupVKEntry">SetupVKEntry</a> {
+    <a href="keyless_account.md#0x1_keyless_account_SetupVKEntry">SetupVKEntry</a> {
+        setup_id,
+        vk,
     }
 }
 </code></pre>
@@ -556,6 +656,32 @@ WARNING: If a malicious key is set, this would lead to stolen funds.
 
 </details>
 
+<a id="0x1_keyless_account_set_vk_map_for_next_epoch"></a>
+
+## Function `set_vk_map_for_next_epoch`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="keyless_account.md#0x1_keyless_account_set_vk_map_for_next_epoch">set_vk_map_for_next_epoch</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, entries: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="keyless_account.md#0x1_keyless_account_SetupVKEntry">keyless_account::SetupVKEntry</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="keyless_account.md#0x1_keyless_account_set_vk_map_for_next_epoch">set_vk_map_for_next_epoch</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, entries: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="keyless_account.md#0x1_keyless_account_SetupVKEntry">SetupVKEntry</a>&gt;) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
+    <b>let</b> map = <a href="keyless_account.md#0x1_keyless_account_SetupsVKs">SetupsVKs</a> { entries };
+    <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(map)
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_keyless_account_set_configuration_for_next_epoch"></a>
 
 ## Function `set_configuration_for_next_epoch`
@@ -760,7 +886,7 @@ Only used in reconfigurations to apply the queued up configuration changes, if t
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="keyless_account.md#0x1_keyless_account_on_new_epoch">on_new_epoch</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="keyless_account.md#0x1_keyless_account_Groth16VerificationKey">Groth16VerificationKey</a>, <a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a> {
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="keyless_account.md#0x1_keyless_account_on_new_epoch">on_new_epoch</a>(fx: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="keyless_account.md#0x1_keyless_account_Groth16VerificationKey">Groth16VerificationKey</a>, <a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>, <a href="keyless_account.md#0x1_keyless_account_SetupsVKs">SetupsVKs</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
 
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Groth16VerificationKey">Groth16VerificationKey</a>&gt;()) {
@@ -780,6 +906,16 @@ Only used in reconfigurations to apply the queued up configuration changes, if t
             <b>move_to</b>(fx, config);
         }
     };
+
+    <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="keyless_account.md#0x1_keyless_account_SetupsVKs">SetupsVKs</a>&gt;()) {
+        <b>let</b> vk_map = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>();
+        <b>if</b> (<b>exists</b>&lt;<a href="keyless_account.md#0x1_keyless_account_SetupsVKs">SetupsVKs</a>&gt;(@aptos_framework)) {
+            *<b>borrow_global_mut</b>&lt;<a href="keyless_account.md#0x1_keyless_account_SetupsVKs">SetupsVKs</a>&gt;(@aptos_framework) = vk_map;
+        } <b>else</b> {
+            <b>move_to</b>(fx, vk_map);
+        }
+    };
+
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/reconfiguration_with_dkg.md
+++ b/aptos-move/framework/aptos-framework/doc/reconfiguration_with_dkg.md
@@ -223,6 +223,7 @@ Abort if no DKG is in progress.
     <b>include</b> <a href="config_buffer.md#0x1_config_buffer_OnNewEpochRequirement">config_buffer::OnNewEpochRequirement</a>&lt;<a href="jwk_consensus_config.md#0x1_jwk_consensus_config_JWKConsensusConfig">jwk_consensus_config::JWKConsensusConfig</a>&gt;;
     <b>include</b> <a href="config_buffer.md#0x1_config_buffer_OnNewEpochRequirement">config_buffer::OnNewEpochRequirement</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">keyless_account::Configuration</a>&gt;;
     <b>include</b> <a href="config_buffer.md#0x1_config_buffer_OnNewEpochRequirement">config_buffer::OnNewEpochRequirement</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Groth16VerificationKey">keyless_account::Groth16VerificationKey</a>&gt;;
+    <b>include</b> <a href="config_buffer.md#0x1_config_buffer_OnNewEpochRequirement">config_buffer::OnNewEpochRequirement</a>&lt;<a href="keyless_account.md#0x1_keyless_account_SetupsVKs">keyless_account::SetupsVKs</a>&gt;;
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration_with_dkg.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration_with_dkg.spec.move
@@ -61,6 +61,7 @@ spec aptos_framework::reconfiguration_with_dkg {
         include config_buffer::OnNewEpochRequirement<jwk_consensus_config::JWKConsensusConfig>;
         include config_buffer::OnNewEpochRequirement<keyless_account::Configuration>;
         include config_buffer::OnNewEpochRequirement<keyless_account::Groth16VerificationKey>;
+        include config_buffer::OnNewEpochRequirement<keyless_account::SetupsVKs>;
     }
 
     spec finish_with_dkg_result(account: &signer, dkg_result: vector<u8>) {

--- a/testsuite/smoke-test/src/keyless.rs
+++ b/testsuite/smoke-test/src/keyless.rs
@@ -21,9 +21,10 @@ use aptos_types::{
     keyless::{
         get_public_inputs_hash,
         test_utils::{
-            self, get_groth16_sig_and_pk_for_upgraded_vk, get_sample_esk,
-            get_sample_groth16_sig_and_pk, get_sample_groth16_sig_and_pk_no_extra_field,
-            get_sample_iss, get_sample_jwk, get_sample_openid_sig_and_pk, get_upgraded_vk,
+            self, get_groth16_sig_and_pk_for_setup_2, get_groth16_sig_and_pk_for_upgraded_vk,
+            get_sample_esk, get_sample_groth16_sig_and_pk,
+            get_sample_groth16_sig_and_pk_no_extra_field, get_sample_iss, get_sample_jwk,
+            get_sample_openid_sig_and_pk, get_upgraded_vk,
         },
         Configuration, EphemeralCertificate, Groth16ProofAndStatement, Groth16VerificationKey,
         KeylessPublicKey, KeylessSignature, TransactionAndProof, DEVNET_VERIFICATION_KEY,
@@ -40,9 +41,7 @@ use aptos_types::{
 use move_core_types::account_address::AccountAddress;
 use rand::thread_rng;
 use serde::de::DeserializeOwned;
-use std::{fmt::Debug, time::Duration};
-use std::collections::HashMap;
-use aptos_types::keyless::test_utils::get_groth16_sig_and_pk_for_setup_2;
+use std::{collections::HashMap, fmt::Debug, time::Duration};
 // TODO(keyless): Test the override aud_val path
 
 #[tokio::test]
@@ -69,11 +68,17 @@ async fn test_keyless_rotate_vk() {
     info!("Initial on-chain state: default_setup=SETUP_0, vk_map={{}}");
 
     info!("A keyless transaction using SETUP_0 should succeed.");
-    assert!(run_txn(&mut info, "SETUP_0", &jwk, &config, &tw_sk, 1).await.is_ok());
+    assert!(run_txn(&mut info, "SETUP_0", &jwk, &config, &tw_sk, 1)
+        .await
+        .is_ok());
 
     info!("A keyless transaction using SETUP_1/SETUP_2 should fail.");
-    assert!(run_txn(&mut info, "SETUP_1", &jwk, &config, &tw_sk, 2).await.is_err());
-    assert!(run_txn(&mut info, "SETUP_2", &jwk, &config, &tw_sk, 2).await.is_err());
+    assert!(run_txn(&mut info, "SETUP_1", &jwk, &config, &tw_sk, 2)
+        .await
+        .is_err());
+    assert!(run_txn(&mut info, "SETUP_2", &jwk, &config, &tw_sk, 2)
+        .await
+        .is_err());
 
     info!("Config update #1, target state: default_setup=SETUP_0, vk_map={{SETUP_1}}");
     let vk = Groth16VerificationKey::from(get_upgraded_vk());
@@ -82,13 +87,19 @@ async fn test_keyless_rotate_vk() {
     rotate_vk_by_governance(&mut cli, &mut info, vk_map_1, root_idx).await;
 
     info!("A keyless transaction using SETUP_0 should still succeed.");
-    assert!(run_txn(&mut info, "SETUP_0", &jwk, &config, &tw_sk, 2).await.is_ok());
+    assert!(run_txn(&mut info, "SETUP_0", &jwk, &config, &tw_sk, 2)
+        .await
+        .is_ok());
 
     info!("A keyless transaction using SETUP_1 should succeed.");
-    assert!(run_txn(&mut info, "SETUP_1", &jwk, &config, &tw_sk, 3).await.is_ok());
+    assert!(run_txn(&mut info, "SETUP_1", &jwk, &config, &tw_sk, 3)
+        .await
+        .is_ok());
 
     info!("A keyless transaction using SETUP_2 should fail.");
-    assert!(run_txn(&mut info, "SETUP_2", &jwk, &config, &tw_sk, 4).await.is_err());
+    assert!(run_txn(&mut info, "SETUP_2", &jwk, &config, &tw_sk, 4)
+        .await
+        .is_err());
 
     info!("Config update #2, target state: default_setup=SETUP_0, vk_map={{SETUP_1, SETUP_2}}");
     let vk_1 = Groth16VerificationKey::from(get_upgraded_vk());
@@ -99,13 +110,19 @@ async fn test_keyless_rotate_vk() {
     rotate_vk_by_governance(&mut cli, &mut info, vk_map_1, root_idx).await;
 
     info!("A keyless transaction using SETUP_0 should succeed.");
-    assert!(run_txn(&mut info, "SETUP_0", &jwk, &config, &tw_sk, 4).await.is_ok());
+    assert!(run_txn(&mut info, "SETUP_0", &jwk, &config, &tw_sk, 4)
+        .await
+        .is_ok());
 
     info!("A keyless transaction using SETUP_1 should succeed.");
-    assert!(run_txn(&mut info, "SETUP_1", &jwk, &config, &tw_sk, 5).await.is_ok());
+    assert!(run_txn(&mut info, "SETUP_1", &jwk, &config, &tw_sk, 5)
+        .await
+        .is_ok());
 
     info!("A keyless transaction using SETUP_2 should succeed.");
-    assert!(run_txn(&mut info, "SETUP_2", &jwk, &config, &tw_sk, 6).await.is_ok());
+    assert!(run_txn(&mut info, "SETUP_2", &jwk, &config, &tw_sk, 6)
+        .await
+        .is_ok());
 
     info!("Config update #3, target state: default_setup=SETUP_0, vk_map={{SETUP_2}}");
     let vk_2 = Groth16VerificationKey::from(get_upgraded_vk());
@@ -114,29 +131,39 @@ async fn test_keyless_rotate_vk() {
     rotate_vk_by_governance(&mut cli, &mut info, vk_map_1, root_idx).await;
 
     info!("A keyless transaction using SETUP_0 should succeed.");
-    assert!(run_txn(&mut info, "SETUP_0", &jwk, &config, &tw_sk, 7).await.is_ok());
+    assert!(run_txn(&mut info, "SETUP_0", &jwk, &config, &tw_sk, 7)
+        .await
+        .is_ok());
 
     info!("A keyless transaction using SETUP_1 should fail.");
-    assert!(run_txn(&mut info, "SETUP_1", &jwk, &config, &tw_sk, 8).await.is_err());
+    assert!(run_txn(&mut info, "SETUP_1", &jwk, &config, &tw_sk, 8)
+        .await
+        .is_err());
 
     info!("A keyless transaction using SETUP_2 should succeed.");
-    assert!(run_txn(&mut info, "SETUP_2", &jwk, &config, &tw_sk, 8).await.is_ok());
+    assert!(run_txn(&mut info, "SETUP_2", &jwk, &config, &tw_sk, 8)
+        .await
+        .is_ok());
 }
 
-async fn run_txn(info: &mut  AptosPublicInfo, setup_id: &str, jwk: &RSA_JWK, config: &Configuration, tw_sk: &Ed25519PrivateKey, seq_num: usize) -> anyhow::Result<()> {
+async fn run_txn(
+    info: &mut AptosPublicInfo,
+    setup_id: &str,
+    jwk: &RSA_JWK,
+    config: &Configuration,
+    tw_sk: &Ed25519PrivateKey,
+    seq_num: usize,
+) -> anyhow::Result<()> {
     let (sig, pk) = match setup_id {
         "SETUP_0" => get_sample_groth16_sig_and_pk(),
         "SETUP_1" => get_groth16_sig_and_pk_for_upgraded_vk(),
         "SETUP_2" => get_groth16_sig_and_pk_for_setup_2(),
         _ => unreachable!(),
     };
-    let signed_txn =
-        sign_transaction(info, sig, pk, jwk, config, Some(tw_sk), seq_num).await;
-    let result = info
-        .client()
+    let signed_txn = sign_transaction(info, sig, pk, jwk, config, Some(tw_sk), seq_num).await;
+    info.client()
         .submit_without_serializing_response(&signed_txn)
-        .await;
-    result
+        .await
 }
 
 #[tokio::test]
@@ -374,17 +401,16 @@ async fn sign_transaction<'a>(
 
     let esk = get_sample_esk();
 
-    let public_inputs_hash: Option<[u8; 32]> =
-        match &sig.cert {
-            EphemeralCertificate::ZeroKnowledgeSig(_)
-            | EphemeralCertificate::ZeroKnowledgeSigV2 { .. } => {
-                // This will only calculate the hash if it's needed, avoiding unnecessary computation.
-                Some(fr_to_bytes_le(
-                    &get_public_inputs_hash(&sig, &pk, jwk, config).unwrap(),
-                ))
-            },
-            EphemeralCertificate::OpenIdSig(_) => None,
-        };
+    let public_inputs_hash: Option<[u8; 32]> = match &sig.cert {
+        EphemeralCertificate::ZeroKnowledgeSig(_)
+        | EphemeralCertificate::ZeroKnowledgeSigV2 { .. } => {
+            // This will only calculate the hash if it's needed, avoiding unnecessary computation.
+            Some(fr_to_bytes_le(
+                &get_public_inputs_hash(&sig, &pk, jwk, config).unwrap(),
+            ))
+        },
+        EphemeralCertificate::OpenIdSig(_) => None,
+    };
 
     let mut txn_and_zkp = TransactionAndProof {
         message: raw_txn.clone(),
@@ -662,6 +688,7 @@ async fn get_latest_jwkset(rest_client: &Client) -> PatchedJWKs {
     response.into_inner()
 }
 
+#[allow(clippy::vec_init_then_push)]
 async fn rotate_vk_by_governance<'a>(
     cli: &mut CliTestFramework,
     info: &mut AptosPublicInfo,
@@ -669,31 +696,55 @@ async fn rotate_vk_by_governance<'a>(
     root_idx: usize,
 ) {
     let mut lines = vec![];
-    lines.push(format!("script {{"));
-    lines.push(format!("    use aptos_framework::keyless_account;"));
-    lines.push(format!("    use aptos_framework::aptos_governance;"));
-    lines.push(format!("    use std::string::utf8;"));
-    lines.push(format!("    use std::vector;"));
-    lines.push(format!("    fun main(core_resources: &signer) {{"));
-    lines.push(format!("        let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @0x1);"));
-    lines.push(format!("        let entries = vector[];"));
+    lines.push("script {".to_string());
+    lines.push("    use aptos_framework::keyless_account;".to_string());
+    lines.push("    use aptos_framework::aptos_governance;".to_string());
+    lines.push("    use std::string::utf8;".to_string());
+    lines.push("    use std::vector;".to_string());
+    lines.push("    fun main(core_resources: &signer) {{".to_string());
+    lines.push("        let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @0x1);".to_string());
+    lines.push("        let entries = vector[];".to_string());
     for (setup_id, vk) in vks {
         lines.push(format!(r#"        let setup_id = utf8(b"{}");"#, setup_id));
-        lines.push(format!(r#"        let alpha_g1 = x"{}";"#, hex::encode(&vk.alpha_g1)));
-        lines.push(format!(r#"        let beta_g2 = x"{}";"#, hex::encode(&vk.beta_g2)));
-        lines.push(format!(r#"        let gamma_g2 = x"{}";"#, hex::encode(&vk.gamma_g2)));
-        lines.push(format!(r#"        let delta_g2 = x"{}";"#, hex::encode(&vk.delta_g2)));
-        lines.push(format!(r#"        let gamma_abc_g1_0 = x"{}";"#, hex::encode(&vk.gamma_abc_g1[0])));
-        lines.push(format!(r#"        let gamma_abc_g1_1 = x"{}";"#, hex::encode(&vk.gamma_abc_g1[1])));
-        lines.push(format!("        let gamma_abc_g1 = vector[gamma_abc_g1_0, gamma_abc_g1_1];"));
-        lines.push(format!("        let vk = keyless_account::new_groth16_verification_key(alpha_g1, beta_g2, gamma_g2, delta_g2, gamma_abc_g1);"));
-        lines.push(format!("        let entry = keyless_account::new_setup_vk_entry(setup_id, vk);"));
-        lines.push(format!("        vector::push_back(&mut entries, entry);"));
+        lines.push(format!(
+            r#"        let alpha_g1 = x"{}";"#,
+            hex::encode(&vk.alpha_g1)
+        ));
+        lines.push(format!(
+            r#"        let beta_g2 = x"{}";"#,
+            hex::encode(&vk.beta_g2)
+        ));
+        lines.push(format!(
+            r#"        let gamma_g2 = x"{}";"#,
+            hex::encode(&vk.gamma_g2)
+        ));
+        lines.push(format!(
+            r#"        let delta_g2 = x"{}";"#,
+            hex::encode(&vk.delta_g2)
+        ));
+        lines.push(format!(
+            r#"        let gamma_abc_g1_0 = x"{}";"#,
+            hex::encode(&vk.gamma_abc_g1[0])
+        ));
+        lines.push(format!(
+            r#"        let gamma_abc_g1_1 = x"{}";"#,
+            hex::encode(&vk.gamma_abc_g1[1])
+        ));
+        lines
+            .push("        let gamma_abc_g1 = vector[gamma_abc_g1_0, gamma_abc_g1_1];".to_string());
+        lines.push("        let vk = keyless_account::new_groth16_verification_key(alpha_g1, beta_g2, gamma_g2, delta_g2, gamma_abc_g1);".to_string());
+        lines.push(
+            "        let entry = keyless_account::new_setup_vk_entry(setup_id, vk);".to_string(),
+        );
+        lines.push("        vector::push_back(&mut entries, entry);".to_string());
     }
-    lines.push(format!("        keyless_account::set_vk_map_for_next_epoch(&framework_signer, entries);"));
-    lines.push(format!("        aptos_governance::force_end_epoch(&framework_signer);"));
-    lines.push(format!("    }}"));
-    lines.push(format!("}}"));
+    lines.push(
+        "        keyless_account::set_vk_map_for_next_epoch(&framework_signer, entries);"
+            .to_string(),
+    );
+    lines.push("        aptos_governance::force_end_epoch(&framework_signer);".to_string());
+    lines.push("    }".to_string());
+    lines.push("}".to_string());
 
     let script = lines.join("\n");
 

--- a/testsuite/smoke-test/src/keyless.rs
+++ b/testsuite/smoke-test/src/keyless.rs
@@ -709,8 +709,9 @@ async fn rotate_vk_by_governance<'a>(
         .await;
     debug!("txn_summary={:?}", txn_summary);
     assert_eq!(Some(true), txn_summary.unwrap().success);
+
     // Increment sequence number as we ran a governance proposal
-    // info.root_account().increment_sequence_number();
+    info.root_account().increment_sequence_number();
 }
 
 async fn print_account_resource<T: DeserializeOwned + Debug>(

--- a/testsuite/smoke-test/src/keyless.rs
+++ b/testsuite/smoke-test/src/keyless.rs
@@ -701,7 +701,7 @@ async fn rotate_vk_by_governance<'a>(
     lines.push("    use aptos_framework::aptos_governance;".to_string());
     lines.push("    use std::string::utf8;".to_string());
     lines.push("    use std::vector;".to_string());
-    lines.push("    fun main(core_resources: &signer) {{".to_string());
+    lines.push("    fun main(core_resources: &signer) {".to_string());
     lines.push("        let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @0x1);".to_string());
     lines.push("        let entries = vector[];".to_string());
     for (setup_id, vk) in vks {

--- a/testsuite/smoke-test/src/keyless.rs
+++ b/testsuite/smoke-test/src/keyless.rs
@@ -664,7 +664,7 @@ async fn get_latest_jwkset(rest_client: &Client) -> PatchedJWKs {
 
 async fn rotate_vk_by_governance<'a>(
     cli: &mut CliTestFramework,
-    _info: &mut AptosPublicInfo,
+    info: &mut AptosPublicInfo,
     vks: HashMap<String, Groth16VerificationKey>,
     root_idx: usize,
 ) {

--- a/testsuite/smoke-test/src/keyless.rs
+++ b/testsuite/smoke-test/src/keyless.rs
@@ -124,7 +124,7 @@ async fn test_keyless_rotate_vk() {
 
 async fn run_txn(info: &mut  AptosPublicInfo, setup_id: &str, jwk: &RSA_JWK, config: &Configuration, tw_sk: &Ed25519PrivateKey, seq_num: usize) -> anyhow::Result<()> {
     let (sig, pk) = match setup_id {
-        "SETUP_0" => get_groth16_sig_and_pk(),
+        "SETUP_0" => get_sample_groth16_sig_and_pk(),
         "SETUP_1" => get_groth16_sig_and_pk_for_upgraded_vk(),
         "SETUP_2" => get_groth16_sig_and_pk_for_upgraded_vk(),
         _ => unreachable!(),

--- a/testsuite/smoke-test/src/keyless.rs
+++ b/testsuite/smoke-test/src/keyless.rs
@@ -42,6 +42,7 @@ use rand::thread_rng;
 use serde::de::DeserializeOwned;
 use std::{fmt::Debug, time::Duration};
 use std::collections::HashMap;
+use aptos_types::keyless::test_utils::get_groth16_sig_and_pk_for_setup_2;
 // TODO(keyless): Test the override aud_val path
 
 #[tokio::test]
@@ -126,15 +127,16 @@ async fn run_txn(info: &mut  AptosPublicInfo, setup_id: &str, jwk: &RSA_JWK, con
     let (sig, pk) = match setup_id {
         "SETUP_0" => get_sample_groth16_sig_and_pk(),
         "SETUP_1" => get_groth16_sig_and_pk_for_upgraded_vk(),
-        "SETUP_2" => get_groth16_sig_and_pk_for_upgraded_vk(),
+        "SETUP_2" => get_groth16_sig_and_pk_for_setup_2(),
         _ => unreachable!(),
     };
     let signed_txn =
         sign_transaction(info, sig, pk, jwk, config, Some(tw_sk), seq_num).await;
-    info
+    let result = info
         .client()
         .submit_without_serializing_response(&signed_txn)
-        .await
+        .await;
+    result
 }
 
 #[tokio::test]

--- a/testsuite/smoke-test/src/keyless.rs
+++ b/testsuite/smoke-test/src/keyless.rs
@@ -375,13 +375,15 @@ async fn sign_transaction<'a>(
     let esk = get_sample_esk();
 
     let public_inputs_hash: Option<[u8; 32]> =
-        if let EphemeralCertificate::ZeroKnowledgeSig(_) = &sig.cert {
-            // This will only calculate the hash if it's needed, avoiding unnecessary computation.
-            Some(fr_to_bytes_le(
-                &get_public_inputs_hash(&sig, &pk, jwk, config).unwrap(),
-            ))
-        } else {
-            None
+        match &sig.cert {
+            EphemeralCertificate::ZeroKnowledgeSig(_)
+            | EphemeralCertificate::ZeroKnowledgeSigV2 { .. } => {
+                // This will only calculate the hash if it's needed, avoiding unnecessary computation.
+                Some(fr_to_bytes_le(
+                    &get_public_inputs_hash(&sig, &pk, jwk, config).unwrap(),
+                ))
+            },
+            EphemeralCertificate::OpenIdSig(_) => None,
         };
 
     let mut txn_and_zkp = TransactionAndProof {

--- a/testsuite/smoke-test/src/keyless.rs
+++ b/testsuite/smoke-test/src/keyless.rs
@@ -673,6 +673,7 @@ async fn rotate_vk_by_governance<'a>(
     lines.push(format!("    use aptos_framework::keyless_account;"));
     lines.push(format!("    use aptos_framework::aptos_governance;"));
     lines.push(format!("    use std::string::utf8;"));
+    lines.push(format!("    use std::vector;"));
     lines.push(format!("    fun main(core_resources: &signer) {{"));
     lines.push(format!("        let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @0x1);"));
     lines.push(format!("        let entries = vector[];"));

--- a/testsuite/smoke-test/src/keyless.rs
+++ b/testsuite/smoke-test/src/keyless.rs
@@ -748,7 +748,7 @@ async fn rotate_vk_by_governance<'a>(
 
     let script = lines.join("\n");
 
-    debug!("Move script for changing VK follows below:\n{:?}", script);
+    println!("Move script for changing VK follows below:\n{:?}", script);
 
     let gas_options = GasOptions {
         gas_unit_price: Some(100),

--- a/types/src/keyless/bn254_circom.rs
+++ b/types/src/keyless/bn254_circom.rs
@@ -366,7 +366,7 @@ pub fn get_public_inputs_hash(
         },
         EphemeralCertificate::OpenIdSig(_) => {
             bail!("Can only call `get_public_inputs_hash` on keyless::Signature with Groth16 ZK proof")
-        }
+        },
     }
 }
 

--- a/types/src/keyless/bn254_circom.rs
+++ b/types/src/keyless/bn254_circom.rs
@@ -279,90 +279,94 @@ pub fn get_public_inputs_hash(
     jwk: &RSA_JWK,
     config: &Configuration,
 ) -> anyhow::Result<Fr> {
-    if let EphemeralCertificate::ZeroKnowledgeSig(proof) = &sig.cert {
-        let (has_extra_field, extra_field_hash) = match &proof.extra_field {
-            None => (Fr::zero(), *EMPTY_EXTRA_FIELD_HASH),
-            Some(extra_field) => (
-                Fr::one(),
-                poseidon_bn254::keyless::pad_and_hash_string(
-                    extra_field,
-                    config.max_extra_field_bytes as usize,
-                )?,
-            ),
-        };
+    match &sig.cert {
+        EphemeralCertificate::ZeroKnowledgeSig(proof)
+        | EphemeralCertificate::ZeroKnowledgeSigV2 { zk_sig: proof, .. } => {
+            let (has_extra_field, extra_field_hash) = match &proof.extra_field {
+                None => (Fr::zero(), *EMPTY_EXTRA_FIELD_HASH),
+                Some(extra_field) => (
+                    Fr::one(),
+                    poseidon_bn254::keyless::pad_and_hash_string(
+                        extra_field,
+                        config.max_extra_field_bytes as usize,
+                    )?,
+                ),
+            };
 
-        let (override_aud_val_hash, use_override_aud) = match &proof.override_aud_val {
-            Some(override_aud_val) => (
-                cached_pad_and_hash_string(override_aud_val, IdCommitment::MAX_AUD_VAL_BYTES)?,
-                ark_bn254::Fr::from(1),
-            ),
-            None => (*EMPTY_OVERRIDE_AUD_FIELD_HASH, ark_bn254::Fr::from(0)),
-        };
+            let (override_aud_val_hash, use_override_aud) = match &proof.override_aud_val {
+                Some(override_aud_val) => (
+                    cached_pad_and_hash_string(override_aud_val, IdCommitment::MAX_AUD_VAL_BYTES)?,
+                    ark_bn254::Fr::from(1),
+                ),
+                None => (*EMPTY_OVERRIDE_AUD_FIELD_HASH, ark_bn254::Fr::from(0)),
+            };
 
-        // Add the hash of the jwt_header with the "." separator appended
-        let jwt_header_b64_with_separator =
-            format!("{}.", base64url_encode_str(sig.jwt_header_json.as_str()));
-        let jwt_header_hash = cached_pad_and_hash_string(
-            &jwt_header_b64_with_separator,
-            config.max_jwt_header_b64_bytes as usize,
-        )?;
+            // Add the hash of the jwt_header with the "." separator appended
+            let jwt_header_b64_with_separator =
+                format!("{}.", base64url_encode_str(sig.jwt_header_json.as_str()));
+            let jwt_header_hash = cached_pad_and_hash_string(
+                &jwt_header_b64_with_separator,
+                config.max_jwt_header_b64_bytes as usize,
+            )?;
 
-        let jwk_hash = cached_jwk_hash(jwk)?;
+            let jwk_hash = cached_jwk_hash(jwk)?;
 
-        // Add the hash of the value of the `iss` field
-        let iss_field_hash =
-            cached_pad_and_hash_string(&pk.iss_val, config.max_iss_val_bytes as usize)?;
+            // Add the hash of the value of the `iss` field
+            let iss_field_hash =
+                cached_pad_and_hash_string(&pk.iss_val, config.max_iss_val_bytes as usize)?;
 
-        // Add the id_commitment as a scalar
-        let idc = Fr::from_le_bytes_mod_order(&pk.idc.0);
+            // Add the id_commitment as a scalar
+            let idc = Fr::from_le_bytes_mod_order(&pk.idc.0);
 
-        // Add the exp_timestamp_secs as a scalar
-        let exp_timestamp_secs = Fr::from(sig.exp_date_secs);
+            // Add the exp_timestamp_secs as a scalar
+            let exp_timestamp_secs = Fr::from(sig.exp_date_secs);
 
-        // Add the epk lifespan as a scalar
-        let exp_horizon_secs = Fr::from(proof.exp_horizon_secs);
+            // Add the epk lifespan as a scalar
+            let exp_horizon_secs = Fr::from(proof.exp_horizon_secs);
 
-        // Add the epk as padded and packed scalars
-        let mut epk_frs = poseidon_bn254::keyless::pad_and_pack_bytes_to_scalars_with_len(
-            sig.ephemeral_pubkey.to_bytes().as_slice(),
-            config.max_commited_epk_bytes as usize,
-        )?;
+            // Add the epk as padded and packed scalars
+            let mut epk_frs = poseidon_bn254::keyless::pad_and_pack_bytes_to_scalars_with_len(
+                sig.ephemeral_pubkey.to_bytes().as_slice(),
+                config.max_commited_epk_bytes as usize,
+            )?;
 
-        // println!("Num EPK scalars:    {}", epk_frs.len());
-        // for (i, e) in epk_frs.iter().enumerate() {
-        //     println!("EPK Fr[{}]:          {}", i, e.to_string())
-        // }
-        // println!("IDC:                {}", idc);
-        // println!("exp_timestamp_secs: {}", exp_timestamp_secs);
-        // println!("exp_horizon_secs:   {}", exp_horizon_secs);
-        // println!("iss field:          {}", pk.iss_val);
-        // println!("iss field hash:     {}", iss_field_hash);
-        // println!("Has extra field:    {}", has_extra_field);
-        // println!("Extra field val:    {:?}", proof.extra_field);
-        // println!("Extra field hash:   {}", extra_field_hash);
-        // println!("JWT header val:     {}", jwt_header_b64_with_separator);
-        // println!("JWT header hash:    {}", jwt_header_hash);
-        // println!("JWK hash:           {}", jwk_hash);
-        // println!("Override aud hash:  {}", override_aud_val_hash);
-        // println!("Use override aud:   {}", use_override_aud.to_string());
+            // println!("Num EPK scalars:    {}", epk_frs.len());
+            // for (i, e) in epk_frs.iter().enumerate() {
+            //     println!("EPK Fr[{}]:          {}", i, e.to_string())
+            // }
+            // println!("IDC:                {}", idc);
+            // println!("exp_timestamp_secs: {}", exp_timestamp_secs);
+            // println!("exp_horizon_secs:   {}", exp_horizon_secs);
+            // println!("iss field:          {}", pk.iss_val);
+            // println!("iss field hash:     {}", iss_field_hash);
+            // println!("Has extra field:    {}", has_extra_field);
+            // println!("Extra field val:    {:?}", proof.extra_field);
+            // println!("Extra field hash:   {}", extra_field_hash);
+            // println!("JWT header val:     {}", jwt_header_b64_with_separator);
+            // println!("JWT header hash:    {}", jwt_header_hash);
+            // println!("JWK hash:           {}", jwk_hash);
+            // println!("Override aud hash:  {}", override_aud_val_hash);
+            // println!("Use override aud:   {}", use_override_aud.to_string());
 
-        let mut frs = vec![];
-        frs.append(&mut epk_frs);
-        frs.push(idc);
-        frs.push(exp_timestamp_secs);
-        frs.push(exp_horizon_secs);
-        frs.push(iss_field_hash);
-        frs.push(has_extra_field);
-        frs.push(extra_field_hash);
-        frs.push(jwt_header_hash);
-        frs.push(jwk_hash);
-        frs.push(override_aud_val_hash);
-        frs.push(use_override_aud);
-        // TODO(keyless): If we plan on avoiding verifying the same PIH twice, there should be no
-        //  need for caching here. If we do not, we should cache the result here too.
-        poseidon_bn254::hash_scalars(frs)
-    } else {
-        bail!("Can only call `get_public_inputs_hash` on keyless::Signature with Groth16 ZK proof")
+            let mut frs = vec![];
+            frs.append(&mut epk_frs);
+            frs.push(idc);
+            frs.push(exp_timestamp_secs);
+            frs.push(exp_horizon_secs);
+            frs.push(iss_field_hash);
+            frs.push(has_extra_field);
+            frs.push(extra_field_hash);
+            frs.push(jwt_header_hash);
+            frs.push(jwk_hash);
+            frs.push(override_aud_val_hash);
+            frs.push(use_override_aud);
+            // TODO(keyless): If we plan on avoiding verifying the same PIH twice, there should be no
+            //  need for caching here. If we do not, we should cache the result here too.
+            poseidon_bn254::hash_scalars(frs)
+        },
+        EphemeralCertificate::OpenIdSig(_) => {
+            bail!("Can only call `get_public_inputs_hash` on keyless::Signature with Groth16 ZK proof")
+        }
     }
 }
 

--- a/types/src/keyless/groth16_sig.rs
+++ b/types/src/keyless/groth16_sig.rs
@@ -12,7 +12,7 @@ use crate::{
     transaction::authenticator::EphemeralSignature,
 };
 use anyhow::bail;
-use aptos_crypto::{CryptoMaterialError, HashValue};
+use aptos_crypto::CryptoMaterialError;
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use ark_bn254::{Bn254, Fr};
 use ark_ff::{BigInteger, PrimeField};

--- a/types/src/keyless/groth16_sig.rs
+++ b/types/src/keyless/groth16_sig.rs
@@ -12,7 +12,7 @@ use crate::{
     transaction::authenticator::EphemeralSignature,
 };
 use anyhow::bail;
-use aptos_crypto::CryptoMaterialError;
+use aptos_crypto::{CryptoMaterialError, HashValue};
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use ark_bn254::{Bn254, Fr};
 use ark_ff::{BigInteger, PrimeField};

--- a/types/src/keyless/groth16_vk.rs
+++ b/types/src/keyless/groth16_vk.rs
@@ -142,3 +142,19 @@ impl Display for Groth16VerificationKey {
         Ok(())
     }
 }
+
+#[derive(Serialize, Deserialize)]
+pub struct SetupVKEntry {
+    pub setup_id: String,
+    pub vk: Groth16VerificationKey,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SetupsVKs {
+    pub setups: Vec<SetupVKEntry>,
+}
+
+impl MoveStructType for SetupsVKs {
+    const MODULE_NAME: &'static IdentStr = ident_str!(KEYLESS_ACCOUNT_MODULE_NAME);
+    const STRUCT_NAME: &'static IdentStr = ident_str!("SetupsVKs");
+}

--- a/types/src/keyless/mod.rs
+++ b/types/src/keyless/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     },
 };
 use anyhow::bail;
-use aptos_crypto::{poseidon_bn254, CryptoMaterialError, ValidCryptoMaterial, HashValue};
+use aptos_crypto::{poseidon_bn254, CryptoMaterialError, ValidCryptoMaterial};
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use ark_bn254::Bn254;
 use ark_groth16::PreparedVerifyingKey;
@@ -41,7 +41,7 @@ pub use bn254_circom::{
 };
 pub use configuration::Configuration;
 pub use groth16_sig::{Groth16Proof, Groth16ProofAndStatement, ZeroKnowledgeSig};
-pub use groth16_vk::{Groth16VerificationKey, SetupsVKs, SetupVKEntry};
+pub use groth16_vk::{Groth16VerificationKey, SetupVKEntry, SetupsVKs};
 pub use openid_sig::{Claims, OpenIdSig};
 pub use zkp_sig::ZKP;
 

--- a/types/src/keyless/mod.rs
+++ b/types/src/keyless/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     },
 };
 use anyhow::bail;
-use aptos_crypto::{poseidon_bn254, CryptoMaterialError, ValidCryptoMaterial};
+use aptos_crypto::{poseidon_bn254, CryptoMaterialError, ValidCryptoMaterial, HashValue};
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use ark_bn254::Bn254;
 use ark_groth16::PreparedVerifyingKey;
@@ -28,7 +28,7 @@ mod bn254_circom;
 mod circuit_constants;
 mod circuit_testcases;
 mod configuration;
-mod groth16_sig;
+pub mod groth16_sig;
 mod groth16_vk;
 mod openid_sig;
 pub mod test_utils;
@@ -41,7 +41,7 @@ pub use bn254_circom::{
 };
 pub use configuration::Configuration;
 pub use groth16_sig::{Groth16Proof, Groth16ProofAndStatement, ZeroKnowledgeSig};
-pub use groth16_vk::Groth16VerificationKey;
+pub use groth16_vk::{Groth16VerificationKey, SetupsVKs, SetupVKEntry};
 pub use openid_sig::{Claims, OpenIdSig};
 pub use zkp_sig::ZKP;
 
@@ -80,6 +80,10 @@ macro_rules! serialize {
 pub enum EphemeralCertificate {
     ZeroKnowledgeSig(ZeroKnowledgeSig),
     OpenIdSig(OpenIdSig),
+    ZeroKnowledgeSigV2 {
+        setup_id: String,
+        zk_sig: ZeroKnowledgeSig,
+    },
 }
 
 /// NOTE: See `KeylessPublicKey` comments for why this cannot be named `Signature`.

--- a/types/src/keyless/test_utils.rs
+++ b/types/src/keyless/test_utils.rs
@@ -125,14 +125,15 @@ pub fn get_upgraded_vk() -> PreparedVerifyingKey<Bn254> {
 /// Note: Does not have a valid ephemeral signature. Use the SAMPLE_ESK to compute one over the
 /// desired TXN.
 pub fn get_groth16_sig_and_pk_for_upgraded_vk() -> (KeylessSignature, KeylessPublicKey) {
-    get_groth16_sig_and_pk_for_setup("SETUP_1".to_string())
+    get_groth16_sig_and_pk_by_setup("SETUP_1".to_string())
 }
 
 pub fn get_groth16_sig_and_pk_for_setup_2() -> (KeylessSignature, KeylessPublicKey) {
-    get_groth16_sig_and_pk_for_setup("SETUP_2".to_string())
+    // For simplicity, we assume SETUP_2 has the same result as SETUP_1...
+    get_groth16_sig_and_pk_by_setup("SETUP_2".to_string())
 }
 
-fn get_groth16_sig_and_pk_for_setup(setup_id: String) -> (KeylessSignature, KeylessPublicKey) {
+fn get_groth16_sig_and_pk_by_setup(setup_id: String) -> (KeylessSignature, KeylessPublicKey) {
     let proof = *SAMPLE_PROOF_FOR_UPGRADED_VK;
 
     let zks = ZeroKnowledgeSig {
@@ -144,7 +145,10 @@ fn get_groth16_sig_and_pk_for_setup(setup_id: String) -> (KeylessSignature, Keyl
     };
 
     let sig = KeylessSignature {
-        cert: EphemeralCertificate::ZeroKnowledgeSigV2{ setup_id, zk_sig: zks.clone() },
+        cert: EphemeralCertificate::ZeroKnowledgeSigV2 {
+            setup_id,
+            zk_sig: zks.clone(),
+        },
         jwt_header_json: SAMPLE_JWT_HEADER_JSON.to_string(),
         exp_date_secs: SAMPLE_EXP_DATE,
         ephemeral_pubkey: SAMPLE_EPK.clone(),
@@ -250,7 +254,7 @@ pub fn maul_raw_groth16_txn(
     // maul ephemeral signature to be over a different proof: (a, b, a) instead of (a, b, c)
     match &mut sig.cert {
         EphemeralCertificate::ZeroKnowledgeSig(proof)
-        | EphemeralCertificate::ZeroKnowledgeSigV2 { zk_sig: proof, ..} => {
+        | EphemeralCertificate::ZeroKnowledgeSigV2 { zk_sig: proof, .. } => {
             let ZKP::Groth16(old_proof) = proof.proof;
 
             txn_and_zkp.proof = Some(

--- a/types/src/keyless/test_utils.rs
+++ b/types/src/keyless/test_utils.rs
@@ -124,7 +124,7 @@ pub fn get_upgraded_vk() -> PreparedVerifyingKey<Bn254> {
 
 /// Note: Does not have a valid ephemeral signature. Use the SAMPLE_ESK to compute one over the
 /// desired TXN.
-pub fn get_groth16_sig_and_pk_for_setup_1() -> (KeylessSignature, KeylessPublicKey) {
+pub fn get_groth16_sig_and_pk_for_upgraded_vk() -> (KeylessSignature, KeylessPublicKey) {
     get_groth16_sig_and_pk_for_setup("SETUP_1".to_string())
 }
 

--- a/types/src/keyless/tests.rs
+++ b/types/src/keyless/tests.rs
@@ -62,7 +62,8 @@ fn test_keyless_groth16_proof_verification() {
 
     let (zk_sig, zk_pk) = get_sample_groth16_sig_and_pk();
     let proof = match &zk_sig.cert {
-        EphemeralCertificate::ZeroKnowledgeSig(proof) => proof.clone(),
+        EphemeralCertificate::ZeroKnowledgeSig(proof)
+        | EphemeralCertificate::ZeroKnowledgeSigV2 { zk_sig: proof, .. } => proof.clone(),
         EphemeralCertificate::OpenIdSig(_) => panic!("Internal inconsistency"),
     };
 
@@ -85,7 +86,8 @@ fn test_keyless_oidc_sig_verifies() {
     let (sig, pk) = get_sample_openid_sig_and_pk();
 
     let oidc_sig = match &sig.cert {
-        EphemeralCertificate::ZeroKnowledgeSig(_) => panic!("Internal inconsistency"),
+        EphemeralCertificate::ZeroKnowledgeSig(_)
+        | EphemeralCertificate::ZeroKnowledgeSigV2 { .. } => panic!("Internal inconsistency"),
         EphemeralCertificate::OpenIdSig(oidc_sig) => oidc_sig.clone(),
     };
 

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -1038,7 +1038,8 @@ impl AnySignature {
 
                 // Add the ZK proof into the `txn_and_zkp` struct, if we are in the ZK path
                 match &signature.cert {
-                    EphemeralCertificate::ZeroKnowledgeSig(proof) => {
+                    EphemeralCertificate::ZeroKnowledgeSig(proof)
+                    | EphemeralCertificate::ZeroKnowledgeSigV2 {zk_sig: proof, .. } => {
                         txn_and_zkp.proof = Some(proof.proof)
                     },
                     EphemeralCertificate::OpenIdSig(_) => {},

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -1039,7 +1039,7 @@ impl AnySignature {
                 // Add the ZK proof into the `txn_and_zkp` struct, if we are in the ZK path
                 match &signature.cert {
                     EphemeralCertificate::ZeroKnowledgeSig(proof)
-                    | EphemeralCertificate::ZeroKnowledgeSigV2 {zk_sig: proof, .. } => {
+                    | EphemeralCertificate::ZeroKnowledgeSigV2 { zk_sig: proof, .. } => {
                         txn_and_zkp.proof = Some(proof.proof)
                     },
                     EphemeralCertificate::OpenIdSig(_) => {},
@@ -1832,7 +1832,8 @@ mod tests {
             proof: None,
         };
         match &mut sig.cert {
-            EphemeralCertificate::ZeroKnowledgeSig(proof) => {
+            EphemeralCertificate::ZeroKnowledgeSig(proof)
+            | EphemeralCertificate::ZeroKnowledgeSigV2 { zk_sig: proof, .. } => {
                 txn_and_zkp.proof = Some(proof.proof);
             },
             EphemeralCertificate::OpenIdSig(_) => panic!("Internal inconsistency"),


### PR DESCRIPTION
## Description

- New on-chain config: `SetupsVKs` to store (Setup, VK) pairs.
- New keyless transaction field that takes a `setup_id`.
- In keyless txn validation, if a `setup_id` is specified, use the corresponding VK from `SetupsVKs` config.

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework

## How Has This Been Tested?
new smoke test.

## Key Areas to Review
- Does this refactoring really NOT need a feature flag?

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
