### PR TITLE
[compiler-v2][linter] Support attributes to suppress specific lint warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10848,6 +10848,8 @@ dependencies = [
  "num 0.4.1",
  "once_cell",
  "petgraph 0.5.1",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "walkdir",
 ]
 

--- a/third_party/move/move-compiler-v2/Cargo.toml
+++ b/third_party/move/move-compiler-v2/Cargo.toml
@@ -37,6 +37,8 @@ num = { workspace = true }
 once_cell = { workspace = true }
 #paste = "1.0.5"
 petgraph = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -54,3 +56,6 @@ doctest = false
 name = "testsuite"
 harness = false
 doctest = false
+
+[package.metadata.cargo-machete]
+ignored = ["strum"]

--- a/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints.rs
@@ -8,20 +8,24 @@ mod unnecessary_boolean_identity_comparison;
 mod unnecessary_numerical_extreme_comparison;
 mod while_true;
 
+use crate::lint_common::{lint_skips_from_attributes, LintChecker};
+use move_compiler::shared::known_attributes::LintAttribute;
 use move_model::{
     ast::ExpData,
-    model::{FunctionEnv, GlobalEnv},
+    model::{FunctionEnv, GlobalEnv, Loc},
 };
+use std::collections::BTreeSet;
 
 /// Perform various lint checks on the model AST.
 pub fn checker(env: &mut GlobalEnv) {
     for module in env.get_modules() {
         if module.is_primary_target() {
+            let module_lint_skips = lint_skips_from_attributes(env, module.get_attributes());
             for function in module.get_functions() {
                 if function.is_native() {
                     continue;
                 }
-                check_function(&function);
+                check_function(&function, &module_lint_skips);
             }
         }
     }
@@ -31,24 +35,38 @@ pub fn checker(env: &mut GlobalEnv) {
 /// expression as we traverse the model AST.
 /// Implement at least one of the `visit` methods to be a useful lint.
 trait ExpressionLinter {
-    /// The name of the lint.
-    fn get_name(&self) -> &'static str;
+    /// The corresponding lint checker enumerated value.
+    fn get_lint_checker(&self) -> LintChecker;
 
     /// Examine `expr` before any of its children have been visited.
-    /// Potentially emit lint warnings using `env.lint_diag()`.
+    /// Potentially emit lint warnings using `self.warning()`.
     fn visit_expr_pre(&mut self, _env: &GlobalEnv, _expr: &ExpData) {}
 
     /// Examine `expr` after all its children have been visited.
-    /// Potentially emit lint warnings using `env.lint_diag()`.
+    /// Potentially emit lint warnings using `self.warning()`.
     fn visit_expr_post(&mut self, _env: &GlobalEnv, _expr: &ExpData) {}
+
+    /// Emit a lint warning with the `msg` highlighting the `loc`.
+    fn warning(&self, env: &GlobalEnv, loc: &Loc, msg: &str) {
+        env.lint_diag_with_notes(loc, msg, vec![
+            format!(
+                "To suppress this warning, annotate the function/module with the attribute `#[{}({})]`.",
+                LintAttribute::SKIP,
+                self.get_lint_checker()
+            ),
+        ]);
+    }
 }
 
 /// Perform the lint checks on the code in `function`.
-fn check_function(function: &FunctionEnv) {
-    let mut expression_linters = get_expression_linter_pipeline();
+fn check_function(function: &FunctionEnv, module_lint_skips: &[LintChecker]) {
+    let env = function.module_env.env;
+    let function_lint_skips = lint_skips_from_attributes(env, function.get_attributes());
+    let mut lint_skips = BTreeSet::from_iter(function_lint_skips);
+    lint_skips.extend(module_lint_skips);
+    let mut expression_linters = get_applicable_lints(lint_skips);
     if let Some(def) = function.get_def() {
         let mut visitor = |post: bool, e: &ExpData| {
-            let env = function.module_env.env;
             if !post {
                 for exp_lint in expression_linters.iter_mut() {
                     exp_lint.visit_expr_pre(env, e);
@@ -64,8 +82,16 @@ fn check_function(function: &FunctionEnv) {
     }
 }
 
-/// Returns a pipeline of "expression linters" to run.
-fn get_expression_linter_pipeline() -> Vec<Box<dyn ExpressionLinter>> {
+/// Returns a pipeline of "expression linters" to run, skipping the ones in `lint_skips`.
+fn get_applicable_lints(lint_skips: BTreeSet<LintChecker>) -> Vec<Box<dyn ExpressionLinter>> {
+    get_default_expression_linter_pipeline()
+        .into_iter()
+        .filter(|lint| !lint_skips.contains(&lint.get_lint_checker()))
+        .collect()
+}
+
+/// Returns a default pipeline of "expression linters" to run.
+fn get_default_expression_linter_pipeline() -> Vec<Box<dyn ExpressionLinter>> {
     vec![
         Box::<blocks_in_conditions::BlocksInConditions>::default(),
         Box::<unnecessary_boolean_identity_comparison::UnnecessaryBooleanIdentityComparison>::default(),

--- a/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints/blocks_in_conditions.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints/blocks_in_conditions.rs
@@ -9,7 +9,7 @@
 //!
 //! We also only report on the outermost condition with blocks.
 
-use crate::env_pipeline::model_ast_lints::ExpressionLinter;
+use crate::{env_pipeline::model_ast_lints::ExpressionLinter, lint_common::LintChecker};
 use move_model::{
     ast::ExpData,
     model::{GlobalEnv, NodeId},
@@ -38,8 +38,8 @@ enum CondExprState {
 }
 
 impl ExpressionLinter for BlocksInConditions {
-    fn get_name(&self) -> &'static str {
-        "blocks_in_conditions"
+    fn get_lint_checker(&self) -> LintChecker {
+        LintChecker::BlocksInConditions
     }
 
     fn visit_expr_pre(&mut self, _env: &GlobalEnv, expr: &ExpData) {
@@ -88,10 +88,10 @@ impl ExpressionLinter for BlocksInConditions {
                 // We are done with traversing the condition of interest.
                 self.state = None;
                 if has_any_block && !has_spec_block {
-                    env.lint_diag(
+                    self.warning(
+                        env,
                         &env.get_node_loc(id),
-                        self.get_name(),
-                        "Having blocks in conditions make code harder to read. Consider rewriting this code.",
+                        "Having blocks in conditions make code harder to read. Consider rewriting this code."
                     );
                 }
             },

--- a/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints/unnecessary_boolean_identity_comparison.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints/unnecessary_boolean_identity_comparison.rs
@@ -9,7 +9,7 @@
 //!   `x == true` ==> `x`
 //!   `false != foo(x)` ==> `!foo(x)`
 
-use crate::env_pipeline::model_ast_lints::ExpressionLinter;
+use crate::{env_pipeline::model_ast_lints::ExpressionLinter, lint_common::LintChecker};
 use move_model::{
     ast::{ExpData, Operation, Value},
     model::GlobalEnv,
@@ -19,8 +19,8 @@ use move_model::{
 pub struct UnnecessaryBooleanIdentityComparison;
 
 impl ExpressionLinter for UnnecessaryBooleanIdentityComparison {
-    fn get_name(&self) -> &'static str {
-        "unnecessary_boolean_identity_comparison"
+    fn get_lint_checker(&self) -> LintChecker {
+        LintChecker::UnnecessaryBooleanIdentityComparison
     }
 
     fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
@@ -45,7 +45,7 @@ impl ExpressionLinter for UnnecessaryBooleanIdentityComparison {
                         },
                         if *b { "true" } else { "false" }
                     );
-                    env.lint_diag(&env.get_node_loc(e.node_id()), self.get_name(), &msg);
+                    self.warning(env, &env.get_node_loc(e.node_id()), &msg);
                 },
                 _ => {},
             }

--- a/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints/unnecessary_numerical_extreme_comparison.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints/unnecessary_numerical_extreme_comparison.rs
@@ -12,7 +12,7 @@
 //!   `x > 0` ==> can be clarified to `x != 0`
 //! and similarly for comparing `x` with u64::MAX.
 
-use crate::env_pipeline::model_ast_lints::ExpressionLinter;
+use crate::{env_pipeline::model_ast_lints::ExpressionLinter, lint_common::LintChecker};
 use move_model::{
     ast::{ExpData, Operation, Value},
     model::GlobalEnv,
@@ -25,8 +25,8 @@ use std::fmt;
 pub struct UnnecessaryNumericalExtremeComparison;
 
 impl ExpressionLinter for UnnecessaryNumericalExtremeComparison {
-    fn get_name(&self) -> &'static str {
-        "unnecessary_numerical_extreme_comparison"
+    fn get_lint_checker(&self) -> LintChecker {
+        LintChecker::UnnecessaryNumericalExtremeComparison
     }
 
     fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
@@ -43,7 +43,7 @@ impl ExpressionLinter for UnnecessaryNumericalExtremeComparison {
             // get the type of the left-hand side.
             let ty = env.get_node_type(lhs.node_id());
             if let Some(result) = Self::check_comparisons_with_extremes(lhs, cmp, rhs, &ty) {
-                env.lint_diag(&env.get_node_loc(*id), self.get_name(), &result.to_string());
+                self.warning(env, &env.get_node_loc(*id), &result.to_string());
             }
         }
     }

--- a/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints/while_true.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints/while_true.rs
@@ -4,7 +4,7 @@
 //! This module implements an expression linter that checks code of the form:
 //! `while (true) { ... }` and suggests to use `loop { ... }` instead.
 
-use crate::env_pipeline::model_ast_lints::ExpressionLinter;
+use crate::{env_pipeline::model_ast_lints::ExpressionLinter, lint_common::LintChecker};
 use move_compiler::parser::syntax::FOR_LOOP_UPDATE_ITER_FLAG;
 use move_model::{
     ast::{Exp, ExpData, Value},
@@ -15,8 +15,8 @@ use move_model::{
 pub struct WhileTrue;
 
 impl ExpressionLinter for WhileTrue {
-    fn get_name(&self) -> &'static str {
-        "while_true"
+    fn get_lint_checker(&self) -> LintChecker {
+        LintChecker::WhileTrue
     }
 
     fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
@@ -37,9 +37,9 @@ impl ExpressionLinter for WhileTrue {
             return;
         }
         // If we are here, it is `while (true) {...}`.
-        env.lint_diag(
+        self.warning(
+            env,
             &env.get_node_loc(*id),
-            self.get_name(),
             "Use the more explicit `loop` instead.",
         );
     }

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -6,6 +6,7 @@ mod bytecode_generator;
 pub mod env_pipeline;
 mod experiments;
 mod file_format_generator;
+pub mod lint_common;
 pub mod logging;
 pub mod options;
 pub mod pipeline;

--- a/third_party/move/move-compiler-v2/src/lint_common.rs
+++ b/third_party/move/move-compiler-v2/src/lint_common.rs
@@ -1,0 +1,89 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module contains common code useful for lint checkers at various stages
+//! of the compilation pipeline.
+
+use move_compiler::shared::known_attributes::LintAttribute;
+use move_model::{ast::Attribute, model::GlobalEnv};
+use std::str::FromStr;
+use strum_macros::{Display, EnumString};
+
+/// Enumeration of all the lint checks that can be performed.
+///
+/// With the use of `strum_macros::EnumString` and `strum_macros::Display`,
+/// each of the variants can be serialized to and deserialized from a string.
+/// The serialization follows "snake_case".
+#[derive(Copy, Clone, Ord, Eq, PartialEq, PartialOrd, EnumString, Display)]
+#[strum(serialize_all = "snake_case")]
+pub enum LintChecker {
+    BlocksInConditions,
+    UnnecessaryBooleanIdentityComparison,
+    UnnecessaryNumericalExtremeComparison,
+    WhileTrue,
+}
+
+/// Extract all the lint checks to skip from the given attributes.
+/// Also performs error-checking on any `LintAttribute::SKIP` attributes.
+pub fn lint_skips_from_attributes(env: &GlobalEnv, attrs: &[Attribute]) -> Vec<LintChecker> {
+    let lint_skip = env.symbol_pool().make(LintAttribute::SKIP);
+    let skip_attr = attrs.iter().find(|attr| attr.name() == lint_skip);
+    if let Some(skip_attr) = skip_attr {
+        parse_lint_skip_attribute(env, skip_attr)
+    } else {
+        vec![]
+    }
+}
+
+/// Extract all the lint checks to skip from `attr`.
+/// Also performs error-checking on the LintAttribute::SKIP `attr`.
+fn parse_lint_skip_attribute(env: &GlobalEnv, attr: &Attribute) -> Vec<LintChecker> {
+    match attr {
+        Attribute::Assign(id, ..) => {
+            env.error(
+                &env.get_node_loc(*id),
+                &format!(
+                    "expected `#[{}(...)]`, not an assigned value",
+                    LintAttribute::SKIP
+                ),
+            );
+            vec![]
+        },
+        Attribute::Apply(id, _, attrs) => {
+            if attrs.is_empty() {
+                env.error(
+                    &env.get_node_loc(*id),
+                    "no lint checks are specified to be skipped",
+                );
+            }
+            attrs
+            .iter()
+            .filter_map(|lint_check| match lint_check {
+                Attribute::Assign(id, ..) => {
+                    env.error(
+                        &env.get_node_loc(*id),
+                        "did not expect an assigned value, expected only the names of the lint checks to be skipped",
+                    );
+                    None
+                },
+                Attribute::Apply(id, name, sub_attrs) => {
+                    if !sub_attrs.is_empty() {
+                        env.error(&env.get_node_loc(*id), "unexpected nested attributes");
+                        None
+                    } else {
+                        let name = name.display(env.symbol_pool()).to_string();
+                        let checker = LintChecker::from_str(&name).ok();
+                        if checker.is_none() {
+                            env.error(
+                                &env.get_node_loc(*id),
+                                &format!("unknown lint check: `{}`", name),
+                            );
+                        }
+                        checker
+                    }
+                },
+            })
+            .collect()
+        },
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/attributes/aptos_stdlib_attributes.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/attributes/aptos_stdlib_attributes.exp
@@ -4,13 +4,13 @@ warning: unknown attribute
   ┌─ tests/checking/attributes/aptos_stdlib_attributes.move:4:7
   │
 4 │     #[a, a(x = 0)]
-  │       ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
   ┌─ tests/checking/attributes/aptos_stdlib_attributes.move:4:10
   │
 4 │     #[a, a(x = 0)]
-  │          ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │          ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 error: duplicate declaration, item, or annotation
   ┌─ tests/checking/attributes/aptos_stdlib_attributes.move:4:10
@@ -24,13 +24,13 @@ warning: unknown attribute
   ┌─ tests/checking/attributes/aptos_stdlib_attributes.move:7:7
   │
 7 │     #[testonly]
-  │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
   ┌─ tests/checking/attributes/aptos_stdlib_attributes.move:8:7
   │
 8 │     #[b(a, a = 0, a(x = 1))]
-  │       ^ Attribute name 'b' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^ Attribute name 'b' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 error: duplicate declaration, item, or annotation
   ┌─ tests/checking/attributes/aptos_stdlib_attributes.move:8:12

--- a/third_party/move/move-compiler-v2/tests/checking/attributes/aptos_stdlib_attributes2.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/attributes/aptos_stdlib_attributes2.exp
@@ -4,7 +4,7 @@ warning: unknown attribute
   ┌─ tests/checking/attributes/aptos_stdlib_attributes2.move:4:7
   │
 4 │     #[testonly]
-  │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 // -- Model dump before bytecode pipeline
 module 0x1::M {

--- a/third_party/move/move-compiler-v2/tests/checking/attributes/attribute_placement.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/attributes/attribute_placement.exp
@@ -4,85 +4,85 @@ warning: unknown attribute
   ┌─ tests/checking/attributes/attribute_placement.move:3:3
   │
 3 │ #[attr]
-  │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
   ┌─ tests/checking/attributes/attribute_placement.move:5:7
   │
 5 │     #[attr]
-  │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
   ┌─ tests/checking/attributes/attribute_placement.move:8:7
   │
 8 │     #[attr]
-  │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:11:7
    │
 11 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:14:7
    │
 14 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:17:7
    │
 17 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:22:3
    │
 22 │ #[attr]
-   │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:24:7
    │
 24 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:27:7
    │
 27 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:31:3
    │
 31 │ #[attr]
-   │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:33:7
    │
 33 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:36:7
    │
 36 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:39:7
    │
 39 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
    ┌─ tests/checking/attributes/attribute_placement.move:44:7
    │
 44 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 // -- Model dump before bytecode pipeline
 module 0x42::N {

--- a/third_party/move/move-compiler-v2/tests/checking/attributes/attribute_variants.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/attributes/attribute_variants.exp
@@ -4,61 +4,61 @@ warning: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:2:3
   │
 2 │ #[attr0]
-  │   ^^^^^ Attribute name 'attr0' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^ Attribute name 'attr0' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:3:3
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
-  │   ^^^^^ Attribute name 'attr1' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^ Attribute name 'attr1' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:3:12
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
-  │            ^^^^^ Attribute name 'attr2' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │            ^^^^^ Attribute name 'attr2' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:3:28
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
-  │                            ^^^^^ Attribute name 'attr3' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │                            ^^^^^ Attribute name 'attr3' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:3:41
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
-  │                                         ^^^^^ Attribute name 'attr4' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │                                         ^^^^^ Attribute name 'attr4' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:3:53
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
-  │                                                     ^^^^^ Attribute name 'attr5' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │                                                     ^^^^^ Attribute name 'attr5' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:4:3
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]
-  │   ^^^^^ Attribute name 'bttr0' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^ Attribute name 'bttr0' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:4:16
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]
-  │                ^^^^^ Attribute name 'bttr1' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │                ^^^^^ Attribute name 'bttr1' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:4:27
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]
-  │                           ^^^^^ Attribute name 'bttr2' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │                           ^^^^^ Attribute name 'bttr2' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
   ┌─ tests/checking/attributes/attribute_variants.move:4:39
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]
-  │                                       ^^^^^ Attribute name 'bttr3' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │                                       ^^^^^ Attribute name 'bttr3' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 // -- Model dump before bytecode pipeline
 module 0x42::M {

--- a/third_party/move/move-compiler-v2/tests/checking/attributes/duplicate_attributes.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/attributes/duplicate_attributes.exp
@@ -4,13 +4,13 @@ warning: unknown attribute
   ┌─ tests/checking/attributes/duplicate_attributes.move:2:7
   │
 2 │     #[a, a(x = 0)]
-  │       ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning: unknown attribute
   ┌─ tests/checking/attributes/duplicate_attributes.move:2:10
   │
 2 │     #[a, a(x = 0)]
-  │          ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │          ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 error: duplicate declaration, item, or annotation
   ┌─ tests/checking/attributes/duplicate_attributes.move:2:10
@@ -24,7 +24,7 @@ warning: unknown attribute
   ┌─ tests/checking/attributes/duplicate_attributes.move:5:7
   │
 5 │     #[b(a, a = 0, a(x = 1))]
-  │       ^ Attribute name 'b' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^ Attribute name 'b' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 error: duplicate declaration, item, or annotation
   ┌─ tests/checking/attributes/duplicate_attributes.move:5:12

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_01.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_01.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: expected `#[lint::skip(...)]`, not an assigned value
+  ┌─ tests/lints/model_ast_lints/bad_lint_attribute_01.move:2:7
+  │
+2 │     #[lint::skip = true]
+  │       ^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_01.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_01.move
@@ -1,0 +1,4 @@
+module 0xc0ffee::m {
+    #[lint::skip = true]
+    public fun bad() {}
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_02.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_02.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: no lint checks are specified to be skipped
+  ┌─ tests/lints/model_ast_lints/bad_lint_attribute_02.move:2:7
+  │
+2 │     #[lint::skip]
+  │       ^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_02.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_02.move
@@ -1,0 +1,5 @@
+module 0xc0ffee::m {
+    #[lint::skip]
+    public fun test() {
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_03.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_03.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: no lint checks are specified to be skipped
+  ┌─ tests/lints/model_ast_lints/bad_lint_attribute_03.move:2:7
+  │
+2 │     #[lint::skip()]
+  │       ^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_03.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_03.move
@@ -1,0 +1,4 @@
+module 0xc0ffee::m {
+    #[lint::skip()]
+    public fun test() {}
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_04.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_04.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: unknown lint check: `unknown_lint`
+  ┌─ tests/lints/model_ast_lints/bad_lint_attribute_04.move:2:18
+  │
+2 │     #[lint::skip(unknown_lint)]
+  │                  ^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_04.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_04.move
@@ -1,0 +1,4 @@
+module 0xc0ffee::m {
+    #[lint::skip(unknown_lint)]
+    public fun test() {}
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_05.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_05.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: did not expect an assigned value, expected only the names of the lint checks to be skipped
+  ┌─ tests/lints/model_ast_lints/bad_lint_attribute_05.move:2:18
+  │
+2 │     #[lint::skip(while_true=1)]
+  │                  ^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_05.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_05.move
@@ -1,0 +1,7 @@
+module 0xc0ffee::m {
+    #[lint::skip(while_true=1)]
+    public fun test() {
+
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_06.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_06.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: unexpected nested attributes
+  ┌─ tests/lints/model_ast_lints/bad_lint_attribute_06.move:2:18
+  │
+2 │     #[lint::skip(while_true(yes=1))]
+  │                  ^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_06.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_06.move
@@ -1,0 +1,4 @@
+module 0xc0ffee::m {
+    #[lint::skip(while_true(yes=1))]
+    public fun test() {}
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_07.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_07.exp
@@ -1,0 +1,9 @@
+
+Diagnostics:
+error: duplicate declaration, item, or annotation
+  ┌─ tests/lints/model_ast_lints/bad_lint_attribute_07.move:2:30
+  │
+2 │     #[lint::skip(while_true, while_true)]
+  │                  ----------  ^^^^^^^^^^ Duplicate attribute 'while_true' attached to the same item
+  │                  │
+  │                  Attribute previously given here

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_07.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_07.move
@@ -1,0 +1,4 @@
+module 0xc0ffee::m {
+    #[lint::skip(while_true, while_true)]
+    public fun test() {}
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_08.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_08.exp
@@ -1,0 +1,9 @@
+
+Diagnostics:
+error: duplicate declaration, item, or annotation
+  ┌─ tests/lints/model_ast_lints/bad_lint_attribute_08.move:3:7
+  │
+2 │     #[lint::skip(while_true)]
+  │       ---------- Attribute previously given here
+3 │     #[lint::skip(blocks_in_conditions)]
+  │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Duplicate attribute 'lint::skip' attached to the same item

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_08.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_08.move
@@ -1,0 +1,5 @@
+module 0xc0ffee::m {
+    #[lint::skip(while_true)]
+    #[lint::skip(blocks_in_conditions)]
+    public fun test() {}
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_09.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_09.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+error: invalid attribute
+  ┌─ tests/lints/model_ast_lints/bad_lint_attribute_09.move:2:7
+  │
+2 │     #[lint::skip(while_true)]
+  │       ^^^^^^^^^^
+  │       │
+  │       Attribute 'lint::skip' is not expected with a use
+  │       Expected to be used with one of the following: module, function

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_09.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_09.move
@@ -1,0 +1,8 @@
+module 0xc0ffee::m {
+    #[lint::skip(while_true)]
+    use std::vector;
+
+    public fun test() {
+        let _x: vector<u8> = vector::empty();
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_10.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_10.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+error: unexpected token
+  ┌─ tests/lints/model_ast_lints/bad_lint_attribute_10.move:3:9
+  │
+3 │         #[lint::skip(while_true)]
+  │         ^
+  │         │
+  │         Unexpected '#'
+  │         Expected an expression term

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_10.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/bad_lint_attribute_10.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+    public fun test() {
+        #[lint::skip(while_true)]
+        while (true) {
+            // do nothing
+        }
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/blocks_in_conditions_warn.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/blocks_in_conditions_warn.exp
@@ -1,55 +1,73 @@
 
 Diagnostics:
-warning: [lint: `blocks_in_conditions`] Having blocks in conditions make code harder to read. Consider rewriting this code.
+warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/lints/model_ast_lints/blocks_in_conditions_warn.move:20:13
    │
 20 │         if ({let x = foo(); !x}) {
    │             ^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
 
-warning: [lint: `blocks_in_conditions`] Having blocks in conditions make code harder to read. Consider rewriting this code.
+warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/lints/model_ast_lints/blocks_in_conditions_warn.move:26:13
    │
 26 │         if ({x = x && foo(); x}) {
    │             ^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
 
-warning: [lint: `blocks_in_conditions`] Having blocks in conditions make code harder to read. Consider rewriting this code.
+warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/lints/model_ast_lints/blocks_in_conditions_warn.move:32:16
    │
 32 │         match ({let x = blah(); x}) {
    │                ^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
 
-warning: [lint: `blocks_in_conditions`] Having blocks in conditions make code harder to read. Consider rewriting this code.
+warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/lints/model_ast_lints/blocks_in_conditions_warn.move:39:13
    │
 39 │         if ({let x = foo(); x}) {
    │             ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
 
-warning: [lint: `blocks_in_conditions`] Having blocks in conditions make code harder to read. Consider rewriting this code.
+warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/lints/model_ast_lints/blocks_in_conditions_warn.move:40:17
    │
 40 │             if ({let x = foo(); x}) {
    │                 ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
 
-warning: [lint: `blocks_in_conditions`] Having blocks in conditions make code harder to read. Consider rewriting this code.
+warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/lints/model_ast_lints/blocks_in_conditions_warn.move:44:17
    │
 44 │             if ({let x = foo(); x}) {
    │                 ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
 
-warning: [lint: `blocks_in_conditions`] Having blocks in conditions make code harder to read. Consider rewriting this code.
+warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/lints/model_ast_lints/blocks_in_conditions_warn.move:52:13
    │
 52 │         if ({if ({let x = foo(); x}) {bar();}; let x = foo(); x}) {
    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
 
-warning: [lint: `blocks_in_conditions`] Having blocks in conditions make code harder to read. Consider rewriting this code.
+warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/lints/model_ast_lints/blocks_in_conditions_warn.move:58:16
    │
 58 │         while ({x = x + 1; x < 10}) {
    │                ^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
 
-warning: [lint: `blocks_in_conditions`] Having blocks in conditions make code harder to read. Consider rewriting this code.
+warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
    ┌─ tests/lints/model_ast_lints/blocks_in_conditions_warn.move:64:13
    │
 64 │         if ({x = x + 1; x < 10} && {x = x + 1; x < 11}) {
    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/blocks_in_conditions_warn.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/blocks_in_conditions_warn.move
@@ -86,3 +86,60 @@ module 0xc0ffee::m {
         }
     }
 }
+
+#[lint::skip(blocks_in_conditions)]
+module 0xc0ffee::no_warn_1 {
+    fun foo(): bool {
+        true
+    }
+
+    fun bar() {}
+
+    enum Blah {
+        Baz(u64),
+        Qux(u64),
+    }
+
+    fun blah(): Blah {
+        Blah::Baz(42)
+    }
+
+    /****** Suppress warnings *****/
+
+    public fun test_warn_1() {
+        if ({let x = foo(); !x}) {
+            bar();
+        }
+    }
+
+    #[lint::skip(blocks_in_conditions)]
+    public fun test_warn_2(x: bool) {
+        if ({x = x && foo(); x}) {
+            bar();
+        }
+    }
+
+    public fun test_warn_3() {
+        match ({let x = blah(); x}) {
+            Blah::Baz(_) => bar(),
+            Blah::Qux(_) => {},
+        }
+    }
+}
+
+module 0xc0ffee::no_warn_2 {
+    fun foo(): bool {
+        true
+    }
+
+    fun bar() {}
+
+    /****** Suppress warnings *****/
+
+    #[lint::skip(blocks_in_conditions)]
+    public fun test_warn_1() {
+        if ({let x = foo(); !x}) {
+            bar();
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/multi_attributes_01.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/multi_attributes_01.exp
@@ -1,0 +1,19 @@
+
+Diagnostics:
+warning: [lint] Having blocks in conditions make code harder to read. Consider rewriting this code.
+   ┌─ tests/lints/model_ast_lints/multi_attributes_01.move:13:13
+   │
+13 │         if ({let y = x + 1; y < 5}) {
+   │             ^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(blocks_in_conditions)]`.
+
+warning: [lint] Use the more explicit `loop` instead.
+   ┌─ tests/lints/model_ast_lints/multi_attributes_01.move:16:9
+   │
+16 │ ╭         while (true) {
+17 │ │             // do nothing
+18 │ │         }
+   │ ╰─────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(while_true)]`.

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/multi_attributes_01.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/multi_attributes_01.move
@@ -1,0 +1,20 @@
+module 0xc0ffee::m {
+    #[lint::skip(while_true, blocks_in_conditions)]
+    public fun test1(x: u64) {
+        if ({let y = x + 1; y < 5}) {
+            // do nothing
+        };
+        while (true) {
+            // do nothing
+        }
+    }
+
+    public fun test2(x: u64) {
+        if ({let y = x + 1; y < 5}) {
+            // do nothing
+        };
+        while (true) {
+            // do nothing
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/multi_attributes_02.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/multi_attributes_02.move
@@ -1,0 +1,22 @@
+#[lint::skip(while_true)]
+module 0xc0ffee::m {
+    #[lint::skip(blocks_in_conditions)]
+    public fun test1(x: u64) {
+        if ({let y = x + 1; y < 5}) {
+            // do nothing
+        };
+        while (true) {
+            // do nothing
+        }
+    }
+
+    #[lint::skip(while_true, blocks_in_conditions)]
+    public fun test2(x: u64) {
+        if ({let y = x + 1; y < 5}) {
+            // do nothing
+        };
+        while (true) {
+            // do nothing
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.exp
@@ -1,91 +1,121 @@
 
 Diagnostics:
-warning: [lint: `unnecessary_boolean_identity_comparison`] Directly use the boolean expression, instead of comparing it with `true`.
+warning: [lint] Directly use the boolean expression, instead of comparing it with `true`.
    ┌─ tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move:13:13
    │
 13 │         if (foo(x) == true) { bar() };
    │             ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
 
-warning: [lint: `unnecessary_boolean_identity_comparison`] Directly use the negation of the boolean expression, instead of comparing it with `false`.
+warning: [lint] Directly use the negation of the boolean expression, instead of comparing it with `false`.
    ┌─ tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move:14:13
    │
 14 │         if (foo(x) == false) { bar() };
    │             ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
 
-warning: [lint: `unnecessary_boolean_identity_comparison`] Directly use the negation of the boolean expression, instead of comparing it with `true`.
+warning: [lint] Directly use the negation of the boolean expression, instead of comparing it with `true`.
    ┌─ tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move:15:13
    │
 15 │         if (foo(x) != true) { bar() };
    │             ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
 
-warning: [lint: `unnecessary_boolean_identity_comparison`] Directly use the boolean expression, instead of comparing it with `false`.
+warning: [lint] Directly use the boolean expression, instead of comparing it with `false`.
    ┌─ tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move:16:13
    │
 16 │         if (foo(x) != false) { bar() };
    │             ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
 
-warning: [lint: `unnecessary_boolean_identity_comparison`] Directly use the boolean expression, instead of comparing it with `true`.
+warning: [lint] Directly use the boolean expression, instead of comparing it with `true`.
    ┌─ tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move:17:21
    │
 17 │         if (true == foo(x)) { bar() };
    │                     ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
 
-warning: [lint: `unnecessary_boolean_identity_comparison`] Directly use the negation of the boolean expression, instead of comparing it with `false`.
+warning: [lint] Directly use the negation of the boolean expression, instead of comparing it with `false`.
    ┌─ tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move:18:22
    │
 18 │         if (false == foo(x)) { bar() };
    │                      ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
 
-warning: [lint: `unnecessary_boolean_identity_comparison`] Directly use the negation of the boolean expression, instead of comparing it with `true`.
+warning: [lint] Directly use the negation of the boolean expression, instead of comparing it with `true`.
    ┌─ tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move:19:21
    │
 19 │         if (true != foo(x)) { bar() };
    │                     ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
 
-warning: [lint: `unnecessary_boolean_identity_comparison`] Directly use the boolean expression, instead of comparing it with `false`.
+warning: [lint] Directly use the boolean expression, instead of comparing it with `false`.
    ┌─ tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move:20:22
    │
 20 │         if (false != foo(x)) { bar() };
    │                      ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
 
-warning: [lint: `unnecessary_boolean_identity_comparison`] Directly use the negation of the boolean expression, instead of comparing it with `false`.
+warning: [lint] Comparison can be clarified to use `!=` instead
    ┌─ tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move:21:13
    │
 21 │         if ((x + 1 > 0) == false) { bar() };
    │             ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison can be clarified to use `!=` instead
+warning: [lint] Directly use the negation of the boolean expression, instead of comparing it with `false`.
    ┌─ tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move:21:13
    │
 21 │         if ((x + 1 > 0) == false) { bar() };
    │             ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
 
-warning: [lint: `unnecessary_boolean_identity_comparison`] Directly use the boolean expression, instead of comparing it with `true`.
+warning: [lint] Directly use the boolean expression, instead of comparing it with `true`.
    ┌─ tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move:22:18
    │
 22 │         let _y = foo(x) == true;
    │                  ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
 
-warning: [lint: `unnecessary_boolean_identity_comparison`] Directly use the boolean expression, instead of comparing it with `true`.
+warning: [lint] Directly use the boolean expression, instead of comparing it with `true`.
    ┌─ tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move:23:25
    │
 23 │         assert!(true == !foo(x), 42);
    │                         ^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
 
-warning: [lint: `unnecessary_boolean_identity_comparison`] Directly use the boolean expression, instead of comparing it with `true`.
+warning: [lint] Directly use the boolean expression, instead of comparing it with `true`.
    ┌─ tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move:24:14
    │
 24 │         take(foo(x) == true);
    │              ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
 
-warning: [lint: `unnecessary_boolean_identity_comparison`] Directly use the boolean expression, instead of comparing it with `true`.
+warning: [lint] Directly use the boolean expression, instead of comparing it with `true`.
    ┌─ tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move:25:18
    │
 25 │         let _z = foo(x) == TRUE;
    │                  ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
 
-warning: [lint: `unnecessary_boolean_identity_comparison`] Directly use the boolean expression, instead of comparing it with `true`.
+warning: [lint] Directly use the boolean expression, instead of comparing it with `true`.
    ┌─ tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move:29:13
    │
 29 │         if ((*x && *y) == true) { bar() };
    │             ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/unnecessary_boolean_identity_comparison.move
@@ -29,3 +29,10 @@ module 0xc0ffee::m {
         if ((*x && *y) == true) { bar() };
     }
 }
+
+module 0xc0ffee::no_warn {
+    #[lint::skip(unnecessary_boolean_identity_comparison)]
+    public fun test(x: bool) {
+        if (x == true) abort 1;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.exp
@@ -1,127 +1,169 @@
 
 Diagnostics:
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison is always false, consider rewriting the code to remove the redundant comparison
+warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
   ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:9:13
   │
 9 │         if (x + 1 > 255) { bar() };
   │             ^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_boolean_identity_comparison`] Directly use the boolean expression, instead of comparing it with `true`.
+warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:13:13
    │
 13 │         if ((*x + *y > 255) == true) { bar() };
    │             ^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison is always false, consider rewriting the code to remove the redundant comparison
+warning: [lint] Directly use the boolean expression, instead of comparing it with `true`.
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:13:13
    │
 13 │         if ((*x + *y > 255) == true) { bar() };
    │             ^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison is always false, consider rewriting the code to remove the redundant comparison
+warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:17:13
    │
 17 │         if (x < 0 || 0 > x) { bar() };
    │             ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison is always false, consider rewriting the code to remove the redundant comparison
+warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:17:22
    │
 17 │         if (x < 0 || 0 > x) { bar() };
    │                      ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison can be simplified to use `==` instead
+warning: [lint] Comparison can be simplified to use `==` instead
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:18:13
    │
 18 │         if (foo(x) <= 0) { bar() };
    │             ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison can be simplified to use `==` instead
+warning: [lint] Comparison can be simplified to use `==` instead
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:19:13
    │
 19 │         if (0 >= foo(x)) { bar() };
    │             ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison can be clarified to use `!=` instead
+warning: [lint] Comparison can be clarified to use `!=` instead
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:20:13
    │
 20 │         if (foo(x) > 0) { bar() };
    │             ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison can be clarified to use `!=` instead
+warning: [lint] Comparison can be clarified to use `!=` instead
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:21:13
    │
 21 │         if (0 < foo(x)) { bar() };
    │             ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison is always true, consider rewriting the code to remove the redundant comparison
+warning: [lint] Comparison is always true, consider rewriting the code to remove the redundant comparison
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:22:13
    │
 22 │         if (foo(x) >= 0) { bar() };
    │             ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison is always true, consider rewriting the code to remove the redundant comparison
+warning: [lint] Comparison is always true, consider rewriting the code to remove the redundant comparison
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:23:13
    │
 23 │         if (0 <= foo(x)) { bar() };
    │             ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison is always false, consider rewriting the code to remove the redundant comparison
+warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:36:13
    │
 36 │         if (a > U8_MAX || f > (U8_MAX as u256)) { bar() };
    │             ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison can be simplified to use `==` instead
+warning: [lint] Comparison can be simplified to use `==` instead
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:37:13
    │
 37 │         if (b >= U16_MAX) { bar() };
    │             ^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison is always false, consider rewriting the code to remove the redundant comparison
+warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:38:13
    │
 38 │         if (U32_MAX < c) { bar() };
    │             ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison can be simplified to use `==` instead
+warning: [lint] Comparison can be simplified to use `==` instead
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:39:13
    │
 39 │         if (U64_MAX <= d) { bar() };
    │             ^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison can be clarified to use `!=` instead
+warning: [lint] Comparison can be clarified to use `!=` instead
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:40:13
    │
 40 │         if (e < U128_MAX) { bar() };
    │             ^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison is always true, consider rewriting the code to remove the redundant comparison
+warning: [lint] Comparison is always true, consider rewriting the code to remove the redundant comparison
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:41:13
    │
 41 │         if (f <= U256_MAX) { bar() };
    │             ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison is always true, consider rewriting the code to remove the redundant comparison
+warning: [lint] Comparison is always true, consider rewriting the code to remove the redundant comparison
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:42:13
    │
 42 │         if (U256_MAX >= f) { bar() };
    │             ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison can be clarified to use `!=` instead
+warning: [lint] Comparison can be clarified to use `!=` instead
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:43:13
    │
 43 │         if (U128_MAX > e) { bar() };
    │             ^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison is always true, consider rewriting the code to remove the redundant comparison
+warning: [lint] Comparison is always true, consider rewriting the code to remove the redundant comparison
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:45:20
    │
 45 │             assert a <= U8_MAX;
    │                    ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
 
-warning: [lint: `unnecessary_numerical_extreme_comparison`] Comparison is always false, consider rewriting the code to remove the redundant comparison
+warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
    ┌─ tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:54:19
    │
 54 │         apply(|x| x > U8_MAX, x)
    │                   ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move
@@ -54,3 +54,10 @@ module 0xc0ffee::m {
         apply(|x| x > U8_MAX, x)
     }
 }
+
+module 0xc0ffee::no_warn {
+    #[lint::skip(unnecessary_numerical_extreme_comparison)]
+    public fun test(x: u8) {
+        if (x < 0) abort 1;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/while_true_warn.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/while_true_warn.exp
@@ -1,17 +1,21 @@
 
 Diagnostics:
-warning: [lint: `while_true`] Use the more explicit `loop` instead.
+warning: [lint] Use the more explicit `loop` instead.
   ┌─ tests/lints/model_ast_lints/while_true_warn.move:3:9
   │
 3 │ ╭         while (true) {
 4 │ │             if (x > 10) { break; } else { test_warn_1(x + 1); }
 5 │ │         }
   │ ╰─────────^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(while_true)]`.
 
-warning: [lint: `while_true`] Use the more explicit `loop` instead.
+warning: [lint] Use the more explicit `loop` instead.
    ┌─ tests/lints/model_ast_lints/while_true_warn.move:11:9
    │
 11 │ ╭         while (true) {
 12 │ │             if (__update_iter_flag) { i = i + 1; } else { __update_iter_flag = true; }
 13 │ │         }
    │ ╰─────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(while_true)]`.

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/while_true_warn.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/while_true_warn.move
@@ -25,3 +25,12 @@ module 0xc0ffee::m {
         }
     }
 }
+
+module 0xc0ffee::no_warn {
+    #[lint::skip(while_true)]
+    public fun test_warn_1(x: u64) {
+        while (true) {
+            if (x > 10) { break; } else { test_warn_1(x + 1); }
+        }
+    }
+}

--- a/third_party/move/move-compiler/src/shared/mod.rs
+++ b/third_party/move/move-compiler/src/shared/mod.rs
@@ -648,6 +648,7 @@ pub mod known_attributes {
         Verification(VerificationAttribute),
         Native(NativeAttribute),
         Deprecation(DeprecationAttribute),
+        Lint(LintAttribute),
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -677,6 +678,12 @@ pub mod known_attributes {
     pub enum DeprecationAttribute {
         // Marks deprecated functions, types, modules, constants, addresses whose use causes warnings
         Deprecated,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub enum LintAttribute {
+        // Allow the user to suppress a specific subset of lint warnings.
+        Allow,
     }
 
     impl fmt::Display for AttributePosition {
@@ -713,6 +720,7 @@ pub mod known_attributes {
                 DeprecationAttribute::DEPRECATED_NAME => {
                     Self::Deprecation(DeprecationAttribute::Deprecated)
                 },
+                LintAttribute::SKIP => Self::Lint(LintAttribute::Allow),
                 _ => return None,
             })
         }
@@ -733,6 +741,7 @@ pub mod known_attributes {
             VerificationAttribute::add_attribute_names(table);
             NativeAttribute::add_attribute_names(table);
             DeprecationAttribute::add_attribute_names(table);
+            LintAttribute::add_attribute_names(table);
         }
 
         fn name(&self) -> &str {
@@ -741,6 +750,7 @@ pub mod known_attributes {
                 Self::Verification(a) => a.name(),
                 Self::Native(a) => a.name(),
                 Self::Deprecation(a) => a.name(),
+                Self::Lint(a) => a.name(),
             }
         }
 
@@ -750,6 +760,7 @@ pub mod known_attributes {
                 Self::Verification(a) => a.expected_positions(),
                 Self::Native(a) => a.expected_positions(),
                 Self::Deprecation(a) => a.expected_positions(),
+                Self::Lint(a) => a.expected_positions(),
             }
         }
     }
@@ -917,6 +928,35 @@ pub mod known_attributes {
             });
             match self {
                 Self::Deprecated => &DEPRECATED_POSITIONS,
+            }
+        }
+    }
+
+    impl LintAttribute {
+        const ALL_ATTRIBUTE_NAMES: [&'static str; 1] = [Self::SKIP];
+        pub const SKIP: &'static str = "lint::skip";
+    }
+
+    impl AttributeKind for LintAttribute {
+        fn add_attribute_names(table: &mut BTreeSet<String>) {
+            for str in Self::ALL_ATTRIBUTE_NAMES {
+                table.insert(str.to_string());
+            }
+        }
+
+        fn name(&self) -> &str {
+            match self {
+                Self::Allow => Self::SKIP,
+            }
+        }
+
+        fn expected_positions(&self) -> &'static BTreeSet<AttributePosition> {
+            static ALLOW_POSITIONS: Lazy<BTreeSet<AttributePosition>> = Lazy::new(|| {
+                IntoIterator::into_iter([AttributePosition::Module, AttributePosition::Function])
+                    .collect()
+            });
+            match self {
+                Self::Allow => &ALLOW_POSITIONS,
             }
         }
     }

--- a/third_party/move/move-compiler/src/unit_test/filter_test_members.rs
+++ b/third_party/move/move-compiler/src/unit_test/filter_test_members.rs
@@ -244,7 +244,8 @@ fn test_attributes(attrs: &P::Attributes) -> Vec<(Loc, known_attributes::Testing
                 KnownAttribute::Testing(test_attr) => Some((attr.loc, test_attr)),
                 KnownAttribute::Verification(_)
                 | KnownAttribute::Native(_)
-                | KnownAttribute::Deprecation(_) => None,
+                | KnownAttribute::Deprecation(_)
+                | KnownAttribute::Lint(_) => None,
             },
         )
         .collect()

--- a/third_party/move/move-compiler/src/verification/ast_filter.rs
+++ b/third_party/move/move-compiler/src/verification/ast_filter.rs
@@ -68,7 +68,8 @@ fn verification_attributes(
                 KnownAttribute::Verification(verify_attr) => Some((attr.loc, verify_attr)),
                 KnownAttribute::Testing(_)
                 | KnownAttribute::Native(_)
-                | KnownAttribute::Deprecation(_) => None,
+                | KnownAttribute::Deprecation(_)
+                | KnownAttribute::Lint(_) => None,
             },
         )
         .collect()

--- a/third_party/move/move-compiler/tests/move_check/parser/aptos_stdlib_attributes.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/aptos_stdlib_attributes.exp
@@ -2,13 +2,13 @@ warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:4:7
   │
 4 │     #[a, a(x = 0)]
-  │       ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:4:10
   │
 4 │     #[a, a(x = 0)]
-  │          ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │          ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:4:10
@@ -22,13 +22,13 @@ warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:7:7
   │
 7 │     #[testonly]
-  │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:8:7
   │
 8 │     #[b(a, a = 0, a(x = 1))]
-  │       ^ Attribute name 'b' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^ Attribute name 'b' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/parser/aptos_stdlib_attributes.move:8:12

--- a/third_party/move/move-compiler/tests/move_check/parser/aptos_stdlib_attributes2.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/aptos_stdlib_attributes2.exp
@@ -2,5 +2,5 @@ warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/aptos_stdlib_attributes2.move:4:7
   │
 4 │     #[testonly]
-  │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 

--- a/third_party/move/move-compiler/tests/move_check/parser/attribute_placement.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/attribute_placement.exp
@@ -2,83 +2,83 @@ warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_placement.move:3:3
   │
 3 │ #[attr]
-  │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_placement.move:5:7
   │
 5 │     #[attr]
-  │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_placement.move:8:7
   │
 8 │     #[attr]
-  │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:11:7
    │
 11 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:14:7
    │
 14 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:17:7
    │
 17 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:22:3
    │
 22 │ #[attr]
-   │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:24:7
    │
 24 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:27:7
    │
 27 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:31:3
    │
 31 │ #[attr]
-   │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │   ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:33:7
    │
 33 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:36:7
    │
 36 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:39:7
    │
 39 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
    ┌─ tests/move_check/parser/attribute_placement.move:44:7
    │
 44 │     #[attr]
-   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'attr' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 

--- a/third_party/move/move-compiler/tests/move_check/parser/attribute_variants.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/attribute_variants.exp
@@ -2,59 +2,59 @@ warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:2:3
   │
 2 │ #[attr0]
-  │   ^^^^^ Attribute name 'attr0' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^ Attribute name 'attr0' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:3:3
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
-  │   ^^^^^ Attribute name 'attr1' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^ Attribute name 'attr1' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:3:12
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
-  │            ^^^^^ Attribute name 'attr2' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │            ^^^^^ Attribute name 'attr2' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:3:28
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
-  │                            ^^^^^ Attribute name 'attr3' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │                            ^^^^^ Attribute name 'attr3' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:3:41
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
-  │                                         ^^^^^ Attribute name 'attr4' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │                                         ^^^^^ Attribute name 'attr4' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:3:53
   │
 3 │ #[attr1=0, attr2=b"hello", attr3=x"0f", attr4=0x42, attr5(attr0, attr1, attr2(attr0, attr1=0))]
-  │                                                     ^^^^^ Attribute name 'attr5' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │                                                     ^^^^^ Attribute name 'attr5' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:4:3
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]
-  │   ^^^^^ Attribute name 'bttr0' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^ Attribute name 'bttr0' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:4:16
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]
-  │                ^^^^^ Attribute name 'bttr1' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │                ^^^^^ Attribute name 'bttr1' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:4:27
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]
-  │                           ^^^^^ Attribute name 'bttr2' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │                           ^^^^^ Attribute name 'bttr2' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/attribute_variants.move:4:39
   │
 4 │ #[bttr0=false, bttr1=0u8, bttr2=0u64, bttr3=0u128]
-  │                                       ^^^^^ Attribute name 'bttr3' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │                                       ^^^^^ Attribute name 'bttr3' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 

--- a/third_party/move/move-compiler/tests/move_check/parser/duplicate_attributes.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/duplicate_attributes.exp
@@ -2,13 +2,13 @@ warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/duplicate_attributes.move:2:7
   │
 2 │     #[a, a(x = 0)]
-  │       ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/duplicate_attributes.move:2:10
   │
 2 │     #[a, a(x = 0)]
-  │          ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │          ^ Attribute name 'a' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/parser/duplicate_attributes.move:2:10
@@ -22,7 +22,7 @@ warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/duplicate_attributes.move:5:7
   │
 5 │     #[b(a, a = 0, a(x = 1))]
-  │       ^ Attribute name 'b' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^ Attribute name 'b' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 error[E02001]: duplicate declaration, item, or annotation
   ┌─ tests/move_check/parser/duplicate_attributes.move:5:12

--- a/third_party/move/move-compiler/tests/move_check/parser/testonly.exp
+++ b/third_party/move/move-compiler/tests/move_check/parser/testonly.exp
@@ -2,11 +2,11 @@ warning[W02016]: unknown attribute
   ┌─ tests/move_check/parser/testonly.move:5:7
   │
 5 │     #[testonly]
-  │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │       ^^^^^^^^ Attribute name 'testonly' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 warning[W02016]: unknown attribute
    ┌─ tests/move_check/parser/testonly.move:15:7
    │
 15 │     #[view]
-   │       ^^^^ Attribute name 'view' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+   │       ^^^^ Attribute name 'view' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -930,10 +930,10 @@ impl GlobalEnv {
         self.diag_with_primary_notes_and_labels(severity, loc, msg, "", vec![], vec![])
     }
 
-    /// Add a lint warning to this environment, given the `lint_name` and `msg`.
-    pub fn lint_diag(&self, loc: &Loc, lint_name: &str, msg: &str) {
-        let msg = format!("[lint: `{}`] {}", lint_name, msg);
-        self.diag(Severity::Warning, loc, &msg)
+    /// Add a lint warning to this environment, with the `msg` and `notes`.
+    pub fn lint_diag_with_notes(&self, loc: &Loc, msg: &str, notes: Vec<String>) {
+        let lint_msg = format!("[lint] {}", msg);
+        self.diag_with_notes(Severity::Warning, loc, &lint_msg, notes)
     }
 
     /// Adds a diagnostic of given severity to this environment, with notes.

--- a/third_party/move/tools/move-cli/tests/build_tests/dependency_chain/args.exp
+++ b/third_party/move/tools/move-cli/tests/build_tests/dependency_chain/args.exp
@@ -6,5 +6,5 @@ warning[W02016]: unknown attribute
   ┌─ ./sources/A.move:1:3
   │
 1 │ #[evm_contract] // for passing evm test flavor
-  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 

--- a/third_party/move/tools/move-cli/tests/build_tests/dependency_chain/args.v2_exp
+++ b/third_party/move/tools/move-cli/tests/build_tests/dependency_chain/args.v2_exp
@@ -6,5 +6,5 @@ warning: unknown attribute
   ┌─ ./sources/A.move:1:3
   │
 1 │ #[evm_contract] // for passing evm test flavor
-  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 

--- a/third_party/move/tools/move-cli/tests/build_tests/dev_address/args.exp
+++ b/third_party/move/tools/move-cli/tests/build_tests/dev_address/args.exp
@@ -4,5 +4,5 @@ warning[W02016]: unknown attribute
   ┌─ ./sources/A.move:1:3
   │
 1 │ #[evm_contract] // for passing evm test flavor
-  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 

--- a/third_party/move/tools/move-cli/tests/build_tests/dev_address/args.v2_exp
+++ b/third_party/move/tools/move-cli/tests/build_tests/dev_address/args.v2_exp
@@ -4,5 +4,5 @@ warning: unknown attribute
   ┌─ ./sources/A.move:1:3
   │
 1 │ #[evm_contract] // for passing evm test flavor
-  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 

--- a/third_party/move/tools/move-cli/tests/build_tests/empty_module_no_deps/args.exp
+++ b/third_party/move/tools/move-cli/tests/build_tests/empty_module_no_deps/args.exp
@@ -4,5 +4,5 @@ warning[W02016]: unknown attribute
   ┌─ ./sources/A.move:1:3
   │
 1 │ #[evm_contract] // for passing evm test flavor
-  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 

--- a/third_party/move/tools/move-cli/tests/build_tests/empty_module_no_deps/args.v2_exp
+++ b/third_party/move/tools/move-cli/tests/build_tests/empty_module_no_deps/args.v2_exp
@@ -4,5 +4,5 @@ warning: unknown attribute
   ┌─ ./sources/A.move:1:3
   │
 1 │ #[evm_contract] // for passing evm test flavor
-  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 

--- a/third_party/move/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.exp
+++ b/third_party/move/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.exp
@@ -4,7 +4,7 @@ warning[W02016]: unknown attribute
   ┌─ ./sources/UseSigner.move:1:3
   │
 1 │ #[evm_contract] // for passing evm test flavor
-  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 error[E03002]: unbound module
   ┌─ ./sources/UseSigner.move:3:7
@@ -25,5 +25,5 @@ warning[W02016]: unknown attribute
   ┌─ ./sources/UseSigner.move:1:3
   │
 1 │ #[evm_contract] // for passing evm test flavor
-  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 

--- a/third_party/move/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.v2_exp
+++ b/third_party/move/tools/move-cli/tests/build_tests/include_exclude_stdlib/args.v2_exp
@@ -4,7 +4,7 @@ warning: unknown attribute
   ┌─ ./sources/UseSigner.move:1:3
   │
 1 │ #[evm_contract] // for passing evm test flavor
-  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 
 error: unbound module
   ┌─ ./sources/UseSigner.move:3:7
@@ -25,5 +25,5 @@ warning: unknown attribute
   ┌─ ./sources/UseSigner.move:1:3
   │
 1 │ #[evm_contract] // for passing evm test flavor
-  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "native_interface", "test", "test_only", "verify_only"}'.
+  │   ^^^^^^^^^^^^ Attribute name 'evm_contract' is unknown (use --skip-attribute-checks CLI option to ignore); known attributes are '{"bytecode_instruction", "deprecated", "expected_failure", "lint::skip", "native_interface", "test", "test_only", "verify_only"}'.
 

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
@@ -26,6 +26,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.v2_exp
@@ -26,6 +26,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.v2_exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.v2_exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.v2_exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
@@ -29,6 +29,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.v2_exp
@@ -29,6 +29,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
@@ -29,6 +29,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.v2_exp
@@ -29,6 +29,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
@@ -30,6 +30,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
@@ -30,6 +30,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep/Move.v2_exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.v2_exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.v2_exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.v2_exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.v2_exp
@@ -28,6 +28,7 @@ CompiledPackageInfo {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.v2_exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.v2_exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.v2_exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.v2_exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.v2_exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.v2_exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.v2_exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.v2_exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.v2_exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep/Move.v2_exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.v2_exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.v2_exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.v2_exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",

--- a/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.v2_exp
+++ b/third_party/move/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.v2_exp
@@ -22,6 +22,7 @@ ResolutionGraph {
                 "bytecode_instruction",
                 "deprecated",
                 "expected_failure",
+                "lint::skip",
                 "native_interface",
                 "test",
                 "test_only",


### PR DESCRIPTION
## Description

In this PR, we add support for suppressing specific lint warnings via attributes on functions and modules.

For example, when lint checks are enabled, running compiler v2 on the following code will report a warning:
```move
module 0xc0ffee::m {
    public fun test(x: u8) {
        if (x < 0) abort 1;
    }
}
```

But, you can now add one or more lint checks to skip using the `#[lint::skip(...)]` attribute. For the code below, we will not report a warning when lint checks are enabled in compiler v2.
```move
module 0xc0ffee::m {
    #[lint::skip(unnecessary_numerical_extreme_comparison)]
    public fun test(x: u8) {
        if (x < 0) abort 1;
    }
}
```

Multiple lint checks can also be suppressed: `#[lint::skip(blocks_in_conditions, while_true)]`.

## Important notes for the reviewer

* Lint checks are not yet directly exposed to the user, and can only be exercised when compiling with v2 and `MVC_EXP=lint-checks=on` env flag.
* Many error checks on the attribute `#[lint::skip(...)]` are performed only when lint checks are enabled. General checks on attributes (such as, unknown top-level attribute name such as `#[lint::skippps]`, misplaced attribute) done regardless of whether lint checks are on, but once we have a syntactically well-formed `#[lint::skip(...)]` attribute, further checks are only performed when lint checks are enabled (i.e., because this is tool specific, it is offloaded to the tool).
* Based on the above point, we do not perform further extensive checks on `#[lint::skip(...)]` attribute when using compiler v1, which does not have a linter. To allow a user to use compiler v1 and v2 on the same code base, we probably do not want to throw an error/warning on seeing `#[lint::skip(...)]` attributes when using compiler v1, but this can be discussed (and whatever we want to do could be done in a followup PR).

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## How Has This Been Tested?
* Several new tests were added to check the newly added functionality
* All baseline updates of existing tests were checked for sanity
