### PR TITLE
[move][aptos-vm] Addressing comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "ambassador"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b27ba24e4d8a188489d5a03c7fabc167a60809a383cdb4d15feb37479cd2a48"
+dependencies = [
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4439,6 +4451,7 @@ dependencies = [
 name = "aptos-vm-types"
 version = "0.0.1"
 dependencies = [
+ "ambassador",
  "anyhow",
  "aptos-aggregator",
  "aptos-gas-algebra",
@@ -11450,6 +11463,7 @@ dependencies = [
 name = "move-vm-runtime"
 version = "0.1.0"
 dependencies = [
+ "ambassador",
  "anyhow",
  "better_any",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -466,6 +466,7 @@ atty = "0.2.14"
 nalgebra = "0.32"
 float-cmp = "0.9.0"
 again = "0.1.2"
+ambassador = "0.4.1"
 anyhow = "1.0.71"
 anstyle = "1.0.1"
 arbitrary = { version = "1.3.2", features = ["derive"] }

--- a/aptos-move/aptos-debugger/src/aptos_debugger.rs
+++ b/aptos-move/aptos-debugger/src/aptos_debugger.rs
@@ -120,12 +120,11 @@ impl AptosDebugger {
 
         let vm = AptosVM::new(&state_view);
         let resolver = state_view.as_move_resolver();
-        let module_and_script_storage = vm.as_aptos_code_storage(&state_view);
+        let code_storage = vm.as_aptos_code_storage(&state_view);
 
         let (status, output, gas_profiler) = vm.execute_user_transaction_with_modified_gas_meter(
             &resolver,
-            &module_and_script_storage,
-            &module_and_script_storage,
+            &code_storage,
             &txn,
             &log_context,
             |gas_meter| {

--- a/aptos-move/aptos-gas-profiling/src/profiler.rs
+++ b/aptos-move/aptos-gas-profiling/src/profiler.rs
@@ -11,7 +11,8 @@ use aptos_types::{
     contract_event::ContractEvent, state_store::state_key::StateKey, write_set::WriteOpSize,
 };
 use aptos_vm_types::{
-    change_set::ChangeSetInterface, resolver::ExecutorView, storage::space_pricing::ChargeAndRefund,
+    change_set::ChangeSetInterface, module_and_script_storage::module_storage::AptosModuleStorage,
+    resolver::ExecutorView, storage::space_pricing::ChargeAndRefund,
 };
 use move_binary_format::{
     errors::{Location, PartialVMResult, VMResult},
@@ -572,6 +573,8 @@ where
         txn_size: NumBytes,
         gas_unit_price: FeePerGasUnit,
         executor_view: &dyn ExecutorView,
+        module_storage: &impl AptosModuleStorage,
+        is_loader_v2_enabled: bool,
     ) -> VMResult<Fee> {
         // The new storage fee are only active since version 7.
         if self.feature_version() < 7 {
@@ -592,7 +595,9 @@ where
         let mut write_fee = Fee::new(0);
         let mut write_set_storage = vec![];
         let mut total_refund = Fee::new(0);
-        for res in change_set.write_op_info_iter_mut(executor_view) {
+        for res in
+            change_set.write_op_info_iter_mut(executor_view, module_storage, is_loader_v2_enabled)
+        {
             let write_op_info = res.map_err(|err| err.finish(Location::Undefined))?;
             let key = write_op_info.key.clone();
             let op_type = write_op_type(&write_op_info.op_size);

--- a/aptos-move/aptos-release-builder/src/simulate.rs
+++ b/aptos-move/aptos-release-builder/src/simulate.rs
@@ -620,12 +620,11 @@ pub async fn simulate_multistep_proposal(
         let log_context = AdapterLogSchema::new(state_view.id(), 0);
 
         let resolver = state_view.as_move_resolver();
-        let module_and_script_storage = vm.as_aptos_code_storage(&state_view);
+        let code_storage = vm.as_aptos_code_storage(&state_view);
 
         let (_vm_status, vm_output) = vm.execute_user_transaction(
             &resolver,
-            &module_and_script_storage,
-            &module_and_script_storage,
+            &code_storage,
             &account
                 .account()
                 .transaction()

--- a/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
+++ b/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
@@ -207,7 +207,6 @@ fn main() -> Result<()> {
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
                 &module_and_script_storage,
-                &module_and_script_storage,
             )?;
         },
         Entrypoint::Module(module_id) => {

--- a/aptos-move/aptos-vm-types/Cargo.toml
+++ b/aptos-move/aptos-vm-types/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+ambassador = { workspace = true }
 anyhow = { workspace = true }
 aptos-aggregator = { workspace = true }
 aptos-gas-algebra = { workspace = true }

--- a/aptos-move/aptos-vm-types/src/change_set.rs
+++ b/aptos-move/aptos-vm-types/src/change_set.rs
@@ -6,6 +6,7 @@ use crate::{
         AbstractResourceWriteOp, GroupWrite, InPlaceDelayedFieldChangeOp,
         ResourceGroupInPlaceDelayedFieldChangeOp, WriteWithDelayedFieldsOp,
     },
+    module_and_script_storage::module_storage::AptosModuleStorage,
     module_write_set::ModuleWriteSet,
     resolver::ExecutorView,
 };
@@ -848,6 +849,8 @@ pub trait ChangeSetInterface {
     fn write_op_info_iter_mut<'a>(
         &'a mut self,
         executor_view: &'a dyn ExecutorView,
+        module_storage: &'a impl AptosModuleStorage,
+        is_loader_v2_enabled: bool,
     ) -> impl Iterator<Item = PartialVMResult<WriteOpInfo>>;
 }
 
@@ -872,6 +875,8 @@ impl ChangeSetInterface for VMChangeSet {
     fn write_op_info_iter_mut<'a>(
         &'a mut self,
         executor_view: &'a dyn ExecutorView,
+        _module_storage: &'a impl AptosModuleStorage,
+        _is_loader_v2_enabled: bool,
     ) -> impl Iterator<Item = PartialVMResult<WriteOpInfo>> {
         let resources = self.resource_write_set.iter_mut().map(|(key, op)| {
             Ok(WriteOpInfo {

--- a/aptos-move/aptos-vm-types/src/module_and_script_storage/code_storage.rs
+++ b/aptos-move/aptos-vm-types/src/module_and_script_storage/code_storage.rs
@@ -1,0 +1,11 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::module_and_script_storage::module_storage::AptosModuleStorage;
+use move_vm_runtime::{CodeStorage, DummyCodeStorage};
+
+/// Represents code storage used by the Aptos blockchain, capable of
+/// caching both scripts and modules.
+pub trait AptosCodeStorage: AptosModuleStorage + CodeStorage {}
+
+impl AptosCodeStorage for DummyCodeStorage {}

--- a/aptos-move/aptos-vm-types/src/module_and_script_storage/mod.rs
+++ b/aptos-move/aptos-vm-types/src/module_and_script_storage/mod.rs
@@ -1,8 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod code_storage;
 pub mod module_storage;
-pub mod script_storage;
 
 mod state_view_adapter;
 pub use state_view_adapter::{AptosCodeStorageAdapter, AsAptosCodeStorage};

--- a/aptos-move/aptos-vm-types/src/module_and_script_storage/module_storage.rs
+++ b/aptos-move/aptos-vm-types/src/module_and_script_storage/module_storage.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_types::state_store::state_value::StateValueMetadata;
+use aptos_types::state_store::{state_key::StateKey, state_value::StateValueMetadata};
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
 use move_vm_runtime::{DummyCodeStorage, ModuleStorage};
@@ -16,6 +16,11 @@ pub trait AptosModuleStorage: ModuleStorage {
         address: &AccountAddress,
         module_name: &IdentStr,
     ) -> PartialVMResult<Option<StateValueMetadata>>;
+
+    fn fetch_module_size_by_state_key(
+        &self,
+        state_key: &StateKey,
+    ) -> PartialVMResult<Option<usize>>;
 }
 
 impl AptosModuleStorage for DummyCodeStorage {
@@ -24,6 +29,13 @@ impl AptosModuleStorage for DummyCodeStorage {
         _address: &AccountAddress,
         _module_name: &IdentStr,
     ) -> PartialVMResult<Option<StateValueMetadata>> {
+        Ok(None)
+    }
+
+    fn fetch_module_size_by_state_key(
+        &self,
+        _state_key: &StateKey,
+    ) -> PartialVMResult<Option<usize>> {
         Ok(None)
     }
 }

--- a/aptos-move/aptos-vm-types/src/module_and_script_storage/script_storage.rs
+++ b/aptos-move/aptos-vm-types/src/module_and_script_storage/script_storage.rs
@@ -1,9 +1,0 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
-
-use move_vm_runtime::{DummyCodeStorage, ScriptStorage};
-
-/// Represents script storage used by the Aptos blockchain.
-pub trait AptosScriptStorage: ScriptStorage {}
-
-impl AptosScriptStorage for DummyCodeStorage {}

--- a/aptos-move/aptos-vm-types/src/module_and_script_storage/state_view_adapter.rs
+++ b/aptos-move/aptos-vm-types/src/module_and_script_storage/state_view_adapter.rs
@@ -72,7 +72,7 @@ impl<'s, S: StateView> ModuleStorage for AptosCodeStorageAdapter<'s, S> {
         &self,
         address: &AccountAddress,
         module_name: &IdentStr,
-    ) -> VMResult<usize> {
+    ) -> VMResult<Option<usize>> {
         self.storage
             .fetch_module_size_in_bytes(address, module_name)
     }

--- a/aptos-move/aptos-vm-types/src/module_and_script_storage/state_view_adapter.rs
+++ b/aptos-move/aptos-vm-types/src/module_and_script_storage/state_view_adapter.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::module_and_script_storage::{
-    module_storage::AptosModuleStorage, script_storage::AptosScriptStorage,
+    code_storage::AptosCodeStorage, module_storage::AptosModuleStorage,
 };
 use aptos_types::state_store::{state_key::StateKey, state_value::StateValueMetadata, StateView};
 use bytes::Bytes;
@@ -13,8 +13,8 @@ use move_binary_format::{
 };
 use move_core_types::{account_address::AccountAddress, identifier::IdentStr, metadata::Metadata};
 use move_vm_runtime::{
-    module_storage_error, move_vm::MoveVM, IntoUnsyncCodeStorage, Module, ModuleBytesStorage,
-    ModuleStorage, Script, ScriptStorage, UnsyncCodeStorage, UnsyncModuleStorage,
+    module_storage_error, move_vm::MoveVM, CodeStorage, IntoUnsyncCodeStorage, Module,
+    ModuleBytesStorage, ModuleStorage, Script, UnsyncCodeStorage, UnsyncModuleStorage,
 };
 use std::sync::Arc;
 
@@ -120,7 +120,7 @@ impl<'s, S: StateView> AptosModuleStorage for AptosCodeStorageAdapter<'s, S> {
     }
 }
 
-impl<'s, S: StateView> ScriptStorage for AptosCodeStorageAdapter<'s, S> {
+impl<'s, S: StateView> CodeStorage for AptosCodeStorageAdapter<'s, S> {
     fn fetch_deserialized_script(&self, serialized_script: &[u8]) -> VMResult<Arc<CompiledScript>> {
         self.storage.fetch_deserialized_script(serialized_script)
     }
@@ -130,7 +130,7 @@ impl<'s, S: StateView> ScriptStorage for AptosCodeStorageAdapter<'s, S> {
     }
 }
 
-impl<'s, S: StateView> AptosScriptStorage for AptosCodeStorageAdapter<'s, S> {}
+impl<'s, S: StateView> AptosCodeStorage for AptosCodeStorageAdapter<'s, S> {}
 
 /// Allows to treat a state view as a code storage with scripts and modules. The
 /// main use case is when transaction or a Move function has to be executed outside

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1565,12 +1565,9 @@ impl AptosVM {
                         }
 
                         let size_if_module_exists = if self.features().is_loader_v2_enabled() {
-                            if module_storage.check_module_exists(addr, name)? {
-                                let size = module_storage.fetch_module_size_in_bytes(addr, name)?;
-                                Some(size as u64)
-                            } else {
-                                None
-                            }
+                            module_storage
+                                .fetch_module_size_in_bytes(addr, name)?
+                                .map(|v| v as u64)
                         } else {
                             resolver
                                 .as_executor_view()

--- a/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/block_executor/vm_wrapper.rs
@@ -56,13 +56,10 @@ impl ExecutorTask for AptosExecutorTask {
         let resolver = self
             .vm
             .as_move_resolver_with_group_view(executor_with_group_view);
-        match self.vm.execute_single_transaction(
-            txn,
-            &resolver,
-            &DummyCodeStorage,
-            &DummyCodeStorage,
-            &log_context,
-        ) {
+        match self
+            .vm
+            .execute_single_transaction(txn, &resolver, &DummyCodeStorage, &log_context)
+        {
             Ok((vm_status, vm_output)) => {
                 if vm_output.status().is_discarded() {
                     speculative_trace!(

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/session_change_sets.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/session_change_sets.rs
@@ -6,6 +6,7 @@ use aptos_types::{
 };
 use aptos_vm_types::{
     change_set::{ChangeSetInterface, VMChangeSet, WriteOpInfo},
+    module_and_script_storage::module_storage::AptosModuleStorage,
     module_write_set::ModuleWriteSet,
     resolver::ExecutorView,
     storage::change_set_configs::ChangeSetConfigs,
@@ -56,10 +57,16 @@ impl ChangeSetInterface for UserSessionChangeSet {
     fn write_op_info_iter_mut<'a>(
         &'a mut self,
         executor_view: &'a dyn ExecutorView,
+        module_storage: &'a impl AptosModuleStorage,
+        is_loader_v2_enabled: bool,
     ) -> impl Iterator<Item = PartialVMResult<WriteOpInfo>> {
         self.change_set
-            .write_op_info_iter_mut(executor_view)
-            .chain(self.module_write_set.write_op_info_iter_mut(executor_view))
+            .write_op_info_iter_mut(executor_view, module_storage, is_loader_v2_enabled)
+            .chain(self.module_write_set.write_op_info_iter_mut(
+                executor_view,
+                module_storage,
+                is_loader_v2_enabled,
+            ))
     }
 
     fn events_iter(&self) -> impl Iterator<Item = &ContractEvent> {
@@ -105,8 +112,11 @@ impl ChangeSetInterface for SystemSessionChangeSet {
     fn write_op_info_iter_mut<'a>(
         &'a mut self,
         executor_view: &'a dyn ExecutorView,
+        module_storage: &'a impl AptosModuleStorage,
+        is_loader_v2_enabled: bool,
     ) -> impl Iterator<Item = PartialVMResult<WriteOpInfo>> {
-        self.change_set.write_op_info_iter_mut(executor_view)
+        self.change_set
+            .write_op_info_iter_mut(executor_view, module_storage, is_loader_v2_enabled)
     }
 
     fn events_iter(&self) -> impl Iterator<Item = &ContractEvent> {

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -678,12 +678,11 @@ impl FakeExecutor {
         let vm = AptosVM::new(self.get_state_view());
 
         let resolver = self.data_store.as_move_resolver();
-        let module_and_script_storage = vm.as_aptos_code_storage(&self.data_store);
+        let code_storage = vm.as_aptos_code_storage(&self.data_store);
 
         let (_status, output, gas_profiler) = vm.execute_user_transaction_with_modified_gas_meter(
             &resolver,
-            &module_and_script_storage,
-            &module_and_script_storage,
+            &code_storage,
             &txn,
             &log_context,
             |gas_meter| {

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -46,7 +46,6 @@ use aptos_vm::{
 use aptos_vm_types::{
     module_and_script_storage::module_storage::AptosModuleStorage, module_write_set::ModuleWriteSet,
 };
-use claims::assert_ok;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
@@ -174,8 +173,8 @@ pub fn encode_aptos_mainnet_genesis_transaction(
 
     let configs = vm.genesis_change_set_configs();
     let (mut change_set, module_write_set) = session.finish(&configs, &module_storage).unwrap();
-    assert_ok!(
-        module_write_set.is_empty_or_invariant_violation(),
+    assert!(
+        module_write_set.is_empty(),
         "Modules cannot be published in this session"
     );
 
@@ -314,8 +313,8 @@ pub fn encode_genesis_change_set(
 
     let configs = vm.genesis_change_set_configs();
     let (mut change_set, module_write_set) = session.finish(&configs, &module_storage).unwrap();
-    assert_ok!(
-        module_write_set.is_empty_or_invariant_violation(),
+    assert!(
+        module_write_set.is_empty(),
         "Modules cannot be published in this session"
     );
 

--- a/crates/aptos/src/common/local_simulation.rs
+++ b/crates/aptos/src/common/local_simulation.rs
@@ -23,15 +23,10 @@ pub fn run_transaction_using_debugger(
     let log_context = AdapterLogSchema::new(state_view.id(), 0);
 
     let resolver = state_view.as_move_resolver();
-    let module_and_script_storage = vm.as_aptos_code_storage(&state_view);
+    let code_storage = vm.as_aptos_code_storage(&state_view);
 
-    let (vm_status, vm_output) = vm.execute_user_transaction(
-        &resolver,
-        &module_and_script_storage,
-        &module_and_script_storage,
-        &transaction,
-        &log_context,
-    );
+    let (vm_status, vm_output) =
+        vm.execute_user_transaction(&resolver, &code_storage, &transaction, &log_context);
 
     Ok((vm_status, vm_output))
 }
@@ -47,14 +42,9 @@ pub fn benchmark_transaction_using_debugger(
     let log_context = AdapterLogSchema::new(state_view.id(), 0);
 
     let resolver = state_view.as_move_resolver();
-    let module_and_script_storage = vm.as_aptos_code_storage(&state_view);
-    let (vm_status, vm_output) = vm.execute_user_transaction(
-        &resolver,
-        &module_and_script_storage,
-        &module_and_script_storage,
-        &transaction,
-        &log_context,
-    );
+    let code_storage = vm.as_aptos_code_storage(&state_view);
+    let (vm_status, vm_output) =
+        vm.execute_user_transaction(&resolver, &code_storage, &transaction, &log_context);
 
     let time_cold = {
         let n = 15;
@@ -64,13 +54,13 @@ pub fn benchmark_transaction_using_debugger(
             // Create a new VM each time so to include code loading as part of the
             // total running time.
             let vm = AptosVM::new(&state_view);
+            let code_storage = vm.as_aptos_code_storage(&state_view);
             let log_context = AdapterLogSchema::new(state_view.id(), 0);
 
             let t1 = Instant::now();
             std::hint::black_box(vm.execute_user_transaction(
                 &resolver,
-                &module_and_script_storage,
-                &module_and_script_storage,
+                &code_storage,
                 &transaction,
                 &log_context,
             ));
@@ -93,8 +83,7 @@ pub fn benchmark_transaction_using_debugger(
             let t1 = Instant::now();
             std::hint::black_box(vm.execute_user_transaction(
                 &resolver,
-                &module_and_script_storage,
-                &module_and_script_storage,
+                &code_storage,
                 &transaction,
                 &log_context,
             ));

--- a/experimental/execution/ptx-executor/src/runner.rs
+++ b/experimental/execution/ptx-executor/src/runner.rs
@@ -260,14 +260,13 @@ impl<'scope, 'view: 'scope, BaseView: StateView + Sync> Worker<'view, BaseView> 
                         OverlayedStateView::new_with_overlay(self.base_view, dependencies);
                     let log_context = AdapterLogSchema::new(self.base_view.id(), txn_idx);
 
-                    let module_and_script_storage = vm.as_aptos_code_storage(&state_view);
+                    let code_storage = vm.as_aptos_code_storage(&state_view);
                     let vm_output = {
                         let _vm = PER_WORKER_TIMER.timer_with(&[&idx, "run_txn_vm"]);
                         vm.execute_single_transaction(
                             &transaction,
                             &vm.as_move_resolver(&state_view),
-                            &module_and_script_storage,
-                            &module_and_script_storage,
+                            &code_storage,
                             &log_context,
                         )
                     };

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -100,8 +100,7 @@ fn test_malformed_resource() {
     let mut module_bytes_storage = LocalModuleBytesStorage::empty();
     module_bytes_storage.add_module_bytes(ms.self_addr(), ms.self_name(), ms_blob.into());
     module_bytes_storage.add_module_bytes(m.self_addr(), m.self_name(), m_blob.into());
-    let module_and_script_storage =
-        module_bytes_storage.into_unsync_code_storage(vm.runtime_environment());
+    let code_storage = module_bytes_storage.into_unsync_code_storage(vm.runtime_environment());
 
     // Execute the first script to publish a resource Foo.
     let mut script_blob = vec![];
@@ -114,8 +113,7 @@ fn test_malformed_resource() {
         vec![MoveValue::Signer(TEST_ADDR).simple_serialize().unwrap()],
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
-        &module_and_script_storage,
-        &module_and_script_storage,
+        &code_storage,
     )
     .map(|_| ())
     .unwrap();
@@ -135,8 +133,7 @@ fn test_malformed_resource() {
             vec![MoveValue::Signer(TEST_ADDR).simple_serialize().unwrap()],
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
-            &module_and_script_storage,
-            &module_and_script_storage,
+            &code_storage,
         )
         .map(|_| ())
         .unwrap();
@@ -165,8 +162,7 @@ fn test_malformed_resource() {
                 vec![MoveValue::Signer(TEST_ADDR).simple_serialize().unwrap()],
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
-                &module_and_script_storage,
-                &module_and_script_storage,
+                &code_storage,
             )
             .map(|_| ())
             .unwrap_err();

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -639,7 +639,7 @@ impl ModuleStorage for BogusModuleStorage {
         &self,
         _address: &AccountAddress,
         _module_name: &IdentStr,
-    ) -> VMResult<usize> {
+    ) -> VMResult<Option<usize>> {
         Err(PartialVMError::new(self.bad_status_code).finish(Location::Undefined))
     }
 

--- a/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
@@ -153,7 +153,7 @@ fn test_run_script_with_custom_max_binary_format_version() {
             move_stdlib::natives::GasParameters::zeros(),
         ));
 
-        let module_and_script_storage =
+        let code_storage =
             LocalModuleBytesStorage::empty().into_unsync_code_storage(vm.runtime_environment());
         let resource_storage = InMemoryStorage::new();
 
@@ -164,8 +164,7 @@ fn test_run_script_with_custom_max_binary_format_version() {
             args.clone(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
-            &module_and_script_storage,
-            &module_and_script_storage,
+            &code_storage,
         )
         .unwrap();
 
@@ -175,8 +174,7 @@ fn test_run_script_with_custom_max_binary_format_version() {
             args.clone(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
-            &module_and_script_storage,
-            &module_and_script_storage,
+            &code_storage,
         )
         .unwrap();
     }
@@ -197,7 +195,7 @@ fn test_run_script_with_custom_max_binary_format_version() {
             },
         );
 
-        let module_and_script_storage =
+        let code_storage =
             LocalModuleBytesStorage::empty().into_unsync_code_storage(vm.runtime_environment());
         let resource_storage = InMemoryStorage::new();
 
@@ -209,8 +207,7 @@ fn test_run_script_with_custom_max_binary_format_version() {
                 args.clone(),
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
-                &module_and_script_storage,
-                &module_and_script_storage,
+                &code_storage,
             )
             .unwrap_err()
             .major_status(),
@@ -223,8 +220,7 @@ fn test_run_script_with_custom_max_binary_format_version() {
             args,
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
-            &module_and_script_storage,
-            &module_and_script_storage,
+            &code_storage,
         )
         .unwrap();
     }

--- a/third_party/move/move-vm/integration-tests/src/tests/invariant_violation_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/invariant_violation_tests.rs
@@ -77,7 +77,7 @@ fn merge_borrow_states_infinite_loop() {
 
     let vm = MoveVM::new(vec![]);
 
-    let module_and_script_storage =
+    let code_storage =
         LocalModuleBytesStorage::empty().into_unsync_code_storage(vm.runtime_environment());
     let resource_storage = InMemoryStorage::new();
 
@@ -91,8 +91,7 @@ fn merge_borrow_states_infinite_loop() {
             Vec::<Vec<u8>>::new(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
-            &module_and_script_storage,
-            &module_and_script_storage,
+            &code_storage,
         )
         .unwrap_err();
 

--- a/third_party/move/move-vm/integration-tests/src/tests/leak_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/leak_tests.rs
@@ -52,7 +52,7 @@ fn leak_with_abort() {
 
     let vm = MoveVM::new(vec![]);
 
-    let module_and_script_storage =
+    let code_storage =
         LocalModuleBytesStorage::empty().into_unsync_code_storage(vm.runtime_environment());
     let resource_storage = InMemoryStorage::new();
 
@@ -66,8 +66,7 @@ fn leak_with_abort() {
             Vec::<Vec<u8>>::new(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
-            &module_and_script_storage,
-            &module_and_script_storage,
+            &code_storage,
         );
     }
 

--- a/third_party/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
@@ -149,7 +149,7 @@ fn test_run_script_with_nested_loops() {
             },
         );
 
-        let module_and_script_storage =
+        let code_storage =
             LocalModuleBytesStorage::empty().into_unsync_code_storage(vm.runtime_environment());
         let resource_storage = InMemoryStorage::new();
 
@@ -161,8 +161,7 @@ fn test_run_script_with_nested_loops() {
             args,
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
-            &module_and_script_storage,
-            &module_and_script_storage,
+            &code_storage,
         )
         .unwrap();
     }
@@ -183,7 +182,7 @@ fn test_run_script_with_nested_loops() {
             },
         );
 
-        let module_and_script_storage =
+        let code_storage =
             LocalModuleBytesStorage::empty().into_unsync_code_storage(vm.runtime_environment());
         let resource_storage = InMemoryStorage::new();
 
@@ -195,8 +194,7 @@ fn test_run_script_with_nested_loops() {
             args,
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
-            &module_and_script_storage,
-            &module_and_script_storage,
+            &code_storage,
         )
         .unwrap_err();
     }

--- a/third_party/move/move-vm/integration-tests/src/tests/regression_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/regression_tests.rs
@@ -126,8 +126,7 @@ fn script_large_ty() {
         decompiled_module.self_name(),
         module.into(),
     );
-    let module_and_script_storage =
-        module_bytes_storage.into_unsync_code_storage(move_vm.runtime_environment());
+    let code_storage = module_bytes_storage.into_unsync_code_storage(move_vm.runtime_environment());
 
     // constructs a type with about 25^3 nodes
     let num_type_args = 25;
@@ -149,8 +148,7 @@ fn script_large_ty() {
             Vec::<Vec<u8>>::new(),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
-            &module_and_script_storage,
-            &module_and_script_storage,
+            &code_storage,
         )
         .unwrap_err();
 

--- a/third_party/move/move-vm/integration-tests/src/tests/vm_arguments_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/vm_arguments_tests.rs
@@ -256,7 +256,7 @@ fn call_script_with_args_ty_args_signers(
 ) -> VMResult<()> {
     let move_vm = MoveVM::new(vec![]);
 
-    let module_and_script_storage =
+    let code_storage =
         LocalModuleBytesStorage::empty().into_unsync_code_storage(move_vm.runtime_environment());
     let resource_storage = InMemoryStorage::new();
 
@@ -270,8 +270,7 @@ fn call_script_with_args_ty_args_signers(
             combine_signers_and_args(signers, non_signer_args),
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
-            &module_and_script_storage,
-            &module_and_script_storage,
+            &code_storage,
         )
         .map(|_| ())
 }

--- a/third_party/move/move-vm/runtime/Cargo.toml
+++ b/third_party/move/move-vm/runtime/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ambassador = { workspace = true }
 better_any = { workspace = true }
 bytes = { workspace = true }
 fail = { workspace = true }

--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -34,7 +34,7 @@ mod storage;
 
 pub use loader::{LoadedFunction, Module, Script};
 pub use storage::{
-    code_storage::{script_hash, CodeStorage},
+    code_storage::{ambassador_impl_CodeStorage, script_hash, CodeStorage},
     dummy::{use_loader_v2_based_on_env, DummyCodeStorage},
     environment::RuntimeEnvironment,
     implementations::{
@@ -44,6 +44,6 @@ pub use storage::{
             IntoUnsyncModuleStorage, LocalModuleBytesStorage, UnsyncModuleStorage,
         },
     },
-    module_storage::{ModuleBytesStorage, ModuleStorage},
+    module_storage::{ambassador_impl_ModuleStorage, ModuleBytesStorage, ModuleStorage},
     publishing::TemporaryModuleStorage,
 };

--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -34,6 +34,7 @@ mod storage;
 
 pub use loader::{LoadedFunction, Module, Script};
 pub use storage::{
+    code_storage::{script_hash, CodeStorage},
     dummy::{use_loader_v2_based_on_env, DummyCodeStorage},
     environment::RuntimeEnvironment,
     implementations::{
@@ -45,5 +46,4 @@ pub use storage::{
     },
     module_storage::{ModuleBytesStorage, ModuleStorage},
     publishing::TemporaryModuleStorage,
-    script_storage::{script_hash, ScriptStorage},
 };

--- a/third_party/move/move-vm/runtime/src/runtime.rs
+++ b/third_party/move/move-vm/runtime/src/runtime.rs
@@ -9,7 +9,7 @@ use crate::{
     module_traversal::TraversalContext,
     native_extensions::NativeContextExtensions,
     session::SerializedReturnValues,
-    storage::{module_storage::ModuleStorage as ModuleStorageV2, script_storage::ScriptStorage},
+    storage::{code_storage::CodeStorage, module_storage::ModuleStorage as ModuleStorageV2},
     RuntimeEnvironment,
 };
 use move_binary_format::{
@@ -485,8 +485,7 @@ impl VMRuntime {
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext,
         extensions: &mut NativeContextExtensions,
-        module_storage: &impl ModuleStorageV2,
-        script_storage: &impl ScriptStorage,
+        code_storage: &impl CodeStorage,
     ) -> VMResult<()> {
         // Load the script first, verify it, and then execute the entry-point main function.
         let main = self.loader.load_script(
@@ -494,8 +493,7 @@ impl VMRuntime {
             &ty_args,
             data_store,
             module_store,
-            module_storage,
-            script_storage,
+            code_storage,
         )?;
 
         self.execute_function_impl(
@@ -503,7 +501,7 @@ impl VMRuntime {
             serialized_args,
             data_store,
             module_store,
-            module_storage,
+            code_storage,
             gas_meter,
             traversal_context,
             extensions,

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -11,7 +11,7 @@ use crate::{
     move_vm::MoveVM,
     native_extensions::NativeContextExtensions,
     storage::module_storage::ModuleStorage,
-    ScriptStorage,
+    CodeStorage,
 };
 use bytes::Bytes;
 use move_binary_format::{compatibility::Compatibility, errors::*, file_format::LocalIndex};
@@ -172,8 +172,7 @@ impl<'r, 'l> Session<'r, 'l> {
         args: Vec<impl Borrow<[u8]>>,
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext,
-        module_storage: &impl ModuleStorage,
-        script_storage: &impl ScriptStorage,
+        code_storage: &impl CodeStorage,
     ) -> VMResult<()> {
         self.move_vm.runtime.execute_script(
             script,
@@ -184,8 +183,7 @@ impl<'r, 'l> Session<'r, 'l> {
             gas_meter,
             traversal_context,
             &mut self.native_extensions,
-            module_storage,
-            script_storage,
+            code_storage,
         )
     }
 
@@ -374,8 +372,7 @@ impl<'r, 'l> Session<'r, 'l> {
     /// Load a script and all of its types into cache
     pub fn load_script(
         &mut self,
-        module_storage: &impl ModuleStorage,
-        script_storage: &impl ScriptStorage,
+        code_storage: &impl CodeStorage,
         script: impl Borrow<[u8]>,
         ty_args: &[TypeTag],
     ) -> VMResult<LoadedFunction> {
@@ -384,8 +381,7 @@ impl<'r, 'l> Session<'r, 'l> {
             ty_args,
             &mut self.data_cache,
             &self.module_store,
-            module_storage,
-            script_storage,
+            code_storage,
         )
     }
 
@@ -534,8 +530,7 @@ impl<'r, 'l> Session<'r, 'l> {
 
     pub fn check_script_dependencies_and_check_gas(
         &mut self,
-        module_storage: &impl ModuleStorage,
-        script_storage: &impl ScriptStorage,
+        code_storage: &impl CodeStorage,
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext,
         script: impl Borrow<[u8]>,
@@ -549,8 +544,7 @@ impl<'r, 'l> Session<'r, 'l> {
                 gas_meter,
                 traversal_context,
                 script.borrow(),
-                module_storage,
-                script_storage,
+                code_storage,
             )
     }
 }

--- a/third_party/move/move-vm/runtime/src/storage/code_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/code_storage.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::loader::Script;
+use crate::{loader::Script, ModuleStorage};
 use move_binary_format::{errors::VMResult, file_format::CompiledScript};
 use sha3::{Digest, Sha3_256};
 use std::sync::Arc;
@@ -13,10 +13,11 @@ pub fn script_hash(serialized_script: &[u8]) -> [u8; 32] {
     sha3_256.finalize().into()
 }
 
-/// Represents storage which caches scripts, executed so far. The clients can
-/// implement this trait to ensure that even script dependency is upgraded, the
-/// correct script is still returned. Scripts are cached based on their hash.
-pub trait ScriptStorage {
+/// Represents storage which in addition to modules, also caches scripts. The
+/// clients can implement this trait to ensure that even script dependency is
+/// upgraded, the correct script is still returned. Scripts are cached based
+/// on their hash.
+pub trait CodeStorage: ModuleStorage {
     /// Returns a deserialized script, either by directly deserializing it from the
     /// provided bytes, or fetching it from the storage (if it has been cached). Note
     /// that there are no guarantees that the returned script is verified. An error

--- a/third_party/move/move-vm/runtime/src/storage/code_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/code_storage.rs
@@ -21,12 +21,15 @@ pub fn script_hash(serialized_script: &[u8]) -> [u8; 32] {
 #[delegatable_trait]
 pub trait CodeStorage: ModuleStorage {
     /// Returns a deserialized script, either by directly deserializing it from the
-    /// provided bytes, or fetching it from the storage (if it has been cached). Note
-    /// that there are no guarantees that the returned script is verified. An error
-    /// is returned if the deserialization fails.
-    fn fetch_deserialized_script(&self, serialized_script: &[u8]) -> VMResult<Arc<CompiledScript>>;
+    /// provided bytes (and caching it), or fetching it from the cache. Note that
+    /// there are no guarantees that the returned script is verified. An error is
+    /// returned if the deserialization fails.
+    fn deserialize_and_cache_script(
+        &self,
+        serialized_script: &[u8],
+    ) -> VMResult<Arc<CompiledScript>>;
 
-    /// Returns a verified script. The script can either be cached, or deserialized and/or
-    /// verified from scratch. An error is returned if script fails to deserialize or verify.
-    fn fetch_verified_script(&self, serialized_script: &[u8]) -> VMResult<Arc<Script>>;
+    /// Returns a verified script. If not yet cached, verified from scratch and cached.
+    /// An error is returned if script fails to deserialize or verify.
+    fn verify_and_cache_script(&self, serialized_script: &[u8]) -> VMResult<Arc<Script>>;
 }

--- a/third_party/move/move-vm/runtime/src/storage/code_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/code_storage.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{loader::Script, ModuleStorage};
+use ambassador::delegatable_trait;
 use move_binary_format::{errors::VMResult, file_format::CompiledScript};
 use sha3::{Digest, Sha3_256};
 use std::sync::Arc;
@@ -17,6 +18,7 @@ pub fn script_hash(serialized_script: &[u8]) -> [u8; 32] {
 /// clients can implement this trait to ensure that even script dependency is
 /// upgraded, the correct script is still returned. Scripts are cached based
 /// on their hash.
+#[delegatable_trait]
 pub trait CodeStorage: ModuleStorage {
     /// Returns a deserialized script, either by directly deserializing it from the
     /// provided bytes, or fetching it from the storage (if it has been cached). Note

--- a/third_party/move/move-vm/runtime/src/storage/dummy.rs
+++ b/third_party/move/move-vm/runtime/src/storage/dummy.rs
@@ -52,7 +52,7 @@ impl ModuleStorage for DummyCodeStorage {
         &self,
         _address: &AccountAddress,
         _module_name: &IdentStr,
-    ) -> VMResult<usize> {
+    ) -> VMResult<Option<usize>> {
         unexpected_unimplemented_error!()
     }
 

--- a/third_party/move/move-vm/runtime/src/storage/dummy.rs
+++ b/third_party/move/move-vm/runtime/src/storage/dummy.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     loader::{Module, Script},
-    storage::{module_storage::ModuleStorage, script_storage::ScriptStorage},
+    storage::{code_storage::CodeStorage, module_storage::ModuleStorage},
 };
 use bytes::Bytes;
 use move_binary_format::{
@@ -89,7 +89,7 @@ impl ModuleStorage for DummyCodeStorage {
     }
 }
 
-impl ScriptStorage for DummyCodeStorage {
+impl CodeStorage for DummyCodeStorage {
     fn fetch_deserialized_script(
         &self,
         _serialized_script: &[u8],

--- a/third_party/move/move-vm/runtime/src/storage/dummy.rs
+++ b/third_party/move/move-vm/runtime/src/storage/dummy.rs
@@ -90,14 +90,14 @@ impl ModuleStorage for DummyCodeStorage {
 }
 
 impl CodeStorage for DummyCodeStorage {
-    fn fetch_deserialized_script(
+    fn deserialize_and_cache_script(
         &self,
         _serialized_script: &[u8],
     ) -> VMResult<Arc<CompiledScript>> {
         unexpected_unimplemented_error!()
     }
 
-    fn fetch_verified_script(&self, _serialized_script: &[u8]) -> VMResult<Arc<Script>> {
+    fn verify_and_cache_script(&self, _serialized_script: &[u8]) -> VMResult<Arc<Script>> {
         unexpected_unimplemented_error!()
     }
 }

--- a/third_party/move/move-vm/runtime/src/storage/implementations/unreachable_code_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/implementations/unreachable_code_storage.rs
@@ -56,7 +56,7 @@ impl ModuleStorage for UnreachableCodeStorage {
         &self,
         _address: &AccountAddress,
         _module_name: &IdentStr,
-    ) -> VMResult<usize> {
+    ) -> VMResult<Option<usize>> {
         unreachable_error!()
     }
 

--- a/third_party/move/move-vm/runtime/src/storage/implementations/unreachable_code_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/implementations/unreachable_code_storage.rs
@@ -86,14 +86,14 @@ impl ModuleStorage for UnreachableCodeStorage {
 }
 
 impl CodeStorage for UnreachableCodeStorage {
-    fn fetch_deserialized_script(
+    fn deserialize_and_cache_script(
         &self,
         _serialized_script: &[u8],
     ) -> VMResult<Arc<CompiledScript>> {
         unreachable_error!()
     }
 
-    fn fetch_verified_script(&self, _serialized_script: &[u8]) -> VMResult<Arc<Script>> {
+    fn verify_and_cache_script(&self, _serialized_script: &[u8]) -> VMResult<Arc<Script>> {
         unreachable_error!()
     }
 }

--- a/third_party/move/move-vm/runtime/src/storage/implementations/unreachable_code_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/implementations/unreachable_code_storage.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Module, ModuleStorage, Script, ScriptStorage};
+use crate::{CodeStorage, Module, ModuleStorage, Script};
 use bytes::Bytes;
 use move_binary_format::{
     errors::{Location, PartialVMError, VMResult},
@@ -85,7 +85,7 @@ impl ModuleStorage for UnreachableCodeStorage {
     }
 }
 
-impl ScriptStorage for UnreachableCodeStorage {
+impl CodeStorage for UnreachableCodeStorage {
     fn fetch_deserialized_script(
         &self,
         _serialized_script: &[u8],

--- a/third_party/move/move-vm/runtime/src/storage/implementations/unsync_code_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/implementations/unsync_code_storage.rs
@@ -189,7 +189,7 @@ impl<M: ModuleStorage + WithEnvironment> ModuleStorage for UnsyncCodeStorage<M> 
         &self,
         address: &AccountAddress,
         module_name: &IdentStr,
-    ) -> VMResult<usize> {
+    ) -> VMResult<Option<usize>> {
         self.module_storage
             .fetch_module_size_in_bytes(address, module_name)
     }

--- a/third_party/move/move-vm/runtime/src/storage/implementations/unsync_code_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/implementations/unsync_code_storage.rs
@@ -8,7 +8,7 @@ use crate::{
         implementations::unsync_module_storage::IntoUnsyncModuleStorage,
         module_storage::ModuleBytesStorage,
     },
-    Module, ModuleStorage, RuntimeEnvironment, Script, ScriptStorage, UnsyncModuleStorage,
+    CodeStorage, Module, ModuleStorage, RuntimeEnvironment, Script, UnsyncModuleStorage,
 };
 use bytes::Bytes;
 use move_binary_format::{
@@ -120,7 +120,7 @@ impl<M: ModuleStorage + WithEnvironment> UnsyncCodeStorage<M> {
     }
 }
 
-impl<M: ModuleStorage + WithEnvironment> ScriptStorage for UnsyncCodeStorage<M> {
+impl<M: ModuleStorage + WithEnvironment> CodeStorage for UnsyncCodeStorage<M> {
     fn fetch_deserialized_script(&self, serialized_script: &[u8]) -> VMResult<Arc<CompiledScript>> {
         use hash_map::Entry::*;
         use ScriptStorageEntry::*;

--- a/third_party/move/move-vm/runtime/src/storage/implementations/unsync_module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/implementations/unsync_module_storage.rs
@@ -237,7 +237,9 @@ impl<'e, B: ModuleBytesStorage> UnsyncModuleStorage<'e, B> {
 
         // Step 1: verify compiled module locally.
         let compiled_module = self.fetch_deserialized_module(address, module_name)?;
-        let size = self.fetch_module_size_in_bytes(address, module_name)?;
+        let size = self
+            .fetch_module_size_in_bytes(address, module_name)?
+            .ok_or_else(|| module_linker_error!(address, module_name))?;
         let partially_verified_module = self
             .runtime_environment
             .build_partially_verified_module(compiled_module, size)?;

--- a/third_party/move/move-vm/runtime/src/storage/implementations/unsync_module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/implementations/unsync_module_storage.rs
@@ -311,8 +311,10 @@ impl<'e, B: ModuleBytesStorage> ModuleStorage for UnsyncModuleStorage<'e, B> {
         &self,
         address: &AccountAddress,
         module_name: &IdentStr,
-    ) -> VMResult<usize> {
-        Ok(self.get_existing_module_bytes(address, module_name)?.len())
+    ) -> VMResult<Option<usize>> {
+        Ok(self
+            .fetch_module_bytes(address, module_name)?
+            .map(|b| b.len()))
     }
 
     fn fetch_module_metadata(
@@ -407,7 +409,7 @@ impl<'e, B: ModuleBytesStorage> UnsyncModuleStorage<'e, B> {
 #[cfg(test)]
 pub(crate) mod test {
     use super::*;
-    use claims::{assert_err, assert_ok};
+    use claims::{assert_err, assert_none, assert_ok};
     use move_binary_format::{
         file_format::empty_module_with_dependencies_and_friends,
         file_format_common::VERSION_DEFAULT,
@@ -449,7 +451,7 @@ pub(crate) mod test {
 
         let result =
             module_storage.fetch_module_size_in_bytes(&AccountAddress::ZERO, ident_str!("a"));
-        assert_eq!(assert_err!(result).major_status(), StatusCode::LINKER_ERROR);
+        assert_none!(assert_ok!(result));
 
         let result = module_storage.fetch_module_metadata(&AccountAddress::ZERO, ident_str!("a"));
         assert_eq!(assert_err!(result).major_status(), StatusCode::LINKER_ERROR);

--- a/third_party/move/move-vm/runtime/src/storage/loader.rs
+++ b/third_party/move/move-vm/runtime/src/storage/loader.rs
@@ -82,7 +82,7 @@ impl LoaderV2 {
         traversal_context: &mut TraversalContext,
         serialized_script: &[u8],
     ) -> VMResult<()> {
-        let compiled_script = code_storage.fetch_deserialized_script(serialized_script)?;
+        let compiled_script = code_storage.deserialize_and_cache_script(serialized_script)?;
         let compiled_script = traversal_context.referenced_scripts.alloc(compiled_script);
 
         // TODO(Gas): Should we charge dependency gas for the script itself?
@@ -151,7 +151,7 @@ impl LoaderV2 {
     ) -> VMResult<LoadedFunction> {
         // Step 1: Load script. During the loading process, if script has not been previously
         // cached, it will be verified.
-        let script = code_storage.fetch_verified_script(serialized_script)?;
+        let script = code_storage.verify_and_cache_script(serialized_script)?;
 
         // Step 2: Load & verify types used as type arguments passed to this script. Note that
         // arguments for scripts are verified on the client side.

--- a/third_party/move/move-vm/runtime/src/storage/mod.rs
+++ b/third_party/move/move-vm/runtime/src/storage/mod.rs
@@ -4,9 +4,9 @@
 pub(crate) mod loader;
 pub(crate) mod struct_name_index_map;
 
+pub mod code_storage;
 pub mod environment;
 pub mod module_storage;
-pub mod script_storage;
 pub mod verifier;
 
 // TODO(loader_v2): Remove when we no longer need the dummy implementation.

--- a/third_party/move/move-vm/runtime/src/storage/module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/module_storage.rs
@@ -26,13 +26,13 @@ pub trait ModuleStorage {
         module_name: &IdentStr,
     ) -> VMResult<Option<Bytes>>;
 
-    /// Returns the size of a module in bytes. An error is returned if the module does
-    /// not exist, or there is a storage error.
+    /// Returns the size of a module in bytes. An error is returned if the there is
+    /// a storage error. If module does not exist, [None] is returned.
     fn fetch_module_size_in_bytes(
         &self,
         address: &AccountAddress,
         module_name: &IdentStr,
-    ) -> VMResult<usize>;
+    ) -> VMResult<Option<usize>>;
 
     /// Returns the metadata in the module. An error is returned if the module does
     /// not exist, or there is a storage error.

--- a/third_party/move/move-vm/runtime/src/storage/module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/module_storage.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::loader::Module;
+use ambassador::delegatable_trait;
 use bytes::Bytes;
 use move_binary_format::{errors::VMResult, CompiledModule};
 use move_core_types::{account_address::AccountAddress, identifier::IdentStr, metadata::Metadata};
@@ -9,6 +10,7 @@ use std::sync::Arc;
 
 /// Represents module storage backend, abstracting away any caching behaviour. The
 /// clients can implement their own module storage to pass to the VM to resolve code.
+#[delegatable_trait]
 pub trait ModuleStorage {
     /// Returns true if the module exists, and false otherwise. An error is returned
     /// if there is a storage error.

--- a/third_party/move/move-vm/runtime/src/storage/publishing.rs
+++ b/third_party/move/move-vm/runtime/src/storage/publishing.rs
@@ -245,7 +245,7 @@ impl<'a, M: ModuleStorage> ModuleStorage for TemporaryModuleStorage<'a, M> {
         &self,
         address: &AccountAddress,
         module_name: &IdentStr,
-    ) -> VMResult<usize> {
+    ) -> VMResult<Option<usize>> {
         self.storage
             .fetch_module_size_in_bytes(address, module_name)
     }

--- a/third_party/move/move-vm/runtime/src/storage/publishing.rs
+++ b/third_party/move/move-vm/runtime/src/storage/publishing.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    IntoUnsyncModuleStorage, Module, ModuleBytesStorage, ModuleStorage, RuntimeEnvironment,
-    UnsyncModuleStorage,
+    ambassador_impl_ModuleStorage, IntoUnsyncModuleStorage, Module, ModuleBytesStorage,
+    ModuleStorage, RuntimeEnvironment, UnsyncModuleStorage,
 };
+use ambassador::Delegate;
 use bytes::Bytes;
 use move_binary_format::{
     access::ModuleAccess,
@@ -162,6 +163,8 @@ impl<'m, M: ModuleStorage> ModuleBytesStorage for TemporaryModuleBytesStorage<'m
 ///   2) Published modules satisfy compatibility constraints.
 ///   3) Published modules are verifiable and can link to existing modules without breaking
 ///      invariants such as cyclic dependencies.
+#[derive(Delegate)]
+#[delegate(ModuleStorage)]
 pub struct TemporaryModuleStorage<'a, M> {
     storage: UnsyncModuleStorage<'a, TemporaryModuleBytesStorage<'a, M>>,
 }
@@ -221,56 +224,5 @@ impl<'a, M: ModuleStorage> TemporaryModuleStorage<'a, M> {
             .temporary_storage
             .into_iter()
             .flat_map(|(_, account_storage)| account_storage.into_values())
-    }
-}
-
-impl<'a, M: ModuleStorage> ModuleStorage for TemporaryModuleStorage<'a, M> {
-    fn check_module_exists(
-        &self,
-        address: &AccountAddress,
-        module_name: &IdentStr,
-    ) -> VMResult<bool> {
-        self.storage.check_module_exists(address, module_name)
-    }
-
-    fn fetch_module_bytes(
-        &self,
-        address: &AccountAddress,
-        module_name: &IdentStr,
-    ) -> VMResult<Option<Bytes>> {
-        self.storage.fetch_module_bytes(address, module_name)
-    }
-
-    fn fetch_module_size_in_bytes(
-        &self,
-        address: &AccountAddress,
-        module_name: &IdentStr,
-    ) -> VMResult<Option<usize>> {
-        self.storage
-            .fetch_module_size_in_bytes(address, module_name)
-    }
-
-    fn fetch_module_metadata(
-        &self,
-        address: &AccountAddress,
-        module_name: &IdentStr,
-    ) -> VMResult<Vec<Metadata>> {
-        self.storage.fetch_module_metadata(address, module_name)
-    }
-
-    fn fetch_deserialized_module(
-        &self,
-        address: &AccountAddress,
-        module_name: &IdentStr,
-    ) -> VMResult<Arc<CompiledModule>> {
-        self.storage.fetch_deserialized_module(address, module_name)
-    }
-
-    fn fetch_verified_module(
-        &self,
-        address: &AccountAddress,
-        module_name: &IdentStr,
-    ) -> VMResult<Arc<Module>> {
-        self.storage.fetch_verified_module(address, module_name)
     }
 }

--- a/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -343,7 +343,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
         extra_args: Self::ExtraRunArgs,
     ) -> Result<Option<String>> {
         let vm = self.vm();
-        let module_and_script_storage = self
+        let code_storage = self
             .module_bytes_storage
             .clone()
             .into_unsync_code_storage(vm.runtime_environment());
@@ -375,8 +375,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
                 args,
                 gas_status,
                 &mut TraversalContext::new(&traversal_storage),
-                &module_and_script_storage,
-                &module_and_script_storage,
+                &code_storage,
             )
         })
         .map_err(|vm_error| {


### PR DESCRIPTION
## Description

Addressing comments from #14206.

1. `ScriptStorage` is now `CodeStorage: ModuleStorage`. After all, you cannot have scripts without modules, I guess, most of the time. Interfaces updated to take a single parameter only, either module or code storage.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
