### PR TITLE
[compiler-v2] Optimization for flushing writes eagerly

### DIFF
--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -204,6 +204,11 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             description: "Whether to run various lint checks.".to_string(),
             default: Given(false),
         },
+        Experiment {
+            name: Experiment::FLUSH_WRITES_OPTIMIZATION.to_string(),
+            description: "Whether to run flush writes processor and optimization".to_string(),
+            default: Inherited(Experiment::OPTIMIZE.to_string()),
+        },
     ];
     experiments
         .into_iter()
@@ -223,6 +228,7 @@ impl Experiment {
     pub const COPY_PROPAGATION: &'static str = "copy-propagation";
     pub const DEAD_CODE_ELIMINATION: &'static str = "dead-code-elimination";
     pub const DUPLICATE_STRUCT_PARAMS_CHECK: &'static str = "duplicate-struct-params-check";
+    pub const FLUSH_WRITES_OPTIMIZATION: &'static str = "flush-writes-optimization";
     pub const GEN_ACCESS_SPECIFIERS: &'static str = "gen-access-specifiers";
     pub const INLINING: &'static str = "inlining";
     pub const KEEP_INLINE_FUNS: &'static str = "keep-inline-funs";

--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -7,7 +7,10 @@ use crate::{
         module_generator::{ModuleContext, ModuleGenerator, SOURCE_MAP_OK},
         peephole_optimizer, Options, MAX_FUNCTION_DEF_COUNT, MAX_LOCAL_COUNT,
     },
-    pipeline::livevar_analysis_processor::LiveVarAnnotation,
+    pipeline::{
+        flush_writes_processor::FlushWritesAnnotation,
+        livevar_analysis_processor::LiveVarAnnotation,
+    },
 };
 use move_binary_format::{
     file_format as FF,
@@ -36,7 +39,10 @@ pub struct FunctionGenerator<'a> {
     /// A map from a temporary to information associated with it.
     temps: BTreeMap<TempIndex, TempInfo>,
     /// The value stack, represented by the temporaries which are located on it.
-    stack: Vec<TempIndex>,
+    /// Each temporary is paired with a bool, indicating whether the value was copied onto
+    /// the stack from a local.
+    /// If a value was copied onto the stack, then we don't have to save it back to the local.
+    stack: Vec<(TempIndex, bool)>,
     /// The locals which have been used so far. This contains the parameters of the function.
     locals: Vec<Type>,
     /// A map from branching labels to information about them.
@@ -349,15 +355,21 @@ impl<'a> FunctionGenerator<'a> {
         result: impl AsRef<[TempIndex]>,
     ) {
         let result = result.as_ref();
-        // If the stack contains already exactly the result and none of the temps is used after,
-        // nothing to do.
-        let stack_ready = self.stack == result
+        let stack = self.stack.iter().map(|(t, _)| *t).collect::<Vec<_>>();
+        // If the stack already contains exactly the result and none of the temps are used after
+        // or were copied from locals, nothing to do.
+        // [TODO]: we could further optimize this when:
+        //   1. `stack == result` and
+        //   2. some stack temps are alive after and were not copied from locals;
+        // then we can flush only until the lowest such temp on the stack, and then push them back,
+        // instead of always fully flushing the stack.
+        let stack_ready = stack == result
             && self
                 .stack
                 .iter()
-                .all(|temp| !ctx.is_alive_after(*temp, &[], false));
+                .all(|(temp, copied)| *copied || !ctx.is_alive_after(*temp, &[], false));
         if !stack_ready {
-            // Flush the stack and push the result
+            // Flush the stack and push the result.
             self.abstract_flush_stack_before(ctx, 0);
             self.abstract_push_args(ctx, result, None);
         }
@@ -555,8 +567,6 @@ impl<'a> FunctionGenerator<'a> {
             },
             Operation::ReadRef => self.gen_builtin(ctx, dest, FF::Bytecode::ReadRef, source),
             Operation::WriteRef => {
-                // TODO: WriteRef in FF bytecode and in stackless bytecode use different operand
-                // order, perhaps we should fix this.
                 self.gen_builtin(ctx, dest, FF::Bytecode::WriteRef, &[source[1], source[0]])
             },
             Operation::Release => {
@@ -917,10 +927,14 @@ impl<'a> FunctionGenerator<'a> {
         // Now compute which temps need to be pushed, on top of any which are already on the stack
         let mut temps_to_push = self.analyze_stack(temps);
         // If any of the temps we need to push now are actually underneath the temps already on the stack,
-        // we need to even flush more of the stack to reach them.
+        // and their values were not copied from locals, we need to even flush more of the stack to reach them.
         let mut stack_to_flush = self.stack.len();
         for temp in temps_to_push {
-            if let Some(offs) = self.stack.iter().position(|t| t == temp) {
+            if let Some(offs) = self
+                .stack
+                .iter()
+                .position(|(t, copied)| !*copied && t == temp)
+            {
                 // The lowest point in the stack we need to flush.
                 stack_to_flush = std::cmp::min(offs, stack_to_flush);
                 // Unfortunately, whatever is on the stack already, needs to be flushed out and
@@ -932,14 +946,18 @@ impl<'a> FunctionGenerator<'a> {
         // Finally, push `temps_to_push` onto the stack.
         for (pos, temp) in temps_to_push.iter().enumerate() {
             let local = self.temp_to_local(fun_ctx, Some(ctx.attr_id), *temp);
+            let copied;
             match push_kind {
                 Some(AssignKind::Move) => {
+                    copied = false;
                     self.emit(FF::Bytecode::MoveLoc(local));
                 },
                 Some(AssignKind::Copy) => {
+                    copied = true;
                     self.emit(FF::Bytecode::CopyLoc(local));
                 },
                 Some(AssignKind::Inferred) | Some(AssignKind::Store) => {
+                    copied = false;
                     fun_ctx
                         .internal_error("Inferred and Store AssignKind should be not appear here.");
                 },
@@ -953,13 +971,15 @@ impl<'a> FunctionGenerator<'a> {
                                 format!("value in `$t{}` expected to be copyable", temp),
                             )
                         }
+                        copied = true;
                         self.emit(FF::Bytecode::CopyLoc(local))
                     } else {
+                        copied = false;
                         self.emit(FF::Bytecode::MoveLoc(local));
                     }
                 },
             }
-            self.stack.push(*temp)
+            self.stack.push((*temp, copied));
         }
     }
 
@@ -979,17 +999,22 @@ impl<'a> FunctionGenerator<'a> {
         let dests = BTreeSet::from_iter(dests.iter());
         let sources = BTreeSet::from_iter(sources.iter());
         let conflicts = dests.difference(&sources).collect::<BTreeSet<_>>();
-        if let Some(pos) = self.stack.iter().position(|t| conflicts.contains(&t)) {
+        if let Some(pos) = self.stack.iter().position(|(t, _)| conflicts.contains(&t)) {
             self.abstract_flush_stack_before(ctx, pos);
         }
     }
 
-    /// Ensures that all `temps` which are on the stack and used after this program
-    /// point are saved to locals. This flushes the stack as deep as needed for this.
+    /// Ensures that all `temps` which are on the stack, were not copied from a local,
+    /// and used after this program point are saved to locals. This flushes the stack
+    /// as deep as needed for this.
     fn save_used_after(&mut self, ctx: &BytecodeContext, temps: &[TempIndex]) {
         let mut stack_to_flush = self.stack.len();
         for (i, temp) in temps.iter().enumerate() {
-            if let Some(pos) = self.stack.iter().position(|t| t == temp) {
+            if let Some(pos) = self
+                .stack
+                .iter()
+                .position(|(t, copied)| !*copied && t == temp)
+            {
                 if ctx.is_alive_after(*temp, &temps[i + 1..], true) {
                     // Determine new lowest point to which we need to flush
                     stack_to_flush = std::cmp::min(stack_to_flush, pos);
@@ -1005,8 +1030,9 @@ impl<'a> FunctionGenerator<'a> {
     /// returns the temps which are not and need to be pushed.
     fn analyze_stack<'t>(&mut self, temps: &'t [TempIndex]) -> &'t [TempIndex] {
         let mut temps_to_push = temps; // worst case need to push all
+        let stack = self.stack.iter().map(|(t, _)| *t).collect::<Vec<_>>();
         for end in (1..=temps.len()).rev() {
-            if self.stack.ends_with(&temps[0..end]) {
+            if stack.ends_with(&temps[0..end]) {
                 // We found 0..end temps which are already on top of the stack. The remaining ones
                 // need to be pushed.
                 temps_to_push = &temps[end..temps.len()];
@@ -1022,14 +1048,15 @@ impl<'a> FunctionGenerator<'a> {
     fn abstract_flush_stack(&mut self, ctx: &BytecodeContext, top: usize, before: bool) {
         let fun_ctx = ctx.fun_ctx;
         while self.stack.len() > top {
-            let temp = self.stack.pop().unwrap();
-            if before && ctx.is_alive_before(temp)
-                || !before && ctx.is_alive_after(temp, &[], false)
-                || self.pinned.contains(&temp)
-                || !ctx.fun_ctx.is_droppable(temp)
+            let (temp, copied) = self.stack.pop().unwrap();
+            if !copied
+                && ((before && ctx.is_alive_before(temp))
+                    || (!before && ctx.is_alive_after(temp, &[], false))
+                    || self.pinned.contains(&temp)
+                    || !ctx.fun_ctx.is_droppable(temp))
             {
-                // Only need to save to a local if the temp is still used afterwards, is pinned,
-                // or if it is not droppable
+                // Only need to save to a local if the temp is: not copied from a local AND,
+                // still used afterwards, is pinned, or is not droppable.
                 let local = self.temp_to_local(fun_ctx, Some(ctx.attr_id), temp);
                 self.emit(FF::Bytecode::StLoc(local));
             } else {
@@ -1050,17 +1077,36 @@ impl<'a> FunctionGenerator<'a> {
 
     /// Push the result of an operation to the abstract stack.
     fn abstract_push_result(&mut self, ctx: &BytecodeContext, result: impl AsRef<[TempIndex]>) {
-        let mut flush_mark = usize::MAX;
-        for temp in result.as_ref() {
+        let pre_stack_len = self.stack.len();
+        let result = result.as_ref();
+        // `flush_mark` is used to find the lowest index in `result` from which we flush.
+        let mut flush_mark = result.len();
+        // Push the temps in `result` onto the stack.
+        // Make `flush_mark` the index of the earliest temp that is pinned.
+        for (i, temp) in result.iter().enumerate() {
             if self.pinned.contains(temp) {
                 // need to flush this right away and maintain a local for it
-                flush_mark = flush_mark.min(self.stack.len())
+                flush_mark = flush_mark.min(i);
             }
-            self.stack.push(*temp);
+            // The result was not copied from a local.
+            self.stack.push((*temp, false));
         }
-        if flush_mark != usize::MAX {
-            self.abstract_flush_stack_after(ctx, flush_mark)
+        // Check if there are any temps that could be flushed right away.
+        // We only need to check from below the `flush_mark` (everything at `flush_mark`
+        // and above will be flushed anyway). We work down the `result` and if we find a
+        // temp that doesn't need to be flushed, we stop. Because, that temp could get
+        // consumed by a subsequent instruction and may never need to be flushed.
+        if let Some(flush_writes) = ctx.get_writes_to_flush() {
+            for (i, temp) in result[..flush_mark].iter().enumerate().rev() {
+                if flush_writes.contains(temp) {
+                    flush_mark = i;
+                } else {
+                    break;
+                }
+            }
         }
+        let stack_flush_mark = pre_stack_len + flush_mark;
+        self.abstract_flush_stack_after(ctx, stack_flush_mark);
     }
 
     /// Pop a value from the abstract stack.
@@ -1203,5 +1249,14 @@ impl<'env> BytecodeContext<'env> {
         an.get_live_var_info_at(self.code_offset)
             .map(|a| a.before.contains_key(&temp))
             .unwrap_or(false)
+    }
+
+    /// Get the set of temps to flush if possible at the current code offset.
+    pub fn get_writes_to_flush(&self) -> Option<&BTreeSet<TempIndex>> {
+        self.fun_ctx
+            .fun
+            .get_annotations()
+            .get::<FlushWritesAnnotation>()
+            .and_then(|annotation| annotation.0.get(&self.code_offset))
     }
 }

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -25,6 +25,7 @@ use crate::{
         copy_propagation::CopyPropagation,
         dead_store_elimination::DeadStoreElimination,
         exit_state_analysis::ExitStateAnalysisProcessor,
+        flush_writes_processor::FlushWritesProcessor,
         livevar_analysis_processor::LiveVarAnalysisProcessor,
         reference_safety::{reference_safety_processor_v2, reference_safety_processor_v3},
         split_critical_edges_processor::SplitCriticalEdgesProcessor,
@@ -459,7 +460,14 @@ pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
 
     // Run live var analysis again because it could be invalidated by previous pipeline steps,
     // but it is needed by file format generator.
+    // There should be no "transforming" processors run after this point.
     pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::new(false)));
+
+    if options.experiment_on(Experiment::FLUSH_WRITES_OPTIMIZATION) {
+        // This processor only adds annotations, does not transform the bytecode.
+        pipeline.add_processor(Box::new(FlushWritesProcessor {}));
+    }
+
     pipeline
 }
 

--- a/third_party/move/move-compiler-v2/src/pipeline/flush_writes_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/flush_writes_processor.rs
@@ -1,0 +1,161 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements a processor that determines which writes to temporaries
+//! are better "flushed" right away by the file format code generator (as long
+//! it does not lead to potentially extra flushes). As such, these are suggestions,
+//! and can be safely ignored by the file format generator.
+//! Read on for more information on what "flushing" means.
+//!
+//! For this pass to be effective, it should be run after all the stackless-bytecode
+//! transformations are done, because the annotations produced by it are used
+//! (when available) by the file-format generator. Code transformations render
+//! previously computed annotations invalid.
+//!
+//! A pre-requisite for this pass is the live-variable analysis annotations.
+//!
+//! The file format generator can keep some writes to temporaries only on the stack,
+//! not writing it back to local memory (as a potential optimization).
+//! However, this is not always good, and this pass helps determine when a write to
+//! a temporary is better flushed right away.
+//! In the context of file format code generator, "flushed" means either store the
+//! value to a local (if used later) or pop if from the stack (if not used later).
+//!
+//! Currently, we suggest to flush those temps right away that are not used within
+//! the same basic block. However, more suggestions are theoretically possible based
+//! on additional analysis.
+
+use crate::pipeline::livevar_analysis_processor::{LiveVarAnnotation, LiveVarInfoAtCodeOffset};
+use itertools::Itertools;
+use move_binary_format::file_format::CodeOffset;
+use move_model::{ast::TempIndex, model::FunctionEnv};
+use move_stackless_bytecode::{
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::Bytecode,
+    stackless_control_flow_graph::StacklessControlFlowGraph,
+};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::RangeInclusive,
+};
+
+/// For a given code offset, tracks which temporaries written at the code offset
+/// should be flushed right away (popped from stack or saving to a local if used
+/// elsewhere) by the file format generator.
+#[derive(Clone)]
+pub struct FlushWritesAnnotation(pub BTreeMap<CodeOffset, BTreeSet<TempIndex>>);
+
+/// A processor for computing the `FlushWritesAnnotation`.
+pub struct FlushWritesProcessor {}
+
+impl FunctionTargetProcessor for FlushWritesProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv,
+        mut data: FunctionData,
+        _scc_opt: Option<&[FunctionEnv]>,
+    ) -> FunctionData {
+        if func_env.is_native() {
+            return data;
+        }
+        let target = FunctionTarget::new(func_env, &data);
+        let live_vars = target
+            .get_annotations()
+            .get::<LiveVarAnnotation>()
+            .expect("live variable annotation is a prerequisite");
+        let code = target.get_bytecode();
+        let cfg = StacklessControlFlowGraph::new_forward(code);
+        let mut unused: BTreeMap<CodeOffset, BTreeSet<TempIndex>> = BTreeMap::new();
+        for block_id in cfg.blocks() {
+            if let Some((lower, upper)) = cfg.instr_offset_bounds(block_id) {
+                extract_all_unused_writes_in_block(lower..=upper, code, live_vars, &mut unused);
+            }
+        }
+        data.annotations.set(FlushWritesAnnotation(unused), true);
+        data
+    }
+
+    fn name(&self) -> String {
+        "FlushWritesProcessor".to_string()
+    }
+}
+
+/// In the basic block given by `block_range` part of `code`, extract the writes
+/// to temporaries that are not used later the block.
+/// At the offset where the write happens, such temporaries are included, in `unused`.
+fn extract_all_unused_writes_in_block(
+    block_range: RangeInclusive<CodeOffset>,
+    code: &[Bytecode],
+    live_vars: &LiveVarAnnotation,
+    unused: &mut BTreeMap<CodeOffset, BTreeSet<TempIndex>>,
+) {
+    let upper = *block_range.end();
+    for offset in block_range {
+        let instr = &code[offset as usize];
+        // Only `Load` and `Call` instructions push results to the stack.
+        if matches!(instr, Bytecode::Load(..) | Bytecode::Call(..)) {
+            if let Some(live_info) = live_vars.get_live_var_info_at(offset) {
+                for dest in instr.dests() {
+                    if is_unused_in_block(dest, offset..=upper, live_info) {
+                        unused.entry(offset).or_default().insert(dest);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Is `temp` unused in `relevant_range`, based on `live_info` at the code offset
+/// where `temp` was written to?
+fn is_unused_in_block(
+    temp: TempIndex,
+    relevant_range: RangeInclusive<CodeOffset>,
+    live_info: &LiveVarInfoAtCodeOffset,
+) -> bool {
+    if let Some(info) = live_info.after.get(&temp) {
+        // Note: loop-carried uses are not considered here.
+        let all_usages_are_outside_block = info
+            .usage_offsets()
+            .iter()
+            .all(|usage| *usage <= *relevant_range.start() || *usage > *relevant_range.end());
+        all_usages_are_outside_block
+    } else {
+        // `temp` has no usages after `offset`.
+        true
+    }
+}
+
+impl FlushWritesProcessor {
+    /// Registers annotation formatter at the given function target.
+    /// Helps with testing and debugging.
+    pub fn register_formatters(target: &FunctionTarget) {
+        target.register_annotation_formatter(Box::new(format_flush_writes_annotation));
+    }
+}
+
+// ====================================================================
+// Formatting functionality for flush writes annotation
+
+pub fn format_flush_writes_annotation(
+    target: &FunctionTarget,
+    code_offset: CodeOffset,
+) -> Option<String> {
+    let FlushWritesAnnotation(map) = target.get_annotations().get::<FlushWritesAnnotation>()?;
+    let temps = map.get(&code_offset)?;
+    if temps.is_empty() {
+        return None;
+    }
+    let mut res = "flush: ".to_string();
+    res.push_str(
+        &temps
+            .iter()
+            .map(|t| {
+                let name = target.get_local_raw_name(*t);
+                format!("{}", name.display(target.symbol_pool()))
+            })
+            .join(", "),
+    );
+    Some(res)
+}

--- a/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/livevar_analysis_processor.rs
@@ -409,15 +409,17 @@ pub fn format_livevar_annotation(
 ) -> Option<String> {
     if let Some(LiveVarAnnotation(map)) = target.get_annotations().get::<LiveVarAnnotation>() {
         if let Some(map_at) = map.get(&code_offset) {
-            let mut res = map_at
-                .before
-                .keys()
-                .map(|idx| {
-                    let name = target.get_local_raw_name(*idx);
-                    format!("{}", name.display(target.symbol_pool()))
-                })
-                .join(", ");
-            res.insert_str(0, "live vars: ");
+            let mut res = "live vars: ".to_string();
+            res.push_str(
+                &map_at
+                    .before
+                    .keys()
+                    .map(|idx| {
+                        let name = target.get_local_raw_name(*idx);
+                        format!("{}", name.display(target.symbol_pool()))
+                    })
+                    .join(", "),
+            );
             return Some(res);
         }
     }

--- a/third_party/move/move-compiler-v2/src/pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/mod.rs
@@ -4,7 +4,7 @@
 
 use crate::pipeline::{
     avail_copies_analysis::AvailCopiesAnalysisProcessor,
-    exit_state_analysis::ExitStateAnalysisProcessor,
+    exit_state_analysis::ExitStateAnalysisProcessor, flush_writes_processor::FlushWritesProcessor,
     livevar_analysis_processor::LiveVarAnalysisProcessor,
     uninitialized_use_checker::UninitializedUseChecker,
     unreachable_code_analysis::UnreachableCodeProcessor, variable_coalescing::VariableCoalescing,
@@ -16,6 +16,7 @@ pub mod avail_copies_analysis;
 pub mod copy_propagation;
 pub mod dead_store_elimination;
 pub mod exit_state_analysis;
+pub mod flush_writes_processor;
 pub mod livevar_analysis_processor;
 pub mod reference_safety;
 pub mod split_critical_edges_processor;
@@ -31,6 +32,7 @@ pub mod visibility_checker;
 /// debugging.
 pub fn register_formatters(target: &FunctionTarget) {
     ExitStateAnalysisProcessor::register_formatters(target);
+    FlushWritesProcessor::register_formatters(target);
     LiveVarAnalysisProcessor::register_formatters(target);
     reference_safety::register_formatters(target);
     AvailCopiesAnalysisProcessor::register_formatters(target);

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance.opt.exp
@@ -28,9 +28,9 @@ B3:
 	11: MoveLoc[2](loc0: &bool)
 	12: MoveLoc[4](loc2: &bool)
 	13: Neq
-	14: MoveLoc[0](Arg0: bool)
-	15: Pack[0](Struct0)
-	16: Pop
+	14: Pop
+	15: MoveLoc[0](Arg0: bool)
+	16: Pack[0](Struct0)
 	17: Pop
 	18: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.opt.exp
@@ -144,36 +144,36 @@ test_constans() /* def_idx: 0 */ {
 B0:
 	0: LdTrue
 	1: Call u<bool>(bool): bool
-	2: LdFalse
-	3: Call u<bool>(bool): bool
-	4: LdU8(1)
-	5: Call u<u8>(u8): u8
-	6: LdU16(7086)
-	7: Call u<u16>(u16): u16
-	8: LdU32(14593408)
-	9: Call u<u32>(u32): u32
-	10: LdU64(51966)
-	11: Call u<u64>(u64): u64
-	12: LdU128(3735928559)
-	13: Call u<u128>(u128): u128
-	14: LdU256(301490978409967)
-	15: Call u<u256>(u256): u256
-	16: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66])
-	17: Call u<address>(address): address
-	18: LdConst[1](Vector(U64): [3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0])
-	19: Call u<vector<u64>>(vector<u64>): vector<u64>
-	20: LdConst[2](Vector(U8): [7, 72, 101, 108, 108, 111, 33, 10])
-	21: Call u<vector<u8>>(vector<u8>): vector<u8>
-	22: Pop
+	2: Pop
+	3: LdFalse
+	4: Call u<bool>(bool): bool
+	5: Pop
+	6: LdU8(1)
+	7: Call u<u8>(u8): u8
+	8: Pop
+	9: LdU16(7086)
+	10: Call u<u16>(u16): u16
+	11: Pop
+	12: LdU32(14593408)
+	13: Call u<u32>(u32): u32
+	14: Pop
+	15: LdU64(51966)
+	16: Call u<u64>(u64): u64
+	17: Pop
+	18: LdU128(3735928559)
+	19: Call u<u128>(u128): u128
+	20: Pop
+	21: LdU256(301490978409967)
+	22: Call u<u256>(u256): u256
 	23: Pop
-	24: Pop
-	25: Pop
+	24: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66])
+	25: Call u<address>(address): address
 	26: Pop
-	27: Pop
-	28: Pop
+	27: LdConst[1](Vector(U64): [3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0])
+	28: Call u<vector<u64>>(vector<u64>): vector<u64>
 	29: Pop
-	30: Pop
-	31: Pop
+	30: LdConst[2](Vector(U8): [7, 72, 101, 108, 108, 111, 33, 10])
+	31: Call u<vector<u8>>(vector<u8>): vector<u8>
 	32: Pop
 	33: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/framework_reduced_06.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/framework_reduced_06.exp
@@ -1,0 +1,83 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct S {
+	f: u64,
+	g: u64
+}
+
+bar(Arg0: &mut S): u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: MoveLoc[0](Arg0: &mut S)
+	2: Pop
+	3: LdU64(1)
+	4: Ret
+}
+f1(Arg0: &mut S, Arg1: u64, Arg2: address): &mut S * address * u64 /* def_idx: 1 */ {
+L3:	loc0: &mut S
+L4:	loc1: address
+L5:	loc2: u64
+B0:
+	0: MoveLoc[0](Arg0: &mut S)
+	1: StLoc[3](loc0: &mut S)
+	2: MoveLoc[2](Arg2: address)
+	3: StLoc[4](loc1: address)
+	4: MoveLoc[1](Arg1: u64)
+	5: StLoc[5](loc2: u64)
+	6: MoveLoc[3](loc0: &mut S)
+	7: MoveLoc[4](loc1: address)
+	8: MoveLoc[5](loc2: u64)
+	9: Ret
+}
+f2(Arg0: address, Arg1: &mut S, Arg2: address, Arg3: u64, Arg4: &mut S) /* def_idx: 2 */ {
+B0:
+	0: MoveLoc[1](Arg1: &mut S)
+	1: Pop
+	2: MoveLoc[4](Arg4: &mut S)
+	3: Pop
+	4: Ret
+}
+f3(Arg0: u64, Arg1: &u64) /* def_idx: 3 */ {
+B0:
+	0: MoveLoc[1](Arg1: &u64)
+	1: Pop
+	2: Ret
+}
+foo(Arg0: address, Arg1: &mut S, Arg2: &mut S): u64 /* def_idx: 4 */ {
+L3:	loc0: u64
+L4:	loc1: u64
+L5:	loc2: address
+L6:	loc3: &mut S
+L7:	loc4: &u64
+L8:	loc5: u64
+B0:
+	0: LdU64(1)
+	1: StLoc[3](loc0: u64)
+	2: MoveLoc[1](Arg1: &mut S)
+	3: MoveLoc[3](loc0: u64)
+	4: MoveLoc[0](Arg0: address)
+	5: Call f1(&mut S, u64, address): &mut S * address * u64
+	6: StLoc[4](loc1: u64)
+	7: StLoc[5](loc2: address)
+	8: StLoc[6](loc3: &mut S)
+	9: CopyLoc[5](loc2: address)
+	10: CopyLoc[6](loc3: &mut S)
+	11: MoveLoc[5](loc2: address)
+	12: CopyLoc[4](loc1: u64)
+	13: MoveLoc[2](Arg2: &mut S)
+	14: Call f2(address, &mut S, address, u64, &mut S)
+	15: MoveLoc[6](loc3: &mut S)
+	16: ImmBorrowField[0](S.g: u64)
+	17: StLoc[7](loc4: &u64)
+	18: CopyLoc[4](loc1: u64)
+	19: MoveLoc[7](loc4: &u64)
+	20: Call f3(u64, &u64)
+	21: MoveLoc[4](loc1: u64)
+	22: StLoc[8](loc5: u64)
+	23: MoveLoc[8](loc5: u64)
+	24: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/framework_reduced_06.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/framework_reduced_06.move
@@ -1,0 +1,26 @@
+module 0xc0ffee::m {
+    struct S {
+        f: u64,
+        g: u64,
+    }
+
+    fun bar(_r: &mut S): (u64, u64) {
+        (1, 1)
+    }
+
+    fun f2(_r1: address, _r2: &mut S, _r3: address, _r4: u64, _r5: &mut S) {}
+
+    fun f3(_r1: u64, _r2: &u64) {}
+
+    fun f1(a: &mut S, b: u64, c: address): (&mut S, address, u64) {
+        (a, c, b)
+    }
+
+    fun foo(a: address, ref1: &mut S, ref2: &mut S): u64 {
+        let (r1, b, c) = f1(ref1, 1, a);
+        f2(b, r1, b, c, ref2);
+        f3(c, &r1.g);
+        c
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/framework_reduced_06.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/framework_reduced_06.opt.exp
@@ -1,0 +1,66 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+struct S {
+	f: u64,
+	g: u64
+}
+
+bar(Arg0: &mut S): u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: MoveLoc[0](Arg0: &mut S)
+	2: Pop
+	3: LdU64(1)
+	4: Ret
+}
+f1(Arg0: &mut S, Arg1: u64, Arg2: address): &mut S * address * u64 /* def_idx: 1 */ {
+B0:
+	0: MoveLoc[0](Arg0: &mut S)
+	1: MoveLoc[2](Arg2: address)
+	2: MoveLoc[1](Arg1: u64)
+	3: Ret
+}
+f2(Arg0: address, Arg1: &mut S, Arg2: address, Arg3: u64, Arg4: &mut S) /* def_idx: 2 */ {
+B0:
+	0: MoveLoc[1](Arg1: &mut S)
+	1: Pop
+	2: MoveLoc[4](Arg4: &mut S)
+	3: Pop
+	4: Ret
+}
+f3(Arg0: u64, Arg1: &u64) /* def_idx: 3 */ {
+B0:
+	0: MoveLoc[1](Arg1: &u64)
+	1: Pop
+	2: Ret
+}
+foo(Arg0: address, Arg1: &mut S, Arg2: &mut S): u64 /* def_idx: 4 */ {
+L3:	loc0: u64
+L4:	loc1: &u64
+B0:
+	0: MoveLoc[1](Arg1: &mut S)
+	1: LdU64(1)
+	2: MoveLoc[0](Arg0: address)
+	3: Call f1(&mut S, u64, address): &mut S * address * u64
+	4: StLoc[3](loc0: u64)
+	5: StLoc[0](Arg0: address)
+	6: StLoc[1](Arg1: &mut S)
+	7: CopyLoc[0](Arg0: address)
+	8: CopyLoc[1](Arg1: &mut S)
+	9: MoveLoc[0](Arg0: address)
+	10: CopyLoc[3](loc0: u64)
+	11: MoveLoc[2](Arg2: &mut S)
+	12: Call f2(address, &mut S, address, u64, &mut S)
+	13: MoveLoc[1](Arg1: &mut S)
+	14: ImmBorrowField[0](S.g: u64)
+	15: StLoc[4](loc1: &u64)
+	16: CopyLoc[3](loc0: u64)
+	17: MoveLoc[4](loc1: &u64)
+	18: Call f3(u64, &u64)
+	19: MoveLoc[3](loc0: u64)
+	20: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.opt.exp
@@ -461,47 +461,44 @@ B10:
 }
 select_common_fields(Arg0: CommonFields): u64 /* def_idx: 9 */ {
 L1:	loc0: &CommonFields
-L2:	loc1: bool
+L2:	loc1: u64
 L3:	loc2: u64
-L4:	loc3: u64
 B0:
 	0: ImmBorrowLoc[0](Arg0: CommonFields)
 	1: ImmBorrowVariantField[3](Foo.x|Bar.x: u64)
 	2: ReadRef
-	3: ImmBorrowLoc[0](Arg0: CommonFields)
-	4: StLoc[1](loc0: &CommonFields)
-	5: CopyLoc[1](loc0: &CommonFields)
-	6: TestVariant[7](CommonFields/Foo)
-	7: StLoc[2](loc1: bool)
-	8: StLoc[3](loc2: u64)
-	9: MoveLoc[2](loc1: bool)
-	10: BrFalse(18)
+	3: StLoc[2](loc1: u64)
+	4: ImmBorrowLoc[0](Arg0: CommonFields)
+	5: StLoc[1](loc0: &CommonFields)
+	6: CopyLoc[1](loc0: &CommonFields)
+	7: TestVariant[7](CommonFields/Foo)
+	8: BrFalse(16)
 B1:
-	11: MoveLoc[1](loc0: &CommonFields)
-	12: Pop
-	13: MoveLoc[0](Arg0: CommonFields)
-	14: UnpackVariant[7](CommonFields/Foo)
-	15: StLoc[4](loc3: u64)
-	16: Pop
-	17: Branch(28)
+	9: MoveLoc[1](loc0: &CommonFields)
+	10: Pop
+	11: MoveLoc[0](Arg0: CommonFields)
+	12: UnpackVariant[7](CommonFields/Foo)
+	13: StLoc[3](loc2: u64)
+	14: Pop
+	15: Branch(26)
 B2:
-	18: MoveLoc[1](loc0: &CommonFields)
-	19: TestVariant[8](CommonFields/Bar)
-	20: BrFalse(26)
+	16: MoveLoc[1](loc0: &CommonFields)
+	17: TestVariant[8](CommonFields/Bar)
+	18: BrFalse(24)
 B3:
-	21: MoveLoc[0](Arg0: CommonFields)
-	22: UnpackVariant[8](CommonFields/Bar)
-	23: StLoc[4](loc3: u64)
-	24: Pop
-	25: Branch(28)
+	19: MoveLoc[0](Arg0: CommonFields)
+	20: UnpackVariant[8](CommonFields/Bar)
+	21: StLoc[3](loc2: u64)
+	22: Pop
+	23: Branch(26)
 B4:
-	26: LdU64(15621340914461310977)
-	27: Abort
+	24: LdU64(15621340914461310977)
+	25: Abort
 B5:
-	28: MoveLoc[3](loc2: u64)
-	29: MoveLoc[4](loc3: u64)
-	30: Add
-	31: Ret
+	26: MoveLoc[2](loc1: u64)
+	27: MoveLoc[3](loc2: u64)
+	28: Add
+	29: Ret
 }
 select_common_fields_different_offset(Arg0: CommonFieldsAtDifferentOffset): u64 /* def_idx: 10 */ {
 L1:	loc0: &CommonFieldsAtDifferentOffset

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/vector.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/vector.opt.exp
@@ -67,33 +67,33 @@ B0:
 	1: Ret
 }
 test_fold() /* def_idx: 2 */ {
-L0:	loc0: vector<u64>
-L1:	loc1: u64
+L0:	loc0: u64
+L1:	loc1: vector<u64>
 L2:	loc2: u64
 B0:
 	0: LdU64(0)
-	1: LdConst[1](Vector(U64): [1, 1, 0, 0, 0, 0, 0, 0, 0])
-	2: StLoc[0](loc0: vector<u64>)
-	3: MutBorrowLoc[0](loc0: vector<u64>)
-	4: Call 1vector::reverse<u64>(&mut vector<u64>)
-	5: StLoc[1](loc1: u64)
+	1: StLoc[0](loc0: u64)
+	2: LdConst[1](Vector(U64): [1, 1, 0, 0, 0, 0, 0, 0, 0])
+	3: StLoc[1](loc1: vector<u64>)
+	4: MutBorrowLoc[1](loc1: vector<u64>)
+	5: Call 1vector::reverse<u64>(&mut vector<u64>)
 B1:
-	6: ImmBorrowLoc[0](loc0: vector<u64>)
+	6: ImmBorrowLoc[1](loc1: vector<u64>)
 	7: Call 1vector::is_empty<u64>(&vector<u64>): bool
 	8: BrTrue(15)
 B2:
-	9: MutBorrowLoc[0](loc0: vector<u64>)
+	9: MutBorrowLoc[1](loc1: vector<u64>)
 	10: VecPopBack(5)
-	11: LdU64(0)
-	12: StLoc[1](loc1: u64)
-	13: Pop
+	11: Pop
+	12: LdU64(0)
+	13: StLoc[0](loc0: u64)
 	14: Branch(16)
 B3:
 	15: Branch(17)
 B4:
 	16: Branch(6)
 B5:
-	17: MoveLoc[1](loc1: u64)
+	17: MoveLoc[0](loc0: u64)
 	18: LdU64(0)
 	19: Eq
 	20: BrFalse(22)

--- a/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.move
@@ -1,0 +1,25 @@
+module 0xc0ffee::m {
+    fun foo(x: u64): (u64, u64) {
+        (x, x - 1)
+    }
+
+    public fun test1(x: u64) {
+        loop {
+            let y: u64;
+            (y, x) = foo(x);
+            if (y == 0) {
+                break;
+            }
+        }
+    }
+
+    public fun test2(x: u64) {
+        loop {
+            let y: u64;
+            (x, y) = foo(x);
+            if (y == 0) {
+                break;
+            }
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.off.exp
@@ -1,0 +1,59 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+foo(Arg0: u64): u64 * u64 /* def_idx: 0 */ {
+L1:	loc0: u64
+L2:	loc1: u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: MoveLoc[0](Arg0: u64)
+	3: LdU64(1)
+	4: Sub
+	5: StLoc[0](Arg0: u64)
+	6: MoveLoc[1](loc0: u64)
+	7: MoveLoc[0](Arg0: u64)
+	8: Ret
+}
+public test1(Arg0: u64) /* def_idx: 1 */ {
+L1:	loc0: u64
+L2:	loc1: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Call foo(u64): u64 * u64
+	2: LdU64(0)
+	3: StLoc[1](loc0: u64)
+	4: StLoc[0](Arg0: u64)
+	5: MoveLoc[1](loc0: u64)
+	6: Eq
+	7: BrFalse(9)
+B1:
+	8: Branch(10)
+B2:
+	9: Branch(0)
+B3:
+	10: Ret
+}
+public test2(Arg0: u64) /* def_idx: 2 */ {
+L1:	loc0: bool
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Call foo(u64): u64 * u64
+	2: LdU64(0)
+	3: Eq
+	4: StLoc[1](loc0: bool)
+	5: StLoc[0](Arg0: u64)
+	6: MoveLoc[1](loc0: bool)
+	7: BrFalse(9)
+B1:
+	8: Branch(10)
+B2:
+	9: Branch(0)
+B3:
+	10: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.on.exp
@@ -1,0 +1,138 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64): (u64, u64) {
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64
+     # live vars: $t0
+  0: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  1: $t3 := 1
+     # live vars: $t0, $t1, $t3
+  2: $t0 := -($t0, $t3)
+     # live vars: $t0, $t1
+  3: return ($t1, $t0)
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     # live vars: $t0
+  0: label L0
+     # flush: $t0
+     # live vars: $t0
+  1: ($t1, $t0) := m::foo($t0)
+     # live vars: $t0, $t1
+  2: $t3 := 0
+     # live vars: $t0, $t1, $t3
+  3: $t2 := ==($t1, $t3)
+     # live vars: $t0, $t2
+  4: if ($t2) goto 5 else goto 7
+     # live vars: $t0
+  5: label L2
+     # live vars:
+  6: goto 10
+     # live vars: $t0
+  7: label L3
+     # live vars: $t0
+  8: label L4
+     # live vars: $t0
+  9: goto 0
+     # live vars:
+ 10: label L1
+     # live vars:
+ 11: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     # live vars: $t0
+  0: label L0
+     # flush: $t0
+     # live vars: $t0
+  1: ($t0, $t1) := m::foo($t0)
+     # live vars: $t0, $t1
+  2: $t3 := 0
+     # live vars: $t0, $t1, $t3
+  3: $t2 := ==($t1, $t3)
+     # live vars: $t0, $t2
+  4: if ($t2) goto 5 else goto 7
+     # live vars: $t0
+  5: label L2
+     # live vars:
+  6: goto 10
+     # live vars: $t0
+  7: label L3
+     # live vars: $t0
+  8: label L4
+     # live vars: $t0
+  9: goto 0
+     # live vars:
+ 10: label L1
+     # live vars:
+ 11: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+foo(Arg0: u64): u64 * u64 /* def_idx: 0 */ {
+L1:	loc0: u64
+L2:	loc1: u64
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: u64)
+	2: MoveLoc[0](Arg0: u64)
+	3: LdU64(1)
+	4: Sub
+	5: StLoc[0](Arg0: u64)
+	6: MoveLoc[1](loc0: u64)
+	7: MoveLoc[0](Arg0: u64)
+	8: Ret
+}
+public test1(Arg0: u64) /* def_idx: 1 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Call foo(u64): u64 * u64
+	2: StLoc[0](Arg0: u64)
+	3: LdU64(0)
+	4: Eq
+	5: BrFalse(7)
+B1:
+	6: Branch(8)
+B2:
+	7: Branch(0)
+B3:
+	8: Ret
+}
+public test2(Arg0: u64) /* def_idx: 2 */ {
+L1:	loc0: bool
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Call foo(u64): u64 * u64
+	2: LdU64(0)
+	3: Eq
+	4: StLoc[1](loc0: bool)
+	5: StLoc[0](Arg0: u64)
+	6: MoveLoc[1](loc0: bool)
+	7: BrFalse(9)
+B1:
+	8: Branch(10)
+B2:
+	9: Branch(0)
+B3:
+	10: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.move
@@ -1,0 +1,26 @@
+module 0xc0ffee::m {
+    fun one(): u64 {
+        1
+    }
+
+    public fun test1(): (u64, u64) {
+        let _x = one();
+        let y = one();
+        let z = one();
+        (y, z)
+    }
+
+    public fun test2(): (u64, u64) {
+        let x = one();
+        let _y = one();
+        let z = one();
+        (x, z)
+    }
+
+    public fun test3(): (u64, u64) {
+        let x = one();
+        let _y = one();
+        let z = one();
+        (z, x)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.off.exp
@@ -1,0 +1,53 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one(): u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test1(): u64 * u64 /* def_idx: 1 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: Call one(): u64
+	2: Call one(): u64
+	3: StLoc[0](loc0: u64)
+	4: StLoc[1](loc1: u64)
+	5: Pop
+	6: MoveLoc[1](loc1: u64)
+	7: MoveLoc[0](loc0: u64)
+	8: Ret
+}
+public test2(): u64 * u64 /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: Call one(): u64
+	2: Call one(): u64
+	3: StLoc[0](loc0: u64)
+	4: Pop
+	5: MoveLoc[0](loc0: u64)
+	6: Ret
+}
+public test3(): u64 * u64 /* def_idx: 3 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: Call one(): u64
+	2: Call one(): u64
+	3: StLoc[0](loc0: u64)
+	4: Pop
+	5: StLoc[1](loc1: u64)
+	6: MoveLoc[0](loc0: u64)
+	7: MoveLoc[1](loc1: u64)
+	8: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.on.exp
@@ -1,0 +1,111 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1(): (u64, u64) {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # flush: $t2
+     # live vars:
+  0: $t2 := m::one()
+     # live vars:
+  1: $t3 := m::one()
+     # live vars: $t3
+  2: $t4 := m::one()
+     # live vars: $t3, $t4
+  3: return ($t3, $t4)
+}
+
+
+[variant baseline]
+public fun m::test2(): (u64, u64) {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t2 := m::one()
+     # flush: $t3
+     # live vars: $t2
+  1: $t3 := m::one()
+     # live vars: $t2
+  2: $t4 := m::one()
+     # live vars: $t2, $t4
+  3: return ($t2, $t4)
+}
+
+
+[variant baseline]
+public fun m::test3(): (u64, u64) {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t2 := m::one()
+     # flush: $t3
+     # live vars: $t2
+  1: $t3 := m::one()
+     # live vars: $t2
+  2: $t4 := m::one()
+     # live vars: $t2, $t4
+  3: return ($t4, $t2)
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one(): u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test1(): u64 * u64 /* def_idx: 1 */ {
+B0:
+	0: Call one(): u64
+	1: Pop
+	2: Call one(): u64
+	3: Call one(): u64
+	4: Ret
+}
+public test2(): u64 * u64 /* def_idx: 2 */ {
+B0:
+	0: Call one(): u64
+	1: Call one(): u64
+	2: Pop
+	3: Call one(): u64
+	4: Ret
+}
+public test3(): u64 * u64 /* def_idx: 3 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: Call one(): u64
+	2: Pop
+	3: Call one(): u64
+	4: StLoc[0](loc0: u64)
+	5: StLoc[1](loc1: u64)
+	6: MoveLoc[0](loc0: u64)
+	7: MoveLoc[1](loc1: u64)
+	8: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.move
@@ -1,0 +1,18 @@
+module 0xc0ffee::m {
+    fun one(): u64 {
+        1
+    }
+
+    fun bar() {}
+
+    public fun test(): (u64, u64) {
+        let x = one();
+        let y = one();
+        let z = one();
+        if (y == 0) {
+            bar();
+        };
+        (x, z)
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.off.exp
@@ -1,0 +1,44 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+bar() /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+one(): u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test(): u64 * u64 /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+L3:	loc3: bool
+L4:	loc4: u64
+B0:
+	0: Call one(): u64
+	1: Call one(): u64
+	2: Call one(): u64
+	3: LdU64(0)
+	4: StLoc[0](loc0: u64)
+	5: StLoc[1](loc1: u64)
+	6: MoveLoc[0](loc0: u64)
+	7: Eq
+	8: StLoc[3](loc3: bool)
+	9: StLoc[4](loc4: u64)
+	10: MoveLoc[3](loc3: bool)
+	11: BrFalse(14)
+B1:
+	12: Call bar()
+	13: Branch(14)
+B2:
+	14: MoveLoc[4](loc4: u64)
+	15: MoveLoc[1](loc1: u64)
+	16: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.on.exp
@@ -1,0 +1,93 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::bar() {
+     # live vars:
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test(): (u64, u64) {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     # flush: $t2
+     # live vars:
+  0: $t2 := m::one()
+     # live vars: $t2
+  1: $t3 := m::one()
+     # flush: $t4
+     # live vars: $t2, $t3
+  2: $t4 := m::one()
+     # live vars: $t2, $t3, $t4
+  3: $t6 := 0
+     # live vars: $t2, $t3, $t4, $t6
+  4: $t5 := ==($t3, $t6)
+     # live vars: $t2, $t4, $t5
+  5: if ($t5) goto 6 else goto 9
+     # live vars: $t2, $t4
+  6: label L0
+     # live vars: $t2, $t4
+  7: m::bar()
+     # live vars: $t2, $t4
+  8: goto 10
+     # live vars: $t2, $t4
+  9: label L1
+     # live vars: $t2, $t4
+ 10: label L2
+     # live vars: $t2, $t4
+ 11: return ($t2, $t4)
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+bar() /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+one(): u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test(): u64 * u64 /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: StLoc[0](loc0: u64)
+	2: Call one(): u64
+	3: Call one(): u64
+	4: StLoc[1](loc1: u64)
+	5: LdU64(0)
+	6: Eq
+	7: BrFalse(10)
+B1:
+	8: Call bar()
+	9: Branch(10)
+B2:
+	10: MoveLoc[0](loc0: u64)
+	11: MoveLoc[1](loc1: u64)
+	12: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.move
@@ -1,0 +1,21 @@
+module 0xc0ffee::m {
+    fun foo(): (u64, u64, u64) {
+        (1, 2, 3)
+    }
+
+    fun bar() {}
+
+    public fun test1() {
+        let (x, y, z) = foo();
+        if (x == 0) {
+            bar();
+        };
+        if (y == 0) {
+            bar();
+        };
+        if (z == 0) {
+            bar();
+        };
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.off.exp
@@ -1,0 +1,55 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+bar() /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+foo(): u64 * u64 * u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(2)
+	2: LdU64(3)
+	3: Ret
+}
+public test1() /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+L3:	loc3: u64
+B0:
+	0: Call foo(): u64 * u64 * u64
+	1: LdU64(0)
+	2: StLoc[0](loc0: u64)
+	3: StLoc[1](loc1: u64)
+	4: StLoc[2](loc2: u64)
+	5: MoveLoc[0](loc0: u64)
+	6: Eq
+	7: BrFalse(10)
+B1:
+	8: Call bar()
+	9: Branch(10)
+B2:
+	10: MoveLoc[2](loc2: u64)
+	11: LdU64(0)
+	12: Eq
+	13: BrFalse(16)
+B3:
+	14: Call bar()
+	15: Branch(16)
+B4:
+	16: MoveLoc[1](loc1: u64)
+	17: LdU64(0)
+	18: Eq
+	19: BrFalse(22)
+B5:
+	20: Call bar()
+	21: Branch(22)
+B6:
+	22: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.on.exp
@@ -1,0 +1,143 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::bar() {
+     # live vars:
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::foo(): (u64, u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: $t2 := 3
+     # live vars: $t0, $t1, $t2
+  3: return ($t0, $t1, $t2)
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: bool [unused]
+     var $t6: u64 [unused]
+     var $t7: bool [unused]
+     var $t8: u64 [unused]
+     # flush: $t1, $t2
+     # live vars:
+  0: ($t0, $t1, $t2) := m::foo()
+     # live vars: $t0, $t1, $t2
+  1: $t4 := 0
+     # live vars: $t0, $t1, $t2, $t4
+  2: $t3 := ==($t0, $t4)
+     # live vars: $t1, $t2, $t3
+  3: if ($t3) goto 4 else goto 7
+     # live vars: $t1, $t2
+  4: label L0
+     # live vars: $t1, $t2
+  5: m::bar()
+     # live vars: $t1, $t2
+  6: goto 8
+     # live vars: $t1, $t2
+  7: label L1
+     # live vars: $t1, $t2
+  8: label L2
+     # live vars: $t1, $t2
+  9: $t0 := 0
+     # live vars: $t0, $t1, $t2
+ 10: $t3 := ==($t1, $t0)
+     # live vars: $t2, $t3
+ 11: if ($t3) goto 12 else goto 15
+     # live vars: $t2
+ 12: label L3
+     # live vars: $t2
+ 13: m::bar()
+     # live vars: $t2
+ 14: goto 16
+     # live vars: $t2
+ 15: label L4
+     # live vars: $t2
+ 16: label L5
+     # live vars: $t2
+ 17: $t0 := 0
+     # live vars: $t0, $t2
+ 18: $t3 := ==($t2, $t0)
+     # live vars: $t3
+ 19: if ($t3) goto 20 else goto 23
+     # live vars:
+ 20: label L6
+     # live vars:
+ 21: m::bar()
+     # live vars:
+ 22: goto 24
+     # live vars:
+ 23: label L7
+     # live vars:
+ 24: label L8
+     # live vars:
+ 25: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+bar() /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+foo(): u64 * u64 * u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(2)
+	2: LdU64(3)
+	3: Ret
+}
+public test1() /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+B0:
+	0: Call foo(): u64 * u64 * u64
+	1: StLoc[0](loc0: u64)
+	2: StLoc[1](loc1: u64)
+	3: LdU64(0)
+	4: Eq
+	5: BrFalse(8)
+B1:
+	6: Call bar()
+	7: Branch(8)
+B2:
+	8: MoveLoc[1](loc1: u64)
+	9: LdU64(0)
+	10: Eq
+	11: BrFalse(14)
+B3:
+	12: Call bar()
+	13: Branch(14)
+B4:
+	14: MoveLoc[0](loc0: u64)
+	15: LdU64(0)
+	16: Eq
+	17: BrFalse(20)
+B5:
+	18: Call bar()
+	19: Branch(20)
+B6:
+	20: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -482,6 +482,35 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
                 FILE_FORMAT_STAGE,
             ]),
         },
+        // Flush writes processor tests
+        TestConfig {
+            name: "flush-writes-on",
+            runner: |p| run_test(p, get_config_by_name("flush-writes-on")),
+            include: vec!["/flush-writes/"],
+            exclude: vec![],
+            exp_suffix: Some("on.exp"),
+            options: opts
+                .clone()
+                .set_experiment(Experiment::FLUSH_WRITES_OPTIMIZATION, true),
+            stop_after: StopAfter::FileFormat,
+            dump_ast: DumpLevel::None,
+            dump_bytecode: DumpLevel::AllStages,
+            dump_bytecode_filter: Some(vec!["FlushWritesProcessor", FILE_FORMAT_STAGE]),
+        },
+        TestConfig {
+            name: "flush-writes-off",
+            runner: |p| run_test(p, get_config_by_name("flush-writes-off")),
+            include: vec!["/flush-writes/"],
+            exclude: vec![],
+            exp_suffix: Some("off.exp"),
+            options: opts
+                .clone()
+                .set_experiment(Experiment::FLUSH_WRITES_OPTIMIZATION, false),
+            stop_after: StopAfter::FileFormat,
+            dump_ast: DumpLevel::None,
+            dump_bytecode: DumpLevel::AllStages,
+            dump_bytecode_filter: Some(vec![FILE_FORMAT_STAGE]),
+        },
         // Unreachable code remover
         TestConfig {
             name: "unreachable-code",

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.exp
@@ -93,16 +93,13 @@ module c0ffee.m {
 
 
 public test(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: MoveLoc[0](Arg0: u64)
 	2: Add
-	3: LdU64(2)
-	4: StLoc[1](loc0: u64)
-	5: Pop
-	6: MoveLoc[1](loc0: u64)
-	7: Ret
+	3: Pop
+	4: LdU64(2)
+	5: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.opt.exp
@@ -82,16 +82,13 @@ module c0ffee.m {
 
 
 public test(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: MoveLoc[0](Arg0: u64)
 	2: Add
-	3: LdU64(2)
-	4: StLoc[1](loc0: u64)
-	5: Pop
-	6: MoveLoc[1](loc0: u64)
-	7: Ret
+	3: Pop
+	4: LdU64(2)
+	5: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.exp
@@ -119,13 +119,11 @@ B0:
 	2: StLoc[0](loc0: u64)
 	3: CopyLoc[0](loc0: u64)
 	4: Add
-	5: CopyLoc[0](loc0: u64)
-	6: MoveLoc[0](loc0: u64)
-	7: Add
-	8: StLoc[0](loc0: u64)
-	9: Pop
-	10: MoveLoc[0](loc0: u64)
-	11: Ret
+	5: Pop
+	6: CopyLoc[0](loc0: u64)
+	7: MoveLoc[0](loc0: u64)
+	8: Add
+	9: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.opt.exp
@@ -99,16 +99,13 @@ module c0ffee.m {
 
 
 test(): u64 /* def_idx: 0 */ {
-L0:	loc0: u64
 B0:
 	0: LdU64(1)
 	1: LdU64(2)
 	2: Add
-	3: LdU64(4)
-	4: StLoc[0](loc0: u64)
-	5: Pop
-	6: MoveLoc[0](loc0: u64)
-	7: Ret
+	3: Pop
+	4: LdU64(4)
+	5: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.opt.exp
@@ -99,16 +99,13 @@ module c0ffee.m {
 
 
 test(): u64 /* def_idx: 0 */ {
-L0:	loc0: u64
 B0:
 	0: LdU64(1)
 	1: LdU64(1)
 	2: Add
-	3: LdU64(2)
-	4: StLoc[0](loc0: u64)
-	5: Pop
-	6: MoveLoc[0](loc0: u64)
-	7: Ret
+	3: Pop
+	4: LdU64(2)
+	5: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.exp
@@ -199,28 +199,28 @@ L2:	loc1: u64
 L3:	loc2: u64
 B0:
 	0: LdU64(0)
-	1: LdU64(0)
-	2: StLoc[1](loc0: u64)
+	1: StLoc[1](loc0: u64)
+	2: LdU64(0)
 	3: StLoc[2](loc1: u64)
 B1:
-	4: CopyLoc[1](loc0: u64)
+	4: CopyLoc[2](loc1: u64)
 	5: LdU64(10)
 	6: Lt
 	7: BrFalse(15)
 B2:
 	8: CopyLoc[0](Arg0: u64)
-	9: StLoc[2](loc1: u64)
-	10: MoveLoc[1](loc0: u64)
+	9: StLoc[1](loc0: u64)
+	10: MoveLoc[2](loc1: u64)
 	11: LdU64(1)
 	12: Add
-	13: StLoc[1](loc0: u64)
+	13: StLoc[2](loc1: u64)
 	14: Branch(16)
 B3:
 	15: Branch(17)
 B4:
 	16: Branch(4)
 B5:
-	17: MoveLoc[2](loc1: u64)
+	17: MoveLoc[1](loc0: u64)
 	18: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.opt.exp
@@ -199,28 +199,28 @@ L2:	loc1: u64
 L3:	loc2: u64
 B0:
 	0: LdU64(0)
-	1: LdU64(0)
-	2: StLoc[1](loc0: u64)
+	1: StLoc[1](loc0: u64)
+	2: LdU64(0)
 	3: StLoc[2](loc1: u64)
 B1:
-	4: CopyLoc[1](loc0: u64)
+	4: CopyLoc[2](loc1: u64)
 	5: LdU64(10)
 	6: Lt
 	7: BrFalse(15)
 B2:
 	8: CopyLoc[0](Arg0: u64)
-	9: StLoc[2](loc1: u64)
-	10: MoveLoc[1](loc0: u64)
+	9: StLoc[1](loc0: u64)
+	10: MoveLoc[2](loc1: u64)
 	11: LdU64(1)
 	12: Add
-	13: StLoc[1](loc0: u64)
+	13: StLoc[2](loc1: u64)
 	14: Branch(16)
 B3:
 	15: Branch(17)
 B4:
 	16: Branch(4)
 B5:
-	17: MoveLoc[2](loc1: u64)
+	17: MoveLoc[1](loc0: u64)
 	18: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
@@ -133,10 +133,10 @@ B0:
 	0: LdU64(1)
 	1: LdU64(1)
 	2: Add
-	3: LdU64(2)
-	4: LdU64(1)
-	5: Add
-	6: Pop
+	3: Pop
+	4: LdU64(2)
+	5: LdU64(1)
+	6: Add
 	7: Pop
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.opt.exp
@@ -133,10 +133,10 @@ B0:
 	0: LdU64(1)
 	1: LdU64(1)
 	2: Add
-	3: LdU64(2)
-	4: LdU64(1)
-	5: Add
-	6: Pop
+	3: Pop
+	4: LdU64(2)
+	5: LdU64(1)
+	6: Add
 	7: Pop
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
@@ -133,10 +133,10 @@ B0:
 	0: LdU32(1)
 	1: LdU32(1)
 	2: Add
-	3: LdU64(2)
-	4: LdU64(1)
-	5: Add
-	6: Pop
+	3: Pop
+	4: LdU64(2)
+	5: LdU64(1)
+	6: Add
 	7: Pop
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.opt.exp
@@ -133,10 +133,10 @@ B0:
 	0: LdU32(1)
 	1: LdU32(1)
 	2: Add
-	3: LdU64(2)
-	4: LdU64(1)
-	5: Add
-	6: Pop
+	3: Pop
+	4: LdU64(2)
+	5: LdU64(1)
+	6: Add
 	7: Pop
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.exp
@@ -455,26 +455,26 @@ L1:	loc1: u64
 L2:	loc2: u64
 B0:
 	0: LdU64(0)
-	1: LdU64(1)
-	2: StLoc[0](loc0: u64)
+	1: StLoc[0](loc0: u64)
+	2: LdU64(1)
 	3: StLoc[1](loc1: u64)
 B1:
-	4: CopyLoc[1](loc1: u64)
+	4: CopyLoc[0](loc0: u64)
 	5: LdU64(42)
 	6: Lt
 	7: BrFalse(13)
 B2:
-	8: MoveLoc[1](loc1: u64)
+	8: MoveLoc[0](loc0: u64)
 	9: LdU64(1)
 	10: Add
-	11: StLoc[1](loc1: u64)
+	11: StLoc[0](loc0: u64)
 	12: Branch(14)
 B3:
 	13: Branch(15)
 B4:
 	14: Branch(4)
 B5:
-	15: MoveLoc[0](loc0: u64)
+	15: MoveLoc[1](loc1: u64)
 	16: Ret
 }
 public test4(Arg0: u64): u64 /* def_idx: 3 */ {

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.opt.exp
@@ -455,26 +455,26 @@ L1:	loc1: u64
 L2:	loc2: u64
 B0:
 	0: LdU64(0)
-	1: LdU64(1)
-	2: StLoc[0](loc0: u64)
+	1: StLoc[0](loc0: u64)
+	2: LdU64(1)
 	3: StLoc[1](loc1: u64)
 B1:
-	4: CopyLoc[1](loc1: u64)
+	4: CopyLoc[0](loc0: u64)
 	5: LdU64(42)
 	6: Lt
 	7: BrFalse(13)
 B2:
-	8: MoveLoc[1](loc1: u64)
+	8: MoveLoc[0](loc0: u64)
 	9: LdU64(1)
 	10: Add
-	11: StLoc[1](loc1: u64)
+	11: StLoc[0](loc0: u64)
 	12: Branch(14)
 B3:
 	13: Branch(15)
 B4:
 	14: Branch(4)
 B5:
-	15: MoveLoc[0](loc0: u64)
+	15: MoveLoc[1](loc1: u64)
 	16: Ret
 }
 public test4(Arg0: u64): u64 /* def_idx: 3 */ {

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.exp
@@ -125,7 +125,6 @@ test(Arg0: u64): bool /* def_idx: 0 */ {
 L1:	loc0: u64
 L2:	loc1: u64
 L3:	loc2: u64
-L4:	loc3: bool
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)
@@ -134,13 +133,11 @@ B0:
 	4: MoveLoc[0](Arg0: u64)
 	5: LdU64(1)
 	6: Add
-	7: MoveLoc[1](loc0: u64)
-	8: MoveLoc[2](loc1: u64)
-	9: Eq
-	10: StLoc[4](loc3: bool)
-	11: Pop
-	12: MoveLoc[4](loc3: bool)
-	13: Ret
+	7: Pop
+	8: MoveLoc[1](loc0: u64)
+	9: MoveLoc[2](loc1: u64)
+	10: Eq
+	11: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.opt.exp
@@ -125,7 +125,6 @@ test(Arg0: u64): bool /* def_idx: 0 */ {
 L1:	loc0: u64
 L2:	loc1: u64
 L3:	loc2: u64
-L4:	loc3: bool
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)
@@ -134,13 +133,11 @@ B0:
 	4: MoveLoc[0](Arg0: u64)
 	5: LdU64(1)
 	6: Add
-	7: MoveLoc[1](loc0: u64)
-	8: MoveLoc[2](loc1: u64)
-	9: Eq
-	10: StLoc[4](loc3: bool)
-	11: Pop
-	12: MoveLoc[4](loc3: bool)
-	13: Ret
+	7: Pop
+	8: MoveLoc[1](loc0: u64)
+	9: MoveLoc[2](loc1: u64)
+	10: Eq
+	11: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.exp
@@ -125,7 +125,6 @@ test(Arg0: u64): bool /* def_idx: 0 */ {
 L1:	loc0: u64
 L2:	loc1: u64
 L3:	loc2: u64
-L4:	loc3: bool
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)
@@ -134,13 +133,11 @@ B0:
 	4: MoveLoc[0](Arg0: u64)
 	5: LdU64(1)
 	6: Add
-	7: MoveLoc[1](loc0: u64)
-	8: MoveLoc[2](loc1: u64)
-	9: Eq
-	10: StLoc[4](loc3: bool)
-	11: Pop
-	12: MoveLoc[4](loc3: bool)
-	13: Ret
+	7: Pop
+	8: MoveLoc[1](loc0: u64)
+	9: MoveLoc[2](loc1: u64)
+	10: Eq
+	11: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.opt.exp
@@ -125,7 +125,6 @@ test(Arg0: u64): bool /* def_idx: 0 */ {
 L1:	loc0: u64
 L2:	loc1: u64
 L3:	loc2: u64
-L4:	loc3: bool
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)
@@ -134,13 +133,11 @@ B0:
 	4: MoveLoc[0](Arg0: u64)
 	5: LdU64(1)
 	6: Add
-	7: MoveLoc[1](loc0: u64)
-	8: MoveLoc[2](loc1: u64)
-	9: Eq
-	10: StLoc[4](loc3: bool)
-	11: Pop
-	12: MoveLoc[4](loc3: bool)
-	13: Ret
+	7: Pop
+	8: MoveLoc[1](loc0: u64)
+	9: MoveLoc[2](loc1: u64)
+	10: Eq
+	11: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.exp
@@ -122,13 +122,11 @@ B0:
 	4: MoveLoc[0](Arg0: u64)
 	5: LdU64(1)
 	6: Add
-	7: MoveLoc[2](loc1: u64)
-	8: MoveLoc[1](loc0: u64)
-	9: Add
-	10: StLoc[1](loc0: u64)
-	11: Pop
-	12: MoveLoc[1](loc0: u64)
-	13: Ret
+	7: Pop
+	8: MoveLoc[2](loc1: u64)
+	9: MoveLoc[1](loc0: u64)
+	10: Add
+	11: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.opt.exp
@@ -122,13 +122,11 @@ B0:
 	4: MoveLoc[0](Arg0: u64)
 	5: LdU64(1)
 	6: Add
-	7: MoveLoc[2](loc1: u64)
-	8: MoveLoc[1](loc0: u64)
-	9: Add
-	10: StLoc[1](loc0: u64)
-	11: Pop
-	12: MoveLoc[1](loc0: u64)
-	13: Ret
+	7: Pop
+	8: MoveLoc[2](loc1: u64)
+	9: MoveLoc[1](loc0: u64)
+	10: Add
+	11: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.optimize-no-simplify.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.optimize-no-simplify.exp
@@ -23,12 +23,9 @@ comparison between v1 and v2 failed:
 = 	4: CopyLoc[1](loc1: &mut u64)
 = 	5: Call id_mut<u64>(&mut u64): &mut u64
 = 	6: ReadRef
-- 	7: Pop
-- 	8: MoveLoc[1](loc1: &mut u64)
-- 	9: ReadRef
-+ 	7: MoveLoc[1](loc1: &mut u64)
-+ 	8: ReadRef
-+ 	9: Pop
+= 	7: Pop
+= 	8: MoveLoc[1](loc1: &mut u64)
+= 	9: ReadRef
 = 	10: Pop
 = 	11: Ret
 = }

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.optimize.exp
@@ -23,12 +23,9 @@ comparison between v1 and v2 failed:
 = 	4: CopyLoc[1](loc1: &mut u64)
 = 	5: Call id_mut<u64>(&mut u64): &mut u64
 = 	6: ReadRef
-- 	7: Pop
-- 	8: MoveLoc[1](loc1: &mut u64)
-- 	9: ReadRef
-+ 	7: MoveLoc[1](loc1: &mut u64)
-+ 	8: ReadRef
-+ 	9: Pop
+= 	7: Pop
+= 	8: MoveLoc[1](loc1: &mut u64)
+= 	9: ReadRef
 = 	10: Pop
 = 	11: Ret
 = }

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
@@ -67,11 +67,11 @@ impl SpecBlockId {
 /// The kind of an assignment in the bytecode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum AssignKind {
-    /// The assign copies the lhs value.
+    /// The assign copies the rhs value.
     Copy,
-    /// The assign moves the lhs value.
+    /// The assign moves the rhs value.
     Move,
-    /// The assign stores the lhs value.
+    /// The assign stores the rhs value.
     // TODO: figure out why we can't treat this as either copy or move. The lifetime analysis
     // currently makes a difference of this case. It originates from stack code where Copy
     // and Move push on the stack and Store pops.
@@ -180,7 +180,7 @@ pub enum Operation {
     Release,
 
     ReadRef,
-    WriteRef,
+    WriteRef, // arguments: (reference, value)
     FreezeRef(/*explicit*/ bool),
     Vector,
 

--- a/third_party/move/move-model/bytecode/src/stackless_control_flow_graph.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_control_flow_graph.rs
@@ -234,6 +234,13 @@ impl StacklessControlFlowGraph {
         }
     }
 
+    pub fn instr_offset_bounds(&self, block_id: BlockId) -> Option<(CodeOffset, CodeOffset)> {
+        match self.blocks[&block_id].content {
+            BlockContent::Basic { lower, upper } => Some((lower, upper)),
+            BlockContent::Dummy => None,
+        }
+    }
+
     pub fn num_blocks(&self) -> u16 {
         self.blocks.len() as u16
     }

--- a/third_party/move/move-prover/tests/sources/functional/enum_abort.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/enum_abort.v2_exp
@@ -99,6 +99,7 @@ error: abort not covered by any of the `aborts_if` clauses
     =     at tests/sources/functional/enum_abort.move:122: test_match_abort
     =         <redacted> = <redacted>
     =         _x = <redacted>
+    =         <redacted> = <redacted>
     =     at tests/sources/functional/enum_abort.move:122: test_match_abort
     =         _z = <redacted>
     =         <redacted> = <redacted>


### PR DESCRIPTION
## Description

This is a PR split off from https://github.com/aptos-labs/aptos-core/pull/14249. As such, you may notice that you are reviewing some of the same code, I apologize for this. I have taken care to address all the reviews left on relevant files in the original PR.

This PR contains two optimizations:
1. Computing flushing writes hints: this is a stackless bytecode pass that computes which writes should be flushed right away (see the processor module documentation for more details) by the file format generator, because they known to be flushed later anyway.
2. During file format generation, keeping track of which values on the stack were copied from locals, so that they do not have to be saved back to locals.

## Type of Change
- [x] Performance improvement

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## How Has This Been Tested?
* All existing tests pass, and when updating baselines, code generated is either better or same.
* See newly added tests under `tests/flush-writes` folder. If you see the `.on.exp` vs. `.off.exp`, it shows the difference between flush writes optimization being on vs. off (all cases are better or same).

## Key Areas to Review
Correctness of the optimizations.