### PR TITLE
[compiler-v2] Complete implementation of enum field selection

### DIFF
--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.exp
@@ -13,6 +13,23 @@ module 0xc0ffee::m {
             z: u64,
         }
     }
+    enum CommonFieldsAtDifferentOffset {
+        Foo {
+            x: u64,
+            y: u64,
+        }
+        Bar {
+            x: u64,
+            z: u64,
+        }
+        Baz {
+            z: u64,
+        }
+        Balt {
+            foo: u8,
+            z: u64,
+        }
+    }
     enum Inner {
         Inner1 {
             x: u64,
@@ -162,7 +179,7 @@ module 0xc0ffee::m {
 
     }
     private fun select_common_fields(s: m::CommonFields): u64 {
-        Add<u64>(select m::CommonFields.x<m::CommonFields>(s), match (s) {
+        Add<u64>(select_variants m::CommonFields.Foo.x|m::CommonFields.Bar.x<m::CommonFields>(s), match (s) {
           m::CommonFields::Foo{ x: _, y } => {
             y
           }
@@ -171,6 +188,9 @@ module 0xc0ffee::m {
           }
         }
         )
+    }
+    private fun select_common_fields_different_offset(s: m::CommonFieldsAtDifferentOffset): u64 {
+        select_variants m::CommonFieldsAtDifferentOffset.Bar.z|m::CommonFieldsAtDifferentOffset.Baz.z|m::CommonFieldsAtDifferentOffset.Balt.z<m::CommonFieldsAtDifferentOffset>(s)
     }
 } // end 0xc0ffee::m
 
@@ -574,6 +594,31 @@ fun m::select_common_fields($t0: m::CommonFields): u64 {
  20: label L0
  21: $t1 := +($t2, $t5)
  22: return $t1
+}
+
+
+[variant baseline]
+fun m::select_common_fields_different_offset($t0: m::CommonFieldsAtDifferentOffset): u64 {
+     var $t1: u64
+     var $t2: &m::CommonFieldsAtDifferentOffset
+     var $t3: &u64
+     var $t4: bool
+  0: $t2 := borrow_local($t0)
+  1: $t4 := test_variant m::CommonFieldsAtDifferentOffset::Bar($t2)
+  2: if ($t4) goto 8 else goto 3
+  3: label L2
+  4: $t4 := test_variant m::CommonFieldsAtDifferentOffset::Balt($t2)
+  5: if ($t4) goto 8 else goto 6
+  6: label L3
+  7: goto 11
+  8: label L1
+  9: $t3 := borrow_variant_field<m::CommonFieldsAtDifferentOffset::Bar|Balt>.z($t2)
+ 10: goto 13
+ 11: label L4
+ 12: $t3 := borrow_variant_field<m::CommonFieldsAtDifferentOffset::Baz>.z($t2)
+ 13: label L0
+ 14: $t1 := read_ref($t3)
+ 15: return $t1
 }
 
 

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.move
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.move
@@ -104,10 +104,22 @@ module 0xc0ffee::m {
     // Common fields
     enum CommonFields {
         Foo{x: u64, y: u64},
-        Bar{z: u64, x: u64}
+        Bar{x: u64, z: u64}
     }
 
     fun select_common_fields(s: CommonFields): u64 {
         s.x + (match (s) { Foo{x: _, y} => y, Bar{z, x: _} => z })
+    }
+
+    enum CommonFieldsAtDifferentOffset has drop {
+       Foo{x: u64, y: u64},
+       Bar{x: u64, z: u64},
+       Baz{z: u64} // `z` at different offset
+       Balt{foo: u8, z: u64}
+    }
+
+    fun select_common_fields_different_offset(s: CommonFieldsAtDifferentOffset): u64 {
+        // We expect branching over the variant to select this field
+        s.z
     }
 }

--- a/third_party/move/move-compiler-v2/tests/checking/positional_fields/common_access.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/positional_fields/common_access.exp
@@ -9,6 +9,6 @@ module 0x42::test {
         }
     }
     private fun common_access(x: test::Foo): u8 {
-        select test::Foo.0<test::Foo>(x)
+        select_variants test::Foo.A.0|test::Foo.B.0<test::Foo>(x)
     }
 } // end 0x42::test

--- a/third_party/move/move-compiler-v2/tests/checking/positional_fields/invalid_common_access.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/positional_fields/invalid_common_access.exp
@@ -1,9 +1,9 @@
 
 Diagnostics:
-error: field `1` not declared in all variants of `Foo`
+error: cannot select field `1` since it has different types in variants of enum `Foo`
   ┌─ tests/checking/positional_fields/invalid_common_access.move:8:9
   │
 8 │         x.1
   │         ^
   │
-  = field must be declared in all variants of `Foo` to be accessible without match expression
+  = field `1` has type `u8` in variant `B` and type `bool` in variant `A`

--- a/third_party/move/move-compiler-v2/tests/checking/positional_fields/invalid_common_access.move
+++ b/third_party/move/move-compiler-v2/tests/checking/positional_fields/invalid_common_access.move
@@ -1,7 +1,7 @@
 module 0x42::test {
     enum Foo has drop {
         A(u8, bool),
-        B(u8),
+        B(u8, u8),
     }
 
     fun common_access(x: Foo): u8 {

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_check_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_check_err.exp
@@ -1,45 +1,45 @@
 
 Diagnostics:
 error: variant `Rgb` not declared in `m::Color`
-   ┌─ tests/checking/variants/variants_check_err.move:15:13
+   ┌─ tests/checking/variants/variants_check_err.move:21:13
    │
-15 │             Color::Rgb{red, green, blue} => false,
+21 │             Color::Rgb{red, green, blue} => false,
    │             ^^^^^^^^^^
 
 error: variants not allowed in this context
-   ┌─ tests/checking/variants/variants_check_err.move:21:34
+   ┌─ tests/checking/variants/variants_check_err.move:27:34
    │
-21 │     fun missplaced_variant(self: Color::Red): bool {
+27 │     fun missplaced_variant(self: Color::Red): bool {
    │                                  ^^^^^^^^^^
 
 error: undeclared struct `m::missplaced_variant`
-   ┌─ tests/checking/variants/variants_check_err.move:22:9
+   ┌─ tests/checking/variants/variants_check_err.move:28:9
    │
-22 │         0x815::m::missplaced_variant::Red();
+28 │         0x815::m::missplaced_variant::Red();
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: variants not allowed in this context
-   ┌─ tests/checking/variants/variants_check_err.move:26:29
+   ┌─ tests/checking/variants/variants_check_err.move:32:29
    │
-26 │     fun missing_field(self: Color::Red): bool {
+32 │     fun missing_field(self: Color::Red): bool {
    │                             ^^^^^^^^^^
 
 error: missing field `blue`
-   ┌─ tests/checking/variants/variants_check_err.move:28:13
+   ┌─ tests/checking/variants/variants_check_err.move:34:13
    │
-28 │             Color::RGB{red, green} => false,
+34 │             Color::RGB{red, green} => false,
    │             ^^^^^^^^^^^^^^^^^^^^^^
 
 error: field `black` not declared in `m::Color`
-   ┌─ tests/checking/variants/variants_check_err.move:34:42
+   ┌─ tests/checking/variants/variants_check_err.move:40:42
    │
-34 │             Color::RGB{red, green, blue, black} => false,
+40 │             Color::RGB{red, green, blue, black} => false,
    │                                          ^^^^^
 
-error: field `red` not declared in all variants of `Color`
-   ┌─ tests/checking/variants/variants_check_err.move:39:9
+error: cannot select field `f1` since it has different types in variants of enum `Fields`
+   ┌─ tests/checking/variants/variants_check_err.move:49:9
    │
-39 │         self.red
+49 │         self.f1 + (self.f2 as u64)
    │         ^^^^
    │
-   = field must be declared in all variants of `Color` to be accessible without match expression
+   = field `f1` has type `u8` in variant `V3` and type `u64` in variant `V1` and type `u64` in variant `V2`

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_check_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_check_err.move
@@ -10,6 +10,12 @@ module 0x815::m {
         red: u64
     }
 
+    enum Fields {
+        V1{f1: u64},
+        V2{f1: u64, f2: u8},
+        V3{f1: u8, f2: u8}
+    }
+
     fun misspelled_variant(self: Color): bool {
         match (self) {
             Color::Rgb{red, green, blue} => false,
@@ -35,7 +41,12 @@ module 0x815::m {
         }
     }
 
-    fun select_variant_field(self: Color): u64 {
+    fun select_variant_field_ok(self: Color): u64 {
         self.red
     }
+
+    fun select_variant_field_err_multiple(self: Fields): u64 {
+        self.f1 + (self.f2 as u64)
+    }
+
 }

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_ok.exp
@@ -28,6 +28,9 @@ module 0x815::m {
             x: u64,
             z: u32,
         }
+        Baz {
+            other: u32,
+        }
     }
     private fun t1(self: m::Color): bool {
         match (self) {
@@ -199,9 +202,9 @@ module 0x815::m {
 
     }
     private fun t9_common_field(self: m::CommonFields): u64 {
-        select m::CommonFields.x<m::CommonFields>(self)
+        select_variants m::CommonFields.Foo.x|m::CommonFields.Bar.x<m::CommonFields>(self)
     }
     private fun t9_common_field_ref(self: &m::CommonFields): &u64 {
-        Borrow(Immutable)(select m::CommonFields.x<&m::CommonFields>(self))
+        Borrow(Immutable)(select_variants m::CommonFields.Foo.x|m::CommonFields.Bar.x<&m::CommonFields>(self))
     }
 } // end 0x815::m

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_ok.move
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_ok.move
@@ -16,6 +16,7 @@ module 0x815::m {
     enum CommonFields {
         Foo{x: u64, y: u8},
         Bar{x: u64, z: u32}
+        Baz{other: u32}
     }
 
     fun t1(self: Color): bool {

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.exp
@@ -15,6 +15,23 @@ enum CommonFields {
 	z: u64
  }
 }
+enum CommonFieldsAtDifferentOffset has drop {
+ Foo{
+	x: u64,
+	y: u64
+ },
+ Bar{
+	x: u64,
+	z: u64
+ },
+ Baz{
+	z: u64
+ },
+ Balt{
+	foo: u8,
+	z: u64
+ }
+}
 enum Inner {
  Inner1{
 	x: u64
@@ -500,6 +517,35 @@ B5:
 	29: MoveLoc[4](loc3: u64)
 	30: Add
 	31: Ret
+}
+select_common_fields_different_offset(Arg0: CommonFieldsAtDifferentOffset): u64 /* def_idx: 10 */ {
+L1:	loc0: &CommonFieldsAtDifferentOffset
+L2:	loc1: &u64
+B0:
+	0: ImmBorrowLoc[0](Arg0: CommonFieldsAtDifferentOffset)
+	1: StLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	2: CopyLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	3: TestVariant[9](CommonFieldsAtDifferentOffset/Bar)
+	4: BrTrue(9)
+B1:
+	5: CopyLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	6: TestVariant[10](CommonFieldsAtDifferentOffset/Balt)
+	7: BrTrue(9)
+B2:
+	8: Branch(13)
+B3:
+	9: MoveLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	10: ImmBorrowVariantField[4](Bar.z|Balt.z: u64)
+	11: StLoc[2](loc1: &u64)
+	12: Branch(16)
+B4:
+	13: MoveLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	14: ImmBorrowVariantField[5](Baz.z: u64)
+	15: StLoc[2](loc1: &u64)
+B5:
+	16: MoveLoc[2](loc1: &u64)
+	17: ReadRef
+	18: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.move
@@ -104,11 +104,22 @@ module 0xc0ffee::m {
     // Common fields
     enum CommonFields {
         Foo{x: u64, y: u64},
-        Bar{z: u64, x: u64}
+        Bar{x: u64, z: u64}
     }
 
     fun select_common_fields(s: CommonFields): u64 {
         s.x + (match (s) { Foo{x: _, y} => y, Bar{z, x: _} => z })
     }
 
+    enum CommonFieldsAtDifferentOffset has drop {
+       Foo{x: u64, y: u64},
+       Bar{x: u64, z: u64},
+       Baz{z: u64} // `z` at different offset
+       Balt{foo: u8, z: u64}
+    }
+
+    fun select_common_fields_different_offset(s: CommonFieldsAtDifferentOffset): u64 {
+        // We expect branching over the variant to select this field
+        s.z
+    }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.opt.exp
@@ -15,6 +15,23 @@ enum CommonFields {
 	z: u64
  }
 }
+enum CommonFieldsAtDifferentOffset has drop {
+ Foo{
+	x: u64,
+	y: u64
+ },
+ Bar{
+	x: u64,
+	z: u64
+ },
+ Baz{
+	z: u64
+ },
+ Balt{
+	foo: u8,
+	z: u64
+ }
+}
 enum Inner {
  Inner1{
 	x: u64
@@ -485,6 +502,35 @@ B5:
 	29: MoveLoc[4](loc3: u64)
 	30: Add
 	31: Ret
+}
+select_common_fields_different_offset(Arg0: CommonFieldsAtDifferentOffset): u64 /* def_idx: 10 */ {
+L1:	loc0: &CommonFieldsAtDifferentOffset
+L2:	loc1: &u64
+B0:
+	0: ImmBorrowLoc[0](Arg0: CommonFieldsAtDifferentOffset)
+	1: StLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	2: CopyLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	3: TestVariant[9](CommonFieldsAtDifferentOffset/Bar)
+	4: BrTrue(9)
+B1:
+	5: CopyLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	6: TestVariant[10](CommonFieldsAtDifferentOffset/Balt)
+	7: BrTrue(9)
+B2:
+	8: Branch(13)
+B3:
+	9: MoveLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	10: ImmBorrowVariantField[4](Bar.z|Balt.z: u64)
+	11: StLoc[2](loc1: &u64)
+	12: Branch(16)
+B4:
+	13: MoveLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	14: ImmBorrowVariantField[5](Baz.z: u64)
+	15: StLoc[2](loc1: &u64)
+B5:
+	16: MoveLoc[2](loc1: &u64)
+	17: ReadRef
+	18: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.exp
@@ -1,0 +1,31 @@
+processed 7 tasks
+
+task 1 'run'. lines 42-42:
+return values: 43
+
+task 2 'run'. lines 44-44:
+return values: 43
+
+task 3 'run'. lines 46-46:
+return values: 43
+
+task 4 'run'. lines 48-48:
+Error: Function execution failed with VMError: {
+    major_status: STRUCT_VARIANT_MISMATCH,
+    sub_status: None,
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(3), 4)],
+}
+
+task 5 'run'. lines 50-50:
+return values: true
+
+task 6 'run'. lines 52-52:
+Error: Function execution failed with VMError: {
+    major_status: STRUCT_VARIANT_MISMATCH,
+    sub_status: None,
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(5), 5)],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.move
@@ -1,0 +1,52 @@
+//# publish
+module 0x42::m {
+
+  enum Data has drop {
+    V1{x: u64},
+    V2{y: bool, x: u64}
+    V3{z: u8, x: u64}
+  }
+
+  fun test_get_x_v1(): u64 {
+    let d = Data::V1{x: 43};
+    d.x
+  }
+
+  fun test_get_x_v2(): u64 {
+    let d = Data::V2{x: 43, y: false};
+    d.x
+  }
+
+  fun test_get_x_v3(): u64 {
+    let d = Data::V3{z: 1, x: 43};
+    d.x
+  }
+
+  fun test_get_y_v1(): bool {
+    let d = Data::V1{x: 43};
+    d.y
+  }
+
+  fun test_get_y_v2(): bool {
+    let d = Data::V2{x: 43, y: true};
+    d.y
+  }
+
+  fun test_get_y_v3(): bool {
+    let d = Data::V3{x: 43, z: 1};
+    d.y
+  }
+
+}
+
+//# run 0x42::m::test_get_x_v1
+
+//# run 0x42::m::test_get_x_v2
+
+//# run 0x42::m::test_get_x_v3
+
+//# run 0x42::m::test_get_y_v1
+
+//# run 0x42::m::test_get_y_v2
+
+//# run 0x42::m::test_get_y_v3

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.no-optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.no-optimize.exp
@@ -1,0 +1,31 @@
+processed 7 tasks
+
+task 1 'run'. lines 42-42:
+return values: 43
+
+task 2 'run'. lines 44-44:
+return values: 43
+
+task 3 'run'. lines 46-46:
+return values: 43
+
+task 4 'run'. lines 48-48:
+Error: Function execution failed with VMError: {
+    major_status: STRUCT_VARIANT_MISMATCH,
+    sub_status: None,
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(3), 4)],
+}
+
+task 5 'run'. lines 50-50:
+return values: true
+
+task 6 'run'. lines 52-52:
+Error: Function execution failed with VMError: {
+    major_status: STRUCT_VARIANT_MISMATCH,
+    sub_status: None,
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(5), 9)],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.optimize-no-simplify.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.optimize-no-simplify.exp
@@ -1,0 +1,31 @@
+processed 7 tasks
+
+task 1 'run'. lines 42-42:
+return values: 43
+
+task 2 'run'. lines 44-44:
+return values: 43
+
+task 3 'run'. lines 46-46:
+return values: 43
+
+task 4 'run'. lines 48-48:
+Error: Function execution failed with VMError: {
+    major_status: STRUCT_VARIANT_MISMATCH,
+    sub_status: None,
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(3), 4)],
+}
+
+task 5 'run'. lines 50-50:
+return values: true
+
+task 6 'run'. lines 52-52:
+Error: Function execution failed with VMError: {
+    major_status: STRUCT_VARIANT_MISMATCH,
+    sub_status: None,
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(5), 9)],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.optimize.exp
@@ -1,0 +1,31 @@
+processed 7 tasks
+
+task 1 'run'. lines 42-42:
+return values: 43
+
+task 2 'run'. lines 44-44:
+return values: 43
+
+task 3 'run'. lines 46-46:
+return values: 43
+
+task 4 'run'. lines 48-48:
+Error: Function execution failed with VMError: {
+    major_status: STRUCT_VARIANT_MISMATCH,
+    sub_status: None,
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(3), 4)],
+}
+
+task 5 'run'. lines 50-50:
+return values: true
+
+task 6 'run'. lines 52-52:
+Error: Function execution failed with VMError: {
+    major_status: STRUCT_VARIANT_MISMATCH,
+    sub_status: None,
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(5), 5)],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
@@ -100,6 +100,7 @@ const SEPARATE_BASELINE: &[&str] = &[
     "/operator_eval/",
     // Creates different code if optimized
     "no-v1-comparison/enum/enum_field_select.move",
+    "no-v1-comparison/enum/enum_field_select_different_offsets.move",
 ];
 
 fn get_config_by_name(name: &str) -> TestConfig {

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -1600,11 +1600,16 @@ pub enum Operation {
     MoveFunction(ModuleId, FunId),
     Pack(ModuleId, StructId, /*variant*/ Option<Symbol>),
     Tuple,
+    Select(ModuleId, StructId, FieldId),
+    SelectVariants(
+        ModuleId,
+        StructId,
+        /* fields from different variants */ Vec<FieldId>,
+    ),
 
     // Specification specific
     SpecFunction(ModuleId, SpecFunId, Option<Vec<MemoryLabel>>),
     Closure(ModuleId, FunId),
-    Select(ModuleId, StructId, FieldId),
     UpdateField(ModuleId, StructId, FieldId),
     Result(usize),
     Index,
@@ -2430,8 +2435,9 @@ impl Operation {
             Closure(..) => false,      // Spec
             Pack(..) => false,         // Could yield an undroppable value
             Tuple => true,
-            Select(..) => false,      // Move-related
-            UpdateField(..) => false, // Move-related
+            Select(..) => false,         // Move-related
+            SelectVariants(..) => false, // Move-related
+            UpdateField(..) => false,    // Move-related
 
             // Specification specific
             Result(..) => false, // Spec
@@ -3247,6 +3253,15 @@ impl<'a> fmt::Display for OperationDisplay<'a> {
             Select(mid, sid, fid) => {
                 write!(f, "select {}", self.field_str(mid, sid, fid))
             },
+            SelectVariants(mid, sid, fids) => {
+                write!(
+                    f,
+                    "select_variants {}",
+                    fids.iter()
+                        .map(|fid| self.field_str(mid, sid, fid))
+                        .join("|")
+                )
+            },
             UpdateField(mid, sid, fid) => {
                 write!(f, "update {}", self.field_str(mid, sid, fid))
             },
@@ -3289,8 +3304,7 @@ impl<'a> OperationDisplay<'a> {
     }
 
     fn field_str(&self, mid: &ModuleId, sid: &StructId, fid: &FieldId) -> String {
-        let struct_env = self.env.get_module(*mid).into_struct(*sid);
-        let field_name = struct_env.get_field(*fid).get_name();
+        let field_name = fid.symbol();
         format!(
             "{}.{}",
             self.struct_str(mid, sid),

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -539,36 +539,34 @@ impl<'env> ModelBuilder<'env> {
             })
     }
 
-    /// Looks up the fields of a structure, with instantiated field types. Returns empty
-    /// map if the struct has variants.
-    pub fn lookup_struct_fields(
+    /// Looks up field declaration, returning a list of optional variant name and type of the field
+    /// in the variant. The variant name is None and the list a singleton for proper struct types.
+    pub fn lookup_struct_field_decl(
         &self,
         id: &QualifiedInstId<StructId>,
-    ) -> (BTreeMap<Symbol, Type>, bool) {
+        field_name: Symbol,
+    ) -> (Vec<(Option<Symbol>, Type)>, bool) {
         let entry = self.lookup_struct_entry(id.to_qualified_id());
-        let instantiate_fields = |fields: &BTreeMap<Symbol, FieldData>, common_only: bool| {
+        let get_instantiated_field = |fields: &BTreeMap<Symbol, FieldData>| {
             fields
-                .values()
-                .filter_map(|f| {
-                    if !common_only || f.common_for_variants {
-                        Some((f.name, f.ty.instantiate(&id.inst)))
-                    } else {
-                        None
-                    }
-                })
-                .collect()
+                .get(&field_name)
+                .map(|data| data.ty.instantiate(&id.inst))
         };
         match &entry.layout {
-            StructLayout::Singleton(fields, _) => (instantiate_fields(fields, false), false),
+            StructLayout::Singleton(fields, _) => (
+                get_instantiated_field(fields)
+                    .map(|ty| vec![(None, ty)])
+                    .unwrap_or_default(),
+                false,
+            ),
             StructLayout::Variants(variants) => (
-                if variants.is_empty() {
-                    BTreeMap::new()
-                } else {
-                    instantiate_fields(&variants[0].fields, true)
-                },
+                variants
+                    .iter()
+                    .filter_map(|v| get_instantiated_field(&v.fields).map(|ty| (Some(v.name), ty)))
+                    .collect(),
                 true,
             ),
-            _ => (BTreeMap::new(), false),
+            _ => (vec![], false),
         }
     }
 

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -1235,7 +1235,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 )
             },
             EA::StructLayout::Variants(variants) => {
-                let mut variant_maps = variants
+                let variant_maps = variants
                     .iter()
                     .map(|v| {
                         let variant_loc = et.to_loc(&v.loc);
@@ -1257,47 +1257,6 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                         }
                     })
                     .collect_vec();
-                if !variant_maps.is_empty() {
-                    // Identify common fields and compute their offsets. Common fields
-                    // occupy the first N slots in a variant layout, where the order
-                    // is determined by the first variant which declares them.
-                    let mut common_fields: BTreeMap<Symbol, usize> = BTreeMap::new();
-                    let main = &variant_maps[0];
-                    for field in main.fields.values().sorted_by_key(|f| f.offset) {
-                        let mut common = true;
-                        for other in &variant_maps[1..variant_maps.len()] {
-                            if !other
-                                .fields
-                                .values()
-                                .any(|f| f.name == field.name && f.ty == field.ty)
-                            {
-                                common = false;
-                                break;
-                            }
-                        }
-                        if common {
-                            common_fields.insert(field.name, common_fields.len());
-                        }
-                    }
-                    // Now adjust the offsets of the fields over all variants.
-                    for variant_map in variant_maps.iter_mut() {
-                        let mut next_offset = common_fields.len();
-                        for field in variant_map
-                            .fields
-                            .values_mut()
-                            .sorted_by_key(|v| v.offset)
-                            .collect_vec()
-                        {
-                            if let Some(offset) = common_fields.get(&field.name) {
-                                field.common_for_variants = true;
-                                field.offset = *offset
-                            } else {
-                                field.offset = next_offset;
-                                next_offset += 1
-                            }
-                        }
-                    }
-                }
                 (StructLayout::Variants(variant_maps), false)
             },
             EA::StructLayout::Native(_) => (StructLayout::None, false),
@@ -1319,9 +1278,9 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         fields: &EA::Fields<EA::Type>,
     ) -> (BTreeMap<Symbol, FieldData>, bool) {
         let mut field_map = BTreeMap::new();
-        for (name_loc, field_name_, (idx, ty)) in fields {
+        for (name_loc, field_name, (idx, ty)) in fields {
             let field_loc = et.to_loc(&name_loc);
-            let field_sym = et.symbol_pool().make(field_name_);
+            let field_sym = et.symbol_pool().make(field_name);
             let field_ty = et.translate_type(ty);
             let field_ty_loc = et.to_loc(&ty.loc);
             for ctr in Constraint::for_field(struct_abilities, &field_ty) {
@@ -1338,7 +1297,6 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 loc: field_loc.clone(),
                 offset: *idx,
                 variant: for_variant,
-                common_for_variants: false,
                 ty: field_ty,
             });
         }
@@ -1354,7 +1312,6 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 loc: loc.clone(),
                 offset: 0,
                 variant: None,
-                common_for_variants: false,
                 ty: field_ty,
             });
             is_empty_struct = true;
@@ -3511,18 +3468,13 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                             attributes: variant.attributes.clone(),
                         });
                         for field in variant.fields.values().sorted_by_key(|f| f.offset).cloned() {
-                            let variant_field_name = if !field.common_for_variants {
-                                // If the field is not common between variants, we need to qualify
-                                // the name with the variant for a unique id.
-                                let pool = self.parent.env.symbol_pool();
-                                pool.make(&FieldId::make_variant_field_id_str(
+                            let pool = self.parent.env.symbol_pool();
+                            let field_id =
+                                FieldId::new(pool.make(&FieldId::make_variant_field_id_str(
                                     pool.string(variant.name).as_str(),
                                     pool.string(field.name).as_str(),
-                                ))
-                            } else {
-                                field.name
-                            };
-                            field_data.insert(FieldId::new(variant_field_name), field);
+                                )));
+                            field_data.insert(field_id, field);
                         }
                     }
                 },

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -1703,7 +1703,6 @@ impl GlobalEnv {
             loc: loc.clone(),
             offset: 0,
             variant: None,
-            common_for_variants: false,
             ty,
         });
         StructData {
@@ -3605,7 +3604,7 @@ impl<'env> StructEnv<'env> {
         self.data
             .field_data
             .values()
-            .filter(|data| data.common_for_variants || variant.is_none() || data.variant == variant)
+            .filter(|data| variant.is_none() || data.variant == variant)
             .sorted_by_key(|data| data.offset)
             .map(move |data| FieldEnv {
                 struct_env: self.clone(),
@@ -3728,9 +3727,6 @@ pub struct FieldData {
     /// If the field is associated with a variant, the name of that variant.
     pub variant: Option<Symbol>,
 
-    /// Whether the field is common between all variants
-    pub common_for_variants: bool,
-
     /// The type of this field.
     pub ty: Type,
 }
@@ -3799,11 +3795,6 @@ impl<'env> FieldEnv<'env> {
     /// Gets the variant this field is associated with
     pub fn get_variant(&self) -> Option<Symbol> {
         self.data.variant
-    }
-
-    /// Returns true if this field is common between variants
-    pub fn is_common_variant_field(&self) -> bool {
-        self.data.common_for_variants
     }
 }
 

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -855,6 +855,10 @@ impl<'env> SpecTranslator<'env> {
             Operation::Select(module_id, struct_id, field_id) => {
                 self.translate_select(node_id, *module_id, *struct_id, *field_id, args)
             },
+            Operation::SelectVariants(_module_id, _struct_id, _field_ids) => {
+                // TODO(#13806): implement for variants
+                self.error(&loc, "variants no yet supported");
+            },
             Operation::UpdateField(module_id, struct_id, field_id) => {
                 self.translate_update_field(node_id, *module_id, *struct_id, *field_id, args)
             },


### PR DESCRIPTION
## Description
 This circles back to the frontend and completes the intended enum implementation as it is now supported by the VM.
    
- Let the checker allow selecting fields which are not present in all variants.
- Adds a new expression operation `SelectVariants` to represent selecting a field from a variant.
 - Implements `SelectVariants` in the bytecode generator to generate a sequence of tests if selecting fields at different positions of variants.
- Removes the now obsolete common_field property. Also, each variant field now has a unique FieldId in contrast to before where common fields shared the same id.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

This is tested in various stages of the compiler including transactional tests.
