### PR TITLE
[execution window] filtering committed transactions

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -229,25 +229,25 @@ impl Default for ConsensusConfig {
                 },
                 // with execution backpressure, only later start reducing block size
                 PipelineBackpressureValues {
-                    back_pressure_pipeline_latency_limit_ms: 2500,
+                    back_pressure_pipeline_latency_limit_ms: 5000,
                     max_sending_block_txns_after_filtering_override: 1000,
                     max_sending_block_bytes_override: MIN_BLOCK_BYTES_OVERRIDE,
                     backpressure_proposal_delay_ms: 300,
                 },
                 PipelineBackpressureValues {
-                    back_pressure_pipeline_latency_limit_ms: 3500,
+                    back_pressure_pipeline_latency_limit_ms: 7000,
                     max_sending_block_txns_after_filtering_override: 200,
                     max_sending_block_bytes_override: MIN_BLOCK_BYTES_OVERRIDE,
                     backpressure_proposal_delay_ms: 300,
                 },
                 PipelineBackpressureValues {
-                    back_pressure_pipeline_latency_limit_ms: 4500,
+                    back_pressure_pipeline_latency_limit_ms: 9000,
                     max_sending_block_txns_after_filtering_override: 30,
                     max_sending_block_bytes_override: MIN_BLOCK_BYTES_OVERRIDE,
                     backpressure_proposal_delay_ms: 300,
                 },
                 PipelineBackpressureValues {
-                    back_pressure_pipeline_latency_limit_ms: 6000,
+                    back_pressure_pipeline_latency_limit_ms: 12000,
                     // in practice, latencies and delay make it such that ~2 blocks/s is max,
                     // meaning that most aggressively we limit to ~10 TPS
                     // For transactions that are more expensive than that, we should

--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 
 // Useful constants for enabling consensus observer on different node types
-const ENABLE_ON_VALIDATORS: bool = true;
-const ENABLE_ON_VALIDATOR_FULLNODES: bool = true;
+const ENABLE_ON_VALIDATORS: bool = false;
+const ENABLE_ON_VALIDATOR_FULLNODES: bool = false;
 const ENABLE_ON_PUBLIC_FULLNODES: bool = false;
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -316,7 +316,11 @@ impl Block {
     /// If this is the genesis block, we skip these checks.
     pub fn validate_signature(&self, validator: &ValidatorVerifier) -> anyhow::Result<()> {
         match self.block_data.block_type() {
-            BlockType::Genesis => bail!("We should not accept genesis from others"),
+            BlockType::Genesis => panic!(
+                "We should not accept genesis from others, epoch: {}, round: {}",
+                self.block_data.epoch(),
+                self.block_data.round()
+            ),
             BlockType::NilBlock { .. } => self.quorum_cert().verify(validator),
             BlockType::Proposal { author, .. } => {
                 let signature = self

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -16,11 +16,13 @@ pub const RETRY_INTERVAL_MSEC: u64 = 500;
 pub const RPC_TIMEOUT_MSEC: u64 = 5000;
 
 /// RPC to get a chain of block of the given length starting from the given block id.
+/// TODO: needs to become a v2 for backwards compatibility
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct BlockRetrievalRequest {
     block_id: HashValue,
     num_blocks: u64,
-    target_block_id: Option<HashValue>,
+    // TODO: remove the Option, if it's not too painful
+    target_epoch_and_round: Option<(u64, u64)>,
 }
 
 impl BlockRetrievalRequest {
@@ -28,19 +30,20 @@ impl BlockRetrievalRequest {
         Self {
             block_id,
             num_blocks,
-            target_block_id: None,
+            target_epoch_and_round: None,
         }
     }
 
-    pub fn new_with_target_block_id(
+    pub fn new_with_target_round(
         block_id: HashValue,
         num_blocks: u64,
-        target_block_id: HashValue,
+        target_epoch: u64,
+        target_round: u64,
     ) -> Self {
         Self {
             block_id,
             num_blocks,
-            target_block_id: Some(target_block_id),
+            target_epoch_and_round: Some((target_epoch, target_round)),
         }
     }
 
@@ -52,12 +55,13 @@ impl BlockRetrievalRequest {
         self.num_blocks
     }
 
-    pub fn target_block_id(&self) -> Option<HashValue> {
-        self.target_block_id
+    pub fn target_epoch_and_round(&self) -> Option<(u64, u64)> {
+        self.target_epoch_and_round
     }
 
-    pub fn match_target_id(&self, hash_value: HashValue) -> bool {
-        self.target_block_id.map_or(false, |id| id == hash_value)
+    pub fn match_target_round(&self, epoch: u64, round: u64) -> bool {
+        self.target_epoch_and_round
+            .map_or(false, |target| (epoch, round) <= target)
     }
 }
 
@@ -117,12 +121,13 @@ impl BlockRetrievalResponse {
         );
         ensure!(
             self.status != BlockRetrievalStatus::SucceededWithTarget
-                || self
-                    .blocks
-                    .last()
-                    .map_or(false, |block| retrieval_request.match_target_id(block.id())),
+                || (!self.blocks.is_empty()
+                    && retrieval_request.match_target_round(
+                        self.blocks.last().unwrap().epoch(),
+                        self.blocks.last().unwrap().round()
+                    )),
             "target not found in blocks returned, expect {:?}",
-            retrieval_request.target_block_id(),
+            retrieval_request.target_epoch_and_round()
         );
         self.blocks
             .iter()

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -129,10 +129,11 @@ pub struct RejectedTransactionSummary {
 
 #[derive(Debug)]
 pub enum DataStatus {
-    Cached(Vec<SignedTransaction>),
+    Cached(Vec<(Vec<SignedTransaction>, u64)>),
     Requested(
         Vec<(
             HashValue,
+            u64,
             oneshot::Receiver<ExecutorResult<Vec<SignedTransaction>>>,
         )>,
     ),

--- a/consensus/consensus-types/src/payload.rs
+++ b/consensus/consensus-types/src/payload.rs
@@ -29,7 +29,7 @@ pub trait TDataInfo {
 
 pub struct DataFetchFut {
     pub iteration: u32,
-    pub fut: Shared<BoxFuture<'static, ExecutorResult<Vec<SignedTransaction>>>>,
+    pub fut: Shared<BoxFuture<'static, ExecutorResult<Vec<(Vec<SignedTransaction>, u64)>>>>,
 }
 
 impl fmt::Debug for DataFetchFut {
@@ -202,10 +202,15 @@ impl InlineBatches {
         self.0.is_empty()
     }
 
-    pub fn transactions(&self) -> Vec<SignedTransaction> {
+    pub fn transactions(&self) -> Vec<(Vec<SignedTransaction>, u64)> {
         self.0
             .iter()
-            .flat_map(|inline_batch| inline_batch.transactions.clone())
+            .map(|inline_batch| {
+                (
+                    inline_batch.transactions.clone(),
+                    inline_batch.batch_info.gas_bucket_start(),
+                )
+            })
             .collect()
     }
 

--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -13,7 +13,7 @@ use crate::{
 use aptos_crypto::hash::{HashValue, ACCUMULATOR_PLACEHOLDER_HASH};
 use aptos_executor_types::{ExecutorResult, StateComputeResult};
 use aptos_infallible::Mutex;
-use aptos_logger::{error, warn};
+use aptos_logger::{error, info, warn};
 use aptos_types::{
     block_info::BlockInfo,
     contract_event::ContractEvent,
@@ -31,6 +31,25 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct OrderedBlockWindow {
+    blocks: Vec<Block>,
+}
+
+impl OrderedBlockWindow {
+    pub fn new(blocks: Vec<Block>) -> Self {
+        Self { blocks }
+    }
+
+    pub fn empty() -> Self {
+        Self { blocks: vec![] }
+    }
+
+    pub fn blocks(&self) -> &Vec<Block> {
+        &self.blocks
+    }
+}
+
 /// A representation of a block that has been added to the execution pipeline. It might either be in ordered
 /// or in executed state. In the ordered state, the block is waiting to be executed. In the executed state,
 /// the block has been executed and the output is available.
@@ -39,6 +58,8 @@ use std::{
 pub struct PipelinedBlock {
     /// Block data that cannot be regenerated.
     block: Block,
+    /// A window of blocks that are needed for execution with the execution pool, excluding the current block
+    block_window: OrderedBlockWindow,
     /// Input transactions in the order of execution
     input_transactions: Vec<SignedTransaction>,
     /// The state_compute_result is calculated for all the pending blocks prior to insertion to
@@ -61,6 +82,7 @@ impl Serialize for PipelinedBlock {
         #[serde(rename = "PipelineBlock")]
         struct SerializedBlock<'a> {
             block: &'a Block,
+            block_window: &'a OrderedBlockWindow,
             input_transactions: &'a Vec<SignedTransaction>,
             state_compute_result: &'a StateComputeResult,
             randomness: Option<&'a Randomness>,
@@ -68,6 +90,7 @@ impl Serialize for PipelinedBlock {
 
         let serialized = SerializedBlock {
             block: &self.block,
+            block_window: &self.block_window,
             input_transactions: &self.input_transactions,
             state_compute_result: &self.state_compute_result,
             randomness: self.randomness.get(),
@@ -85,6 +108,7 @@ impl<'de> Deserialize<'de> for PipelinedBlock {
         #[serde(rename = "PipelineBlock")]
         struct SerializedBlock {
             block: Block,
+            block_window: OrderedBlockWindow,
             input_transactions: Vec<SignedTransaction>,
             state_compute_result: StateComputeResult,
             randomness: Option<Randomness>,
@@ -92,6 +116,7 @@ impl<'de> Deserialize<'de> for PipelinedBlock {
 
         let SerializedBlock {
             block,
+            block_window,
             input_transactions,
             state_compute_result,
             randomness,
@@ -99,6 +124,7 @@ impl<'de> Deserialize<'de> for PipelinedBlock {
 
         let block = PipelinedBlock {
             block,
+            block_window,
             input_transactions,
             state_compute_result,
             randomness: OnceCell::new(),
@@ -213,8 +239,18 @@ impl PipelinedBlock {
         input_transactions: Vec<SignedTransaction>,
         state_compute_result: StateComputeResult,
     ) -> Self {
+        info!(
+            "New PipelinedBlock with block_id: {}, parent_id: {}, round: {}, epoch: {}, txns: {}",
+            block.id(),
+            block.parent_id(),
+            block.round(),
+            block.epoch(),
+            block.payload().map_or(0, |p| p.len())
+        );
+
         Self {
             block,
+            block_window: OrderedBlockWindow::new(vec![]),
             input_transactions,
             state_compute_result,
             randomness: OnceCell::new(),
@@ -224,9 +260,18 @@ impl PipelinedBlock {
         }
     }
 
-    pub fn new_ordered(block: Block) -> Self {
+    pub fn new_ordered(block: Block, window: OrderedBlockWindow) -> Self {
+        info!(
+            "New Ordered PipelinedBlock with block_id: {}, parent_id: {}, round: {}, epoch: {}, txns: {}",
+            block.id(),
+            block.parent_id(),
+            block.round(),
+            block.epoch(),
+            block.payload().map_or(0, |p| p.len())
+        );
         Self {
             block,
+            block_window: window,
             input_transactions: vec![],
             state_compute_result: StateComputeResult::new_dummy(),
             randomness: OnceCell::new(),
@@ -238,6 +283,11 @@ impl PipelinedBlock {
 
     pub fn block(&self) -> &Block {
         &self.block
+    }
+
+    // TODO: make this an Option?
+    pub fn block_window(&self) -> &OrderedBlockWindow {
+        &self.block_window
     }
 
     pub fn id(&self) -> HashValue {

--- a/consensus/src/block_preparer.rs
+++ b/consensus/src/block_preparer.rs
@@ -3,15 +3,18 @@
 
 use crate::{
     counters::{self, MAX_TXNS_FROM_BLOCK_TO_EXECUTE, TXN_SHUFFLE_SECONDS},
+    monitor,
     payload_manager::TPayloadManager,
     transaction_deduper::TransactionDeduper,
     transaction_filter::TransactionFilter,
     transaction_shuffler::TransactionShuffler,
 };
-use aptos_consensus_types::block::Block;
+use aptos_consensus_types::{block::Block, pipelined_block::OrderedBlockWindow};
 use aptos_executor_types::ExecutorResult;
+use aptos_logger::info;
 use aptos_types::transaction::SignedTransaction;
 use fail::fail_point;
+use futures::{stream::FuturesOrdered, StreamExt};
 use std::{sync::Arc, time::Instant};
 
 pub struct BlockPreparer {
@@ -36,7 +39,38 @@ impl BlockPreparer {
         }
     }
 
-    pub async fn prepare_block(&self, block: &Block) -> ExecutorResult<Vec<SignedTransaction>> {
+    async fn get_transactions(
+        &self,
+        block: &Block,
+        block_window: &OrderedBlockWindow,
+    ) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>)> {
+        let mut txns = vec![];
+        let mut futures = FuturesOrdered::new();
+        for block in block_window.blocks().iter().chain(std::iter::once(block)) {
+            futures.push_back(async move { self.payload_manager.get_transactions(block).await });
+        }
+        let mut max_txns_from_block_to_execute = None;
+        loop {
+            match futures.next().await {
+                // TODO: we are turning off the max txns from block to execute feature for now
+                Some(Ok((block_txns, _max_txns))) => {
+                    txns.extend(block_txns);
+                    max_txns_from_block_to_execute = None;
+                },
+                Some(Err(e)) => {
+                    return Err(e);
+                },
+                None => break,
+            }
+        }
+        Ok((txns, max_txns_from_block_to_execute))
+    }
+
+    pub async fn prepare_block(
+        &self,
+        block: &Block,
+        block_window: &OrderedBlockWindow,
+    ) -> ExecutorResult<Vec<SignedTransaction>> {
         fail_point!("consensus::prepare_block", |_| {
             use aptos_executor_types::ExecutorError;
             use std::{thread, time::Duration};
@@ -44,8 +78,19 @@ impl BlockPreparer {
             Err(ExecutorError::CouldNotGetData)
         });
         let start_time = Instant::now();
-        let (txns, max_txns_from_block_to_execute) =
-            self.payload_manager.get_transactions(block).await?;
+        info!(
+            "BlockPreparer: Preparing for block {} and window {:?}",
+            block.id(),
+            block_window
+                .blocks()
+                .iter()
+                .map(|b| b.id())
+                .collect::<Vec<_>>()
+        );
+
+        let (txns, max_txns_from_block_to_execute) = monitor!("get_transactions", {
+            self.get_transactions(block, block_window).await?
+        });
         let txn_filter = self.txn_filter.clone();
         let txn_deduper = self.txn_deduper.clone();
         let txn_shuffler = self.txn_shuffler.clone();

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -21,7 +21,7 @@ use anyhow::{bail, ensure, format_err, Context};
 use aptos_consensus_types::{
     block::Block,
     common::Round,
-    pipelined_block::{ExecutionSummary, PipelinedBlock},
+    pipelined_block::{ExecutionSummary, OrderedBlockWindow, PipelinedBlock},
     quorum_cert::QuorumCert,
     sync_info::SyncInfo,
     timeout_2chain::TwoChainTimeoutCertificate,
@@ -39,7 +39,10 @@ use std::collections::VecDeque;
 use std::sync::atomic::AtomicBool;
 #[cfg(any(test, feature = "fuzzing"))]
 use std::sync::atomic::Ordering;
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 #[cfg(test)]
 #[path = "block_store_test.rs"]
@@ -84,6 +87,7 @@ pub struct BlockStore {
     #[cfg(any(test, feature = "fuzzing"))]
     back_pressure_for_test: AtomicBool,
     order_vote_enabled: bool,
+    window_size: usize,
     pending_blocks: Arc<Mutex<PendingBlocks>>,
 }
 
@@ -97,6 +101,7 @@ impl BlockStore {
         vote_back_pressure_limit: Round,
         payload_manager: Arc<dyn TPayloadManager>,
         order_vote_enabled: bool,
+        window_size: usize,
         pending_blocks: Arc<Mutex<PendingBlocks>>,
     ) -> Self {
         let highest_2chain_tc = initial_data.highest_2chain_timeout_certificate();
@@ -114,6 +119,7 @@ impl BlockStore {
             vote_back_pressure_limit,
             payload_manager,
             order_vote_enabled,
+            window_size,
             pending_blocks,
         ));
         block_on(block_store.try_send_for_execution());
@@ -152,9 +158,10 @@ impl BlockStore {
         vote_back_pressure_limit: Round,
         payload_manager: Arc<dyn TPayloadManager>,
         order_vote_enabled: bool,
+        window_size: usize,
         pending_blocks: Arc<Mutex<PendingBlocks>>,
     ) -> Self {
-        let RootInfo(root_block, root_qc, root_ordered_cert, root_commit_cert) = root;
+        let RootInfo(root_block, window_block, root_qc, root_ordered_cert, root_commit_cert) = root;
 
         //verify root is correct
         assert!(
@@ -188,18 +195,20 @@ impl BlockStore {
         );
 
         let pipelined_root_block = PipelinedBlock::new(
-            *root_block,
+            *window_block,
             vec![],
             // Create a dummy state_compute_result with necessary fields filled in.
             result,
         );
 
         let tree = BlockTree::new(
+            root_block.id(),
             pipelined_root_block,
             root_qc,
             root_ordered_cert,
             root_commit_cert,
             max_pruned_blocks_in_mem,
+            window_size,
             highest_2chain_timeout_cert.map(Arc::new),
         );
 
@@ -214,6 +223,7 @@ impl BlockStore {
             back_pressure_for_test: AtomicBool::new(false),
             order_vote_enabled,
             pending_blocks,
+            window_size,
         };
 
         for block in blocks {
@@ -242,6 +252,13 @@ impl BlockStore {
         let block_to_commit = self
             .get_block(block_id_to_commit)
             .ok_or_else(|| format_err!("Committed block id not found"))?;
+
+        info!(
+            "send_for_execution for block {} with round {}, commit root round {}",
+            block_id_to_commit,
+            block_to_commit.round(),
+            self.commit_root().round()
+        );
 
         // First make sure that this commit is new.
         ensure!(
@@ -324,6 +341,7 @@ impl BlockStore {
             self.vote_back_pressure_limit,
             self.payload_manager.clone(),
             self.order_vote_enabled,
+            self.window_size,
             self.pending_blocks.clone(),
         )
         .await;
@@ -347,33 +365,56 @@ impl BlockStore {
         if let Some(existing_block) = self.get_block(block.id()) {
             return Ok(existing_block);
         }
-        ensure!(
-            self.inner.read().ordered_root().round() < block.round(),
-            "Block with old round"
-        );
 
-        let pipelined_block = PipelinedBlock::new_ordered(block.clone());
         // ensure local time past the block time
-        let block_time = Duration::from_micros(pipelined_block.timestamp_usecs());
+        let block_time = Duration::from_micros(block.timestamp_usecs());
         let current_timestamp = self.time_service.get_current_timestamp();
         if let Some(t) = block_time.checked_sub(current_timestamp) {
             if t > Duration::from_secs(1) {
-                warn!(
-                    "Long wait time {}ms for block {}",
-                    t.as_millis(),
-                    pipelined_block.block()
-                );
+                warn!("Long wait time {}ms for block {}", t.as_millis(), block);
             }
             self.time_service.wait_until(block_time).await;
         }
-        if let Some(payload) = pipelined_block.block().payload() {
+        if let Some(payload) = block.payload() {
             self.payload_manager
-                .prefetch_payload_data(payload, pipelined_block.block().timestamp_usecs());
+                .prefetch_payload_data(payload, block.timestamp_usecs());
         }
         self.storage
-            .save_tree(vec![pipelined_block.block().clone()], vec![])
+            .save_tree(vec![block.clone()], vec![])
             .context("Insert block failed when saving block")?;
-        self.inner.write().insert_block(pipelined_block)
+        let mut block_tree = self.inner.write();
+        if let Some(block_window) = block_tree.get_block_window(&block) {
+            let now = Instant::now();
+            for block in block_window.blocks() {
+                if let Some(payload) = block.payload() {
+                    self.payload_manager
+                        .prefetch_payload_data(payload, block.timestamp_usecs());
+                }
+            }
+            info!(
+                "block_window for PipelinedBlock with block_id: {}, parent_id: {}, round: {}, epoch: {}, block_window: {:?}, prefetch time: {} ms",
+                block.id(),
+                block.parent_id(),
+                block.round(),
+                block.epoch(),
+                block_window.blocks().iter().map(|b| format!("{}", b.id())).collect::<Vec<_>>(),
+                now.elapsed().as_millis()
+            );
+            let pipelined_block = PipelinedBlock::new_ordered(block.clone(), block_window);
+            block_tree.insert_block(pipelined_block)
+        } else {
+            info!(
+                "no block_window for PipelinedBlock with block_id: {}, parent_id: {}, round: {}, epoch: {}",
+                block.id(),
+                block.parent_id(),
+                block.round(),
+                block.epoch(),
+            );
+            // TODO: assert that this is an older block than commit root
+            let pipelined_block =
+                PipelinedBlock::new_ordered(block.clone(), OrderedBlockWindow::empty());
+            block_tree.insert_block(pipelined_block)
+        }
     }
 
     /// Validates quorum certificates and inserts it into block tree assuming dependencies exist.

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -636,6 +636,10 @@ impl BlockReader for BlockStore {
         self.inner.read().commit_root()
     }
 
+    fn window_root(&self) -> Arc<PipelinedBlock> {
+        self.inner.read().window_root()
+    }
+
     fn get_quorum_cert_for_block(&self, block_id: HashValue) -> Option<Arc<QuorumCert>> {
         self.inner.read().get_quorum_cert_for_block(&block_id)
     }
@@ -646,6 +650,10 @@ impl BlockReader for BlockStore {
 
     fn path_from_commit_root(&self, block_id: HashValue) -> Option<Vec<Arc<PipelinedBlock>>> {
         self.inner.read().path_from_commit_root(block_id)
+    }
+
+    fn path_from_window_root(&self, block_id: HashValue) -> Option<Vec<Arc<PipelinedBlock>>> {
+        self.inner.read().path_from_window_root(block_id)
     }
 
     #[cfg(test)]

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -21,7 +21,7 @@ use anyhow::{bail, ensure, format_err, Context};
 use aptos_consensus_types::{
     block::Block,
     common::Round,
-    pipelined_block::{ExecutionSummary, OrderedBlockWindow, PipelinedBlock},
+    pipelined_block::{ExecutionSummary, PipelinedBlock},
     quorum_cert::QuorumCert,
     sync_info::SyncInfo,
     timeout_2chain::TwoChainTimeoutCertificate,
@@ -31,7 +31,9 @@ use aptos_crypto::{hash::ACCUMULATOR_PLACEHOLDER_HASH, HashValue};
 use aptos_executor_types::StateComputeResult;
 use aptos_infallible::{Mutex, RwLock};
 use aptos_logger::prelude::*;
-use aptos_types::ledger_info::LedgerInfoWithSignatures;
+use aptos_types::{
+    account_config::NewBlockEvent, ledger_info::LedgerInfoWithSignatures, transaction::Version,
+};
 use futures::executor::block_on;
 #[cfg(test)]
 use std::collections::VecDeque;
@@ -227,9 +229,21 @@ impl BlockStore {
         };
 
         for block in blocks {
-            block_store.insert_block(block).await.unwrap_or_else(|e| {
-                panic!("[BlockStore] failed to insert block during build {:?}", e)
-            });
+            if block.round() <= root_block.round() {
+                block_store
+                    .insert_committed_block(block)
+                    .await
+                    .unwrap_or_else(|e| {
+                        panic!(
+                            "[BlockStore] failed to insert committed block during build {:?}",
+                            e
+                        )
+                    });
+            } else {
+                block_store.insert_block(block).await.unwrap_or_else(|e| {
+                    panic!("[BlockStore] failed to insert block during build {:?}", e)
+                });
+            }
         }
         for qc in quorum_certs {
             block_store
@@ -353,6 +367,88 @@ impl BlockStore {
         self.try_send_for_execution().await;
     }
 
+    pub async fn insert_committed_block(
+        &self,
+        block: Block,
+    ) -> anyhow::Result<Arc<PipelinedBlock>> {
+        // TODO: factor out repeated code
+
+        // ensure local time past the block time
+        let block_time = Duration::from_micros(block.timestamp_usecs());
+        let current_timestamp = self.time_service.get_current_timestamp();
+        if let Some(t) = block_time.checked_sub(current_timestamp) {
+            if t > Duration::from_secs(1) {
+                warn!("Long wait time {}ms for block {}", t.as_millis(), block);
+            }
+            self.time_service.wait_until(block_time).await;
+        }
+        if let Some(payload) = block.payload() {
+            self.payload_manager
+                .prefetch_payload_data(payload, block.timestamp_usecs());
+        }
+        self.storage
+            .save_tree(vec![block.clone()], vec![])
+            .context("Insert block failed when saving block")?;
+        let mut block_tree = self.inner.write();
+
+        info!(
+            "recovering committed transactions for PipelinedBlock with block_id: {}, parent_id: {}, round: {}, epoch: {}",
+            block.id(),
+            block.parent_id(),
+            block.round(),
+            block.epoch(),
+        );
+        let aptos_db = self.storage.aptos_db();
+        let latest_block_event = aptos_db
+            .get_latest_block_events(1)
+            .expect("at least one block");
+        let latest_block_event_with_version =
+            latest_block_event.first().expect("at least one block");
+        let latest_new_block_event = latest_block_event_with_version
+            .event
+            .expect_new_block_event()
+            .expect("new block event");
+        let mut height = latest_new_block_event.height();
+        let committed_transactions;
+        loop {
+            let (start_version, end_version, new_block_event): (Version, Version, NewBlockEvent) =
+                self.storage
+                    .aptos_db()
+                    .get_block_info_by_height(height)
+                    .expect("block id by height");
+            if new_block_event.epoch() < block.epoch() {
+                panic!(
+                    "the epoch of the latest block event {} is less than the block epoch {}",
+                    new_block_event.epoch(),
+                    block.epoch(),
+                );
+            }
+            if new_block_event.round() < block.round() {
+                info!(
+                    "the round of the latest block event {} is less than the block round {}",
+                    new_block_event.round(),
+                    block.round(),
+                );
+                committed_transactions = vec![];
+                break;
+            }
+            if new_block_event.epoch() == block.epoch() && new_block_event.round() == block.round()
+            {
+                let iter = aptos_db
+                    .get_transaction_info_iterator(start_version, end_version - start_version + 1)
+                    .expect("iterator");
+                committed_transactions = iter
+                    .map(|info| info.expect("info").transaction_hash())
+                    .collect();
+                break;
+            }
+            height -= 1;
+        }
+
+        let pipelined_block = PipelinedBlock::new_recovered(block.clone(), committed_transactions);
+        block_tree.insert_block(pipelined_block)
+    }
+
     /// Insert a block if it passes all validation tests.
     /// Returns the Arc to the block kept in the block store after persisting it to storage
     ///
@@ -400,20 +496,16 @@ impl BlockStore {
                 block_window.blocks().iter().map(|b| format!("{}", b.id())).collect::<Vec<_>>(),
                 now.elapsed().as_millis()
             );
-            let pipelined_block = PipelinedBlock::new_ordered(block.clone(), block_window);
+            let pipelined_block = PipelinedBlock::new_with_window(block.clone(), block_window);
             block_tree.insert_block(pipelined_block)
         } else {
-            info!(
+            panic!(
                 "no block_window for PipelinedBlock with block_id: {}, parent_id: {}, round: {}, epoch: {}",
                 block.id(),
                 block.parent_id(),
                 block.round(),
-                block.epoch(),
+                block.epoch()
             );
-            // TODO: assert that this is an older block than commit root
-            let pipelined_block =
-                PipelinedBlock::new_ordered(block.clone(), OrderedBlockWindow::empty());
-            block_tree.insert_block(pipelined_block)
         }
     }
 

--- a/consensus/src/block_storage/block_tree.rs
+++ b/consensus/src/block_storage/block_tree.rs
@@ -205,6 +205,11 @@ impl BlockTree {
             .expect("Commit root must exist")
     }
 
+    pub(super) fn window_root(&self) -> Arc<PipelinedBlock> {
+        self.get_block(&self.window_root_id)
+            .expect("Window root must exist")
+    }
+
     pub(super) fn highest_certified_block(&self) -> Arc<PipelinedBlock> {
         self.get_block(&self.highest_certified_block_id)
             .expect("Highest cerfified block must exist")
@@ -551,6 +556,13 @@ impl BlockTree {
         block_id: HashValue,
     ) -> Option<Vec<Arc<PipelinedBlock>>> {
         self.path_from_root_to_block(block_id, self.commit_root_id, self.commit_root().round())
+    }
+
+    pub(super) fn path_from_window_root(
+        &self,
+        block_id: HashValue,
+    ) -> Option<Vec<Arc<PipelinedBlock>>> {
+        self.path_from_root_to_block(block_id, self.window_root_id, self.window_root().round())
     }
 
     pub(super) fn max_pruned_blocks_in_mem(&self) -> usize {

--- a/consensus/src/block_storage/block_tree.rs
+++ b/consensus/src/block_storage/block_tree.rs
@@ -276,11 +276,18 @@ impl BlockTree {
                     );
                     break;
                 }
+                if current_block.is_genesis_block() {
+                    info!(
+                        "Break at genesis block: {}, for window of block: {}",
+                        current_block, block
+                    );
+                    break;
+                }
                 info!(
                     "Added block: {}, for window of block: {}",
                     current_block, block
                 );
-                window.push(current_block.clone());
+                window.push(parent_block);
             } else {
                 info!(
                     "Visiting block: {} was not found, parent of block: {}, for window of block: {}",

--- a/consensus/src/block_storage/block_tree.rs
+++ b/consensus/src/block_storage/block_tree.rs
@@ -10,8 +10,12 @@ use crate::{
 };
 use anyhow::bail;
 use aptos_consensus_types::{
-    pipelined_block::PipelinedBlock, quorum_cert::QuorumCert,
-    timeout_2chain::TwoChainTimeoutCertificate, wrapped_ledger_info::WrappedLedgerInfo,
+    block::Block,
+    common::Round,
+    pipelined_block::{OrderedBlockWindow, PipelinedBlock},
+    quorum_cert::QuorumCert,
+    timeout_2chain::TwoChainTimeoutCertificate,
+    wrapped_ledger_info::WrappedLedgerInfo,
 };
 use aptos_crypto::HashValue;
 use aptos_logger::prelude::*;
@@ -72,6 +76,7 @@ pub struct BlockTree {
     ordered_root_id: HashValue,
     /// Commit Root id: this is the root of commit phase
     commit_root_id: HashValue,
+    window_root_id: HashValue,
     /// A certified block id with highest round
     highest_certified_block_id: HashValue,
 
@@ -89,26 +94,28 @@ pub struct BlockTree {
     pruned_block_ids: VecDeque<HashValue>,
     /// Num pruned blocks to keep in memory.
     max_pruned_blocks_in_mem: usize,
+    window_size: usize,
 }
 
 impl BlockTree {
     pub(super) fn new(
-        root: PipelinedBlock,
+        root_block_id: HashValue,
+        // TODO: need the certs?
+        window_root: PipelinedBlock,
         root_quorum_cert: QuorumCert,
         root_ordered_cert: WrappedLedgerInfo,
         root_commit_cert: WrappedLedgerInfo,
         max_pruned_blocks_in_mem: usize,
+        window_size: usize,
         highest_2chain_timeout_cert: Option<Arc<TwoChainTimeoutCertificate>>,
     ) -> Self {
-        assert_eq!(
-            root.id(),
-            root_ordered_cert.commit_info().id(),
-            "inconsistent root and ledger info"
-        );
-        let root_id = root.id();
+        assert_eq!(window_root.epoch(), root_ordered_cert.commit_info().epoch());
+        assert!(window_root.round() <= root_ordered_cert.commit_info().round());
+        let window_root_id = window_root.id();
 
+        // Build the tree from the window root block which is <= the commit root block.
         let mut id_to_block = HashMap::new();
-        id_to_block.insert(root_id, LinkableBlock::new(root));
+        id_to_block.insert(window_root_id, LinkableBlock::new(window_root));
         counters::NUM_BLOCKS_IN_TREE.set(1);
 
         let root_quorum_cert = Arc::new(root_quorum_cert);
@@ -122,15 +129,17 @@ impl BlockTree {
 
         BlockTree {
             id_to_block,
-            ordered_root_id: root_id,
-            commit_root_id: root_id, // initially we set commit_root_id = root_id
-            highest_certified_block_id: root_id,
+            ordered_root_id: root_block_id,
+            commit_root_id: root_block_id, // initially we set commit_root_id = root_id
+            window_root_id,
+            highest_certified_block_id: root_block_id,
             highest_quorum_cert: Arc::clone(&root_quorum_cert),
             highest_ordered_cert: Arc::new(root_ordered_cert),
             highest_commit_cert: Arc::new(root_commit_cert),
             id_to_quorum_cert,
             pruned_block_ids,
             max_pruned_blocks_in_mem,
+            window_size,
             highest_2chain_timeout_cert,
         }
     }
@@ -163,7 +172,13 @@ impl BlockTree {
             .expect("Root must exist")
     }
 
+    fn linkable_window_root(&self) -> &LinkableBlock {
+        self.get_linkable_block(&self.window_root_id)
+            .expect("Window root must exist")
+    }
+
     fn remove_block(&mut self, block_id: HashValue) {
+        info!("remove_block: {}", block_id);
         // Remove the block from the store
         self.id_to_block.remove(&block_id);
         self.id_to_quorum_cert.remove(&block_id);
@@ -221,6 +236,65 @@ impl BlockTree {
         self.id_to_quorum_cert.get(block_id).cloned()
     }
 
+    // TODO: return an error when not enough blocks?
+    // TODO: how to know if the window is complete?
+    pub fn get_block_window(&self, block: &Block) -> Option<OrderedBlockWindow> {
+        // TODO: any other special cases that need to always have an empty window?
+        if block.is_nil_block() {
+            return Some(OrderedBlockWindow::new(vec![]));
+        }
+
+        let window_start_round = (block.round() + 1).saturating_sub(self.window_size as u64);
+        let window_size = (block.round() + 1) - window_start_round;
+        assert!(window_size > 0, "window_size must be greater than 0");
+        if window_size == 1 {
+            return Some(OrderedBlockWindow::new(vec![]));
+        }
+
+        let mut window = vec![];
+        let mut current_block = block.clone();
+        loop {
+            if current_block.parent_id() == HashValue::zero() {
+                info!(
+                    "Break at block: {}, for window of block: {}",
+                    current_block, block
+                );
+                break;
+            }
+            if let Some(parent_block) = self.get_block(&current_block.parent_id()) {
+                current_block = parent_block.block().clone();
+                info!(
+                    "Visiting block: {}, for window of block: {}",
+                    current_block, block
+                );
+                if current_block.round() < window_start_round {
+                    info!(
+                        "Break at block: {}, for window of block: {}",
+                        current_block, block
+                    );
+                    break;
+                }
+                info!(
+                    "Added block: {}, for window of block: {}",
+                    current_block, block
+                );
+                window.push(current_block.clone());
+            } else {
+                info!(
+                    "Visiting block: {} was not found, parent of block: {}, for window of block: {}",
+                    current_block.parent_id(),
+                    current_block,
+                    block
+                );
+                return None;
+            }
+        }
+        // The window order is lower round -> higher round
+        window.reverse();
+        assert!(window.len() < window_size as usize);
+        Some(OrderedBlockWindow::new(window))
+    }
+
     pub(super) fn insert_block(
         &mut self,
         block: PipelinedBlock,
@@ -250,6 +324,12 @@ impl BlockTree {
         if new_commit_cert.commit_info().round() > self.highest_commit_cert.commit_info().round() {
             self.highest_commit_cert = Arc::new(new_commit_cert);
             self.update_commit_root(self.highest_commit_cert.commit_info().id());
+        } else {
+            warn!(
+                "Trying to update highest commit cert with lower round: {} <= {}",
+                new_commit_cert.commit_info().round(),
+                self.highest_commit_cert.commit_info().round()
+            );
         }
     }
 
@@ -309,19 +389,22 @@ impl BlockTree {
     /// B3--> B4, root = B3
     ///
     /// Note this function is read-only, use with process_pruned_blocks to do the actual prune.
-    pub(super) fn find_blocks_to_prune(&self, next_root_id: HashValue) -> VecDeque<HashValue> {
-        // Nothing to do if this is the commit root
-        if next_root_id == self.commit_root_id {
+    pub(super) fn find_blocks_to_prune(
+        &self,
+        next_window_root_id: HashValue,
+    ) -> VecDeque<HashValue> {
+        // Nothing to do if this is the window root
+        if next_window_root_id == self.window_root_id {
             return VecDeque::new();
         }
 
         let mut blocks_pruned = VecDeque::new();
-        let mut blocks_to_be_pruned = vec![self.linkable_root()];
+        let mut blocks_to_be_pruned = vec![self.linkable_window_root()];
         while let Some(block_to_remove) = blocks_to_be_pruned.pop() {
             // Add the children to the blocks to be pruned (if any), but stop when it reaches the
             // new root
             for child_id in block_to_remove.children() {
-                if next_root_id == *child_id {
+                if next_window_root_id == *child_id {
                     continue;
                 }
                 blocks_to_be_pruned.push(
@@ -343,6 +426,46 @@ impl BlockTree {
     pub(super) fn update_commit_root(&mut self, root_id: HashValue) {
         assert!(self.block_exists(&root_id));
         self.commit_root_id = root_id;
+    }
+
+    pub(super) fn update_window_root(&mut self, root_id: HashValue) {
+        assert!(
+            self.block_exists(&root_id),
+            "Block {} not found, previous window_root: {}",
+            root_id,
+            self.window_root_id
+        );
+        self.window_root_id = root_id;
+    }
+
+    pub(super) fn find_window_root(
+        &self,
+        commit_round: Round,
+        commit_root_id: HashValue,
+    ) -> HashValue {
+        let window_start_round = commit_round
+            .saturating_add(1)
+            .saturating_sub(self.window_size as u64);
+        let mut window_start_id = HashValue::zero();
+        let mut curr_block_id = commit_root_id;
+        info!("Start at commit_root_id: {}", curr_block_id);
+        while let Some(block) = self.get_block(&curr_block_id) {
+            if block.round() < window_start_round {
+                window_start_id = curr_block_id;
+                break;
+            }
+
+            window_start_id = curr_block_id;
+            curr_block_id = block.parent_id();
+        }
+        // TODO: panic or bail?
+        assert_ne!(
+            window_start_id,
+            HashValue::zero(),
+            "Window start block not found"
+        );
+
+        window_start_id
     }
 
     /// Process the data returned by the prune_tree, they're separated because caller might
@@ -428,6 +551,8 @@ impl BlockTree {
         finality_proof: WrappedLedgerInfo,
         commit_decision: LedgerInfoWithSignatures,
     ) {
+        info!("commit_callback blocks_to_commit: {:?}", blocks_to_commit);
+
         let commit_proof = finality_proof
             .create_merged_with_executed_state(commit_decision)
             .expect("Inconsistent commit proof and evaluation decision, cannot commit block");
@@ -442,7 +567,10 @@ impl BlockTree {
             block_id = block_to_commit.id(),
         );
 
-        let ids_to_remove = self.find_blocks_to_prune(block_to_commit.id());
+        let window_root_id = self.find_window_root(committed_round, block_to_commit.id());
+        info!("Updating to window_root_id: {}", window_root_id);
+        let ids_to_remove = self.find_blocks_to_prune(window_root_id);
+        info!("Pruning blocks: {:?}", ids_to_remove);
         if let Err(e) = storage.prune_tree(ids_to_remove.clone().into_iter().collect()) {
             // it's fine to fail here, as long as the commit succeeds, the next restart will clean
             // up dangling blocks, and we need to prune the tree to keep the root consistent with
@@ -451,6 +579,7 @@ impl BlockTree {
         }
         self.process_pruned_blocks(ids_to_remove);
         self.update_highest_commit_cert(commit_proof);
+        self.update_window_root(window_root_id);
     }
 }
 

--- a/consensus/src/block_storage/mod.rs
+++ b/consensus/src/block_storage/mod.rs
@@ -34,6 +34,8 @@ pub trait BlockReader: Send + Sync {
     /// Get the current commit root block of the BlockTree.
     fn commit_root(&self) -> Arc<PipelinedBlock>;
 
+    fn window_root(&self) -> Arc<PipelinedBlock>;
+
     fn get_quorum_cert_for_block(&self, block_id: HashValue) -> Option<Arc<QuorumCert>>;
 
     /// Returns all the blocks between the ordered/commit root and the given block, including the given block
@@ -46,6 +48,8 @@ pub trait BlockReader: Send + Sync {
     fn path_from_ordered_root(&self, block_id: HashValue) -> Option<Vec<Arc<PipelinedBlock>>>;
 
     fn path_from_commit_root(&self, block_id: HashValue) -> Option<Vec<Arc<PipelinedBlock>>>;
+
+    fn path_from_window_root(&self, block_id: HashValue) -> Option<Vec<Arc<PipelinedBlock>>>;
 
     /// Return the certified block with the highest round.
     #[cfg(test)]

--- a/consensus/src/block_storage/pending_blocks.rs
+++ b/consensus/src/block_storage/pending_blocks.rs
@@ -3,23 +3,20 @@
 
 use crate::counters::BLOCK_RETRIEVAL_LOCAL_FULFILL_COUNT;
 use aptos_consensus_types::{block::Block, common::Round};
-use aptos_crypto::HashValue;
 use aptos_logger::info;
 use futures_channel::oneshot;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 /// A local buffer to hold incoming blocks before it reaches round manager.
 /// Which can be used to fulfill block request from local due to out of order messages.
 pub struct PendingBlocks {
-    blocks_by_hash: HashMap<HashValue, Block>,
     blocks_by_round: BTreeMap<Round, Block>,
-    pending_request: Option<(HashValue, oneshot::Sender<Block>)>,
+    pending_request: Option<(Round, oneshot::Sender<Block>)>,
 }
 
 impl PendingBlocks {
     pub fn new() -> Self {
         Self {
-            blocks_by_hash: HashMap::new(),
             blocks_by_round: BTreeMap::new(),
             pending_request: None,
         }
@@ -27,39 +24,36 @@ impl PendingBlocks {
 
     pub fn insert_block(&mut self, block: Block) {
         info!("Pending block inserted: {}", block.id());
-        self.blocks_by_hash.insert(block.id(), block.clone());
         self.blocks_by_round.insert(block.round(), block.clone());
-        if let Some((id, tx)) = self.pending_request.take() {
-            if id == block.id() {
-                info!("FulFill block request from incoming block: {}", id);
+        if let Some((round, tx)) = self.pending_request.take() {
+            if round == block.round() {
+                info!(
+                    "FulFill block request from incoming block for round: {}",
+                    round
+                );
                 BLOCK_RETRIEVAL_LOCAL_FULFILL_COUNT.inc();
                 tx.send(block).ok();
             } else {
-                self.pending_request = Some((id, tx));
+                self.pending_request = Some((round, tx));
             }
         }
     }
 
-    pub fn insert_request(&mut self, block_id: HashValue, tx: oneshot::Sender<Block>) {
-        if let Some(block) = self.blocks_by_hash.get(&block_id) {
-            info!("FulFill block request from existing buffer: {}", block_id);
+    pub fn insert_request(&mut self, block_round: u64, tx: oneshot::Sender<Block>) {
+        if let Some(block) = self.blocks_by_round.get(&block_round) {
+            info!(
+                "Fulfill block request from existing buffer: {}",
+                block_round
+            );
             BLOCK_RETRIEVAL_LOCAL_FULFILL_COUNT.inc();
             tx.send(block.clone()).ok();
         } else {
-            info!("Insert block request for: {}", block_id);
-            self.pending_request = Some((block_id, tx));
+            info!("Insert block request for: {}", block_round);
+            self.pending_request = Some((block_round, tx));
         }
     }
 
     pub fn gc(&mut self, round: Round) {
-        let mut to_remove = vec![];
-        for (r, _) in self.blocks_by_round.range(..=round) {
-            to_remove.push(*r);
-        }
-        for r in to_remove {
-            if let Some(block) = self.blocks_by_round.remove(&r) {
-                self.blocks_by_hash.remove(&block.id());
-            }
-        }
+        self.blocks_by_round = self.blocks_by_round.split_off(&round);
     }
 }

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -20,7 +20,7 @@ use crate::{
     network::{IncomingBlockRetrievalRequest, NetworkSender},
     network_interface::ConsensusMsg,
     payload_manager::TPayloadManager,
-    persistent_liveness_storage::{LedgerRecoveryData, PersistentLivenessStorage, RecoveryData},
+    persistent_liveness_storage::{PersistentLivenessStorage, RecoveryData},
     pipeline::execution_client::TExecutionClient,
 };
 use anyhow::{anyhow, bail, Context};
@@ -431,7 +431,8 @@ impl BlockStore {
         }
 
         // Check early that recovery will succeed, and return before corrupting our state in case it will not.
-        LedgerRecoveryData::new(highest_commit_cert.ledger_info().clone())
+        storage
+            .recover_from_ledger_with_ledger_info(highest_commit_cert.ledger_info().clone())
             .find_root(
                 &mut blocks.clone(),
                 &mut quorum_certs.clone(),

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -42,11 +42,17 @@ use aptos_types::{
     account_address::AccountAddress, epoch_change::EpochChangeProof,
     ledger_info::LedgerInfoWithSignatures,
 };
+use claims::assert_ge;
 use fail::fail_point;
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 use futures_channel::oneshot;
 use rand::{prelude::*, Rng};
-use std::{clone::Clone, cmp::min, sync::Arc, time::Duration};
+use std::{
+    clone::Clone,
+    cmp::{max, min},
+    sync::Arc,
+    time::Duration,
+};
 use tokio::{time, time::timeout};
 
 #[derive(Debug, PartialEq, Eq)]
@@ -224,7 +230,8 @@ impl BlockStore {
                 .retrieve_blocks_in_range(
                     retrieve_qc.certified_block().id(),
                     1,
-                    retrieve_qc.certified_block().id(),
+                    retrieve_qc.certified_block().epoch(),
+                    retrieve_qc.certified_block().round(),
                     qc.ledger_info()
                         .get_voters(&retriever.validator_addresses()),
                 )
@@ -267,6 +274,7 @@ impl BlockStore {
             self.execution_client.clone(),
             self.payload_manager.clone(),
             self.order_vote_enabled,
+            self.window_size,
         )
         .await?
         .take();
@@ -298,6 +306,7 @@ impl BlockStore {
         execution_client: Arc<dyn TExecutionClient>,
         payload_manager: Arc<dyn TPayloadManager>,
         order_vote_enabled: bool,
+        window_size: usize,
     ) -> anyhow::Result<RecoveryData> {
         info!(
             LogSchema::new(LogEvent::StateSync).remote_peer(retriever.preferred_peer),
@@ -306,10 +315,24 @@ impl BlockStore {
             highest_quorum_cert,
         );
 
-        // we fetch the blocks from
-        let num_blocks = highest_quorum_cert.certified_block().round()
-            - highest_commit_cert.ledger_info().ledger_info().round()
-            + 1;
+        // For execution, we need the window starting from the highest_commit_cert + 1.
+        // TODO: what happens cross-epoch?
+        let highest_commit_cert_round = highest_commit_cert.ledger_info().ledger_info().round();
+        // TODO: we should not retrieve genesis, double check this is the right way to do that
+        let target_round = max(
+            1,
+            min(
+                highest_commit_cert_round,
+                // commit_cert + 1 - (window_size - 1)
+                highest_commit_cert_round.saturating_sub(window_size as u64),
+            ),
+        );
+
+        let num_blocks = highest_quorum_cert.certified_block().round() - target_round + 1;
+        info!(
+            "fast_forward_sync window_size: {}, target_round: {}, num_blocks: {}",
+            window_size, target_round, num_blocks
+        );
 
         // although unlikely, we might wrap num_blocks around on a 32-bit machine
         assert!(num_blocks < std::usize::MAX as u64);
@@ -319,7 +342,8 @@ impl BlockStore {
             .retrieve_blocks_in_range(
                 highest_quorum_cert.certified_block().id(),
                 num_blocks,
-                highest_commit_cert.commit_info().id(),
+                highest_commit_cert.commit_info().epoch(),
+                target_round,
                 highest_quorum_cert
                     .ledger_info()
                     .get_voters(&retriever.validator_addresses()),
@@ -334,10 +358,12 @@ impl BlockStore {
             blocks.first().expect("blocks are empty").id(),
         );
 
-        // Confirm retrieval ended when it hit the last block we care about, even if it didn't reach all num_blocks blocks.
-        assert_eq!(
-            blocks.last().expect("blocks are empty").id(),
-            highest_commit_cert.commit_info().id()
+        // Confirm retrieval hit at least the last round we care about
+        assert!(
+            blocks.last().expect("blocks are empty").round() <= target_round,
+            "Expecting in the retrieval response, last block should be <= {}, but got {}",
+            target_round,
+            blocks.last().expect("blocks are empty").round()
         );
 
         let mut quorum_certs = vec![highest_quorum_cert.clone()];
@@ -349,14 +375,14 @@ impl BlockStore {
         );
 
         if !order_vote_enabled {
+            // TODO: this is probably still necessary, but need to think harder, it's pretty subtle
             // check if highest_commit_cert comes from a fork
             // if so, we need to fetch it's block as well, to have a proof of commit.
-            let highest_commit_certified_block_id = highest_commit_cert
-                .certified_block(order_vote_enabled)?
-                .id();
+            let highest_commit_certified_block =
+                highest_commit_cert.certified_block(order_vote_enabled)?;
             if !blocks
                 .iter()
-                .any(|block| block.id() == highest_commit_certified_block_id)
+                .any(|block| block.id() == highest_commit_certified_block.id())
             {
                 info!(
                     "Found forked QC {}, fetching it as well",
@@ -365,9 +391,10 @@ impl BlockStore {
                 BLOCKS_FETCHED_FROM_NETWORK_WHILE_FAST_FORWARD_SYNC.inc_by(1);
                 let mut additional_blocks = retriever
                     .retrieve_blocks_in_range(
-                        highest_commit_certified_block_id,
+                        highest_commit_certified_block.id(),
                         1,
-                        highest_commit_certified_block_id,
+                        highest_commit_certified_block.epoch(),
+                        highest_commit_certified_block.round(),
                         highest_commit_cert
                             .ledger_info()
                             .get_voters(&retriever.validator_addresses()),
@@ -378,9 +405,9 @@ impl BlockStore {
                 let block = additional_blocks.pop().expect("blocks are empty");
                 assert_eq!(
                     block.id(),
-                    highest_commit_certified_block_id,
+                    highest_commit_certified_block.id(),
                     "Expecting in the retrieval response, for commit certificate fork, first block should be {}, but got {}",
-                    highest_commit_certified_block_id,
+                    highest_commit_certified_block.id(),
                     block.id(),
                 );
                 blocks.push(block);
@@ -409,6 +436,7 @@ impl BlockStore {
                 &mut blocks.clone(),
                 &mut quorum_certs.clone(),
                 order_vote_enabled,
+                window_size,
             )
             .with_context(|| {
                 // for better readability
@@ -438,7 +466,7 @@ impl BlockStore {
         // we do not need to update block_tree.highest_commit_decision_ledger_info here
         // because the block_tree is going to rebuild itself.
 
-        let recovery_data = match storage.start(order_vote_enabled) {
+        let recovery_data = match storage.start(order_vote_enabled, window_size) {
             LivenessStorageData::FullRecoveryData(recovery_data) => recovery_data,
             _ => panic!("Failed to construct recovery data after fast forward sync"),
         };
@@ -480,13 +508,37 @@ impl BlockStore {
         let mut id = request.req.block_id();
         while (blocks.len() as u64) < request.req.num_blocks() {
             if let Some(executed_block) = self.get_block(id) {
-                blocks.push(executed_block.block().clone());
-                if request.req.match_target_id(id) {
+                info!(
+                    "Block found: {}, round: ({}, {})",
+                    executed_block.block().id(),
+                    executed_block.epoch(),
+                    executed_block.round()
+                );
+                if !executed_block.block().is_genesis_block() {
+                    blocks.push(executed_block.block().clone());
+                } else {
+                    info!(
+                        "Skipping genesis block: ({}, {})",
+                        executed_block.epoch(),
+                        executed_block.round()
+                    );
+                }
+                if request
+                    .req
+                    .match_target_round(executed_block.epoch(), executed_block.round())
+                {
+                    info!(
+                        "SucceededWithTarget: ({}, {}) <= {:?}",
+                        executed_block.epoch(),
+                        executed_block.round(),
+                        request.req.target_epoch_and_round(),
+                    );
                     status = BlockRetrievalStatus::SucceededWithTarget;
                     break;
                 }
                 id = executed_block.parent_id();
             } else {
+                info!("NotEnoughBlocks: {}", id);
                 status = BlockRetrievalStatus::NotEnoughBlocks;
                 break;
             }
@@ -540,7 +592,9 @@ impl BlockRetriever {
     async fn retrieve_block_for_id_chunk(
         &mut self,
         block_id: HashValue,
-        target_block_id: HashValue,
+        // TODO: epoch is unneeded?
+        target_epoch: u64,
+        target_round: u64,
         retrieve_batch_size: u64,
         mut peers: Vec<AccountAddress>,
     ) -> anyhow::Result<BlockRetrievalResponse> {
@@ -557,9 +611,7 @@ impl BlockRetriever {
             let mut futures = FuturesUnordered::new();
             if retrieve_batch_size == 1 {
                 let (tx, rx) = oneshot::channel();
-                self.pending_blocks
-                    .lock()
-                    .insert_request(target_block_id, tx);
+                self.pending_blocks.lock().insert_request(target_round, tx);
                 let author = self.network.author();
                 futures.push(
                     async move {
@@ -576,22 +628,23 @@ impl BlockRetriever {
                     .boxed(),
                 )
             }
-            let request = BlockRetrievalRequest::new_with_target_block_id(
+            let request = BlockRetrievalRequest::new_with_target_round(
                 block_id,
                 retrieve_batch_size,
-                target_block_id,
+                target_epoch,
+                target_round,
             );
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
                         // send batch request to a set of peers of size request_num_peers (or 1 for the first time)
                         let next_peers = if cur_retry < num_retries {
-                            let first_atempt = cur_retry == 0;
+                            let first_attempt = cur_retry == 0;
                             cur_retry += 1;
                             self.pick_peers(
-                                first_atempt,
+                                first_attempt,
                                 &mut peers,
-                                if first_atempt { 1 } else {request_num_peers}
+                                if first_attempt { 1 } else {request_num_peers}
                             )
                         } else {
                             Vec::new()
@@ -650,13 +703,14 @@ impl BlockRetriever {
     async fn retrieve_block_for_id(
         &mut self,
         block_id: HashValue,
-        target_block_id: HashValue,
+        target_epoch: u64,
+        target_round: u64,
         peers: Vec<AccountAddress>,
         num_blocks: u64,
     ) -> anyhow::Result<Vec<Block>> {
         info!(
-            "Retrieving {} blocks starting from {}",
-            num_blocks, block_id
+            "Retrieving {} blocks starting from {} with target_epoch {} and target_round {}",
+            num_blocks, block_id, target_epoch, target_round
         );
         let mut progress = 0;
         let mut last_block_id = block_id;
@@ -677,7 +731,8 @@ impl BlockRetriever {
             let response = self
                 .retrieve_block_for_id_chunk(
                     last_block_id,
-                    target_block_id,
+                    target_epoch,
+                    target_round,
                     retrieve_batch_size,
                     peers.clone(),
                 )
@@ -707,12 +762,26 @@ impl BlockRetriever {
                 },
             }
         }
-        assert_eq!(
+
+        info!(
+            "Retrieved {} blocks: {:?}",
+            result_blocks.len(),
+            result_blocks
+        );
+
+        assert_ge!(
+            target_epoch,
             result_blocks
                 .last()
                 .expect("Expected at least a result_block")
-                .id(),
-            target_block_id
+                .epoch()
+        );
+        assert_ge!(
+            target_round,
+            result_blocks
+                .last()
+                .expect("Expected at least a result_block")
+                .round()
         );
         Ok(result_blocks)
     }
@@ -722,12 +791,19 @@ impl BlockRetriever {
         &mut self,
         initial_block_id: HashValue,
         num_blocks: u64,
-        target_block_id: HashValue,
+        target_epoch: u64,
+        target_round: u64,
         peers: Vec<AccountAddress>,
     ) -> anyhow::Result<Vec<Block>> {
         BLOCKS_FETCHED_FROM_NETWORK_IN_BLOCK_RETRIEVER.inc_by(num_blocks);
-        self.retrieve_block_for_id(initial_block_id, target_block_id, peers, num_blocks)
-            .await
+        self.retrieve_block_for_id(
+            initial_block_id,
+            target_epoch,
+            target_round,
+            peers,
+            num_blocks,
+        )
+        .await
     }
 
     fn pick_peer(&self, first_atempt: bool, peers: &mut Vec<AccountAddress>) -> AccountAddress {

--- a/consensus/src/consensus_observer/network/observer_message.rs
+++ b/consensus/src/consensus_observer/network/observer_message.rs
@@ -784,6 +784,7 @@ mod test {
         block::Block,
         block_data::{BlockData, BlockType},
         common::{Author, ProofWithData, ProofWithDataWithTxnLimit},
+        pipelined_block::OrderedBlockWindow,
         proof_of_store::BatchId,
         quorum_cert::QuorumCert,
     };
@@ -1314,7 +1315,10 @@ mod test {
             BlockType::Genesis,
         );
         let block = Block::new_for_testing(block_info.id(), block_data, None);
-        Arc::new(PipelinedBlock::new_ordered(block))
+        Arc::new(PipelinedBlock::new_ordered(
+            block,
+            OrderedBlockWindow::empty(),
+        ))
     }
 
     /// Creates and returns a new pipelined block with the given block info and parent ID
@@ -1344,7 +1348,10 @@ mod test {
 
         // Create the pipelined block
         let block = Block::new_for_testing(block_info.id(), block_data, None);
-        Arc::new(PipelinedBlock::new_ordered(block))
+        Arc::new(PipelinedBlock::new_ordered(
+            block,
+            OrderedBlockWindow::empty(),
+        ))
     }
 
     /// Creates a returns multiple signed transactions

--- a/consensus/src/consensus_observer/observer/active_state.rs
+++ b/consensus/src/consensus_observer/observer/active_state.rs
@@ -334,6 +334,7 @@ mod test {
     use aptos_consensus_types::{
         block::Block,
         block_data::{BlockData, BlockType},
+        pipelined_block::OrderedBlockWindow,
         quorum_cert::QuorumCert,
     };
     use aptos_crypto::HashValue;
@@ -536,7 +537,10 @@ mod test {
                 BlockType::Genesis,
             );
             let block = Block::new_for_testing(block_info.id(), block_data, None);
-            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(block));
+            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(
+                block,
+                OrderedBlockWindow::empty(),
+            ));
 
             // Create an ordered block
             let blocks = vec![pipelined_block];
@@ -594,7 +598,10 @@ mod test {
             BlockType::Genesis,
         );
         let block = Block::new_for_testing(block_info.id(), block_data, None);
-        Arc::new(PipelinedBlock::new_ordered(block))
+        Arc::new(PipelinedBlock::new_ordered(
+            block,
+            OrderedBlockWindow::empty(),
+        ))
     }
 
     /// Creates and returns a reconfig notifier and listener

--- a/consensus/src/consensus_observer/observer/active_state.rs
+++ b/consensus/src/consensus_observer/observer/active_state.rs
@@ -537,7 +537,7 @@ mod test {
                 BlockType::Genesis,
             );
             let block = Block::new_for_testing(block_info.id(), block_data, None);
-            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(
+            let pipelined_block = Arc::new(PipelinedBlock::new_with_window(
                 block,
                 OrderedBlockWindow::empty(),
             ));
@@ -598,7 +598,7 @@ mod test {
             BlockType::Genesis,
         );
         let block = Block::new_for_testing(block_info.id(), block_data, None);
-        Arc::new(PipelinedBlock::new_ordered(
+        Arc::new(PipelinedBlock::new_with_window(
             block,
             OrderedBlockWindow::empty(),
         ))

--- a/consensus/src/consensus_observer/observer/ordered_blocks.rs
+++ b/consensus/src/consensus_observer/observer/ordered_blocks.rs
@@ -212,7 +212,7 @@ mod test {
     use aptos_consensus_types::{
         block::Block,
         block_data::{BlockData, BlockType},
-        pipelined_block::PipelinedBlock,
+        pipelined_block::{OrderedBlockWindow, PipelinedBlock},
         quorum_cert::QuorumCert,
     };
     use aptos_crypto::HashValue;
@@ -683,7 +683,10 @@ mod test {
                 BlockType::Genesis,
             );
             let block = Block::new_for_testing(block_info.id(), block_data, None);
-            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(block));
+            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(
+                block,
+                OrderedBlockWindow::empty(),
+            ));
 
             // Create an ordered block
             let blocks = vec![pipelined_block];

--- a/consensus/src/consensus_observer/observer/ordered_blocks.rs
+++ b/consensus/src/consensus_observer/observer/ordered_blocks.rs
@@ -683,7 +683,7 @@ mod test {
                 BlockType::Genesis,
             );
             let block = Block::new_for_testing(block_info.id(), block_data, None);
-            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(
+            let pipelined_block = Arc::new(PipelinedBlock::new_with_window(
                 block,
                 OrderedBlockWindow::empty(),
             ));

--- a/consensus/src/consensus_observer/observer/payload_store.rs
+++ b/consensus/src/consensus_observer/observer/payload_store.rs
@@ -284,6 +284,7 @@ mod test {
         block::Block,
         block_data::{BlockData, BlockType},
         common::{Author, Payload, ProofWithData},
+        pipelined_block::OrderedBlockWindow,
         proof_of_store::{BatchId, BatchInfo, ProofOfStore},
         quorum_cert::QuorumCert,
     };
@@ -1076,7 +1077,10 @@ mod test {
                 block_type,
             );
             let block = Block::new_for_testing(block_info.id(), block_data, None);
-            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(block));
+            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(
+                block,
+                OrderedBlockWindow::empty(),
+            ));
 
             // Add the pipelined block to the list
             pipelined_blocks.push(pipelined_block.clone());

--- a/consensus/src/consensus_observer/observer/payload_store.rs
+++ b/consensus/src/consensus_observer/observer/payload_store.rs
@@ -1077,7 +1077,7 @@ mod test {
                 block_type,
             );
             let block = Block::new_for_testing(block_info.id(), block_data, None);
-            let pipelined_block = Arc::new(PipelinedBlock::new_ordered(
+            let pipelined_block = Arc::new(PipelinedBlock::new_with_window(
                 block,
                 OrderedBlockWindow::empty(),
             ));

--- a/consensus/src/consensus_observer/observer/pending_blocks.rs
+++ b/consensus/src/consensus_observer/observer/pending_blocks.rs
@@ -820,7 +820,7 @@ mod test {
                     BlockType::Genesis,
                 );
                 let block = Block::new_for_testing(block_info.id(), block_data, None);
-                let pipelined_block = Arc::new(PipelinedBlock::new_ordered(
+                let pipelined_block = Arc::new(PipelinedBlock::new_with_window(
                     block,
                     OrderedBlockWindow::empty(),
                 ));

--- a/consensus/src/consensus_observer/observer/pending_blocks.rs
+++ b/consensus/src/consensus_observer/observer/pending_blocks.rs
@@ -198,7 +198,7 @@ mod test {
     use aptos_consensus_types::{
         block::Block,
         block_data::{BlockData, BlockType},
-        pipelined_block::PipelinedBlock,
+        pipelined_block::{OrderedBlockWindow, PipelinedBlock},
         quorum_cert::QuorumCert,
     };
     use aptos_crypto::HashValue;
@@ -820,7 +820,10 @@ mod test {
                     BlockType::Genesis,
                 );
                 let block = Block::new_for_testing(block_info.id(), block_data, None);
-                let pipelined_block = Arc::new(PipelinedBlock::new_ordered(block));
+                let pipelined_block = Arc::new(PipelinedBlock::new_ordered(
+                    block,
+                    OrderedBlockWindow::empty(),
+                ));
 
                 // Add the pipelined block to the list
                 pipelined_blocks.push(pipelined_block);

--- a/consensus/src/dag/tests/helpers.rs
+++ b/consensus/src/dag/tests/helpers.rs
@@ -11,10 +11,12 @@ use crate::{
 use aptos_consensus_types::{
     block::Block,
     common::{Author, Payload, Round},
+    pipelined_block::PipelinedBlock,
 };
 use aptos_executor_types::ExecutorResult;
 use aptos_types::{aggregate_signature::AggregateSignature, transaction::SignedTransaction};
 use async_trait::async_trait;
+use std::sync::Arc;
 
 pub(super) const TEST_DAG_WINDOW: u64 = 5;
 
@@ -24,7 +26,7 @@ pub(super) struct MockPayloadManager {}
 impl TPayloadManager for MockPayloadManager {
     fn prefetch_payload_data(&self, _payload: &Payload, _timestamp: u64) {}
 
-    fn notify_commit(&self, _block_timestamp: u64, _payloads: Vec<Payload>) {}
+    fn notify_commit(&self, _block_timestamp: u64, _blocks: &[Arc<PipelinedBlock>]) {}
 
     fn check_payload_availability(&self, _block: &Block) -> bool {
         unimplemented!()

--- a/consensus/src/dag/tests/helpers.rs
+++ b/consensus/src/dag/tests/helpers.rs
@@ -35,7 +35,7 @@ impl TPayloadManager for MockPayloadManager {
     async fn get_transactions(
         &self,
         _block: &Block,
-    ) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>)> {
+    ) -> ExecutorResult<(Vec<(Vec<SignedTransaction>, u64)>, Option<u64>)> {
         Ok((Vec::new(), None))
     }
 }

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -656,6 +656,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 .max_blocks_per_sending_request(onchain_consensus_config.quorum_store_enabled()),
             self.payload_manager.clone(),
             onchain_consensus_config.order_vote_enabled(),
+            onchain_consensus_config.window_size(),
             self.pending_blocks.clone(),
         );
         tokio::spawn(recovery_manager.start(recovery_manager_rx, close_rx));
@@ -823,6 +824,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             self.config.vote_back_pressure_limit,
             payload_manager,
             onchain_consensus_config.order_vote_enabled(),
+            onchain_consensus_config.window_size(),
             self.pending_blocks.clone(),
         ));
 
@@ -1253,7 +1255,10 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         fast_rand_config: Option<RandConfig>,
         rand_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingRandGenRequest>,
     ) {
-        match self.storage.start(consensus_config.order_vote_enabled()) {
+        match self.storage.start(
+            consensus_config.order_vote_enabled(),
+            consensus_config.window_size(),
+        ) {
             LivenessStorageData::FullRecoveryData(initial_data) => {
                 self.recovery_mode = false;
                 self.start_round_manager(

--- a/consensus/src/liveness/proposal_generator.rs
+++ b/consensus/src/liveness/proposal_generator.rs
@@ -372,11 +372,11 @@ impl ProposalGenerator {
             // being executed: pending blocks vector keeps all the pending ancestors of the extended branch.
             let mut pending_blocks = self
                 .block_store
-                .path_from_commit_root(hqc.certified_block().id())
+                .path_from_window_root(hqc.certified_block().id())
                 .ok_or_else(|| format_err!("HQC {} already pruned", hqc.certified_block().id()))?;
             // Avoid txn manager long poll if the root block has txns, so that the leader can
             // deliver the commit proof to others without delay.
-            pending_blocks.push(self.block_store.commit_root());
+            pending_blocks.push(self.block_store.window_root());
 
             // Exclude all the pending transactions: these are all the ancestors of
             // parent (including) up to the root (including).

--- a/consensus/src/payload_manager.rs
+++ b/consensus/src/payload_manager.rs
@@ -14,6 +14,7 @@ use aptos_consensus_types::{
     block::Block,
     common::{DataStatus, Payload, ProofWithData, Round},
     payload::{BatchPointer, DataFetchFut, TDataInfo},
+    pipelined_block::PipelinedBlock,
     proof_of_store::BatchInfo,
 };
 use aptos_crypto::HashValue;
@@ -27,7 +28,7 @@ use aptos_types::{transaction::SignedTransaction, PeerId};
 use async_trait::async_trait;
 use futures::{channel::mpsc::Sender, FutureExt};
 use std::{
-    collections::{btree_map::Entry, BTreeMap},
+    collections::{btree_map::Entry, BTreeMap, HashSet},
     ops::Deref,
     sync::Arc,
 };
@@ -39,7 +40,7 @@ use tokio::sync::oneshot;
 pub trait TPayloadManager: Send + Sync {
     /// Notify the payload manager that a block has been committed. This indicates that the
     /// transactions in the block's payload are no longer required for consensus.
-    fn notify_commit(&self, block_timestamp: u64, payloads: Vec<Payload>);
+    fn notify_commit(&self, block_timestamp: u64, blocks: &[Arc<PipelinedBlock>]);
 
     /// Prefetch the data for a payload. This is used to ensure that the data for a payload is
     /// available when block is executed.
@@ -68,7 +69,7 @@ impl DirectMempoolPayloadManager {
 
 #[async_trait]
 impl TPayloadManager for DirectMempoolPayloadManager {
-    fn notify_commit(&self, _block_timestamp: u64, _payloads: Vec<Payload>) {}
+    fn notify_commit(&self, _block_timestamp: u64, _blocks: &[Arc<PipelinedBlock>]) {}
 
     fn prefetch_payload_data(&self, _payload: &Payload, _timestamp: u64) {}
 
@@ -150,54 +151,90 @@ impl QuorumStorePayloadManager {
         }
         receivers
     }
+
+    fn batches_in_block(block: &Block) -> Vec<BatchInfo> {
+        let mut batches = vec![];
+        for payload in block.payload().iter() {
+            match payload {
+                Payload::DirectMempool(_) => {
+                    unreachable!("InQuorumStore should be used");
+                },
+                Payload::InQuorumStore(proof_with_status) => {
+                    for proof in proof_with_status.proofs.iter() {
+                        batches.push(proof.info().clone());
+                    }
+                },
+                Payload::InQuorumStoreWithLimit(proof_with_status) => {
+                    for proof in proof_with_status.proof_with_data.proofs.iter() {
+                        batches.push(proof.info().clone());
+                    }
+                },
+                Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _) => {
+                    for (batch_info, _) in inline_batches.iter() {
+                        batches.push(batch_info.clone());
+                    }
+                    for proof in proof_with_data.proofs.iter() {
+                        batches.push(proof.info().clone());
+                    }
+                },
+                Payload::OptQuorumStore(opt_quorum_store_payload) => {
+                    // TODO: how to avoid the clone?
+                    batches = opt_quorum_store_payload
+                        .clone()
+                        .into_inner()
+                        .get_all_batch_infos();
+                },
+            }
+        }
+        batches
+    }
+
+    fn batches_removed_from_window(block: &PipelinedBlock) -> Vec<BatchInfo> {
+        let mut batches_removed = HashSet::new();
+        if let Some(block_removed) = block
+            .block_window()
+            .blocks()
+            .iter()
+            .chain(std::iter::once(block.block()))
+            .next()
+        {
+            for batch in Self::batches_in_block(block_removed) {
+                batches_removed.insert(batch);
+            }
+        }
+        block
+            .block_window()
+            .blocks()
+            .iter()
+            .chain(std::iter::once(block.block()))
+            .skip(1)
+            .for_each(|block| {
+                for batch in Self::batches_in_block(block) {
+                    batches_removed.remove(&batch);
+                }
+            });
+        batches_removed.into_iter().collect()
+    }
 }
 
 #[async_trait]
 impl TPayloadManager for QuorumStorePayloadManager {
-    fn notify_commit(&self, block_timestamp: u64, payloads: Vec<Payload>) {
+    fn notify_commit(&self, block_timestamp: u64, blocks: &[Arc<PipelinedBlock>]) {
         self.batch_reader
             .update_certified_timestamp(block_timestamp);
 
-        let batches: Vec<_> = payloads
-            .into_iter()
-            .flat_map(|payload| match payload {
-                Payload::DirectMempool(_) => {
-                    unreachable!("InQuorumStore should be used");
-                },
-                Payload::InQuorumStore(proof_with_status) => proof_with_status
-                    .proofs
-                    .iter()
-                    .map(|proof| proof.info().clone())
-                    .collect::<Vec<_>>(),
-                Payload::InQuorumStoreWithLimit(proof_with_status) => proof_with_status
-                    .proof_with_data
-                    .proofs
-                    .iter()
-                    .map(|proof| proof.info().clone())
-                    .collect::<Vec<_>>(),
-                Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _) => {
-                    inline_batches
-                        .iter()
-                        .map(|(batch_info, _)| batch_info.clone())
-                        .chain(
-                            proof_with_data
-                                .proofs
-                                .iter()
-                                .map(|proof| proof.info().clone()),
-                        )
-                        .collect::<Vec<_>>()
-                },
-                Payload::OptQuorumStore(opt_quorum_store_payload) => {
-                    opt_quorum_store_payload.into_inner().get_all_batch_infos()
-                },
-            })
-            .collect();
+        let mut batches_removed = HashSet::new();
+        for block in blocks {
+            for batch in Self::batches_removed_from_window(block) {
+                batches_removed.insert(batch);
+            }
+        }
 
         let mut tx = self.coordinator_tx.clone();
 
         if let Err(e) = tx.try_send(CoordinatorCommand::CommitNotification(
             block_timestamp,
-            batches,
+            batches_removed.into_iter().collect(),
         )) {
             warn!(
                 "CommitNotification failed. Is the epoch shutting down? error: {}",
@@ -677,7 +714,7 @@ impl ConsensusObserverPayloadManager {
 
 #[async_trait]
 impl TPayloadManager for ConsensusObserverPayloadManager {
-    fn notify_commit(&self, _block_timestamp: u64, _payloads: Vec<Payload>) {
+    fn notify_commit(&self, _block_timestamp: u64, _blocks: &[Arc<PipelinedBlock>]) {
         // noop
     }
 

--- a/consensus/src/persistent_liveness_storage.rs
+++ b/consensus/src/persistent_liveness_storage.rs
@@ -76,8 +76,8 @@ impl Debug for RootInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "RootInfo: [block: {}, quorum_cert: {}, ordered_cert: {}, commit_cert: {}]",
-            self.0, self.1, self.2, self.3
+            "RootInfo: [root block: {}, window block: {}, quorum_cert: {}, ordered_cert: {}, commit_cert: {}]",
+            self.0, self.1, self.2, self.3, self.4
         )
     }
 }

--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -569,7 +569,11 @@ impl BufferManager {
         self.previous_commit_time = Instant::now();
         self.commit_proof_rb_handle.take();
         // purge the incoming blocks queue
-        while let Ok(Some(_)) = self.block_rx.try_next() {}
+        while let Ok(Some(ordered_blocks)) = self.block_rx.try_next() {
+            for block in &ordered_blocks.ordered_blocks {
+                block.cancel_committed_transactions();
+            }
+        }
         // Wait for ongoing tasks to finish before sending back ack.
         while self.ongoing_tasks.load(Ordering::SeqCst) > 0 {
             tokio::time::sleep(Duration::from_millis(10)).await;

--- a/consensus/src/pipeline/execution_schedule_phase.rs
+++ b/consensus/src/pipeline/execution_schedule_phase.rs
@@ -11,7 +11,7 @@ use crate::{
 use aptos_consensus_types::pipelined_block::PipelinedBlock;
 use aptos_crypto::HashValue;
 use aptos_executor_types::ExecutorError;
-use aptos_logger::debug;
+use aptos_logger::{debug, info};
 use async_trait::async_trait;
 use futures::TryFutureExt;
 use std::{
@@ -79,10 +79,12 @@ impl StatelessPipeline for ExecutionSchedulePhase {
         // make sure they are scheduled in order.
         let mut futs = vec![];
         for b in &ordered_blocks {
+            info!("calling schedule_compute 1, block: {}", b.block());
             let fut = self
                 .execution_proxy
                 .schedule_compute(
                     b.block(),
+                    b.block_window(),
                     b.parent_id(),
                     b.randomness().cloned(),
                     lifetime_guard.spawn(()),

--- a/consensus/src/recovery_manager.rs
+++ b/consensus/src/recovery_manager.rs
@@ -35,6 +35,7 @@ pub struct RecoveryManager {
     max_blocks_to_request: u64,
     payload_manager: Arc<dyn TPayloadManager>,
     order_vote_enabled: bool,
+    window_size: usize,
     pending_blocks: Arc<Mutex<PendingBlocks>>,
 }
 
@@ -48,6 +49,7 @@ impl RecoveryManager {
         max_blocks_to_request: u64,
         payload_manager: Arc<dyn TPayloadManager>,
         order_vote_enabled: bool,
+        window_size: usize,
         pending_blocks: Arc<Mutex<PendingBlocks>>,
     ) -> Self {
         RecoveryManager {
@@ -59,6 +61,7 @@ impl RecoveryManager {
             max_blocks_to_request,
             payload_manager,
             order_vote_enabled,
+            window_size,
             pending_blocks,
         }
     }
@@ -106,6 +109,7 @@ impl RecoveryManager {
             self.execution_client.clone(),
             self.payload_manager.clone(),
             self.order_vote_enabled,
+            self.window_size,
         )
         .await?;
 

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -90,6 +90,7 @@ fn build_empty_store(
         10,
         Arc::from(DirectMempoolPayloadManager::new()),
         false,
+        1,
         Arc::new(Mutex::new(PendingBlocks::new())),
     ))
 }

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -287,6 +287,7 @@ impl NodeSetup {
             10,
             Arc::from(DirectMempoolPayloadManager::new()),
             false,
+            1,
             Arc::new(Mutex::new(PendingBlocks::new())),
         ));
 
@@ -359,7 +360,10 @@ impl NodeSetup {
     pub fn restart(self, playground: &mut NetworkPlayground, executor: Handle) -> Self {
         let recover_data = self
             .storage
-            .try_start(self.onchain_consensus_config.order_vote_enabled())
+            .try_start(
+                self.onchain_consensus_config.order_vote_enabled(),
+                self.onchain_consensus_config.window_size(),
+            )
             .unwrap_or_else(|e| panic!("fail to restart due to: {}", e));
         Self::new(
             playground,

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -316,6 +316,7 @@ impl StateComputer for ExecutionProxy {
 
         let blocks_vec = blocks.to_vec();
         let wrapped_callback = move || {
+            payload_manager.notify_commit(block_timestamp, &blocks_vec);
             callback(&blocks_vec, finality_proof);
         };
         self.async_state_sync_notifier
@@ -325,7 +326,6 @@ impl StateComputer for ExecutionProxy {
             .expect("Failed to send async state sync notification");
 
         *latest_logical_time = logical_time;
-        payload_manager.notify_commit(block_timestamp, blocks);
         Ok(())
     }
 

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -155,7 +155,7 @@ impl StateComputer for ExecutionProxy {
     async fn schedule_compute(
         &self,
         // The block to be executed.
-        block: &Block,
+        block: &PipelinedBlock,
         block_window: &OrderedBlockWindow,
         // The parent block id.
         parent_block_id: HashValue,
@@ -194,9 +194,11 @@ impl StateComputer for ExecutionProxy {
 
         let timestamp = block.timestamp_usecs();
         let metadata = if is_randomness_enabled {
-            block.new_metadata_with_randomness(&validators, randomness)
+            block
+                .block()
+                .new_metadata_with_randomness(&validators, randomness)
         } else {
-            block.new_block_metadata(&validators).into()
+            block.block().new_block_metadata(&validators).into()
         };
 
         let pipeline_entry_time = Instant::now();

--- a/consensus/src/state_computer_tests.rs
+++ b/consensus/src/state_computer_tests.rs
@@ -171,6 +171,7 @@ async fn schedule_compute_should_discover_validator_txns() {
         ]),
         None,
     );
+    let pipelined_block = PipelinedBlock::new_with_window(block, OrderedBlockWindow::empty());
 
     let epoch_state = EpochState::empty();
 
@@ -186,7 +187,7 @@ async fn schedule_compute_should_discover_validator_txns() {
     // Ensure the dummy executor has received the txns.
     let _ = execution_policy
         .schedule_compute(
-            &block,
+            &pipelined_block,
             &OrderedBlockWindow::empty(),
             HashValue::zero(),
             None,

--- a/consensus/src/state_computer_tests.rs
+++ b/consensus/src/state_computer_tests.rs
@@ -10,7 +10,11 @@ use crate::{
 };
 use aptos_config::config::transaction_filter_type::Filter;
 use aptos_consensus_notifications::{ConsensusNotificationSender, Error};
-use aptos_consensus_types::{block::Block, block_data::BlockData, pipelined_block::PipelinedBlock};
+use aptos_consensus_types::{
+    block::Block,
+    block_data::BlockData,
+    pipelined_block::{OrderedBlockWindow, PipelinedBlock},
+};
 use aptos_crypto::HashValue;
 use aptos_executor_types::{
     state_checkpoint_output::StateCheckpointOutput, BlockExecutorTrait, ExecutorResult,
@@ -181,7 +185,13 @@ async fn schedule_compute_should_discover_validator_txns() {
 
     // Ensure the dummy executor has received the txns.
     let _ = execution_policy
-        .schedule_compute(&block, HashValue::zero(), None, dummy_guard())
+        .schedule_compute(
+            &block,
+            &OrderedBlockWindow::empty(),
+            HashValue::zero(),
+            None,
+            dummy_guard(),
+        )
         .await
         .await;
 

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -8,10 +8,7 @@ use crate::{
     transaction_deduper::TransactionDeduper, transaction_shuffler::TransactionShuffler,
 };
 use anyhow::Result;
-use aptos_consensus_types::{
-    block::Block,
-    pipelined_block::{OrderedBlockWindow, PipelinedBlock},
-};
+use aptos_consensus_types::pipelined_block::{OrderedBlockWindow, PipelinedBlock};
 use aptos_crypto::HashValue;
 use aptos_executor_types::ExecutorResult;
 use aptos_types::{
@@ -31,7 +28,7 @@ pub trait StateComputer: Send + Sync {
     async fn schedule_compute(
         &self,
         // The block that will be computed.
-        _block: &Block,
+        _block: &PipelinedBlock,
         _block_window: &OrderedBlockWindow,
         // The parent block root hash.
         _parent_block_id: HashValue,

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -8,7 +8,10 @@ use crate::{
     transaction_deduper::TransactionDeduper, transaction_shuffler::TransactionShuffler,
 };
 use anyhow::Result;
-use aptos_consensus_types::{block::Block, pipelined_block::PipelinedBlock};
+use aptos_consensus_types::{
+    block::Block,
+    pipelined_block::{OrderedBlockWindow, PipelinedBlock},
+};
 use aptos_crypto::HashValue;
 use aptos_executor_types::ExecutorResult;
 use aptos_types::{
@@ -29,6 +32,7 @@ pub trait StateComputer: Send + Sync {
         &self,
         // The block that will be computed.
         _block: &Block,
+        _block_window: &OrderedBlockWindow,
         // The parent block root hash.
         _parent_block_id: HashValue,
         _randomness: Option<Randomness>,

--- a/consensus/src/test_utils/mock_execution_client.rs
+++ b/consensus/src/test_utils/mock_execution_client.rs
@@ -79,7 +79,11 @@ impl MockExecutionClient {
             txns.append(&mut payload_txns);
         }
         // they may fail during shutdown
-        let _ = self.state_sync_client.unbounded_send(txns);
+        let _ = self.state_sync_client.unbounded_send(
+            txns.into_iter()
+                .flat_map(|(txns, _)| txns.into_iter())
+                .collect(),
+        );
 
         callback(
             &ordered_blocks.into_iter().map(Arc::new).collect::<Vec<_>>(),

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -13,8 +13,9 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_consensus_types::{
-    block::Block, pipeline_execution_result::PipelineExecutionResult,
-    pipelined_block::PipelinedBlock,
+    block::Block,
+    pipeline_execution_result::PipelineExecutionResult,
+    pipelined_block::{OrderedBlockWindow, PipelinedBlock},
 };
 use aptos_crypto::HashValue;
 use aptos_executor_types::{ExecutorError, ExecutorResult, StateComputeResult};
@@ -109,6 +110,7 @@ impl StateComputer for RandomComputeResultStateComputer {
     async fn schedule_compute(
         &self,
         _block: &Block,
+        _block_window: &OrderedBlockWindow,
         parent_block_id: HashValue,
         _randomness: Option<Randomness>,
         _lifetime_guard: CountedRequest<()>,

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_consensus_types::{
-    block::Block,
     pipeline_execution_result::PipelineExecutionResult,
     pipelined_block::{OrderedBlockWindow, PipelinedBlock},
 };
@@ -109,7 +108,7 @@ impl RandomComputeResultStateComputer {
 impl StateComputer for RandomComputeResultStateComputer {
     async fn schedule_compute(
         &self,
-        _block: &Block,
+        _block: &PipelinedBlock,
         _block_window: &OrderedBlockWindow,
         parent_block_id: HashValue,
         _randomness: Option<Randomness>,

--- a/consensus/src/test_utils/mock_storage.rs
+++ b/consensus/src/test_utils/mock_storage.rs
@@ -94,10 +94,11 @@ impl MockStorage {
     }
 
     pub fn get_ledger_recovery_data(&self) -> LedgerRecoveryData {
-        LedgerRecoveryData::new(LedgerInfoWithSignatures::new(
+        let ledger_info = LedgerInfoWithSignatures::new(
             self.storage_ledger.lock().clone(),
             AggregateSignature::empty(),
-        ))
+        );
+        LedgerRecoveryData::new(ledger_info.clone(), ledger_info)
     }
 
     pub fn try_start(&self, order_vote_enabled: bool, window_size: usize) -> Result<RecoveryData> {
@@ -204,6 +205,13 @@ impl PersistentLivenessStorage for MockStorage {
         self.get_ledger_recovery_data()
     }
 
+    fn recover_from_ledger_with_ledger_info(
+        &self,
+        _latest_ledger_info: LedgerInfoWithSignatures,
+    ) -> LedgerRecoveryData {
+        self.recover_from_ledger()
+    }
+
     fn start(&self, order_vote_enabled: bool, window_size: usize) -> LivenessStorageData {
         match self.try_start(order_vote_enabled, window_size) {
             Ok(recovery_data) => LivenessStorageData::FullRecoveryData(recovery_data),
@@ -274,10 +282,18 @@ impl PersistentLivenessStorage for EmptyStorage {
     }
 
     fn recover_from_ledger(&self) -> LedgerRecoveryData {
-        LedgerRecoveryData::new(LedgerInfoWithSignatures::new(
+        let ledger_info = LedgerInfoWithSignatures::new(
             LedgerInfo::mock_genesis(None),
             AggregateSignature::empty(),
-        ))
+        );
+        LedgerRecoveryData::new(ledger_info.clone(), ledger_info)
+    }
+
+    fn recover_from_ledger_with_ledger_info(
+        &self,
+        _latest_ledger_info: LedgerInfoWithSignatures,
+    ) -> LedgerRecoveryData {
+        self.recover_from_ledger()
     }
 
     fn start(&self, order_vote_enabled: bool, window_size: usize) -> LivenessStorageData {

--- a/consensus/src/test_utils/mock_storage.rs
+++ b/consensus/src/test_utils/mock_storage.rs
@@ -100,7 +100,7 @@ impl MockStorage {
         ))
     }
 
-    pub fn try_start(&self, order_vote_enabled: bool) -> Result<RecoveryData> {
+    pub fn try_start(&self, order_vote_enabled: bool, window_size: usize) -> Result<RecoveryData> {
         let ledger_recovery_data = self.get_ledger_recovery_data();
         let mut blocks: Vec<_> = self
             .shared_storage
@@ -131,19 +131,20 @@ impl MockStorage {
             quorum_certs,
             qc,
             order_vote_enabled,
+            window_size,
         )
     }
 
     pub fn verify_consistency(&self) -> Result<()> {
         // TODO: Also test by setting order_vote_enabled to true
-        self.try_start(false).map(|_| ())
+        self.try_start(false, 1).map(|_| ())
     }
 
     pub fn start_for_testing(validator_set: ValidatorSet) -> (RecoveryData, Arc<Self>) {
         let shared_storage = Arc::new(MockSharedStorage::new(validator_set.clone()));
         let genesis_li = LedgerInfo::mock_genesis(Some(validator_set));
         let storage = Self::new_with_ledger_info(shared_storage, genesis_li);
-        let recovery_data = match storage.start(false) {
+        let recovery_data = match storage.start(false, 1) {
             LivenessStorageData::FullRecoveryData(recovery_data) => recovery_data,
             _ => panic!("Mock storage should never fail constructing recovery data"),
         };
@@ -203,8 +204,8 @@ impl PersistentLivenessStorage for MockStorage {
         self.get_ledger_recovery_data()
     }
 
-    fn start(&self, order_vote_enabled: bool) -> LivenessStorageData {
-        match self.try_start(order_vote_enabled) {
+    fn start(&self, order_vote_enabled: bool, window_size: usize) -> LivenessStorageData {
+        match self.try_start(order_vote_enabled, window_size) {
             Ok(recovery_data) => LivenessStorageData::FullRecoveryData(recovery_data),
             Err(_) => LivenessStorageData::PartialRecoveryData(self.recover_from_ledger()),
         }
@@ -251,7 +252,7 @@ impl EmptyStorage {
 
     pub fn start_for_testing() -> (RecoveryData, Arc<Self>) {
         let storage = Arc::new(EmptyStorage::new());
-        let recovery_data = match storage.start(false) {
+        let recovery_data = match storage.start(false, 1) {
             LivenessStorageData::FullRecoveryData(recovery_data) => recovery_data,
             _ => panic!("Mock storage should never fail constructing recovery data"),
         };
@@ -279,7 +280,7 @@ impl PersistentLivenessStorage for EmptyStorage {
         ))
     }
 
-    fn start(&self, order_vote_enabled: bool) -> LivenessStorageData {
+    fn start(&self, order_vote_enabled: bool, window_size: usize) -> LivenessStorageData {
         match RecoveryData::new(
             None,
             self.recover_from_ledger(),
@@ -288,6 +289,7 @@ impl PersistentLivenessStorage for EmptyStorage {
             vec![],
             None,
             order_vote_enabled,
+            window_size,
         ) {
             Ok(recovery_data) => LivenessStorageData::FullRecoveryData(recovery_data),
             Err(e) => {

--- a/consensus/src/test_utils/mod.rs
+++ b/consensus/src/test_utils/mod.rs
@@ -95,6 +95,7 @@ pub fn build_empty_tree() -> Arc<BlockStore> {
         10,
         Arc::from(DirectMempoolPayloadManager::new()),
         false,
+        1,
         Arc::new(Mutex::new(PendingBlocks::new())),
     ))
 }

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -437,9 +437,10 @@ impl StateComputeResult {
         assert_eq!(
             input_txns.len(),
             self.compute_status_for_input_txns().len(),
-            "{:?} != {:?}",
+            "{:?} != {:?}, for block_id: {}",
             input_txns.iter().map(|t| t.type_name()).collect::<Vec<_>>(),
-            self.compute_status_for_input_txns()
+            self.compute_status_for_input_txns(),
+            block_id
         );
         let output = itertools::zip_eq(input_txns, self.compute_status_for_input_txns())
             .filter_map(|(txn, status)| {

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -434,6 +434,14 @@ impl StateComputeResult {
         input_txns: Vec<Transaction>,
         block_id: HashValue,
     ) -> Vec<Transaction> {
+        // if !input_txns.is_empty() || !self.compute_status_for_input_txns().is_empty() {
+        //     println!(
+        //         "{:?} vs {:?}, for block_id: {}",
+        //         input_txns.iter().map(|t| t.type_name()).collect::<Vec<_>>(),
+        //         self.compute_status_for_input_txns(),
+        //         block_id
+        //     )
+        // }
         assert_eq!(
             input_txns.len(),
             self.compute_status_for_input_txns().len(),

--- a/execution/executor-types/src/state_checkpoint_output.rs
+++ b/execution/executor-types/src/state_checkpoint_output.rs
@@ -18,7 +18,7 @@ pub struct TransactionsByStatus {
     // Statuses of the input transactions, in the same order as the input transactions.
     // Contains BlockMetadata/Validator transactions,
     // but doesn't contain StateCheckpoint/BlockEpilogue, as those get added during execution
-    statuses_for_input_txns: Vec<TransactionStatus>,
+    pub statuses_for_input_txns: Vec<TransactionStatus>,
     // List of all transactions to be committed, including StateCheckpoint/BlockEpilogue if needed.
     to_commit: TransactionsWithParsedOutput,
     to_discard: TransactionsWithParsedOutput,
@@ -63,7 +63,7 @@ impl TransactionsByStatus {
 
 #[derive(Default)]
 pub struct StateCheckpointOutput {
-    txns: TransactionsByStatus,
+    pub txns: TransactionsByStatus,
     per_version_state_updates: Vec<ShardedStateUpdates>,
     state_checkpoint_hashes: Vec<Option<HashValue>>,
     state_updates_before_last_checkpoint: Option<ShardedStateUpdates>,

--- a/testsuite/smoke-test/src/smoke_test_environment.rs
+++ b/testsuite/smoke-test/src/smoke_test_environment.rs
@@ -17,7 +17,7 @@ use rand::rngs::OsRng;
 use std::{num::NonZeroUsize, sync::Arc};
 use tokio::task::JoinHandle;
 
-const SWARM_BUILD_NUM_RETRIES: u8 = 3;
+const SWARM_BUILD_NUM_RETRIES: u8 = 0;
 
 #[derive(Clone)]
 pub struct SwarmBuilder {

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -257,7 +257,7 @@ impl OnChainConsensusConfig {
 
     // TODO: actually add to onchain config
     pub fn window_size(&self) -> usize {
-        3
+        2
     }
 
     pub fn is_dag_enabled(&self) -> bool {

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -255,6 +255,11 @@ impl OnChainConsensusConfig {
         }
     }
 
+    // TODO: actually add to onchain config
+    pub fn window_size(&self) -> usize {
+        3
+    }
+
     pub fn is_dag_enabled(&self) -> bool {
         match self {
             OnChainConsensusConfig::V1(_) => false,

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -257,7 +257,7 @@ impl OnChainConsensusConfig {
 
     // TODO: actually add to onchain config
     pub fn window_size(&self) -> usize {
-        2
+        3
     }
 
     pub fn is_dag_enabled(&self) -> bool {

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -257,7 +257,7 @@ impl OnChainConsensusConfig {
 
     // TODO: actually add to onchain config
     pub fn window_size(&self) -> usize {
-        3
+        5
     }
 
     pub fn is_dag_enabled(&self) -> bool {

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -92,7 +92,7 @@ impl BlockGasLimitType {
             conflict_penalty_window: 9,
             use_granular_resource_group_conflicts: false,
             use_module_publishing_block_conflict: true,
-            block_output_limit: Some(5 * 1024 * 1024),
+            block_output_limit: Some(4 * 5 * 1024 * 1024),
             include_user_txn_size_in_block_output: true,
             add_block_limit_outcome_onchain: true,
         }

--- a/types/src/transaction/signature_verified_transaction.rs
+++ b/types/src/transaction/signature_verified_transaction.rs
@@ -79,9 +79,9 @@ impl BlockExecutableTransaction for SignatureVerifiedTransaction {
 impl From<Transaction> for SignatureVerifiedTransaction {
     fn from(txn: Transaction) -> Self {
         match txn {
-            Transaction::UserTransaction(txn) => match txn.verify_signature() {
-                Ok(_) => SignatureVerifiedTransaction::Valid(Transaction::UserTransaction(txn)),
-                Err(_) => SignatureVerifiedTransaction::Invalid(Transaction::UserTransaction(txn)),
+            Transaction::UserTransaction(txn) => match txn.is_valid_signature() {
+                true => SignatureVerifiedTransaction::Valid(Transaction::UserTransaction(txn)),
+                false => SignatureVerifiedTransaction::Invalid(Transaction::UserTransaction(txn)),
             },
             _ => SignatureVerifiedTransaction::Valid(txn),
         }


### PR DESCRIPTION
- introduce committed_transactions, do it blocking in prepare phase for now
- support committed transactions with a once_cell. (might need to change)
- some more logging

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
