### PR TITLE
[move 2] Synchronize Move and Rust enum serialization

### DIFF
--- a/aptos-move/e2e-benchmark/src/main.rs
+++ b/aptos-move/e2e-benchmark/src/main.rs
@@ -123,8 +123,8 @@ fn main() {
         (29000, EntryPoints::InitializeVectorPicture {
             length: 30 * 1024,
         }),
-        (4510, EntryPoints::VectorPicture { length: 30 * 1024 }),
-        (4400, EntryPoints::VectorPictureRead { length: 30 * 1024 }),
+        (5900, EntryPoints::VectorPicture { length: 30 * 1024 }),
+        (5870, EntryPoints::VectorPictureRead { length: 30 * 1024 }),
         (33580, EntryPoints::SmartTablePicture {
             length: 30 * 1024,
             num_points_per_txn: 200,

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -153,7 +153,7 @@ publish-package	1	VM	0.950	1.040	143.9
 mix_publish_transfer	1	VM	0.967	1.163	2173.8
 batch100-transfer	1	VM	0.859	1.021	667.8
 batch100-transfer	1	native	0.784	1.222	1862.1
-vector-picture30k	1	VM	0.935	1.023	138.5
+vector-picture30k	1	VM	0.935	1.023	110.0
 vector-picture30k	20	VM	0.819	1.038	1347.9
 smart-table-picture30-k-with200-change	1	VM	0.959	1.054	21.4
 smart-table-picture30-k-with200-change	20	VM	0.923	1.057	182.6

--- a/third_party/move/move-binary-format/src/file_format_common.rs
+++ b/third_party/move/move-binary-format/src/file_format_common.rs
@@ -13,6 +13,7 @@
 //! It's used to compress mostly indexes into the main binary tables.
 use crate::file_format::Bytecode;
 use anyhow::{bail, Result};
+use move_core_types::value;
 use std::{
     io::{Cursor, Read},
     mem::size_of,
@@ -76,7 +77,7 @@ pub const ACQUIRES_COUNT_MAX: u64 = 255;
 
 pub const FIELD_COUNT_MAX: u64 = 255;
 pub const FIELD_OFFSET_MAX: u64 = 255;
-pub const VARIANT_COUNT_MAX: u64 = 127;
+pub const VARIANT_COUNT_MAX: u64 = value::VARIANT_COUNT_MAX;
 pub const VARIANT_OFFSET_MAX: u64 = 127;
 
 pub const TYPE_PARAMETER_COUNT_MAX: u64 = 255;


### PR DESCRIPTION
## Description

After using Rust macro expand to analyze how serde deals with Rust enums, updating the Move serializers to align with this. Uses now serde's `serialize_unit_variant`, `serialize_newtype_variant`, and `serialize_tuple_variant` and the matching counterparts for deserialization.

Onne obstacle here until now was the need to pass `&static str` variant names to the serializers. However, those names are not used by bcs serialization logic, which uses variant tags instead, they are only required by serde for other formats. This is a solved by having a static cache which constructs those strings via box leaking as `"0"`, `"1"`, etc.

Closes #14159.


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

There are multiple new tests, including roundtrip serialization Rust <-> Move in `serialization_tests`. Also verified manually that the generated bytecode blobs are optimal, with the numerical tag directly followed by the field blobs.

