### PR TITLE
[Framework] Safe onchain key rotation address mapping for standard accounts

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/account.md
+++ b/aptos-move/framework/aptos-framework/doc/account.md
@@ -67,6 +67,7 @@
     -  [Function `exists_at`](#@Specification_1_exists_at)
     -  [Function `get_guid_next_creation_num`](#@Specification_1_get_guid_next_creation_num)
     -  [Function `get_sequence_number`](#@Specification_1_get_sequence_number)
+    -  [Function `originating_address`](#@Specification_1_originating_address)
     -  [Function `increment_sequence_number`](#@Specification_1_increment_sequence_number)
     -  [Function `get_authentication_key`](#@Specification_1_get_authentication_key)
     -  [Function `rotate_authentication_key_internal`](#@Specification_1_rotate_authentication_key_internal)
@@ -74,6 +75,7 @@
     -  [Function `rotate_authentication_key`](#@Specification_1_rotate_authentication_key)
     -  [Function `rotate_authentication_key_with_rotation_capability`](#@Specification_1_rotate_authentication_key_with_rotation_capability)
     -  [Function `offer_rotation_capability`](#@Specification_1_offer_rotation_capability)
+    -  [Function `set_originating_address`](#@Specification_1_set_originating_address)
     -  [Function `is_rotation_capability_offered`](#@Specification_1_is_rotation_capability_offered)
     -  [Function `get_rotation_capability_offer_for`](#@Specification_1_get_rotation_capability_offer_for)
     -  [Function `revoke_rotation_capability`](#@Specification_1_revoke_rotation_capability)
@@ -2675,6 +2677,23 @@ The Account does not exist under the new address before creating the account.
 
 
 
+<a id="@Specification_1_originating_address"></a>
+
+### Function `originating_address`
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="account.md#0x1_account_originating_address">originating_address</a>(auth_key: <b>address</b>): <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> verify=<b>false</b>;
+</code></pre>
+
+
+
 <a id="@Specification_1_increment_sequence_number"></a>
 
 ### Function `increment_sequence_number`
@@ -2942,6 +2961,22 @@ The authentication scheme is ED25519_SCHEME and MULTI_ED25519_SCHEME
 <b>modifies</b> <b>global</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(source_address);
 <b>let</b> <b>post</b> offer_for = <b>global</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(source_address).rotation_capability_offer.for;
 <b>ensures</b> <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_spec_borrow">option::spec_borrow</a>(offer_for) == recipient_address;
+</code></pre>
+
+
+
+<a id="@Specification_1_set_originating_address"></a>
+
+### Function `set_originating_address`
+
+
+<pre><code>entry <b>fun</b> <a href="account.md#0x1_account_set_originating_address">set_originating_address</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> verify=<b>false</b>;
 </code></pre>
 
 
@@ -3285,6 +3320,7 @@ The value of signer_capability_offer.for of Account resource under the signer is
     <b>aborts_if</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table_spec_contains">table::spec_contains</a>(address_map, curr_auth_key) &&
         <a href="../../aptos-stdlib/doc/table.md#0x1_table_spec_get">table::spec_get</a>(address_map, curr_auth_key) != originating_addr;
     <b>aborts_if</b> !<a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs_deserializable">from_bcs::deserializable</a>&lt;<b>address</b>&gt;(new_auth_key_vector);
+    <b>aborts_if</b> curr_auth_key == new_auth_key;
     <b>aborts_if</b> curr_auth_key != new_auth_key && <a href="../../aptos-stdlib/doc/table.md#0x1_table_spec_contains">table::spec_contains</a>(address_map, new_auth_key);
     <b>ensures</b> <a href="../../aptos-stdlib/doc/table.md#0x1_table_spec_contains">table::spec_contains</a>(<b>global</b>&lt;<a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a>&gt;(@aptos_framework).address_map, <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs_deserialize">from_bcs::deserialize</a>&lt;<b>address</b>&gt;(new_auth_key_vector));
 }

--- a/aptos-move/framework/aptos-framework/doc/account.md
+++ b/aptos-move/framework/aptos-framework/doc/account.md
@@ -27,6 +27,7 @@
 -  [Function `exists_at`](#0x1_account_exists_at)
 -  [Function `get_guid_next_creation_num`](#0x1_account_get_guid_next_creation_num)
 -  [Function `get_sequence_number`](#0x1_account_get_sequence_number)
+-  [Function `originating_address`](#0x1_account_originating_address)
 -  [Function `increment_sequence_number`](#0x1_account_increment_sequence_number)
 -  [Function `get_authentication_key`](#0x1_account_get_authentication_key)
 -  [Function `rotate_authentication_key_internal`](#0x1_account_rotate_authentication_key_internal)
@@ -34,6 +35,7 @@
 -  [Function `rotate_authentication_key`](#0x1_account_rotate_authentication_key)
 -  [Function `rotate_authentication_key_with_rotation_capability`](#0x1_account_rotate_authentication_key_with_rotation_capability)
 -  [Function `offer_rotation_capability`](#0x1_account_offer_rotation_capability)
+-  [Function `set_originating_address`](#0x1_account_set_originating_address)
 -  [Function `is_rotation_capability_offered`](#0x1_account_is_rotation_capability_offered)
 -  [Function `get_rotation_capability_offer_for`](#0x1_account_get_rotation_capability_offer_for)
 -  [Function `revoke_rotation_capability`](#0x1_account_revoke_rotation_capability)
@@ -774,6 +776,26 @@ The provided authentication key has an invalid length
 
 
 
+<a id="0x1_account_ENEW_AUTH_KEY_ALREADY_MAPPED"></a>
+
+The new authentication key already has an entry in the <code><a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a></code> table
+
+
+<pre><code><b>const</b> <a href="account.md#0x1_account_ENEW_AUTH_KEY_ALREADY_MAPPED">ENEW_AUTH_KEY_ALREADY_MAPPED</a>: u64 = 21;
+</code></pre>
+
+
+
+<a id="0x1_account_ENEW_AUTH_KEY_SAME_AS_CURRENT"></a>
+
+The current authentication key and the new authentication key are the same
+
+
+<pre><code><b>const</b> <a href="account.md#0x1_account_ENEW_AUTH_KEY_SAME_AS_CURRENT">ENEW_AUTH_KEY_SAME_AS_CURRENT</a>: u64 = 22;
+</code></pre>
+
+
+
 <a id="0x1_account_ENO_CAPABILITY"></a>
 
 The caller does not have a digital-signature-based capability to call this function
@@ -1119,6 +1141,36 @@ is returned. This way, the caller of this function can publish additional resour
 
 </details>
 
+<a id="0x1_account_originating_address"></a>
+
+## Function `originating_address`
+
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="account.md#0x1_account_originating_address">originating_address</a>(auth_key: <b>address</b>): <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<b>address</b>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="account.md#0x1_account_originating_address">originating_address</a>(auth_key: <b>address</b>): Option&lt;<b>address</b>&gt; <b>acquires</b> <a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a> {
+    <b>let</b> address_map_ref = &<b>borrow_global</b>&lt;<a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a>&gt;(@aptos_framework).address_map;
+    <b>if</b> (<a href="../../aptos-stdlib/doc/table.md#0x1_table_contains">table::contains</a>(address_map_ref, auth_key)) {
+        <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(*<a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow">table::borrow</a>(address_map_ref, auth_key))
+    } <b>else</b> {
+        <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
+    }
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_account_increment_sequence_number"></a>
 
 ## Function `increment_sequence_number`
@@ -1220,6 +1272,9 @@ Note that this does not update the <code><a href="account.md#0x1_account_Origina
 does not come with a proof-of-knowledge of the underlying SK. Nonetheless, we need this functionality due to
 the introduction of non-standard key algorithms, such as passkeys, which cannot produce proofs-of-knowledge in
 the format expected in <code>rotate_authentication_key</code>.
+
+If you'd like to followup with updating the <code><a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a></code> table, you can call
+<code><a href="account.md#0x1_account_set_originating_address">set_originating_address</a>()</code>.
 
 
 <pre><code>entry <b>fun</b> <a href="account.md#0x1_account_rotate_authentication_key_call">rotate_authentication_key_call</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_auth_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
@@ -1493,6 +1548,56 @@ offer, calling this function will replace the previous <code>recipient_address</
 
     // <b>update</b> the existing rotation capability offer or put in a new rotation capability offer for the current <a href="account.md#0x1_account">account</a>
     <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_swap_or_fill">option::swap_or_fill</a>(&<b>mut</b> account_resource.rotation_capability_offer.for, recipient_address);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_account_set_originating_address"></a>
+
+## Function `set_originating_address`
+
+For the given account, add an entry to <code><a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a></code> table mapping the account's
+authentication key to the account's address.
+
+Can be used as a followup to <code><a href="account.md#0x1_account_rotate_authentication_key_call">rotate_authentication_key_call</a>()</code> to reconcile the
+<code><a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a></code> table, or to establish a mapping for a new account that has not yet had
+its authentication key rotated.
+
+Aborts if there is already an entry in the <code><a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a></code> table for the account's
+authentication key.
+
+Kept as a private entry function to ensure that after an unproven rotation via
+<code><a href="account.md#0x1_account_rotate_authentication_key_call">rotate_authentication_key_call</a>()</code>, the <code><a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a></code> table is only updated under the
+authority of the new authentication key.
+
+
+<pre><code>entry <b>fun</b> <a href="account.md#0x1_account_set_originating_address">set_originating_address</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>entry <b>fun</b> <a href="account.md#0x1_account_set_originating_address">set_originating_address</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="account.md#0x1_account_Account">Account</a>, <a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a> {
+    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>assert</b>!(<b>exists</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(account_addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account.md#0x1_account_EACCOUNT_DOES_NOT_EXIST">EACCOUNT_DOES_NOT_EXIST</a>));
+    <b>let</b> auth_key_as_address =
+        <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs_to_address">from_bcs::to_address</a>(<b>borrow_global</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(account_addr).authentication_key);
+    <b>let</b> address_map_ref_mut =
+        &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a>&gt;(@aptos_framework).address_map;
+    <b>if</b> (<a href="../../aptos-stdlib/doc/table.md#0x1_table_contains">table::contains</a>(address_map_ref_mut, auth_key_as_address)) {
+        <b>assert</b>!(
+            *<a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow">table::borrow</a>(address_map_ref_mut, auth_key_as_address) == account_addr,
+            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="account.md#0x1_account_ENEW_AUTH_KEY_ALREADY_MAPPED">ENEW_AUTH_KEY_ALREADY_MAPPED</a>)
+        );
+    } <b>else</b> {
+        <a href="../../aptos-stdlib/doc/table.md#0x1_table_add">table::add</a>(address_map_ref_mut, auth_key_as_address, account_addr);
+    };
 }
 </code></pre>
 
@@ -1894,6 +1999,11 @@ in the event of key recovery.
 ) <b>acquires</b> <a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a> {
     <b>let</b> address_map = &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a>&gt;(@aptos_framework).address_map;
     <b>let</b> curr_auth_key = <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs_to_address">from_bcs::to_address</a>(account_resource.authentication_key);
+    <b>let</b> new_auth_key = <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs_to_address">from_bcs::to_address</a>(new_auth_key_vector);
+    <b>assert</b>!(
+        new_auth_key != curr_auth_key,
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="account.md#0x1_account_ENEW_AUTH_KEY_SAME_AS_CURRENT">ENEW_AUTH_KEY_SAME_AS_CURRENT</a>)
+    );
 
     // Checks `<a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a>[curr_auth_key]` is either unmapped, or mapped <b>to</b> `originating_address`.
     // If it's mapped <b>to</b> the originating <b>address</b>, removes that mapping.
@@ -1915,7 +2025,10 @@ in the event of key recovery.
     };
 
     // Set `<a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a>[new_auth_key] = originating_address`.
-    <b>let</b> new_auth_key = <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs_to_address">from_bcs::to_address</a>(new_auth_key_vector);
+    <b>assert</b>!(
+        !<a href="../../aptos-stdlib/doc/table.md#0x1_table_contains">table::contains</a>(address_map, new_auth_key),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="account.md#0x1_account_ENEW_AUTH_KEY_ALREADY_MAPPED">ENEW_AUTH_KEY_ALREADY_MAPPED</a>)
+    );
     <a href="../../aptos-stdlib/doc/table.md#0x1_table_add">table::add</a>(address_map, new_auth_key, originating_addr);
 
     <b>if</b> (std::features::module_event_migration_enabled()) {

--- a/aptos-move/framework/aptos-framework/sources/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account.move
@@ -175,6 +175,10 @@ module aptos_framework::account {
     const ENO_SIGNER_CAPABILITY_OFFERED: u64 = 19;
     // This account has exceeded the allocated GUIDs it can create. It should be impossible to reach this number for real applications.
     const EEXCEEDED_MAX_GUID_CREATION_NUM: u64 = 20;
+    /// The new authentication key already has an entry in the `OriginatingAddress` table
+    const ENEW_AUTH_KEY_ALREADY_MAPPED: u64 = 21;
+    /// The current authentication key and the new authentication key are the same
+    const ENEW_AUTH_KEY_SAME_AS_CURRENT: u64 = 22;
 
     /// Explicitly separate the GUID space between Object and Account to prevent accidental overlap.
     const MAX_GUID_CREATION_NUM: u64 = 0x4000000000000;
@@ -260,6 +264,16 @@ module aptos_framework::account {
         borrow_global<Account>(addr).sequence_number
     }
 
+    #[view]
+    public fun originating_address(auth_key: address): Option<address> acquires OriginatingAddress {
+        let address_map_ref = &borrow_global<OriginatingAddress>(@aptos_framework).address_map;
+        if (table::contains(address_map_ref, auth_key)) {
+            option::some(*table::borrow(address_map_ref, auth_key))
+        } else {
+            option::none()
+        }
+    }
+
     public(friend) fun increment_sequence_number(addr: address) acquires Account {
         let sequence_number = &mut borrow_global_mut<Account>(addr).sequence_number;
 
@@ -297,6 +311,9 @@ module aptos_framework::account {
     /// does not come with a proof-of-knowledge of the underlying SK. Nonetheless, we need this functionality due to
     /// the introduction of non-standard key algorithms, such as passkeys, which cannot produce proofs-of-knowledge in
     /// the format expected in `rotate_authentication_key`.
+    ///
+    /// If you'd like to followup with updating the `OriginatingAddress` table, you can call
+    /// `set_originating_address()`.
     entry fun rotate_authentication_key_call(account: &signer, new_auth_key: vector<u8>) acquires Account {
         rotate_authentication_key_internal(account, new_auth_key);
     }
@@ -501,6 +518,36 @@ module aptos_framework::account {
         option::swap_or_fill(&mut account_resource.rotation_capability_offer.for, recipient_address);
     }
 
+    /// For the given account, add an entry to `OriginatingAddress` table mapping the account's
+    /// authentication key to the account's address.
+    ///
+    /// Can be used as a followup to `rotate_authentication_key_call()` to reconcile the
+    /// `OriginatingAddress` table, or to establish a mapping for a new account that has not yet had
+    /// its authentication key rotated.
+    ///
+    /// Aborts if there is already an entry in the `OriginatingAddress` table for the account's
+    /// authentication key.
+    ///
+    /// Kept as a private entry function to ensure that after an unproven rotation via
+    /// `rotate_authentication_key_call()`, the `OriginatingAddress` table is only updated under the
+    /// authority of the new authentication key.
+    entry fun set_originating_address(account: &signer) acquires Account, OriginatingAddress {
+        let account_addr = signer::address_of(account);
+        assert!(exists<Account>(account_addr), error::not_found(EACCOUNT_DOES_NOT_EXIST));
+        let auth_key_as_address =
+            from_bcs::to_address(borrow_global<Account>(account_addr).authentication_key);
+        let address_map_ref_mut =
+            &mut borrow_global_mut<OriginatingAddress>(@aptos_framework).address_map;
+        if (table::contains(address_map_ref_mut, auth_key_as_address)) {
+            assert!(
+                *table::borrow(address_map_ref_mut, auth_key_as_address) == account_addr,
+                error::invalid_argument(ENEW_AUTH_KEY_ALREADY_MAPPED)
+            );
+        } else {
+            table::add(address_map_ref_mut, auth_key_as_address, account_addr);
+        };
+    }
+
     #[view]
     /// Returns true if the account at `account_addr` has a rotation capability offer.
     public fun is_rotation_capability_offered(account_addr: address): bool acquires Account {
@@ -662,6 +709,11 @@ module aptos_framework::account {
     ) acquires OriginatingAddress {
         let address_map = &mut borrow_global_mut<OriginatingAddress>(@aptos_framework).address_map;
         let curr_auth_key = from_bcs::to_address(account_resource.authentication_key);
+        let new_auth_key = from_bcs::to_address(new_auth_key_vector);
+        assert!(
+            new_auth_key != curr_auth_key,
+            error::invalid_argument(ENEW_AUTH_KEY_SAME_AS_CURRENT)
+        );
 
         // Checks `OriginatingAddress[curr_auth_key]` is either unmapped, or mapped to `originating_address`.
         // If it's mapped to the originating address, removes that mapping.
@@ -683,7 +735,10 @@ module aptos_framework::account {
         };
 
         // Set `OriginatingAddress[new_auth_key] = originating_address`.
-        let new_auth_key = from_bcs::to_address(new_auth_key_vector);
+        assert!(
+            !table::contains(address_map, new_auth_key),
+            error::invalid_argument(ENEW_AUTH_KEY_ALREADY_MAPPED)
+        );
         table::add(address_map, new_auth_key, originating_addr);
 
         if (std::features::module_event_migration_enabled()) {

--- a/aptos-move/framework/aptos-framework/sources/account.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/account.spec.move
@@ -661,6 +661,10 @@ spec aptos_framework::account {
         aborts_if account.sequence_number != 0;
     }
 
+    spec originating_address(auth_key: address): Option<address> {
+        pragma verify=false;
+    }
+
     spec update_auth_key_and_originating_address_table(
         originating_addr: address,
         account_resource: &mut Account,
@@ -681,6 +685,7 @@ spec aptos_framework::account {
         aborts_if table::spec_contains(address_map, curr_auth_key) &&
             table::spec_get(address_map, curr_auth_key) != originating_addr;
         aborts_if !from_bcs::deserializable<address>(new_auth_key_vector);
+        aborts_if curr_auth_key == new_auth_key;
         aborts_if curr_auth_key != new_auth_key && table::spec_contains(address_map, new_auth_key);
 
         ensures table::spec_contains(global<OriginatingAddress>(@aptos_framework).address_map, from_bcs::deserialize<address>(new_auth_key_vector));
@@ -728,5 +733,9 @@ spec aptos_framework::account {
         // );
 
         aborts_if account_scheme != ED25519_SCHEME && account_scheme != MULTI_ED25519_SCHEME;
+    }
+
+    spec set_originating_address(account: &signer) {
+        pragma verify=false;
     }
 }

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -136,6 +136,9 @@ pub enum EntryFunctionCall {
     /// does not come with a proof-of-knowledge of the underlying SK. Nonetheless, we need this functionality due to
     /// the introduction of non-standard key algorithms, such as passkeys, which cannot produce proofs-of-knowledge in
     /// the format expected in `rotate_authentication_key`.
+    ///
+    /// If you'd like to followup with updating the `OriginatingAddress` table, you can call
+    /// `set_originating_address()`.
     AccountRotateAuthenticationKeyCall {
         new_auth_key: Vec<u8>,
     },
@@ -146,6 +149,21 @@ pub enum EntryFunctionCall {
         new_public_key_bytes: Vec<u8>,
         cap_update_table: Vec<u8>,
     },
+
+    /// For the given account, add an entry to `OriginatingAddress` table mapping the account's
+    /// authentication key to the account's address.
+    ///
+    /// Can be used as a followup to `rotate_authentication_key_call()` to reconcile the
+    /// `OriginatingAddress` table, or to establish a mapping for a new account that has not yet had
+    /// its authentication key rotated.
+    ///
+    /// Aborts if there is already an entry in the `OriginatingAddress` table for the account's
+    /// authentication key.
+    ///
+    /// Kept as a private entry function to ensure that after an unproven rotation via
+    /// `rotate_authentication_key_call()`, the `OriginatingAddress` table is only updated under the
+    /// authority of the new authentication key.
+    AccountSetOriginatingAddress {},
 
     /// Batch version of APT transfer.
     AptosAccountBatchTransfer {
@@ -1191,6 +1209,7 @@ impl EntryFunctionCall {
                 new_public_key_bytes,
                 cap_update_table,
             ),
+            AccountSetOriginatingAddress {} => account_set_originating_address(),
             AptosAccountBatchTransfer {
                 recipients,
                 amounts,
@@ -1993,6 +2012,9 @@ pub fn account_rotate_authentication_key(
 /// does not come with a proof-of-knowledge of the underlying SK. Nonetheless, we need this functionality due to
 /// the introduction of non-standard key algorithms, such as passkeys, which cannot produce proofs-of-knowledge in
 /// the format expected in `rotate_authentication_key`.
+///
+/// If you'd like to followup with updating the `OriginatingAddress` table, you can call
+/// `set_originating_address()`.
 pub fn account_rotate_authentication_key_call(new_auth_key: Vec<u8>) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
@@ -2030,6 +2052,34 @@ pub fn account_rotate_authentication_key_with_rotation_capability(
             bcs::to_bytes(&new_public_key_bytes).unwrap(),
             bcs::to_bytes(&cap_update_table).unwrap(),
         ],
+    ))
+}
+
+/// For the given account, add an entry to `OriginatingAddress` table mapping the account's
+/// authentication key to the account's address.
+///
+/// Can be used as a followup to `rotate_authentication_key_call()` to reconcile the
+/// `OriginatingAddress` table, or to establish a mapping for a new account that has not yet had
+/// its authentication key rotated.
+///
+/// Aborts if there is already an entry in the `OriginatingAddress` table for the account's
+/// authentication key.
+///
+/// Kept as a private entry function to ensure that after an unproven rotation via
+/// `rotate_authentication_key_call()`, the `OriginatingAddress` table is only updated under the
+/// authority of the new authentication key.
+pub fn account_set_originating_address() -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("account").to_owned(),
+        ),
+        ident_str!("set_originating_address").to_owned(),
+        vec![],
+        vec![],
     ))
 }
 
@@ -5064,6 +5114,16 @@ mod decoder {
         }
     }
 
+    pub fn account_set_originating_address(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(_script) = payload {
+            Some(EntryFunctionCall::AccountSetOriginatingAddress {})
+        } else {
+            None
+        }
+    }
+
     pub fn aptos_account_batch_transfer(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(EntryFunctionCall::AptosAccountBatchTransfer {
@@ -6790,6 +6850,10 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
         map.insert(
             "account_rotate_authentication_key_with_rotation_capability".to_string(),
             Box::new(decoder::account_rotate_authentication_key_with_rotation_capability),
+        );
+        map.insert(
+            "account_set_originating_address".to_string(),
+            Box::new(decoder::account_set_originating_address),
         );
         map.insert(
             "aptos_account_batch_transfer".to_string(),


### PR DESCRIPTION
@banool @gregnazario

Closes #13517

AIP: https://github.com/aptos-foundation/AIPs/issues/487

# Background

There are currently several issues with the `OriginatingAddress` table (which is
supposed to be a one-to-one lookup table) that render the mapping unsafe in
practice:

1. Per #13517, `rotate_authentication_key_call` does not update the
   `OriginatingAddress` table for an "unproven" key rotation without a
   `RotationProofChallenge` (resolved in this PR with new
   `set_originating_address` private entry function).
1. During an operation that attempts to map an authentication key (which has
   already been mapped) to a different originating address, the inner function
   `update_auth_key_and_originating_address_table` overwrites the initial
   mapping, rather than aborting. This oversight can lead to account loss if
   someone accidentally attempts to rotate to the same authentication key twice
   (resolved in this PR with `ENEW_AUTH_KEY_ALREADY_MAPPED` check), because they
   will not be able to identify their account from private key alone unless they
   keep an external record of the rotated accounts the private key in question
   has been used to secure.
1. Standard accounts that have not yet had their key rotated are not registered
   in the `OriginatingAddress` table, such that two accounts can be
   authenticated by the same authentication key: the original account whose
   address is its authentication key, and another account that has had its
   authentication key rotated to the authentication key of the original account.
   Since `OriginatingAddress` is one-to-one, a dual-account situation can
   inhibit indexing and OpSec (resolved in this PR with
   `set_originating_address` private entry function).

# Contribution history

I originally proposed a large set of changes associated with authentication key
rotation for accounts secured by a Ledger wallet in #11151, which paired with a
docs PR at https://github.com/aptos-labs/developer-docs/pull/367. Due to the key
rotation issues raised during development functionality, I included the features
now isolated in this PR.

However, due to the difficulty of merging large sets of changes as an external
contributor, I'm splitting off into this PR the minimum amount of functionality
required to support safe authentication key rotation mapping, as I did similarly
in #14084 and #14266.

# Verifying the changes in this PR

1. Install the Aptos CLI [from source] using the changes in this PR.
1. Make a new test directory called `localnet-data`, then use it to start a
   localnet with the framework changes in this PR:

    ```sh
    aptos node run-localnet --test-dir localnet-data
    ```

1. Save the localnet shell running off to the side.
1. In a new shell, create a private key file:

    ```sh
    aptos key generate --output-file keyfile-a
    ```

1. Use it to create a localnet profile:

    ```sh
    aptos init \
        --network local \
        --private-key-file keyfile-a \
        --profile localnet-a
    ```

1. Store the address:

    ```sh
    ADDR_A=<profile-address>
    ```

1. Use the new `originating_address` view function to observe that the account
   does *not* have an entry in the `OriginatingAddress` table:

    ```sh
    aptos move view \
        --args address:$ADDR_A \
        --function-id 0x1::account::originating_address \
        --profile localnet-a
    ```

1. Use the new `set_originating_address` private entry function to set a mapping
   in the table:

    ```sh
    aptos move run \
        --function-id 0x1::account::set_originating_address \
        --profile localnet-a
    ```

1. Check the `originating_address` view function again and note the result:

    ```sh
    aptos move view \
        --args address:$ADDR_A \
        --function-id 0x1::account::originating_address \
        --profile localnet-a
    ```

1. Now that you've established a one-to-one mapping for the authentication key,
   the new check for `ENEW_AUTH_KEY_ALREADY_MAPPED` in
   `update_auth_key_and_originating_address_table` will prevent another account
   from rotating its authentication key to that of `keyfile-a`, thus preserving
   a one-to-one mapping. To verify this, create a new profile:

    ```sh
    aptos init \
        --network local \
        --profile localnet-b
    ```

1. Press `enter` when prompted to generate a new private key for the profile.
   Then observe the new guard against breaking the one-to-one mapping, by
   trying to rotate the authentication key to that of `keyfile-a`:

    ```sh
    aptos account rotate-key \
        --new-private-key-file keyfile-a \
        --profile localnet-b \
        --save-to-profile localnet-b-secured-by-keyfile-a
    ```

# Housekeeping

The following was run from repository root to ensure CI passes:

```sh
cargo build -p aptos-cached-packages
pre-commit run --all-files
scripts/rust_lint.sh
aptos move test --package-dir aptos-move/framework/aptos-framework/ --dev
```

[from source]: https://aptos.dev/en/build/cli/install-cli/install-cli-specific-version