### PR TITLE
[Consensus Observer] Downgrade unnecessary error logs.

### DIFF
--- a/consensus/src/consensus_observer/observer/active_state.rs
+++ b/consensus/src/consensus_observer/observer/active_state.rs
@@ -243,7 +243,7 @@ async fn extract_on_chain_configs(
     let onchain_randomness_config_seq_num: anyhow::Result<RandomnessConfigSeqNum> =
         on_chain_configs.get();
     if let Err(error) = &onchain_randomness_config_seq_num {
-        error!(
+        warn!(
             LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                 "Failed to read on-chain randomness config seq num! Error: {:?}",
                 error

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -346,7 +346,7 @@ impl NetworkSender {
             if self.author == peer {
                 let self_msg = Event::Message(self.author, msg.clone());
                 if let Err(err) = self_sender.send(self_msg).await {
-                    error!(error = ?err, "Error delivering a self msg");
+                    warn!(error = ?err, "Error delivering a self msg");
                 }
                 continue;
             }


### PR DESCRIPTION
## Description
This PR downgrades several consensus observer (CO) error logs to warnings:
1. `Failed to read on-chain randomness config seq num!`: Looks like this is expected (e.g., [consensus will just use the default](https://github.com/aptos-labs/aptos-core/blob/793eeb7273c25543a15ebd94de4db37335f0d8b2/consensus/src/epoch_manager.rs#L1100) and not log anything if it can't read it) so we can do the same.
2. `Error delivering a self msg`: CO doesn't [register to receive self-sent messages](https://github.com/aptos-labs/aptos-core/blob/4fbb77ebb9ebd2025893c8a158cb0cd5699464c4/consensus/src/consensus_provider.rs#L143), so we should downgrade the failed send.
    - I'm not sure we want to alert on failed self sends anyway. Consensus should already be resilient to that (@zekun000 to confirm? 😄). If not, we'll need to special case CO.

## Testing Plan
Existing test infrastructure.
