### PR TITLE
[block-stm] Integrate script caches

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -3122,7 +3122,7 @@ pub(crate) fn is_account_init_for_sponsored_transaction(
                 None,
             )
             .map_err(|e| e.finish(Location::Undefined))?;
-        return Ok(maybe_bytes.is_some());
+        return Ok(maybe_bytes.is_none());
     }
     Ok(false)
 }

--- a/aptos-move/block-executor/src/modules_and_scripts.rs
+++ b/aptos-move/block-executor/src/modules_and_scripts.rs
@@ -20,7 +20,8 @@ use move_binary_format::{
 };
 use move_core_types::{account_address::AccountAddress, identifier::IdentStr, metadata::Metadata};
 use move_vm_runtime::{
-    module_cyclic_dependency_error, module_linker_error, CodeStorage, Module, ModuleStorage, Script,
+    deserialize_script, module_cyclic_dependency_error, module_linker_error, script_hash,
+    CodeStorage, Module, ModuleStorage, Script,
 };
 use std::{collections::HashSet, sync::Arc};
 
@@ -63,15 +64,79 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> CodeStorage
 {
     fn deserialize_and_cache_script(
         &self,
-        _serialized_script: &[u8],
+        serialized_script: &[u8],
     ) -> VMResult<Arc<CompiledScript>> {
-        // TODO(loader_v2): Support scripts.
-        todo!()
+        let hash = script_hash(serialized_script);
+
+        let maybe_compiled_script = match &self.latest_view {
+            ViewState::Sync(state) => state
+                .versioned_map
+                .code_storage()
+                .get_deserialized_script(&hash),
+            ViewState::Unsync(state) => state.unsync_map.get_deserialized_script(&hash),
+        };
+
+        Ok(match maybe_compiled_script {
+            Some(compiled_script) => compiled_script,
+            None => {
+                let compiled_script = self.deserialize_script(serialized_script)?;
+
+                match &self.latest_view {
+                    ViewState::Sync(state) => state
+                        .versioned_map
+                        .code_storage()
+                        .cache_deserialized_script(hash, compiled_script.clone()),
+                    ViewState::Unsync(state) => state
+                        .unsync_map
+                        .cache_deserialized_script(hash, compiled_script.clone()),
+                }
+                compiled_script
+            },
+        })
     }
 
-    fn verify_and_cache_script(&self, _serialized_script: &[u8]) -> VMResult<Arc<Script>> {
-        // TODO(loader_v2): Support scripts.
-        todo!()
+    fn verify_and_cache_script(&self, serialized_script: &[u8]) -> VMResult<Arc<Script>> {
+        let hash = script_hash(serialized_script);
+
+        let maybe_verified_script = match &self.latest_view {
+            ViewState::Sync(state) => state
+                .versioned_map
+                .code_storage()
+                .get_verified_script(&hash),
+            ViewState::Unsync(state) => state.unsync_map.get_verified_script(&hash),
+        };
+
+        let compiled_script = match maybe_verified_script {
+            Some(Ok(script)) => return Ok(script),
+            Some(Err(compiled_script)) => compiled_script,
+            None => self.deserialize_and_cache_script(serialized_script)?,
+        };
+
+        // Locally verify the script.
+        let partially_verified_script = self
+            .runtime_environment
+            .build_partially_verified_script(compiled_script)?;
+
+        // Verify the script by also looking at its dependencies.
+        let immediate_dependencies = partially_verified_script
+            .immediate_dependencies_iter()
+            .map(|(addr, name)| self.fetch_verified_module(addr, name))
+            .collect::<VMResult<Vec<_>>>()?;
+        let script = self
+            .runtime_environment
+            .build_verified_script(partially_verified_script, &immediate_dependencies)?;
+        let script = Arc::new(script);
+
+        match &self.latest_view {
+            ViewState::Sync(state) => state
+                .versioned_map
+                .code_storage()
+                .cache_verified_script(hash, script.clone()),
+            ViewState::Unsync(state) => {
+                state.unsync_map.cache_verified_script(hash, script.clone())
+            },
+        }
+        Ok(script)
     }
 }
 
@@ -179,14 +244,13 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
 
                 // Otherwise, we need to go to the multi-version data structure to get it, and
                 // record under captured reads.
-                let read =
-                    state
-                        .versioned_map
-                        .module_storage()
-                        .get_or_else(key, self.txn_idx, || {
-                            self.get_base_module_storage_entry(key)
-                        })?;
-
+                let read = state
+                    .versioned_map
+                    .code_storage()
+                    .module_storage()
+                    .get_or_else(key, self.txn_idx, || {
+                        self.get_base_module_storage_entry(key)
+                    })?;
                 state
                     .captured_reads
                     .borrow_mut()
@@ -308,11 +372,11 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
                         key.clone(),
                         ModuleStorageRead::Versioned(version.clone(), verified_entry.clone()),
                     );
-                state.versioned_map.module_storage().write_if_not_verified(
-                    &key,
-                    version,
-                    verified_entry,
-                );
+                state
+                    .versioned_map
+                    .code_storage()
+                    .module_storage()
+                    .write_if_not_verified(&key, version, verified_entry);
             },
             ViewState::Unsync(state) => {
                 state
@@ -321,5 +385,12 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> LatestView<
             },
         }
         Ok(module)
+    }
+
+    /// Returns the deserialized script based on the current runtime environment.
+    fn deserialize_script(&self, serialized_script: &[u8]) -> VMResult<Arc<CompiledScript>> {
+        let deserializer_config = &self.runtime_environment.vm_config().deserializer_config;
+        let compiled_script = deserialize_script(serialized_script, deserializer_config)?;
+        Ok(Arc::new(compiled_script))
     }
 }

--- a/aptos-move/mvhashmap/Cargo.toml
+++ b/aptos-move/mvhashmap/Cargo.toml
@@ -26,6 +26,7 @@ derivative = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 move-vm-types = { workspace = true }
+move-vm-runtime = { workspace = true }
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/aptos-move/mvhashmap/src/lib.rs
+++ b/aptos-move/mvhashmap/src/lib.rs
@@ -3,13 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    versioned_data::VersionedData, versioned_delayed_fields::VersionedDelayedFields,
-    versioned_group_data::VersionedGroupData, versioned_module_storage::VersionedModuleStorage,
+    versioned_code_storage::VersionedCodeStorage, versioned_data::VersionedData,
+    versioned_delayed_fields::VersionedDelayedFields, versioned_group_data::VersionedGroupData,
     versioned_modules::VersionedModules,
 };
 use aptos_types::{
     executable::{Executable, ModulePath},
-    vm::modules::ModuleStorageEntry,
     write_set::TransactionWrite,
 };
 use serde::Serialize;
@@ -17,12 +16,14 @@ use std::{fmt::Debug, hash::Hash};
 
 pub mod types;
 pub mod unsync_map;
+pub mod versioned_code_storage;
 pub mod versioned_data;
 pub mod versioned_delayed_fields;
 pub mod versioned_group_data;
 pub mod versioned_module_storage;
 pub mod versioned_modules;
 
+mod scripts;
 #[cfg(test)]
 mod unit_tests;
 
@@ -40,7 +41,7 @@ pub struct MVHashMap<K, T, V: TransactionWrite, X: Executable, I: Clone> {
     group_data: VersionedGroupData<K, T, V>,
     delayed_fields: VersionedDelayedFields<I>,
     modules: VersionedModules<K, V, X>,
-    module_storage: VersionedModuleStorage<K, ModuleStorageEntry>,
+    code_storage: VersionedCodeStorage<K>,
 }
 
 impl<
@@ -61,7 +62,7 @@ impl<
             delayed_fields: VersionedDelayedFields::new(),
             modules: VersionedModules::new(),
 
-            module_storage: VersionedModuleStorage::empty(),
+            code_storage: VersionedCodeStorage::empty(),
         }
     }
 
@@ -95,8 +96,8 @@ impl<
         &self.modules
     }
 
-    pub fn module_storage(&self) -> &VersionedModuleStorage<K, ModuleStorageEntry> {
-        &self.module_storage
+    pub fn code_storage(&self) -> &VersionedCodeStorage<K> {
+        &self.code_storage
     }
 }
 

--- a/aptos-move/mvhashmap/src/scripts.rs
+++ b/aptos-move/mvhashmap/src/scripts.rs
@@ -1,0 +1,32 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::file_format::CompiledScript;
+use move_vm_runtime::Script;
+use std::sync::Arc;
+
+/// An entry for the script cache, used by the Aptos code cache. Entries
+/// can live in the cache in different states (deserialized / verified).
+#[derive(Debug)]
+pub(crate) enum ScriptCacheEntry {
+    Deserialized(Arc<CompiledScript>),
+    Verified(Arc<Script>),
+}
+
+impl ScriptCacheEntry {
+    /// Returns the deserialized (compiled) representation of the script.
+    pub(crate) fn as_compiled_script(&self) -> Arc<CompiledScript> {
+        match self {
+            Self::Deserialized(compiled_script) => compiled_script.clone(),
+            Self::Verified(script) => script.as_compiled_script(),
+        }
+    }
+
+    /// Returns true if the script entry has already been verified.
+    pub(crate) fn is_verified(&self) -> bool {
+        match self {
+            Self::Verified(_) => true,
+            Self::Deserialized(_) => false,
+        }
+    }
+}

--- a/aptos-move/mvhashmap/src/versioned_code_storage.rs
+++ b/aptos-move/mvhashmap/src/versioned_code_storage.rs
@@ -1,0 +1,105 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    scripts::ScriptCacheEntry, types::TxnIndex, versioned_module_storage::VersionedModuleStorage,
+};
+use aptos_types::{
+    delayed_fields::PanicError, executable::ModulePath, vm::modules::ModuleStorageEntry,
+    write_set::TransactionWrite,
+};
+use crossbeam::utils::CachePadded;
+use dashmap::{mapref::entry::Entry, DashMap};
+use move_binary_format::file_format::CompiledScript;
+use move_vm_runtime::{RuntimeEnvironment, Script};
+use std::{fmt::Debug, hash::Hash, sync::Arc};
+
+/// Code storage, that holds script cache and (versioned) module storage.
+pub struct VersionedCodeStorage<K> {
+    /// Caches deserialized and verified scripts. In the current cache
+    /// implementation it is flushed on any module upgrade.
+    script_cache: DashMap<[u8; 32], CachePadded<ScriptCacheEntry>>,
+    /// Stores modules and pending code publishes observed by the Block-STM.
+    module_storage: VersionedModuleStorage<K, ModuleStorageEntry>,
+}
+
+impl<K: Debug + Hash + Clone + Eq + ModulePath> VersionedCodeStorage<K> {
+    /// Returns a new empty versioned code storage.
+    pub(crate) fn empty() -> Self {
+        Self {
+            script_cache: DashMap::new(),
+            module_storage: VersionedModuleStorage::empty(),
+        }
+    }
+
+    /// Tries to get a deserialized script if it exists in cache. If not, returns [None].
+    pub fn get_deserialized_script(&self, hash: &[u8; 32]) -> Option<Arc<CompiledScript>> {
+        let entry = self.script_cache.get(hash)?;
+        let e = &**entry.value();
+        Some(e.as_compiled_script())
+    }
+
+    /// Stores the deserialized script to script cache.
+    pub fn cache_deserialized_script(&self, hash: [u8; 32], compiled_script: Arc<CompiledScript>) {
+        use ScriptCacheEntry::*;
+        self.script_cache
+            .insert(hash, CachePadded::new(Deserialized(compiled_script)));
+    }
+
+    /// Tries to get a verified script if it exists in cache. If not, returns [None].
+    /// If the deserialized version exists instead.
+    pub fn get_verified_script(
+        &self,
+        hash: &[u8; 32],
+    ) -> Option<Result<Arc<Script>, Arc<CompiledScript>>> {
+        let entry = self.script_cache.get(hash)?;
+
+        use ScriptCacheEntry::*;
+        Some(match &**entry.value() {
+            Verified(script) => Ok(script.clone()),
+            Deserialized(compiled_script) => Err(compiled_script.clone()),
+        })
+    }
+
+    /// Stores the verified script to script cache, unless it already exists.
+    pub fn cache_verified_script(&self, hash: [u8; 32], script: Arc<Script>) {
+        let entry = self.script_cache.entry(hash);
+
+        use ScriptCacheEntry::*;
+        if let Entry::Occupied(mut e) = entry {
+            if !e.get().is_verified() {
+                e.insert(CachePadded::new(Verified(script)));
+            }
+        }
+    }
+
+    /// Writes multiple published modules to the storage, which is also visible for
+    /// the transactions with higher indices. This function invalidates and flushes
+    /// the script cache.
+    pub fn write_published_modules<V: TransactionWrite>(
+        &self,
+        idx_to_publish: TxnIndex,
+        runtime_environment: &RuntimeEnvironment,
+        writes: impl Iterator<Item = (K, V)>,
+    ) -> Result<(), PanicError> {
+        // In case of module publishing, flush script cache. This is the simplest thing
+        // to do for now and can be improved if needed.
+        self.script_cache.clear();
+
+        for (key, write) in writes {
+            let entry = ModuleStorageEntry::from_transaction_write(runtime_environment, write)?;
+            self.module_storage
+                .write_published(&key, idx_to_publish, entry);
+        }
+        Ok(())
+    }
+
+    pub fn module_storage(&self) -> &VersionedModuleStorage<K, ModuleStorageEntry> {
+        &self.module_storage
+    }
+}
+
+#[cfg(test)]
+mod test {
+    // TODO(loader_v2): Add tests here.
+}

--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -34,7 +34,7 @@ mod storage;
 
 pub use loader::{LoadedFunction, Module, Script};
 pub use storage::{
-    code_storage::{ambassador_impl_CodeStorage, script_hash, CodeStorage},
+    code_storage::{ambassador_impl_CodeStorage, deserialize_script, script_hash, CodeStorage},
     dummy::use_loader_v2_based_on_env,
     environment::{RuntimeEnvironment, WithRuntimeEnvironment},
     implementations::{

--- a/third_party/move/move-vm/runtime/src/storage/environment.rs
+++ b/third_party/move/move-vm/runtime/src/storage/environment.rs
@@ -8,7 +8,7 @@ use crate::{
     Module, Script,
 };
 use move_binary_format::{
-    access::ModuleAccess,
+    access::{ModuleAccess, ScriptAccess},
     errors::{Location, VMResult},
     file_format::CompiledScript,
     CompiledModule,
@@ -42,6 +42,14 @@ impl PartiallyVerifiedModule {
 /// Wrapper around partially verified compiled script, i.e., one that passed
 /// local bytecode verification, but not the dependency checks yet.
 pub struct PartiallyVerifiedScript(Arc<CompiledScript>);
+
+impl PartiallyVerifiedScript {
+    pub fn immediate_dependencies_iter(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = (&AccountAddress, &IdentStr)> {
+        self.0.immediate_dependencies_iter()
+    }
+}
 
 /// [MoveVM] runtime environment encapsulating different configurations. Shared
 /// between the VM and the code cache.


### PR DESCRIPTION
## Description

This completes Block-STM integration for the code cache by adding an implementation to deserialize/verify and cache scripts. Right now, we opt for a very basic policy of:
```
any module published ==> flush the script cache
```
We can revisit this in later PRs, but for now it suffices to get things running. Correctness is guaranteed because we publish at commit time, and so if there is a txn with a script that used older versions of code, it will be invalidated since there will be at least a single module dependency that gets loaded and is invalidated.

Other:
- This PR also fixed a bug in sponsored account creation introduced by one of the earlier PRs where `is_none()` got replaced by `is_some()`.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

For tests, see the PR stacked on top.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
