### PR TITLE
wait for all futs to clear from ExecutionPipeline before dropping lif…

### DIFF
--- a/consensus/src/pipeline/execution_schedule_phase.rs
+++ b/consensus/src/pipeline/execution_schedule_phase.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use aptos_consensus_types::pipelined_block::PipelinedBlock;
 use aptos_crypto::HashValue;
-use aptos_executor_types::ExecutorError;
+use aptos_executor_types::{ExecutorError, ExecutorResult};
 use aptos_logger::debug;
 use async_trait::async_trait;
 use futures::TryFutureExt;
@@ -92,15 +92,22 @@ impl StatelessPipeline for ExecutionSchedulePhase {
         //      ExecutionWait phase is never kicked off.
         let fut = tokio::task::spawn(async move {
             let mut results = vec![];
-            for (block, fut) in itertools::zip_eq(ordered_blocks, futs) {
+            // wait for all futs so that lifetime_guard is guaranteed to be dropped only
+            // after all executor calls are over
+            for (block, fut) in itertools::zip_eq(&ordered_blocks, futs) {
                 debug!("try to receive compute result for block {}", block.id());
-                let PipelineExecutionResult {
-                    input_txns,
-                    result,
-                    execution_time,
-                } = fut.await?;
-                results.push(block.set_execution_result(input_txns, result, execution_time));
+                results.push(fut.await)
             }
+            let results = itertools::zip_eq(ordered_blocks, results)
+                .map(|(block, res)| {
+                    let PipelineExecutionResult {
+                        input_txns,
+                        result,
+                        execution_time,
+                    } = res?;
+                    Ok(block.set_execution_result(input_txns, result, execution_time))
+                })
+                .collect::<ExecutorResult<Vec<_>>>()?;
             drop(lifetime_guard);
             Ok(results)
         })


### PR DESCRIPTION
…etime_guard

It's in theory safer this way and it avoids error logs before

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Validator Node


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

existing coverage, forge