### PR TITLE
[Prover] Bitwise operation in aborts_if condition

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -164,20 +164,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all git history for accurate target determination
 
-      - name: Check if dev_setup.sh has changed
-        id: check_changes
-        run: |
-          git fetch origin ${{ github.event.pull_request.base.sha }}
-          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -q 'scripts/dev_setup.sh'; then
-            echo "scripts/dev_setup.sh has changed"
-            echo "dev_setup_changed=true" >> $GITHUB_ENV
-          else
-            echo "scripts/dev_setup.sh has not changed"
-            echo "dev_setup_changed=false" >> $GITHUB_ENV
-          fi
-
       - name: Run dev_setup.sh
-        if: env.dev_setup_changed == 'true'
         run: |
           scripts/dev_setup.sh -b -p -r -y -P -t
 

--- a/third_party/move/move-prover/tests/sources/functional/bv_aborts.exp
+++ b/third_party/move/move-prover/tests/sources/functional/bv_aborts.exp
@@ -1,0 +1,30 @@
+Move prover returns: exiting with model building errors
+error: unsupported language construct
+  ┌─ tests/sources/functional/bv_aborts.move:8:9
+  │
+8 │         assert!(x > 815);
+  │         ^^^^^^ single-parameter assert! macro not supported by this compiler
+
+error: too few arguments
+  ┌─ tests/sources/functional/bv_aborts.move:8:9
+  │
+8 │         assert!(x > 815);
+  │         ^^^^^^^^^^^^^^^^
+  │         │      │
+  │         │      Found 1 argument(s) here
+  │         Invalid call of 'assert'. The call expected 2 argument(s) but got 1
+
+error: unsupported language construct
+   ┌─ tests/sources/functional/bv_aborts.move:12:9
+   │
+12 │         assert!(x > 815);
+   │         ^^^^^^ single-parameter assert! macro not supported by this compiler
+
+error: too few arguments
+   ┌─ tests/sources/functional/bv_aborts.move:12:9
+   │
+12 │         assert!(x > 815);
+   │         ^^^^^^^^^^^^^^^^
+   │         │      │
+   │         │      Found 1 argument(s) here
+   │         Invalid call of 'assert'. The call expected 2 argument(s) but got 1

--- a/third_party/move/move-prover/tests/sources/functional/bv_aborts.move
+++ b/third_party/move/move-prover/tests/sources/functional/bv_aborts.move
@@ -1,0 +1,18 @@
+module 0x42::test {
+
+    spec module {
+        pragma verify = true;
+    }
+
+    fun assert_no_spec(x: u64) {
+        assert!(x > 815);
+    }
+
+    fun assert_with_spec(x: u64) {
+        assert!(x > 815);
+    }
+    spec assert_with_spec  {
+        // This will fail
+        aborts_if x > 815 with std::error::internal(0) | (0xCA26CBD9BE << 24);
+    }
+}

--- a/third_party/move/move-prover/tests/sources/functional/bv_aborts.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/bv_aborts.v2_exp
@@ -1,0 +1,29 @@
+Move prover returns: exiting with verification errors
+error: function does not abort under this condition
+   ┌─ tests/sources/functional/bv_aborts.move:16:9
+   │
+16 │         aborts_if x > 815 with std::error::internal(0) | (0xCA26CBD9BE << 24);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/bv_aborts.move:11: assert_with_spec
+   =         x = <redacted>
+   =     at tests/sources/functional/bv_aborts.move:12: assert_with_spec
+   =     at tests/sources/functional/bv_aborts.move:13: assert_with_spec
+   =     at tests/sources/functional/bv_aborts.move:16: assert_with_spec (spec)
+
+error: abort not covered by any of the `aborts_if` clauses
+   ┌─ tests/sources/functional/bv_aborts.move:14:5
+   │
+12 │           assert!(x > 815);
+   │           ------ abort happened here
+13 │       }
+14 │ ╭     spec assert_with_spec  {
+15 │ │         // This will fail
+16 │ │         aborts_if x > 815 with std::error::internal(0) | (0xCA26CBD9BE << 24);
+17 │ │     }
+   │ ╰─────^
+   │
+   =     at tests/sources/functional/bv_aborts.move:11: assert_with_spec
+   =         x = <redacted>
+   =     at tests/sources/functional/bv_aborts.move:12: assert_with_spec
+   =         ABORTED


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR closes #14459 by adding support of expression with bv operation in the abort_if condition.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Added a new test.


## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
