### PR TITLE
[bug-fix][trivial] Use the built release binary instead of debug

### DIFF
--- a/third_party/move/scripts/compare_num_instructions.py
+++ b/third_party/move/scripts/compare_num_instructions.py
@@ -84,7 +84,7 @@ def count_instructions(file_name):
     """
     result = subprocess.run(
         [
-            "../../../target/debug/move-disassembler",
+            "../../../target/release/move-disassembler",
             "--skip-code",
             "--skip-locals",
             "--print-bytecode-stats",


### PR DESCRIPTION
## Description

The script used to compare number of instructions in two builds of the project, builds disassembler in release mode, but uses disassembler in debug mode. It used to work for me because I had not done a `cargo clean`.

We now build and use the release mode disassembler binary for this script.


## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## How Has This Been Tested?
Manual
