### PR TITLE
[compiler-v1] Omit warning for unused `self` parameter

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/receiver/dont_warn_unused_self.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/dont_warn_unused_self.exp
@@ -1,0 +1,13 @@
+// -- Model dump before bytecode pipeline
+module 0x42::m {
+    struct S {
+        x: u64,
+    }
+    private fun receiver(self: m::S,_y: u64) {
+        Tuple()
+    }
+    spec {
+      requires true;
+    }
+
+} // end 0x42::m

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/dont_warn_unused_self.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/dont_warn_unused_self.exp
@@ -1,9 +1,17 @@
+
+Diagnostics:
+warning: Unused parameter `y`. Consider removing or prefixing with an underscore: `_y`
+  ┌─ tests/checking/receiver/dont_warn_unused_self.move:5:27
+  │
+5 │     fun receiver(self: S, y: u64) {
+  │                           ^
+
 // -- Model dump before bytecode pipeline
 module 0x42::m {
     struct S {
         x: u64,
     }
-    private fun receiver(self: m::S,_y: u64) {
+    private fun receiver(self: m::S,y: u64) {
         Tuple()
     }
     spec {

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/dont_warn_unused_self.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/dont_warn_unused_self.move
@@ -2,10 +2,10 @@ module 0x42::m {
 
     struct S has drop { x: u64 }
 
-    fun receiver(self: S, _y: u64) {
+    fun receiver(self: S, y: u64) {
     }
 
-    spec receiver(self: S, _y: u64) {
+    spec receiver(self: S, y: u64) {
         requires true;
     }
 }

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/dont_warn_unused_self.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/dont_warn_unused_self.move
@@ -1,0 +1,11 @@
+module 0x42::m {
+
+    struct S has drop { x: u64 }
+
+    fun receiver(self: S, _y: u64) {
+    }
+
+    spec receiver(self: S, _y: u64) {
+        requires true;
+    }
+}

--- a/third_party/move/move-compiler/src/hlir/ast.rs
+++ b/third_party/move/move-compiler/src/hlir/ast.rs
@@ -371,6 +371,13 @@ impl FunctionSignature {
             .iter()
             .any(|(parameter_name, _)| parameter_name == v)
     }
+
+    pub fn is_first_parameter(&self, v: &Var) -> bool {
+        self.parameters
+            .first()
+            .map(|(parameter_name, _)| parameter_name == v)
+            .unwrap_or(false)
+    }
 }
 
 impl Command_ {

--- a/third_party/move/move-compiler/src/hlir/translate.rs
+++ b/third_party/move/move-compiler/src/hlir/translate.rs
@@ -1972,6 +1972,11 @@ fn check_unused_locals(
             DisplayVar::Tmp => panic!("ICE unused tmp"),
             DisplayVar::Orig(vstr) => vstr,
         };
+        if signature.is_parameter(&v) && vstr == "self" {
+            // Special treatment for `self` Move 2 parameter: do not warn if unused
+            // for the case v1 compiles v2 code
+            continue;
+        }
         let loc = v.loc();
         let msg = if signature.is_parameter(&v) {
             format!(

--- a/third_party/move/move-compiler/src/hlir/translate.rs
+++ b/third_party/move/move-compiler/src/hlir/translate.rs
@@ -1972,7 +1972,7 @@ fn check_unused_locals(
             DisplayVar::Tmp => panic!("ICE unused tmp"),
             DisplayVar::Orig(vstr) => vstr,
         };
-        if signature.is_parameter(&v) && vstr == "self" {
+        if signature.is_first_parameter(&v) && vstr == "self" {
             // Special treatment for `self` Move 2 parameter: do not warn if unused
             // for the case v1 compiles v2 code
             continue;

--- a/third_party/move/move-compiler/tests/move_check/locals/dont_warn_unused_self.exp
+++ b/third_party/move/move-compiler/tests/move_check/locals/dont_warn_unused_self.exp
@@ -1,0 +1,6 @@
+warning[W09002]: unused variable
+  ┌─ tests/move_check/locals/dont_warn_unused_self.move:5:27
+  │
+5 │     fun receiver(self: S, y: u64) {
+  │                           ^ Unused parameter 'y'. Consider removing or prefixing with an underscore: '_y'
+

--- a/third_party/move/move-compiler/tests/move_check/locals/dont_warn_unused_self.move
+++ b/third_party/move/move-compiler/tests/move_check/locals/dont_warn_unused_self.move
@@ -2,10 +2,10 @@ module 0x42::m {
 
     struct S has drop { x: u64 }
 
-    fun receiver(self: S, _y: u64) {
+    fun receiver(self: S, y: u64) {
     }
 
-    spec receiver(self: S, _y: u64) {
+    spec receiver(self: S, y: u64) {
         requires true;
     }
 }

--- a/third_party/move/move-compiler/tests/move_check/locals/dont_warn_unused_self.move
+++ b/third_party/move/move-compiler/tests/move_check/locals/dont_warn_unused_self.move
@@ -1,0 +1,11 @@
+module 0x42::m {
+
+    struct S has drop { x: u64 }
+
+    fun receiver(self: S, _y: u64) {
+    }
+
+    spec receiver(self: S, _y: u64) {
+        requires true;
+    }
+}


### PR DESCRIPTION
## Description

This omits the warning for unused self parameters in the v1 compiler, in case we run it on v2 code.
v2 does already omit the warning.

Fixes #14361


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Added test cases for both v1 and v2.


