### PR TITLE
[cli] Preparing release 4.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/aptos-move/e2e-move-tests/src/tests/metadata.rs
+++ b/aptos-move/e2e-move-tests/src/tests/metadata.rs
@@ -151,7 +151,7 @@ fn test_duplicate_compilation_metadata_entries() {
     };
     let result = test_compilation_metadata_with_changes(
         duplicate_compilation_metatdata,
-        CompilerVersion::V2_0,
+        CompilerVersion::V2_1,
     );
     assert_vm_status!(result, StatusCode::CONSTRAINT_NOT_SATISFIED);
     let result = test_compilation_metadata_with_changes(
@@ -230,7 +230,7 @@ fn test_compilation_metadata_internal(
     let path = builder.write_to_temp().unwrap();
 
     let compiler_version = if v2_flag {
-        CompilerVersion::V2_0
+        CompilerVersion::V2_1
     } else {
         CompilerVersion::V1
     };
@@ -298,7 +298,7 @@ fn test_compilation_metadata_script_internal(
     let path = builder.write_to_temp().unwrap();
 
     let compiler_version = if v2_flag {
-        CompilerVersion::V2_0
+        CompilerVersion::V2_1
     } else {
         CompilerVersion::V1
     };

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,9 +3,15 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
-- Add safe methods to delete a profile, to rename a profile, and to output the private key of a profile.
-- Add `aptos update movefmt`. This installs / updates the `movefmt` binary, which is needed for the new `aptos move fmt` subcommand.
-- Integrate the Move formatter `movefmt` which is now available via `aptos move fmt`
+
+## [4.1.0] - 2024/08/30
+- Marks Move 2 and compiler v2 as stable.
+- Adds new `--move-2` flag to work with Move 2 without need for multiple other flags. 
+- Adds `aptos move lint` to produce lint warnings for the current package. Only a few lint rules are implemented for now,
+  but more are coming.
+- Adds `aptos move fmt`, which runs the Move formatter, `movefmt`, on the current package. Also adds
+  `aptos update movefmt`. This installs / updates the `movefmt` binary.
+- Adds safe methods to delete a profile, to rename a profile, and to output the private key of a profile.
 
 ## [4.0.0] - 2024/08/13
 - **Breaking Change**: change key rotation options such that user has to either pass the name of a new profile or explicitly flag that no profile should be generated, since without this update the interactive profile generator could fail out after the key has already been rotated. This forces the check for new profile validity before doing anything onchain.

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "4.0.0"
+version = "4.1.0"
 
 # Workspace inherited keys
 authors = { workspace = true }

--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -122,10 +122,10 @@ impl ModuleGenerator {
     ) -> (FF::CompiledModule, SourceMap, Option<FF::FunctionHandle>) {
         let options = module_env.env.get_extension::<Options>().expect("options");
         let language_version = options.language_version.unwrap_or_default();
+        let compiler_version = options.compiler_version.unwrap_or(CompilerVersion::V2_0);
         let gen_access_specifiers = language_version.is_at_least(LanguageVersion::V2_0)
             && options.experiment_on(Experiment::GEN_ACCESS_SPECIFIERS);
-        let compilation_metadata =
-            CompilationMetadata::new(CompilerVersion::V2_0, language_version);
+        let compilation_metadata = CompilationMetadata::new(compiler_version, language_version);
         let metadata = Metadata {
             key: COMPILATION_METADATA_KEY.to_vec(),
             value: bcs::to_bytes(&compilation_metadata)
@@ -1101,8 +1101,8 @@ impl<'env> ModuleContext<'env> {
                 if *mid == fun.module_env.get_id() =>
                     {
                         result.insert(*sid);
-                    },
-                _ => {},
+                    }
+                _ => {}
             }
         }
         result

--- a/third_party/move/move-compiler-v2/src/options.rs
+++ b/third_party/move/move-compiler-v2/src/options.rs
@@ -14,7 +14,7 @@ use move_compiler::{
         warn_of_deprecation_use_in_aptos_libs_env_var,
     },
 };
-use move_model::metadata::LanguageVersion;
+use move_model::metadata::{CompilerVersion, LanguageVersion};
 use once_cell::sync::Lazy;
 use std::{
     cell::RefCell,
@@ -46,6 +46,10 @@ pub struct Options {
     /// The language version to use.
     #[clap(long, value_parser = clap::value_parser!(LanguageVersion))]
     pub language_version: Option<LanguageVersion>,
+
+    /// The compiler version to use.
+    #[clap(long, value_parser = clap::value_parser!(CompilerVersion))]
+    pub compiler_version: Option<CompilerVersion>,
 
     /// Do not complain about unknown attributes in Move code.
     #[clap(long, default_value = "false")]

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/acquires_list_generic.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/acquires_list_generic.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: not supported before language version `2.0-unstable`: access specifier type instantiation. Try removing the type instantiation.
+error: not supported before language version `2.0`: access specifier type instantiation. Try removing the type instantiation.
   ┌─ tests/checking-lang-v1/acquires_list_generic.move:6:24
   │
 6 │     fun foo() acquires B<CupC<R>> {

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/assert_one_arg.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/assert_one_arg.exp
@@ -1,18 +1,18 @@
 
 Diagnostics:
-error: not supported before language version `2.0-unstable`: single-argument `assert!` macro
+error: not supported before language version `2.0`: single-argument `assert!` macro
   ┌─ tests/checking-lang-v1/assert_one_arg.move:3:9
   │
 3 │         assert!(false);
   │         ^^^^^^
 
-error: not supported before language version `2.0-unstable`: single-argument `assert!` macro
+error: not supported before language version `2.0`: single-argument `assert!` macro
   ┌─ tests/checking-lang-v1/assert_one_arg.move:4:9
   │
 4 │         assert!(0 != 1);
   │         ^^^^^^
 
-error: not supported before language version `2.0-unstable`: single-argument `assert!` macro
+error: not supported before language version `2.0`: single-argument `assert!` macro
   ┌─ tests/checking-lang-v1/assert_one_arg.move:5:9
   │
 5 │         assert!(x != y);

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/conditional_global_operations.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/conditional_global_operations.exp
@@ -1,18 +1,18 @@
 
 Diagnostics:
-error: not supported before language version `2.0-unstable`: access specifier type instantiation. Try removing the type instantiation.
+error: not supported before language version `2.0`: access specifier type instantiation. Try removing the type instantiation.
    ┌─ tests/checking-lang-v1/conditional_global_operations.move:14:49
    │
 14 │     fun ex<T>(s: &signer, a1: address) acquires Box<R>, Box<T>, Pair<S, R> {
    │                                                 ^^^^^^
 
-error: not supported before language version `2.0-unstable`: access specifier type instantiation. Try removing the type instantiation.
+error: not supported before language version `2.0`: access specifier type instantiation. Try removing the type instantiation.
    ┌─ tests/checking-lang-v1/conditional_global_operations.move:14:57
    │
 14 │     fun ex<T>(s: &signer, a1: address) acquires Box<R>, Box<T>, Pair<S, R> {
    │                                                         ^^^^^^
 
-error: not supported before language version `2.0-unstable`: access specifier type instantiation. Try removing the type instantiation.
+error: not supported before language version `2.0`: access specifier type instantiation. Try removing the type instantiation.
    ┌─ tests/checking-lang-v1/conditional_global_operations.move:14:65
    │
 14 │     fun ex<T>(s: &signer, a1: address) acquires Box<R>, Box<T>, Pair<S, R> {

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/receiver_calls.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/receiver_calls.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: not supported before language version `2.0-unstable`: receiver style function calls
+error: not supported before language version `2.0`: receiver style function calls
    ┌─ tests/checking-lang-v1/receiver_calls.move:24:9
    │
 24 │         s.receiver(1);
    │         ^^^^^^^^^^^^^
 
-error: not supported before language version `2.0-unstable`: receiver style function calls
+error: not supported before language version `2.0`: receiver style function calls
    ┌─ tests/checking-lang-v1/receiver_calls.move:25:9
    │
 25 │         s.receiver_ref(1);
    │         ^^^^^^^^^^^^^^^^^
 
-error: not supported before language version `2.0-unstable`: receiver style function calls
+error: not supported before language version `2.0`: receiver style function calls
    ┌─ tests/checking-lang-v1/receiver_calls.move:26:9
    │
 26 │         s.receiver_ref_mut(1);
    │         ^^^^^^^^^^^^^^^^^^^^^
 
-error: not supported before language version `2.0-unstable`: receiver style function calls
+error: not supported before language version `2.0`: receiver style function calls
    ┌─ tests/checking-lang-v1/receiver_calls.move:27:9
    │
 27 │         s.inline_receiver_ref_mut(1)

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/v1-typing/invalid_type_acquire.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/v1-typing/invalid_type_acquire.exp
@@ -6,7 +6,7 @@ error: invalid access specifier
 18 │         T,
    │         ^
 
-error: not supported before language version `2.0-unstable`: address and wildcard access specifiers. Only resource type names can be provided.
+error: not supported before language version `2.0`: address and wildcard access specifiers. Only resource type names can be provided.
    ┌─ tests/checking-lang-v1/v1-typing/invalid_type_acquire.move:18:9
    │
 18 │         T,
@@ -18,7 +18,7 @@ error: invalid access specifier
 19 │         u64,
    │         ^^^
 
-error: not supported before language version `2.0-unstable`: address and wildcard access specifiers. Only resource type names can be provided.
+error: not supported before language version `2.0`: address and wildcard access specifiers. Only resource type names can be provided.
    ┌─ tests/checking-lang-v1/v1-typing/invalid_type_acquire.move:19:9
    │
 19 │         u64,

--- a/third_party/move/move-model/src/metadata.rs
+++ b/third_party/move/move-model/src/metadata.rs
@@ -81,6 +81,8 @@ pub enum CompilerVersion {
     /// The v2 compiler, starting with 2.0-unstable. Each new released version of the compiler
     /// should get an enum entry here.
     V2_0,
+    /// Upcoming Version 2.1 of the compiler
+    V2_1,
 }
 
 impl Default for CompilerVersion {
@@ -107,6 +109,7 @@ impl FromStr for CompilerVersion {
             // For legacy reasons, also support v1 and v2
             "1" | "v1" => Ok(Self::V1),
             "2" | "v2" | "2.0" => Ok(Self::V2_0),
+            "2.1" => Ok(Self::V2_1),
             _ => bail!(
                 "unrecognized compiler version `{}` (supported versions: `1`, `2`, `2.0`)",
                 s
@@ -123,6 +126,7 @@ impl Display for CompilerVersion {
             match self {
                 CompilerVersion::V1 => "1",
                 CompilerVersion::V2_0 => "2.0",
+                CompilerVersion::V2_1 => "2.1",
             },
             if self.unstable() { UNSTABLE_MARKER } else { "" }
         )
@@ -135,7 +139,8 @@ impl CompilerVersion {
     pub fn unstable(self) -> bool {
         match self {
             CompilerVersion::V1 => false,
-            CompilerVersion::V2_0 => true,
+            CompilerVersion::V2_0 => false,
+            CompilerVersion::V2_1 => true,
         }
     }
 
@@ -150,7 +155,7 @@ impl CompilerVersion {
                     Ok(())
                 }
             },
-            CompilerVersion::V2_0 => Ok(()),
+            CompilerVersion::V2_0 | CompilerVersion::V2_1 => Ok(()),
         }
     }
 }
@@ -172,12 +177,10 @@ pub enum LanguageVersion {
     /// functions with lambda parameters, as well as a simple form of `for`
     /// loops.
     V1,
-    /// The upcoming (currently unstable) 2.0 version of Move. The following
-    /// experimental language features are supported so far:
-    ///
-    /// - Access control specifiers as described in AIP-56.
-    /// - Receiver style (method) function calls with auto-referencing
+    /// The 2.0 version of Move.
     V2_0,
+    /// The currently unstable 2.1 version of Move
+    V2_1,
 }
 
 impl Default for LanguageVersion {
@@ -202,6 +205,7 @@ impl FromStr for LanguageVersion {
         match s1.as_str() {
             "1" => Ok(Self::V1),
             "2" | "2.0" => Ok(Self::V2_0),
+            "2.1" => Ok(Self::V2_1),
             _ => bail!(
                 "unrecognized language version `{}` (supported versions: `1`, `2`, `2.0`)",
                 s
@@ -216,7 +220,8 @@ impl LanguageVersion {
     pub fn unstable(self) -> bool {
         match self {
             LanguageVersion::V1 => false,
-            LanguageVersion::V2_0 => true,
+            LanguageVersion::V2_0 => false,
+            LanguageVersion::V2_1 => true,
         }
     }
 
@@ -231,6 +236,7 @@ impl LanguageVersion {
         env::get_bytecode_version_from_env(version).unwrap_or(match self {
             LanguageVersion::V1 => VERSION_DEFAULT,
             LanguageVersion::V2_0 => VERSION_DEFAULT_LANG_V2,
+            LanguageVersion::V2_1 => VERSION_DEFAULT_LANG_V2, // Update once we have v8 bytecode
         })
     }
 }
@@ -243,6 +249,7 @@ impl Display for LanguageVersion {
             match self {
                 LanguageVersion::V1 => "1",
                 LanguageVersion::V2_0 => "2.0",
+                LanguageVersion::V2_1 => "2.1",
             },
             if self.unstable() { UNSTABLE_MARKER } else { "" }
         )

--- a/third_party/move/move-prover/src/cli.rs
+++ b/third_party/move/move-prover/src/cli.rs
@@ -120,7 +120,7 @@ impl Default for Options {
             skip_attribute_checks: false,
             compiler_v2: match CompilerVersion::default() {
                 CompilerVersion::V1 => false,
-                CompilerVersion::V2_0 => true,
+                CompilerVersion::V2_0 | CompilerVersion::V2_1 => true,
             },
             language_version: None,
         }

--- a/third_party/move/move-prover/src/lib.rs
+++ b/third_party/move/move-prover/src/lib.rs
@@ -77,6 +77,7 @@ pub fn run_move_prover_v2<W: WriteColor>(
         named_address_mapping: cloned_options.move_named_address_values,
         output_dir: cloned_options.output_path,
         language_version: cloned_options.language_version,
+        compiler_version: None, // TODO: need to pass v2.x here
         skip_attribute_checks: true,
         known_attributes: Default::default(),
         testing: cloned_options.backend.stable_test_output,

--- a/third_party/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/third_party/move/tools/move-package/src/compilation/compiled_package.rs
@@ -516,15 +516,15 @@ impl CompiledPackage {
         // TODO: add more tests for the different caching cases
         !(package.has_source_changed_since_last_compile(resolved_package) // recompile if source has changed
             // Recompile if the flags are different
-                || package.are_build_flags_different(&resolution_graph.build_options)
-                // Force root package recompilation in test mode
-                || resolution_graph.build_options.test_mode && is_root_package
-                // Recompile if force recompilation is set
-                || resolution_graph.build_options.force_recompilation) &&
-                // Dive deeper to make sure that instantiations haven't changed since that
-                // can be changed by other packages above us in the dependency graph possibly
-                package.package.compiled_package_info.address_alias_instantiation
-                    == resolved_package.resolution_table
+            || package.are_build_flags_different(&resolution_graph.build_options)
+            // Force root package recompilation in test mode
+            || resolution_graph.build_options.test_mode && is_root_package
+            // Recompile if force recompilation is set
+            || resolution_graph.build_options.force_recompilation) &&
+            // Dive deeper to make sure that instantiations haven't changed since that
+            // can be changed by other packages above us in the dependency graph possibly
+            package.package.compiled_package_info.address_alias_instantiation
+                == resolved_package.resolution_table
     }
 
     pub(crate) fn build_all<W: Write>(
@@ -642,7 +642,7 @@ impl CompiledPackage {
                     Compiler::from_package_paths(paths, bytecode_deps, flags, &known_attributes);
                 compiler_driver_v1(compiler)?
             },
-            CompilerVersion::V2_0 => {
+            version @ CompilerVersion::V2_0 | version @ CompilerVersion::V2_1 => {
                 let to_str_vec = |ps: &[Symbol]| {
                     ps.iter()
                         .map(move |s| s.as_str().to_owned())
@@ -688,6 +688,7 @@ impl CompiledPackage {
                     skip_attribute_checks,
                     known_attributes: known_attributes.clone(),
                     language_version: Some(effective_language_version),
+                    compiler_version: Some(version),
                     compile_test_code: flags.keep_testing_functions(),
                     experiments: config.experiments.clone(),
                     ..Default::default()
@@ -840,12 +841,12 @@ impl CompiledPackage {
                     let name_conflict_error_msg = occurence_infos
                         .into_iter()
                         .map(|(name, is_module, fpath)| {
-                                format!(
-                                    "\t{} '{}' at path '{}'",
-                                    if is_module { "Module" } else { "Script" },
-                                    name,
-                                    fpath
-                                )
+                            format!(
+                                "\t{} '{}' at path '{}'",
+                                if is_module { "Module" } else { "Script" },
+                                name,
+                                fpath
+                            )
                         })
                         .collect::<Vec<_>>()
                         .join("\n");

--- a/third_party/move/tools/move-package/src/compilation/model_builder.rs
+++ b/third_party/move/tools/move-package/src/compilation/model_builder.rs
@@ -136,13 +136,14 @@ impl ModelBuilder {
                 skip_attribute_checks,
                 known_attributes,
             ),
-            CompilerVersion::V2_0 => {
+            CompilerVersion::V2_0 | CompilerVersion::V2_1 => {
                 let mut options = make_options_for_v2_compiler(all_targets, all_deps);
                 options.language_version = self
                     .resolution_graph
                     .build_options
                     .compiler_config
                     .language_version;
+                options.compiler_version = Some(self.model_config.compiler_version);
                 options.known_attributes.clone_from(known_attributes);
                 options.skip_attribute_checks = skip_attribute_checks;
                 let mut error_writer = StandardStream::stderr(ColorChoice::Auto);


### PR DESCRIPTION
## Description

Prepare for CLI release 4.1. This makes compiler v2 stable and adds a few new tools.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

Manually tested that `--move-2` is not producing a warning about unstable compiler or language. 

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
