### PR TITLE
[experimental] LayeredMap: base-exclusive

### DIFF
--- a/experimental/storage/hexy/src/in_mem/overlay.rs
+++ b/experimental/storage/hexy/src/in_mem/overlay.rs
@@ -27,7 +27,7 @@ impl HexyOverlay {
     pub fn view(&self, base: &Arc<HexyBase>, base_overlay: &HexyOverlay) -> HexyView {
         HexyView::new(
             base.clone(),
-            self.overlay.view_layers_since(&base_overlay.overlay),
+            self.overlay.view_layers_after(&base_overlay.overlay),
         )
     }
 

--- a/experimental/storage/layered-map/src/iterator.rs
+++ b/experimental/storage/layered-map/src/iterator.rs
@@ -47,7 +47,7 @@ where
                 NodeStrongRef::Leaf(leaf) => Some(Box::new(
                     leaf.content
                         .clone()
-                        .into_iter(self.layered_map.bottom_layer()),
+                        .into_iter(self.layered_map.base_layer()),
                 )),
                 NodeStrongRef::Internal(internal) => {
                     let left = self.layered_map.get_node_strong(&internal.left);

--- a/experimental/storage/layered-map/src/node.rs
+++ b/experimental/storage/layered-map/src/node.rs
@@ -26,12 +26,12 @@ pub(crate) enum LeafContent<K, V> {
 }
 
 impl<K, V> LeafContent<K, V> {
-    pub fn into_iter(self, min_layer: u64) -> impl Iterator<Item = (K, V)> {
+    pub fn into_iter(self, base_layer: u64) -> impl Iterator<Item = (K, V)> {
         match self {
             LeafContent::UniqueLatest { key, value } => Either::Left(std::iter::once((key, value))),
             LeafContent::Collision(map) => {
                 Either::Right(map.into_iter().filter_map(move |(key, cell)| {
-                    (cell.layer >= min_layer).then_some((key, cell.value))
+                    (cell.layer > base_layer).then_some((key, cell.value))
                 }))
             },
         }
@@ -53,6 +53,9 @@ impl<K, V> LeafContent<K, V> {
     {
         use LeafContent::*;
 
+        assert!(layer < other_layer);
+        assert!(base_layer < other_layer);
+
         match (self, other) {
             // Collision should be rare, this is likely.
             (UniqueLatest { key: old_key, .. }, UniqueLatest { key, value }) if old_key == key => {
@@ -64,8 +67,8 @@ impl<K, V> LeafContent<K, V> {
                 let map: BTreeMap<_, _> = myself
                     .into_cell_iter(layer)
                     .chain(other.into_cell_iter(other_layer))
-                    // retire entries that's older than the base_layer
-                    .filter(|(_key, cell)| cell.layer >= base_layer)
+                    // retire entries that's at base_layer or even older
+                    .filter(|(_key, cell)| cell.layer > base_layer)
                     .collect();
 
                 assert!(!map.is_empty());
@@ -83,7 +86,7 @@ impl<K, V> LeafContent<K, V> {
         }
     }
 
-    fn get(&self, key: &K, min_layer: u64) -> Option<&V>
+    fn get(&self, key: &K, base_layer: u64) -> Option<&V>
     where
         K: Eq + Ord,
     {
@@ -98,7 +101,7 @@ impl<K, V> LeafContent<K, V> {
                 }
             },
             Collision(map) => map.get(key).and_then(|cell| {
-                if cell.layer >= min_layer {
+                if cell.layer > base_layer {
                     Some(&cell.value)
                 } else {
                     None
@@ -116,11 +119,11 @@ pub(crate) struct LeafNode<K, V> {
 }
 
 impl<K, V> LeafNode<K, V> {
-    pub fn get_value(&self, key: &K, min_layer: u64) -> Option<&V>
+    pub fn get_value(&self, key: &K, base_layer: u64) -> Option<&V>
     where
         K: Eq + Ord,
     {
-        self.content.get(key, min_layer)
+        self.content.get(key, base_layer)
     }
 }
 
@@ -144,13 +147,13 @@ impl<K, V> NodeRef<K, V> {
         Self::Internal(Ref::Strong(Arc::new(InternalNode { left, right, layer })))
     }
 
-    pub fn get_strong_with_min_layer(&self, min_layer: u64) -> NodeStrongRef<K, V> {
+    pub fn get_strong(&self, base_layer: u64) -> NodeStrongRef<K, V> {
         match self {
             NodeRef::Empty => NodeStrongRef::Empty,
             NodeRef::Leaf(leaf) => match leaf.try_get_strong() {
                 None => NodeStrongRef::Empty,
                 Some(leaf) => {
-                    if leaf.layer >= min_layer {
+                    if leaf.layer > base_layer {
                         NodeStrongRef::Leaf(leaf)
                     } else {
                         NodeStrongRef::Empty
@@ -160,7 +163,7 @@ impl<K, V> NodeRef<K, V> {
             NodeRef::Internal(internal) => match internal.try_get_strong() {
                 None => NodeStrongRef::Empty,
                 Some(internal) => {
-                    if internal.layer >= min_layer {
+                    if internal.layer > base_layer {
                         NodeStrongRef::Internal(internal)
                     } else {
                         NodeStrongRef::Empty

--- a/experimental/storage/layered-map/src/tests.rs
+++ b/experimental/storage/layered-map/src/tests.rs
@@ -25,15 +25,15 @@ fn naive_view_layers<K: Ord, V>(layers: impl Iterator<Item = Vec<(K, V)>>) -> BT
 
 fn arb_test_case() -> impl Strategy<Value = (Vec<Vec<(HashCollide, u8)>>, usize, usize, usize)> {
     vec(vec(any::<(u8, u8)>(), 0..100), 1..100).prop_flat_map(|items_per_layer| {
-        let num_layers = items_per_layer.len();
-        let items_per_layer = items_per_layer.clone();
-        vec(0..num_layers, 3).prop_map(move |mut layer_indices| {
+        let num_overlay_layers = items_per_layer.len();
+        let items_per_update = items_per_layer.clone();
+        vec(0..=num_overlay_layers, 3).prop_map(move |mut layer_indices| {
             layer_indices.sort();
             let ancestor = layer_indices[0];
-            let bottom = layer_indices[1];
+            let base = layer_indices[1];
             let top = layer_indices[2];
 
-            let items_per_layer = items_per_layer
+            let items_per_update = items_per_update
                 .iter()
                 .map(|items| {
                     items
@@ -43,30 +43,31 @@ fn arb_test_case() -> impl Strategy<Value = (Vec<Vec<(HashCollide, u8)>>, usize,
                 })
                 .collect_vec();
 
-            (items_per_layer, ancestor, bottom, top)
+            (items_per_update, ancestor, base, top)
         })
     })
 }
 
 fn layers(
-    items_per_layer: &[Vec<(HashCollide, u8)>],
+    items_per_update: &[Vec<(HashCollide, u8)>],
     max_base_layer: u64,
 ) -> Vec<MapLayer<HashCollide, u8>> {
     let mut base_layer = MapLayer::new_family("test");
     let mut latest_layer = base_layer.clone();
 
     let mut base_layer_idx = 0;
-    let mut layers = Vec::new();
+    let mut layers = vec![base_layer.clone()];
 
-    for (layer_idx, layer_items) in items_per_layer.iter().enumerate() {
+    for (prev_layer_idx, layer_items) in items_per_update.iter().enumerate() {
+        let layer_idx = prev_layer_idx + 1;
         let items_vec: Vec<_> = layer_items.iter().map(|(k, v)| (*k, *v)).collect();
         latest_layer = latest_layer
-            .view_layers_since(&base_layer)
+            .view_layers_after(&base_layer)
             .new_layer(&items_vec);
         layers.push(latest_layer.clone());
 
         // advance base layer occasionally to expose more edge cases
-        if base_layer_idx < max_base_layer as usize && layer_idx % 2 == 1 {
+        if base_layer_idx < max_base_layer as usize && layer_idx % 2 == 0 {
             base_layer_idx += 1;
             base_layer = layers[base_layer_idx].clone();
         }
@@ -78,16 +79,17 @@ fn layers(
 proptest! {
     #[test]
     fn test_layered_map_get(
-        (mut items_per_layer, ancestor, bottom, top) in arb_test_case()
+        (mut items_per_update, ancestor, base, top) in arb_test_case()
     ) {
-        let (_ancestor_layer, bottom_layer, top_layer) = {
-            let layers = layers(&items_per_layer, ancestor as u64);
-            (layers[ancestor].clone(), layers[bottom].clone(), layers[top].clone())
+        let (_ancestor_layer, base_layer, top_layer) = {
+            let layers = layers(&items_per_update, ancestor as u64);
+            (layers[ancestor].clone(), layers[base].clone(), layers[top].clone())
         };
 
-        let layered_map = top_layer.into_layers_view_since(bottom_layer);
+        let layered_map = top_layer.into_layers_view_after(base_layer);
 
-        let all = naive_view_layers(items_per_layer.drain(bottom..=top));
+        // n.b. notice items_per_update doesn't have a placeholder for the root layer
+        let all = naive_view_layers(items_per_update.drain(base..top));
 
         // get() individually
         for (k, v) in &all {


### PR DESCRIPTION
A view represents the content of a left-exclusive, right-exclusive range of layers, so that the batches we merge into the HexyBase won't have overlaps.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Validator Node


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

unit tests