### PR TITLE
[forge] use default syncing mode for working quorum test

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -987,7 +987,7 @@ fn changing_working_quorum_test_high_load() -> ForgeConfig {
         120,
         500,
         300,
-        true,
+        false,
         true,
         true,
         ChangingWorkingQuorumTest {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

It seems that using default syncing mode passes the working quorum test. 

https://github.com/aptos-labs/aptos-core/actions/runs/10517320138
