### PR TITLE
[optqs] add new metrics, batch tracing, and bug fixes

### DIFF
--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -646,41 +646,44 @@ impl From<&Vec<&Payload>> for PayloadFilter {
             }
             PayloadFilter::DirectMempool(exclude_txns)
         } else {
-            let mut exclude_proofs = HashSet::new();
+            let mut exclude_batches = HashSet::new();
             for payload in exclude_payloads {
                 match payload {
                     Payload::InQuorumStore(proof_with_status) => {
                         for proof in &proof_with_status.proofs {
-                            exclude_proofs.insert(proof.info().clone());
+                            exclude_batches.insert(proof.info().clone());
                         }
                     },
                     Payload::InQuorumStoreWithLimit(proof_with_status) => {
                         for proof in &proof_with_status.proof_with_data.proofs {
-                            exclude_proofs.insert(proof.info().clone());
+                            exclude_batches.insert(proof.info().clone());
                         }
                     },
                     Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _) => {
                         for proof in &proof_with_data.proofs {
-                            exclude_proofs.insert(proof.info().clone());
+                            exclude_batches.insert(proof.info().clone());
                         }
                         for (batch_info, _) in inline_batches {
-                            exclude_proofs.insert(batch_info.clone());
+                            exclude_batches.insert(batch_info.clone());
                         }
                     },
                     Payload::DirectMempool(_) => {
                         error!("DirectMempool payload in InQuorumStore filter");
                     },
                     Payload::OptQuorumStore(opt_qs_payload) => {
+                        for batch in opt_qs_payload.inline_batches().iter() {
+                            exclude_batches.insert(batch.info().clone());
+                        }
                         for batch_info in &opt_qs_payload.opt_batches().batch_summary {
-                            exclude_proofs.insert(batch_info.clone());
+                            exclude_batches.insert(batch_info.clone());
                         }
                         for proof in &opt_qs_payload.proof_with_data().batch_summary {
-                            exclude_proofs.insert(proof.info().clone());
+                            exclude_batches.insert(proof.info().clone());
                         }
                     },
                 }
             }
-            PayloadFilter::InQuorumStore(exclude_proofs)
+            PayloadFilter::InQuorumStore(exclude_batches)
         }
     }
 }

--- a/consensus/consensus-types/src/payload.rs
+++ b/consensus/consensus-types/src/payload.rs
@@ -178,6 +178,10 @@ impl InlineBatch {
             transactions,
         }
     }
+
+    pub fn info(&self) -> &BatchInfo {
+        &self.batch_info
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -152,7 +152,7 @@ pub struct EpochManager<P: OnChainConfigProvider> {
     epoch_state: Option<Arc<EpochState>>,
     block_retrieval_tx:
         Option<aptos_channel::Sender<AccountAddress, IncomingBlockRetrievalRequest>>,
-    quorum_store_msg_tx: Option<aptos_channel::Sender<AccountAddress, VerifiedEvent>>,
+    quorum_store_msg_tx: Option<aptos_channel::Sender<AccountAddress, (Author, VerifiedEvent)>>,
     quorum_store_coordinator_tx: Option<Sender<CoordinatorCommand>>,
     quorum_store_storage: Arc<dyn QuorumStoreStorage>,
     batch_retrieval_tx:
@@ -1593,7 +1593,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
     }
 
     fn forward_event(
-        quorum_store_msg_tx: Option<aptos_channel::Sender<AccountAddress, VerifiedEvent>>,
+        quorum_store_msg_tx: Option<aptos_channel::Sender<AccountAddress, (Author, VerifiedEvent)>>,
         round_manager_tx: Option<
             aptos_channel::Sender<(Author, Discriminant<VerifiedEvent>), (Author, VerifiedEvent)>,
         >,
@@ -1613,7 +1613,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             quorum_store_event @ (VerifiedEvent::SignedBatchInfo(_)
             | VerifiedEvent::ProofOfStoreMsg(_)
             | VerifiedEvent::BatchMsg(_)) => {
-                Self::forward_event_to(quorum_store_msg_tx, peer_id, quorum_store_event)
+                Self::forward_event_to(quorum_store_msg_tx, peer_id, (peer_id, quorum_store_event))
                     .context("quorum store sender")
             },
             proposal_event @ VerifiedEvent::ProposalMsg(_) => {

--- a/consensus/src/liveness/proposal_status_tracker.rs
+++ b/consensus/src/liveness/proposal_status_tracker.rs
@@ -7,7 +7,7 @@ use aptos_consensus_types::{
     common::Author, payload_pull_params::OptQSPayloadPullParams, round_timeout::RoundTimeoutReason,
 };
 use aptos_infallible::Mutex;
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 pub trait TPastProposalStatusTracker: Send + Sync {
     fn push(&self, status: NewRoundReason);
@@ -133,7 +133,7 @@ impl TOptQSPullParamsProvider for OptQSPullParamsProvider {
         let exclude_authors = tracker.get_exclude_authors();
         Some(OptQSPayloadPullParams {
             exclude_authors,
-            minimum_batch_age_usecs: 50_000_000,
+            minimum_batch_age_usecs: Duration::from_millis(10).as_micros() as u64,
         })
     }
 }

--- a/consensus/src/quorum_store/batch_coordinator.rs
+++ b/consensus/src/quorum_store/batch_coordinator.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    monitor,
     network::{NetworkSender, QuorumStoreSender},
     quorum_store::{
         batch_generator::BatchGeneratorCommand,
@@ -167,7 +168,10 @@ impl BatchCoordinator {
                     break;
                 },
                 BatchCoordinatorCommand::NewBatches(author, batches) => {
-                    self.handle_batches_msg(author, batches).await;
+                    monitor!(
+                        "qs_handle_batches_msg",
+                        self.handle_batches_msg(author, batches).await
+                    );
                 },
             }
         }

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -180,7 +180,7 @@ pub fn num_txn_per_batch(bucket_start: &str, num: usize) {
 pub static BLOCK_SIZE_WHEN_PULL: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         "quorum_store_block_size_when_pull",
-        "Histogram for the number of transactions per block when pulled for consensus.",
+        "Histogram for the number of unique transactions per block when pulled for consensus.",
         TRANSACTION_COUNT_BUCKETS.clone(),
     )
     .unwrap()
@@ -189,8 +189,40 @@ pub static BLOCK_SIZE_WHEN_PULL: Lazy<Histogram> = Lazy::new(|| {
 pub static TOTAL_BLOCK_SIZE_WHEN_PULL: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(
         "quorum_store_total_block_size_when_pull",
-        "Histogram for the total size of transactions per block when pulled for consensus.",
+        "Histogram for the total number of transactions including duplicates per block when pulled for consensus.",
         BYTE_BUCKETS.clone(),
+    )
+    .unwrap()
+});
+
+/// Histogram for the number of transactions per block when pulled for consensus.
+pub static CONSENSUS_PULL_NUM_TXNS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "quorum_store_consensus_pull_num_txns",
+        "Histogram for the number of transactions including duplicates when pulled for consensus.",
+        &["pull_kind"],
+        TRANSACTION_COUNT_BUCKETS.clone(),
+    )
+    .unwrap()
+});
+
+/// Histogram for the number of transactions per block when pulled for consensus.
+pub static CONSENSUS_PULL_NUM_UNIQUE_TXNS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "quorum_store_consensus_pull_num_unique_txns",
+        "Histogram for the number of unique transactions when pulled for consensus.",
+        &["pull_kind"],
+        TRANSACTION_COUNT_BUCKETS.clone(),
+    )
+    .unwrap()
+});
+
+pub static CONSENSUS_PULL_SIZE_IN_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "quorum_store_consensus_pull_size_in_bytes",
+        "Histogram for the size of the pulled transactions for consensus.",
+        &["pull_kind"],
+        TRANSACTION_COUNT_BUCKETS.clone(),
     )
     .unwrap()
 });

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -956,3 +956,33 @@ pub static BATCH_COORDINATOR_NUM_BATCH_REQS: Lazy<IntCounterVec> = Lazy::new(|| 
     )
     .unwrap()
 });
+
+// Histogram buckets that expand DEFAULT_BUCKETS with more granularity:
+// * 0.3 to 2.0: step 0.1
+// * 2.0 to 4.0: step 0.2
+// * 4.0 to 7.5: step 0.5
+const BATCH_TRACING_BUCKETS: &[f64] = &[
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1,
+    1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0, 3.2, 3.4, 3.6, 3.8, 4.0,
+    4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5, 10.0,
+];
+
+pub static BATCH_TRACING: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "quorum_store_batch_tracing",
+        "Histogram for different stages of a QS batch",
+        &["author", "stage"],
+        BATCH_TRACING_BUCKETS.to_vec()
+    )
+    .unwrap()
+});
+
+pub static BATCH_VOTE_PROGRESS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "quorum_store_batch_vote_progress",
+        "Histogram for vote collection of a QS batch",
+        &["author", "vote_pct"],
+        BATCH_TRACING_BUCKETS.to_vec()
+    )
+    .unwrap()
+});

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -947,3 +947,12 @@ pub static BATCH_RECEIVED_LATE_REPLIES_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub static BATCH_COORDINATOR_NUM_BATCH_REQS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "quorum_store_batch_coord_requests",
+        "Number of requests to batch coordinator.",
+        &["bucket"]
+    )
+    .unwrap()
+});

--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -986,3 +986,12 @@ pub static BATCH_VOTE_PROGRESS: Lazy<HistogramVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub static PROOF_MANAGER_OUT_OF_ORDER_PROOF_INSERTION: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "quorum_store_proof_manager_ooo_proof_insert",
+        "Number of ooo proof insertions into proof manager",
+        &["author"]
+    )
+    .unwrap()
+});

--- a/consensus/src/quorum_store/mod.rs
+++ b/consensus/src/quorum_store/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod proof_manager;
 pub(crate) mod quorum_store_builder;
 pub(crate) mod quorum_store_coordinator;
 pub mod quorum_store_db;
+pub(crate) mod tracing;
 pub mod types;
 pub(crate) mod utils;
 

--- a/consensus/src/quorum_store/network_listener.rs
+++ b/consensus/src/quorum_store/network_listener.rs
@@ -39,6 +39,7 @@ impl NetworkListener {
 
     pub async fn start(mut self) {
         info!("QS: starting networking");
+        let mut next_batch_coordinator_idx = 0;
         while let Some(msg) = self.network_msg_rx.next().await {
             monitor!("qs_network_listener_main_loop", {
                 match msg {
@@ -71,14 +72,19 @@ impl NetworkListener {
                         let batches = batch_msg.take();
                         counters::RECEIVED_BATCH_MSG_COUNT.inc();
 
-                        let idx =
-                            author.to_vec()[0] as usize % self.remote_batch_coordinator_tx.len();
+                        // Round-robin assignment to batch coordinator.
+                        let idx = next_batch_coordinator_idx;
+                        next_batch_coordinator_idx = (next_batch_coordinator_idx + 1)
+                            % self.remote_batch_coordinator_tx.len();
                         trace!(
                             "QS: peer_id {:?},  # network_worker {}, hashed to idx {}",
                             author,
                             self.remote_batch_coordinator_tx.len(),
                             idx
                         );
+                        counters::BATCH_COORDINATOR_NUM_BATCH_REQS
+                            .with_label_values(&[&idx.to_string()])
+                            .inc();
                         self.remote_batch_coordinator_tx[idx]
                             .send(BatchCoordinatorCommand::NewBatches(author, batches))
                             .await

--- a/consensus/src/quorum_store/proof_coordinator.rs
+++ b/consensus/src/quorum_store/proof_coordinator.rs
@@ -293,6 +293,9 @@ impl ProofCoordinator {
         let mut batch_ids = vec![];
         for signed_batch_info_info in self.timeouts.expire() {
             if let Some(state) = self.batch_info_to_proof.remove(&signed_batch_info_info) {
+                if !state.completed {
+                    batch_ids.push(signed_batch_info_info.batch_id());
+                }
                 Self::update_counters_on_expire(&state);
 
                 // We skip metrics if the proof did not complete and did not get a self vote, as it
@@ -302,8 +305,6 @@ impl ProofCoordinator {
                 }
 
                 if !state.completed {
-                    batch_ids.push(signed_batch_info_info.batch_id());
-
                     counters::TIMEOUT_BATCHES_COUNT.inc();
                     info!(
                         LogSchema::new(LogEvent::IncrementalProofExpired),

--- a/consensus/src/quorum_store/proof_coordinator.rs
+++ b/consensus/src/quorum_store/proof_coordinator.rs
@@ -263,9 +263,7 @@ impl ProofCoordinator {
         let mut batch_ids = vec![];
         for signed_batch_info_info in self.timeouts.expire() {
             if let Some(state) = self.batch_info_to_proof.remove(&signed_batch_info_info) {
-                if !state.completed {
-                    batch_ids.push(signed_batch_info_info.batch_id());
-                }
+                Self::update_counters_on_expire(&state);
 
                 // We skip metrics if the proof did not complete and did not get a self vote, as it
                 // is considered a proof that was re-inited due to a very late vote.
@@ -274,6 +272,8 @@ impl ProofCoordinator {
                 }
 
                 if !state.completed {
+                    batch_ids.push(signed_batch_info_info.batch_id());
+
                     counters::TIMEOUT_BATCHES_COUNT.inc();
                     info!(
                         LogSchema::new(LogEvent::IncrementalProofExpired),
@@ -281,7 +281,6 @@ impl ProofCoordinator {
                         self_voted = state.self_voted,
                     );
                 }
-                Self::update_counters_on_expire(&state, validator_verifier);
             }
         }
         if self

--- a/consensus/src/quorum_store/proof_coordinator.rs
+++ b/consensus/src/quorum_store/proof_coordinator.rs
@@ -6,13 +6,22 @@ use crate::{
     monitor,
     network::QuorumStoreSender,
     quorum_store::{
-        batch_generator::BatchGeneratorCommand, batch_store::BatchReader, counters, utils::Timeouts,
+        batch_generator::BatchGeneratorCommand,
+        batch_store::BatchReader,
+        counters,
+        tracing::{observe_batch, observe_batch_vote_pct, BatchStage},
+        utils::Timeouts,
     },
 };
-use aptos_consensus_types::proof_of_store::{
-    BatchInfo, ProofCache, ProofOfStore, SignedBatchInfo, SignedBatchInfoError, SignedBatchInfoMsg,
+use aptos_consensus_types::{
+    payload::TDataInfo,
+    proof_of_store::{
+        BatchInfo, ProofCache, ProofOfStore, SignedBatchInfo, SignedBatchInfoError,
+        SignedBatchInfoMsg,
+    },
 };
 use aptos_logger::prelude::*;
+use aptos_short_hex_str::AsShortHexStr;
 use aptos_types::{
     ledger_info::SignatureAggregator, validator_verifier::ValidatorVerifier, PeerId,
 };
@@ -28,23 +37,28 @@ use tokio::{
 
 #[derive(Debug)]
 pub(crate) enum ProofCoordinatorCommand {
-    AppendSignature(SignedBatchInfoMsg),
+    AppendSignature(PeerId, SignedBatchInfoMsg),
     CommitNotification(Vec<BatchInfo>),
     Shutdown(TokioOneshot::Sender<()>),
 }
 
 struct IncrementalProofState {
     signature_aggregator: SignatureAggregator<BatchInfo>,
+    aggregated_voting_power: u128,
     self_voted: bool,
     completed: bool,
+    // Pct last time the diff was over 10%
+    last_increment_pct: u8,
 }
 
 impl IncrementalProofState {
     fn new(info: BatchInfo) -> Self {
         Self {
             signature_aggregator: SignatureAggregator::new(info),
+            aggregated_voting_power: 0,
             self_voted: false,
             completed: false,
+            last_increment_pct: 0,
         }
     }
 
@@ -52,6 +66,8 @@ impl IncrementalProofState {
         self.signature_aggregator.all_voters().count() as u64
     }
 
+    // Returns the aggregated voting power of all signatures include those that are invalid.
+    #[allow(unused)]
     pub fn aggregate_voting_power(&self, verifier: &ValidatorVerifier) -> u64 {
         self.signature_aggregator
             .check_voting_power(verifier, true)
@@ -71,11 +87,12 @@ impl IncrementalProofState {
         }
 
         match validator_verifier.get_voting_power(&signed_batch_info.signer()) {
-            Some(_voting_power) => {
+            Some(voting_power) => {
                 self.signature_aggregator.add_signature(
                     signed_batch_info.signer(),
                     signed_batch_info.signature_with_status(),
                 );
+                self.aggregated_voting_power += voting_power as u128;
                 if signed_batch_info.signer() == self.signature_aggregator.data().author() {
                     self.self_voted = true;
                 }
@@ -100,6 +117,20 @@ impl IncrementalProofState {
         self.signature_aggregator
             .check_voting_power(validator_verifier, check_super_majority)
             .is_ok()
+    }
+
+    /// Observes the voting percentage if it's 10% higher than last observation i.e. it
+    /// approximately observes every 10% increase in voting power.
+    fn observe_voting_pct(&mut self, timestamp: u64, validator_verifier: &ValidatorVerifier) {
+        let pct = self
+            .aggregated_voting_power
+            .saturating_mul(100)
+            .saturating_div(validator_verifier.total_voting_power()) as u8;
+        let author = self.signature_aggregator.data().author();
+        if pct >= self.last_increment_pct + 10 {
+            observe_batch_vote_pct(timestamp, author, pct);
+            self.last_increment_pct = pct;
+        }
     }
 
     /// Try to aggregate all signatures if the voting power is enough. If the aggregated signature is
@@ -139,6 +170,7 @@ pub(crate) struct ProofCoordinator {
     batch_generator_cmd_tx: tokio::sync::mpsc::Sender<BatchGeneratorCommand>,
     proof_cache: ProofCache,
     broadcast_proofs: bool,
+    batch_expiry_gap_when_init_usecs: u64,
 }
 
 //PoQS builder object - gather signed digest to form PoQS
@@ -150,6 +182,7 @@ impl ProofCoordinator {
         batch_generator_cmd_tx: tokio::sync::mpsc::Sender<BatchGeneratorCommand>,
         proof_cache: ProofCache,
         broadcast_proofs: bool,
+        batch_expiry_gap_when_init_usecs: u64,
     ) -> Self {
         Self {
             peer_id,
@@ -161,6 +194,7 @@ impl ProofCoordinator {
             batch_generator_cmd_tx,
             proof_cache,
             broadcast_proofs,
+            batch_expiry_gap_when_init_usecs,
         }
     }
 
@@ -241,10 +275,7 @@ impl ProofCoordinator {
         Ok(None)
     }
 
-    fn update_counters_on_expire(
-        state: &IncrementalProofState,
-        validator_verifier: &ValidatorVerifier,
-    ) {
+    fn update_counters_on_expire(state: &IncrementalProofState) {
         // Count late votes separately
         if !state.completed && !state.self_voted {
             counters::BATCH_RECEIVED_LATE_REPLIES_COUNT.inc_by(state.voter_count());
@@ -252,14 +283,13 @@ impl ProofCoordinator {
         }
 
         counters::BATCH_RECEIVED_REPLIES_COUNT.observe(state.voter_count() as f64);
-        counters::BATCH_RECEIVED_REPLIES_VOTING_POWER
-            .observe(state.aggregate_voting_power(validator_verifier) as f64);
+        counters::BATCH_RECEIVED_REPLIES_VOTING_POWER.observe(state.aggregated_voting_power as f64);
         if !state.completed {
             counters::BATCH_SUCCESSFUL_CREATION.observe(0.0);
         }
     }
 
-    async fn expire(&mut self, validator_verifier: &ValidatorVerifier) {
+    async fn expire(&mut self) {
         let mut batch_ids = vec![];
         for signed_batch_info_info in self.timeouts.expire() {
             if let Some(state) = self.batch_info_to_proof.remove(&signed_batch_info_info) {
@@ -333,9 +363,19 @@ impl ProofCoordinator {
                                 }
                             }
                         },
-                        ProofCoordinatorCommand::AppendSignature(signed_batch_infos) => {
+                        ProofCoordinatorCommand::AppendSignature(signer, signed_batch_infos) => {
+                            let signed_batch_infos = signed_batch_infos.take();
+                            let Some(signed_batch_info) = signed_batch_infos.first() else {
+                                error!("Empty signed batch info received from {}", signer.short_str().as_str());
+                                return;
+                            };
+                            let info = signed_batch_info.info().clone();
+                            let approx_created_ts_usecs = signed_batch_info
+                                .expiration()
+                                .saturating_sub(self.batch_expiry_gap_when_init_usecs);
+
                             let mut proofs = vec![];
-                            for signed_batch_info in signed_batch_infos.take().into_iter() {
+                            for signed_batch_info in signed_batch_infos.into_iter() {
                                 let peer_id = signed_batch_info.signer();
                                 let digest = *signed_batch_info.digest();
                                 let batch_id = signed_batch_info.batch_id();
@@ -360,7 +400,11 @@ impl ProofCoordinator {
                                     },
                                 }
                             }
+                            if let Some(value) = self.batch_info_to_proof.get_mut(&info) {
+                                value.observe_voting_pct(approx_created_ts_usecs, &validator_verifier);
+                            }
                             if !proofs.is_empty() {
+                                observe_batch(approx_created_ts_usecs, self.peer_id, BatchStage::POS_FORMED);
                                 if self.broadcast_proofs {
                                     network_sender.broadcast_proof_of_store_msg(proofs).await;
                                 } else {
@@ -371,7 +415,7 @@ impl ProofCoordinator {
                     }
                 }),
                 _ = interval.tick() => {
-                    monitor!("proof_coordinator_handle_tick", self.expire(&validator_verifier).await);
+                    monitor!("proof_coordinator_handle_tick", self.expire().await);
                 }
             }
         }

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -98,123 +98,112 @@ impl ProofManager {
     }
 
     pub(crate) fn handle_proposal_request(&mut self, msg: GetPayloadCommand) {
-        match msg {
-            GetPayloadCommand::GetPayloadRequest(request) => {
-                let excluded_batches: HashSet<_> = match request.filter {
-                    PayloadFilter::Empty => HashSet::new(),
-                    PayloadFilter::DirectMempool(_) => {
-                        unreachable!()
-                    },
-                    PayloadFilter::InQuorumStore(proofs) => proofs,
-                };
+        let GetPayloadCommand::GetPayloadRequest(request) = msg;
 
-                let (
-                    proof_block,
-                    txns_with_proof_size,
-                    cur_unique_txns,
-                    proof_queue_fully_utilized,
-                ) = self.batch_proof_queue.pull_proofs(
-                    &excluded_batches,
-                    request.max_txns,
-                    request.max_txns_after_filtering,
-                    request.soft_max_txns_after_filtering,
-                    request.return_non_full,
-                    request.block_timestamp,
-                );
-
-                counters::NUM_BATCHES_WITHOUT_PROOF_OF_STORE
-                    .observe(self.batch_proof_queue.num_batches_without_proof() as f64);
-                counters::PROOF_QUEUE_FULLY_UTILIZED
-                    .observe(if proof_queue_fully_utilized { 1.0 } else { 0.0 });
-
-                let (opt_batches, opt_batch_txns_size) =
-                    // TODO(ibalajiarun): Support unique txn calculation
-                    if let Some(ref params) = request.maybe_optqs_payload_pull_params {
-                        let max_opt_batch_txns_size = request.max_txns - txns_with_proof_size;
-                        let (opt_batches, opt_payload_size, _) =
-                            self.batch_proof_queue.pull_batches(
-                                &excluded_batches
-                                    .iter()
-                                    .cloned()
-                                    .chain(proof_block.iter().map(|proof| proof.info().clone()))
-                                    .collect(),
-                                &params.exclude_authors,
-                                max_opt_batch_txns_size,
-                                request.max_txns_after_filtering,
-                                request.soft_max_txns_after_filtering,
-                                request.return_non_full,
-                                request.block_timestamp,
-                                Some(params.minimum_batch_age_usecs),
-                            );
-
-                        (opt_batches, opt_payload_size)
-                    } else {
-                        (Vec::new(), PayloadTxnsSize::zero())
-                    };
-
-                let cur_txns = txns_with_proof_size + opt_batch_txns_size;
-                let (inline_block, inline_block_size) =
-                    if self.allow_batches_without_pos_in_proposal && proof_queue_fully_utilized {
-                        let mut max_inline_txns_to_pull = request
-                            .max_txns
-                            .saturating_sub(cur_txns)
-                            .minimum(request.max_inline_txns);
-                        max_inline_txns_to_pull.set_count(min(
-                            max_inline_txns_to_pull.count(),
-                            request
-                                .max_txns_after_filtering
-                                .saturating_sub(cur_unique_txns),
-                        ));
-                        let (inline_batches, inline_payload_size, _) =
-                            self.batch_proof_queue.pull_batches_with_transactions(
-                                &excluded_batches
-                                    .iter()
-                                    .cloned()
-                                    .chain(proof_block.iter().map(|proof| proof.info().clone()))
-                                    .collect(),
-                                max_inline_txns_to_pull,
-                                request.max_txns_after_filtering,
-                                request.soft_max_txns_after_filtering,
-                                request.return_non_full,
-                                request.block_timestamp,
-                            );
-                        (inline_batches, inline_payload_size)
-                    } else {
-                        (Vec::new(), PayloadTxnsSize::zero())
-                    };
-                counters::NUM_INLINE_BATCHES.observe(inline_block.len() as f64);
-                counters::NUM_INLINE_TXNS.observe(inline_block_size.count() as f64);
-
-                let response = if request.maybe_optqs_payload_pull_params.is_some() {
-                    let inline_batches = inline_block.into();
-                    Payload::OptQuorumStore(OptQuorumStorePayload::new(
-                        inline_batches,
-                        opt_batches.into(),
-                        proof_block.into(),
-                        PayloadExecutionLimit::None,
-                    ))
-                } else if proof_block.is_empty() && inline_block.is_empty() {
-                    Payload::empty(true, self.allow_batches_without_pos_in_proposal)
-                } else {
-                    trace!(
-                        "QS: GetBlockRequest excluded len {}, block len {}, inline len {}",
-                        excluded_batches.len(),
-                        proof_block.len(),
-                        inline_block.len()
-                    );
-                    Payload::QuorumStoreInlineHybrid(
-                        inline_block,
-                        ProofWithData::new(proof_block),
-                        None,
-                    )
-                };
-
-                let res = GetPayloadResponse::GetPayloadResponse(response);
-                match request.callback.send(Ok(res)) {
-                    Ok(_) => (),
-                    Err(err) => debug!("BlockResponse receiver not available! error {:?}", err),
-                }
+        let excluded_batches: HashSet<_> = match request.filter {
+            PayloadFilter::Empty => HashSet::new(),
+            PayloadFilter::DirectMempool(_) => {
+                unreachable!()
             },
+            PayloadFilter::InQuorumStore(batches) => batches,
+        };
+
+        let (proof_block, txns_with_proof_size, cur_unique_txns, proof_queue_fully_utilized) =
+            self.batch_proof_queue.pull_proofs(
+                &excluded_batches,
+                request.max_txns,
+                request.max_txns_after_filtering,
+                request.soft_max_txns_after_filtering,
+                request.return_non_full,
+                request.block_timestamp,
+            );
+
+        counters::NUM_BATCHES_WITHOUT_PROOF_OF_STORE
+            .observe(self.batch_proof_queue.num_batches_without_proof() as f64);
+        counters::PROOF_QUEUE_FULLY_UTILIZED
+            .observe(if proof_queue_fully_utilized { 1.0 } else { 0.0 });
+
+        let (opt_batches, opt_batch_txns_size) =
+            // TODO(ibalajiarun): Support unique txn calculation
+            if let Some(ref params) = request.maybe_optqs_payload_pull_params {
+                let max_opt_batch_txns_size = request.max_txns - txns_with_proof_size;
+                let (opt_batches, opt_payload_size, _) =
+                    self.batch_proof_queue.pull_batches(
+                        &excluded_batches
+                            .iter()
+                            .cloned()
+                            .chain(proof_block.iter().map(|proof| proof.info().clone()))
+                            .collect(),
+                        &params.exclude_authors,
+                        max_opt_batch_txns_size,
+                        request.max_txns_after_filtering,
+                        request.soft_max_txns_after_filtering,
+                        request.return_non_full,
+                        request.block_timestamp,
+                        Some(params.minimum_batch_age_usecs),
+                    );
+                (opt_batches, opt_payload_size)
+            } else {
+                (Vec::new(), PayloadTxnsSize::zero())
+            };
+
+        let cur_txns = txns_with_proof_size + opt_batch_txns_size;
+        let (inline_block, inline_block_size) =
+            if self.allow_batches_without_pos_in_proposal && proof_queue_fully_utilized {
+                let mut max_inline_txns_to_pull = request
+                    .max_txns
+                    .saturating_sub(cur_txns)
+                    .minimum(request.max_inline_txns);
+                max_inline_txns_to_pull.set_count(min(
+                    max_inline_txns_to_pull.count(),
+                    request
+                        .max_txns_after_filtering
+                        .saturating_sub(cur_unique_txns),
+                ));
+                let (inline_batches, inline_payload_size, _) =
+                    self.batch_proof_queue.pull_batches_with_transactions(
+                        &excluded_batches
+                            .iter()
+                            .cloned()
+                            .chain(proof_block.iter().map(|proof| proof.info().clone()))
+                            .collect(),
+                        max_inline_txns_to_pull,
+                        request.max_txns_after_filtering,
+                        request.soft_max_txns_after_filtering,
+                        request.return_non_full,
+                        request.block_timestamp,
+                    );
+                (inline_batches, inline_payload_size)
+            } else {
+                (Vec::new(), PayloadTxnsSize::zero())
+            };
+        counters::NUM_INLINE_BATCHES.observe(inline_block.len() as f64);
+        counters::NUM_INLINE_TXNS.observe(inline_block_size.count() as f64);
+
+        let response = if request.maybe_optqs_payload_pull_params.is_some() {
+            let inline_batches = inline_block.into();
+            Payload::OptQuorumStore(OptQuorumStorePayload::new(
+                inline_batches,
+                opt_batches.into(),
+                proof_block.into(),
+                PayloadExecutionLimit::None,
+            ))
+        } else if proof_block.is_empty() && inline_block.is_empty() {
+            Payload::empty(true, self.allow_batches_without_pos_in_proposal)
+        } else {
+            trace!(
+                "QS: GetBlockRequest excluded len {}, block len {}, inline len {}",
+                excluded_batches.len(),
+                proof_block.len(),
+                inline_block.len()
+            );
+            Payload::QuorumStoreInlineHybrid(inline_block, ProofWithData::new(proof_block), None)
+        };
+
+        let res = GetPayloadResponse::GetPayloadResponse(response);
+        match request.callback.send(Ok(res)) {
+            Ok(_) => (),
+            Err(err) => debug!("BlockResponse receiver not available! error {:?}", err),
         }
     }
 

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -127,6 +127,7 @@ impl ProofManager {
             // TODO(ibalajiarun): Support unique txn calculation
             if let Some(ref params) = request.maybe_optqs_payload_pull_params {
                 let max_opt_batch_txns_size = request.max_txns - txns_with_proof_size;
+                let max_opt_batch_txns_after_filtering = request.max_txns_after_filtering - cur_unique_txns;
                 let (opt_batches, opt_payload_size, _) =
                     self.batch_proof_queue.pull_batches(
                         &excluded_batches
@@ -136,7 +137,7 @@ impl ProofManager {
                             .collect(),
                         &params.exclude_authors,
                         max_opt_batch_txns_size,
-                        request.max_txns_after_filtering,
+                        max_opt_batch_txns_after_filtering,
                         request.soft_max_txns_after_filtering,
                         request.return_non_full,
                         request.block_timestamp,
@@ -166,6 +167,7 @@ impl ProofManager {
                             .iter()
                             .cloned()
                             .chain(proof_block.iter().map(|proof| proof.info().clone()))
+                            .chain(opt_batches.clone())
                             .collect(),
                         max_inline_txns_to_pull,
                         request.max_txns_after_filtering,

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -52,7 +52,7 @@ impl QuorumStoreBuilder {
         consensus_publisher: Option<Arc<ConsensusPublisher>>,
     ) -> (
         Arc<dyn TPayloadManager>,
-        Option<aptos_channel::Sender<AccountAddress, VerifiedEvent>>,
+        Option<aptos_channel::Sender<AccountAddress, (Author, VerifiedEvent)>>,
     ) {
         match self {
             QuorumStoreBuilder::DirectMempool(inner) => inner.init_payload_manager(),
@@ -101,7 +101,7 @@ impl DirectMempoolInnerBuilder {
         &mut self,
     ) -> (
         Arc<dyn TPayloadManager>,
-        Option<aptos_channel::Sender<AccountAddress, VerifiedEvent>>,
+        Option<aptos_channel::Sender<AccountAddress, (Author, VerifiedEvent)>>,
     ) {
         (Arc::from(DirectMempoolPayloadManager::new()), None)
     }
@@ -141,8 +141,8 @@ pub struct InnerBuilder {
     back_pressure_tx: tokio::sync::mpsc::Sender<BackPressure>,
     back_pressure_rx: Option<tokio::sync::mpsc::Receiver<BackPressure>>,
     quorum_store_storage: Arc<dyn QuorumStoreStorage>,
-    quorum_store_msg_tx: aptos_channel::Sender<AccountAddress, VerifiedEvent>,
-    quorum_store_msg_rx: Option<aptos_channel::Receiver<AccountAddress, VerifiedEvent>>,
+    quorum_store_msg_tx: aptos_channel::Sender<AccountAddress, (Author, VerifiedEvent)>,
+    quorum_store_msg_rx: Option<aptos_channel::Receiver<AccountAddress, (Author, VerifiedEvent)>>,
     remote_batch_coordinator_cmd_tx: Vec<tokio::sync::mpsc::Sender<BatchCoordinatorCommand>>,
     remote_batch_coordinator_cmd_rx: Vec<tokio::sync::mpsc::Receiver<BatchCoordinatorCommand>>,
     batch_store: Option<Arc<BatchStore>>,
@@ -176,7 +176,7 @@ impl InnerBuilder {
             tokio::sync::mpsc::channel(config.channel_size);
         let (back_pressure_tx, back_pressure_rx) = tokio::sync::mpsc::channel(config.channel_size);
         let (quorum_store_msg_tx, quorum_store_msg_rx) =
-            aptos_channel::new::<AccountAddress, VerifiedEvent>(
+            aptos_channel::new::<AccountAddress, (Author, VerifiedEvent)>(
                 QueueStyle::FIFO,
                 config.channel_size,
                 None,
@@ -328,6 +328,7 @@ impl InnerBuilder {
                 self.config.receiver_max_batch_bytes as u64,
                 self.config.receiver_max_total_txns as u64,
                 self.config.receiver_max_total_bytes as u64,
+                self.config.batch_expiry_gap_when_init_usecs,
             );
             #[allow(unused_variables)]
             let name = format!("batch_coordinator-{}", i);
@@ -345,6 +346,7 @@ impl InnerBuilder {
             self.batch_generator_cmd_tx.clone(),
             self.proof_cache,
             self.broadcast_proofs,
+            self.config.batch_expiry_gap_when_init_usecs,
         );
         spawn_named!(
             "proof_coordinator",
@@ -435,7 +437,7 @@ impl InnerBuilder {
         consensus_publisher: Option<Arc<ConsensusPublisher>>,
     ) -> (
         Arc<dyn TPayloadManager>,
-        Option<aptos_channel::Sender<AccountAddress, VerifiedEvent>>,
+        Option<aptos_channel::Sender<AccountAddress, (Author, VerifiedEvent)>>,
     ) {
         let batch_reader = self.create_batch_store();
 

--- a/consensus/src/quorum_store/tests/proof_coordinator_test.rs
+++ b/consensus/src/quorum_store/tests/proof_coordinator_test.rs
@@ -58,6 +58,7 @@ async fn test_proof_coordinator_basic() {
         tx,
         proof_cache.clone(),
         true,
+        10,
     );
     let (proof_coordinator_tx, proof_coordinator_rx) = channel(100);
     let (tx, mut rx) = channel(100);
@@ -75,6 +76,7 @@ async fn test_proof_coordinator_basic() {
         let signed_batch_info = SignedBatchInfo::new(batch.batch_info().clone(), signer).unwrap();
         assert!(proof_coordinator_tx
             .send(ProofCoordinatorCommand::AppendSignature(
+                signer.author(),
                 SignedBatchInfoMsg::new(vec![signed_batch_info])
             ))
             .await
@@ -108,6 +110,7 @@ async fn test_proof_coordinator_with_unverified_signatures() {
         tx,
         proof_cache.clone(),
         true,
+        10,
     );
     let (proof_coordinator_tx, proof_coordinator_rx) = channel(100);
     let (tx, mut rx) = channel(100);
@@ -127,6 +130,7 @@ async fn test_proof_coordinator_with_unverified_signatures() {
                     .expect("Failed to create SignedBatchInfo");
                 assert!(proof_coordinator_tx
                     .send(ProofCoordinatorCommand::AppendSignature(
+                        signer.author(),
                         SignedBatchInfoMsg::new(vec![signed_batch_info]),
                     ))
                     .await
@@ -136,6 +140,7 @@ async fn test_proof_coordinator_with_unverified_signatures() {
                     SignedBatchInfo::dummy(batch.batch_info().clone(), signer.author());
                 assert!(proof_coordinator_tx
                     .send(ProofCoordinatorCommand::AppendSignature(
+                        signer.author(),
                         SignedBatchInfoMsg::new(vec![signed_batch_info]),
                     ))
                     .await

--- a/consensus/src/quorum_store/tracing.rs
+++ b/consensus/src/quorum_store/tracing.rs
@@ -1,0 +1,35 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::quorum_store::counters;
+use aptos_consensus_types::common::Author;
+use aptos_infallible::duration_since_epoch;
+use aptos_short_hex_str::AsShortHexStr;
+use std::time::Duration;
+
+pub struct BatchStage;
+
+impl BatchStage {
+    pub const POS_FORMED: &'static str = "pos";
+    pub const RECEIVED: &'static str = "received";
+    pub const SIGNED: &'static str = "signed";
+}
+
+/// Record the time during each stage of a batch.
+pub fn observe_batch(timestamp: u64, author: Author, stage: &'static str) {
+    if let Some(t) = duration_since_epoch().checked_sub(Duration::from_micros(timestamp)) {
+        counters::BATCH_TRACING
+            .with_label_values(&[author.short_str().as_str(), stage])
+            .observe(t.as_secs_f64());
+    }
+}
+
+pub fn observe_batch_vote_pct(timestamp: u64, author: Author, pct: u8) {
+    if let Some(t) = duration_since_epoch().checked_sub(Duration::from_micros(timestamp)) {
+        let pct = (pct / 10) * 10;
+        counters::BATCH_VOTE_PROGRESS
+            .with_label_values(&[author.short_str().as_str(), &pct.to_string()])
+            .observe(t.as_secs_f64());
+    }
+}

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -179,6 +179,10 @@ impl BatchSortKey {
     pub fn author(&self) -> PeerId {
         self.batch_key.author
     }
+
+    pub fn gas_bucket_start(&self) -> u64 {
+        self.gas_bucket_start
+    }
 }
 
 impl PartialOrd<Self> for BatchSortKey {

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -403,17 +403,19 @@ impl RoundManager {
             let safety_rules = self.safety_rules.clone();
             let proposer_election = self.proposer_election.clone();
             tokio::spawn(async move {
-                if let Err(e) = Self::generate_and_send_proposal(
-                    epoch_state,
-                    new_round_event,
-                    network,
-                    sync_info,
-                    proposal_generator,
-                    safety_rules,
-                    proposer_election,
-                )
-                .await
-                {
+                if let Err(e) = monitor!(
+                    "generate_and_send_proposal",
+                    Self::generate_and_send_proposal(
+                        epoch_state,
+                        new_round_event,
+                        network,
+                        sync_info,
+                        proposal_generator,
+                        safety_rules,
+                        proposer_election,
+                    )
+                    .await
+                ) {
                     warn!("Error generating and sending proposal: {}", e);
                 }
             });


### PR DESCRIPTION
## Description

This PR fixes a config bug and adds metrics for OptQS and QS batch tracing.
- Fixes `minimum_batch_age_usecs` to 10 milliseconds. It was set to 50 secs instead of 50ms.
- Adjusts unique transactions when pulling optQS based on the number of proofs pulled. 
- BatchCoordinator: assign batches to coordinator in round-robin instead of using author-based index.
- Fixes a metrics call issue where late votes were never counted at all.
- Trace batch from sender to receiver and back to form a PoS. Also observe time for every 10% increment in accumulated voting power.