### PR TITLE
Fix ‘address with no value’

### DIFF
--- a/aptos-move/move-examples/groth16_example/Move.toml
+++ b/aptos-move/move-examples/groth16_example/Move.toml
@@ -2,5 +2,8 @@
 name = "GenericGroth16"
 version = "0.0.0"
 
+[addresses]
+groth16_example = "0x42"
+
 [dependencies]
 AptosFramework = { local = "../../framework/aptos-framework" }


### PR DESCRIPTION
Fix: Error "address 'groth16_example' is not assigned a value. Try assigning it a value when calling the compiler"

# Add

```toml
[addresses]
groth16_example = "0x42"
```

# Before Fix

output: Error

```error
error[E03001]: address with no value
  ┌─ /Users/simons/Documents/GitHub/move-examples-zh/17-groth16_example/sources/groth16.move:6:8
  │
6 │ module groth16_example::groth16 {
  │        ^^^^^^^^^^^^^^^ address 'groth16_example' is not assigned a value. Try assigning it a value when calling the compiler
```

# After Fix

output: Success

```success
Running Move unit tests
[ PASS    ] 0x42::groth16::test_verify_proof_prepared_fq12_with_bls12381
[ PASS    ] 0x42::groth16::test_verify_proof_prepared_with_bls12381
[ PASS    ] 0x42::groth16::test_verify_proof_with_bls12381
Test result: OK. Total tests: 3; passed: 3; failed: 0
{
  "Result": "Success"
}
```