### PR TITLE
BlockSynchronizationView/Event & simple barrier (block metadata txn)

### DIFF
--- a/aptos-move/aptos-vm/src/move_vm_ext/session/view_with_change_set.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/view_with_change_set.rs
@@ -25,8 +25,8 @@ use aptos_vm_types::{
     abstract_write_op::{AbstractResourceWriteOp, WriteWithDelayedFieldsOp},
     change_set::{randomly_check_layout_matches, VMChangeSet},
     resolver::{
-        ExecutorView, ResourceGroupSize, ResourceGroupView, StateStorageView, TModuleView,
-        TResourceGroupView, TResourceView,
+        BlockSynchronizationEvent, BlockSynchronizationView, ExecutorView, ResourceGroupSize,
+        ResourceGroupView, StateStorageView, TModuleView, TResourceGroupView, TResourceView,
     },
 };
 use bytes::Bytes;
@@ -56,6 +56,13 @@ impl<'r> ExecutorViewWithChangeSet<'r> {
             base_resource_group_view,
             change_set,
         }
+    }
+}
+
+impl<'r> BlockSynchronizationView for ExecutorViewWithChangeSet<'r> {
+    fn signal_sync_event(&self, event: BlockSynchronizationEvent) {
+        // Forward the signal.
+        self.base_executor_view.signal_sync_event(event);
     }
 }
 

--- a/aptos-move/block-executor/src/barriers.rs
+++ b/aptos-move/block-executor/src/barriers.rs
@@ -1,0 +1,47 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_aggregator::types::code_invariant_error;
+use aptos_mvhashmap::types::TxnIndex;
+use aptos_types::delayed_fields::PanicError;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+pub(crate) struct BlockBarriers {
+    ready_to_start_idx: AtomicU32,
+}
+
+impl BlockBarriers {
+    pub(crate) fn new() -> Self {
+        Self {
+            ready_to_start_idx: AtomicU32::new(0),
+        }
+    }
+
+    pub(crate) fn wait_to_start(&self, txn_idx: TxnIndex) {
+        while self.ready_to_start_idx.load(Ordering::Acquire) < txn_idx {}
+    }
+
+    // Transactions must be signaled to start in order. However, once a signal
+    // is received subsequent signals for the same index are ignored (idempotent)
+    pub(crate) fn signal_can_start(&self, txn_idx: TxnIndex) -> Result<(), PanicError> {
+        if txn_idx == 0 {
+            return Err(code_invariant_error(
+                "Txn can start signal should not be called for txn 0",
+            ));
+        }
+        if let Err(cur_idx) = self.ready_to_start_idx.compare_exchange(
+            txn_idx - 1,
+            txn_idx,
+            Ordering::Release,
+            Ordering::Relaxed,
+        ) {
+            if cur_idx < txn_idx {
+                return Err(code_invariant_error(format!(
+                    "Txn can start signal not in order: called for {}, observed {}",
+                    txn_idx, cur_idx,
+                )));
+            }
+        }
+        Ok(())
+    }
+}

--- a/aptos-move/block-executor/src/lib.rs
+++ b/aptos-move/block-executor/src/lib.rs
@@ -139,6 +139,7 @@ subsequent incarnation to finish.
 #[macro_use(defer)]
 extern crate scopeguard;
 
+mod barriers;
 mod captured_reads;
 pub mod counters;
 pub mod errors;

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -25,7 +25,7 @@ use aptos_types::{
     transaction::BlockExecutableTransaction as Transaction,
     write_set::{TransactionWrite, WriteOp, WriteOpKind},
 };
-use aptos_vm_types::resolver::{TExecutorView, TResourceGroupView};
+use aptos_vm_types::resolver::{BlockSynchronizationEvent, TExecutorView, TResourceGroupView};
 use bytes::Bytes;
 use claims::{assert_ge, assert_le, assert_ok};
 use move_core_types::{identifier::IdentStr, value::MoveTypeLayout};
@@ -865,6 +865,12 @@ where
         txn: &Self::Txn,
         txn_idx: TxnIndex,
     ) -> ExecutionStatus<Self::Output, Self::Error> {
+        let write_barrier = txn_idx == 0 || txn_idx == 100;
+        view.signal_sync_event(BlockSynchronizationEvent::TransactionStart { write_barrier });
+        // view.signal_sync_event(BlockSynchronizationEvent::TransactionStart {
+        //     write_barrier: false,
+        // });
+
         match txn {
             MockTransaction::Write {
                 incarnation_counter,


### PR DESCRIPTION
This should be an improvement over the current state of affairs, as finishing of block metadata txn would trigger everything that has done a read already (timestamp, randomness) to re-execute. With this change, workers will wait to start, which the blockmetadata transaction will allow after it finishes. saves wasted concurrent work and invalidation, but to discuss:
- should we do a condvar so workers are not busy waiting?
- should we pre-populate/hint the entries (timestamp, randomness), and allow the transactions to start earlier? Should be consistent with this design too though as we could just move the signal_can_start on write barrier earlier (but maybe we want to do this differently?)

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
Testing two types of barriers in proptests
