### PR TITLE
Use committed traffic estimate for PFN load balancing

### DIFF
--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -142,6 +142,10 @@ fn spawn_commit_notification_handler<NetworkClient, TransactionValidator>(
     let mempool = smp.mempool.clone();
     let mempool_validator = smp.validator.clone();
     let use_case_history = smp.use_case_history.clone();
+    let num_committed_txns_recieved_since_peers_updated = smp
+        .network_interface
+        .num_committed_txns_received_since_peers_updated
+        .clone();
 
     tokio::spawn(async move {
         while let Some(commit_notification) = mempool_listener.next().await {
@@ -150,6 +154,7 @@ fn spawn_commit_notification_handler<NetworkClient, TransactionValidator>(
                 &mempool_validator,
                 &use_case_history,
                 commit_notification,
+                &num_committed_txns_recieved_since_peers_updated,
             );
         }
     });
@@ -177,7 +182,8 @@ async fn handle_client_request<NetworkClient, TransactionValidator>(
                 counters::CLIENT_EVENT_LABEL,
                 counters::START_LABEL,
             );
-            smp.network_interface.num_txns_received_since_peers_updated += 1;
+            smp.network_interface
+                .num_mempool_txns_received_since_peers_updated += 1;
             bounded_executor
                 .spawn(tasks::process_client_transaction_submission(
                     smp.clone(),
@@ -218,6 +224,7 @@ fn handle_commit_notification<TransactionValidator>(
     mempool_validator: &Arc<RwLock<TransactionValidator>>,
     use_case_history: &Arc<Mutex<UseCaseHistory>>,
     msg: MempoolCommitNotification,
+    num_committed_txns_recieved_since_peers_updated: &Arc<RwLock<u64>>,
 ) where
     TransactionValidator: TransactionValidation,
 {
@@ -233,6 +240,7 @@ fn handle_commit_notification<TransactionValidator>(
         counters::COMMIT_STATE_SYNC_LABEL,
         msg.transactions.len(),
     );
+    *num_committed_txns_recieved_since_peers_updated.write() += msg.transactions.len() as u64;
     process_committed_transactions(
         mempool,
         use_case_history,
@@ -289,7 +297,8 @@ async fn process_received_txns<NetworkClient, TransactionValidator>(
     NetworkClient: NetworkClientInterface<MempoolSyncMsg> + 'static,
     TransactionValidator: TransactionValidation + 'static,
 {
-    smp.network_interface.num_txns_received_since_peers_updated += transactions.len() as u64;
+    smp.network_interface
+        .num_mempool_txns_received_since_peers_updated += transactions.len() as u64;
     let smp_clone = smp.clone();
     let peer = PeerNetworkId::new(network_id, peer_id);
     let ineligible_for_broadcast = (smp.network_interface.is_validator()

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -109,7 +109,8 @@ pub(crate) struct MempoolNetworkInterface<NetworkClient> {
     node_type: NodeType,
     mempool_config: MempoolConfig,
     prioritized_peers_state: PrioritizedPeersState,
-    pub num_txns_received_since_peers_updated: u64,
+    pub num_mempool_txns_received_since_peers_updated: u64,
+    pub num_committed_txns_received_since_peers_updated: Arc<RwLock<u64>>,
 }
 
 impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterface<NetworkClient> {
@@ -126,7 +127,8 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
             node_type,
             mempool_config,
             prioritized_peers_state,
-            num_txns_received_since_peers_updated: 0,
+            num_mempool_txns_received_since_peers_updated: 0,
+            num_committed_txns_received_since_peers_updated: Arc::new(RwLock::new(0)),
         }
     }
 
@@ -240,10 +242,12 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
         // Update the prioritized peers list
         self.prioritized_peers_state.update_prioritized_peers(
             peers_and_metadata,
-            self.num_txns_received_since_peers_updated,
+            self.num_mempool_txns_received_since_peers_updated,
+            *self.num_committed_txns_received_since_peers_updated.read(),
         );
         // Resetting the counter
-        self.num_txns_received_since_peers_updated = 0;
+        self.num_mempool_txns_received_since_peers_updated = 0;
+        *self.num_committed_txns_received_since_peers_updated.write() = 0;
     }
 
     pub fn is_validator(&self) -> bool {

--- a/mempool/src/shared_mempool/priority.rs
+++ b/mempool/src/shared_mempool/priority.rs
@@ -245,7 +245,8 @@ impl PrioritizedPeersState {
     fn update_sender_bucket_for_peers(
         &mut self,
         peer_monitoring_data: &HashMap<PeerNetworkId, Option<&PeerMonitoringMetadata>>,
-        num_txns_received_since_peers_updated: u64,
+        num_mempool_txns_received_since_peers_updated: u64,
+        num_committed_txns_received_since_peers_updated: u64,
     ) {
         // TODO: If the top peer set didn't change, then don't change the Primary sender bucket assignment.
         // TODO: (Minor) If the load is low, don't do load balancing for Failover buckets.
@@ -261,8 +262,12 @@ impl PrioritizedPeersState {
                     .as_secs()
             });
 
-        let average_mempool_traffic_observed = num_txns_received_since_peers_updated as f64
+        let average_mempool_traffic_observed = num_mempool_txns_received_since_peers_updated as f64
             / max(1, time_elapsed_since_last_update) as f64;
+        let average_committed_traffic_observed = num_committed_txns_received_since_peers_updated
+            as f64
+            / max(1, time_elapsed_since_last_update) as f64;
+
         // Obtain the highest threshold from mempool_config.load_balancing_thresholds for which avg_mempool_traffic_threshold_in_tps exceeds average_mempool_traffic_observed
         let threshold_config = self
             .mempool_config
@@ -272,7 +277,10 @@ impl PrioritizedPeersState {
             .rev()
             .find(|threshold_config| {
                 threshold_config.avg_mempool_traffic_threshold_in_tps
-                    <= average_mempool_traffic_observed as u64
+                    <= max(
+                        average_mempool_traffic_observed as u64,
+                        average_committed_traffic_observed as u64,
+                    )
             })
             .unwrap_or_default();
 
@@ -289,13 +297,17 @@ impl PrioritizedPeersState {
         );
         info!(
             "Time elapsed since last peer update: {:?}\n
-            Number of transactions received since last peer update: {:?},\n
+            Number of mempool transactions received since last peer update: {:?},\n
             Average mempool traffic observed: {:?},\n
+            Number of committed transactions received since last peer update: {:?},\n
+            Average committed traffic observed: {:?},\n
             Load balancing threshold config: {:?},\n
             Number of top peers picked: {:?}",
             time_elapsed_since_last_update,
-            num_txns_received_since_peers_updated,
+            num_mempool_txns_received_since_peers_updated,
             average_mempool_traffic_observed,
+            num_committed_txns_received_since_peers_updated,
+            average_committed_traffic_observed,
             threshold_config,
             num_top_peers
         );
@@ -391,7 +403,8 @@ impl PrioritizedPeersState {
     pub fn update_prioritized_peers(
         &mut self,
         peers_and_metadata: Vec<(PeerNetworkId, Option<&PeerMonitoringMetadata>)>,
-        num_txns_received_since_peers_updated: u64,
+        num_mempool_txns_received_since_peers_updated: u64,
+        num_committed_txns_recieved_since_peers_updated: u64,
     ) {
         let peer_monitoring_data: HashMap<PeerNetworkId, Option<&PeerMonitoringMetadata>> =
             peers_and_metadata.clone().into_iter().collect();
@@ -415,7 +428,8 @@ impl PrioritizedPeersState {
         // Divide the sender buckets amongst the top peers
         self.update_sender_bucket_for_peers(
             &peer_monitoring_data,
-            num_txns_received_since_peers_updated,
+            num_mempool_txns_received_since_peers_updated,
+            num_committed_txns_recieved_since_peers_updated,
         );
 
         // Set the last peer priority update time
@@ -786,7 +800,7 @@ mod test {
         let peer_4 = (create_public_peer(), Some(&peer_metadata_4));
 
         let all_peers = vec![peer_1, peer_2, peer_3, peer_4];
-        prioritized_peers_state.update_prioritized_peers(all_peers, 5000);
+        prioritized_peers_state.update_prioritized_peers(all_peers, 5000, 7000);
         assert!(!prioritized_peers_state.peer_to_sender_buckets.is_empty());
         prioritized_peer_state_well_formed(
             &prioritized_peers_state,
@@ -798,7 +812,7 @@ mod test {
         );
 
         let all_peers = vec![peer_1, peer_2, peer_4];
-        prioritized_peers_state.update_prioritized_peers(all_peers, 3000);
+        prioritized_peers_state.update_prioritized_peers(all_peers, 3000, 7000);
         assert!(!prioritized_peers_state.peer_to_sender_buckets.is_empty());
         prioritized_peer_state_well_formed(
             &prioritized_peers_state,
@@ -810,7 +824,7 @@ mod test {
         );
 
         let all_peers = vec![peer_3, peer_1];
-        prioritized_peers_state.update_prioritized_peers(all_peers, 0);
+        prioritized_peers_state.update_prioritized_peers(all_peers, 0, 0);
         assert!(!prioritized_peers_state.peer_to_sender_buckets.is_empty());
         prioritized_peer_state_well_formed(
             &prioritized_peers_state,
@@ -840,7 +854,7 @@ mod test {
         let peer_4 = (create_public_peer(), Some(&peer_metadata_4));
 
         let all_peers = vec![peer_1, peer_2, peer_3, peer_4];
-        prioritized_peers_state.update_prioritized_peers(all_peers, 5000);
+        prioritized_peers_state.update_prioritized_peers(all_peers, 5000, 2000);
         assert!(!prioritized_peers_state.peer_to_sender_buckets.is_empty());
         prioritized_peer_state_well_formed(
             &prioritized_peers_state,
@@ -848,7 +862,7 @@ mod test {
         );
 
         let all_peers = vec![peer_1, peer_2, peer_4];
-        prioritized_peers_state.update_prioritized_peers(all_peers, 3000);
+        prioritized_peers_state.update_prioritized_peers(all_peers, 3000, 2000);
         assert!(!prioritized_peers_state.peer_to_sender_buckets.is_empty());
         prioritized_peer_state_well_formed(
             &prioritized_peers_state,
@@ -856,7 +870,7 @@ mod test {
         );
 
         let all_peers = vec![peer_3, peer_1];
-        prioritized_peers_state.update_prioritized_peers(all_peers, 0);
+        prioritized_peers_state.update_prioritized_peers(all_peers, 0, 0);
         assert!(!prioritized_peers_state.peer_to_sender_buckets.is_empty());
         prioritized_peer_state_well_formed(
             &prioritized_peers_state,
@@ -1113,7 +1127,7 @@ mod test {
 
         // Update the prioritized peers
         let all_peers = vec![public_peer_1, public_peer_2, public_peer_3, public_peer_4];
-        prioritized_peers_state.update_prioritized_peers(all_peers, 5000);
+        prioritized_peers_state.update_prioritized_peers(all_peers, 5000, 7000);
 
         // Verify that the prioritized peers were updated correctly
         let expected_peers = vec![
@@ -1140,7 +1154,7 @@ mod test {
 
         // Update the prioritized peers for only peers with ping latencies
         let all_peers = vec![public_peer_1, public_peer_2, public_peer_3];
-        prioritized_peers_state.update_prioritized_peers(all_peers, 5000);
+        prioritized_peers_state.update_prioritized_peers(all_peers, 5000, 1000);
 
         // Verify that the prioritized peers were updated correctly
         let expected_peers = vec![public_peer_3.0, public_peer_1.0, public_peer_2.0];
@@ -1181,7 +1195,7 @@ mod test {
 
         // Update the prioritized peers
         let all_peers = vec![validator_peer, vfn_peer, public_peer];
-        prioritized_peers_state.update_prioritized_peers(all_peers, 5000);
+        prioritized_peers_state.update_prioritized_peers(all_peers, 5000, 2000);
 
         // Verify that the prioritized peers were updated correctly
         let expected_peers = vec![validator_peer.0, vfn_peer.0, public_peer.0];
@@ -1202,7 +1216,7 @@ mod test {
         // Update the prioritized peers multiple times and verify that the order is consistent
         let prioritized_peers = prioritized_peers_state.sort_peers_by_priority(&all_peers);
         for _ in 0..10 {
-            prioritized_peers_state.update_prioritized_peers(all_peers.clone(), 5000);
+            prioritized_peers_state.update_prioritized_peers(all_peers.clone(), 5000, 2000);
             let new_prioritized_peers = prioritized_peers_state.prioritized_peers.read().clone();
             assert_eq!(prioritized_peers, new_prioritized_peers);
         }

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -602,11 +602,12 @@ fn k8s_test_suite() -> ForgeConfig {
 fn get_land_blocking_test(
     test_name: &str,
     duration: Duration,
-    test_cmd: &TestCommand,
+    _test_cmd: &TestCommand,
 ) -> Option<ForgeConfig> {
     let test = match test_name {
         "land_blocking" | "realistic_env_max_load" => {
-            realistic_env_max_load_test(duration, test_cmd, 7, 5)
+            // realistic_env_max_load_test(duration, test_cmd, 7, 5)
+            pfn_const_tps(duration, true, true, false)
         },
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
