### PR TITLE
[move-package]: make `make_source_and_deps_for_compiler` public

### DIFF
--- a/third_party/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/third_party/move/tools/move-package/src/compilation/compiled_package.rs
@@ -1059,7 +1059,8 @@ pub(crate) fn apply_named_address_renaming(
         .collect()
 }
 
-pub(crate) fn make_source_and_deps_for_compiler(
+/// Collects source and dependency files with their address mappings.
+pub fn make_source_and_deps_for_compiler(
     resolution_graph: &ResolvedGraph,
     root: &ResolvedPackage,
     deps: Vec<(


### PR DESCRIPTION
## Description
This PR is makes the `make_source_and_deps_for_compiler` function public so it can by the external `move-mutator` tool located in the [eiger/move-spec-testing](https://github.com/eigerco/move-spec-testing) repo.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
N/A - no new functionality has been added.

## Key Areas to Review
Simple API visibility change.

One can observe here how it is used in the external repository:
https://github.com/eigerco/move-spec-testing/blob/703d6a75deae02e9080b678ebd102c0d34926f33/third_party/move/tools/move-mutator/src/compiler.rs#L155

The above solution locally references `move-package`, but in the next iteration of the tool, `move-package` and all other `aptos-core` files will be removed from that repository, so such an option won't be available. 

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

