### PR TITLE
[qs][fix] return full status in ProofBatchQueue::pull_internal

### DIFF
--- a/consensus/src/quorum_store/batch_proof_queue.rs
+++ b/consensus/src/quorum_store/batch_proof_queue.rs
@@ -596,9 +596,9 @@ impl BatchProofQueue {
         if full || return_non_full {
             // Stable sort, so the order of proofs within an author will not change.
             result.sort_by_key(|item| Reverse(item.info.gas_bucket_start()));
-            (result, cur_all_txns, cur_unique_txns, !full)
+            (result, cur_all_txns, cur_unique_txns, full)
         } else {
-            (Vec::new(), PayloadTxnsSize::zero(), 0, !full)
+            (Vec::new(), PayloadTxnsSize::zero(), 0, full)
         }
     }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

`pull_internal` is returning the `!full`, but it is expected to return `full` to indicate when the block was fully packed with proofs. This fixes it. 