### PR TITLE
[compiler-v2][lint] Needless reference in field access

### DIFF
--- a/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints.rs
@@ -5,6 +5,7 @@
 
 mod blocks_in_conditions;
 mod needless_bool;
+mod needless_ref_in_field_access;
 mod simpler_numeric_expression;
 mod unnecessary_boolean_identity_comparison;
 mod unnecessary_numerical_extreme_comparison;
@@ -97,6 +98,7 @@ fn get_default_expression_linter_pipeline() -> Vec<Box<dyn ExpressionLinter>> {
     vec![
         Box::<blocks_in_conditions::BlocksInConditions>::default(),
         Box::<needless_bool::NeedlessBool>::default(),
+        Box::<needless_ref_in_field_access::NeedlessRefInFieldAccess>::default(),
         Box::<simpler_numeric_expression::SimplerNumericExpression>::default(),
         Box::<unnecessary_boolean_identity_comparison::UnnecessaryBooleanIdentityComparison>::default(),
         Box::<unnecessary_numerical_extreme_comparison::UnnecessaryNumericalExtremeComparison>::default(),

--- a/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints/needless_ref_in_field_access.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints/needless_ref_in_field_access.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements an expression linter that checks for needless references
+//! taken for field access.
+//! E.g., `(&s).f` can be simplified to `s.f`.
+//!       `(&mut s).f = 42;` can be simplified to `s.f = 42;`.
+//! making code easier to read in these cases.
+
+use crate::{env_pipeline::model_ast_lints::ExpressionLinter, lint_common::LintChecker};
+use move_model::{
+    ast::{ExpData, Operation},
+    model::GlobalEnv,
+};
+
+#[derive(Default)]
+pub struct NeedlessRefInFieldAccess;
+
+impl ExpressionLinter for NeedlessRefInFieldAccess {
+    fn get_lint_checker(&self) -> LintChecker {
+        LintChecker::NeedlessRefInFieldAccess
+    }
+
+    fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
+        use ExpData::Call;
+        if let Call(_, Operation::Select(.., field_id), args) = expr {
+            debug_assert!(
+                args.len() == 1,
+                "there should be exactly one argument for field access"
+            );
+            if let Call(id, Operation::Borrow(kind), ..) = args[0].as_ref() {
+                let field_name = field_id.symbol().display(env.symbol_pool()).to_string();
+                let ref_kind = kind.to_string();
+                self.warning(
+                    env,
+                    &env.get_node_loc(*id),
+                    &format!(
+                        "Needless {} taken for field access: \
+                        consider removing {} and directly accessing the field `{}`",
+                        ref_kind, ref_kind, field_name
+                    ),
+                );
+            }
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/src/lint_common.rs
+++ b/third_party/move/move-compiler-v2/src/lint_common.rs
@@ -20,6 +20,7 @@ pub enum LintChecker {
     AvoidCopyOnIdentityComparison,
     BlocksInConditions,
     NeedlessBool,
+    NeedlessRefInFieldAccess,
     SimplerNumericExpression,
     UnnecessaryBooleanIdentityComparison,
     UnnecessaryNumericalExtremeComparison,

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/needless_ref_in_field_access_warn.exp
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/needless_ref_in_field_access_warn.exp
@@ -1,0 +1,156 @@
+
+Diagnostics:
+warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `x`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:19:9
+   │
+19 │         (&s).x
+   │         ^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `y`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:27:11
+   │
+27 │         (&(&s).y).a + (&((&s).y)).a
+   │           ^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `a`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:27:9
+   │
+27 │         (&(&s).y).a + (&((&s).y)).a
+   │         ^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `y`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:27:26
+   │
+27 │         (&(&s).y).a + (&((&s).y)).a
+   │                          ^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `a`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:27:23
+   │
+27 │         (&(&s).y).a + (&((&s).y)).a
+   │                       ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `y`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:35:9
+   │
+35 │         (&s).y.a + (&s.y).a + (&(&s).y).a + (&(s.y)).a
+   │         ^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `a`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:35:20
+   │
+35 │         (&s).y.a + (&s.y).a + (&(&s).y).a + (&(s.y)).a
+   │                    ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `y`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:35:33
+   │
+35 │         (&s).y.a + (&s.y).a + (&(&s).y).a + (&(s.y)).a
+   │                                 ^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `a`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:35:31
+   │
+35 │         (&s).y.a + (&s.y).a + (&(&s).y).a + (&(s.y)).a
+   │                               ^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `a`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:35:45
+   │
+35 │         (&s).y.a + (&s.y).a + (&(&s).y).a + (&(s.y)).a
+   │                                             ^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&` taken for field access: consider removing `&` and directly accessing the field `y`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:43:9
+   │
+43 │         (&make_S()).y.a
+   │         ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&mut` taken for field access: consider removing `&mut` and directly accessing the field `y`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:51:9
+   │
+51 │         (&mut make_S()).y.a + (&mut (&mut s).y).a
+   │         ^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&mut` taken for field access: consider removing `&mut` and directly accessing the field `y`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:51:37
+   │
+51 │         (&mut make_S()).y.a + (&mut (&mut s).y).a
+   │                                     ^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&mut` taken for field access: consider removing `&mut` and directly accessing the field `a`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:51:31
+   │
+51 │         (&mut make_S()).y.a + (&mut (&mut s).y).a
+   │                               ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&mut` taken for field access: consider removing `&mut` and directly accessing the field `x`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:59:9
+   │
+59 │         (&mut s).x = 5;
+   │         ^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&mut` taken for field access: consider removing `&mut` and directly accessing the field `y`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:67:15
+   │
+67 │         (&mut (&mut s).y).a = 5;
+   │               ^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&mut` taken for field access: consider removing `&mut` and directly accessing the field `a`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:67:9
+   │
+67 │         (&mut (&mut s).y).a = 5;
+   │         ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&mut` taken for field access: consider removing `&mut` and directly accessing the field `a`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:68:9
+   │
+68 │         (&mut (s.y)).a = 6;
+   │         ^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+warning: [lint] Needless `&mut` taken for field access: consider removing `&mut` and directly accessing the field `a`
+   ┌─ tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move:77:9
+   │
+77 │         (&mut make_S().y).a = 5;
+   │         ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_in_field_access)]`.
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move
+++ b/third_party/move/move-compiler-v2/tests/lints/model_ast_lints/needless_ref_in_field_access_warn.move
@@ -1,0 +1,106 @@
+module 0xc0ffee::m {
+    struct S has key, drop {
+        x: u64,
+        y: U,
+    }
+
+    struct U has copy, store, drop {
+        a: u64
+    }
+
+    public fun make_S(): S {
+        S {
+            x: 5,
+            y: U { a: 6 }
+        }
+    }
+
+    public fun test1_warn(s: S): u64 {
+        (&s).x
+    }
+
+    public fun test1_no_warn(s: S): u64 {
+        s.x
+    }
+
+    public fun test2_warn(s: S): u64 {
+        (&(&s).y).a + (&((&s).y)).a
+    }
+
+    public fun test2_no_warn(s: S): u64 {
+        s.y.a + s.y.a
+    }
+
+    public fun test3_warn(s: S): u64 {
+        (&s).y.a + (&s.y).a + (&(&s).y).a + (&(s.y)).a
+    }
+
+    public fun test3_no_warn(s: S): u64 {
+        s.y.a + s.y.a
+    }
+
+    public fun test4_warn(): u64 {
+        (&make_S()).y.a
+    }
+
+    public fun test4_no_warn(): u64 {
+        make_S().y.a
+    }
+
+    public fun test5_warn(s: S): u64 {
+        (&mut make_S()).y.a + (&mut (&mut s).y).a
+    }
+
+    public fun test5_no_warn(s: S): u64 {
+        make_S().y.a + s.y.a
+    }
+
+    public fun test6_warn(s: S) {
+        (&mut s).x = 5;
+    }
+
+    public fun test6_no_warn(s: S) {
+        s.x = 5;
+    }
+
+    public fun test7_warn(s: S) {
+        (&mut (&mut s).y).a = 5;
+        (&mut (s.y)).a = 6;
+    }
+
+    public fun test7_no_warn(s: S) {
+        s.y.a = 5;
+        s.y.a = 6;
+    }
+
+    public fun test8_warn() {
+        (&mut make_S().y).a = 5;
+    }
+
+    public fun test8_no_warn() {
+        make_S().y.a = 5;
+    }
+}
+
+
+module 0xc0ffee::no_warn_1 {
+    struct S has key, drop {
+        x: u64,
+    }
+
+    #[lint::skip(needless_ref_in_field_access)]
+    public fun test1_warn(s: S): u64 {
+        (&s).x
+    }
+}
+
+#[lint::skip(needless_ref_in_field_access)]
+module 0xc0ffee::no_warn_2 {
+    struct S has key, drop {
+        x: u64,
+    }
+
+    public fun test1_warn(s: S): u64 {
+        (&s).x + (&mut s).x
+    }
+}


### PR DESCRIPTION
## Description

Adds a new lint check to catch needless reference during field access, e.g.,
* `(&s).f` can be simplified to `s.f`.
* `(&mut s).f = 42;` can be simplified to `s.f = 42;`.


## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## How Has This Been Tested?
* Added tests to showcase the lint rule working
* Existing tests all pass as is
* Ran on the aptos-framework, but did not find any violations of this lint.
