### PR TITLE
[crypto] added more aptos-dkg benchmarks

### DIFF
--- a/crates/aptos-dkg/src/pvss/das/unweighted_protocol.rs
+++ b/crates/aptos-dkg/src/pvss/das/unweighted_protocol.rs
@@ -164,6 +164,7 @@ impl traits::Transcript for Transcript {
         }
 
         // Derive challenges deterministically via Fiat-Shamir; easier to debug for distributed systems
+        // TODO: benchmark this
         let (f, extra) = fiat_shamir::fiat_shamir(
             self,
             sc,
@@ -199,6 +200,7 @@ impl traits::Transcript for Transcript {
 
         // TODO(Performance): Change the Fiat-Shamir transform to use 128-bit random exponents.
         // r_i = \tau^i, \forall i \in [n]
+        // TODO: benchmark this
         let taus = get_nonzero_powers_of_tau(&extra[1], sc.n);
 
         // Compute the multiexps from above.

--- a/crates/aptos-dkg/src/pvss/low_degree_test.rs
+++ b/crates/aptos-dkg/src/pvss/low_degree_test.rs
@@ -192,7 +192,7 @@ impl<'a> LowDegreeTest<'a> {
     /// [CD17e] SCRAPE: Scalable Randomness Attested by Public Entities; by Ignacio Cascudo and
     /// Bernardo David; in Cryptology ePrint Archive, Report 2017/216; 2017;
     /// https://eprint.iacr.org/2017/216
-    fn dual_code_word(self) -> Vec<Scalar> {
+    pub fn dual_code_word(self) -> Vec<Scalar> {
         // println!("dual_code_word   > t: {t}, n: {n}, includes_zero: {includes_zero}");
 
         // Accounts for the size of `f` being the `n` evaluations of f(X) at the roots-of-unity and f(0)

--- a/crates/aptos-dkg/src/pvss/test_utils.rs
+++ b/crates/aptos-dkg/src/pvss/test_utils.rs
@@ -172,7 +172,11 @@ pub fn get_weighted_configs_for_testing() -> Vec<WeightedConfig> {
 }
 
 pub fn get_threshold_configs_for_benchmarking() -> Vec<ThresholdConfig> {
+    // [XDL+24] The Latency Price of Threshold Cryptosystem in Blockchains; by Zhuolun Xiang et al; 2024
     vec![
+        ThresholdConfig::new(143, 254).unwrap(), // from XDL+24
+        ThresholdConfig::new(184, 254).unwrap(), // from XDL+24
+        ThresholdConfig::new(548, 821).unwrap(), // from initial deployment
         ThresholdConfig::new(333, 1_000).unwrap(),
         ThresholdConfig::new(666, 1_000).unwrap(),
         ThresholdConfig::new(3_333, 10_000).unwrap(),

--- a/crates/aptos-dkg/src/pvss/weighted/weighted_config.rs
+++ b/crates/aptos-dkg/src/pvss/weighted/weighted_config.rs
@@ -29,7 +29,9 @@ pub struct WeightedConfig {
     /// `W[a, a + weight[player])`. Useful during weighted secret reconstruction.
     starting_index: Vec<usize>,
     /// The maximum weight of any player.
-    max_player_weight: usize,
+    max_weight: usize,
+    /// The minimum weight of any player.
+    min_weight: usize,
 }
 
 impl WeightedConfig {
@@ -46,7 +48,8 @@ impl WeightedConfig {
         if weights.is_empty() {
             return Err(anyhow!("expected a non-empty vector of player weights"));
         }
-        let max_player_weight = *weights.iter().max().unwrap();
+        let max_weight = *weights.iter().max().unwrap();
+        let min_weight = *weights.iter().min().unwrap();
 
         let n = weights.len();
         let W = weights.iter().sum();
@@ -70,12 +73,47 @@ impl WeightedConfig {
             num_players: n,
             weight: weights,
             starting_index,
-            max_player_weight,
+            max_weight,
+            min_weight,
         })
     }
 
-    pub fn get_max_player_weight(&self) -> usize {
-        self.max_player_weight
+    pub fn get_min_weight(&self) -> usize {
+        self.min_weight
+    }
+
+    /// Returns _a_ player who has the smallest weight.
+    pub fn get_min_weight_player(&self) -> Player {
+        if let Some((i, _weight)) = self
+            .weight
+            .iter()
+            .enumerate()
+            .min_by_key(|&(_, &weight)| weight)
+        {
+            // println!("Player {} has the smallest weight: {}", i, _weight);
+            self.get_player(i)
+        } else {
+            panic!("Weights vector should not be empty");
+        }
+    }
+
+    /// Returns _a_ player who has the largest weight.
+    pub fn get_max_weight_player(&self) -> Player {
+        if let Some((i, _weight)) = self
+            .weight
+            .iter()
+            .enumerate()
+            .max_by_key(|&(_, &weight)| weight)
+        {
+            // println!("Player {} has the largest weight: {}", i, _weight);
+            self.get_player(i)
+        } else {
+            panic!("Weights vector should not be empty");
+        }
+    }
+
+    pub fn get_max_weight(&self) -> usize {
+        self.max_weight
     }
 
     pub fn get_threshold_config(&self) -> &ThresholdConfig {


### PR DESCRIPTION
## Description

This PR adds more benchmarks in our `aptos-dkg` crate, which were added as I was working on our SBC'24 presentation of the randomness crypto. These benchmarks should've been there to begin with though.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests
- [x] Benchmarks

## Which Components or Systems Does This Change Impact?
- [x] Validator Node (_maybe?_ cc @danielxiangzl)
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Other (specify): **none**

## How Has This Been Tested?

It has not.

## Key Areas to Review

@danielxiangzl, is the change to the `WeightedConfig` struct problematic? Does that end up being serialized? AFAICT, it does not. Trying to figure this out by removing the (de)serialization derives...

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
