### PR TITLE
Fix execution summary being set twice, due to execution retry

### DIFF
--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -9,8 +9,9 @@ use crate::{
     quorum_cert::QuorumCert,
     vote_proposal::VoteProposal,
 };
-use aptos_crypto::hash::HashValue;
+use aptos_crypto::hash::{HashValue, ACCUMULATOR_PLACEHOLDER_HASH};
 use aptos_executor_types::StateComputeResult;
+use aptos_logger::{error, warn};
 use aptos_types::{
     block_info::BlockInfo,
     contract_event::ContractEvent,
@@ -124,18 +125,38 @@ impl PipelinedBlock {
             }
         }
 
-        assert!(self
-            .execution_summary
-            .set(ExecutionSummary {
-                payload_len: self
-                    .block
-                    .payload()
-                    .map_or(0, |payload| payload.len_for_execution()),
-                to_commit,
-                to_retry,
-                execution_time,
-            })
-            .is_ok());
+        let execution_summary = ExecutionSummary {
+            payload_len: self
+                .block
+                .payload()
+                .map_or(0, |payload| payload.len_for_execution()),
+            to_commit,
+            to_retry,
+            execution_time,
+            root_hash: self.state_compute_result.root_hash(),
+        };
+
+        // We might be retrying execution, so it might have already been set.
+        // Because we use this for statistics, it's ok that we drop the newer value.
+        if let Some(previous) = self.execution_summary.get() {
+            if previous.root_hash == execution_summary.root_hash
+                || previous.root_hash == *ACCUMULATOR_PLACEHOLDER_HASH
+            {
+                warn!(
+                    "Skipping re-inserting execution result, from {:?} to {:?}",
+                    previous, execution_summary
+                );
+            } else {
+                error!(
+                    "Re-inserting execution result with different root hash: from {:?} to {:?}",
+                    previous, execution_summary
+                );
+            }
+        } else {
+            self.execution_summary
+                .set(execution_summary)
+                .expect("inserting into empty execution summary");
+        }
 
         self
     }
@@ -294,4 +315,5 @@ pub struct ExecutionSummary {
     pub to_commit: u64,
     pub to_retry: u64,
     pub execution_time: Duration,
+    pub root_hash: HashValue,
 }

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -1002,6 +1002,16 @@ pub static BUFFER_MANAGER_RETRY_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Count of the buffer manager receiving executor error
+pub static BUFFER_MANAGER_RECEIVED_EXECUTOR_ERROR_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_consensus_buffer_manager_received_executor_error_count",
+        "Count of the buffer manager receiving executor error",
+        &["error_type"],
+    )
+    .unwrap()
+});
+
 const PROPSER_ELECTION_DURATION_BUCKETS: [f64; 17] = [
     0.001, 0.002, 0.003, 0.004, 0.006, 0.008, 0.01, 0.012, 0.014, 0.0175, 0.02, 0.025, 0.05, 0.25,
     0.5, 1.0, 2.0,

--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -501,14 +501,23 @@ impl BufferManager {
         let executed_blocks = match inner {
             Ok(result) => result,
             Err(ExecutorError::CouldNotGetData) => {
+                counters::BUFFER_MANAGER_RECEIVED_EXECUTOR_ERROR_COUNT
+                    .with_label_values(&["CouldNotGetData"])
+                    .inc();
                 warn!("Execution error - CouldNotGetData {}", block_id);
                 return;
             },
             Err(ExecutorError::BlockNotFound(block_id)) => {
+                counters::BUFFER_MANAGER_RECEIVED_EXECUTOR_ERROR_COUNT
+                    .with_label_values(&["BlockNotFound"])
+                    .inc();
                 warn!("Execution error BlockNotFound {}", block_id);
                 return;
             },
             Err(e) => {
+                counters::BUFFER_MANAGER_RECEIVED_EXECUTOR_ERROR_COUNT
+                    .with_label_values(&["UnexpectedError"])
+                    .inc();
                 error!("Execution error {:?} for {}", e, block_id);
                 return;
             },


### PR DESCRIPTION
Cherry-pick of https://github.com/aptos-labs/aptos-core/pull/14200 