### PR TITLE
[compiler-v2][optimization] Improvements to flush writes processor

### DIFF
--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -222,7 +222,7 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
         Experiment {
             name: Experiment::FLUSH_WRITES_OPTIMIZATION.to_string(),
             description: "Whether to run flush writes processor and optimization".to_string(),
-            default: Inherited(Experiment::OPTIMIZE.to_string()),
+            default: Inherited(Experiment::OPTIMIZE_WAITING_FOR_COMPARE_TESTS.to_string()),
         },
         Experiment {
             name: Experiment::STOP_BEFORE_STACKLESS_BYTECODE.to_string(),

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -483,7 +483,7 @@ pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
     // Run live var analysis again because it could be invalidated by previous pipeline steps,
     // but it is needed by file format generator.
     // There should be no "transforming" processors run after this point.
-    pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::new(false)));
+    pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::new(true)));
 
     if options.experiment_on(Experiment::FLUSH_WRITES_OPTIMIZATION) {
         // This processor only adds annotations, does not transform the bytecode.

--- a/third_party/move/move-compiler-v2/src/pipeline/flush_writes_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/flush_writes_processor.rs
@@ -3,8 +3,9 @@
 
 //! This module implements a processor that determines which writes to temporaries
 //! are better "flushed" right away by the file format code generator (as long
-//! it does not lead to potentially extra flushes). As such, these are suggestions,
-//! and can be safely ignored by the file format generator.
+//! it does not lead to potentially extra flushes: this condition is assumed to be
+//! implicit in the rest of this file, to avoid repetition). As such, these are
+//! suggestions, and can be safely ignored by the file format generator.
 //! Read on for more information on what "flushing" means.
 //!
 //! For this pass to be effective, it should be run after all the stackless-bytecode
@@ -12,7 +13,8 @@
 //! (when available) by the file-format generator. Code transformations render
 //! previously computed annotations invalid.
 //!
-//! A pre-requisite for this pass is the live-variable analysis annotations.
+//! Prerequisite: the `LiveVarAnnotation` should already be computed by running the
+//! `LiveVarAnalysisProcessor` in the `track_all_usages` mode.
 //!
 //! The file format generator can keep some writes to temporaries only on the stack,
 //! not writing it back to local memory (as a potential optimization).
@@ -21,9 +23,24 @@
 //! In the context of file format code generator, "flushed" means either store the
 //! value to a local (if used later) or pop if from the stack (if not used later).
 //!
-//! Currently, we suggest to flush those temps right away that are not used within
-//! the same basic block. However, more suggestions are theoretically possible based
-//! on additional analysis.
+//! Currently, we suggest to flush those temps right away that are:
+//! 1. Not used within the same basic block, because these will be flushed without
+//!    getting consumed anyway at the end of the block.
+//! 2. Used multiple times. Before getting consumed, these have to be flushed to local
+//!    memory anyway.
+//! 3. Used in the wrong order in an instruction, than they are put on the stack.
+//!    In such a case, they would be flushed before getting consumed anyway.
+//!    For example, in the code below:
+//!    ```move
+//!    let a = foo(); // stack: [`a`]
+//!    let b = foo(); // stack: [`a`, `b`]
+//!    consume(b, a); // we need the stack to be [`b`, `a`], so the entire stack has
+//!                   // to be flushed and reloaded in the right order.
+//!    ```
+//!    Instead, by flushing `a` eagerly when it is written, we can avoid flushing and
+//!    reloading `b`.
+//! In all these cases, the file format generator can avoid extra stack operations due
+//! to eager flushing.
 
 use crate::pipeline::livevar_analysis_processor::{LiveVarAnnotation, LiveVarInfoAtCodeOffset};
 use itertools::Itertools;
@@ -32,7 +49,7 @@ use move_model::{ast::TempIndex, model::FunctionEnv};
 use move_stackless_bytecode::{
     function_target::{FunctionData, FunctionTarget},
     function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
-    stackless_bytecode::Bytecode,
+    stackless_bytecode::{Bytecode, Operation},
     stackless_control_flow_graph::StacklessControlFlowGraph,
 };
 use std::{
@@ -45,6 +62,96 @@ use std::{
 /// elsewhere) by the file format generator.
 #[derive(Clone)]
 pub struct FlushWritesAnnotation(pub BTreeMap<CodeOffset, BTreeSet<TempIndex>>);
+
+/// A point in the code where a temporary is defined or used.
+/// Note: the order of the fields is important for comparisons.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone)]
+struct DefOrUsePoint {
+    offset: CodeOffset, // code offset of the instruction
+    index: usize,       // source (for use) or destination (for def) index in the instruction
+}
+
+/// Collection of links between definitions and uses of temporaries in a function.
+/// Note that this includes only the uses of explicit definitions in the function,
+/// in particular, the uses of function parameters are not included.
+struct UseDefLinks {
+    /// Maps a use point to the set of definition points that define the temporary used.
+    use_to_def: BTreeMap<DefOrUsePoint, BTreeSet<DefOrUsePoint>>,
+    /// Maps a definition point to the set of use points that use the temporary defined.
+    def_to_use: BTreeMap<DefOrUsePoint, BTreeSet<DefOrUsePoint>>,
+}
+
+impl UseDefLinks {
+    /// Create a new `UseDefLinks` instance for a function with `code` and `live_vars`.
+    pub fn new(code: &[Bytecode], live_vars: &LiveVarAnnotation) -> Self {
+        let mut use_to_def: BTreeMap<DefOrUsePoint, BTreeSet<DefOrUsePoint>> = BTreeMap::new();
+        let mut def_to_use: BTreeMap<DefOrUsePoint, BTreeSet<DefOrUsePoint>> = BTreeMap::new();
+        for (def_offset, def_instr) in code.iter().enumerate() {
+            let live_info = live_vars.get_info_at(def_offset as CodeOffset);
+            for (dest_index, dest) in def_instr.dests().into_iter().enumerate() {
+                let mut use_points = Self::compute_use_points(dest, code, live_info).peekable();
+                if use_points.peek().is_none() {
+                    // If there are no uses, there are no links to create.
+                    continue;
+                }
+                let def_point = DefOrUsePoint {
+                    offset: def_offset as CodeOffset,
+                    index: dest_index,
+                };
+                let use_set = def_to_use.entry(def_point.clone()).or_default();
+                for use_point in use_points {
+                    use_to_def
+                        .entry(use_point.clone())
+                        .or_default()
+                        .insert(def_point.clone());
+                    use_set.insert(use_point);
+                }
+            }
+        }
+        Self {
+            use_to_def,
+            def_to_use,
+        }
+    }
+
+    /// Compute the use points of `dest` defined at an instruction which has `live_info`.
+    fn compute_use_points<'a>(
+        dest: TempIndex,
+        code: &'a [Bytecode],
+        live_info: &LiveVarInfoAtCodeOffset,
+    ) -> Box<dyn Iterator<Item = DefOrUsePoint> + 'a> {
+        if let Some(info) = live_info.after.get(&dest) {
+            Box::new(
+                info.usage_offsets()
+                    .into_iter()
+                    .flat_map(move |use_offset| {
+                        let use_instr = &code[use_offset as usize];
+                        let mut sources = use_instr.sources();
+                        // We need to handle `WriteRef` instructions specially, because the order
+                        // of operands in stackless bytecode and stack-based bytecode is reversed.
+                        if let Bytecode::Call(_, _, Operation::WriteRef, _, _) = use_instr {
+                            sources.reverse();
+                        }
+                        sources
+                            .into_iter()
+                            .enumerate()
+                            .filter_map(move |(src_index, src)| {
+                                if src == dest {
+                                    Some(DefOrUsePoint {
+                                        offset: use_offset,
+                                        index: src_index,
+                                    })
+                                } else {
+                                    None
+                                }
+                            })
+                    }),
+            )
+        } else {
+            Box::new(std::iter::empty())
+        }
+    }
+}
 
 /// A processor for computing the `FlushWritesAnnotation`.
 pub struct FlushWritesProcessor {}
@@ -66,14 +173,21 @@ impl FunctionTargetProcessor for FlushWritesProcessor {
             .get::<LiveVarAnnotation>()
             .expect("live variable annotation is a prerequisite");
         let code = target.get_bytecode();
+        let use_def_links = UseDefLinks::new(code, live_vars);
         let cfg = StacklessControlFlowGraph::new_forward(code);
-        let mut unused: BTreeMap<CodeOffset, BTreeSet<TempIndex>> = BTreeMap::new();
+        let mut flush_writes: BTreeMap<CodeOffset, BTreeSet<TempIndex>> = BTreeMap::new();
         for block_id in cfg.blocks() {
             if let Some((lower, upper)) = cfg.instr_offset_bounds(block_id) {
-                extract_all_unused_writes_in_block(lower..=upper, code, live_vars, &mut unused);
+                Self::extract_flush_writes_in_block(
+                    lower..=upper,
+                    code,
+                    &use_def_links,
+                    &mut flush_writes,
+                );
             }
         }
-        data.annotations.set(FlushWritesAnnotation(unused), true);
+        data.annotations
+            .set(FlushWritesAnnotation(flush_writes), true);
         data
     }
 
@@ -82,52 +196,87 @@ impl FunctionTargetProcessor for FlushWritesProcessor {
     }
 }
 
-/// In the basic block given by `block_range` part of `code`, extract the writes
-/// to temporaries that are not used later the block.
-/// At the offset where the write happens, such temporaries are included, in `unused`.
-fn extract_all_unused_writes_in_block(
-    block_range: RangeInclusive<CodeOffset>,
-    code: &[Bytecode],
-    live_vars: &LiveVarAnnotation,
-    unused: &mut BTreeMap<CodeOffset, BTreeSet<TempIndex>>,
-) {
-    let upper = *block_range.end();
-    for offset in block_range {
-        let instr = &code[offset as usize];
-        // Only `Load` and `Call` instructions push results to the stack.
-        if matches!(instr, Bytecode::Load(..) | Bytecode::Call(..)) {
-            if let Some(live_info) = live_vars.get_live_var_info_at(offset) {
-                for dest in instr.dests() {
-                    if is_unused_in_block(dest, offset..=upper, live_info) {
-                        unused.entry(offset).or_default().insert(dest);
+impl FlushWritesProcessor {
+    /// In the basic block given by `block_range` part of `code`, extract the writes
+    /// to temporaries that are better flushed right away. At the offset where the
+    /// write happens, such temporaries are included, in the out param `flush_writes`.
+    fn extract_flush_writes_in_block(
+        block_range: RangeInclusive<CodeOffset>,
+        code: &[Bytecode],
+        use_def_links: &UseDefLinks,
+        flush_writes: &mut BTreeMap<CodeOffset, BTreeSet<TempIndex>>,
+    ) {
+        let upper = *block_range.end();
+        for offset in block_range {
+            let instr = &code[offset as usize];
+            // Only `Load` and `Call` instructions push temps to the stack.
+            // We need to find if any of these temps are better flushed right away.
+            if matches!(instr, Bytecode::Load(..) | Bytecode::Call(..)) {
+                for (dest_index, dest) in instr.dests().into_iter().enumerate() {
+                    let def = DefOrUsePoint {
+                        offset,
+                        index: dest_index,
+                    };
+                    if Self::could_flush_right_away(def, upper, use_def_links) {
+                        flush_writes.entry(offset).or_default().insert(dest);
                     }
                 }
             }
         }
     }
-}
 
-/// Is `temp` unused in `relevant_range`, based on `live_info` at the code offset
-/// where `temp` was written to?
-fn is_unused_in_block(
-    temp: TempIndex,
-    relevant_range: RangeInclusive<CodeOffset>,
-    live_info: &LiveVarInfoAtCodeOffset,
-) -> bool {
-    if let Some(info) = live_info.after.get(&temp) {
-        // Note: loop-carried uses are not considered here.
-        let all_usages_are_outside_block = info
-            .usage_offsets()
-            .iter()
-            .all(|usage| *usage <= *relevant_range.start() || *usage > *relevant_range.end());
-        all_usages_are_outside_block
-    } else {
-        // `temp` has no usages after `offset`.
-        true
+    /// Is the `def` better flushed right away?
+    /// `block_end` is the end of the block that has `def`.
+    fn could_flush_right_away(
+        def: DefOrUsePoint,
+        block_end: CodeOffset,
+        use_def_links: &UseDefLinks,
+    ) -> bool {
+        use_def_links.def_to_use.get(&def).map_or(true, |uses| {
+            let exactly_one_use = uses.len() == 1;
+            if !exactly_one_use {
+                // If there is more than one use, flush right away.
+                return true;
+            }
+            let use_ = uses.first().expect("there is exactly one use");
+            let use_outside_block = use_.offset <= def.offset || use_.offset > block_end;
+            if use_outside_block {
+                // If used outside the basic block, flush right away.
+                return true;
+            }
+            // If has intervening definition, flush right away.
+            Self::has_intervening_def(def, use_, use_def_links)
+        })
     }
-}
 
-impl FlushWritesProcessor {
+    /// Given the `use_` of `def`, is there a previous use of any temp at the same
+    /// instruction as `use_`, which has a definition after `def` and before
+    /// the `use_` instruction?
+    fn has_intervening_def(
+        def: DefOrUsePoint,
+        use_: &DefOrUsePoint,
+        use_def_links: &UseDefLinks,
+    ) -> bool {
+        let DefOrUsePoint {
+            offset: use_offset,
+            index: use_index,
+        } = use_;
+        (0..*use_index).any(|prev| {
+            let prev_use_at_usage_instr = DefOrUsePoint {
+                offset: *use_offset,
+                index: prev,
+            };
+            use_def_links
+                .use_to_def
+                .get(&prev_use_at_usage_instr)
+                .map_or(false, |defs| {
+                    defs.iter().any(|defs_of_prev_use| {
+                        defs_of_prev_use > &def && defs_of_prev_use.offset < *use_offset
+                    })
+                })
+        })
+    }
+
     /// Registers annotation formatter at the given function target.
     /// Helps with testing and debugging.
     pub fn register_formatters(target: &FunctionTarget) {

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
@@ -43,53 +43,44 @@ B0:
 	2: Ret
 }
 mut_field(Arg0: &mut S): u64 /* def_idx: 3 */ {
-L1:	loc0: u64
-L2:	loc1: &mut u64
+L1:	loc0: &mut u64
 B0:
 	0: MoveLoc[0](Arg0: &mut S)
 	1: MutBorrowField[0](S.f: u64)
-	2: LdU64(22)
-	3: StLoc[1](loc0: u64)
-	4: StLoc[2](loc1: &mut u64)
-	5: MoveLoc[1](loc0: u64)
-	6: CopyLoc[2](loc1: &mut u64)
-	7: WriteRef
-	8: MoveLoc[2](loc1: &mut u64)
-	9: ReadRef
-	10: Ret
+	2: StLoc[1](loc0: &mut u64)
+	3: LdU64(22)
+	4: CopyLoc[1](loc0: &mut u64)
+	5: WriteRef
+	6: MoveLoc[1](loc0: &mut u64)
+	7: ReadRef
+	8: Ret
 }
 mut_local(Arg0: u64): u64 /* def_idx: 4 */ {
 L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: &mut u64
+L2:	loc1: &mut u64
 B0:
 	0: LdU64(33)
 	1: StLoc[1](loc0: u64)
 	2: MutBorrowLoc[1](loc0: u64)
-	3: LdU64(22)
-	4: StLoc[2](loc1: u64)
-	5: StLoc[3](loc2: &mut u64)
-	6: MoveLoc[2](loc1: u64)
-	7: CopyLoc[3](loc2: &mut u64)
-	8: WriteRef
-	9: MoveLoc[3](loc2: &mut u64)
-	10: ReadRef
-	11: Ret
-}
-mut_param(Arg0: u64): u64 /* def_idx: 5 */ {
-L1:	loc0: u64
-L2:	loc1: &mut u64
-B0:
-	0: MutBorrowLoc[0](Arg0: u64)
-	1: LdU64(22)
-	2: StLoc[1](loc0: u64)
 	3: StLoc[2](loc1: &mut u64)
-	4: MoveLoc[1](loc0: u64)
+	4: LdU64(22)
 	5: CopyLoc[2](loc1: &mut u64)
 	6: WriteRef
 	7: MoveLoc[2](loc1: &mut u64)
 	8: ReadRef
 	9: Ret
+}
+mut_param(Arg0: u64): u64 /* def_idx: 5 */ {
+L1:	loc0: &mut u64
+B0:
+	0: MutBorrowLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: &mut u64)
+	2: LdU64(22)
+	3: CopyLoc[1](loc0: &mut u64)
+	4: WriteRef
+	5: MoveLoc[1](loc0: &mut u64)
+	6: ReadRef
+	7: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.opt.exp
@@ -43,20 +43,17 @@ B0:
 	2: Ret
 }
 mut_field(Arg0: &mut S): u64 /* def_idx: 3 */ {
-L1:	loc0: u64
-L2:	loc1: &mut u64
+L1:	loc0: &mut u64
 B0:
 	0: MoveLoc[0](Arg0: &mut S)
 	1: MutBorrowField[0](S.f: u64)
-	2: LdU64(22)
-	3: StLoc[1](loc0: u64)
-	4: StLoc[2](loc1: &mut u64)
-	5: MoveLoc[1](loc0: u64)
-	6: CopyLoc[2](loc1: &mut u64)
-	7: WriteRef
-	8: MoveLoc[2](loc1: &mut u64)
-	9: ReadRef
-	10: Ret
+	2: StLoc[1](loc0: &mut u64)
+	3: LdU64(22)
+	4: CopyLoc[1](loc0: &mut u64)
+	5: WriteRef
+	6: MoveLoc[1](loc0: &mut u64)
+	7: ReadRef
+	8: Ret
 }
 mut_local(Arg0: u64): u64 /* def_idx: 4 */ {
 L1:	loc0: u64
@@ -65,30 +62,25 @@ B0:
 	0: LdU64(33)
 	1: StLoc[1](loc0: u64)
 	2: MutBorrowLoc[1](loc0: u64)
-	3: LdU64(22)
-	4: StLoc[0](Arg0: u64)
-	5: StLoc[2](loc1: &mut u64)
-	6: MoveLoc[0](Arg0: u64)
-	7: CopyLoc[2](loc1: &mut u64)
-	8: WriteRef
-	9: MoveLoc[2](loc1: &mut u64)
-	10: ReadRef
-	11: Ret
-}
-mut_param(Arg0: u64): u64 /* def_idx: 5 */ {
-L1:	loc0: u64
-L2:	loc1: &mut u64
-B0:
-	0: MutBorrowLoc[0](Arg0: u64)
-	1: LdU64(22)
-	2: StLoc[1](loc0: u64)
 	3: StLoc[2](loc1: &mut u64)
-	4: MoveLoc[1](loc0: u64)
+	4: LdU64(22)
 	5: CopyLoc[2](loc1: &mut u64)
 	6: WriteRef
 	7: MoveLoc[2](loc1: &mut u64)
 	8: ReadRef
 	9: Ret
+}
+mut_param(Arg0: u64): u64 /* def_idx: 5 */ {
+L1:	loc0: &mut u64
+B0:
+	0: MutBorrowLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: &mut u64)
+	2: LdU64(22)
+	3: CopyLoc[1](loc0: &mut u64)
+	4: WriteRef
+	5: MoveLoc[1](loc0: &mut u64)
+	6: ReadRef
+	7: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance.exp
@@ -24,9 +24,9 @@ B2:
 	8: MoveLoc[2](loc0: &bool)
 	9: MoveLoc[4](loc2: &bool)
 	10: Neq
-	11: MoveLoc[0](Arg0: bool)
-	12: Pack[0](Struct0)
-	13: Pop
+	11: Pop
+	12: MoveLoc[0](Arg0: bool)
+	13: Pack[0](Struct0)
 	14: Pop
 	15: Ret
 B3:

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
@@ -144,36 +144,36 @@ test_constans() /* def_idx: 0 */ {
 B0:
 	0: LdTrue
 	1: Call u<bool>(bool): bool
-	2: LdFalse
-	3: Call u<bool>(bool): bool
-	4: LdU8(1)
-	5: Call u<u8>(u8): u8
-	6: LdU16(7086)
-	7: Call u<u16>(u16): u16
-	8: LdU32(14593408)
-	9: Call u<u32>(u32): u32
-	10: LdU64(51966)
-	11: Call u<u64>(u64): u64
-	12: LdU128(3735928559)
-	13: Call u<u128>(u128): u128
-	14: LdU256(301490978409967)
-	15: Call u<u256>(u256): u256
-	16: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66])
-	17: Call u<address>(address): address
-	18: LdConst[1](Vector(U64): [3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0])
-	19: Call u<vector<u64>>(vector<u64>): vector<u64>
-	20: LdConst[2](Vector(U8): [7, 72, 101, 108, 108, 111, 33, 10])
-	21: Call u<vector<u8>>(vector<u8>): vector<u8>
-	22: Pop
+	2: Pop
+	3: LdFalse
+	4: Call u<bool>(bool): bool
+	5: Pop
+	6: LdU8(1)
+	7: Call u<u8>(u8): u8
+	8: Pop
+	9: LdU16(7086)
+	10: Call u<u16>(u16): u16
+	11: Pop
+	12: LdU32(14593408)
+	13: Call u<u32>(u32): u32
+	14: Pop
+	15: LdU64(51966)
+	16: Call u<u64>(u64): u64
+	17: Pop
+	18: LdU128(3735928559)
+	19: Call u<u128>(u128): u128
+	20: Pop
+	21: LdU256(301490978409967)
+	22: Call u<u256>(u256): u256
 	23: Pop
-	24: Pop
-	25: Pop
+	24: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66])
+	25: Call u<address>(address): address
 	26: Pop
-	27: Pop
-	28: Pop
+	27: LdConst[1](Vector(U64): [3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0])
+	28: Call u<vector<u64>>(vector<u64>): vector<u64>
 	29: Pop
-	30: Pop
-	31: Pop
+	30: LdConst[2](Vector(U8): [7, 72, 101, 108, 108, 111, 33, 10])
+	31: Call u<vector<u8>>(vector<u8>): vector<u8>
 	32: Pop
 	33: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.exp
@@ -460,47 +460,44 @@ B10:
 	40: Abort
 }
 select_common_fields(Arg0: CommonFields): u64 /* def_idx: 9 */ {
-L1:	loc0: &CommonFields
-L2:	loc1: bool
+L1:	loc0: u64
+L2:	loc1: &CommonFields
 L3:	loc2: u64
-L4:	loc3: u64
 B0:
 	0: ImmBorrowLoc[0](Arg0: CommonFields)
 	1: ImmBorrowVariantField[3](Foo.x|Bar.x: u64)
 	2: ReadRef
-	3: ImmBorrowLoc[0](Arg0: CommonFields)
-	4: StLoc[1](loc0: &CommonFields)
-	5: CopyLoc[1](loc0: &CommonFields)
-	6: TestVariant[7](CommonFields/Foo)
-	7: StLoc[2](loc1: bool)
-	8: StLoc[3](loc2: u64)
-	9: MoveLoc[2](loc1: bool)
-	10: BrFalse(21)
+	3: StLoc[1](loc0: u64)
+	4: ImmBorrowLoc[0](Arg0: CommonFields)
+	5: StLoc[2](loc1: &CommonFields)
+	6: CopyLoc[2](loc1: &CommonFields)
+	7: TestVariant[7](CommonFields/Foo)
+	8: BrFalse(19)
 B1:
-	11: MoveLoc[1](loc0: &CommonFields)
-	12: Pop
-	13: MoveLoc[0](Arg0: CommonFields)
-	14: UnpackVariant[7](CommonFields/Foo)
-	15: StLoc[4](loc3: u64)
-	16: Pop
+	9: MoveLoc[2](loc1: &CommonFields)
+	10: Pop
+	11: MoveLoc[0](Arg0: CommonFields)
+	12: UnpackVariant[7](CommonFields/Foo)
+	13: StLoc[3](loc2: u64)
+	14: Pop
 B2:
-	17: MoveLoc[3](loc2: u64)
-	18: MoveLoc[4](loc3: u64)
-	19: Add
-	20: Ret
+	15: MoveLoc[1](loc0: u64)
+	16: MoveLoc[3](loc2: u64)
+	17: Add
+	18: Ret
 B3:
-	21: MoveLoc[1](loc0: &CommonFields)
-	22: TestVariant[8](CommonFields/Bar)
-	23: BrFalse(29)
+	19: MoveLoc[2](loc1: &CommonFields)
+	20: TestVariant[8](CommonFields/Bar)
+	21: BrFalse(27)
 B4:
-	24: MoveLoc[0](Arg0: CommonFields)
-	25: UnpackVariant[8](CommonFields/Bar)
-	26: StLoc[4](loc3: u64)
-	27: Pop
-	28: Branch(17)
+	22: MoveLoc[0](Arg0: CommonFields)
+	23: UnpackVariant[8](CommonFields/Bar)
+	24: StLoc[3](loc2: u64)
+	25: Pop
+	26: Branch(15)
 B5:
-	29: LdU64(14566554180833181697)
-	30: Abort
+	27: LdU64(14566554180833181697)
+	28: Abort
 }
 select_common_fields_different_offset(Arg0: CommonFieldsAtDifferentOffset): u64 /* def_idx: 10 */ {
 L1:	loc0: &CommonFieldsAtDifferentOffset

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
@@ -69,8 +69,8 @@ B0:
 	1: Ret
 }
 test_fold() /* def_idx: 2 */ {
-L0:	loc0: vector<u64>
-L1:	loc1: u64
+L0:	loc0: u64
+L1:	loc1: vector<u64>
 L2:	loc2: u64
 L3:	loc3: u64
 L4:	loc4: u64
@@ -78,29 +78,29 @@ L5:	loc5: u64
 L6:	loc6: u64
 B0:
 	0: LdU64(0)
-	1: LdConst[1](Vector(U64): [1, 1, 0, 0, 0, 0, 0, 0, 0])
-	2: StLoc[0](loc0: vector<u64>)
-	3: MutBorrowLoc[0](loc0: vector<u64>)
-	4: Call 1vector::reverse<u64>(&mut vector<u64>)
-	5: StLoc[1](loc1: u64)
+	1: StLoc[0](loc0: u64)
+	2: LdConst[1](Vector(U64): [1, 1, 0, 0, 0, 0, 0, 0, 0])
+	3: StLoc[1](loc1: vector<u64>)
+	4: MutBorrowLoc[1](loc1: vector<u64>)
+	5: Call 1vector::reverse<u64>(&mut vector<u64>)
 B1:
-	6: ImmBorrowLoc[0](loc0: vector<u64>)
+	6: ImmBorrowLoc[1](loc1: vector<u64>)
 	7: Call 1vector::is_empty<u64>(&vector<u64>): bool
 	8: Not
 	9: BrFalse(20)
 B2:
-	10: MutBorrowLoc[0](loc0: vector<u64>)
+	10: MutBorrowLoc[1](loc1: vector<u64>)
 	11: VecPopBack(5)
 	12: StLoc[2](loc2: u64)
-	13: MoveLoc[1](loc1: u64)
+	13: MoveLoc[0](loc0: u64)
 	14: StLoc[3](loc3: u64)
 	15: MoveLoc[2](loc2: u64)
 	16: StLoc[4](loc4: u64)
 	17: LdU64(0)
-	18: StLoc[1](loc1: u64)
+	18: StLoc[0](loc0: u64)
 	19: Branch(6)
 B3:
-	20: MoveLoc[1](loc1: u64)
+	20: MoveLoc[0](loc0: u64)
 	21: StLoc[5](loc5: u64)
 	22: LdU64(0)
 	23: StLoc[6](loc6: u64)

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_01.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_01.move
@@ -1,0 +1,15 @@
+module 0xc0ffee::m {
+    fun one_one(): (u64, u64) {
+        (1, 1)
+    }
+
+    fun take1(_x: u64) {}
+
+    fun take2(_x: u64, _y: u64) {}
+
+    public fun test() {
+        let (a, b) = one_one();
+        take1(b);
+        take2(a, b);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_01.off.exp
@@ -1,0 +1,33 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one_one(): u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(1)
+	2: Ret
+}
+take1(Arg0: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+B0:
+	0: Ret
+}
+public test() /* def_idx: 3 */ {
+L0:	loc0: u64
+B0:
+	0: Call one_one(): u64 * u64
+	1: StLoc[0](loc0: u64)
+	2: CopyLoc[0](loc0: u64)
+	3: Call take1(u64)
+	4: MoveLoc[0](loc0: u64)
+	5: Call take2(u64, u64)
+	6: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_01.on.exp
@@ -1,0 +1,77 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::one_one(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 1
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+
+[variant baseline]
+fun m::take1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     # flush: $t1
+     # live vars:
+  0: ($t0, $t1) := m::one_one()
+     # live vars: $t0, $t1
+  1: m::take1($t1)
+     # live vars: $t0, $t1
+  2: m::take2($t0, $t1)
+     # live vars:
+  3: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one_one(): u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(1)
+	2: Ret
+}
+take1(Arg0: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+B0:
+	0: Ret
+}
+public test() /* def_idx: 3 */ {
+L0:	loc0: u64
+B0:
+	0: Call one_one(): u64 * u64
+	1: StLoc[0](loc0: u64)
+	2: CopyLoc[0](loc0: u64)
+	3: Call take1(u64)
+	4: MoveLoc[0](loc0: u64)
+	5: Call take2(u64, u64)
+	6: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_02.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_02.move
@@ -1,0 +1,15 @@
+module 0xc0ffee::m {
+    fun one_one(): (u64, u64) {
+        (1, 1)
+    }
+
+    fun take1(_x: u64) {}
+
+    fun take2(_x: u64, _y: u64) {}
+
+    public fun test() {
+        let (a, b) = one_one();
+        take1(b);
+        take2(b, a);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_02.off.exp
@@ -1,0 +1,36 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one_one(): u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(1)
+	2: Ret
+}
+take1(Arg0: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+B0:
+	0: Ret
+}
+public test() /* def_idx: 3 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one_one(): u64 * u64
+	1: StLoc[0](loc0: u64)
+	2: CopyLoc[0](loc0: u64)
+	3: Call take1(u64)
+	4: StLoc[1](loc1: u64)
+	5: MoveLoc[0](loc0: u64)
+	6: MoveLoc[1](loc1: u64)
+	7: Call take2(u64, u64)
+	8: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_02.on.exp
@@ -1,0 +1,80 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::one_one(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 1
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+
+[variant baseline]
+fun m::take1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     # flush: $t0, $t1
+     # live vars:
+  0: ($t0, $t1) := m::one_one()
+     # live vars: $t0, $t1
+  1: m::take1($t1)
+     # live vars: $t0, $t1
+  2: m::take2($t1, $t0)
+     # live vars:
+  3: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one_one(): u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(1)
+	2: Ret
+}
+take1(Arg0: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+B0:
+	0: Ret
+}
+public test() /* def_idx: 3 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one_one(): u64 * u64
+	1: StLoc[0](loc0: u64)
+	2: StLoc[1](loc1: u64)
+	3: CopyLoc[0](loc0: u64)
+	4: Call take1(u64)
+	5: MoveLoc[0](loc0: u64)
+	6: MoveLoc[1](loc1: u64)
+	7: Call take2(u64, u64)
+	8: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_03.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_03.move
@@ -1,0 +1,15 @@
+module 0xc0ffee::m {
+    fun one_one(): (u64, u64) {
+        (1, 1)
+    }
+
+    fun take1(_x: u64) {}
+
+    fun take2(_x: u64, _y: u64) {}
+
+    public fun test() {
+        let (a, b) = one_one();
+        take1(b);
+        take2(a, a);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_03.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_03.off.exp
@@ -1,0 +1,33 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one_one(): u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(1)
+	2: Ret
+}
+take1(Arg0: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+B0:
+	0: Ret
+}
+public test() /* def_idx: 3 */ {
+L0:	loc0: u64
+B0:
+	0: Call one_one(): u64 * u64
+	1: Call take1(u64)
+	2: StLoc[0](loc0: u64)
+	3: CopyLoc[0](loc0: u64)
+	4: MoveLoc[0](loc0: u64)
+	5: Call take2(u64, u64)
+	6: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_03.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_03.on.exp
@@ -1,0 +1,77 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::one_one(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 1
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+
+[variant baseline]
+fun m::take1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     # flush: $t0
+     # live vars:
+  0: ($t0, $t1) := m::one_one()
+     # live vars: $t0, $t1
+  1: m::take1($t1)
+     # live vars: $t0
+  2: m::take2($t0, $t0)
+     # live vars:
+  3: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one_one(): u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(1)
+	2: Ret
+}
+take1(Arg0: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+B0:
+	0: Ret
+}
+public test() /* def_idx: 3 */ {
+L0:	loc0: u64
+B0:
+	0: Call one_one(): u64 * u64
+	1: Call take1(u64)
+	2: StLoc[0](loc0: u64)
+	3: CopyLoc[0](loc0: u64)
+	4: MoveLoc[0](loc0: u64)
+	5: Call take2(u64, u64)
+	6: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_04.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_04.move
@@ -1,0 +1,15 @@
+module 0xc0ffee::m {
+    fun one_one(): (u64, u64) {
+        (1, 1)
+    }
+
+    fun take1(_x: u64) {}
+
+    fun take2(_x: u64, _y: u64) {}
+
+    public fun test() {
+        let (a, b) = one_one();
+        take1(a);
+        take2(b, b);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_04.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_04.off.exp
@@ -1,0 +1,34 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one_one(): u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(1)
+	2: Ret
+}
+take1(Arg0: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+B0:
+	0: Ret
+}
+public test() /* def_idx: 3 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one_one(): u64 * u64
+	1: StLoc[0](loc0: u64)
+	2: Call take1(u64)
+	3: CopyLoc[0](loc0: u64)
+	4: MoveLoc[0](loc0: u64)
+	5: Call take2(u64, u64)
+	6: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_04.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_04.on.exp
@@ -1,0 +1,77 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::one_one(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 1
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+
+[variant baseline]
+fun m::take1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     # flush: $t1
+     # live vars:
+  0: ($t0, $t1) := m::one_one()
+     # live vars: $t0, $t1
+  1: m::take1($t0)
+     # live vars: $t1
+  2: m::take2($t1, $t1)
+     # live vars:
+  3: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one_one(): u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(1)
+	2: Ret
+}
+take1(Arg0: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+B0:
+	0: Ret
+}
+public test() /* def_idx: 3 */ {
+L0:	loc0: u64
+B0:
+	0: Call one_one(): u64 * u64
+	1: StLoc[0](loc0: u64)
+	2: Call take1(u64)
+	3: CopyLoc[0](loc0: u64)
+	4: MoveLoc[0](loc0: u64)
+	5: Call take2(u64, u64)
+	6: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_05.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_05.move
@@ -1,0 +1,15 @@
+module 0xc0ffee::m {
+    fun one_one(): (u64, u64) {
+        (1, 1)
+    }
+
+    fun take1(_x: u64) {}
+
+    fun take2(_x: u64, _y: u64) {}
+
+    public fun test() {
+        let (a, b) = one_one();
+        take1(a);
+        take1(b);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_05.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_05.off.exp
@@ -1,0 +1,33 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one_one(): u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(1)
+	2: Ret
+}
+take1(Arg0: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+B0:
+	0: Ret
+}
+public test() /* def_idx: 3 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one_one(): u64 * u64
+	1: StLoc[0](loc0: u64)
+	2: Call take1(u64)
+	3: MoveLoc[0](loc0: u64)
+	4: Call take1(u64)
+	5: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_05.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_05.on.exp
@@ -1,0 +1,76 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::one_one(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 1
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+
+[variant baseline]
+fun m::take1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: ($t0, $t1) := m::one_one()
+     # live vars: $t0, $t1
+  1: m::take1($t0)
+     # live vars: $t1
+  2: m::take1($t1)
+     # live vars:
+  3: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one_one(): u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(1)
+	2: Ret
+}
+take1(Arg0: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+B0:
+	0: Ret
+}
+public test() /* def_idx: 3 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one_one(): u64 * u64
+	1: StLoc[0](loc0: u64)
+	2: Call take1(u64)
+	3: MoveLoc[0](loc0: u64)
+	4: Call take1(u64)
+	5: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_06.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_06.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+    fun one(): u64 {
+        1
+    }
+
+    fun take2(_x: u64, _y: u64) {}
+
+    public fun test(b: u64) {
+        let a = one();
+        take2(b, a);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_06.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_06.off.exp
@@ -1,0 +1,27 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one(): u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+take2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+public test(Arg0: u64) /* def_idx: 2 */ {
+L1:	loc0: u64
+B0:
+	0: Call one(): u64
+	1: StLoc[1](loc0: u64)
+	2: MoveLoc[0](Arg0: u64)
+	3: MoveLoc[1](loc0: u64)
+	4: Call take2(u64, u64)
+	5: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_06.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_06.on.exp
@@ -1,0 +1,57 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun m::take2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64) {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := m::one()
+     # live vars: $t0, $t1
+  1: m::take2($t0, $t1)
+     # live vars:
+  2: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+one(): u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+take2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+public test(Arg0: u64) /* def_idx: 2 */ {
+L1:	loc0: u64
+B0:
+	0: Call one(): u64
+	1: StLoc[1](loc0: u64)
+	2: MoveLoc[0](Arg0: u64)
+	3: MoveLoc[1](loc0: u64)
+	4: Call take2(u64, u64)
+	5: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_07.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_07.move
@@ -1,0 +1,15 @@
+module 0xc0ffee::m {
+    fun one(): u64 {
+        1
+    }
+
+    fun foo(x: u64): u64 {
+        x + 1
+    }
+
+    public fun test(): u64 {
+        let x = one();
+        x = foo(x);
+        x
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_07.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_07.off.exp
@@ -1,0 +1,28 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+foo(Arg0: u64): u64 /* def_idx: 0 */ {
+L1:	loc0: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: Ret
+}
+one(): u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test(): u64 /* def_idx: 2 */ {
+L0:	loc0: u64
+B0:
+	0: Call one(): u64
+	1: Call foo(u64): u64
+	2: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_07.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_07.on.exp
@@ -1,0 +1,68 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t0 := +($t0, $t2)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test(): u64 {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+  0: $t1 := m::one()
+     # live vars: $t1
+  1: $t2 := m::foo($t1)
+     # live vars: $t2
+  2: $t1 := move($t2)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+foo(Arg0: u64): u64 /* def_idx: 0 */ {
+L1:	loc0: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: Ret
+}
+one(): u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test(): u64 /* def_idx: 2 */ {
+L0:	loc0: u64
+B0:
+	0: Call one(): u64
+	1: Call foo(u64): u64
+	2: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_08.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_08.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+    fun foo(): (u64, u64, u64, u64) {
+        (1, 2, 3, 4)
+    }
+
+    fun take(_x: u64, _y: u64, _z: u64, _w: u64) {}
+
+    public fun test() {
+        let (a, b, c, d) = foo();
+        take(b, c, d, a);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_08.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_08.off.exp
@@ -1,0 +1,38 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+foo(): u64 * u64 * u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(2)
+	2: LdU64(3)
+	3: LdU64(4)
+	4: Ret
+}
+take(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+public test() /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+L3:	loc3: u64
+B0:
+	0: Call foo(): u64 * u64 * u64 * u64
+	1: StLoc[0](loc0: u64)
+	2: StLoc[1](loc1: u64)
+	3: StLoc[2](loc2: u64)
+	4: StLoc[3](loc3: u64)
+	5: MoveLoc[2](loc2: u64)
+	6: MoveLoc[1](loc1: u64)
+	7: MoveLoc[0](loc0: u64)
+	8: MoveLoc[3](loc3: u64)
+	9: Call take(u64, u64, u64, u64)
+	10: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_08.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_08.on.exp
@@ -1,0 +1,81 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::foo(): (u64, u64, u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: $t2 := 3
+     # live vars: $t0, $t1, $t2
+  3: $t3 := 4
+     # live vars: $t0, $t1, $t2, $t3
+  4: return ($t0, $t1, $t2, $t3)
+}
+
+
+[variant baseline]
+fun m::take($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     # live vars: $t0, $t1, $t2, $t3
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # flush: $t0
+     # live vars:
+  0: ($t0, $t1, $t2, $t3) := m::foo()
+     # live vars: $t0, $t1, $t2, $t3
+  1: m::take($t1, $t2, $t3, $t0)
+     # live vars:
+  2: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+foo(): u64 * u64 * u64 * u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(2)
+	2: LdU64(3)
+	3: LdU64(4)
+	4: Ret
+}
+take(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 1 */ {
+B0:
+	0: Ret
+}
+public test() /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+L3:	loc3: u64
+B0:
+	0: Call foo(): u64 * u64 * u64 * u64
+	1: StLoc[0](loc0: u64)
+	2: StLoc[1](loc1: u64)
+	3: StLoc[2](loc2: u64)
+	4: StLoc[3](loc3: u64)
+	5: MoveLoc[2](loc2: u64)
+	6: MoveLoc[1](loc1: u64)
+	7: MoveLoc[0](loc0: u64)
+	8: MoveLoc[3](loc3: u64)
+	9: Call take(u64, u64, u64, u64)
+	10: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/loop_02.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/loop_02.move
@@ -1,0 +1,15 @@
+module 0xc0ffee::m {
+    fun inc(x: u64): u64 {
+        x + 1
+    }
+
+    public fun test() {
+        let x = 0;
+        loop {
+            x = inc(x);
+            if (x > 10) {
+                break;
+            }
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/loop_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/loop_02.off.exp
@@ -1,0 +1,33 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+inc(Arg0: u64): u64 /* def_idx: 0 */ {
+L1:	loc0: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: Ret
+}
+public test() /* def_idx: 1 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: LdU64(0)
+	1: StLoc[0](loc0: u64)
+B1:
+	2: MoveLoc[0](loc0: u64)
+	3: Call inc(u64): u64
+	4: StLoc[0](loc0: u64)
+	5: CopyLoc[0](loc0: u64)
+	6: LdU64(10)
+	7: Gt
+	8: BrFalse(2)
+B2:
+	9: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/loop_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/loop_02.on.exp
@@ -1,0 +1,75 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::inc($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t0 := +($t0, $t2)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64 [unused]
+     # flush: $t0
+     # live vars:
+  0: $t0 := 0
+     # live vars: $t0
+  1: label L0
+     # live vars: $t0
+  2: $t1 := m::inc($t0)
+     # live vars: $t1
+  3: $t0 := move($t1)
+     # live vars: $t0
+  4: $t1 := 10
+     # live vars: $t0, $t1
+  5: $t2 := >($t0, $t1)
+     # live vars: $t0, $t2
+  6: if ($t2) goto 7 else goto 1
+     # live vars: $t0
+  7: label L2
+     # live vars:
+  8: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+inc(Arg0: u64): u64 /* def_idx: 0 */ {
+L1:	loc0: u64
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: Add
+	3: Ret
+}
+public test() /* def_idx: 1 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: LdU64(0)
+	1: StLoc[0](loc0: u64)
+B1:
+	2: MoveLoc[0](loc0: u64)
+	3: Call inc(u64): u64
+	4: StLoc[0](loc0: u64)
+	5: CopyLoc[0](loc0: u64)
+	6: LdU64(10)
+	7: Gt
+	8: BrFalse(2)
+B2:
+	9: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_01.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_01.move
@@ -1,0 +1,26 @@
+module 0xc0ffee::m {
+    public fun one(): u64 {
+        1
+    }
+
+    public fun consume(
+        _a: u64,
+        _b: u64,
+        _c: u64,
+        _d: u64,
+        _e: u64,
+        _f: u64,
+        _g: u64
+    ) {}
+
+    public fun test() {
+        let a = one();
+        let b = one();
+        let c = one();
+        let d = one();
+        let e = one();
+        let f = one();
+        let g = one();
+        consume(b, c, d, e, f, g, a);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_01.off.exp
@@ -1,0 +1,50 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64, Arg6: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+public one(): u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test() /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+L3:	loc3: u64
+L4:	loc4: u64
+L5:	loc5: u64
+L6:	loc6: u64
+B0:
+	0: Call one(): u64
+	1: Call one(): u64
+	2: Call one(): u64
+	3: Call one(): u64
+	4: Call one(): u64
+	5: Call one(): u64
+	6: Call one(): u64
+	7: StLoc[0](loc0: u64)
+	8: StLoc[1](loc1: u64)
+	9: StLoc[2](loc2: u64)
+	10: StLoc[3](loc3: u64)
+	11: StLoc[4](loc4: u64)
+	12: StLoc[5](loc5: u64)
+	13: StLoc[6](loc6: u64)
+	14: MoveLoc[5](loc5: u64)
+	15: MoveLoc[4](loc4: u64)
+	16: MoveLoc[3](loc3: u64)
+	17: MoveLoc[2](loc2: u64)
+	18: MoveLoc[1](loc1: u64)
+	19: MoveLoc[0](loc0: u64)
+	20: MoveLoc[6](loc6: u64)
+	21: Call consume(u64, u64, u64, u64, u64, u64, u64)
+	22: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_01.on.exp
@@ -1,0 +1,81 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+public fun m::consume($t0: u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64, $t5: u64, $t6: u64) {
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # flush: $t0
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::one()
+     # live vars: $t0, $t1
+  2: $t2 := m::one()
+     # live vars: $t0, $t1, $t2
+  3: $t3 := m::one()
+     # live vars: $t0, $t1, $t2, $t3
+  4: $t4 := m::one()
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  5: $t5 := m::one()
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
+  6: $t6 := m::one()
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
+  7: m::consume($t1, $t2, $t3, $t4, $t5, $t6, $t0)
+     # live vars:
+  8: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64, Arg6: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+public one(): u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test() /* def_idx: 2 */ {
+L0:	loc0: u64
+B0:
+	0: Call one(): u64
+	1: StLoc[0](loc0: u64)
+	2: Call one(): u64
+	3: Call one(): u64
+	4: Call one(): u64
+	5: Call one(): u64
+	6: Call one(): u64
+	7: Call one(): u64
+	8: MoveLoc[0](loc0: u64)
+	9: Call consume(u64, u64, u64, u64, u64, u64, u64)
+	10: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_02.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_02.move
@@ -1,0 +1,13 @@
+module 0xc0ffee::m {
+    fun one(): u64 {
+        1
+    }
+
+    fun consume(_a: u64, _b: u64, _c: u64) {}
+
+    public fun test() {
+        let a = one();
+        let b = one();
+        consume(b, a, a);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_02.off.exp
@@ -1,0 +1,31 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+consume(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+one(): u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test() /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: Call one(): u64
+	2: StLoc[0](loc0: u64)
+	3: StLoc[1](loc1: u64)
+	4: MoveLoc[0](loc0: u64)
+	5: CopyLoc[1](loc1: u64)
+	6: MoveLoc[1](loc1: u64)
+	7: Call consume(u64, u64, u64)
+	8: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_02.on.exp
@@ -1,0 +1,62 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64) {
+     # live vars: $t0, $t1, $t2
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     # flush: $t0
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::one()
+     # live vars: $t0, $t1
+  2: m::consume($t1, $t0, $t0)
+     # live vars:
+  3: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+consume(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+one(): u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test() /* def_idx: 2 */ {
+L0:	loc0: u64
+B0:
+	0: Call one(): u64
+	1: StLoc[0](loc0: u64)
+	2: Call one(): u64
+	3: CopyLoc[0](loc0: u64)
+	4: MoveLoc[0](loc0: u64)
+	5: Call consume(u64, u64, u64)
+	6: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_03.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_03.move
@@ -1,0 +1,12 @@
+module 0xc0ffee::m {
+    fun one_one(): (u64, u64) {
+        (1, 1)
+    }
+
+    fun consume(_a: u64, _b: u64, _c: u64) {}
+
+    public fun test() {
+        let (a, b) = one_one();
+        consume(b, a, a);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_03.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_03.off.exp
@@ -1,0 +1,31 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+consume(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+one_one(): u64 * u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(1)
+	2: Ret
+}
+public test() /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one_one(): u64 * u64
+	1: StLoc[0](loc0: u64)
+	2: StLoc[1](loc1: u64)
+	3: MoveLoc[0](loc0: u64)
+	4: CopyLoc[1](loc1: u64)
+	5: MoveLoc[1](loc1: u64)
+	6: Call consume(u64, u64, u64)
+	7: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_03.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_03.on.exp
@@ -1,0 +1,66 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64) {
+     # live vars: $t0, $t1, $t2
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one_one(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 1
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     # flush: $t0
+     # live vars:
+  0: ($t0, $t1) := m::one_one()
+     # live vars: $t0, $t1
+  1: m::consume($t1, $t0, $t0)
+     # live vars:
+  2: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+consume(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+one_one(): u64 * u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: LdU64(1)
+	2: Ret
+}
+public test() /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one_one(): u64 * u64
+	1: StLoc[0](loc0: u64)
+	2: StLoc[1](loc1: u64)
+	3: MoveLoc[0](loc0: u64)
+	4: CopyLoc[1](loc1: u64)
+	5: MoveLoc[1](loc1: u64)
+	6: Call consume(u64, u64, u64)
+	7: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_04.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_04.move
@@ -1,0 +1,13 @@
+module 0xc0ffee::m {
+    fun one(): u64 {
+        1
+    }
+
+    fun consume(_a: u64, _b: u64, _c: u64) {}
+
+    public fun test() {
+        let a = one();
+        let b = one();
+        consume(a, b, a);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_04.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_04.off.exp
@@ -1,0 +1,31 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+consume(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+one(): u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test() /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: Call one(): u64
+	2: StLoc[0](loc0: u64)
+	3: StLoc[1](loc1: u64)
+	4: CopyLoc[1](loc1: u64)
+	5: MoveLoc[0](loc0: u64)
+	6: MoveLoc[1](loc1: u64)
+	7: Call consume(u64, u64, u64)
+	8: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_04.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_04.on.exp
@@ -1,0 +1,65 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64) {
+     # live vars: $t0, $t1, $t2
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     # flush: $t0
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::one()
+     # live vars: $t0, $t1
+  2: m::consume($t0, $t1, $t0)
+     # live vars:
+  3: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+consume(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+one(): u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public test() /* def_idx: 2 */ {
+L0:	loc0: u64
+L1:	loc1: u64
+B0:
+	0: Call one(): u64
+	1: StLoc[0](loc0: u64)
+	2: Call one(): u64
+	3: StLoc[1](loc1: u64)
+	4: CopyLoc[0](loc0: u64)
+	5: MoveLoc[1](loc1: u64)
+	6: MoveLoc[0](loc0: u64)
+	7: Call consume(u64, u64, u64)
+	8: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.on.exp
@@ -55,6 +55,7 @@ public fun m::test3(): (u64, u64) {
      var $t2: u64
      var $t3: u64
      var $t4: u64
+     # flush: $t2
      # live vars:
   0: $t2 := m::one()
      # flush: $t3
@@ -98,14 +99,12 @@ L0:	loc0: u64
 L1:	loc1: u64
 B0:
 	0: Call one(): u64
-	1: Call one(): u64
-	2: Pop
-	3: Call one(): u64
-	4: StLoc[0](loc0: u64)
-	5: StLoc[1](loc1: u64)
-	6: MoveLoc[0](loc0: u64)
-	7: MoveLoc[1](loc1: u64)
-	8: Ret
+	1: StLoc[0](loc0: u64)
+	2: Call one(): u64
+	3: Pop
+	4: Call one(): u64
+	5: MoveLoc[0](loc0: u64)
+	6: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/write_ref_01.move
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/write_ref_01.move
@@ -1,0 +1,7 @@
+module 0xc0ffee::m {
+    public fun test(x: u64) {
+        let y = &mut x;
+        *y = 42;
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/flush-writes/write_ref_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/write_ref_01.off.exp
@@ -1,0 +1,21 @@
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public test(Arg0: u64) /* def_idx: 0 */ {
+L1:	loc0: u64
+L2:	loc1: &mut u64
+B0:
+	0: MutBorrowLoc[0](Arg0: u64)
+	1: LdU64(42)
+	2: StLoc[1](loc0: u64)
+	3: StLoc[2](loc1: &mut u64)
+	4: MoveLoc[1](loc0: u64)
+	5: MoveLoc[2](loc1: &mut u64)
+	6: WriteRef
+	7: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/flush-writes/write_ref_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/write_ref_01.on.exp
@@ -1,0 +1,35 @@
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64) {
+     var $t1: &mut u64
+     var $t2: u64
+     # flush: $t1
+     # live vars: $t0
+  0: $t1 := borrow_local($t0)
+     # live vars: $t1
+  1: $t2 := 42
+     # live vars: $t1, $t2
+  2: write_ref($t1, $t2)
+     # live vars:
+  3: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+public test(Arg0: u64) /* def_idx: 0 */ {
+L1:	loc0: &mut u64
+B0:
+	0: MutBorrowLoc[0](Arg0: u64)
+	1: StLoc[1](loc0: &mut u64)
+	2: LdU64(42)
+	3: MoveLoc[1](loc0: &mut u64)
+	4: WriteRef
+	5: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.old.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.old.exp
@@ -3,7 +3,7 @@
 
 Diagnostics:
 bug: bytecode verification failed with unexpected status code `WRITEREF_EXISTS_BORROW_ERROR`. This is a compiler bug, consider reporting it.
-   ┌─ tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.move:10:9
+   ┌─ tests/reference-safety/v1-borrow-tests/writeref_borrow_invalid.move:10:18
    │
 10 │         *g_mut = G { v: 0 };
-   │         ^^^^^^^^^^^^^^^^^^^
+   │                  ^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.exp
@@ -97,20 +97,17 @@ module c0ffee.m {
 
 test(Arg0: u64): u64 /* def_idx: 0 */ {
 L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: &mut u64
+L2:	loc1: &mut u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)
 	2: MutBorrowLoc[0](Arg0: u64)
-	3: LdU64(1)
-	4: StLoc[2](loc1: u64)
-	5: StLoc[3](loc2: &mut u64)
-	6: MoveLoc[2](loc1: u64)
-	7: MoveLoc[3](loc2: &mut u64)
-	8: WriteRef
-	9: MoveLoc[1](loc0: u64)
-	10: Ret
+	3: StLoc[2](loc1: &mut u64)
+	4: LdU64(1)
+	5: MoveLoc[2](loc1: &mut u64)
+	6: WriteRef
+	7: MoveLoc[1](loc0: u64)
+	8: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.opt.exp
@@ -97,20 +97,17 @@ module c0ffee.m {
 
 test(Arg0: u64): u64 /* def_idx: 0 */ {
 L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: &mut u64
+L2:	loc1: &mut u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: StLoc[1](loc0: u64)
 	2: MutBorrowLoc[0](Arg0: u64)
-	3: LdU64(1)
-	4: StLoc[2](loc1: u64)
-	5: StLoc[3](loc2: &mut u64)
-	6: MoveLoc[2](loc1: u64)
-	7: MoveLoc[3](loc2: &mut u64)
-	8: WriteRef
-	9: MoveLoc[1](loc0: u64)
-	10: Ret
+	3: StLoc[2](loc1: &mut u64)
+	4: LdU64(1)
+	5: MoveLoc[2](loc1: &mut u64)
+	6: WriteRef
+	7: MoveLoc[1](loc0: u64)
+	8: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.exp
@@ -149,8 +149,7 @@ struct S has copy, drop {
 test(Arg0: S): u64 /* def_idx: 0 */ {
 L1:	loc0: S
 L2:	loc1: S
-L3:	loc2: u64
-L4:	loc3: &mut u64
+L3:	loc2: &mut u64
 B0:
 	0: MoveLoc[0](Arg0: S)
 	1: StLoc[1](loc0: S)
@@ -158,16 +157,14 @@ B0:
 	3: StLoc[2](loc1: S)
 	4: MutBorrowLoc[1](loc0: S)
 	5: MutBorrowField[0](S.a: u64)
-	6: LdU64(0)
-	7: StLoc[3](loc2: u64)
-	8: StLoc[4](loc3: &mut u64)
-	9: MoveLoc[3](loc2: u64)
-	10: MoveLoc[4](loc3: &mut u64)
-	11: WriteRef
-	12: ImmBorrowLoc[2](loc1: S)
-	13: ImmBorrowField[0](S.a: u64)
-	14: ReadRef
-	15: Ret
+	6: StLoc[3](loc2: &mut u64)
+	7: LdU64(0)
+	8: MoveLoc[3](loc2: &mut u64)
+	9: WriteRef
+	10: ImmBorrowLoc[2](loc1: S)
+	11: ImmBorrowField[0](S.a: u64)
+	12: ReadRef
+	13: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.opt.exp
@@ -149,8 +149,7 @@ struct S has copy, drop {
 test(Arg0: S): u64 /* def_idx: 0 */ {
 L1:	loc0: S
 L2:	loc1: S
-L3:	loc2: u64
-L4:	loc3: &mut u64
+L3:	loc2: &mut u64
 B0:
 	0: MoveLoc[0](Arg0: S)
 	1: StLoc[1](loc0: S)
@@ -158,16 +157,14 @@ B0:
 	3: StLoc[2](loc1: S)
 	4: MutBorrowLoc[1](loc0: S)
 	5: MutBorrowField[0](S.a: u64)
-	6: LdU64(0)
-	7: StLoc[3](loc2: u64)
-	8: StLoc[4](loc3: &mut u64)
-	9: MoveLoc[3](loc2: u64)
-	10: MoveLoc[4](loc3: &mut u64)
-	11: WriteRef
-	12: ImmBorrowLoc[2](loc1: S)
-	13: ImmBorrowField[0](S.a: u64)
-	14: ReadRef
-	15: Ret
+	6: StLoc[3](loc2: &mut u64)
+	7: LdU64(0)
+	8: MoveLoc[3](loc2: &mut u64)
+	9: WriteRef
+	10: ImmBorrowLoc[2](loc1: S)
+	11: ImmBorrowField[0](S.a: u64)
+	12: ReadRef
+	13: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
@@ -103,8 +103,6 @@ module c0ffee.m {
 
 test(): u64 /* def_idx: 0 */ {
 L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
 B0:
 	0: LdU64(1)
 	1: LdU64(2)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
@@ -99,16 +99,13 @@ module c0ffee.m {
 
 test(): u64 /* def_idx: 0 */ {
 L0:	loc0: u64
-L1:	loc1: u64
 B0:
 	0: LdU64(2)
-	1: LdU64(9)
-	2: StLoc[0](loc0: u64)
-	3: StLoc[1](loc1: u64)
-	4: MoveLoc[0](loc0: u64)
-	5: MoveLoc[1](loc1: u64)
-	6: Add
-	7: Ret
+	1: StLoc[0](loc0: u64)
+	2: LdU64(9)
+	3: MoveLoc[0](loc0: u64)
+	4: Add
+	5: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.optimize-no-simplify.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.optimize-no-simplify.exp
@@ -27,5 +27,5 @@ Error: Function execution failed with VMError: {
     sub_status: None,
     location: 0x42::m,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(5), 9)],
+    offsets: [(FunctionDefinitionIndex(5), 7)],
 }

--- a/third_party/move/move-prover/tests/sources/functional/enum_abort.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/enum_abort.v2_exp
@@ -99,7 +99,6 @@ error: abort not covered by any of the `aborts_if` clauses
     =     at tests/sources/functional/enum_abort.move:122: test_match_abort
     =         <redacted> = <redacted>
     =         _x = <redacted>
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/enum_abort.move:122: test_match_abort
     =         _z = <redacted>
     =         <redacted> = <redacted>


### PR DESCRIPTION
## Description

In this PR, we make some improvements to the flush writes processor (which was introduced in https://github.com/aptos-labs/aptos-core/pull/14394).

Flush writes processor is a stackless bytecode pass that provides hints to the file format generator to possibly flush writes eagerly. This is done in such a way that we either improve the generated code, or keep it the same - it should never be worse.

We add two more cases where we can flush writes eagerly: (a) when there are multiple uses of a definition, (b) when a definition has an intervening definition after, that is used out of order in the same instruction. For more details, refer to the module documentation of the flush writes processor.

On the `aptos-framework`, turning on the flush writes processor provides about 2% reduction in the number of instructions generated.

In some cases, such as the added test `third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_01.move`, we generate 10 instead of 22 instructions (see corresponding `.on.exp` vs. `.off.exp`).

Keen reviewers might note that we can likely do an analogue in terms of loading things on to the stack eagerly with a similar mechanism - I will explore this in a follow up PR.

## Type of Change
- [x] Performance improvement

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## How Has This Been Tested?
* Added several tests
* Existing tests pass, when updating baselines, I have verified that we either improve code or leave it equal (in terms of number of instructions generated).

## Key Areas to Review
The logic for when it makes sense to flush writes eagerly.
