### PR TITLE
optimize LayeredMap::get()

### DIFF
--- a/experimental/storage/layered-map/benches/maps.rs
+++ b/experimental/storage/layered-map/benches/maps.rs
@@ -161,14 +161,14 @@ fn compare_maps(c: &mut Criterion) {
 
     {
         let mut group = c.benchmark_group("get_existing");
-        for map_size_k in [1000, 128_000] {
+        for map_size_k in [100, 1000, 128_000] {
             get_existing(&mut group, map_size_k);
         }
     }
 
     {
         let mut group = c.benchmark_group("get_non_existing");
-        for map_size_k in [1000, 128_000] {
+        for map_size_k in [100, 1000, 128_000] {
             get_non_existing(&mut group, map_size_k);
         }
     }

--- a/experimental/storage/layered-map/src/flatten_perfect_tree.rs
+++ b/experimental/storage/layered-map/src/flatten_perfect_tree.rs
@@ -1,0 +1,108 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    node::{NodeRef, NodeStrongRef},
+    utils,
+};
+use std::{
+    fmt,
+    fmt::{Debug, Formatter},
+};
+
+pub(crate) struct FlattenPerfectTree<K, V> {
+    leaves: Vec<NodeRef<K, V>>,
+}
+
+impl<K, V> FlattenPerfectTree<K, V> {
+    pub fn new_with_empty_nodes(height: usize) -> Self {
+        let num_leaves = if height == 0 { 0 } else { 1 << (height - 1) };
+
+        Self {
+            leaves: vec![NodeRef::Empty; num_leaves],
+        }
+    }
+
+    pub fn get_ref(&self) -> FptRef<K, V> {
+        FptRef {
+            leaves: &self.leaves,
+        }
+    }
+
+    pub fn get_mut(&mut self) -> FptRefMut<K, V> {
+        FptRefMut {
+            leaves: &mut self.leaves,
+        }
+    }
+
+    pub(crate) fn take_for_drop(&mut self) -> Self {
+        let mut ret = Self { leaves: Vec::new() };
+        std::mem::swap(self, &mut ret);
+
+        ret
+    }
+}
+
+impl<K, V> Debug for FlattenPerfectTree<K, V> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "FlattenPerfectTree({})", self.leaves.len())
+    }
+}
+
+pub(crate) struct FptRef<'a, K, V> {
+    leaves: &'a [NodeRef<K, V>],
+}
+
+impl<'a, K, V> FptRef<'a, K, V> {
+    pub fn num_leaves(&self) -> usize {
+        self.leaves.len()
+    }
+
+    pub fn expect_sub_trees(self) -> (Self, Self) {
+        assert!(!self.is_single_node());
+        let (left, right) = self.leaves.split_at(self.leaves.len() / 2);
+        (Self { leaves: left }, Self { leaves: right })
+    }
+
+    pub fn is_single_node(&self) -> bool {
+        self.leaves.len() == 1
+    }
+
+    pub fn expect_single_node(&self, base_layer: u64) -> NodeStrongRef<K, V> {
+        assert!(self.is_single_node());
+        self.leaves[0].get_strong(base_layer)
+    }
+
+    pub fn expect_foot(&self, foot: usize, base_layer: u64) -> NodeStrongRef<K, V> {
+        self.leaves[foot].get_strong(base_layer)
+    }
+
+    pub fn height(&self) -> usize {
+        utils::binary_tree_height(self.leaves.len())
+    }
+
+    pub fn into_feet_iter(self) -> impl Iterator<Item = &'a NodeRef<K, V>> {
+        self.leaves.iter()
+    }
+}
+
+pub(crate) struct FptRefMut<'a, K, V> {
+    leaves: &'a mut [NodeRef<K, V>],
+}
+
+impl<'a, K, V> FptRefMut<'a, K, V> {
+    pub fn is_single_node(&self) -> bool {
+        self.leaves.len() == 1
+    }
+
+    pub fn expect_into_single_node_mut(self) -> &'a mut NodeRef<K, V> {
+        assert!(self.is_single_node());
+        &mut self.leaves[0]
+    }
+
+    pub fn expect_into_sub_trees(self) -> (Self, Self) {
+        assert!(!self.is_single_node());
+        let (left, right) = self.leaves.split_at_mut(self.leaves.len() / 2);
+        (Self { leaves: left }, Self { leaves: right })
+    }
+}

--- a/experimental/storage/layered-map/src/lib.rs
+++ b/experimental/storage/layered-map/src/lib.rs
@@ -7,6 +7,7 @@ pub use map::LayeredMap;
 use std::hash::Hash;
 
 mod dropper;
+mod flatten_perfect_tree;
 pub mod iterator;
 mod layer;
 mod map;
@@ -15,6 +16,7 @@ mod node;
 pub(crate) mod r#ref;
 #[cfg(test)]
 mod tests;
+mod utils;
 
 /// When recursively creating a new `MapLayer` (a crit bit tree overlay), partitioning and passing
 /// down `Vec<(K, Option<V>)>` would mean a lot of memory allocation. That's why we require

--- a/experimental/storage/layered-map/src/map/new_layer_impl.rs
+++ b/experimental/storage/layered-map/src/map/new_layer_impl.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    flatten_perfect_tree::{FlattenPerfectTree, FptRef, FptRefMut},
     metrics::TIMER,
     node::{CollisionCell, LeafContent, LeafNode, NodeRef, NodeStrongRef},
+    utils::binary_tree_height,
     Key, KeyHash, LayeredMap, MapLayer, Value,
 };
 use aptos_drop_helper::ArcAsyncDrop;
@@ -16,97 +18,6 @@ where
     K: ArcAsyncDrop + Key,
     V: ArcAsyncDrop + Value,
 {
-    fn new_leaf(&self, key_hash: KeyHash, items: &[Item<K, V>]) -> NodeRef<K, V> {
-        let new_layer = self.top_layer() + 1;
-        NodeRef::new_leaf(key_hash, to_leaf_content(items, new_layer), new_layer)
-    }
-
-    fn new_leaf_overwriting_old(
-        &self,
-        key_hash: KeyHash,
-        old_leaf: &LeafNode<K, V>,
-        new_items: &[Item<K, V>],
-    ) -> NodeRef<K, V> {
-        let new_layer = self.top_layer() + 1;
-
-        let old = old_leaf.content.clone();
-        let new = to_leaf_content(new_items, new_layer);
-        let content = old.combined_with(old_leaf.layer, new, new_layer, self.base_layer());
-
-        NodeRef::new_leaf(key_hash, content, new_layer)
-    }
-
-    fn new_internal(&self, left: NodeRef<K, V>, right: NodeRef<K, V>) -> NodeRef<K, V> {
-        NodeRef::new_internal(left, right, self.top_layer() + 1)
-    }
-
-    fn branch_down(
-        &self,
-        depth: usize,
-        node: NodeStrongRef<K, V>,
-    ) -> (NodeStrongRef<K, V>, NodeStrongRef<K, V>) {
-        use crate::node::NodeStrongRef::*;
-
-        match &node {
-            Empty => (Empty, Empty),
-            Leaf(leaf) => {
-                if leaf.key_hash.bit(depth) {
-                    (Empty, node)
-                } else {
-                    (node, Empty)
-                }
-            },
-            Internal(internal) => (
-                self.get_node_strong(&internal.left),
-                self.get_node_strong(&internal.right),
-            ),
-        }
-    }
-
-    fn merge_up(&self, left: NodeRef<K, V>, right: NodeRef<K, V>) -> NodeRef<K, V> {
-        use crate::node::NodeRef::*;
-
-        match (&left, &right) {
-            (Empty, Leaf(..)) => right,
-            (Leaf(..), Empty) => left,
-            (Empty, Empty) => unreachable!("merge_up with two empty nodes"),
-            _ => self.new_internal(left, right),
-        }
-    }
-
-    fn create_tree(
-        &self,
-        depth: usize,
-        current_root: NodeStrongRef<K, V>,
-        items: &[Item<K, V>],
-    ) -> NodeRef<K, V> {
-        if items.is_empty() {
-            return current_root.weak_ref();
-        }
-
-        // See if the whole range is of the same key hash, which maps to a leaf node
-        let first_key_hash = items[0].key_hash();
-        if first_key_hash == items[items.len() - 1].key_hash() {
-            match &current_root {
-                NodeStrongRef::Empty => return self.new_leaf(first_key_hash, items),
-                NodeStrongRef::Leaf(leaf) => {
-                    if leaf.key_hash == first_key_hash {
-                        return self.new_leaf_overwriting_old(first_key_hash, leaf, items);
-                    }
-                },
-                NodeStrongRef::Internal(_) => {},
-            }
-        }
-
-        let pivot = items.partition_point(|item| !item.key_hash.bit(depth));
-        let (left_items, right_items) = items.split_at(pivot);
-        let (left_root, right_root) = self.branch_down(depth, current_root);
-        self.merge_up(
-            self.create_tree(depth + 1, left_root, left_items),
-            self.create_tree(depth + 1, right_root, right_items),
-        )
-    }
-
     pub fn new_layer_with_hasher(&self, kvs: &[(K, V)], hash_builder: &S) -> MapLayer<K, V>
     where
         S: core::hash::BuildHasher,
@@ -126,9 +37,25 @@ where
             .sorted_by_key(Item::full_key)
             .collect_vec();
 
-        let root = self.create_tree(0, self.root(), &items);
+        let height = Self::new_peak_height(self.top_layer.peak().num_leaves(), items.len());
+        let mut new_peak = FlattenPerfectTree::new_with_empty_nodes(height);
+        let builder = SubTreeBuilder {
+            layer: self.top_layer.layer() + 1,
+            base_layer: self.base_layer(),
+            depth: 0,
+            position_info: PositionInfo::new(self.top_layer.peak(), self.base_layer()),
+            output_position_info: OutputPositionInfo::new(new_peak.get_mut()),
+            items: &items,
+        };
+        builder.build().finalize();
 
-        self.top_layer.spawn(root, self.base_layer())
+        self.top_layer.spawn(new_peak, self.base_layer())
+    }
+
+    fn new_peak_height(previous_peak_feet: usize, items_in_new_layer: usize) -> usize {
+        let old = binary_tree_height(previous_peak_feet);
+        let new = 2.max(binary_tree_height(items_in_new_layer)) - 1;
+        1.max(old - 1).max(new)
     }
 
     pub fn new_layer(&self, items: &[(K, V)]) -> MapLayer<K, V>
@@ -166,28 +93,333 @@ impl<'a, K, V> Item<'a, K, V> {
     }
 }
 
-fn to_leaf_content<K: Key, V: Value>(items: &[Item<K, V>], layer: u64) -> LeafContent<K, V> {
-    assert!(!items.is_empty());
-    if items.len() == 1 {
-        let (key, value) = items[0].kv().clone();
-        LeafContent::UniqueLatest { key, value }
-    } else {
-        // deduplication
-        let mut map: BTreeMap<_, _> = items
-            .iter()
-            .map(|item| {
-                let (key, value) = item.kv().clone();
-                (key, CollisionCell { value, layer })
-            })
-            .collect();
-        if map.len() == 1 {
-            let (key, cell) = map.pop_first().unwrap();
-            LeafContent::UniqueLatest {
-                key,
-                value: cell.value,
-            }
+enum PositionInfo<'a, K, V> {
+    AbovePeakFeet(FptRef<'a, K, V>),
+    PeakFootOrBelow(NodeStrongRef<K, V>),
+}
+
+impl<'a, K, V> PositionInfo<'a, K, V> {
+    fn new(peak: FptRef<'a, K, V>, base_layer: u64) -> Self {
+        if peak.num_leaves() == 1 {
+            Self::PeakFootOrBelow(peak.expect_single_node(base_layer))
         } else {
-            LeafContent::Collision(map)
+            Self::AbovePeakFeet(peak)
+        }
+    }
+
+    fn is_above_peak_feet(&self) -> bool {
+        matches!(self, Self::AbovePeakFeet(..))
+    }
+
+    fn expect_peak_foot_or_below(&self) -> NodeStrongRef<K, V> {
+        match self {
+            Self::AbovePeakFeet(..) => panic!("Still in Peak"),
+            Self::PeakFootOrBelow(node) => node.clone(),
+        }
+    }
+
+    fn children(self, depth: usize, base_layer: u64) -> (Self, Self) {
+        use PositionInfo::*;
+
+        match self {
+            AbovePeakFeet(fpt) => {
+                let (left, right) = fpt.expect_sub_trees();
+                if left.is_single_node() {
+                    (
+                        PeakFootOrBelow(left.expect_single_node(base_layer)),
+                        PeakFootOrBelow(right.expect_single_node(base_layer)),
+                    )
+                } else {
+                    (AbovePeakFeet(left), AbovePeakFeet(right))
+                }
+            },
+            PeakFootOrBelow(node) => {
+                let (left, right) = node.children(depth, base_layer);
+                (PeakFootOrBelow(left), PeakFootOrBelow(right))
+            },
+        }
+    }
+}
+
+enum OutputPositionInfo<'a, K, V> {
+    AboveOrAtPeakFeet(FptRefMut<'a, K, V>),
+    BelowPeakFeet,
+}
+
+impl<'a, K, V> OutputPositionInfo<'a, K, V> {
+    pub fn new(fpt_mut: FptRefMut<'a, K, V>) -> Self {
+        Self::AboveOrAtPeakFeet(fpt_mut)
+    }
+
+    pub fn is_above_peak_feet(&self) -> bool {
+        if let OutputPositionInfo::AboveOrAtPeakFeet(fpt) = self {
+            !fpt.is_single_node()
+        } else {
+            false
+        }
+    }
+
+    pub fn is_below_peak_feet(&self) -> bool {
+        matches!(self, OutputPositionInfo::BelowPeakFeet)
+    }
+
+    pub fn into_pending_build(
+        self,
+    ) -> (
+        PendingBuild<'a, K, V>,
+        OutputPositionInfo<'a, K, V>,
+        OutputPositionInfo<'a, K, V>,
+    ) {
+        match self {
+            OutputPositionInfo::AboveOrAtPeakFeet(fpt_mut) => {
+                if fpt_mut.is_single_node() {
+                    (
+                        PendingBuild::FootOfPeak(fpt_mut.expect_into_single_node_mut()),
+                        OutputPositionInfo::BelowPeakFeet,
+                        OutputPositionInfo::BelowPeakFeet,
+                    )
+                } else {
+                    let (left, right) = fpt_mut.expect_into_sub_trees();
+                    (
+                        PendingBuild::AbovePeakFeet,
+                        OutputPositionInfo::AboveOrAtPeakFeet(left),
+                        OutputPositionInfo::AboveOrAtPeakFeet(right),
+                    )
+                }
+            },
+            OutputPositionInfo::BelowPeakFeet => (
+                PendingBuild::BelowPeakFeet,
+                OutputPositionInfo::BelowPeakFeet,
+                OutputPositionInfo::BelowPeakFeet,
+            ),
+        }
+    }
+}
+
+enum PendingBuild<'a, K, V> {
+    AbovePeakFeet,
+    FootOfPeak(&'a mut NodeRef<K, V>),
+    BelowPeakFeet,
+}
+
+impl<'a, K, V> PendingBuild<'a, K, V> {
+    fn seal_with_node(&mut self, node: NodeRef<K, V>) -> BuiltSubTree<K, V> {
+        match self {
+            PendingBuild::AbovePeakFeet => unreachable!("Trying to put node above peak feet."),
+            PendingBuild::FootOfPeak(ref_mut) => {
+                **ref_mut = node;
+                BuiltSubTree::InOrAtFootOfPeak
+            },
+            PendingBuild::BelowPeakFeet => BuiltSubTree::BelowPeak(node),
+        }
+    }
+
+    fn seal_with_children(
+        &mut self,
+        left: BuiltSubTree<K, V>,
+        right: BuiltSubTree<K, V>,
+        layer: u64,
+    ) -> BuiltSubTree<K, V> {
+        match (left, right) {
+            (BuiltSubTree::InOrAtFootOfPeak, BuiltSubTree::InOrAtFootOfPeak) => {
+                assert!(
+                    matches!(self, PendingBuild::AbovePeakFeet),
+                    "Expecting nodes."
+                );
+                BuiltSubTree::InOrAtFootOfPeak
+            },
+            (BuiltSubTree::BelowPeak(left), BuiltSubTree::BelowPeak(right)) => {
+                let internal_node = Self::merge_subtrees(left, right, layer);
+                self.seal_with_node(internal_node)
+            },
+            _ => unreachable!("Children should be of same flavor."),
+        }
+    }
+
+    fn merge_subtrees(left: NodeRef<K, V>, right: NodeRef<K, V>, layer: u64) -> NodeRef<K, V> {
+        use crate::node::NodeRef::*;
+
+        match (&left, &right) {
+            (Empty, Leaf(..)) => right,
+            (Leaf(..), Empty) => left,
+            (Empty, Empty) => Empty,
+            _ => NodeRef::new_internal(left, right, layer),
+        }
+    }
+}
+
+#[must_use = "Must finalize()"]
+enum BuiltSubTree<K, V> {
+    InOrAtFootOfPeak,
+    BelowPeak(NodeRef<K, V>),
+}
+
+impl<K, V> BuiltSubTree<K, V> {
+    fn finalize(self) {
+        // note: need to carry height to assert more strongly
+        // (that it's built all the way to the root)
+        assert!(
+            matches!(self, BuiltSubTree::InOrAtFootOfPeak),
+            "Haven't reached the peak."
+        );
+    }
+}
+
+struct SubTreeBuilder<'a, K, V> {
+    /// the layer being built
+    layer: u64,
+    /// anything at this layer or earlier is assumed invisible
+    base_layer: u64,
+    depth: usize,
+    position_info: PositionInfo<'a, K, V>,
+    output_position_info: OutputPositionInfo<'a, K, V>,
+    items: &'a [Item<'a, K, V>],
+}
+
+impl<'a, K, V> SubTreeBuilder<'a, K, V>
+where
+    K: ArcAsyncDrop + Key,
+    V: ArcAsyncDrop + Value,
+{
+    fn all_items_same_key_hash(&self) -> Option<KeyHash> {
+        let items = &self.items;
+
+        assert!(!items.is_empty());
+        let first_key_hash = items[0].key_hash();
+        if first_key_hash == items[items.len() - 1].key_hash() {
+            Some(first_key_hash)
+        } else {
+            None
+        }
+    }
+
+    fn still_in_peak(&self) -> bool {
+        self.position_info.is_above_peak_feet() || self.output_position_info.is_above_peak_feet()
+    }
+
+    pub fn build(self) -> BuiltSubTree<K, V> {
+        if self.still_in_peak() {
+            // Can't start building up unless deep enough to see the bottoms of the peaks.
+            self.branch_further()
+        } else if self.items.is_empty() {
+            // No new leaves to add in this branch, return weak ref to the current node.
+            let node = self.position_info.expect_peak_foot_or_below().weak_ref();
+            self.terminate_with_node(node)
+        } else {
+            match self.all_items_same_key_hash() {
+                None => {
+                    // Still multiple leaves to add, branch further down.
+                    self.branch_further()
+                },
+                Some(key_hash) => {
+                    // All new items belong to the same new leaf node.
+                    match self.position_info.expect_peak_foot_or_below() {
+                        NodeStrongRef::Empty => {
+                            let node = self.new_leaf(key_hash, self.items);
+                            self.terminate_with_node(node)
+                        },
+                        NodeStrongRef::Leaf(leaf) => {
+                            if leaf.key_hash == key_hash {
+                                let node =
+                                    self.new_leaf_overwriting_old(key_hash, &leaf, self.items);
+                                self.terminate_with_node(node)
+                            } else {
+                                self.branch_further()
+                            }
+                        },
+                        NodeStrongRef::Internal(_) => self.branch_further(),
+                    }
+                }, // end Some(key_hash) == all_items_same_key_hash()
+            } // end match
+        } // end else
+    }
+
+    fn branch_further(self) -> BuiltSubTree<K, V> {
+        let Self {
+            layer,
+            base_layer,
+            depth,
+            position_info,
+            output_position_info,
+            items,
+        } = self;
+
+        let (mut pending_build, out_left, out_right) = output_position_info.into_pending_build();
+        let (pos_left, pos_right) = position_info.children(depth, base_layer);
+
+        let pivot = items.partition_point(|item| !item.key_hash.bit(depth));
+        let (items_left, items_right) = items.split_at(pivot);
+
+        let left = Self {
+            layer,
+            base_layer,
+            depth: depth + 1,
+            position_info: pos_left,
+            output_position_info: out_left,
+            items: items_left,
+        };
+        let right = Self {
+            layer,
+            base_layer,
+            depth: depth + 1,
+            position_info: pos_right,
+            output_position_info: out_right,
+            items: items_right,
+        };
+        pending_build.seal_with_children(left.build(), right.build(), layer)
+    }
+
+    fn terminate_with_node(self, node: NodeRef<K, V>) -> BuiltSubTree<K, V> {
+        let (mut pending_build, left, right) = self.output_position_info.into_pending_build();
+        assert!(left.is_below_peak_feet() && right.is_below_peak_feet());
+
+        pending_build.seal_with_node(node)
+    }
+
+    fn new_leaf(&self, key_hash: KeyHash, items: &[Item<K, V>]) -> NodeRef<K, V> {
+        NodeRef::new_leaf(
+            key_hash,
+            Self::to_leaf_content(items, self.layer),
+            self.layer,
+        )
+    }
+
+    fn new_leaf_overwriting_old(
+        &self,
+        key_hash: KeyHash,
+        old_leaf: &LeafNode<K, V>,
+        new_items: &[Item<K, V>],
+    ) -> NodeRef<K, V> {
+        let old = old_leaf.content.clone();
+        let new = Self::to_leaf_content(new_items, self.layer);
+        let content = old.combined_with(old_leaf.layer, new, self.layer, self.base_layer);
+
+        NodeRef::new_leaf(key_hash, content, self.layer)
+    }
+
+    fn to_leaf_content(items: &[Item<K, V>], layer: u64) -> LeafContent<K, V> {
+        assert!(!items.is_empty());
+        if items.len() == 1 {
+            let (key, value) = items[0].kv().clone();
+            LeafContent::UniqueLatest { key, value }
+        } else {
+            // deduplication
+            let mut map: BTreeMap<_, _> = items
+                .iter()
+                .map(|item| {
+                    let (key, value) = item.kv().clone();
+                    (key, CollisionCell { value, layer })
+                })
+                .collect();
+            if map.len() == 1 {
+                let (key, cell) = map.pop_first().unwrap();
+                LeafContent::UniqueLatest {
+                    key,
+                    value: cell.value,
+                }
+            } else {
+                LeafContent::Collision(map)
+            }
         }
     }
 }

--- a/experimental/storage/layered-map/src/utils.rs
+++ b/experimental/storage/layered-map/src/utils.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#[inline]
+pub(crate) fn binary_tree_height(num_leaves: usize) -> usize {
+    if num_leaves == 0 {
+        0
+    } else {
+        num_leaves.next_power_of_two().trailing_zeros() as usize + 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::binary_tree_height;
+    #[test]
+    fn test_height() {
+        assert_eq!(binary_tree_height(0), 0);
+        assert_eq!(binary_tree_height(1), 1);
+        assert_eq!(binary_tree_height(2), 2);
+        assert_eq!(binary_tree_height(3), 3);
+        assert_eq!(binary_tree_height(4), 3);
+        assert_eq!(binary_tree_height(5), 4);
+        assert_eq!(binary_tree_height(6), 4);
+        assert_eq!(binary_tree_height(7), 4);
+        assert_eq!(binary_tree_height(8), 4);
+        assert_eq!(binary_tree_height(9), 5);
+        assert_eq!(binary_tree_height(16), 5);
+        assert_eq!(binary_tree_height(17), 6);
+    }
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Compress the top of the critbit tree by using a newly introduced FlattenedPerfectTree, which omits the internal nodes.

<details>
<summary>
Due to the complexity of the code, update is slower.
</summary>

```
insert_in_batches/layered_map_1_batches_of_10k_updates
                        time:   [1.6578 ms 1.6878 ms 1.7120 ms]
                        thrpt:  [5.9814 Melem/s 6.0671 Melem/s 6.1768 Melem/s]
                 change:
                        time:   [+14.571% +18.106% +21.934%] (p = 0.00 < 0.05)
                        thrpt:  [-17.988% -15.331% -12.718%]
                Performance has regressed.
insert_in_batches/layered_map_8_batches_of_10k_updates
                        time:   [21.700 ms 21.854 ms 22.016 ms]
                        thrpt:  [3.7210 Melem/s 3.7485 Melem/s 3.7752 Melem/s]
                 change:
                        time:   [-2.5688% -1.7149% -0.9398%] (p = 0.00 < 0.05)
                        thrpt:  [+0.9487% +1.7449% +2.6365%]
                        Change within noise threshold.
insert_in_batches/layered_map_1_batches_of_100k_updates                                                                                                                                                                                                             time:   [18.788 ms 18.974 ms 19.140 ms]
                        thrpt:  [5.3500 Melem/s 5.3970 Melem/s 5.4503 Melem/s]
                 change:
                        time:   [+25.470% +26.981% +28.499%] (p = 0.00 < 0.05)
                        thrpt:  [-22.178% -21.248% -20.300%]
                        Performance has regressed.
Benchmarking insert_in_batches/layered_map_8_batches_of_100k_updates: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 41.8s, or reduce sample count to 10.
insert_in_batches/layered_map_8_batches_of_100k_updates
                        time:   [405.39 ms 406.99 ms 408.59 ms]
                        thrpt:  [2.0050 Melem/s 2.0128 Melem/s 2.0208 Melem/s]
                 change:
                        time:   [+11.535% +11.973% +12.406%] (p = 0.00 < 0.05)
                        thrpt:  [-11.037% -10.693% -10.342%]
                        Performance has regressed.
```
</details>


<details>
<summary>
However reading is greatly faster
</summary>

```
get_existing/layered_map_1000k_items
                        time:   [1.0122 ms 1.0130 ms 1.0139 ms]
                        thrpt:  [10.099 Melem/s 10.109 Melem/s 10.117 Melem/s]
                 change:
                        time:   [-63.890% -63.330% -62.865%] (p = 0.00 < 0.05)
                        thrpt:  [+169.29% +172.70% +176.93%]
                        Performance has improved.
Benchmarking get_existing/layered_map_128000k_items: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 7.4s, enable flat sampling, or reduce sample count to 50.
get_existing/layered_map_128000k_items
                        time:   [1.3693 ms 1.3753 ms 1.3824 ms]
                        thrpt:  [7.4073 Melem/s 7.4457 Melem/s 7.4783 Melem/s]
                 change:
                        time:   [-78.212% -78.015% -77.792%] (p = 0.00 < 0.05)
                        thrpt:  [+350.30% +354.86% +358.98%]
                        Performance has improved.
```

</details>

<details>
<summary>
Net-net, Hexy update is significantly faster
</summary>

``` text                                                                                                            
Benchmarking hexy_updates/hexy_update_leaves_128m_batch_10k_pipeline_depth_0: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.1s, or reduce sample count to 80.
hexy_updates/hexy_update_leaves_128m_batch_10k_pipeline_depth_0
                        time:   [61.543 ms 61.747 ms 61.953 ms]
                        thrpt:  [165.29 Kelem/s 165.84 Kelem/s 166.39 Kelem/s]
                 change:
                        time:   [-3.0909% -2.6292% -2.1623%] (p = 0.00 < 0.05)
                        thrpt:  [+2.2101% +2.7002% +3.1895%]
                        Performance has improved.
Benchmarking hexy_updates/hexy_update_leaves_128m_batch_10k_pipeline_depth_2: Warming up for 3.0000 s                                                                                                                                       Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.9s, or reduce sample count to 50.
hexy_updates/hexy_update_leaves_128m_batch_10k_pipeline_depth_2
                        time:   [102.99 ms 103.91 ms 104.86 ms]
                        thrpt:  [97.653 Kelem/s 98.548 Kelem/s 99.423 Kelem/s]
                 change:
                        time:   [-28.540% -27.875% -27.126%] (p = 0.00 < 0.05)
                        thrpt:  [+37.223% +38.647% +39.938%]
                        Performance has improved.
Benchmarking hexy_updates/hexy_update_leaves_128m_batch_10k_pipeline_depth_8: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 16.0s, or reduce sample count to 30.
hexy_updates/hexy_update_leaves_128m_batch_10k_pipeline_depth_8
                        time:   [162.87 ms 163.54 ms 164.27 ms]
                        thrpt:  [62.337 Kelem/s 62.615 Kelem/s 62.872 Kelem/s]
                 change:
                        time:   [-27.008% -26.279% -25.573%] (p = 0.00 < 0.05) 
                        thrpt:  [+34.360% +35.647% +37.000%]
                        Performance has improved. 
```
</details>

## Type of Change
- [x] Performance improvement


## Which Components or Systems Does This Change Impact?
- [x] Validator Node


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

unit tests
benchmarks
