### PR TITLE
[aptos-workspace] initial workspace server implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4598,6 +4598,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-workspace-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos",
+ "aptos-cached-packages",
+ "aptos-config",
+ "aptos-faucet-core",
+ "aptos-node",
+ "aptos-types",
+ "futures",
+ "rand 0.7.3",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "aptos-move/aptos-vm-logging",
     "aptos-move/aptos-vm-profiling",
     "aptos-move/aptos-vm-types",
+    "aptos-move/aptos-workspace-server",
     "aptos-move/block-executor",
     "aptos-move/e2e-benchmark",
     "aptos-move/e2e-move-tests",

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -194,8 +194,9 @@ pub fn new_test_context_inner(
 
     // Configure the testing depending on which API version we're testing.
     let runtime_handle = tokio::runtime::Handle::current();
-    let poem_address = attach_poem_to_runtime(&runtime_handle, context.clone(), &node_config, true)
-        .expect("Failed to attach poem to runtime");
+    let poem_address =
+        attach_poem_to_runtime(&runtime_handle, context.clone(), &node_config, true, None)
+            .expect("Failed to attach poem to runtime");
     let api_specific_config = ApiSpecificConfig::V1(poem_address);
 
     TestContext::new(

--- a/aptos-move/aptos-workspace-server/Cargo.toml
+++ b/aptos-move/aptos-workspace-server/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "aptos-workspace-server"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+aptos = { workspace = true }
+aptos-cached-packages = { workspace = true }
+aptos-config = { workspace = true }
+aptos-faucet-core = { workspace = true }
+aptos-node = { workspace = true }
+aptos-types = { workspace = true }
+
+anyhow = { workspace = true }
+futures = { workspace = true }
+rand = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }

--- a/aptos-move/aptos-workspace-server/src/main.rs
+++ b/aptos-move/aptos-workspace-server/src/main.rs
@@ -1,0 +1,176 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use aptos::node::local_testnet::HealthChecker;
+use aptos_config::config::NodeConfig;
+use aptos_faucet_core::server::{FunderKeyEnum, RunConfig};
+use aptos_node::{load_node_config, start_and_report_ports};
+use aptos_types::network_address::{NetworkAddress, Protocol};
+use futures::channel::oneshot;
+use rand::{rngs::StdRng, SeedableRng};
+use std::{
+    net::{IpAddr, Ipv4Addr},
+    path::Path,
+    thread,
+    time::Duration,
+};
+use url::Url;
+
+pub fn zero_all_ports(config: &mut NodeConfig) {
+    // TODO: Double check if all ports are covered.
+
+    config.admin_service.port = 0;
+    config.api.address.set_port(0);
+    config.inspection_service.port = 0;
+    config.storage.backup_service_address.set_port(0);
+    config.indexer_grpc.address.set_port(0);
+
+    if let Some(network) = config.validator_network.as_mut() {
+        network.listen_address = NetworkAddress::from_protocols(vec![
+            Protocol::Ip4("0.0.0.0".parse().unwrap()),
+            Protocol::Tcp(0),
+        ])
+        .unwrap();
+    }
+    for network in config.full_node_networks.iter_mut() {
+        network.listen_address = NetworkAddress::from_protocols(vec![
+            Protocol::Ip4("0.0.0.0".parse().unwrap()),
+            Protocol::Tcp(0),
+        ])
+        .unwrap();
+    }
+}
+
+async fn spawn_node(test_dir: &Path) -> Result<()> {
+    let rng = StdRng::from_entropy();
+
+    let mut node_config = load_node_config(
+        &None,
+        &None,
+        test_dir,
+        false,
+        false,
+        false,
+        aptos_cached_packages::head_release_bundle(),
+        rng,
+    )?;
+
+    zero_all_ports(&mut node_config);
+    node_config.indexer_grpc.enabled = true;
+    node_config.indexer_grpc.use_data_service_interface = true;
+    node_config.storage.enable_indexer = true;
+
+    node_config
+        .api
+        .address
+        .set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+    node_config
+        .indexer_grpc
+        .address
+        .set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+
+    node_config.admin_service.address = "127.0.0.1".to_string();
+    node_config.inspection_service.address = "127.0.0.1".to_string();
+
+    let (api_port_tx, api_port_rx) = oneshot::channel();
+    let (indexer_grpc_port_tx, indexer_grpc_port_rx) = oneshot::channel();
+
+    let run_node = {
+        let test_dir = test_dir.to_owned();
+        let node_config = node_config.clone();
+        move || -> Result<()> {
+            start_and_report_ports(
+                node_config,
+                Some(test_dir.join("validator.log")),
+                false,
+                Some(api_port_tx),
+                Some(indexer_grpc_port_tx),
+            )
+        }
+    };
+
+    let _node_thread_handle = thread::spawn(move || {
+        let res = run_node();
+
+        if let Err(err) = res {
+            println!("Node stopped unexpectedly {:?}", err);
+        }
+    });
+
+    let api_port = api_port_rx.await?;
+    let indexer_grpc_port = indexer_grpc_port_rx.await?;
+
+    let api_health_checker = HealthChecker::NodeApi(
+        Url::parse(&format!(
+            "http://{}:{}",
+            node_config.api.address.ip(),
+            api_port
+        ))
+        .unwrap(),
+    );
+    let indexer_grpc_health_checker = HealthChecker::DataServiceGrpc(
+        Url::parse(&format!(
+            "http://{}:{}",
+            node_config.indexer_grpc.address.ip(),
+            indexer_grpc_port
+        ))
+        .unwrap(),
+    );
+
+    api_health_checker.wait(None).await?;
+    eprintln!(
+        "Node API is ready. Endpoint: http://127.0.0.1:{}/",
+        api_port
+    );
+
+    indexer_grpc_health_checker.wait(None).await?;
+    eprintln!(
+        "Transaction stream is ready. Endpoint: http://127.0.0.1:{}/",
+        indexer_grpc_port
+    );
+
+    let faucet_run_config = RunConfig::build_for_cli(
+        Url::parse(&format!(
+            "http://{}:{}",
+            node_config.api.address.ip(),
+            api_port
+        ))
+        .unwrap(),
+        "127.0.0.1".to_string(),
+        0,
+        FunderKeyEnum::KeyFile(test_dir.join("mint.key")),
+        false,
+        None,
+    );
+
+    let (faucet_port_tx, faucet_port_rx) = oneshot::channel();
+    tokio::spawn(faucet_run_config.run_and_report_port(faucet_port_tx));
+
+    let faucet_port = faucet_port_rx.await?;
+
+    let faucet_health_checker =
+        HealthChecker::http_checker_from_port(faucet_port, "Faucet".to_string());
+    faucet_health_checker.wait(None).await?;
+    eprintln!(
+        "Faucet is ready. Endpoint: http://127.0.0.1:{}",
+        faucet_port
+    );
+
+    eprintln!("Indexer API is ready. Endpoint: http://127.0.0.1:0/");
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let test_dir = tempfile::tempdir()?;
+
+    println!("Test directory: {}", test_dir.path().display());
+
+    spawn_node(test_dir.path()).await?;
+
+    loop {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -26,7 +26,7 @@ use aptos_logger::{prelude::*, telemetry_log_writer::TelemetryLog, Level, Logger
 use aptos_state_sync_driver::driver_factory::StateSyncRuntimes;
 use aptos_types::{chain_id::ChainId, on_chain_config::OnChainJWKConsensusConfig};
 use clap::Parser;
-use futures::channel::mpsc;
+use futures::channel::{mpsc, oneshot};
 use hex::{FromHex, FromHexError};
 use rand::{rngs::StdRng, SeedableRng};
 use std::{
@@ -209,11 +209,21 @@ pub struct AptosHandle {
     _indexer_db_runtime: Option<Runtime>,
 }
 
-/// Start an Aptos node
 pub fn start(
     config: NodeConfig,
     log_file: Option<PathBuf>,
     create_global_rayon_pool: bool,
+) -> anyhow::Result<()> {
+    start_and_report_ports(config, log_file, create_global_rayon_pool, None, None)
+}
+
+/// Start an Aptos node
+pub fn start_and_report_ports(
+    config: NodeConfig,
+    log_file: Option<PathBuf>,
+    create_global_rayon_pool: bool,
+    api_port_tx: Option<oneshot::Sender<u16>>,
+    indexer_grpc_port_tx: Option<oneshot::Sender<u16>>,
 ) -> anyhow::Result<()> {
     // Setup panic handler
     aptos_crash_handler::setup_panic_handler();
@@ -252,8 +262,13 @@ pub fn start(
     }
 
     // Set up the node environment and start it
-    let _node_handle =
-        setup_environment_and_start_node(config, remote_log_receiver, Some(logger_filter_update))?;
+    let _node_handle = setup_environment_and_start_node(
+        config,
+        remote_log_receiver,
+        Some(logger_filter_update),
+        api_port_tx,
+        indexer_grpc_port_tx,
+    )?;
     let term = Arc::new(AtomicBool::new(false));
     while !term.load(Ordering::Acquire) {
         thread::park();
@@ -597,6 +612,8 @@ pub fn setup_environment_and_start_node(
     mut node_config: NodeConfig,
     remote_log_rx: Option<mpsc::Receiver<TelemetryLog>>,
     logger_filter_update_job: Option<LoggerFilterUpdater>,
+    api_port_tx: Option<oneshot::Sender<u16>>,
+    indexer_grpc_port_tx: Option<oneshot::Sender<u16>>,
 ) -> anyhow::Result<AptosHandle> {
     // Log the node config at node startup
     node_config.log_all_configs();
@@ -693,6 +710,8 @@ pub fn setup_environment_and_start_node(
         chain_id,
         indexer_db_opt,
         update_receiver,
+        api_port_tx,
+        indexer_grpc_port_tx,
     )?;
 
     // Create mempool and get the consensus to mempool sender

--- a/aptos-node/src/services.rs
+++ b/aptos-node/src/services.rs
@@ -32,7 +32,7 @@ use aptos_storage_interface::{DbReader, DbReaderWriter};
 use aptos_time_service::TimeService;
 use aptos_types::{chain_id::ChainId, indexer::indexer_db_reader::IndexerReader};
 use aptos_validator_transaction_pool::VTxnPoolState;
-use futures::channel::{mpsc, mpsc::Sender};
+use futures::channel::{mpsc, mpsc::Sender, oneshot};
 use std::{sync::Arc, time::Instant};
 use tokio::{
     runtime::{Handle, Runtime},
@@ -50,6 +50,8 @@ pub fn bootstrap_api_and_indexer(
     chain_id: ChainId,
     internal_indexer_db: Option<InternalIndexerDB>,
     update_receiver: Option<WatchReceiver<u64>>,
+    api_port_tx: Option<oneshot::Sender<u16>>,
+    indexer_grpc_port_tx: Option<oneshot::Sender<u16>>,
 ) -> anyhow::Result<(
     Receiver<MempoolClientRequest>,
     Option<Runtime>,
@@ -97,6 +99,7 @@ pub fn bootstrap_api_and_indexer(
             db_rw.reader.clone(),
             mempool_client_sender.clone(),
             indexer_reader.clone(),
+            api_port_tx,
         )?)
     } else {
         None
@@ -109,6 +112,7 @@ pub fn bootstrap_api_and_indexer(
         db_rw.reader.clone(),
         mempool_client_sender.clone(),
         indexer_reader,
+        indexer_grpc_port_tx,
     );
 
     // Create the indexer runtime

--- a/crates/aptos-faucet/core/src/server/run.rs
+++ b/crates/aptos-faucet/core/src/server/run.rs
@@ -12,7 +12,7 @@ use crate::{
     funder::{ApiConnectionConfig, FunderConfig, MintFunderConfig, TransactionSubmissionConfig},
     middleware::middleware_log,
 };
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use aptos_config::keys::ConfigKey;
 use aptos_faucet_metrics_server::{run_metrics_server, MetricsServerConfig};
 use aptos_logger::info;
@@ -21,12 +21,12 @@ use aptos_sdk::{
     types::{account_config::aptos_test_root_address, chain_id::ChainId},
 };
 use clap::Parser;
-use futures::lock::Mutex;
-use poem::{http::Method, listener::TcpListener, middleware::Cors, EndpointExt, Route, Server};
+use futures::{channel::oneshot::Sender as OneShotSender, lock::Mutex};
+use poem::{http::Method, listener::TcpAcceptor, middleware::Cors, EndpointExt, Route, Server};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::{fs::File, io::BufReader, path::PathBuf, pin::Pin, str::FromStr, sync::Arc};
-use tokio::{sync::Semaphore, task::JoinSet};
+use tokio::{net::TcpListener, sync::Semaphore, task::JoinSet};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HandlerConfig {
@@ -68,6 +68,14 @@ pub struct RunConfig {
 
 impl RunConfig {
     pub async fn run(self) -> Result<()> {
+        self.run_impl(None).await
+    }
+
+    pub async fn run_and_report_port(self, port_tx: OneShotSender<u16>) -> Result<()> {
+        self.run_impl(Some(port_tx)).await
+    }
+
+    async fn run_impl(self, port_tx: Option<OneShotSender<u16>>) -> Result<()> {
         info!("Running with config: {:#?}", self);
 
         // Set whether we should use useful errors.
@@ -177,12 +185,19 @@ impl RunConfig {
             }));
         }
 
-        // Create a future for the API server.
-        let api_server_future = Server::new(TcpListener::bind((
+        let listener = TcpListener::bind((
             self.server_config.listen_address.clone(),
             self.server_config.listen_port,
-        )))
-        .run(
+        ))
+        .await?;
+        let port = listener.local_addr()?.port();
+
+        if let Some(tx) = port_tx {
+            tx.send(port).map_err(|_| anyhow!("failed to send port"))?;
+        }
+
+        // Create a future for the API server.
+        let api_server_future = Server::new_with_acceptor(TcpAcceptor::from_tokio(listener)?).run(
             Route::new()
                 .nest(
                     &self.server_config.api_path_base,

--- a/crates/aptos/src/node/local_testnet/mod.rs
+++ b/crates/aptos/src/node/local_testnet/mod.rs
@@ -17,7 +17,6 @@ pub mod traits;
 
 use self::{
     faucet::FaucetArgs,
-    health_checker::HealthChecker,
     indexer_api::IndexerApiArgs,
     logging::ThreadNameMakeWriter,
     node::NodeArgs,
@@ -41,6 +40,7 @@ use anyhow::{Context, Result};
 use aptos_indexer_grpc_server_framework::setup_logging;
 use async_trait::async_trait;
 use clap::Parser;
+pub use health_checker::HealthChecker;
 use std::{
     collections::HashSet,
     fs::{create_dir_all, remove_dir_all},

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/runtime.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/runtime.rs
@@ -19,9 +19,13 @@ use aptos_protos::{
 };
 use aptos_storage_interface::DbReader;
 use aptos_types::{chain_id::ChainId, indexer::indexer_db_reader::IndexerReader};
-use std::{net::ToSocketAddrs, sync::Arc};
-use tokio::runtime::Runtime;
-use tonic::{codec::CompressionEncoding, transport::Server};
+use futures::channel::oneshot;
+use std::sync::Arc;
+use tokio::{net::TcpListener, runtime::Runtime};
+use tonic::{
+    codec::CompressionEncoding,
+    transport::{server::TcpIncoming, Server},
+};
 
 // Default Values
 pub const DEFAULT_NUM_RETRIES: usize = 3;
@@ -35,6 +39,7 @@ pub fn bootstrap(
     db: Arc<dyn DbReader>,
     mp_sender: MempoolClientSender,
     indexer_reader: Option<Arc<dyn IndexerReader>>,
+    port_tx: Option<oneshot::Sender<u16>>,
 ) -> Option<Runtime> {
     if !config.indexer_grpc.enabled {
         return None;
@@ -105,11 +110,16 @@ pub fn bootstrap(
                 tonic_server.add_service(svc)
             },
         };
+
+        let listener = TcpListener::bind(address).await.unwrap();
+        if let Some(port_tx) = port_tx {
+            port_tx.send(listener.local_addr().unwrap().port()).unwrap();
+        }
+        let incoming = TcpIncoming::from_listener(listener, false, None).unwrap();
+
         // Make port into a config
-        router
-            .serve(address.to_socket_addrs().unwrap().next().unwrap())
-            .await
-            .unwrap();
+        router.serve_with_incoming(incoming).await.unwrap();
+
         info!(address = address, "[indexer-grpc] Started GRPC server");
     });
     Some(runtime)


### PR DESCRIPTION
This is the initial implementation of Aptos Workspace Server, a new binary that is capable of spawning a fully self-contained local network, powering [Aptos Workspace, our new integration testing framework](https://github.com/aptos-labs/workspace/).

As a side effect, this introduces alternative entrypoints to both the node and the faucet to allow them to report the ports used via oneshot channels. This makes it possible to bind the services to random ports, allowing multiple instances of the workspace server to be spawned simultaneously, which is a necessity for integration tests.