### PR TITLE
[Compiler-v2] test cases for MOVELOC_UNAVAILABLE_ERROR and borrow analysis

### DIFF
--- a/third_party/move/move-compiler-v2/tests/ability-check/bug_14189.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-check/bug_14189.exp
@@ -1,0 +1,9 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `MOVELOC_UNAVAILABLE_ERROR`. This is a compiler bug, consider reporting it.
+   ┌─ tests/ability-check/bug_14189.move:34:18
+   │
+34 │         let x2 = S3 { x: x1, y: x0, z: x1 };
+   │                  ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/ability-check/bug_14189.move
+++ b/third_party/move/move-compiler-v2/tests/ability-check/bug_14189.move
@@ -1,0 +1,38 @@
+module 0x42::test {
+    struct S0 has copy, drop {
+        x: u8,
+    }
+
+    struct S1 has drop {
+        x: u64,
+        y: bool,
+    }
+
+    struct S2 has drop {
+        x: S0,
+        y: u8,
+    }
+
+    struct S3 has drop {
+        x: S2,
+        y: S0,
+        z: S2,
+    }
+
+    fun assign_chained(x: S3): S3 {
+        x.x.x.x + x.y.x + x.z.x.x;
+        x.x.x.x = 0;
+        x.y.x = 1;
+        x.z.x.x = 2;
+        x
+    }
+
+    fun test_assign_chained(): S3 {
+        let x0 = S0 { x: 42 };
+        let x1 = S2 { x: x0, y: 42 };
+        // x1: S2 where S2 is not copy
+        let x2 = S3 { x: x1, y: x0, z: x1 };
+        x2 = assign_chained(x2);
+        x2
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/ability-check/bug_14227.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-check/bug_14227.exp
@@ -1,0 +1,13 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `MOVELOC_UNAVAILABLE_ERROR`. This is a compiler bug, consider reporting it.
+   ┌─ tests/ability-check/bug_14227.move:19:32
+   │
+19 │           let _common_vector_2 = CommonFieldsVector::Bar {
+   │ ╭────────────────────────────────^
+20 │ │             x: vector[2],
+21 │ │             y: vector[_common_fields]
+22 │ │         };
+   │ ╰─────────^

--- a/third_party/move/move-compiler-v2/tests/ability-check/bug_14227.move
+++ b/third_party/move/move-compiler-v2/tests/ability-check/bug_14227.move
@@ -1,0 +1,29 @@
+module 0x815::m {
+
+    enum CommonFields has drop {
+    Foo{x: u64, y: u8},
+    Bar{x: u64, y: u8, z: u32}
+    }
+
+    enum CommonFieldsVector has drop {
+    Foo{x: vector<u8>},
+    Bar{x: vector<u8>, y: vector<CommonFields>}
+    }
+
+    fun test_enum_vector() {
+        let _common_fields = CommonFields::Bar {
+            x: 30,
+            y: 40,
+            z: 50
+        };
+        let _common_vector_2 = CommonFieldsVector::Bar {
+            x: vector[2],
+            y: vector[_common_fields]
+        };
+        let _common_vector_3 = CommonFieldsVector::Bar {
+            x: vector[2],
+            y: vector[_common_fields]
+        };
+
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/immu_borrow_bug.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/immu_borrow_bug.exp
@@ -1,0 +1,15 @@
+
+Diagnostics:
+error: cannot immutably borrow since mutable references exist
+   ┌─ tests/reference-safety/immu_borrow_bug.move:15:9
+   │
+14 │         common.x = 15;
+   │         --------
+   │         │
+   │         used by field borrow
+   │         previous mutable local borrow
+15 │         common.x
+   │         ^^^^^^--
+   │         │
+   │         requirement enforced here
+   │         immutable borrow attempted here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/immu_borrow_bug.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/immu_borrow_bug.move
@@ -1,0 +1,17 @@
+module 0x815::m {
+
+    enum CommonFields has drop {
+    Foo{x: u64, y: u8},
+    Bar{x: u64, y: u8, z: u32}
+    }
+
+    fun t9_common_field(): u64 {
+        let common = CommonFields::Bar {
+            x: 30,
+            y: 40,
+            z: 50
+        };
+        common.x = 15;
+        common.x
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/immu_borrow_bug.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/immu_borrow_bug.no-opt.exp
@@ -1,0 +1,15 @@
+
+Diagnostics:
+error: cannot immutably borrow since mutable references exist
+   ┌─ tests/reference-safety/immu_borrow_bug.move:15:9
+   │
+14 │         common.x = 15;
+   │         --------
+   │         │
+   │         used by field borrow
+   │         previous mutable local borrow
+15 │         common.x
+   │         ^^^^^^--
+   │         │
+   │         requirement enforced here
+   │         immutable borrow attempted here


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Two test cases from #14189 and #14227 and one test case generating the error `cannot immutably borrow since mutable references exist`
