### PR TITLE
Enable FA for APT for regression single node benchmark

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/aptos_account.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_account.md
@@ -585,7 +585,7 @@ TODO: once migration is complete, rename to just "transfer_only" and make it an 
 to transfer APT) - if we want to allow APT PFS without account itself
 
 
-<pre><code><b>fun</b> <a href="aptos_account.md#0x1_aptos_account_fungible_transfer_only">fungible_transfer_only</a>(source: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <b>to</b>: <b>address</b>, amount: u64)
+<pre><code><b>public</b>(<b>friend</b>) entry <b>fun</b> <a href="aptos_account.md#0x1_aptos_account_fungible_transfer_only">fungible_transfer_only</a>(source: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <b>to</b>: <b>address</b>, amount: u64)
 </code></pre>
 
 
@@ -594,7 +594,7 @@ to transfer APT) - if we want to allow APT PFS without account itself
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="aptos_account.md#0x1_aptos_account_fungible_transfer_only">fungible_transfer_only</a>(
+<pre><code><b>public</b>(<b>friend</b>) entry <b>fun</b> <a href="aptos_account.md#0x1_aptos_account_fungible_transfer_only">fungible_transfer_only</a>(
     source: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <b>to</b>: <b>address</b>, amount: u64
 ) {
     <b>let</b> sender_store = <a href="aptos_account.md#0x1_aptos_account_ensure_primary_fungible_store_exists">ensure_primary_fungible_store_exists</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(source));
@@ -1127,7 +1127,7 @@ Check if the AptosCoin under the address existed.
 ### Function `fungible_transfer_only`
 
 
-<pre><code><b>fun</b> <a href="aptos_account.md#0x1_aptos_account_fungible_transfer_only">fungible_transfer_only</a>(source: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <b>to</b>: <b>address</b>, amount: u64)
+<pre><code><b>public</b>(<b>friend</b>) entry <b>fun</b> <a href="aptos_account.md#0x1_aptos_account_fungible_transfer_only">fungible_transfer_only</a>(source: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <b>to</b>: <b>address</b>, amount: u64)
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/aptos_account.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_account.move
@@ -199,7 +199,7 @@ module aptos_framework::aptos_account {
     /// This would create the recipient APT PFS first, which also registers it to receive APT, before transferring.
     /// TODO: once migration is complete, rename to just "transfer_only" and make it an entry function (for cheapest way
     /// to transfer APT) - if we want to allow APT PFS without account itself
-    fun fungible_transfer_only(
+    public(friend) entry fun fungible_transfer_only(
         source: &signer, to: address, amount: u64
     ) {
         let sender_store = ensure_primary_fungible_store_exists(signer::address_of(source));

--- a/crates/transaction-generator-lib/src/args.rs
+++ b/crates/transaction-generator-lib/src/args.rs
@@ -14,6 +14,7 @@ pub enum TransactionTypeArg {
     // custom
     #[default]
     CoinTransfer,
+    AptFaTransfer,
     CoinTransferWithInvalid,
     NonConflictingCoinTransfer,
     AccountGeneration,
@@ -96,16 +97,26 @@ impl TransactionTypeArg {
             TransactionTypeArg::CoinTransfer => TransactionType::CoinTransfer {
                 invalid_transaction_ratio: 0,
                 sender_use_account_pool,
+                non_conflicting: false,
+                use_fa_transfer: false,
             },
-            TransactionTypeArg::NonConflictingCoinTransfer => {
-                TransactionType::NonConflictingCoinTransfer {
-                    invalid_transaction_ratio: 0,
-                    sender_use_account_pool,
-                }
+            TransactionTypeArg::AptFaTransfer => TransactionType::CoinTransfer {
+                invalid_transaction_ratio: 0,
+                sender_use_account_pool,
+                non_conflicting: false,
+                use_fa_transfer: true,
+            },
+            TransactionTypeArg::NonConflictingCoinTransfer => TransactionType::CoinTransfer {
+                invalid_transaction_ratio: 0,
+                sender_use_account_pool,
+                non_conflicting: true,
+                use_fa_transfer: false,
             },
             TransactionTypeArg::CoinTransferWithInvalid => TransactionType::CoinTransfer {
                 invalid_transaction_ratio: 10,
                 sender_use_account_pool,
+                non_conflicting: false,
+                use_fa_transfer: false,
             },
             TransactionTypeArg::AccountGeneration => TransactionType::AccountGeneration {
                 add_created_accounts_to_pool: true,

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -428,6 +428,8 @@ struct GasMeasurement {
     pub io_gas: f64,
     pub execution_gas: f64,
 
+    pub storage_fee: f64,
+
     pub approx_block_output: f64,
 
     pub gas_count: u64,
@@ -449,10 +451,17 @@ impl GasMeasurement {
     pub fn now() -> GasMeasurement {
         let gas = Self::sequential_gas_counter(GasType::NON_STORAGE_GAS).get_sample_sum()
             + Self::parallel_gas_counter(GasType::NON_STORAGE_GAS).get_sample_sum();
+
         let io_gas = Self::sequential_gas_counter(GasType::IO_GAS).get_sample_sum()
             + Self::parallel_gas_counter(GasType::IO_GAS).get_sample_sum();
         let execution_gas = Self::sequential_gas_counter(GasType::EXECUTION_GAS).get_sample_sum()
             + Self::parallel_gas_counter(GasType::EXECUTION_GAS).get_sample_sum();
+
+        let storage_fee = Self::sequential_gas_counter(GasType::STORAGE_FEE).get_sample_sum()
+            + Self::parallel_gas_counter(GasType::STORAGE_FEE).get_sample_sum() - (
+                Self::sequential_gas_counter(GasType::STORAGE_FEE_REFUND).get_sample_sum()
+            + Self::parallel_gas_counter(GasType::STORAGE_FEE_REFUND).get_sample_sum()
+        );
 
         let gas_count = Self::sequential_gas_counter(GasType::NON_STORAGE_GAS).get_sample_count()
             + Self::parallel_gas_counter(GasType::NON_STORAGE_GAS).get_sample_count();
@@ -478,6 +487,7 @@ impl GasMeasurement {
             effective_block_gas,
             io_gas,
             execution_gas,
+            storage_fee,
             approx_block_output,
             gas_count,
             speculative_abort_count,
@@ -492,6 +502,7 @@ impl GasMeasurement {
             effective_block_gas: end.effective_block_gas - self.effective_block_gas,
             io_gas: end.io_gas - self.io_gas,
             execution_gas: end.execution_gas - self.execution_gas,
+            storage_fee: end.storage_fee - self.storage_fee,
             approx_block_output: end.approx_block_output - self.approx_block_output,
             gas_count: end.gas_count - self.gas_count,
             speculative_abort_count: end.speculative_abort_count - self.speculative_abort_count,
@@ -643,6 +654,11 @@ impl OverallMeasuring {
             "{} GPT: {} gas/txn",
             prefix,
             delta_gas.gas / (delta_gas.gas_count as f64).max(1.0)
+        );
+        info!(
+            "{} Storage fee: {} octas/txn",
+            prefix,
+            delta_gas.storage_fee / (delta_gas.gas_count as f64).max(1.0)
         );
         info!(
             "{} approx_output: {} bytes/s",

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -64,7 +64,7 @@ NOISE_UPPER_LIMIT_WARN = None if IS_MAINNET else 1.05
 
 # bump after a perf improvement, so you can easily distinguish runs
 # that are on top of this commit
-CODE_PERF_VERSION = "v5"
+CODE_PERF_VERSION = "v6"
 
 # default to using production number of execution threads for assertions
 NUMBER_OF_EXECUTION_THREADS = int(
@@ -149,8 +149,8 @@ CALIBRATION_SEPARATOR = "	"
 CALIBRATION = """
 no-op	1	VM	0.896	1.057	41218.8
 no-op	1000	VM	0.902	1.030	22359.4
-coin-transfer	1	VM	0.891	1.056	28721.7
-coin-transfer	1	native	0.848	1.157	40469.1
+apt-fa-transfer	1	VM	0.891	1.056	28721.7
+apt-fa-transfer	1	native	0.848	1.157	40469.1
 account-generation	1	VM	0.888	1.030	22359.4
 account-generation	1	native	0.717	1.153	33440.0
 account-resource32-b	1	VM	0.934	1.074	36855.5
@@ -192,14 +192,63 @@ no-op-fee-payer	1	VM	0.922	1.022	2392.0
 no-op-fee-payer	50	VM	0.898	1.028	27699.5
 """
 
+
+# temporary table, until recalibration can be done.
+CALIBRATION_SEPARATOR = " "
+
+# transaction_type                                 module_working_set  executor      block_size    expected t/s    t/s
+CALIBRATION = """
+warmup                                                            1  VM                 10000             0    20373
+no-op                                                             1  VM                 10000         41218.8  33211
+no-op                                                          1000  VM                 10000         22359.4  20593
+apt-fa-transfer                                                   1  VM                 10000         28721.7  25699
+account-generation                                                1  VM                 10000         22359.4  20728
+account-resource32-b                                              1  VM                 10000         36855.5  30215
+modify-global-resource                                            1  VM                  3082          3082.9   2853
+modify-global-resource                                           10  VM                 10000         17905.3  16934
+publish-package                                                   1  VM                   143           143.9    149
+mix_publish_transfer                                              1  VM                  2173          2173.8   2272
+batch100-transfer                                                 1  VM                   667           667.8    768
+vector-picture30k                                                 1  VM                   110           110      110
+vector-picture30k                                                20  VM                  1347          1347.9   1124
+smart-table-picture30-k-with200-change                            1  VM                    21            21.4     22
+smart-table-picture30-k-with200-change                           20  VM                   182           182.6    191
+modify-global-resource-agg-v2                                     1  VM                 10000         39728.8  30580
+modify-global-flag-agg-v2                                         1  VM                  6111          6111.4   5288
+modify-global-bounded-agg-v2                                      1  VM                 10000         10494.1   9035
+modify-global-milestone-agg-v2                                    1  VM                 10000         29251.9  24582
+resource-groups-global-write-tag1-kb                              1  VM                  9389          9389.9   9271
+resource-groups-global-write-and-read-tag1-kb                     1  VM                  6446          6446.3   6276
+resource-groups-sender-write-tag1-kb                              1  VM                 10000         22359.4  21517
+resource-groups-sender-multi-change1-kb                           1  VM                 10000         17562.1  15941
+token-v1ft-mint-and-transfer                                      1  VM                  1347          1347.9   1271
+token-v1ft-mint-and-transfer                                     20  VM                 10000         12114.8  11409
+token-v1nft-mint-and-transfer-sequential                          1  VM                   812           812.9    815
+token-v1nft-mint-and-transfer-sequential                         20  VM                  7881          7881.5   7583
+coin-init-and-mint                                                1  VM                 10000         30932.7  27459
+coin-init-and-mint                                               20  VM                 10000         25786.3  23818
+fungible-asset-mint                                               1  VM                 10000         25331.5  21542
+fungible-asset-mint                                              20  VM                 10000         22763.8  19915
+no-op5-signers                                                    1  VM                 10000         41978.3  34432
+token-v2-ambassador-mint                                          1  VM                 10000         17905.3  15378
+token-v2-ambassador-mint                                         20  VM                 10000         17562.1  15351
+liquidity-pool-swap                                               1  VM                   975           975.7    973
+liquidity-pool-swap                                              20  VM                  8359          8359.6   8213
+liquidity-pool-swap-stable                                        1  VM                   957           957.5    952
+liquidity-pool-swap-stable                                       20  VM                  8035          8035.3   7993
+deserialize-u256                                                  1  VM                 10000         39728.8  32416
+no-op-fee-payer                                                   1  VM                  2392          2392     2193
+no-op-fee-payer                                                  50  VM                 10000         27699.5  25762
+"""
+
 # when adding a new test, add estimated expected_tps to it, as well as waived=True.
 # And then after a day or two - add calibration result for it above, removing expected_tps/waived fields.
 
 TESTS = [
     RunGroupConfig(key=RunGroupKey("no-op"), included_in=LAND_BLOCKING_AND_C),
     RunGroupConfig(key=RunGroupKey("no-op", module_working_set_size=1000), included_in=LAND_BLOCKING_AND_C),
-    RunGroupConfig(key=RunGroupKey("coin-transfer"), included_in=LAND_BLOCKING_AND_C | Flow.REPRESENTATIVE),
-    RunGroupConfig(key=RunGroupKey("coin-transfer", executor_type="native"), included_in=LAND_BLOCKING_AND_C),
+    RunGroupConfig(key=RunGroupKey("apt-fa-transfer"), included_in=LAND_BLOCKING_AND_C | Flow.REPRESENTATIVE),
+    RunGroupConfig(key=RunGroupKey("apt-fa-transfer", executor_type="native"), included_in=LAND_BLOCKING_AND_C),
     RunGroupConfig(key=RunGroupKey("account-generation"), included_in=LAND_BLOCKING_AND_C | Flow.REPRESENTATIVE),
     RunGroupConfig(key=RunGroupKey("account-generation", executor_type="native"), included_in=Flow.CONTINUOUS),
     RunGroupConfig(key=RunGroupKey("account-resource32-b"), included_in=Flow.CONTINUOUS),
@@ -207,7 +256,7 @@ TESTS = [
     RunGroupConfig(key=RunGroupKey("modify-global-resource", module_working_set_size=10), included_in=Flow.CONTINUOUS),
     RunGroupConfig(key=RunGroupKey("publish-package"), included_in=LAND_BLOCKING_AND_C | Flow.REPRESENTATIVE),
     RunGroupConfig(key=RunGroupKey("mix_publish_transfer"), key_extra=RunGroupKeyExtra(
-        transaction_type_override="publish-package coin-transfer",
+        transaction_type_override="publish-package apt-fa-transfer",
         transaction_weights_override="1 500",
     ), included_in=LAND_BLOCKING_AND_C),
     RunGroupConfig(key=RunGroupKey("batch100-transfer"), included_in=LAND_BLOCKING_AND_C),

--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # Copyright © Aptos Foundation
 # SPDX-License-Identifier: Apache-2.0
@@ -87,6 +87,13 @@ if os.environ.get("PROD_DB_FLAGS"):
     DB_CONFIG_FLAGS = ""
 else:
     DB_CONFIG_FLAGS = "--enable-storage-sharding"
+
+if os.environ.get("DISABLE_FA_APT"):
+    FEATURE_FLAGS = ""
+    SKIP_NATIVE = False
+else:
+    FEATURE_FLAGS = "--enable-feature NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE --enable-feature OPERATIONS_DEFAULT_TO_FA_APT_STORE"
+    SKIP_NATIVE = True
 
 if os.environ.get("ENABLE_PRUNER"):
     DB_PRUNER_FLAGS = "--enable-state-pruner --enable-ledger-pruner --enable-epoch-snapshot-pruner --ledger-pruning-batch-size 10000 --state-prune-window 3000000 --epoch-snapshot-prune-window 3000000 --ledger-prune-window 3000000"
@@ -332,6 +339,7 @@ class RunResults:
     io_gps: float
     execution_gps: float
     gpt: float
+    storage_fee_pt: float
     output_bps: float
     fraction_in_execution: float
     fraction_of_execution_in_vm: float
@@ -369,6 +377,7 @@ def extract_run_results(
         io_gps = 0
         execution_gps = 0
         gpt = 0
+        storage_fee_pt = 0
         output_bps = 0
         fraction_in_execution = 0
         fraction_of_execution_in_vm = 0
@@ -386,6 +395,12 @@ def extract_run_results(
             get_only(re.findall(prefix + r" executionGPS: (\d+\.?\d*) gas/s", output))
         )
         gpt = float(get_only(re.findall(prefix + r" GPT: (\d+\.?\d*) gas/txn", output)))
+        storage_fee_pt = float(
+            get_only(
+                re.findall(prefix + r" Storage fee: (\-?\d+\.?\d*) octas/txn", output)
+            )
+        )
+
         output_bps = float(
             get_only(re.findall(prefix + r" output: (\d+\.?\d*) bytes/s", output))
         )
@@ -410,6 +425,7 @@ def extract_run_results(
         io_gps=io_gps,
         execution_gps=execution_gps,
         gpt=gpt,
+        storage_fee_pt=storage_fee_pt,
         output_bps=output_bps,
         fraction_in_execution=fraction_in_execution,
         fraction_of_execution_in_vm=fraction_of_execution_in_vm,
@@ -451,6 +467,7 @@ def print_table(
                 "io g/s",
                 "exe g/s",
                 "g/t",
+                "fee/t",
                 "out B/s",
             ]
         )
@@ -488,6 +505,7 @@ def print_table(
             row.append(int(round(result.single_node_result.io_gps)))
             row.append(int(round(result.single_node_result.execution_gps)))
             row.append(int(round(result.single_node_result.gpt)))
+            row.append(int(round(result.single_node_result.storage_fee_pt)))
             row.append(int(round(result.single_node_result.output_bps)))
         rows.append(row)
 
@@ -529,7 +547,7 @@ with tempfile.TemporaryDirectory() as tmpdirname:
 
     execute_command(f"cargo build {BUILD_FLAG} --package aptos-executor-benchmark")
     print(f"Warmup - creating DB with {NUM_ACCOUNTS} accounts")
-    create_db_command = f"RUST_BACKTRACE=1 {BUILD_FOLDER}/aptos-executor-benchmark --block-size {MAX_BLOCK_SIZE} --execution-threads {NUMBER_OF_EXECUTION_THREADS} {DB_CONFIG_FLAGS} {DB_PRUNER_FLAGS} create-db --data-dir {tmpdirname}/db --num-accounts {NUM_ACCOUNTS}"
+    create_db_command = f"RUST_BACKTRACE=1 {BUILD_FOLDER}/aptos-executor-benchmark --block-size {MAX_BLOCK_SIZE} --execution-threads {NUMBER_OF_EXECUTION_THREADS} {DB_CONFIG_FLAGS} {DB_PRUNER_FLAGS} create-db {FEATURE_FLAGS} --data-dir {tmpdirname}/db --num-accounts {NUM_ACCOUNTS}"
     output = execute_command(create_db_command)
 
     results = []
@@ -549,6 +567,9 @@ with tempfile.TemporaryDirectory() as tmpdirname:
         test,
     ) in enumerate(TESTS):
         if SELECTED_FLOW not in test.included_in:
+            continue
+
+        if SKIP_NATIVE and test.key.executor_type == "native":
             continue
 
         if test.key in calibrated_expected_tps:
@@ -589,7 +610,7 @@ with tempfile.TemporaryDirectory() as tmpdirname:
             * (1 if test.key_extra.smaller_working_set else NUM_BLOCKS)
         )
 
-        common_command_suffix = f"{executor_type_str} {txn_emitter_prefix_str} --block-size {cur_block_size} {DB_CONFIG_FLAGS} {DB_PRUNER_FLAGS} run-executor {workload_args_str} --module-working-set-size {test.key.module_working_set_size} --main-signer-accounts {MAIN_SIGNER_ACCOUNTS} --additional-dst-pool-accounts {ADDITIONAL_DST_POOL_ACCOUNTS} --data-dir {tmpdirname}/db  --checkpoint-dir {tmpdirname}/cp"
+        common_command_suffix = f"{executor_type_str} {txn_emitter_prefix_str} --block-size {cur_block_size} {DB_CONFIG_FLAGS} {DB_PRUNER_FLAGS} run-executor {FEATURE_FLAGS} {workload_args_str} --module-working-set-size {test.key.module_working_set_size} --main-signer-accounts {MAIN_SIGNER_ACCOUNTS} --additional-dst-pool-accounts {ADDITIONAL_DST_POOL_ACCOUNTS} --data-dir {tmpdirname}/db  --checkpoint-dir {tmpdirname}/cp"
 
         number_of_threads_results = {}
 
@@ -671,6 +692,19 @@ with tempfile.TemporaryDirectory() as tmpdirname:
                 results,
                 by_levels=True,
                 single_field=("g/s", lambda r: int(round(r.gps))),
+            )
+            print_table(
+                results,
+                by_levels=False,
+                single_field=("gas/txn", lambda r: int(round(r.gpt))),
+            )
+            print_table(
+                results,
+                by_levels=False,
+                single_field=(
+                    "storage fee/txn",
+                    lambda r: int(round(r.storage_fee_pt)),
+                ),
             )
             print_table(
                 results,

--- a/testsuite/smoke-test/src/consensus/quorum_store_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/quorum_store_fault_tolerance.rs
@@ -40,6 +40,8 @@ async fn generate_traffic_and_assert_committed(
             TransactionType::CoinTransfer {
                 invalid_transaction_ratio: 0,
                 sender_use_account_pool: false,
+                non_conflicting: false,
+                use_fa_transfer: false,
             },
             70,
         ),

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -123,6 +123,8 @@ async fn test_gas_estimation_inner(swarm: &mut LocalSwarm) {
             TransactionType::CoinTransfer {
                 invalid_transaction_ratio: 0,
                 sender_use_account_pool: false,
+                non_conflicting: false,
+                use_fa_transfer: false,
             },
             100,
         )]],


### PR DESCRIPTION
## Description

Enabling FA for APT in regression benchmarks, so we can track and catch any regressions in the FA framework.

Also added storage_fee to reports.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
