### PR TITLE
[CI/CD] Increase merge base check for v1.18 release branch.

### DIFF
--- a/devtools/aptos-cargo-cli/src/common.rs
+++ b/devtools/aptos-cargo-cli/src/common.rs
@@ -42,7 +42,7 @@ const IGNORED_DETERMINATOR_PATHS: [&str; 8] = [
 ];
 
 // The maximum number of days allowed since the merge-base commit for the branch
-const MAX_NUM_DAYS_SINCE_MERGE_BASE: u64 = 7;
+const MAX_NUM_DAYS_SINCE_MERGE_BASE: u64 = 1000;
 
 // The delimiter used to separate the package path and the package name.
 pub const PACKAGE_NAME_DELIMITER: &str = "#";


### PR DESCRIPTION
## Description
This PR increases the merge base date check for the 1.18 release branch. This check will be updated on `main` to avoid impacting release branches.

## Testing Plan
Manual verification.
