### PR TITLE
[quorum-store] broadcast msgs to potential proposers first

### DIFF
--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -4,7 +4,8 @@
 use crate::{
     quorum_store::{
         batch_coordinator::BatchCoordinatorCommand, batch_generator::BatchGenerator,
-        batch_store::BatchWriter, quorum_store_db::MockQuorumStoreDB, types::PersistedValue,
+        batch_store::BatchWriter, quorum_store_db::MockQuorumStoreDB,
+        tests::test_helpers::MockProposersProvider, types::PersistedValue,
     },
     test_utils::{
         create_signed_transaction, create_vec_signed_transactions,
@@ -102,6 +103,7 @@ async fn test_batch_creation() {
         Arc::new(MockBatchWriter::new()),
         quorum_store_to_mempool_tx,
         1000,
+        Arc::new(MockProposersProvider::new()),
     );
 
     let join_handle = tokio::spawn(async move {
@@ -212,6 +214,7 @@ async fn test_bucketed_batch_creation() {
         Arc::new(MockBatchWriter::new()),
         quorum_store_to_mempool_tx,
         1000,
+        Arc::new(MockProposersProvider::new()),
     );
 
     let mut num_txns = 0;
@@ -344,6 +347,7 @@ async fn test_max_batch_txns() {
         Arc::new(MockBatchWriter::new()),
         quorum_store_to_mempool_tx,
         1000,
+        Arc::new(MockProposersProvider::new()),
     );
 
     let join_handle = tokio::spawn(async move {
@@ -406,6 +410,7 @@ async fn test_max_batch_bytes() {
         Arc::new(MockBatchWriter::new()),
         quorum_store_to_mempool_tx,
         1000,
+        Arc::new(MockProposersProvider::new()),
     );
 
     let join_handle = tokio::spawn(async move {
@@ -465,6 +470,7 @@ async fn test_max_num_batches() {
         Arc::new(MockBatchWriter::new()),
         quorum_store_to_mempool_tx,
         1000,
+        Arc::new(MockProposersProvider::new()),
     );
 
     let join_handle = tokio::spawn(async move {
@@ -522,6 +528,7 @@ async fn test_last_bucketed_batch() {
         Arc::new(MockBatchWriter::new()),
         quorum_store_to_mempool_tx,
         1000,
+        Arc::new(MockProposersProvider::new()),
     );
 
     let join_handle = tokio::spawn(async move {
@@ -586,6 +593,7 @@ async fn test_sender_max_num_batches_single_bucket() {
         Arc::new(MockBatchWriter::new()),
         quorum_store_to_mempool_tx,
         1000,
+        Arc::new(MockProposersProvider::new()),
     );
 
     let join_handle = tokio::spawn(async move {
@@ -645,6 +653,7 @@ async fn test_sender_max_num_batches_multi_buckets() {
         Arc::new(MockBatchWriter::new()),
         quorum_store_to_mempool_tx,
         1000,
+        Arc::new(MockProposersProvider::new()),
     );
 
     let join_handle = tokio::spawn(async move {
@@ -703,6 +712,7 @@ async fn test_batches_in_progress_same_txn_across_batches() {
         Arc::new(MockBatchWriter::new()),
         quorum_store_to_mempool_tx,
         1000,
+        Arc::new(MockProposersProvider::new()),
     );
 
     let join_handle = tokio::spawn(async move {
@@ -759,6 +769,7 @@ async fn test_remote_batches_in_progress() {
         Arc::new(MockBatchWriter::new()),
         quorum_store_to_mempool_tx,
         1000,
+        Arc::new(MockProposersProvider::new()),
     );
 
     let signed_txns = create_vec_signed_transactions(3);

--- a/consensus/src/quorum_store/tests/batch_requester_test.rs
+++ b/consensus/src/quorum_store/tests/batch_requester_test.rs
@@ -54,11 +54,15 @@ impl QuorumStoreSender for MockBatchRequester {
         unimplemented!()
     }
 
-    async fn broadcast_batch_msg(&mut self, _batches: Vec<Batch>) {
+    async fn broadcast_batch_msg(&mut self, _batches: Vec<Batch>, _priority_peers: Vec<Author>) {
         unimplemented!()
     }
 
-    async fn broadcast_proof_of_store_msg(&mut self, _proof_of_stores: Vec<ProofOfStore>) {
+    async fn broadcast_proof_of_store_msg(
+        &mut self,
+        _proof_of_stores: Vec<ProofOfStore>,
+        _priority_peers: Vec<Author>,
+    ) {
         unimplemented!()
     }
 

--- a/consensus/src/quorum_store/tests/mod.rs
+++ b/consensus/src/quorum_store/tests/mod.rs
@@ -8,5 +8,6 @@ mod direct_mempool_quorum_store_test;
 mod proof_coordinator_test;
 mod proof_manager_test;
 mod quorum_store_db_test;
+mod test_helpers;
 mod types_test;
 mod utils;

--- a/consensus/src/quorum_store/tests/proof_coordinator_test.rs
+++ b/consensus/src/quorum_store/tests/proof_coordinator_test.rs
@@ -6,6 +6,7 @@ use crate::{
     quorum_store::{
         batch_store::BatchReader,
         proof_coordinator::{ProofCoordinator, ProofCoordinatorCommand},
+        tests::test_helpers::MockProposersProvider,
         types::Batch,
     },
     test_utils::{create_vec_signed_transactions, mock_quorum_store_sender::MockQuorumStoreSender},
@@ -58,6 +59,7 @@ async fn test_proof_coordinator_basic() {
         tx,
         proof_cache.clone(),
         true,
+        Arc::new(MockProposersProvider::new()),
     );
     let (proof_coordinator_tx, proof_coordinator_rx) = channel(100);
     let (tx, mut rx) = channel(100);

--- a/consensus/src/quorum_store/tests/test_helpers.rs
+++ b/consensus/src/quorum_store/tests/test_helpers.rs
@@ -1,0 +1,16 @@
+use crate::liveness::proposer_election::TNextProposersProvider;
+use aptos_consensus_types::common::{Author, Round};
+
+pub struct MockProposersProvider {}
+
+impl MockProposersProvider {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl TNextProposersProvider for MockProposersProvider {
+    fn get_next_proposers(&self, _current_round: Round, _count: u64) -> Vec<Author> {
+        Vec::new()
+    }
+}

--- a/consensus/src/rand/rand_gen/rand_manager.rs
+++ b/consensus/src/rand/rand_gen/rand_manager.rs
@@ -4,7 +4,7 @@
 use crate::{
     counters::RAND_QUEUE_SIZE,
     logging::{LogEvent, LogSchema},
-    network::{IncomingRandGenRequest, NetworkSender, TConsensusMsg},
+    network::{BroadcastOrder, IncomingRandGenRequest, NetworkSender, TConsensusMsg},
     pipeline::buffer_manager::{OrderedBlocks, ResetAck, ResetRequest, ResetSignal},
     rand::rand_gen::{
         aug_data_store::AugDataStore,
@@ -163,8 +163,10 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
         }
 
         rand_store.add_rand_metadata(metadata.clone());
-        self.network_sender
-            .broadcast_without_self(RandMessage::<S, D>::Share(self_share).into_network_message());
+        self.network_sender.broadcast_without_self(
+            RandMessage::<S, D>::Share(self_share).into_network_message(),
+            BroadcastOrder::ByDecreasingLatency,
+        );
         self.spawn_aggregate_shares_task(metadata.metadata)
     }
 

--- a/consensus/src/test_utils/mock_quorum_store_sender.rs
+++ b/consensus/src/test_utils/mock_quorum_store_sender.rs
@@ -51,11 +51,15 @@ impl QuorumStoreSender for MockQuorumStoreSender {
             .expect("could not send");
     }
 
-    async fn broadcast_batch_msg(&mut self, _batches: Vec<Batch>) {
+    async fn broadcast_batch_msg(&mut self, _batches: Vec<Batch>, _priority_peers: Vec<Author>) {
         unimplemented!()
     }
 
-    async fn broadcast_proof_of_store_msg(&mut self, proof_of_stores: Vec<ProofOfStore>) {
+    async fn broadcast_proof_of_store_msg(
+        &mut self,
+        proof_of_stores: Vec<ProofOfStore>,
+        _priority_peers: Vec<Author>,
+    ) {
         self.tx
             .send((
                 ConsensusMsg::ProofOfStoreMsg(Box::new(ProofOfStoreMsg::new(proof_of_stores))),

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -281,6 +281,7 @@ fn main() -> Result<()> {
     let args = Args::parse();
     let duration = Duration::from_secs(args.duration_secs as u64);
     let suite_name: &str = args.suite.as_ref();
+    let suite_name = "realistic_env_load_sweep";
 
     let runtime = Runtime::new()?;
     match args.cli_cmd {
@@ -1096,7 +1097,7 @@ fn background_traffic_for_sweep_with_latency(criteria: &[(f32, f32)]) -> Option<
 }
 
 fn realistic_env_load_sweep_test() -> ForgeConfig {
-    realistic_env_sweep_wrap(20, 10, LoadVsPerfBenchmark {
+    realistic_env_sweep_wrap(100, 10, LoadVsPerfBenchmark {
         test: Box::new(PerformanceBenchmark),
         workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000, 7000]),
         criteria: [
@@ -1245,13 +1246,11 @@ fn realistic_env_graceful_workload_sweep() -> ForgeConfig {
 
 fn load_vs_perf_benchmark() -> ForgeConfig {
     ForgeConfig::default()
-        .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
+        .with_initial_validator_count(NonZeroUsize::new(100).unwrap())
         .with_initial_fullnode_count(10)
         .add_network_test(LoadVsPerfBenchmark {
             test: Box::new(PerformanceBenchmark),
-            workloads: Workloads::TPS(vec![
-                200, 1000, 3000, 5000, 7000, 7500, 8000, 9000, 10000, 12000, 15000,
-            ]),
+            workloads: Workloads::TPS(vec![100, 1000, 5000]),
             criteria: Vec::new(),
             background_traffic: None,
         })


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

#13568 prioritized sending broadcast messages to peers in order of their distance i.e. messages to far away peers is sent first. However, for quorum store, it makes sense to catch the leader for inlined batches and proofs. This PR adds this capability.

It introduces a `BroadcastOrder` enum that allows broadcast callers to specify the broadcast by latency or target some priority peers in addition. A `NextProposersProvider` trait is also introduces to not expose ProposerElection to QuorumStore.