### PR TITLE
[trivial] switch usecase counter to measure e2e

### DIFF
--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -170,7 +170,12 @@ impl Mempool {
         }
     }
 
-    fn log_commit_and_parked_latency(insertion_info: &InsertionInfo, bucket: &str, priority: &str) {
+    fn log_commit_and_parked_latency(
+        insertion_info: &InsertionInfo,
+        bucket: &str,
+        priority: &str,
+        tracked_use_case: Option<(UseCaseKey, &String)>,
+    ) {
         let parked_duration = if let Some(park_time) = insertion_info.park_time {
             let parked_duration = insertion_info
                 .ready_time
@@ -200,6 +205,22 @@ impl Mempool {
                 commit_minus_parked,
                 priority,
             );
+
+            if insertion_info.park_time.is_none() {
+                let use_case_label = tracked_use_case
+                    .as_ref()
+                    .map_or("entry_user_other", |(_, use_case_name)| {
+                        use_case_name.as_str()
+                    });
+
+                counters::TXN_E2E_USE_CASE_COMMIT_LATENCY
+                    .with_label_values(&[
+                        use_case_label,
+                        insertion_info.submitted_by_label(),
+                        bucket,
+                    ])
+                    .observe(commit_duration.as_secs_f64());
+            }
         }
     }
 
@@ -224,6 +245,7 @@ impl Mempool {
                 insertion_info,
                 bucket,
                 priority.to_string().as_str(),
+                tracked_use_case,
             );
 
             let insertion_timestamp =
@@ -236,20 +258,6 @@ impl Mempool {
                     insertion_to_block,
                     priority.to_string().as_str(),
                 );
-
-                let use_case_label = tracked_use_case
-                    .as_ref()
-                    .map_or("entry_user_other", |(_, use_case_name)| {
-                        use_case_name.as_str()
-                    });
-
-                counters::TXN_E2E_USE_CASE_COMMIT_LATENCY
-                    .with_label_values(&[
-                        use_case_label,
-                        insertion_info.submitted_by_label(),
-                        bucket,
-                    ])
-                    .observe(insertion_to_block.as_secs_f64());
             }
         }
     }


### PR DESCRIPTION
## Description
Missunderstood which mempool counter is for what - switching usecase counter to give e2e breakdown, only for non-parked txns.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
