### PR TITLE
[compiler-v2] Stackless bytecode instruction reordering optimization

### DIFF
--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/diamond_clicker.v2_exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/diamond_clicker.v2_exp
@@ -16,54 +16,50 @@ struct OuterStruct has key {
 
 entry public test_upgrade(Arg0: &signer) /* def_idx: 0 */ {
 L1:	loc0: &signer
-L2:	loc1: OuterStruct
-L3:	loc2: &mut vector<InnerStruct>
+L2:	loc1: &mut vector<InnerStruct>
+L3:	loc2: u64
 L4:	loc3: u64
-L5:	loc4: u64
-L6:	loc5: &mut vector<InnerStruct>
-L7:	loc6: u64
+L5:	loc4: &mut vector<InnerStruct>
 B0:
 	0: CopyLoc[0](Arg0: &signer)
 	1: Call signer::address_of(&signer): address
-	2: VecPack(3, 0)
-	3: Pack[1](OuterStruct)
-	4: StLoc[2](loc1: OuterStruct)
-	5: MoveLoc[0](Arg0: &signer)
-	6: MoveLoc[2](loc1: OuterStruct)
-	7: MoveTo[1](OuterStruct)
-	8: MutBorrowGlobal[1](OuterStruct)
-	9: MutBorrowField[0](OuterStruct.any_field: vector<InnerStruct>)
-	10: StLoc[3](loc2: &mut vector<InnerStruct>)
-	11: LdU64(0)
-	12: CopyLoc[3](loc2: &mut vector<InnerStruct>)
-	13: FreezeRef
-	14: VecLen(3)
-	15: StLoc[4](loc3: u64)
-	16: StLoc[5](loc4: u64)
+	2: MoveLoc[0](Arg0: &signer)
+	3: VecPack(3, 0)
+	4: Pack[1](OuterStruct)
+	5: MoveTo[1](OuterStruct)
+	6: MutBorrowGlobal[1](OuterStruct)
+	7: MutBorrowField[0](OuterStruct.any_field: vector<InnerStruct>)
+	8: StLoc[2](loc1: &mut vector<InnerStruct>)
+	9: LdU64(0)
+	10: StLoc[3](loc2: u64)
+	11: CopyLoc[2](loc1: &mut vector<InnerStruct>)
+	12: FreezeRef
+	13: VecLen(3)
+	14: StLoc[4](loc3: u64)
 B1:
-	17: CopyLoc[5](loc4: u64)
-	18: CopyLoc[4](loc3: u64)
-	19: Lt
-	20: BrFalse(31)
+	15: CopyLoc[3](loc2: u64)
+	16: CopyLoc[4](loc3: u64)
+	17: Lt
+	18: BrFalse(29)
 B2:
-	21: CopyLoc[3](loc2: &mut vector<InnerStruct>)
-	22: CopyLoc[5](loc4: u64)
-	23: VecMutBorrow(3)
-	24: FreezeRef
-	25: Call debug::print<InnerStruct>(&InnerStruct)
-	26: MoveLoc[5](loc4: u64)
-	27: LdU64(1)
-	28: Add
-	29: StLoc[5](loc4: u64)
-	30: Branch(34)
+	19: CopyLoc[2](loc1: &mut vector<InnerStruct>)
+	20: CopyLoc[3](loc2: u64)
+	21: VecMutBorrow(3)
+	22: FreezeRef
+	23: Call debug::print<InnerStruct>(&InnerStruct)
+	24: MoveLoc[3](loc2: u64)
+	25: LdU64(1)
+	26: Add
+	27: StLoc[3](loc2: u64)
+	28: Branch(32)
 B3:
-	31: MoveLoc[3](loc2: &mut vector<InnerStruct>)
-	32: Pop
-	33: Branch(35)
+	29: MoveLoc[2](loc1: &mut vector<InnerStruct>)
+	30: Pop
+	31: Branch(33)
 B4:
-	34: Branch(17)
+	32: Branch(15)
 B5:
-	35: Ret
+	33: Ret
 }
 }
 

--- a/third_party/move/evm/move-to-yul/src/functions.rs
+++ b/third_party/move/evm/move-to-yul/src/functions.rs
@@ -452,9 +452,9 @@ impl<'a> FunctionGenerator<'a> {
                         print_loc();
                         self.write_ref(
                             ctx,
-                            &get_local_type(srcs[1]),
-                            local(&srcs[0]),
+                            &get_local_type(srcs[0]),
                             local(&srcs[1]),
+                            local(&srcs[0]),
                         )
                     },
                     // FreezeRef transforms a mutable reference to an immutable one so just
@@ -557,6 +557,7 @@ impl<'a> FunctionGenerator<'a> {
 
                     // Specification or other operations which can be ignored here
                     Release
+                    | Prepare
                     | GetField(_, _, _, _)
                     | GetGlobal(_, _, _)
                     | IsParent(_, _)

--- a/third_party/move/evm/move-to-yul/tests/AccountStateMachine.exp
+++ b/third_party/move/evm/move-to-yul/tests/AccountStateMachine.exp
@@ -368,7 +368,7 @@ object "A3_AccountStateMachine" {
                         $t10 := $AddU64($t9, v)
                         // $t11 := borrow_field<AccountStateMachine::Account>.value($t0)
                         $t11 := $IndexPtr(this, 32)
-                        // write_ref($t11, $t10)
+                        // write_ref($t10, $t11)
                         $StoreU64($t11, $t10)
                         // return ()
                         leave
@@ -416,7 +416,7 @@ object "A3_AccountStateMachine" {
                         $t8 := $Sub($t7, v)
                         // $t9 := borrow_field<AccountStateMachine::Account>.value($t0)
                         $t9 := $IndexPtr(this, 32)
-                        // write_ref($t9, $t8)
+                        // write_ref($t8, $t9)
                         $StoreU64($t9, $t8)
                         // return ()
                         leave
@@ -792,7 +792,7 @@ object "A3_AccountStateMachine" {
                 $t6 := 1
                 // $t7 := +($t5, $t6)
                 $t7 := $AddU64($t5, $t6)
-                // write_ref($t3, $t7)
+                // write_ref($t7, $t3)
                 $StoreU64($t3, $t7)
                 // return $t4
                 $result := $t4

--- a/third_party/move/evm/move-to-yul/tests/AccountStateMachine.v2_exp
+++ b/third_party/move/evm/move-to-yul/tests/AccountStateMachine.v2_exp
@@ -368,7 +368,7 @@ object "A3_AccountStateMachine" {
                         $t10 := $AddU64($t9, v)
                         // $t11 := borrow_field<AccountStateMachine::Account>.value($t0)
                         $t11 := $IndexPtr(this, 32)
-                        // write_ref($t11, $t10)
+                        // write_ref($t10, $t11)
                         $StoreU64($t11, $t10)
                         // return ()
                         leave
@@ -416,7 +416,7 @@ object "A3_AccountStateMachine" {
                         $t8 := $Sub($t7, v)
                         // $t9 := borrow_field<AccountStateMachine::Account>.value($t0)
                         $t9 := $IndexPtr(this, 32)
-                        // write_ref($t9, $t8)
+                        // write_ref($t8, $t9)
                         $StoreU64($t9, $t8)
                         // return ()
                         leave
@@ -792,7 +792,7 @@ object "A3_AccountStateMachine" {
                 $t6 := 1
                 // $t7 := +($t5, $t6)
                 $t7 := $AddU64($t5, $t6)
-                // write_ref($t3, $t7)
+                // write_ref($t7, $t3)
                 $StoreU64($t3, $t7)
                 // return $t4
                 $result := $t4

--- a/third_party/move/evm/move-to-yul/tests/GlobalVectors.exp
+++ b/third_party/move/evm/move-to-yul/tests/GlobalVectors.exp
@@ -144,7 +144,7 @@ object "test_A2_GlobalVectors_test_borrow_mut_global" {
                     $t17 := A1_vector_borrow_mut$u64$($t15, $t16)
                     // $t18 := 12
                     $t18 := 12
-                    // write_ref($t17, $t18)
+                    // write_ref($t18, $t17)
                     $StoreU64($t17, $t18)
                     // $t19 := 0x42
                     $t19 := 0x42

--- a/third_party/move/evm/move-to-yul/tests/GlobalVectors.v2_exp
+++ b/third_party/move/evm/move-to-yul/tests/GlobalVectors.v2_exp
@@ -144,7 +144,7 @@ object "test_A2_GlobalVectors_test_borrow_mut_global" {
                     $t17 := A1_vector_borrow_mut$u64$($t15, $t16)
                     // $t18 := 12
                     $t18 := 12
-                    // write_ref($t17, $t18)
+                    // write_ref($t18, $t17)
                     $StoreU64($t17, $t18)
                     // $t19 := 0x42
                     $t19 := 0x42

--- a/third_party/move/evm/move-to-yul/tests/Locals.exp
+++ b/third_party/move/evm/move-to-yul/tests/Locals.exp
@@ -53,7 +53,7 @@ object "A2_M" {
                 $t11 := 1
                 // $t12 := +($t10, $t11)
                 $t12 := $AddU64($t10, $t11)
-                // write_ref($t8, $t12)
+                // write_ref($t12, $t8)
                 $StoreU64($t8, $t12)
                 // $t13 := move($t0)
                 $t13 := mload($locals)
@@ -318,7 +318,7 @@ object "test_A2_M_test_call_by_ref" {
             let $t1
             // $t1 := 2
             $t1 := 2
-            // write_ref($t0, $t1)
+            // write_ref($t1, $t0)
             $StoreU64(a, $t1)
             // return ()
         }
@@ -562,7 +562,7 @@ object "test_A2_M_test_evaded" {
             $t11 := 1
             // $t12 := +($t10, $t11)
             $t12 := $AddU64($t10, $t11)
-            // write_ref($t8, $t12)
+            // write_ref($t12, $t8)
             $StoreU64($t8, $t12)
             // $t13 := move($t0)
             $t13 := mload($locals)

--- a/third_party/move/evm/move-to-yul/tests/Locals.v2_exp
+++ b/third_party/move/evm/move-to-yul/tests/Locals.v2_exp
@@ -53,7 +53,7 @@ object "A2_M" {
                 $t11 := 1
                 // $t12 := +($t10, $t11)
                 $t12 := $AddU64($t10, $t11)
-                // write_ref($t8, $t12)
+                // write_ref($t12, $t8)
                 $StoreU64($t8, $t12)
                 // $t13 := move($t0)
                 $t13 := mload($locals)
@@ -318,7 +318,7 @@ object "test_A2_M_test_call_by_ref" {
             let $t1
             // $t1 := 2
             $t1 := 2
-            // write_ref($t0, $t1)
+            // write_ref($t1, $t0)
             $StoreU64(a, $t1)
             // return ()
         }
@@ -562,7 +562,7 @@ object "test_A2_M_test_evaded" {
             $t11 := 1
             // $t12 := +($t10, $t11)
             $t12 := $AddU64($t10, $t11)
-            // write_ref($t8, $t12)
+            // write_ref($t12, $t8)
             $StoreU64($t8, $t12)
             // $t13 := move($t0)
             $t13 := mload($locals)

--- a/third_party/move/evm/move-to-yul/tests/Resources.exp
+++ b/third_party/move/evm/move-to-yul/tests/Resources.exp
@@ -131,7 +131,7 @@ object "test_A2_M_test_increment_a" {
             $t6 := $AddU64($t4, $t5)
             // $t7 := borrow_field<M::S>.a($t2)
             $t7 := $IndexPtr($t2, 32)
-            // write_ref($t7, $t6)
+            // write_ref($t6, $t7)
             $StoreU64($t7, $t6)
             // return ()
         }

--- a/third_party/move/evm/move-to-yul/tests/Resources.exp.capture-source-info
+++ b/third_party/move/evm/move-to-yul/tests/Resources.exp.capture-source-info
@@ -159,7 +159,7 @@ object "test_A2_M_test_increment_a" {
             // $t7 := borrow_field<M::S>.a($t2)
             /// @src 1:1142:1145
             $t7 := $IndexPtr($t2, 32)
-            // write_ref($t7, $t6)
+            // write_ref($t6, $t7)
             /// @src 1:1142:1155
             $StoreU64($t7, $t6)
             // return ()

--- a/third_party/move/evm/move-to-yul/tests/Resources.v2_exp
+++ b/third_party/move/evm/move-to-yul/tests/Resources.v2_exp
@@ -131,7 +131,7 @@ object "test_A2_M_test_increment_a" {
             $t6 := $AddU64($t4, $t5)
             // $t7 := borrow_field<M::S>.a($t2)
             $t7 := $IndexPtr($t2, 32)
-            // write_ref($t7, $t6)
+            // write_ref($t6, $t7)
             $StoreU64($t7, $t6)
             // return ()
         }

--- a/third_party/move/evm/move-to-yul/tests/Resources.v2_exp.capture-source-info
+++ b/third_party/move/evm/move-to-yul/tests/Resources.v2_exp.capture-source-info
@@ -159,7 +159,7 @@ object "test_A2_M_test_increment_a" {
             // $t7 := borrow_field<M::S>.a($t2)
             /// @src 1:1142:1145
             $t7 := $IndexPtr($t2, 32)
-            // write_ref($t7, $t6)
+            // write_ref($t6, $t7)
             /// @src 1:1142:1155
             $StoreU64($t7, $t6)
             // return ()

--- a/third_party/move/evm/move-to-yul/tests/Structs.exp
+++ b/third_party/move/evm/move-to-yul/tests/Structs.exp
@@ -1474,7 +1474,7 @@ object "test_A2_M_test_read_and_write_S" {
             let $t2, $t3, $t4, $t5, $t6, $t7
             // $t2 := borrow_field<M::S>.a($t0)
             $t2 := $IndexPtr(s, 32)
-            // write_ref($t2, $t1)
+            // write_ref($t1, $t2)
             $StoreU64($t2, v)
             // $t3 := borrow_field<M::S>.a($t0)
             $t3 := $IndexPtr(s, 32)
@@ -1488,7 +1488,7 @@ object "test_A2_M_test_read_and_write_S" {
             }
             // $t7 := borrow_field<M::S2>.x($t6)
             $t7 := $t6
-            // write_ref($t7, $t5)
+            // write_ref($t5, $t7)
             $StoreU128($t7, $t5)
             // return ()
         }
@@ -2097,7 +2097,7 @@ object "test_A2_M_test_write_S" {
             let $t2, $t3, $t4, $t5, $t6, $t7
             // $t2 := borrow_field<M::S>.a($t0)
             $t2 := $IndexPtr(s, 32)
-            // write_ref($t2, $t1)
+            // write_ref($t1, $t2)
             $StoreU64($t2, v)
             // $t3 := borrow_field<M::S>.a($t0)
             $t3 := $IndexPtr(s, 32)
@@ -2111,7 +2111,7 @@ object "test_A2_M_test_write_S" {
             }
             // $t7 := borrow_field<M::S2>.x($t6)
             $t7 := $t6
-            // write_ref($t7, $t5)
+            // write_ref($t5, $t7)
             $StoreU128($t7, $t5)
             // return ()
         }

--- a/third_party/move/evm/move-to-yul/tests/Structs.v2_exp
+++ b/third_party/move/evm/move-to-yul/tests/Structs.v2_exp
@@ -1474,7 +1474,7 @@ object "test_A2_M_test_read_and_write_S" {
             let $t2, $t3, $t4, $t5, $t6, $t7
             // $t2 := borrow_field<M::S>.a($t0)
             $t2 := $IndexPtr(s, 32)
-            // write_ref($t2, $t1)
+            // write_ref($t1, $t2)
             $StoreU64($t2, v)
             // $t3 := borrow_field<M::S>.a($t0)
             $t3 := $IndexPtr(s, 32)
@@ -1488,7 +1488,7 @@ object "test_A2_M_test_read_and_write_S" {
             }
             // $t7 := borrow_field<M::S2>.x($t6)
             $t7 := $t6
-            // write_ref($t7, $t5)
+            // write_ref($t5, $t7)
             $StoreU128($t7, $t5)
             // return ()
         }
@@ -2097,7 +2097,7 @@ object "test_A2_M_test_write_S" {
             let $t2, $t3, $t4, $t5, $t6, $t7
             // $t2 := borrow_field<M::S>.a($t0)
             $t2 := $IndexPtr(s, 32)
-            // write_ref($t2, $t1)
+            // write_ref($t1, $t2)
             $StoreU64($t2, v)
             // $t3 := borrow_field<M::S>.a($t0)
             $t3 := $IndexPtr(s, 32)
@@ -2111,7 +2111,7 @@ object "test_A2_M_test_write_S" {
             }
             // $t7 := borrow_field<M::S2>.x($t6)
             $t7 := $t6
-            // write_ref($t7, $t5)
+            // write_ref($t5, $t7)
             $StoreU128($t7, $t5)
             // return ()
         }

--- a/third_party/move/evm/move-to-yul/tests/Tables.exp
+++ b/third_party/move/evm/move-to-yul/tests/Tables.exp
@@ -98,7 +98,7 @@ object "test_A2_Tables_test_borrow_fail" {
                     $t16 := A2_Table_borrow_mut$u64_u128$($t13, $t15)
                     // $t17 := 1
                     $t17 := 1
-                    // write_ref($t16, $t17)
+                    // write_ref($t17, $t16)
                     $StoreU128($t16, $t17)
                     // $t18 := 0x42
                     $t18 := 0x42
@@ -1967,7 +1967,7 @@ object "test_A2_Tables_test_struct" {
                     $t81 := $Sub($t79, $t80)
                     // $t82 := borrow_field<Tables::Balance>.value($t77)
                     $t82 := $t77
-                    // write_ref($t82, $t81)
+                    // write_ref($t81, $t82)
                     $StoreU256($t82, $t81)
                     // $t83 := 0xcd
                     $t83 := 0xcd
@@ -3113,7 +3113,7 @@ object "test_A2_Tables_test_u256" {
                     $t23 := $MakePtr(false, add($locals, 32))
                     // $t24 := Table::borrow_mut<U256::U256, U256::U256>($t22, $t23)
                     $t24 := A2_Table_borrow_mut$A2_U256_U256_A2_U256_U256$($t22, $t23)
-                    // write_ref($t24, $t8)
+                    // write_ref($t8, $t24)
                     $StoreU256($t24, $t8)
                     // $t25 := borrow_local($t3)
                     $t25 := $MakePtr(false, $locals)

--- a/third_party/move/evm/move-to-yul/tests/Tables.v2_exp
+++ b/third_party/move/evm/move-to-yul/tests/Tables.v2_exp
@@ -98,7 +98,7 @@ object "test_A2_Tables_test_borrow_fail" {
                     $t16 := A2_Table_borrow_mut$u64_u128$($t13, $t15)
                     // $t17 := 1
                     $t17 := 1
-                    // write_ref($t16, $t17)
+                    // write_ref($t17, $t16)
                     $StoreU128($t16, $t17)
                     // $t18 := 0x42
                     $t18 := 0x42
@@ -1967,7 +1967,7 @@ object "test_A2_Tables_test_struct" {
                     $t81 := $Sub($t79, $t80)
                     // $t82 := borrow_field<Tables::Balance>.value($t77)
                     $t82 := $t77
-                    // write_ref($t82, $t81)
+                    // write_ref($t81, $t82)
                     $StoreU256($t82, $t81)
                     // $t83 := 0xcd
                     $t83 := 0xcd
@@ -3113,7 +3113,7 @@ object "test_A2_Tables_test_u256" {
                     $t23 := $MakePtr(false, add($locals, 32))
                     // $t24 := Table::borrow_mut<U256::U256, U256::U256>($t22, $t23)
                     $t24 := A2_Table_borrow_mut$A2_U256_U256_A2_U256_U256$($t22, $t23)
-                    // write_ref($t24, $t8)
+                    // write_ref($t8, $t24)
                     $StoreU256($t24, $t8)
                     // $t25 := borrow_local($t3)
                     $t25 := $MakePtr(false, $locals)

--- a/third_party/move/evm/move-to-yul/tests/TestStringLiteral.exp
+++ b/third_party/move/evm/move-to-yul/tests/TestStringLiteral.exp
@@ -263,7 +263,7 @@ object "test_A2_M_h1" {
                     }
                     // $t39 := borrow_field<M::T>.s($t38)
                     $t39 := $t38
-                    // write_ref($t39, $t36)
+                    // write_ref($t36, $t39)
                     if $IsStoragePtr($t39){
                         let $storage_ptr_2300595445 := $NewLinkedStorageBase(0x89204cf5)
                         let $size_2300595445 := $MemoryLoadU64($t36)

--- a/third_party/move/evm/move-to-yul/tests/TestStringLiteral.v2_exp
+++ b/third_party/move/evm/move-to-yul/tests/TestStringLiteral.v2_exp
@@ -263,7 +263,7 @@ object "test_A2_M_h1" {
                     }
                     // $t39 := borrow_field<M::T>.s($t38)
                     $t39 := $t38
-                    // write_ref($t39, $t36)
+                    // write_ref($t36, $t39)
                     if $IsStoragePtr($t39){
                         let $storage_ptr_2300595445 := $NewLinkedStorageBase(0x89204cf5)
                         let $size_2300595445 := $MemoryLoadU64($t36)

--- a/third_party/move/evm/move-to-yul/tests/Vectors.exp
+++ b/third_party/move/evm/move-to-yul/tests/Vectors.exp
@@ -642,19 +642,19 @@ object "test_A2_Vectors_test_borrow_mut" {
                     $t11 := 90
                     // $t12 := borrow_field<Vectors::S>.x($t10)
                     $t12 := $t10
-                    // write_ref($t12, $t11)
+                    // write_ref($t11, $t12)
                     $StoreU128($t12, $t11)
                     // $t13 := false
                     $t13 := false
                     // $t14 := borrow_field<Vectors::S>.y($t10)
                     $t14 := $IndexPtr($t10, 24)
-                    // write_ref($t14, $t13)
+                    // write_ref($t13, $t14)
                     $StoreU8($t14, $t13)
                     // $t15 := 1028
                     $t15 := 1028
                     // $t16 := borrow_field<Vectors::S>.z($t10)
                     $t16 := $IndexPtr($t10, 16)
-                    // write_ref($t16, $t15)
+                    // write_ref($t15, $t16)
                     $StoreU64($t16, $t15)
                     // $t17 := borrow_local($t2)
                     $t17 := $MakePtr(false, $locals)
@@ -852,19 +852,19 @@ object "test_A2_Vectors_test_borrow_mut" {
                     $t68 := 10
                     // $t69 := borrow_field<Vectors::S>.x($t67)
                     $t69 := $t67
-                    // write_ref($t69, $t68)
+                    // write_ref($t68, $t69)
                     $StoreU128($t69, $t68)
                     // $t70 := true
                     $t70 := true
                     // $t71 := borrow_field<Vectors::S>.y($t67)
                     $t71 := $IndexPtr($t67, 24)
-                    // write_ref($t71, $t70)
+                    // write_ref($t70, $t71)
                     $StoreU8($t71, $t70)
                     // $t72 := 456
                     $t72 := 456
                     // $t73 := borrow_field<Vectors::S>.z($t67)
                     $t73 := $IndexPtr($t67, 16)
-                    // write_ref($t73, $t72)
+                    // write_ref($t72, $t73)
                     $StoreU64($t73, $t72)
                     // $t74 := borrow_local($t2)
                     $t74 := $MakePtr(false, $locals)
@@ -7425,7 +7425,7 @@ object "test_A2_Vectors_test_vectors_in_structs" {
                     $t46 := 1
                     // $t47 := vector::borrow_mut<u64>($t45, $t46)
                     $t47 := A1_vector_borrow_mut$u64$($t45, $t46)
-                    // write_ref($t47, $t43)
+                    // write_ref($t43, $t47)
                     $StoreU64($t47, $t43)
                     // $t48 := borrow_local($t0)
                     $t48 := $MakePtr(false, r)
@@ -7466,7 +7466,7 @@ object "test_A2_Vectors_test_vectors_in_structs" {
                     $t57 := $MakePtr(false, r)
                     // $t58 := borrow_field<Vectors::R>.v($t57)
                     $t58 := $IndexPtr($t57, 32)
-                    // write_ref($t58, $t56)
+                    // write_ref($t56, $t58)
                     if $IsStoragePtr($t58){
                         let $storage_ptr_814019441 := $NewLinkedStorageBase(0x3084f371)
                         let $size_814019441 := $MemoryLoadU64($t56)

--- a/third_party/move/evm/move-to-yul/tests/Vectors.v2_exp
+++ b/third_party/move/evm/move-to-yul/tests/Vectors.v2_exp
@@ -642,19 +642,19 @@ object "test_A2_Vectors_test_borrow_mut" {
                     $t11 := 90
                     // $t12 := borrow_field<Vectors::S>.x($t10)
                     $t12 := $t10
-                    // write_ref($t12, $t11)
+                    // write_ref($t11, $t12)
                     $StoreU128($t12, $t11)
                     // $t13 := false
                     $t13 := false
                     // $t14 := borrow_field<Vectors::S>.y($t10)
                     $t14 := $IndexPtr($t10, 24)
-                    // write_ref($t14, $t13)
+                    // write_ref($t13, $t14)
                     $StoreU8($t14, $t13)
                     // $t15 := 1028
                     $t15 := 1028
                     // $t16 := borrow_field<Vectors::S>.z($t10)
                     $t16 := $IndexPtr($t10, 16)
-                    // write_ref($t16, $t15)
+                    // write_ref($t15, $t16)
                     $StoreU64($t16, $t15)
                     // $t17 := borrow_local($t2)
                     $t17 := $MakePtr(false, $locals)
@@ -852,19 +852,19 @@ object "test_A2_Vectors_test_borrow_mut" {
                     $t68 := 10
                     // $t69 := borrow_field<Vectors::S>.x($t67)
                     $t69 := $t67
-                    // write_ref($t69, $t68)
+                    // write_ref($t68, $t69)
                     $StoreU128($t69, $t68)
                     // $t70 := true
                     $t70 := true
                     // $t71 := borrow_field<Vectors::S>.y($t67)
                     $t71 := $IndexPtr($t67, 24)
-                    // write_ref($t71, $t70)
+                    // write_ref($t70, $t71)
                     $StoreU8($t71, $t70)
                     // $t72 := 456
                     $t72 := 456
                     // $t73 := borrow_field<Vectors::S>.z($t67)
                     $t73 := $IndexPtr($t67, 16)
-                    // write_ref($t73, $t72)
+                    // write_ref($t72, $t73)
                     $StoreU64($t73, $t72)
                     // $t74 := borrow_local($t2)
                     $t74 := $MakePtr(false, $locals)
@@ -7425,7 +7425,7 @@ object "test_A2_Vectors_test_vectors_in_structs" {
                     $t46 := 1
                     // $t47 := vector::borrow_mut<u64>($t45, $t46)
                     $t47 := A1_vector_borrow_mut$u64$($t45, $t46)
-                    // write_ref($t47, $t43)
+                    // write_ref($t43, $t47)
                     $StoreU64($t47, $t43)
                     // $t48 := borrow_local($t0)
                     $t48 := $MakePtr(false, r)
@@ -7466,7 +7466,7 @@ object "test_A2_Vectors_test_vectors_in_structs" {
                     $t57 := $MakePtr(false, r)
                     // $t58 := borrow_field<Vectors::R>.v($t57)
                     $t58 := $IndexPtr($t57, 32)
-                    // write_ref($t58, $t56)
+                    // write_ref($t56, $t58)
                     if $IsStoragePtr($t58){
                         let $storage_ptr_814019441 := $NewLinkedStorageBase(0x3084f371)
                         let $size_814019441 := $MemoryLoadU64($t56)

--- a/third_party/move/evm/move-to-yul/tests/test-dispatcher/DispatcherBasicStorage.exp
+++ b/third_party/move/evm/move-to-yul/tests/test-dispatcher/DispatcherBasicStorage.exp
@@ -159,7 +159,7 @@ object "A2_M" {
                 $t4 := $AddU64($t2, $t3)
                 // $t5 := borrow_field<M::Storage>.counter($t0)
                 $t5 := self
-                // write_ref($t5, $t4)
+                // write_ref($t4, $t5)
                 $StoreU64($t5, $t4)
                 // return ()
             }
@@ -176,7 +176,7 @@ object "A2_M" {
                 $t4 := $AddU64($t2, $t3)
                 // $t5 := borrow_field<M::Storage>.counter($t0)
                 $t5 := self
-                // write_ref($t5, $t4)
+                // write_ref($t4, $t5)
                 $StoreU64($t5, $t4)
                 // return ()
             }

--- a/third_party/move/evm/move-to-yul/tests/test-dispatcher/DispatcherBasicStorage.v2_exp
+++ b/third_party/move/evm/move-to-yul/tests/test-dispatcher/DispatcherBasicStorage.v2_exp
@@ -159,7 +159,7 @@ object "A2_M" {
                 $t4 := $AddU64($t2, $t3)
                 // $t5 := borrow_field<M::Storage>.counter($t0)
                 $t5 := self
-                // write_ref($t5, $t4)
+                // write_ref($t4, $t5)
                 $StoreU64($t5, $t4)
                 // return ()
             }
@@ -176,7 +176,7 @@ object "A2_M" {
                 $t4 := $AddU64($t2, $t3)
                 // $t5 := borrow_field<M::Storage>.counter($t0)
                 $t5 := self
-                // write_ref($t5, $t4)
+                // write_ref($t4, $t5)
                 $StoreU64($t5, $t4)
                 // return ()
             }

--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -407,7 +407,7 @@ impl<'env> Generator<'env> {
                     );
                 }
                 self.emit_call(*id, targets, BytecodeOperation::WriteRef, vec![
-                    lhs_temp, rhs_temp,
+                    rhs_temp, lhs_temp,
                 ])
             },
             ExpData::Assign(id, lhs, rhs) => self.gen_assign(*id, lhs, rhs, None),

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -193,6 +193,16 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             description: "Whether to attach the compiled module to the global env.".to_string(),
             default: Given(false),
         },
+        Experiment {
+            name: Experiment::INSTRUCTION_REORDERING.to_string(),
+            description: "Whether to run instruction reordering transformation".to_string(),
+            default: Inherited(Experiment::OPTIMIZE.to_string()),
+        },
+        Experiment {
+            name: Experiment::FLUSH_WRITES_OPTIMIZATION.to_string(),
+            description: "Whether to run flush writes processor and optimization".to_string(),
+            default: Inherited(Experiment::OPTIMIZE.to_string()),
+        },
     ];
     experiments
         .into_iter()
@@ -212,8 +222,10 @@ impl Experiment {
     pub const COPY_PROPAGATION: &'static str = "copy-propagation";
     pub const DEAD_CODE_ELIMINATION: &'static str = "dead-code-elimination";
     pub const DUPLICATE_STRUCT_PARAMS_CHECK: &'static str = "duplicate-struct-params-check";
+    pub const FLUSH_WRITES_OPTIMIZATION: &'static str = "flush-writes-optimization";
     pub const GEN_ACCESS_SPECIFIERS: &'static str = "gen-access-specifiers";
     pub const INLINING: &'static str = "inlining";
+    pub const INSTRUCTION_REORDERING: &'static str = "instruction-reordering";
     pub const KEEP_INLINE_FUNS: &'static str = "keep-inline-funs";
     pub const KEEP_UNINIT_ANNOTATIONS: &'static str = "keep-uninit-annotations";
     pub const LAMBDA_LIFTING: &'static str = "lambda-lifting";

--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -7,7 +7,11 @@ use crate::{
         module_generator::{ModuleContext, ModuleGenerator, SOURCE_MAP_OK},
         peephole_optimizer, Options, MAX_FUNCTION_DEF_COUNT, MAX_LOCAL_COUNT,
     },
-    pipeline::livevar_analysis_processor::LiveVarAnnotation,
+    pipeline::{
+        flush_writes_processor::FlushWritesAnnotation,
+        instruction_reordering::PrepareUseAnnotation,
+        livevar_analysis_processor::LiveVarAnnotation,
+    },
 };
 use move_binary_format::{
     file_format as FF,
@@ -36,7 +40,10 @@ pub struct FunctionGenerator<'a> {
     /// A map from a temporary to information associated with it.
     temps: BTreeMap<TempIndex, TempInfo>,
     /// The value stack, represented by the temporaries which are located on it.
-    stack: Vec<TempIndex>,
+    /// Each temporary is paired with a bool, indicating whether the temporary is maybe stack-only
+    /// value (true) or definitely not a stack-only value (false).
+    /// If a value is copied from a local to the stack, it is definitely not a stack-only value.
+    stack: Vec<(TempIndex, bool)>,
     /// The locals which have been used so far. This contains the parameters of the function.
     locals: Vec<Type>,
     /// A map from branching labels to information about them.
@@ -551,14 +558,15 @@ impl<'a> FunctionGenerator<'a> {
                 )
             },
             Operation::ReadRef => self.gen_builtin(ctx, dest, FF::Bytecode::ReadRef, source),
-            Operation::WriteRef => {
-                // TODO: WriteRef in FF bytecode and in stackless bytecode use different operand
-                // order, perhaps we should fix this.
-                self.gen_builtin(ctx, dest, FF::Bytecode::WriteRef, &[source[1], source[0]])
-            },
+            Operation::WriteRef => self.gen_builtin(ctx, dest, FF::Bytecode::WriteRef, source),
             Operation::Release => {
                 // Move bytecode does not process release, values are released indirectly
                 // when the borrowed head of the borrow chain is destroyed
+            },
+            Operation::Prepare => {
+                // This is an indication that we may need to copy or move the value to the stack.
+                // It is inserted by the instruction reordering optimization pass, and *only* by it.
+                self.prepare_arg(ctx, source[0]);
             },
             Operation::Drop => {
                 // Currently Destroy is only translated for references. It may also make
@@ -897,6 +905,51 @@ impl<'a> FunctionGenerator<'a> {
         self.code.push(bc)
     }
 
+    /// Prepare a temporary, i.e., attempt to put it on the stack.
+    /// It is always safe to consider this instruction as a no-op.
+    fn prepare_arg(&mut self, ctx: &BytecodeContext, temp: TempIndex) {
+        let fun_ctx = ctx.fun_ctx;
+        let PrepareUseAnnotation(prepare_use_map) = fun_ctx
+            .fun
+            .get_annotations()
+            .get::<PrepareUseAnnotation>()
+            .expect("prepare-use annotation is a prerequisite");
+        let use_info = prepare_use_map
+            .get(&ctx.code_offset)
+            .expect("code offset for `Prepare` must be in the map");
+        // If it is already on the stack, let's not mess with the stack. Make this a no-op.
+        if self.stack.iter().any(|(t, _)| *t == temp) {
+            return;
+        }
+        // If this arg appears multiple times in the use instruction, make this a no-op.
+        let use_instr = &fun_ctx.fun.data.code[use_info.offset as usize];
+        if use_instr.sources().iter().filter(|s| *s == &temp).count() > 1 {
+            return;
+        }
+        let live_var_annotation = fun_ctx
+            .fun
+            .get_annotations()
+            .get::<LiveVarAnnotation>()
+            .expect("livevar analysis is a prerequisite");
+        let alive_after = !use_instr.dests().contains(&temp)
+            && live_var_annotation
+                .get_live_var_info_at(use_info.offset)
+                .map(|a| a.after.contains_key(&temp))
+                .unwrap_or(false);
+        let local: u8 = self.temp_to_local(fun_ctx, Some(ctx.attr_id), temp);
+        // Either move or copy the local to the top of the stack.
+        if fun_ctx.is_copyable(temp) && (alive_after || use_info.copy_only) {
+            self.emit(FF::Bytecode::CopyLoc(local));
+            self.stack.push((temp, false));
+        } else if use_info.copy_only {
+            // Only copy is allowed, but it is not copy-able. Make this a no-op.
+            return;
+        } else {
+            self.emit(FF::Bytecode::MoveLoc(local));
+            self.stack.push((temp, true));
+        }
+    }
+
     /// Ensure that on the abstract stack of the generator, the given temporaries are ready,
     /// in order, to be consumed. Ideally those are already on the stack, but if they are not,
     /// they will be made available.
@@ -913,10 +966,14 @@ impl<'a> FunctionGenerator<'a> {
         // Now compute which temps need to be pushed, on top of any which are already on the stack
         let mut temps_to_push = self.analyze_stack(temps);
         // If any of the temps we need to push now are actually underneath the temps already on the stack,
-        // we need to even flush more of the stack to reach them.
+        // and their values are stack only, we need to even flush more of the stack to reach them.
         let mut stack_to_flush = self.stack.len();
         for temp in temps_to_push {
-            if let Some(offs) = self.stack.iter().position(|t| t == temp) {
+            if let Some(offs) = self
+                .stack
+                .iter()
+                .position(|(t, stack_only)| *stack_only && t == temp)
+            {
                 // The lowest point in the stack we need to flush.
                 stack_to_flush = std::cmp::min(offs, stack_to_flush);
                 // Unfortunately, whatever is on the stack already, needs to be flushed out and
@@ -928,14 +985,18 @@ impl<'a> FunctionGenerator<'a> {
         // Finally, push `temps_to_push` onto the stack.
         for (pos, temp) in temps_to_push.iter().enumerate() {
             let local = self.temp_to_local(fun_ctx, Some(ctx.attr_id), *temp);
+            let stack_only;
             match push_kind {
                 Some(AssignKind::Move) => {
+                    stack_only = true;
                     self.emit(FF::Bytecode::MoveLoc(local));
                 },
                 Some(AssignKind::Copy) => {
+                    stack_only = false;
                     self.emit(FF::Bytecode::CopyLoc(local));
                 },
                 Some(AssignKind::Inferred) | Some(AssignKind::Store) => {
+                    stack_only = true;
                     fun_ctx
                         .internal_error("Inferred and Store AssignKind should be not appear here.");
                 },
@@ -946,13 +1007,15 @@ impl<'a> FunctionGenerator<'a> {
                         && (ctx.is_alive_after(*temp, true)
                             || temps_to_push[pos + 1..].contains(temp))
                     {
+                        stack_only = false;
                         self.emit(FF::Bytecode::CopyLoc(local))
                     } else {
+                        stack_only = true;
                         self.emit(FF::Bytecode::MoveLoc(local));
                     }
                 },
             }
-            self.stack.push(*temp)
+            self.stack.push((*temp, stack_only))
         }
     }
 
@@ -972,7 +1035,7 @@ impl<'a> FunctionGenerator<'a> {
         let dests = BTreeSet::from_iter(dests.iter());
         let sources = BTreeSet::from_iter(sources.iter());
         let conflicts = dests.difference(&sources).collect::<BTreeSet<_>>();
-        if let Some(pos) = self.stack.iter().position(|t| conflicts.contains(&t)) {
+        if let Some(pos) = self.stack.iter().position(|(t, _)| conflicts.contains(&t)) {
             self.abstract_flush_stack_before(ctx, pos);
         }
     }
@@ -982,7 +1045,12 @@ impl<'a> FunctionGenerator<'a> {
     fn save_used_after(&mut self, ctx: &BytecodeContext, temps: &[TempIndex]) {
         let mut stack_to_flush = self.stack.len();
         for temp in temps {
-            if let Some(pos) = self.stack.iter().position(|t| t == temp) {
+            // If the temp is only on the stack and used after this point, we need to flush it.
+            if let Some(pos) = self
+                .stack
+                .iter()
+                .position(|(t, stack_only)| *stack_only && t == temp)
+            {
                 if ctx.is_alive_after(*temp, true) {
                     // Determine new lowest point to which we need to flush
                     stack_to_flush = std::cmp::min(stack_to_flush, pos);
@@ -998,8 +1066,9 @@ impl<'a> FunctionGenerator<'a> {
     /// returns the temps which are not and need to be pushed.
     fn analyze_stack<'t>(&mut self, temps: &'t [TempIndex]) -> &'t [TempIndex] {
         let mut temps_to_push = temps; // worst case need to push all
+        let stack = self.stack.iter().map(|(t, _)| *t).collect::<Vec<_>>();
         for end in (1..=temps.len()).rev() {
-            if self.stack.ends_with(&temps[0..end]) {
+            if stack.ends_with(&temps[0..end]) {
                 // We found 0..end temps which are already on top of the stack. The remaining ones
                 // need to be pushed.
                 temps_to_push = &temps[end..temps.len()];
@@ -1015,12 +1084,14 @@ impl<'a> FunctionGenerator<'a> {
     fn abstract_flush_stack(&mut self, ctx: &BytecodeContext, top: usize, before: bool) {
         let fun_ctx = ctx.fun_ctx;
         while self.stack.len() > top {
-            let temp = self.stack.pop().unwrap();
-            if before && ctx.is_alive_before(temp)
-                || !before && ctx.is_alive_after(temp, false)
-                || self.pinned.contains(&temp)
+            let (temp, stack_only) = self.stack.pop().unwrap();
+            if stack_only
+                && ((before && ctx.is_alive_before(temp))
+                    || (!before && ctx.is_alive_after(temp, false))
+                    || self.pinned.contains(&temp))
             {
-                // Only need to save to a local if the temp is still used afterwards
+                // Only need to save to a local if the temp is still used afterwards and
+                // the temp is only on the stack.
                 let local = self.temp_to_local(fun_ctx, Some(ctx.attr_id), temp);
                 self.emit(FF::Bytecode::StLoc(local));
             } else {
@@ -1041,17 +1112,35 @@ impl<'a> FunctionGenerator<'a> {
 
     /// Push the result of an operation to the abstract stack.
     fn abstract_push_result(&mut self, ctx: &BytecodeContext, result: impl AsRef<[TempIndex]>) {
-        let mut flush_mark = usize::MAX;
-        for temp in result.as_ref() {
+        let pre_stack_len = self.stack.len();
+        let result = result.as_ref();
+        let mut flush_mark = result.len();
+        for (i, temp) in result.as_ref().iter().enumerate() {
             if self.pinned.contains(temp) {
                 // need to flush this right away and maintain a local for it
-                flush_mark = flush_mark.min(self.stack.len())
+                flush_mark = flush_mark.min(i);
             }
-            self.stack.push(*temp);
+            // The result is on stack only.
+            self.stack.push((*temp, true));
         }
-        if flush_mark != usize::MAX {
-            self.abstract_flush_stack_after(ctx, flush_mark)
+        // Check if there are any temps that need to be flushed right away.
+        if let Some(flush_writes) = ctx
+            .fun_ctx
+            .fun
+            .get_annotations()
+            .get::<FlushWritesAnnotation>()
+            .and_then(|annotation| annotation.0.get(&ctx.code_offset))
+        {
+            for (i, temp) in result[..flush_mark].iter().enumerate().rev() {
+                if flush_writes.contains(temp) {
+                    flush_mark = i;
+                } else {
+                    break;
+                }
+            }
         }
+        let flush_mark = pre_stack_len + flush_mark;
+        self.abstract_flush_stack_after(ctx, flush_mark);
     }
 
     /// Pop a value from the abstract stack.

--- a/third_party/move/move-compiler-v2/src/pipeline/ability_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/ability_processor.rs
@@ -330,10 +330,10 @@ impl<'a> Transformer<'a> {
                         );
                     },
                     WriteRef => {
-                        let ty = self.builder.get_local_type(srcs[0]);
+                        let ty = self.builder.get_local_type(srcs[1]);
                         self.check_drop_for_type(
                             *id,
-                            srcs[0],
+                            srcs[1],
                             ty.get_target_type().expect("reference type"),
                             || ("reference content dropped here".to_string(), vec![]),
                         );

--- a/third_party/move/move-compiler-v2/src/pipeline/flush_writes_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/flush_writes_processor.rs
@@ -1,0 +1,143 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements a processor that determines which writes to temporaries
+//! are better "flushed" immediately by the file format code generator. Read on
+//! for more information on what "flushing" means.
+//!
+//! For this pass to be effective, it should be run after all the stackless-bytecode
+//! transformations are done, because the annotations produced by it are used
+//! (when available) by the file-format generator. Code transformations render
+//! previously computed annotations invalid.
+//!
+//! A pre-requisite for this pass is the live-variable analysis annotations.
+//!
+//! The file format generator can keep some writes to temporaries only on the stack,
+//! not writing it back to local memory (as a potential optimization).
+//! However, this is not always good, and this pass helps determine when a write to
+//! a temporary should be flushed right away.
+//! In the context of file format code generator, "flushed" means either store the
+//! value to a local (if used later) or pop if from the stack (if not used later).
+//! Currently, we instruct to flush those temps right away that are not used within
+//! the same basic block.
+
+use crate::pipeline::livevar_analysis_processor::LiveVarAnnotation;
+use itertools::Itertools;
+use move_binary_format::file_format::CodeOffset;
+use move_model::{ast::TempIndex, model::FunctionEnv};
+use move_stackless_bytecode::{
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::Bytecode,
+    stackless_control_flow_graph::StacklessControlFlowGraph,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// For a given code offset, tracks which temporaries written at the code offset
+/// should be flushed right away by the file format generator.
+#[derive(Clone)]
+pub struct FlushWritesAnnotation(pub BTreeMap<CodeOffset, BTreeSet<TempIndex>>);
+
+/// A processor for computing the `FlushWritesAnnotation`.
+pub struct FlushWritesProcessor {}
+
+impl FunctionTargetProcessor for FlushWritesProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv,
+        mut data: FunctionData,
+        _scc_opt: Option<&[FunctionEnv]>,
+    ) -> FunctionData {
+        if func_env.is_native() {
+            return data;
+        }
+        let target = FunctionTarget::new(func_env, &data);
+        let live_vars = target
+            .get_annotations()
+            .get::<LiveVarAnnotation>()
+            .expect("live variable annotation is a prerequisite");
+        let code = target.get_bytecode();
+        let cfg = StacklessControlFlowGraph::new_forward(code);
+        let mut unused: BTreeMap<CodeOffset, BTreeSet<TempIndex>> = BTreeMap::new();
+        for block_id in cfg.blocks() {
+            if let Some((lower, upper)) = cfg.instr_offset_bounds(block_id) {
+                extract_unused_writes_in_block(lower, upper, code, live_vars, &mut unused);
+            }
+        }
+        data.annotations.set(FlushWritesAnnotation(unused), true);
+        data
+    }
+
+    fn name(&self) -> String {
+        "FlushWritesProcessor".to_string()
+    }
+}
+
+/// In the basic block defined by `code[lower..=upper]`, extract the writes to
+/// temporaries that are not used later the block. At the offset where the write
+/// happens, such temporaries are included, in `unused`.
+fn extract_unused_writes_in_block(
+    lower: u16,
+    upper: u16,
+    code: &[Bytecode],
+    live_vars: &LiveVarAnnotation,
+    unused: &mut BTreeMap<CodeOffset, BTreeSet<TempIndex>>,
+) {
+    for offset in lower..=upper {
+        let instr = &code[offset as usize];
+        // Only `Load` and `Call` instructions push results to the stack.
+        if matches!(instr, Bytecode::Load(..) | Bytecode::Call(..)) {
+            if let Some(live_info) = live_vars.get_live_var_info_at(offset) {
+                for dest in instr.dests() {
+                    if let Some(info) = live_info.after.get(&dest) {
+                        // Note: loop-carried uses are not considered here.
+                        let all_usages_are_outside_block = info
+                            .usage_offsets()
+                            .iter()
+                            .all(|usage| *usage <= offset || *usage > upper);
+                        if all_usages_are_outside_block {
+                            unused.entry(offset).or_default().insert(dest);
+                        }
+                    } else {
+                        // `dest` is not alive after `offset`, so it is not used.
+                        unused.entry(offset).or_default().insert(dest);
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl FlushWritesProcessor {
+    /// Registers annotation formatter at the given function target.
+    /// Helps with testing and debugging.
+    pub fn register_formatters(target: &FunctionTarget) {
+        target.register_annotation_formatter(Box::new(format_flush_writes_annotation));
+    }
+}
+
+// ====================================================================
+// Formatting functionality for flush writes annotation
+
+pub fn format_flush_writes_annotation(
+    target: &FunctionTarget,
+    code_offset: CodeOffset,
+) -> Option<String> {
+    let FlushWritesAnnotation(map) = target.get_annotations().get::<FlushWritesAnnotation>()?;
+    let temps = map.get(&code_offset)?;
+    if temps.is_empty() {
+        return None;
+    }
+    let mut res = "flush: ".to_string();
+    res.push_str(
+        &temps
+            .iter()
+            .map(|t| {
+                let name = target.get_local_raw_name(*t);
+                format!("{}", name.display(target.symbol_pool()))
+            })
+            .join(", "),
+    );
+    Some(res)
+}

--- a/third_party/move/move-compiler-v2/src/pipeline/instruction_reordering.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/instruction_reordering.rs
@@ -1,0 +1,771 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! In this module, we implement an intra-block instruction reordering optimization.
+//! The goal of this reordering is to make the code friendlier for generating stack
+//! machine bytecode.
+//!
+//! It is expected that this pass is run as the last transformation in the pipeline.
+//! The prerequisite for this transformation is that all error checks have already been
+//! performed and erroneous code has been rejected.
+//!
+//! In order to perform the reordering of instructions within a block, we construct
+//! an edge-ordered data dependence graph. The data dependencies are use-def edges,
+//! and are ordered based on the order of sources in the use instruction.
+//!
+//! There are a set of constraints that restrict what reorderings are safe to perform.
+//! * True data dependencies (read-after-write) must be respected.
+//! * False data dependencies (write-after-read and write-after-write) must be respected.
+//! * Certain reference-related instructions (like freezing a reference) cannot be
+//!   reordered with respect to any other reads of the reference.
+//! * When a temp is moved, any reads of the temp cannot be reordered with respect to
+//!   the move.
+//! * Certain instructions are relatively non-reorderable. These cannot be reordered
+//!   with respect to each other.
+//!
+//! We start from the bottom of a block, and perform a post-order depth-first search
+//! on the edge-ordered data dependence graph and check if any of the constraints are
+//! violated. If the constraints are not violated, we reorder the instructions.
+//! Else, we move on to the instruction above.
+//!
+//! In addition to instruction reordering, this transformation also inserts `Prepare`
+//! instructions and corresponding annotations. A `Prepare` instruction is instructs
+//! the file format generator to prepare a value on the stack (i.e., move or copy it)
+//! for a future use. A `Prepare` instruction can always be safely ignored.
+//! Currently, a `Prepare` instruction is inserted when a source is not defined within
+//! the block, and the source is not the last source of an instruction.
+
+use move_binary_format::file_format::CodeOffset;
+use move_model::{ast::TempIndex, model::FunctionEnv};
+use move_stackless_bytecode::{
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::{AssignKind, Bytecode, Operation},
+    stackless_control_flow_graph::StacklessControlFlowGraph,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Mapping from every `Prepare` instruction's offset to the corresponding use
+/// information (use of a `Prepare` instruction is the original instruction
+/// for which we are preparing a value on the stack).
+#[derive(Clone, Default)]
+pub struct PrepareUseAnnotation(pub BTreeMap<CodeOffset, UseInfo>);
+
+impl PrepareUseAnnotation {
+    /// Remap the offsets in the `PrepareUseAnnotation` based on the given `mapping`.
+    /// Note that `mapping` could be missing some offsets for `Prepare` instructions,
+    /// in which case, the entries are dropped.
+    /// However, `mapping` cannot be missing offsets for non-`Prepare` instructions
+    /// (specifically, offsets for use instructions).
+    pub fn filter_remap(&mut self, mapping: BTreeMap<CodeOffset, CodeOffset>) {
+        self.0 = self
+            .0
+            .iter()
+            .filter_map(|(prepare_offset, use_info)| {
+                mapping.get(prepare_offset).map(|remapped_prepare_offset| {
+                    (*remapped_prepare_offset, UseInfo {
+                        offset: *mapping.get(&use_info.offset).expect("existing offset"),
+                        copy_only: use_info.copy_only,
+                    })
+                })
+            })
+            .collect();
+    }
+
+    /// Extend with the `other` annotation.
+    /// The `base_offset` is added to the instruction offsets in `other`.
+    pub fn extend_with(&mut self, other: Self, base_offset: CodeOffset) {
+        for (prepare_offset, use_info) in other.0.into_iter() {
+            self.0.insert(base_offset + prepare_offset, UseInfo {
+                offset: base_offset + use_info.offset,
+                ..use_info
+            });
+        }
+    }
+}
+
+/// Use information corresponding to a `Prepare` instruction.
+/// It refers to the original instruction for which the `Prepare` instruction
+/// is being inserted.
+#[derive(Clone)]
+pub struct UseInfo {
+    // Offset of the original instruction for which the `Prepare` instruction is inserted.
+    pub offset: CodeOffset,
+    // Instructs the file format generator that when true, the corresponding `Prepare`
+    // can only result in a copy (not a move). If a copy is not possible, then
+    // the `Prepare` instruction should be a no-op.
+    // When false, the `Prepare` instruction can result in a move or a copy.
+    pub copy_only: bool,
+}
+
+/// Hold various information to safely perform reordering of instructions within a block.
+struct BlockReordering {
+    instructions: Vec<Bytecode>,
+    dd_graph: DataDependenceGraph,
+    prepare_use: PrepareUseAnnotation,
+    constraints: BTreeMap<CodeOffset, BTreeSet<CodeOffset>>,
+    original_block_len: usize,
+}
+
+impl BlockReordering {
+    /// Given `instructions` of a basic block, insert required `Prepare` instructions
+    /// and safely reorder the instructions when possible, to be friendlier for
+    /// generating stack machine bytecode.
+    pub fn prepare_and_reorder(instructions: Vec<Bytecode>) -> ReorderedInstructions {
+        let original_block_len = instructions.len();
+        let mut this = Self {
+            instructions,
+            dd_graph: DataDependenceGraph(BTreeMap::new()),
+            prepare_use: PrepareUseAnnotation::default(),
+            constraints: BTreeMap::new(),
+            original_block_len,
+        };
+        this.fill_data_dependence_graph();
+        this.fill_prepare_instructions();
+        this.fill_constraints();
+        this.reorder_instructions();
+
+        ReorderedInstructions {
+            instructions: this.instructions,
+            prepare_use: this.prepare_use,
+        }
+    }
+
+    /// Populate an edge-ordered data dependence graph based on original instructions
+    /// in the basic block.
+    fn fill_data_dependence_graph(&mut self) {
+        // Map a temp to the offset of its latest write.
+        let mut latest_write: BTreeMap<TempIndex, CodeOffset> = BTreeMap::new();
+        let graph = &mut self.dd_graph.0;
+        for (offset, instr) in self.instructions.iter().enumerate() {
+            let offset = offset as CodeOffset;
+            let sources = instr.sources();
+            if !sources.is_empty() {
+                let edges = graph.entry(offset).or_default();
+                for src in sources.iter() {
+                    let def_offset = latest_write.get(src).copied();
+                    edges.push(def_offset);
+                }
+            }
+            for dest in instr.dests() {
+                latest_write.insert(dest, offset);
+            }
+        }
+    }
+
+    /// Insert `Prepare` instructions to the basic block.
+    /// Also, fill the corresponding `prepare_use` annotations.
+    fn fill_prepare_instructions(&mut self) {
+        // When a source is not defined within the block, then insert a `Prepare` instruction.
+        // Do this only when the source is not the last source of an instruction.
+        let prepare_use_map = &mut self.prepare_use.0;
+        let graph = &mut self.dd_graph.0;
+        let mut prepare_instrs: Vec<Bytecode> = vec![];
+        for (usage_offset, usage_instr) in self.instructions.iter().enumerate() {
+            let sources = usage_instr.sources();
+            if sources.len() < 2 {
+                // No need to insert `Prepare` for non-multi-source instructions.
+                continue;
+            }
+            let usage_offset = usage_offset as CodeOffset;
+            if let Some(defs) = graph.get_mut(&usage_offset) {
+                // We do not have to `Prepare` the last operand, as it can be brought
+                // to the top of the stack when actually needed by the use.
+                let without_last_len = if defs.is_empty() { 0 } else { defs.len() - 1 };
+                for (def, tmp) in defs.iter_mut().zip(sources.iter()).take(without_last_len) {
+                    if def.is_none() {
+                        // The definition is not explicit in the block.
+                        // So, let's insert a `Prepare` instruction.
+                        let prepare_offset =
+                            (self.original_block_len + prepare_instrs.len()) as CodeOffset;
+                        let prepare = Bytecode::Call(
+                            usage_instr.get_attr_id(),
+                            vec![],
+                            Operation::Prepare,
+                            vec![*tmp],
+                            None,
+                        );
+                        prepare_instrs.push(prepare);
+                        *def = Some(prepare_offset);
+                        prepare_use_map.insert(prepare_offset, UseInfo {
+                            offset: usage_offset,
+                            copy_only: false, // this may be updated later to true
+                        });
+                    }
+                }
+            }
+        }
+        self.instructions.extend(prepare_instrs);
+    }
+
+    /// Add all the constraints that restrict the reordering of instructions.
+    /// All these constraints must be respected when reordering instructions.
+    fn fill_constraints(&mut self) {
+        self.constraints = DependenceConstraints::compute_from(self);
+    }
+
+    /// Perform instruction reordering using the edge-ordered data dependence graph,
+    /// subject to the constraints.
+    fn reorder_instructions(&mut self) {
+        let mut reordered_block = vec![];
+        // Tracking instruction offsets that have already been included in the reordered block.
+        let mut taken = vec![false; self.instructions.len()];
+        let ref_args = self.get_ref_args();
+        let reads = self.get_reads();
+        let prepares = self.get_prepares();
+        // Start traversing from the bottom of the original block.
+        for (offset, instr) in self
+            .instructions
+            .iter()
+            .enumerate()
+            .take(self.original_block_len)
+            .rev()
+        {
+            if taken[offset] {
+                // Already taken, skip this instruction.
+                continue;
+            }
+            let ordered_offsets = self.dfs_post_order(offset as CodeOffset);
+            if let Some((ordered_offsets, copy_only_prepares)) = self.adjusted_ordering(
+                ordered_offsets,
+                offset as CodeOffset,
+                &ref_args,
+                &reads,
+                &prepares,
+            ) {
+                // We have a valid ordering that respects all constraints.
+                // Instructions are added to the reordered block in reverse order.
+                for off in ordered_offsets.into_iter().rev() {
+                    let off = usize::from(off);
+                    reordered_block.push((off, self.instructions[off].clone()));
+                    taken[off] = true;
+                }
+                // Adjust the `copy_only` flag for the `Prepare` instructions in `copy_only_prepares`.
+                for copy_only_offset in copy_only_prepares {
+                    self.prepare_use
+                        .0
+                        .get_mut(&copy_only_offset)
+                        .expect("prepare offset")
+                        .copy_only = true;
+                }
+            } else {
+                // Only the current instruction is added to the reordered block.
+                reordered_block.push((offset, instr.clone()));
+                taken[offset] = true;
+            }
+        }
+        reordered_block.reverse();
+        let remap = reordered_block
+            .iter()
+            .enumerate()
+            .map(|(i, (off, _))| (*off as CodeOffset, i as CodeOffset))
+            .collect::<BTreeMap<_, _>>();
+        self.prepare_use.filter_remap(remap);
+        self.instructions = reordered_block
+            .into_iter()
+            .map(|(_, instr)| instr)
+            .collect();
+    }
+
+    /// Perform a post-order depth-first search on the edge-ordered data dependence graph.
+    /// TODO: this DFS traversal can be memoized.
+    fn dfs_post_order(&self, start_node: CodeOffset) -> Vec<CodeOffset> {
+        let mut visited = BTreeSet::new();
+        let mut post_order = vec![];
+        self.dfs_post_order_recurse(start_node, &mut visited, &mut post_order);
+        post_order
+    }
+
+    /// Helper function for `dfs_post_order`.
+    fn dfs_post_order_recurse(
+        &self,
+        node: CodeOffset,
+        visited: &mut BTreeSet<CodeOffset>,
+        post_order: &mut Vec<CodeOffset>,
+    ) {
+        if !visited.insert(node) {
+            return;
+        }
+        for dependent in self
+            .dd_graph
+            .0
+            .get(&node)
+            .map(|deps| deps.iter().filter_map(|d| *d).collect::<Vec<_>>())
+            .unwrap_or_default()
+        {
+            self.dfs_post_order_recurse(dependent, visited, post_order);
+        }
+        post_order.push(node);
+    }
+
+    /// Map temps to the set of code offsets where the temp is used as a source to a
+    /// reference-related instruction.
+    fn get_ref_args(&self) -> BTreeMap<TempIndex, BTreeSet<CodeOffset>> {
+        let mut ref_args: BTreeMap<TempIndex, BTreeSet<CodeOffset>> = BTreeMap::new();
+        for (offset, instr) in self
+            .instructions
+            .iter()
+            .take(self.original_block_len)
+            .enumerate()
+        {
+            let offset = offset as CodeOffset;
+            if is_ref_related_instr(instr) {
+                for src in instr.sources() {
+                    ref_args.entry(src).or_default().insert(offset);
+                }
+            }
+        }
+        ref_args
+    }
+
+    /// Map temps to the set of code offsets where the temp is read.
+    fn get_reads(&self) -> BTreeMap<TempIndex, BTreeSet<CodeOffset>> {
+        let mut reads: BTreeMap<TempIndex, BTreeSet<CodeOffset>> = BTreeMap::new();
+        for (offset, instr) in self
+            .instructions
+            .iter()
+            .take(self.original_block_len)
+            .enumerate()
+        {
+            let offset = offset as CodeOffset;
+            for src in instr.sources() {
+                reads.entry(src).or_default().insert(offset);
+            }
+        }
+        reads
+    }
+
+    /// Map `Prepare` instruction offsets to the temps they prepare.
+    fn get_prepares(&self) -> BTreeMap<CodeOffset, TempIndex> {
+        let mut prepares: BTreeMap<CodeOffset, TempIndex> = BTreeMap::new();
+        for (offset, instr) in self
+            .instructions
+            .iter()
+            .enumerate()
+            .skip(self.original_block_len)
+        {
+            let offset = offset as CodeOffset;
+            if let Bytecode::Call(_, _, Operation::Prepare, sources, _) = instr {
+                prepares.insert(offset, sources[0]);
+            } else {
+                unreachable!("only `Prepare` instructions are inserted after the original block");
+            }
+        }
+        prepares
+    }
+
+    /// If the ordering provided by `offsets` is not valid, return `None`.
+    /// Otherwise, return the adjusted ordering (with some `Prepare` instructions potentially
+    /// removed) and the set of `Prepare` instructions that can only result in a copy.
+    fn adjusted_ordering(
+        &self,
+        offsets: Vec<CodeOffset>,
+        node: CodeOffset,
+        ref_args: &BTreeMap<TempIndex, BTreeSet<CodeOffset>>,
+        reads: &BTreeMap<TempIndex, BTreeSet<CodeOffset>>,
+        prepares: &BTreeMap<CodeOffset, TempIndex>,
+    ) -> Option<(Vec<CodeOffset>, BTreeSet<CodeOffset>)> {
+        assert!(offsets.contains(&node));
+        // Check that for each ordered pair of DFS-ordered offsets starting from `node`,
+        // all the constraints are satisfied.
+        for i in 0..offsets.len() {
+            for j in i + 1..offsets.len() {
+                let before = offsets[i];
+                let after = offsets[j];
+                if self
+                    .constraints
+                    .get(&after)
+                    .is_some_and(|nodes| nodes.contains(&before))
+                {
+                    return None;
+                }
+            }
+        }
+        // Check that for each DFS-unvisited offset that lies between any of the visited
+        // offsets and `node`, all the constraints are satisfied when unvisited offsets
+        // are moved above all visited offsets.
+        // These checks do not have to consider `Prepare` instructions.
+        let visited = offsets.iter().collect::<BTreeSet<_>>();
+        let min_visited = **visited
+            .first()
+            .expect("at least one offset must be visited");
+        for before in min_visited..=node {
+            if !visited.contains(&before) {
+                // Is it safe to move `before` before everything else?
+                for after in offsets.iter() {
+                    if self
+                        .constraints
+                        .get(after)
+                        .map_or(false, |nodes| nodes.contains(&before))
+                    {
+                        return None;
+                    }
+                }
+            }
+        }
+        // Additional checks and restrictions corresponding to the placement of
+        // `Prepare` instructions.
+        let mut skip_prepares = BTreeSet::new();
+        let mut copy_only_prepares = BTreeSet::new();
+        for (i, offset) in offsets.iter().enumerate() {
+            if let Some(prepared_tmp) = prepares.get(offset) {
+                // For each `Prepare tmp` instruction, check if:
+                // 1. Until its use, whether there are any reference-related instructions
+                //    targeting `tmp`. In such a case, we have to skip this `Prepare`
+                //    instruction, because we cannot eagerly access `tmp`.
+                // 2. Until its use, whether there are any reads of `tmp`. In such a case,
+                //    we have to notify that this `Prepare` instruction can only result in
+                //    a copy of `tmp` (or a no-op, which is always safe for `Prepare`
+                //    instructions). If it results in a move, then a subsequent read of
+                //    `tmp` will be invalid.
+                let use_offset = self
+                    .constraints
+                    .get(offset)
+                    .expect("Prepare must have a use")
+                    .first()
+                    .expect("Prepare must have exactly one use");
+                let mut j = i + 1;
+                while j < offsets.len() {
+                    let scanned_offset = offsets[j];
+                    if scanned_offset == *use_offset {
+                        break;
+                    }
+                    j += 1;
+                    if ref_args
+                        .get(prepared_tmp)
+                        .map_or(false, |nodes| nodes.contains(&scanned_offset))
+                    {
+                        // Skip the `Prepare` instructions corresponding to `offset`,
+                        // because of 1.
+                        copy_only_prepares.remove(offset);
+                        skip_prepares.insert(*offset);
+                        break;
+                    }
+                    if reads
+                        .get(prepared_tmp)
+                        .map_or(false, |nodes| nodes.contains(&scanned_offset))
+                    {
+                        // Insert a `copy_only` notice for the `Prepare` instruction,
+                        // because of 2.
+                        copy_only_prepares.insert(*offset);
+                        break;
+                    }
+                }
+            }
+        }
+        let new_offsets = offsets
+            .into_iter()
+            .filter(|o| !skip_prepares.contains(o))
+            .collect::<Vec<_>>();
+        Some((new_offsets, copy_only_prepares))
+    }
+}
+
+/// Collection of instructions that have been reordered (along with the insertion of
+/// `Prepare` instructions). Includes the corresponding `PrepareUseAnnotation`.
+struct ReorderedInstructions {
+    instructions: Vec<Bytecode>,
+    prepare_use: PrepareUseAnnotation,
+}
+
+/// Edge-ordered data dependence graph for a basic block.
+/// Maps a "use" instruction offset to the list of "def" instruction offsets that it
+/// depends on (i.e., use-def edges). The edges are ordered based on the order of
+/// sources in the use instruction.
+/// The graph does not carry loop-carried dependencies, and is therefore a directed
+/// acyclic graph.
+/// If the definition of a source is not found in the block, then the definition is
+/// represented as `None`.
+#[derive(Debug)]
+struct DataDependenceGraph(pub BTreeMap<CodeOffset, Vec<Option<CodeOffset>>>);
+
+/// Collection of constraints that restrict the reordering of instructions within a block.
+/// If there is an edge from instruction offsets `a` to `b`, then `a` must be appear
+/// before `b` in a basic block.
+#[derive(Default)]
+struct DependenceConstraints {
+    edges: BTreeMap<CodeOffset, BTreeSet<CodeOffset>>,
+}
+
+impl DependenceConstraints {
+    /// Compute the all the constraints for block reordering.
+    pub fn compute_from(block: &BlockReordering) -> BTreeMap<CodeOffset, BTreeSet<CodeOffset>> {
+        let mut constraints = Self::default();
+        constraints
+            .add_false_dependencies(&block.instructions, block.original_block_len)
+            .add_true_dependencies(&block.dd_graph)
+            .add_ref_arg_dependencies(&block.instructions, block.original_block_len)
+            .add_move_dependencies(&block.instructions, block.original_block_len)
+            .add_relatively_non_reorderable_dependencies(
+                &block.instructions,
+                block.original_block_len,
+            );
+        debug_assert!(!constraints.has_cycle(block.instructions.len()));
+        constraints.edges
+    }
+
+    /// Compute and add false dependencies for a `block` (of straight-line code).
+    /// False dependencies include write-after-read and write-after-write dependencies.
+    /// Note: we do not add false dependencies for `Prepare` instructions.
+    fn add_false_dependencies(&mut self, block: &[Bytecode], upper: usize) -> &mut Self {
+        // Track all the reads of a tmp before a write to it.
+        let mut reads_before: BTreeMap<TempIndex, BTreeSet<CodeOffset>> = BTreeMap::new();
+        // Track the most recent write to a tmp.
+        let mut latest_write: BTreeMap<TempIndex, CodeOffset> = BTreeMap::new();
+        for (offset, instr) in block.iter().take(upper).enumerate() {
+            let offset = offset as CodeOffset;
+            for tmp in instr.sources() {
+                reads_before.entry(tmp).or_default().insert(offset);
+            }
+            for tmp in instr.dests() {
+                if let Some(nodes) = reads_before.remove(&tmp) {
+                    // Add write-after-read dependencies.
+                    for node in nodes.iter().filter(|n| **n != offset) {
+                        self.edges.entry(*node).or_default().insert(offset);
+                    }
+                }
+                if let Some(node) = latest_write.insert(tmp, offset) {
+                    if node != offset {
+                        // Add write-after-write dependencies.
+                        self.edges.entry(node).or_default().insert(offset);
+                    }
+                }
+            }
+        }
+        self
+    }
+
+    /// Add all true dependencies in a block based on the data dependence graph.
+    /// A true dependency is a read-after-write dependency.
+    fn add_true_dependencies(&mut self, dd_graph: &DataDependenceGraph) -> &mut Self {
+        for (use_offset, def_offsets) in dd_graph.0.iter() {
+            for def_offset in def_offsets.iter().filter_map(|d| *d) {
+                self.edges
+                    .entry(def_offset)
+                    .or_default()
+                    .insert(*use_offset);
+            }
+        }
+        self
+    }
+
+    /// Add dependencies for reference-related instructions and the reads of the
+    /// temps the reference-related instructions target.
+    /// Note: we do not add ref arg dependencies for `Prepare` instructions.
+    fn add_ref_arg_dependencies(&mut self, block: &[Bytecode], upper: usize) -> &mut Self {
+        let mut reads: BTreeMap<TempIndex, BTreeSet<CodeOffset>> = BTreeMap::new();
+        let mut ref_args: BTreeMap<TempIndex, CodeOffset> = BTreeMap::new();
+        for (offset, instr) in block.iter().take(upper).enumerate() {
+            let offset = offset as CodeOffset;
+            if is_ref_related_instr(instr) {
+                for src in instr.sources() {
+                    if let Some(prev_reads) = reads.remove(&src) {
+                        for prev_read in prev_reads {
+                            self.edges.entry(prev_read).or_default().insert(offset);
+                        }
+                    }
+                    if let Some(prev_ref_arg) = ref_args.insert(src, offset) {
+                        self.edges.entry(prev_ref_arg).or_default().insert(offset);
+                    }
+                }
+            } else {
+                for src in instr.sources() {
+                    reads.entry(src).or_default().insert(offset);
+                    if let Some(prev_ref_arg_offset) = ref_args.get(&src) {
+                        self.edges
+                            .entry(*prev_ref_arg_offset)
+                            .or_default()
+                            .insert(offset);
+                    }
+                }
+            }
+        }
+        self
+    }
+
+    /// Add dependencies between the reads of temps and their moves.
+    /// Note: we do not add move dependencies for `Prepare` instructions.
+    fn add_move_dependencies(&mut self, block: &[Bytecode], upper: usize) -> &mut Self {
+        let mut reads_before_move: BTreeMap<TempIndex, BTreeSet<CodeOffset>> = BTreeMap::new();
+        use AssignKind::*;
+        for (offset, instr) in block.iter().take(upper).enumerate() {
+            if let Bytecode::Assign(_, _, src, Move | Inferred | Store) = instr {
+                if let Some(reads) = reads_before_move.remove(src) {
+                    for read in reads {
+                        self.edges
+                            .entry(read)
+                            .or_default()
+                            .insert(offset as CodeOffset);
+                    }
+                }
+            } else {
+                for src in instr.sources() {
+                    reads_before_move
+                        .entry(src)
+                        .or_default()
+                        .insert(offset as CodeOffset);
+                }
+            }
+        }
+        self
+    }
+
+    /// Add dependencies between instructions that are relatively non-reorderable.
+    fn add_relatively_non_reorderable_dependencies(
+        &mut self,
+        block: &[Bytecode],
+        upper: usize,
+    ) -> &mut Self {
+        let mut prev_offset = None;
+        for (offset, instr) in block.iter().take(upper).enumerate() {
+            if Self::is_relatively_non_reorderable(instr) {
+                let offset = offset as CodeOffset;
+                if let Some(prev_offset) = prev_offset {
+                    self.edges.entry(prev_offset).or_default().insert(offset);
+                }
+                prev_offset = Some(offset);
+            }
+        }
+        self
+    }
+
+    /// Is the `instr` relatively non-reorderable?
+    /// Two relatively non-reorderable instructions cannot change their relative order.
+    fn is_relatively_non_reorderable(instr: &Bytecode) -> bool {
+        use Bytecode::*;
+        use Operation::*;
+        match instr {
+            Ret(..) | Branch(..) | Jump(..) | Label(..) | Abort(..) => true,
+            Call(_, _, op, ..) => {
+                op.can_abort() || matches!(op, WriteRef | ReadRef | FreezeRef(_) | Drop)
+            },
+            _ => false,
+        }
+    }
+
+    /// Check if the constraints form a cycle.
+    fn has_cycle(&self, num_nodes: usize) -> bool {
+        let mut visited_ever = BTreeSet::new();
+        let mut ancestors = BTreeSet::new();
+        for node in 0..num_nodes {
+            if self.dfs(node as CodeOffset, &mut visited_ever, &mut ancestors) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Helper for cycle detection.
+    fn dfs(
+        &self,
+        node: CodeOffset,
+        visited_ever: &mut BTreeSet<CodeOffset>,
+        ancestors: &mut BTreeSet<CodeOffset>,
+    ) -> bool {
+        if !visited_ever.insert(node) {
+            return false;
+        }
+        ancestors.insert(node);
+        if let Some(children) = self.edges.get(&node) {
+            for child in children {
+                if ancestors.contains(child) || self.dfs(*child, visited_ever, ancestors) {
+                    return true;
+                }
+            }
+        }
+        ancestors.remove(&node);
+        false
+    }
+}
+
+/// Helper function to check if the instruction is a reference-related instruction.
+fn is_ref_related_instr(instr: &Bytecode) -> bool {
+    use Operation::*;
+    match instr {
+        Bytecode::Call(_, _, op, _, _) => {
+            matches!(op, FreezeRef(_) | WriteRef | BorrowLoc | BorrowField(..))
+        },
+        _ => false,
+    }
+}
+
+pub struct InstructionReorderingProcessor {}
+
+impl FunctionTargetProcessor for InstructionReorderingProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv,
+        mut data: FunctionData,
+        _scc_opt: Option<&[FunctionEnv]>,
+    ) -> FunctionData {
+        if func_env.is_native() {
+            return data;
+        }
+        let target = FunctionTarget::new(func_env, &data);
+        let ReorderedInstructions {
+            instructions,
+            prepare_use,
+        } = Self::compute_reordered_instructions(&target);
+        // Clear all previous annotations, because reordering can change code
+        // and invalidate previous annotations.
+        data.annotations.clear();
+        data.code = instructions;
+        data.annotations.set(prepare_use, true);
+        data
+    }
+
+    fn name(&self) -> String {
+        "InstructionReorderingProcessor".to_string()
+    }
+}
+
+impl InstructionReorderingProcessor {
+    fn compute_reordered_instructions(target: &FunctionTarget) -> ReorderedInstructions {
+        let code = target.get_bytecode();
+        let cfg = StacklessControlFlowGraph::new_forward(code);
+        let mut block_ranges = cfg
+            .blocks()
+            .iter()
+            .filter_map(|block_id| cfg.instr_offset_bounds(*block_id))
+            .collect::<Vec<_>>();
+        // TODO: Explicit sorting can be skipped if `block_ranges` can be guaranteed to be already
+        // sorted (i.e., guaranteed based on the methods used on the `StacklessControlFlowGraph`).
+        block_ranges.sort_by_key(|k| k.0);
+        let mut new_code = vec![];
+        let mut function_level_prepare_use = PrepareUseAnnotation::default();
+        for (lower, upper) in block_ranges {
+            let block = code[usize::from(lower)..=usize::from(upper)].to_vec();
+            let ReorderedInstructions {
+                instructions,
+                prepare_use,
+            } = Self::optimize_for_stack_machine(block);
+            let new_lower = new_code.len() as CodeOffset;
+            new_code.extend(instructions);
+            function_level_prepare_use.extend_with(prepare_use, new_lower);
+        }
+        ReorderedInstructions {
+            instructions: new_code,
+            prepare_use: function_level_prepare_use,
+        }
+    }
+
+    fn optimize_for_stack_machine(block: Vec<Bytecode>) -> ReorderedInstructions {
+        // If there are any specification-only instructions or inline spec blocks,
+        // we do not perform any reordering optimizations, as dependencies in spec blocks
+        // are not captured. We may be able to relax this limitation in the future.
+        if block.iter().any(|instr| {
+            instr.is_spec_only()
+                || matches!(instr, Bytecode::SpecBlock(..))
+                || matches!(instr, Bytecode::Call(_, _, _, _, Some(_)))
+        }) {
+            return {
+                ReorderedInstructions {
+                    instructions: block,
+                    prepare_use: PrepareUseAnnotation::default(),
+                }
+            };
+        }
+        BlockReordering::prepare_and_reorder(block)
+    }
+}

--- a/third_party/move/move-compiler-v2/src/pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/mod.rs
@@ -4,7 +4,7 @@
 
 use crate::pipeline::{
     avail_copies_analysis::AvailCopiesAnalysisProcessor,
-    exit_state_analysis::ExitStateAnalysisProcessor,
+    exit_state_analysis::ExitStateAnalysisProcessor, flush_writes_processor::FlushWritesProcessor,
     livevar_analysis_processor::LiveVarAnalysisProcessor,
     reference_safety_processor::ReferenceSafetyProcessor,
     uninitialized_use_checker::UninitializedUseChecker,
@@ -17,6 +17,8 @@ pub mod avail_copies_analysis;
 pub mod copy_propagation;
 pub mod dead_store_elimination;
 pub mod exit_state_analysis;
+pub mod flush_writes_processor;
+pub mod instruction_reordering;
 pub mod livevar_analysis_processor;
 pub mod reference_safety_processor;
 pub mod split_critical_edges_processor;
@@ -32,6 +34,7 @@ pub mod visibility_checker;
 /// debugging.
 pub fn register_formatters(target: &FunctionTarget) {
     ExitStateAnalysisProcessor::register_formatters(target);
+    FlushWritesProcessor::register_formatters(target);
     LiveVarAnalysisProcessor::register_formatters(target);
     ReferenceSafetyProcessor::register_formatters(target);
     AvailCopiesAnalysisProcessor::register_formatters(target);

--- a/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/reference_safety_processor.rs
@@ -2049,7 +2049,7 @@ impl<'env> TransferFunctions for LifeTimeAnalysis<'env> {
                         );
                     },
                     ReadRef => step.read_ref(dests[0], srcs[0]),
-                    WriteRef => step.write_ref(srcs[0], srcs[1]),
+                    WriteRef => step.write_ref(srcs[1], srcs[0]),
                     FreezeRef(explicit) => {
                         step.freeze_ref(code_offset, *explicit, dests[0], srcs[0])
                     },

--- a/third_party/move/move-compiler-v2/tests/ability-transform/by_reference.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/by_reference.exp
@@ -71,11 +71,11 @@ fun <SELF>_0::check() {
  36: $t13 := 0
  37: $t12 := borrow_local($t13)
  38: $t14 := 1
- 39: write_ref($t12, $t14)
+ 39: write_ref($t14, $t12)
  40: $t16 := [104, 101, 108, 108, 111]
  41: $t15 := borrow_local($t16)
  42: $t17 := [98, 121, 101]
- 43: write_ref($t15, $t17)
+ 43: write_ref($t17, $t15)
  44: $t19 := read_ref($t12)
  45: $t20 := 1
  46: $t18 := ==($t19, $t20)
@@ -228,7 +228,7 @@ fun <SELF>_0::check() {
      # live vars: $t12
  38: $t14 := 1
      # live vars: $t12, $t14
- 39: write_ref($t12, $t14)
+ 39: write_ref($t14, $t12)
      # live vars: $t12
  40: $t16 := [104, 101, 108, 108, 111]
      # live vars: $t12, $t16
@@ -236,7 +236,7 @@ fun <SELF>_0::check() {
      # live vars: $t12, $t15
  42: $t17 := [98, 121, 101]
      # live vars: $t12, $t15, $t17
- 43: write_ref($t15, $t17)
+ 43: write_ref($t17, $t15)
      # live vars: $t12, $t15
  44: $t19 := read_ref($t12)
      # live vars: $t15, $t19
@@ -426,7 +426,7 @@ fun <SELF>_0::check() {
      # live vars: $t12
  38: $t14 := 1
      # live vars: $t12, $t14
- 39: write_ref($t12, $t14)
+ 39: write_ref($t14, $t12)
      # live vars: $t12
  40: $t16 := [104, 101, 108, 108, 111]
      # live vars: $t12, $t16
@@ -434,7 +434,7 @@ fun <SELF>_0::check() {
      # live vars: $t12, $t15
  42: $t17 := [98, 121, 101]
      # live vars: $t12, $t15, $t17
- 43: write_ref($t15, $t17)
+ 43: write_ref($t17, $t15)
      # live vars: $t12, $t15
  44: $t19 := read_ref($t12)
      # live vars: $t15, $t19
@@ -784,7 +784,7 @@ fun <SELF>_0::check() {
      # locals: {$t12=@2501,$t13=@2500}
      # globals: {}
      #
- 39: write_ref($t12, $t14)
+ 39: write_ref($t14, $t12)
      # live vars: $t12
      # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[]}
      # locals: {$t12=@2501,$t13=@2500}
@@ -808,7 +808,7 @@ fun <SELF>_0::check() {
      # locals: {$t12=@2501,$t13=@2500,$t15=@2901,$t16=@2900}
      # globals: {}
      #
- 43: write_ref($t15, $t17)
+ 43: write_ref($t17, $t15)
      # live vars: $t12, $t15
      # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
      # locals: {$t12=@2501,$t13=@2500,$t15=@2901,$t16=@2900}
@@ -1346,7 +1346,7 @@ fun <SELF>_0::check() {
      # locals: {$t12=@2501,$t13=@2500}
      # globals: {}
      #
- 39: write_ref($t12, $t14)
+ 39: write_ref($t14, $t12)
      # abort state: {returns,aborts}
      # live vars: $t12
      # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[]}
@@ -1374,7 +1374,7 @@ fun <SELF>_0::check() {
      # locals: {$t12=@2501,$t13=@2500,$t15=@2901,$t16=@2900}
      # globals: {}
      #
- 43: write_ref($t15, $t17)
+ 43: write_ref($t17, $t15)
      # abort state: {returns,aborts}
      # live vars: $t12, $t15
      # graph: {@2500=local($t13)[borrow_mut -> @2501],@2501=derived[],@2900=local($t16)[borrow_mut -> @2901],@2901=derived[]}
@@ -1709,11 +1709,11 @@ fun <SELF>_0::check() {
  36: $t13 := 0
  37: $t12 := borrow_local($t13)
  38: $t14 := 1
- 39: write_ref($t12, $t14)
+ 39: write_ref($t14, $t12)
  40: $t16 := [104, 101, 108, 108, 111]
  41: $t15 := borrow_local($t16)
  42: $t17 := [98, 121, 101]
- 43: write_ref($t15, $t17)
+ 43: write_ref($t17, $t15)
  44: $t19 := read_ref($t12)
  45: $t20 := 1
  46: $t18 := ==($t19, $t20)

--- a/third_party/move/move-compiler-v2/tests/ability-transform/drop_after_loop.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/drop_after_loop.exp
@@ -17,7 +17,7 @@ fun m::drop_after_loop() {
   4: if ($t2) goto 5 else goto 11
   5: label L2
   6: $t3 := 2
-  7: write_ref($t1, $t3)
+  7: write_ref($t3, $t1)
   8: $t4 := false
   9: $t2 := infer($t4)
  10: goto 13
@@ -65,7 +65,7 @@ fun m::drop_after_loop() {
      # live vars: $t0, $t1
   6: $t3 := 2
      # live vars: $t0, $t1, $t3
-  7: write_ref($t1, $t3)
+  7: write_ref($t3, $t1)
      # live vars: $t0, $t1
   8: $t4 := false
      # live vars: $t0, $t1, $t4
@@ -131,7 +131,7 @@ fun m::drop_after_loop() {
      # live vars: $t0, $t1
   6: $t3 := 2
      # live vars: $t0, $t1, $t3
-  7: write_ref($t1, $t3)
+  7: write_ref($t3, $t1)
      # live vars: $t0, $t1
   8: $t4 := false
      # live vars: $t0, $t1, $t4
@@ -229,7 +229,7 @@ fun m::drop_after_loop() {
      # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  7: write_ref($t1, $t3)
+  7: write_ref($t3, $t1)
      # live vars: $t0, $t1
      # graph: {@100=local($t0)[borrow_mut -> @101],@101=derived[]}
      # locals: {$t0=@100,$t1=@101}
@@ -407,7 +407,7 @@ fun m::drop_after_loop() {
      # locals: {$t0=@100,$t1=@101}
      # globals: {}
      #
-  7: write_ref($t1, $t3)
+  7: write_ref($t3, $t1)
      # abort state: {returns,aborts}
      # live vars: $t0, $t1
      # graph: {@100=local($t0)[borrow_mut -> @101],@101=derived[]}
@@ -555,7 +555,7 @@ fun m::drop_after_loop() {
   4: if ($t2) goto 5 else goto 11
   5: label L2
   6: $t3 := 2
-  7: write_ref($t1, $t3)
+  7: write_ref($t3, $t1)
   8: $t4 := false
   9: $t2 := move($t4)
  10: goto 14

--- a/third_party/move/move-compiler-v2/tests/ability-transform/foreach_mut_expanded.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/foreach_mut_expanded.exp
@@ -26,7 +26,7 @@ fun m::test_for_each_mut() {
   8: label L2
   9: $t6 := vector::borrow_mut<u64>($t4, $t1)
  10: $t7 := 2
- 11: write_ref($t6, $t7)
+ 11: write_ref($t7, $t6)
  12: $t9 := 1
  13: $t8 := +($t1, $t9)
  14: $t1 := infer($t8)
@@ -88,7 +88,7 @@ fun m::test_for_each_mut() {
      # live vars: $t0, $t1, $t2, $t4, $t6
  10: $t7 := 2
      # live vars: $t0, $t1, $t2, $t4, $t6, $t7
- 11: write_ref($t6, $t7)
+ 11: write_ref($t7, $t6)
      # live vars: $t0, $t1, $t2, $t4
  12: $t9 := 1
      # live vars: $t0, $t1, $t2, $t4, $t9
@@ -169,7 +169,7 @@ fun m::test_for_each_mut() {
      # live vars: $t0, $t1, $t2, $t4, $t6
  10: $t7 := 2
      # live vars: $t0, $t1, $t2, $t4, $t6, $t7
- 11: write_ref($t6, $t7)
+ 11: write_ref($t7, $t6)
      # live vars: $t0, $t1, $t2, $t4
  12: $t9 := 1
      # live vars: $t0, $t1, $t2, $t4, $t9
@@ -300,7 +300,7 @@ fun m::test_for_each_mut() {
      # globals: {}
      # derived-from: @900=$t4
      #
- 11: write_ref($t6, $t7)
+ 11: write_ref($t7, $t6)
      # live vars: $t0, $t1, $t2, $t4
      # graph: {@200=local($t0)[borrow_mut -> @401],@401=derived[]}
      # locals: {$t0=@200,$t4=@401}
@@ -519,7 +519,7 @@ fun m::test_for_each_mut() {
      # globals: {}
      # derived-from: @900=$t4
      #
- 11: write_ref($t6, $t7)
+ 11: write_ref($t7, $t6)
      # abort state: {returns,aborts}
      # live vars: $t0, $t1, $t2, $t4
      # graph: {@200=local($t0)[borrow_mut -> @401],@401=derived[]}
@@ -685,7 +685,7 @@ fun m::test_for_each_mut() {
   9: $t13 := copy($t4)
  10: $t6 := vector::borrow_mut<u64>($t13, $t1)
  11: $t7 := 2
- 12: write_ref($t6, $t7)
+ 12: write_ref($t7, $t6)
  13: $t9 := 1
  14: $t8 := +($t1, $t9)
  15: $t1 := move($t8)

--- a/third_party/move/move-compiler-v2/tests/ability-transform/mutate_vector.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/mutate_vector.exp
@@ -13,7 +13,7 @@ public fun m::new_scalar_from_u8($t0: u8): m::Scalar {
   2: $t4 := borrow_field<m::Scalar>.data($t5)
   3: $t6 := 0
   4: $t3 := vector::borrow_mut<u8>($t4, $t6)
-  5: write_ref($t3, $t0)
+  5: write_ref($t0, $t3)
   6: $t1 := infer($t2)
   7: return $t1
 }
@@ -49,7 +49,7 @@ public fun m::new_scalar_from_u8($t0: u8): m::Scalar {
      # live vars: $t0, $t2, $t4, $t6
   4: $t3 := vector::borrow_mut<u8>($t4, $t6)
      # live vars: $t0, $t2, $t3
-  5: write_ref($t3, $t0)
+  5: write_ref($t0, $t3)
      # live vars: $t2
   6: $t1 := infer($t2)
      # live vars: $t1
@@ -90,7 +90,7 @@ public fun m::new_scalar_from_u8($t0: u8): m::Scalar {
      # live vars: $t0, $t2, $t4, $t6
   4: $t3 := vector::borrow_mut<u8>($t4, $t6)
      # live vars: $t0, $t2, $t3
-  5: write_ref($t3, $t0)
+  5: write_ref($t0, $t3)
      # live vars: $t2
   6: $t1 := infer($t2)
      # live vars: $t1
@@ -158,7 +158,7 @@ public fun m::new_scalar_from_u8($t0: u8): m::Scalar {
      # globals: {}
      # derived-from: @201=$t5,@400=$t4
      #
-  5: write_ref($t3, $t0)
+  5: write_ref($t0, $t3)
      # live vars: $t2
      # graph: {@100=local($t2)[]}
      # locals: {$t2=@100}
@@ -252,7 +252,7 @@ public fun m::new_scalar_from_u8($t0: u8): m::Scalar {
      # globals: {}
      # derived-from: @201=$t5,@400=$t4
      #
-  5: write_ref($t3, $t0)
+  5: write_ref($t0, $t3)
      # abort state: {returns}
      # live vars: $t2
      # graph: {@100=local($t2)[]}
@@ -312,7 +312,7 @@ public fun m::new_scalar_from_u8($t0: u8): m::Scalar {
   2: $t4 := borrow_field<m::Scalar>.data($t5)
   3: $t6 := 0
   4: $t3 := vector::borrow_mut<u8>($t4, $t6)
-  5: write_ref($t3, $t0)
+  5: write_ref($t0, $t3)
   6: $t1 := move($t2)
   7: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/assign.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/assign.exp
@@ -31,7 +31,7 @@ module 0x42::assign {
 fun assign::assign_field($t0: &mut assign::S, $t1: u64) {
      var $t2: &mut u64
   0: $t2 := borrow_field<assign::S>.f($t0)
-  1: write_ref($t2, $t1)
+  1: write_ref($t1, $t2)
   2: return ()
 }
 
@@ -40,7 +40,7 @@ fun assign::assign_field($t0: &mut assign::S, $t1: u64) {
 fun assign::assign_int($t0: &mut u64) {
      var $t1: u64
   0: $t1 := 42
-  1: write_ref($t0, $t1)
+  1: write_ref($t1, $t0)
   2: return ()
 }
 
@@ -66,7 +66,7 @@ fun assign::assign_struct($t0: &mut assign::S) {
   1: $t4 := 42
   2: $t3 := pack assign::T($t4)
   3: $t1 := pack assign::S($t2, $t3)
-  4: write_ref($t0, $t1)
+  4: write_ref($t1, $t0)
   5: return ()
 }
 

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/borrow.exp
@@ -102,7 +102,7 @@ fun borrow::mut_field($t0: &mut borrow::S): u64 {
      var $t3: u64
   0: $t2 := borrow_field<borrow::S>.f($t0)
   1: $t3 := 22
-  2: write_ref($t2, $t3)
+  2: write_ref($t3, $t2)
   3: $t1 := read_ref($t2)
   4: return $t1
 }
@@ -117,7 +117,7 @@ fun borrow::mut_local($t0: u64): u64 {
   0: $t2 := 33
   1: $t3 := borrow_local($t2)
   2: $t4 := 22
-  3: write_ref($t3, $t4)
+  3: write_ref($t4, $t3)
   4: $t1 := read_ref($t3)
   5: return $t1
 }
@@ -130,7 +130,7 @@ fun borrow::mut_param($t0: u64): u64 {
      var $t3: u64
   0: $t2 := borrow_local($t0)
   1: $t3 := 22
-  2: write_ref($t2, $t3)
+  2: write_ref($t3, $t2)
   3: $t1 := read_ref($t2)
   4: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/conditional_borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/conditional_borrow.exp
@@ -162,13 +162,13 @@ fun M::test1($t0: u64): u64 {
   8: label L2
   9: $t2 := borrow_local($t3)
  10: $t6 := 10
- 11: write_ref($t2, $t6)
+ 11: write_ref($t6, $t2)
  12: $t7 := infer($t0)
  13: $t8 := borrow_local($t7)
  14: $t10 := read_ref($t8)
  15: $t11 := 1
  16: $t9 := +($t10, $t11)
- 17: write_ref($t8, $t9)
+ 17: write_ref($t9, $t8)
  18: $t12 := infer($t7)
  19: $t15 := 0
  20: $t14 := +($t12, $t15)
@@ -176,27 +176,27 @@ fun M::test1($t0: u64): u64 {
  22: $t17 := read_ref($t13)
  23: $t18 := 2
  24: $t16 := +($t17, $t18)
- 25: write_ref($t13, $t16)
+ 25: write_ref($t16, $t13)
  26: $t19 := infer($t12)
  27: $t21 := infer($t19)
  28: $t20 := borrow_local($t21)
  29: $t23 := read_ref($t20)
  30: $t24 := 4
  31: $t22 := +($t23, $t24)
- 32: write_ref($t20, $t22)
+ 32: write_ref($t22, $t20)
  33: $t26 := infer($t19)
  34: $t25 := borrow_local($t26)
  35: $t28 := read_ref($t25)
  36: $t29 := 8
  37: $t27 := +($t28, $t29)
- 38: write_ref($t25, $t27)
+ 38: write_ref($t27, $t25)
  39: $t32 := 3
  40: $t31 := infer($t19)
  41: $t30 := borrow_local($t31)
  42: $t34 := read_ref($t30)
  43: $t35 := 16
  44: $t33 := +($t34, $t35)
- 45: write_ref($t30, $t33)
+ 45: write_ref($t33, $t30)
  46: $t1 := infer($t19)
  47: return $t1
 }
@@ -279,7 +279,7 @@ fun M::test1b($t0: M::S): u64 {
  16: $t13 := read_ref($t4)
  17: $t14 := borrow_local($t13)
  18: $t12 := borrow_field<M::S>.f($t14)
- 19: write_ref($t12, $t11)
+ 19: write_ref($t11, $t12)
  20: $t15 := infer($t0)
  21: $t16 := borrow_local($t15)
  22: $t19 := read_ref($t16)
@@ -291,14 +291,14 @@ fun M::test1b($t0: M::S): u64 {
  28: $t24 := read_ref($t16)
  29: $t25 := borrow_local($t24)
  30: $t23 := borrow_field<M::S>.f($t25)
- 31: write_ref($t23, $t17)
+ 31: write_ref($t17, $t23)
  32: $t26 := infer($t15)
  33: $t28 := borrow_local($t26)
  34: $t27 := borrow_field<M::S>.f($t28)
  35: $t30 := read_ref($t27)
  36: $t31 := 1
  37: $t29 := +($t30, $t31)
- 38: write_ref($t27, $t29)
+ 38: write_ref($t29, $t27)
  39: $t32 := infer($t26)
  40: $t35 := borrow_local($t32)
  41: $t36 := borrow_field<M::S>.f($t35)
@@ -307,7 +307,7 @@ fun M::test1b($t0: M::S): u64 {
  44: $t38 := read_ref($t33)
  45: $t39 := 1
  46: $t37 := +($t38, $t39)
- 47: write_ref($t33, $t37)
+ 47: write_ref($t37, $t33)
  48: $t42 := borrow_local($t32)
  49: $t43 := borrow_field<M::S>.f($t42)
  50: $t41 := read_ref($t43)
@@ -315,7 +315,7 @@ fun M::test1b($t0: M::S): u64 {
  52: $t45 := read_ref($t40)
  53: $t46 := 8
  54: $t44 := +($t45, $t46)
- 55: write_ref($t40, $t44)
+ 55: write_ref($t44, $t40)
  56: $t49 := 3
  57: $t50 := borrow_local($t32)
  58: $t51 := borrow_field<M::S>.f($t50)
@@ -324,7 +324,7 @@ fun M::test1b($t0: M::S): u64 {
  61: $t53 := read_ref($t47)
  62: $t54 := 16
  63: $t52 := +($t53, $t54)
- 64: write_ref($t47, $t52)
+ 64: write_ref($t52, $t47)
  65: $t55 := borrow_local($t32)
  66: $t56 := borrow_field<M::S>.f($t55)
  67: $t1 := read_ref($t56)

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/fields.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/fields.exp
@@ -103,7 +103,7 @@ fun fields::read_val($t0: fields::S): u64 {
 fun fields::write_generic_val($t0: &mut fields::G<u64>, $t1: u64) {
      var $t2: &mut u64
   0: $t2 := borrow_field<fields::G<u64>>.f($t0)
-  1: write_ref($t2, $t1)
+  1: write_ref($t1, $t2)
   2: return ()
 }
 
@@ -127,7 +127,7 @@ fun fields::write_local_direct(): fields::S {
   5: $t8 := borrow_local($t1)
   6: $t7 := borrow_field<fields::S>.g($t8)
   7: $t6 := borrow_field<fields::T>.h($t7)
-  8: write_ref($t6, $t5)
+  8: write_ref($t5, $t6)
   9: $t0 := infer($t1)
  10: return $t0
 }
@@ -152,7 +152,7 @@ fun fields::write_local_via_ref(): fields::S {
   5: $t6 := 42
   6: $t8 := borrow_field<fields::S>.g($t5)
   7: $t7 := borrow_field<fields::T>.h($t8)
-  8: write_ref($t7, $t6)
+  8: write_ref($t6, $t7)
   9: $t0 := infer($t1)
  10: return $t0
 }
@@ -177,7 +177,7 @@ fun fields::write_local_via_ref_2(): fields::S {
   5: $t6 := borrow_field<fields::S>.g($t7)
   6: $t5 := borrow_field<fields::T>.h($t6)
   7: $t8 := 42
-  8: write_ref($t5, $t8)
+  8: write_ref($t8, $t5)
   9: $t0 := infer($t1)
  10: return $t0
 }
@@ -191,7 +191,7 @@ fun fields::write_param($t0: &mut fields::S) {
   0: $t1 := 42
   1: $t3 := borrow_field<fields::S>.g($t0)
   2: $t2 := borrow_field<fields::T>.h($t3)
-  3: write_ref($t2, $t1)
+  3: write_ref($t1, $t2)
   4: return ()
 }
 
@@ -207,7 +207,7 @@ fun fields::write_val($t0: fields::S): fields::S {
   1: $t5 := borrow_local($t0)
   2: $t4 := borrow_field<fields::S>.g($t5)
   3: $t3 := borrow_field<fields::T>.h($t4)
-  4: write_ref($t3, $t2)
+  4: write_ref($t2, $t3)
   5: $t1 := infer($t0)
   6: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/freeze_mut_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/freeze_mut_ref.exp
@@ -237,11 +237,11 @@ public fun freeze_mut_ref::t5($t0: &mut freeze_mut_ref::G) {
  12: $t10 := borrow_local($t11)
  13: $t13 := 2
  14: $t15 := 0
- 15: write_ref($t2, $t15)
+ 15: write_ref($t15, $t2)
  16: $t16 := freeze_ref(implicit)($t10)
  17: $t12 := infer($t16)
  18: $t14 := infer($t6)
- 19: write_ref($t14, $t13)
+ 19: write_ref($t13, $t14)
  20: return ()
 }
 

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/globals.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/globals.exp
@@ -79,7 +79,7 @@ fun globals::write($t0: address, $t1: u64): u64 {
   0: $t3 := borrow_global<globals::R>($t0)
   1: $t4 := 2
   2: $t5 := borrow_field<globals::R>.f($t3)
-  3: write_ref($t5, $t4)
+  3: write_ref($t4, $t5)
   4: $t2 := 9
   5: return $t2
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/reference_conversion.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/reference_conversion.exp
@@ -35,7 +35,7 @@ fun reference_conversion::use_it(): u64 {
   0: $t1 := 42
   1: $t2 := borrow_local($t1)
   2: $t3 := 43
-  3: write_ref($t2, $t3)
+  3: write_ref($t3, $t2)
   4: $t4 := freeze_ref(implicit)($t2)
   5: $t0 := reference_conversion::deref($t4)
   6: return $t0

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/wildcard4.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/wildcard4.exp
@@ -34,7 +34,7 @@ fun m::test() {
   3: $t3 := freeze_ref($t2)
   4: $t4 := infer($t3)
   5: $t5 := 4
-  6: write_ref($t1, $t5)
+  6: write_ref($t5, $t1)
   7: return ()
 }
 

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/call_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/call_2.exp
@@ -4,7 +4,7 @@
 fun m::update($t0: &mut u64) {
      var $t1: u64
   0: $t1 := 0
-  1: write_ref($t0, $t1)
+  1: write_ref($t1, $t0)
   2: return ()
 }
 
@@ -31,7 +31,7 @@ fun m::test($t0: u64): u64 {
 fun m::update($t0: &mut u64) {
      var $t1: u64
   0: $t1 := 0
-  1: write_ref($t0, $t1)
+  1: write_ref($t1, $t0)
   2: return ()
 }
 

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_1.exp
@@ -9,7 +9,7 @@ fun m::test($t0: u64): u64 {
   0: $t2 := infer($t0)
   1: $t3 := borrow_local($t0)
   2: $t4 := 1
-  3: write_ref($t3, $t4)
+  3: write_ref($t4, $t3)
   4: $t1 := infer($t2)
   5: return $t1
 }
@@ -25,7 +25,7 @@ fun m::test($t0: u64): u64 {
   0: $t2 := copy($t0)
   1: $t3 := borrow_local($t0)
   2: $t4 := 1
-  3: write_ref($t3, $t4)
+  3: write_ref($t4, $t3)
   4: $t1 := move($t2)
   5: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_2.exp
@@ -15,7 +15,7 @@ fun m::test($t0: m::S): u64 {
   2: $t5 := borrow_local($t2)
   3: $t4 := borrow_field<m::S>.a($t5)
   4: $t6 := 0
-  5: write_ref($t4, $t6)
+  5: write_ref($t6, $t4)
   6: $t7 := borrow_local($t3)
   7: $t8 := borrow_field<m::S>.a($t7)
   8: $t1 := read_ref($t8)
@@ -61,7 +61,7 @@ fun m::test($t0: m::S): u64 {
   2: $t5 := borrow_local($t2)
   3: $t4 := borrow_field<m::S>.a($t5)
   4: $t6 := 0
-  5: write_ref($t4, $t6)
+  5: write_ref($t6, $t4)
   6: $t7 := borrow_local($t3)
   7: $t8 := borrow_field<m::S>.a($t7)
   8: $t1 := read_ref($t8)

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_3.exp
@@ -11,7 +11,7 @@ fun m::test($t0: u64): u64 {
   1: $t3 := infer($t2)
   2: $t4 := infer($t3)
   3: $t5 := 0
-  4: write_ref($t2, $t5)
+  4: write_ref($t5, $t2)
   5: $t1 := read_ref($t4)
   6: return $t1
 }
@@ -39,7 +39,7 @@ fun m::test($t0: u64): u64 {
   1: $t3 := copy($t2)
   2: $t4 := move($t3)
   3: $t5 := 0
-  4: write_ref($t2, $t5)
+  4: write_ref($t5, $t2)
   5: $t1 := read_ref($t4)
   6: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_4.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/mut_refs_4.exp
@@ -13,7 +13,7 @@ fun m::test($t0: u64): u64 {
   2: $t4 := infer($t3)
   3: $t5 := infer($t4)
   4: $t6 := 0
-  5: write_ref($t2, $t6)
+  5: write_ref($t6, $t2)
   6: $t1 := infer($t5)
   7: return $t1
 }
@@ -46,7 +46,7 @@ fun m::test($t0: u64): u64 {
   2: $t4 := move($t3)
   3: $t5 := move($t4)
   4: $t6 := 0
-  5: write_ref($t2, $t6)
+  5: write_ref($t6, $t2)
   6: $t1 := move($t5)
   7: return $t1
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/assign.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/assign.opt.exp
@@ -11,15 +11,12 @@ struct S has drop {
 }
 
 assign_field(Arg0: &mut S, Arg1: u64) /* def_idx: 0 */ {
-L2:	loc0: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: &mut S)
-	1: MutBorrowField[0](S.f: u64)
-	2: StLoc[2](loc0: &mut u64)
-	3: MoveLoc[1](Arg1: u64)
-	4: MoveLoc[2](loc0: &mut u64)
-	5: WriteRef
-	6: Ret
+	0: MoveLoc[1](Arg1: u64)
+	1: MoveLoc[0](Arg0: &mut S)
+	2: MutBorrowField[0](S.f: u64)
+	3: WriteRef
+	4: Ret
 }
 assign_int(Arg0: &mut u64) /* def_idx: 1 */ {
 B0:

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.opt.exp
@@ -43,52 +43,44 @@ B0:
 	2: Ret
 }
 mut_field(Arg0: &mut S): u64 /* def_idx: 3 */ {
-L1:	loc0: u64
-L2:	loc1: &mut u64
+L1:	loc0: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: &mut S)
-	1: MutBorrowField[0](S.f: u64)
-	2: LdU64(22)
-	3: StLoc[1](loc0: u64)
-	4: StLoc[2](loc1: &mut u64)
-	5: MoveLoc[1](loc0: u64)
-	6: CopyLoc[2](loc1: &mut u64)
-	7: WriteRef
-	8: MoveLoc[2](loc1: &mut u64)
-	9: ReadRef
-	10: Ret
+	0: LdU64(22)
+	1: MoveLoc[0](Arg0: &mut S)
+	2: MutBorrowField[0](S.f: u64)
+	3: StLoc[1](loc0: &mut u64)
+	4: CopyLoc[1](loc0: &mut u64)
+	5: WriteRef
+	6: MoveLoc[1](loc0: &mut u64)
+	7: ReadRef
+	8: Ret
 }
 mut_local(Arg0: u64): u64 /* def_idx: 4 */ {
 L1:	loc0: u64
 L2:	loc1: &mut u64
 B0:
-	0: LdU64(33)
-	1: StLoc[1](loc0: u64)
-	2: MutBorrowLoc[1](loc0: u64)
-	3: LdU64(22)
-	4: StLoc[0](Arg0: u64)
-	5: StLoc[2](loc1: &mut u64)
-	6: MoveLoc[0](Arg0: u64)
-	7: CopyLoc[2](loc1: &mut u64)
-	8: WriteRef
-	9: MoveLoc[2](loc1: &mut u64)
-	10: ReadRef
-	11: Ret
-}
-mut_param(Arg0: u64): u64 /* def_idx: 5 */ {
-L1:	loc0: u64
-L2:	loc1: &mut u64
-B0:
-	0: MutBorrowLoc[0](Arg0: u64)
-	1: LdU64(22)
+	0: LdU64(22)
+	1: LdU64(33)
 	2: StLoc[1](loc0: u64)
-	3: StLoc[2](loc1: &mut u64)
-	4: MoveLoc[1](loc0: u64)
+	3: MutBorrowLoc[1](loc0: u64)
+	4: StLoc[2](loc1: &mut u64)
 	5: CopyLoc[2](loc1: &mut u64)
 	6: WriteRef
 	7: MoveLoc[2](loc1: &mut u64)
 	8: ReadRef
 	9: Ret
+}
+mut_param(Arg0: u64): u64 /* def_idx: 5 */ {
+L1:	loc0: &mut u64
+B0:
+	0: LdU64(22)
+	1: MutBorrowLoc[0](Arg0: u64)
+	2: StLoc[1](loc0: &mut u64)
+	3: CopyLoc[1](loc0: &mut u64)
+	4: WriteRef
+	5: MoveLoc[1](loc0: &mut u64)
+	6: ReadRef
+	7: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.opt.exp
@@ -144,36 +144,36 @@ test_constans() /* def_idx: 0 */ {
 B0:
 	0: LdTrue
 	1: Call u<bool>(bool): bool
-	2: LdFalse
-	3: Call u<bool>(bool): bool
-	4: LdU8(1)
-	5: Call u<u8>(u8): u8
-	6: LdU16(7086)
-	7: Call u<u16>(u16): u16
-	8: LdU32(14593408)
-	9: Call u<u32>(u32): u32
-	10: LdU64(51966)
-	11: Call u<u64>(u64): u64
-	12: LdU128(3735928559)
-	13: Call u<u128>(u128): u128
-	14: LdU256(301490978409967)
-	15: Call u<u256>(u256): u256
-	16: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66])
-	17: Call u<address>(address): address
-	18: LdConst[1](Vector(U64): [3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0])
-	19: Call u<vector<u64>>(vector<u64>): vector<u64>
-	20: LdConst[2](Vector(U8): [7, 72, 101, 108, 108, 111, 33, 10])
-	21: Call u<vector<u8>>(vector<u8>): vector<u8>
-	22: Pop
+	2: Pop
+	3: LdFalse
+	4: Call u<bool>(bool): bool
+	5: Pop
+	6: LdU8(1)
+	7: Call u<u8>(u8): u8
+	8: Pop
+	9: LdU16(7086)
+	10: Call u<u16>(u16): u16
+	11: Pop
+	12: LdU32(14593408)
+	13: Call u<u32>(u32): u32
+	14: Pop
+	15: LdU64(51966)
+	16: Call u<u64>(u64): u64
+	17: Pop
+	18: LdU128(3735928559)
+	19: Call u<u128>(u128): u128
+	20: Pop
+	21: LdU256(301490978409967)
+	22: Call u<u256>(u256): u256
 	23: Pop
-	24: Pop
-	25: Pop
+	24: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66])
+	25: Call u<address>(address): address
 	26: Pop
-	27: Pop
-	28: Pop
+	27: LdConst[1](Vector(U64): [3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0])
+	28: Call u<vector<u64>>(vector<u64>): vector<u64>
 	29: Pop
-	30: Pop
-	31: Pop
+	30: LdConst[2](Vector(U8): [7, 72, 101, 108, 108, 111, 33, 10])
+	31: Call u<vector<u8>>(vector<u8>): vector<u8>
 	32: Pop
 	33: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/globals.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/globals.opt.exp
@@ -21,15 +21,12 @@ B0:
 	2: Ret
 }
 publish(Arg0: &signer) /* def_idx: 1 */ {
-L1:	loc0: R
 B0:
-	0: LdU64(1)
-	1: Pack[0](R)
-	2: StLoc[1](loc0: R)
-	3: MoveLoc[0](Arg0: &signer)
-	4: MoveLoc[1](loc0: R)
-	5: MoveTo[0](R)
-	6: Ret
+	0: MoveLoc[0](Arg0: &signer)
+	1: LdU64(1)
+	2: Pack[0](R)
+	3: MoveTo[0](R)
+	4: Ret
 }
 read(Arg0: address): u64 /* def_idx: 2 */ {
 B0:
@@ -40,20 +37,14 @@ B0:
 	4: Ret
 }
 write(Arg0: address, Arg1: u64): u64 /* def_idx: 3 */ {
-L2:	loc0: &mut R
-L3:	loc1: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: address)
-	1: MutBorrowGlobal[0](R)
-	2: LdU64(2)
-	3: StLoc[1](Arg1: u64)
-	4: MutBorrowField[0](R.f: u64)
-	5: StLoc[3](loc1: &mut u64)
-	6: MoveLoc[1](Arg1: u64)
-	7: MoveLoc[3](loc1: &mut u64)
-	8: WriteRef
-	9: LdU64(9)
-	10: Ret
+	0: LdU64(2)
+	1: MoveLoc[0](Arg0: address)
+	2: MutBorrowGlobal[0](R)
+	3: MutBorrowField[0](R.f: u64)
+	4: WriteRef
+	5: LdU64(9)
+	6: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.opt.exp
@@ -6,7 +6,6 @@ module 42.if_else {
 
 if_else(Arg0: bool, Arg1: u64): u64 /* def_idx: 0 */ {
 L2:	loc0: u64
-L3:	loc1: u64
 B0:
 	0: MoveLoc[0](Arg0: bool)
 	1: BrFalse(7)
@@ -27,7 +26,6 @@ B3:
 }
 if_else_nested(Arg0: bool, Arg1: u64): u64 /* def_idx: 1 */ {
 L2:	loc0: u64
-L3:	loc1: u64
 B0:
 	0: MoveLoc[0](Arg0: bool)
 	1: BrFalse(7)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/loop.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/loop.opt.exp
@@ -5,7 +5,6 @@ module 42.loops {
 
 
 nested_loop(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: LdU64(0)
@@ -37,7 +36,6 @@ B6:
 	21: Ret
 }
 while_loop(Arg0: u64): u64 /* def_idx: 1 */ {
-L1:	loc0: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: LdU64(0)
@@ -58,7 +56,6 @@ B4:
 	12: Ret
 }
 while_loop_with_break_and_continue(Arg0: u64): u64 /* def_idx: 2 */ {
-L1:	loc0: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: LdU64(0)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.opt.exp
@@ -11,15 +11,12 @@ struct S {
 }
 
 pack(Arg0: u64, Arg1: u64): S /* def_idx: 0 */ {
-L2:	loc0: T
 B0:
-	0: MoveLoc[1](Arg1: u64)
-	1: Pack[0](T)
-	2: StLoc[2](loc0: T)
-	3: MoveLoc[0](Arg0: u64)
-	4: MoveLoc[2](loc0: T)
-	5: Pack[1](S)
-	6: Ret
+	0: MoveLoc[0](Arg0: u64)
+	1: MoveLoc[1](Arg1: u64)
+	2: Pack[0](T)
+	3: Pack[1](S)
+	4: Ret
 }
 unpack(Arg0: S): u64 * u64 /* def_idx: 1 */ {
 B0:

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.opt.exp
@@ -461,47 +461,44 @@ B10:
 }
 select_common_fields(Arg0: CommonFields): u64 /* def_idx: 9 */ {
 L1:	loc0: &CommonFields
-L2:	loc1: bool
+L2:	loc1: u64
 L3:	loc2: u64
-L4:	loc3: u64
 B0:
 	0: ImmBorrowLoc[0](Arg0: CommonFields)
 	1: ImmBorrowVariantField[3](Foo.x|Bar.x: u64)
 	2: ReadRef
-	3: ImmBorrowLoc[0](Arg0: CommonFields)
-	4: StLoc[1](loc0: &CommonFields)
-	5: CopyLoc[1](loc0: &CommonFields)
-	6: TestVariant[7](CommonFields/Foo)
-	7: StLoc[2](loc1: bool)
-	8: StLoc[3](loc2: u64)
-	9: MoveLoc[2](loc1: bool)
-	10: BrFalse(18)
+	3: StLoc[2](loc1: u64)
+	4: ImmBorrowLoc[0](Arg0: CommonFields)
+	5: StLoc[1](loc0: &CommonFields)
+	6: CopyLoc[1](loc0: &CommonFields)
+	7: TestVariant[7](CommonFields/Foo)
+	8: BrFalse(16)
 B1:
-	11: MoveLoc[1](loc0: &CommonFields)
-	12: Pop
-	13: MoveLoc[0](Arg0: CommonFields)
-	14: UnpackVariant[7](CommonFields/Foo)
-	15: StLoc[4](loc3: u64)
-	16: Pop
-	17: Branch(28)
+	9: MoveLoc[1](loc0: &CommonFields)
+	10: Pop
+	11: MoveLoc[0](Arg0: CommonFields)
+	12: UnpackVariant[7](CommonFields/Foo)
+	13: StLoc[3](loc2: u64)
+	14: Pop
+	15: Branch(26)
 B2:
-	18: MoveLoc[1](loc0: &CommonFields)
-	19: TestVariant[8](CommonFields/Bar)
-	20: BrFalse(26)
+	16: MoveLoc[1](loc0: &CommonFields)
+	17: TestVariant[8](CommonFields/Bar)
+	18: BrFalse(24)
 B3:
-	21: MoveLoc[0](Arg0: CommonFields)
-	22: UnpackVariant[8](CommonFields/Bar)
-	23: StLoc[4](loc3: u64)
-	24: Pop
-	25: Branch(28)
+	19: MoveLoc[0](Arg0: CommonFields)
+	20: UnpackVariant[8](CommonFields/Bar)
+	21: StLoc[3](loc2: u64)
+	22: Pop
+	23: Branch(26)
 B4:
-	26: LdU64(15621340914461310977)
-	27: Abort
+	24: LdU64(15621340914461310977)
+	25: Abort
 B5:
-	28: MoveLoc[3](loc2: u64)
-	29: MoveLoc[4](loc3: u64)
-	30: Add
-	31: Ret
+	26: MoveLoc[2](loc1: u64)
+	27: MoveLoc[3](loc2: u64)
+	28: Add
+	29: Ret
 }
 select_common_fields_different_offset(Arg0: CommonFieldsAtDifferentOffset): u64 /* def_idx: 10 */ {
 L1:	loc0: &CommonFieldsAtDifferentOffset

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/vector.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/vector.opt.exp
@@ -9,15 +9,15 @@ use 0000000000000000000000000000000000000000000000000000000000000001::vector as 
 
 public remove<Ty0>(Arg0: &mut vector<Ty0>, Arg1: u64): Ty0 /* def_idx: 0 */ {
 L2:	loc0: u64
-L3:	loc1: u64
-L4:	loc2: &mut vector<Ty0>
+L3:	loc1: &mut vector<Ty0>
+L4:	loc2: u64
 L5:	loc3: u64
 B0:
-	0: CopyLoc[0](Arg0: &mut vector<Ty0>)
-	1: FreezeRef
-	2: VecLen(1)
-	3: StLoc[2](loc0: u64)
-	4: CopyLoc[1](Arg1: u64)
+	0: CopyLoc[1](Arg1: u64)
+	1: CopyLoc[0](Arg0: &mut vector<Ty0>)
+	2: FreezeRef
+	3: VecLen(1)
+	4: StLoc[2](loc0: u64)
 	5: CopyLoc[2](loc0: u64)
 	6: Ge
 	7: BrFalse(12)
@@ -38,17 +38,17 @@ B3:
 	19: BrFalse(35)
 B4:
 	20: CopyLoc[0](Arg0: &mut vector<Ty0>)
-	21: StLoc[4](loc2: &mut vector<Ty0>)
+	21: StLoc[3](loc1: &mut vector<Ty0>)
 	22: CopyLoc[1](Arg1: u64)
-	23: StLoc[3](loc1: u64)
+	23: StLoc[4](loc2: u64)
 	24: MoveLoc[1](Arg1: u64)
 	25: LdU64(1)
 	26: Add
 	27: StLoc[1](Arg1: u64)
 	28: CopyLoc[1](Arg1: u64)
 	29: StLoc[5](loc3: u64)
-	30: MoveLoc[4](loc2: &mut vector<Ty0>)
-	31: MoveLoc[3](loc1: u64)
+	30: MoveLoc[3](loc1: &mut vector<Ty0>)
+	31: MoveLoc[4](loc2: u64)
 	32: MoveLoc[5](loc3: u64)
 	33: VecSwap(1)
 	34: Branch(36)
@@ -67,33 +67,32 @@ B0:
 	1: Ret
 }
 test_fold() /* def_idx: 2 */ {
-L0:	loc0: vector<u64>
-L1:	loc1: u64
-L2:	loc2: u64
+L0:	loc0: u64
+L1:	loc1: vector<u64>
 B0:
 	0: LdU64(0)
-	1: LdConst[1](Vector(U64): [1, 1, 0, 0, 0, 0, 0, 0, 0])
-	2: StLoc[0](loc0: vector<u64>)
-	3: MutBorrowLoc[0](loc0: vector<u64>)
-	4: Call 1vector::reverse<u64>(&mut vector<u64>)
-	5: StLoc[1](loc1: u64)
+	1: StLoc[0](loc0: u64)
+	2: LdConst[1](Vector(U64): [1, 1, 0, 0, 0, 0, 0, 0, 0])
+	3: StLoc[1](loc1: vector<u64>)
+	4: MutBorrowLoc[1](loc1: vector<u64>)
+	5: Call 1vector::reverse<u64>(&mut vector<u64>)
 B1:
-	6: ImmBorrowLoc[0](loc0: vector<u64>)
+	6: ImmBorrowLoc[1](loc1: vector<u64>)
 	7: Call 1vector::is_empty<u64>(&vector<u64>): bool
 	8: BrTrue(15)
 B2:
-	9: MutBorrowLoc[0](loc0: vector<u64>)
+	9: MutBorrowLoc[1](loc1: vector<u64>)
 	10: VecPopBack(5)
-	11: LdU64(0)
-	12: StLoc[1](loc1: u64)
-	13: Pop
+	11: Pop
+	12: LdU64(0)
+	13: StLoc[0](loc0: u64)
 	14: Branch(16)
 B3:
 	15: Branch(17)
 B4:
 	16: Branch(6)
 B5:
-	17: MoveLoc[1](loc1: u64)
+	17: MoveLoc[0](loc0: u64)
 	18: LdU64(0)
 	19: Eq
 	20: BrFalse(22)

--- a/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.move
@@ -1,0 +1,25 @@
+module 0xc0ffee::m {
+    fun foo(x: u64): (u64, u64) {
+        (x, x - 1)
+    }
+
+    public fun test1(x: u64) {
+        loop {
+            let y: u64;
+            (y, x) = foo(x);
+            if (y == 0) {
+                break;
+            }
+        }
+    }
+
+    public fun test2(x: u64) {
+        loop {
+            let y: u64;
+            (x, y) = foo(x);
+            if (y == 0) {
+                break;
+            }
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.off.exp
@@ -1,0 +1,59 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+foo(Arg0: u64): u64 * u64 /* def_idx: 0 */ {
+L1:	loc0: u64
+L2:	loc1: u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: MoveLoc[0](Arg0: u64)
+	3: LdU64(1)
+	4: Sub
+	5: StLoc[0](Arg0: u64)
+	6: MoveLoc[1](loc0: u64)
+	7: MoveLoc[0](Arg0: u64)
+	8: Ret
+}
+public test1(Arg0: u64) /* def_idx: 1 */ {
+L1:	loc0: u64
+L2:	loc1: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Call foo(u64): u64 * u64
+	2: LdU64(0)
+	3: StLoc[1](loc0: u64)
+	4: StLoc[0](Arg0: u64)
+	5: MoveLoc[1](loc0: u64)
+	6: Eq
+	7: BrFalse(9)
+B1:
+	8: Branch(10)
+B2:
+	9: Branch(0)
+B3:
+	10: Ret
+}
+public test2(Arg0: u64) /* def_idx: 2 */ {
+L1:	loc0: bool
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Call foo(u64): u64 * u64
+	2: LdU64(0)
+	3: Eq
+	4: StLoc[1](loc0: bool)
+	5: StLoc[0](Arg0: u64)
+	6: MoveLoc[1](loc0: bool)
+	7: BrFalse(9)
+B1:
+	8: Branch(10)
+B2:
+	9: Branch(0)
+B3:
+	10: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.on.exp
@@ -1,0 +1,139 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64): (u64, u64) {
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64
+     # live vars: $t0
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  1: touch($t0)
+     # live vars: $t0, $t1
+  2: $t3 := 1
+     # live vars: $t0, $t1, $t3
+  3: $t0 := -($t0, $t3)
+     # live vars: $t0, $t1
+  4: return ($t1, $t0)
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     # live vars: $t0
+  0: label L0
+     # flush: $t0
+     # live vars: $t0
+  1: ($t1, $t0) := m::foo($t0)
+     # live vars: $t0, $t1
+  2: $t3 := 0
+     # live vars: $t0, $t1, $t3
+  3: $t2 := ==($t1, $t3)
+     # live vars: $t0, $t2
+  4: if ($t2) goto 5 else goto 7
+     # live vars: $t0
+  5: label L2
+     # live vars:
+  6: goto 10
+     # live vars: $t0
+  7: label L3
+     # live vars: $t0
+  8: label L4
+     # live vars: $t0
+  9: goto 0
+     # live vars:
+ 10: label L1
+     # live vars:
+ 11: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     # live vars: $t0
+  0: label L0
+     # flush: $t0
+     # live vars: $t0
+  1: ($t0, $t1) := m::foo($t0)
+     # live vars: $t0, $t1
+  2: $t3 := 0
+     # live vars: $t0, $t1, $t3
+  3: $t2 := ==($t1, $t3)
+     # live vars: $t0, $t2
+  4: if ($t2) goto 5 else goto 7
+     # live vars: $t0
+  5: label L2
+     # live vars:
+  6: goto 10
+     # live vars: $t0
+  7: label L3
+     # live vars: $t0
+  8: label L4
+     # live vars: $t0
+  9: goto 0
+     # live vars:
+ 10: label L1
+     # live vars:
+ 11: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+foo(Arg0: u64): u64 * u64 /* def_idx: 0 */ {
+L1:	loc0: u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: MoveLoc[0](Arg0: u64)
+	3: LdU64(1)
+	4: Sub
+	5: StLoc[0](Arg0: u64)
+	6: MoveLoc[1](loc0: u64)
+	7: MoveLoc[0](Arg0: u64)
+	8: Ret
+}
+public test1(Arg0: u64) /* def_idx: 1 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Call foo(u64): u64 * u64
+	2: StLoc[0](Arg0: u64)
+	3: LdU64(0)
+	4: Eq
+	5: BrFalse(7)
+B1:
+	6: Branch(8)
+B2:
+	7: Branch(0)
+B3:
+	8: Ret
+}
+public test2(Arg0: u64) /* def_idx: 2 */ {
+L1:	loc0: bool
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Call foo(u64): u64 * u64
+	2: LdU64(0)
+	3: Eq
+	4: StLoc[1](loc0: bool)
+	5: StLoc[0](Arg0: u64)
+	6: MoveLoc[1](loc0: bool)
+	7: BrFalse(9)
+B1:
+	8: Branch(10)
+B2:
+	9: Branch(0)
+B3:
+	10: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.move
@@ -1,0 +1,26 @@
+module 0xc0ffee::m {
+    fun one(): u64 {
+        1
+    }
+
+    public fun test1(): (u64, u64) {
+        let _x = one();
+        let y = one();
+        let z = one();
+        (y, z)
+    }
+
+    public fun test2(): (u64, u64) {
+        let x = one();
+        let _y = one();
+        let z = one();
+        (x, z)
+    }
+
+    public fun test3(): (u64, u64) {
+        let x = one();
+        let _y = one();
+        let z = one();
+        (z, x)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.off.exp
@@ -1,0 +1,53 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one(): u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test1(): u64 * u64 /* def_idx: 1 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: Call one(): u64
+	2: Call one(): u64
+	3: StLoc[0](loc0: u64)
+	4: StLoc[1](loc1: u64)
+	5: Pop
+	6: MoveLoc[1](loc1: u64)
+	7: MoveLoc[0](loc0: u64)
+	8: Ret
+}
+public test2(): u64 * u64 /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: Call one(): u64
+	2: Call one(): u64
+	3: StLoc[0](loc0: u64)
+	4: Pop
+	5: MoveLoc[0](loc0: u64)
+	6: Ret
+}
+public test3(): u64 * u64 /* def_idx: 3 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: Call one(): u64
+	2: Call one(): u64
+	3: StLoc[0](loc0: u64)
+	4: Pop
+	5: StLoc[1](loc1: u64)
+	6: MoveLoc[0](loc0: u64)
+	7: MoveLoc[1](loc1: u64)
+	8: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.on.exp
@@ -1,0 +1,111 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1(): (u64, u64) {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # flush: $t2
+     # live vars:
+  0: $t2 := m::one()
+     # live vars:
+  1: $t3 := m::one()
+     # live vars: $t3
+  2: $t4 := m::one()
+     # live vars: $t3, $t4
+  3: return ($t3, $t4)
+}
+
+
+[variant baseline]
+public fun m::test2(): (u64, u64) {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t2 := m::one()
+     # flush: $t3
+     # live vars: $t2
+  1: $t3 := m::one()
+     # live vars: $t2
+  2: $t4 := m::one()
+     # live vars: $t2, $t4
+  3: return ($t2, $t4)
+}
+
+
+[variant baseline]
+public fun m::test3(): (u64, u64) {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t2 := m::one()
+     # flush: $t3
+     # live vars: $t2
+  1: $t3 := m::one()
+     # live vars: $t2
+  2: $t4 := m::one()
+     # live vars: $t2, $t4
+  3: return ($t4, $t2)
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one(): u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test1(): u64 * u64 /* def_idx: 1 */ {
+B0:
+	0: Call one(): u64
+	1: Pop
+	2: Call one(): u64
+	3: Call one(): u64
+	4: Ret
+}
+public test2(): u64 * u64 /* def_idx: 2 */ {
+B0:
+	0: Call one(): u64
+	1: Call one(): u64
+	2: Pop
+	3: Call one(): u64
+	4: Ret
+}
+public test3(): u64 * u64 /* def_idx: 3 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: Call one(): u64
+	2: Pop
+	3: Call one(): u64
+	4: StLoc[0](loc0: u64)
+	5: StLoc[1](loc1: u64)
+	6: MoveLoc[0](loc0: u64)
+	7: MoveLoc[1](loc1: u64)
+	8: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.move
@@ -1,0 +1,18 @@
+module 0xc0ffee::m {
+    fun one(): u64 {
+        1
+    }
+
+    fun bar() {}
+
+    public fun test(): (u64, u64) {
+        let x = one();
+        let y = one();
+        let z = one();
+        if (y == 0) {
+            bar();
+        };
+        (x, z)
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.off.exp
@@ -1,0 +1,44 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+bar() /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+one(): u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test(): u64 * u64 /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+L3:	loc3: bool
+L4:	loc4: u64
+B0:
+	0: Call one(): u64
+	1: Call one(): u64
+	2: Call one(): u64
+	3: LdU64(0)
+	4: StLoc[0](loc0: u64)
+	5: StLoc[1](loc1: u64)
+	6: MoveLoc[0](loc0: u64)
+	7: Eq
+	8: StLoc[3](loc3: bool)
+	9: StLoc[4](loc4: u64)
+	10: MoveLoc[3](loc3: bool)
+	11: BrFalse(14)
+B1:
+	12: Call bar()
+	13: Branch(14)
+B2:
+	14: MoveLoc[4](loc4: u64)
+	15: MoveLoc[1](loc1: u64)
+	16: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.on.exp
@@ -1,0 +1,95 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::bar() {
+     # live vars:
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test(): (u64, u64) {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     # flush: $t2
+     # live vars:
+  0: $t2 := m::one()
+     # live vars: $t2
+  1: $t3 := m::one()
+     # flush: $t4
+     # live vars: $t2, $t3
+  2: $t4 := m::one()
+     # live vars: $t2, $t3, $t4
+  3: $t6 := 0
+     # live vars: $t2, $t3, $t4, $t6
+  4: $t5 := ==($t3, $t6)
+     # live vars: $t2, $t4, $t5
+  5: if ($t5) goto 6 else goto 9
+     # live vars: $t2, $t4
+  6: label L0
+     # live vars: $t2, $t4
+  7: m::bar()
+     # live vars: $t2, $t4
+  8: goto 10
+     # live vars: $t2, $t4
+  9: label L1
+     # live vars: $t2, $t4
+ 10: label L2
+     # live vars: $t2, $t4
+ 11: touch($t2)
+     # live vars: $t2, $t4
+ 12: return ($t2, $t4)
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+bar() /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+one(): u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test(): u64 * u64 /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: StLoc[0](loc0: u64)
+	2: Call one(): u64
+	3: Call one(): u64
+	4: StLoc[1](loc1: u64)
+	5: LdU64(0)
+	6: Eq
+	7: BrFalse(10)
+B1:
+	8: Call bar()
+	9: Branch(10)
+B2:
+	10: MoveLoc[0](loc0: u64)
+	11: MoveLoc[1](loc1: u64)
+	12: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.move
@@ -1,0 +1,21 @@
+module 0xc0ffee::m {
+    fun foo(): (u64, u64, u64) {
+        (1, 2, 3)
+    }
+
+    fun bar() {}
+
+    public fun test1() {
+        let (x, y, z) = foo();
+        if (x == 0) {
+            bar();
+        };
+        if (y == 0) {
+            bar();
+        };
+        if (z == 0) {
+            bar();
+        };
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.off.exp
@@ -1,0 +1,55 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+bar() /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+foo(): u64 * u64 * u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(2)
+	2: LdU64(3)
+	3: Ret
+}
+public test1() /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+L3:	loc3: u64
+B0:
+	0: Call foo(): u64 * u64 * u64
+	1: LdU64(0)
+	2: StLoc[0](loc0: u64)
+	3: StLoc[1](loc1: u64)
+	4: StLoc[2](loc2: u64)
+	5: MoveLoc[0](loc0: u64)
+	6: Eq
+	7: BrFalse(10)
+B1:
+	8: Call bar()
+	9: Branch(10)
+B2:
+	10: MoveLoc[2](loc2: u64)
+	11: LdU64(0)
+	12: Eq
+	13: BrFalse(16)
+B3:
+	14: Call bar()
+	15: Branch(16)
+B4:
+	16: MoveLoc[1](loc1: u64)
+	17: LdU64(0)
+	18: Eq
+	19: BrFalse(22)
+B5:
+	20: Call bar()
+	21: Branch(22)
+B6:
+	22: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.on.exp
@@ -1,0 +1,146 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::bar() {
+     # live vars:
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::foo(): (u64, u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: $t2 := 3
+     # live vars: $t0, $t1, $t2
+  3: return ($t0, $t1, $t2)
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: bool [unused]
+     var $t6: u64 [unused]
+     var $t7: bool [unused]
+     var $t8: u64 [unused]
+     # flush: $t1, $t2
+     # live vars:
+  0: ($t0, $t1, $t2) := m::foo()
+     # live vars: $t0, $t1, $t2
+  1: $t4 := 0
+     # live vars: $t0, $t1, $t2, $t4
+  2: $t3 := ==($t0, $t4)
+     # live vars: $t1, $t2, $t3
+  3: if ($t3) goto 4 else goto 7
+     # live vars: $t1, $t2
+  4: label L0
+     # live vars: $t1, $t2
+  5: m::bar()
+     # live vars: $t1, $t2
+  6: goto 8
+     # live vars: $t1, $t2
+  7: label L1
+     # live vars: $t1, $t2
+  8: label L2
+     # live vars: $t1, $t2
+  9: touch($t1)
+     # live vars: $t1, $t2
+ 10: $t0 := 0
+     # live vars: $t0, $t1, $t2
+ 11: $t3 := ==($t1, $t0)
+     # live vars: $t2, $t3
+ 12: if ($t3) goto 13 else goto 16
+     # live vars: $t2
+ 13: label L3
+     # live vars: $t2
+ 14: m::bar()
+     # live vars: $t2
+ 15: goto 17
+     # live vars: $t2
+ 16: label L4
+     # live vars: $t2
+ 17: label L5
+     # live vars: $t2
+ 18: touch($t2)
+     # live vars: $t2
+ 19: $t0 := 0
+     # live vars: $t0, $t2
+ 20: $t3 := ==($t2, $t0)
+     # live vars: $t3
+ 21: if ($t3) goto 22 else goto 25
+     # live vars:
+ 22: label L6
+     # live vars:
+ 23: m::bar()
+     # live vars:
+ 24: goto 26
+     # live vars:
+ 25: label L7
+     # live vars:
+ 26: label L8
+     # live vars:
+ 27: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+bar() /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+foo(): u64 * u64 * u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(2)
+	2: LdU64(3)
+	3: Ret
+}
+public test1() /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call foo(): u64 * u64 * u64
+	1: StLoc[0](loc0: u64)
+	2: StLoc[1](loc1: u64)
+	3: LdU64(0)
+	4: Eq
+	5: BrFalse(8)
+B1:
+	6: Call bar()
+	7: Branch(8)
+B2:
+	8: MoveLoc[1](loc1: u64)
+	9: LdU64(0)
+	10: Eq
+	11: BrFalse(14)
+B3:
+	12: Call bar()
+	13: Branch(14)
+B4:
+	14: MoveLoc[0](loc0: u64)
+	15: LdU64(0)
+	16: Eq
+	17: BrFalse(20)
+B5:
+	18: Call bar()
+	19: Branch(20)
+B6:
+	20: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/addition.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/addition.move
@@ -1,0 +1,69 @@
+module 0xc0ffee::m {
+
+    public fun test1(x: u64): u64 {
+        x + 1
+    }
+
+    public fun test2(a: u64, b: u64): u64 {
+        let a = a + 1;
+        let b = b + 1;
+        a + b
+    }
+
+    public fun test3(a: u64, b: u64, c: u64, d: u64): u64 {
+        let a = 1 + a;
+        let b = 1 + b;
+        let c = 1 + c;
+        let d = 1 + d;
+        let _ = a + b;
+        c + d
+    }
+
+    public fun test4(p: u64, q: u64): u64 {
+        let x = p + 1;
+        let y = q + 1;
+        x + y
+    }
+
+    public fun test5(): u64 {
+        let x = 1;
+        let y = x;
+        x = 2;
+        let z = x;
+        z + y
+    }
+
+    public fun test6(): u64 {
+        let x = 1;
+        let y = x;
+        x = 2;
+        let z = x;
+        y + z
+    }
+
+    public fun test7(p: u64, q: u64): u64 {
+        let x = p + 1;
+        let y = q + 1;
+        x + y
+    }
+
+    fun one(): u64 {
+        1
+    }
+
+    public fun test8(x: u64): u64 {
+        x + one()
+    }
+
+    public fun test9(p: u64, q: u64): u64 {
+        let x = &p;
+        let y = &q;
+        *y + *x
+    }
+
+    public fun test10(p: u64, q: u64): u64 {
+        let x = &p;
+        let y = &q;
+        *x + *y
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/addition.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/addition.off.exp
@@ -1,0 +1,1559 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+public fun m::test10($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t1, $t3
+  1: $t4 := borrow_local($t1)
+     # live vars: $t3, $t4
+  2: $t5 := read_ref($t3)
+     # live vars: $t4, $t5
+  3: $t6 := read_ref($t4)
+     # live vars: $t5, $t6
+  4: $t2 := +($t5, $t6)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t1, $t3
+  2: $t6 := 1
+     # live vars: $t1, $t3, $t6
+  3: $t5 := +($t1, $t6)
+     # live vars: $t3, $t5
+  4: $t2 := +($t3, $t5)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test3($t0: u64, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t6 := 1
+     # live vars: $t0, $t1, $t2, $t3, $t6
+  1: $t5 := +($t6, $t0)
+     # live vars: $t1, $t2, $t3, $t5
+  2: $t8 := 1
+     # live vars: $t1, $t2, $t3, $t5, $t8
+  3: $t7 := +($t8, $t1)
+     # live vars: $t2, $t3, $t5, $t7
+  4: $t10 := 1
+     # live vars: $t2, $t3, $t5, $t7, $t10
+  5: $t9 := +($t10, $t2)
+     # live vars: $t3, $t5, $t7, $t9
+  6: $t12 := 1
+     # live vars: $t3, $t5, $t7, $t9, $t12
+  7: $t11 := +($t12, $t3)
+     # live vars: $t5, $t7, $t9, $t11
+  8: $t13 := +($t5, $t7)
+     # live vars: $t9, $t11, $t13
+  9: $t14 := infer($t13)
+     # live vars: $t9, $t11
+ 10: $t4 := +($t9, $t11)
+     # live vars: $t4
+ 11: return $t4
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t1, $t3
+  2: $t6 := 1
+     # live vars: $t1, $t3, $t6
+  3: $t5 := +($t1, $t6)
+     # live vars: $t3, $t5
+  4: $t2 := +($t3, $t5)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test5(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t2 := infer($t1)
+     # live vars: $t2
+  2: $t3 := 2
+     # live vars: $t2, $t3
+  3: $t1 := infer($t3)
+     # live vars: $t1, $t2
+  4: $t4 := infer($t1)
+     # live vars: $t2, $t4
+  5: $t0 := +($t4, $t2)
+     # live vars: $t0
+  6: return $t0
+}
+
+
+[variant baseline]
+public fun m::test6(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t2 := infer($t1)
+     # live vars: $t2
+  2: $t3 := 2
+     # live vars: $t2, $t3
+  3: $t1 := infer($t3)
+     # live vars: $t1, $t2
+  4: $t4 := infer($t1)
+     # live vars: $t2, $t4
+  5: $t0 := +($t2, $t4)
+     # live vars: $t0
+  6: return $t0
+}
+
+
+[variant baseline]
+public fun m::test7($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t1, $t3
+  2: $t6 := 1
+     # live vars: $t1, $t3, $t6
+  3: $t5 := +($t1, $t6)
+     # live vars: $t3, $t5
+  4: $t2 := +($t3, $t5)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test8($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := infer($t0)
+     # live vars: $t2
+  1: $t3 := m::one()
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+public fun m::test9($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t1, $t3
+  1: $t4 := borrow_local($t1)
+     # live vars: $t3, $t4
+  2: $t5 := read_ref($t4)
+     # live vars: $t3, $t5
+  3: $t6 := read_ref($t3)
+     # live vars: $t5, $t6
+  4: $t2 := +($t5, $t6)
+     # live vars: $t2
+  5: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+public fun m::test10($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t1, $t3
+  1: $t4 := borrow_local($t1)
+     # live vars: $t3, $t4
+  2: $t5 := read_ref($t3)
+     # live vars: $t4, $t5
+  3: $t6 := read_ref($t4)
+     # live vars: $t5, $t6
+  4: $t2 := +($t5, $t6)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t1, $t3
+  2: $t6 := 1
+     # live vars: $t1, $t3, $t6
+  3: $t5 := +($t1, $t6)
+     # live vars: $t3, $t5
+  4: $t2 := +($t3, $t5)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test3($t0: u64, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t6 := 1
+     # live vars: $t0, $t1, $t2, $t3, $t6
+  1: $t5 := +($t6, $t0)
+     # live vars: $t1, $t2, $t3, $t5
+  2: $t8 := 1
+     # live vars: $t1, $t2, $t3, $t5, $t8
+  3: $t7 := +($t8, $t1)
+     # live vars: $t2, $t3, $t5, $t7
+  4: $t10 := 1
+     # live vars: $t2, $t3, $t5, $t7, $t10
+  5: $t9 := +($t10, $t2)
+     # live vars: $t3, $t5, $t7, $t9
+  6: $t12 := 1
+     # live vars: $t3, $t5, $t7, $t9, $t12
+  7: $t11 := +($t12, $t3)
+     # live vars: $t5, $t7, $t9, $t11
+  8: $t13 := +($t5, $t7)
+     # live vars: $t9, $t11, $t13
+  9: $t14 := infer($t13)
+     # live vars: $t9, $t11
+ 10: $t4 := +($t9, $t11)
+     # live vars: $t4
+ 11: return $t4
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t1, $t3
+  2: $t6 := 1
+     # live vars: $t1, $t3, $t6
+  3: $t5 := +($t1, $t6)
+     # live vars: $t3, $t5
+  4: $t2 := +($t3, $t5)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test5(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t2 := infer($t1)
+     # live vars: $t2
+  2: $t3 := 2
+     # live vars: $t2, $t3
+  3: $t1 := infer($t3)
+     # live vars: $t1, $t2
+  4: $t4 := infer($t1)
+     # live vars: $t2, $t4
+  5: $t0 := +($t4, $t2)
+     # live vars: $t0
+  6: return $t0
+}
+
+
+[variant baseline]
+public fun m::test6(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t2 := infer($t1)
+     # live vars: $t2
+  2: $t3 := 2
+     # live vars: $t2, $t3
+  3: $t1 := infer($t3)
+     # live vars: $t1, $t2
+  4: $t4 := infer($t1)
+     # live vars: $t2, $t4
+  5: $t0 := +($t2, $t4)
+     # live vars: $t0
+  6: return $t0
+}
+
+
+[variant baseline]
+public fun m::test7($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t1, $t3
+  2: $t6 := 1
+     # live vars: $t1, $t3, $t6
+  3: $t5 := +($t1, $t6)
+     # live vars: $t3, $t5
+  4: $t2 := +($t3, $t5)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test8($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := infer($t0)
+     # live vars: $t2
+  1: $t3 := m::one()
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+public fun m::test9($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t1, $t3
+  1: $t4 := borrow_local($t1)
+     # live vars: $t3, $t4
+  2: $t5 := read_ref($t4)
+     # live vars: $t3, $t5
+  3: $t6 := read_ref($t3)
+     # live vars: $t5, $t6
+  4: $t2 := +($t5, $t6)
+     # live vars: $t2
+  5: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+public fun m::test10($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t1, $t3
+  1: $t4 := borrow_local($t1)
+     # live vars: $t3, $t4
+  2: $t5 := read_ref($t3)
+     # live vars: $t4, $t5
+  3: $t6 := read_ref($t4)
+     # live vars: $t5, $t6
+  4: $t2 := +($t5, $t6)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t1, $t3
+  2: $t6 := 1
+     # live vars: $t1, $t3, $t6
+  3: $t5 := +($t1, $t6)
+     # live vars: $t3, $t5
+  4: $t2 := +($t3, $t5)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test3($t0: u64, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t6 := 1
+     # live vars: $t0, $t1, $t2, $t3, $t6
+  1: $t5 := +($t6, $t0)
+     # live vars: $t1, $t2, $t3, $t5
+  2: $t8 := 1
+     # live vars: $t1, $t2, $t3, $t5, $t8
+  3: $t7 := +($t8, $t1)
+     # live vars: $t2, $t3, $t5, $t7
+  4: $t10 := 1
+     # live vars: $t2, $t3, $t5, $t7, $t10
+  5: $t9 := +($t10, $t2)
+     # live vars: $t3, $t5, $t7, $t9
+  6: $t12 := 1
+     # live vars: $t3, $t5, $t7, $t9, $t12
+  7: $t11 := +($t12, $t3)
+     # live vars: $t5, $t7, $t9, $t11
+  8: $t13 := +($t5, $t7)
+     # live vars: $t9, $t11, $t13
+  9: $t14 := move($t13)
+     # live vars: $t9, $t11
+ 10: $t4 := +($t9, $t11)
+     # live vars: $t4
+ 11: return $t4
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t1, $t3
+  2: $t6 := 1
+     # live vars: $t1, $t3, $t6
+  3: $t5 := +($t1, $t6)
+     # live vars: $t3, $t5
+  4: $t2 := +($t3, $t5)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test5(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t2 := move($t1)
+     # live vars: $t2
+  2: $t3 := 2
+     # live vars: $t2, $t3
+  3: $t1 := move($t3)
+     # live vars: $t1, $t2
+  4: $t4 := move($t1)
+     # live vars: $t2, $t4
+  5: $t0 := +($t4, $t2)
+     # live vars: $t0
+  6: return $t0
+}
+
+
+[variant baseline]
+public fun m::test6(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t2 := move($t1)
+     # live vars: $t2
+  2: $t3 := 2
+     # live vars: $t2, $t3
+  3: $t1 := move($t3)
+     # live vars: $t1, $t2
+  4: $t4 := move($t1)
+     # live vars: $t2, $t4
+  5: $t0 := +($t2, $t4)
+     # live vars: $t0
+  6: return $t0
+}
+
+
+[variant baseline]
+public fun m::test7($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t1, $t3
+  2: $t6 := 1
+     # live vars: $t1, $t3, $t6
+  3: $t5 := +($t1, $t6)
+     # live vars: $t3, $t5
+  4: $t2 := +($t3, $t5)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test8($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := move($t0)
+     # live vars: $t2
+  1: $t3 := m::one()
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+public fun m::test9($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t1, $t3
+  1: $t4 := borrow_local($t1)
+     # live vars: $t3, $t4
+  2: $t5 := read_ref($t4)
+     # live vars: $t3, $t5
+  3: $t6 := read_ref($t3)
+     # live vars: $t5, $t6
+  4: $t2 := +($t5, $t6)
+     # live vars: $t2
+  5: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+public fun m::test10($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t1, $t3
+  1: $t4 := borrow_local($t1)
+     # live vars: $t3, $t4
+  2: $t5 := read_ref($t3)
+     # live vars: $t4, $t5
+  3: $t6 := read_ref($t4)
+     # live vars: $t5, $t6
+  4: $t2 := +($t5, $t6)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t1, $t3
+  2: $t6 := 1
+     # live vars: $t1, $t3, $t6
+  3: $t5 := +($t1, $t6)
+     # live vars: $t3, $t5
+  4: $t2 := +($t3, $t5)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test3($t0: u64, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64 [unused]
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t6 := 1
+     # live vars: $t0, $t1, $t2, $t3, $t6
+  1: $t5 := +($t6, $t0)
+     # live vars: $t1, $t2, $t3, $t5
+  2: $t8 := 1
+     # live vars: $t1, $t2, $t3, $t5, $t8
+  3: $t7 := +($t8, $t1)
+     # live vars: $t2, $t3, $t5, $t7
+  4: $t10 := 1
+     # live vars: $t2, $t3, $t5, $t7, $t10
+  5: $t9 := +($t10, $t2)
+     # live vars: $t3, $t5, $t7, $t9
+  6: $t12 := 1
+     # live vars: $t3, $t5, $t7, $t9, $t12
+  7: $t11 := +($t12, $t3)
+     # live vars: $t5, $t7, $t9, $t11
+  8: $t13 := +($t5, $t7)
+     # live vars: $t9, $t11
+  9: $t4 := +($t9, $t11)
+     # live vars: $t4
+ 10: return $t4
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t1, $t3
+  2: $t6 := 1
+     # live vars: $t1, $t3, $t6
+  3: $t5 := +($t1, $t6)
+     # live vars: $t3, $t5
+  4: $t2 := +($t3, $t5)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test5(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t2 := move($t1)
+     # live vars: $t2
+  2: $t3 := 2
+     # live vars: $t2, $t3
+  3: $t1 := move($t3)
+     # live vars: $t1, $t2
+  4: $t4 := move($t1)
+     # live vars: $t2, $t4
+  5: $t0 := +($t4, $t2)
+     # live vars: $t0
+  6: return $t0
+}
+
+
+[variant baseline]
+public fun m::test6(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t2 := move($t1)
+     # live vars: $t2
+  2: $t3 := 2
+     # live vars: $t2, $t3
+  3: $t1 := move($t3)
+     # live vars: $t1, $t2
+  4: $t4 := move($t1)
+     # live vars: $t2, $t4
+  5: $t0 := +($t2, $t4)
+     # live vars: $t0
+  6: return $t0
+}
+
+
+[variant baseline]
+public fun m::test7($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t1, $t3
+  2: $t6 := 1
+     # live vars: $t1, $t3, $t6
+  3: $t5 := +($t1, $t6)
+     # live vars: $t3, $t5
+  4: $t2 := +($t3, $t5)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+public fun m::test8($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := move($t0)
+     # live vars: $t2
+  1: $t3 := m::one()
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+public fun m::test9($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t1, $t3
+  1: $t4 := borrow_local($t1)
+     # live vars: $t3, $t4
+  2: $t5 := read_ref($t4)
+     # live vars: $t3, $t5
+  3: $t6 := read_ref($t3)
+     # live vars: $t5, $t6
+  4: $t2 := +($t5, $t6)
+     # live vars: $t2
+  5: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t0 := +($t0, $t2)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+public fun m::test10($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t1, $t3
+  1: $t4 := borrow_local($t1)
+     # live vars: $t3, $t4
+  2: $t5 := read_ref($t3)
+     # live vars: $t4, $t5
+  3: $t6 := read_ref($t4)
+     # live vars: $t5, $t6
+  4: $t5 := +($t5, $t6)
+     # live vars: $t5
+  5: return $t5
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t0 := +($t0, $t4)
+     # live vars: $t0, $t1
+  2: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  3: $t1 := +($t1, $t4)
+     # live vars: $t0, $t1
+  4: $t0 := +($t0, $t1)
+     # live vars: $t0
+  5: return $t0
+}
+
+
+[variant baseline]
+public fun m::test3($t0: u64, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: u64
+     var $t7: u64 [unused]
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+     var $t10: u64 [unused]
+     var $t11: u64 [unused]
+     var $t12: u64 [unused]
+     var $t13: u64 [unused]
+     var $t14: u64 [unused]
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t6 := 1
+     # live vars: $t0, $t1, $t2, $t3, $t6
+  1: $t0 := +($t6, $t0)
+     # live vars: $t0, $t1, $t2, $t3
+  2: $t6 := 1
+     # live vars: $t0, $t1, $t2, $t3, $t6
+  3: $t1 := +($t6, $t1)
+     # live vars: $t0, $t1, $t2, $t3
+  4: $t6 := 1
+     # live vars: $t0, $t1, $t2, $t3, $t6
+  5: $t2 := +($t6, $t2)
+     # live vars: $t0, $t1, $t2, $t3
+  6: $t6 := 1
+     # live vars: $t0, $t1, $t2, $t3, $t6
+  7: $t3 := +($t6, $t3)
+     # live vars: $t0, $t1, $t2, $t3
+  8: $t0 := +($t0, $t1)
+     # live vars: $t2, $t3
+  9: $t1 := +($t2, $t3)
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t0 := +($t0, $t4)
+     # live vars: $t0, $t1
+  2: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  3: $t1 := +($t1, $t4)
+     # live vars: $t0, $t1
+  4: $t0 := +($t0, $t1)
+     # live vars: $t0
+  5: return $t0
+}
+
+
+[variant baseline]
+public fun m::test5(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64 [unused]
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t2 := move($t1)
+     # live vars: $t2
+  2: $t3 := 2
+     # live vars: $t2, $t3
+  3: $t1 := move($t3)
+     # live vars: $t1, $t2
+  4: $t1 := move($t1)
+     # live vars: $t1, $t2
+  5: $t1 := +($t1, $t2)
+     # live vars: $t1
+  6: return $t1
+}
+
+
+[variant baseline]
+public fun m::test6(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64 [unused]
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t2 := move($t1)
+     # live vars: $t2
+  2: $t3 := 2
+     # live vars: $t2, $t3
+  3: $t1 := move($t3)
+     # live vars: $t1, $t2
+  4: $t1 := move($t1)
+     # live vars: $t1, $t2
+  5: $t1 := +($t2, $t1)
+     # live vars: $t1
+  6: return $t1
+}
+
+
+[variant baseline]
+public fun m::test7($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t0 := +($t0, $t4)
+     # live vars: $t0, $t1
+  2: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  3: $t1 := +($t1, $t4)
+     # live vars: $t0, $t1
+  4: $t0 := +($t0, $t1)
+     # live vars: $t0
+  5: return $t0
+}
+
+
+[variant baseline]
+public fun m::test8($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64
+     # live vars: $t0
+  0: $t0 := move($t0)
+     # live vars: $t0
+  1: $t3 := m::one()
+     # live vars: $t0, $t3
+  2: $t0 := +($t0, $t3)
+     # live vars: $t0
+  3: return $t0
+}
+
+
+[variant baseline]
+public fun m::test9($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t1, $t3
+  1: $t4 := borrow_local($t1)
+     # live vars: $t3, $t4
+  2: $t5 := read_ref($t4)
+     # live vars: $t3, $t5
+  3: $t6 := read_ref($t3)
+     # live vars: $t5, $t6
+  4: $t5 := +($t5, $t6)
+     # live vars: $t5
+  5: return $t5
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t0 := +($t0, $t2)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+public fun m::test10($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t1, $t3
+  1: $t4 := borrow_local($t1)
+     # live vars: $t3, $t4
+  2: $t5 := read_ref($t3)
+     # live vars: $t4, $t5
+  3: $t6 := read_ref($t4)
+     # live vars: $t5, $t6
+  4: $t5 := +($t5, $t6)
+     # live vars: $t5
+  5: return $t5
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t0 := +($t0, $t4)
+     # live vars: $t0, $t1
+  2: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  3: $t1 := +($t1, $t4)
+     # live vars: $t0, $t1
+  4: $t0 := +($t0, $t1)
+     # live vars: $t0
+  5: return $t0
+}
+
+
+[variant baseline]
+public fun m::test3($t0: u64, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: u64
+     var $t7: u64 [unused]
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+     var $t10: u64 [unused]
+     var $t11: u64 [unused]
+     var $t12: u64 [unused]
+     var $t13: u64 [unused]
+     var $t14: u64 [unused]
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t6 := 1
+     # live vars: $t0, $t1, $t2, $t3, $t6
+  1: $t0 := +($t6, $t0)
+     # live vars: $t0, $t1, $t2, $t3
+  2: $t6 := 1
+     # live vars: $t0, $t1, $t2, $t3, $t6
+  3: $t1 := +($t6, $t1)
+     # live vars: $t0, $t1, $t2, $t3
+  4: $t6 := 1
+     # live vars: $t0, $t1, $t2, $t3, $t6
+  5: $t2 := +($t6, $t2)
+     # live vars: $t0, $t1, $t2, $t3
+  6: $t6 := 1
+     # live vars: $t0, $t1, $t2, $t3, $t6
+  7: $t3 := +($t6, $t3)
+     # live vars: $t0, $t1, $t2, $t3
+  8: $t0 := +($t0, $t1)
+     # live vars: $t2, $t3
+  9: $t1 := +($t2, $t3)
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t0 := +($t0, $t4)
+     # live vars: $t0, $t1
+  2: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  3: $t1 := +($t1, $t4)
+     # live vars: $t0, $t1
+  4: $t0 := +($t0, $t1)
+     # live vars: $t0
+  5: return $t0
+}
+
+
+[variant baseline]
+public fun m::test5(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64 [unused]
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t2 := move($t1)
+     # live vars: $t2
+  2: $t3 := 2
+     # live vars: $t2, $t3
+  3: $t1 := move($t3)
+     # live vars: $t1, $t2
+  4: $t1 := +($t1, $t2)
+     # live vars: $t1
+  5: return $t1
+}
+
+
+[variant baseline]
+public fun m::test6(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64 [unused]
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t2 := move($t1)
+     # live vars: $t2
+  2: $t3 := 2
+     # live vars: $t2, $t3
+  3: $t1 := move($t3)
+     # live vars: $t1, $t2
+  4: $t1 := +($t2, $t1)
+     # live vars: $t1
+  5: return $t1
+}
+
+
+[variant baseline]
+public fun m::test7($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t0 := +($t0, $t4)
+     # live vars: $t0, $t1
+  2: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  3: $t1 := +($t1, $t4)
+     # live vars: $t0, $t1
+  4: $t0 := +($t0, $t1)
+     # live vars: $t0
+  5: return $t0
+}
+
+
+[variant baseline]
+public fun m::test8($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64
+     # live vars: $t0
+  0: $t3 := m::one()
+     # live vars: $t0, $t3
+  1: $t0 := +($t0, $t3)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+public fun m::test9($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t1, $t3
+  1: $t4 := borrow_local($t1)
+     # live vars: $t3, $t4
+  2: $t5 := read_ref($t4)
+     # live vars: $t3, $t5
+  3: $t6 := read_ref($t3)
+     # live vars: $t5, $t6
+  4: $t5 := +($t5, $t6)
+     # live vars: $t5
+  5: return $t5
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one(): u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test1(Arg0: u64): u64 /* def_idx: 1 */ {
+L1:	loc0: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: Ret
+}
+public test10(Arg0: u64, Arg1: u64): u64 /* def_idx: 2 */ {
+L2:	loc0: &u64
+L3:	loc1: &u64
+B0:
+	0: ImmBorrowLoc[0](Arg0: u64)
+	1: ImmBorrowLoc[1](Arg1: u64)
+	2: StLoc[2](loc0: &u64)
+	3: ReadRef
+	4: MoveLoc[2](loc0: &u64)
+	5: ReadRef
+	6: Add
+	7: Ret
+}
+public test2(Arg0: u64, Arg1: u64): u64 /* def_idx: 3 */ {
+L2:	loc0: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: MoveLoc[1](Arg1: u64)
+	4: LdU64(1)
+	5: Add
+	6: Add
+	7: Ret
+}
+public test3(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64): u64 /* def_idx: 4 */ {
+B0:
+	0: LdU64(1)
+	1: MoveLoc[0](Arg0: u64)
+	2: Add
+	3: LdU64(1)
+	4: MoveLoc[1](Arg1: u64)
+	5: Add
+	6: LdU64(1)
+	7: MoveLoc[2](Arg2: u64)
+	8: Add
+	9: LdU64(1)
+	10: MoveLoc[3](Arg3: u64)
+	11: Add
+	12: StLoc[3](Arg3: u64)
+	13: StLoc[2](Arg2: u64)
+	14: Add
+	15: MoveLoc[2](Arg2: u64)
+	16: MoveLoc[3](Arg3: u64)
+	17: Add
+	18: StLoc[1](Arg1: u64)
+	19: Pop
+	20: MoveLoc[1](Arg1: u64)
+	21: Ret
+}
+public test4(Arg0: u64, Arg1: u64): u64 /* def_idx: 5 */ {
+L2:	loc0: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: MoveLoc[1](Arg1: u64)
+	4: LdU64(1)
+	5: Add
+	6: Add
+	7: Ret
+}
+public test5(): u64 /* def_idx: 6 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: LdU64(1)
+	1: StLoc[0](loc0: u64)
+	2: LdU64(2)
+	3: MoveLoc[0](loc0: u64)
+	4: Add
+	5: Ret
+}
+public test6(): u64 /* def_idx: 7 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: LdU64(1)
+	1: StLoc[0](loc0: u64)
+	2: MoveLoc[0](loc0: u64)
+	3: LdU64(2)
+	4: Add
+	5: Ret
+}
+public test7(Arg0: u64, Arg1: u64): u64 /* def_idx: 8 */ {
+L2:	loc0: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: MoveLoc[1](Arg1: u64)
+	4: LdU64(1)
+	5: Add
+	6: Add
+	7: Ret
+}
+public test8(Arg0: u64): u64 /* def_idx: 9 */ {
+L1:	loc0: u64
+B0:
+	0: Call one(): u64
+	1: StLoc[1](loc0: u64)
+	2: MoveLoc[0](Arg0: u64)
+	3: MoveLoc[1](loc0: u64)
+	4: Add
+	5: Ret
+}
+public test9(Arg0: u64, Arg1: u64): u64 /* def_idx: 10 */ {
+L2:	loc0: u64
+L3:	loc1: &u64
+L4:	loc2: u64
+B0:
+	0: ImmBorrowLoc[0](Arg0: u64)
+	1: ImmBorrowLoc[1](Arg1: u64)
+	2: ReadRef
+	3: StLoc[2](loc0: u64)
+	4: ReadRef
+	5: StLoc[4](loc2: u64)
+	6: MoveLoc[2](loc0: u64)
+	7: MoveLoc[4](loc2: u64)
+	8: Add
+	9: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/addition.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/addition.on.exp
@@ -1,0 +1,300 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+  0: $t0 := 1
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+  0: touch($t0)
+  1: $t2 := 1
+  2: $t0 := +($t0, $t2)
+  3: return $t0
+}
+
+
+[variant baseline]
+public fun m::test10($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+  0: $t3 := borrow_local($t0)
+  1: $t5 := read_ref($t3)
+  2: $t4 := borrow_local($t1)
+  3: $t6 := read_ref($t4)
+  4: $t5 := +($t5, $t6)
+  5: return $t5
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+  0: touch($t0)
+  1: $t4 := 1
+  2: $t0 := +($t0, $t4)
+  3: touch($t1)
+  4: $t4 := 1
+  5: $t1 := +($t1, $t4)
+  6: $t0 := +($t0, $t1)
+  7: return $t0
+}
+
+
+[variant baseline]
+public fun m::test3($t0: u64, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: u64
+     var $t7: u64 [unused]
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+     var $t10: u64 [unused]
+     var $t11: u64 [unused]
+     var $t12: u64 [unused]
+     var $t13: u64 [unused]
+     var $t14: u64 [unused]
+  0: $t6 := 1
+  1: $t0 := +($t6, $t0)
+  2: $t6 := 1
+  3: $t1 := +($t6, $t1)
+  4: $t6 := 1
+  5: $t2 := +($t6, $t2)
+  6: $t6 := 1
+  7: $t3 := +($t6, $t3)
+  8: $t0 := +($t0, $t1)
+  9: $t1 := +($t2, $t3)
+ 10: return $t1
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+  0: touch($t0)
+  1: $t4 := 1
+  2: $t0 := +($t0, $t4)
+  3: touch($t1)
+  4: $t4 := 1
+  5: $t1 := +($t1, $t4)
+  6: $t0 := +($t0, $t1)
+  7: return $t0
+}
+
+
+[variant baseline]
+public fun m::test5(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64 [unused]
+  0: $t1 := 1
+  1: $t2 := move($t1)
+  2: $t3 := 2
+  3: $t1 := move($t3)
+  4: $t1 := +($t1, $t2)
+  5: return $t1
+}
+
+
+[variant baseline]
+public fun m::test6(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64 [unused]
+  0: $t1 := 1
+  1: $t2 := move($t1)
+  2: $t3 := 2
+  3: $t1 := move($t3)
+  4: $t1 := +($t2, $t1)
+  5: return $t1
+}
+
+
+[variant baseline]
+public fun m::test7($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+  0: touch($t0)
+  1: $t4 := 1
+  2: $t0 := +($t0, $t4)
+  3: touch($t1)
+  4: $t4 := 1
+  5: $t1 := +($t1, $t4)
+  6: $t0 := +($t0, $t1)
+  7: return $t0
+}
+
+
+[variant baseline]
+public fun m::test8($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64
+  0: touch($t0)
+  1: $t3 := m::one()
+  2: $t0 := +($t0, $t3)
+  3: return $t0
+}
+
+
+[variant baseline]
+public fun m::test9($t0: u64, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: u64
+  0: $t4 := borrow_local($t1)
+  1: $t5 := read_ref($t4)
+  2: $t3 := borrow_local($t0)
+  3: $t6 := read_ref($t3)
+  4: $t5 := +($t5, $t6)
+  5: return $t5
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one(): u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test1(Arg0: u64): u64 /* def_idx: 1 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: Ret
+}
+public test10(Arg0: u64, Arg1: u64): u64 /* def_idx: 2 */ {
+B0:
+	0: ImmBorrowLoc[0](Arg0: u64)
+	1: ReadRef
+	2: ImmBorrowLoc[1](Arg1: u64)
+	3: ReadRef
+	4: Add
+	5: Ret
+}
+public test2(Arg0: u64, Arg1: u64): u64 /* def_idx: 3 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: MoveLoc[1](Arg1: u64)
+	4: LdU64(1)
+	5: Add
+	6: Add
+	7: Ret
+}
+public test3(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64): u64 /* def_idx: 4 */ {
+B0:
+	0: LdU64(1)
+	1: MoveLoc[0](Arg0: u64)
+	2: Add
+	3: LdU64(1)
+	4: MoveLoc[1](Arg1: u64)
+	5: Add
+	6: LdU64(1)
+	7: MoveLoc[2](Arg2: u64)
+	8: Add
+	9: LdU64(1)
+	10: MoveLoc[3](Arg3: u64)
+	11: Add
+	12: StLoc[3](Arg3: u64)
+	13: StLoc[2](Arg2: u64)
+	14: Add
+	15: Pop
+	16: MoveLoc[2](Arg2: u64)
+	17: MoveLoc[3](Arg3: u64)
+	18: Add
+	19: Ret
+}
+public test4(Arg0: u64, Arg1: u64): u64 /* def_idx: 5 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: MoveLoc[1](Arg1: u64)
+	4: LdU64(1)
+	5: Add
+	6: Add
+	7: Ret
+}
+public test5(): u64 /* def_idx: 6 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: LdU64(1)
+	1: StLoc[0](loc0: u64)
+	2: LdU64(2)
+	3: MoveLoc[0](loc0: u64)
+	4: Add
+	5: Ret
+}
+public test6(): u64 /* def_idx: 7 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: LdU64(1)
+	1: StLoc[0](loc0: u64)
+	2: MoveLoc[0](loc0: u64)
+	3: LdU64(2)
+	4: Add
+	5: Ret
+}
+public test7(Arg0: u64, Arg1: u64): u64 /* def_idx: 8 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: MoveLoc[1](Arg1: u64)
+	4: LdU64(1)
+	5: Add
+	6: Add
+	7: Ret
+}
+public test8(Arg0: u64): u64 /* def_idx: 9 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Call one(): u64
+	2: Add
+	3: Ret
+}
+public test9(Arg0: u64, Arg1: u64): u64 /* def_idx: 10 */ {
+B0:
+	0: ImmBorrowLoc[1](Arg1: u64)
+	1: ReadRef
+	2: ImmBorrowLoc[0](Arg0: u64)
+	3: ReadRef
+	4: Add
+	5: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/call_sequence.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/call_sequence.move
@@ -1,0 +1,19 @@
+module 0xc0ffee::m {
+    struct Foo has key {
+        x: u64
+    }
+
+    fun foo(p: u64, x: &u64): u64 {
+        p + *x
+    }
+
+    fun bar(_q: u64, _y: u64) {
+    }
+
+    public fun test(addr: address, p: u64, q: u64) acquires Foo {
+        let x = &borrow_global<Foo>(addr).x;
+        let y = foo(p, x);
+        bar(q, y);
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/call_sequence.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/call_sequence.off.exp
@@ -1,0 +1,275 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t3 := read_ref($t1)
+     # live vars: $t0, $t3
+  1: $t2 := +($t0, $t3)
+     # live vars: $t2
+  2: return $t2
+}
+
+
+[variant baseline]
+public fun m::test($t0: address, $t1: u64, $t2: u64) {
+     var $t3: &u64
+     var $t4: &m::Foo
+     var $t5: u64
+     # live vars: $t0, $t1, $t2
+  0: $t4 := borrow_global<m::Foo>($t0)
+     # live vars: $t1, $t2, $t4
+  1: $t3 := borrow_field<m::Foo>.x($t4)
+     # live vars: $t1, $t2, $t3
+  2: $t5 := m::foo($t1, $t3)
+     # live vars: $t2, $t5
+  3: m::bar($t2, $t5)
+     # live vars:
+  4: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t3 := read_ref($t1)
+     # live vars: $t0, $t3
+  1: $t2 := +($t0, $t3)
+     # live vars: $t2
+  2: return $t2
+}
+
+
+[variant baseline]
+public fun m::test($t0: address, $t1: u64, $t2: u64) {
+     var $t3: &u64
+     var $t4: &m::Foo
+     var $t5: u64
+     # live vars: $t0, $t1, $t2
+  0: $t4 := borrow_global<m::Foo>($t0)
+     # live vars: $t1, $t2, $t4
+  1: $t3 := borrow_field<m::Foo>.x($t4)
+     # live vars: $t1, $t2, $t3
+  2: $t5 := m::foo($t1, $t3)
+     # live vars: $t2, $t5
+  3: m::bar($t2, $t5)
+     # live vars:
+  4: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t3 := read_ref($t1)
+     # live vars: $t0, $t3
+  1: $t2 := +($t0, $t3)
+     # live vars: $t2
+  2: return $t2
+}
+
+
+[variant baseline]
+public fun m::test($t0: address, $t1: u64, $t2: u64) {
+     var $t3: &u64
+     var $t4: &m::Foo
+     var $t5: u64
+     # live vars: $t0, $t1, $t2
+  0: $t4 := borrow_global<m::Foo>($t0)
+     # live vars: $t1, $t2, $t4
+  1: $t3 := borrow_field<m::Foo>.x($t4)
+     # live vars: $t1, $t2, $t3
+  2: $t5 := m::foo($t1, $t3)
+     # live vars: $t2, $t5
+  3: m::bar($t2, $t5)
+     # live vars:
+  4: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t3 := read_ref($t1)
+     # live vars: $t0, $t3
+  1: $t2 := +($t0, $t3)
+     # live vars: $t2
+  2: return $t2
+}
+
+
+[variant baseline]
+public fun m::test($t0: address, $t1: u64, $t2: u64) {
+     var $t3: &u64
+     var $t4: &m::Foo
+     var $t5: u64
+     # live vars: $t0, $t1, $t2
+  0: $t4 := borrow_global<m::Foo>($t0)
+     # live vars: $t1, $t2, $t4
+  1: $t3 := borrow_field<m::Foo>.x($t4)
+     # live vars: $t1, $t2, $t3
+  2: $t5 := m::foo($t1, $t3)
+     # live vars: $t2, $t5
+  3: m::bar($t2, $t5)
+     # live vars:
+  4: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: &u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t3 := read_ref($t1)
+     # live vars: $t0, $t3
+  1: $t0 := +($t0, $t3)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+public fun m::test($t0: address, $t1: u64, $t2: u64) {
+     var $t3: &u64
+     var $t4: &m::Foo
+     var $t5: u64 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t4 := borrow_global<m::Foo>($t0)
+     # live vars: $t1, $t2, $t4
+  1: $t3 := borrow_field<m::Foo>.x($t4)
+     # live vars: $t1, $t2, $t3
+  2: $t1 := m::foo($t1, $t3)
+     # live vars: $t1, $t2
+  3: m::bar($t2, $t1)
+     # live vars:
+  4: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: &u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t3 := read_ref($t1)
+     # live vars: $t0, $t3
+  1: $t0 := +($t0, $t3)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+public fun m::test($t0: address, $t1: u64, $t2: u64) {
+     var $t3: &u64
+     var $t4: &m::Foo
+     var $t5: u64 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t4 := borrow_global<m::Foo>($t0)
+     # live vars: $t1, $t2, $t4
+  1: $t3 := borrow_field<m::Foo>.x($t4)
+     # live vars: $t1, $t2, $t3
+  2: $t1 := m::foo($t1, $t3)
+     # live vars: $t1, $t2
+  3: m::bar($t2, $t1)
+     # live vars:
+  4: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct Foo has key {
+	x: u64
+}
+
+bar(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+foo(Arg0: u64, Arg1: &u64): u64 /* def_idx: 1 */ {
+L2:	loc0: u64
+B0:
+	0: MoveLoc[1](Arg1: &u64)
+	1: ReadRef
+	2: StLoc[2](loc0: u64)
+	3: MoveLoc[0](Arg0: u64)
+	4: MoveLoc[2](loc0: u64)
+	5: Add
+	6: Ret
+}
+public test(Arg0: address, Arg1: u64, Arg2: u64) /* def_idx: 2 */ {
+L3:	loc0: &u64
+B0:
+	0: MoveLoc[0](Arg0: address)
+	1: ImmBorrowGlobal[0](Foo)
+	2: ImmBorrowField[0](Foo.x: u64)
+	3: StLoc[3](loc0: &u64)
+	4: MoveLoc[1](Arg1: u64)
+	5: MoveLoc[3](loc0: &u64)
+	6: Call foo(u64, &u64): u64
+	7: StLoc[1](Arg1: u64)
+	8: MoveLoc[2](Arg2: u64)
+	9: MoveLoc[1](Arg1: u64)
+	10: Call bar(u64, u64)
+	11: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/call_sequence.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/call_sequence.on.exp
@@ -1,0 +1,66 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: u64, $t1: u64) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: &u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64
+  0: touch($t0)
+  1: $t3 := read_ref($t1)
+  2: $t0 := +($t0, $t3)
+  3: return $t0
+}
+
+
+[variant baseline]
+public fun m::test($t0: address, $t1: u64, $t2: u64) {
+     var $t3: &u64
+     var $t4: &m::Foo
+     var $t5: u64 [unused]
+  0: touch($t2)
+  1: touch($t1)
+  2: $t4 := borrow_global<m::Foo>($t0)
+  3: $t3 := borrow_field<m::Foo>.x($t4)
+  4: $t1 := m::foo($t1, $t3)
+  5: m::bar($t2, $t1)
+  6: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct Foo has key {
+	x: u64
+}
+
+bar(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+foo(Arg0: u64, Arg1: &u64): u64 /* def_idx: 1 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: MoveLoc[1](Arg1: &u64)
+	2: ReadRef
+	3: Add
+	4: Ret
+}
+public test(Arg0: address, Arg1: u64, Arg2: u64) /* def_idx: 2 */ {
+B0:
+	0: MoveLoc[2](Arg2: u64)
+	1: MoveLoc[1](Arg1: u64)
+	2: MoveLoc[0](Arg0: address)
+	3: ImmBorrowGlobal[0](Foo)
+	4: ImmBorrowField[0](Foo.x: u64)
+	5: Call foo(u64, &u64): u64
+	6: Call bar(u64, u64)
+	7: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/copy_and_move_01.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/copy_and_move_01.move
@@ -1,0 +1,7 @@
+module 0xc0ffee::m {
+    public fun test(p: u64): u64 {
+        let x = p;
+        x + x
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/copy_and_move_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/copy_and_move_01.off.exp
@@ -1,0 +1,97 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := infer($t0)
+     # live vars: $t2
+  1: $t1 := +($t2, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := infer($t0)
+     # live vars: $t2
+  1: $t1 := +($t2, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := move($t0)
+     # live vars: $t2
+  1: $t1 := +($t2, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := move($t0)
+     # live vars: $t2
+  1: $t1 := +($t2, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     # live vars: $t0
+  0: $t0 := move($t0)
+     # live vars: $t0
+  1: $t0 := +($t0, $t0)
+     # live vars: $t0
+  2: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     # live vars: $t0
+  0: $t0 := +($t0, $t0)
+     # live vars: $t0
+  1: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public test(Arg0: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: MoveLoc[0](Arg0: u64)
+	2: Add
+	3: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/copy_and_move_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/copy_and_move_01.on.exp
@@ -1,0 +1,26 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+  0: touch($t0)
+  1: $t0 := +($t0, $t0)
+  2: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public test(Arg0: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: MoveLoc[0](Arg0: u64)
+	2: Add
+	3: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/copy_and_move_02.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/copy_and_move_02.move
@@ -1,0 +1,14 @@
+module 0xc0ffee::m {
+    struct S has copy {x: u64}
+
+    fun consume(x: S, y: S) {
+        let S{x: _} = x;
+        let S{x: _} = y;
+    }
+
+    public fun test(x: S) {
+        let y = copy x;
+        let z = move x;
+        consume(z, y);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/copy_and_move_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/copy_and_move_02.off.exp
@@ -1,0 +1,202 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: m::S, $t1: m::S) {
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t2 := unpack m::S($t0)
+     # live vars: $t1
+  1: $t3 := unpack m::S($t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: m::S) {
+     var $t1: m::S
+     var $t2: m::S
+     # live vars: $t0
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  1: $t2 := move($t0)
+     # live vars: $t1, $t2
+  2: m::consume($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: m::S, $t1: m::S) {
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t2 := unpack m::S($t0)
+     # live vars: $t1
+  1: $t3 := unpack m::S($t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: m::S) {
+     var $t1: m::S
+     var $t2: m::S
+     # live vars: $t0
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  1: $t2 := move($t0)
+     # live vars: $t1, $t2
+  2: m::consume($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: m::S, $t1: m::S) {
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t2 := unpack m::S($t0)
+     # live vars: $t1
+  1: $t3 := unpack m::S($t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: m::S) {
+     var $t1: m::S
+     var $t2: m::S
+     # live vars: $t0
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  1: $t2 := move($t0)
+     # live vars: $t1, $t2
+  2: m::consume($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: m::S, $t1: m::S) {
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t2 := unpack m::S($t0)
+     # live vars: $t1
+  1: $t3 := unpack m::S($t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: m::S) {
+     var $t1: m::S
+     var $t2: m::S
+     # live vars: $t0
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  1: $t2 := move($t0)
+     # live vars: $t1, $t2
+  2: m::consume($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: m::S, $t1: m::S) {
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t2 := unpack m::S($t0)
+     # live vars: $t1
+  1: $t3 := unpack m::S($t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: m::S) {
+     var $t1: m::S
+     var $t2: m::S [unused]
+     # live vars: $t0
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  1: $t0 := move($t0)
+     # live vars: $t0, $t1
+  2: m::consume($t0, $t1)
+     # live vars:
+  3: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: m::S, $t1: m::S) {
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t2 := unpack m::S($t0)
+     # live vars: $t1
+  1: $t3 := unpack m::S($t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: m::S) {
+     var $t1: m::S
+     var $t2: m::S [unused]
+     # live vars: $t0
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  1: m::consume($t0, $t1)
+     # live vars:
+  2: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct S has copy {
+	x: u64
+}
+
+consume(Arg0: S, Arg1: S) /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: S)
+	1: Unpack[0](S)
+	2: MoveLoc[1](Arg1: S)
+	3: Unpack[0](S)
+	4: Pop
+	5: Pop
+	6: Ret
+}
+public test(Arg0: S) /* def_idx: 1 */ {
+L1:	loc0: S
+B0:
+	0: CopyLoc[0](Arg0: S)
+	1: StLoc[1](loc0: S)
+	2: MoveLoc[0](Arg0: S)
+	3: MoveLoc[1](loc0: S)
+	4: Call consume(S, S)
+	5: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/copy_and_move_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/copy_and_move_02.on.exp
@@ -1,0 +1,52 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: m::S, $t1: m::S) {
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := unpack m::S($t0)
+  1: $t3 := unpack m::S($t1)
+  2: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: m::S) {
+     var $t1: m::S
+     var $t2: m::S [unused]
+  0: touch($t0)
+  1: $t1 := copy($t0)
+  2: m::consume($t0, $t1)
+  3: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct S has copy {
+	x: u64
+}
+
+consume(Arg0: S, Arg1: S) /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: S)
+	1: Unpack[0](S)
+	2: Pop
+	3: MoveLoc[1](Arg1: S)
+	4: Unpack[0](S)
+	5: Pop
+	6: Ret
+}
+public test(Arg0: S) /* def_idx: 1 */ {
+L1:	loc0: S
+B0:
+	0: CopyLoc[0](Arg0: S)
+	1: StLoc[1](loc0: S)
+	2: MoveLoc[0](Arg0: S)
+	3: MoveLoc[1](loc0: S)
+	4: Call consume(S, S)
+	5: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_01.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_01.move
@@ -1,0 +1,14 @@
+module 0xc0ffee::m {
+    fun take_ref(x: &u64): u64 {
+        *x
+    }
+
+    fun consume(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64) {
+    }
+
+    public fun test(a: u64, b: u64, c: u64, d: u64) {
+        let x = take_ref(&a);
+        consume(a, x, b, c, d);
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_01.off.exp
@@ -1,0 +1,230 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64) {
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take_ref($t0: &u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := read_ref($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     var $t4: u64
+     var $t5: &u64
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t3, $t5
+  1: $t4 := m::take_ref($t5)
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  2: m::consume($t0, $t4, $t1, $t2, $t3)
+     # live vars:
+  3: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64) {
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take_ref($t0: &u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := read_ref($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     var $t4: u64
+     var $t5: &u64
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t3, $t5
+  1: $t4 := m::take_ref($t5)
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  2: m::consume($t0, $t4, $t1, $t2, $t3)
+     # live vars:
+  3: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64) {
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take_ref($t0: &u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := read_ref($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     var $t4: u64
+     var $t5: &u64
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t3, $t5
+  1: $t4 := m::take_ref($t5)
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  2: m::consume($t0, $t4, $t1, $t2, $t3)
+     # live vars:
+  3: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64) {
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take_ref($t0: &u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := read_ref($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     var $t4: u64
+     var $t5: &u64
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t3, $t5
+  1: $t4 := m::take_ref($t5)
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  2: m::consume($t0, $t4, $t1, $t2, $t3)
+     # live vars:
+  3: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64) {
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take_ref($t0: &u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := read_ref($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     var $t4: u64
+     var $t5: &u64
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t3, $t5
+  1: $t4 := m::take_ref($t5)
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  2: m::consume($t0, $t4, $t1, $t2, $t3)
+     # live vars:
+  3: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64) {
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take_ref($t0: &u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := read_ref($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     var $t4: u64
+     var $t5: &u64
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t3, $t5
+  1: $t4 := m::take_ref($t5)
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  2: m::consume($t0, $t4, $t1, $t2, $t3)
+     # live vars:
+  3: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+take_ref(Arg0: &u64): u64 /* def_idx: 1 */ {
+B0:
+	0: MoveLoc[0](Arg0: &u64)
+	1: ReadRef
+	2: Ret
+}
+public test(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 2 */ {
+L4:	loc0: u64
+B0:
+	0: ImmBorrowLoc[0](Arg0: u64)
+	1: Call take_ref(&u64): u64
+	2: StLoc[4](loc0: u64)
+	3: MoveLoc[0](Arg0: u64)
+	4: MoveLoc[4](loc0: u64)
+	5: MoveLoc[1](Arg1: u64)
+	6: MoveLoc[2](Arg2: u64)
+	7: MoveLoc[3](Arg3: u64)
+	8: Call consume(u64, u64, u64, u64, u64)
+	9: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_01.on.exp
@@ -1,0 +1,60 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take_ref($t0: &u64): u64 {
+     var $t1: u64
+  0: $t1 := read_ref($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     var $t4: u64
+     var $t5: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := m::take_ref($t5)
+  2: touch($t1)
+  3: touch($t2)
+  4: m::consume($t0, $t4, $t1, $t2, $t3)
+  5: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+take_ref(Arg0: &u64): u64 /* def_idx: 1 */ {
+B0:
+	0: MoveLoc[0](Arg0: &u64)
+	1: ReadRef
+	2: Ret
+}
+public test(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 2 */ {
+L4:	loc0: u64
+B0:
+	0: ImmBorrowLoc[0](Arg0: u64)
+	1: Call take_ref(&u64): u64
+	2: StLoc[4](loc0: u64)
+	3: MoveLoc[0](Arg0: u64)
+	4: MoveLoc[4](loc0: u64)
+	5: MoveLoc[1](Arg1: u64)
+	6: MoveLoc[2](Arg2: u64)
+	7: MoveLoc[3](Arg3: u64)
+	8: Call consume(u64, u64, u64, u64, u64)
+	9: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_02.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_02.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+    fun blah(_x: &u64) {}
+
+    public fun test(x: &u64) {
+        blah(x);
+        blah(x);
+        blah(x);
+        blah(x);
+        blah(x);
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_02.off.exp
@@ -1,0 +1,235 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::blah($t0: &u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: &u64) {
+     # live vars: $t0
+  0: m::blah($t0)
+     # live vars: $t0
+  1: m::blah($t0)
+     # live vars: $t0
+  2: m::blah($t0)
+     # live vars: $t0
+  3: m::blah($t0)
+     # live vars: $t0
+  4: m::blah($t0)
+     # live vars:
+  5: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::blah($t0: &u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: &u64) {
+     # live vars: $t0
+  0: m::blah($t0)
+     # live vars: $t0
+  1: m::blah($t0)
+     # live vars: $t0
+  2: m::blah($t0)
+     # live vars: $t0
+  3: m::blah($t0)
+     # live vars: $t0
+  4: m::blah($t0)
+     # live vars:
+  5: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::blah($t0: &u64) {
+     # live vars: $t0
+  0: drop($t0)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: &u64) {
+     var $t1: &u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     # live vars: $t0
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  1: m::blah($t1)
+     # live vars: $t0
+  2: $t2 := copy($t0)
+     # live vars: $t0, $t2
+  3: m::blah($t2)
+     # live vars: $t0
+  4: $t3 := copy($t0)
+     # live vars: $t0, $t3
+  5: m::blah($t3)
+     # live vars: $t0
+  6: $t4 := copy($t0)
+     # live vars: $t0, $t4
+  7: m::blah($t4)
+     # live vars: $t0
+  8: m::blah($t0)
+     # live vars:
+  9: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::blah($t0: &u64) {
+     # live vars: $t0
+  0: drop($t0)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: &u64) {
+     var $t1: &u64
+     var $t2: &u64
+     var $t3: &u64
+     var $t4: &u64
+     # live vars: $t0
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  1: m::blah($t1)
+     # live vars: $t0
+  2: $t2 := copy($t0)
+     # live vars: $t0, $t2
+  3: m::blah($t2)
+     # live vars: $t0
+  4: $t3 := copy($t0)
+     # live vars: $t0, $t3
+  5: m::blah($t3)
+     # live vars: $t0
+  6: $t4 := copy($t0)
+     # live vars: $t0, $t4
+  7: m::blah($t4)
+     # live vars: $t0
+  8: m::blah($t0)
+     # live vars:
+  9: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::blah($t0: &u64) {
+     # live vars: $t0
+  0: drop($t0)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: &u64) {
+     var $t1: &u64
+     var $t2: &u64 [unused]
+     var $t3: &u64 [unused]
+     var $t4: &u64 [unused]
+     # live vars: $t0
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  1: m::blah($t1)
+     # live vars: $t0
+  2: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  3: m::blah($t1)
+     # live vars: $t0
+  4: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  5: m::blah($t1)
+     # live vars: $t0
+  6: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  7: m::blah($t1)
+     # live vars: $t0
+  8: m::blah($t0)
+     # live vars:
+  9: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::blah($t0: &u64) {
+     # live vars: $t0
+  0: drop($t0)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: &u64) {
+     var $t1: &u64
+     var $t2: &u64 [unused]
+     var $t3: &u64 [unused]
+     var $t4: &u64 [unused]
+     # live vars: $t0
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  1: m::blah($t1)
+     # live vars: $t0
+  2: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  3: m::blah($t1)
+     # live vars: $t0
+  4: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  5: m::blah($t1)
+     # live vars: $t0
+  6: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  7: m::blah($t1)
+     # live vars: $t0
+  8: m::blah($t0)
+     # live vars:
+  9: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+blah(Arg0: &u64) /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: &u64)
+	1: Pop
+	2: Ret
+}
+public test(Arg0: &u64) /* def_idx: 1 */ {
+L1:	loc0: &u64
+B0:
+	0: CopyLoc[0](Arg0: &u64)
+	1: Call blah(&u64)
+	2: CopyLoc[0](Arg0: &u64)
+	3: Call blah(&u64)
+	4: CopyLoc[0](Arg0: &u64)
+	5: Call blah(&u64)
+	6: CopyLoc[0](Arg0: &u64)
+	7: Call blah(&u64)
+	8: MoveLoc[0](Arg0: &u64)
+	9: Call blah(&u64)
+	10: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_02.on.exp
@@ -1,0 +1,56 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+fun m::blah($t0: &u64) {
+  0: drop($t0)
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: &u64) {
+     var $t1: &u64
+     var $t2: &u64 [unused]
+     var $t3: &u64 [unused]
+     var $t4: &u64 [unused]
+  0: $t1 := copy($t0)
+  1: m::blah($t1)
+  2: $t1 := copy($t0)
+  3: m::blah($t1)
+  4: $t1 := copy($t0)
+  5: m::blah($t1)
+  6: $t1 := copy($t0)
+  7: m::blah($t1)
+  8: m::blah($t0)
+  9: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+blah(Arg0: &u64) /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: &u64)
+	1: Pop
+	2: Ret
+}
+public test(Arg0: &u64) /* def_idx: 1 */ {
+L1:	loc0: &u64
+B0:
+	0: CopyLoc[0](Arg0: &u64)
+	1: Call blah(&u64)
+	2: CopyLoc[0](Arg0: &u64)
+	3: Call blah(&u64)
+	4: CopyLoc[0](Arg0: &u64)
+	5: Call blah(&u64)
+	6: CopyLoc[0](Arg0: &u64)
+	7: Call blah(&u64)
+	8: MoveLoc[0](Arg0: &u64)
+	9: Call blah(&u64)
+	10: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_03.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_03.move
@@ -1,0 +1,14 @@
+module 0xc0ffee::m {
+    fun compute(x: u64): u64 {
+        x + 1
+    }
+
+    fun take1(x: &u64): u64 { *x }
+
+    fun take2(_x: &u64, _y: u64) {}
+
+    public fun test(x: u64) {
+        let k = compute(x);
+        take2(&x, take1(&k));
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_03.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_03.off.exp
@@ -1,0 +1,360 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::compute($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun m::take1($t0: &u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := read_ref($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::take2($t0: &u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: u64
+     var $t4: &u64
+     # live vars: $t0
+  0: $t1 := m::compute($t0)
+     # live vars: $t0, $t1
+  1: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  2: $t4 := borrow_local($t1)
+     # live vars: $t2, $t4
+  3: $t3 := m::take1($t4)
+     # live vars: $t2, $t3
+  4: m::take2($t2, $t3)
+     # live vars:
+  5: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::compute($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun m::take1($t0: &u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := read_ref($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::take2($t0: &u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: u64
+     var $t4: &u64
+     # live vars: $t0
+  0: $t1 := m::compute($t0)
+     # live vars: $t0, $t1
+  1: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  2: $t4 := borrow_local($t1)
+     # live vars: $t2, $t4
+  3: $t3 := m::take1($t4)
+     # live vars: $t2, $t3
+  4: m::take2($t2, $t3)
+     # live vars:
+  5: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::compute($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun m::take1($t0: &u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := read_ref($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::take2($t0: &u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: drop($t0)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: u64
+     var $t4: &u64
+     # live vars: $t0
+  0: $t1 := m::compute($t0)
+     # live vars: $t0, $t1
+  1: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  2: $t4 := borrow_local($t1)
+     # live vars: $t2, $t4
+  3: $t3 := m::take1($t4)
+     # live vars: $t2, $t3
+  4: m::take2($t2, $t3)
+     # live vars:
+  5: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::compute($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun m::take1($t0: &u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := read_ref($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::take2($t0: &u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: drop($t0)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: u64
+     var $t4: &u64
+     # live vars: $t0
+  0: $t1 := m::compute($t0)
+     # live vars: $t0, $t1
+  1: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  2: $t4 := borrow_local($t1)
+     # live vars: $t2, $t4
+  3: $t3 := m::take1($t4)
+     # live vars: $t2, $t3
+  4: m::take2($t2, $t3)
+     # live vars:
+  5: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::compute($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t0 := +($t0, $t2)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun m::take1($t0: &u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := read_ref($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::take2($t0: &u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: drop($t0)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: u64
+     var $t4: &u64
+     # live vars: $t0
+  0: $t1 := m::compute($t0)
+     # live vars: $t0, $t1
+  1: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  2: $t4 := borrow_local($t1)
+     # live vars: $t2, $t4
+  3: $t3 := m::take1($t4)
+     # live vars: $t2, $t3
+  4: m::take2($t2, $t3)
+     # live vars:
+  5: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::compute($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t0 := +($t0, $t2)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun m::take1($t0: &u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := read_ref($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::take2($t0: &u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: drop($t0)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: u64
+     var $t4: &u64
+     # live vars: $t0
+  0: $t1 := m::compute($t0)
+     # live vars: $t0, $t1
+  1: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  2: $t4 := borrow_local($t1)
+     # live vars: $t2, $t4
+  3: $t3 := m::take1($t4)
+     # live vars: $t2, $t3
+  4: m::take2($t2, $t3)
+     # live vars:
+  5: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+compute(Arg0: u64): u64 /* def_idx: 0 */ {
+L1:	loc0: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: Ret
+}
+take1(Arg0: &u64): u64 /* def_idx: 1 */ {
+B0:
+	0: MoveLoc[0](Arg0: &u64)
+	1: ReadRef
+	2: Ret
+}
+take2(Arg0: &u64, Arg1: u64) /* def_idx: 2 */ {
+B0:
+	0: MoveLoc[0](Arg0: &u64)
+	1: Pop
+	2: Ret
+}
+public test(Arg0: u64) /* def_idx: 3 */ {
+L1:	loc0: u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: Call compute(u64): u64
+	2: StLoc[1](loc0: u64)
+	3: ImmBorrowLoc[0](Arg0: u64)
+	4: ImmBorrowLoc[1](loc0: u64)
+	5: Call take1(&u64): u64
+	6: Call take2(&u64, u64)
+	7: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_03.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_03.on.exp
@@ -1,0 +1,81 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+fun m::compute($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+  0: touch($t0)
+  1: $t2 := 1
+  2: $t0 := +($t0, $t2)
+  3: return $t0
+}
+
+
+[variant baseline]
+fun m::take1($t0: &u64): u64 {
+     var $t1: u64
+  0: $t1 := read_ref($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::take2($t0: &u64, $t1: u64) {
+  0: drop($t0)
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: u64
+     var $t4: &u64
+  0: $t1 := m::compute($t0)
+  1: $t2 := borrow_local($t0)
+  2: $t4 := borrow_local($t1)
+  3: $t3 := m::take1($t4)
+  4: m::take2($t2, $t3)
+  5: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+compute(Arg0: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: Ret
+}
+take1(Arg0: &u64): u64 /* def_idx: 1 */ {
+B0:
+	0: MoveLoc[0](Arg0: &u64)
+	1: ReadRef
+	2: Ret
+}
+take2(Arg0: &u64, Arg1: u64) /* def_idx: 2 */ {
+B0:
+	0: MoveLoc[0](Arg0: &u64)
+	1: Pop
+	2: Ret
+}
+public test(Arg0: u64) /* def_idx: 3 */ {
+L1:	loc0: u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: Call compute(u64): u64
+	2: StLoc[1](loc0: u64)
+	3: ImmBorrowLoc[0](Arg0: u64)
+	4: ImmBorrowLoc[1](loc0: u64)
+	5: Call take1(&u64): u64
+	6: Call take2(&u64, u64)
+	7: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_04.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_04.move
@@ -1,0 +1,19 @@
+module 0xc0ffee::m {
+    struct Foo {
+        x: u64,
+    }
+
+    fun bar(x: &u64): u64 {
+        *x + 1
+    }
+
+    fun baz(x: &mut u64, y: u64) {
+        *x = *x + y;
+    }
+
+    public fun test(v: &mut Foo) {
+        let n = bar(&v.x);
+        baz(&mut v.x, n + 1);
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_04.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_04.off.exp
@@ -1,0 +1,385 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun m::baz($t0: &mut u64, $t1: u64) {
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t3 := read_ref($t0)
+     # live vars: $t0, $t1, $t3
+  1: $t2 := +($t3, $t1)
+     # live vars: $t0, $t2
+  2: write_ref($t2, $t0)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: &mut m::Foo) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &mut u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t2 := borrow_field<m::Foo>.x($t0)
+     # live vars: $t0, $t2
+  1: $t1 := m::bar($t2)
+     # live vars: $t0, $t1
+  2: $t3 := borrow_field<m::Foo>.x($t0)
+     # live vars: $t1, $t3
+  3: $t5 := 1
+     # live vars: $t1, $t3, $t5
+  4: $t4 := +($t1, $t5)
+     # live vars: $t3, $t4
+  5: m::baz($t3, $t4)
+     # live vars:
+  6: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun m::baz($t0: &mut u64, $t1: u64) {
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t3 := read_ref($t0)
+     # live vars: $t0, $t1, $t3
+  1: $t2 := +($t3, $t1)
+     # live vars: $t0, $t2
+  2: write_ref($t2, $t0)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: &mut m::Foo) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &mut u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t2 := borrow_field<m::Foo>.x($t0)
+     # live vars: $t0, $t2
+  1: $t1 := m::bar($t2)
+     # live vars: $t0, $t1
+  2: $t3 := borrow_field<m::Foo>.x($t0)
+     # live vars: $t1, $t3
+  3: $t5 := 1
+     # live vars: $t1, $t3, $t5
+  4: $t4 := +($t1, $t5)
+     # live vars: $t3, $t4
+  5: m::baz($t3, $t4)
+     # live vars:
+  6: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun m::baz($t0: &mut u64, $t1: u64) {
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t3 := read_ref($t0)
+     # live vars: $t0, $t1, $t3
+  1: $t2 := +($t3, $t1)
+     # live vars: $t0, $t2
+  2: write_ref($t2, $t0)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: &mut m::Foo) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &mut u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t2 := borrow_field<m::Foo>.x($t0)
+     # live vars: $t0, $t2
+  1: $t1 := m::bar($t2)
+     # live vars: $t0, $t1
+  2: $t3 := borrow_field<m::Foo>.x($t0)
+     # live vars: $t1, $t3
+  3: $t5 := 1
+     # live vars: $t1, $t3, $t5
+  4: $t4 := +($t1, $t5)
+     # live vars: $t3, $t4
+  5: m::baz($t3, $t4)
+     # live vars:
+  6: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun m::baz($t0: &mut u64, $t1: u64) {
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t3 := read_ref($t0)
+     # live vars: $t0, $t1, $t3
+  1: $t2 := +($t3, $t1)
+     # live vars: $t0, $t2
+  2: write_ref($t2, $t0)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: &mut m::Foo) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &mut u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t2 := borrow_field<m::Foo>.x($t0)
+     # live vars: $t0, $t2
+  1: $t1 := m::bar($t2)
+     # live vars: $t0, $t1
+  2: $t3 := borrow_field<m::Foo>.x($t0)
+     # live vars: $t1, $t3
+  3: $t5 := 1
+     # live vars: $t1, $t3, $t5
+  4: $t4 := +($t1, $t5)
+     # live vars: $t3, $t4
+  5: m::baz($t3, $t4)
+     # live vars:
+  6: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: &u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t2 := +($t2, $t3)
+     # live vars: $t2
+  3: return $t2
+}
+
+
+[variant baseline]
+fun m::baz($t0: &mut u64, $t1: u64) {
+     var $t2: u64 [unused]
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t3 := read_ref($t0)
+     # live vars: $t0, $t1, $t3
+  1: $t1 := +($t3, $t1)
+     # live vars: $t0, $t1
+  2: write_ref($t1, $t0)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: &mut m::Foo) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &mut u64
+     var $t4: u64 [unused]
+     var $t5: u64
+     # live vars: $t0
+  0: $t2 := borrow_field<m::Foo>.x($t0)
+     # live vars: $t0, $t2
+  1: $t1 := m::bar($t2)
+     # live vars: $t0, $t1
+  2: $t3 := borrow_field<m::Foo>.x($t0)
+     # live vars: $t1, $t3
+  3: $t5 := 1
+     # live vars: $t1, $t3, $t5
+  4: $t1 := +($t1, $t5)
+     # live vars: $t1, $t3
+  5: m::baz($t3, $t1)
+     # live vars:
+  6: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: &u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t2 := +($t2, $t3)
+     # live vars: $t2
+  3: return $t2
+}
+
+
+[variant baseline]
+fun m::baz($t0: &mut u64, $t1: u64) {
+     var $t2: u64 [unused]
+     var $t3: u64
+     # live vars: $t0, $t1
+  0: $t3 := read_ref($t0)
+     # live vars: $t0, $t1, $t3
+  1: $t1 := +($t3, $t1)
+     # live vars: $t0, $t1
+  2: write_ref($t1, $t0)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: &mut m::Foo) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &mut u64
+     var $t4: u64 [unused]
+     var $t5: u64
+     # live vars: $t0
+  0: $t2 := borrow_field<m::Foo>.x($t0)
+     # live vars: $t0, $t2
+  1: $t1 := m::bar($t2)
+     # live vars: $t0, $t1
+  2: $t3 := borrow_field<m::Foo>.x($t0)
+     # live vars: $t1, $t3
+  3: $t5 := 1
+     # live vars: $t1, $t3, $t5
+  4: $t1 := +($t1, $t5)
+     # live vars: $t1, $t3
+  5: m::baz($t3, $t1)
+     # live vars:
+  6: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct Foo {
+	x: u64
+}
+
+bar(Arg0: &u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: &u64)
+	1: ReadRef
+	2: LdU64(1)
+	3: Add
+	4: Ret
+}
+baz(Arg0: &mut u64, Arg1: u64) /* def_idx: 1 */ {
+B0:
+	0: CopyLoc[0](Arg0: &mut u64)
+	1: ReadRef
+	2: MoveLoc[1](Arg1: u64)
+	3: Add
+	4: MoveLoc[0](Arg0: &mut u64)
+	5: WriteRef
+	6: Ret
+}
+public test(Arg0: &mut Foo) /* def_idx: 2 */ {
+L1:	loc0: u64
+L2:	loc1: &mut u64
+L3:	loc2: u64
+B0:
+	0: CopyLoc[0](Arg0: &mut Foo)
+	1: ImmBorrowField[0](Foo.x: u64)
+	2: Call bar(&u64): u64
+	3: MoveLoc[0](Arg0: &mut Foo)
+	4: MutBorrowField[0](Foo.x: u64)
+	5: LdU64(1)
+	6: StLoc[1](loc0: u64)
+	7: StLoc[2](loc1: &mut u64)
+	8: MoveLoc[1](loc0: u64)
+	9: Add
+	10: StLoc[3](loc2: u64)
+	11: MoveLoc[2](loc1: &mut u64)
+	12: MoveLoc[3](loc2: u64)
+	13: Call baz(&mut u64, u64)
+	14: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_04.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/framework_reduced_04.on.exp
@@ -1,0 +1,90 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: &u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t2 := +($t2, $t3)
+  3: return $t2
+}
+
+
+[variant baseline]
+fun m::baz($t0: &mut u64, $t1: u64) {
+     var $t2: u64 [unused]
+     var $t3: u64
+  0: $t3 := read_ref($t0)
+  1: $t1 := +($t3, $t1)
+  2: write_ref($t1, $t0)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: &mut m::Foo) {
+     var $t1: u64
+     var $t2: &u64
+     var $t3: &mut u64
+     var $t4: u64 [unused]
+     var $t5: u64
+  0: $t2 := borrow_field<m::Foo>.x($t0)
+  1: $t1 := m::bar($t2)
+  2: $t3 := borrow_field<m::Foo>.x($t0)
+  3: $t5 := 1
+  4: $t1 := +($t1, $t5)
+  5: m::baz($t3, $t1)
+  6: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct Foo {
+	x: u64
+}
+
+bar(Arg0: &u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: &u64)
+	1: ReadRef
+	2: LdU64(1)
+	3: Add
+	4: Ret
+}
+baz(Arg0: &mut u64, Arg1: u64) /* def_idx: 1 */ {
+B0:
+	0: CopyLoc[0](Arg0: &mut u64)
+	1: ReadRef
+	2: MoveLoc[1](Arg1: u64)
+	3: Add
+	4: MoveLoc[0](Arg0: &mut u64)
+	5: WriteRef
+	6: Ret
+}
+public test(Arg0: &mut Foo) /* def_idx: 2 */ {
+L1:	loc0: u64
+L2:	loc1: &mut u64
+L3:	loc2: u64
+B0:
+	0: CopyLoc[0](Arg0: &mut Foo)
+	1: ImmBorrowField[0](Foo.x: u64)
+	2: Call bar(&u64): u64
+	3: MoveLoc[0](Arg0: &mut Foo)
+	4: MutBorrowField[0](Foo.x: u64)
+	5: LdU64(1)
+	6: StLoc[1](loc0: u64)
+	7: StLoc[2](loc1: &mut u64)
+	8: MoveLoc[1](loc0: u64)
+	9: Add
+	10: StLoc[3](loc2: u64)
+	11: MoveLoc[2](loc1: &mut u64)
+	12: MoveLoc[3](loc2: u64)
+	13: Call baz(&mut u64, u64)
+	14: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/intermingled_01.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/intermingled_01.move
@@ -1,0 +1,48 @@
+module 0xc0ffee::m {
+    fun one(): u64 {
+        1
+    }
+
+    fun two(): u64 {
+        2
+    }
+
+    fun id(x: u64): u64 {
+        x
+    }
+
+    public fun test1() {
+        let x = one();
+        let y = two();
+        id(x);
+        id(y);
+    }
+
+    struct Foo {
+        x: u64
+    }
+
+    public fun test2() {
+        let x = 1;
+        let y = 2;
+        id(x);
+        id(y);
+    }
+
+    public fun test3(x: u64): u64 {
+        x + 1 + x + x
+    }
+
+    fun bar(_x: u64, _y: u64) {}
+
+    fun baz(_x: u64) {}
+
+    public fun test4() {
+        let a = one();
+        let b = two();
+        let c = one() + two();
+        bar(a, b);
+        baz(c);
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/intermingled_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/intermingled_01.off.exp
@@ -1,0 +1,851 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::baz($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := infer($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::two()
+     # live vars: $t0, $t1
+  2: $t2 := m::id($t0)
+     # live vars: $t1
+  3: $t3 := m::id($t1)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t0 := m::id($t1)
+     # live vars:
+  2: $t3 := 2
+     # live vars: $t3
+  3: $t2 := m::id($t3)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test3($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t4 := 1
+     # live vars: $t0, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t0, $t3
+  2: $t2 := +($t3, $t0)
+     # live vars: $t0, $t2
+  3: $t1 := +($t2, $t0)
+     # live vars: $t1
+  4: return $t1
+}
+
+
+[variant baseline]
+public fun m::test4() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::two()
+     # live vars: $t0, $t1
+  2: $t3 := m::one()
+     # live vars: $t0, $t1, $t3
+  3: $t4 := m::two()
+     # live vars: $t0, $t1, $t3, $t4
+  4: $t2 := +($t3, $t4)
+     # live vars: $t0, $t1, $t2
+  5: m::bar($t0, $t1)
+     # live vars: $t2
+  6: m::baz($t2)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun m::two(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 2
+     # live vars: $t0
+  1: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::baz($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := infer($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::two()
+     # live vars: $t0, $t1
+  2: $t2 := m::id($t0)
+     # live vars: $t1
+  3: $t3 := m::id($t1)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t0 := m::id($t1)
+     # live vars:
+  2: $t3 := 2
+     # live vars: $t3
+  3: $t2 := m::id($t3)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test3($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t4 := 1
+     # live vars: $t0, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t0, $t3
+  2: $t2 := +($t3, $t0)
+     # live vars: $t0, $t2
+  3: $t1 := +($t2, $t0)
+     # live vars: $t1
+  4: return $t1
+}
+
+
+[variant baseline]
+public fun m::test4() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::two()
+     # live vars: $t0, $t1
+  2: $t3 := m::one()
+     # live vars: $t0, $t1, $t3
+  3: $t4 := m::two()
+     # live vars: $t0, $t1, $t3, $t4
+  4: $t2 := +($t3, $t4)
+     # live vars: $t0, $t1, $t2
+  5: m::bar($t0, $t1)
+     # live vars: $t2
+  6: m::baz($t2)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun m::two(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 2
+     # live vars: $t0
+  1: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::baz($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := move($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::two()
+     # live vars: $t0, $t1
+  2: $t2 := m::id($t0)
+     # live vars: $t1
+  3: $t3 := m::id($t1)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t0 := m::id($t1)
+     # live vars:
+  2: $t3 := 2
+     # live vars: $t3
+  3: $t2 := m::id($t3)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test3($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t4 := 1
+     # live vars: $t0, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t0, $t3
+  2: $t2 := +($t3, $t0)
+     # live vars: $t0, $t2
+  3: $t1 := +($t2, $t0)
+     # live vars: $t1
+  4: return $t1
+}
+
+
+[variant baseline]
+public fun m::test4() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::two()
+     # live vars: $t0, $t1
+  2: $t3 := m::one()
+     # live vars: $t0, $t1, $t3
+  3: $t4 := m::two()
+     # live vars: $t0, $t1, $t3, $t4
+  4: $t2 := +($t3, $t4)
+     # live vars: $t0, $t1, $t2
+  5: m::bar($t0, $t1)
+     # live vars: $t2
+  6: m::baz($t2)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun m::two(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 2
+     # live vars: $t0
+  1: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::baz($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := move($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::two()
+     # live vars: $t0, $t1
+  2: $t2 := m::id($t0)
+     # live vars: $t1
+  3: $t3 := m::id($t1)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t0 := m::id($t1)
+     # live vars:
+  2: $t3 := 2
+     # live vars: $t3
+  3: $t2 := m::id($t3)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test3($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t4 := 1
+     # live vars: $t0, $t4
+  1: $t3 := +($t0, $t4)
+     # live vars: $t0, $t3
+  2: $t2 := +($t3, $t0)
+     # live vars: $t0, $t2
+  3: $t1 := +($t2, $t0)
+     # live vars: $t1
+  4: return $t1
+}
+
+
+[variant baseline]
+public fun m::test4() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::two()
+     # live vars: $t0, $t1
+  2: $t3 := m::one()
+     # live vars: $t0, $t1, $t3
+  3: $t4 := m::two()
+     # live vars: $t0, $t1, $t3, $t4
+  4: $t2 := +($t3, $t4)
+     # live vars: $t0, $t1, $t2
+  5: m::bar($t0, $t1)
+     # live vars: $t2
+  6: m::baz($t2)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun m::two(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 2
+     # live vars: $t0
+  1: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::baz($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64 [unused]
+     # live vars: $t0
+  0: $t0 := move($t0)
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::two()
+     # live vars: $t0, $t1
+  2: $t0 := m::id($t0)
+     # live vars: $t1
+  3: $t1 := m::id($t1)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t0 := m::id($t1)
+     # live vars:
+  2: $t1 := 2
+     # live vars: $t1
+  3: $t1 := m::id($t1)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test3($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     # live vars: $t0
+  0: $t4 := 1
+     # live vars: $t0, $t4
+  1: $t4 := +($t0, $t4)
+     # live vars: $t0, $t4
+  2: $t4 := +($t4, $t0)
+     # live vars: $t0, $t4
+  3: $t0 := +($t4, $t0)
+     # live vars: $t0
+  4: return $t0
+}
+
+
+[variant baseline]
+public fun m::test4() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::two()
+     # live vars: $t0, $t1
+  2: $t3 := m::one()
+     # live vars: $t0, $t1, $t3
+  3: $t4 := m::two()
+     # live vars: $t0, $t1, $t3, $t4
+  4: $t3 := +($t3, $t4)
+     # live vars: $t0, $t1, $t3
+  5: m::bar($t0, $t1)
+     # live vars: $t3
+  6: m::baz($t3)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun m::two(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 2
+     # live vars: $t0
+  1: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::baz($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64 [unused]
+     # live vars: $t0
+  0: return $t0
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::two()
+     # live vars: $t0, $t1
+  2: $t0 := m::id($t0)
+     # live vars: $t1
+  3: $t1 := m::id($t1)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t0 := m::id($t1)
+     # live vars:
+  2: $t1 := 2
+     # live vars: $t1
+  3: $t1 := m::id($t1)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test3($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     # live vars: $t0
+  0: $t4 := 1
+     # live vars: $t0, $t4
+  1: $t4 := +($t0, $t4)
+     # live vars: $t0, $t4
+  2: $t4 := +($t4, $t0)
+     # live vars: $t0, $t4
+  3: $t0 := +($t4, $t0)
+     # live vars: $t0
+  4: return $t0
+}
+
+
+[variant baseline]
+public fun m::test4() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::two()
+     # live vars: $t0, $t1
+  2: $t3 := m::one()
+     # live vars: $t0, $t1, $t3
+  3: $t4 := m::two()
+     # live vars: $t0, $t1, $t3, $t4
+  4: $t3 := +($t3, $t4)
+     # live vars: $t0, $t1, $t3
+  5: m::bar($t0, $t1)
+     # live vars: $t3
+  6: m::baz($t3)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun m::two(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 2
+     # live vars: $t0
+  1: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct Foo {
+	x: u64
+}
+
+bar(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+baz(Arg0: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+id(Arg0: u64): u64 /* def_idx: 2 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Ret
+}
+one(): u64 /* def_idx: 3 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test1() /* def_idx: 4 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: Call two(): u64
+	2: StLoc[0](loc0: u64)
+	3: Call id(u64): u64
+	4: MoveLoc[0](loc0: u64)
+	5: Call id(u64): u64
+	6: Pop
+	7: Pop
+	8: Ret
+}
+public test2() /* def_idx: 5 */ {
+B0:
+	0: LdU64(1)
+	1: Call id(u64): u64
+	2: LdU64(2)
+	3: Call id(u64): u64
+	4: Pop
+	5: Pop
+	6: Ret
+}
+public test3(Arg0: u64): u64 /* def_idx: 6 */ {
+L1:	loc0: u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: CopyLoc[0](Arg0: u64)
+	4: Add
+	5: MoveLoc[0](Arg0: u64)
+	6: Add
+	7: Ret
+}
+public test4() /* def_idx: 7 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+B0:
+	0: Call one(): u64
+	1: Call two(): u64
+	2: Call one(): u64
+	3: Call two(): u64
+	4: Add
+	5: StLoc[0](loc0: u64)
+	6: Call bar(u64, u64)
+	7: MoveLoc[0](loc0: u64)
+	8: Call baz(u64)
+	9: Ret
+}
+two(): u64 /* def_idx: 8 */ {
+B0:
+	0: LdU64(2)
+	1: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/intermingled_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/intermingled_01.on.exp
@@ -1,0 +1,181 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: u64, $t1: u64) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::baz($t0: u64) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64 [unused]
+  0: return $t0
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+  0: $t0 := 1
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+  0: $t0 := m::one()
+  1: $t1 := m::two()
+  2: $t0 := m::id($t0)
+  3: $t1 := m::id($t1)
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+  0: $t1 := 1
+  1: $t0 := m::id($t1)
+  2: $t1 := 2
+  3: $t1 := m::id($t1)
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test3($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+  0: touch($t0)
+  1: $t4 := 1
+  2: $t4 := +($t0, $t4)
+  3: $t4 := +($t4, $t0)
+  4: $t0 := +($t4, $t0)
+  5: return $t0
+}
+
+
+[variant baseline]
+public fun m::test4() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: u64
+  0: $t0 := m::one()
+  1: $t1 := m::two()
+  2: $t3 := m::one()
+  3: $t4 := m::two()
+  4: $t3 := +($t3, $t4)
+  5: m::bar($t0, $t1)
+  6: m::baz($t3)
+  7: return ()
+}
+
+
+[variant baseline]
+fun m::two(): u64 {
+     var $t0: u64
+  0: $t0 := 2
+  1: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct Foo {
+	x: u64
+}
+
+bar(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+baz(Arg0: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+id(Arg0: u64): u64 /* def_idx: 2 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Ret
+}
+one(): u64 /* def_idx: 3 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test1() /* def_idx: 4 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: Call two(): u64
+	2: StLoc[0](loc0: u64)
+	3: Call id(u64): u64
+	4: Pop
+	5: MoveLoc[0](loc0: u64)
+	6: Call id(u64): u64
+	7: Pop
+	8: Ret
+}
+public test2() /* def_idx: 5 */ {
+B0:
+	0: LdU64(1)
+	1: Call id(u64): u64
+	2: Pop
+	3: LdU64(2)
+	4: Call id(u64): u64
+	5: Pop
+	6: Ret
+}
+public test3(Arg0: u64): u64 /* def_idx: 6 */ {
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: CopyLoc[0](Arg0: u64)
+	4: Add
+	5: MoveLoc[0](Arg0: u64)
+	6: Add
+	7: Ret
+}
+public test4() /* def_idx: 7 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+B0:
+	0: Call one(): u64
+	1: Call two(): u64
+	2: Call one(): u64
+	3: Call two(): u64
+	4: Add
+	5: StLoc[0](loc0: u64)
+	6: Call bar(u64, u64)
+	7: MoveLoc[0](loc0: u64)
+	8: Call baz(u64)
+	9: Ret
+}
+two(): u64 /* def_idx: 8 */ {
+B0:
+	0: LdU64(2)
+	1: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/intermingled_02.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/intermingled_02.move
@@ -1,0 +1,11 @@
+module 0xc0ffee::m {
+    fun foo(_: &u64) {}
+
+    public fun test(p: u64, q: u64) {
+        let x = &p;
+        let y = &q;
+        foo(x);
+        foo(y);
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/intermingled_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/intermingled_02.off.exp
@@ -1,0 +1,184 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: &u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64) {
+     var $t2: &u64
+     var $t3: &u64
+     # live vars: $t0, $t1
+  0: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  1: $t3 := borrow_local($t1)
+     # live vars: $t2, $t3
+  2: m::foo($t2)
+     # live vars: $t3
+  3: m::foo($t3)
+     # live vars:
+  4: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: &u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64) {
+     var $t2: &u64
+     var $t3: &u64
+     # live vars: $t0, $t1
+  0: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  1: $t3 := borrow_local($t1)
+     # live vars: $t2, $t3
+  2: m::foo($t2)
+     # live vars: $t3
+  3: m::foo($t3)
+     # live vars:
+  4: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: &u64) {
+     # live vars: $t0
+  0: drop($t0)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64) {
+     var $t2: &u64
+     var $t3: &u64
+     # live vars: $t0, $t1
+  0: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  1: $t3 := borrow_local($t1)
+     # live vars: $t2, $t3
+  2: m::foo($t2)
+     # live vars: $t3
+  3: m::foo($t3)
+     # live vars:
+  4: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: &u64) {
+     # live vars: $t0
+  0: drop($t0)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64) {
+     var $t2: &u64
+     var $t3: &u64
+     # live vars: $t0, $t1
+  0: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  1: $t3 := borrow_local($t1)
+     # live vars: $t2, $t3
+  2: m::foo($t2)
+     # live vars: $t3
+  3: m::foo($t3)
+     # live vars:
+  4: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: &u64) {
+     # live vars: $t0
+  0: drop($t0)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64) {
+     var $t2: &u64
+     var $t3: &u64
+     # live vars: $t0, $t1
+  0: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  1: $t3 := borrow_local($t1)
+     # live vars: $t2, $t3
+  2: m::foo($t2)
+     # live vars: $t3
+  3: m::foo($t3)
+     # live vars:
+  4: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: &u64) {
+     # live vars: $t0
+  0: drop($t0)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64) {
+     var $t2: &u64
+     var $t3: &u64
+     # live vars: $t0, $t1
+  0: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  1: $t3 := borrow_local($t1)
+     # live vars: $t2, $t3
+  2: m::foo($t2)
+     # live vars: $t3
+  3: m::foo($t3)
+     # live vars:
+  4: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+foo(Arg0: &u64) /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: &u64)
+	1: Pop
+	2: Ret
+}
+public test(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+L2:	loc0: &u64
+L3:	loc1: &u64
+B0:
+	0: ImmBorrowLoc[0](Arg0: u64)
+	1: ImmBorrowLoc[1](Arg1: u64)
+	2: StLoc[2](loc0: &u64)
+	3: Call foo(&u64)
+	4: MoveLoc[2](loc0: &u64)
+	5: Call foo(&u64)
+	6: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/intermingled_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/intermingled_02.on.exp
@@ -1,0 +1,42 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: &u64) {
+  0: drop($t0)
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64, $t1: u64) {
+     var $t2: &u64
+     var $t3: &u64
+  0: $t2 := borrow_local($t0)
+  1: m::foo($t2)
+  2: $t3 := borrow_local($t1)
+  3: m::foo($t3)
+  4: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+foo(Arg0: &u64) /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: &u64)
+	1: Pop
+	2: Ret
+}
+public test(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+B0:
+	0: ImmBorrowLoc[0](Arg0: u64)
+	1: Call foo(&u64)
+	2: ImmBorrowLoc[1](Arg1: u64)
+	3: Call foo(&u64)
+	4: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/loop_01.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/loop_01.move
@@ -1,0 +1,23 @@
+module 0xc0ffee::m {
+    fun foo(x: u64): u64 {
+        x + 1
+    }
+
+    public fun test1(x: u64) {
+        loop {
+            x = foo(x);
+            if (x > 10) {
+                break;
+            }
+        }
+    }
+
+    public fun test2(x: u64, y: u64, z: u64): u64 {
+        while (y < z) {
+            x = foo(y);
+            y = x;
+        };
+        x + y
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/loop_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/loop_01.off.exp
@@ -1,0 +1,576 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     # live vars: $t0
+  0: label L0
+     # live vars: $t0
+  1: $t1 := m::foo($t0)
+     # live vars: $t1
+  2: $t0 := infer($t1)
+     # live vars: $t0
+  3: $t3 := 10
+     # live vars: $t0, $t3
+  4: $t2 := >($t0, $t3)
+     # live vars: $t0, $t2
+  5: if ($t2) goto 6 else goto 9
+     # live vars: $t0
+  6: label L2
+     # live vars:
+  7: goto 12
+     # live vars: $t0
+  8: goto 10
+     # live vars: $t0
+  9: label L3
+     # live vars: $t0
+ 10: label L4
+     # live vars: $t0
+ 11: goto 0
+     # live vars:
+ 12: label L1
+     # live vars:
+ 13: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64, $t1: u64, $t2: u64): u64 {
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     # live vars: $t0, $t1, $t2
+  0: label L0
+     # live vars: $t0, $t1, $t2
+  1: $t4 := <($t1, $t2)
+     # live vars: $t0, $t1, $t2, $t4
+  2: if ($t4) goto 3 else goto 8
+     # live vars: $t0, $t1, $t2
+  3: label L2
+     # live vars: $t1, $t2
+  4: $t5 := m::foo($t1)
+     # live vars: $t2, $t5
+  5: $t0 := infer($t5)
+     # live vars: $t0, $t2
+  6: $t1 := infer($t0)
+     # live vars: $t0, $t1, $t2
+  7: goto 10
+     # live vars: $t0, $t1, $t2
+  8: label L3
+     # live vars: $t0, $t1
+  9: goto 12
+     # live vars: $t0, $t1, $t2
+ 10: label L4
+     # live vars: $t0, $t1, $t2
+ 11: goto 0
+     # live vars: $t0, $t1
+ 12: label L1
+     # live vars: $t0, $t1
+ 13: $t3 := +($t0, $t1)
+     # live vars: $t3
+ 14: return $t3
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     # live vars: $t0
+  0: label L0
+     # live vars: $t0
+  1: $t1 := m::foo($t0)
+     # live vars: $t1
+  2: $t0 := infer($t1)
+     # live vars: $t0
+  3: $t3 := 10
+     # live vars: $t0, $t3
+  4: $t2 := >($t0, $t3)
+     # live vars: $t0, $t2
+  5: if ($t2) goto 6 else goto 9
+     # live vars: $t0
+  6: label L2
+     # live vars:
+  7: goto 12
+     # live vars: $t0
+  8: goto 10
+     # live vars: $t0
+  9: label L3
+     # live vars: $t0
+ 10: label L4
+     # live vars: $t0
+ 11: goto 0
+     # live vars:
+ 12: label L1
+     # live vars:
+ 13: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64, $t1: u64, $t2: u64): u64 {
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     # live vars: $t0, $t1, $t2
+  0: label L0
+     # live vars: $t0, $t1, $t2
+  1: $t4 := <($t1, $t2)
+     # live vars: $t0, $t1, $t2, $t4
+  2: if ($t4) goto 3 else goto 8
+     # live vars: $t0, $t1, $t2
+  3: label L2
+     # live vars: $t1, $t2
+  4: $t5 := m::foo($t1)
+     # live vars: $t2, $t5
+  5: $t0 := infer($t5)
+     # live vars: $t0, $t2
+  6: $t1 := infer($t0)
+     # live vars: $t0, $t1, $t2
+  7: goto 10
+     # live vars: $t0, $t1, $t2
+  8: label L3
+     # live vars: $t0, $t1
+  9: goto 12
+     # live vars: $t0, $t1, $t2
+ 10: label L4
+     # live vars: $t0, $t1, $t2
+ 11: goto 0
+     # live vars: $t0, $t1
+ 12: label L1
+     # live vars: $t0, $t1
+ 13: $t3 := +($t0, $t1)
+     # live vars: $t3
+ 14: return $t3
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     # live vars: $t0
+  0: label L0
+     # live vars: $t0
+  1: $t1 := m::foo($t0)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t3 := 10
+     # live vars: $t0, $t3
+  4: $t2 := >($t0, $t3)
+     # live vars: $t0, $t2
+  5: if ($t2) goto 6 else goto 8
+     # live vars: $t0
+  6: label L2
+     # live vars:
+  7: goto 11
+     # live vars: $t0
+  8: label L3
+     # live vars: $t0
+  9: label L4
+     # live vars: $t0
+ 10: goto 0
+     # live vars:
+ 11: label L1
+     # live vars:
+ 12: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64, $t1: u64, $t2: u64): u64 {
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     # live vars: $t0, $t1, $t2
+  0: label L0
+     # live vars: $t0, $t1, $t2
+  1: $t4 := <($t1, $t2)
+     # live vars: $t0, $t1, $t2, $t4
+  2: if ($t4) goto 3 else goto 8
+     # live vars: $t0, $t1, $t2
+  3: label L2
+     # live vars: $t1, $t2
+  4: $t5 := m::foo($t1)
+     # live vars: $t2, $t5
+  5: $t0 := move($t5)
+     # live vars: $t0, $t2
+  6: $t1 := copy($t0)
+     # live vars: $t0, $t1, $t2
+  7: goto 10
+     # live vars: $t0, $t1, $t2
+  8: label L3
+     # live vars: $t0, $t1
+  9: goto 12
+     # live vars: $t0, $t1, $t2
+ 10: label L4
+     # live vars: $t0, $t1, $t2
+ 11: goto 0
+     # live vars: $t0, $t1
+ 12: label L1
+     # live vars: $t0, $t1
+ 13: $t3 := +($t0, $t1)
+     # live vars: $t3
+ 14: return $t3
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     # live vars: $t0
+  0: label L0
+     # live vars: $t0
+  1: $t1 := m::foo($t0)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t3 := 10
+     # live vars: $t0, $t3
+  4: $t2 := >($t0, $t3)
+     # live vars: $t0, $t2
+  5: if ($t2) goto 6 else goto 8
+     # live vars: $t0
+  6: label L2
+     # live vars:
+  7: goto 11
+     # live vars: $t0
+  8: label L3
+     # live vars: $t0
+  9: label L4
+     # live vars: $t0
+ 10: goto 0
+     # live vars:
+ 11: label L1
+     # live vars:
+ 12: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64, $t1: u64, $t2: u64): u64 {
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     # live vars: $t0, $t1, $t2
+  0: label L0
+     # live vars: $t0, $t1, $t2
+  1: $t4 := <($t1, $t2)
+     # live vars: $t0, $t1, $t2, $t4
+  2: if ($t4) goto 3 else goto 8
+     # live vars: $t0, $t1, $t2
+  3: label L2
+     # live vars: $t1, $t2
+  4: $t5 := m::foo($t1)
+     # live vars: $t2, $t5
+  5: $t0 := move($t5)
+     # live vars: $t0, $t2
+  6: $t1 := copy($t0)
+     # live vars: $t0, $t1, $t2
+  7: goto 10
+     # live vars: $t0, $t1, $t2
+  8: label L3
+     # live vars: $t0, $t1
+  9: goto 12
+     # live vars: $t0, $t1, $t2
+ 10: label L4
+     # live vars: $t0, $t1, $t2
+ 11: goto 0
+     # live vars: $t0, $t1
+ 12: label L1
+     # live vars: $t0, $t1
+ 13: $t3 := +($t0, $t1)
+     # live vars: $t3
+ 14: return $t3
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t0 := +($t0, $t2)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64 [unused]
+     # live vars: $t0
+  0: label L0
+     # live vars: $t0
+  1: $t1 := m::foo($t0)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t1 := 10
+     # live vars: $t0, $t1
+  4: $t2 := >($t0, $t1)
+     # live vars: $t0, $t2
+  5: if ($t2) goto 6 else goto 8
+     # live vars: $t0
+  6: label L2
+     # live vars:
+  7: goto 11
+     # live vars: $t0
+  8: label L3
+     # live vars: $t0
+  9: label L4
+     # live vars: $t0
+ 10: goto 0
+     # live vars:
+ 11: label L1
+     # live vars:
+ 12: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64, $t1: u64, $t2: u64): u64 {
+     var $t3: u64 [unused]
+     var $t4: bool
+     var $t5: u64
+     # live vars: $t0, $t1, $t2
+  0: label L0
+     # live vars: $t0, $t1, $t2
+  1: $t4 := <($t1, $t2)
+     # live vars: $t0, $t1, $t2, $t4
+  2: if ($t4) goto 3 else goto 8
+     # live vars: $t0, $t1, $t2
+  3: label L2
+     # live vars: $t1, $t2
+  4: $t5 := m::foo($t1)
+     # live vars: $t2, $t5
+  5: $t0 := move($t5)
+     # live vars: $t0, $t2
+  6: $t1 := copy($t0)
+     # live vars: $t0, $t1, $t2
+  7: goto 10
+     # live vars: $t0, $t1, $t2
+  8: label L3
+     # live vars: $t0, $t1
+  9: goto 12
+     # live vars: $t0, $t1, $t2
+ 10: label L4
+     # live vars: $t0, $t1, $t2
+ 11: goto 0
+     # live vars: $t0, $t1
+ 12: label L1
+     # live vars: $t0, $t1
+ 13: $t0 := +($t0, $t1)
+     # live vars: $t0
+ 14: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t0 := +($t0, $t2)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64 [unused]
+     # live vars: $t0
+  0: label L0
+     # live vars: $t0
+  1: $t1 := m::foo($t0)
+     # live vars: $t1
+  2: $t0 := move($t1)
+     # live vars: $t0
+  3: $t1 := 10
+     # live vars: $t0, $t1
+  4: $t2 := >($t0, $t1)
+     # live vars: $t0, $t2
+  5: if ($t2) goto 6 else goto 8
+     # live vars: $t0
+  6: label L2
+     # live vars:
+  7: goto 11
+     # live vars: $t0
+  8: label L3
+     # live vars: $t0
+  9: label L4
+     # live vars: $t0
+ 10: goto 0
+     # live vars:
+ 11: label L1
+     # live vars:
+ 12: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64, $t1: u64, $t2: u64): u64 {
+     var $t3: u64 [unused]
+     var $t4: bool
+     var $t5: u64
+     # live vars: $t0, $t1, $t2
+  0: label L0
+     # live vars: $t0, $t1, $t2
+  1: $t4 := <($t1, $t2)
+     # live vars: $t0, $t1, $t2, $t4
+  2: if ($t4) goto 3 else goto 8
+     # live vars: $t0, $t1, $t2
+  3: label L2
+     # live vars: $t1, $t2
+  4: $t5 := m::foo($t1)
+     # live vars: $t2, $t5
+  5: $t0 := move($t5)
+     # live vars: $t0, $t2
+  6: $t1 := copy($t0)
+     # live vars: $t0, $t1, $t2
+  7: goto 10
+     # live vars: $t0, $t1, $t2
+  8: label L3
+     # live vars: $t0, $t1
+  9: goto 12
+     # live vars: $t0, $t1, $t2
+ 10: label L4
+     # live vars: $t0, $t1, $t2
+ 11: goto 0
+     # live vars: $t0, $t1
+ 12: label L1
+     # live vars: $t0, $t1
+ 13: $t0 := +($t0, $t1)
+     # live vars: $t0
+ 14: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+foo(Arg0: u64): u64 /* def_idx: 0 */ {
+L1:	loc0: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: Ret
+}
+public test1(Arg0: u64) /* def_idx: 1 */ {
+L1:	loc0: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Call foo(u64): u64
+	2: StLoc[0](Arg0: u64)
+	3: CopyLoc[0](Arg0: u64)
+	4: LdU64(10)
+	5: Gt
+	6: BrFalse(8)
+B1:
+	7: Branch(9)
+B2:
+	8: Branch(0)
+B3:
+	9: Ret
+}
+public test2(Arg0: u64, Arg1: u64, Arg2: u64): u64 /* def_idx: 2 */ {
+B0:
+	0: CopyLoc[1](Arg1: u64)
+	1: CopyLoc[2](Arg2: u64)
+	2: Lt
+	3: BrFalse(10)
+B1:
+	4: MoveLoc[1](Arg1: u64)
+	5: Call foo(u64): u64
+	6: StLoc[0](Arg0: u64)
+	7: CopyLoc[0](Arg0: u64)
+	8: StLoc[1](Arg1: u64)
+	9: Branch(11)
+B2:
+	10: Branch(12)
+B3:
+	11: Branch(0)
+B4:
+	12: MoveLoc[0](Arg0: u64)
+	13: MoveLoc[1](Arg1: u64)
+	14: Add
+	15: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/loop_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/loop_01.on.exp
@@ -1,0 +1,113 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+  0: touch($t0)
+  1: $t2 := 1
+  2: $t0 := +($t0, $t2)
+  3: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64 [unused]
+  0: label L0
+  1: $t1 := m::foo($t0)
+  2: $t0 := move($t1)
+  3: $t1 := 10
+  4: $t2 := >($t0, $t1)
+  5: if ($t2) goto 6 else goto 8
+  6: label L2
+  7: goto 11
+  8: label L3
+  9: label L4
+ 10: goto 0
+ 11: label L1
+ 12: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64, $t1: u64, $t2: u64): u64 {
+     var $t3: u64 [unused]
+     var $t4: bool
+     var $t5: u64
+  0: label L0
+  1: touch($t1)
+  2: $t4 := <($t1, $t2)
+  3: if ($t4) goto 4 else goto 9
+  4: label L2
+  5: $t5 := m::foo($t1)
+  6: $t0 := move($t5)
+  7: $t1 := copy($t0)
+  8: goto 11
+  9: label L3
+ 10: goto 13
+ 11: label L4
+ 12: goto 0
+ 13: label L1
+ 14: touch($t0)
+ 15: $t0 := +($t0, $t1)
+ 16: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+foo(Arg0: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: Ret
+}
+public test1(Arg0: u64) /* def_idx: 1 */ {
+L1:	loc0: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Call foo(u64): u64
+	2: StLoc[0](Arg0: u64)
+	3: CopyLoc[0](Arg0: u64)
+	4: LdU64(10)
+	5: Gt
+	6: BrFalse(8)
+B1:
+	7: Branch(9)
+B2:
+	8: Branch(0)
+B3:
+	9: Ret
+}
+public test2(Arg0: u64, Arg1: u64, Arg2: u64): u64 /* def_idx: 2 */ {
+B0:
+	0: CopyLoc[1](Arg1: u64)
+	1: CopyLoc[2](Arg2: u64)
+	2: Lt
+	3: BrFalse(10)
+B1:
+	4: MoveLoc[1](Arg1: u64)
+	5: Call foo(u64): u64
+	6: StLoc[0](Arg0: u64)
+	7: CopyLoc[0](Arg0: u64)
+	8: StLoc[1](Arg1: u64)
+	9: Branch(11)
+B2:
+	10: Branch(12)
+B3:
+	11: Branch(0)
+B4:
+	12: MoveLoc[0](Arg0: u64)
+	13: MoveLoc[1](Arg1: u64)
+	14: Add
+	15: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/multi_use.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/multi_use.move
@@ -1,0 +1,30 @@
+module 0xc0ffee::m {
+    fun multi_consume(_a: u64, _b: u64, _c: u64, _d: u64) {}
+
+    fun consume(_a: u64, _b: u64) {}
+
+    fun one(): u64 {
+        1
+    }    
+
+    public fun test1() {
+        let x = one();
+        multi_consume(x, 2, x, 1);
+    }
+
+    public fun test2(x: u64) {
+        multi_consume(x, 2, x, 1);
+    }
+
+    public fun test3() {
+        let x = one();
+        consume(x, 2);
+        consume(x, 1);
+    }
+
+    public fun test4(x: u64) {
+        consume(x, 2);
+        consume(x, 1);
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/multi_use.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/multi_use.off.exp
@@ -1,0 +1,651 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::multi_consume($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     # live vars: $t0, $t1, $t2, $t3
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: $t2 := 1
+     # live vars: $t0, $t1, $t2
+  3: m::multi_consume($t0, $t1, $t0, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t1 := 2
+     # live vars: $t0, $t1
+  1: $t2 := 1
+     # live vars: $t0, $t1, $t2
+  2: m::multi_consume($t0, $t1, $t0, $t2)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test3() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: m::consume($t0, $t1)
+     # live vars: $t0
+  3: $t2 := 1
+     # live vars: $t0, $t2
+  4: m::consume($t0, $t2)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64) {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t1 := 2
+     # live vars: $t0, $t1
+  1: m::consume($t0, $t1)
+     # live vars: $t0
+  2: $t2 := 1
+     # live vars: $t0, $t2
+  3: m::consume($t0, $t2)
+     # live vars:
+  4: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::multi_consume($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     # live vars: $t0, $t1, $t2, $t3
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: $t2 := 1
+     # live vars: $t0, $t1, $t2
+  3: m::multi_consume($t0, $t1, $t0, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t1 := 2
+     # live vars: $t0, $t1
+  1: $t2 := 1
+     # live vars: $t0, $t1, $t2
+  2: m::multi_consume($t0, $t1, $t0, $t2)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test3() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: m::consume($t0, $t1)
+     # live vars: $t0
+  3: $t2 := 1
+     # live vars: $t0, $t2
+  4: m::consume($t0, $t2)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64) {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t1 := 2
+     # live vars: $t0, $t1
+  1: m::consume($t0, $t1)
+     # live vars: $t0
+  2: $t2 := 1
+     # live vars: $t0, $t2
+  3: m::consume($t0, $t2)
+     # live vars:
+  4: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::multi_consume($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     # live vars: $t0, $t1, $t2, $t3
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: $t2 := 1
+     # live vars: $t0, $t1, $t2
+  3: m::multi_consume($t0, $t1, $t0, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t1 := 2
+     # live vars: $t0, $t1
+  1: $t2 := 1
+     # live vars: $t0, $t1, $t2
+  2: m::multi_consume($t0, $t1, $t0, $t2)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test3() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: m::consume($t0, $t1)
+     # live vars: $t0
+  3: $t2 := 1
+     # live vars: $t0, $t2
+  4: m::consume($t0, $t2)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64) {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t1 := 2
+     # live vars: $t0, $t1
+  1: m::consume($t0, $t1)
+     # live vars: $t0
+  2: $t2 := 1
+     # live vars: $t0, $t2
+  3: m::consume($t0, $t2)
+     # live vars:
+  4: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::multi_consume($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     # live vars: $t0, $t1, $t2, $t3
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: $t2 := 1
+     # live vars: $t0, $t1, $t2
+  3: m::multi_consume($t0, $t1, $t0, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t1 := 2
+     # live vars: $t0, $t1
+  1: $t2 := 1
+     # live vars: $t0, $t1, $t2
+  2: m::multi_consume($t0, $t1, $t0, $t2)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test3() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: m::consume($t0, $t1)
+     # live vars: $t0
+  3: $t2 := 1
+     # live vars: $t0, $t2
+  4: m::consume($t0, $t2)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64) {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t1 := 2
+     # live vars: $t0, $t1
+  1: m::consume($t0, $t1)
+     # live vars: $t0
+  2: $t2 := 1
+     # live vars: $t0, $t2
+  3: m::consume($t0, $t2)
+     # live vars:
+  4: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::multi_consume($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     # live vars: $t0, $t1, $t2, $t3
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: $t2 := 1
+     # live vars: $t0, $t1, $t2
+  3: m::multi_consume($t0, $t1, $t0, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t1 := 2
+     # live vars: $t0, $t1
+  1: $t2 := 1
+     # live vars: $t0, $t1, $t2
+  2: m::multi_consume($t0, $t1, $t0, $t2)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test3() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64 [unused]
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: m::consume($t0, $t1)
+     # live vars: $t0
+  3: $t1 := 1
+     # live vars: $t0, $t1
+  4: m::consume($t0, $t1)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64) {
+     var $t1: u64
+     var $t2: u64 [unused]
+     # live vars: $t0
+  0: $t1 := 2
+     # live vars: $t0, $t1
+  1: m::consume($t0, $t1)
+     # live vars: $t0
+  2: $t1 := 1
+     # live vars: $t0, $t1
+  3: m::consume($t0, $t1)
+     # live vars:
+  4: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::multi_consume($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     # live vars: $t0, $t1, $t2, $t3
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: $t2 := 1
+     # live vars: $t0, $t1, $t2
+  3: m::multi_consume($t0, $t1, $t0, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t1 := 2
+     # live vars: $t0, $t1
+  1: $t2 := 1
+     # live vars: $t0, $t1, $t2
+  2: m::multi_consume($t0, $t1, $t0, $t2)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test3() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64 [unused]
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: m::consume($t0, $t1)
+     # live vars: $t0
+  3: $t1 := 1
+     # live vars: $t0, $t1
+  4: m::consume($t0, $t1)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64) {
+     var $t1: u64
+     var $t2: u64 [unused]
+     # live vars: $t0
+  0: $t1 := 2
+     # live vars: $t0, $t1
+  1: m::consume($t0, $t1)
+     # live vars: $t0
+  2: $t1 := 1
+     # live vars: $t0, $t1
+  3: m::consume($t0, $t1)
+     # live vars:
+  4: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+consume(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+multi_consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+one(): u64 /* def_idx: 2 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test1() /* def_idx: 3 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+B0:
+	0: Call one(): u64
+	1: LdU64(2)
+	2: LdU64(1)
+	3: StLoc[0](loc0: u64)
+	4: StLoc[1](loc1: u64)
+	5: StLoc[2](loc2: u64)
+	6: CopyLoc[2](loc2: u64)
+	7: MoveLoc[1](loc1: u64)
+	8: MoveLoc[2](loc2: u64)
+	9: MoveLoc[0](loc0: u64)
+	10: Call multi_consume(u64, u64, u64, u64)
+	11: Ret
+}
+public test2(Arg0: u64) /* def_idx: 4 */ {
+L1:	loc0: u64
+L2:	loc1: u64
+B0:
+	0: LdU64(2)
+	1: LdU64(1)
+	2: StLoc[1](loc0: u64)
+	3: StLoc[2](loc1: u64)
+	4: CopyLoc[0](Arg0: u64)
+	5: MoveLoc[2](loc1: u64)
+	6: MoveLoc[0](Arg0: u64)
+	7: MoveLoc[1](loc0: u64)
+	8: Call multi_consume(u64, u64, u64, u64)
+	9: Ret
+}
+public test3() /* def_idx: 5 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: LdU64(2)
+	2: StLoc[0](loc0: u64)
+	3: StLoc[1](loc1: u64)
+	4: CopyLoc[1](loc1: u64)
+	5: MoveLoc[0](loc0: u64)
+	6: Call consume(u64, u64)
+	7: MoveLoc[1](loc1: u64)
+	8: LdU64(1)
+	9: Call consume(u64, u64)
+	10: Ret
+}
+public test4(Arg0: u64) /* def_idx: 6 */ {
+L1:	loc0: u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: LdU64(2)
+	2: Call consume(u64, u64)
+	3: MoveLoc[0](Arg0: u64)
+	4: LdU64(1)
+	5: Call consume(u64, u64)
+	6: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/multi_use.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/multi_use.on.exp
@@ -1,0 +1,155 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::multi_consume($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+  0: $t0 := 1
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+  0: $t0 := m::one()
+  1: $t1 := 2
+  2: $t2 := 1
+  3: m::multi_consume($t0, $t1, $t0, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: u64
+     var $t2: u64
+  0: touch($t0)
+  1: $t1 := 2
+  2: touch($t0)
+  3: $t2 := 1
+  4: m::multi_consume($t0, $t1, $t0, $t2)
+  5: return ()
+}
+
+
+[variant baseline]
+public fun m::test3() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64 [unused]
+  0: $t0 := m::one()
+  1: $t1 := 2
+  2: m::consume($t0, $t1)
+  3: $t1 := 1
+  4: m::consume($t0, $t1)
+  5: return ()
+}
+
+
+[variant baseline]
+public fun m::test4($t0: u64) {
+     var $t1: u64
+     var $t2: u64 [unused]
+  0: touch($t0)
+  1: $t1 := 2
+  2: m::consume($t0, $t1)
+  3: touch($t0)
+  4: $t1 := 1
+  5: m::consume($t0, $t1)
+  6: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+consume(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+multi_consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+one(): u64 /* def_idx: 2 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test1() /* def_idx: 3 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+B0:
+	0: Call one(): u64
+	1: LdU64(2)
+	2: LdU64(1)
+	3: StLoc[0](loc0: u64)
+	4: StLoc[1](loc1: u64)
+	5: StLoc[2](loc2: u64)
+	6: CopyLoc[2](loc2: u64)
+	7: MoveLoc[1](loc1: u64)
+	8: MoveLoc[2](loc2: u64)
+	9: MoveLoc[0](loc0: u64)
+	10: Call multi_consume(u64, u64, u64, u64)
+	11: Ret
+}
+public test2(Arg0: u64) /* def_idx: 4 */ {
+L1:	loc0: u64
+L2:	loc1: u64
+B0:
+	0: LdU64(2)
+	1: LdU64(1)
+	2: StLoc[1](loc0: u64)
+	3: StLoc[2](loc1: u64)
+	4: CopyLoc[0](Arg0: u64)
+	5: MoveLoc[2](loc1: u64)
+	6: MoveLoc[0](Arg0: u64)
+	7: MoveLoc[1](loc0: u64)
+	8: Call multi_consume(u64, u64, u64, u64)
+	9: Ret
+}
+public test3() /* def_idx: 5 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: LdU64(2)
+	2: StLoc[0](loc0: u64)
+	3: StLoc[1](loc1: u64)
+	4: CopyLoc[1](loc1: u64)
+	5: MoveLoc[0](loc0: u64)
+	6: Call consume(u64, u64)
+	7: MoveLoc[1](loc1: u64)
+	8: LdU64(1)
+	9: Call consume(u64, u64)
+	10: Ret
+}
+public test4(Arg0: u64) /* def_idx: 6 */ {
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: LdU64(2)
+	2: Call consume(u64, u64)
+	3: MoveLoc[0](Arg0: u64)
+	4: LdU64(1)
+	5: Call consume(u64, u64)
+	6: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/mut_refs_01.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/mut_refs_01.move
@@ -1,0 +1,15 @@
+module 0xc0ffee::m {
+    fun inc_immut(x: u64): u64 {
+        x + 1
+    }
+
+    public fun test1(): u64 {
+        let x = 1;
+        inc_immut({x = inc_mut(&mut x) + 1; x = x + 1; x}) + {x = inc_mut(&mut x) + 1; x}
+    }
+
+    fun inc_mut(x: &mut u64): u64 {
+        *x = *x + 1;
+        *x
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/mut_refs_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/mut_refs_01.off.exp
@@ -1,0 +1,611 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::inc_immut($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun m::inc_mut($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t3 := read_ref($t0)
+     # live vars: $t0, $t3
+  1: $t4 := 1
+     # live vars: $t0, $t3, $t4
+  2: $t2 := +($t3, $t4)
+     # live vars: $t0, $t2
+  3: write_ref($t2, $t0)
+     # live vars: $t0
+  4: $t1 := read_ref($t0)
+     # live vars: $t1
+  5: return $t1
+}
+
+
+[variant baseline]
+public fun m::test1(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: &mut u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: &mut u64
+     var $t14: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t6 := borrow_local($t1)
+     # live vars: $t6
+  2: $t5 := m::inc_mut($t6)
+     # live vars: $t5
+  3: $t7 := 1
+     # live vars: $t5, $t7
+  4: $t4 := +($t5, $t7)
+     # live vars: $t4
+  5: $t1 := infer($t4)
+     # live vars: $t1
+  6: $t9 := 1
+     # live vars: $t1, $t9
+  7: $t8 := +($t1, $t9)
+     # live vars: $t8
+  8: $t1 := infer($t8)
+     # live vars: $t1
+  9: $t3 := infer($t1)
+     # live vars: $t1, $t3
+ 10: $t2 := m::inc_immut($t3)
+     # live vars: $t1, $t2
+ 11: $t13 := borrow_local($t1)
+     # live vars: $t2, $t13
+ 12: $t12 := m::inc_mut($t13)
+     # live vars: $t2, $t12
+ 13: $t14 := 1
+     # live vars: $t2, $t12, $t14
+ 14: $t11 := +($t12, $t14)
+     # live vars: $t2, $t11
+ 15: $t1 := infer($t11)
+     # live vars: $t1, $t2
+ 16: $t10 := infer($t1)
+     # live vars: $t2, $t10
+ 17: $t0 := +($t2, $t10)
+     # live vars: $t0
+ 18: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::inc_immut($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun m::inc_mut($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t3 := read_ref($t0)
+     # live vars: $t0, $t3
+  1: $t4 := 1
+     # live vars: $t0, $t3, $t4
+  2: $t2 := +($t3, $t4)
+     # live vars: $t0, $t2
+  3: write_ref($t2, $t0)
+     # live vars: $t0
+  4: $t1 := read_ref($t0)
+     # live vars: $t1
+  5: return $t1
+}
+
+
+[variant baseline]
+public fun m::test1(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: &mut u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: &mut u64
+     var $t14: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t6 := borrow_local($t1)
+     # live vars: $t6
+  2: $t5 := m::inc_mut($t6)
+     # live vars: $t5
+  3: $t7 := 1
+     # live vars: $t5, $t7
+  4: $t4 := +($t5, $t7)
+     # live vars: $t4
+  5: $t1 := infer($t4)
+     # live vars: $t1
+  6: $t9 := 1
+     # live vars: $t1, $t9
+  7: $t8 := +($t1, $t9)
+     # live vars: $t8
+  8: $t1 := infer($t8)
+     # live vars: $t1
+  9: $t3 := infer($t1)
+     # live vars: $t1, $t3
+ 10: $t2 := m::inc_immut($t3)
+     # live vars: $t1, $t2
+ 11: $t13 := borrow_local($t1)
+     # live vars: $t2, $t13
+ 12: $t12 := m::inc_mut($t13)
+     # live vars: $t2, $t12
+ 13: $t14 := 1
+     # live vars: $t2, $t12, $t14
+ 14: $t11 := +($t12, $t14)
+     # live vars: $t2, $t11
+ 15: $t1 := infer($t11)
+     # live vars: $t1, $t2
+ 16: $t10 := infer($t1)
+     # live vars: $t2, $t10
+ 17: $t0 := +($t2, $t10)
+     # live vars: $t0
+ 18: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::inc_immut($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun m::inc_mut($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t3 := read_ref($t0)
+     # live vars: $t0, $t3
+  1: $t4 := 1
+     # live vars: $t0, $t3, $t4
+  2: $t2 := +($t3, $t4)
+     # live vars: $t0, $t2
+  3: write_ref($t2, $t0)
+     # live vars: $t0
+  4: $t1 := read_ref($t0)
+     # live vars: $t1
+  5: return $t1
+}
+
+
+[variant baseline]
+public fun m::test1(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: &mut u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: &mut u64
+     var $t14: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t6 := borrow_local($t1)
+     # live vars: $t6
+  2: $t5 := m::inc_mut($t6)
+     # live vars: $t5
+  3: $t7 := 1
+     # live vars: $t5, $t7
+  4: $t4 := +($t5, $t7)
+     # live vars: $t4
+  5: $t1 := move($t4)
+     # live vars: $t1
+  6: $t9 := 1
+     # live vars: $t1, $t9
+  7: $t8 := +($t1, $t9)
+     # live vars: $t8
+  8: $t1 := move($t8)
+     # live vars: $t1
+  9: $t3 := copy($t1)
+     # live vars: $t1, $t3
+ 10: $t2 := m::inc_immut($t3)
+     # live vars: $t1, $t2
+ 11: $t13 := borrow_local($t1)
+     # live vars: $t2, $t13
+ 12: $t12 := m::inc_mut($t13)
+     # live vars: $t2, $t12
+ 13: $t14 := 1
+     # live vars: $t2, $t12, $t14
+ 14: $t11 := +($t12, $t14)
+     # live vars: $t2, $t11
+ 15: $t1 := move($t11)
+     # live vars: $t1, $t2
+ 16: $t10 := move($t1)
+     # live vars: $t2, $t10
+ 17: $t0 := +($t2, $t10)
+     # live vars: $t0
+ 18: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::inc_immut($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun m::inc_mut($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t3 := read_ref($t0)
+     # live vars: $t0, $t3
+  1: $t4 := 1
+     # live vars: $t0, $t3, $t4
+  2: $t2 := +($t3, $t4)
+     # live vars: $t0, $t2
+  3: write_ref($t2, $t0)
+     # live vars: $t0
+  4: $t1 := read_ref($t0)
+     # live vars: $t1
+  5: return $t1
+}
+
+
+[variant baseline]
+public fun m::test1(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: &mut u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: &mut u64
+     var $t14: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t6 := borrow_local($t1)
+     # live vars: $t6
+  2: $t5 := m::inc_mut($t6)
+     # live vars: $t5
+  3: $t7 := 1
+     # live vars: $t5, $t7
+  4: $t4 := +($t5, $t7)
+     # live vars: $t4
+  5: $t1 := move($t4)
+     # live vars: $t1
+  6: $t9 := 1
+     # live vars: $t1, $t9
+  7: $t8 := +($t1, $t9)
+     # live vars: $t8
+  8: $t1 := move($t8)
+     # live vars: $t1
+  9: $t3 := copy($t1)
+     # live vars: $t1, $t3
+ 10: $t2 := m::inc_immut($t3)
+     # live vars: $t1, $t2
+ 11: $t13 := borrow_local($t1)
+     # live vars: $t2, $t13
+ 12: $t12 := m::inc_mut($t13)
+     # live vars: $t2, $t12
+ 13: $t14 := 1
+     # live vars: $t2, $t12, $t14
+ 14: $t11 := +($t12, $t14)
+     # live vars: $t2, $t11
+ 15: $t1 := move($t11)
+     # live vars: $t1, $t2
+ 16: $t10 := move($t1)
+     # live vars: $t2, $t10
+ 17: $t0 := +($t2, $t10)
+     # live vars: $t0
+ 18: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::inc_immut($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t0 := +($t0, $t2)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun m::inc_mut($t0: &mut u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t3 := read_ref($t0)
+     # live vars: $t0, $t3
+  1: $t4 := 1
+     # live vars: $t0, $t3, $t4
+  2: $t3 := +($t3, $t4)
+     # live vars: $t0, $t3
+  3: write_ref($t3, $t0)
+     # live vars: $t0
+  4: $t3 := read_ref($t0)
+     # live vars: $t3
+  5: return $t3
+}
+
+
+[variant baseline]
+public fun m::test1(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: u64
+     var $t6: &mut u64
+     var $t7: u64
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+     var $t10: u64 [unused]
+     var $t11: u64 [unused]
+     var $t12: u64 [unused]
+     var $t13: &mut u64 [unused]
+     var $t14: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t6 := borrow_local($t1)
+     # live vars: $t6
+  2: $t5 := m::inc_mut($t6)
+     # live vars: $t5
+  3: $t7 := 1
+     # live vars: $t5, $t7
+  4: $t5 := +($t5, $t7)
+     # live vars: $t5
+  5: $t1 := move($t5)
+     # live vars: $t1
+  6: $t5 := 1
+     # live vars: $t1, $t5
+  7: $t5 := +($t1, $t5)
+     # live vars: $t5
+  8: $t1 := move($t5)
+     # live vars: $t1
+  9: $t5 := copy($t1)
+     # live vars: $t1, $t5
+ 10: $t5 := m::inc_immut($t5)
+     # live vars: $t1, $t5
+ 11: $t6 := borrow_local($t1)
+     # live vars: $t5, $t6
+ 12: $t7 := m::inc_mut($t6)
+     # live vars: $t5, $t7
+ 13: $t14 := 1
+     # live vars: $t5, $t7, $t14
+ 14: $t7 := +($t7, $t14)
+     # live vars: $t5, $t7
+ 15: $t1 := move($t7)
+     # live vars: $t1, $t5
+ 16: $t7 := move($t1)
+     # live vars: $t5, $t7
+ 17: $t5 := +($t5, $t7)
+     # live vars: $t5
+ 18: return $t5
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::inc_immut($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t0 := +($t0, $t2)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun m::inc_mut($t0: &mut u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t3 := read_ref($t0)
+     # live vars: $t0, $t3
+  1: $t4 := 1
+     # live vars: $t0, $t3, $t4
+  2: $t3 := +($t3, $t4)
+     # live vars: $t0, $t3
+  3: write_ref($t3, $t0)
+     # live vars: $t0
+  4: $t3 := read_ref($t0)
+     # live vars: $t3
+  5: return $t3
+}
+
+
+[variant baseline]
+public fun m::test1(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: u64
+     var $t6: &mut u64
+     var $t7: u64
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+     var $t10: u64 [unused]
+     var $t11: u64 [unused]
+     var $t12: u64 [unused]
+     var $t13: &mut u64 [unused]
+     var $t14: u64
+     # live vars:
+  0: $t1 := 1
+     # live vars: $t1
+  1: $t6 := borrow_local($t1)
+     # live vars: $t6
+  2: $t5 := m::inc_mut($t6)
+     # live vars: $t5
+  3: $t7 := 1
+     # live vars: $t5, $t7
+  4: $t5 := +($t5, $t7)
+     # live vars: $t5
+  5: $t1 := move($t5)
+     # live vars: $t1
+  6: $t5 := 1
+     # live vars: $t1, $t5
+  7: $t5 := +($t1, $t5)
+     # live vars: $t5
+  8: $t1 := move($t5)
+     # live vars: $t1
+  9: $t5 := copy($t1)
+     # live vars: $t1, $t5
+ 10: $t5 := m::inc_immut($t5)
+     # live vars: $t1, $t5
+ 11: $t6 := borrow_local($t1)
+     # live vars: $t5, $t6
+ 12: $t7 := m::inc_mut($t6)
+     # live vars: $t5, $t7
+ 13: $t14 := 1
+     # live vars: $t5, $t7, $t14
+ 14: $t7 := +($t7, $t14)
+     # live vars: $t5, $t7
+ 15: $t1 := move($t7)
+     # live vars: $t1, $t5
+ 16: $t7 := move($t1)
+     # live vars: $t5, $t7
+ 17: $t5 := +($t5, $t7)
+     # live vars: $t5
+ 18: return $t5
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+inc_immut(Arg0: u64): u64 /* def_idx: 0 */ {
+L1:	loc0: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: Ret
+}
+inc_mut(Arg0: &mut u64): u64 /* def_idx: 1 */ {
+B0:
+	0: CopyLoc[0](Arg0: &mut u64)
+	1: ReadRef
+	2: LdU64(1)
+	3: Add
+	4: CopyLoc[0](Arg0: &mut u64)
+	5: WriteRef
+	6: MoveLoc[0](Arg0: &mut u64)
+	7: ReadRef
+	8: Ret
+}
+public test1(): u64 /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+B0:
+	0: LdU64(1)
+	1: StLoc[0](loc0: u64)
+	2: MutBorrowLoc[0](loc0: u64)
+	3: Call inc_mut(&mut u64): u64
+	4: LdU64(1)
+	5: Add
+	6: StLoc[0](loc0: u64)
+	7: MoveLoc[0](loc0: u64)
+	8: LdU64(1)
+	9: Add
+	10: StLoc[0](loc0: u64)
+	11: CopyLoc[0](loc0: u64)
+	12: Call inc_immut(u64): u64
+	13: MutBorrowLoc[0](loc0: u64)
+	14: Call inc_mut(&mut u64): u64
+	15: LdU64(1)
+	16: Add
+	17: Add
+	18: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/mut_refs_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/mut_refs_01.on.exp
@@ -1,0 +1,118 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+fun m::inc_immut($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+  0: touch($t0)
+  1: $t2 := 1
+  2: $t0 := +($t0, $t2)
+  3: return $t0
+}
+
+
+[variant baseline]
+fun m::inc_mut($t0: &mut u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: u64
+  0: $t3 := read_ref($t0)
+  1: $t4 := 1
+  2: $t3 := +($t3, $t4)
+  3: write_ref($t3, $t0)
+  4: $t3 := read_ref($t0)
+  5: return $t3
+}
+
+
+[variant baseline]
+public fun m::test1(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: u64
+     var $t6: &mut u64
+     var $t7: u64
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+     var $t10: u64 [unused]
+     var $t11: u64 [unused]
+     var $t12: u64 [unused]
+     var $t13: &mut u64 [unused]
+     var $t14: u64
+  0: $t1 := 1
+  1: $t6 := borrow_local($t1)
+  2: $t5 := m::inc_mut($t6)
+  3: $t7 := 1
+  4: $t5 := +($t5, $t7)
+  5: $t1 := move($t5)
+  6: $t5 := 1
+  7: $t5 := +($t1, $t5)
+  8: $t1 := move($t5)
+  9: $t5 := copy($t1)
+ 10: $t5 := m::inc_immut($t5)
+ 11: $t6 := borrow_local($t1)
+ 12: $t7 := m::inc_mut($t6)
+ 13: $t14 := 1
+ 14: $t7 := +($t7, $t14)
+ 15: $t1 := move($t7)
+ 16: $t7 := move($t1)
+ 17: $t5 := +($t5, $t7)
+ 18: return $t5
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+inc_immut(Arg0: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: Ret
+}
+inc_mut(Arg0: &mut u64): u64 /* def_idx: 1 */ {
+B0:
+	0: CopyLoc[0](Arg0: &mut u64)
+	1: ReadRef
+	2: LdU64(1)
+	3: Add
+	4: CopyLoc[0](Arg0: &mut u64)
+	5: WriteRef
+	6: MoveLoc[0](Arg0: &mut u64)
+	7: ReadRef
+	8: Ret
+}
+public test1(): u64 /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+B0:
+	0: LdU64(1)
+	1: StLoc[0](loc0: u64)
+	2: MutBorrowLoc[0](loc0: u64)
+	3: Call inc_mut(&mut u64): u64
+	4: LdU64(1)
+	5: Add
+	6: StLoc[0](loc0: u64)
+	7: MoveLoc[0](loc0: u64)
+	8: LdU64(1)
+	9: Add
+	10: StLoc[0](loc0: u64)
+	11: CopyLoc[0](loc0: u64)
+	12: Call inc_immut(u64): u64
+	13: MutBorrowLoc[0](loc0: u64)
+	14: Call inc_mut(&mut u64): u64
+	15: LdU64(1)
+	16: Add
+	17: Add
+	18: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/mut_refs_02.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/mut_refs_02.move
@@ -1,0 +1,15 @@
+module 0xc0ffee::m {
+
+fun update(r: &mut u64, x: u64, y: u64) {
+    *r = x + y;
+}
+
+fun test(): u64 {
+    let x = 0;
+    let rx = &mut x;
+    update(rx, 3, 4);
+    update(rx, 5, 6);
+    x
+}
+
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/mut_refs_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/mut_refs_02.off.exp
@@ -1,0 +1,329 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::update($t0: &mut u64, $t1: u64, $t2: u64) {
+     var $t3: u64
+     # live vars: $t0, $t1, $t2
+  0: $t3 := +($t1, $t2)
+     # live vars: $t0, $t3
+  1: write_ref($t3, $t0)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars:
+  0: $t1 := 0
+     # live vars: $t1
+  1: $t2 := borrow_local($t1)
+     # live vars: $t1, $t2
+  2: $t3 := 3
+     # live vars: $t1, $t2, $t3
+  3: $t4 := 4
+     # live vars: $t1, $t2, $t3, $t4
+  4: m::update($t2, $t3, $t4)
+     # live vars: $t1, $t2
+  5: $t5 := 5
+     # live vars: $t1, $t2, $t5
+  6: $t6 := 6
+     # live vars: $t1, $t2, $t5, $t6
+  7: m::update($t2, $t5, $t6)
+     # live vars: $t1
+  8: $t0 := infer($t1)
+     # live vars: $t0
+  9: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::update($t0: &mut u64, $t1: u64, $t2: u64) {
+     var $t3: u64
+     # live vars: $t0, $t1, $t2
+  0: $t3 := +($t1, $t2)
+     # live vars: $t0, $t3
+  1: write_ref($t3, $t0)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars:
+  0: $t1 := 0
+     # live vars: $t1
+  1: $t2 := borrow_local($t1)
+     # live vars: $t1, $t2
+  2: $t3 := 3
+     # live vars: $t1, $t2, $t3
+  3: $t4 := 4
+     # live vars: $t1, $t2, $t3, $t4
+  4: m::update($t2, $t3, $t4)
+     # live vars: $t1, $t2
+  5: $t5 := 5
+     # live vars: $t1, $t2, $t5
+  6: $t6 := 6
+     # live vars: $t1, $t2, $t5, $t6
+  7: m::update($t2, $t5, $t6)
+     # live vars: $t1
+  8: $t0 := infer($t1)
+     # live vars: $t0
+  9: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::update($t0: &mut u64, $t1: u64, $t2: u64) {
+     var $t3: u64
+     # live vars: $t0, $t1, $t2
+  0: $t3 := +($t1, $t2)
+     # live vars: $t0, $t3
+  1: write_ref($t3, $t0)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: &mut u64
+     # live vars:
+  0: $t1 := 0
+     # live vars: $t1
+  1: $t2 := borrow_local($t1)
+     # live vars: $t1, $t2
+  2: $t3 := 3
+     # live vars: $t1, $t2, $t3
+  3: $t4 := 4
+     # live vars: $t1, $t2, $t3, $t4
+  4: $t7 := copy($t2)
+     # live vars: $t1, $t2, $t3, $t4, $t7
+  5: m::update($t7, $t3, $t4)
+     # live vars: $t1, $t2
+  6: $t5 := 5
+     # live vars: $t1, $t2, $t5
+  7: $t6 := 6
+     # live vars: $t1, $t2, $t5, $t6
+  8: m::update($t2, $t5, $t6)
+     # live vars: $t1
+  9: $t0 := move($t1)
+     # live vars: $t0
+ 10: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::update($t0: &mut u64, $t1: u64, $t2: u64) {
+     var $t3: u64
+     # live vars: $t0, $t1, $t2
+  0: $t3 := +($t1, $t2)
+     # live vars: $t0, $t3
+  1: write_ref($t3, $t0)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: &mut u64
+     # live vars:
+  0: $t1 := 0
+     # live vars: $t1
+  1: $t2 := borrow_local($t1)
+     # live vars: $t1, $t2
+  2: $t3 := 3
+     # live vars: $t1, $t2, $t3
+  3: $t4 := 4
+     # live vars: $t1, $t2, $t3, $t4
+  4: $t7 := copy($t2)
+     # live vars: $t1, $t2, $t3, $t4, $t7
+  5: m::update($t7, $t3, $t4)
+     # live vars: $t1, $t2
+  6: $t5 := 5
+     # live vars: $t1, $t2, $t5
+  7: $t6 := 6
+     # live vars: $t1, $t2, $t5, $t6
+  8: m::update($t2, $t5, $t6)
+     # live vars: $t1
+  9: $t0 := move($t1)
+     # live vars: $t0
+ 10: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::update($t0: &mut u64, $t1: u64, $t2: u64) {
+     var $t3: u64 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t1 := +($t1, $t2)
+     # live vars: $t0, $t1
+  1: write_ref($t1, $t0)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+     var $t7: &mut u64
+     # live vars:
+  0: $t1 := 0
+     # live vars: $t1
+  1: $t2 := borrow_local($t1)
+     # live vars: $t1, $t2
+  2: $t3 := 3
+     # live vars: $t1, $t2, $t3
+  3: $t4 := 4
+     # live vars: $t1, $t2, $t3, $t4
+  4: $t7 := copy($t2)
+     # live vars: $t1, $t2, $t3, $t4, $t7
+  5: m::update($t7, $t3, $t4)
+     # live vars: $t1, $t2
+  6: $t3 := 5
+     # live vars: $t1, $t2, $t3
+  7: $t4 := 6
+     # live vars: $t1, $t2, $t3, $t4
+  8: m::update($t2, $t3, $t4)
+     # live vars: $t1
+  9: $t3 := move($t1)
+     # live vars: $t3
+ 10: return $t3
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::update($t0: &mut u64, $t1: u64, $t2: u64) {
+     var $t3: u64 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t1 := +($t1, $t2)
+     # live vars: $t0, $t1
+  1: write_ref($t1, $t0)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+     var $t7: &mut u64
+     # live vars:
+  0: $t1 := 0
+     # live vars: $t1
+  1: $t2 := borrow_local($t1)
+     # live vars: $t1, $t2
+  2: $t3 := 3
+     # live vars: $t1, $t2, $t3
+  3: $t4 := 4
+     # live vars: $t1, $t2, $t3, $t4
+  4: $t7 := copy($t2)
+     # live vars: $t1, $t2, $t3, $t4, $t7
+  5: m::update($t7, $t3, $t4)
+     # live vars: $t1, $t2
+  6: $t3 := 5
+     # live vars: $t1, $t2, $t3
+  7: $t4 := 6
+     # live vars: $t1, $t2, $t3, $t4
+  8: m::update($t2, $t3, $t4)
+     # live vars: $t1
+  9: $t3 := move($t1)
+     # live vars: $t3
+ 10: return $t3
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+update(Arg0: &mut u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[1](Arg1: u64)
+	1: MoveLoc[2](Arg2: u64)
+	2: Add
+	3: MoveLoc[0](Arg0: &mut u64)
+	4: WriteRef
+	5: Ret
+}
+test(): u64 /* def_idx: 1 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+L3:	loc3: &mut u64
+L4:	loc4: &mut u64
+B0:
+	0: LdU64(0)
+	1: StLoc[0](loc0: u64)
+	2: MutBorrowLoc[0](loc0: u64)
+	3: LdU64(3)
+	4: LdU64(4)
+	5: StLoc[1](loc1: u64)
+	6: StLoc[2](loc2: u64)
+	7: StLoc[3](loc3: &mut u64)
+	8: CopyLoc[3](loc3: &mut u64)
+	9: MoveLoc[2](loc2: u64)
+	10: MoveLoc[1](loc1: u64)
+	11: Call update(&mut u64, u64, u64)
+	12: LdU64(5)
+	13: LdU64(6)
+	14: StLoc[1](loc1: u64)
+	15: StLoc[2](loc2: u64)
+	16: MoveLoc[3](loc3: &mut u64)
+	17: MoveLoc[2](loc2: u64)
+	18: MoveLoc[1](loc1: u64)
+	19: Call update(&mut u64, u64, u64)
+	20: MoveLoc[0](loc0: u64)
+	21: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/mut_refs_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/mut_refs_02.on.exp
@@ -1,0 +1,84 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+fun m::update($t0: &mut u64, $t1: u64, $t2: u64) {
+     var $t3: u64 [unused]
+  0: touch($t1)
+  1: $t1 := +($t1, $t2)
+  2: write_ref($t1, $t0)
+  3: return ()
+}
+
+
+[variant baseline]
+fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+     var $t7: &mut u64
+  0: $t1 := 0
+  1: $t2 := borrow_local($t1)
+  2: $t7 := copy($t2)
+  3: $t3 := 3
+  4: $t4 := 4
+  5: m::update($t7, $t3, $t4)
+  6: $t3 := 5
+  7: $t4 := 6
+  8: m::update($t2, $t3, $t4)
+  9: $t3 := move($t1)
+ 10: return $t3
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+update(Arg0: &mut u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[1](Arg1: u64)
+	1: MoveLoc[2](Arg2: u64)
+	2: Add
+	3: MoveLoc[0](Arg0: &mut u64)
+	4: WriteRef
+	5: Ret
+}
+test(): u64 /* def_idx: 1 */ {
+L0:	loc0: u64
+L1:	loc1: &mut u64
+L2:	loc2: &mut u64
+L3:	loc3: u64
+L4:	loc4: u64
+B0:
+	0: LdU64(0)
+	1: StLoc[0](loc0: u64)
+	2: MutBorrowLoc[0](loc0: u64)
+	3: StLoc[1](loc1: &mut u64)
+	4: CopyLoc[1](loc1: &mut u64)
+	5: StLoc[2](loc2: &mut u64)
+	6: LdU64(3)
+	7: LdU64(4)
+	8: StLoc[3](loc3: u64)
+	9: StLoc[4](loc4: u64)
+	10: MoveLoc[2](loc2: &mut u64)
+	11: MoveLoc[4](loc4: u64)
+	12: MoveLoc[3](loc3: u64)
+	13: Call update(&mut u64, u64, u64)
+	14: LdU64(5)
+	15: LdU64(6)
+	16: StLoc[3](loc3: u64)
+	17: StLoc[4](loc4: u64)
+	18: MoveLoc[1](loc1: &mut u64)
+	19: MoveLoc[4](loc4: u64)
+	20: MoveLoc[3](loc3: u64)
+	21: Call update(&mut u64, u64, u64)
+	22: MoveLoc[0](loc0: u64)
+	23: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/several_args.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/several_args.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+    fun bar(a: &u64, b: u64, c: u64, d: u64, e: u64, f: u64, g: u64): u64 {
+        *a + b + c + d + e + f + g
+    }
+
+    public fun test(x: &u64): u64 {
+        bar(x, 2, 3, 4, 5, 6, 7)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/several_args.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/several_args.off.exp
@@ -1,0 +1,398 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: &u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64, $t5: u64, $t6: u64): u64 {
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
+  0: $t13 := read_ref($t0)
+     # live vars: $t1, $t2, $t3, $t4, $t5, $t6, $t13
+  1: $t12 := +($t13, $t1)
+     # live vars: $t2, $t3, $t4, $t5, $t6, $t12
+  2: $t11 := +($t12, $t2)
+     # live vars: $t3, $t4, $t5, $t6, $t11
+  3: $t10 := +($t11, $t3)
+     # live vars: $t4, $t5, $t6, $t10
+  4: $t9 := +($t10, $t4)
+     # live vars: $t5, $t6, $t9
+  5: $t8 := +($t9, $t5)
+     # live vars: $t6, $t8
+  6: $t7 := +($t8, $t6)
+     # live vars: $t7
+  7: return $t7
+}
+
+
+[variant baseline]
+public fun m::test($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0
+  0: $t2 := 2
+     # live vars: $t0, $t2
+  1: $t3 := 3
+     # live vars: $t0, $t2, $t3
+  2: $t4 := 4
+     # live vars: $t0, $t2, $t3, $t4
+  3: $t5 := 5
+     # live vars: $t0, $t2, $t3, $t4, $t5
+  4: $t6 := 6
+     # live vars: $t0, $t2, $t3, $t4, $t5, $t6
+  5: $t7 := 7
+     # live vars: $t0, $t2, $t3, $t4, $t5, $t6, $t7
+  6: $t1 := m::bar($t0, $t2, $t3, $t4, $t5, $t6, $t7)
+     # live vars: $t1
+  7: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: &u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64, $t5: u64, $t6: u64): u64 {
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
+  0: $t13 := read_ref($t0)
+     # live vars: $t1, $t2, $t3, $t4, $t5, $t6, $t13
+  1: $t12 := +($t13, $t1)
+     # live vars: $t2, $t3, $t4, $t5, $t6, $t12
+  2: $t11 := +($t12, $t2)
+     # live vars: $t3, $t4, $t5, $t6, $t11
+  3: $t10 := +($t11, $t3)
+     # live vars: $t4, $t5, $t6, $t10
+  4: $t9 := +($t10, $t4)
+     # live vars: $t5, $t6, $t9
+  5: $t8 := +($t9, $t5)
+     # live vars: $t6, $t8
+  6: $t7 := +($t8, $t6)
+     # live vars: $t7
+  7: return $t7
+}
+
+
+[variant baseline]
+public fun m::test($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0
+  0: $t2 := 2
+     # live vars: $t0, $t2
+  1: $t3 := 3
+     # live vars: $t0, $t2, $t3
+  2: $t4 := 4
+     # live vars: $t0, $t2, $t3, $t4
+  3: $t5 := 5
+     # live vars: $t0, $t2, $t3, $t4, $t5
+  4: $t6 := 6
+     # live vars: $t0, $t2, $t3, $t4, $t5, $t6
+  5: $t7 := 7
+     # live vars: $t0, $t2, $t3, $t4, $t5, $t6, $t7
+  6: $t1 := m::bar($t0, $t2, $t3, $t4, $t5, $t6, $t7)
+     # live vars: $t1
+  7: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: &u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64, $t5: u64, $t6: u64): u64 {
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
+  0: $t13 := read_ref($t0)
+     # live vars: $t1, $t2, $t3, $t4, $t5, $t6, $t13
+  1: $t12 := +($t13, $t1)
+     # live vars: $t2, $t3, $t4, $t5, $t6, $t12
+  2: $t11 := +($t12, $t2)
+     # live vars: $t3, $t4, $t5, $t6, $t11
+  3: $t10 := +($t11, $t3)
+     # live vars: $t4, $t5, $t6, $t10
+  4: $t9 := +($t10, $t4)
+     # live vars: $t5, $t6, $t9
+  5: $t8 := +($t9, $t5)
+     # live vars: $t6, $t8
+  6: $t7 := +($t8, $t6)
+     # live vars: $t7
+  7: return $t7
+}
+
+
+[variant baseline]
+public fun m::test($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0
+  0: $t2 := 2
+     # live vars: $t0, $t2
+  1: $t3 := 3
+     # live vars: $t0, $t2, $t3
+  2: $t4 := 4
+     # live vars: $t0, $t2, $t3, $t4
+  3: $t5 := 5
+     # live vars: $t0, $t2, $t3, $t4, $t5
+  4: $t6 := 6
+     # live vars: $t0, $t2, $t3, $t4, $t5, $t6
+  5: $t7 := 7
+     # live vars: $t0, $t2, $t3, $t4, $t5, $t6, $t7
+  6: $t1 := m::bar($t0, $t2, $t3, $t4, $t5, $t6, $t7)
+     # live vars: $t1
+  7: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: &u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64, $t5: u64, $t6: u64): u64 {
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
+  0: $t13 := read_ref($t0)
+     # live vars: $t1, $t2, $t3, $t4, $t5, $t6, $t13
+  1: $t12 := +($t13, $t1)
+     # live vars: $t2, $t3, $t4, $t5, $t6, $t12
+  2: $t11 := +($t12, $t2)
+     # live vars: $t3, $t4, $t5, $t6, $t11
+  3: $t10 := +($t11, $t3)
+     # live vars: $t4, $t5, $t6, $t10
+  4: $t9 := +($t10, $t4)
+     # live vars: $t5, $t6, $t9
+  5: $t8 := +($t9, $t5)
+     # live vars: $t6, $t8
+  6: $t7 := +($t8, $t6)
+     # live vars: $t7
+  7: return $t7
+}
+
+
+[variant baseline]
+public fun m::test($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0
+  0: $t2 := 2
+     # live vars: $t0, $t2
+  1: $t3 := 3
+     # live vars: $t0, $t2, $t3
+  2: $t4 := 4
+     # live vars: $t0, $t2, $t3, $t4
+  3: $t5 := 5
+     # live vars: $t0, $t2, $t3, $t4, $t5
+  4: $t6 := 6
+     # live vars: $t0, $t2, $t3, $t4, $t5, $t6
+  5: $t7 := 7
+     # live vars: $t0, $t2, $t3, $t4, $t5, $t6, $t7
+  6: $t1 := m::bar($t0, $t2, $t3, $t4, $t5, $t6, $t7)
+     # live vars: $t1
+  7: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: &u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64, $t5: u64, $t6: u64): u64 {
+     var $t7: u64 [unused]
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+     var $t10: u64 [unused]
+     var $t11: u64 [unused]
+     var $t12: u64 [unused]
+     var $t13: u64
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
+  0: $t13 := read_ref($t0)
+     # live vars: $t1, $t2, $t3, $t4, $t5, $t6, $t13
+  1: $t1 := +($t13, $t1)
+     # live vars: $t1, $t2, $t3, $t4, $t5, $t6
+  2: $t1 := +($t1, $t2)
+     # live vars: $t1, $t3, $t4, $t5, $t6
+  3: $t1 := +($t1, $t3)
+     # live vars: $t1, $t4, $t5, $t6
+  4: $t1 := +($t1, $t4)
+     # live vars: $t1, $t5, $t6
+  5: $t1 := +($t1, $t5)
+     # live vars: $t1, $t6
+  6: $t1 := +($t1, $t6)
+     # live vars: $t1
+  7: return $t1
+}
+
+
+[variant baseline]
+public fun m::test($t0: &u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0
+  0: $t2 := 2
+     # live vars: $t0, $t2
+  1: $t3 := 3
+     # live vars: $t0, $t2, $t3
+  2: $t4 := 4
+     # live vars: $t0, $t2, $t3, $t4
+  3: $t5 := 5
+     # live vars: $t0, $t2, $t3, $t4, $t5
+  4: $t6 := 6
+     # live vars: $t0, $t2, $t3, $t4, $t5, $t6
+  5: $t7 := 7
+     # live vars: $t0, $t2, $t3, $t4, $t5, $t6, $t7
+  6: $t2 := m::bar($t0, $t2, $t3, $t4, $t5, $t6, $t7)
+     # live vars: $t2
+  7: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: &u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64, $t5: u64, $t6: u64): u64 {
+     var $t7: u64 [unused]
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+     var $t10: u64 [unused]
+     var $t11: u64 [unused]
+     var $t12: u64 [unused]
+     var $t13: u64
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
+  0: $t13 := read_ref($t0)
+     # live vars: $t1, $t2, $t3, $t4, $t5, $t6, $t13
+  1: $t1 := +($t13, $t1)
+     # live vars: $t1, $t2, $t3, $t4, $t5, $t6
+  2: $t1 := +($t1, $t2)
+     # live vars: $t1, $t3, $t4, $t5, $t6
+  3: $t1 := +($t1, $t3)
+     # live vars: $t1, $t4, $t5, $t6
+  4: $t1 := +($t1, $t4)
+     # live vars: $t1, $t5, $t6
+  5: $t1 := +($t1, $t5)
+     # live vars: $t1, $t6
+  6: $t1 := +($t1, $t6)
+     # live vars: $t1
+  7: return $t1
+}
+
+
+[variant baseline]
+public fun m::test($t0: &u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0
+  0: $t2 := 2
+     # live vars: $t0, $t2
+  1: $t3 := 3
+     # live vars: $t0, $t2, $t3
+  2: $t4 := 4
+     # live vars: $t0, $t2, $t3, $t4
+  3: $t5 := 5
+     # live vars: $t0, $t2, $t3, $t4, $t5
+  4: $t6 := 6
+     # live vars: $t0, $t2, $t3, $t4, $t5, $t6
+  5: $t7 := 7
+     # live vars: $t0, $t2, $t3, $t4, $t5, $t6, $t7
+  6: $t2 := m::bar($t0, $t2, $t3, $t4, $t5, $t6, $t7)
+     # live vars: $t2
+  7: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+bar(Arg0: &u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64, Arg6: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: &u64)
+	1: ReadRef
+	2: MoveLoc[1](Arg1: u64)
+	3: Add
+	4: MoveLoc[2](Arg2: u64)
+	5: Add
+	6: MoveLoc[3](Arg3: u64)
+	7: Add
+	8: MoveLoc[4](Arg4: u64)
+	9: Add
+	10: MoveLoc[5](Arg5: u64)
+	11: Add
+	12: MoveLoc[6](Arg6: u64)
+	13: Add
+	14: Ret
+}
+public test(Arg0: &u64): u64 /* def_idx: 1 */ {
+L1:	loc0: u64
+L2:	loc1: u64
+L3:	loc2: u64
+L4:	loc3: u64
+L5:	loc4: u64
+L6:	loc5: u64
+B0:
+	0: LdU64(2)
+	1: LdU64(3)
+	2: LdU64(4)
+	3: LdU64(5)
+	4: LdU64(6)
+	5: LdU64(7)
+	6: StLoc[1](loc0: u64)
+	7: StLoc[2](loc1: u64)
+	8: StLoc[3](loc2: u64)
+	9: StLoc[4](loc3: u64)
+	10: StLoc[5](loc4: u64)
+	11: StLoc[6](loc5: u64)
+	12: MoveLoc[0](Arg0: &u64)
+	13: MoveLoc[6](loc5: u64)
+	14: MoveLoc[5](loc4: u64)
+	15: MoveLoc[4](loc3: u64)
+	16: MoveLoc[3](loc2: u64)
+	17: MoveLoc[2](loc1: u64)
+	18: MoveLoc[1](loc0: u64)
+	19: Call bar(&u64, u64, u64, u64, u64, u64, u64): u64
+	20: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/several_args.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/several_args.on.exp
@@ -1,0 +1,80 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: &u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64, $t5: u64, $t6: u64): u64 {
+     var $t7: u64 [unused]
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+     var $t10: u64 [unused]
+     var $t11: u64 [unused]
+     var $t12: u64 [unused]
+     var $t13: u64
+  0: $t13 := read_ref($t0)
+  1: $t1 := +($t13, $t1)
+  2: $t1 := +($t1, $t2)
+  3: $t1 := +($t1, $t3)
+  4: $t1 := +($t1, $t4)
+  5: $t1 := +($t1, $t5)
+  6: $t1 := +($t1, $t6)
+  7: return $t1
+}
+
+
+[variant baseline]
+public fun m::test($t0: &u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: touch($t0)
+  1: $t2 := 2
+  2: $t3 := 3
+  3: $t4 := 4
+  4: $t5 := 5
+  5: $t6 := 6
+  6: $t7 := 7
+  7: $t2 := m::bar($t0, $t2, $t3, $t4, $t5, $t6, $t7)
+  8: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+bar(Arg0: &u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64, Arg6: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: &u64)
+	1: ReadRef
+	2: MoveLoc[1](Arg1: u64)
+	3: Add
+	4: MoveLoc[2](Arg2: u64)
+	5: Add
+	6: MoveLoc[3](Arg3: u64)
+	7: Add
+	8: MoveLoc[4](Arg4: u64)
+	9: Add
+	10: MoveLoc[5](Arg5: u64)
+	11: Add
+	12: MoveLoc[6](Arg6: u64)
+	13: Add
+	14: Ret
+}
+public test(Arg0: &u64): u64 /* def_idx: 1 */ {
+B0:
+	0: MoveLoc[0](Arg0: &u64)
+	1: LdU64(2)
+	2: LdU64(3)
+	3: LdU64(4)
+	4: LdU64(5)
+	5: LdU64(6)
+	6: LdU64(7)
+	7: Call bar(&u64, u64, u64, u64, u64, u64, u64): u64
+	8: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/simple_add.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/simple_add.move
@@ -1,0 +1,6 @@
+module 0xc0ffee::m {
+    public fun test(x: u64): u64 {
+        x + 1
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/simple_add.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/simple_add.off.exp
@@ -1,0 +1,100 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := +($t0, $t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t0 := +($t0, $t2)
+     # live vars: $t0
+  2: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t0 := +($t0, $t2)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public test(Arg0: u64): u64 /* def_idx: 0 */ {
+L1:	loc0: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/simple_add.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/simple_add.on.exp
@@ -1,0 +1,27 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+  0: touch($t0)
+  1: $t2 := 1
+  2: $t0 := +($t0, $t2)
+  3: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public test(Arg0: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/subtract.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/subtract.move
@@ -1,0 +1,7 @@
+module 0xc0ffee::m {
+    public fun test(a: u16, b: u16): u32 {
+        let r = ((b - a) as u32);
+        r
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/subtract.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/subtract.off.exp
@@ -1,0 +1,116 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u16, $t1: u16): u32 {
+     var $t2: u32
+     var $t3: u32
+     var $t4: u16
+     # live vars: $t0, $t1
+  0: $t4 := -($t1, $t0)
+     # live vars: $t4
+  1: $t3 := (u32)($t4)
+     # live vars: $t3
+  2: $t2 := infer($t3)
+     # live vars: $t2
+  3: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u16, $t1: u16): u32 {
+     var $t2: u32
+     var $t3: u32
+     var $t4: u16
+     # live vars: $t0, $t1
+  0: $t4 := -($t1, $t0)
+     # live vars: $t4
+  1: $t3 := (u32)($t4)
+     # live vars: $t3
+  2: $t2 := infer($t3)
+     # live vars: $t2
+  3: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u16, $t1: u16): u32 {
+     var $t2: u32
+     var $t3: u32
+     var $t4: u16
+     # live vars: $t0, $t1
+  0: $t4 := -($t1, $t0)
+     # live vars: $t4
+  1: $t3 := (u32)($t4)
+     # live vars: $t3
+  2: $t2 := move($t3)
+     # live vars: $t2
+  3: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u16, $t1: u16): u32 {
+     var $t2: u32
+     var $t3: u32
+     var $t4: u16
+     # live vars: $t0, $t1
+  0: $t4 := -($t1, $t0)
+     # live vars: $t4
+  1: $t3 := (u32)($t4)
+     # live vars: $t3
+  2: $t2 := move($t3)
+     # live vars: $t2
+  3: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u16, $t1: u16): u32 {
+     var $t2: u32 [unused]
+     var $t3: u32
+     var $t4: u16 [unused]
+     # live vars: $t0, $t1
+  0: $t0 := -($t1, $t0)
+     # live vars: $t0
+  1: $t3 := (u32)($t0)
+     # live vars: $t3
+  2: $t3 := move($t3)
+     # live vars: $t3
+  3: return $t3
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u16, $t1: u16): u32 {
+     var $t2: u32 [unused]
+     var $t3: u32
+     var $t4: u16 [unused]
+     # live vars: $t0, $t1
+  0: $t0 := -($t1, $t0)
+     # live vars: $t0
+  1: $t3 := (u32)($t0)
+     # live vars: $t3
+  2: return $t3
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public test(Arg0: u16, Arg1: u16): u32 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[1](Arg1: u16)
+	1: MoveLoc[0](Arg0: u16)
+	2: Sub
+	3: CastU32
+	4: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/subtract.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/subtract.on.exp
@@ -1,0 +1,29 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u16, $t1: u16): u32 {
+     var $t2: u32 [unused]
+     var $t3: u32
+     var $t4: u16 [unused]
+  0: touch($t1)
+  1: $t0 := -($t1, $t0)
+  2: $t3 := (u32)($t0)
+  3: return $t3
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public test(Arg0: u16, Arg1: u16): u32 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[1](Arg1: u16)
+	1: MoveLoc[0](Arg0: u16)
+	2: Sub
+	3: CastU32
+	4: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/swap_remove.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/swap_remove.move
@@ -1,0 +1,16 @@
+module 0xc0ffee::m {
+    
+    public fun is_empty<Element>(v: &vector<Element>): bool {
+        use std::vector::length;
+        length(v) == 0
+    }
+
+    public fun swap_remove<Element>(v: &mut vector<Element>, i: u64): Element {
+        use std::vector::{length, pop_back, swap};
+        assert!(!is_empty(v), 0);
+        let last_idx = length(v) - 1;
+        swap(v, i, last_idx);
+        pop_back(v)
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/swap_remove.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/swap_remove.off.exp
@@ -1,0 +1,458 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::is_empty<#0>($t0: &vector<#0>): bool {
+     var $t1: bool
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := vector::length<#0>($t0)
+     # live vars: $t2
+  1: $t3 := 0
+     # live vars: $t2, $t3
+  2: $t1 := ==($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+public fun m::swap_remove<#0>($t0: &mut vector<#0>, $t1: u64): #0 {
+     var $t2: #0
+     var $t3: bool
+     var $t4: bool
+     var $t5: &vector<#0>
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: &vector<#0>
+     var $t10: u64
+     # live vars: $t0, $t1
+  0: $t5 := freeze_ref(implicit)($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := m::is_empty<#0>($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t3 := !($t4)
+     # live vars: $t0, $t1, $t3
+  3: if ($t3) goto 4 else goto 6
+     # live vars: $t0, $t1
+  4: label L0
+     # live vars: $t0, $t1
+  5: goto 9
+     # live vars: $t0, $t1
+  6: label L1
+     # live vars:
+  7: $t6 := 0
+     # live vars: $t6
+  8: abort($t6)
+     # live vars: $t0, $t1
+  9: label L2
+     # live vars: $t0, $t1
+ 10: $t9 := freeze_ref(implicit)($t0)
+     # live vars: $t0, $t1, $t9
+ 11: $t8 := vector::length<#0>($t9)
+     # live vars: $t0, $t1, $t8
+ 12: $t10 := 1
+     # live vars: $t0, $t1, $t8, $t10
+ 13: $t7 := -($t8, $t10)
+     # live vars: $t0, $t1, $t7
+ 14: vector::swap<#0>($t0, $t1, $t7)
+     # live vars: $t0
+ 15: $t2 := vector::pop_back<#0>($t0)
+     # live vars: $t2
+ 16: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::is_empty<#0>($t0: &vector<#0>): bool {
+     var $t1: bool
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := vector::length<#0>($t0)
+     # live vars: $t2
+  1: $t3 := 0
+     # live vars: $t2, $t3
+  2: $t1 := ==($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+public fun m::swap_remove<#0>($t0: &mut vector<#0>, $t1: u64): #0 {
+     var $t2: #0
+     var $t3: bool
+     var $t4: bool
+     var $t5: &vector<#0>
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: &vector<#0>
+     var $t10: u64
+     # live vars: $t0, $t1
+  0: $t5 := freeze_ref(implicit)($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := m::is_empty<#0>($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t3 := !($t4)
+     # live vars: $t0, $t1, $t3
+  3: if ($t3) goto 4 else goto 6
+     # live vars: $t0, $t1
+  4: label L0
+     # live vars: $t0, $t1
+  5: goto 9
+     # live vars: $t0, $t1
+  6: label L1
+     # live vars:
+  7: $t6 := 0
+     # live vars: $t6
+  8: abort($t6)
+     # live vars: $t0, $t1
+  9: label L2
+     # live vars: $t0, $t1
+ 10: $t9 := freeze_ref(implicit)($t0)
+     # live vars: $t0, $t1, $t9
+ 11: $t8 := vector::length<#0>($t9)
+     # live vars: $t0, $t1, $t8
+ 12: $t10 := 1
+     # live vars: $t0, $t1, $t8, $t10
+ 13: $t7 := -($t8, $t10)
+     # live vars: $t0, $t1, $t7
+ 14: vector::swap<#0>($t0, $t1, $t7)
+     # live vars: $t0
+ 15: $t2 := vector::pop_back<#0>($t0)
+     # live vars: $t2
+ 16: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::is_empty<#0>($t0: &vector<#0>): bool {
+     var $t1: bool
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := vector::length<#0>($t0)
+     # live vars: $t2
+  1: $t3 := 0
+     # live vars: $t2, $t3
+  2: $t1 := ==($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+public fun m::swap_remove<#0>($t0: &mut vector<#0>, $t1: u64): #0 {
+     var $t2: #0
+     var $t3: bool
+     var $t4: bool
+     var $t5: &vector<#0>
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: &vector<#0>
+     var $t10: u64
+     var $t11: &mut vector<#0>
+     # live vars: $t0, $t1
+  0: $t5 := freeze_ref(implicit)($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := m::is_empty<#0>($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t3 := !($t4)
+     # live vars: $t0, $t1, $t3
+  3: if ($t3) goto 4 else goto 6
+     # live vars: $t0, $t1
+  4: label L0
+     # live vars: $t0, $t1
+  5: goto 10
+     # live vars: $t0, $t1
+  6: label L1
+     # live vars: $t0
+  7: drop($t0)
+     # live vars:
+  8: $t6 := 0
+     # live vars: $t6
+  9: abort($t6)
+     # live vars: $t0, $t1
+ 10: label L2
+     # live vars: $t0, $t1
+ 11: $t9 := freeze_ref(implicit)($t0)
+     # live vars: $t0, $t1, $t9
+ 12: $t8 := vector::length<#0>($t9)
+     # live vars: $t0, $t1, $t8
+ 13: $t10 := 1
+     # live vars: $t0, $t1, $t8, $t10
+ 14: $t7 := -($t8, $t10)
+     # live vars: $t0, $t1, $t7
+ 15: $t11 := copy($t0)
+     # live vars: $t0, $t1, $t7, $t11
+ 16: vector::swap<#0>($t11, $t1, $t7)
+     # live vars: $t0
+ 17: $t2 := vector::pop_back<#0>($t0)
+     # live vars: $t2
+ 18: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::is_empty<#0>($t0: &vector<#0>): bool {
+     var $t1: bool
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := vector::length<#0>($t0)
+     # live vars: $t2
+  1: $t3 := 0
+     # live vars: $t2, $t3
+  2: $t1 := ==($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+public fun m::swap_remove<#0>($t0: &mut vector<#0>, $t1: u64): #0 {
+     var $t2: #0
+     var $t3: bool
+     var $t4: bool
+     var $t5: &vector<#0>
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: &vector<#0>
+     var $t10: u64
+     var $t11: &mut vector<#0>
+     # live vars: $t0, $t1
+  0: $t5 := freeze_ref(implicit)($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := m::is_empty<#0>($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t3 := !($t4)
+     # live vars: $t0, $t1, $t3
+  3: if ($t3) goto 4 else goto 6
+     # live vars: $t0, $t1
+  4: label L0
+     # live vars: $t0, $t1
+  5: goto 10
+     # live vars: $t0, $t1
+  6: label L1
+     # live vars: $t0
+  7: drop($t0)
+     # live vars:
+  8: $t6 := 0
+     # live vars: $t6
+  9: abort($t6)
+     # live vars: $t0, $t1
+ 10: label L2
+     # live vars: $t0, $t1
+ 11: $t9 := freeze_ref(implicit)($t0)
+     # live vars: $t0, $t1, $t9
+ 12: $t8 := vector::length<#0>($t9)
+     # live vars: $t0, $t1, $t8
+ 13: $t10 := 1
+     # live vars: $t0, $t1, $t8, $t10
+ 14: $t7 := -($t8, $t10)
+     # live vars: $t0, $t1, $t7
+ 15: $t11 := copy($t0)
+     # live vars: $t0, $t1, $t7, $t11
+ 16: vector::swap<#0>($t11, $t1, $t7)
+     # live vars: $t0
+ 17: $t2 := vector::pop_back<#0>($t0)
+     # live vars: $t2
+ 18: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::is_empty<#0>($t0: &vector<#0>): bool {
+     var $t1: bool
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := vector::length<#0>($t0)
+     # live vars: $t2
+  1: $t3 := 0
+     # live vars: $t2, $t3
+  2: $t1 := ==($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+public fun m::swap_remove<#0>($t0: &mut vector<#0>, $t1: u64): #0 {
+     var $t2: #0
+     var $t3: bool [unused]
+     var $t4: bool
+     var $t5: &vector<#0>
+     var $t6: u64
+     var $t7: u64 [unused]
+     var $t8: u64 [unused]
+     var $t9: &vector<#0> [unused]
+     var $t10: u64
+     var $t11: &mut vector<#0>
+     # live vars: $t0, $t1
+  0: $t5 := freeze_ref(implicit)($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := m::is_empty<#0>($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t4 := !($t4)
+     # live vars: $t0, $t1, $t4
+  3: if ($t4) goto 4 else goto 6
+     # live vars: $t0, $t1
+  4: label L0
+     # live vars: $t0, $t1
+  5: goto 10
+     # live vars: $t0, $t1
+  6: label L1
+     # live vars: $t0
+  7: drop($t0)
+     # live vars:
+  8: $t6 := 0
+     # live vars: $t6
+  9: abort($t6)
+     # live vars: $t0, $t1
+ 10: label L2
+     # live vars: $t0, $t1
+ 11: $t5 := freeze_ref(implicit)($t0)
+     # live vars: $t0, $t1, $t5
+ 12: $t6 := vector::length<#0>($t5)
+     # live vars: $t0, $t1, $t6
+ 13: $t10 := 1
+     # live vars: $t0, $t1, $t6, $t10
+ 14: $t6 := -($t6, $t10)
+     # live vars: $t0, $t1, $t6
+ 15: $t11 := copy($t0)
+     # live vars: $t0, $t1, $t6, $t11
+ 16: vector::swap<#0>($t11, $t1, $t6)
+     # live vars: $t0
+ 17: $t2 := vector::pop_back<#0>($t0)
+     # live vars: $t2
+ 18: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::is_empty<#0>($t0: &vector<#0>): bool {
+     var $t1: bool
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := vector::length<#0>($t0)
+     # live vars: $t2
+  1: $t3 := 0
+     # live vars: $t2, $t3
+  2: $t1 := ==($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+public fun m::swap_remove<#0>($t0: &mut vector<#0>, $t1: u64): #0 {
+     var $t2: #0
+     var $t3: bool [unused]
+     var $t4: bool
+     var $t5: &vector<#0>
+     var $t6: u64
+     var $t7: u64 [unused]
+     var $t8: u64 [unused]
+     var $t9: &vector<#0> [unused]
+     var $t10: u64
+     var $t11: &mut vector<#0>
+     # live vars: $t0, $t1
+  0: $t5 := freeze_ref(implicit)($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := m::is_empty<#0>($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t4 := !($t4)
+     # live vars: $t0, $t1, $t4
+  3: if ($t4) goto 4 else goto 6
+     # live vars: $t0, $t1
+  4: label L0
+     # live vars: $t0, $t1
+  5: goto 10
+     # live vars: $t0, $t1
+  6: label L1
+     # live vars: $t0
+  7: drop($t0)
+     # live vars:
+  8: $t6 := 0
+     # live vars: $t6
+  9: abort($t6)
+     # live vars: $t0, $t1
+ 10: label L2
+     # live vars: $t0, $t1
+ 11: $t5 := freeze_ref(implicit)($t0)
+     # live vars: $t0, $t1, $t5
+ 12: $t6 := vector::length<#0>($t5)
+     # live vars: $t0, $t1, $t6
+ 13: $t10 := 1
+     # live vars: $t0, $t1, $t6, $t10
+ 14: $t6 := -($t6, $t10)
+     # live vars: $t0, $t1, $t6
+ 15: $t11 := copy($t0)
+     # live vars: $t0, $t1, $t6, $t11
+ 16: vector::swap<#0>($t11, $t1, $t6)
+     # live vars: $t0
+ 17: $t2 := vector::pop_back<#0>($t0)
+     # live vars: $t2
+ 18: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public is_empty<Ty0>(Arg0: &vector<Ty0>): bool /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: &vector<Ty0>)
+	1: VecLen(2)
+	2: LdU64(0)
+	3: Eq
+	4: Ret
+}
+public swap_remove<Ty0>(Arg0: &mut vector<Ty0>, Arg1: u64): Ty0 /* def_idx: 1 */ {
+L2:	loc0: &mut vector<Ty0>
+L3:	loc1: u64
+B0:
+	0: CopyLoc[0](Arg0: &mut vector<Ty0>)
+	1: FreezeRef
+	2: Call is_empty<Ty0>(&vector<Ty0>): bool
+	3: BrTrue(5)
+B1:
+	4: Branch(9)
+B2:
+	5: MoveLoc[0](Arg0: &mut vector<Ty0>)
+	6: Pop
+	7: LdU64(0)
+	8: Abort
+B3:
+	9: CopyLoc[0](Arg0: &mut vector<Ty0>)
+	10: FreezeRef
+	11: VecLen(2)
+	12: LdU64(1)
+	13: Sub
+	14: CopyLoc[0](Arg0: &mut vector<Ty0>)
+	15: StLoc[2](loc0: &mut vector<Ty0>)
+	16: StLoc[3](loc1: u64)
+	17: MoveLoc[2](loc0: &mut vector<Ty0>)
+	18: MoveLoc[1](Arg1: u64)
+	19: MoveLoc[3](loc1: u64)
+	20: VecSwap(2)
+	21: MoveLoc[0](Arg0: &mut vector<Ty0>)
+	22: VecPopBack(2)
+	23: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/swap_remove.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/swap_remove.on.exp
@@ -1,0 +1,95 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+public fun m::is_empty<#0>($t0: &vector<#0>): bool {
+     var $t1: bool
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := vector::length<#0>($t0)
+  1: $t3 := 0
+  2: $t1 := ==($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+public fun m::swap_remove<#0>($t0: &mut vector<#0>, $t1: u64): #0 {
+     var $t2: #0
+     var $t3: bool [unused]
+     var $t4: bool
+     var $t5: &vector<#0>
+     var $t6: u64
+     var $t7: u64 [unused]
+     var $t8: u64 [unused]
+     var $t9: &vector<#0> [unused]
+     var $t10: u64
+     var $t11: &mut vector<#0>
+  0: $t5 := freeze_ref(implicit)($t0)
+  1: $t4 := m::is_empty<#0>($t5)
+  2: $t4 := !($t4)
+  3: if ($t4) goto 4 else goto 6
+  4: label L0
+  5: goto 10
+  6: label L1
+  7: drop($t0)
+  8: $t6 := 0
+  9: abort($t6)
+ 10: label L2
+ 11: $t5 := freeze_ref(implicit)($t0)
+ 12: $t6 := vector::length<#0>($t5)
+ 13: $t10 := 1
+ 14: $t6 := -($t6, $t10)
+ 15: $t11 := copy($t0)
+ 16: vector::swap<#0>($t11, $t1, $t6)
+ 17: $t2 := vector::pop_back<#0>($t0)
+ 18: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public is_empty<Ty0>(Arg0: &vector<Ty0>): bool /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: &vector<Ty0>)
+	1: VecLen(2)
+	2: LdU64(0)
+	3: Eq
+	4: Ret
+}
+public swap_remove<Ty0>(Arg0: &mut vector<Ty0>, Arg1: u64): Ty0 /* def_idx: 1 */ {
+L2:	loc0: &mut vector<Ty0>
+L3:	loc1: u64
+B0:
+	0: CopyLoc[0](Arg0: &mut vector<Ty0>)
+	1: FreezeRef
+	2: Call is_empty<Ty0>(&vector<Ty0>): bool
+	3: BrTrue(5)
+B1:
+	4: Branch(9)
+B2:
+	5: MoveLoc[0](Arg0: &mut vector<Ty0>)
+	6: Pop
+	7: LdU64(0)
+	8: Abort
+B3:
+	9: CopyLoc[0](Arg0: &mut vector<Ty0>)
+	10: FreezeRef
+	11: VecLen(2)
+	12: LdU64(1)
+	13: Sub
+	14: CopyLoc[0](Arg0: &mut vector<Ty0>)
+	15: StLoc[2](loc0: &mut vector<Ty0>)
+	16: StLoc[3](loc1: u64)
+	17: MoveLoc[2](loc0: &mut vector<Ty0>)
+	18: MoveLoc[1](Arg1: u64)
+	19: MoveLoc[3](loc1: u64)
+	20: VecSwap(2)
+	21: MoveLoc[0](Arg0: &mut vector<Ty0>)
+	22: VecPopBack(2)
+	23: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/vector_01.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/vector_01.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+    use std::vector;
+
+    public fun contains(features: &vector<u8>, feature: u64): bool {
+        let bit_mask = 1 << (feature as u8);
+        0 < vector::length(features) && (*vector::borrow(features, 0) & bit_mask) != 0
+    }
+}
+

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/vector_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/vector_01.off.exp
@@ -1,0 +1,401 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::contains($t0: &vector<u8>, $t1: u64): bool {
+     var $t2: bool
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     var $t9: u8
+     var $t10: u8
+     var $t11: &u8
+     var $t12: u64
+     var $t13: u8
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t5 := (u8)($t1)
+     # live vars: $t0, $t4, $t5
+  2: $t3 := <<($t4, $t5)
+     # live vars: $t0, $t3
+  3: $t7 := 0
+     # live vars: $t0, $t3, $t7
+  4: $t8 := vector::length<u8>($t0)
+     # live vars: $t0, $t3, $t7, $t8
+  5: $t6 := <($t7, $t8)
+     # live vars: $t0, $t3, $t6
+  6: if ($t6) goto 7 else goto 15
+     # live vars: $t0, $t3
+  7: label L0
+     # live vars: $t0, $t3
+  8: $t12 := 0
+     # live vars: $t0, $t3, $t12
+  9: $t11 := vector::borrow<u8>($t0, $t12)
+     # live vars: $t3, $t11
+ 10: $t10 := read_ref($t11)
+     # live vars: $t3, $t10
+ 11: $t9 := &($t10, $t3)
+     # live vars: $t9
+ 12: $t13 := 0
+     # live vars: $t9, $t13
+ 13: $t2 := !=($t9, $t13)
+     # live vars: $t2
+ 14: goto 17
+     # live vars: $t0, $t3
+ 15: label L1
+     # live vars:
+ 16: $t2 := false
+     # live vars: $t2
+ 17: label L2
+     # live vars: $t2
+ 18: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::contains($t0: &vector<u8>, $t1: u64): bool {
+     var $t2: bool
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     var $t9: u8
+     var $t10: u8
+     var $t11: &u8
+     var $t12: u64
+     var $t13: u8
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t5 := (u8)($t1)
+     # live vars: $t0, $t4, $t5
+  2: $t3 := <<($t4, $t5)
+     # live vars: $t0, $t3
+  3: $t7 := 0
+     # live vars: $t0, $t3, $t7
+  4: $t8 := vector::length<u8>($t0)
+     # live vars: $t0, $t3, $t7, $t8
+  5: $t6 := <($t7, $t8)
+     # live vars: $t0, $t3, $t6
+  6: if ($t6) goto 7 else goto 15
+     # live vars: $t0, $t3
+  7: label L0
+     # live vars: $t0, $t3
+  8: $t12 := 0
+     # live vars: $t0, $t3, $t12
+  9: $t11 := vector::borrow<u8>($t0, $t12)
+     # live vars: $t3, $t11
+ 10: $t10 := read_ref($t11)
+     # live vars: $t3, $t10
+ 11: $t9 := &($t10, $t3)
+     # live vars: $t9
+ 12: $t13 := 0
+     # live vars: $t9, $t13
+ 13: $t2 := !=($t9, $t13)
+     # live vars: $t2
+ 14: goto 17
+     # live vars: $t0, $t3
+ 15: label L1
+     # live vars:
+ 16: $t2 := false
+     # live vars: $t2
+ 17: label L2
+     # live vars: $t2
+ 18: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::contains($t0: &vector<u8>, $t1: u64): bool {
+     var $t2: bool
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     var $t9: u8
+     var $t10: u8
+     var $t11: &u8
+     var $t12: u64
+     var $t13: u8
+     var $t14: &vector<u8>
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t5 := (u8)($t1)
+     # live vars: $t0, $t4, $t5
+  2: $t3 := <<($t4, $t5)
+     # live vars: $t0, $t3
+  3: $t7 := 0
+     # live vars: $t0, $t3, $t7
+  4: $t14 := copy($t0)
+     # live vars: $t0, $t3, $t7, $t14
+  5: $t8 := vector::length<u8>($t14)
+     # live vars: $t0, $t3, $t7, $t8
+  6: $t6 := <($t7, $t8)
+     # live vars: $t0, $t3, $t6
+  7: if ($t6) goto 8 else goto 16
+     # live vars: $t0, $t3
+  8: label L0
+     # live vars: $t0, $t3
+  9: $t12 := 0
+     # live vars: $t0, $t3, $t12
+ 10: $t11 := vector::borrow<u8>($t0, $t12)
+     # live vars: $t3, $t11
+ 11: $t10 := read_ref($t11)
+     # live vars: $t3, $t10
+ 12: $t9 := &($t10, $t3)
+     # live vars: $t9
+ 13: $t13 := 0
+     # live vars: $t9, $t13
+ 14: $t2 := !=($t9, $t13)
+     # live vars: $t2
+ 15: goto 19
+     # live vars: $t0, $t3
+ 16: label L1
+     # live vars: $t0
+ 17: drop($t0)
+     # live vars:
+ 18: $t2 := false
+     # live vars: $t2
+ 19: label L2
+     # live vars: $t2
+ 20: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::contains($t0: &vector<u8>, $t1: u64): bool {
+     var $t2: bool
+     var $t3: u8
+     var $t4: u8
+     var $t5: u8
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     var $t9: u8
+     var $t10: u8
+     var $t11: &u8
+     var $t12: u64
+     var $t13: u8
+     var $t14: &vector<u8>
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t5 := (u8)($t1)
+     # live vars: $t0, $t4, $t5
+  2: $t3 := <<($t4, $t5)
+     # live vars: $t0, $t3
+  3: $t7 := 0
+     # live vars: $t0, $t3, $t7
+  4: $t14 := copy($t0)
+     # live vars: $t0, $t3, $t7, $t14
+  5: $t8 := vector::length<u8>($t14)
+     # live vars: $t0, $t3, $t7, $t8
+  6: $t6 := <($t7, $t8)
+     # live vars: $t0, $t3, $t6
+  7: if ($t6) goto 8 else goto 16
+     # live vars: $t0, $t3
+  8: label L0
+     # live vars: $t0, $t3
+  9: $t12 := 0
+     # live vars: $t0, $t3, $t12
+ 10: $t11 := vector::borrow<u8>($t0, $t12)
+     # live vars: $t3, $t11
+ 11: $t10 := read_ref($t11)
+     # live vars: $t3, $t10
+ 12: $t9 := &($t10, $t3)
+     # live vars: $t9
+ 13: $t13 := 0
+     # live vars: $t9, $t13
+ 14: $t2 := !=($t9, $t13)
+     # live vars: $t2
+ 15: goto 19
+     # live vars: $t0, $t3
+ 16: label L1
+     # live vars: $t0
+ 17: drop($t0)
+     # live vars:
+ 18: $t2 := false
+     # live vars: $t2
+ 19: label L2
+     # live vars: $t2
+ 20: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::contains($t0: &vector<u8>, $t1: u64): bool {
+     var $t2: bool [unused]
+     var $t3: u8 [unused]
+     var $t4: u8
+     var $t5: u8
+     var $t6: bool
+     var $t7: u64 [unused]
+     var $t8: u64
+     var $t9: u8 [unused]
+     var $t10: u8 [unused]
+     var $t11: &u8
+     var $t12: u64 [unused]
+     var $t13: u8
+     var $t14: &vector<u8>
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t5 := (u8)($t1)
+     # live vars: $t0, $t4, $t5
+  2: $t4 := <<($t4, $t5)
+     # live vars: $t0, $t4
+  3: $t1 := 0
+     # live vars: $t0, $t1, $t4
+  4: $t14 := copy($t0)
+     # live vars: $t0, $t1, $t4, $t14
+  5: $t8 := vector::length<u8>($t14)
+     # live vars: $t0, $t1, $t4, $t8
+  6: $t6 := <($t1, $t8)
+     # live vars: $t0, $t4, $t6
+  7: if ($t6) goto 8 else goto 16
+     # live vars: $t0, $t4
+  8: label L0
+     # live vars: $t0, $t4
+  9: $t1 := 0
+     # live vars: $t0, $t1, $t4
+ 10: $t11 := vector::borrow<u8>($t0, $t1)
+     # live vars: $t4, $t11
+ 11: $t5 := read_ref($t11)
+     # live vars: $t4, $t5
+ 12: $t5 := &($t5, $t4)
+     # live vars: $t5
+ 13: $t13 := 0
+     # live vars: $t5, $t13
+ 14: $t6 := !=($t5, $t13)
+     # live vars: $t6
+ 15: goto 19
+     # live vars: $t0, $t4
+ 16: label L1
+     # live vars: $t0
+ 17: drop($t0)
+     # live vars:
+ 18: $t6 := false
+     # live vars: $t6
+ 19: label L2
+     # live vars: $t6
+ 20: return $t6
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::contains($t0: &vector<u8>, $t1: u64): bool {
+     var $t2: bool [unused]
+     var $t3: u8 [unused]
+     var $t4: u8
+     var $t5: u8
+     var $t6: bool
+     var $t7: u64 [unused]
+     var $t8: u64
+     var $t9: u8 [unused]
+     var $t10: u8 [unused]
+     var $t11: &u8
+     var $t12: u64 [unused]
+     var $t13: u8
+     var $t14: &vector<u8>
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t5 := (u8)($t1)
+     # live vars: $t0, $t4, $t5
+  2: $t4 := <<($t4, $t5)
+     # live vars: $t0, $t4
+  3: $t1 := 0
+     # live vars: $t0, $t1, $t4
+  4: $t14 := copy($t0)
+     # live vars: $t0, $t1, $t4, $t14
+  5: $t8 := vector::length<u8>($t14)
+     # live vars: $t0, $t1, $t4, $t8
+  6: $t6 := <($t1, $t8)
+     # live vars: $t0, $t4, $t6
+  7: if ($t6) goto 8 else goto 16
+     # live vars: $t0, $t4
+  8: label L0
+     # live vars: $t0, $t4
+  9: $t1 := 0
+     # live vars: $t0, $t1, $t4
+ 10: $t11 := vector::borrow<u8>($t0, $t1)
+     # live vars: $t4, $t11
+ 11: $t5 := read_ref($t11)
+     # live vars: $t4, $t5
+ 12: $t5 := &($t5, $t4)
+     # live vars: $t5
+ 13: $t13 := 0
+     # live vars: $t5, $t13
+ 14: $t6 := !=($t5, $t13)
+     # live vars: $t6
+ 15: goto 19
+     # live vars: $t0, $t4
+ 16: label L1
+     # live vars: $t0
+ 17: drop($t0)
+     # live vars:
+ 18: $t6 := false
+     # live vars: $t6
+ 19: label L2
+     # live vars: $t6
+ 20: return $t6
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public contains(Arg0: &vector<u8>, Arg1: u64): bool /* def_idx: 0 */ {
+L2:	loc0: &vector<u8>
+L3:	loc1: bool
+L4:	loc2: u8
+B0:
+	0: LdU8(1)
+	1: MoveLoc[1](Arg1: u64)
+	2: CastU8
+	3: Shl
+	4: LdU64(0)
+	5: CopyLoc[0](Arg0: &vector<u8>)
+	6: VecLen(2)
+	7: Lt
+	8: StLoc[3](loc1: bool)
+	9: StLoc[4](loc2: u8)
+	10: MoveLoc[3](loc1: bool)
+	11: BrFalse(22)
+B1:
+	12: MoveLoc[0](Arg0: &vector<u8>)
+	13: LdU64(0)
+	14: VecImmBorrow(2)
+	15: ReadRef
+	16: MoveLoc[4](loc2: u8)
+	17: BitAnd
+	18: LdU8(0)
+	19: Neq
+	20: StLoc[3](loc1: bool)
+	21: Branch(26)
+B2:
+	22: MoveLoc[0](Arg0: &vector<u8>)
+	23: Pop
+	24: LdFalse
+	25: StLoc[3](loc1: bool)
+B3:
+	26: MoveLoc[3](loc1: bool)
+	27: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/vector_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/vector_01.on.exp
@@ -1,0 +1,84 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+public fun m::contains($t0: &vector<u8>, $t1: u64): bool {
+     var $t2: bool [unused]
+     var $t3: u8 [unused]
+     var $t4: u8
+     var $t5: u8
+     var $t6: bool
+     var $t7: u64 [unused]
+     var $t8: u64
+     var $t9: u8 [unused]
+     var $t10: u8 [unused]
+     var $t11: &u8
+     var $t12: u64 [unused]
+     var $t13: u8
+     var $t14: &vector<u8>
+  0: $t4 := 1
+  1: $t5 := (u8)($t1)
+  2: $t4 := <<($t4, $t5)
+  3: $t1 := 0
+  4: $t14 := copy($t0)
+  5: $t8 := vector::length<u8>($t14)
+  6: $t6 := <($t1, $t8)
+  7: if ($t6) goto 8 else goto 17
+  8: label L0
+  9: touch($t0)
+ 10: $t1 := 0
+ 11: $t11 := vector::borrow<u8>($t0, $t1)
+ 12: $t5 := read_ref($t11)
+ 13: $t5 := &($t5, $t4)
+ 14: $t13 := 0
+ 15: $t6 := !=($t5, $t13)
+ 16: goto 20
+ 17: label L1
+ 18: drop($t0)
+ 19: $t6 := false
+ 20: label L2
+ 21: return $t6
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public contains(Arg0: &vector<u8>, Arg1: u64): bool /* def_idx: 0 */ {
+L2:	loc0: u8
+L3:	loc1: &vector<u8>
+L4:	loc2: bool
+B0:
+	0: LdU8(1)
+	1: MoveLoc[1](Arg1: u64)
+	2: CastU8
+	3: Shl
+	4: StLoc[2](loc0: u8)
+	5: LdU64(0)
+	6: CopyLoc[0](Arg0: &vector<u8>)
+	7: VecLen(2)
+	8: Lt
+	9: BrFalse(20)
+B1:
+	10: MoveLoc[0](Arg0: &vector<u8>)
+	11: LdU64(0)
+	12: VecImmBorrow(2)
+	13: ReadRef
+	14: MoveLoc[2](loc0: u8)
+	15: BitAnd
+	16: LdU8(0)
+	17: Neq
+	18: StLoc[4](loc2: bool)
+	19: Branch(24)
+B2:
+	20: MoveLoc[0](Arg0: &vector<u8>)
+	21: Pop
+	22: LdFalse
+	23: StLoc[4](loc2: bool)
+B3:
+	24: MoveLoc[4](loc2: bool)
+	25: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_01.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_01.move
@@ -1,0 +1,14 @@
+module 0xc0ffee::m {
+    public fun test1(x: u64, z: u64) {
+        let y = &mut x;
+        *y = z;
+    }
+
+    public fun test2(x: u64) {
+        let a = &mut x;
+        *a = 2;
+        let b = &mut x;
+        *b = 3;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_01.off.exp
@@ -1,0 +1,254 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test1($t0: u64, $t1: u64) {
+     var $t2: &mut u64
+     # live vars: $t0, $t1
+  0: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  1: write_ref($t1, $t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: &mut u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t1 := borrow_local($t0)
+     # live vars: $t0, $t1
+  1: $t2 := 2
+     # live vars: $t0, $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars: $t0
+  3: $t3 := borrow_local($t0)
+     # live vars: $t3
+  4: $t4 := 3
+     # live vars: $t3, $t4
+  5: write_ref($t4, $t3)
+     # live vars:
+  6: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test1($t0: u64, $t1: u64) {
+     var $t2: &mut u64
+     # live vars: $t0, $t1
+  0: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  1: write_ref($t1, $t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: &mut u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t1 := borrow_local($t0)
+     # live vars: $t0, $t1
+  1: $t2 := 2
+     # live vars: $t0, $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars: $t0
+  3: $t3 := borrow_local($t0)
+     # live vars: $t3
+  4: $t4 := 3
+     # live vars: $t3, $t4
+  5: write_ref($t4, $t3)
+     # live vars:
+  6: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test1($t0: u64, $t1: u64) {
+     var $t2: &mut u64
+     # live vars: $t0, $t1
+  0: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  1: write_ref($t1, $t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: &mut u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t1 := borrow_local($t0)
+     # live vars: $t0, $t1
+  1: $t2 := 2
+     # live vars: $t0, $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars: $t0
+  3: $t3 := borrow_local($t0)
+     # live vars: $t3
+  4: $t4 := 3
+     # live vars: $t3, $t4
+  5: write_ref($t4, $t3)
+     # live vars:
+  6: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test1($t0: u64, $t1: u64) {
+     var $t2: &mut u64
+     # live vars: $t0, $t1
+  0: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  1: write_ref($t1, $t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: &mut u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t1 := borrow_local($t0)
+     # live vars: $t0, $t1
+  1: $t2 := 2
+     # live vars: $t0, $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars: $t0
+  3: $t3 := borrow_local($t0)
+     # live vars: $t3
+  4: $t4 := 3
+     # live vars: $t3, $t4
+  5: write_ref($t4, $t3)
+     # live vars:
+  6: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test1($t0: u64, $t1: u64) {
+     var $t2: &mut u64
+     # live vars: $t0, $t1
+  0: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  1: write_ref($t1, $t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: &mut u64
+     var $t2: u64
+     var $t3: &mut u64 [unused]
+     var $t4: u64 [unused]
+     # live vars: $t0
+  0: $t1 := borrow_local($t0)
+     # live vars: $t0, $t1
+  1: $t2 := 2
+     # live vars: $t0, $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars: $t0
+  3: $t1 := borrow_local($t0)
+     # live vars: $t1
+  4: $t2 := 3
+     # live vars: $t1, $t2
+  5: write_ref($t2, $t1)
+     # live vars:
+  6: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test1($t0: u64, $t1: u64) {
+     var $t2: &mut u64
+     # live vars: $t0, $t1
+  0: $t2 := borrow_local($t0)
+     # live vars: $t1, $t2
+  1: write_ref($t1, $t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: &mut u64
+     var $t2: u64
+     var $t3: &mut u64 [unused]
+     var $t4: u64 [unused]
+     # live vars: $t0
+  0: $t1 := borrow_local($t0)
+     # live vars: $t0, $t1
+  1: $t2 := 2
+     # live vars: $t0, $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars: $t0
+  3: $t1 := borrow_local($t0)
+     # live vars: $t1
+  4: $t2 := 3
+     # live vars: $t1, $t2
+  5: write_ref($t2, $t1)
+     # live vars:
+  6: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public test1(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+L2:	loc0: &mut u64
+B0:
+	0: MutBorrowLoc[0](Arg0: u64)
+	1: StLoc[2](loc0: &mut u64)
+	2: MoveLoc[1](Arg1: u64)
+	3: MoveLoc[2](loc0: &mut u64)
+	4: WriteRef
+	5: Ret
+}
+public test2(Arg0: u64) /* def_idx: 1 */ {
+L1:	loc0: u64
+L2:	loc1: &mut u64
+B0:
+	0: MutBorrowLoc[0](Arg0: u64)
+	1: LdU64(2)
+	2: StLoc[1](loc0: u64)
+	3: StLoc[2](loc1: &mut u64)
+	4: MoveLoc[1](loc0: u64)
+	5: MoveLoc[2](loc1: &mut u64)
+	6: WriteRef
+	7: MutBorrowLoc[0](Arg0: u64)
+	8: LdU64(3)
+	9: StLoc[1](loc0: u64)
+	10: StLoc[2](loc1: &mut u64)
+	11: MoveLoc[1](loc0: u64)
+	12: MoveLoc[2](loc1: &mut u64)
+	13: WriteRef
+	14: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_01.on.exp
@@ -1,0 +1,52 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+public fun m::test1($t0: u64, $t1: u64) {
+     var $t2: &mut u64
+  0: touch($t1)
+  1: $t2 := borrow_local($t0)
+  2: write_ref($t1, $t2)
+  3: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: &mut u64
+     var $t2: u64
+     var $t3: &mut u64 [unused]
+     var $t4: u64 [unused]
+  0: $t2 := 2
+  1: $t1 := borrow_local($t0)
+  2: write_ref($t2, $t1)
+  3: $t2 := 3
+  4: $t1 := borrow_local($t0)
+  5: write_ref($t2, $t1)
+  6: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public test1(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[1](Arg1: u64)
+	1: MutBorrowLoc[0](Arg0: u64)
+	2: WriteRef
+	3: Ret
+}
+public test2(Arg0: u64) /* def_idx: 1 */ {
+B0:
+	0: LdU64(2)
+	1: MutBorrowLoc[0](Arg0: u64)
+	2: WriteRef
+	3: LdU64(3)
+	4: MutBorrowLoc[0](Arg0: u64)
+	5: WriteRef
+	6: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_02.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_02.move
@@ -1,0 +1,8 @@
+module 0xc0ffee::m {
+    public fun test(p: u64): u64 {
+        let a = p;
+        let b = &mut p;
+        *b = 1;
+        a
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_02.off.exp
@@ -1,0 +1,155 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t2 := infer($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_local($t0)
+     # live vars: $t2, $t3
+  2: $t4 := 1
+     # live vars: $t2, $t3, $t4
+  3: write_ref($t4, $t3)
+     # live vars: $t2
+  4: $t1 := infer($t2)
+     # live vars: $t1
+  5: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t2 := infer($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_local($t0)
+     # live vars: $t2, $t3
+  2: $t4 := 1
+     # live vars: $t2, $t3, $t4
+  3: write_ref($t4, $t3)
+     # live vars: $t2
+  4: $t1 := infer($t2)
+     # live vars: $t1
+  5: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_local($t0)
+     # live vars: $t2, $t3
+  2: $t4 := 1
+     # live vars: $t2, $t3, $t4
+  3: write_ref($t4, $t3)
+     # live vars: $t2
+  4: $t1 := move($t2)
+     # live vars: $t1
+  5: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_local($t0)
+     # live vars: $t2, $t3
+  2: $t4 := 1
+     # live vars: $t2, $t3, $t4
+  3: write_ref($t4, $t3)
+     # live vars: $t2
+  4: $t1 := move($t2)
+     # live vars: $t1
+  5: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_local($t0)
+     # live vars: $t2, $t3
+  2: $t4 := 1
+     # live vars: $t2, $t3, $t4
+  3: write_ref($t4, $t3)
+     # live vars: $t2
+  4: $t2 := move($t2)
+     # live vars: $t2
+  5: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_local($t0)
+     # live vars: $t2, $t3
+  2: $t4 := 1
+     # live vars: $t2, $t3, $t4
+  3: write_ref($t4, $t3)
+     # live vars: $t2
+  4: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public test(Arg0: u64): u64 /* def_idx: 0 */ {
+L1:	loc0: u64
+L2:	loc1: u64
+L3:	loc2: &mut u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: MutBorrowLoc[0](Arg0: u64)
+	3: LdU64(1)
+	4: StLoc[2](loc1: u64)
+	5: StLoc[3](loc2: &mut u64)
+	6: MoveLoc[2](loc1: u64)
+	7: MoveLoc[3](loc2: &mut u64)
+	8: WriteRef
+	9: MoveLoc[1](loc0: u64)
+	10: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_02.on.exp
@@ -1,0 +1,34 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+  0: $t2 := copy($t0)
+  1: $t4 := 1
+  2: $t3 := borrow_local($t0)
+  3: write_ref($t4, $t3)
+  4: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public test(Arg0: u64): u64 /* def_idx: 0 */ {
+L1:	loc0: u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: LdU64(1)
+	3: MutBorrowLoc[0](Arg0: u64)
+	4: WriteRef
+	5: MoveLoc[1](loc0: u64)
+	6: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_03.move
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_03.move
@@ -1,0 +1,13 @@
+module 0xc0ffee::m {
+    fun foo(y: u64, x: &mut u64) {
+        *x = y;
+    }
+
+    public fun test(): u64 {
+        let x = 0;
+        foo(3, &mut x);
+        foo(4, &mut x);
+        x
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_03.off.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_03.off.exp
@@ -1,0 +1,264 @@
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: &mut u64) {
+     # live vars: $t0, $t1
+  0: write_ref($t0, $t1)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+     var $t5: &mut u64
+     # live vars:
+  0: $t1 := 0
+     # live vars: $t1
+  1: $t2 := 3
+     # live vars: $t1, $t2
+  2: $t3 := borrow_local($t1)
+     # live vars: $t1, $t2, $t3
+  3: m::foo($t2, $t3)
+     # live vars: $t1
+  4: $t4 := 4
+     # live vars: $t1, $t4
+  5: $t5 := borrow_local($t1)
+     # live vars: $t1, $t4, $t5
+  6: m::foo($t4, $t5)
+     # live vars: $t1
+  7: $t0 := infer($t1)
+     # live vars: $t0
+  8: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: &mut u64) {
+     # live vars: $t0, $t1
+  0: write_ref($t0, $t1)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+     var $t5: &mut u64
+     # live vars:
+  0: $t1 := 0
+     # live vars: $t1
+  1: $t2 := 3
+     # live vars: $t1, $t2
+  2: $t3 := borrow_local($t1)
+     # live vars: $t1, $t2, $t3
+  3: m::foo($t2, $t3)
+     # live vars: $t1
+  4: $t4 := 4
+     # live vars: $t1, $t4
+  5: $t5 := borrow_local($t1)
+     # live vars: $t1, $t4, $t5
+  6: m::foo($t4, $t5)
+     # live vars: $t1
+  7: $t0 := infer($t1)
+     # live vars: $t0
+  8: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: &mut u64) {
+     # live vars: $t0, $t1
+  0: write_ref($t0, $t1)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+     var $t5: &mut u64
+     # live vars:
+  0: $t1 := 0
+     # live vars: $t1
+  1: $t2 := 3
+     # live vars: $t1, $t2
+  2: $t3 := borrow_local($t1)
+     # live vars: $t1, $t2, $t3
+  3: m::foo($t2, $t3)
+     # live vars: $t1
+  4: $t4 := 4
+     # live vars: $t1, $t4
+  5: $t5 := borrow_local($t1)
+     # live vars: $t1, $t4, $t5
+  6: m::foo($t4, $t5)
+     # live vars: $t1
+  7: $t0 := move($t1)
+     # live vars: $t0
+  8: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: &mut u64) {
+     # live vars: $t0, $t1
+  0: write_ref($t0, $t1)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64
+     var $t5: &mut u64
+     # live vars:
+  0: $t1 := 0
+     # live vars: $t1
+  1: $t2 := 3
+     # live vars: $t1, $t2
+  2: $t3 := borrow_local($t1)
+     # live vars: $t1, $t2, $t3
+  3: m::foo($t2, $t3)
+     # live vars: $t1
+  4: $t4 := 4
+     # live vars: $t1, $t4
+  5: $t5 := borrow_local($t1)
+     # live vars: $t1, $t4, $t5
+  6: m::foo($t4, $t5)
+     # live vars: $t1
+  7: $t0 := move($t1)
+     # live vars: $t0
+  8: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: &mut u64) {
+     # live vars: $t0, $t1
+  0: write_ref($t0, $t1)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64 [unused]
+     var $t5: &mut u64 [unused]
+     # live vars:
+  0: $t1 := 0
+     # live vars: $t1
+  1: $t2 := 3
+     # live vars: $t1, $t2
+  2: $t3 := borrow_local($t1)
+     # live vars: $t1, $t2, $t3
+  3: m::foo($t2, $t3)
+     # live vars: $t1
+  4: $t2 := 4
+     # live vars: $t1, $t2
+  5: $t3 := borrow_local($t1)
+     # live vars: $t1, $t2, $t3
+  6: m::foo($t2, $t3)
+     # live vars: $t1
+  7: $t2 := move($t1)
+     # live vars: $t2
+  8: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: &mut u64) {
+     # live vars: $t0, $t1
+  0: write_ref($t0, $t1)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64 [unused]
+     var $t5: &mut u64 [unused]
+     # live vars:
+  0: $t1 := 0
+     # live vars: $t1
+  1: $t2 := 3
+     # live vars: $t1, $t2
+  2: $t3 := borrow_local($t1)
+     # live vars: $t1, $t2, $t3
+  3: m::foo($t2, $t3)
+     # live vars: $t1
+  4: $t2 := 4
+     # live vars: $t1, $t2
+  5: $t3 := borrow_local($t1)
+     # live vars: $t1, $t2, $t3
+  6: m::foo($t2, $t3)
+     # live vars: $t1
+  7: $t2 := move($t1)
+     # live vars: $t2
+  8: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+foo(Arg0: u64, Arg1: &mut u64) /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: MoveLoc[1](Arg1: &mut u64)
+	2: WriteRef
+	3: Ret
+}
+public test(): u64 /* def_idx: 1 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: LdU64(0)
+	1: StLoc[0](loc0: u64)
+	2: LdU64(3)
+	3: MutBorrowLoc[0](loc0: u64)
+	4: Call foo(u64, &mut u64)
+	5: LdU64(4)
+	6: MutBorrowLoc[0](loc0: u64)
+	7: Call foo(u64, &mut u64)
+	8: MoveLoc[0](loc0: u64)
+	9: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_03.on.exp
+++ b/third_party/move/move-compiler-v2/tests/instruction-reordering/write_ref_03.on.exp
@@ -1,0 +1,59 @@
+============ after InstructionReorderingProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64, $t1: &mut u64) {
+  0: touch($t0)
+  1: write_ref($t0, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+public fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64
+     var $t3: &mut u64
+     var $t4: u64 [unused]
+     var $t5: &mut u64 [unused]
+  0: $t2 := 3
+  1: $t1 := 0
+  2: $t3 := borrow_local($t1)
+  3: m::foo($t2, $t3)
+  4: $t2 := 4
+  5: $t3 := borrow_local($t1)
+  6: m::foo($t2, $t3)
+  7: $t2 := move($t1)
+  8: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+foo(Arg0: u64, Arg1: &mut u64) /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: MoveLoc[1](Arg1: &mut u64)
+	2: WriteRef
+	3: Ret
+}
+public test(): u64 /* def_idx: 1 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: LdU64(3)
+	1: LdU64(0)
+	2: StLoc[0](loc0: u64)
+	3: MutBorrowLoc[0](loc0: u64)
+	4: Call foo(u64, &mut u64)
+	5: LdU64(4)
+	6: MutBorrowLoc[0](loc0: u64)
+	7: Call foo(u64, &mut u64)
+	8: MoveLoc[0](loc0: u64)
+	9: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13927.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13927.exp
@@ -1,9 +1,9 @@
 
-============ bytecode verification failed ========
-
 Diagnostics:
-bug: bytecode verification failed with unexpected status code `FREEZEREF_EXISTS_MUTABLE_BORROW_ERROR`. This is a compiler bug, consider reporting it.
-  ┌─ tests/reference-safety/bug_13927.move:9:28
-  │
-9 │         let returned_ref = foo(result);
-  │                            ^^^^^^^^^^^
+error: cannot freeze local `result` since other mutable usages for this reference exist
+   ┌─ tests/reference-safety/bug_13927.move:10:9
+   │
+10 │         freeze(result);
+   │         ^^^^^^^^^^^^^^ frozen here
+11 │         returned_ref
+   │         ------------ used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13927.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13927.no-opt.exp
@@ -1,9 +1,9 @@
 
-============ bytecode verification failed ========
-
 Diagnostics:
-bug: bytecode verification failed with unexpected status code `FREEZEREF_EXISTS_MUTABLE_BORROW_ERROR`. This is a compiler bug, consider reporting it.
+error: cannot freeze local `result` since other mutable usages for this reference exist
    ┌─ tests/reference-safety/bug_13927.move:10:9
    │
 10 │         freeze(result);
-   │         ^^^^^^^^^^^^^^
+   │         ^^^^^^^^^^^^^^ frozen here
+11 │         returned_ref
+   │         ------------ used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/bug_13952.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/bug_13952.no-opt.exp
@@ -15,11 +15,4 @@ warning: Unused assignment to `var67`. Consider removing or prefixing with an un
   │                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
-============ bytecode verification failed ========
-
-Diagnostics:
-bug: bytecode verification failed with unexpected status code `STLOC_UNSAFE_TO_DESTROY_ERROR`. This is a compiler bug, consider reporting it.
-  ┌─ tests/reference-safety/bug_13952.move:8:36
-  │
-8 │         let var67 =  (&(var21) != &((var21 || var23)));
-  │                                    ^^^^^^^^^^^^^^^^^^
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -457,6 +457,68 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
                 FILE_FORMAT_STAGE,
             ]),
         },
+        // Instruction reordering tests
+        TestConfig {
+            name: "instruction-reordering-on",
+            runner: |p| run_test(p, get_config_by_name("instruction-reordering-on")),
+            include: vec!["/instruction-reordering/"],
+            exclude: vec![],
+            exp_suffix: Some("on.exp"),
+            options: opts
+                .clone()
+                .set_experiment(Experiment::INSTRUCTION_REORDERING, true)
+                .set_experiment(Experiment::FLUSH_WRITES_OPTIMIZATION, true),
+            stop_after: StopAfter::FileFormat,
+            dump_ast: DumpLevel::None,
+            dump_bytecode: DumpLevel::AllStages,
+            dump_bytecode_filter: Some(vec!["InstructionReorderingProcessor", FILE_FORMAT_STAGE]),
+        },
+        TestConfig {
+            name: "instruction-reordering-off",
+            runner: |p| run_test(p, get_config_by_name("instruction-reordering-off")),
+            include: vec!["/instruction-reordering/"],
+            exclude: vec![],
+            exp_suffix: Some("off.exp"),
+            options: opts
+                .clone()
+                .set_experiment(Experiment::INSTRUCTION_REORDERING, false)
+                .set_experiment(Experiment::FLUSH_WRITES_OPTIMIZATION, false),
+            stop_after: StopAfter::FileFormat,
+            dump_ast: DumpLevel::None,
+            dump_bytecode: DumpLevel::AllStages,
+            dump_bytecode_filter: Some(vec!["LiveVarAnalysisProcessor", FILE_FORMAT_STAGE]),
+        },
+        // Flush writes processor tests
+        TestConfig {
+            name: "flush-writes-on",
+            runner: |p| run_test(p, get_config_by_name("flush-writes-on")),
+            include: vec!["/flush-writes/"],
+            exclude: vec![],
+            exp_suffix: Some("on.exp"),
+            options: opts
+                .clone()
+                .set_experiment(Experiment::INSTRUCTION_REORDERING, true)
+                .set_experiment(Experiment::FLUSH_WRITES_OPTIMIZATION, true),
+            stop_after: StopAfter::FileFormat,
+            dump_ast: DumpLevel::None,
+            dump_bytecode: DumpLevel::AllStages,
+            dump_bytecode_filter: Some(vec!["FlushWritesProcessor", FILE_FORMAT_STAGE]),
+        },
+        TestConfig {
+            name: "flush-writes-off",
+            runner: |p| run_test(p, get_config_by_name("flush-writes-off")),
+            include: vec!["/flush-writes/"],
+            exclude: vec![],
+            exp_suffix: Some("off.exp"),
+            options: opts
+                .clone()
+                .set_experiment(Experiment::INSTRUCTION_REORDERING, false)
+                .set_experiment(Experiment::FLUSH_WRITES_OPTIMIZATION, false),
+            stop_after: StopAfter::FileFormat,
+            dump_ast: DumpLevel::None,
+            dump_bytecode: DumpLevel::AllStages,
+            dump_bytecode_filter: Some(vec![FILE_FORMAT_STAGE]),
+        },
         // Unreachable code remover
         TestConfig {
             name: "unreachable-code",

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.exp
@@ -160,7 +160,6 @@ B0:
 }
 public test(Arg0: u64): u64 /* def_idx: 1 */ {
 L1:	loc0: u64
-L2:	loc1: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.opt.exp
@@ -160,7 +160,6 @@ B0:
 }
 public test(Arg0: u64): u64 /* def_idx: 1 */ {
 L1:	loc0: u64
-L2:	loc1: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.exp
@@ -127,7 +127,6 @@ module c0ffee.m {
 
 
 foo(Arg0: bool, Arg1: u64): u64 /* def_idx: 0 */ {
-L2:	loc0: u64
 B0:
 	0: MoveLoc[0](Arg0: bool)
 	1: BrFalse(5)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.opt.exp
@@ -127,7 +127,6 @@ module c0ffee.m {
 
 
 foo(Arg0: bool, Arg1: u64): u64 /* def_idx: 0 */ {
-L2:	loc0: u64
 B0:
 	0: MoveLoc[0](Arg0: bool)
 	1: BrFalse(5)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.exp
@@ -237,7 +237,6 @@ script {
 
 main() /* def_idx: 0 */ {
 L0:	loc0: u64
-L1:	loc1: u64
 B0:
 	0: LdTrue
 	1: BrFalse(5)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.opt.exp
@@ -237,7 +237,6 @@ script {
 
 main() /* def_idx: 0 */ {
 L0:	loc0: u64
-L1:	loc1: u64
 B0:
 	0: LdTrue
 	1: BrFalse(5)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.exp
@@ -217,7 +217,6 @@ module 32.m {
 
 main() /* def_idx: 0 */ {
 L0:	loc0: u64
-L1:	loc1: u64
 B0:
 	0: LdU64(0)
 	1: StLoc[0](loc0: u64)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.opt.exp
@@ -217,7 +217,6 @@ module 32.m {
 
 main() /* def_idx: 0 */ {
 L0:	loc0: u64
-L1:	loc1: u64
 B0:
 	0: LdU64(0)
 	1: StLoc[0](loc0: u64)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.exp
@@ -4,7 +4,7 @@
 fun m::update($t0: &mut u64) {
      var $t1: u64
   0: $t1 := 0
-  1: write_ref($t0, $t1)
+  1: write_ref($t1, $t0)
   2: return ()
 }
 
@@ -31,7 +31,7 @@ fun m::test($t0: u64): u64 {
 fun m::update($t0: &mut u64) {
      var $t1: u64
   0: $t1 := 0
-  1: write_ref($t0, $t1)
+  1: write_ref($t1, $t0)
   2: return ()
 }
 
@@ -62,7 +62,7 @@ fun m::update($t0: &mut u64) {
   0: $t1 := 0
      # live vars: $t0, $t1
      # events: e:$t0, e:$t1
-  1: write_ref($t0, $t1)
+  1: write_ref($t1, $t0)
      # live vars:
   2: return ()
 }
@@ -104,7 +104,7 @@ fun m::test($t0: u64): u64 {
 fun m::update($t0: &mut u64) {
      var $t1: u64
   0: $t1 := 0
-  1: write_ref($t0, $t1)
+  1: write_ref($t1, $t0)
   2: return ()
 }
 
@@ -131,7 +131,7 @@ fun m::test($t0: u64): u64 {
 fun m::update($t0: &mut u64) {
      var $t1: u64
   0: $t1 := 0
-  1: write_ref($t0, $t1)
+  1: write_ref($t1, $t0)
   2: return ()
 }
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.opt.exp
@@ -4,7 +4,7 @@
 fun m::update($t0: &mut u64) {
      var $t1: u64
   0: $t1 := 0
-  1: write_ref($t0, $t1)
+  1: write_ref($t1, $t0)
   2: return ()
 }
 
@@ -31,7 +31,7 @@ fun m::test($t0: u64): u64 {
 fun m::update($t0: &mut u64) {
      var $t1: u64
   0: $t1 := 0
-  1: write_ref($t0, $t1)
+  1: write_ref($t1, $t0)
   2: return ()
 }
 
@@ -62,7 +62,7 @@ fun m::update($t0: &mut u64) {
   0: $t1 := 0
      # live vars: $t0, $t1
      # events: e:$t0, e:$t1
-  1: write_ref($t0, $t1)
+  1: write_ref($t1, $t0)
      # live vars:
   2: return ()
 }
@@ -104,7 +104,7 @@ fun m::test($t0: u64): u64 {
 fun m::update($t0: &mut u64) {
      var $t1: u64
   0: $t1 := 0
-  1: write_ref($t0, $t1)
+  1: write_ref($t1, $t0)
   2: return ()
 }
 
@@ -131,7 +131,7 @@ fun m::test($t0: u64): u64 {
 fun m::update($t0: &mut u64) {
      var $t1: u64
   0: $t1 := 0
-  1: write_ref($t0, $t1)
+  1: write_ref($t1, $t0)
   2: return ()
 }
 

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.exp
@@ -93,16 +93,13 @@ module c0ffee.m {
 
 
 public test(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: MoveLoc[0](Arg0: u64)
 	2: Add
-	3: LdU64(2)
-	4: StLoc[1](loc0: u64)
-	5: Pop
-	6: MoveLoc[1](loc0: u64)
-	7: Ret
+	3: Pop
+	4: LdU64(2)
+	5: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.opt.exp
@@ -82,16 +82,13 @@ module c0ffee.m {
 
 
 public test(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: MoveLoc[0](Arg0: u64)
 	2: Add
-	3: LdU64(2)
-	4: StLoc[1](loc0: u64)
-	5: Pop
-	6: MoveLoc[1](loc0: u64)
-	7: Ret
+	3: Pop
+	4: LdU64(2)
+	5: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.exp
@@ -188,7 +188,6 @@ B0:
 	0: Ret
 }
 test(Arg0: u64, Arg1: bool) /* def_idx: 1 */ {
-L2:	loc0: u64
 B0:
 	0: MoveLoc[1](Arg1: bool)
 	1: BrFalse(5)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.opt.exp
@@ -188,7 +188,6 @@ B0:
 	0: Ret
 }
 test(Arg0: u64, Arg1: bool) /* def_idx: 1 */ {
-L2:	loc0: u64
 B0:
 	0: MoveLoc[1](Arg1: bool)
 	1: BrFalse(5)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.exp
@@ -141,7 +141,6 @@ module c0ffee.m {
 test(Arg0: bool): u64 /* def_idx: 0 */ {
 L1:	loc0: u64
 L2:	loc1: u64
-L3:	loc2: u64
 B0:
 	0: LdU64(2)
 	1: StLoc[1](loc0: u64)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.exp
@@ -315,12 +315,10 @@ public test1(Arg0: u64) /* def_idx: 2 */ {
 L1:	loc0: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: u64)
-	2: MoveLoc[0](Arg0: u64)
+	1: Call consume(u64)
+	2: CopyLoc[0](Arg0: u64)
 	3: Call consume(u64)
-	4: MoveLoc[1](loc0: u64)
-	5: Call consume(u64)
-	6: Ret
+	4: Ret
 }
 public test2(Arg0: u64) /* def_idx: 3 */ {
 L1:	loc0: u64
@@ -335,12 +333,10 @@ public test3(Arg0: W) /* def_idx: 4 */ {
 L1:	loc0: W
 B0:
 	0: CopyLoc[0](Arg0: W)
-	1: StLoc[1](loc0: W)
-	2: MoveLoc[0](Arg0: W)
+	1: Call consume_(W)
+	2: CopyLoc[0](Arg0: W)
 	3: Call consume_(W)
-	4: MoveLoc[1](loc0: W)
-	5: Call consume_(W)
-	6: Ret
+	4: Ret
 }
 public test4(Arg0: W) /* def_idx: 5 */ {
 L1:	loc0: W

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.opt.exp
@@ -315,12 +315,10 @@ public test1(Arg0: u64) /* def_idx: 2 */ {
 L1:	loc0: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: u64)
-	2: MoveLoc[0](Arg0: u64)
+	1: Call consume(u64)
+	2: CopyLoc[0](Arg0: u64)
 	3: Call consume(u64)
-	4: MoveLoc[1](loc0: u64)
-	5: Call consume(u64)
-	6: Ret
+	4: Ret
 }
 public test2(Arg0: u64) /* def_idx: 3 */ {
 L1:	loc0: u64
@@ -335,12 +333,10 @@ public test3(Arg0: W) /* def_idx: 4 */ {
 L1:	loc0: W
 B0:
 	0: CopyLoc[0](Arg0: W)
-	1: StLoc[1](loc0: W)
-	2: MoveLoc[0](Arg0: W)
+	1: Call consume_(W)
+	2: CopyLoc[0](Arg0: W)
 	3: Call consume_(W)
-	4: MoveLoc[1](loc0: W)
-	5: Call consume_(W)
-	6: Ret
+	4: Ret
 }
 public test4(Arg0: W) /* def_idx: 5 */ {
 L1:	loc0: W

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.exp
@@ -331,7 +331,6 @@ B5:
 	13: Ret
 }
 public test2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
-L2:	loc0: u64
 B0:
 	0: LdU64(0)
 	1: StLoc[1](Arg1: u64)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.opt.exp
@@ -331,7 +331,6 @@ B5:
 	13: Ret
 }
 public test2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
-L2:	loc0: u64
 B0:
 	0: LdU64(0)
 	1: StLoc[1](Arg1: u64)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.exp
@@ -119,13 +119,11 @@ B0:
 	2: StLoc[0](loc0: u64)
 	3: CopyLoc[0](loc0: u64)
 	4: Add
-	5: CopyLoc[0](loc0: u64)
-	6: MoveLoc[0](loc0: u64)
-	7: Add
-	8: StLoc[0](loc0: u64)
-	9: Pop
-	10: MoveLoc[0](loc0: u64)
-	11: Ret
+	5: Pop
+	6: CopyLoc[0](loc0: u64)
+	7: MoveLoc[0](loc0: u64)
+	8: Add
+	9: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.opt.exp
@@ -99,16 +99,13 @@ module c0ffee.m {
 
 
 test(): u64 /* def_idx: 0 */ {
-L0:	loc0: u64
 B0:
 	0: LdU64(1)
 	1: LdU64(2)
 	2: Add
-	3: LdU64(4)
-	4: StLoc[0](loc0: u64)
-	5: Pop
-	6: MoveLoc[0](loc0: u64)
-	7: Ret
+	3: Pop
+	4: LdU64(4)
+	5: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.exp
@@ -121,21 +121,13 @@ module c0ffee.m {
 
 test(): u64 /* def_idx: 0 */ {
 L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
 B0:
-	0: LdU64(1)
-	1: LdU64(2)
+	0: LdU64(2)
+	1: LdU64(1)
 	2: LdU64(1)
-	3: StLoc[0](loc0: u64)
-	4: StLoc[1](loc1: u64)
-	5: MoveLoc[0](loc0: u64)
-	6: Add
-	7: StLoc[2](loc2: u64)
-	8: MoveLoc[1](loc1: u64)
-	9: MoveLoc[2](loc2: u64)
-	10: Add
-	11: Ret
+	3: Add
+	4: Add
+	5: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.exp
@@ -121,20 +121,13 @@ module c0ffee.m {
 
 
 test(): u64 /* def_idx: 0 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
 B0:
 	0: LdU64(1)
-	1: LdU64(2)
-	2: LdU64(1)
-	3: StLoc[0](loc0: u64)
-	4: StLoc[1](loc1: u64)
-	5: MoveLoc[0](loc0: u64)
-	6: Add
-	7: Pop
-	8: MoveLoc[1](loc1: u64)
-	9: Ret
+	1: LdU64(1)
+	2: Add
+	3: Pop
+	4: LdU64(2)
+	5: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.opt.exp
@@ -99,16 +99,13 @@ module c0ffee.m {
 
 
 test(): u64 /* def_idx: 0 */ {
-L0:	loc0: u64
 B0:
 	0: LdU64(1)
 	1: LdU64(1)
 	2: Add
-	3: LdU64(2)
-	4: StLoc[0](loc0: u64)
-	5: Pop
-	6: MoveLoc[0](loc0: u64)
-	7: Ret
+	3: Pop
+	4: LdU64(2)
+	5: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.exp
@@ -196,31 +196,30 @@ module c0ffee.m {
 test(Arg0: u64): u64 /* def_idx: 0 */ {
 L1:	loc0: u64
 L2:	loc1: u64
-L3:	loc2: u64
 B0:
 	0: LdU64(0)
-	1: LdU64(0)
-	2: StLoc[1](loc0: u64)
+	1: StLoc[1](loc0: u64)
+	2: LdU64(0)
 	3: StLoc[2](loc1: u64)
 B1:
-	4: CopyLoc[1](loc0: u64)
+	4: CopyLoc[2](loc1: u64)
 	5: LdU64(10)
 	6: Lt
 	7: BrFalse(15)
 B2:
 	8: CopyLoc[0](Arg0: u64)
-	9: StLoc[2](loc1: u64)
-	10: MoveLoc[1](loc0: u64)
+	9: StLoc[1](loc0: u64)
+	10: MoveLoc[2](loc1: u64)
 	11: LdU64(1)
 	12: Add
-	13: StLoc[1](loc0: u64)
+	13: StLoc[2](loc1: u64)
 	14: Branch(16)
 B3:
 	15: Branch(17)
 B4:
 	16: Branch(4)
 B5:
-	17: MoveLoc[2](loc1: u64)
+	17: MoveLoc[1](loc0: u64)
 	18: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.opt.exp
@@ -196,31 +196,30 @@ module c0ffee.m {
 test(Arg0: u64): u64 /* def_idx: 0 */ {
 L1:	loc0: u64
 L2:	loc1: u64
-L3:	loc2: u64
 B0:
 	0: LdU64(0)
-	1: LdU64(0)
-	2: StLoc[1](loc0: u64)
+	1: StLoc[1](loc0: u64)
+	2: LdU64(0)
 	3: StLoc[2](loc1: u64)
 B1:
-	4: CopyLoc[1](loc0: u64)
+	4: CopyLoc[2](loc1: u64)
 	5: LdU64(10)
 	6: Lt
 	7: BrFalse(15)
 B2:
 	8: CopyLoc[0](Arg0: u64)
-	9: StLoc[2](loc1: u64)
-	10: MoveLoc[1](loc0: u64)
+	9: StLoc[1](loc0: u64)
+	10: MoveLoc[2](loc1: u64)
 	11: LdU64(1)
 	12: Add
-	13: StLoc[1](loc0: u64)
+	13: StLoc[2](loc1: u64)
 	14: Branch(16)
 B3:
 	15: Branch(17)
 B4:
 	16: Branch(4)
 B5:
-	17: MoveLoc[2](loc1: u64)
+	17: MoveLoc[1](loc0: u64)
 	18: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.exp
@@ -196,7 +196,6 @@ module c0ffee.m {
 test(Arg0: u64): u64 /* def_idx: 0 */ {
 L1:	loc0: u64
 L2:	loc1: u64
-L3:	loc2: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.opt.exp
@@ -196,7 +196,6 @@ module c0ffee.m {
 test(Arg0: u64): u64 /* def_idx: 0 */ {
 L1:	loc0: u64
 L2:	loc1: u64
-L3:	loc2: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.exp
@@ -9,7 +9,7 @@ fun m::test($t0: u64): u64 {
   0: $t2 := infer($t0)
   1: $t3 := borrow_local($t0)
   2: $t4 := 1
-  3: write_ref($t3, $t4)
+  3: write_ref($t4, $t3)
   4: $t1 := infer($t2)
   5: return $t1
 }
@@ -25,7 +25,7 @@ fun m::test($t0: u64): u64 {
   0: $t2 := copy($t0)
   1: $t3 := borrow_local($t0)
   2: $t4 := 1
-  3: write_ref($t3, $t4)
+  3: write_ref($t4, $t3)
   4: $t1 := move($t2)
   5: return $t1
 }
@@ -49,7 +49,7 @@ fun m::test($t0: u64): u64 {
   2: $t4 := 1
      # live vars: $t2, $t3, $t4
      # events: e:$t3, e:$t4
-  3: write_ref($t3, $t4)
+  3: write_ref($t4, $t3)
      # live vars: $t2
      # events: e:$t2, b:$t1
   4: $t1 := move($t2)
@@ -69,7 +69,7 @@ fun m::test($t0: u64): u64 {
   0: $t2 := copy($t0)
   1: $t3 := borrow_local($t0)
   2: $t4 := 1
-  3: write_ref($t3, $t4)
+  3: write_ref($t4, $t3)
   4: $t2 := move($t2)
   5: return $t2
 }
@@ -85,7 +85,7 @@ fun m::test($t0: u64): u64 {
   0: $t2 := copy($t0)
   1: $t3 := borrow_local($t0)
   2: $t4 := 1
-  3: write_ref($t3, $t4)
+  3: write_ref($t4, $t3)
   4: return $t2
 }
 
@@ -97,20 +97,14 @@ module c0ffee.m {
 
 test(Arg0: u64): u64 /* def_idx: 0 */ {
 L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: &mut u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)
-	2: MutBorrowLoc[0](Arg0: u64)
-	3: LdU64(1)
-	4: StLoc[2](loc1: u64)
-	5: StLoc[3](loc2: &mut u64)
-	6: MoveLoc[2](loc1: u64)
-	7: MoveLoc[3](loc2: &mut u64)
-	8: WriteRef
-	9: MoveLoc[1](loc0: u64)
-	10: Ret
+	2: LdU64(1)
+	3: MutBorrowLoc[0](Arg0: u64)
+	4: WriteRef
+	5: MoveLoc[1](loc0: u64)
+	6: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.opt.exp
@@ -9,7 +9,7 @@ fun m::test($t0: u64): u64 {
   0: $t2 := infer($t0)
   1: $t3 := borrow_local($t0)
   2: $t4 := 1
-  3: write_ref($t3, $t4)
+  3: write_ref($t4, $t3)
   4: $t1 := infer($t2)
   5: return $t1
 }
@@ -25,7 +25,7 @@ fun m::test($t0: u64): u64 {
   0: $t2 := copy($t0)
   1: $t3 := borrow_local($t0)
   2: $t4 := 1
-  3: write_ref($t3, $t4)
+  3: write_ref($t4, $t3)
   4: $t1 := move($t2)
   5: return $t1
 }
@@ -49,7 +49,7 @@ fun m::test($t0: u64): u64 {
   2: $t4 := 1
      # live vars: $t2, $t3, $t4
      # events: e:$t3, e:$t4
-  3: write_ref($t3, $t4)
+  3: write_ref($t4, $t3)
      # live vars: $t2
      # events: e:$t2, b:$t1
   4: $t1 := move($t2)
@@ -69,7 +69,7 @@ fun m::test($t0: u64): u64 {
   0: $t2 := copy($t0)
   1: $t3 := borrow_local($t0)
   2: $t4 := 1
-  3: write_ref($t3, $t4)
+  3: write_ref($t4, $t3)
   4: $t2 := move($t2)
   5: return $t2
 }
@@ -85,7 +85,7 @@ fun m::test($t0: u64): u64 {
   0: $t2 := copy($t0)
   1: $t3 := borrow_local($t0)
   2: $t4 := 1
-  3: write_ref($t3, $t4)
+  3: write_ref($t4, $t3)
   4: return $t2
 }
 
@@ -97,20 +97,14 @@ module c0ffee.m {
 
 test(Arg0: u64): u64 /* def_idx: 0 */ {
 L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: &mut u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)
-	2: MutBorrowLoc[0](Arg0: u64)
-	3: LdU64(1)
-	4: StLoc[2](loc1: u64)
-	5: StLoc[3](loc2: &mut u64)
-	6: MoveLoc[2](loc1: u64)
-	7: MoveLoc[3](loc2: &mut u64)
-	8: WriteRef
-	9: MoveLoc[1](loc0: u64)
-	10: Ret
+	2: LdU64(1)
+	3: MutBorrowLoc[0](Arg0: u64)
+	4: WriteRef
+	5: MoveLoc[1](loc0: u64)
+	6: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.exp
@@ -15,7 +15,7 @@ fun m::test($t0: m::S): u64 {
   2: $t5 := borrow_local($t2)
   3: $t4 := borrow_field<m::S>.a($t5)
   4: $t6 := 0
-  5: write_ref($t4, $t6)
+  5: write_ref($t6, $t4)
   6: $t7 := borrow_local($t3)
   7: $t8 := borrow_field<m::S>.a($t7)
   8: $t1 := read_ref($t8)
@@ -39,7 +39,7 @@ fun m::test($t0: m::S): u64 {
   2: $t5 := borrow_local($t2)
   3: $t4 := borrow_field<m::S>.a($t5)
   4: $t6 := 0
-  5: write_ref($t4, $t6)
+  5: write_ref($t6, $t4)
   6: $t7 := borrow_local($t3)
   7: $t8 := borrow_field<m::S>.a($t7)
   8: $t1 := read_ref($t8)
@@ -74,7 +74,7 @@ fun m::test($t0: m::S): u64 {
   4: $t6 := 0
      # live vars: $t3, $t4, $t6
      # events: e:$t4, e:$t6
-  5: write_ref($t4, $t6)
+  5: write_ref($t6, $t4)
      # live vars: $t3
      # events: b:$t7
   6: $t7 := borrow_local($t3)
@@ -106,7 +106,7 @@ fun m::test($t0: m::S): u64 {
   2: $t5 := borrow_local($t2)
   3: $t4 := borrow_field<m::S>.a($t5)
   4: $t6 := 0
-  5: write_ref($t4, $t6)
+  5: write_ref($t6, $t4)
   6: $t7 := borrow_local($t3)
   7: $t8 := borrow_field<m::S>.a($t7)
   8: $t6 := read_ref($t8)
@@ -130,7 +130,7 @@ fun m::test($t0: m::S): u64 {
   2: $t5 := borrow_local($t2)
   3: $t4 := borrow_field<m::S>.a($t5)
   4: $t6 := 0
-  5: write_ref($t4, $t6)
+  5: write_ref($t6, $t4)
   6: $t7 := borrow_local($t3)
   7: $t8 := borrow_field<m::S>.a($t7)
   8: $t6 := read_ref($t8)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.opt.exp
@@ -15,7 +15,7 @@ fun m::test($t0: m::S): u64 {
   2: $t5 := borrow_local($t2)
   3: $t4 := borrow_field<m::S>.a($t5)
   4: $t6 := 0
-  5: write_ref($t4, $t6)
+  5: write_ref($t6, $t4)
   6: $t7 := borrow_local($t3)
   7: $t8 := borrow_field<m::S>.a($t7)
   8: $t1 := read_ref($t8)
@@ -39,7 +39,7 @@ fun m::test($t0: m::S): u64 {
   2: $t5 := borrow_local($t2)
   3: $t4 := borrow_field<m::S>.a($t5)
   4: $t6 := 0
-  5: write_ref($t4, $t6)
+  5: write_ref($t6, $t4)
   6: $t7 := borrow_local($t3)
   7: $t8 := borrow_field<m::S>.a($t7)
   8: $t1 := read_ref($t8)
@@ -74,7 +74,7 @@ fun m::test($t0: m::S): u64 {
   4: $t6 := 0
      # live vars: $t3, $t4, $t6
      # events: e:$t4, e:$t6
-  5: write_ref($t4, $t6)
+  5: write_ref($t6, $t4)
      # live vars: $t3
      # events: b:$t7
   6: $t7 := borrow_local($t3)
@@ -106,7 +106,7 @@ fun m::test($t0: m::S): u64 {
   2: $t5 := borrow_local($t2)
   3: $t4 := borrow_field<m::S>.a($t5)
   4: $t6 := 0
-  5: write_ref($t4, $t6)
+  5: write_ref($t6, $t4)
   6: $t7 := borrow_local($t3)
   7: $t8 := borrow_field<m::S>.a($t7)
   8: $t6 := read_ref($t8)
@@ -130,7 +130,7 @@ fun m::test($t0: m::S): u64 {
   2: $t5 := borrow_local($t2)
   3: $t4 := borrow_field<m::S>.a($t5)
   4: $t6 := 0
-  5: write_ref($t4, $t6)
+  5: write_ref($t6, $t4)
   6: $t7 := borrow_local($t3)
   7: $t8 := borrow_field<m::S>.a($t7)
   8: $t6 := read_ref($t8)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
@@ -133,10 +133,10 @@ B0:
 	0: LdU64(1)
 	1: LdU64(1)
 	2: Add
-	3: LdU64(2)
-	4: LdU64(1)
-	5: Add
-	6: Pop
+	3: Pop
+	4: LdU64(2)
+	5: LdU64(1)
+	6: Add
 	7: Pop
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.opt.exp
@@ -133,10 +133,10 @@ B0:
 	0: LdU64(1)
 	1: LdU64(1)
 	2: Add
-	3: LdU64(2)
-	4: LdU64(1)
-	5: Add
-	6: Pop
+	3: Pop
+	4: LdU64(2)
+	5: LdU64(1)
+	6: Add
 	7: Pop
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
@@ -133,10 +133,10 @@ B0:
 	0: LdU32(1)
 	1: LdU32(1)
 	2: Add
-	3: LdU64(2)
-	4: LdU64(1)
-	5: Add
-	6: Pop
+	3: Pop
+	4: LdU64(2)
+	5: LdU64(1)
+	6: Add
 	7: Pop
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.opt.exp
@@ -133,10 +133,10 @@ B0:
 	0: LdU32(1)
 	1: LdU32(1)
 	2: Add
-	3: LdU64(2)
-	4: LdU64(1)
-	5: Add
-	6: Pop
+	3: Pop
+	4: LdU64(2)
+	5: LdU64(1)
+	6: Add
 	7: Pop
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
@@ -102,18 +102,13 @@ module c0ffee.m {
 
 
 test(): u64 /* def_idx: 0 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
 B0:
 	0: LdU64(1)
 	1: LdU64(2)
-	2: LdU64(3)
-	3: StLoc[0](loc0: u64)
+	2: Add
+	3: LdU64(3)
 	4: Add
-	5: MoveLoc[0](loc0: u64)
-	6: Add
-	7: Ret
+	5: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
@@ -98,17 +98,11 @@ module c0ffee.m {
 
 
 test(): u64 /* def_idx: 0 */ {
-L0:	loc0: u64
-L1:	loc1: u64
 B0:
-	0: LdU64(2)
-	1: LdU64(9)
-	2: StLoc[0](loc0: u64)
-	3: StLoc[1](loc1: u64)
-	4: MoveLoc[0](loc0: u64)
-	5: MoveLoc[1](loc1: u64)
-	6: Add
-	7: Ret
+	0: LdU64(9)
+	1: LdU64(2)
+	2: Add
+	3: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.exp
@@ -452,34 +452,32 @@ B0:
 public test3(): u64 /* def_idx: 2 */ {
 L0:	loc0: u64
 L1:	loc1: u64
-L2:	loc2: u64
 B0:
 	0: LdU64(0)
-	1: LdU64(1)
-	2: StLoc[0](loc0: u64)
+	1: StLoc[0](loc0: u64)
+	2: LdU64(1)
 	3: StLoc[1](loc1: u64)
 B1:
-	4: CopyLoc[1](loc1: u64)
+	4: CopyLoc[0](loc0: u64)
 	5: LdU64(42)
 	6: Lt
 	7: BrFalse(13)
 B2:
-	8: MoveLoc[1](loc1: u64)
+	8: MoveLoc[0](loc0: u64)
 	9: LdU64(1)
 	10: Add
-	11: StLoc[1](loc1: u64)
+	11: StLoc[0](loc0: u64)
 	12: Branch(14)
 B3:
 	13: Branch(15)
 B4:
 	14: Branch(4)
 B5:
-	15: MoveLoc[0](loc0: u64)
+	15: MoveLoc[1](loc1: u64)
 	16: Ret
 }
 public test4(Arg0: u64): u64 /* def_idx: 3 */ {
 L1:	loc0: u64
-L2:	loc1: u64
 B0:
 	0: LdU64(0)
 	1: StLoc[1](loc0: u64)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.opt.exp
@@ -452,34 +452,32 @@ B0:
 public test3(): u64 /* def_idx: 2 */ {
 L0:	loc0: u64
 L1:	loc1: u64
-L2:	loc2: u64
 B0:
 	0: LdU64(0)
-	1: LdU64(1)
-	2: StLoc[0](loc0: u64)
+	1: StLoc[0](loc0: u64)
+	2: LdU64(1)
 	3: StLoc[1](loc1: u64)
 B1:
-	4: CopyLoc[1](loc1: u64)
+	4: CopyLoc[0](loc0: u64)
 	5: LdU64(42)
 	6: Lt
 	7: BrFalse(13)
 B2:
-	8: MoveLoc[1](loc1: u64)
+	8: MoveLoc[0](loc0: u64)
 	9: LdU64(1)
 	10: Add
-	11: StLoc[1](loc1: u64)
+	11: StLoc[0](loc0: u64)
 	12: Branch(14)
 B3:
 	13: Branch(15)
 B4:
 	14: Branch(4)
 B5:
-	15: MoveLoc[0](loc0: u64)
+	15: MoveLoc[1](loc1: u64)
 	16: Ret
 }
 public test4(Arg0: u64): u64 /* def_idx: 3 */ {
 L1:	loc0: u64
-L2:	loc1: u64
 B0:
 	0: LdU64(0)
 	1: StLoc[1](loc0: u64)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.exp
@@ -124,8 +124,6 @@ module c0ffee.m {
 test(Arg0: u64): bool /* def_idx: 0 */ {
 L1:	loc0: u64
 L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: bool
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)
@@ -134,13 +132,11 @@ B0:
 	4: MoveLoc[0](Arg0: u64)
 	5: LdU64(1)
 	6: Add
-	7: MoveLoc[1](loc0: u64)
-	8: MoveLoc[2](loc1: u64)
-	9: Eq
-	10: StLoc[4](loc3: bool)
-	11: Pop
-	12: MoveLoc[4](loc3: bool)
-	13: Ret
+	7: Pop
+	8: MoveLoc[1](loc0: u64)
+	9: MoveLoc[2](loc1: u64)
+	10: Eq
+	11: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.opt.exp
@@ -124,8 +124,6 @@ module c0ffee.m {
 test(Arg0: u64): bool /* def_idx: 0 */ {
 L1:	loc0: u64
 L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: bool
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)
@@ -134,13 +132,11 @@ B0:
 	4: MoveLoc[0](Arg0: u64)
 	5: LdU64(1)
 	6: Add
-	7: MoveLoc[1](loc0: u64)
-	8: MoveLoc[2](loc1: u64)
-	9: Eq
-	10: StLoc[4](loc3: bool)
-	11: Pop
-	12: MoveLoc[4](loc3: bool)
-	13: Ret
+	7: Pop
+	8: MoveLoc[1](loc0: u64)
+	9: MoveLoc[2](loc1: u64)
+	10: Eq
+	11: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.exp
@@ -124,8 +124,6 @@ module c0ffee.m {
 test(Arg0: u64): bool /* def_idx: 0 */ {
 L1:	loc0: u64
 L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: bool
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)
@@ -134,13 +132,11 @@ B0:
 	4: MoveLoc[0](Arg0: u64)
 	5: LdU64(1)
 	6: Add
-	7: MoveLoc[1](loc0: u64)
-	8: MoveLoc[2](loc1: u64)
-	9: Eq
-	10: StLoc[4](loc3: bool)
-	11: Pop
-	12: MoveLoc[4](loc3: bool)
-	13: Ret
+	7: Pop
+	8: MoveLoc[1](loc0: u64)
+	9: MoveLoc[2](loc1: u64)
+	10: Eq
+	11: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.opt.exp
@@ -124,8 +124,6 @@ module c0ffee.m {
 test(Arg0: u64): bool /* def_idx: 0 */ {
 L1:	loc0: u64
 L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: bool
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)
@@ -134,13 +132,11 @@ B0:
 	4: MoveLoc[0](Arg0: u64)
 	5: LdU64(1)
 	6: Add
-	7: MoveLoc[1](loc0: u64)
-	8: MoveLoc[2](loc1: u64)
-	9: Eq
-	10: StLoc[4](loc3: bool)
-	11: Pop
-	12: MoveLoc[4](loc3: bool)
-	13: Ret
+	7: Pop
+	8: MoveLoc[1](loc0: u64)
+	9: MoveLoc[2](loc1: u64)
+	10: Eq
+	11: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.exp
@@ -113,7 +113,6 @@ module c0ffee.m {
 copy_kill(Arg0: u64): u64 /* def_idx: 0 */ {
 L1:	loc0: u64
 L2:	loc1: u64
-L3:	loc2: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)
@@ -122,13 +121,11 @@ B0:
 	4: MoveLoc[0](Arg0: u64)
 	5: LdU64(1)
 	6: Add
-	7: MoveLoc[2](loc1: u64)
-	8: MoveLoc[1](loc0: u64)
-	9: Add
-	10: StLoc[1](loc0: u64)
-	11: Pop
-	12: MoveLoc[1](loc0: u64)
-	13: Ret
+	7: Pop
+	8: MoveLoc[2](loc1: u64)
+	9: MoveLoc[1](loc0: u64)
+	10: Add
+	11: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.opt.exp
@@ -113,7 +113,6 @@ module c0ffee.m {
 copy_kill(Arg0: u64): u64 /* def_idx: 0 */ {
 L1:	loc0: u64
 L2:	loc1: u64
-L3:	loc2: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)
@@ -122,13 +121,11 @@ B0:
 	4: MoveLoc[0](Arg0: u64)
 	5: LdU64(1)
 	6: Add
-	7: MoveLoc[2](loc1: u64)
-	8: MoveLoc[1](loc0: u64)
-	9: Add
-	10: StLoc[1](loc0: u64)
-	11: Pop
-	12: MoveLoc[1](loc0: u64)
-	13: Ret
+	7: Pop
+	8: MoveLoc[2](loc1: u64)
+	9: MoveLoc[1](loc0: u64)
+	10: Add
+	11: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.optimize-no-simplify.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.optimize-no-simplify.exp
@@ -24,12 +24,9 @@ comparison between v1 and v2 failed:
 = 	4: CopyLoc[1](loc1: &mut u64)
 = 	5: Call id_mut<u64>(&mut u64): &mut u64
 = 	6: ReadRef
-- 	7: Pop
-- 	8: MoveLoc[1](loc1: &mut u64)
-- 	9: ReadRef
-+ 	7: MoveLoc[1](loc1: &mut u64)
-+ 	8: ReadRef
-+ 	9: Pop
+= 	7: Pop
+= 	8: MoveLoc[1](loc1: &mut u64)
+= 	9: ReadRef
 = 	10: Pop
 = 	11: Ret
 = }

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.optimize.exp
@@ -24,12 +24,9 @@ comparison between v1 and v2 failed:
 = 	4: CopyLoc[1](loc1: &mut u64)
 = 	5: Call id_mut<u64>(&mut u64): &mut u64
 = 	6: ReadRef
-- 	7: Pop
-- 	8: MoveLoc[1](loc1: &mut u64)
-- 	9: ReadRef
-+ 	7: MoveLoc[1](loc1: &mut u64)
-+ 	8: ReadRef
-+ 	9: Pop
+= 	7: Pop
+= 	8: MoveLoc[1](loc1: &mut u64)
+= 	9: ReadRef
 = 	10: Pop
 = 	11: Ret
 = }

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.optimize-no-simplify.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.optimize-no-simplify.exp
@@ -27,5 +27,5 @@ Error: Function execution failed with VMError: {
     sub_status: None,
     location: 0x42::m,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(5), 9)],
+    offsets: [(FunctionDefinitionIndex(5), 5)],
 }

--- a/third_party/move/move-model/bytecode/src/debug_instrumentation.rs
+++ b/third_party/move/move-model/bytecode/src/debug_instrumentation.rs
@@ -69,7 +69,7 @@ impl FunctionTargetProcessor for DebugInstrumenter {
                     builder.emit(bc);
                 },
                 Call(_, _, Operation::WriteRef, srcs, _)
-                    if srcs[0] < fun_env.get_local_count().unwrap_or_default() =>
+                    if srcs[1] < fun_env.get_local_count().unwrap_or_default() =>
                 {
                     builder.set_loc_from_attr(bc.get_attr_id());
                     builder.emit(bc.clone());
@@ -77,8 +77,8 @@ impl FunctionTargetProcessor for DebugInstrumenter {
                         Call(
                             id,
                             vec![],
-                            Operation::TraceLocal(srcs[0]),
-                            vec![srcs[0]],
+                            Operation::TraceLocal(srcs[1]),
+                            vec![srcs[1]],
                             None,
                         )
                     });

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode_generator.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode_generator.rs
@@ -1106,8 +1106,8 @@ impl<'a> StacklessBytecodeGenerator<'a> {
                 let ref_operand_index = self.temp_stack.pop().unwrap();
                 let val_operand_index = self.temp_stack.pop().unwrap();
                 self.code.push(mk_call(Operation::WriteRef, vec![], vec![
-                    ref_operand_index,
                     val_operand_index,
+                    ref_operand_index,
                 ]));
             },
 

--- a/third_party/move/move-model/bytecode/src/stackless_control_flow_graph.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_control_flow_graph.rs
@@ -234,6 +234,13 @@ impl StacklessControlFlowGraph {
         }
     }
 
+    pub fn instr_offset_bounds(&self, block_id: BlockId) -> Option<(CodeOffset, CodeOffset)> {
+        match self.blocks[&block_id].content {
+            BlockContent::Basic { lower, upper } => Some((lower, upper)),
+            BlockContent::Dummy => None,
+        }
+    }
+
     pub fn num_blocks(&self) -> u16 {
         self.blocks.len() as u16
     }

--- a/third_party/move/move-model/bytecode/tests/borrow/basic_test.exp
+++ b/third_party/move/move-model/bytecode/tests/borrow/basic_test.exp
@@ -19,7 +19,7 @@ fun TestBorrow::test1(): TestBorrow::R {
   5: $t1 := $t5
   6: $t6 := 0
   7: $t7 := move($t1)
-  8: write_ref($t7, $t6)
+  8: write_ref($t6, $t7)
   9: $t8 := move($t0)
  10: return $t8
 }
@@ -31,7 +31,7 @@ fun TestBorrow::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t3: &mut u64
   0: $t2 := move($t1)
   1: $t3 := move($t0)
-  2: write_ref($t3, $t2)
+  2: write_ref($t2, $t3)
   3: return ()
 }
 
@@ -254,7 +254,7 @@ fun TestBorrow::test1(): TestBorrow::R {
      # live_nodes: Reference($t4)
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t4))}
      # borrows_from: Reference($t3) -> {(@, LocalRoot($t0))}, Reference($t4) -> {(.x (u64), Reference($t3))}
-  5: write_ref($t4, $t5)
+  5: write_ref($t5, $t4)
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t4))}
      # borrows_from: Reference($t3) -> {(@, LocalRoot($t0))}, Reference($t4) -> {(.x (u64), Reference($t3))}
   6: $t6 := move($t0)
@@ -268,7 +268,7 @@ fun TestBorrow::test1(): TestBorrow::R {
 [variant baseline]
 fun TestBorrow::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      # live_nodes: LocalRoot($t1), Reference($t0)
-  0: write_ref($t0, $t1)
+  0: write_ref($t1, $t0)
      # live_nodes: LocalRoot($t1)
   1: return ()
 }

--- a/third_party/move/move-model/bytecode/tests/borrow/basic_test.v2_exp
+++ b/third_party/move/move-model/bytecode/tests/borrow/basic_test.v2_exp
@@ -19,7 +19,7 @@ fun TestBorrow::test1(): TestBorrow::R {
   5: $t1 := $t5
   6: $t6 := 0
   7: $t7 := move($t1)
-  8: write_ref($t7, $t6)
+  8: write_ref($t6, $t7)
   9: $t8 := move($t0)
  10: return $t8
 }
@@ -31,7 +31,7 @@ fun TestBorrow::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t3: &mut u64
   0: $t2 := move($t1)
   1: $t3 := move($t0)
-  2: write_ref($t3, $t2)
+  2: write_ref($t2, $t3)
   3: return ()
 }
 
@@ -254,7 +254,7 @@ fun TestBorrow::test1(): TestBorrow::R {
      # live_nodes: Reference($t4)
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t4))}
      # borrows_from: Reference($t3) -> {(@, LocalRoot($t0))}, Reference($t4) -> {(.x (u64), Reference($t3))}
-  5: write_ref($t4, $t5)
+  5: write_ref($t5, $t4)
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t4))}
      # borrows_from: Reference($t3) -> {(@, LocalRoot($t0))}, Reference($t4) -> {(.x (u64), Reference($t3))}
   6: $t6 := move($t0)
@@ -268,7 +268,7 @@ fun TestBorrow::test1(): TestBorrow::R {
 [variant baseline]
 fun TestBorrow::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      # live_nodes: LocalRoot($t1), Reference($t0)
-  0: write_ref($t0, $t1)
+  0: write_ref($t1, $t0)
      # live_nodes: LocalRoot($t1)
   1: return ()
 }

--- a/third_party/move/move-model/bytecode/tests/borrow/hyper_edge.exp
+++ b/third_party/move/move-model/bytecode/tests/borrow/hyper_edge.exp
@@ -123,7 +123,7 @@ public fun Test::foo<#0>($t0|i: u64) {
   6: $t7 := 0
   7: $t8 := move($t2)
   8: $t9 := borrow_field<Test::Token<#0>>.value($t8)
-  9: write_ref($t9, $t7)
+  9: write_ref($t7, $t9)
  10: return ()
 }
 
@@ -269,7 +269,7 @@ public fun Test::foo<#0>($t0|i: u64) {
      # live_nodes: LocalRoot($t0), Reference($t6)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, Reference($t3) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t4))}, Reference($t4) -> {(.value (u64), Reference($t6))}
      # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}, Reference($t4) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t3))}, Reference($t6) -> {(.value (u64), Reference($t4))}
-  5: write_ref($t6, $t5)
+  5: write_ref($t5, $t6)
      # live_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, Reference($t3) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t4))}, Reference($t4) -> {(.value (u64), Reference($t6))}
      # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}, Reference($t4) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t3))}, Reference($t6) -> {(.value (u64), Reference($t4))}

--- a/third_party/move/move-model/bytecode/tests/borrow/hyper_edge.v2_exp
+++ b/third_party/move/move-model/bytecode/tests/borrow/hyper_edge.v2_exp
@@ -123,7 +123,7 @@ public fun Test::foo<#0>($t0|i: u64) {
   6: $t7 := 0
   7: $t8 := move($t2)
   8: $t9 := borrow_field<Test::Token<#0>>.value($t8)
-  9: write_ref($t9, $t7)
+  9: write_ref($t7, $t9)
  10: return ()
 }
 
@@ -269,7 +269,7 @@ public fun Test::foo<#0>($t0|i: u64) {
      # live_nodes: LocalRoot($t0), Reference($t6)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, Reference($t3) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t4))}, Reference($t4) -> {(.value (u64), Reference($t6))}
      # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}, Reference($t4) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t3))}, Reference($t6) -> {(.value (u64), Reference($t4))}
-  5: write_ref($t6, $t5)
+  5: write_ref($t5, $t6)
      # live_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t3))}, Reference($t3) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t4))}, Reference($t4) -> {(.value (u64), Reference($t6))}
      # borrows_from: Reference($t3) -> {(@, LocalRoot($t1))}, Reference($t4) -> {(.items (vector<Test::Token<#0>>)/[], Reference($t3))}, Reference($t6) -> {(.value (u64), Reference($t4))}

--- a/third_party/move/move-model/bytecode/tests/borrow_strong/basic_test.exp
+++ b/third_party/move/move-model/bytecode/tests/borrow_strong/basic_test.exp
@@ -21,7 +21,7 @@ fun TestBorrow::test1(): TestBorrow::R {
   6: $t1 := $t6
   7: $t7 := 0
   8: $t8 := move($t1)
-  9: write_ref($t8, $t7)
+  9: write_ref($t7, $t8)
  10: $t9 := move($t0)
  11: return $t9
 }
@@ -73,7 +73,7 @@ fun TestBorrow::test10($t0|b: bool): TestBorrow::R {
  23: label L2
  24: $t16 := 0
  25: $t17 := move($t2)
- 26: write_ref($t17, $t16)
+ 26: write_ref($t16, $t17)
  27: $t18 := move($t1)
  28: return $t18
 }
@@ -85,7 +85,7 @@ fun TestBorrow::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t3: &mut u64
   0: $t2 := move($t1)
   1: $t3 := move($t0)
-  2: write_ref($t3, $t2)
+  2: write_ref($t2, $t3)
   3: return ()
 }
 
@@ -328,7 +328,7 @@ fun TestBorrow::test9($t0|b: bool, $t1|r_ref: &mut TestBorrow::R): &mut u64 {
  16: label L2
  17: $t10 := 0
  18: $t11 := copy($t2)
- 19: write_ref($t11, $t10)
+ 19: write_ref($t10, $t11)
  20: $t12 := move($t2)
  21: return $t12
 }
@@ -360,7 +360,7 @@ fun TestBorrow::test1(): TestBorrow::R {
      # live_nodes: Reference($t5)
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t4))}, Reference($t4) -> {(.x (u64), Reference($t5))}
      # borrows_from: Reference($t4) -> {(@, LocalRoot($t0))}, Reference($t5) -> {(.x (u64), Reference($t4))}
-  6: write_ref($t5, $t6)
+  6: write_ref($t6, $t5)
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t4))}, Reference($t4) -> {(.x (u64), Reference($t5))}
      # borrows_from: Reference($t4) -> {(@, LocalRoot($t0))}, Reference($t5) -> {(.x (u64), Reference($t4))}
   7: $t7 := move($t0)
@@ -441,7 +441,7 @@ fun TestBorrow::test10($t0|b: bool): TestBorrow::R {
      # live_nodes: LocalRoot($t0), Reference($t2)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
- 16: write_ref($t2, $t8)
+ 16: write_ref($t8, $t2)
      # live_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
@@ -480,7 +480,7 @@ fun TestBorrow::test10($t0|b: bool): TestBorrow::R {
 [variant baseline]
 fun TestBorrow::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      # live_nodes: LocalRoot($t1), Reference($t0)
-  0: write_ref($t0, $t1)
+  0: write_ref($t1, $t0)
      # live_nodes: LocalRoot($t1)
   1: return ()
 }
@@ -932,7 +932,7 @@ fun TestBorrow::test9($t0|b: bool, $t1|r_ref: &mut TestBorrow::R): &mut u64 {
      # live_nodes: LocalRoot($t0), Reference($t2)
      # borrowed_by: Reference($t1) -> {(.y (u64), Reference($t2)), (.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(.y (u64), Reference($t1)), (@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
- 12: write_ref($t2, $t4)
+ 12: write_ref($t4, $t2)
      # live_nodes: LocalRoot($t0), Reference($t2)
      # borrowed_by: Reference($t1) -> {(.y (u64), Reference($t2)), (.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(.y (u64), Reference($t1)), (@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}

--- a/third_party/move/move-model/bytecode/tests/borrow_strong/basic_test.v2_exp
+++ b/third_party/move/move-model/bytecode/tests/borrow_strong/basic_test.v2_exp
@@ -21,7 +21,7 @@ fun TestBorrow::test1(): TestBorrow::R {
   6: $t1 := $t6
   7: $t7 := 0
   8: $t8 := move($t1)
-  9: write_ref($t8, $t7)
+  9: write_ref($t7, $t8)
  10: $t9 := move($t0)
  11: return $t9
 }
@@ -73,7 +73,7 @@ fun TestBorrow::test10($t0|b: bool): TestBorrow::R {
  23: label L2
  24: $t16 := 0
  25: $t17 := move($t2)
- 26: write_ref($t17, $t16)
+ 26: write_ref($t16, $t17)
  27: $t18 := move($t1)
  28: return $t18
 }
@@ -85,7 +85,7 @@ fun TestBorrow::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t3: &mut u64
   0: $t2 := move($t1)
   1: $t3 := move($t0)
-  2: write_ref($t3, $t2)
+  2: write_ref($t2, $t3)
   3: return ()
 }
 
@@ -328,7 +328,7 @@ fun TestBorrow::test9($t0|b: bool, $t1|r_ref: &mut TestBorrow::R): &mut u64 {
  16: label L2
  17: $t10 := 0
  18: $t11 := copy($t2)
- 19: write_ref($t11, $t10)
+ 19: write_ref($t10, $t11)
  20: $t12 := move($t2)
  21: return $t12
 }
@@ -360,7 +360,7 @@ fun TestBorrow::test1(): TestBorrow::R {
      # live_nodes: Reference($t5)
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t4))}, Reference($t4) -> {(.x (u64), Reference($t5))}
      # borrows_from: Reference($t4) -> {(@, LocalRoot($t0))}, Reference($t5) -> {(.x (u64), Reference($t4))}
-  6: write_ref($t5, $t6)
+  6: write_ref($t6, $t5)
      # borrowed_by: LocalRoot($t0) -> {(@, Reference($t4))}, Reference($t4) -> {(.x (u64), Reference($t5))}
      # borrows_from: Reference($t4) -> {(@, LocalRoot($t0))}, Reference($t5) -> {(.x (u64), Reference($t4))}
   7: $t7 := move($t0)
@@ -441,7 +441,7 @@ fun TestBorrow::test10($t0|b: bool): TestBorrow::R {
      # live_nodes: LocalRoot($t0), Reference($t2)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
- 16: write_ref($t2, $t8)
+ 16: write_ref($t8, $t2)
      # live_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6))}, Reference($t6) -> {(.y (u64), Reference($t2)), (.x (u64)/@, Reference($t2)), (.x (u64), Reference($t7))}, Reference($t7) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(.y (u64), Reference($t6)), (.x (u64)/@, Reference($t6)), (@, Reference($t7))}, Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(.x (u64), Reference($t6))}
@@ -480,7 +480,7 @@ fun TestBorrow::test10($t0|b: bool): TestBorrow::R {
 [variant baseline]
 fun TestBorrow::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      # live_nodes: LocalRoot($t1), Reference($t0)
-  0: write_ref($t0, $t1)
+  0: write_ref($t1, $t0)
      # live_nodes: LocalRoot($t1)
   1: return ()
 }
@@ -932,7 +932,7 @@ fun TestBorrow::test9($t0|b: bool, $t1|r_ref: &mut TestBorrow::R): &mut u64 {
      # live_nodes: LocalRoot($t0), Reference($t2)
      # borrowed_by: Reference($t1) -> {(.y (u64), Reference($t2)), (.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(.y (u64), Reference($t1)), (@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}
- 12: write_ref($t2, $t4)
+ 12: write_ref($t4, $t2)
      # live_nodes: LocalRoot($t0), Reference($t2)
      # borrowed_by: Reference($t1) -> {(.y (u64), Reference($t2)), (.x (u64), Reference($t3))}, Reference($t3) -> {(@, Reference($t2))}
      # borrows_from: Reference($t2) -> {(.y (u64), Reference($t1)), (@, Reference($t3))}, Reference($t3) -> {(.x (u64), Reference($t1))}

--- a/third_party/move/move-model/bytecode/tests/borrow_strong/mut_ref.exp
+++ b/third_party/move/move-model/bytecode/tests/borrow_strong/mut_ref.exp
@@ -102,7 +102,7 @@ fun TestMutRef::call_return_ref_different_path($t0|b: bool): TestMutRef::N {
   8: $t1 := $t9
   9: $t10 := 5
  10: $t11 := move($t1)
- 11: write_ref($t11, $t10)
+ 11: write_ref($t10, $t11)
  12: $t12 := move($t2)
  13: return $t12
 }
@@ -149,7 +149,7 @@ fun TestMutRef::call_return_ref_different_path_vec($t0|b: bool): TestMutRef::V {
  17: $t2 := $t16
  18: $t17 := 5
  19: $t18 := move($t2)
- 20: write_ref($t18, $t17)
+ 20: write_ref($t17, $t18)
  21: $t19 := move($t4)
  22: return $t19
 }
@@ -210,7 +210,7 @@ fun TestMutRef::call_return_ref_different_path_vec2($t0|b: bool): TestMutRef::V 
  25: $t2 := $t22
  26: $t23 := 5
  27: $t24 := move($t2)
- 28: write_ref($t24, $t23)
+ 28: write_ref($t23, $t24)
  29: $t25 := move($t4)
  30: return $t25
 }
@@ -271,7 +271,7 @@ fun TestMutRef::call_return_ref_different_path_vec2_incorrect($t0|b: bool): Test
  25: $t2 := $t22
  26: $t23 := 0
  27: $t24 := move($t2)
- 28: write_ref($t24, $t23)
+ 28: write_ref($t23, $t24)
  29: $t25 := move($t4)
  30: return $t25
 }
@@ -307,7 +307,7 @@ fun TestMutRef::call_return_ref_different_root($t0|b: bool): (TestMutRef::T, Tes
  10: $t1 := $t11
  11: $t12 := 5
  12: $t13 := move($t1)
- 13: write_ref($t13, $t12)
+ 13: write_ref($t12, $t13)
  14: $t14 := move($t2)
  15: $t15 := move($t3)
  16: return ($t14, $t15)
@@ -565,7 +565,7 @@ fun TestMutRef::call_return_ref_different_path($t0|b: bool): TestMutRef::N {
      # live_nodes: LocalRoot($t0), Reference($t7)
      # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, Reference($t6) -> {(.value (u64), Reference($t7)), (.t (TestMutRef::T)/.value (u64), Reference($t7))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(.value (u64), Reference($t6)), (.t (TestMutRef::T)/.value (u64), Reference($t6))}
-  7: write_ref($t7, $t8)
+  7: write_ref($t8, $t7)
      # live_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, Reference($t6) -> {(.value (u64), Reference($t7)), (.t (TestMutRef::T)/.value (u64), Reference($t7))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(.value (u64), Reference($t6)), (.t (TestMutRef::T)/.value (u64), Reference($t6))}
@@ -642,7 +642,7 @@ fun TestMutRef::call_return_ref_different_path_vec($t0|b: bool): TestMutRef::V {
      # live_nodes: LocalRoot($t0), LocalRoot($t10), Reference($t12)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6)), (@, Reference($t8))}, LocalRoot($t4) -> {(@, Reference($t11))}, Reference($t11) -> {(.is (vector<u64>)/[], Reference($t12))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t8) -> {(@, LocalRoot($t1))}, Reference($t11) -> {(@, LocalRoot($t4))}, Reference($t12) -> {(.is (vector<u64>)/[], Reference($t11))}
- 13: write_ref($t12, $t13)
+ 13: write_ref($t13, $t12)
      # live_nodes: LocalRoot($t0), LocalRoot($t10)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6)), (@, Reference($t8))}, LocalRoot($t4) -> {(@, Reference($t11))}, Reference($t11) -> {(.is (vector<u64>)/[], Reference($t12))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t8) -> {(@, LocalRoot($t1))}, Reference($t11) -> {(@, LocalRoot($t4))}, Reference($t12) -> {(.is (vector<u64>)/[], Reference($t11))}
@@ -761,7 +761,7 @@ fun TestMutRef::call_return_ref_different_path_vec2($t0|b: bool): TestMutRef::V 
      # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16), Reference($t18)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
      # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
- 22: write_ref($t18, $t19)
+ 22: write_ref($t19, $t18)
      # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
      # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
@@ -880,7 +880,7 @@ fun TestMutRef::call_return_ref_different_path_vec2_incorrect($t0|b: bool): Test
      # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16), Reference($t18)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
      # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
- 22: write_ref($t18, $t19)
+ 22: write_ref($t19, $t18)
      # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
      # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
@@ -930,7 +930,7 @@ fun TestMutRef::call_return_ref_different_root($t0|b: bool): (TestMutRef::T, Tes
      # live_nodes: LocalRoot($t0), Reference($t8)
      # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, LocalRoot($t3) -> {(@, Reference($t7))}, Reference($t6) -> {(.value (u64), Reference($t8))}, Reference($t7) -> {(.value (u64), Reference($t8))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(@, LocalRoot($t3))}, Reference($t8) -> {(.value (u64), Reference($t6)), (.value (u64), Reference($t7))}
-  8: write_ref($t8, $t9)
+  8: write_ref($t9, $t8)
      # live_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, LocalRoot($t3) -> {(@, Reference($t7))}, Reference($t6) -> {(.value (u64), Reference($t8))}, Reference($t7) -> {(.value (u64), Reference($t8))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(@, LocalRoot($t3))}, Reference($t8) -> {(.value (u64), Reference($t6)), (.value (u64), Reference($t7))}

--- a/third_party/move/move-model/bytecode/tests/borrow_strong/mut_ref.v2_exp
+++ b/third_party/move/move-model/bytecode/tests/borrow_strong/mut_ref.v2_exp
@@ -102,7 +102,7 @@ fun TestMutRef::call_return_ref_different_path($t0|b: bool): TestMutRef::N {
   8: $t1 := $t9
   9: $t10 := 5
  10: $t11 := move($t1)
- 11: write_ref($t11, $t10)
+ 11: write_ref($t10, $t11)
  12: $t12 := move($t2)
  13: return $t12
 }
@@ -149,7 +149,7 @@ fun TestMutRef::call_return_ref_different_path_vec($t0|b: bool): TestMutRef::V {
  17: $t2 := $t16
  18: $t17 := 5
  19: $t18 := move($t2)
- 20: write_ref($t18, $t17)
+ 20: write_ref($t17, $t18)
  21: $t19 := move($t4)
  22: return $t19
 }
@@ -210,7 +210,7 @@ fun TestMutRef::call_return_ref_different_path_vec2($t0|b: bool): TestMutRef::V 
  25: $t2 := $t22
  26: $t23 := 5
  27: $t24 := move($t2)
- 28: write_ref($t24, $t23)
+ 28: write_ref($t23, $t24)
  29: $t25 := move($t4)
  30: return $t25
 }
@@ -271,7 +271,7 @@ fun TestMutRef::call_return_ref_different_path_vec2_incorrect($t0|b: bool): Test
  25: $t2 := $t22
  26: $t23 := 0
  27: $t24 := move($t2)
- 28: write_ref($t24, $t23)
+ 28: write_ref($t23, $t24)
  29: $t25 := move($t4)
  30: return $t25
 }
@@ -307,7 +307,7 @@ fun TestMutRef::call_return_ref_different_root($t0|b: bool): (TestMutRef::T, Tes
  10: $t1 := $t11
  11: $t12 := 5
  12: $t13 := move($t1)
- 13: write_ref($t13, $t12)
+ 13: write_ref($t12, $t13)
  14: $t14 := move($t2)
  15: $t15 := move($t3)
  16: return ($t14, $t15)
@@ -565,7 +565,7 @@ fun TestMutRef::call_return_ref_different_path($t0|b: bool): TestMutRef::N {
      # live_nodes: LocalRoot($t0), Reference($t7)
      # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, Reference($t6) -> {(.value (u64), Reference($t7)), (.t (TestMutRef::T)/.value (u64), Reference($t7))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(.value (u64), Reference($t6)), (.t (TestMutRef::T)/.value (u64), Reference($t6))}
-  7: write_ref($t7, $t8)
+  7: write_ref($t8, $t7)
      # live_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, Reference($t6) -> {(.value (u64), Reference($t7)), (.t (TestMutRef::T)/.value (u64), Reference($t7))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(.value (u64), Reference($t6)), (.t (TestMutRef::T)/.value (u64), Reference($t6))}
@@ -642,7 +642,7 @@ fun TestMutRef::call_return_ref_different_path_vec($t0|b: bool): TestMutRef::V {
      # live_nodes: LocalRoot($t0), LocalRoot($t10), Reference($t12)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6)), (@, Reference($t8))}, LocalRoot($t4) -> {(@, Reference($t11))}, Reference($t11) -> {(.is (vector<u64>)/[], Reference($t12))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t8) -> {(@, LocalRoot($t1))}, Reference($t11) -> {(@, LocalRoot($t4))}, Reference($t12) -> {(.is (vector<u64>)/[], Reference($t11))}
- 13: write_ref($t12, $t13)
+ 13: write_ref($t13, $t12)
      # live_nodes: LocalRoot($t0), LocalRoot($t10)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t6)), (@, Reference($t8))}, LocalRoot($t4) -> {(@, Reference($t11))}, Reference($t11) -> {(.is (vector<u64>)/[], Reference($t12))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t1))}, Reference($t8) -> {(@, LocalRoot($t1))}, Reference($t11) -> {(@, LocalRoot($t4))}, Reference($t12) -> {(.is (vector<u64>)/[], Reference($t11))}
@@ -761,7 +761,7 @@ fun TestMutRef::call_return_ref_different_path_vec2($t0|b: bool): TestMutRef::V 
      # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16), Reference($t18)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
      # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
- 22: write_ref($t18, $t19)
+ 22: write_ref($t19, $t18)
      # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
      # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
@@ -880,7 +880,7 @@ fun TestMutRef::call_return_ref_different_path_vec2_incorrect($t0|b: bool): Test
      # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16), Reference($t18)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
      # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
- 22: write_ref($t18, $t19)
+ 22: write_ref($t19, $t18)
      # live_nodes: LocalRoot($t0), LocalRoot($t15), LocalRoot($t16)
      # borrowed_by: LocalRoot($t1) -> {(@, Reference($t5)), (@, Reference($t7))}, LocalRoot($t3) -> {(@, Reference($t9)), (@, Reference($t12))}, LocalRoot($t4) -> {(@, Reference($t17))}, Reference($t17) -> {(.is (vector<u64>)/[], Reference($t18)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t18))}
      # borrows_from: Reference($t5) -> {(@, LocalRoot($t1))}, Reference($t7) -> {(@, LocalRoot($t1))}, Reference($t9) -> {(@, LocalRoot($t3))}, Reference($t12) -> {(@, LocalRoot($t3))}, Reference($t17) -> {(@, LocalRoot($t4))}, Reference($t18) -> {(.is (vector<u64>)/[], Reference($t17)), (.ts (vector<TestMutRef::T>)/[]/.value (u64), Reference($t17))}
@@ -930,7 +930,7 @@ fun TestMutRef::call_return_ref_different_root($t0|b: bool): (TestMutRef::T, Tes
      # live_nodes: LocalRoot($t0), Reference($t8)
      # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, LocalRoot($t3) -> {(@, Reference($t7))}, Reference($t6) -> {(.value (u64), Reference($t8))}, Reference($t7) -> {(.value (u64), Reference($t8))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(@, LocalRoot($t3))}, Reference($t8) -> {(.value (u64), Reference($t6)), (.value (u64), Reference($t7))}
-  8: write_ref($t8, $t9)
+  8: write_ref($t9, $t8)
      # live_nodes: LocalRoot($t0)
      # borrowed_by: LocalRoot($t2) -> {(@, Reference($t6))}, LocalRoot($t3) -> {(@, Reference($t7))}, Reference($t6) -> {(.value (u64), Reference($t8))}, Reference($t7) -> {(.value (u64), Reference($t8))}
      # borrows_from: Reference($t6) -> {(@, LocalRoot($t2))}, Reference($t7) -> {(@, LocalRoot($t3))}, Reference($t8) -> {(.value (u64), Reference($t6)), (.value (u64), Reference($t7))}

--- a/third_party/move/move-model/bytecode/tests/from_move/regression_generic_and_native_type.exp
+++ b/third_party/move/move-model/bytecode/tests/from_move/regression_generic_and_native_type.exp
@@ -142,7 +142,7 @@ public fun Diem::preburn<#0>($t0|preburn_ref: &mut Diem::Preburn<#0>, $t1|coin: 
  14: $t15 := +($t13, $t14)
  15: $t16 := move($t3)
  16: $t17 := borrow_field<Diem::Info<#0>>.preburn_value($t16)
- 17: write_ref($t17, $t15)
+ 17: write_ref($t15, $t17)
  18: return ()
 }
 

--- a/third_party/move/move-model/bytecode/tests/from_move/regression_generic_and_native_type.v2_exp
+++ b/third_party/move/move-model/bytecode/tests/from_move/regression_generic_and_native_type.v2_exp
@@ -142,7 +142,7 @@ public fun Diem::preburn<#0>($t0|preburn_ref: &mut Diem::Preburn<#0>, $t1|coin: 
  14: $t15 := +($t13, $t14)
  15: $t16 := move($t3)
  16: $t17 := borrow_field<Diem::Info<#0>>.preburn_value($t16)
- 17: write_ref($t17, $t15)
+ 17: write_ref($t15, $t17)
  18: return ()
 }
 

--- a/third_party/move/move-model/bytecode/tests/usage_analysis/test.exp
+++ b/third_party/move/move-model/bytecode/tests/usage_analysis/test.exp
@@ -10,7 +10,7 @@ public fun Test::update<#0>($t0|x: #0) {
   1: $t2 := 0x1
   2: $t3 := borrow_global<Test::A<#0, #0>>($t2)
   3: $t4 := borrow_field<Test::A<#0, #0>>.x1($t3)
-  4: write_ref($t4, $t1)
+  4: write_ref($t1, $t4)
   5: return ()
 }
 
@@ -70,7 +70,7 @@ public fun Test::update_ints() {
   1: $t1 := 0x1
   2: $t2 := borrow_global<Test::A<u64, u128>>($t1)
   3: $t3 := borrow_field<Test::A<u64, u128>>.x1($t2)
-  4: write_ref($t3, $t0)
+  4: write_ref($t0, $t3)
   5: return ()
 }
 
@@ -86,7 +86,7 @@ public fun Test::update<#0>($t0|x: #0) {
   1: $t2 := 0x1
   2: $t3 := borrow_global<Test::A<#0, #0>>($t2)
   3: $t4 := borrow_field<Test::A<#0, #0>>.x1($t3)
-  4: write_ref($t4, $t1)
+  4: write_ref($t1, $t4)
   5: return ()
 }
 
@@ -146,7 +146,7 @@ public fun Test::update_ints() {
   1: $t1 := 0x1
   2: $t2 := borrow_global<Test::A<u64, u128>>($t1)
   3: $t3 := borrow_field<Test::A<u64, u128>>.x1($t2)
-  4: write_ref($t3, $t0)
+  4: write_ref($t0, $t3)
   5: return ()
 }
 

--- a/third_party/move/move-model/bytecode/tests/usage_analysis/test.v2_exp
+++ b/third_party/move/move-model/bytecode/tests/usage_analysis/test.v2_exp
@@ -10,7 +10,7 @@ public fun Test::update<#0>($t0|x: #0) {
   1: $t2 := 0x1
   2: $t3 := borrow_global<Test::A<#0, #0>>($t2)
   3: $t4 := borrow_field<Test::A<#0, #0>>.x1($t3)
-  4: write_ref($t4, $t1)
+  4: write_ref($t1, $t4)
   5: return ()
 }
 
@@ -70,7 +70,7 @@ public fun Test::update_ints() {
   1: $t1 := 0x1
   2: $t2 := borrow_global<Test::A<u64, u128>>($t1)
   3: $t3 := borrow_field<Test::A<u64, u128>>.x1($t2)
-  4: write_ref($t3, $t0)
+  4: write_ref($t0, $t3)
   5: return ()
 }
 
@@ -86,7 +86,7 @@ public fun Test::update<#0>($t0|x: #0) {
   1: $t2 := 0x1
   2: $t3 := borrow_global<Test::A<#0, #0>>($t2)
   3: $t4 := borrow_field<Test::A<#0, #0>>.x1($t3)
-  4: write_ref($t4, $t1)
+  4: write_ref($t1, $t4)
   5: return ()
 }
 
@@ -146,7 +146,7 @@ public fun Test::update_ints() {
   1: $t1 := 0x1
   2: $t2 := borrow_global<Test::A<u64, u128>>($t1)
   3: $t3 := borrow_field<Test::A<u64, u128>>.x1($t2)
-  4: write_ref($t3, $t0)
+  4: write_ref($t0, $t3)
   5: return ()
 }
 

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -1202,8 +1202,8 @@ impl<'env> FunctionTranslator<'env> {
                         );
                     },
                     WriteRef => {
-                        let reference = srcs[0];
-                        let value = srcs[1];
+                        let reference = srcs[1];
+                        let value = srcs[0];
                         emitln!(
                             writer,
                             "{} := $UpdateMutation({}, {});",
@@ -2187,7 +2187,7 @@ impl<'env> FunctionTranslator<'env> {
                     Uninit => {
                         emitln!(writer, "assume $t{}->l == $Uninitialized();", srcs[0]);
                     },
-                    Drop | Release => {},
+                    Drop | Release | Prepare => {},
                     TraceLocal(idx) => {
                         let num_oper = global_state
                             .get_temp_index_oper(mid, fid, srcs[0], baseline_flag)

--- a/third_party/move/move-prover/bytecode-pipeline/src/clean_and_optimize.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/clean_and_optimize.rs
@@ -98,7 +98,7 @@ impl<'a> TransferFunctions for Optimizer<'a> {
         if let Call(_, _, oper, srcs, _) = instr {
             match oper {
                 WriteRef => {
-                    state.unwritten.insert(Reference(srcs[0]));
+                    state.unwritten.insert(Reference(srcs[1]));
                 },
                 WriteBack(Reference(dest), ..) => {
                     if state.unwritten.contains(&Reference(srcs[0])) {

--- a/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/number_operation_analysis.rs
@@ -716,7 +716,19 @@ impl<'a> TransferFunctions for NumberOperationAnalysis<'a> {
                             baseline_flag,
                         );
                     },
-                    WriteRef | Lt | Le | Gt | Ge | Eq | Neq => {
+                    WriteRef => {
+                        self.check_and_propagate(
+                            id,
+                            state,
+                            &srcs[1],
+                            &srcs[0],
+                            cur_mid,
+                            cur_fid,
+                            &mut global_state,
+                            baseline_flag,
+                        );
+                    },
+                    Lt | Le | Gt | Ge | Eq | Neq => {
                         self.check_and_propagate(
                             id,
                             state,

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
@@ -784,7 +784,7 @@ impl<'a> Instrumenter<'a> {
                     id,
                     vec![],
                     Operation::WriteRef,
-                    vec![mem_ref, rhs_temp],
+                    vec![rhs_temp, mem_ref],
                     None,
                 )
             });

--- a/third_party/move/move-prover/bytecode-pipeline/tests/data_invariant_instrumentation/borrow.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/data_invariant_instrumentation/borrow.exp
@@ -36,11 +36,11 @@ public fun Test::test_borrow_mut<#0>(): u64 {
   4: $t4 := copy($t0)
   5: $t5 := borrow_field<Test::R<#0>>.s($t4)
   6: $t6 := borrow_field<Test::S>.y($t5)
-  7: write_ref($t6, $t3)
+  7: write_ref($t3, $t6)
   8: $t7 := 3
   9: $t8 := copy($t0)
  10: $t9 := borrow_field<Test::R<#0>>.x($t8)
- 11: write_ref($t9, $t7)
+ 11: write_ref($t7, $t9)
  12: $t10 := move($t0)
  13: $t11 := borrow_field<Test::R<#0>>.x($t10)
  14: $t12 := read_ref($t11)
@@ -78,11 +78,11 @@ public fun Test::test_borrow_mut_local(): Test::R<u64> {
   9: $t9 := copy($t1)
  10: $t10 := borrow_field<Test::R<u64>>.s($t9)
  11: $t11 := borrow_field<Test::S>.y($t10)
- 12: write_ref($t11, $t8)
+ 12: write_ref($t8, $t11)
  13: $t12 := 3
  14: $t13 := move($t1)
  15: $t14 := borrow_field<Test::R<u64>>.x($t13)
- 16: write_ref($t14, $t12)
+ 16: write_ref($t12, $t14)
  17: $t15 := move($t0)
  18: return $t15
 }
@@ -124,12 +124,12 @@ public fun Test::test_borrow_mut<#0>(): u64 {
   3: $t4 := 2
   4: $t5 := borrow_field<Test::R<#0>>.s($t2)
   5: $t6 := borrow_field<Test::S>.y($t5)
-  6: write_ref($t6, $t4)
+  6: write_ref($t4, $t6)
   7: write_back[Reference($t5).y (u64)]($t6)
   8: write_back[Reference($t2).s (Test::S)]($t5)
   9: $t7 := 3
  10: $t8 := borrow_field<Test::R<#0>>.x($t2)
- 11: write_ref($t8, $t7)
+ 11: write_ref($t7, $t8)
  12: write_back[Reference($t2).x (u64)]($t8)
  13: $t9 := get_field<Test::R<#0>>.x($t2)
      # data invariant at tests/data_invariant_instrumentation/borrow.move:13:9+18
@@ -176,12 +176,12 @@ public fun Test::test_borrow_mut_local(): Test::R<u64> {
   8: $t7 := 2
   9: $t8 := borrow_field<Test::R<u64>>.s($t6)
  10: $t9 := borrow_field<Test::S>.y($t8)
- 11: write_ref($t9, $t7)
+ 11: write_ref($t7, $t9)
  12: write_back[Reference($t8).y (u64)]($t9)
  13: write_back[Reference($t6).s (Test::S)]($t8)
  14: $t10 := 3
  15: $t11 := borrow_field<Test::R<u64>>.x($t6)
- 16: write_ref($t11, $t10)
+ 16: write_ref($t10, $t11)
  17: write_back[Reference($t6).x (u64)]($t11)
      # data invariant at tests/data_invariant_instrumentation/borrow.move:13:9+18
      # VC: data invariant does not hold at tests/data_invariant_instrumentation/borrow.move:13:9+18

--- a/third_party/move/move-prover/bytecode-pipeline/tests/data_invariant_instrumentation/borrow.v2_exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/data_invariant_instrumentation/borrow.v2_exp
@@ -36,11 +36,11 @@ public fun Test::test_borrow_mut<#0>(): u64 {
   4: $t4 := copy($t0)
   5: $t5 := borrow_field<Test::R<#0>>.s($t4)
   6: $t6 := borrow_field<Test::S>.y($t5)
-  7: write_ref($t6, $t3)
+  7: write_ref($t3, $t6)
   8: $t7 := 3
   9: $t8 := copy($t0)
  10: $t9 := borrow_field<Test::R<#0>>.x($t8)
- 11: write_ref($t9, $t7)
+ 11: write_ref($t7, $t9)
  12: $t10 := move($t0)
  13: $t11 := borrow_field<Test::R<#0>>.x($t10)
  14: $t12 := read_ref($t11)
@@ -78,11 +78,11 @@ public fun Test::test_borrow_mut_local(): Test::R<u64> {
   9: $t9 := copy($t1)
  10: $t10 := borrow_field<Test::R<u64>>.s($t9)
  11: $t11 := borrow_field<Test::S>.y($t10)
- 12: write_ref($t11, $t8)
+ 12: write_ref($t8, $t11)
  13: $t12 := 3
  14: $t13 := move($t1)
  15: $t14 := borrow_field<Test::R<u64>>.x($t13)
- 16: write_ref($t14, $t12)
+ 16: write_ref($t12, $t14)
  17: $t15 := move($t0)
  18: return $t15
 }
@@ -124,12 +124,12 @@ public fun Test::test_borrow_mut<#0>(): u64 {
   3: $t4 := 2
   4: $t5 := borrow_field<Test::R<#0>>.s($t2)
   5: $t6 := borrow_field<Test::S>.y($t5)
-  6: write_ref($t6, $t4)
+  6: write_ref($t4, $t6)
   7: write_back[Reference($t5).y (u64)]($t6)
   8: write_back[Reference($t2).s (Test::S)]($t5)
   9: $t7 := 3
  10: $t8 := borrow_field<Test::R<#0>>.x($t2)
- 11: write_ref($t8, $t7)
+ 11: write_ref($t7, $t8)
  12: write_back[Reference($t2).x (u64)]($t8)
  13: $t9 := get_field<Test::R<#0>>.x($t2)
      # data invariant at tests/data_invariant_instrumentation/borrow.move:13:9+18
@@ -176,12 +176,12 @@ public fun Test::test_borrow_mut_local(): Test::R<u64> {
   8: $t7 := 2
   9: $t8 := borrow_field<Test::R<u64>>.s($t6)
  10: $t9 := borrow_field<Test::S>.y($t8)
- 11: write_ref($t9, $t7)
+ 11: write_ref($t7, $t9)
  12: write_back[Reference($t8).y (u64)]($t9)
  13: write_back[Reference($t6).s (Test::S)]($t8)
  14: $t10 := 3
  15: $t11 := borrow_field<Test::R<u64>>.x($t6)
- 16: write_ref($t11, $t10)
+ 16: write_ref($t10, $t11)
  17: write_back[Reference($t6).x (u64)]($t11)
      # data invariant at tests/data_invariant_instrumentation/borrow.move:13:9+18
      # VC: data invariant does not hold at tests/data_invariant_instrumentation/borrow.move:13:9+18

--- a/third_party/move/move-prover/bytecode-pipeline/tests/eliminate_imm_refs/basic_test.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/eliminate_imm_refs/basic_test.exp
@@ -19,7 +19,7 @@ fun TestEliminateImmRefs::test1(): TestEliminateImmRefs::R {
   5: $t1 := $t5
   6: $t6 := 0
   7: $t7 := move($t1)
-  8: write_ref($t7, $t6)
+  8: write_ref($t6, $t7)
   9: $t8 := move($t0)
  10: return $t8
 }
@@ -108,7 +108,7 @@ fun TestEliminateImmRefs::test1(): TestEliminateImmRefs::R {
   5: $t1 := $t5
   6: $t6 := 0
   7: $t7 := move($t1)
-  8: write_ref($t7, $t6)
+  8: write_ref($t6, $t7)
   9: $t8 := move($t0)
  10: return $t8
 }

--- a/third_party/move/move-prover/bytecode-pipeline/tests/eliminate_imm_refs/basic_test.v2_exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/eliminate_imm_refs/basic_test.v2_exp
@@ -19,7 +19,7 @@ fun TestEliminateImmRefs::test1(): TestEliminateImmRefs::R {
   5: $t1 := $t5
   6: $t6 := 0
   7: $t7 := move($t1)
-  8: write_ref($t7, $t6)
+  8: write_ref($t6, $t7)
   9: $t8 := move($t0)
  10: return $t8
 }
@@ -108,7 +108,7 @@ fun TestEliminateImmRefs::test1(): TestEliminateImmRefs::R {
   5: $t1 := $t5
   6: $t6 := 0
   7: $t7 := move($t1)
-  8: write_ref($t7, $t6)
+  8: write_ref($t6, $t7)
   9: $t8 := move($t0)
  10: return $t8
 }

--- a/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_analysis/uninst_type_param_in_inv.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_analysis/uninst_type_param_in_inv.exp
@@ -22,7 +22,7 @@ fun Demo::f1($t0|addr: address) {
   5: $t4 := copy($t0)
   6: $t5 := borrow_global<Demo::S1<bool>>($t4)
   7: $t6 := borrow_field<Demo::S1<bool>>.v($t5)
-  8: write_ref($t6, $t3)
+  8: write_ref($t3, $t6)
   9: goto 10
  10: label L0
  11: $t7 := copy($t0)
@@ -33,7 +33,7 @@ fun Demo::f1($t0|addr: address) {
  16: $t10 := move($t0)
  17: $t11 := borrow_global<Demo::S1<u64>>($t10)
  18: $t12 := borrow_field<Demo::S1<u64>>.v($t11)
- 19: write_ref($t12, $t9)
+ 19: write_ref($t9, $t12)
  20: goto 21
  21: label L2
  22: return ()
@@ -58,7 +58,7 @@ fun Demo::f1($t0|addr: address) {
   3: $t2 := 0
   4: $t3 := borrow_global<Demo::S1<bool>>($t0) on_abort goto 22 with $t4
   5: $t5 := borrow_field<Demo::S1<bool>>.v($t3)
-  6: write_ref($t5, $t2)
+  6: write_ref($t2, $t5)
   7: write_back[Reference($t3).v (u8)]($t5)
   8: write_back[Demo::S1<bool>@]($t3)
   9: label L0
@@ -68,7 +68,7 @@ fun Demo::f1($t0|addr: address) {
  13: $t7 := 0
  14: $t8 := borrow_global<Demo::S1<u64>>($t0) on_abort goto 22 with $t4
  15: $t9 := borrow_field<Demo::S1<u64>>.v($t8)
- 16: write_ref($t9, $t7)
+ 16: write_ref($t7, $t9)
  17: write_back[Reference($t8).v (u8)]($t9)
  18: write_back[Demo::S1<u64>@]($t8)
  19: label L2

--- a/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_analysis/uninst_type_param_in_inv.v2_exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_analysis/uninst_type_param_in_inv.v2_exp
@@ -22,7 +22,7 @@ fun Demo::f1($t0|addr: address) {
   5: $t4 := copy($t0)
   6: $t5 := borrow_global<Demo::S1<bool>>($t4)
   7: $t6 := borrow_field<Demo::S1<bool>>.v($t5)
-  8: write_ref($t6, $t3)
+  8: write_ref($t3, $t6)
   9: goto 10
  10: label L0
  11: $t7 := copy($t0)
@@ -33,7 +33,7 @@ fun Demo::f1($t0|addr: address) {
  16: $t10 := move($t0)
  17: $t11 := borrow_global<Demo::S1<u64>>($t10)
  18: $t12 := borrow_field<Demo::S1<u64>>.v($t11)
- 19: write_ref($t12, $t9)
+ 19: write_ref($t9, $t12)
  20: goto 21
  21: label L2
  22: return ()
@@ -58,7 +58,7 @@ fun Demo::f1($t0|addr: address) {
   3: $t2 := 0
   4: $t3 := borrow_global<Demo::S1<bool>>($t0) on_abort goto 22 with $t4
   5: $t5 := borrow_field<Demo::S1<bool>>.v($t3)
-  6: write_ref($t5, $t2)
+  6: write_ref($t2, $t5)
   7: write_back[Reference($t3).v (u8)]($t5)
   8: write_back[Demo::S1<bool>@]($t3)
   9: label L0
@@ -68,7 +68,7 @@ fun Demo::f1($t0|addr: address) {
  13: $t7 := 0
  14: $t8 := borrow_global<Demo::S1<u64>>($t0) on_abort goto 22 with $t4
  15: $t9 := borrow_field<Demo::S1<u64>>.v($t8)
- 16: write_ref($t9, $t7)
+ 16: write_ref($t7, $t9)
  17: write_back[Reference($t8).v (u8)]($t9)
  18: write_back[Demo::S1<u64>@]($t8)
  19: label L2

--- a/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_instrumentation/borrow.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_instrumentation/borrow.exp
@@ -22,7 +22,7 @@ public fun Test::borrow($t0|a: address) {
   7: $t8 := +($t6, $t7)
   8: $t9 := move($t1)
   9: $t10 := borrow_field<Test::R>.x($t9)
- 10: write_ref($t10, $t8)
+ 10: write_ref($t8, $t10)
  11: return ()
 }
 
@@ -44,7 +44,7 @@ public fun Test::borrow($t0|a: address) {
   3: $t5 := 1
   4: $t6 := +($t4, $t5) on_abort goto 12 with $t3
   5: $t7 := borrow_field<Test::R>.x($t2)
-  6: write_ref($t7, $t6)
+  6: write_ref($t6, $t7)
   7: write_back[Reference($t2).x (u64)]($t7)
   8: write_back[Test::R@]($t2)
      # global invariant at tests/global_invariant_instrumentation/borrow.move:7:9+57

--- a/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_instrumentation/borrow.v2_exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_instrumentation/borrow.v2_exp
@@ -22,7 +22,7 @@ public fun Test::borrow($t0|a: address) {
   7: $t8 := +($t6, $t7)
   8: $t9 := move($t1)
   9: $t10 := borrow_field<Test::R>.x($t9)
- 10: write_ref($t10, $t8)
+ 10: write_ref($t8, $t10)
  11: return ()
 }
 
@@ -44,7 +44,7 @@ public fun Test::borrow($t0|a: address) {
   3: $t5 := 1
   4: $t6 := +($t4, $t5) on_abort goto 12 with $t3
   5: $t7 := borrow_field<Test::R>.x($t2)
-  6: write_ref($t7, $t6)
+  6: write_ref($t6, $t7)
   7: write_back[Reference($t2).x (u64)]($t7)
   8: write_back[Test::R@]($t2)
      # global invariant at tests/global_invariant_instrumentation/borrow.move:7:9+57

--- a/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_instrumentation/update.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_instrumentation/update.exp
@@ -22,7 +22,7 @@ public fun Test::incr($t0|a: address) {
   7: $t8 := +($t6, $t7)
   8: $t9 := move($t1)
   9: $t10 := borrow_field<Test::R>.x($t9)
- 10: write_ref($t10, $t8)
+ 10: write_ref($t8, $t10)
  11: return ()
 }
 
@@ -42,7 +42,7 @@ public fun Test::incr($t0|a: address) {
   2: $t5 := 1
   3: $t6 := +($t4, $t5) on_abort goto 12 with $t3
   4: $t7 := borrow_field<Test::R>.x($t2)
-  5: write_ref($t7, $t6)
+  5: write_ref($t6, $t7)
   6: write_back[Reference($t2).x (u64)]($t7)
      # state save for global update invariants
   7: @1 := save_mem(Test::R)

--- a/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_instrumentation/update.v2_exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_instrumentation/update.v2_exp
@@ -22,7 +22,7 @@ public fun Test::incr($t0|a: address) {
   7: $t8 := +($t6, $t7)
   8: $t9 := move($t1)
   9: $t10 := borrow_field<Test::R>.x($t9)
- 10: write_ref($t10, $t8)
+ 10: write_ref($t8, $t10)
  11: return ()
 }
 
@@ -42,7 +42,7 @@ public fun Test::incr($t0|a: address) {
   2: $t5 := 1
   3: $t6 := +($t4, $t5) on_abort goto 12 with $t3
   4: $t7 := borrow_field<Test::R>.x($t2)
-  5: write_ref($t7, $t6)
+  5: write_ref($t6, $t7)
   6: write_back[Reference($t2).x (u64)]($t7)
      # state save for global update invariants
   7: @1 := save_mem(Test::R)

--- a/third_party/move/move-prover/bytecode-pipeline/tests/memory_instr/basic_test.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/memory_instr/basic_test.exp
@@ -19,7 +19,7 @@ fun TestPackref::test1(): TestPackref::R {
   5: $t1 := $t5
   6: $t6 := 0
   7: $t7 := move($t1)
-  8: write_ref($t7, $t6)
+  8: write_ref($t6, $t7)
   9: $t8 := move($t0)
  10: return $t8
 }
@@ -31,7 +31,7 @@ fun TestPackref::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t3: &mut u64
   0: $t2 := move($t1)
   1: $t3 := move($t0)
-  2: write_ref($t3, $t2)
+  2: write_ref($t2, $t3)
   3: return ()
 }
 
@@ -245,7 +245,7 @@ fun TestPackref::test1(): TestPackref::R {
   2: $t3 := borrow_local($t0)
   3: $t4 := borrow_field<TestPackref::R>.x($t3)
   4: $t5 := 0
-  5: write_ref($t4, $t5)
+  5: write_ref($t5, $t4)
   6: write_back[Reference($t3).x (u64)]($t4)
   7: write_back[LocalRoot($t0)@]($t3)
   8: trace_local[r]($t0)
@@ -256,7 +256,7 @@ fun TestPackref::test1(): TestPackref::R {
 
 [variant baseline]
 fun TestPackref::test2($t0|x_ref: &mut u64, $t1|v: u64) {
-  0: write_ref($t0, $t1)
+  0: write_ref($t1, $t0)
   1: trace_local[x_ref]($t0)
   2: return ()
 }

--- a/third_party/move/move-prover/bytecode-pipeline/tests/memory_instr/basic_test.v2_exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/memory_instr/basic_test.v2_exp
@@ -19,7 +19,7 @@ fun TestPackref::test1(): TestPackref::R {
   5: $t1 := $t5
   6: $t6 := 0
   7: $t7 := move($t1)
-  8: write_ref($t7, $t6)
+  8: write_ref($t6, $t7)
   9: $t8 := move($t0)
  10: return $t8
 }
@@ -31,7 +31,7 @@ fun TestPackref::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t3: &mut u64
   0: $t2 := move($t1)
   1: $t3 := move($t0)
-  2: write_ref($t3, $t2)
+  2: write_ref($t2, $t3)
   3: return ()
 }
 
@@ -245,7 +245,7 @@ fun TestPackref::test1(): TestPackref::R {
   2: $t3 := borrow_local($t0)
   3: $t4 := borrow_field<TestPackref::R>.x($t3)
   4: $t5 := 0
-  5: write_ref($t4, $t5)
+  5: write_ref($t5, $t4)
   6: write_back[Reference($t3).x (u64)]($t4)
   7: write_back[LocalRoot($t0)@]($t3)
   8: trace_local[r]($t0)
@@ -256,7 +256,7 @@ fun TestPackref::test1(): TestPackref::R {
 
 [variant baseline]
 fun TestPackref::test2($t0|x_ref: &mut u64, $t1|v: u64) {
-  0: write_ref($t0, $t1)
+  0: write_ref($t1, $t0)
   1: trace_local[x_ref]($t0)
   2: return ()
 }

--- a/third_party/move/move-prover/bytecode-pipeline/tests/memory_instr/mut_ref.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/memory_instr/mut_ref.exp
@@ -32,7 +32,7 @@ public fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T) {
   4: $t6 := -($t4, $t5)
   5: $t7 := move($t0)
   6: $t8 := borrow_field<TestMutRefs::T>.value($t7)
-  7: write_ref($t8, $t6)
+  7: write_ref($t6, $t8)
   8: $t9 := 0x0
   9: $t10 := borrow_global<TestMutRefs::TSum>($t9)
  10: $t1 := $t10
@@ -43,7 +43,7 @@ public fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T) {
  15: $t15 := -($t13, $t14)
  16: $t16 := move($t1)
  17: $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
- 18: write_ref($t17, $t15)
+ 18: write_ref($t15, $t17)
  19: return ()
 }
 
@@ -76,7 +76,7 @@ public fun TestMutRefs::delete($t0|x: TestMutRefs::T) {
  10: $t11 := -($t9, $t10)
  11: $t12 := move($t1)
  12: $t13 := borrow_field<TestMutRefs::TSum>.sum($t12)
- 13: write_ref($t13, $t11)
+ 13: write_ref($t11, $t13)
  14: return ()
 }
 
@@ -107,7 +107,7 @@ public fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T) {
   4: $t6 := +($t4, $t5)
   5: $t7 := move($t0)
   6: $t8 := borrow_field<TestMutRefs::T>.value($t7)
-  7: write_ref($t8, $t6)
+  7: write_ref($t6, $t8)
   8: $t9 := 0x0
   9: $t10 := borrow_global<TestMutRefs::TSum>($t9)
  10: $t1 := $t10
@@ -118,7 +118,7 @@ public fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T) {
  15: $t15 := +($t13, $t14)
  16: $t16 := move($t1)
  17: $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
- 18: write_ref($t17, $t15)
+ 18: write_ref($t15, $t17)
  19: return ()
 }
 
@@ -139,7 +139,7 @@ public fun TestMutRefs::increment_invalid($t0|x: &mut TestMutRefs::T) {
   4: $t5 := +($t3, $t4)
   5: $t6 := move($t0)
   6: $t7 := borrow_field<TestMutRefs::T>.value($t6)
-  7: write_ref($t7, $t5)
+  7: write_ref($t5, $t7)
   8: return ()
 }
 
@@ -168,7 +168,7 @@ public fun TestMutRefs::new($t0|x: u64): TestMutRefs::T {
   7: $t8 := +($t6, $t7)
   8: $t9 := move($t1)
   9: $t10 := borrow_field<TestMutRefs::TSum>.sum($t9)
- 10: write_ref($t10, $t8)
+ 10: write_ref($t8, $t10)
  11: $t11 := move($t0)
  12: $t12 := pack TestMutRefs::T($t11)
  13: return $t12
@@ -207,7 +207,7 @@ fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T) {
   4: $t6 := -($t4, $t5)
   5: $t7 := move($t0)
   6: $t8 := borrow_field<TestMutRefs::T>.value($t7)
-  7: write_ref($t8, $t6)
+  7: write_ref($t6, $t8)
   8: $t9 := 0x0
   9: $t10 := borrow_global<TestMutRefs::TSum>($t9)
  10: $t1 := $t10
@@ -218,7 +218,7 @@ fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T) {
  15: $t15 := -($t13, $t14)
  16: $t16 := move($t1)
  17: $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
- 18: write_ref($t17, $t15)
+ 18: write_ref($t15, $t17)
  19: return ()
 }
 
@@ -297,7 +297,7 @@ public fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T) {
   1: $t3 := 1
   2: $t4 := -($t2, $t3)
   3: $t5 := borrow_field<TestMutRefs::T>.value($t0)
-  4: write_ref($t5, $t4)
+  4: write_ref($t4, $t5)
   5: write_back[Reference($t0).value (u64)]($t5)
   6: trace_local[x]($t0)
   7: $t6 := 0x0
@@ -306,7 +306,7 @@ public fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T) {
  10: $t9 := 1
  11: $t10 := -($t8, $t9)
  12: $t11 := borrow_field<TestMutRefs::TSum>.sum($t7)
- 13: write_ref($t11, $t10)
+ 13: write_ref($t10, $t11)
  14: write_back[Reference($t7).sum (u64)]($t11)
  15: write_back[TestMutRefs::TSum@]($t7)
  16: trace_local[x]($t0)
@@ -330,7 +330,7 @@ public fun TestMutRefs::delete($t0|x: TestMutRefs::T) {
   3: $t6 := get_field<TestMutRefs::TSum>.sum($t4)
   4: $t7 := -($t6, $t5)
   5: $t8 := borrow_field<TestMutRefs::TSum>.sum($t4)
-  6: write_ref($t8, $t7)
+  6: write_ref($t7, $t8)
   7: write_back[Reference($t4).sum (u64)]($t8)
   8: write_back[TestMutRefs::TSum@]($t4)
   9: return ()
@@ -354,7 +354,7 @@ public fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T) {
   1: $t3 := 1
   2: $t4 := +($t2, $t3)
   3: $t5 := borrow_field<TestMutRefs::T>.value($t0)
-  4: write_ref($t5, $t4)
+  4: write_ref($t4, $t5)
   5: write_back[Reference($t0).value (u64)]($t5)
   6: trace_local[x]($t0)
   7: $t6 := 0x0
@@ -363,7 +363,7 @@ public fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T) {
  10: $t9 := 1
  11: $t10 := +($t8, $t9)
  12: $t11 := borrow_field<TestMutRefs::TSum>.sum($t7)
- 13: write_ref($t11, $t10)
+ 13: write_ref($t10, $t11)
  14: write_back[Reference($t7).sum (u64)]($t11)
  15: write_back[TestMutRefs::TSum@]($t7)
  16: trace_local[x]($t0)
@@ -381,7 +381,7 @@ public fun TestMutRefs::increment_invalid($t0|x: &mut TestMutRefs::T) {
   1: $t2 := 1
   2: $t3 := +($t1, $t2)
   3: $t4 := borrow_field<TestMutRefs::T>.value($t0)
-  4: write_ref($t4, $t3)
+  4: write_ref($t3, $t4)
   5: write_back[Reference($t0).value (u64)]($t4)
   6: trace_local[x]($t0)
   7: trace_local[x]($t0)
@@ -403,7 +403,7 @@ public fun TestMutRefs::new($t0|x: u64): TestMutRefs::T {
   2: $t4 := get_field<TestMutRefs::TSum>.sum($t3)
   3: $t5 := +($t4, $t0)
   4: $t6 := borrow_field<TestMutRefs::TSum>.sum($t3)
-  5: write_ref($t6, $t5)
+  5: write_ref($t5, $t6)
   6: write_back[Reference($t3).sum (u64)]($t6)
   7: write_back[TestMutRefs::TSum@]($t3)
   8: $t7 := pack TestMutRefs::T($t0)
@@ -435,7 +435,7 @@ fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T) {
   1: $t3 := 1
   2: $t4 := -($t2, $t3)
   3: $t5 := borrow_field<TestMutRefs::T>.value($t0)
-  4: write_ref($t5, $t4)
+  4: write_ref($t4, $t5)
   5: write_back[Reference($t0).value (u64)]($t5)
   6: trace_local[x]($t0)
   7: $t6 := 0x0
@@ -444,7 +444,7 @@ fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T) {
  10: $t9 := 1
  11: $t10 := -($t8, $t9)
  12: $t11 := borrow_field<TestMutRefs::TSum>.sum($t7)
- 13: write_ref($t11, $t10)
+ 13: write_ref($t10, $t11)
  14: write_back[Reference($t7).sum (u64)]($t11)
  15: write_back[TestMutRefs::TSum@]($t7)
  16: trace_local[x]($t0)

--- a/third_party/move/move-prover/bytecode-pipeline/tests/memory_instr/mut_ref.v2_exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/memory_instr/mut_ref.v2_exp
@@ -32,7 +32,7 @@ public fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T) {
   4: $t6 := -($t4, $t5)
   5: $t7 := move($t0)
   6: $t8 := borrow_field<TestMutRefs::T>.value($t7)
-  7: write_ref($t8, $t6)
+  7: write_ref($t6, $t8)
   8: $t9 := 0x0
   9: $t10 := borrow_global<TestMutRefs::TSum>($t9)
  10: $t1 := $t10
@@ -43,7 +43,7 @@ public fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T) {
  15: $t15 := -($t13, $t14)
  16: $t16 := move($t1)
  17: $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
- 18: write_ref($t17, $t15)
+ 18: write_ref($t15, $t17)
  19: return ()
 }
 
@@ -76,7 +76,7 @@ public fun TestMutRefs::delete($t0|x: TestMutRefs::T) {
  10: $t11 := -($t9, $t10)
  11: $t12 := move($t1)
  12: $t13 := borrow_field<TestMutRefs::TSum>.sum($t12)
- 13: write_ref($t13, $t11)
+ 13: write_ref($t11, $t13)
  14: return ()
 }
 
@@ -107,7 +107,7 @@ public fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T) {
   4: $t6 := +($t4, $t5)
   5: $t7 := move($t0)
   6: $t8 := borrow_field<TestMutRefs::T>.value($t7)
-  7: write_ref($t8, $t6)
+  7: write_ref($t6, $t8)
   8: $t9 := 0x0
   9: $t10 := borrow_global<TestMutRefs::TSum>($t9)
  10: $t1 := $t10
@@ -118,7 +118,7 @@ public fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T) {
  15: $t15 := +($t13, $t14)
  16: $t16 := move($t1)
  17: $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
- 18: write_ref($t17, $t15)
+ 18: write_ref($t15, $t17)
  19: return ()
 }
 
@@ -139,7 +139,7 @@ public fun TestMutRefs::increment_invalid($t0|x: &mut TestMutRefs::T) {
   4: $t5 := +($t3, $t4)
   5: $t6 := move($t0)
   6: $t7 := borrow_field<TestMutRefs::T>.value($t6)
-  7: write_ref($t7, $t5)
+  7: write_ref($t5, $t7)
   8: return ()
 }
 
@@ -168,7 +168,7 @@ public fun TestMutRefs::new($t0|x: u64): TestMutRefs::T {
   7: $t8 := +($t6, $t7)
   8: $t9 := move($t1)
   9: $t10 := borrow_field<TestMutRefs::TSum>.sum($t9)
- 10: write_ref($t10, $t8)
+ 10: write_ref($t8, $t10)
  11: $t11 := move($t0)
  12: $t12 := pack TestMutRefs::T($t11)
  13: return $t12
@@ -207,7 +207,7 @@ fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T) {
   4: $t6 := -($t4, $t5)
   5: $t7 := move($t0)
   6: $t8 := borrow_field<TestMutRefs::T>.value($t7)
-  7: write_ref($t8, $t6)
+  7: write_ref($t6, $t8)
   8: $t9 := 0x0
   9: $t10 := borrow_global<TestMutRefs::TSum>($t9)
  10: $t1 := $t10
@@ -218,7 +218,7 @@ fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T) {
  15: $t15 := -($t13, $t14)
  16: $t16 := move($t1)
  17: $t17 := borrow_field<TestMutRefs::TSum>.sum($t16)
- 18: write_ref($t17, $t15)
+ 18: write_ref($t15, $t17)
  19: return ()
 }
 
@@ -297,7 +297,7 @@ public fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T) {
   1: $t3 := 1
   2: $t4 := -($t2, $t3)
   3: $t5 := borrow_field<TestMutRefs::T>.value($t0)
-  4: write_ref($t5, $t4)
+  4: write_ref($t4, $t5)
   5: write_back[Reference($t0).value (u64)]($t5)
   6: trace_local[x]($t0)
   7: $t6 := 0x0
@@ -306,7 +306,7 @@ public fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T) {
  10: $t9 := 1
  11: $t10 := -($t8, $t9)
  12: $t11 := borrow_field<TestMutRefs::TSum>.sum($t7)
- 13: write_ref($t11, $t10)
+ 13: write_ref($t10, $t11)
  14: write_back[Reference($t7).sum (u64)]($t11)
  15: write_back[TestMutRefs::TSum@]($t7)
  16: trace_local[x]($t0)
@@ -330,7 +330,7 @@ public fun TestMutRefs::delete($t0|x: TestMutRefs::T) {
   3: $t6 := get_field<TestMutRefs::TSum>.sum($t4)
   4: $t7 := -($t6, $t5)
   5: $t8 := borrow_field<TestMutRefs::TSum>.sum($t4)
-  6: write_ref($t8, $t7)
+  6: write_ref($t7, $t8)
   7: write_back[Reference($t4).sum (u64)]($t8)
   8: write_back[TestMutRefs::TSum@]($t4)
   9: return ()
@@ -354,7 +354,7 @@ public fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T) {
   1: $t3 := 1
   2: $t4 := +($t2, $t3)
   3: $t5 := borrow_field<TestMutRefs::T>.value($t0)
-  4: write_ref($t5, $t4)
+  4: write_ref($t4, $t5)
   5: write_back[Reference($t0).value (u64)]($t5)
   6: trace_local[x]($t0)
   7: $t6 := 0x0
@@ -363,7 +363,7 @@ public fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T) {
  10: $t9 := 1
  11: $t10 := +($t8, $t9)
  12: $t11 := borrow_field<TestMutRefs::TSum>.sum($t7)
- 13: write_ref($t11, $t10)
+ 13: write_ref($t10, $t11)
  14: write_back[Reference($t7).sum (u64)]($t11)
  15: write_back[TestMutRefs::TSum@]($t7)
  16: trace_local[x]($t0)
@@ -381,7 +381,7 @@ public fun TestMutRefs::increment_invalid($t0|x: &mut TestMutRefs::T) {
   1: $t2 := 1
   2: $t3 := +($t1, $t2)
   3: $t4 := borrow_field<TestMutRefs::T>.value($t0)
-  4: write_ref($t4, $t3)
+  4: write_ref($t3, $t4)
   5: write_back[Reference($t0).value (u64)]($t4)
   6: trace_local[x]($t0)
   7: trace_local[x]($t0)
@@ -403,7 +403,7 @@ public fun TestMutRefs::new($t0|x: u64): TestMutRefs::T {
   2: $t4 := get_field<TestMutRefs::TSum>.sum($t3)
   3: $t5 := +($t4, $t0)
   4: $t6 := borrow_field<TestMutRefs::TSum>.sum($t3)
-  5: write_ref($t6, $t5)
+  5: write_ref($t5, $t6)
   6: write_back[Reference($t3).sum (u64)]($t6)
   7: write_back[TestMutRefs::TSum@]($t3)
   8: $t7 := pack TestMutRefs::T($t0)
@@ -435,7 +435,7 @@ fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T) {
   1: $t3 := 1
   2: $t4 := -($t2, $t3)
   3: $t5 := borrow_field<TestMutRefs::T>.value($t0)
-  4: write_ref($t5, $t4)
+  4: write_ref($t4, $t5)
   5: write_back[Reference($t0).value (u64)]($t5)
   6: trace_local[x]($t0)
   7: $t6 := 0x0
@@ -444,7 +444,7 @@ fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T) {
  10: $t9 := 1
  11: $t10 := -($t8, $t9)
  12: $t11 := borrow_field<TestMutRefs::TSum>.sum($t7)
- 13: write_ref($t11, $t10)
+ 13: write_ref($t10, $t11)
  14: write_back[Reference($t7).sum (u64)]($t11)
  15: write_back[TestMutRefs::TSum@]($t7)
  16: trace_local[x]($t0)

--- a/third_party/move/move-prover/bytecode-pipeline/tests/mut_ref_instrumentation/basic_test.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/mut_ref_instrumentation/basic_test.exp
@@ -19,7 +19,7 @@ fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
   5: $t1 := $t5
   6: $t6 := 0
   7: $t7 := move($t1)
-  8: write_ref($t7, $t6)
+  8: write_ref($t6, $t7)
   9: $t8 := move($t0)
  10: return $t8
 }
@@ -31,7 +31,7 @@ fun TestEliminateMutRefs::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t3: &mut u64
   0: $t2 := move($t1)
   1: $t3 := move($t0)
-  2: write_ref($t3, $t2)
+  2: write_ref($t2, $t3)
   3: return ()
 }
 
@@ -250,7 +250,7 @@ fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
   5: $t1 := $t5
   6: $t6 := 0
   7: $t7 := move($t1)
-  8: write_ref($t7, $t6)
+  8: write_ref($t6, $t7)
   9: $t8 := move($t0)
  10: return $t8
 }
@@ -262,7 +262,7 @@ fun TestEliminateMutRefs::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t3: &mut u64
   0: $t2 := move($t1)
   1: $t3 := copy($t0)
-  2: write_ref($t3, $t2)
+  2: write_ref($t2, $t3)
   3: trace_local[x_ref]($t0)
   4: return ()
 }

--- a/third_party/move/move-prover/bytecode-pipeline/tests/mut_ref_instrumentation/basic_test.v2_exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/mut_ref_instrumentation/basic_test.v2_exp
@@ -19,7 +19,7 @@ fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
   5: $t1 := $t5
   6: $t6 := 0
   7: $t7 := move($t1)
-  8: write_ref($t7, $t6)
+  8: write_ref($t6, $t7)
   9: $t8 := move($t0)
  10: return $t8
 }
@@ -31,7 +31,7 @@ fun TestEliminateMutRefs::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t3: &mut u64
   0: $t2 := move($t1)
   1: $t3 := move($t0)
-  2: write_ref($t3, $t2)
+  2: write_ref($t2, $t3)
   3: return ()
 }
 
@@ -250,7 +250,7 @@ fun TestEliminateMutRefs::test1(): TestEliminateMutRefs::R {
   5: $t1 := $t5
   6: $t6 := 0
   7: $t7 := move($t1)
-  8: write_ref($t7, $t6)
+  8: write_ref($t6, $t7)
   9: $t8 := move($t0)
  10: return $t8
 }
@@ -262,7 +262,7 @@ fun TestEliminateMutRefs::test2($t0|x_ref: &mut u64, $t1|v: u64) {
      var $t3: &mut u64
   0: $t2 := move($t1)
   1: $t3 := copy($t0)
-  2: write_ref($t3, $t2)
+  2: write_ref($t2, $t3)
   3: trace_local[x_ref]($t0)
   4: return ()
 }

--- a/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/fun_spec.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/fun_spec.exp
@@ -98,7 +98,7 @@ fun Test::mut_ref_param($t0|r: &mut Test::R): u64 {
   8: $t9 := -($t7, $t8)
   9: $t10 := move($t0)
  10: $t11 := borrow_field<Test::R>.v($t10)
- 11: write_ref($t11, $t9)
+ 11: write_ref($t9, $t11)
  12: $t12 := move($t1)
  13: return $t12
 }
@@ -160,7 +160,7 @@ fun Test::resource_with_old($t0|val: u64) {
  15: $t12 := +($t10, $t11)
  16: $t13 := move($t1)
  17: $t14 := borrow_field<Test::R>.v($t13)
- 18: write_ref($t14, $t12)
+ 18: write_ref($t12, $t14)
  19: return ()
 }
 
@@ -267,7 +267,7 @@ fun Test::mut_ref_param($t0|r: &mut Test::R): u64 {
   3: $t5 := 1
   4: $t6 := -($t4, $t5) on_abort goto 15 with $t7
   5: $t8 := borrow_field<Test::R>.v($t0)
-  6: write_ref($t8, $t6)
+  6: write_ref($t6, $t8)
   7: write_back[Reference($t0).v (u64)]($t8)
   8: trace_local[r]($t0)
   9: trace_local[r]($t0)
@@ -342,7 +342,7 @@ fun Test::resource_with_old($t0|val: u64) {
  15: $t9 := get_field<Test::R>.v($t8)
  16: $t10 := +($t9, $t0) on_abort goto 26 with $t6
  17: $t11 := borrow_field<Test::R>.v($t8)
- 18: write_ref($t11, $t10)
+ 18: write_ref($t10, $t11)
  19: write_back[Reference($t8).v (u64)]($t11)
  20: write_back[Test::R@]($t8)
  21: label L2

--- a/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/fun_spec.v2_exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/fun_spec.v2_exp
@@ -98,7 +98,7 @@ fun Test::mut_ref_param($t0|r: &mut Test::R): u64 {
   8: $t9 := -($t7, $t8)
   9: $t10 := move($t0)
  10: $t11 := borrow_field<Test::R>.v($t10)
- 11: write_ref($t11, $t9)
+ 11: write_ref($t9, $t11)
  12: $t12 := move($t1)
  13: return $t12
 }
@@ -160,7 +160,7 @@ fun Test::resource_with_old($t0|val: u64) {
  15: $t12 := +($t10, $t11)
  16: $t13 := move($t1)
  17: $t14 := borrow_field<Test::R>.v($t13)
- 18: write_ref($t14, $t12)
+ 18: write_ref($t12, $t14)
  19: return ()
 }
 
@@ -267,7 +267,7 @@ fun Test::mut_ref_param($t0|r: &mut Test::R): u64 {
   3: $t5 := 1
   4: $t6 := -($t4, $t5) on_abort goto 15 with $t7
   5: $t8 := borrow_field<Test::R>.v($t0)
-  6: write_ref($t8, $t6)
+  6: write_ref($t6, $t8)
   7: write_back[Reference($t0).v (u64)]($t8)
   8: trace_local[r]($t0)
   9: trace_local[r]($t0)
@@ -342,7 +342,7 @@ fun Test::resource_with_old($t0|val: u64) {
  15: $t9 := get_field<Test::R>.v($t8)
  16: $t10 := +($t9, $t0) on_abort goto 26 with $t6
  17: $t11 := borrow_field<Test::R>.v($t8)
- 18: write_ref($t11, $t10)
+ 18: write_ref($t10, $t11)
  19: write_back[Reference($t8).v (u64)]($t11)
  20: write_back[Test::R@]($t8)
  21: label L2

--- a/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/modifies.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/modifies.exp
@@ -14,7 +14,7 @@ public fun A::mutate_at($t0|addr: address) {
   3: $t4 := 2
   4: $t5 := move($t1)
   5: $t6 := borrow_field<A::S>.x($t5)
-  6: write_ref($t6, $t4)
+  6: write_ref($t4, $t6)
   7: return ()
 }
 
@@ -153,7 +153,7 @@ public fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
   6: $t9 := 2
   7: $t10 := move($t2)
   8: $t11 := borrow_field<B::T>.x($t10)
-  9: write_ref($t11, $t9)
+  9: write_ref($t9, $t11)
  10: $t12 := move($t1)
  11: $t13 := A::read_at($t12)
  12: $t4 := $t13
@@ -177,7 +177,7 @@ public fun A::mutate_at($t0|addr: address) {
   3: $t2 := borrow_global<A::S>($t0) on_abort goto 13 with $t3
   4: $t4 := 2
   5: $t5 := borrow_field<A::S>.x($t2)
-  6: write_ref($t5, $t4)
+  6: write_ref($t4, $t5)
   7: write_back[Reference($t2).x (u64)]($t5)
   8: write_back[A::S@]($t2)
   9: label L1
@@ -434,7 +434,7 @@ public fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
  12: $t8 := borrow_global<B::T>($t0) on_abort goto 31 with $t7
  13: $t9 := 2
  14: $t10 := borrow_field<B::T>.x($t8)
- 15: write_ref($t10, $t9)
+ 15: write_ref($t9, $t10)
  16: write_back[Reference($t8).x (u64)]($t10)
  17: write_back[B::T@]($t8)
  18: $t11 := opaque begin: A::read_at($t1)

--- a/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/modifies.v2_exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/modifies.v2_exp
@@ -14,7 +14,7 @@ public fun A::mutate_at($t0|addr: address) {
   3: $t4 := 2
   4: $t5 := move($t1)
   5: $t6 := borrow_field<A::S>.x($t5)
-  6: write_ref($t6, $t4)
+  6: write_ref($t4, $t6)
   7: return ()
 }
 
@@ -153,7 +153,7 @@ public fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
   6: $t9 := 2
   7: $t10 := move($t2)
   8: $t11 := borrow_field<B::T>.x($t10)
-  9: write_ref($t11, $t9)
+  9: write_ref($t9, $t11)
  10: $t12 := move($t1)
  11: $t13 := A::read_at($t12)
  12: $t4 := $t13
@@ -177,7 +177,7 @@ public fun A::mutate_at($t0|addr: address) {
   3: $t2 := borrow_global<A::S>($t0) on_abort goto 13 with $t3
   4: $t4 := 2
   5: $t5 := borrow_field<A::S>.x($t2)
-  6: write_ref($t5, $t4)
+  6: write_ref($t4, $t5)
   7: write_back[Reference($t2).x (u64)]($t5)
   8: write_back[A::S@]($t2)
   9: label L1
@@ -434,7 +434,7 @@ public fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
  12: $t8 := borrow_global<B::T>($t0) on_abort goto 31 with $t7
  13: $t9 := 2
  14: $t10 := borrow_field<B::T>.x($t8)
- 15: write_ref($t10, $t9)
+ 15: write_ref($t9, $t10)
  16: write_back[Reference($t8).x (u64)]($t10)
  17: write_back[B::T@]($t8)
  18: $t11 := opaque begin: A::read_at($t1)

--- a/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/opaque_call.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/opaque_call.exp
@@ -43,7 +43,7 @@ fun Test::get_and_incr($t0|addr: address): u64 {
  19: $t16 := +($t14, $t15)
  20: $t17 := move($t1)
  21: $t18 := borrow_field<Test::R>.v($t17)
- 22: write_ref($t18, $t16)
+ 22: write_ref($t16, $t18)
  23: $t19 := move($t2)
  24: return $t19
 }
@@ -99,7 +99,7 @@ fun Test::get_and_incr($t0|addr: address): u64 {
  15: $t10 := 1
  16: $t11 := +($t9, $t10) on_abort goto 27 with $t6
  17: $t12 := borrow_field<Test::R>.v($t7)
- 18: write_ref($t12, $t11)
+ 18: write_ref($t11, $t12)
  19: write_back[Reference($t7).v (u64)]($t12)
  20: write_back[Test::R@]($t7)
  21: label L2

--- a/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/opaque_call.v2_exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/opaque_call.v2_exp
@@ -43,7 +43,7 @@ fun Test::get_and_incr($t0|addr: address): u64 {
  19: $t16 := +($t14, $t15)
  20: $t17 := move($t1)
  21: $t18 := borrow_field<Test::R>.v($t17)
- 22: write_ref($t18, $t16)
+ 22: write_ref($t16, $t18)
  23: $t19 := move($t2)
  24: return $t19
 }
@@ -99,7 +99,7 @@ fun Test::get_and_incr($t0|addr: address): u64 {
  15: $t10 := 1
  16: $t11 := +($t9, $t10) on_abort goto 27 with $t6
  17: $t12 := borrow_field<Test::R>.v($t7)
- 18: write_ref($t12, $t11)
+ 18: write_ref($t11, $t12)
  19: write_back[Reference($t7).v (u64)]($t12)
  20: write_back[Test::R@]($t7)
  21: label L2

--- a/third_party/move/move-prover/tests/sources/functional/ModifiesSchemaTest.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/ModifiesSchemaTest.v2_exp
@@ -13,8 +13,8 @@ error: caller does not have permission to modify `A::S` at given address
    =     at tests/sources/functional/ModifiesSchemaTest.move:30: mutate_at_wrapper2
    =     at tests/sources/functional/ModifiesSchemaTest.move:12: mutate_at
    =         addr = <redacted>
+   =     at tests/sources/functional/ModifiesSchemaTest.move:14: mutate_at
    =     at tests/sources/functional/ModifiesSchemaTest.move:13: mutate_at
    =     at tests/sources/functional/ModifiesSchemaTest.move:14: mutate_at
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/ModifiesSchemaTest.move:15: mutate_at
    =     at tests/sources/functional/ModifiesSchemaTest.move:31: mutate_at_wrapper2

--- a/third_party/move/move-prover/tests/sources/functional/aborts_if.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/aborts_if.v2_exp
@@ -102,7 +102,7 @@ error: abort not covered by any of the `aborts_if` clauses
     ┌─ tests/sources/functional/aborts_if.move:139:5
     │
 137 │           if (x == 2 || x == 3) abort 1;
-    │                         ------ abort happened here with code 0x1
+    │                                 ------- abort happened here with code 0x1
 138 │       }
 139 │ ╭     spec abort_at_2_or_3_total_incorrect {
 140 │ │         // Counter check that we get an error message without the pragma.
@@ -136,7 +136,7 @@ error: abort not covered by any of the `aborts_if` clauses
     ┌─ tests/sources/functional/aborts_if.move:157:5
     │
 155 │           if (x == 2 || x == 3) abort 1;
-    │                         ------ abort happened here with code 0x1
+    │                                 ------- abort happened here with code 0x1
 156 │       }
 157 │ ╭     spec abort_at_2_or_3_strict_incorrect {
 158 │ │         // When the strict mode is enabled, no aborts_if clause means aborts_if false.

--- a/third_party/move/move-prover/tests/sources/functional/aborts_if_with_code.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/aborts_if_with_code.v2_exp
@@ -2,22 +2,21 @@ Move prover returns: exiting with verification errors
 error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
    ┌─ tests/sources/functional/aborts_if_with_code.move:38:5
    │
-30 │   ╭         if (x == 1) {
-31 │   │             abort 2
-32 │   │         };
-   │   ╰─────────' abort happened here with code 0x2
-   ·   │
-38 │ ╭       spec conditional_abort_invalid {
-39 │ │           aborts_if x == 1 with 1; // wrong code
-40 │ │           aborts_if y == 2 with 3;
-41 │ │           ensures result == x;
-42 │ │       }
-   │ ╰───────^
+31 │               abort 2
+   │               ------- abort happened here with code 0x2
+   ·
+38 │ ╭     spec conditional_abort_invalid {
+39 │ │         aborts_if x == 1 with 1; // wrong code
+40 │ │         aborts_if y == 2 with 3;
+41 │ │         ensures result == x;
+42 │ │     }
+   │ ╰─────^
    │
    =     at tests/sources/functional/aborts_if_with_code.move:29: conditional_abort_invalid
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/aborts_if_with_code.move:30: conditional_abort_invalid
+   =     at tests/sources/functional/aborts_if_with_code.move:31: conditional_abort_invalid
    =         ABORTED
 
 error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
@@ -40,8 +39,8 @@ error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
 error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
    ┌─ tests/sources/functional/aborts_if_with_code.move:77:5
    │
-73 │           if (x == 2) {
-   │               ------ abort happened here with code 0x2
+74 │               abort(2)
+   │               -------- abort happened here with code 0x2
    ·
 77 │ ╭     spec aborts_if_with_code_mixed_invalid {
 78 │ │         aborts_if x == 1;
@@ -52,15 +51,15 @@ error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
    =     at tests/sources/functional/aborts_if_with_code.move:69: aborts_if_with_code_mixed_invalid
    =         x = <redacted>
    =     at tests/sources/functional/aborts_if_with_code.move:70: aborts_if_with_code_mixed_invalid
-   =     at tests/sources/functional/aborts_if_with_code.move:71: aborts_if_with_code_mixed_invalid
    =     at tests/sources/functional/aborts_if_with_code.move:73: aborts_if_with_code_mixed_invalid
+   =     at tests/sources/functional/aborts_if_with_code.move:74: aborts_if_with_code_mixed_invalid
    =         ABORTED
 
 error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
     ┌─ tests/sources/functional/aborts_if_with_code.move:105:5
     │
-101 │           if (x == 2) {
-    │               ------ abort happened here with code 0x2
+102 │               abort(2)
+    │               -------- abort happened here with code 0x2
     ·
 105 │ ╭     spec aborts_with_invalid {
 106 │ │         aborts_with 1,3;
@@ -70,15 +69,15 @@ error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
     =     at tests/sources/functional/aborts_if_with_code.move:97: aborts_with_invalid
     =         x = <redacted>
     =     at tests/sources/functional/aborts_if_with_code.move:98: aborts_with_invalid
-    =     at tests/sources/functional/aborts_if_with_code.move:99: aborts_with_invalid
     =     at tests/sources/functional/aborts_if_with_code.move:101: aborts_with_invalid
+    =     at tests/sources/functional/aborts_if_with_code.move:102: aborts_with_invalid
     =         ABORTED
 
 error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
     ┌─ tests/sources/functional/aborts_if_with_code.move:131:5
     │
-127 │           if (x == 2) {
-    │               ------ abort happened here with code 0x1
+128 │               abort(1)
+    │               -------- abort happened here with code 0x1
     ·
 131 │ ╭     spec aborts_with_mixed_invalid {
 132 │ │         pragma aborts_if_is_partial = true;
@@ -90,6 +89,6 @@ error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
     =     at tests/sources/functional/aborts_if_with_code.move:123: aborts_with_mixed_invalid
     =         x = <redacted>
     =     at tests/sources/functional/aborts_if_with_code.move:124: aborts_with_mixed_invalid
-    =     at tests/sources/functional/aborts_if_with_code.move:125: aborts_with_mixed_invalid
     =     at tests/sources/functional/aborts_if_with_code.move:127: aborts_with_mixed_invalid
+    =     at tests/sources/functional/aborts_if_with_code.move:128: aborts_with_mixed_invalid
     =         ABORTED

--- a/third_party/move/move-prover/tests/sources/functional/address_quant.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/address_quant.v2_exp
@@ -11,6 +11,5 @@ error: post-condition does not hold
    =     at tests/sources/functional/address_quant.move:46: multiple_copy_incorrect
    =         sndr = <redacted>
    =     at tests/sources/functional/address_quant.move:47: multiple_copy_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/address_quant.move:48: multiple_copy_incorrect
    =     at tests/sources/functional/address_quant.move:53

--- a/third_party/move/move-prover/tests/sources/functional/choice.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/choice.v2_exp
@@ -30,9 +30,7 @@ error: post-condition does not hold
    =         s1 = <redacted>
    =         s2 = <redacted>
    =     at tests/sources/functional/choice.move:47: populate_R
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/choice.move:48: populate_R
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/choice.move:49: populate_R
    =     at tests/sources/functional/choice.move:56: populate_R (spec)
 
@@ -46,8 +44,8 @@ error: post-condition does not hold
    =         v = <redacted>
    =     at tests/sources/functional/choice.move:77: test_not_using_min_incorrect
    =     at tests/sources/functional/choice.move:78: test_not_using_min_incorrect
-   =         <redacted> = <redacted>
    =         v_ref = <redacted>
+   =         <redacted> = <redacted>
    =     at tests/sources/functional/choice.move:79: test_not_using_min_incorrect
    =         <redacted> = <redacted>
    =     at tests/sources/functional/choice.move:80: test_not_using_min_incorrect
@@ -132,7 +130,6 @@ error: post-condition does not hold
     =         ballot_account = <redacted>
     =     at tests/sources/functional/choice.move:284: create_ballot
     =     at tests/sources/functional/choice.move:283: create_ballot
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/choice.move:291
     =     at tests/sources/functional/choice.move:286: create_ballot
     =     at tests/sources/functional/choice.move:272: new_ballot_id

--- a/third_party/move/move-prover/tests/sources/functional/data_invariant_in_map.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/data_invariant_in_map.v2_exp
@@ -6,8 +6,8 @@ error: data invariant does not hold
   │         ^^^^^^^^^^^^^^^^^^^^^
   │
   =     at tests/sources/functional/data_invariant_in_map.move:20: violation_1
+  =     at tests/sources/functional/data_invariant_in_map.move:23: violation_1
   =     at tests/sources/functional/data_invariant_in_map.move:21: violation_1
   =     at tests/sources/functional/data_invariant_in_map.move:22: violation_1
   =     at tests/sources/functional/data_invariant_in_map.move:23: violation_1
-  =         <redacted> = <redacted>
   =     at tests/sources/functional/data_invariant_in_map.move:8

--- a/third_party/move/move-prover/tests/sources/functional/emits.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/emits.v2_exp
@@ -8,7 +8,6 @@ error: function does not emit the expected event
    =     at tests/sources/functional/emits.move:19: simple_wrong_msg_incorrect
    =         handle = <redacted>
    =     at tests/sources/functional/emits.move:20: simple_wrong_msg_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/emits.move:19: simple_wrong_msg_incorrect
    =         handle = <redacted>
    =     at tests/sources/functional/emits.move:21: simple_wrong_msg_incorrect
@@ -24,7 +23,6 @@ error: function does not emit the expected event
    =         handle = <redacted>
    =         _handle2 = <redacted>
    =     at tests/sources/functional/emits.move:27: simple_wrong_handle_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/emits.move:26: simple_wrong_handle_incorrect
    =         handle = <redacted>
    =         _handle2 = <redacted>
@@ -42,7 +40,6 @@ error: function does not emit the expected event
    =     at tests/sources/functional/emits.move:48: multiple_incorrect
    =         <redacted> = <redacted>
    =     at tests/sources/functional/emits.move:49: multiple_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/emits.move:47: multiple_incorrect
    =         handle = <redacted>
    =     at tests/sources/functional/emits.move:50: multiple_incorrect
@@ -59,7 +56,6 @@ error: function does not emit the expected event
    =     at tests/sources/functional/emits.move:66: multiple_same_incorrect
    =         handle = <redacted>
    =     at tests/sources/functional/emits.move:67: multiple_same_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/emits.move:66: multiple_same_incorrect
    =         handle = <redacted>
    =     at tests/sources/functional/emits.move:68: multiple_same_incorrect
@@ -149,7 +145,6 @@ error: emitted event not covered by any of the `emits` clauses
     =     at tests/sources/functional/emits.move:232: partial_incorrect
     =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:233: partial_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:231: partial_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:234: partial_incorrect
@@ -169,7 +164,6 @@ error: emitted event not covered by any of the `emits` clauses
     =     at tests/sources/functional/emits.move:252: strict_incorrect
     =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:253: strict_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:251: strict_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:254: strict_incorrect
@@ -187,7 +181,6 @@ error: function does not emit the expected event
     =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:288: opaque_incorrect
     =     at tests/sources/functional/emits.move:289: opaque_incorrect
-    =         <redacted> = <redacted>
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:290: opaque_incorrect
     =     at tests/sources/functional/emits.move:292: opaque_incorrect (spec)
@@ -212,7 +205,6 @@ error: emitted event not covered by any of the `emits` clauses
     =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:311: opaque_completeness_incorrect
     =     at tests/sources/functional/emits.move:312: opaque_completeness_incorrect
-    =         <redacted> = <redacted>
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:313: opaque_completeness_incorrect
     =     at tests/sources/functional/emits.move:315: opaque_completeness_incorrect (spec)
@@ -238,7 +230,6 @@ error: emitted event not covered by any of the `emits` clauses
     =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:352: opaque_partial_incorrect
     =     at tests/sources/functional/emits.move:353: opaque_partial_incorrect
-    =         <redacted> = <redacted>
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:354: opaque_partial_incorrect
     =     at tests/sources/functional/emits.move:356: opaque_partial_incorrect (spec)

--- a/third_party/move/move-prover/tests/sources/functional/fixed_point_arithm.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/fixed_point_arithm.v2_exp
@@ -22,8 +22,6 @@ error: post-condition does not hold
    =     at tests/sources/functional/fixed_point_arithm.move:42: multiply_x_0_incorrect
    =         x = <redacted>
    =     at tests/sources/functional/fixed_point_arithm.move:43: multiply_x_0_incorrect
-   =         <redacted> = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:43: multiply_x_0_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/fixed_point_arithm.move:44: multiply_x_0_incorrect
    =     at tests/sources/functional/fixed_point_arithm.move:46: multiply_x_0_incorrect (spec)
@@ -56,8 +54,6 @@ error: post-condition does not hold
    =     at ../move-stdlib/sources/fixed_point32.move:126
    =     at ../move-stdlib/sources/fixed_point32.move:127
    =     at tests/sources/functional/fixed_point_arithm.move:82: multiply_x_1_incorrect
-   =         <redacted> = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:82: multiply_x_1_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/fixed_point_arithm.move:83: multiply_x_1_incorrect
    =     at tests/sources/functional/fixed_point_arithm.move:85: multiply_x_1_incorrect (spec)
@@ -80,7 +76,6 @@ error: post-condition does not hold
     =     at ../move-stdlib/sources/fixed_point32.move:151: get_raw_value
     =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =         y_raw_val = <redacted>
-    =         y = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect
     =         result = <redacted>
@@ -104,7 +99,6 @@ error: post-condition does not hold
     =     at ../move-stdlib/sources/fixed_point32.move:151: get_raw_value
     =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =         y_raw_val = <redacted>
-    =         y = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect
     =         result = <redacted>

--- a/third_party/move/move-prover/tests/sources/functional/generic_invariants.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/generic_invariants.v2_exp
@@ -12,7 +12,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:11: publish_u64_bool
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
 
 error: global memory invariant does not hold
@@ -28,7 +27,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:16: publish_u64_y
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
 
 error: global memory invariant does not hold
@@ -44,7 +42,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:21: publish_x_bool
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
 
 error: global memory invariant does not hold
@@ -60,7 +57,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:26: publish_x_y
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
 
 error: global memory invariant does not hold
@@ -76,7 +72,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:11: publish_u64_bool
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
    =     at tests/sources/functional/generic_invariants.move:39
 
@@ -93,7 +88,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:16: publish_u64_y
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
    =     at tests/sources/functional/generic_invariants.move:39
 
@@ -110,7 +104,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:21: publish_x_bool
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
    =     at tests/sources/functional/generic_invariants.move:39
 
@@ -127,7 +120,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:26: publish_x_y
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
    =     at tests/sources/functional/generic_invariants.move:39
 
@@ -144,7 +136,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:11: publish_u64_bool
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
    =     at tests/sources/functional/generic_invariants.move:39
    =     at tests/sources/functional/generic_invariants.move:44
@@ -162,7 +153,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:16: publish_u64_y
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
    =     at tests/sources/functional/generic_invariants.move:39
    =     at tests/sources/functional/generic_invariants.move:44
@@ -180,7 +170,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:21: publish_x_bool
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
    =     at tests/sources/functional/generic_invariants.move:39
    =     at tests/sources/functional/generic_invariants.move:44
@@ -198,7 +187,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:26: publish_x_y
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
    =     at tests/sources/functional/generic_invariants.move:39
    =     at tests/sources/functional/generic_invariants.move:44
@@ -216,7 +204,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:11: publish_u64_bool
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
    =     at tests/sources/functional/generic_invariants.move:39
    =     at tests/sources/functional/generic_invariants.move:44
@@ -235,7 +222,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:16: publish_u64_y
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
    =     at tests/sources/functional/generic_invariants.move:39
    =     at tests/sources/functional/generic_invariants.move:44
@@ -254,7 +240,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:21: publish_x_bool
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
    =     at tests/sources/functional/generic_invariants.move:39
    =     at tests/sources/functional/generic_invariants.move:44
@@ -273,7 +258,6 @@ error: global memory invariant does not hold
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/generic_invariants.move:26: publish_x_y
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/generic_invariants.move:34
    =     at tests/sources/functional/generic_invariants.move:39
    =     at tests/sources/functional/generic_invariants.move:44

--- a/third_party/move/move-prover/tests/sources/functional/global_invariants.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/global_invariants.v2_exp
@@ -8,7 +8,6 @@ error: global memory invariant does not hold
    =     at tests/sources/functional/global_invariants.move:38: create_R_invalid
    =         account = <redacted>
    =     at tests/sources/functional/global_invariants.move:40: create_R_invalid
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/global_invariants.move:38: create_R_invalid
    =     at tests/sources/functional/global_invariants.move:40: create_R_invalid
    =     at tests/sources/functional/global_invariants.move:18

--- a/third_party/move/move-prover/tests/sources/functional/global_vars.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/global_vars.v2_exp
@@ -62,7 +62,6 @@ error: global memory invariant does not hold
     =     at tests/sources/functional/global_vars.move:220: publish
     =         s = <redacted>
     =     at tests/sources/functional/global_vars.move:221: publish
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/global_vars.move:222: publish
     =     at tests/sources/functional/global_vars.move:230: limit_change_invalid
     =     at tests/sources/functional/global_vars.move:232: limit_change_invalid (spec)

--- a/third_party/move/move-prover/tests/sources/functional/invariants.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/invariants.v2_exp
@@ -37,12 +37,12 @@ error: data invariant does not hold
     =     at tests/sources/functional/invariants.move:143
     =     at tests/sources/functional/invariants.move:154: lifetime_invalid_S_branching
     =         a = <redacted>
+    =     at tests/sources/functional/invariants.move:156: lifetime_invalid_S_branching
+    =         a_ref = <redacted>
     =     at tests/sources/functional/invariants.move:155: lifetime_invalid_S_branching
     =     at tests/sources/functional/invariants.move:150
     =     at tests/sources/functional/invariants.move:155: lifetime_invalid_S_branching
     =         b = <redacted>
-    =     at tests/sources/functional/invariants.move:156: lifetime_invalid_S_branching
-    =         a_ref = <redacted>
     =     at tests/sources/functional/invariants.move:157: lifetime_invalid_S_branching
     =         b_ref = <redacted>
     =     at tests/sources/functional/invariants.move:158: lifetime_invalid_S_branching

--- a/third_party/move/move-prover/tests/sources/functional/loop_unroll.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/loop_unroll.v2_exp
@@ -19,7 +19,6 @@ error: abort not covered by any of the `aborts_if` clauses
     =     at tests/sources/functional/loop_unroll.move:94: t6_failure
     =     at tests/sources/functional/loop_unroll.move:90: t6_failure
     =     at tests/sources/functional/loop_unroll.move:96: t6_failure
-    =         <redacted> = <redacted>
     =         i = <redacted>
     =     at tests/sources/functional/loop_unroll.move:97: t6_failure
     =         <redacted> = <redacted>
@@ -30,18 +29,6 @@ error: abort not covered by any of the `aborts_if` clauses
     =     at tests/sources/functional/loop_unroll.move:94: t6_failure
     =     at tests/sources/functional/loop_unroll.move:90: t6_failure
     =     at tests/sources/functional/loop_unroll.move:96: t6_failure
-    =         <redacted> = <redacted>
-    =         i = <redacted>
-    =     at tests/sources/functional/loop_unroll.move:97: t6_failure
-    =         <redacted> = <redacted>
-    =     at tests/sources/functional/loop_unroll.move:95: t6_failure
-    =     at tests/sources/functional/loop_unroll.move:90: t6_failure
-    =     at tests/sources/functional/loop_unroll.move:91: t6_failure
-    =     at tests/sources/functional/loop_unroll.move:92: t6_failure
-    =     at tests/sources/functional/loop_unroll.move:94: t6_failure
-    =     at tests/sources/functional/loop_unroll.move:90: t6_failure
-    =     at tests/sources/functional/loop_unroll.move:96: t6_failure
-    =         <redacted> = <redacted>
     =         i = <redacted>
     =     at tests/sources/functional/loop_unroll.move:97: t6_failure
     =         <redacted> = <redacted>
@@ -52,7 +39,6 @@ error: abort not covered by any of the `aborts_if` clauses
     =     at tests/sources/functional/loop_unroll.move:94: t6_failure
     =     at tests/sources/functional/loop_unroll.move:90: t6_failure
     =     at tests/sources/functional/loop_unroll.move:96: t6_failure
-    =         <redacted> = <redacted>
     =         i = <redacted>
     =     at tests/sources/functional/loop_unroll.move:97: t6_failure
     =         <redacted> = <redacted>
@@ -63,7 +49,16 @@ error: abort not covered by any of the `aborts_if` clauses
     =     at tests/sources/functional/loop_unroll.move:94: t6_failure
     =     at tests/sources/functional/loop_unroll.move:90: t6_failure
     =     at tests/sources/functional/loop_unroll.move:96: t6_failure
+    =         i = <redacted>
+    =     at tests/sources/functional/loop_unroll.move:97: t6_failure
     =         <redacted> = <redacted>
+    =     at tests/sources/functional/loop_unroll.move:95: t6_failure
+    =     at tests/sources/functional/loop_unroll.move:90: t6_failure
+    =     at tests/sources/functional/loop_unroll.move:91: t6_failure
+    =     at tests/sources/functional/loop_unroll.move:92: t6_failure
+    =     at tests/sources/functional/loop_unroll.move:94: t6_failure
+    =     at tests/sources/functional/loop_unroll.move:90: t6_failure
+    =     at tests/sources/functional/loop_unroll.move:96: t6_failure
     =         i = <redacted>
     =     at tests/sources/functional/loop_unroll.move:97: t6_failure
     =         <redacted> = <redacted>
@@ -74,7 +69,7 @@ error: abort not covered by any of the `aborts_if` clauses
     ┌─ tests/sources/functional/loop_unroll.move:128:5
     │
 124 │               assert!(i != 5, 0);
-    │                       ------ abort happened here with code 0x0
+    │               ------ abort happened here with code 0x0
     ·
 128 │ ╭     spec t7_failure {
 129 │ │         pragma unroll = 6;

--- a/third_party/move/move-prover/tests/sources/functional/loops.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/loops.v2_exp
@@ -38,8 +38,6 @@ error: abort not covered by any of the `aborts_if` clauses
    =         <redacted> = <redacted>
    =     at tests/sources/functional/loops.move:78: iter10_abort_incorrect
    =     at tests/sources/functional/loops.move:82: iter10_abort_incorrect
-   =         <redacted> = <redacted>
-   =     at tests/sources/functional/loops.move:82: iter10_abort_incorrect
    =         ABORTED
 
 error: induction case of the loop invariant does not hold
@@ -64,7 +62,6 @@ error: induction case of the loop invariant does not hold
     =     at tests/sources/functional/loops.move:123: nested_loop_outer_invariant_incorrect
     =     at tests/sources/functional/loops.move:128: nested_loop_outer_invariant_incorrect
     =     at tests/sources/functional/loops.move:131: nested_loop_outer_invariant_incorrect
-    =         <redacted> = <redacted>
     =         x = <redacted>
     =     at tests/sources/functional/loops.move:117: nested_loop_outer_invariant_incorrect
     =     at tests/sources/functional/loops.move:119: nested_loop_outer_invariant_incorrect
@@ -87,7 +84,6 @@ error: induction case of the loop invariant does not hold
     =     loop invariant holds at current state
     =     at tests/sources/functional/loops.move:147: nested_loop_inner_invariant_incorrect
     =     at tests/sources/functional/loops.move:150: nested_loop_inner_invariant_incorrect
-    =         <redacted> = <redacted>
     =         y = <redacted>
     =     at tests/sources/functional/loops.move:143: nested_loop_inner_invariant_incorrect
     =     at tests/sources/functional/loops.move:145: nested_loop_inner_invariant_incorrect
@@ -111,7 +107,6 @@ error: induction case of the loop invariant does not hold
     =     at tests/sources/functional/loops.move:191: loop_with_two_back_edges_incorrect
     =     at tests/sources/functional/loops.move:195: loop_with_two_back_edges_incorrect
     =     at tests/sources/functional/loops.move:196: loop_with_two_back_edges_incorrect
-    =         <redacted> = <redacted>
     =         x = <redacted>
     =     at tests/sources/functional/loops.move:197: loop_with_two_back_edges_incorrect
     =     at tests/sources/functional/loops.move:189: loop_with_two_back_edges_incorrect
@@ -147,7 +142,6 @@ error: induction case of the loop invariant does not hold
     =     at tests/sources/functional/loops.move:225: loop_invariant_induction_invalid
     =     at tests/sources/functional/loops.move:221: loop_invariant_induction_invalid
     =     at tests/sources/functional/loops.move:227: loop_invariant_induction_invalid
-    =         <redacted> = <redacted>
     =         x = <redacted>
     =     at tests/sources/functional/loops.move:226: loop_invariant_induction_invalid
     =     at tests/sources/functional/loops.move:221: loop_invariant_induction_invalid

--- a/third_party/move/move-prover/tests/sources/functional/loops_with_memory_ops.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/loops_with_memory_ops.v2_exp
@@ -44,9 +44,9 @@ error: induction case of the loop invariant does not hold
    =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =         a = <redacted>
+   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =         b = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
-   =         <redacted> = <redacted>
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:89: nested_loop2
@@ -105,11 +105,8 @@ error: unknown assertion failed
    =     at tests/sources/functional/loops_with_memory_ops.move:75: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:80: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =         a = <redacted>
-   =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =         b = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
-   =         <redacted> = <redacted>
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:87: nested_loop2

--- a/third_party/move/move-prover/tests/sources/functional/module_level_spec.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/module_level_spec.v2_exp
@@ -11,5 +11,4 @@ error: global memory invariant does not hold
    =         s = <redacted>
    =         value = <redacted>
    =     at tests/sources/functional/module_level_spec.move:11: store_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/module_level_spec.move:18

--- a/third_party/move/move-prover/tests/sources/functional/script_incorrect.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/script_incorrect.v2_exp
@@ -7,10 +7,10 @@ error: abort not covered by any of the `aborts_if` clauses
 14 │ │     }
    │ ╰─────^
    │
-   ┌─ tests/sources/functional/script_provider.move:10:9
+   ┌─ tests/sources/functional/script_provider.move:10:26
    │
 10 │         move_to(account, Info<T>{})
-   │         --------------------------- abort happened here with execution failure
+   │                          --------- abort happened here with execution failure
    │
    =     at tests/sources/functional/script_incorrect.move:6: main
    =         account = <redacted>
@@ -25,7 +25,5 @@ error: abort not covered by any of the `aborts_if` clauses
    =         result = <redacted>
    =     at ../move-stdlib/sources/signer.move:14: address_of
    =     at tests/sources/functional/script_provider.move:9: register
-   =     at tests/sources/functional/script_provider.move:10: register
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/script_provider.move:10: register
    =         ABORTED

--- a/third_party/move/move-prover/tests/sources/functional/strong_edges.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/strong_edges.v2_exp
@@ -9,9 +9,9 @@ error: post-condition does not hold
    =     at tests/sources/functional/strong_edges.move:56: glob_and_field_edges_incorrect (spec)
    =     at tests/sources/functional/strong_edges.move:47: glob_and_field_edges_incorrect
    =         addr = <redacted>
+   =     at tests/sources/functional/strong_edges.move:49: glob_and_field_edges_incorrect
    =     at tests/sources/functional/strong_edges.move:48: glob_and_field_edges_incorrect
    =     at tests/sources/functional/strong_edges.move:49: glob_and_field_edges_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/strong_edges.move:50: glob_and_field_edges_incorrect
    =     at tests/sources/functional/strong_edges.move:55: glob_and_field_edges_incorrect (spec)
    =     at tests/sources/functional/strong_edges.move:54: glob_and_field_edges_incorrect (spec)

--- a/third_party/move/move-prover/tests/sources/functional/trace.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/trace.v2_exp
@@ -47,7 +47,7 @@ error: post-condition does not hold
    │
    = Related Global Memory:
    =         Resource name: TestTracing_R
-   =         Values:  {Address(18467): <redacted>, Default: empty}
+   =         Values:  {Address(18467): <redacted>, Default: TestTracing.R{x = 4}}
    = Related Bindings:
    =         addr = <redacted>
    =         exists<R>(addr) = <redacted>
@@ -61,7 +61,6 @@ error: post-condition does not hold
    =         s = <redacted>
    =         x = <redacted>
    =     at tests/sources/functional/trace.move:30: publish_invalid
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/trace.move:38
    =     at tests/sources/functional/trace.move:31: publish_invalid
    =     at tests/sources/functional/trace.move:34: publish_invalid (spec)
@@ -75,7 +74,7 @@ error: global memory invariant does not hold
    │
    = Related Global Memory:
    =         Resource name: TestTracing_R
-   =         Values:  {Address(0): <redacted>, Default: empty}
+   =         Values:  {Address(0): <redacted>, Default: TestTracing.R{x = 5}}
    =     at tests/sources/functional/trace.move:29: publish_invalid
    =     at tests/sources/functional/trace.move:33: publish_invalid (spec)
    =         `let addr = signer::address_of(s);` = <redacted>
@@ -83,5 +82,4 @@ error: global memory invariant does not hold
    =         s = <redacted>
    =         x = <redacted>
    =     at tests/sources/functional/trace.move:30: publish_invalid
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/trace.move:38

--- a/third_party/move/move-prover/tests/sources/functional/type_dependent_code.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/type_dependent_code.v2_exp
@@ -61,7 +61,6 @@ error: post-condition does not hold
    =         result = <redacted>
    =     at ../move-stdlib/sources/signer.move:14: address_of
    =     at tests/sources/functional/type_dependent_code.move:47: test1
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/type_dependent_code.move:48: test1
    =     at tests/sources/functional/type_dependent_code.move:50: test1 (spec)
 
@@ -83,6 +82,5 @@ error: post-condition does not hold
    =         result = <redacted>
    =     at ../move-stdlib/sources/signer.move:14: address_of
    =     at tests/sources/functional/type_dependent_code.move:63: test2
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/type_dependent_code.move:64: test2
    =     at tests/sources/functional/type_dependent_code.move:66: test2 (spec)

--- a/third_party/move/move-prover/tests/sources/regression/Escape.v2_exp
+++ b/third_party/move/move-prover/tests/sources/regression/Escape.v2_exp
@@ -9,7 +9,6 @@ error: global memory invariant does not hold
    =         account = <redacted>
    =         thing = <redacted>
    =     at tests/sources/regression/Escape.move:25: install
-   =         <redacted> = <redacted>
    =     at tests/sources/regression/Escape.move:36
 
 error: global memory invariant does not hold
@@ -22,6 +21,5 @@ error: global memory invariant does not hold
    =         account = <redacted>
    =         thing = <redacted>
    =     at tests/sources/regression/Escape.move:25: install
-   =         <redacted> = <redacted>
    =     at tests/sources/regression/Escape.move:36
    =     at tests/sources/regression/Escape.move:37

--- a/third_party/move/move-prover/tests/sources/regression/mono_after_global_invariant.v2_exp
+++ b/third_party/move/move-prover/tests/sources/regression/mono_after_global_invariant.v2_exp
@@ -13,10 +13,8 @@ error: global memory invariant does not hold
    =     at tests/sources/regression/mono_after_global_invariant.move:9: put_b
    =         s = <redacted>
    =     at tests/sources/regression/mono_after_global_invariant.move:10: put_b
-   =         <redacted> = <redacted>
    =     at tests/sources/regression/mono_after_global_invariant.move:14: put_b
    =     at tests/sources/regression/mono_after_global_invariant.move:32: put_r
-   =         <redacted> = <redacted>
    =     at tests/sources/regression/mono_after_global_invariant.move:30: put_r
    =     at tests/sources/regression/mono_after_global_invariant.move:32: put_r
    =     at tests/sources/regression/mono_after_global_invariant.move:44


### PR DESCRIPTION
## Description

The goal of this PR is to reduce the number of instructions generated when using compiler v2. Along with peephole optimizations, the optimizations implemented in this PR result in ~3.5% increase in the number of instructions when comparing complier v2 to compiler v1 upon compilation of the aptos framework. Without any of these optimizations, the increase between complier v2 and v1 is ~14.5%.

In this PR, we implement the following optimizations:
- Reordering of stackless bytecode instructions to be friendlier for stack machine bytecode generation.
- Insertion of `Prepare` instructions at the stackless bytecode level to eagerly copy/move values used later.
- Computing which values on the stack should be flushed right away, so that they do not interfere with other stack operations later. This can be further improved to include more scenarios, but currently includes some basic ones.
- Keeping track of which values on the stack have copies available in locals, so that they do not have to be saved back to locals.

There are also some relevant changes that affect these optimizations. For example, the order of operands for `WriteRef` was different for stackless bytecode and stack machine bytecode: the stackless bytecode operand order has now been fixed to be the same as the stack machine bytecode.

There are some performance optimizations/refactoring possible, and some of improvements to the optimizations:
- relaxing some of the constraints safely
- generalizing `Prepare` instructions
- covering more cases in the flush writes process

These will done in a follow up PR.

## Type of Change
- [x] Performance improvement

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## How Has This Been Tested?
* Manually added several tests
* Baselines have been updated and verified that they result in generally better code

## Key Areas to Review
- Reordering optimization
- File format generator changes
- Flush writes processor
