### PR TITLE
[compiler-v2] Adding and verifying some missing v1 tests

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/acquires_list_generic.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/acquires_list_generic.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: not supported before language version `2.0-unstable`: access specifier type instantiation. Try removing the type instantiation.
+  ┌─ tests/checking-lang-v1/acquires_list_generic.move:6:24
+  │
+6 │     fun foo() acquires B<CupC<R>> {
+  │                        ^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/acquires_list_generic.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/acquires_list_generic.move
@@ -1,0 +1,9 @@
+module 0x42::M {
+    struct CupC<phantom T> {}
+    struct R {}
+    struct B<phantom T> {}
+
+    fun foo() acquires B<CupC<R>> {
+        abort 0
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/access_specifiers/acquires_list_generic.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/access_specifiers/acquires_list_generic.exp
@@ -1,0 +1,17 @@
+// -- Model dump before bytecode pipeline
+module 0x42::M {
+    struct B {
+        dummy_field: bool,
+    }
+    struct CupC {
+        dummy_field: bool,
+    }
+    struct R {
+        dummy_field: bool,
+    }
+    private fun foo()
+        acquires M::B<M::CupC<M::R>>(*)
+     {
+        Abort(0)
+    }
+} // end 0x42::M

--- a/third_party/move/move-compiler-v2/tests/checking/access_specifiers/acquires_list_generic.move
+++ b/third_party/move/move-compiler-v2/tests/checking/access_specifiers/acquires_list_generic.move
@@ -1,0 +1,9 @@
+module 0x42::M {
+    struct CupC<phantom T> {}
+    struct R {}
+    struct B<phantom T> {}
+
+    fun foo() acquires B<CupC<R>> {
+        abort 0
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_bad.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_bad.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_bad.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_bad.move
@@ -1,0 +1,42 @@
+module 0x8675309::Tester {
+    fun eqtest1() {
+        let x: u64;
+        let r: &mut u64;
+
+        x = 0;
+        r = &mut x;
+        _ = copy r == copy r;
+    }
+
+    fun eqtest2() {
+        let x: u64;
+        let r: &mut u64;
+
+        x = 0;
+        r = &mut x;
+        _ = copy r == move r;
+    }
+
+    fun neqtest1() {
+        let x: u64;
+        let r: &mut u64;
+
+        x = 0;
+        r = &mut x;
+        _ = copy r != copy r;
+    }
+
+    fun neqtest2() {
+        let x: u64;
+        let r: &mut u64;
+
+        x = 0;
+        r = &mut x;
+        _ = copy r != move r;
+    }
+}
+
+// check: READREF_EXISTS_MUTABLE_BORROW_ERROR
+// check: READREF_EXISTS_MUTABLE_BORROW_ERROR
+// check: READREF_EXISTS_MUTABLE_BORROW_ERROR
+// check: READREF_EXISTS_MUTABLE_BORROW_ERROR

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_bad.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_bad.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_bad.old.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_bad.old.exp
@@ -1,0 +1,41 @@
+
+Diagnostics:
+error: mutable reference in local `r` requires exclusive access but is borrowed
+  ┌─ tests/reference-safety/v1-borrow-tests/eq_bad.move:8:23
+  │
+8 │         _ = copy r == copy r;
+  │             ----------^^^^^^
+  │             │         │
+  │             │         requirement enforced here
+  │             conflicting reference used here
+  │             previous freeze
+
+error: mutable reference in local `r` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-borrow-tests/eq_bad.move:17:23
+   │
+17 │         _ = copy r == move r;
+   │             ----------^^^^^^
+   │             │         │
+   │             │         requirement enforced here
+   │             conflicting reference used here
+   │             previous freeze
+
+error: mutable reference in local `r` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-borrow-tests/eq_bad.move:26:23
+   │
+26 │         _ = copy r != copy r;
+   │             ----------^^^^^^
+   │             │         │
+   │             │         requirement enforced here
+   │             conflicting reference used here
+   │             previous freeze
+
+error: mutable reference in local `r` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-borrow-tests/eq_bad.move:35:23
+   │
+35 │         _ = copy r != move r;
+   │             ----------^^^^^^
+   │             │         │
+   │             │         requirement enforced here
+   │             conflicting reference used here
+   │             previous freeze

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_ok.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_ok.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_ok.move
@@ -1,0 +1,37 @@
+module 0x8675309::Tester {
+    fun eqtest1() {
+        let x: u64;
+        let r: &mut u64;
+
+        x = 0;
+        r = &mut x;
+        _ = freeze(copy r) == freeze(copy r);
+    }
+
+    fun eqtest2() {
+        let x: u64;
+        let r: &mut u64;
+
+        x = 0;
+        r = &mut x;
+        _ = freeze(copy r) == freeze(move r);
+    }
+
+    fun neqtest1() {
+        let x: u64;
+        let r: &mut u64;
+
+        x = 0;
+        r = &mut x;
+        _ = freeze(copy r) != freeze(copy r);
+    }
+
+    fun neqtest2() {
+        let x: u64;
+        let r: &mut u64;
+
+        x = 0;
+        r = &mut x;
+        _ = freeze(copy r) != freeze(move r);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_ok.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_ok.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_ok.old.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_ok.old.exp
@@ -1,0 +1,41 @@
+
+Diagnostics:
+error: mutable reference in local `r` requires exclusive access but is borrowed
+  ┌─ tests/reference-safety/v1-borrow-tests/eq_ok.move:8:38
+  │
+8 │         _ = freeze(copy r) == freeze(copy r);
+  │             -------------------------^^^^^^-
+  │             │                        │
+  │             │                        requirement enforced here
+  │             conflicting reference used here
+  │             previous freeze
+
+error: mutable reference in local `r` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-borrow-tests/eq_ok.move:17:38
+   │
+17 │         _ = freeze(copy r) == freeze(move r);
+   │             -------------------------^^^^^^-
+   │             │                        │
+   │             │                        requirement enforced here
+   │             conflicting reference used here
+   │             previous freeze
+
+error: mutable reference in local `r` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-borrow-tests/eq_ok.move:26:38
+   │
+26 │         _ = freeze(copy r) != freeze(copy r);
+   │             -------------------------^^^^^^-
+   │             │                        │
+   │             │                        requirement enforced here
+   │             conflicting reference used here
+   │             previous freeze
+
+error: mutable reference in local `r` requires exclusive access but is borrowed
+   ┌─ tests/reference-safety/v1-borrow-tests/eq_ok.move:35:38
+   │
+35 │         _ = freeze(copy r) != freeze(move r);
+   │             -------------------------^^^^^^-
+   │             │                        │
+   │             │                        requirement enforced here
+   │             conflicting reference used here
+   │             previous freeze

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/factor_valid_2.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/factor_valid_2.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/factor_valid_2.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/factor_valid_2.move
@@ -1,0 +1,45 @@
+module 0x8675309::M {
+    struct S { g: u64 }
+
+    fun t1(root: &mut S, cond: bool) {
+        let x1 = 0;
+        let eps = if (cond) bar(root) else &x1;
+        let g = &root.g;
+        eps;
+        g;
+        eps;
+    }
+
+    fun t2() {
+        let x1 = 0;
+        let x2 = 1;
+        let eps = foo(&x1, &x2);
+        baz(&x1, eps);
+    }
+
+    fun t3() {
+        let x1 = 0;
+        let x2 = 1;
+        let eps = foo(&x1, &x2);
+        baz(freeze(&mut x1), eps);
+    }
+
+    fun foo(a: &u64, b: &u64): &u64 {
+        let ret;
+        if (*a > *b) {
+            ret = move a;
+            move b;
+        } else {
+            ret = move b;
+            move a;
+        };
+        ret
+    }
+
+    fun bar(a: &mut S): &u64 {
+        &a.g
+    }
+
+    fun baz(_a: &u64, _b: &u64) {
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/factor_valid_2.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/factor_valid_2.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/factor_valid_2.old.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/factor_valid_2.old.exp
@@ -1,0 +1,15 @@
+
+Diagnostics:
+error: cannot mutably borrow since immutable references exist
+   ┌─ tests/reference-safety/v1-borrow-tests/factor_valid_2.move:24:20
+   │
+23 │         let eps = foo(&x1, &x2);
+   │                   -------------
+   │                   │   │
+   │                   │   previous local borrow
+   │                   used by call result
+24 │         baz(freeze(&mut x1), eps);
+   │         -----------^^^^^^^-------
+   │         │          │
+   │         │          mutable borrow attempted here
+   │         requirement enforced here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_loc_valid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_loc_valid.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_loc_valid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_loc_valid.move
@@ -1,0 +1,38 @@
+module 0x8675309::Tester {
+    use std::signer;
+
+    struct Data has key { v1: u64, v2: u64 }
+    struct Box has key { f: u64 }
+
+    // the resource struct is here to just give a feeling why the computation might not be reorderable
+    fun bump_and_pick(account: &signer, b1: &mut Box, b2: &mut Box): &u64 acquires Data {
+        let sender = signer::address_of(account);
+        let data = borrow_global_mut<Data>(sender);
+        b1.f = data.v1;
+        b2.f = data.v2;
+        if (b1.f > b2.f) &b1.f else &b2.f
+    }
+
+    fun larger_field(account: &signer, drop: address, result: &mut u64) acquires Box, Data {
+        let sender = signer::address_of(account);
+        let b1 = move_from<Box>(sender);
+        let b2 = move_from<Box>(drop);
+
+        assert!(b1.f == 0, 42);
+        assert!(b2.f == 0, 42);
+
+        let returned_ref = bump_and_pick(account, &mut b1, &mut b2);
+
+        // imagine some more interesting check than these asserts
+        assert!(b1.f != 0, 42);
+        assert!(b2.f != 0, 42);
+        assert!(
+            (returned_ref == &(&mut b1).f) != (returned_ref == &(&mut b2).f),
+            42
+        );
+
+        *result = *returned_ref;
+        move_to<Box>(account, b1);
+        Box { f: _ } = b2;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_loc_valid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_loc_valid.no-opt.exp
@@ -1,0 +1,2 @@
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_loc_valid.old.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_loc_valid.old.exp
@@ -1,0 +1,37 @@
+
+Diagnostics:
+error: cannot immutably borrow since mutable references exist
+   ┌─ tests/reference-safety/v1-borrow-tests/imm_borrow_loc_valid.move:27:17
+   │
+24 │         let returned_ref = bump_and_pick(account, &mut b1, &mut b2);
+   │                            ----------------------------------------
+   │                            │                      │
+   │                            │                      previous mutable local borrow
+   │                            used by call result
+   ·
+27 │         assert!(b1.f != 0, 42);
+   │                 ^^--
+   │                 │
+   │                 requirement enforced here
+   │                 immutable borrow attempted here
+   ·
+30 │             (returned_ref == &(&mut b1).f) != (returned_ref == &(&mut b2).f),
+   │             ------------------------------ conflicting reference `returned_ref` used here
+
+error: cannot immutably borrow since mutable references exist
+   ┌─ tests/reference-safety/v1-borrow-tests/imm_borrow_loc_valid.move:28:17
+   │
+24 │         let returned_ref = bump_and_pick(account, &mut b1, &mut b2);
+   │                            ----------------------------------------
+   │                            │                               │
+   │                            │                               previous mutable local borrow
+   │                            used by call result
+   ·
+28 │         assert!(b2.f != 0, 42);
+   │                 ^^--
+   │                 │
+   │                 requirement enforced here
+   │                 immutable borrow attempted here
+29 │         assert!(
+30 │             (returned_ref == &(&mut b1).f) != (returned_ref == &(&mut b2).f),
+   │             ------------------------------ conflicting reference `returned_ref` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/mutable_borrow_local_twice_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/mutable_borrow_local_twice_invalid.exp
@@ -1,0 +1,12 @@
+
+Diagnostics:
+error: cannot write local `r2` since it is borrowed
+  ┌─ tests/reference-safety/v1-borrow-tests/mutable_borrow_local_twice_invalid.move:6:9
+  │
+4 │         let r1 = &mut a;
+  │                  ------ previously mutably borrowed here
+5 │         let r2 = &mut a;
+6 │         *r2 = 2;
+  │         ^^^^^^^ write attempted here
+7 │         *r1 = 1;
+  │         ------- conflicting reference `r1` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/mutable_borrow_local_twice_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/mutable_borrow_local_twice_invalid.move
@@ -1,0 +1,11 @@
+module 0x8675309::M {
+    fun t1() {
+        let a = 0;
+        let r1 = &mut a;
+        let r2 = &mut a;
+        *r2 = 2;
+        *r1 = 1;
+    }
+}
+
+// check: WRITEREF_EXISTS_BORROW_ERROR

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/mutable_borrow_local_twice_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/mutable_borrow_local_twice_invalid.no-opt.exp
@@ -1,0 +1,12 @@
+
+Diagnostics:
+error: cannot write local `r2` since it is borrowed
+  ┌─ tests/reference-safety/v1-borrow-tests/mutable_borrow_local_twice_invalid.move:6:9
+  │
+4 │         let r1 = &mut a;
+  │                  ------ previously mutably borrowed here
+5 │         let r2 = &mut a;
+6 │         *r2 = 2;
+  │         ^^^^^^^ write attempted here
+7 │         *r1 = 1;
+  │         ------- conflicting reference `r1` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/mutable_borrow_local_twice_invalid.old.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/mutable_borrow_local_twice_invalid.old.exp
@@ -1,0 +1,9 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `WRITEREF_EXISTS_BORROW_ERROR`. This is a compiler bug, consider reporting it.
+  ┌─ tests/reference-safety/v1-borrow-tests/mutable_borrow_local_twice_invalid.move:6:9
+  │
+6 │         *r2 = 2;
+  │         ^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.exp
@@ -1,0 +1,12 @@
+
+Diagnostics:
+error: cannot write local `g_mut` since it is borrowed
+   ┌─ tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.move:10:9
+   │
+ 6 │         let v_mut = &mut root.g.v;
+   │                     ------------- field `v` previously mutably borrowed here
+   ·
+10 │         *g_mut = G { v: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^ write attempted here
+11 │         v_mut;
+   │         ----- conflicting reference `v_mut` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.move
@@ -1,0 +1,13 @@
+module 0x8675309::M {
+    struct G has copy, drop { v: u64 }
+    struct S has copy, drop { g: G }
+
+    fun t1(root: &mut S) {
+        let v_mut = &mut root.g.v;
+        let g_mut = &mut root.g;
+
+        // INVALID
+        *g_mut = G { v: 0 };
+        v_mut;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.no-opt.exp
@@ -1,0 +1,12 @@
+
+Diagnostics:
+error: cannot write local `g_mut` since it is borrowed
+   ┌─ tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.move:10:9
+   │
+ 6 │         let v_mut = &mut root.g.v;
+   │                     ------------- field `v` previously mutably borrowed here
+   ·
+10 │         *g_mut = G { v: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^ write attempted here
+11 │         v_mut;
+   │         ----- conflicting reference `v_mut` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.old.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.old.exp
@@ -1,0 +1,9 @@
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `WRITEREF_EXISTS_BORROW_ERROR`. This is a compiler bug, consider reporting it.
+   ┌─ tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.move:10:9
+   │
+10 │         *g_mut = G { v: 0 };
+   │         ^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/v1.matched
+++ b/third_party/move/move-compiler-v2/tests/v1.matched
@@ -22,14 +22,18 @@ move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/copy_loc_bo
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/copy_loc_borrowed_indirect.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/copy_loc_borrowed_indirect.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/copy_loc_borrowed_indirect_invalid.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/copy_loc_borrowed_indirect_invalid.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/copy_loc_borrowed_invalid.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/copy_loc_borrowed_invalid.exp
+move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/eq_bad.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_bad.exp
+move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/eq_ok.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/eq_ok.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/factor_invalid_1.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/factor_invalid_1.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/factor_invalid_2.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/factor_invalid_2.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/factor_valid_1.exp   move-compiler-v2/tests/acquires-checker/v1-borrow-tests/factor_valid_1.exp
+move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/factor_valid_2.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/factor_valid_2.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/imm_borrow_global_invalid.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_global_invalid.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/imm_borrow_global_requires_acquire.exp   move-compiler-v2/tests/acquires-checker/v1-borrow-tests/imm_borrow_global_requires_acquire.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/imm_borrow_loc.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_loc.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/imm_borrow_loc_trivial.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_loc_trivial.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/imm_borrow_loc_trivial_valid.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_loc_trivial_valid.exp
+move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/imm_borrow_loc_valid.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_loc_valid.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/imm_borrow_on_mut.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_on_mut.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/imm_borrow_on_mut_invalid.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_on_mut_invalid.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/imm_borrow_on_mut_trivial.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_on_mut_trivial.exp
@@ -38,6 +42,7 @@ move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/join_borrow
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/move_one_branch.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/move_one_branch.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/mutable_borrow_invalid.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/mutable_borrow_invalid.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/mutable_borrow_local_twice.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/mutable_borrow_local_twice.exp
+move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/mutable_borrow_local_twice_invalid.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/mutable_borrow_local_twice_invalid.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/mutate_with_borrowed_loc.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/mutate_with_borrowed_loc.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/mutate_with_borrowed_loc_invalid.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/mutate_with_borrowed_loc_invalid.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/mutate_with_borrowed_loc_struct_invalid.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/mutate_with_borrowed_loc_struct_invalid.exp
@@ -46,6 +51,7 @@ move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/release_cyc
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/return_with_borrowed_loc.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/return_with_borrowed_loc.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/return_with_borrowed_loc_invalid.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/return_with_borrowed_loc_invalid.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/return_with_borrowed_loc_resource_invalid.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/return_with_borrowed_loc_resource_invalid.exp
+move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/writeref_borrow_invalid.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/writeref_borrow_valid1.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/writeref_borrow_valid1.exp
 move-compiler/tests/move_check/translated_ir_tests/move/borrow_tests/writeref_borrow_valid2.exp   move-compiler-v2/tests/reference-safety/v1-borrow-tests/writeref_borrow_valid2.exp
 move-compiler/tests/move_check/borrows/assign_local_combo.exp   move-compiler-v2/tests/reference-safety/v1-tests/assign_local_combo.exp
@@ -266,6 +272,7 @@ move-compiler/tests/move_check/naming/unresolved_type_with_args.exp   move-compi
 move-compiler/tests/move_check/naming/vector_literal_type_arity.exp   move-compiler-v2/tests/checking/typing/v1-naming/vector_literal_type_arity.exp
 move-compiler/tests/move_check/translated_ir_tests/move/operators/boolean_not_non_boolean.exp   move-compiler-v2/tests/checking/typing/v1-operators/boolean_not_non_boolean.exp
 move-compiler/tests/move_check/translated_ir_tests/move/operators/casting_operators_types_mismatch.exp   move-compiler-v2/tests/checking/typing/v1-operators/casting_operators_types_mismatch.exp
+move-compiler/tests/move_check/parser/acquires_list_generic.exp   move-compiler-v2/tests/checking-lang-v1/acquires_list_generic.exp
 move-compiler/tests/move_check/parser/aptos_stdlib_attributes.exp   move-compiler-v2/tests/checking/attributes/aptos_stdlib_attributes.exp
 move-compiler/tests/move_check/parser/aptos_stdlib_attributes2.exp   move-compiler-v2/tests/checking/attributes/aptos_stdlib_attributes2.exp
 move-compiler/tests/move_check/parser/attribute_no_closing_bracket.exp   move-compiler-v2/tests/checking/attributes/attribute_no_closing_bracket.exp

--- a/third_party/move/move-compiler-v2/tests/v1.unmatched
+++ b/third_party/move/move-compiler-v2/tests/v1.unmatched
@@ -1,12 +1,6 @@
 move-compiler/tests/move_check/borrow_tests/{
   borrow_global_acquires_duplicate_annotation.move,
-  eq_bad.move,
-  eq_ok.move,
-  factor_valid_2.move,
   imm_borrow_global_lossy_acquire_invalid.move,
-  imm_borrow_loc_valid.move,
-  mutable_borrow_local_twice_invalid.move,
-  writeref_borrow_invalid.move,
 }
 move-compiler/tests/move_check/commands/{
   abort_negative_stack_size.move,
@@ -61,13 +55,13 @@ move-compiler/tests/move_check/locals/{
 move-compiler/tests/move_check/parser/{
   ability_constraint_trailing_plus.move,
   ability_modifier_trailing_comma.move,
-  acquires_list_generic.move,
   address_misspelled.move,
   address_not_hex.move,
   address_too_long.move,
   address_too_long_decimal.move,
   address_too_long_decimal_exp.move,
   address_too_long_exp.move,
+  anonymous_field_fail.move,
   break_with_value.move,
   byte_string_invalid_escaped_sequence.move,
   byte_string_invalid_hex.move,
@@ -187,6 +181,7 @@ move-compiler/tests/move_check/parser/{
   phantom_param_invalid_keyword.move,
   phantom_param_missing_type_var.move,
   preserve_address_syntax.move,
+  public_packge_visibility.move,
   return_in_binop.move,
   spec_parsing_emits_fail.move,
   spec_parsing_fun_type_fail.move,

--- a/third_party/move/move-compiler-v2/tools/testdiff/src/main.rs
+++ b/third_party/move/move-compiler-v2/tools/testdiff/src/main.rs
@@ -105,6 +105,7 @@ static UNIT_PATH_REMAP: Lazy<Vec<(&'static str, &'static str)>> = Lazy::new(|| {
         ("unused-assignment/v1-liveness", "liveness"),
         ("unused-assignment/v1-commands", "commands"),
         ("checking-lang-v1/v1-typing", "typing"),
+        ("checking-lang-v1", "parser"),
         ("ability-check/v1-typing", "typing"),
         ("ability-check/v1-signer", "signer"),
         ("ability-check/v1-borrow-tests", "commands"),


### PR DESCRIPTION
## Description

This goes through all urgent bugs in the spreadsheet from issue #13747 and verifies that they have been resolved with recent changes.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Migrates tests from v1 to v2

