### PR TITLE
[Target Determinator] Small improvements to metadata and merge base checks.

### DIFF
--- a/.github/actions/rust-check-merge-base/action.yaml
+++ b/.github/actions/rust-check-merge-base/action.yaml
@@ -1,0 +1,19 @@
+name: Rust Check Merge Base
+description: Runs the rust merge base freshness check
+inputs:
+  GIT_CREDENTIALS:
+    description: "Optional credentials to pass to git. Useful if you need to pull private repos for dependencies"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    # The source code must be checked out by the workflow that invokes this action.
+    - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+      with:
+        GIT_CREDENTIALS: ${{ inputs.GIT_CREDENTIALS }}
+
+    # Check the freshness of the merge base
+    - name: Check the freshness of the merge base
+      run: cargo x check-merge-base -vvv
+      shell: bash

--- a/.github/actions/rust-targeted-unit-tests/action.yaml
+++ b/.github/actions/rust-targeted-unit-tests/action.yaml
@@ -17,18 +17,18 @@ runs:
 
     # Output the changed files
     - name: Output the changed files
-      run: cargo x changed-files -vv
+      run: cargo x changed-files -vvv
       shell: bash
 
     # Output the affected packages
     - name: Output the affected packages
-      run: cargo x affected-packages -vv
+      run: cargo x affected-packages -vvv
       shell: bash
 
     # Run only the targeted rust unit tests
     - name: Run only the targeted unit tests
       run: |
-        cargo x targeted-unit-tests -vv --profile ci --cargo-profile ci --locked --no-fail-fast --retries 3
+        cargo x targeted-unit-tests -vvv --profile ci --cargo-profile ci --locked --no-fail-fast --retries 3
       shell: bash
       env:
         INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -132,6 +132,24 @@ jobs:
       - run: echo "Skipping rust smoke tests! Unrelated changes detected."
         if: needs.file_change_determinator.outputs.only_docs_changed == 'true'
 
+  # Check the freshess of the merge base. This is a PR required job.
+  rust-check-merge-base:
+    if: | # Don't run on release branches
+      (
+        !contains(github.event.pull_request.base.ref, '-release-')
+      )
+    needs: file_change_determinator
+    runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 # Fetch all git history for accurate target determination
+      - name: Run the merge base freshness check
+        uses: ./.github/actions/rust-check-merge-base
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+
   # Run only the targeted rust unit tests. This is a PR required job.
   rust-targeted-unit-tests:
     if: | # Don't run on release branches. Instead, all unit tests will be triggered.

--- a/devtools/aptos-cargo-cli/src/lib.rs
+++ b/devtools/aptos-cargo-cli/src/lib.rs
@@ -71,6 +71,7 @@ pub enum AptosCargoCommand {
     AffectedPackages(CommonArgs),
     ChangedFiles(CommonArgs),
     Check(CommonArgs),
+    CheckMergeBase(CommonArgs),
     Xclippy(CommonArgs),
     Fmt(CommonArgs),
     Nextest(CommonArgs),
@@ -99,6 +100,7 @@ impl AptosCargoCommand {
             AptosCargoCommand::AffectedPackages(args) => args,
             AptosCargoCommand::ChangedFiles(args) => args,
             AptosCargoCommand::Check(args) => args,
+            AptosCargoCommand::CheckMergeBase(args) => args,
             AptosCargoCommand::Xclippy(args) => args,
             AptosCargoCommand::Fmt(args) => args,
             AptosCargoCommand::Nextest(args) => args,
@@ -162,6 +164,10 @@ impl AptosCargoCommand {
                 // Calculate and display the changed files
                 let (_, _, changed_files) = package_args.identify_changed_files()?;
                 output_changed_files(changed_files)
+            },
+            AptosCargoCommand::CheckMergeBase(_) => {
+                // Check the merge base
+                package_args.check_merge_base()
             },
             AptosCargoCommand::TargetedCLITests(_) => {
                 // Run the targeted CLI tests (if necessary).


### PR DESCRIPTION
## Description
This PR makes several small improvements to the target determinator. Specifically:
1. We add a new "check merge base" CI/CD job that will ensure the merge base for PRs is up-to-date (within 7 days). Although we already have this check, the new job will only run on PRs to the `main` branch, so it should help us avoid the issue we're currently seeing with release branches (i.e. the need for these fixes: https://github.com/aptos-labs/aptos-core/pull/14120).
1. We improve the cargo metadata error handling during the target determination process. If cargo metadata cannot be fetched remotely (e.g., from GCS), we instead compute it locally by checking out a temporary clone of the `aptos-core` repository at the merge base and computing the metadata. This should help to avoid issues with remote fetching.

Once this lands, I'll make the new merge base check land-blocking.

## Testing Plan
Manual verification.