### PR TITLE
[compiler-v2] add usage check for enum in expansion phase

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/unused/unused_enum.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/unused/unused_enum.exp
@@ -1,0 +1,13 @@
+// -- Model dump before bytecode pipeline
+module 0x42::enum_types {
+    use std::string;
+    enum MessageHolder {
+        Empty,
+        Message {
+            message: string::String,
+        }
+        NewMessage {
+            message: string::String,
+        }
+    }
+} // end 0x42::enum_types

--- a/third_party/move/move-compiler-v2/tests/checking/unused/unused_enum.move
+++ b/third_party/move/move-compiler-v2/tests/checking/unused/unused_enum.move
@@ -1,0 +1,14 @@
+module 0x42::enum_types {
+
+    use std::string;
+
+    enum MessageHolder has key, drop {
+        Empty,
+        Message{
+            message: string::String,
+        }
+        NewMessage{
+            message: string::String,
+        }
+    }
+}

--- a/third_party/move/move-compiler/src/expansion/dependency_ordering.rs
+++ b/third_party/move/move-compiler/src/expansion/dependency_ordering.rs
@@ -337,6 +337,13 @@ fn function_acquires(context: &mut Context, acqs: &[E::ModuleAccess]) {
 fn struct_def(context: &mut Context, sdef: &E::StructDefinition) {
     if let E::StructLayout::Singleton(fields, _) = &sdef.layout {
         fields.iter().for_each(|(_, _, (_, bt))| type_(context, bt));
+    } else if let E::StructLayout::Variants(variants) = &sdef.layout {
+        for variant in variants {
+            variant
+                .fields
+                .iter()
+                .for_each(|(_, _, (_, bt))| type_(context, bt));
+        }
     }
 }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR closes #14400 by adding the case for enum type when analyzing dependency.

FIxes #14400.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Existing tests pass.
Added a new test.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
