### PR TITLE
[move-2] Optimize serialization logic

### DIFF
--- a/aptos-move/e2e-benchmark/src/main.rs
+++ b/aptos-move/e2e-benchmark/src/main.rs
@@ -123,8 +123,8 @@ fn main() {
         (29000, EntryPoints::InitializeVectorPicture {
             length: 30 * 1024,
         }),
-        (5900, EntryPoints::VectorPicture { length: 30 * 1024 }),
-        (5870, EntryPoints::VectorPictureRead { length: 30 * 1024 }),
+        (4510, EntryPoints::VectorPicture { length: 30 * 1024 }),
+        (4400, EntryPoints::VectorPictureRead { length: 30 * 1024 }),
         (33580, EntryPoints::SmartTablePicture {
             length: 30 * 1024,
             num_points_per_txn: 200,

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -153,7 +153,7 @@ publish-package	1	VM	0.950	1.040	143.9
 mix_publish_transfer	1	VM	0.967	1.163	2173.8
 batch100-transfer	1	VM	0.859	1.021	667.8
 batch100-transfer	1	native	0.784	1.222	1862.1
-vector-picture30k	1	VM	0.935	1.023	110.0
+vector-picture30k	1	VM	0.935	1.023	138.5
 vector-picture30k	20	VM	0.819	1.038	1347.9
 smart-table-picture30-k-with200-change	1	VM	0.959	1.054	21.4
 smart-table-picture30-k-with200-change	20	VM	0.923	1.057	182.6

--- a/third_party/move/move-core/types/src/value.rs
+++ b/third_party/move/move-core/types/src/value.rs
@@ -713,7 +713,6 @@ impl serde::Serialize for MoveStruct {
                 t.end()
             },
             Self::RuntimeVariant(tag, values) => {
-                // Variants need to be serialized as sequences, as the size is not statically known.
                 let tag_idx = *tag as usize;
                 let variant_tag = tag_idx as u32;
                 let variant_name = variant_name_placeholder((tag + 1) as usize)[tag_idx];


### PR DESCRIPTION

## Description

Fixing perf regression in ValueImpl serialization code by re-arranging the code.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Performance test

