### PR TITLE
[Node Infra] Small tweaks and logging improvements.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 
 // The maximum message size per state sync message
-const MAX_MESSAGE_SIZE: usize = 6 * 1024 * 1024; /* 6 MiB */
+const MAX_MESSAGE_SIZE: usize = 8 * 1024 * 1024; /* 8 MiB */
 
 // The maximum chunk sizes for data client requests and response
 const MAX_EPOCH_CHUNK_SIZE: u64 = 200;

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -139,7 +139,7 @@ impl Default for StateSyncDriverConfig {
             max_pending_data_chunks: 50,
             max_pending_mempool_notifications: 100,
             max_stream_wait_time_ms: 5000,
-            num_versions_to_skip_snapshot_sync: 100_000_000, // At 5k TPS, this allows a node to fail for about 6 hours.
+            num_versions_to_skip_snapshot_sync: 400_000_000, // At 5k TPS, this allows a node to fail for about 24 hours.
         }
     }
 }

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -194,11 +194,15 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
     ) -> (Vec<PeerNetworkId>, Vec<PeerNetworkId>) {
         // Get the upstream peers to add or disable, using a read lock
         let (to_add, to_disable) = self.get_upstream_peers_to_add_and_disable(all_connected_peers);
-        info!(
-            "Mempool peers added: {:?}, Mempool peers disabled: {:?}",
-            to_add.iter().map(|(peer, _)| peer).collect::<Vec<_>>(),
-            to_disable
-        );
+
+        if !to_add.is_empty() || !to_disable.is_empty() {
+            info!(
+                "Mempool peers added: {:?}, Mempool peers disabled: {:?}",
+                to_add.iter().map(|(peer, _)| peer).collect::<Vec<_>>(),
+                to_disable
+            );
+        }
+
         // If there are updates, apply using a write lock
         self.add_and_disable_upstream_peers(&to_add, &to_disable);
 

--- a/network/framework/src/transport/mod.rs
+++ b/network/framework/src/transport/mod.rs
@@ -280,7 +280,7 @@ async fn upgrade_inbound<T: TSocket>(
             if err.should_security_log() {
                 sample!(
                     SampleRate::Duration(Duration::from_secs(15)),
-                    error!(
+                    warn!(
                         SecurityEvent::NoiseHandshake,
                         NetworkSchema::new(&ctxt.noise.network_context)
                             .network_address(&addr)
@@ -362,7 +362,7 @@ pub async fn upgrade_outbound<T: TSocket>(
             if err.should_security_log() {
                 sample!(
                     SampleRate::Duration(Duration::from_secs(15)),
-                    error!(
+                    warn!(
                         SecurityEvent::NoiseHandshake,
                         NetworkSchema::new(&ctxt.noise.network_context)
                             .network_address(&addr)

--- a/state-sync/data-streaming-service/src/data_stream.rs
+++ b/state-sync/data-streaming-service/src/data_stream.rs
@@ -838,16 +838,6 @@ impl<T: AptosDataClientInterface + Send + Clone + 'static> DataStream<T> {
                     Error::IntegerOverflow("Number of entries to remove has overflown!".into())
                 })?;
 
-            debug!(
-                (LogSchema::new(LogEntry::StreamNotification)
-                    .stream_id(self.data_stream_id)
-                    .event(LogEvent::Success)
-                    .message(&format!(
-                        "Garbage collecting {:?} items from the notification response map.",
-                        num_entries_to_remove
-                    )))
-            );
-
             // Collect all the keys that need to removed. Note: BTreeMap keys
             // are sorted, so we'll remove the lowest notification IDs. These
             // will be the oldest notifications.

--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -555,12 +555,13 @@ impl<
                 .ok_or_else(|| {
                     Error::IntegerOverflow("The number of versions behind has overflown!".into())
                 })?;
-            if num_versions_behind
-                < self
-                    .driver_configuration
-                    .config
-                    .num_versions_to_skip_snapshot_sync
-            {
+            let max_num_versions_behind = self
+                .driver_configuration
+                .config
+                .num_versions_to_skip_snapshot_sync;
+
+            // Check if the node is too far behind to fast sync
+            if num_versions_behind < max_num_versions_behind {
                 info!(LogSchema::new(LogEntry::Bootstrapper).message(&format!(
                     "The node is only {} versions behind, will skip bootstrapping.",
                     num_versions_behind
@@ -570,10 +571,11 @@ impl<
                 // validator, consensus will take control and sync depending on how it sees fit.
                 self.bootstrapping_complete().await
             } else {
-                panic!("Fast syncing is currently unsupported for nodes with existing state! \
-                        You are currently {:?} versions behind the latest snapshot version ({:?}). Either \
-                        select a different syncing mode, or delete your storage and restart your node.",
-                       num_versions_behind, highest_known_ledger_version);
+                panic!("You are currently {:?} versions behind the latest snapshot version ({:?}). This is \
+                        more than the maximum allowed for fast sync ({:?}). If you want to fast sync to the \
+                        latest state, delete your storage and restart your node. Otherwise, if you want to \
+                        sync all the missing data, use intelligent syncing mode!",
+                       num_versions_behind, highest_known_ledger_version, max_num_versions_behind);
             }
         }
     }

--- a/state-sync/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/tests/bootstrapper.rs
@@ -1401,7 +1401,9 @@ async fn test_snapshot_sync_lag() {
 }
 
 #[tokio::test]
-#[should_panic(expected = "Fast syncing is currently unsupported for nodes with existing state!")]
+#[should_panic(
+    expected = "You are currently 10000 versions behind the latest snapshot version (1000000)"
+)]
 async fn test_snapshot_sync_lag_panic() {
     // Create test data
     let num_versions_behind = 10000;


### PR DESCRIPTION
## Description
This PR makes several small tweaks and logging improvements to node infra related components. The commits are as follows:
1. Increase the supported fast sync lag and improve the error message.
1. Downgrade the noise handshake network error logs.
1. Increase the maximum chunk size for state sync from 6MB -> 8MB (we want to favor output syncing slightly more, given that latency aware peer dialing is working).
1. Reduce/remove some unnecessary logs.

## Testing Plan
Existing test infrastructure.