### PR TITLE
[metrics] add a failure reason in counters for expired transactions

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -30,6 +30,8 @@ pub const TXN_COMMIT_SUCCESS_LABEL: &str = "success";
 pub const TXN_COMMIT_FAILED_LABEL: &str = "failed";
 /// Transaction commit failed (will not be retried) because of a duplicate
 pub const TXN_COMMIT_FAILED_DUPLICATE_LABEL: &str = "failed_duplicate";
+/// Transaction commit failed (will not be retried) because it expired
+pub const TXN_COMMIT_FAILED_EXPIRED_LABEL: &str = "failed_expired";
 /// Transaction commit was unsuccessful, but will be retried
 pub const TXN_COMMIT_RETRY_LABEL: &str = "retry";
 
@@ -1178,6 +1180,8 @@ pub fn update_counters_for_committed_blocks(blocks_to_commit: &[Arc<PipelinedBlo
                         TXN_COMMIT_RETRY_LABEL
                     } else if *reason == DiscardedVMStatus::SEQUENCE_NUMBER_TOO_OLD {
                         TXN_COMMIT_FAILED_DUPLICATE_LABEL
+                    } else if *reason == DiscardedVMStatus::TRANSACTION_EXPIRED {
+                        TXN_COMMIT_FAILED_EXPIRED_LABEL
                     } else {
                         TXN_COMMIT_FAILED_LABEL
                     }

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -312,6 +312,10 @@ pub fn update_counters_for_processed_chunk<T, O>(
                     // Specialize duplicate txns for alerts
                     if *discard_status_code == StatusCode::SEQUENCE_NUMBER_TOO_OLD {
                         "discard_sequence_number_too_old"
+                    } else if *discard_status_code == StatusCode::SEQUENCE_NUMBER_TOO_NEW {
+                        "discard_sequence_number_too_new"
+                    } else if *discard_status_code == StatusCode::TRANSACTION_EXPIRED {
+                        "discard_transaction_expired"
                     } else {
                         "discard"
                     },


### PR DESCRIPTION
## Description
As this can be a common reason and not really a cause for concern in terms of transaction failures themselves.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
