### PR TITLE
Add counters in quorum store to track received messages

### DIFF
--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -850,6 +850,15 @@ pub static BATCH_SUCCESSFUL_CREATION: Lazy<Histogram> = Lazy::new(|| {
     )
 });
 
+pub static QUORUM_STORE_MSG_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "quorum_store_msg_count",
+        "Count of messages received by various quoroum store components",
+        &["type"]
+    )
+    .unwrap()
+});
+
 /// Number of validators for which we received signed replies
 pub static BATCH_RECEIVED_REPLIES_COUNT: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(

--- a/consensus/src/quorum_store/network_listener.rs
+++ b/consensus/src/quorum_store/network_listener.rs
@@ -44,6 +44,9 @@ impl NetworkListener {
                 match msg {
                     // TODO: does the assumption have to be that network listener is shutdown first?
                     VerifiedEvent::Shutdown(ack_tx) => {
+                        counters::QUORUM_STORE_MSG_COUNT
+                            .with_label_values(&["NetworkListener::shutdown"])
+                            .inc();
                         info!("QS: shutdown network listener received");
                         ack_tx
                             .send(())
@@ -51,6 +54,9 @@ impl NetworkListener {
                         break;
                     },
                     VerifiedEvent::SignedBatchInfo(signed_batch_infos) => {
+                        counters::QUORUM_STORE_MSG_COUNT
+                            .with_label_values(&["NetworkListener::signedbatchinfo"])
+                            .inc();
                         let cmd = ProofCoordinatorCommand::AppendSignature(*signed_batch_infos);
                         self.proof_coordinator_tx
                             .send(cmd)
@@ -58,6 +64,9 @@ impl NetworkListener {
                             .expect("Could not send signed_batch_info to proof_coordinator");
                     },
                     VerifiedEvent::BatchMsg(batch_msg) => {
+                        counters::QUORUM_STORE_MSG_COUNT
+                            .with_label_values(&["NetworkListener::batchmsg"])
+                            .inc();
                         let author = batch_msg.author();
                         let batches = batch_msg.take();
                         counters::RECEIVED_BATCH_MSG_COUNT.inc();
@@ -76,6 +85,9 @@ impl NetworkListener {
                             .expect("Could not send remote batch");
                     },
                     VerifiedEvent::ProofOfStoreMsg(proofs) => {
+                        counters::QUORUM_STORE_MSG_COUNT
+                            .with_label_values(&["NetworkListener::proofofstore"])
+                            .inc();
                         let cmd = ProofManagerCommand::ReceiveProofs(*proofs);
                         self.proof_manager_tx
                             .send(cmd)

--- a/consensus/src/quorum_store/proof_coordinator.rs
+++ b/consensus/src/quorum_store/proof_coordinator.rs
@@ -309,12 +309,14 @@ impl ProofCoordinator {
                 Some(command) = rx.recv() => monitor!("proof_coordinator_handle_command", {
                     match command {
                         ProofCoordinatorCommand::Shutdown(ack_tx) => {
+                            counters::QUORUM_STORE_MSG_COUNT.with_label_values(&["ProofCoordinator::shutdown"]).inc();
                             ack_tx
                                 .send(())
                                 .expect("Failed to send shutdown ack to QuorumStore");
                             break;
                         },
                         ProofCoordinatorCommand::CommitNotification(batches) => {
+                            counters::QUORUM_STORE_MSG_COUNT.with_label_values(&["ProofCoordinator::commit_notification"]).inc();
                             for batch in batches {
                                 let digest = batch.digest();
                                 if let Entry::Occupied(existing_proof) = self.batch_info_to_proof.entry(batch.clone()) {

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -262,18 +262,22 @@ impl ProofManager {
                         monitor!("proof_manager_handle_command", {
                         match msg {
                             ProofManagerCommand::Shutdown(ack_tx) => {
+                                counters::QUORUM_STORE_MSG_COUNT.with_label_values(&["ProofManager::shutdown"]).inc();
                                 ack_tx
                                     .send(())
                                     .expect("Failed to send shutdown ack to QuorumStore");
                                 break;
                             },
                             ProofManagerCommand::ReceiveProofs(proofs) => {
+                                counters::QUORUM_STORE_MSG_COUNT.with_label_values(&["ProofManager::receive_proofs"]).inc();
                                 self.receive_proofs(proofs.take());
                             },
                             ProofManagerCommand::ReceiveBatches(batches) => {
+                                counters::QUORUM_STORE_MSG_COUNT.with_label_values(&["ProofManager::receive_batches"]).inc();
                                 self.receive_batches(batches);
                             }
                             ProofManagerCommand::CommitNotification(block_timestamp, batches) => {
+                                counters::QUORUM_STORE_MSG_COUNT.with_label_values(&["ProofManager::commit_notification"]).inc();
                                 self.handle_commit_notification(
                                     block_timestamp,
                                     batches,


### PR DESCRIPTION
## Description
Sometimes in our load tests, some validators' proof queue size is increasing uncontrollably. These validators don't seem to be receiving commit notifications. Added some counters to check what messages quorum store is receiving. 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
