### PR TITLE
Add option to retain all logs for adhoc forge workflow

### DIFF
--- a/.github/workflows/adhoc-forge.yaml
+++ b/.github/workflows/adhoc-forge.yaml
@@ -44,6 +44,10 @@ on:
         required: false
         type: string
         description: Number of validator fullnodes to use for the forge test
+      FORGE_RETAIN_DEBUG_LOGS:
+        required: false
+        type: boolean
+        description: Retain debug logs for all nodes
 
 permissions:
   contents: read
@@ -66,6 +70,7 @@ jobs:
           echo "FORGE_ENABLE_HAPROXY: ${{ inputs.FORGE_ENABLE_HAPROXY }}"
           echo "FORGE_NUM_VALIDATORS: ${{ inputs.FORGE_NUM_VALIDATORS }}"
           echo "FORGE_NUM_VALIDATOR_FULLNODES: ${{ inputs.FORGE_NUM_VALIDATOR_FULLNODES }}"
+          echo "FORGE_RETAIN_DEBUG_LOGS: ${{ inputs.FORGE_RETAIN_DEBUG_LOGS }}"
     outputs:
       gitSha: ${{ inputs.GIT_SHA }}
       imageTag: ${{ inputs.IMAGE_TAG }}
@@ -78,7 +83,7 @@ jobs:
       forgeNumValidatorFullnodes: ${{ inputs.FORGE_NUM_VALIDATOR_FULLNODES }}
 
   adhoc-forge-test:
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@aluon/retain-all-forge-logs
     needs: [determine-forge-run-metadata]
     secrets: inherit
     with:
@@ -91,3 +96,4 @@ jobs:
       FORGE_ENABLE_HAPROXY: ${{ needs.determine-forge-run-metadata.outputs.forgeEnableHaproxy }}
       FORGE_NUM_VALIDATORS: ${{ needs.determine-forge-run-metadata.outputs.forgeNumValidators }}
       FORGE_NUM_VALIDATOR_FULLNODES: ${{ needs.determine-forge-run-metadata.outputs.forgeNumValidatorFullnodes }}
+      FORGE_RETAIN_DEBUG_LOGS: ${{ inputs.FORGE_RETAIN_DEBUG_LOGS }}

--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -61,6 +61,10 @@ on:
         required: false
         type: string
         description: Whether to use performance images
+      FORGE_RETAIN_DEBUG_LOGS:
+        required: false
+        type: boolean
+        description: Retain debug logs for all nodes
       COMMENT_HEADER:
         required: false
         type: string
@@ -104,6 +108,7 @@ env:
   POST_TO_SLACK: ${{ inputs.POST_TO_SLACK }}
   FORGE_ENABLE_FAILPOINTS: ${{ inputs.FORGE_ENABLE_FAILPOINTS }}
   FORGE_ENABLE_PERFORMANCE: ${{ inputs.FORGE_ENABLE_PERFORMANCE }}
+  FORGE_RETAIN_DEBUG_LOGS: ${{ inputs.FORGE_RETAIN_DEBUG_LOGS }}
   COMMENT_HEADER: ${{ inputs.COMMENT_HEADER }}
   VERBOSE: true
   COMMENT_ON_PR: ${{ inputs.COMMENT_ON_PR }}

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -188,6 +188,11 @@ struct K8sSwarm {
     keep: bool,
     #[clap(long, help = "If set, enables HAProxy for each of the validators")]
     enable_haproxy: bool,
+    #[clap(
+        long,
+        help = "Retain debug logs and above for all nodes instead of just the first 5 nodes"
+    )]
+    retain_debug_logs: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/testsuite/forge-test-runner-template.yaml
+++ b/testsuite/forge-test-runner-template.yaml
@@ -36,6 +36,8 @@ spec:
           value: {FORGE_TEST_SUITE}
         - name: FORGE_USERNAME
           value: {FORGE_USERNAME}
+        - name: FORGE_RETAIN_DEBUG_LOGS
+          value: "{FORGE_RETAIN_DEBUG_LOGS}"
         - name: PROMETHEUS_URL
           valueFrom:
             secretKeyRef:

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -265,6 +265,7 @@ class ForgeContext:
     forge_test_suite: str
     forge_username: str
     forge_blocking: bool
+    forge_retain_debug_logs: str
 
     github_actions: str
     github_job_url: Optional[str]
@@ -838,6 +839,7 @@ class K8sForgeRunner(ForgeRunner):
             FORGE_TRIGGERED_BY=forge_triggered_by,
             FORGE_TEST_SUITE=sanitize_k8s_resource_name(context.forge_test_suite),
             FORGE_USERNAME=sanitize_k8s_resource_name(context.forge_username),
+            FORGE_RETAIN_DEBUG_LOGS=context.forge_retain_debug_logs,
             VALIDATOR_NODE_SELECTOR=validator_node_selector,
             KUBECONFIG=MULTIREGION_KUBECONFIG_PATH,
             MULTIREGION_KUBECONFIG_DIR=MULTIREGION_KUBECONFIG_DIR,
@@ -1331,6 +1333,7 @@ def seeded_random_choice(namespace: str, cluster_names: Sequence[str]) -> str:
 @envoption("FORGE_TEST_SUITE")
 @envoption("FORGE_RUNNER_DURATION_SECS", "300")
 @envoption("FORGE_IMAGE_TAG")
+@envoption("FORGE_RETAIN_DEBUG_LOGS", "false")
 @envoption("IMAGE_TAG")
 @envoption("UPGRADE_IMAGE_TAG")
 @envoption("FORGE_NAMESPACE")
@@ -1373,6 +1376,7 @@ def test(
     forge_test_suite: str,
     forge_runner_duration_secs: str,
     forge_image_tag: Optional[str],
+    forge_retain_debug_logs: str,
     image_tag: Optional[str],
     upgrade_image_tag: Optional[str],
     forge_namespace: Optional[str],
@@ -1620,6 +1624,7 @@ def test(
         forge_cluster=forge_cluster,
         forge_test_suite=forge_test_suite,
         forge_username=forge_username,
+        forge_retain_debug_logs=forge_retain_debug_logs,
         forge_blocking=forge_blocking == "true",
         github_actions=github_actions,
         github_job_url=(

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -75,6 +75,9 @@ pub struct Options {
     /// NO-OP: unsupported option, exists for compatibility with the default test harness
     /// Show captured stdout of successful tests
     show_output: bool,
+    /// Retain debug logs and above for all nodes instead of just the first 5 nodes
+    #[clap(long, default_value = "false", env = "FORGE_RETAIN_DEBUG_LOGS")]
+    retain_debug_logs: bool,
 }
 
 impl Options {
@@ -167,6 +170,9 @@ pub struct ForgeConfig {
     validator_resource_override: NodeResourceOverride,
 
     fullnode_resource_override: NodeResourceOverride,
+
+    /// Retain debug logs and above for all nodes instead of just the first 5 nodes
+    retain_debug_logs: bool,
 }
 
 impl ForgeConfig {
@@ -257,7 +263,7 @@ impl ForgeConfig {
         OverrideNodeConfig::new(override_config, base_config)
     }
 
-    pub fn build_node_helm_config_fn(&self) -> Option<NodeConfigFn> {
+    pub fn build_node_helm_config_fn(&self, retain_debug_logs: bool) -> Option<NodeConfigFn> {
         let validator_override_node_config = self
             .validator_override_node_config_fn
             .clone()
@@ -322,6 +328,15 @@ impl ForgeConfig {
             }
             if let Some(storage_gib) = fullnode_resource_override.storage_gib {
                 helm_values["fullnode"]["storage"]["size"] = format!("{}Gi", storage_gib).into();
+            }
+
+            if retain_debug_logs {
+                helm_values["validator"]["podAnnotations"]["aptos.dev/min-log-level-to-retain"] =
+                    serde_yaml::Value::String("debug".to_owned());
+                helm_values["fullnode"]["podAnnotations"]["aptos.dev/min-log-level-to-retain"] =
+                    serde_yaml::Value::String("debug".to_owned());
+                helm_values["validator"]["rust_log"] = "debug,hyper=off".into();
+                helm_values["fullnode"]["rust_log"] = "debug,hyper=off".into();
             }
         }))
     }
@@ -484,6 +499,7 @@ impl Default for ForgeConfig {
             existing_db_tag: None,
             validator_resource_override: NodeResourceOverride::default(),
             fullnode_resource_override: NodeResourceOverride::default(),
+            retain_debug_logs: false,
         }
     }
 }
@@ -539,6 +555,7 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
     pub fn run(&self) -> Result<TestReport> {
         let test_count = self.filter_tests(&self.tests.all_tests()).count();
         let filtered_out = test_count.saturating_sub(self.tests.all_tests().len());
+        let retain_debug_logs = self.options.retain_debug_logs || self.tests.retain_debug_logs;
 
         let mut report = TestReport::new();
         let mut summary = TestSummary::new(test_count, filtered_out);
@@ -566,7 +583,7 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                 self.tests.genesis_config.as_ref(),
                 self.global_duration + Duration::from_secs(NAMESPACE_CLEANUP_DURATION_BUFFER_SECS),
                 self.tests.genesis_helm_config_fn.clone(),
-                self.tests.build_node_helm_config_fn(),
+                self.tests.build_node_helm_config_fn(retain_debug_logs),
                 self.tests.existing_db_tag.clone(),
             ))?;
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
Update the ad-hoc Forge workflow with an input to retain all Forge logs

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
- Ran the adhoc Forge workflow
- `helm get values aptos-node -n forge-runner-1724090704`
- Check that the new values are in the helm values
```
  podAnnotations:
    aptos.dev/log-levels: warn,info,error
```

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
