### PR TITLE
[move-compiler-v2] Restrict usage of mutably borrowed locals in branch conditions

### DIFF
--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13973_branch_cond_borrowed.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13973_branch_cond_borrowed.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: cannot use local `x` which is still mutably borrowed as branch condition
+  ┌─ tests/reference-safety/bug_13973_branch_cond_borrowed.move:4:9
+  │
+3 │           let y: &mut bool =  &mut x;
+  │                               ------ previous mutable local borrow
+4 │ ╭         if (x) {
+5 │ │         } else {
+6 │ │             *y= false;
+  │ │             --------- conflicting reference `y` used here
+7 │ │         };
+  │ ╰─────────^ used in this context

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13973_branch_cond_borrowed.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13973_branch_cond_borrowed.exp
@@ -11,3 +11,14 @@ error: cannot use local `x` which is still mutably borrowed as branch condition
   │ │             --------- conflicting reference `y` used here
 7 │ │         };
   │ ╰─────────^ used in this context
+
+error: cannot use local `x` which is still mutably borrowed as branch condition
+   ┌─ tests/reference-safety/bug_13973_branch_cond_borrowed.move:13:9
+   │
+12 │           let y: &mut bool =  &mut x;
+   │                               ------ previous mutable local borrow
+13 │ ╭         while (x) {
+14 │ │             *y= false;
+   │ │             --------- conflicting reference `y` used here
+15 │ │         };
+   │ ╰─────────^ used in this context

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13973_branch_cond_borrowed.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13973_branch_cond_borrowed.move
@@ -7,4 +7,13 @@ module 0xCAFE::Module0 {
         };
         if (copy x) { } else { };
     }
+
+    public fun f2(x: bool) {
+        let y: &mut bool =  &mut x;
+        while (x) {
+            *y= false;
+        };
+        if (copy x) { } else { };
+    }
+
 }

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13973_branch_cond_borrowed.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13973_branch_cond_borrowed.move
@@ -1,0 +1,10 @@
+module 0xCAFE::Module0 {
+    public fun f1(x: bool) {
+        let y: &mut bool =  &mut x;
+        if (x) {
+        } else {
+            *y= false;
+        };
+        if (copy x) { } else { };
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13973_branch_cond_borrowed.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13973_branch_cond_borrowed.no-opt.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: cannot use local `x` which is still mutably borrowed as branch condition
+  ┌─ tests/reference-safety/bug_13973_branch_cond_borrowed.move:4:9
+  │
+3 │           let y: &mut bool =  &mut x;
+  │                               ------ previous mutable local borrow
+4 │ ╭         if (x) {
+5 │ │         } else {
+6 │ │             *y= false;
+  │ │             --------- conflicting reference `y` used here
+7 │ │         };
+  │ ╰─────────^ used in this context

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13973_branch_cond_borrowed.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13973_branch_cond_borrowed.no-opt.exp
@@ -11,3 +11,14 @@ error: cannot use local `x` which is still mutably borrowed as branch condition
   │ │             --------- conflicting reference `y` used here
 7 │ │         };
   │ ╰─────────^ used in this context
+
+error: cannot use local `x` which is still mutably borrowed as branch condition
+   ┌─ tests/reference-safety/bug_13973_branch_cond_borrowed.move:13:9
+   │
+12 │           let y: &mut bool =  &mut x;
+   │                               ------ previous mutable local borrow
+13 │ ╭         while (x) {
+14 │ │             *y= false;
+   │ │             --------- conflicting reference `y` used here
+15 │ │         };
+   │ ╰─────────^ used in this context

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -281,7 +281,7 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             dump_ast: DumpLevel::None,
             dump_bytecode: DumpLevel::None,
             dump_bytecode_filter:
-            // For debugging:
+            // For debugging (dump_bytecode set DumpLevel::AllStages)
              Some(vec![
                INITIAL_BYTECODE_STAGE,
                "ReferenceSafetyProcessor",


### PR DESCRIPTION
## Description

Fixes #13973.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

New test from the bug

