### PR TITLE
[compiler-v2] Basic block merging peephole optimization

### DIFF
--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/diamond_clicker.v2_exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/diamond_clicker.v2_exp
@@ -15,49 +15,47 @@ struct OuterStruct has key {
 }
 
 entry public test_upgrade(Arg0: &signer) /* def_idx: 0 */ {
-L1:	loc0: &signer
-L2:	loc1: OuterStruct
-L3:	loc2: &mut vector<InnerStruct>
+L1:	loc0: OuterStruct
+L2:	loc1: &mut vector<InnerStruct>
+L3:	loc2: u64
 L4:	loc3: u64
 L5:	loc4: u64
-L6:	loc5: &mut vector<InnerStruct>
-L7:	loc6: u64
 B0:
 	0: CopyLoc[0](Arg0: &signer)
 	1: Call signer::address_of(&signer): address
 	2: VecPack(3, 0)
 	3: Pack[1](OuterStruct)
-	4: StLoc[2](loc1: OuterStruct)
+	4: StLoc[1](loc0: OuterStruct)
 	5: MoveLoc[0](Arg0: &signer)
-	6: MoveLoc[2](loc1: OuterStruct)
+	6: MoveLoc[1](loc0: OuterStruct)
 	7: MoveTo[1](OuterStruct)
 	8: MutBorrowGlobal[1](OuterStruct)
 	9: MutBorrowField[0](OuterStruct.any_field: vector<InnerStruct>)
-	10: StLoc[3](loc2: &mut vector<InnerStruct>)
+	10: StLoc[2](loc1: &mut vector<InnerStruct>)
 	11: LdU64(0)
-	12: CopyLoc[3](loc2: &mut vector<InnerStruct>)
+	12: CopyLoc[2](loc1: &mut vector<InnerStruct>)
 	13: FreezeRef
 	14: VecLen(3)
-	15: StLoc[4](loc3: u64)
-	16: StLoc[5](loc4: u64)
+	15: StLoc[3](loc2: u64)
+	16: StLoc[4](loc3: u64)
 B1:
-	17: CopyLoc[5](loc4: u64)
-	18: CopyLoc[4](loc3: u64)
+	17: CopyLoc[4](loc3: u64)
+	18: CopyLoc[3](loc2: u64)
 	19: Lt
 	20: BrFalse(31)
 B2:
-	21: CopyLoc[3](loc2: &mut vector<InnerStruct>)
-	22: CopyLoc[5](loc4: u64)
+	21: CopyLoc[2](loc1: &mut vector<InnerStruct>)
+	22: CopyLoc[4](loc3: u64)
 	23: VecMutBorrow(3)
 	24: FreezeRef
 	25: Call debug::print<InnerStruct>(&InnerStruct)
-	26: MoveLoc[5](loc4: u64)
+	26: MoveLoc[4](loc3: u64)
 	27: LdU64(1)
 	28: Add
-	29: StLoc[5](loc4: u64)
+	29: StLoc[4](loc3: u64)
 	30: Branch(34)
 B3:
-	31: MoveLoc[3](loc2: &mut vector<InnerStruct>)
+	31: MoveLoc[2](loc1: &mut vector<InnerStruct>)
 	32: Pop
 	33: Branch(35)
 B4:

--- a/aptos-move/framework/aptos-stdlib/tests/compiler-v2-doc/math128.md
+++ b/aptos-move/framework/aptos-stdlib/tests/compiler-v2-doc/math128.md
@@ -11,6 +11,7 @@ Standard math utilities missing in the Move Language.
 -  [Function `min`](#0x1_math128_min)
 -  [Function `average`](#0x1_math128_average)
 -  [Function `gcd`](#0x1_math128_gcd)
+-  [Function `lcm`](#0x1_math128_lcm)
 -  [Function `mul_div`](#0x1_math128_mul_div)
 -  [Function `clamp`](#0x1_math128_clamp)
 -  [Function `pow`](#0x1_math128_pow)
@@ -154,6 +155,35 @@ Return greatest common divisor of <code>a</code> & <code>b</code>, via the Eucli
         large = tmp;
     };
     large
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_math128_lcm"></a>
+
+## Function `lcm`
+
+Return least common multiple of <code>a</code> & <code>b</code>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math128.md#0x1_math128_lcm">lcm</a>(a: u128, b: u128): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="math128.md#0x1_math128_lcm">lcm</a>(a: u128, b: u128): u128 {
+    <b>if</b> (a == 0 || b == 0) {
+        0
+    } <b>else</b> {
+        a / <a href="math128.md#0x1_math128_gcd">gcd</a>(a, b) * b
+    }
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-stdlib/tests/compiler-v2-doc/math64.md
+++ b/aptos-move/framework/aptos-stdlib/tests/compiler-v2-doc/math64.md
@@ -11,6 +11,7 @@ Standard math utilities missing in the Move Language.
 -  [Function `min`](#0x1_math64_min)
 -  [Function `average`](#0x1_math64_average)
 -  [Function `gcd`](#0x1_math64_gcd)
+-  [Function `lcm`](#0x1_math64_lcm)
 -  [Function `mul_div`](#0x1_math64_mul_div)
 -  [Function `clamp`](#0x1_math64_clamp)
 -  [Function `pow`](#0x1_math64_pow)
@@ -152,6 +153,35 @@ Return greatest common divisor of <code>a</code> & <code>b</code>, via the Eucli
         large = tmp;
     };
     large
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_math64_lcm"></a>
+
+## Function `lcm`
+
+Returns least common multiple of <code>a</code> & <code>b</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math64.md#0x1_math64_lcm">lcm</a>(a: u64, b: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="math64.md#0x1_math64_lcm">lcm</a>(a: u64, b: u64): u64 {
+    <b>if</b> (a == 0 || b == 0) {
+        0
+    } <b>else</b> {
+        a / <a href="math64.md#0x1_math64_gcd">gcd</a>(a, b) * b
+    }
 }
 </code></pre>
 

--- a/third_party/move/move-compiler-v2/src/file_format_generator/peephole_optimizer/reducible_pairs.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/peephole_optimizer/reducible_pairs.rs
@@ -27,8 +27,11 @@
 //!    target.
 //!    - stack is left unaffected (the first instruction pushes a constant, the second
 //!      takes it off).
+//! 6. [`LdTrue`, `BrFalse`] or [`LdFalse`, `BrTrue`]: Remove the pair.
+//!    - stack is left unaffected.
 //!    - locals are unaffected.
-//! 6. [`Not`, `BrFalse`] or [`Not`, `BrTrue`]: Replace with `BrTrue` or `BrFalse`.
+//!    - basic blocks are merged.
+//! 7. [`Not`, `BrFalse`] or [`Not`, `BrTrue`]: Replace with `BrTrue` or `BrFalse`.
 //!    - stack is left unaffected (first instruction negates the top, second takes it
 //!      off, vs. just take off the top).
 //!    - locals are unaffected.
@@ -57,6 +60,7 @@ impl FixedWindowOptimizer for ReduciblePairs {
             },
             (CopyLoc(_), Pop) => Some(vec![]),
             (LdTrue, BrTrue(target)) | (LdFalse, BrFalse(target)) => Some(vec![Branch(*target)]),
+            (LdTrue, BrFalse(_)) | (LdFalse, BrTrue(_)) => Some(vec![]),
             (Not, BrFalse(target)) => Some(vec![BrTrue(*target)]),
             (Not, BrTrue(target)) => Some(vec![BrFalse(*target)]),
             _ => None,

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/has_script.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/has_script.opt.exp
@@ -6,15 +6,12 @@ script {
 
 main() /* def_idx: 0 */ {
 B0:
-	0: LdTrue
-	1: BrFalse(3)
+	0: Branch(3)
 B1:
-	2: Branch(5)
+	1: LdU64(1)
+	2: Abort
 B2:
-	3: LdU64(1)
-	4: Abort
-B3:
-	5: Ret
+	3: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.exp
@@ -239,27 +239,24 @@ main() /* def_idx: 0 */ {
 L0:	loc0: u64
 L1:	loc1: u64
 B0:
-	0: LdTrue
-	1: BrFalse(5)
+	0: LdU64(5)
+	1: StLoc[0](loc0: u64)
+	2: Branch(5)
 B1:
-	2: LdU64(5)
-	3: StLoc[0](loc0: u64)
-	4: Branch(7)
+	3: LdU64(0)
+	4: StLoc[0](loc0: u64)
 B2:
-	5: LdU64(0)
-	6: StLoc[0](loc0: u64)
+	5: MoveLoc[0](loc0: u64)
+	6: LdU64(5)
+	7: Eq
+	8: BrFalse(10)
 B3:
-	7: MoveLoc[0](loc0: u64)
-	8: LdU64(5)
-	9: Eq
-	10: BrFalse(12)
+	9: Branch(12)
 B4:
-	11: Branch(14)
+	10: LdU64(42)
+	11: Abort
 B5:
-	12: LdU64(42)
-	13: Abort
-B6:
-	14: Ret
+	12: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.opt.exp
@@ -239,27 +239,24 @@ main() /* def_idx: 0 */ {
 L0:	loc0: u64
 L1:	loc1: u64
 B0:
-	0: LdTrue
-	1: BrFalse(5)
+	0: LdU64(5)
+	1: StLoc[0](loc0: u64)
+	2: Branch(5)
 B1:
-	2: LdU64(5)
-	3: StLoc[0](loc0: u64)
-	4: Branch(7)
+	3: LdU64(0)
+	4: StLoc[0](loc0: u64)
 B2:
-	5: LdU64(0)
-	6: StLoc[0](loc0: u64)
+	5: MoveLoc[0](loc0: u64)
+	6: LdU64(5)
+	7: Eq
+	8: BrFalse(10)
 B3:
-	7: MoveLoc[0](loc0: u64)
-	8: LdU64(5)
-	9: Eq
-	10: BrFalse(12)
+	9: Branch(12)
 B4:
-	11: Branch(14)
+	10: LdU64(42)
+	11: Abort
 B5:
-	12: LdU64(42)
-	13: Abort
-B6:
-	14: Ret
+	12: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.exp
@@ -220,29 +220,24 @@ L0:	loc0: u64
 L1:	loc1: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[0](loc0: u64)
-	2: LdTrue
-	3: BrFalse(9)
+	1: LdU64(1)
+	2: Add
+	3: StLoc[0](loc0: u64)
+	4: Branch(6)
 B1:
-	4: MoveLoc[0](loc0: u64)
-	5: LdU64(1)
-	6: Add
-	7: StLoc[0](loc0: u64)
-	8: Branch(10)
+	5: Branch(6)
 B2:
-	9: Branch(10)
+	6: MoveLoc[0](loc0: u64)
+	7: LdU64(1)
+	8: Eq
+	9: BrFalse(11)
 B3:
-	10: MoveLoc[0](loc0: u64)
-	11: LdU64(1)
-	12: Eq
-	13: BrFalse(15)
+	10: Branch(13)
 B4:
-	14: Branch(17)
+	11: LdU64(42)
+	12: Abort
 B5:
-	15: LdU64(42)
-	16: Abort
-B6:
-	17: Ret
+	13: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.opt.exp
@@ -220,29 +220,24 @@ L0:	loc0: u64
 L1:	loc1: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[0](loc0: u64)
-	2: LdTrue
-	3: BrFalse(9)
+	1: LdU64(1)
+	2: Add
+	3: StLoc[0](loc0: u64)
+	4: Branch(6)
 B1:
-	4: MoveLoc[0](loc0: u64)
-	5: LdU64(1)
-	6: Add
-	7: StLoc[0](loc0: u64)
-	8: Branch(10)
+	5: Branch(6)
 B2:
-	9: Branch(10)
+	6: MoveLoc[0](loc0: u64)
+	7: LdU64(1)
+	8: Eq
+	9: BrFalse(11)
 B3:
-	10: MoveLoc[0](loc0: u64)
-	11: LdU64(1)
-	12: Eq
-	13: BrFalse(15)
+	10: Branch(13)
 B4:
-	14: Branch(17)
+	11: LdU64(42)
+	12: Abort
 B5:
-	15: LdU64(42)
-	16: Abort
-B6:
-	17: Ret
+	13: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/tools/move-cli/tests/build_tests/disassemble_script/args.v2_exp
+++ b/third_party/move/tools/move-cli/tests/build_tests/disassemble_script/args.v2_exp
@@ -5,14 +5,11 @@ script {
 
 main() /* def_idx: 0 */ {
 B0:
-	0: LdTrue
-	1: BrFalse(3)
+	0: Branch(3)
 B1:
-	2: Branch(5)
+	1: LdU64(0)
+	2: Abort
 B2:
-	3: LdU64(0)
-	4: Abort
-B3:
-	5: Ret
+	3: Ret
 }
 }


### PR DESCRIPTION
## Description

In this PR, we add a new peephole optimization on the file format bytecode: instances of pairs (`LdTrue`, `BrFalse`) and (`LdFalse`, `BrTrue`) are both removed. This was originally suggested by @brianrmurphy during a code review.

Note that these new peephole optimizations can change basic blocks by merging then, and we have found instances where redoing peephole optimizations on the new basic blocks can reduce code (see changed exp files). Therefore, we rerun basic block optimizations every time the number of basic blocks change.

## Type of Change
- [x] Generated bytecode optimization

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## How Has This Been Tested?
Existing tests, all updated exp files were validated to produce better (or equal) code.

## Key Areas to Review
Changes to rust files.