### PR TITLE
[Consensus Observer] Further improvements and tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,6 +885,7 @@ dependencies = [
  "aptos-logger",
  "aptos-mempool",
  "aptos-metrics-core",
+ "aptos-netcore",
  "aptos-network",
  "aptos-peer-monitoring-service-types",
  "aptos-reliable-broadcast",

--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -105,7 +105,7 @@ impl ConfigOptimizer for ConsensusObserverConfig {
                 }
             },
             NodeType::PublicFullnode => {
-                if ENABLE_ON_PUBLIC_FULLNODES && !observer_manually_set {
+                if ENABLE_ON_PUBLIC_FULLNODES && !observer_manually_set && !publisher_manually_set {
                     // Enable both the observer and the publisher for PFNs
                     consensus_observer_config.observer_enabled = true;
                     consensus_observer_config.publisher_enabled = true;

--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -37,10 +37,12 @@ pub struct ConsensusObserverConfig {
     /// Maximum timeout (in milliseconds) we'll wait for the synced version to
     /// increase before terminating the active subscription.
     pub max_synced_version_timeout_ms: u64,
-    /// Interval (in milliseconds) to check the optimality of the subscribed peers
-    pub peer_optimality_check_interval_ms: u64,
     /// Interval (in milliseconds) to check progress of the consensus observer
     pub progress_check_interval_ms: u64,
+    /// Interval (in milliseconds) to check for subscription related peer changes
+    pub subscription_peer_change_interval_ms: u64,
+    /// Interval (in milliseconds) to refresh the subscription
+    pub subscription_refresh_interval_ms: u64,
 }
 
 impl Default for ConsensusObserverConfig {
@@ -55,8 +57,9 @@ impl Default for ConsensusObserverConfig {
             max_num_pending_blocks: 100,                       // 100 blocks
             max_subscription_timeout_ms: 30_000,               // 30 seconds
             max_synced_version_timeout_ms: 60_000,             // 60 seconds
-            peer_optimality_check_interval_ms: 120_000,        // 2 minutes
             progress_check_interval_ms: 5_000,                 // 5 seconds
+            subscription_peer_change_interval_ms: 60_000,      // 1 minute
+            subscription_refresh_interval_ms: 300_000,         // 5 minutes
         }
     }
 }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -92,6 +92,7 @@ aptos-consensus-types = { workspace = true, features = ["fuzzing"] }
 aptos-executor-test-helpers = { workspace = true }
 aptos-keygen = { workspace = true }
 aptos-mempool = { workspace = true, features = ["fuzzing"] }
+aptos-netcore = { workspace = true }
 aptos-network = { workspace = true, features = ["fuzzing"] }
 aptos-safety-rules = { workspace = true, features = ["testing"] }
 aptos-vm = { workspace = true, features = ["fuzzing"] }

--- a/consensus/src/consensus_observer/observer/active_state.rs
+++ b/consensus/src/consensus_observer/observer/active_state.rs
@@ -309,6 +309,15 @@ fn handle_committed_blocks(
     // the new ledger info round is greater than the current root
     // round. Otherwise, this can race with the state sync process.
     if ledger_info.commit_info().round() > root.commit_info().round() {
+        info!(
+            LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                "Updating the root ledger info! Old root: (epoch: {:?}, round: {:?}). New root: (epoch: {:?}, round: {:?})",
+                root.commit_info().epoch(),
+                root.commit_info().round(),
+                ledger_info.commit_info().epoch(),
+                ledger_info.commit_info().round(),
+            ))
+        );
         *root = ledger_info;
     }
 }

--- a/consensus/src/consensus_observer/observer/subscription.rs
+++ b/consensus/src/consensus_observer/observer/subscription.rs
@@ -326,7 +326,7 @@ pub fn sort_peers_by_subscription_optimality(
     sorted_peers
 }
 
-/// Returns true iff the peer metadata indicates support for the consensus observer
+/// Returns true iff the peer metadata indicates support for consensus observer
 fn supports_consensus_observer(peer_metadata: &PeerMetadata) -> bool {
     peer_metadata.supports_protocol(ProtocolId::ConsensusObserver)
         && peer_metadata.supports_protocol(ProtocolId::ConsensusObserverRpc)

--- a/consensus/src/consensus_observer/observer/subscription_manager.rs
+++ b/consensus/src/consensus_observer/observer/subscription_manager.rs
@@ -632,7 +632,7 @@ mod test {
         // Elapse enough time to trigger the peer optimality check
         let mock_time_service = time_service.clone().into_mock();
         mock_time_service.advance(Duration::from_millis(
-            consensus_observer_config.peer_optimality_check_interval_ms + 1,
+            consensus_observer_config.subscription_peer_change_interval_ms + 1,
         ));
 
         // Check the active subscription and verify that it is removed (the peer is suboptimal)

--- a/consensus/src/consensus_observer/publisher/consensus_publisher.rs
+++ b/consensus/src/consensus_observer/publisher/consensus_publisher.rs
@@ -20,7 +20,7 @@ use aptos_config::{config::ConsensusObserverConfig, network_id::PeerNetworkId};
 use aptos_infallible::RwLock;
 use aptos_logger::{error, info, warn};
 use aptos_network::application::interface::NetworkClient;
-use futures::{SinkExt, StreamExt};
+use futures::StreamExt;
 use futures_channel::mpsc;
 use std::{collections::HashSet, sync::Arc, time::Duration};
 use tokio::time::interval;
@@ -70,10 +70,15 @@ impl ConsensusPublisher {
         (consensus_publisher, outbound_message_receiver)
     }
 
+    /// Adds the given subscriber to the set of active subscribers
+    fn add_active_subscriber(&self, peer_network_id: PeerNetworkId) {
+        self.active_subscribers.write().insert(peer_network_id);
+    }
+
     /// Garbage collect inactive subscriptions by removing peers that are no longer connected
     fn garbage_collect_subscriptions(&self) {
         // Get the set of active subscribers
-        let active_subscribers = self.active_subscribers.read().clone();
+        let active_subscribers = self.get_active_subscribers();
 
         // Get the connected peers and metadata
         let peers_and_metadata = self.consensus_observer_client.get_peers_and_metadata();
@@ -102,7 +107,7 @@ impl ConsensusPublisher {
 
         // Remove any subscriptions from peers that are no longer connected
         for peer_network_id in &disconnected_subscribers {
-            self.active_subscribers.write().remove(peer_network_id);
+            self.remove_active_subscriber(peer_network_id);
             info!(LogSchema::new(LogEntry::ConsensusPublisher)
                 .event(LogEvent::Subscription)
                 .message(&format!(
@@ -112,7 +117,7 @@ impl ConsensusPublisher {
         }
 
         // Update the number of active subscribers for each network
-        let active_subscribers = self.active_subscribers.read().clone();
+        let active_subscribers = self.get_active_subscribers();
         for network_id in peers_and_metadata.get_registered_networks() {
             // Calculate the number of active subscribers for the network
             let num_active_subscribers = active_subscribers
@@ -134,6 +139,11 @@ impl ConsensusPublisher {
         self.active_subscribers.read().clone()
     }
 
+    /// Removes the given subscriber from the set of active subscribers
+    fn remove_active_subscriber(&self, peer_network_id: &PeerNetworkId) {
+        self.active_subscribers.write().remove(peer_network_id);
+    }
+
     /// Processes a network message received by the consensus publisher
     fn process_network_message(&self, network_message: ConsensusPublisherNetworkMessage) {
         // Unpack the network message
@@ -150,7 +160,7 @@ impl ConsensusPublisher {
         match message {
             ConsensusObserverRequest::Subscribe => {
                 // Add the peer to the set of active subscribers
-                self.active_subscribers.write().insert(peer_network_id);
+                self.add_active_subscriber(peer_network_id);
                 info!(LogSchema::new(LogEntry::ConsensusPublisher)
                     .event(LogEvent::Subscription)
                     .message(&format!(
@@ -163,7 +173,7 @@ impl ConsensusPublisher {
             },
             ConsensusObserverRequest::Unsubscribe => {
                 // Remove the peer from the set of active subscribers
-                self.active_subscribers.write().remove(&peer_network_id);
+                self.remove_active_subscriber(&peer_network_id);
                 info!(LogSchema::new(LogEntry::ConsensusPublisher)
                     .event(LogEvent::Subscription)
                     .message(&format!(
@@ -177,25 +187,25 @@ impl ConsensusPublisher {
         }
     }
 
-    /// Publishes a direct send message to all active subscribers
-    pub async fn publish_message(&self, message: ConsensusObserverDirectSend) {
-        // Get the set of active subscribers
-        let active_subscribers = self.active_subscribers.read().clone();
+    /// Publishes a direct send message to all active subscribers. Note: this method
+    /// is non-blocking (to avoid blocking callers during publishing, e.g., consensus).
+    pub fn publish_message(&self, message: ConsensusObserverDirectSend) {
+        // Get the active subscribers
+        let active_subscribers = self.get_active_subscribers();
 
         // Send the message to all active subscribers
         for peer_network_id in &active_subscribers {
             // Send the message to the outbound receiver for publishing
             let mut outbound_message_sender = self.outbound_message_sender.clone();
-            if let Err(error) = outbound_message_sender
-                .send((*peer_network_id, message.clone()))
-                .await
+            if let Err(error) =
+                outbound_message_sender.try_send((*peer_network_id, message.clone()))
             {
                 // The message send failed
                 warn!(LogSchema::new(LogEntry::ConsensusPublisher)
-                    .event(LogEvent::SendDirectSendMessage)
-                    .message(&format!(
-                        "Failed to send outbound message to the receiver for peer {:?}! Error: {:?}",
-                        peer_network_id, error
+                        .event(LogEvent::SendDirectSendMessage)
+                        .message(&format!(
+                            "Failed to send outbound message to the receiver for peer {:?}! Error: {:?}",
+                            peer_network_id, error
                     )));
             }
         }
@@ -493,9 +503,7 @@ mod test {
                 AggregateSignature::empty(),
             ),
         );
-        consensus_publisher
-            .publish_message(ordered_block_message.clone())
-            .await;
+        consensus_publisher.publish_message(ordered_block_message.clone());
 
         // Verify that the message was sent to the outbound message receiver
         let (peer_network_id, message) = outbound_message_receiver.next().await.unwrap();
@@ -521,9 +529,7 @@ mod test {
             BlockInfo::empty(),
             transaction_payload,
         );
-        consensus_publisher
-            .publish_message(block_payload_message.clone())
-            .await;
+        consensus_publisher.publish_message(block_payload_message.clone());
 
         // Verify that the message was sent to all active subscribers
         let num_expected_messages = additional_peer_network_ids.len() + 1;
@@ -545,9 +551,7 @@ mod test {
                 LedgerInfo::new(BlockInfo::empty(), HashValue::zero()),
                 AggregateSignature::empty(),
             ));
-        consensus_publisher
-            .publish_message(commit_decision_message.clone())
-            .await;
+        consensus_publisher.publish_message(commit_decision_message.clone());
 
         // Verify that the message was sent to all active subscribers except the first peer
         for _ in 0..additional_peer_network_ids.len() {
@@ -566,9 +570,7 @@ mod test {
             BlockInfo::empty(),
             BlockTransactionPayload::empty(),
         );
-        consensus_publisher
-            .publish_message(block_payload_message.clone())
-            .await;
+        consensus_publisher.publish_message(block_payload_message.clone());
 
         // Verify that no messages were sent to the outbound message receiver
         assert!(outbound_message_receiver.next().now_or_never().is_none());

--- a/consensus/src/payload_manager.rs
+++ b/consensus/src/payload_manager.rs
@@ -428,7 +428,7 @@ impl TPayloadManager for QuorumStorePayloadManager {
                 block.gen_block_info(HashValue::zero(), 0, None),
                 transaction_payload.clone(),
             );
-            consensus_publisher.publish_message(message).await;
+            consensus_publisher.publish_message(message);
         }
 
         Ok((
@@ -477,7 +477,7 @@ async fn get_transactions_for_observer(
             block.gen_block_info(HashValue::zero(), 0, None),
             transaction_payload.clone(),
         );
-        consensus_publisher.publish_message(message).await;
+        consensus_publisher.publish_message(message);
     }
 
     // Return the transactions and the transaction limit

--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -316,7 +316,7 @@ impl BufferManager {
                 ordered_blocks.clone().into_iter().map(Arc::new).collect(),
                 ordered_proof.clone(),
             );
-            consensus_publisher.publish_message(message).await;
+            consensus_publisher.publish_message(message);
         }
         self.execution_schedule_phase_tx
             .send(request)
@@ -421,7 +421,7 @@ impl BufferManager {
                 if let Some(consensus_publisher) = &self.consensus_publisher {
                     let message =
                         ConsensusObserverMessage::new_commit_decision_message(commit_proof.clone());
-                    consensus_publisher.publish_message(message).await;
+                    consensus_publisher.publish_message(message);
                 }
                 self.persisting_phase_tx
                     .send(self.create_new_request(PersistingRequest {

--- a/state-sync/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-driver/src/driver.rs
@@ -97,7 +97,7 @@ pub struct StateSyncDriver<
     // The listener for commit notifications
     commit_notification_listener: CommitNotificationListener,
 
-    // The handler for notifications from consensus
+    // The handler for notifications from consensus or consensus observer
     consensus_notification_handler: ConsensusNotificationHandler,
 
     // The component that manages the continuous syncing of the node
@@ -223,12 +223,10 @@ impl<
                     self.handle_client_notification(notification).await;
                 },
                 notification = self.commit_notification_listener.select_next_some() => {
-                    // TODO(joshlind): we should probably just remove this path
-                    // now that we aren't reusing it.
-                    self.handle_commit_notification(notification).await;
+                    self.handle_snapshot_commit_notification(notification).await;
                 }
                 notification = self.consensus_notification_handler.select_next_some() => {
-                    self.handle_consensus_notification(notification).await;
+                    self.handle_consensus_or_observer_notification(notification).await;
                 }
                 notification = self.error_notification_listener.select_next_some() => {
                     self.handle_error_notification(notification).await;
@@ -240,11 +238,13 @@ impl<
         }
     }
 
-    /// Handles a notification sent by consensus
-    async fn handle_consensus_notification(&mut self, notification: ConsensusNotification) {
-        // Verify the notification: full nodes shouldn't receive notifications
-        // and consensus should only send notifications after bootstrapping!
-        let result = if !self.is_consensus_enabled() {
+    /// Handles a notification sent by consensus or consensus observer
+    async fn handle_consensus_or_observer_notification(
+        &mut self,
+        notification: ConsensusNotification,
+    ) {
+        // Verify the notification before processing it
+        let result = if !self.is_consensus_or_observer_enabled() {
             Err(Error::FullNodeConsensusNotification(format!(
                 "Received consensus notification: {:?}",
                 notification
@@ -258,7 +258,7 @@ impl<
             Ok(())
         };
 
-        // Respond to consensus with any verification errors and then return
+        // Handle any verification errors
         if let Err(error) = result {
             match notification {
                 ConsensusNotification::NotifyCommit(commit_notification) => {
@@ -300,7 +300,7 @@ impl<
         }
     }
 
-    /// Handles a commit notification sent by consensus
+    /// Handles a commit notification sent by consensus or consensus observer
     async fn handle_consensus_commit_notification(
         &mut self,
         consensus_commit_notification: ConsensusCommitNotification,
@@ -328,7 +328,7 @@ impl<
         )
         .await;
 
-        // Respond to consensus successfully
+        // Respond successfully
         self.consensus_notification_handler
             .respond_to_commit_notification(consensus_commit_notification, Ok(()))
             .await?;
@@ -373,7 +373,7 @@ impl<
         }
     }
 
-    /// Handles a consensus notification to sync to a specified target
+    /// Handles a consensus or consensus observer request to sync to a specified target
     async fn handle_consensus_sync_notification(
         &mut self,
         sync_notification: ConsensusSyncNotification,
@@ -423,9 +423,11 @@ impl<
         }
     }
 
-    /// Handles a commit notification sent by the storage synchronizer for a
-    /// new state snapshot.
-    async fn handle_commit_notification(&mut self, commit_notification: CommitNotification) {
+    /// Handles a notification from the storage synchronizer for a new state snapshot
+    async fn handle_snapshot_commit_notification(
+        &mut self,
+        commit_notification: CommitNotification,
+    ) {
         let CommitNotification::CommittedStateSnapshot(committed_snapshot) = commit_notification;
         info!(
             LogSchema::new(LogEntry::SynchronizerNotification).message(&format!(
@@ -533,18 +535,18 @@ impl<
         // so that in the event another sync request occurs, we have fresh state.
         if !self.active_sync_request() {
             self.continuous_syncer.reset_active_stream(None).await?;
-            self.storage_synchronizer.finish_chunk_executor(); // Consensus is now in control
+            self.storage_synchronizer.finish_chunk_executor(); // Consensus or consensus observer is now in control
         }
         Ok(())
     }
 
-    /// Returns true iff there's an active sync request from consensus
+    /// Returns true iff there's an active sync request from consensus or consensus observer
     fn active_sync_request(&self) -> bool {
         self.consensus_notification_handler.active_sync_request()
     }
 
-    /// Returns true iff this node enables consensus
-    fn is_consensus_enabled(&self) -> bool {
+    /// Returns true iff this node enables consensus or consensus observer
+    fn is_consensus_or_observer_enabled(&self) -> bool {
         self.driver_configuration.role == RoleType::Validator
             || self
                 .driver_configuration
@@ -552,9 +554,9 @@ impl<
                 .observer_enabled
     }
 
-    /// Returns true iff consensus is currently executing
-    fn check_if_consensus_executing(&self) -> bool {
-        self.is_consensus_enabled()
+    /// Returns true iff consensus or consensus observer is currently executing
+    fn check_if_consensus_or_observer_executing(&self) -> bool {
+        self.is_consensus_or_observer_enabled()
             && self.bootstrapper.is_bootstrapped()
             && !self.active_sync_request()
     }
@@ -565,7 +567,7 @@ impl<
     /// and state sync is trivial.
     async fn check_auto_bootstrapping(&mut self) {
         if !self.bootstrapper.is_bootstrapped()
-            && self.is_consensus_enabled()
+            && self.is_consensus_or_observer_enabled()
             && self.driver_configuration.config.enable_auto_bootstrapping
             && self.driver_configuration.waypoint.version() == 0
         {
@@ -611,13 +613,16 @@ impl<
                 .message("Error found when checking the sync request progress!"));
         }
 
-        // If consensus is executing, there's nothing to do
-        if self.check_if_consensus_executing() {
-            trace!(LogSchema::new(LogEntry::Driver)
-                .message("Consensus is executing. There's nothing to do."));
+        // If consensus or consensus observer is executing, there's nothing to do
+        if self.check_if_consensus_or_observer_executing() {
+            let executing_component = if self.driver_configuration.role.is_validator() {
+                ExecutingComponent::Consensus
+            } else {
+                ExecutingComponent::ConsensusObserver
+            };
             metrics::increment_counter(
                 &metrics::EXECUTING_COMPONENT,
-                ExecutingComponent::Consensus.get_label(),
+                executing_component.get_label(),
             );
             return;
         }

--- a/state-sync/state-sync-driver/src/metrics.rs
+++ b/state-sync/state-sync-driver/src/metrics.rs
@@ -42,6 +42,7 @@ pub const STORAGE_SYNCHRONIZER_STATE_SNAPSHOT_RECEIVER: &str = "state_snapshot_r
 pub enum ExecutingComponent {
     Bootstrapper,
     Consensus,
+    ConsensusObserver,
     ContinuousSyncer,
 }
 
@@ -50,6 +51,7 @@ impl ExecutingComponent {
         match self {
             ExecutingComponent::Bootstrapper => "bootstrapper",
             ExecutingComponent::Consensus => "consensus",
+            ExecutingComponent::ConsensusObserver => "consensus_observer",
             ExecutingComponent::ContinuousSyncer => "continuous_syncer",
         }
     }

--- a/state-sync/state-sync-driver/src/notification_handlers.rs
+++ b/state-sync/state-sync-driver/src/notification_handlers.rs
@@ -168,7 +168,7 @@ impl ConsensusSyncRequest {
     }
 }
 
-/// A simple handler for consensus notifications
+/// A simple handler for consensus or consensus observer notifications
 pub struct ConsensusNotificationHandler {
     // The listener for notifications from consensus
     consensus_listener: ConsensusNotificationListener,

--- a/testsuite/smoke-test/src/consensus_observer.rs
+++ b/testsuite/smoke-test/src/consensus_observer.rs
@@ -8,7 +8,10 @@ use crate::{
     utils::{create_test_accounts, execute_transactions, wait_for_all_nodes},
 };
 use aptos_config::config::NodeConfig;
-use aptos_forge::NodeExt;
+use aptos_forge::{LocalNode, NodeExt};
+use aptos_types::on_chain_config::{
+    ConsensusAlgorithmConfig, OnChainConsensusConfig, ValidatorTxnConfig,
+};
 use std::sync::Arc;
 
 #[tokio::test]
@@ -24,8 +27,8 @@ async fn test_consensus_observer_fast_sync_no_epoch_changes() {
 }
 
 #[tokio::test]
-async fn test_consensus_observer_fullnode_sync() {
-    // Create a validator swarm of 1 validator with consensus observer enabled
+async fn test_consensus_observer_fullnode_restart() {
+    // Create a swarm of 1 validator with consensus observer enabled
     let mut swarm = SwarmBuilder::new_local(1)
         .with_aptos()
         .with_init_config(Arc::new(|_, config, _| {
@@ -34,12 +37,51 @@ async fn test_consensus_observer_fullnode_sync() {
         .build()
         .await;
 
-    // Create a fullnode config that uses consensus observer
+    // Create a VFN config that uses consensus observer
     let mut vfn_config = NodeConfig::get_default_vfn_config();
     enable_consensus_observer(true, &mut vfn_config);
 
-    // Create the fullnode
-    let _ = state_sync_utils::create_fullnode(vfn_config, &mut swarm).await;
+    // Create the VFN and test its ability to stay up-to-date
+    let vfn_peer_id = state_sync_utils::create_fullnode(vfn_config, &mut swarm).await;
+    state_sync_utils::test_fullnode_sync(vfn_peer_id, &mut swarm, true, false).await;
+}
+
+#[tokio::test]
+async fn test_consensus_observer_fullnode_restart_wipe() {
+    // Create a swarm of 1 validator with consensus observer enabled
+    let mut swarm = SwarmBuilder::new_local(1)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            enable_consensus_observer(true, config);
+        }))
+        .build()
+        .await;
+
+    // Create a VFN config that uses consensus observer
+    let mut vfn_config = NodeConfig::get_default_vfn_config();
+    enable_consensus_observer(true, &mut vfn_config);
+
+    // Create the VFN and test its ability to stay up-to-date (after a data wipe)
+    let vfn_peer_id = state_sync_utils::create_fullnode(vfn_config, &mut swarm).await;
+    state_sync_utils::test_fullnode_sync(vfn_peer_id, &mut swarm, true, true).await;
+}
+
+#[tokio::test]
+async fn test_consensus_observer_fullnode_sync() {
+    // Create a VFN config with consensus observer enabled
+    let mut vfn_config = NodeConfig::get_default_vfn_config();
+    enable_consensus_observer(true, &mut vfn_config);
+
+    // Create a swarm of 1 validator and VFN with consensus observer enabled
+    let mut swarm = SwarmBuilder::new_local(1)
+        .with_num_fullnodes(1)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            enable_consensus_observer(true, config);
+        }))
+        .with_vfn_config(vfn_config)
+        .build()
+        .await;
 
     // Execute a number of transactions on the validator
     let validator_peer_id = swarm.validators().next().unwrap().peer_id();
@@ -54,48 +96,141 @@ async fn test_consensus_observer_fullnode_sync() {
     )
     .await;
 
-    // Verify the fullnode is up-to-date
+    // Verify the VFN is up-to-date
     wait_for_all_nodes(&mut swarm).await;
 }
 
 #[tokio::test]
-async fn test_consensus_observer_fullnode_restart() {
-    // Create a validator swarm of 1 validator with consensus observer enabled
+async fn test_consensus_observer_fullnode_sync_disable_quorum_store() {
+    // Create a VFN config with consensus observer enabled
+    let mut vfn_config = NodeConfig::get_default_vfn_config();
+    enable_consensus_observer(true, &mut vfn_config);
+
+    // Create a swarm of 1 validator and VFN with quorum store disabled
     let mut swarm = SwarmBuilder::new_local(1)
+        .with_num_fullnodes(1)
         .with_aptos()
         .with_init_config(Arc::new(|_, config, _| {
             enable_consensus_observer(true, config);
         }))
+        .with_init_genesis_config(Arc::new(|genesis_config| {
+            genesis_config.consensus_config = OnChainConsensusConfig::V3 {
+                alg: ConsensusAlgorithmConfig::default_with_quorum_store_disabled(),
+                vtxn: ValidatorTxnConfig::default_for_genesis(),
+            };
+        }))
+        .with_vfn_config(vfn_config)
         .build()
         .await;
 
-    // Create a fullnode config that uses consensus observer
-    let mut vfn_config = NodeConfig::get_default_vfn_config();
-    enable_consensus_observer(true, &mut vfn_config);
+    // Execute a number of transactions on the validator
+    let validator_peer_id = swarm.validators().next().unwrap().peer_id();
+    let validator_client = swarm.validator(validator_peer_id).unwrap().rest_client();
+    let (mut account_0, account_1) = create_test_accounts(&mut swarm).await;
+    execute_transactions(
+        &mut swarm,
+        &validator_client,
+        &mut account_0,
+        &account_1,
+        false,
+    )
+    .await;
 
-    // Create the fullnode and test its ability to stay up-to-date
-    let vfn_peer_id = state_sync_utils::create_fullnode(vfn_config, &mut swarm).await;
-    state_sync_utils::test_fullnode_sync(vfn_peer_id, &mut swarm, true, false).await;
+    // Verify the VFN is up-to-date
+    wait_for_all_nodes(&mut swarm).await;
 }
 
 #[tokio::test]
-async fn test_consensus_observer_fullnode_restart_wipe() {
-    // Create a validator swarm of 1 validator with consensus observer enabled
-    let mut swarm = SwarmBuilder::new_local(1)
+async fn test_consensus_observer_fullnode_sync_disconnected() {
+    // Create a VFN config with consensus observer enabled
+    let mut vfn_config = NodeConfig::get_default_vfn_config();
+    enable_consensus_observer(true, &mut vfn_config);
+
+    // Create a swarm of 3 validators and VFNs with consensus observer enabled
+    let mut swarm = SwarmBuilder::new_local(3)
+        .with_num_fullnodes(3)
         .with_aptos()
         .with_init_config(Arc::new(|_, config, _| {
             enable_consensus_observer(true, config);
         }))
+        .with_vfn_config(vfn_config)
         .build()
         .await;
 
-    // Create a fullnode config that uses consensus observer
+    // Execute a number of transactions on the first validator
+    let validator_peer_id = swarm.validators().next().unwrap().peer_id();
+    let validator_client = swarm.validator(validator_peer_id).unwrap().rest_client();
+    let (mut account_0, account_1) = create_test_accounts(&mut swarm).await;
+    execute_transactions(
+        &mut swarm,
+        &validator_client,
+        &mut account_0,
+        &account_1,
+        false,
+    )
+    .await;
+
+    // Remove the VFN network from the first VFN (so that it relies on the public network)
+    let vfn_peer_id = swarm.fullnodes().next().unwrap().peer_id();
+    let vfn = swarm.fullnode_mut(vfn_peer_id).unwrap();
+    let mut vfn_config = vfn.config().clone();
+    let mut full_node_networks = vec![];
+    for network in vfn_config.full_node_networks.iter_mut() {
+        if network.network_id.is_public_network() {
+            full_node_networks.push(network.clone());
+        }
+    }
+    vfn_config.full_node_networks = full_node_networks;
+
+    // Update and restart the VFN
+    update_node_config_and_restart(vfn, vfn_config);
+
+    // Execute a number of transactions on the first validator (again)
+    execute_transactions(
+        &mut swarm,
+        &validator_client,
+        &mut account_0,
+        &account_1,
+        false,
+    )
+    .await;
+
+    // Verify the VFNs are up-to-date
+    wait_for_all_nodes(&mut swarm).await;
+}
+
+#[tokio::test]
+async fn test_consensus_observer_fullnode_sync_multiple_nodes() {
+    // Create a VFN config with consensus observer enabled
     let mut vfn_config = NodeConfig::get_default_vfn_config();
     enable_consensus_observer(true, &mut vfn_config);
 
-    // Create the fullnode and test its ability to stay up-to-date (after a data wipe)
-    let vfn_peer_id = state_sync_utils::create_fullnode(vfn_config, &mut swarm).await;
-    state_sync_utils::test_fullnode_sync(vfn_peer_id, &mut swarm, true, true).await;
+    // Create a swarm of 3 validators and VFNs with consensus observer enabled
+    let mut swarm = SwarmBuilder::new_local(3)
+        .with_num_fullnodes(3)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            enable_consensus_observer(true, config);
+        }))
+        .with_vfn_config(vfn_config)
+        .build()
+        .await;
+
+    // Execute a number of transactions on the first validator
+    let validator_peer_id = swarm.validators().next().unwrap().peer_id();
+    let validator_client = swarm.validator(validator_peer_id).unwrap().rest_client();
+    let (mut account_0, account_1) = create_test_accounts(&mut swarm).await;
+    execute_transactions(
+        &mut swarm,
+        &validator_client,
+        &mut account_0,
+        &account_1,
+        false,
+    )
+    .await;
+
+    // Verify the VFNs are all able to sync
+    wait_for_all_nodes(&mut swarm).await;
 }
 
 #[tokio::test]
@@ -113,21 +248,20 @@ async fn test_consensus_observer_validator_restart_wipe() {
 /// A simple helper function that tests the ability of a validator (and it's
 /// corresponding VFN) to catch up after a restart or data wipe.
 async fn test_validator_restart(clear_storage: bool) {
-    // Create a validator swarm of 4 validators with consensus observer enabled
+    // Create a VFN config with consensus observer enabled
+    let mut vfn_config = NodeConfig::get_default_vfn_config();
+    enable_consensus_observer(true, &mut vfn_config);
+
+    // Create a swarm of 4 validators and 1 VFN with consensus observer enabled
     let mut swarm = SwarmBuilder::new_local(4)
+        .with_num_fullnodes(1)
         .with_aptos()
         .with_init_config(Arc::new(|_, config, _| {
             enable_consensus_observer(true, config);
         }))
+        .with_vfn_config(vfn_config)
         .build()
         .await;
-
-    // Create a fullnode config that uses consensus observer
-    let mut vfn_config = NodeConfig::get_default_vfn_config();
-    enable_consensus_observer(true, &mut vfn_config);
-
-    // Create the fullnode (i.e., a VFN for the first validator)
-    let _ = state_sync_utils::create_fullnode(vfn_config, &mut swarm).await;
 
     // Execute transactions on the first validator
     let validator_peer_id = swarm.validators().next().unwrap().peer_id();
@@ -173,4 +307,17 @@ async fn test_validator_restart(clear_storage: bool) {
 
     // Verify that all nodes can catch up
     wait_for_all_nodes(&mut swarm).await;
+}
+
+/// Update the specified node's config and restart the node
+fn update_node_config_and_restart(node: &mut LocalNode, mut config: NodeConfig) {
+    // Stop the node
+    node.stop();
+
+    // Update the node's config
+    let node_path = node.config_path();
+    config.save_to_path(node_path).unwrap();
+
+    // Restart the node
+    node.start().unwrap();
 }

--- a/testsuite/smoke-test/src/state_sync_utils.rs
+++ b/testsuite/smoke-test/src/state_sync_utils.rs
@@ -51,6 +51,7 @@ pub fn enable_consensus_observer(use_consensus_observer: bool, node_config: &mut
             },
             aptos_config::config::RoleType::FullNode => {
                 node_config.consensus_observer.observer_enabled = true;
+                node_config.consensus_observer.publisher_enabled = true;
             },
         }
     }

--- a/testsuite/smoke-test/src/utils.rs
+++ b/testsuite/smoke-test/src/utils.rs
@@ -3,20 +3,75 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_cached_packages::aptos_stdlib;
+use aptos_config::{
+    config::{NodeConfig, Peer, PeerRole, HANDSHAKE_VERSION},
+    network_id::NetworkId,
+};
 use aptos_forge::{reconfig, LocalSwarm, NodeExt, Swarm, SwarmExt};
 use aptos_rest_client::{Client as RestClient, Client};
 use aptos_sdk::{
     transaction_builder::TransactionFactory,
     types::{transaction::SignedTransaction, LocalAccount},
 };
-use aptos_types::on_chain_config::{OnChainConfig, OnChainConsensusConfig, OnChainExecutionConfig};
+use aptos_types::{
+    network_address::{NetworkAddress, Protocol},
+    on_chain_config::{OnChainConfig, OnChainConsensusConfig, OnChainExecutionConfig},
+};
 use move_core_types::language_storage::CORE_CODE_ADDRESS;
 use rand::random;
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashSet, net::Ipv4Addr, sync::Arc, time::Duration};
 
 pub const MAX_CATCH_UP_WAIT_SECS: u64 = 180; // The max time we'll wait for nodes to catch up
 pub const MAX_CONNECTIVITY_WAIT_SECS: u64 = 180; // The max time we'll wait for nodes to gain connectivity
 pub const MAX_HEALTHY_WAIT_SECS: u64 = 120; // The max time we'll wait for nodes to become healthy
+
+pub fn add_node_to_seeds(
+    dest_config: &mut NodeConfig,
+    seed_config: &NodeConfig,
+    network_id: NetworkId,
+    peer_role: PeerRole,
+) {
+    let dest_network_config = dest_config
+        .full_node_networks
+        .iter_mut()
+        .find(|network| network.network_id == network_id)
+        .unwrap();
+    let seed_network_config = seed_config
+        .full_node_networks
+        .iter()
+        .find(|network| network.network_id == network_id)
+        .unwrap();
+
+    let seed_peer_id = seed_network_config.peer_id();
+    let seed_key = seed_network_config.identity_key().public_key();
+
+    let seed_peer = if peer_role != PeerRole::Downstream {
+        // For upstreams, we know the address, but so don't duplicate the keys in the config (lazy way)
+        // TODO: This is ridiculous, we need a better way to manipulate these `NetworkAddress`s
+        let address = seed_network_config.listen_address.clone();
+        let port_protocol = address
+            .as_slice()
+            .iter()
+            .find(|protocol| matches!(protocol, Protocol::Tcp(_)))
+            .unwrap();
+        let address = NetworkAddress::from_protocols(vec![
+            Protocol::Ip4(Ipv4Addr::new(127, 0, 0, 1)),
+            port_protocol.clone(),
+            Protocol::NoiseIK(seed_key),
+            Protocol::Handshake(HANDSHAKE_VERSION),
+        ])
+        .unwrap();
+
+        Peer::new(vec![address], HashSet::new(), peer_role)
+    } else {
+        // For downstreams, we don't know the address, but we know the keys
+        let mut seed_keys = HashSet::new();
+        seed_keys.insert(seed_key);
+        Peer::new(vec![], seed_keys, peer_role)
+    };
+
+    dest_network_config.seeds.insert(seed_peer_id, seed_peer);
+}
 
 pub async fn create_and_fund_account(swarm: &'_ mut dyn Swarm, amount: u64) -> LocalAccount {
     let mut info = swarm.aptos_public_info();

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -31,6 +31,14 @@ impl ConsensusAlgorithmConfig {
         }
     }
 
+    pub fn default_with_quorum_store_disabled() -> Self {
+        Self::JolteonV2 {
+            main: ConsensusConfigV1::default(),
+            quorum_store_enabled: false,
+            order_vote_enabled: true,
+        }
+    }
+
     pub fn default_if_missing() -> Self {
         Self::JolteonV2 {
             main: ConsensusConfigV1::default(),


### PR DESCRIPTION
## Description
This PR makes several small improvements to consensus observer (each in their own commit):
1. Make `publish_message()` non-blocking. This helps to ensure that consensus is never blocked by a failure to publish a message.
1. Add more simple smoke tests for consensus observer, including: (i) disabling quorum store; and (ii) disconnecting a validator and VFN.
1. Update consensus observer peer selection to ignore peers that don't support consensus observer. This is done by checking which network protocol IDs are supported at the connection level.
1. Add a simple PFN smoke test for consensus observer.
1. Improve the subscription optimality check logic to only execute if: (i) peers have changed since the last check; or (ii) enough time has elapsed to force a refresh.
1. Small renames and updates to comments in state sync.

## Testing Plan
New and existing test infrastructure.