### PR TITLE
[State Sync] Add metrics and logs for pipeline backpressure.

### DIFF
--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -271,6 +271,7 @@ pub trait TransactionReplayer: Send {
 }
 
 /// A structure that holds relevant information about a chunk that was committed.
+#[derive(Clone)]
 pub struct ChunkCommitNotification {
     pub subscribable_events: Vec<ContractEvent>,
     pub committed_transactions: Vec<Transaction>,

--- a/state-sync/state-sync-driver/src/metrics.rs
+++ b/state-sync/state-sync-driver/src/metrics.rs
@@ -31,6 +31,13 @@ pub const STORAGE_SYNCHRONIZER_COMMIT_CHUNK: &str = "commit_chunk";
 pub const STORAGE_SYNCHRONIZER_COMMIT_POST_PROCESS: &str = "commit_post_process";
 pub const STORAGE_SYNCHRONIZER_STATE_VALUE_CHUNK: &str = "state_value_chunk";
 
+/// Storage synchronizer pipeline channel labels
+pub const STORAGE_SYNCHRONIZER_EXECUTOR: &str = "executor";
+pub const STORAGE_SYNCHRONIZER_LEDGER_UPDATER: &str = "ledger_updater";
+pub const STORAGE_SYNCHRONIZER_COMMITTER: &str = "committer";
+pub const STORAGE_SYNCHRONIZER_COMMIT_POST_PROCESSOR: &str = "commit_post_processor";
+pub const STORAGE_SYNCHRONIZER_STATE_SNAPSHOT_RECEIVER: &str = "state_snapshot_receiver";
+
 /// An enum representing the component currently executing
 pub enum ExecutingComponent {
     Bootstrapper,
@@ -189,6 +196,17 @@ pub static STORAGE_SYNCHRONIZER_OPERATIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+/// Gauges for tracking the storage synchronizer pipeline channel backpressure
+pub static STORAGE_SYNCHRONIZER_PIPELINE_CHANNEL_BACKPRESSURE: Lazy<IntGaugeVec> =
+    Lazy::new(|| {
+        register_int_gauge_vec!(
+            "aptos_state_sync_storage_synchronizer_pipeline_channel_backpressure",
+            "Gauges for tracking the storage synchronizer pipeline channel backpressure",
+            &["channel"]
+        )
+        .unwrap()
+    });
 
 /// Increments the given counter with the provided label values.
 pub fn increment_counter(counter: &Lazy<IntCounterVec>, label: &str) {


### PR DESCRIPTION
## Description
This PR adds metrics and logs to better track pipeline channel backpressure in the storage synchronizer. Specifically, when a channel gets full, we log the backpressure and track the backpressure in a gauge. This should help us better identify blockages in the pipeline 😄 

## Testing Plan
New and existing test infrastructure.
