### PR TITLE
[compiler-v2][lint] Needless boolean and Simpler numerical expressions lints

### DIFF
--- a/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints.rs
@@ -4,6 +4,8 @@
 //! This module (and its submodules) contain various model-AST-based lint checks.
 
 mod blocks_in_conditions;
+mod needless_bool;
+mod simpler_numeric_expression;
 mod unnecessary_boolean_identity_comparison;
 mod unnecessary_numerical_extreme_comparison;
 mod while_true;
@@ -94,6 +96,8 @@ fn get_applicable_lints(lint_skips: BTreeSet<LintChecker>) -> Vec<Box<dyn Expres
 fn get_default_expression_linter_pipeline() -> Vec<Box<dyn ExpressionLinter>> {
     vec![
         Box::<blocks_in_conditions::BlocksInConditions>::default(),
+        Box::<needless_bool::NeedlessBool>::default(),
+        Box::<simpler_numeric_expression::SimplerNumericExpression>::default(),
         Box::<unnecessary_boolean_identity_comparison::UnnecessaryBooleanIdentityComparison>::default(),
         Box::<unnecessary_numerical_extreme_comparison::UnnecessaryNumericalExtremeComparison>::default(),
         Box::<while_true::WhileTrue>::default(),

--- a/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints/needless_bool.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints/needless_bool.rs
@@ -1,0 +1,89 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements an expression linter that checks for needless bool
+//! of the forms:
+//! 1. `if (x) true else false`, which can be replaced with just `x`.
+//! 2. `if (x) false else true`, which can be replaced with just `!x`.
+//! 3. `if (x) true else true`, which should be rewritten to remove the redundant branch.
+//!
+//! In addition, it also handles similar cases where both branches explicitly return
+//! boolean values.
+
+use crate::{env_pipeline::model_ast_lints::ExpressionLinter, lint_common::LintChecker};
+use move_model::{
+    ast::{ExpData, Value},
+    model::GlobalEnv,
+};
+
+#[derive(Default)]
+pub struct NeedlessBool;
+
+impl ExpressionLinter for NeedlessBool {
+    fn get_lint_checker(&self) -> LintChecker {
+        LintChecker::NeedlessBool
+    }
+
+    fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
+        use ExpData::IfElse;
+        if let IfElse(id, _, then, else_) = expr {
+            match Self::fixed_bool_values(then, else_) {
+                None => {},
+                Some(ThenElseFixedValues { then, else_, .. }) if then == else_ => {
+                    self.warning(
+                        env,
+                        &env.get_node_loc(*id),
+                        "This if-else has the same bool expression in both branches, consider rewriting the code to remove this redundancy",
+                    );
+                },
+                Some(ThenElseFixedValues {
+                    then,
+                    both_returned,
+                    ..
+                }) => {
+                    let negation = if then { "" } else { "the negation of " };
+                    let returned = if both_returned { " returning" } else { "" };
+                    self.warning(
+                        env,
+                        &env.get_node_loc(*id),
+                        &format!(
+                            "This if-else can be replaced with just{} {}the condition",
+                            returned, negation
+                        ),
+                    );
+                },
+            }
+        }
+    }
+}
+
+/// Fixed boolean values of the `then` and `else` branches of an if-else expression.
+struct ThenElseFixedValues {
+    then: bool,
+    else_: bool,
+    // true if both branches have explicit returns
+    both_returned: bool,
+}
+
+impl NeedlessBool {
+    /// Determine the fixed boolean values of both the `then` and `else_` branches
+    /// of an if-else expression, if they exist.
+    fn fixed_bool_values(then: &ExpData, else_: &ExpData) -> Option<ThenElseFixedValues> {
+        use ExpData::{Return, Value as ExpValue};
+        use Value::Bool;
+        match (then, else_) {
+            (ExpValue(_, Bool(then)), ExpValue(_, Bool(else_))) => Some(ThenElseFixedValues {
+                then: *then,
+                else_: *else_,
+                both_returned: false,
+            }),
+            (Return(_, then), Return(_, else_)) => {
+                Self::fixed_bool_values(then.as_ref(), else_.as_ref()).map(|mut v| {
+                    v.both_returned = true;
+                    v
+                })
+            },
+            _ => None,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints/simpler_numeric_expression.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints/simpler_numeric_expression.rs
@@ -1,0 +1,72 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements an expression linter that checks for numerical expressions
+//! that can be simplified and warns about them.
+//!
+//! The following cases are checked and simplifications suggested (here, `x` stands
+//! for an arbitrary expression, `=>` stands for "can be simplified to"):
+//! * `x & 0`, `x * 0`, `0 & x`, `0 * x`, `0 << x`, `0 >> x`, `x % 1` => `0`
+//! * `x | 0`, `x ^ 0`, `x >> 0`, `x << 0`, `x + 0`, `x - 0`, `x / 1`, `x * 1`,
+//!   `0 | x`, `0 ^ x`, `0 + x`, `1 * x` => `x`
+
+use crate::{env_pipeline::model_ast_lints::ExpressionLinter, lint_common::LintChecker};
+use move_model::{
+    ast::{ExpData, Operation, Value},
+    model::GlobalEnv,
+};
+use num::BigInt;
+
+#[derive(Default)]
+pub struct SimplerNumericExpression;
+
+impl ExpressionLinter for SimplerNumericExpression {
+    fn get_lint_checker(&self) -> LintChecker {
+        LintChecker::SimplerNumericExpression
+    }
+
+    fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
+        use ExpData::{Call, Value as ExpVal};
+        use Operation::*;
+        use Value::Number as N;
+        let Call(id, op, args) = expr else { return };
+        if args.len() != 2 {
+            return;
+        }
+        let (lhs, rhs): (&ExpData, &ExpData) = (&args[0], &args[1]);
+        let zero = BigInt::from(0);
+        let one = BigInt::from(1);
+        if let Some(msg) = match (lhs, op, rhs) {
+            (_, BitAnd | Mul, ExpVal(_, N(n))) | (ExpVal(_, N(n)), BitAnd | Mul | Shl | Shr, _)
+                if n == &zero =>
+            {
+                // `x & 0`, `x * 0`, `0 & x`, `0 * x`, `0 << x`, `0 >> x`
+                // Note that in that last two cases, `x` must be u8 because of type checking.
+                Some("This expression can be simplified to just `0`")
+            },
+            (_, Mod, ExpVal(_, N(n))) if n == &one => {
+                // `x % 1`
+                Some("This expression can be simplified to just `0`")
+            },
+            (_, BitOr | Xor | Shr | Shl | Add | Sub, ExpVal(_, N(n))) if n == &zero => {
+                // `x | 0`, `x ^ 0`, `x >> 0`, `x << 0`, `x + 0`, `x - 0`
+                Some("This binary operation can be simplified to just the left-hand side")
+            },
+            (_, Div | Mul, ExpVal(_, N(n))) if n == &one => {
+                // `x / 1`, `x * 1`
+                Some("This binary operation can be simplified to just the left-hand side")
+            },
+            (ExpVal(_, N(n)), BitOr | Xor | Add, _) if n == &zero => {
+                // `0 | x`, `0 ^ x`, `0 + x`
+                Some("This binary operation can be simplified to just the right-hand side")
+            },
+            (ExpVal(_, N(n)), Mul, _) if n == &one => {
+                // `1 * x`
+                Some("This binary operation can be simplified to just the right-hand side")
+            },
+            _ => None,
+        } {
+            self.warning(env, &env.get_node_loc(*id), msg);
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/src/lint_common.rs
+++ b/third_party/move/move-compiler-v2/src/lint_common.rs
@@ -19,6 +19,8 @@ use strum_macros::{Display, EnumString};
 pub enum LintChecker {
     AvoidCopyOnIdentityComparison,
     BlocksInConditions,
+    NeedlessBool,
+    SimplerNumericExpression,
     UnnecessaryBooleanIdentityComparison,
     UnnecessaryNumericalExtremeComparison,
     WhileTrue,

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/needless_bool_warn.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/needless_bool_warn.exp
@@ -1,0 +1,56 @@
+
+Diagnostics:
+warning: [lint] This if-else can be replaced with just the condition
+  ┌─ tests/lints/model_ast_lints/needless_bool_warn.move:7:9
+  │
+7 │         if (foo()) true else false
+  │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_bool)]`.
+
+warning: [lint] This if-else can be replaced with just the negation of the condition
+   ┌─ tests/lints/model_ast_lints/needless_bool_warn.move:11:9
+   │
+11 │ ╭         if (foo()) { false }
+12 │ │         else {
+13 │ │             // because la blah blah
+14 │ │             true
+15 │ │         }
+   │ ╰─────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_bool)]`.
+
+warning: [lint] This if-else can be replaced with just returning the condition
+   ┌─ tests/lints/model_ast_lints/needless_bool_warn.move:19:9
+   │
+19 │ ╭         if (foo()) {
+20 │ │             return true
+21 │ │         } else {
+22 │ │             return false
+23 │ │         }
+   │ ╰─────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_bool)]`.
+
+warning: [lint] This if-else can be replaced with just returning the negation of the condition
+   ┌─ tests/lints/model_ast_lints/needless_bool_warn.move:28:13
+   │
+28 │ ╭             if (foo()) {
+29 │ │                 return false
+30 │ │             } else {
+31 │ │                 return true
+32 │ │             }
+   │ ╰─────────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_bool)]`.
+
+warning: [lint] This if-else has the same bool expression in both branches, consider rewriting the code to remove this redundancy
+   ┌─ tests/lints/model_ast_lints/needless_bool_warn.move:38:9
+   │
+38 │         if (x) { return false } else { return false }
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_bool)]`.
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/needless_bool_warn.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/needless_bool_warn.move
@@ -1,0 +1,58 @@
+module 0xc0ffee::m {
+    fun foo(): bool {
+        true
+    }
+
+    public fun test1_warn(): bool {
+        if (foo()) true else false
+    }
+
+    public fun test2_warn(): bool {
+        if (foo()) { false }
+        else {
+            // because la blah blah
+            true
+        }
+    }
+
+    public fun test3_warn(): bool {
+        if (foo()) {
+            return true
+        } else {
+            return false
+        }
+    }
+
+    public fun test4_warn(x: bool): bool {
+        if (x) {
+            if (foo()) {
+                return false
+            } else {
+                return true
+            }
+        };
+        x
+    }
+
+    public fun test5_warn(x: bool): bool {
+        if (x) { return false } else { return false }
+    }
+
+    public fun test6_no_warn(): bool {
+        if (foo()) {
+            return true
+        } else { false }
+    }
+
+    public fun test7_no_warn(): bool {
+        let x = if (foo()) {
+            return true
+        } else { false };
+        !x
+    }
+
+    #[lint::skip(needless_bool)]
+    public fun test1_no_warn(): bool {
+        if (foo()) true else false
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/simpler_numeric_expression_warn.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/simpler_numeric_expression_warn.exp
@@ -1,0 +1,156 @@
+
+Diagnostics:
+warning: [lint] This expression can be simplified to just `0`
+  ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:3:9
+  │
+3 │         (x & 0) + 1
+  │         ^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This expression can be simplified to just `0`
+  ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:7:9
+  │
+7 │         (0 & x) * 0
+  │         ^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This expression can be simplified to just `0`
+  ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:7:9
+  │
+7 │         (0 & x) * 0
+  │         ^^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This expression can be simplified to just `0`
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:11:10
+   │
+11 │         ((0 * x) % 1) | 0
+   │          ^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This expression can be simplified to just `0`
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:11:9
+   │
+11 │         ((0 * x) % 1) | 0
+   │         ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This binary operation can be simplified to just the left-hand side
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:11:9
+   │
+11 │         ((0 * x) % 1) | 0
+   │         ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This binary operation can be simplified to just the left-hand side
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:15:9
+   │
+15 │         (x ^ 0) - 0 + (x >> 0) + (x << 0) + 0
+   │         ^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This binary operation can be simplified to just the left-hand side
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:15:9
+   │
+15 │         (x ^ 0) - 0 + (x >> 0) + (x << 0) + 0
+   │         ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This binary operation can be simplified to just the left-hand side
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:15:23
+   │
+15 │         (x ^ 0) - 0 + (x >> 0) + (x << 0) + 0
+   │                       ^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This binary operation can be simplified to just the left-hand side
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:15:34
+   │
+15 │         (x ^ 0) - 0 + (x >> 0) + (x << 0) + 0
+   │                                  ^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This binary operation can be simplified to just the left-hand side
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:15:9
+   │
+15 │         (x ^ 0) - 0 + (x >> 0) + (x << 0) + 0
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This binary operation can be simplified to just the left-hand side
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:19:9
+   │
+19 │         (x / 1) * 1
+   │         ^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This binary operation can be simplified to just the left-hand side
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:19:9
+   │
+19 │         (x / 1) * 1
+   │         ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This binary operation can be simplified to just the right-hand side
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:23:13
+   │
+23 │         0 + (0 | x) + (0 ^ x)
+   │             ^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This binary operation can be simplified to just the right-hand side
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:23:9
+   │
+23 │         0 + (0 | x) + (0 ^ x)
+   │         ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This binary operation can be simplified to just the right-hand side
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:23:23
+   │
+23 │         0 + (0 | x) + (0 ^ x)
+   │                       ^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This binary operation can be simplified to just the right-hand side
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:27:9
+   │
+27 │         1 * x
+   │         ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This binary operation can be simplified to just the left-hand side
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:31:14
+   │
+31 │         0 >> x + 0 << x
+   │              ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+warning: [lint] This expression can be simplified to just `0`
+   ┌─ tests/lints/model_ast_lints/simpler_numeric_expression_warn.move:31:9
+   │
+31 │         0 >> x + 0 << x
+   │         ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_numeric_expression)]`.
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/simpler_numeric_expression_warn.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/simpler_numeric_expression_warn.move
@@ -1,0 +1,47 @@
+module 0xc0ffee::m {
+    public fun test1(x: u64): u64 {
+        (x & 0) + 1
+    }
+
+    public fun test2(x: u64): u64 {
+        (0 & x) * 0
+    }
+
+    public fun test3(x: u64): u64 {
+        ((0 * x) % 1) | 0
+    }
+
+    public fun test4(x: u64): u64 {
+        (x ^ 0) - 0 + (x >> 0) + (x << 0) + 0
+    }
+
+    public fun test5(x: u64): u64 {
+        (x / 1) * 1
+    }
+
+    public fun test6(x: u64): u64 {
+        0 + (0 | x) + (0 ^ x)
+    }
+
+    public fun test7(x: u64): u64 {
+        1 * x
+    }
+
+    public fun test8(x: u8): u64 {
+        0 >> x + 0 << x
+    }
+}
+
+#[lint::skip(simpler_numeric_expression)]
+module 0xc0ffee::no_warn1 {
+    public fun test8(x: u8): u64 {
+        0 >> x + 0 << x
+    }
+}
+
+module 0xc0ffee::no_warn2 {
+    #[lint::skip(simpler_numeric_expression)]
+    public fun test8(x: u8): u64 {
+        0 >> x + 0 << x
+    }
+}


### PR DESCRIPTION
## Description

This PR implements two model-AST lint checks, both inspired from similar rust clippy checks.

### Needless Bool

We identify code of the form `if (cond) true else false`, and suggest that they can be replaced by just `cond` (similarly, `!cond`, if the the branches were flipped).

### Simpler Numeric Expression

We identify various cases of numeric operations that can be replaced with simpler expressions, which can make code simpler to read.

The following cases are checked and simplifications suggested (here, `x` stands for an arbitrary expression, `=>` stands for "can be simplified to"):
* `x & 0`, `x * 0`, `0 & x`, `0 * x`, `0 << x`, `0 >> x`, `x % 1` => `0`
* `x | 0`, `x ^ 0`, `x >> 0`, `x << 0`, `x + 0`, `x - 0`, `x / 1`, `x * 1`, `0 | x`, `0 ^ x`, `0 + x`, `1 * x` => `x`


## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## How Has This Been Tested?
- Existing tests pass
- New tests have been added to demonstrate the new lints work (and can be suppressed)
- Ran on aptos-framework, found one violation that was a true positive.

## Key Areas to Review
Correctness of the lints, possibilities for false positives.
