### PR TITLE
Have CoinInfo rust resources clarify their types

### DIFF
--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -21,7 +21,7 @@ use aptos_types::{
         authenticator::{AuthenticationKey, TransactionAuthenticator},
         EntryFunction, Script, SignedTransaction,
     },
-    utility_coin::APTOS_COIN_TYPE,
+    utility_coin::{AptosCoinType, CoinType},
 };
 use move_core_types::{
     identifier::Identifier,
@@ -879,7 +879,7 @@ async fn test_get_txn_execute_failed_by_invalid_entry_function_address() {
         "0x1222",
         "Coin",
         "transfer",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![AptosCoinType::type_tag()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             bcs::to_bytes(&1u64).unwrap(),
@@ -898,7 +898,7 @@ async fn test_get_txn_execute_failed_by_invalid_entry_function_module_name() {
         "0x1",
         "CoinInvalid",
         "transfer",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![AptosCoinType::type_tag()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             bcs::to_bytes(&1u64).unwrap(),
@@ -917,7 +917,7 @@ async fn test_get_txn_execute_failed_by_invalid_entry_function_name() {
         "0x1",
         "Coin",
         "transfer_invalid",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![AptosCoinType::type_tag()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             bcs::to_bytes(&1u64).unwrap(),
@@ -936,7 +936,7 @@ async fn test_get_txn_execute_failed_by_invalid_entry_function_arguments() {
         "0x1",
         "Coin",
         "transfer",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![AptosCoinType::type_tag()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             bcs::to_bytes(&1u8).unwrap(), // invalid type
@@ -955,7 +955,7 @@ async fn test_get_txn_execute_failed_by_missing_entry_function_arguments() {
         "0x1",
         "Coin",
         "transfer",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![AptosCoinType::type_tag()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             // missing arguments
@@ -978,7 +978,7 @@ async fn test_get_txn_execute_failed_by_entry_function_validation() {
         "0x1",
         "Coin",
         "transfer",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![AptosCoinType::type_tag()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             bcs::to_bytes(&123u64).unwrap(), // exceed limit, account balance is 0.
@@ -1001,7 +1001,7 @@ async fn test_get_txn_execute_failed_by_entry_function_invalid_module_name() {
         "0x1",
         "coin",
         "transfer::what::what",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![AptosCoinType::type_tag()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             bcs::to_bytes(&123u64).unwrap(), // exceed limit, account balance is 0.
@@ -1024,7 +1024,7 @@ async fn test_get_txn_execute_failed_by_entry_function_invalid_function_name() {
         "0x1",
         "coin::coin",
         "transfer",
-        vec![APTOS_COIN_TYPE.clone()],
+        vec![AptosCoinType::type_tag()],
         vec![
             bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
             bcs::to_bytes(&123u64).unwrap(), // exceed limit, account balance is 0.
@@ -1565,7 +1565,7 @@ async fn test_simulation_failure_with_detail_error() {
                 Identifier::new("MemeCoin").unwrap(),
             ),
             Identifier::new("transfer").unwrap(),
-            vec![APTOS_COIN_TYPE.clone()],
+            vec![AptosCoinType::type_tag()],
             vec![
                 bcs::to_bytes(&AccountAddress::from_hex_literal("0xdd").unwrap()).unwrap(),
                 bcs::to_bytes(&1u64).unwrap(),

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -37,7 +37,7 @@ use aptos_types::{
         RawTransactionWithData, SignedTransaction, TransactionPayload,
     },
     vm_status::StatusCode,
-    APTOS_COIN_TYPE,
+    AptosCoinType, CoinType,
 };
 use aptos_vm::{AptosSimulationVM, AptosVM};
 use move_core_types::{ident_str, language_storage::ModuleId, vm_status::VMStatus};
@@ -568,7 +568,7 @@ impl TransactionsApi {
                     &state_view,
                     ModuleId::new(AccountAddress::ONE, ident_str!("coin").into()),
                     ident_str!("balance").into(),
-                    vec![APTOS_COIN_TYPE.clone()],
+                    vec![AptosCoinType::type_tag()],
                     vec![signed_transaction.sender().to_vec()],
                     context.node_config.api.max_gas_view_function,
                 );

--- a/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
+++ b/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
@@ -26,6 +26,7 @@ use aptos_types::{
         Script as TransactionScript, Transaction, TransactionOutput, TransactionStatus,
     },
     vm::configs::set_paranoid_type_checks,
+    AptosCoinType,
 };
 use aptos_vm::{AptosVM, VMExecutor};
 use aptos_vm_genesis::GENESIS_KEYPAIR;
@@ -433,7 +434,7 @@ impl<'a> AptosTestAdapter<'a> {
 
     /// Obtain the AptosCoin amount under address `signer_addr`
     fn fetch_account_balance(&self, signer_addr: &AccountAddress) -> Result<u64> {
-        let aptos_coin_tag = CoinStoreResource::struct_tag();
+        let aptos_coin_tag = CoinStoreResource::<AptosCoinType>::struct_tag();
 
         let balance_blob = self
             .storage

--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -32,6 +32,7 @@ use aptos_types::{
         TransactionArgument, TransactionOutput, TransactionPayload, TransactionStatus,
         ViewFunctionOutput,
     },
+    AptosCoinType,
 };
 use claims::assert_ok;
 use move_core_types::{
@@ -790,9 +791,12 @@ impl MoveHarness {
     }
 
     pub fn read_aptos_balance(&self, addr: &AccountAddress) -> u64 {
-        self.read_resource::<CoinStoreResource>(addr, CoinStoreResource::struct_tag())
-            .map(|c| c.coin())
-            .unwrap_or(0)
+        self.read_resource::<CoinStoreResource<AptosCoinType>>(
+            addr,
+            CoinStoreResource::<AptosCoinType>::struct_tag(),
+        )
+        .map(|c| c.coin())
+        .unwrap_or(0)
             + self
                 .read_resource_from_resource_group::<FungibleStoreResource>(
                     &aptos_types::account_config::fungible_store::primary_store(addr),

--- a/aptos-move/e2e-move-tests/src/tests/fee_payer.rs
+++ b/aptos-move/e2e-move-tests/src/tests/fee_payer.rs
@@ -13,6 +13,7 @@ use aptos_types::{
     move_utils::MemberId,
     on_chain_config::FeatureFlag,
     transaction::{EntryFunction, ExecutionStatus, Script, TransactionPayload, TransactionStatus},
+    AptosCoinType,
 };
 use aptos_vm_types::storage::StorageGasParameters;
 use move_core_types::{move_resource::MoveStructType, vm_status::StatusCode};
@@ -114,8 +115,10 @@ fn test_account_not_exist_with_fee_payer() {
     let alice = Account::new();
     let bob = h.new_account_at(AccountAddress::from_hex_literal("0xb0b").unwrap());
 
-    let alice_start =
-        h.read_resource::<CoinStoreResource>(alice.address(), CoinStoreResource::struct_tag());
+    let alice_start = h.read_resource::<CoinStoreResource<AptosCoinType>>(
+        alice.address(),
+        CoinStoreResource::<AptosCoinType>::struct_tag(),
+    );
     assert!(alice_start.is_none());
     let bob_start = h.read_aptos_balance(bob.address());
 
@@ -131,8 +134,10 @@ fn test_account_not_exist_with_fee_payer() {
     let output = h.run_raw(transaction);
     assert_success!(*output.status());
 
-    let alice_after =
-        h.read_resource::<CoinStoreResource>(alice.address(), CoinStoreResource::struct_tag());
+    let alice_after = h.read_resource::<CoinStoreResource<AptosCoinType>>(
+        alice.address(),
+        CoinStoreResource::<AptosCoinType>::struct_tag(),
+    );
     assert!(alice_after.is_none());
     let bob_after = h.read_aptos_balance(bob.address());
 
@@ -152,8 +157,10 @@ fn test_account_not_exist_with_fee_payer_insufficient_gas() {
     let alice = Account::new();
     let bob = h.new_account_at(AccountAddress::from_hex_literal("0xb0b").unwrap());
 
-    let alice_start =
-        h.read_resource::<CoinStoreResource>(alice.address(), CoinStoreResource::struct_tag());
+    let alice_start = h.read_resource::<CoinStoreResource<AptosCoinType>>(
+        alice.address(),
+        CoinStoreResource::<AptosCoinType>::struct_tag(),
+    );
     assert!(alice_start.is_none());
     let bob_start = h.read_aptos_balance(bob.address());
 
@@ -172,8 +179,10 @@ fn test_account_not_exist_with_fee_payer_insufficient_gas() {
         &TransactionStatus::Discard(StatusCode::MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS),
     ));
 
-    let alice_after =
-        h.read_resource::<CoinStoreResource>(alice.address(), CoinStoreResource::struct_tag());
+    let alice_after = h.read_resource::<CoinStoreResource<AptosCoinType>>(
+        alice.address(),
+        CoinStoreResource::<AptosCoinType>::struct_tag(),
+    );
     assert!(alice_after.is_none());
     let bob_after = h.read_aptos_balance(bob.address());
     assert_eq!(bob_start, bob_after);
@@ -192,8 +201,10 @@ fn test_account_not_exist_and_move_abort_with_fee_payer_create_account() {
     let alice = Account::new();
     let bob = h.new_account_at(AccountAddress::from_hex_literal("0xb0b").unwrap());
 
-    let alice_start =
-        h.read_resource::<CoinStoreResource>(alice.address(), CoinStoreResource::struct_tag());
+    let alice_start = h.read_resource::<CoinStoreResource<AptosCoinType>>(
+        alice.address(),
+        CoinStoreResource::<AptosCoinType>::struct_tag(),
+    );
     assert!(alice_start.is_none());
     let bob_start = h.read_aptos_balance(bob.address());
 
@@ -227,8 +238,10 @@ fn test_account_not_exist_and_move_abort_with_fee_payer_create_account() {
     assert!(output.gas_used() <= PRICING.new_account_upfront(GAS_UNIT_PRICE));
     assert!(output.gas_used() > PRICING.new_account_min_abort(GAS_UNIT_PRICE));
 
-    let alice_after =
-        h.read_resource::<CoinStoreResource>(alice.address(), CoinStoreResource::struct_tag());
+    let alice_after = h.read_resource::<CoinStoreResource<AptosCoinType>>(
+        alice.address(),
+        CoinStoreResource::<AptosCoinType>::struct_tag(),
+    );
     assert!(alice_after.is_none());
     let bob_after = h.read_aptos_balance(bob.address());
 
@@ -335,8 +348,10 @@ fn test_account_not_exist_with_fee_payer_without_create_account() {
     let alice = Account::new();
     let bob = h.new_account_at(AccountAddress::from_hex_literal("0xb0b").unwrap());
 
-    let alice_start =
-        h.read_resource::<CoinStoreResource>(alice.address(), CoinStoreResource::struct_tag());
+    let alice_start = h.read_resource::<CoinStoreResource<AptosCoinType>>(
+        alice.address(),
+        CoinStoreResource::<AptosCoinType>::struct_tag(),
+    );
     assert!(alice_start.is_none());
 
     let payload = aptos_stdlib::aptos_account_set_allow_direct_coin_transfers(true);

--- a/aptos-move/e2e-tests/src/account.rs
+++ b/aptos-move/e2e-tests/src/account.rs
@@ -20,6 +20,7 @@ use aptos_types::{
         EntryFunction, RawTransaction, Script, SignedTransaction, TransactionPayload,
     },
     write_set::{WriteOp, WriteSet, WriteSetMut},
+    AptosCoinType,
 };
 use aptos_vm_genesis::GENESIS_KEYPAIR;
 use move_core_types::move_resource::MoveStructType;
@@ -171,8 +172,11 @@ impl Account {
     ///
     /// Use this to retrieve or publish the Account CoinStore blob.
     pub fn make_coin_store_access_path(&self) -> AccessPath {
-        AccessPath::resource_access_path(self.addr, CoinStoreResource::struct_tag())
-            .expect("access path in  test")
+        AccessPath::resource_access_path(
+            self.addr,
+            CoinStoreResource::<AptosCoinType>::struct_tag(),
+        )
+        .expect("access path in  test")
     }
 
     /// Changes the keys for this account to the provided ones.
@@ -381,7 +385,7 @@ impl CoinStore {
 
     /// Returns the Move Value for the account's CoinStore
     pub fn to_bytes(&self) -> Vec<u8> {
-        let coin_store = CoinStoreResource::new(
+        let coin_store = CoinStoreResource::<AptosCoinType>::new(
             self.coin,
             self.frozen,
             self.deposit_events.clone(),
@@ -507,7 +511,8 @@ impl AccountData {
                 WriteOp::legacy_modification(self.to_bytes().into()),
             ),
             (
-                StateKey::resource_typed::<CoinStoreResource>(self.address()).unwrap(),
+                StateKey::resource_typed::<CoinStoreResource<AptosCoinType>>(self.address())
+                    .unwrap(),
                 WriteOp::legacy_modification(self.coin_store.to_bytes().into()),
             ),
         ];

--- a/aptos-move/e2e-tests/src/account_universe.rs
+++ b/aptos-move/e2e-tests/src/account_universe.rs
@@ -401,7 +401,7 @@ pub fn assert_accounts_match(
             .read_account_resource(account.account())
             .expect("account resource must exist");
         let coin_store_resource = executor
-            .read_coin_store_resource(account.account())
+            .read_apt_coin_store_resource(account.account())
             .expect("account balance resource must exist");
         let auth_key = account.account().auth_key();
         prop_assert_eq!(

--- a/aptos-move/e2e-tests/src/data_store.rs
+++ b/aptos-move/e2e-tests/src/data_store.rs
@@ -14,6 +14,7 @@ use aptos_types::{
     },
     transaction::ChangeSet,
     write_set::{TransactionWrite, WriteSet},
+    AptosCoinType,
 };
 use aptos_vm_genesis::{
     generate_genesis_change_set_for_mainnet, generate_genesis_change_set_for_testing,
@@ -105,7 +106,7 @@ impl FakeDataStore {
 
     /// Adds CoinInfo to this data store.
     pub fn add_coin_info(&mut self) {
-        let coin_info = CoinInfoResource::random(u128::MAX);
+        let coin_info = CoinInfoResource::<AptosCoinType>::random(u128::MAX);
         let write_set = coin_info.to_writeset(0).expect("access path in test");
         self.add_write_set(&write_set)
     }

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -45,6 +45,7 @@ use aptos_types::{
     },
     vm_status::VMStatus,
     write_set::WriteSet,
+    AptosCoinType, CoinType,
 };
 use aptos_vm::{
     block_executor::{AptosTransactionOutput, BlockAptosVM},
@@ -391,7 +392,7 @@ impl FakeExecutor {
         // if new_added_supply = 0, it is a noop.
         if new_added_supply != 0 {
             let coin_info_resource = self
-                .read_coin_info_resource()
+                .read_apt_coin_info_resource()
                 .expect("coin info must exist in data store");
             let old_supply = self.read_coin_supply().unwrap();
             self.data_store.add_write_set(
@@ -439,8 +440,11 @@ impl FakeExecutor {
     }
 
     /// Reads the CoinStore resource value for an account from this executor's data store.
-    pub fn read_coin_store_resource(&self, account: &Account) -> Option<CoinStoreResource> {
-        self.read_coin_store_resource_at_address(account.address())
+    pub fn read_apt_coin_store_resource(
+        &self,
+        account: &Account,
+    ) -> Option<CoinStoreResource<AptosCoinType>> {
+        self.read_apt_coin_store_resource_at_address(account.address())
     }
 
     /// Reads supply from CoinInfo resource value from this executor's data store.
@@ -462,16 +466,16 @@ impl FakeExecutor {
     }
 
     /// Reads the CoinInfo resource value from this executor's data store.
-    pub fn read_coin_info_resource(&self) -> Option<CoinInfoResource> {
-        self.read_resource(&AccountAddress::ONE)
+    pub fn read_apt_coin_info_resource(&self) -> Option<CoinInfoResource<AptosCoinType>> {
+        self.read_resource(&AptosCoinType::coin_info_address())
     }
 
     /// Reads the CoinStore resource value for an account under the given address from this executor's
     /// data store.
-    pub fn read_coin_store_resource_at_address(
+    pub fn read_apt_coin_store_resource_at_address(
         &self,
         addr: &AccountAddress,
-    ) -> Option<CoinStoreResource> {
+    ) -> Option<CoinStoreResource<AptosCoinType>> {
         self.read_resource(addr)
     }
 

--- a/aptos-move/e2e-testsuite/src/tests/create_account.rs
+++ b/aptos-move/e2e-testsuite/src/tests/create_account.rs
@@ -35,7 +35,7 @@ fn create_account() {
         .expect("sender must exist");
 
     let updated_receiver_balance = executor
-        .read_coin_store_resource(&new_account)
+        .read_apt_coin_store_resource(&new_account)
         .expect("receiver balance must exist");
     assert_eq!(initial_amount, updated_receiver_balance.coin());
     assert_eq!(1, updated_sender.sequence_number());

--- a/aptos-move/e2e-testsuite/src/tests/peer_to_peer.rs
+++ b/aptos-move/e2e-testsuite/src/tests/peer_to_peer.rs
@@ -40,10 +40,10 @@ fn single_peer_to_peer_with_event() {
         .read_account_resource(sender.account())
         .expect("sender must exist");
     let updated_sender_balance = executor
-        .read_coin_store_resource(sender.account())
+        .read_apt_coin_store_resource(sender.account())
         .expect("sender balance must exist");
     let updated_receiver_balance = executor
-        .read_coin_store_resource(receiver.account())
+        .read_apt_coin_store_resource(receiver.account())
         .expect("receiver balance must exist");
     assert_eq!(receiver_balance, updated_receiver_balance.coin());
     assert_eq!(sender_balance, updated_sender_balance.coin());
@@ -102,10 +102,10 @@ fn few_peer_to_peer_with_event() {
         }
 
         let original_sender_balance = executor
-            .read_coin_store_resource(sender.account())
+            .read_apt_coin_store_resource(sender.account())
             .expect("sender balance must exist");
         let original_receiver_balance = executor
-            .read_coin_store_resource(receiver.account())
+            .read_apt_coin_store_resource(receiver.account())
             .expect("receiver balcne must exist");
         executor.apply_write_set(txn_output.write_set());
 
@@ -116,10 +116,10 @@ fn few_peer_to_peer_with_event() {
             .read_account_resource(sender.account())
             .expect("sender must exist");
         let updated_sender_balance = executor
-            .read_coin_store_resource(sender.account())
+            .read_apt_coin_store_resource(sender.account())
             .expect("sender balance must exist");
         let updated_receiver_balance = executor
-            .read_coin_store_resource(receiver.account())
+            .read_apt_coin_store_resource(receiver.account())
             .expect("receiver balance must exist");
         assert_eq!(receiver_balance, updated_receiver_balance.coin());
         assert_eq!(sender_balance, updated_sender_balance.coin());
@@ -249,12 +249,12 @@ pub(crate) fn check_and_apply_transfer_output(
             .read_account_resource(sender)
             .expect("sender must exist");
         let sender_balance = executor
-            .read_coin_store_resource(sender)
+            .read_apt_coin_store_resource(sender)
             .expect("sender balance must exist");
         let sender_initial_balance = sender_balance.coin();
         let sender_seq_num = sender_resource.sequence_number();
         let receiver_initial_balance = executor
-            .read_coin_store_resource(receiver)
+            .read_apt_coin_store_resource(receiver)
             .expect("receiver balance must exist")
             .coin();
 
@@ -269,10 +269,10 @@ pub(crate) fn check_and_apply_transfer_output(
             .read_account_resource(sender)
             .expect("sender must exist");
         let updated_sender_balance = executor
-            .read_coin_store_resource(sender)
+            .read_apt_coin_store_resource(sender)
             .expect("sender balance must exist");
         let updated_receiver_balance = executor
-            .read_coin_store_resource(receiver)
+            .read_apt_coin_store_resource(receiver)
             .expect("receiver balance must exist");
         assert_eq!(receiver_balance, updated_receiver_balance.coin());
         assert_eq!(sender_balance, updated_sender_balance.coin());

--- a/aptos-move/e2e-testsuite/src/tests/scripts.rs
+++ b/aptos-move/e2e-testsuite/src/tests/scripts.rs
@@ -63,7 +63,7 @@ fn script_code_unverifiable() {
         .read_account_resource(sender.account())
         .expect("sender must exist");
     let updated_sender_balance = executor
-        .read_coin_store_resource(sender.account())
+        .read_apt_coin_store_resource(sender.account())
         .expect("sender balance must exist");
     assert_eq!(balance, updated_sender_balance.coin());
     assert_eq!(11, updated_sender.sequence_number());
@@ -142,7 +142,7 @@ fn script_none_existing_module_dep() {
         .read_account_resource(sender.account())
         .expect("sender must exist");
     let updated_sender_balance = executor
-        .read_coin_store_resource(sender.account())
+        .read_apt_coin_store_resource(sender.account())
         .expect("sender balance must exist");
     assert_eq!(balance, updated_sender_balance.coin());
     assert_eq!(11, updated_sender.sequence_number());
@@ -221,7 +221,7 @@ fn script_non_existing_function_dep() {
         .read_account_resource(sender.account())
         .expect("sender must exist");
     let updated_sender_balance = executor
-        .read_coin_store_resource(sender.account())
+        .read_apt_coin_store_resource(sender.account())
         .expect("sender balance must exist");
     assert_eq!(balance, updated_sender_balance.coin());
     assert_eq!(11, updated_sender.sequence_number());
@@ -301,7 +301,7 @@ fn script_bad_sig_function_dep() {
         .read_account_resource(sender.account())
         .expect("sender must exist");
     let updated_sender_balance = executor
-        .read_coin_store_resource(sender.account())
+        .read_apt_coin_store_resource(sender.account())
         .expect("sender balance must exist");
     assert_eq!(balance, updated_sender_balance.coin());
     assert_eq!(11, updated_sender.sequence_number());
@@ -367,7 +367,7 @@ fn script_type_argument_module_does_not_exist() {
         .read_account_resource(sender.account())
         .expect("sender must exist");
     let updated_sender_balance = executor
-        .read_coin_store_resource(sender.account())
+        .read_apt_coin_store_resource(sender.account())
         .expect("sender balance must exist");
     assert_eq!(balance, updated_sender_balance.coin());
     assert_eq!(11, updated_sender.sequence_number());
@@ -435,7 +435,7 @@ fn script_nested_type_argument_module_does_not_exist() {
         .read_account_resource(sender.account())
         .expect("sender must exist");
     let updated_sender_balance = executor
-        .read_coin_store_resource(sender.account())
+        .read_apt_coin_store_resource(sender.account())
         .expect("sender balance must exist");
     assert_eq!(balance, updated_sender_balance.coin());
     assert_eq!(11, updated_sender.sequence_number());
@@ -516,7 +516,7 @@ fn forbid_script_emitting_events() {
         .read_account_resource(sender.account())
         .expect("sender must exist");
     let updated_sender_balance = executor
-        .read_coin_store_resource(sender.account())
+        .read_apt_coin_store_resource(sender.account())
         .expect("sender balance must exist");
     assert_eq!(balance, updated_sender_balance.coin());
     assert_eq!(11, updated_sender.sequence_number());

--- a/aptos-move/framework/cached-packages/src/aptos_stdlib.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_stdlib.rs
@@ -12,15 +12,12 @@ use aptos_package_builder::PackageBuilder;
 use aptos_types::{
     account_address::AccountAddress,
     transaction::{EntryFunction, TransactionPayload},
+    AptosCoinType, CoinType,
 };
 use move_core_types::{ident_str, language_storage::ModuleId};
 
 pub fn aptos_coin_transfer(to: AccountAddress, amount: u64) -> TransactionPayload {
-    coin_transfer(
-        aptos_types::utility_coin::APTOS_COIN_TYPE.clone(),
-        to,
-        amount,
-    )
+    coin_transfer(AptosCoinType::type_tag(), to, amount)
 }
 
 pub fn publish_module_source(module_name: &str, module_src: &str) -> TransactionPayload {

--- a/crates/aptos-faucet/core/src/funder/transfer.rs
+++ b/crates/aptos-faucet/core/src/funder/transfer.rs
@@ -22,7 +22,7 @@ use aptos_sdk::{
         account_address::AccountAddress,
         chain_id::ChainId,
         transaction::{authenticator::AuthenticationKey, SignedTransaction, TransactionPayload},
-        LocalAccount,
+        AptosCoinType, LocalAccount,
     },
 };
 use async_trait::async_trait;
@@ -314,7 +314,7 @@ impl FunderTrait for TransferFunder {
         let account_address = self.faucet_account.read().await.address();
         let funder_balance = match self
             .get_api_client()
-            .get_account_balance_bcs(account_address, "0x1::aptos_coin::AptosCoin")
+            .get_account_balance_bcs::<AptosCoinType>(account_address)
             .await
         {
             Ok(response) => response.into_inner(),

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -38,6 +38,7 @@ use aptos_types::{
     contract_event::EventWithVersion,
     state_store::state_key::StateKey,
     transaction::SignedTransaction,
+    CoinType,
 };
 use move_core_types::language_storage::StructTag;
 use reqwest::{
@@ -220,16 +221,12 @@ impl Client {
         })
     }
 
-    pub async fn get_account_balance_bcs(
+    pub async fn get_account_balance_bcs<C: CoinType>(
         &self,
         address: AccountAddress,
-        coin_type: &str,
     ) -> AptosResult<Response<u64>> {
         let resp = self
-            .get_account_resource_bcs::<CoinStoreResource>(
-                address,
-                &format!("0x1::coin::CoinStore<{}>", coin_type),
-            )
+            .get_account_resource_bcs::<CoinStoreResource<C>>(address, &C::type_tag().to_string())
             .await?;
         resp.and_then(|resource| Ok(resource.coin()))
     }

--- a/crates/aptos-rosetta/src/account.rs
+++ b/crates/aptos-rosetta/src/account.rs
@@ -18,7 +18,7 @@ use crate::{
 use aptos_logger::{debug, trace, warn};
 use aptos_types::{
     account_address::AccountAddress,
-    account_config::{AccountResource, CoinStoreResource},
+    account_config::{AccountResource, CoinStoreResourceUntyped},
 };
 use std::{collections::HashSet, str::FromStr};
 use warp::Filter;
@@ -165,7 +165,7 @@ async fn get_balances(
                 (AccountAddress::ONE, COIN_MODULE, COIN_STORE_RESOURCE) => {
                     // Only show coins on the base account
                     if account.is_base_account() {
-                        let coin_store: CoinStoreResource = bcs::from_bytes(&bytes)?;
+                        let coin_store: CoinStoreResourceUntyped = bcs::from_bytes(&bytes)?;
                         if let Some(coin_type) = struct_tag.type_args.first() {
                             // Only display supported coins
                             if coin_type == &native_coin_tag() {

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -28,7 +28,7 @@ use aptos_logger::warn;
 use aptos_rest_client::aptos_api_types::{TransactionOnChainData, U64};
 use aptos_types::{
     account_address::AccountAddress,
-    account_config::{AccountResource, CoinStoreResource, WithdrawEvent},
+    account_config::{AccountResource, CoinStoreResourceUntyped, WithdrawEvent},
     contract_event::{ContractEvent, FEE_STATEMENT_EVENT_TYPE},
     event::EventKey,
     fee_statement::FeeStatement,
@@ -1793,7 +1793,7 @@ async fn parse_coinstore_changes(
     events: &[ContractEvent],
     mut operation_index: u64,
 ) -> ApiResult<Vec<Operation>> {
-    let coin_store: CoinStoreResource = if let Ok(coin_store) = bcs::from_bytes(data) {
+    let coin_store: CoinStoreResourceUntyped = if let Ok(coin_store) = bcs::from_bytes(data) {
         coin_store
     } else {
         warn!(

--- a/crates/aptos/src/account/balance.rs
+++ b/crates/aptos/src/account/balance.rs
@@ -5,7 +5,7 @@ use crate::common::types::{
     CliCommand, CliConfig, CliError, CliTypedResult, ConfigSearchMode, ProfileOptions, RestOptions,
 };
 use aptos_api_types::ViewFunction;
-use aptos_types::{account_address::AccountAddress, APTOS_COIN_TYPE};
+use aptos_types::{account_address::AccountAddress, AptosCoinType, CoinType};
 use async_trait::async_trait;
 use clap::Parser;
 use move_core_types::{ident_str, language_storage::ModuleId, parser::parse_type_tag};
@@ -66,7 +66,7 @@ impl CliCommand<Vec<AccountBalance>> for Balance {
             })?
         } else {
             // If nothing is given, use the default APT
-            APTOS_COIN_TYPE.to_owned()
+            AptosCoinType::type_tag()
         };
 
         let client = self.rest_options.client(&self.profile_options)?;

--- a/crates/indexer/src/models/coin_models/coin_activities.rs
+++ b/crates/indexer/src/models/coin_models/coin_activities.rs
@@ -19,7 +19,7 @@ use aptos_api_types::{
     Event as APIEvent, Transaction as APITransaction, TransactionInfo as APITransactionInfo,
     TransactionPayload, UserTransactionRequest, WriteSetChange as APIWriteSetChange,
 };
-use aptos_types::APTOS_COIN_TYPE;
+use aptos_types::{AptosCoinType, CoinType as CoinTypeTrait};
 use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
@@ -267,7 +267,7 @@ impl CoinActivity {
             event_creation_number: BURN_GAS_EVENT_CREATION_NUM,
             event_sequence_number: user_transaction_request.sequence_number.0 as i64,
             owner_address: standardize_address(&user_transaction_request.sender.to_string()),
-            coin_type: APTOS_COIN_TYPE.to_string(),
+            coin_type: AptosCoinType::type_tag().to_string(),
             amount: aptos_coin_burned,
             activity_type: GAS_FEE_EVENT.to_string(),
             is_gas_fee: true,

--- a/crates/indexer/src/processors/coin_processor.rs
+++ b/crates/indexer/src/processors/coin_processor.rs
@@ -19,7 +19,7 @@ use crate::{
     schema,
 };
 use aptos_api_types::Transaction as APITransaction;
-use aptos_types::APTOS_COIN_TYPE;
+use aptos_types::{AptosCoinType, CoinType};
 use async_trait::async_trait;
 use diesel::{pg::upsert::excluded, result::Error, ExpressionMethods, PgConnection};
 use field_count::FieldCount;
@@ -280,7 +280,8 @@ impl TransactionProcessor for CoinTransactionProcessor {
         // get aptos_coin info for supply tracking
         // TODO: This only needs to be fetched once. Need to persist somehow
         let maybe_aptos_coin_info =
-            &CoinInfoQuery::get_by_coin_type(APTOS_COIN_TYPE.to_string(), &mut conn).unwrap();
+            &CoinInfoQuery::get_by_coin_type(AptosCoinType::type_tag().to_string(), &mut conn)
+                .unwrap();
 
         let mut all_coin_activities = vec![];
         let mut all_coin_balances = vec![];

--- a/execution/block-partitioner/src/test_utils.rs
+++ b/execution/block-partitioner/src/test_utils.rs
@@ -30,7 +30,7 @@ use aptos_types::{
         analyzed_transaction::AnalyzedTransaction, EntryFunction, RawTransaction,
         SignedTransaction, Transaction, TransactionPayload,
     },
-    utility_coin::APTOS_COIN_TYPE,
+    AptosCoinType, CoinType,
 };
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
@@ -84,7 +84,7 @@ pub fn create_signed_p2p_transaction(
         let transaction_payload = TransactionPayload::EntryFunction(EntryFunction::new(
             ModuleId::new(AccountAddress::ONE, Identifier::new("coin").unwrap()),
             Identifier::new("transfer").unwrap(),
-            vec![APTOS_COIN_TYPE.clone()],
+            vec![AptosCoinType::type_tag()],
             vec![
                 bcs::to_bytes(&receiver.account_address).unwrap(),
                 bcs::to_bytes(&1u64).unwrap(),

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -31,12 +31,12 @@ use aptos_types::{
         signature_verified_transaction::{
             into_signature_verified_block, SignatureVerifiedTransaction,
         },
-        Transaction,
-        Transaction::UserTransaction,
+        Transaction::{self, UserTransaction},
         TransactionListWithProof, TransactionWithProof, WriteSetPayload,
     },
     trusted_state::{TrustedState, TrustedStateChange},
     waypoint::Waypoint,
+    AptosCoinType,
 };
 use aptos_vm::AptosVM;
 use rand::SeedableRng;
@@ -555,7 +555,7 @@ pub fn create_db_and_executor<P: AsRef<std::path::Path>>(
 }
 
 pub fn get_account_balance(state_view: &dyn StateView, address: &AccountAddress) -> u64 {
-    CoinStoreResource::fetch_move_resource(state_view, address)
+    CoinStoreResource::<AptosCoinType>::fetch_move_resource(state_view, address)
         .unwrap()
         .map_or(0, |coin_store| coin_store.coin())
 }

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -32,6 +32,7 @@ use aptos_types::{
     validator_signer::ValidatorSigner,
     waypoint::Waypoint,
     write_set::{WriteOp, WriteSetMut},
+    AptosCoinType,
 };
 use aptos_vm::AptosVM;
 use move_core_types::{language_storage::TypeTag, move_resource::MoveStructType};
@@ -167,7 +168,7 @@ fn get_aptos_coin_transfer_transaction(
 
 fn get_balance(account: &AccountAddress, db: &DbReaderWriter) -> u64 {
     let db_state_view = db.reader.latest_state_checkpoint_view().unwrap();
-    CoinStoreResource::fetch_move_resource(&db_state_view, account)
+    CoinStoreResource::<AptosCoinType>::fetch_move_resource(&db_state_view, account)
         .unwrap()
         .unwrap()
         .coin()
@@ -227,9 +228,9 @@ fn test_new_genesis() {
                 ),
             ),
             (
-                StateKey::resource_typed::<CoinStoreResource>(&account1).unwrap(),
+                StateKey::resource_typed::<CoinStoreResource<AptosCoinType>>(&account1).unwrap(),
                 WriteOp::legacy_modification(
-                    bcs::to_bytes(&CoinStoreResource::new(
+                    bcs::to_bytes(&CoinStoreResource::<AptosCoinType>::new(
                         100_000_000,
                         false,
                         EventHandle::random(0),

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -23,6 +23,7 @@ use aptos_types::{
     account_config::{AccountResource, ChainIdResource, CoinInfoResource, CoinStoreResource},
     nibble::nibble_path::NibblePath,
     state_store::state_key::inner::StateKeyTag,
+    AptosCoinType,
 };
 use arr_macro::arr;
 use proptest::{collection::hash_map, prelude::*};
@@ -217,7 +218,7 @@ fn test_get_values_by_key_prefix() {
     assert_eq!(*key_value_map.get(&key1).unwrap(), value1_v0);
     assert_eq!(*key_value_map.get(&key2).unwrap(), value2_v0);
 
-    let key4 = StateKey::resource_typed::<CoinInfoResource>(&address).unwrap();
+    let key4 = StateKey::resource_typed::<CoinInfoResource<AptosCoinType>>(&address).unwrap();
 
     let value2_v1 = StateValue::from(String::from("value2_v1").into_bytes());
     let value4_v1 = StateValue::from(String::from("value4_v1").into_bytes());
@@ -247,7 +248,7 @@ fn test_get_values_by_key_prefix() {
 
     // Add values for one more account and verify the state
     let address1 = AccountAddress::new([22u8; AccountAddress::LENGTH]);
-    let key5 = StateKey::resource_typed::<CoinStoreResource>(&address1).unwrap();
+    let key5 = StateKey::resource_typed::<CoinStoreResource<AptosCoinType>>(&address1).unwrap();
     let value5_v2 = StateValue::from(String::from("value5_v2").into_bytes());
 
     let account1_key_prefix = StateKeyPrefix::new(StateKeyTag::AccessPath, address1.to_vec());

--- a/testsuite/generate-format/src/api.rs
+++ b/testsuite/generate-format/src/api.rs
@@ -19,14 +19,14 @@ use aptos_types::{
         state_key::StateKey,
         state_value::{PersistedStateValueMetadata, StateValueMetadata},
     },
-    transaction,
     transaction::{
+        self,
         authenticator::{AccountAuthenticator, TransactionAuthenticator},
         block_epilogue::BlockEpiloguePayload,
     },
     validator_txn::ValidatorTransaction,
     vm_status::AbortLocation,
-    write_set,
+    write_set, AptosCoinType,
 };
 use move_core_types::language_storage;
 use rand::{rngs::StdRng, SeedableRng};
@@ -136,7 +136,7 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<aptos_api_types::TransactionOnChainData>(&samples)?;
 
     // output types
-    tracer.trace_type::<CoinStoreResource>(&samples)?;
+    tracer.trace_type::<CoinStoreResource<AptosCoinType>>(&samples)?;
 
     // aliases within StructTag
     tracer.ignore_aliases("StructTag", &["type_params"])?;

--- a/types/src/account_config/resources/aggregator.rs
+++ b/types/src/account_config/resources/aggregator.rs
@@ -1,0 +1,72 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::state_store::{state_key::StateKey, table::TableHandle};
+use move_core_types::account_address::AccountAddress;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AggregatorResource<T> {
+    value: T,
+    max_value: T,
+}
+
+impl<T> AggregatorResource<T> {
+    pub fn new(value: T, max_value: T) -> Self {
+        Self { value, max_value }
+    }
+
+    pub fn get(&self) -> &T {
+        &self.value
+    }
+
+    pub fn set(&mut self, value: T) {
+        self.value = value;
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AggregatorSnapshotResource<T> {
+    value: T,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DerivedStringSnapshotResource {
+    value: String,
+    padding: Vec<u8>,
+}
+
+/// Deprecated:
+
+/// Rust representation of Aggregator Move struct.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AggregatorV1Resource {
+    handle: AccountAddress,
+    key: AccountAddress,
+    limit: u128,
+}
+
+impl AggregatorV1Resource {
+    pub fn new(handle: AccountAddress, key: AccountAddress, limit: u128) -> Self {
+        Self { handle, key, limit }
+    }
+
+    /// Helper function to return the state key where the actual value is stored.
+    pub fn state_key(&self) -> StateKey {
+        StateKey::table_item(&TableHandle(self.handle), self.key.as_ref())
+    }
+}
+
+/// Rust representation of Integer Move struct.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct IntegerResource {
+    pub value: u128,
+    limit: u128,
+}
+
+/// Rust representation of OptionalAggregator Move struct.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct OptionalAggregatorV1Resource {
+    pub aggregator: Option<AggregatorV1Resource>,
+    pub integer: Option<IntegerResource>,
+}

--- a/types/src/account_config/resources/coin_store.rs
+++ b/types/src/account_config/resources/coin_store.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{event::EventHandle, utility_coin::APTOS_COIN_TYPE};
+use crate::{event::EventHandle, CoinType};
 use move_core_types::{
     ident_str,
     identifier::IdentStr,
@@ -11,18 +11,49 @@ use move_core_types::{
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
 
 /// The balance resource held under an account.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
-pub struct CoinStoreResource {
+pub struct CoinStoreResourceUntyped {
     coin: u64,
     frozen: bool,
     deposit_events: EventHandle,
     withdraw_events: EventHandle,
 }
 
-impl CoinStoreResource {
+impl CoinStoreResourceUntyped {
+    pub fn coin(&self) -> u64 {
+        self.coin
+    }
+
+    pub fn frozen(&self) -> bool {
+        self.frozen
+    }
+
+    pub fn deposit_events(&self) -> &EventHandle {
+        &self.deposit_events
+    }
+
+    pub fn withdraw_events(&self) -> &EventHandle {
+        &self.withdraw_events
+    }
+}
+
+// Separate out typed info that goes with "key", to not require CoinInfoResource to be typed when not needed
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+pub struct CoinStoreResource<C: CoinType> {
+    coin: u64,
+    frozen: bool,
+    deposit_events: EventHandle,
+    withdraw_events: EventHandle,
+    #[serde(skip)]
+    phantom_data: PhantomData<C>,
+}
+
+impl<C: CoinType> CoinStoreResource<C> {
     pub fn new(
         coin: u64,
         frozen: bool,
@@ -34,6 +65,7 @@ impl CoinStoreResource {
             frozen,
             deposit_events,
             withdraw_events,
+            phantom_data: PhantomData,
         }
     }
 
@@ -54,13 +86,13 @@ impl CoinStoreResource {
     }
 }
 
-impl MoveStructType for CoinStoreResource {
+impl<C: CoinType> MoveStructType for CoinStoreResource<C> {
     const MODULE_NAME: &'static IdentStr = ident_str!("coin");
     const STRUCT_NAME: &'static IdentStr = ident_str!("CoinStore");
 
     fn type_args() -> Vec<TypeTag> {
-        vec![APTOS_COIN_TYPE.clone()]
+        vec![C::type_tag()]
     }
 }
 
-impl MoveResource for CoinStoreResource {}
+impl<C: CoinType> MoveResource for CoinStoreResource<C> {}

--- a/types/src/account_config/resources/mod.rs
+++ b/types/src/account_config/resources/mod.rs
@@ -2,6 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod aggregator;
 pub mod chain_id;
 pub mod challenge;
 pub mod coin_info;

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -32,6 +32,7 @@ use crate::{
     validator_verifier::{ValidatorConsensusInfo, ValidatorVerifier},
     vm_status::VMStatus,
     write_set::{WriteOp, WriteSet, WriteSetMut},
+    AptosCoinType,
 };
 use aptos_crypto::{
     bls12381::{self, bls12381_keys},
@@ -660,8 +661,8 @@ pub struct CoinStoreResourceGen {
 }
 
 impl CoinStoreResourceGen {
-    pub fn materialize(self) -> CoinStoreResource {
-        CoinStoreResource::new(
+    pub fn materialize(self) -> CoinStoreResource<AptosCoinType> {
+        CoinStoreResource::<AptosCoinType>::new(
             self.coin,
             false,
             EventHandle::random(0),
@@ -693,7 +694,7 @@ impl AccountStateGen {
                 bcs::to_bytes(&account_resource).unwrap(),
             ),
             (
-                StateKey::resource_typed::<CoinStoreResource>(address).unwrap(),
+                StateKey::resource_typed::<CoinStoreResource<AptosCoinType>>(address).unwrap(),
                 bcs::to_bytes(&balance_resource).unwrap(),
             ),
         ]

--- a/types/src/state_store/state_key/prefix.rs
+++ b/types/src/state_store/state_key/prefix.rs
@@ -47,6 +47,7 @@ mod tests {
     use crate::{
         account_config::{AccountResource, CoinStoreResource},
         state_store::state_key::{inner::StateKeyTag, prefix::StateKeyPrefix, StateKey},
+        AptosCoinType,
     };
     use move_core_types::account_address::AccountAddress;
 
@@ -55,7 +56,7 @@ mod tests {
         let address1 = AccountAddress::new([12u8; AccountAddress::LENGTH]);
         let address2 = AccountAddress::new([22u8; AccountAddress::LENGTH]);
         let key1 = StateKey::resource_typed::<AccountResource>(&address1).unwrap();
-        let key2 = StateKey::resource_typed::<CoinStoreResource>(&address2).unwrap();
+        let key2 = StateKey::resource_typed::<CoinStoreResource<AptosCoinType>>(&address2).unwrap();
 
         let account1_key_prefx = StateKeyPrefix::new(StateKeyTag::AccessPath, address1.to_vec());
         let account2_key_prefx = StateKeyPrefix::new(StateKeyTag::AccessPath, address2.to_vec());

--- a/types/src/transaction/analyzed_transaction.rs
+++ b/types/src/transaction/analyzed_transaction.rs
@@ -10,6 +10,7 @@ use crate::{
         signature_verified_transaction::SignatureVerifiedTransaction, Transaction,
         TransactionPayload,
     },
+    AptosCoinType, CoinType,
 };
 use aptos_crypto::HashValue;
 pub use move_core_types::abi::{
@@ -161,7 +162,9 @@ pub fn account_resource_location(address: AccountAddress) -> StorageLocation {
 }
 
 pub fn coin_store_location(address: AccountAddress) -> StorageLocation {
-    StorageLocation::Specific(StateKey::resource_typed::<CoinStoreResource>(&address).unwrap())
+    StorageLocation::Specific(
+        StateKey::resource_typed::<CoinStoreResource<AptosCoinType>>(&address).unwrap(),
+    )
 }
 
 pub fn current_ts_location() -> StorageLocation {
@@ -174,7 +177,10 @@ pub fn features_location() -> StorageLocation {
 
 pub fn aptos_coin_info_location() -> StorageLocation {
     StorageLocation::Specific(
-        StateKey::resource_typed::<CoinInfoResource>(&AccountAddress::ONE).unwrap(),
+        StateKey::resource_typed::<CoinInfoResource<AptosCoinType>>(
+            &AptosCoinType::coin_info_address(),
+        )
+        .unwrap(),
     )
 }
 

--- a/types/src/utility_coin.rs
+++ b/types/src/utility_coin.rs
@@ -8,7 +8,13 @@ use move_core_types::{
 };
 use once_cell::sync::Lazy;
 
-pub static APTOS_COIN_TYPE: Lazy<TypeTag> = Lazy::new(|| {
+pub trait CoinType {
+    fn type_tag() -> TypeTag;
+
+    fn coin_info_address() -> AccountAddress;
+}
+
+static APTOS_COIN_TYPE: Lazy<TypeTag> = Lazy::new(|| {
     TypeTag::Struct(Box::new(StructTag {
         address: AccountAddress::ONE,
         module: ident_str!("aptos_coin").to_owned(),
@@ -16,3 +22,15 @@ pub static APTOS_COIN_TYPE: Lazy<TypeTag> = Lazy::new(|| {
         type_args: vec![],
     }))
 });
+
+pub struct AptosCoinType;
+
+impl CoinType for AptosCoinType {
+    fn type_tag() -> TypeTag {
+        APTOS_COIN_TYPE.clone()
+    }
+
+    fn coin_info_address() -> AccountAddress {
+        AccountAddress::ONE
+    }
+}


### PR DESCRIPTION
## Description

CoinInfo / CoinStore rust structs were implicitly hardcoding that they work on APT, which wasn't obvious. 

Cleanup the code to make it explicit and aligned. 

This helps stacked PR ( #14465 ) do it's changes more easily

Changes are:
* CoinStoreResource becomes tamplate CoinStoreResource<C: CoinType>, similar for CoinInfoResource
* more explicit naming for utility functions with having "apt" in the name: read_coin_store_resource() => read_apt_coin_store_resource(), etc
* moving aggregator related resource types from coin_info.rs to aggregator.rs, and renaming V1 types from Aggregator to AggregatorV1Resource, so it is clear.
* APTOS_COIN_TYPE => AptosCoinType::type_tag()
* having CoinStoreResourceUntyped for when we are deserializing for an unknown coin type


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
