### PR TITLE
Add a public version of from_bcs::from_bytes

### DIFF
--- a/aptos-move/framework/aptos-stdlib/sources/from_bcs.move
+++ b/aptos-move/framework/aptos-stdlib/sources/from_bcs.move
@@ -59,6 +59,8 @@ module aptos_std::from_bcs {
         s
     }
 
+    public native fun from_bytes_public<T>(bytes: vector<u8>): T;
+
     /// Package private native function to deserialize a type T.
     ///
     /// Note that this function does not put any constraint on `T`. If code uses this function to


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

As long as calling it won't break the chain, we can make it public? I got a request from an ecosystem team want to use this. See this thread https://github.com/aptos-labs/aptos-developer-discussions/discussions/389#discussioncomment-10544217

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
