### PR TITLE
[compiler-v2] Implements `x is Foo::Variant` feature

### DIFF
--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -749,6 +749,9 @@ impl<'env> Generator<'env> {
             Operation::MoveFunction(m, f) => {
                 self.gen_function_call(targets, id, m.qualified(*f), args)
             },
+            Operation::TestVariants(mid, sid, variants) => {
+                self.gen_test_variants(targets, id, mid.qualified(*sid), variants, args)
+            },
             Operation::Cast => self.gen_cast_call(targets, id, args),
             Operation::Add => self.gen_op_call(targets, id, BytecodeOperation::Add, args),
             Operation::Sub => self.gen_op_call(targets, id, BytecodeOperation::Sub, args),
@@ -823,6 +826,31 @@ impl<'env> Generator<'env> {
                 format!("unsupported specification construct: `{:?}`", op),
             ),
         }
+    }
+
+    fn gen_test_variants(
+        &mut self,
+        targets: Vec<TempIndex>,
+        id: NodeId,
+        struct_id: QualifiedId<StructId>,
+        variants: &[Symbol],
+        args: &[Exp],
+    ) {
+        let target = self.require_unary_target(id, targets);
+        let temp =
+            self.gen_auto_ref_arg(&self.require_unary_arg(id, args), ReferenceKind::Immutable);
+        let mut bool_temp = Some(target);
+        let success_label = self.new_label(id);
+        let inst = self.env().get_node_instantiation(id);
+        self.gen_test_variants_operation(
+            id,
+            &mut bool_temp,
+            success_label,
+            &struct_id.instantiate(inst),
+            variants.to_vec(),
+            temp,
+        );
+        self.emit_with(id, |attr| Bytecode::Label(attr, success_label))
     }
 
     fn gen_cast_call(&mut self, targets: Vec<TempIndex>, id: NodeId, args: &[Exp]) {
@@ -1265,37 +1293,28 @@ impl<'env> Generator<'env> {
             };
             while let Some((offset, group_fields)) = ordered_groups.pop() {
                 let next_group_label = if !ordered_groups.is_empty() {
-                    // Insert a test by generating the equivalent of
-                    // `src is V1 || src is V2 || ..` for all variants in this group
-                    // This can be done more efficiently once we have a switch opcode.
-                    let bool_temp = if let Some(t) = bool_temp {
-                        t
-                    } else {
-                        let t = self.new_temp(Type::new_prim(PrimitiveType::Bool));
-                        bool_temp = Some(t);
-                        t
-                    };
+                    let next_group_label = self.new_label(id);
                     let this_group_label = self.new_label(id);
-                    for field in group_fields {
-                        self.emit_call(
-                            id,
-                            vec![bool_temp],
-                            BytecodeOperation::TestVariant(
-                                str.module_id,
-                                str.id,
+                    self.gen_test_variants_operation(
+                        id,
+                        &mut bool_temp,
+                        this_group_label,
+                        &str,
+                        group_fields
+                            .iter()
+                            .map(|fid| {
                                 self.env()
                                     .get_struct(str.to_qualified_id())
-                                    .get_field(*field)
+                                    .get_field(*fid)
                                     .get_variant()
-                                    .expect("variant field has variant name"),
-                                str.inst.clone(),
-                            ),
-                            vec![src],
-                        );
-                        self.branch_to_exit_if_true(id, bool_temp, this_group_label)
-                    }
-                    let next_group_label = self.new_label(id);
+                                    .expect("variant name defined")
+                            })
+                            .collect(),
+                        src,
+                    );
+                    // Ending here means no test succeeded
                     self.emit_with(id, |attr| Bytecode::Jump(attr, next_group_label));
+                    // Ending here means some test succeeded
                     self.emit_with(id, |attr| Bytecode::Label(attr, this_group_label));
                     Some(next_group_label)
                 } else {
@@ -1327,6 +1346,35 @@ impl<'env> Generator<'env> {
         }
     }
 
+    /// Generate a test for variants.
+    fn gen_test_variants_operation(
+        &mut self,
+        id: NodeId,
+        bool_temp: &mut Option<TempIndex>,
+        success_label: Label,
+        str: &QualifiedInstId<StructId>,
+        variants: Vec<Symbol>,
+        src: TempIndex,
+    ) {
+        let bool_temp = if let Some(t) = *bool_temp {
+            t
+        } else {
+            let t = self.new_temp(Type::new_prim(PrimitiveType::Bool));
+            *bool_temp = Some(t);
+            t
+        };
+        for variant in variants {
+            self.emit_call(
+                id,
+                vec![bool_temp],
+                BytecodeOperation::TestVariant(str.module_id, str.id, variant, str.inst.clone()),
+                vec![src],
+            );
+            self.branch_to_exit_if_true(id, bool_temp, success_label)
+        }
+    }
+
+    /// Generate field borrow for fields at the same offset.
     fn gen_borrow_field_same_offset(
         &mut self,
         id: NodeId,

--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -1356,13 +1356,8 @@ impl<'env> Generator<'env> {
         variants: Vec<Symbol>,
         src: TempIndex,
     ) {
-        let bool_temp = if let Some(t) = *bool_temp {
-            t
-        } else {
-            let t = self.new_temp(Type::new_prim(PrimitiveType::Bool));
-            *bool_temp = Some(t);
-            t
-        };
+        let bool_temp =
+            *bool_temp.get_or_insert_with(|| self.new_temp(Type::new_prim(PrimitiveType::Bool)));
         for variant in variants {
             self.emit_call(
                 id,

--- a/third_party/move/move-compiler-v2/tests/ability-check/v1-typing/pack_constraint_not_satisfied.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-check/v1-typing/pack_constraint_not_satisfied.exp
@@ -11,18 +11,18 @@ error: type `Coin` is missing required ability `drop` (type was inferred)
   │
   = required by instantiating type parameter `T:drop` of struct `S`
 
-error: type `R<key>` is missing required ability `key` (type was inferred)
-   ┌─ tests/ability-check/v1-typing/pack_constraint_not_satisfied.move:12:9
+error: type `R<key + integer>` is missing required ability `key` (type was inferred)
+   ┌─ tests/ability-check/v1-typing/pack_constraint_not_satisfied.move:12:30
    │
  3 │     struct R<T: key>  { r: T }
    │              - declaration of type parameter `T`
    ·
 12 │         R {r: R { r: _ } } = R { r: R { r: 0 }};
-   │         ^^^^^^^^^^^^^^^^^^
+   │                              ^
    │
    = required by instantiating type parameter `T:key` of struct `R`
 
-error: type `R<key + integer>` is missing required ability `key` (type was inferred)
+error: type `R<key>` is missing required ability `key` (type was inferred)
    ┌─ tests/ability-check/v1-typing/pack_constraint_not_satisfied.move:12:30
    │
  3 │     struct R<T: key>  { r: T }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.exp
@@ -192,6 +192,12 @@ module 0xc0ffee::m {
     private fun select_common_fields_different_offset(s: m::CommonFieldsAtDifferentOffset): u64 {
         select_variants m::CommonFieldsAtDifferentOffset.Bar.z|m::CommonFieldsAtDifferentOffset.Baz.z|m::CommonFieldsAtDifferentOffset.Balt.z<m::CommonFieldsAtDifferentOffset>(s)
     }
+    private fun test_common(s: m::CommonFields): bool {
+        test_variants m::CommonFields::Foo|Bar(s)
+    }
+    private fun test_common_ref(s: &m::CommonFields): bool {
+        test_variants m::CommonFields::Foo|Bar(s)
+    }
 } // end 0xc0ffee::m
 
 ============ initial bytecode ================
@@ -606,15 +612,15 @@ fun m::select_common_fields_different_offset($t0: m::CommonFieldsAtDifferentOffs
   0: $t2 := borrow_local($t0)
   1: $t4 := test_variant m::CommonFieldsAtDifferentOffset::Bar($t2)
   2: if ($t4) goto 8 else goto 3
-  3: label L2
+  3: label L3
   4: $t4 := test_variant m::CommonFieldsAtDifferentOffset::Balt($t2)
   5: if ($t4) goto 8 else goto 6
-  6: label L3
+  6: label L4
   7: goto 11
-  8: label L1
+  8: label L2
   9: $t3 := borrow_variant_field<m::CommonFieldsAtDifferentOffset::Bar|Balt>.z($t2)
  10: goto 13
- 11: label L4
+ 11: label L1
  12: $t3 := borrow_variant_field<m::CommonFieldsAtDifferentOffset::Baz>.z($t2)
  13: label L0
  14: $t1 := read_ref($t3)
@@ -622,4 +628,39 @@ fun m::select_common_fields_different_offset($t0: m::CommonFieldsAtDifferentOffs
 }
 
 
-============ bytecode verification succeeded ========
+[variant baseline]
+fun m::test_common($t0: m::CommonFields): bool {
+     var $t1: bool
+     var $t2: &m::CommonFields
+  0: $t2 := borrow_local($t0)
+  1: $t1 := test_variant m::CommonFields::Foo($t2)
+  2: if ($t1) goto 7 else goto 3
+  3: label L1
+  4: $t1 := test_variant m::CommonFields::Bar($t2)
+  5: if ($t1) goto 7 else goto 6
+  6: label L2
+  7: label L0
+  8: return $t1
+}
+
+
+[variant baseline]
+fun m::test_common_ref($t0: &m::CommonFields): bool {
+     var $t1: bool
+  0: $t1 := test_variant m::CommonFields::Foo($t0)
+  1: if ($t1) goto 6 else goto 2
+  2: label L1
+  3: $t1 := test_variant m::CommonFields::Bar($t0)
+  4: if ($t1) goto 6 else goto 5
+  5: label L2
+  6: label L0
+  7: return $t1
+}
+
+
+Diagnostics:
+error: local `s` of type `m::CommonFields` does not have the `drop` ability
+    ┌─ tests/bytecode-generator/matching_ok.move:128:10
+    │
+128 │         (s is Foo|Bar)
+    │          ^ still borrowed but will be implicitly dropped later since it is no longer used

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.move
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.move
@@ -122,4 +122,13 @@ module 0xc0ffee::m {
         // We expect branching over the variant to select this field
         s.z
     }
+
+    // Variant tests
+    fun test_common(s: CommonFields): bool {
+        (s is Foo|Bar)
+    }
+
+    fun test_common_ref(s: &CommonFields): bool {
+        (s is Foo|Bar)
+    }
 }

--- a/third_party/move/move-compiler-v2/tests/checking/error_context/assign.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/error_context/assign.exp
@@ -7,10 +7,10 @@ error: cannot assign `R` to left-hand side of type `S`
    │          ^^^^^^^
 
 error: cannot assign `S` to left-hand side of type `R`
-   ┌─ tests/checking/error_context/assign.move:15:19
+   ┌─ tests/checking/error_context/assign.move:15:24
    │
 15 │         (S{x, y}, R{z, s}) = (r, s);
-   │                   ^^^^^^^
+   │                        ^
 
 error: the left-hand side has 2 items but the right-hand side provided 3
    ┌─ tests/checking/error_context/assign.move:20:9

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_err.exp
@@ -6,19 +6,19 @@ error: variant `Circle` not declared in `m::Color`
 16 │         (c is Red|Circle)
    │                   ^^^^^^
 
-error: expected `Color` but found a value of type `Shape`
+error: cannot return `Shape` from a function with result type `Color`
    ┌─ tests/checking/variants/variants_test_err.move:20:19
    │
 20 │         (c is Red|Shape::Circle)
    │                   ^^^^^^^^^^^^^
 
-error: expected `Generic<T>` but found a value of type `Generic<u64>`
+error: cannot return `Generic<u64>` from a function with result type `Generic<T>`
    ┌─ tests/checking/variants/variants_test_err.move:29:15
    │
 29 │         (x is Foo<u64>)
    │               ^^^^^^^^
 
-error: expected `Generic<T>` but found a value of type `Generic<u64>`
+error: cannot return `Generic<u64>` from a function with result type `Generic<T>`
    ┌─ tests/checking/variants/variants_test_err.move:33:22
    │
 33 │         (x is Foo<T>|Bar<u64>)

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_err.exp
@@ -1,0 +1,25 @@
+
+Diagnostics:
+error: variant `Circle` not declared in `m::Color`
+   ┌─ tests/checking/variants/variants_test_err.move:16:19
+   │
+16 │         (c is Red|Circle)
+   │                   ^^^^^^
+
+error: expected `Color` but found a value of type `Shape`
+   ┌─ tests/checking/variants/variants_test_err.move:20:19
+   │
+20 │         (c is Red|Shape::Circle)
+   │                   ^^^^^^^^^^^^^
+
+error: expected `Generic<T>` but found a value of type `Generic<u64>`
+   ┌─ tests/checking/variants/variants_test_err.move:29:15
+   │
+29 │         (x is Foo<u64>)
+   │               ^^^^^^^^
+
+error: expected `Generic<T>` but found a value of type `Generic<u64>`
+   ┌─ tests/checking/variants/variants_test_err.move:33:22
+   │
+33 │         (x is Foo<T>|Bar<u64>)
+   │                      ^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_err.move
@@ -1,0 +1,35 @@
+module 0x815::m {
+
+    enum Color {
+        RGB{red: u64, green: u64, blue: u64},
+        Red,
+        Blue,
+    }
+
+    enum Shape {
+        Quadrant{length: u64},
+        Circle{radius: u64}
+
+    }
+
+    fun test1(c: Color): bool {
+        (c is Red|Circle)
+    }
+
+    fun test2(c: Color): bool {
+        (c is Red|Shape::Circle)
+    }
+
+    enum Generic<T> {
+        Foo(T),
+        Bar(u64)
+    }
+
+    fun test_generic<T>(x: &Generic<T>): bool {
+        (x is Foo<u64>)
+    }
+
+    fun test_generic_qualified<T>(x: &Generic<T>): bool {
+        (x is Foo<T>|Bar<u64>)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_ok.exp
@@ -1,0 +1,35 @@
+// -- Model dump before bytecode pipeline
+module 0x815::m {
+    enum Color {
+        RGB {
+            red: u64,
+            green: u64,
+            blue: u64,
+        }
+        Red,
+        Blue,
+    }
+    enum Generic {
+        Foo {
+            0: #0,
+        }
+        Bar {
+            0: u64,
+        }
+    }
+    private fun test(c: m::Color): bool {
+        test_variants m::Color::Red|RGB(c)
+    }
+    private fun test_fully_qualified(c: m::Color): bool {
+        test_variants m::Color::Red(c)
+    }
+    private fun test_generic<T>(x: &m::Generic<#0>): bool {
+        test_variants m::Generic::Foo<T>(x)
+    }
+    private fun test_generic_qualified<T>(x: &m::Generic<#0>): bool {
+        test_variants m::Generic::Foo<T>(x)
+    }
+    private fun test_qualified(c: m::Color): bool {
+        test_variants m::Color::Red|RGB(c)
+    }
+} // end 0x815::m

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_ok.move
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_ok.move
@@ -1,0 +1,33 @@
+module 0x815::m {
+
+    enum Color {
+        RGB{red: u64, green: u64, blue: u64},
+        Red,
+        Blue,
+    }
+
+    fun test(c: Color): bool {
+        (c is Red|RGB)
+    }
+
+    fun test_qualified(c: Color): bool {
+        (c is Color::Red|RGB)
+    }
+
+    fun test_fully_qualified(c: Color): bool {
+        (c is 0x815::m::Color::Red)
+    }
+
+    enum Generic<T> {
+        Foo(T),
+        Bar(u64)
+    }
+
+    fun test_generic<T>(x: &Generic<T>): bool {
+        (x is Foo<T>)
+    }
+
+    fun test_generic_qualified<T>(x: &Generic<T>): bool {
+        (x is Generic::Foo<T>)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_parse_err1.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_parse_err1.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+error: unexpected token
+   ┌─ tests/checking/variants/variants_test_parse_err1.move:10:19
+   │
+10 │         (c is Red|)
+   │                   ^
+   │                   │
+   │                   Unexpected ')'
+   │                   Expected a type name

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_parse_err1.move
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_parse_err1.move
@@ -1,0 +1,12 @@
+module 0x815::m {
+
+    enum Color {
+        RGB{red: u64, green: u64, blue: u64},
+        Red,
+        Blue,
+    }
+
+    fun test_red_or_rgb(c: Color): bool {
+        (c is Red|)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_parse_err2.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_parse_err2.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+error: unexpected token
+   ┌─ tests/checking/variants/variants_test_parse_err2.move:10:11
+   │
+10 │         c is Red
+   │           ^^
+   │           │
+   │           Unexpected 'is'
+   │           Expected ';'

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_parse_err2.move
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_parse_err2.move
@@ -1,0 +1,12 @@
+module 0x815::m {
+
+    enum Color {
+        RGB{red: u64, green: u64, blue: u64},
+        Red,
+        Blue,
+    }
+
+    fun test_red_or_rgb(c: Color): bool {
+        c is Red
+    }
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_variant_test.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_variant_test.exp
@@ -1,0 +1,7 @@
+processed 3 tasks
+
+task 1 'run'. lines 23-23:
+return values: true
+
+task 2 'run'. lines 25-25:
+return values: true

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_variant_test.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_variant_test.move
@@ -1,0 +1,25 @@
+//# publish
+module 0x42::m {
+
+  enum Data has drop {
+    V1{x: u64},
+    V2{x: u64, y: bool}
+    V3
+  }
+
+  fun test_v1(): bool {
+    let d = Data::V1{x: 43};
+    (d is V1)
+  }
+
+  fun test_v1v3(): bool {
+    let d = Data::V1{x: 43};
+    let t = (d is V1|V3);
+    let d = Data::V3{};
+    t && (d is V1|V3)
+  }
+}
+
+//# run 0x42::m::test_v1
+
+//# run 0x42::m::test_v1v3

--- a/third_party/move/move-compiler/src/expansion/ast.rs
+++ b/third_party/move/move-compiler/src/expansion/ast.rs
@@ -509,6 +509,7 @@ pub enum Exp_ {
 
     Cast(Box<Exp>, Type),
     Annotate(Box<Exp>, Type),
+    Test(Box<Exp>, Vec<Type>),
 
     Spec(SpecId, BTreeSet<Name>, BTreeSet<Name>),
 
@@ -1719,6 +1720,16 @@ impl AstDebug for Exp_ {
                 e.ast_debug(w);
                 w.write(" as ");
                 ty.ast_debug(w);
+                w.write(")");
+            },
+            E::Test(e, tys) => {
+                w.write("(");
+                e.ast_debug(w);
+                w.write(" is ");
+                w.list(tys, "|", |w, item| {
+                    item.ast_debug(w);
+                    false
+                });
                 w.write(")");
             },
             E::Index(oper, index) => {

--- a/third_party/move/move-compiler/src/expansion/dependency_ordering.rs
+++ b/third_party/move/move-compiler/src/expansion/dependency_ordering.rs
@@ -500,6 +500,10 @@ fn exp(context: &mut Context, sp!(_loc, e_): &E::Exp) {
             exp(context, e);
             type_(context, ty)
         },
+        E::Test(e, tys) => {
+            exp(context, e);
+            tys.iter().for_each(|ty| type_(context, ty))
+        },
 
         E::Lambda(ll, e) => {
             lvalues(context, &ll.value);

--- a/third_party/move/move-compiler/src/expansion/translate.rs
+++ b/third_party/move/move-compiler/src/expansion/translate.rs
@@ -2699,6 +2699,10 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
             },
         },
         PE::Cast(e, ty) => EE::Cast(exp(context, *e), type_(context, ty)),
+        PE::Test(e, tys) => EE::Test(
+            exp(context, *e),
+            tys.into_iter().map(|ty| type_(context, ty)).collect(),
+        ),
         PE::Index(e, i) => {
             if context.env.flags().lang_v2() || context.in_spec_context {
                 EE::Index(exp(context, *e), exp(context, *i))
@@ -3206,6 +3210,7 @@ fn unbound_names_exp(unbound: &mut UnboundNames, sp!(_, e_): &E::Exp) {
         | EE::UnaryExp(_, e)
         | EE::Borrow(_, e)
         | EE::Cast(e, _)
+        | EE::Test(e, _)
         | EE::Annotate(e, _) => unbound_names_exp(unbound, e),
         EE::FieldMutate(ed, er) => {
             unbound_names_exp(unbound, er);

--- a/third_party/move/move-compiler/src/naming/translate.rs
+++ b/third_party/move/move-compiler/src/naming/translate.rs
@@ -1107,8 +1107,8 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
             assert!(context.env.has_errors());
             NE::UnresolvedError
         },
-        // Matches variants only allowed in Move 2
-        EE::Match(..) => {
+        // Variants only allowed in Move 2
+        EE::Match(..) | EE::Test(..) => {
             panic!("ICE unexpected Move 2 construct")
         },
         // Matches variants only allowed in specs (we handle the allowed ones above)

--- a/third_party/move/move-compiler/src/parser/ast.rs
+++ b/third_party/move/move-compiler/src/parser/ast.rs
@@ -705,6 +705,9 @@ pub enum Exp_ {
     // (e: t)
     Annotate(Box<Exp>, Type),
 
+    // (e is t1 | .. | tn)
+    Test(Box<Exp>, Vec<Type>),
+
     // spec { ... }
     Spec(SpecBlock),
 
@@ -1931,6 +1934,16 @@ impl AstDebug for Exp_ {
                 e.ast_debug(w);
                 w.write(" as ");
                 ty.ast_debug(w);
+                w.write(")");
+            },
+            E::Test(e, tys) => {
+                w.write("(");
+                e.ast_debug(w);
+                w.write(" is ");
+                w.list(tys, "|", |w, item| {
+                    item.ast_debug(w);
+                    false
+                });
                 w.write(")");
             },
             E::Index(e, i) => {

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -1606,6 +1606,7 @@ pub enum Operation {
         StructId,
         /* fields from different variants */ Vec<FieldId>,
     ),
+    TestVariants(ModuleId, StructId, /* variants */ Vec<Symbol>),
 
     // Specification specific
     SpecFunction(ModuleId, SpecFunId, Option<Vec<MemoryLabel>>),
@@ -2529,6 +2530,7 @@ impl Operation {
             EventStoreIncludedIn => false, // Spec
 
             // Operation with no effect
+            TestVariants(..) => true, // Cannot abort
             NoOp => true,
         }
     }
@@ -3259,6 +3261,17 @@ impl<'a> fmt::Display for OperationDisplay<'a> {
                     "select_variants {}",
                     fids.iter()
                         .map(|fid| self.field_str(mid, sid, fid))
+                        .join("|")
+                )
+            },
+            TestVariants(mid, sid, variants) => {
+                write!(
+                    f,
+                    "test_variants {}::{}",
+                    self.struct_str(mid, sid),
+                    variants
+                        .iter()
+                        .map(|v| v.display(self.env.symbol_pool()).to_string())
                         .join("|")
                 )
             },

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -981,6 +981,24 @@ impl Type {
         }
     }
 
+    /// Drop reference, consuming the type.
+    pub fn drop_reference(self) -> Type {
+        if let Type::Reference(_, bt) = self {
+            *bt
+        } else {
+            self
+        }
+    }
+
+    /// If this is a reference, return its kind.
+    pub fn try_reference_kind(&self) -> Option<ReferenceKind> {
+        if let Type::Reference(k, _) = self {
+            Some(*k)
+        } else {
+            None
+        }
+    }
+
     /// If this is a struct type, replace the type instantiation.
     pub fn replace_struct_instantiation(&self, inst: &[Type]) -> Type {
         match self {

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -857,7 +857,11 @@ impl<'env> SpecTranslator<'env> {
             },
             Operation::SelectVariants(_module_id, _struct_id, _field_ids) => {
                 // TODO(#13806): implement for variants
-                self.error(&loc, "variants no yet supported");
+                self.error(&loc, "selection from variants no yet supported");
+            },
+            Operation::TestVariants(_module_id, _struct_id, _variants) => {
+                // TODO(#13806): implement for variants
+                self.error(&loc, "testing of variants no yet supported");
             },
             Operation::UpdateField(module_id, struct_id, field_id) => {
                 self.translate_update_field(node_id, *module_id, *struct_id, *field_id, args)


### PR DESCRIPTION
## Description
 This adds the last missing feature to enums, namely the variant test `x is Foo::Variant`.
    
- Extends the parser and expansion phase
- Extends checker, introducing a new Exp `Operation::TestVariants`
 - Extends the bytecode generator to map this down to the (existing) TestVariant opcode

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Tests have been added for the various stages of the pipeline
