### PR TITLE
enable_pre_commit config also guards buffer manager back pressure

### DIFF
--- a/consensus/src/pipeline/decoupled_execution_utils.rs
+++ b/consensus/src/pipeline/decoupled_execution_utils.rs
@@ -27,6 +27,7 @@ use std::sync::{
 };
 
 /// build channels and return phases and buffer manager
+#[allow(clippy::too_many_arguments)]
 pub fn prepare_phases_and_buffer_manager(
     author: Author,
     execution_proxy: Arc<dyn StateComputer>,
@@ -39,6 +40,7 @@ pub fn prepare_phases_and_buffer_manager(
     epoch_state: Arc<EpochState>,
     bounded_executor: BoundedExecutor,
     order_vote_enabled: bool,
+    back_pressure_enabled: bool,
     highest_committed_round: u64,
     consensus_observer_config: ConsensusObserverConfig,
     consensus_publisher: Option<Arc<ConsensusPublisher>>,
@@ -128,6 +130,7 @@ pub fn prepare_phases_and_buffer_manager(
             reset_flag.clone(),
             bounded_executor,
             order_vote_enabled,
+            back_pressure_enabled,
             highest_committed_round,
             consensus_observer_config,
             consensus_publisher,

--- a/consensus/src/pipeline/execution_client.rs
+++ b/consensus/src/pipeline/execution_client.rs
@@ -192,6 +192,7 @@ impl ExecutionProxyClient {
         onchain_consensus_config: &OnChainConsensusConfig,
         rand_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingRandGenRequest>,
         highest_committed_round: Round,
+        buffer_manager_back_pressure_enabled: bool,
         consensus_observer_config: ConsensusObserverConfig,
         consensus_publisher: Option<Arc<ConsensusPublisher>>,
     ) {
@@ -277,6 +278,7 @@ impl ExecutionProxyClient {
             epoch_state,
             self.bounded_executor.clone(),
             onchain_consensus_config.order_vote_enabled(),
+            buffer_manager_back_pressure_enabled,
             highest_committed_round,
             consensus_observer_config,
             consensus_publisher,
@@ -315,6 +317,7 @@ impl TExecutionClient for ExecutionProxyClient {
             onchain_consensus_config,
             rand_msg_rx,
             highest_committed_round,
+            self.consensus_config.enable_pre_commit,
             self.consensus_observer_config,
             self.consensus_publisher.clone(),
         );

--- a/consensus/src/pipeline/tests/buffer_manager_tests.rs
+++ b/consensus/src/pipeline/tests/buffer_manager_tests.rs
@@ -157,6 +157,7 @@ pub fn prepare_buffer_manager(
         }),
         bounded_executor,
         false,
+        true,
         0,
         ConsensusObserverConfig::default(),
         None,


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

When we disable pre-commit via local config, also disable buffer manager -- so that consensus behaves more like pre-pre-commit era.

## Type of Change
- [x] New feature


## Which Components or Systems Does This Change Impact?
- [x] Validator Node

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

manual forge run 