### PR TITLE
[prover] Add support of using receiver style `self` in struct invariants

### DIFF
--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -32,7 +32,7 @@ use crate::{
     },
     symbol::{Symbol, SymbolPool},
     ty::{Constraint, ConstraintContext, ErrorMessageContext, PrimitiveType, Type, BOOL_TYPE},
-    LanguageVersion,
+    well_known, LanguageVersion,
 };
 use codespan_reporting::diagnostic::Severity;
 use itertools::Itertools;
@@ -1776,7 +1776,17 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 et.define_type_params(loc, &entry.type_params, false);
                 if let StructLayout::Singleton(fields, _is_positional) = &entry.layout {
                     et.enter_scope();
+                    let lang_ver_ge_2 =
+                        et.env().language_version.is_at_least(LanguageVersion::V2_0);
                     for f in fields.values() {
+                        // In Aptos Move 2.0 and above, field `self` is omitted from local bindings
+                        // so `self` can be used to refer to `self` parameter.
+                        if lang_ver_ge_2
+                            && f.name.display(et.symbol_pool()).to_string()
+                                == well_known::RECEIVER_PARAM_NAME
+                        {
+                            continue;
+                        }
                         et.define_local(
                             loc,
                             f.name,
@@ -1788,6 +1798,12 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                             )),
                             None,
                         );
+                    }
+                    if lang_ver_ge_2 {
+                        let receiver_param_name =
+                            et.symbol_pool().make(well_known::RECEIVER_PARAM_NAME);
+                        let struct_type = Type::Struct(entry.module_id, entry.struct_id, vec![]);
+                        et.define_local(loc, receiver_param_name, struct_type, None, None);
                     }
                 }
 

--- a/third_party/move/move-prover/tests/sources/functional/invariants.exp
+++ b/third_party/move/move-prover/tests/sources/functional/invariants.exp
@@ -2,8 +2,8 @@ Move prover returns: exiting with verification errors
 error: data invariant does not hold
    ┌─ tests/sources/functional/invariants.move:15:9
    │
-15 │         invariant greater_one(x);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+15 │         invariant greater_one(self.x);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    =     at tests/sources/functional/invariants.move:42: invalid_R_pack
    =     at tests/sources/functional/invariants.move:15
@@ -11,8 +11,8 @@ error: data invariant does not hold
 error: data invariant does not hold
    ┌─ tests/sources/functional/invariants.move:15:9
    │
-15 │         invariant greater_one(x);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+15 │         invariant greater_one(self.x);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    =     at tests/sources/functional/invariants.move:113: lifetime_invalid_R
    =     at tests/sources/functional/invariants.move:15
@@ -53,3 +53,21 @@ error: data invariant does not hold
     =     at tests/sources/functional/invariants.move:160: lifetime_invalid_S_branching
     =     at tests/sources/functional/invariants.move:163: lifetime_invalid_S_branching
     =     at tests/sources/functional/invariants.move:150
+
+error: data invariant does not hold
+    ┌─ tests/sources/functional/invariants.move:174:9
+    │
+174 │         invariant self.self > 10;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/invariants.move:178: pack_struct_self
+    =     at tests/sources/functional/invariants.move:174
+
+error: data invariant does not hold
+    ┌─ tests/sources/functional/invariants.move:186:9
+    │
+186 │         invariant self.x > 10;
+    │         ^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/invariants.move:190: pack_struct_RR
+    =     at tests/sources/functional/invariants.move:186

--- a/third_party/move/move-prover/tests/sources/functional/invariants.move
+++ b/third_party/move/move-prover/tests/sources/functional/invariants.move
@@ -12,7 +12,7 @@ module 0x42::TestInvariants {
 
     spec R {
         // We must always have a value greater one.
-        invariant greater_one(x);
+        invariant greater_one(self.x);
 
         // When we update via a reference, the new value must be smaller or equal the old one.
         // invariant update x <= old(x) && tautology();
@@ -165,4 +165,29 @@ module 0x42::TestInvariants {
 
         (a, b)
     }
+
+    struct StructSelf has key, copy, drop {
+        self: u64
+    }
+
+    spec StructSelf {
+        invariant self.self > 10;
+    }
+
+    fun pack_struct_self(): StructSelf  {
+        StructSelf { self: 2 }
+    }
+
+    struct RR has key, copy, drop {
+        x: u64
+    }
+
+    spec RR {
+        invariant self.x > 10;
+    }
+
+    fun pack_struct_RR(): RR  {
+        RR { x: 2 }
+    }
+
 }

--- a/third_party/move/move-prover/tests/sources/functional/invariants.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/invariants.v2_exp
@@ -2,8 +2,8 @@ Move prover returns: exiting with verification errors
 error: data invariant does not hold
    ┌─ tests/sources/functional/invariants.move:15:9
    │
-15 │         invariant greater_one(x);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+15 │         invariant greater_one(self.x);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    =     at tests/sources/functional/invariants.move:42: invalid_R_pack
    =     at tests/sources/functional/invariants.move:15
@@ -11,8 +11,8 @@ error: data invariant does not hold
 error: data invariant does not hold
    ┌─ tests/sources/functional/invariants.move:15:9
    │
-15 │         invariant greater_one(x);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+15 │         invariant greater_one(self.x);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    =     at tests/sources/functional/invariants.move:113: lifetime_invalid_R
    =     at tests/sources/functional/invariants.move:15
@@ -53,3 +53,21 @@ error: data invariant does not hold
     =     at tests/sources/functional/invariants.move:160: lifetime_invalid_S_branching
     =     at tests/sources/functional/invariants.move:163: lifetime_invalid_S_branching
     =     at tests/sources/functional/invariants.move:150
+
+error: data invariant does not hold
+    ┌─ tests/sources/functional/invariants.move:174:9
+    │
+174 │         invariant self.self > 10;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/invariants.move:178: pack_struct_self
+    =     at tests/sources/functional/invariants.move:174
+
+error: data invariant does not hold
+    ┌─ tests/sources/functional/invariants.move:186:9
+    │
+186 │         invariant self.x > 10;
+    │         ^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/invariants.move:190: pack_struct_RR
+    =     at tests/sources/functional/invariants.move:186

--- a/third_party/move/move-prover/tests/sources/functional/invariants_positional.exp
+++ b/third_party/move/move-prover/tests/sources/functional/invariants_positional.exp
@@ -1,0 +1,18 @@
+Move prover returns: exiting with model building errors
+error: unsupported language construct
+  ┌─ tests/sources/functional/invariants_positional.move:6:28
+  │
+6 │     struct PositionalStruct(u64, u64) has key, copy, drop;
+  │                            ^ Move 2 language construct is not enabled: positional fields
+
+error: unsupported language construct
+  ┌─ tests/sources/functional/invariants_positional.move:9:24
+  │
+9 │         invariant self.0 > 10;
+  │                        ^ Move 2 language construct is not enabled: positional field
+
+error: unsupported language construct
+   ┌─ tests/sources/functional/invariants_positional.move:10:24
+   │
+10 │         invariant self.1 < 10;
+   │                        ^ Move 2 language construct is not enabled: positional field

--- a/third_party/move/move-prover/tests/sources/functional/invariants_positional.move
+++ b/third_party/move/move-prover/tests/sources/functional/invariants_positional.move
@@ -1,0 +1,21 @@
+module 0x42::TestInvariants {
+    spec module {
+        pragma verify = true;
+    }
+
+    struct PositionalStruct(u64, u64) has key, copy, drop;
+
+    spec PositionalStruct {
+        invariant self.0 > 10;
+        invariant self.1 < 10;
+    }
+
+    fun pack_positional_struct_correct(): PositionalStruct {
+        PositionalStruct(12, 8)
+    }
+
+    fun pack_positional_struct_incorrect(): PositionalStruct {
+        PositionalStruct(8, 12)
+    }
+
+}

--- a/third_party/move/move-prover/tests/sources/functional/invariants_positional.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/invariants_positional.v2_exp
@@ -1,0 +1,9 @@
+Move prover returns: exiting with verification errors
+error: data invariant does not hold
+  ┌─ tests/sources/functional/invariants_positional.move:9:9
+  │
+9 │         invariant self.0 > 10;
+  │         ^^^^^^^^^^^^^^^^^^^^^^
+  │
+  =     at tests/sources/functional/invariants_positional.move:18: pack_positional_struct_incorrect
+  =     at tests/sources/functional/invariants_positional.move:9


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR allows users to use the receiver style `self` in struct invariants when the language version is at least 2.0. For instance, for the struct below:

```
module 0x42::TestInvariants {
    struct PositionalStruct(u64, u64) has key, copy, drop;
}
```

We can write the invariant as below:

```
   spec PositionalStruct {
        invariant self.0 > 10;
        invariant self.1 < 10;
    }
```

Note that if a struct has a field called `self`:

```
    struct StructSelf has key, copy, drop {
        self: u64
    }
```

We need to use `self.self` to access the field instead of directly using `self`:

```
    spec StructSelf {
        invariant self.self > 10;
    }
```




## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Existing tests pass and new tests.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
