### PR TITLE
[compiler-v2] Add test cases for a number of reference safety bugs

### DIFF
--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_12394.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_12394.exp
@@ -1,0 +1,23 @@
+
+Diagnostics:
+warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+  ┌─ tests/reference-safety/bug_12394.move:9:18
+  │
+9 │         (x, y) = t2(&mut 3, &mut 4);
+  │                  ^^^^^^^^^^^^^^^^^^
+
+warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+  ┌─ tests/reference-safety/bug_12394.move:9:18
+  │
+9 │         (x, y) = t2(&mut 3, &mut 4);
+  │                  ^^^^^^^^^^^^^^^^^^
+
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `STLOC_TYPE_MISMATCH_ERROR`. This is a compiler bug, consider reporting it.
+  ┌─ tests/reference-safety/bug_12394.move:9:18
+  │
+9 │         (x, y) = t2(&mut 3, &mut 4);
+  │                  ^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_12394.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_12394.move
@@ -1,0 +1,11 @@
+// TODO(#12394): after fix, rename file to reflect issue (`bug_nnn.move` to `bug_nnn_<issue>.move`)
+module 0x815::m {
+    fun t2(u1: &mut u64, u2: &mut u64): (&mut u64, &mut u64) {
+        (u1, u2)
+    }
+    fun test_4() {
+        let x: &u64;
+        let y: &u64;
+        (x, y) = t2(&mut 3, &mut 4);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_12394.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_12394.no-opt.exp
@@ -1,0 +1,23 @@
+
+Diagnostics:
+warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+  ┌─ tests/reference-safety/bug_12394.move:9:18
+  │
+9 │         (x, y) = t2(&mut 3, &mut 4);
+  │                  ^^^^^^^^^^^^^^^^^^
+
+warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+  ┌─ tests/reference-safety/bug_12394.move:9:18
+  │
+9 │         (x, y) = t2(&mut 3, &mut 4);
+  │                  ^^^^^^^^^^^^^^^^^^
+
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `STLOC_TYPE_MISMATCH_ERROR`. This is a compiler bug, consider reporting it.
+  ┌─ tests/reference-safety/bug_12394.move:9:18
+  │
+9 │         (x, y) = t2(&mut 3, &mut 4);
+  │                  ^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13149.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13149.exp
@@ -1,0 +1,9 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `WRITEREF_EXISTS_BORROW_ERROR`. This is a compiler bug, consider reporting it.
+  ┌─ tests/reference-safety/bug_13149.move:7:9
+  │
+7 │         *r2 = 2;
+  │         ^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13149.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13149.move
@@ -1,0 +1,10 @@
+// TODO(#13149): after fix, rename file to reflect issue (`bug_nnn.move` to `bug_nnn_<issue>.move`)
+module 0x815::m {
+    fun t1() {
+        let a = 0;
+        let r1 = &mut a;
+        let r2 = &mut a;
+        *r2 = 2;
+        *r1 = 1;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13149.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13149.no-opt.exp
@@ -1,0 +1,9 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `WRITEREF_EXISTS_BORROW_ERROR`. This is a compiler bug, consider reporting it.
+  ┌─ tests/reference-safety/bug_13149.move:7:9
+  │
+7 │         *r2 = 2;
+  │         ^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13488.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13488.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13488.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13488.move
@@ -1,0 +1,17 @@
+// TODO(#13488): after fix, rename file to reflect issue (`bug_nnn.move` to `bug_nnn_<issue>.move`)
+module 0x8675309::Tester {
+    fun t() {
+        let x = 0;
+        let y = 0;
+        let r1 = foo(&x, &y);
+        let r2 = foo(&x, &y);
+        x + copy x;
+        y + copy y;
+        r1;
+        r2;
+    }
+
+    fun foo(_r: &u64, r2: &u64): &u64 {
+        r2
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13488.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13488.no-opt.exp
@@ -1,0 +1,9 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+error: reference safety check failed on bytecode level. This is a known issue, to be fixed later, resulting from differences between safety rules of the v1 and v2 compiler. Try to rewrite your code to workaround this problem.
+  ┌─ tests/reference-safety/bug_13488.move:8:9
+  │
+8 │         x + copy x;
+  │         ^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13687.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13687.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13687.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13687.move
@@ -1,0 +1,22 @@
+// TODO(#13912): after fix, rename file to reflect issue (`bug_nnn.move` to `bug_nnn_<issue>.move`)
+module 0xCAFE::Module1 {
+    struct Struct3 has drop, copy {
+        var32: u16,
+        var33: u32,
+        var34: u8,
+        var35: u32,
+        var36: u32,
+    }
+
+    public fun function6(): Struct3 {
+        let var44: u16 =  21859u16;
+        let var45: u32 =  1399722001u32;
+        Struct3 {
+            var32: var44,
+            var33: var45,
+            var34: 154u8,
+            var35: var45,
+            var36: var45,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13687.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13687.no-opt.exp
@@ -1,0 +1,15 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `MOVELOC_UNAVAILABLE_ERROR`. This is a compiler bug, consider reporting it.
+   ┌─ tests/reference-safety/bug_13687.move:14:9
+   │
+14 │ ╭         Struct3 {
+15 │ │             var32: var44,
+16 │ │             var33: var45,
+17 │ │             var34: 154u8,
+18 │ │             var35: var45,
+19 │ │             var36: var45,
+20 │ │         }
+   │ ╰─────────^

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13912.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13912.exp
@@ -1,0 +1,12 @@
+
+Diagnostics:
+error: cannot copy local `var4` which is still mutably borrowed
+  ┌─ tests/reference-safety/bug_13912.move:5:30
+  │
+5 │         (&mut (var4) != &mut (copy var4))
+  │         ---------------------^^^^^^^^^^^-
+  │         ││                   │
+  │         ││                   copied here
+  │         │previous mutable local borrow
+  │         │used by freeze
+  │         conflicting reference used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13912.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13912.move
@@ -1,0 +1,7 @@
+// TODO(#13912): after fix, rename file to reflect issue (`bug_nnn.move` to `bug_nnn_<issue>.move`)
+module 0xCAFE::Module0 {
+    // Expected to succeed without borrow errors
+    public fun function2(var4: u8): bool {
+        (&mut (var4) != &mut (copy var4))
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13912.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13912.no-opt.exp
@@ -1,0 +1,12 @@
+
+Diagnostics:
+error: cannot copy local `var4` which is still mutably borrowed
+  ┌─ tests/reference-safety/bug_13912.move:5:30
+  │
+5 │         (&mut (var4) != &mut (copy var4))
+  │         ---------------------^^^^^^^^^^^-
+  │         ││                   │
+  │         ││                   copied here
+  │         │previous mutable local borrow
+  │         │used by freeze
+  │         conflicting reference used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13927.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13927.exp
@@ -1,0 +1,9 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `FREEZEREF_EXISTS_MUTABLE_BORROW_ERROR`. This is a compiler bug, consider reporting it.
+  ┌─ tests/reference-safety/bug_13927.move:9:28
+  │
+9 │         let returned_ref = foo(result);
+  │                            ^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13927.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13927.move
@@ -1,0 +1,13 @@
+// TODO(#13927): after fix, rename file to reflect issue (`bug_nnn.move` to `bug_nnn_<issue>.move`)
+module 0x8675309::Tester {
+
+    fun foo(_other: &mut u64): &mut u64 {
+        _other
+    }
+
+    fun test(result: &mut u64): &u64 {
+        let returned_ref = foo(result);
+        freeze(result);
+        returned_ref
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13927.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13927.no-opt.exp
@@ -1,0 +1,9 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `FREEZEREF_EXISTS_MUTABLE_BORROW_ERROR`. This is a compiler bug, consider reporting it.
+   ┌─ tests/reference-safety/bug_13927.move:10:9
+   │
+10 │         freeze(result);
+   │         ^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13952.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13952.exp
@@ -1,0 +1,18 @@
+
+Diagnostics:
+warning: Unused local variable `var67`. Consider removing or prefixing with an underscore: `_var67`
+  ┌─ tests/reference-safety/bug_13952.move:8:13
+  │
+8 │         let var67 =  (&(var21) != &((var21 || var23)));
+  │             ^^^^^
+
+
+Diagnostics:
+warning: Unused assignment to `var67`. Consider removing or prefixing with an underscore: `_var67`
+  ┌─ tests/reference-safety/bug_13952.move:8:22
+  │
+8 │         let var67 =  (&(var21) != &((var21 || var23)));
+  │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13952.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13952.move
@@ -1,0 +1,13 @@
+// TODO(#13952): after fix, rename file to reflect issue (`bug_nnn.move` to `bug_nnn_<issue>.move`)
+module 0xCAFE::Module0 {
+    struct Struct0 has drop, copy {
+        x: bool,
+    }
+
+    public fun function5(var21: bool, var23: bool) {
+        let var67 =  (&(var21) != &((var21 || var23)));
+        Struct0 {
+            x: var21
+        };
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13952.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13952.no-opt.exp
@@ -1,0 +1,25 @@
+
+Diagnostics:
+warning: Unused local variable `var67`. Consider removing or prefixing with an underscore: `_var67`
+  ┌─ tests/reference-safety/bug_13952.move:8:13
+  │
+8 │         let var67 =  (&(var21) != &((var21 || var23)));
+  │             ^^^^^
+
+
+Diagnostics:
+warning: Unused assignment to `var67`. Consider removing or prefixing with an underscore: `_var67`
+  ┌─ tests/reference-safety/bug_13952.move:8:22
+  │
+8 │         let var67 =  (&(var21) != &((var21 || var23)));
+  │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `STLOC_UNSAFE_TO_DESTROY_ERROR`. This is a compiler bug, consider reporting it.
+  ┌─ tests/reference-safety/bug_13952.move:8:36
+  │
+8 │         let var67 =  (&(var21) != &((var21 || var23)));
+  │                                    ^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13976.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13976.exp
@@ -1,0 +1,9 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `CALL_BORROWED_MUTABLE_REFERENCE_ERROR`. This is a compiler bug, consider reporting it.
+   ┌─ tests/reference-safety/bug_13976.move:12:13
+   │
+12 │             lifted_lambda(&mut a, z))
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13976.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13976.move
@@ -1,0 +1,14 @@
+// TODO(#13976): after fix, rename file to reflect issue (`bug_nnn.move` to `bug_nnn_<issue>.move`)
+module 0x815::m {
+    fun lifted_lambda(ap: &mut u64, z: u64): u64 {
+        *ap = *ap + 1;
+        z * *ap
+    }
+
+    entry fun foo2(): u64 {
+        let a = 2;
+        let z = 3;
+        lifted_lambda(&mut a,
+            lifted_lambda(&mut a, z))
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13976.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13976.no-opt.exp
@@ -1,0 +1,9 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `CALL_BORROWED_MUTABLE_REFERENCE_ERROR`. This is a compiler bug, consider reporting it.
+   ┌─ tests/reference-safety/bug_13976.move:12:13
+   │
+12 │             lifted_lambda(&mut a, z))
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_14060.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_14060.exp
@@ -1,0 +1,9 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `EQUALITY_OP_TYPE_MISMATCH_ERROR`. This is a compiler bug, consider reporting it.
+  ┌─ tests/reference-safety/bug_14060.move:6:9
+  │
+6 │         x != copy y;
+  │         ^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_14060.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_14060.move
@@ -1,0 +1,8 @@
+// TODO(#14060): after fix, rename file to reflect issue (`bug_nnn.move` to `bug_nnn_<issue>.move`)
+module 0xCAFE::Module0 {
+    public fun f() {
+        let x = &mut 0u8;
+        let y = &mut 1u8;
+        x != copy y;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_14060.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_14060.no-opt.exp
@@ -1,0 +1,9 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `EQUALITY_OP_TYPE_MISMATCH_ERROR`. This is a compiler bug, consider reporting it.
+  ┌─ tests/reference-safety/bug_14060.move:6:9
+  │
+6 │         x != copy y;
+  │         ^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_14096.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_14096.exp
@@ -1,0 +1,18 @@
+
+Diagnostics:
+error: mutable reference in local `x` requires exclusive access but is borrowed
+  ┌─ tests/reference-safety/bug_14096.move:6:20
+  │
+6 │         (copy x == copy x);
+  │         -----------^^^^^^-
+  │         │          │
+  │         │          requirement enforced here
+  │         conflicting reference used here
+
+error: same mutable reference in value is also used in other value in argument list
+  ┌─ tests/reference-safety/bug_14096.move:6:9
+  │
+5 │         let x = &mut 0u8;
+  │                 -------- previous mutable local borrow
+6 │         (copy x == copy x);
+  │         ^^^^^^^^^^^^^^^^^^ requirement enforced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_14096.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_14096.move
@@ -1,0 +1,8 @@
+// TODO(#14096): after fix, rename file to reflect issue (`bug_nnn.move` to `bug_nnn_<issue>.move`)
+module 0xCAFE::Module0 {
+    // Expected to compile without errors
+    public fun function2() {
+        let x = &mut 0u8;
+        (copy x == copy x);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_14096.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_14096.no-opt.exp
@@ -1,0 +1,18 @@
+
+Diagnostics:
+error: mutable reference in local `x` requires exclusive access but is borrowed
+  ┌─ tests/reference-safety/bug_14096.move:6:20
+  │
+6 │         (copy x == copy x);
+  │         -----------^^^^^^-
+  │         │          │
+  │         │          requirement enforced here
+  │         conflicting reference used here
+
+error: same mutable reference in value is also used in other value in argument list
+  ┌─ tests/reference-safety/bug_14096.move:6:9
+  │
+5 │         let x = &mut 0u8;
+  │                 -------- previous mutable local borrow
+6 │         (copy x == copy x);
+  │         ^^^^^^^^^^^^^^^^^^ requirement enforced here

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.move
@@ -1,0 +1,14 @@
+// TODO(#14243)
+//# print-bytecode --input=module
+module 0xc0ffee::m {
+   fun id_mut<T>(r: &mut T): &mut T {
+        r
+    }
+
+    fun t0() {
+        let x = &mut 0;
+        let y = id_mut(x);
+        *y;
+        *x;
+    }
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.no-optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.no-optimize.exp
@@ -1,0 +1,47 @@
+comparison between v1 and v2 failed:
+= processed 1 task
+= 
+= task 0 'print-bytecode'. lines 2-14:
+- // Move bytecode v6
++ // Move bytecode v7
+= module c0ffee.m {
+= 
+= 
+= id_mut<Ty0>(Arg0: &mut Ty0): &mut Ty0 /* def_idx: 0 */ {
++ L1:	loc0: &mut Ty0
+= B0:
+= 	0: MoveLoc[0](Arg0: &mut Ty0)
+- 	1: Ret
++ 	1: StLoc[1](loc0: &mut Ty0)
++ 	2: MoveLoc[1](loc0: &mut Ty0)
++ 	3: Ret
+= }
+= t0() /* def_idx: 1 */ {
+= L0:	loc0: u64
+= L1:	loc1: &mut u64
++ L2:	loc2: &mut u64
+= B0:
+= 	0: LdU64(0)
+= 	1: StLoc[0](loc0: u64)
+= 	2: MutBorrowLoc[0](loc0: u64)
+= 	3: StLoc[1](loc1: &mut u64)
+= 	4: CopyLoc[1](loc1: &mut u64)
+- 	5: Call id_mut<u64>(&mut u64): &mut u64
+- 	6: ReadRef
+- 	7: Pop
+- 	8: MoveLoc[1](loc1: &mut u64)
+- 	9: ReadRef
+- 	10: Pop
+- 	11: Ret
++ 	5: StLoc[2](loc2: &mut u64)
++ 	6: MoveLoc[2](loc2: &mut u64)
++ 	7: Call id_mut<u64>(&mut u64): &mut u64
++ 	8: ReadRef
++ 	9: MoveLoc[1](loc1: &mut u64)
++ 	10: ReadRef
++ 	11: Pop
++ 	12: Pop
++ 	13: Ret
+= }
+= }
+= 

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.optimize-no-simplify.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.optimize-no-simplify.exp
@@ -1,0 +1,37 @@
+comparison between v1 and v2 failed:
+= processed 1 task
+= 
+= task 0 'print-bytecode'. lines 2-14:
+- // Move bytecode v6
++ // Move bytecode v7
+= module c0ffee.m {
+= 
+= 
+= id_mut<Ty0>(Arg0: &mut Ty0): &mut Ty0 /* def_idx: 0 */ {
+= B0:
+= 	0: MoveLoc[0](Arg0: &mut Ty0)
+= 	1: Ret
+= }
+= t0() /* def_idx: 1 */ {
+= L0:	loc0: u64
+= L1:	loc1: &mut u64
++ L2:	loc2: &mut u64
+= B0:
+= 	0: LdU64(0)
+= 	1: StLoc[0](loc0: u64)
+= 	2: MutBorrowLoc[0](loc0: u64)
+= 	3: StLoc[1](loc1: &mut u64)
+= 	4: CopyLoc[1](loc1: &mut u64)
+= 	5: Call id_mut<u64>(&mut u64): &mut u64
+= 	6: ReadRef
+- 	7: Pop
+- 	8: MoveLoc[1](loc1: &mut u64)
+- 	9: ReadRef
++ 	7: MoveLoc[1](loc1: &mut u64)
++ 	8: ReadRef
++ 	9: Pop
+= 	10: Pop
+= 	11: Ret
+= }
+= }
+= 

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.optimize.exp
@@ -1,0 +1,37 @@
+comparison between v1 and v2 failed:
+= processed 1 task
+= 
+= task 0 'print-bytecode'. lines 2-14:
+- // Move bytecode v6
++ // Move bytecode v7
+= module c0ffee.m {
+= 
+= 
+= id_mut<Ty0>(Arg0: &mut Ty0): &mut Ty0 /* def_idx: 0 */ {
+= B0:
+= 	0: MoveLoc[0](Arg0: &mut Ty0)
+= 	1: Ret
+= }
+= t0() /* def_idx: 1 */ {
+= L0:	loc0: u64
+= L1:	loc1: &mut u64
++ L2:	loc2: &mut u64
+= B0:
+= 	0: LdU64(0)
+= 	1: StLoc[0](loc0: u64)
+= 	2: MutBorrowLoc[0](loc0: u64)
+= 	3: StLoc[1](loc1: &mut u64)
+= 	4: CopyLoc[1](loc1: &mut u64)
+= 	5: Call id_mut<u64>(&mut u64): &mut u64
+= 	6: ReadRef
+- 	7: Pop
+- 	8: MoveLoc[1](loc1: &mut u64)
+- 	9: ReadRef
++ 	7: MoveLoc[1](loc1: &mut u64)
++ 	8: ReadRef
++ 	9: Pop
+= 	10: Pop
+= 	11: Ret
+= }
+= }
+= 

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
@@ -96,6 +96,7 @@ const SEPARATE_BASELINE: &[&str] = &[
     "constants/large_vectors.move",
     // Printing bytecode is different depending on optimizations
     "no-v1-comparison/print_bytecode.move",
+    "bug_14243_stack_size.move",
     // The output of the tests could be different depending on the language version
     "/operator_eval/",
     // Creates different code if optimized


### PR DESCRIPTION
## Description

This adds the reproducing test cases for all the urgent and some high priority bugs related to reference safety. Some of those issues have overlaps, so its good to see all tests in place and the effect of a given change. The tests are marked with the `TODO(#nnn)` code marker for discoverability.
    
There is also a test for an issue related to v1/v2 used stack size.


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Thesa are tests

