### PR TITLE
[compiler-v2] More concise visibility declarations

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/direct_visibility.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/direct_visibility.exp
@@ -1,0 +1,19 @@
+
+Diagnostics:
+error: unsupported language construct
+  ┌─ tests/checking-lang-v1/direct_visibility.move:2:5
+  │
+2 │     package fun f() {}
+  │     ^^^^^^^ Move 2 language construct is not enabled: direct `package` declaration
+
+error: unsupported language construct
+  ┌─ tests/checking-lang-v1/direct_visibility.move:7:5
+  │
+7 │     friend fun f() {}
+  │     ^^^^^^ Move 2 language construct is not enabled: direct `friend` declaration
+
+error: unsupported language construct
+   ┌─ tests/checking-lang-v1/direct_visibility.move:11:5
+   │
+11 │     friend fun f() {
+   │     ^^^^^^ Move 2 language construct is not enabled: direct `friend` declaration

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/direct_visibility.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/direct_visibility.move
@@ -1,0 +1,15 @@
+module 0x815::a {
+    package fun f() {}
+}
+
+module 0x815::b {
+    friend 0x815::c;
+    friend fun f() {}
+}
+
+module 0x815::c {
+    friend fun f() {
+        0x815::a::f();
+        0x815::b::f();
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility.exp
@@ -1,0 +1,22 @@
+// -- Model dump before bytecode pipeline
+module 0x815::b {
+    friend fun f() {
+        Tuple()
+    }
+} // end 0x815::b
+module 0x815::a {
+    friend fun f() {
+        Tuple()
+    }
+    friend fun g() {
+        Tuple()
+    }
+} // end 0x815::a
+module 0x815::c {
+    public fun f() {
+        a::f();
+        a::g();
+        b::f();
+        Tuple()
+    }
+} // end 0x815::c

--- a/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility.move
+++ b/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility.move
@@ -1,0 +1,17 @@
+module 0x815::a {
+    package fun f() {}
+    public(package) fun g(){}
+}
+
+module 0x815::b {
+    friend 0x815::c;
+    friend fun f() {}
+}
+
+module 0x815::c {
+    public fun f() {
+        0x815::a::f();
+        0x815::a::g();
+        0x815::b::f();
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility_err.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+error: function `0x815::b::f` cannot be called from function `0x815::c::f` because module `0x815::c` is not a `friend` of `0x815::b`
+  ┌─ tests/checking/visibility-checker/direct_visibility_err.move:2:16
+  │
+2 │     friend fun f() {}
+  │                ^ callee
+  ·
+7 │         0x815::b::f();
+  │         ------------- called here

--- a/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility_err.move
@@ -1,0 +1,9 @@
+module 0x815::b {
+    friend fun f() {}
+}
+
+module 0x815::c {
+    public fun f() {
+        0x815::b::f();
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility_err2.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility_err2.exp
@@ -1,0 +1,9 @@
+
+Diagnostics:
+error: duplicate declaration, item, or annotation
+  ┌─ tests/checking/visibility-checker/direct_visibility_err2.move:2:13
+  │
+2 │     package friend fun f() {}
+  │     ------- ^^^^^^ Duplicate visibility modifier
+  │     │
+  │     Visibility modifier previously given here

--- a/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility_err2.move
+++ b/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility_err2.move
@@ -1,0 +1,3 @@
+module 0x815::a {
+    package friend fun f() {}
+}

--- a/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility_err3.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility_err3.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+error: unexpected token
+  ┌─ tests/checking/visibility-checker/direct_visibility_err3.move:2:13
+  │
+2 │     package 0x815::a;
+  │             ^^^^^
+  │             │
+  │             Unexpected '0x815'
+  │             Expected a module member: 'spec', 'use', 'friend', 'const', 'fun', 'inline', or 'struct'

--- a/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility_err3.move
+++ b/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility_err3.move
@@ -1,0 +1,3 @@
+module 0x815::b {
+    package 0x815::a;
+}


### PR DESCRIPTION
## Description

The syntax `public(friend) fun` and `public(package) fun` is unnecessary verbose. Taken over from Rust, perhaps in Rust `pub(crate) fn` is OK, but Move does add to much noise.

This PR suggests to introduce the syntax `package fun` and `friend fun`. Those read naturally and are also in this in other languages. (E.g. C#).

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

New tests
