### PR TITLE
[Forge] Increase PFN const TPS limits.

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -2473,10 +2473,10 @@ fn pfn_const_tps(
                 .add_no_restarts()
                 .add_max_expired_tps(0)
                 .add_max_failed_submission_tps(0)
-                // Percentile thresholds are set to +1 second of non-PFN tests. Should be revisited.
-                .add_latency_threshold(2.5, LatencyType::P50)
-                .add_latency_threshold(4., LatencyType::P90)
-                .add_latency_threshold(5., LatencyType::P99)
+                // Percentile thresholds are estimated and should be revisited.
+                .add_latency_threshold(3.5, LatencyType::P50)
+                .add_latency_threshold(4.5, LatencyType::P90)
+                .add_latency_threshold(5.5, LatencyType::P99)
                 .add_wait_for_catchup_s(
                     // Give at least 60s for catchup and at most 10% of the run
                     (duration.as_secs() / 10).max(60),


### PR DESCRIPTION
## Description
This PR bumps the PFN const TPS forge stable latency criteria. The TPS was increased by this [PR](https://github.com/aptos-labs/aptos-core/commit/681a54de09d0843288fe2fb02be4de5480624200) (from 100 -> 5k), but the latency criteria was not updated. Thus, the job is failing for forge stable.

## Testing Plan
Existing test infrastructure.