### PR TITLE
enable defaulting to FA with concurrent balance on devnet

### DIFF
--- a/aptos-move/aptos-release-builder/data/manual/features.move
+++ b/aptos-move/aptos-release-builder/data/manual/features.move
@@ -1,0 +1,27 @@
+// Script hash: a9f09ee9
+// Modifying on-chain feature flags:
+// Enabled Features:
+//   NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE = 64,
+//   DEFAULT_TO_CONCURRENT_FUNGIBLE_BALANCE = 68,
+// Disabled Features:
+//   None
+script {
+    use aptos_framework::aptos_governance;
+    use std::features;
+
+    fun main(core_resources: &signer) {
+        let core_signer = aptos_governance::get_signer_testnet_only(core_resources, @0x1);
+
+        let framework_signer = &core_signer;
+
+        let enabled_blob: vector<u64> = vector[
+            64, 68,
+        ];
+
+        let disabled_blob: vector<u64> = vector[
+        ];
+
+        features::change_feature_flags_for_next_epoch(framework_signer, enabled_blob, disabled_blob);
+        aptos_governance::reconfigure(framework_signer);
+    }
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
