### PR TITLE
[compiler-v2][trivial] Changing hardcoded bytecode versions with their corresponding defined consts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "clap 4.4.14",
  "futures",
  "itertools 0.13.0",
+ "move-binary-format",
  "move-compiler",
  "move-core-types",
  "move-model",

--- a/aptos-move/aptos-e2e-comparison-testing/Cargo.toml
+++ b/aptos-move/aptos-e2e-comparison-testing/Cargo.toml
@@ -22,6 +22,7 @@ bcs = { workspace = true }
 clap = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
+move-binary-format = { workspace = true }
 move-compiler = { workspace = true }
 move-core-types = { workspace = true }
 move-model = { workspace = true }
@@ -31,4 +32,3 @@ serde = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
-

--- a/aptos-move/aptos-e2e-comparison-testing/src/execution.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/execution.rs
@@ -19,6 +19,7 @@ use aptos_types::{
 use aptos_validator_interface::AptosValidatorInterface;
 use clap::ValueEnum;
 use itertools::Itertools;
+use move_binary_format::file_format_common::VERSION_6;
 use move_core_types::{account_address::AccountAddress, language_storage::ModuleId};
 use move_model::metadata::CompilerVersion;
 use std::{cmp, collections::HashMap, path::PathBuf, sync::Arc};
@@ -101,7 +102,7 @@ impl Execution {
         Self {
             input_path,
             execution_mode,
-            bytecode_version: 6,
+            bytecode_version: VERSION_6,
         }
     }
 

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -16,7 +16,7 @@ use codespan_reporting::{
     term::termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor},
 };
 use itertools::Itertools;
-use move_binary_format::CompiledModule;
+use move_binary_format::{file_format_common::VERSION_7, CompiledModule};
 use move_command_line_common::files::MOVE_COMPILED_EXTENSION;
 use move_compiler::compiled_unit::{CompiledUnit, NamedCompiledModule};
 use move_compiler_v2::{options::Options, Experiment};
@@ -138,7 +138,7 @@ impl Default for BuildOptions {
 impl BuildOptions {
     pub fn move_2() -> Self {
         BuildOptions {
-            bytecode_version: Some(7),
+            bytecode_version: Some(VERSION_7),
             language_version: Some(LanguageVersion::V2_0),
             compiler_version: Some(CompilerVersion::V2_0),
             ..Self::default()


### PR DESCRIPTION
## Description
In a couple of places (that I could discover), we seem to use hard-coded literals for setting bytecode versions, while we have consts defined for them.

Using these consts instead of hard-coded literals will help with discoverability (e.g., you can show all references on a constant and see where it is used and whether that usage needs version upgrade).

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine
- [x] Other: comparison testing

## How Has This Been Tested?
Existing tests.
