### PR TITLE
[Consensus Observer] Support multiple observer subscriptions.

### DIFF
--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -30,6 +30,8 @@ pub struct ConsensusObserverConfig {
 
     /// Interval (in milliseconds) to garbage collect peer state
     pub garbage_collection_interval_ms: u64,
+    /// The maximum number of concurrent subscriptions
+    pub max_concurrent_subscriptions: u64,
     /// Maximum number of blocks to keep in memory (e.g., pending blocks, ordered blocks, etc.)
     pub max_num_pending_blocks: u64,
     /// Maximum timeout (in milliseconds) for active subscriptions
@@ -52,8 +54,9 @@ impl Default for ConsensusObserverConfig {
             publisher_enabled: false,
             max_network_channel_size: 1000,
             max_parallel_serialization_tasks: num_cpus::get(), // Default to the number of CPUs
-            network_request_timeout_ms: 10_000,                // 10 seconds
+            network_request_timeout_ms: 5_000,                 // 5 seconds
             garbage_collection_interval_ms: 60_000,            // 60 seconds
+            max_concurrent_subscriptions: 2,                   // 2 streams should be sufficient
             max_num_pending_blocks: 100,                       // 100 blocks
             max_subscription_timeout_ms: 30_000,               // 30 seconds
             max_synced_version_timeout_ms: 60_000,             // 60 seconds

--- a/consensus/src/consensus_observer/common/error.rs
+++ b/consensus/src/consensus_observer/common/error.rs
@@ -21,6 +21,9 @@ pub enum Error {
     #[error("Subscription progress stopped: {0}")]
     SubscriptionProgressStopped(String),
 
+    #[error("Subscriptions reset: {0}")]
+    SubscriptionsReset(String),
+
     #[error("Subscription suboptimal: {0}")]
     SubscriptionSuboptimal(String),
 
@@ -40,6 +43,7 @@ impl Error {
             Self::RpcError(_) => "rpc_error",
             Self::SubscriptionDisconnected(_) => "subscription_disconnected",
             Self::SubscriptionProgressStopped(_) => "subscription_progress_stopped",
+            Self::SubscriptionsReset(_) => "subscriptions_reset",
             Self::SubscriptionSuboptimal(_) => "subscription_suboptimal",
             Self::SubscriptionTimeout(_) => "subscription_timeout",
             Self::UnexpectedError(_) => "unexpected_error",

--- a/consensus/src/consensus_observer/common/metrics.rs
+++ b/consensus/src/consensus_observer/common/metrics.rs
@@ -16,7 +16,7 @@ pub const COMMIT_DECISION_LABEL: &str = "commit_decision";
 pub const COMMITTED_BLOCKS_LABEL: &str = "committed_blocks";
 pub const CREATED_SUBSCRIPTION_LABEL: &str = "created_subscription";
 pub const ORDERED_BLOCK_ENTRIES_LABEL: &str = "ordered_block_entries";
-pub const ORDERED_BLOCKS_LABEL: &str = "ordered_blocks";
+pub const ORDERED_BLOCK_LABEL: &str = "ordered_block";
 pub const PENDING_BLOCK_ENTRIES_LABEL: &str = "pending_block_entries";
 pub const PENDING_BLOCKS_LABEL: &str = "pending_blocks";
 pub const STORED_PAYLOADS_LABEL: &str = "stored_payloads";
@@ -191,8 +191,8 @@ pub static PUBLISHER_SENT_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Increments the given request counter with the provided values
-pub fn increment_request_counter(
+/// Increments the given counter with the provided values
+pub fn increment_counter(
     counter: &Lazy<IntCounterVec>,
     label: &str,
     peer_network_id: &PeerNetworkId,

--- a/consensus/src/consensus_observer/common/metrics.rs
+++ b/consensus/src/consensus_observer/common/metrics.rs
@@ -13,6 +13,7 @@ use once_cell::sync::Lazy;
 // Useful metric labels
 pub const BLOCK_PAYLOAD_LABEL: &str = "block_payload";
 pub const COMMIT_DECISION_LABEL: &str = "commit_decision";
+pub const COMMITTED_BLOCKS_LABEL: &str = "committed_blocks";
 pub const CREATED_SUBSCRIPTION_LABEL: &str = "created_subscription";
 pub const ORDERED_BLOCK_ENTRIES_LABEL: &str = "ordered_block_entries";
 pub const ORDERED_BLOCKS_LABEL: &str = "ordered_blocks";
@@ -26,6 +27,16 @@ pub static OBSERVER_CREATED_SUBSCRIPTIONS: Lazy<IntCounterVec> = Lazy::new(|| {
         "consensus_observer_created_subscriptions",
         "Counters for created subscriptions for consensus observer",
         &["creation_label", "network_id"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking dropped (direct send) messages by the consensus observer
+pub static OBSERVER_DROPPED_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "consensus_observer_dropped_messages",
+        "Counters related to dropped (direct send) messages by the consensus observer",
+        &["message_type", "network_id"]
     )
     .unwrap()
 });

--- a/consensus/src/consensus_observer/common/metrics.rs
+++ b/consensus/src/consensus_observer/common/metrics.rs
@@ -5,8 +5,8 @@
 
 use aptos_config::network_id::{NetworkId, PeerNetworkId};
 use aptos_metrics_core::{
-    register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, HistogramVec,
-    IntCounterVec, IntGaugeVec,
+    register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge_vec,
+    HistogramVec, IntCounter, IntCounterVec, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
 
@@ -31,11 +31,29 @@ pub static OBSERVER_CREATED_SUBSCRIPTIONS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Counter for tracking the number of times the block state was cleared by the consensus observer
+pub static OBSERVER_CLEARED_BLOCK_STATE: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "consensus_observer_cleared_block_state",
+        "Counter for tracking the number of times the block state was cleared by the consensus observer",
+    ).unwrap()
+});
+
 /// Counter for tracking dropped (direct send) messages by the consensus observer
 pub static OBSERVER_DROPPED_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "consensus_observer_dropped_messages",
         "Counters related to dropped (direct send) messages by the consensus observer",
+        &["message_type", "network_id"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking rejected (direct send) messages by the consensus observer
+pub static OBSERVER_REJECTED_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "consensus_observer_rejected_messages",
+        "Counters related to rejected (direct send) messages by the consensus observer",
         &["message_type", "network_id"]
     )
     .unwrap()
@@ -201,6 +219,11 @@ pub fn increment_counter(
     counter
         .with_label_values(&[label, network_id.as_str()])
         .inc();
+}
+
+/// Increments the given counter without labels
+pub fn increment_counter_without_labels(counter: &Lazy<IntCounter>) {
+    counter.inc();
 }
 
 /// Observes the value for the provided histogram and label

--- a/consensus/src/consensus_observer/network/observer_client.rs
+++ b/consensus/src/consensus_observer/network/observer_client.rs
@@ -46,7 +46,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusObserverMessage>>
         message_label: &str,
     ) -> Result<(), Error> {
         // Increment the message counter
-        metrics::increment_request_counter(
+        metrics::increment_counter(
             &metrics::PUBLISHER_SENT_MESSAGES,
             message_label,
             peer_network_id,
@@ -74,7 +74,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusObserverMessage>>
                 .message(&format!("Failed to send message: {:?}", error)));
 
             // Update the direct send error metrics
-            metrics::increment_request_counter(
+            metrics::increment_counter(
                 &metrics::PUBLISHER_SENT_MESSAGE_ERRORS,
                 error.get_label(),
                 peer_network_id,
@@ -125,7 +125,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusObserverMessage>>
                     .message(&format!("Failed to serialize message: {:?}", error)));
 
                 // Update the direct send error metrics
-                metrics::increment_request_counter(
+                metrics::increment_counter(
                     &metrics::PUBLISHER_SENT_MESSAGE_ERRORS,
                     error.get_label(),
                     peer_network_id,
@@ -147,7 +147,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusObserverMessage>>
         let request_id = rand::thread_rng().gen();
 
         // Increment the request counter
-        metrics::increment_request_counter(
+        metrics::increment_counter(
             &metrics::OBSERVER_SENT_REQUESTS,
             request.get_label(),
             peer_network_id,
@@ -174,7 +174,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusObserverMessage>>
         match result {
             Ok(consensus_observer_response) => {
                 // Update the RPC success metrics
-                metrics::increment_request_counter(
+                metrics::increment_counter(
                     &metrics::OBSERVER_RECEIVED_MESSAGE_RESPONSES,
                     request_label,
                     peer_network_id,
@@ -192,7 +192,7 @@ impl<NetworkClient: NetworkClientInterface<ConsensusObserverMessage>>
                     .error(&error));
 
                 // Update the RPC error metrics
-                metrics::increment_request_counter(
+                metrics::increment_counter(
                     &metrics::OBSERVER_SENT_MESSAGE_ERRORS,
                     error.get_label(),
                     peer_network_id,

--- a/consensus/src/consensus_observer/network/observer_message.rs
+++ b/consensus/src/consensus_observer/network/observer_message.rs
@@ -312,8 +312,8 @@ impl CommitDecision {
 /// The transaction payload and proof of each block
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PayloadWithProof {
-    pub transactions: Vec<SignedTransaction>,
-    pub proofs: Vec<ProofOfStore>,
+    transactions: Vec<SignedTransaction>,
+    proofs: Vec<ProofOfStore>,
 }
 
 impl PayloadWithProof {
@@ -337,8 +337,8 @@ impl PayloadWithProof {
 /// The transaction payload and proof of each block with a transaction limit
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PayloadWithProofAndLimit {
-    pub payload_with_proof: PayloadWithProof,
-    pub transaction_limit: Option<u64>,
+    payload_with_proof: PayloadWithProof,
+    transaction_limit: Option<u64>,
 }
 
 impl PayloadWithProofAndLimit {
@@ -629,8 +629,8 @@ impl BlockTransactionPayload {
 /// Payload message contains the block and transaction payload
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BlockPayload {
-    pub block: BlockInfo,
-    pub transaction_payload: BlockTransactionPayload,
+    block: BlockInfo,
+    transaction_payload: BlockTransactionPayload,
 }
 
 impl BlockPayload {
@@ -639,6 +639,26 @@ impl BlockPayload {
             block,
             transaction_payload,
         }
+    }
+
+    /// Returns a reference to the block info
+    pub fn block(&self) -> &BlockInfo {
+        &self.block
+    }
+
+    /// Returns the epoch of the block info
+    pub fn epoch(&self) -> u64 {
+        self.block.epoch()
+    }
+
+    /// Returns the round of the block info
+    pub fn round(&self) -> Round {
+        self.block.round()
+    }
+
+    /// Returns a reference to the block transaction payload
+    pub fn transaction_payload(&self) -> &BlockTransactionPayload {
+        &self.transaction_payload
     }
 
     /// Verifies the block payload digests and returns an error if the data is invalid

--- a/consensus/src/consensus_observer/observer/active_state.rs
+++ b/consensus/src/consensus_observer/observer/active_state.rs
@@ -101,8 +101,8 @@ impl ActiveObserverState {
     /// root ledger info and remove the blocks from the given stores.
     pub fn create_commit_callback(
         &self,
-        pending_ordered_blocks: OrderedBlockStore,
-        block_payload_store: BlockPayloadStore,
+        pending_ordered_blocks: Arc<Mutex<OrderedBlockStore>>,
+        block_payload_store: Arc<Mutex<BlockPayloadStore>>,
     ) -> StateComputerCommitCallBackType {
         // Clone the root pointer
         let root = self.root.clone();
@@ -282,15 +282,17 @@ async fn extract_on_chain_configs(
 /// A simple helper function that handles the committed blocks
 /// (as part of the commit callback).
 fn handle_committed_blocks(
-    pending_ordered_blocks: OrderedBlockStore,
-    block_payload_store: BlockPayloadStore,
+    pending_ordered_blocks: Arc<Mutex<OrderedBlockStore>>,
+    block_payload_store: Arc<Mutex<BlockPayloadStore>>,
     root: Arc<Mutex<LedgerInfoWithSignatures>>,
     blocks: &[Arc<PipelinedBlock>],
     ledger_info: LedgerInfoWithSignatures,
 ) {
     // Remove the committed blocks from the payload and pending stores
-    block_payload_store.remove_committed_blocks(blocks);
-    pending_ordered_blocks.remove_blocks_for_commit(&ledger_info);
+    block_payload_store.lock().remove_committed_blocks(blocks);
+    pending_ordered_blocks
+        .lock()
+        .remove_blocks_for_commit(&ledger_info);
 
     // Verify the ledger info is for the same epoch
     let mut root = root.lock();
@@ -407,8 +409,12 @@ mod test {
         let root = Arc::new(Mutex::new(create_ledger_info(epoch, round)));
 
         // Create the ordered block store and block payload store
-        let ordered_block_store = OrderedBlockStore::new(node_config.consensus_observer);
-        let mut block_payload_store = BlockPayloadStore::new(node_config.consensus_observer);
+        let ordered_block_store = Arc::new(Mutex::new(OrderedBlockStore::new(
+            node_config.consensus_observer,
+        )));
+        let block_payload_store = Arc::new(Mutex::new(BlockPayloadStore::new(
+            node_config.consensus_observer,
+        )));
 
         // Handle the committed blocks at the wrong epoch and verify the root is not updated
         handle_committed_blocks(
@@ -432,12 +438,16 @@ mod test {
 
         // Add pending ordered blocks
         let num_ordered_blocks = 10;
-        let ordered_blocks =
-            create_and_add_ordered_blocks(&ordered_block_store, num_ordered_blocks, epoch, round);
+        let ordered_blocks = create_and_add_ordered_blocks(
+            ordered_block_store.clone(),
+            num_ordered_blocks,
+            epoch,
+            round,
+        );
 
         // Add block payloads for the ordered blocks
         for ordered_block in &ordered_blocks {
-            create_and_add_payloads_for_ordered_block(&mut block_payload_store, ordered_block);
+            create_and_add_payloads_for_ordered_block(block_payload_store.clone(), ordered_block);
         }
 
         // Create the commit ledger info (for the second to last block)
@@ -461,8 +471,11 @@ mod test {
         );
 
         // Verify the committed blocks are removed from the stores
-        assert_eq!(ordered_block_store.get_all_ordered_blocks().len(), 1);
-        assert_eq!(block_payload_store.get_block_payloads().lock().len(), 1);
+        assert_eq!(ordered_block_store.lock().get_all_ordered_blocks().len(), 1);
+        assert_eq!(
+            block_payload_store.lock().get_block_payloads().lock().len(),
+            1
+        );
 
         // Verify the root is updated
         assert_eq!(root.lock().clone(), committed_ledger_info);
@@ -495,7 +508,7 @@ mod test {
 
     /// Creates and adds the specified number of ordered blocks to the ordered blocks
     fn create_and_add_ordered_blocks(
-        ordered_block_store: &OrderedBlockStore,
+        ordered_block_store: Arc<Mutex<OrderedBlockStore>>,
         num_ordered_blocks: usize,
         epoch: u64,
         starting_round: Round,
@@ -532,7 +545,9 @@ mod test {
             let ordered_block = OrderedBlock::new(blocks, ordered_proof);
 
             // Insert the block into the ordered block store
-            ordered_block_store.insert_ordered_block(ordered_block.clone());
+            ordered_block_store
+                .lock()
+                .insert_ordered_block(ordered_block.clone());
 
             // Add the block to the ordered blocks
             ordered_blocks.push(ordered_block);
@@ -543,13 +558,15 @@ mod test {
 
     /// Creates and adds payloads for the ordered block
     fn create_and_add_payloads_for_ordered_block(
-        block_payload_store: &mut BlockPayloadStore,
+        block_payload_store: Arc<Mutex<BlockPayloadStore>>,
         ordered_block: &OrderedBlock,
     ) {
         for block in ordered_block.blocks() {
             let block_payload =
                 BlockPayload::new(block.block_info(), BlockTransactionPayload::empty());
-            block_payload_store.insert_block_payload(block_payload, true);
+            block_payload_store
+                .lock()
+                .insert_block_payload(block_payload, true);
         }
     }
 

--- a/consensus/src/consensus_observer/observer/consensus_observer.rs
+++ b/consensus/src/consensus_observer/observer/consensus_observer.rs
@@ -322,8 +322,8 @@ impl ConsensusObserver {
         block_payload: BlockPayload,
     ) {
         // Get the epoch and round for the block
-        let block_epoch = block_payload.block.epoch();
-        let block_round = block_payload.block.round();
+        let block_epoch = block_payload.epoch();
+        let block_round = block_payload.round();
 
         // Determine if the payload is behind the last ordered block, or if it already exists
         let last_ordered_block = self.get_last_ordered_block();
@@ -349,7 +349,8 @@ impl ConsensusObserver {
             error!(
                 LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                     "Failed to verify block payload digests! Ignoring block: {:?}. Error: {:?}",
-                    block_payload.block, error
+                    block_payload.block(),
+                    error
                 ))
             );
             return;
@@ -363,7 +364,7 @@ impl ConsensusObserver {
                 error!(
                     LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                         "Failed to verify block payload signatures! Ignoring block: {:?}. Error: {:?}",
-                        block_payload.block, error
+                        block_payload.block(), error
                     ))
                 );
                 return;
@@ -543,7 +544,7 @@ impl ConsensusObserver {
         }
 
         // Increment the received message counter
-        metrics::increment_request_counter(
+        metrics::increment_counter(
             &metrics::OBSERVER_RECEIVED_MESSAGES,
             message.get_label(),
             &peer_network_id,
@@ -902,7 +903,8 @@ fn update_metrics_for_block_payload_message(
     // Log the received block payload message
     let log_message = format!(
         "Received block payload: {}, from peer: {}!",
-        block_payload.block, peer_network_id
+        block_payload.block(),
+        peer_network_id
     );
     log_received_message(log_message);
 
@@ -910,7 +912,7 @@ fn update_metrics_for_block_payload_message(
     metrics::set_gauge_with_label(
         &metrics::OBSERVER_RECEIVED_MESSAGE_ROUNDS,
         metrics::BLOCK_PAYLOAD_LABEL,
-        block_payload.block.round(),
+        block_payload.round(),
     );
 }
 
@@ -941,7 +943,7 @@ fn update_metrics_for_dropped_block_payload_message(
     block_payload: &BlockPayload,
 ) {
     // Increment the dropped message counter
-    metrics::increment_request_counter(
+    metrics::increment_counter(
         &metrics::OBSERVER_DROPPED_MESSAGES,
         metrics::BLOCK_PAYLOAD_LABEL,
         &peer_network_id,
@@ -952,8 +954,8 @@ fn update_metrics_for_dropped_block_payload_message(
         LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
             "Ignoring block payload message from peer: {:?}! Block epoch and round: ({}, {})",
             peer_network_id,
-            block_payload.block.epoch(),
-            block_payload.block.round()
+            block_payload.epoch(),
+            block_payload.round()
         ))
     );
 }
@@ -964,7 +966,7 @@ fn update_metrics_for_dropped_commit_decision_message(
     commit_decision: &CommitDecision,
 ) {
     // Increment the dropped message counter
-    metrics::increment_request_counter(
+    metrics::increment_counter(
         &metrics::OBSERVER_DROPPED_MESSAGES,
         metrics::COMMITTED_BLOCKS_LABEL,
         &peer_network_id,
@@ -987,9 +989,9 @@ fn update_metrics_for_dropped_ordered_block_message(
     ordered_block: &OrderedBlock,
 ) {
     // Increment the dropped message counter
-    metrics::increment_request_counter(
+    metrics::increment_counter(
         &metrics::OBSERVER_DROPPED_MESSAGES,
-        metrics::ORDERED_BLOCKS_LABEL,
+        metrics::ORDERED_BLOCK_LABEL,
         &peer_network_id,
     );
 
@@ -1020,7 +1022,7 @@ fn update_metrics_for_ordered_block_message(
     // Update the metrics for the received ordered block
     metrics::set_gauge_with_label(
         &metrics::OBSERVER_RECEIVED_MESSAGE_ROUNDS,
-        metrics::ORDERED_BLOCKS_LABEL,
+        metrics::ORDERED_BLOCK_LABEL,
         ordered_block.proof_block_info().round(),
     );
 }

--- a/consensus/src/consensus_observer/observer/ordered_blocks.rs
+++ b/consensus/src/consensus_observer/observer/ordered_blocks.rs
@@ -177,7 +177,7 @@ impl OrderedBlockStore {
             .sum();
         metrics::set_gauge_with_label(
             &metrics::OBSERVER_NUM_PROCESSED_BLOCKS,
-            metrics::ORDERED_BLOCKS_LABEL,
+            metrics::ORDERED_BLOCK_LABEL,
             num_ordered_blocks,
         );
 
@@ -189,7 +189,7 @@ impl OrderedBlockStore {
             .unwrap_or(0);
         metrics::set_gauge_with_label(
             &metrics::OBSERVER_PROCESSED_BLOCK_ROUNDS,
-            metrics::ORDERED_BLOCKS_LABEL,
+            metrics::ORDERED_BLOCK_LABEL,
             highest_ordered_round,
         );
 

--- a/consensus/src/consensus_observer/observer/ordered_blocks.rs
+++ b/consensus/src/consensus_observer/observer/ordered_blocks.rs
@@ -321,6 +321,20 @@ mod test {
 
         // Verify the highest committed epoch and round is the last ordered block (in the next epoch)
         verify_highest_committed_epoch_round(&ordered_block_store, &last_ordered_block_info);
+
+        // Create a commit decision for an out-of-date ordered block
+        let out_of_date_ordered_block = ordered_blocks.first().unwrap();
+        let out_of_date_ordered_block_info = out_of_date_ordered_block.last_block().block_info();
+        let commit_decision = CommitDecision::new(LedgerInfoWithSignatures::new(
+            LedgerInfo::new(out_of_date_ordered_block_info.clone(), HashValue::random()),
+            AggregateSignature::empty(),
+        ));
+
+        // Update the commit decision for the out-of-date ordered block
+        ordered_block_store.update_commit_decision(&commit_decision);
+
+        // Verify the highest committed epoch and round is still the last ordered block (in the next epoch)
+        verify_highest_committed_epoch_round(&ordered_block_store, &last_ordered_block_info);
     }
 
     #[test]

--- a/consensus/src/consensus_observer/observer/ordered_blocks.rs
+++ b/consensus/src/consensus_observer/observer/ordered_blocks.rs
@@ -10,46 +10,43 @@ use crate::consensus_observer::{
 };
 use aptos_config::config::ConsensusObserverConfig;
 use aptos_consensus_types::common::Round;
-use aptos_infallible::Mutex;
 use aptos_logger::{debug, warn};
 use aptos_types::{block_info::BlockInfo, ledger_info::LedgerInfoWithSignatures};
-use std::{collections::BTreeMap, sync::Arc};
+use std::collections::BTreeMap;
 
 /// A simple struct to store ordered blocks
-#[derive(Clone)]
 pub struct OrderedBlockStore {
     // The configuration of the consensus observer
     consensus_observer_config: ConsensusObserverConfig,
 
     // Ordered blocks. The key is the epoch and round of the last block in the
     // ordered block. Each entry contains the block and the commit decision (if any).
-    ordered_blocks: Arc<Mutex<BTreeMap<(u64, Round), (OrderedBlock, Option<CommitDecision>)>>>,
+    ordered_blocks: BTreeMap<(u64, Round), (OrderedBlock, Option<CommitDecision>)>,
 }
 
 impl OrderedBlockStore {
     pub fn new(consensus_observer_config: ConsensusObserverConfig) -> Self {
         Self {
             consensus_observer_config,
-            ordered_blocks: Arc::new(Mutex::new(BTreeMap::new())),
+            ordered_blocks: BTreeMap::new(),
         }
     }
 
     /// Clears all ordered blocks
-    pub fn clear_all_ordered_blocks(&self) {
-        self.ordered_blocks.lock().clear();
+    pub fn clear_all_ordered_blocks(&mut self) {
+        self.ordered_blocks.clear();
     }
 
     /// Returns a copy of the ordered blocks
     pub fn get_all_ordered_blocks(
         &self,
     ) -> BTreeMap<(u64, Round), (OrderedBlock, Option<CommitDecision>)> {
-        self.ordered_blocks.lock().clone()
+        self.ordered_blocks.clone()
     }
 
     /// Returns the last ordered block (if any)
     pub fn get_last_ordered_block(&self) -> Option<BlockInfo> {
         self.ordered_blocks
-            .lock()
             .last_key_value()
             .map(|(_, (ordered_block, _))| ordered_block.last_block().block_info())
     }
@@ -57,7 +54,6 @@ impl OrderedBlockStore {
     /// Returns the ordered block for the given epoch and round (if any)
     pub fn get_ordered_block(&self, epoch: u64, round: Round) -> Option<OrderedBlock> {
         self.ordered_blocks
-            .lock()
             .get(&(epoch, round))
             .map(|(ordered_block, _)| ordered_block.clone())
     }
@@ -65,10 +61,10 @@ impl OrderedBlockStore {
     /// Inserts the given ordered block into the ordered blocks. This function
     /// assumes the block has already been checked to extend the current ordered
     /// blocks, and that the ordered proof has been verified.
-    pub fn insert_ordered_block(&self, ordered_block: OrderedBlock) {
+    pub fn insert_ordered_block(&mut self, ordered_block: OrderedBlock) {
         // Verify that the number of ordered blocks doesn't exceed the maximum
         let max_num_ordered_blocks = self.consensus_observer_config.max_num_pending_blocks as usize;
-        if self.ordered_blocks.lock().len() >= max_num_ordered_blocks {
+        if self.ordered_blocks.len() >= max_num_ordered_blocks {
             warn!(
                 LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                     "Exceeded the maximum number of ordered blocks: {:?}. Dropping block: {:?}.",
@@ -94,32 +90,32 @@ impl OrderedBlockStore {
 
         // Insert the ordered block
         self.ordered_blocks
-            .lock()
             .insert((last_block_epoch, last_block_round), (ordered_block, None));
     }
 
     /// Removes the ordered blocks for the given commit ledger info. This will
     /// remove all blocks up to (and including) the epoch and round of the commit.
-    pub fn remove_blocks_for_commit(&self, commit_ledger_info: &LedgerInfoWithSignatures) {
+    pub fn remove_blocks_for_commit(&mut self, commit_ledger_info: &LedgerInfoWithSignatures) {
         // Determine the epoch and round to split off
         let split_off_epoch = commit_ledger_info.ledger_info().epoch();
         let split_off_round = commit_ledger_info.commit_info().round().saturating_add(1);
 
         // Remove the blocks from the ordered blocks
-        let mut ordered_blocks = self.ordered_blocks.lock();
-        *ordered_blocks = ordered_blocks.split_off(&(split_off_epoch, split_off_round));
+        self.ordered_blocks = self
+            .ordered_blocks
+            .split_off(&(split_off_epoch, split_off_round));
     }
 
     /// Updates the commit decision of the ordered block (if found)
-    pub fn update_commit_decision(&self, commit_decision: &CommitDecision) {
+    pub fn update_commit_decision(&mut self, commit_decision: &CommitDecision) {
         // Get the epoch and round of the commit decision
         let commit_decision_epoch = commit_decision.epoch();
         let commit_decision_round = commit_decision.round();
 
         // Update the commit decision for the ordered blocks
-        let mut ordered_blocks = self.ordered_blocks.lock();
-        if let Some((_, existing_commit_decision)) =
-            ordered_blocks.get_mut(&(commit_decision_epoch, commit_decision_round))
+        if let Some((_, existing_commit_decision)) = self
+            .ordered_blocks
+            .get_mut(&(commit_decision_epoch, commit_decision_round))
         {
             *existing_commit_decision = Some(commit_decision.clone());
         }
@@ -128,8 +124,7 @@ impl OrderedBlockStore {
     /// Updates the metrics for the ordered blocks
     pub fn update_ordered_blocks_metrics(&self) {
         // Update the number of ordered block entries
-        let ordered_blocks = self.ordered_blocks.lock();
-        let num_entries = ordered_blocks.len() as u64;
+        let num_entries = self.ordered_blocks.len() as u64;
         metrics::set_gauge_with_label(
             &metrics::OBSERVER_NUM_PROCESSED_BLOCKS,
             metrics::ORDERED_BLOCK_ENTRIES_LABEL,
@@ -137,7 +132,8 @@ impl OrderedBlockStore {
         );
 
         // Update the total number of ordered blocks
-        let num_ordered_blocks = ordered_blocks
+        let num_ordered_blocks = self
+            .ordered_blocks
             .values()
             .map(|(ordered_block, _)| ordered_block.blocks().len() as u64)
             .sum();
@@ -148,7 +144,8 @@ impl OrderedBlockStore {
         );
 
         // Update the highest round for the ordered blocks
-        let highest_ordered_round = ordered_blocks
+        let highest_ordered_round = self
+            .ordered_blocks
             .last_key_value()
             .map(|(_, (ordered_block, _))| ordered_block.last_block().round())
             .unwrap_or(0);
@@ -173,28 +170,29 @@ mod test {
     use aptos_types::{
         aggregate_signature::AggregateSignature, ledger_info::LedgerInfo, transaction::Version,
     };
+    use std::sync::Arc;
 
     #[test]
     fn test_clear_all_ordered_blocks() {
         // Create a new ordered block store
-        let ordered_block_store = OrderedBlockStore::new(ConsensusObserverConfig::default());
+        let mut ordered_block_store = OrderedBlockStore::new(ConsensusObserverConfig::default());
 
         // Insert several ordered blocks for the current epoch
         let current_epoch = 0;
         let num_ordered_blocks = 10;
-        create_and_add_ordered_blocks(&ordered_block_store, num_ordered_blocks, current_epoch);
+        create_and_add_ordered_blocks(&mut ordered_block_store, num_ordered_blocks, current_epoch);
 
         // Clear all ordered blocks
         ordered_block_store.clear_all_ordered_blocks();
 
         // Check that all the ordered blocks were removed
-        assert!(ordered_block_store.ordered_blocks.lock().is_empty());
+        assert!(ordered_block_store.ordered_blocks.is_empty());
     }
 
     #[test]
     fn test_get_last_ordered_block() {
         // Create a new ordered block store
-        let ordered_block_store = OrderedBlockStore::new(ConsensusObserverConfig::default());
+        let mut ordered_block_store = OrderedBlockStore::new(ConsensusObserverConfig::default());
 
         // Verify that we have no last ordered block
         assert!(ordered_block_store.get_last_ordered_block().is_none());
@@ -202,8 +200,11 @@ mod test {
         // Insert several ordered blocks for the current epoch
         let current_epoch = 0;
         let num_ordered_blocks = 50;
-        let ordered_blocks =
-            create_and_add_ordered_blocks(&ordered_block_store, num_ordered_blocks, current_epoch);
+        let ordered_blocks = create_and_add_ordered_blocks(
+            &mut ordered_block_store,
+            num_ordered_blocks,
+            current_epoch,
+        );
 
         // Verify the last ordered block is the block with the highest round
         let last_ordered_block = ordered_blocks.last().unwrap();
@@ -217,7 +218,7 @@ mod test {
         let next_epoch = current_epoch + 1;
         let num_ordered_blocks = 50;
         let ordered_blocks =
-            create_and_add_ordered_blocks(&ordered_block_store, num_ordered_blocks, next_epoch);
+            create_and_add_ordered_blocks(&mut ordered_block_store, num_ordered_blocks, next_epoch);
 
         // Verify the last ordered block is the block with the highest epoch and round
         let last_ordered_block = ordered_blocks.last().unwrap();
@@ -231,13 +232,16 @@ mod test {
     #[test]
     fn test_get_ordered_block() {
         // Create a new ordered block store
-        let ordered_block_store = OrderedBlockStore::new(ConsensusObserverConfig::default());
+        let mut ordered_block_store = OrderedBlockStore::new(ConsensusObserverConfig::default());
 
         // Insert several ordered blocks for the current epoch
         let current_epoch = 0;
         let num_ordered_blocks = 50;
-        let ordered_blocks =
-            create_and_add_ordered_blocks(&ordered_block_store, num_ordered_blocks, current_epoch);
+        let ordered_blocks = create_and_add_ordered_blocks(
+            &mut ordered_block_store,
+            num_ordered_blocks,
+            current_epoch,
+        );
 
         // Ensure the ordered blocks were all inserted
         let all_ordered_blocks = ordered_block_store.get_all_ordered_blocks();
@@ -272,12 +276,12 @@ mod test {
         };
 
         // Create a new ordered block store
-        let ordered_block_store = OrderedBlockStore::new(consensus_observer_config);
+        let mut ordered_block_store = OrderedBlockStore::new(consensus_observer_config);
 
         // Insert several ordered blocks for the current epoch
         let current_epoch = 0;
         let num_ordered_blocks = max_num_pending_blocks * 2; // Insert more than the maximum
-        create_and_add_ordered_blocks(&ordered_block_store, num_ordered_blocks, current_epoch);
+        create_and_add_ordered_blocks(&mut ordered_block_store, num_ordered_blocks, current_epoch);
 
         // Verify the ordered blocks were inserted up to the maximum
         let all_ordered_blocks = ordered_block_store.get_all_ordered_blocks();
@@ -287,7 +291,7 @@ mod test {
         let next_epoch = current_epoch + 1;
         let num_ordered_blocks = max_num_pending_blocks - 1; // Insert one less than the maximum
         let ordered_blocks =
-            create_and_add_ordered_blocks(&ordered_block_store, num_ordered_blocks, next_epoch);
+            create_and_add_ordered_blocks(&mut ordered_block_store, num_ordered_blocks, next_epoch);
 
         // Verify the ordered blocks were not inserted (they should have just been dropped)
         for ordered_block in &ordered_blocks {
@@ -305,19 +309,22 @@ mod test {
     #[test]
     fn test_remove_blocks_for_commit() {
         // Create a new ordered block store
-        let ordered_block_store = OrderedBlockStore::new(ConsensusObserverConfig::default());
+        let mut ordered_block_store = OrderedBlockStore::new(ConsensusObserverConfig::default());
 
         // Insert several ordered blocks for the current epoch
         let current_epoch = 10;
         let num_ordered_blocks = 10;
-        let ordered_blocks =
-            create_and_add_ordered_blocks(&ordered_block_store, num_ordered_blocks, current_epoch);
+        let ordered_blocks = create_and_add_ordered_blocks(
+            &mut ordered_block_store,
+            num_ordered_blocks,
+            current_epoch,
+        );
 
         // Insert several ordered blocks for the next epoch
         let next_epoch = current_epoch + 1;
         let num_ordered_blocks_next_epoch = 20;
         let ordered_blocks_next_epoch = create_and_add_ordered_blocks(
-            &ordered_block_store,
+            &mut ordered_block_store,
             num_ordered_blocks_next_epoch,
             next_epoch,
         );
@@ -326,7 +333,7 @@ mod test {
         let future_epoch = next_epoch + 1;
         let num_ordered_blocks_future_epoch = 30;
         create_and_add_ordered_blocks(
-            &ordered_block_store,
+            &mut ordered_block_store,
             num_ordered_blocks_future_epoch,
             future_epoch,
         );
@@ -399,19 +406,22 @@ mod test {
     #[test]
     fn test_update_commit_decision() {
         // Create a new ordered block store
-        let ordered_block_store = OrderedBlockStore::new(ConsensusObserverConfig::default());
+        let mut ordered_block_store = OrderedBlockStore::new(ConsensusObserverConfig::default());
 
         // Insert several ordered blocks for the current epoch
         let current_epoch = 0;
         let num_ordered_blocks = 10;
-        let ordered_blocks =
-            create_and_add_ordered_blocks(&ordered_block_store, num_ordered_blocks, current_epoch);
+        let ordered_blocks = create_and_add_ordered_blocks(
+            &mut ordered_block_store,
+            num_ordered_blocks,
+            current_epoch,
+        );
 
         // Insert several ordered blocks for the next epoch
         let next_epoch = current_epoch + 1;
         let num_ordered_blocks_next_epoch = 20;
         let ordered_blocks_next_epoch = create_and_add_ordered_blocks(
-            &ordered_block_store,
+            &mut ordered_block_store,
             num_ordered_blocks_next_epoch,
             next_epoch,
         );
@@ -499,7 +509,7 @@ mod test {
 
     /// Creates and adds the specified number of ordered blocks to the ordered blocks
     fn create_and_add_ordered_blocks(
-        ordered_block_store: &OrderedBlockStore,
+        ordered_block_store: &mut OrderedBlockStore,
         num_ordered_blocks: usize,
         epoch: u64,
     ) -> Vec<OrderedBlock> {

--- a/consensus/src/consensus_observer/observer/pending_blocks.rs
+++ b/consensus/src/consensus_observer/observer/pending_blocks.rs
@@ -19,41 +19,36 @@ use std::{
 };
 
 /// A simple struct to hold blocks that are waiting for payloads
-#[derive(Clone)]
 pub struct PendingBlockStore {
     // The configuration of the consensus observer
     consensus_observer_config: ConsensusObserverConfig,
 
-    // A map of ordered blocks that are without payloads. The key is the
-    // (epoch, round) of the first block in the ordered block.
-    blocks_without_payloads: Arc<Mutex<BTreeMap<(u64, Round), OrderedBlock>>>,
+    // A map of ordered blocks that are without payloads. The key is
+    // the (epoch, round) of the first block in the ordered block.
+    blocks_without_payloads: BTreeMap<(u64, Round), OrderedBlock>,
 }
 
 impl PendingBlockStore {
     pub fn new(consensus_observer_config: ConsensusObserverConfig) -> Self {
         Self {
             consensus_observer_config,
-            blocks_without_payloads: Arc::new(Mutex::new(BTreeMap::new())),
+            blocks_without_payloads: BTreeMap::new(),
         }
     }
 
     /// Clears all missing blocks from the store
-    pub fn clear_missing_blocks(&self) {
-        self.blocks_without_payloads.lock().clear();
+    pub fn clear_missing_blocks(&mut self) {
+        self.blocks_without_payloads.clear();
     }
 
     /// Inserts a block (without payloads) into the store
-    pub fn insert_pending_block(&self, ordered_block: OrderedBlock) {
+    pub fn insert_pending_block(&mut self, ordered_block: OrderedBlock) {
         // Get the epoch and round of the first block
         let first_block = ordered_block.first_block();
         let first_block_epoch_round = (first_block.epoch(), first_block.round());
 
         // Insert the block into the store using the round of the first block
-        match self
-            .blocks_without_payloads
-            .lock()
-            .entry(first_block_epoch_round)
-        {
+        match self.blocks_without_payloads.entry(first_block_epoch_round) {
             Entry::Occupied(_) => {
                 // The block is already in the store
                 warn!(
@@ -75,16 +70,15 @@ impl PendingBlockStore {
 
     /// Garbage collects the pending blocks store by removing
     /// the oldest blocks if the store is too large.
-    fn garbage_collect_pending_blocks(&self) {
+    fn garbage_collect_pending_blocks(&mut self) {
         // Calculate the number of blocks to remove
-        let mut blocks_without_payloads = self.blocks_without_payloads.lock();
-        let num_pending_blocks = blocks_without_payloads.len() as u64;
+        let num_pending_blocks = self.blocks_without_payloads.len() as u64;
         let max_pending_blocks = self.consensus_observer_config.max_num_pending_blocks;
         let num_blocks_to_remove = num_pending_blocks.saturating_sub(max_pending_blocks);
 
         // Remove the oldest blocks if the store is too large
         for _ in 0..num_blocks_to_remove {
-            if let Some((oldest_epoch_round, _)) = blocks_without_payloads.pop_first() {
+            if let Some((oldest_epoch_round, _)) = self.blocks_without_payloads.pop_first() {
                 warn!(
                     LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                         "The pending block store is too large: {:?} blocks. Removing the block for the oldest epoch and round: {:?}",
@@ -98,25 +92,28 @@ impl PendingBlockStore {
     /// Removes and returns the block from the store that is now ready
     /// to be processed (after the new payload has been received).
     pub fn remove_ready_block(
-        &self,
+        &mut self,
         received_payload_epoch: u64,
         received_payload_round: Round,
-        block_payload_store: &BlockPayloadStore,
+        block_payload_store: Arc<Mutex<BlockPayloadStore>>,
     ) -> Option<OrderedBlock> {
         // Calculate the round at which to split the blocks
         let split_round = received_payload_round.saturating_add(1);
 
         // Split the blocks at the epoch and round
-        let mut blocks_without_payloads = self.blocks_without_payloads.lock();
-        let mut blocks_at_higher_rounds =
-            blocks_without_payloads.split_off(&(received_payload_epoch, split_round));
+        let mut blocks_at_higher_rounds = self
+            .blocks_without_payloads
+            .split_off(&(received_payload_epoch, split_round));
 
         // Check if the last block is ready (this should be the only ready block).
         // Any earlier blocks are considered out-of-date and will be dropped.
         let mut ready_block = None;
-        if let Some((epoch_and_round, ordered_block)) = blocks_without_payloads.pop_last() {
+        if let Some((epoch_and_round, ordered_block)) = self.blocks_without_payloads.pop_last() {
             // If all payloads exist for the block, then the block is ready
-            if block_payload_store.all_payloads_exist(ordered_block.blocks()) {
+            if block_payload_store
+                .lock()
+                .all_payloads_exist(ordered_block.blocks())
+            {
                 ready_block = Some(ordered_block);
             } else {
                 // Otherwise, check if we're still waiting for higher payloads for the block
@@ -127,18 +124,18 @@ impl PendingBlockStore {
         }
 
         // Check if any out-of-date blocks were dropped
-        if !blocks_without_payloads.is_empty() {
+        if !self.blocks_without_payloads.is_empty() {
             info!(
                 LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                     "Dropped {:?} out-of-date pending blocks before epoch and round: {:?}",
-                    blocks_without_payloads.len(),
+                    self.blocks_without_payloads.len(),
                     (received_payload_epoch, received_payload_round)
                 ))
             );
         }
 
         // Update the pending blocks to only include the blocks at higher rounds
-        *blocks_without_payloads = blocks_at_higher_rounds;
+        self.blocks_without_payloads = blocks_at_higher_rounds;
 
         // Return the ready block (if one exists)
         ready_block
@@ -147,8 +144,7 @@ impl PendingBlockStore {
     /// Updates the metrics for the pending blocks
     pub fn update_pending_blocks_metrics(&self) {
         // Update the number of pending block entries
-        let blocks_without_payloads = self.blocks_without_payloads.lock();
-        let num_entries = blocks_without_payloads.len() as u64;
+        let num_entries = self.blocks_without_payloads.len() as u64;
         metrics::set_gauge_with_label(
             &metrics::OBSERVER_NUM_PROCESSED_BLOCKS,
             metrics::PENDING_BLOCK_ENTRIES_LABEL,
@@ -156,7 +152,8 @@ impl PendingBlockStore {
         );
 
         // Update the total number of pending blocks
-        let num_pending_blocks = blocks_without_payloads
+        let num_pending_blocks = self
+            .blocks_without_payloads
             .values()
             .map(|block| block.blocks().len() as u64)
             .sum();
@@ -167,7 +164,8 @@ impl PendingBlockStore {
         );
 
         // Update the highest round for the pending blocks
-        let highest_pending_round = blocks_without_payloads
+        let highest_pending_round = self
+            .blocks_without_payloads
             .last_key_value()
             .map(|(_, pending_block)| pending_block.last_block().round())
             .unwrap_or(0);
@@ -208,13 +206,15 @@ mod test {
             max_num_pending_blocks: max_num_pending_blocks as u64,
             ..ConsensusObserverConfig::default()
         };
-        let pending_block_store = PendingBlockStore::new(consensus_observer_config);
+        let pending_block_store = Arc::new(Mutex::new(PendingBlockStore::new(
+            consensus_observer_config,
+        )));
 
         // Insert the maximum number of blocks into the store
         let current_epoch = 0;
         let starting_round = 0;
         let missing_blocks = create_and_add_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks,
             current_epoch,
             starting_round,
@@ -223,17 +223,19 @@ mod test {
 
         // Verify that the store is not empty
         verify_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks,
             &missing_blocks,
         );
 
         // Clear the missing blocks from the store
-        pending_block_store.clear_missing_blocks();
+        pending_block_store.lock().clear_missing_blocks();
 
         // Verify that the store is now empty
-        let blocks_without_payloads = pending_block_store.blocks_without_payloads.lock();
-        assert!(blocks_without_payloads.is_empty());
+        assert!(pending_block_store
+            .lock()
+            .blocks_without_payloads
+            .is_empty());
     }
 
     #[test]
@@ -244,13 +246,15 @@ mod test {
             max_num_pending_blocks: max_num_pending_blocks as u64,
             ..ConsensusObserverConfig::default()
         };
-        let pending_block_store = PendingBlockStore::new(consensus_observer_config);
+        let pending_block_store = Arc::new(Mutex::new(PendingBlockStore::new(
+            consensus_observer_config,
+        )));
 
         // Insert the maximum number of blocks into the store
         let current_epoch = 0;
         let starting_round = 0;
         let pending_blocks = create_and_add_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks,
             current_epoch,
             starting_round,
@@ -259,7 +263,7 @@ mod test {
 
         // Verify that all blocks were inserted correctly
         verify_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks,
             &pending_blocks,
         );
@@ -267,7 +271,7 @@ mod test {
         // Insert the maximum number of blocks into the store again
         let starting_round = (max_num_pending_blocks * 100) as Round;
         let pending_blocks = create_and_add_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks,
             current_epoch,
             starting_round,
@@ -276,7 +280,7 @@ mod test {
 
         // Verify that all blocks were inserted correctly
         verify_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks,
             &pending_blocks,
         );
@@ -284,12 +288,17 @@ mod test {
         // Insert one more block into the store (for the next epoch)
         let next_epoch = 1;
         let starting_round = 0;
-        let new_pending_block =
-            create_and_add_pending_blocks(&pending_block_store, 1, next_epoch, starting_round, 5);
+        let new_pending_block = create_and_add_pending_blocks(
+            pending_block_store.clone(),
+            1,
+            next_epoch,
+            starting_round,
+            5,
+        );
 
         // Verify the new block was inserted correctly
         verify_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks,
             &new_pending_block,
         );
@@ -303,13 +312,15 @@ mod test {
             max_num_pending_blocks: max_num_pending_blocks as u64,
             ..ConsensusObserverConfig::default()
         };
-        let pending_block_store = PendingBlockStore::new(consensus_observer_config);
+        let pending_block_store = Arc::new(Mutex::new(PendingBlockStore::new(
+            consensus_observer_config,
+        )));
 
         // Insert the maximum number of blocks into the store
         let current_epoch = 0;
         let starting_round = 200;
         let mut pending_blocks = create_and_add_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks,
             current_epoch,
             starting_round,
@@ -318,7 +329,7 @@ mod test {
 
         // Verify that all blocks were inserted correctly
         verify_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks,
             &pending_blocks,
         );
@@ -329,7 +340,7 @@ mod test {
             // Insert one more block into the store
             let starting_round = ((max_num_pending_blocks * 10) + (i * 100)) as Round;
             let new_pending_block = create_and_add_pending_blocks(
-                &pending_block_store,
+                pending_block_store.clone(),
                 1,
                 current_epoch,
                 starting_round,
@@ -338,7 +349,7 @@ mod test {
 
             // Verify the new block was inserted correctly
             verify_pending_blocks(
-                &pending_block_store,
+                pending_block_store.clone(),
                 max_num_pending_blocks,
                 &new_pending_block,
             );
@@ -348,7 +359,8 @@ mod test {
             let oldest_block_round = oldest_block.first_block().round();
 
             // Verify that the oldest block was garbage collected
-            let blocks_without_payloads = pending_block_store.blocks_without_payloads.lock();
+            let blocks_without_payloads =
+                pending_block_store.lock().blocks_without_payloads.clone();
             assert!(!blocks_without_payloads.contains_key(&(current_epoch, oldest_block_round)));
         }
 
@@ -359,7 +371,7 @@ mod test {
             // Insert one more block into the store
             let starting_round = i;
             let new_pending_block = create_and_add_pending_blocks(
-                &pending_block_store,
+                pending_block_store.clone(),
                 1,
                 next_epoch,
                 starting_round,
@@ -368,7 +380,7 @@ mod test {
 
             // Verify the new block was inserted correctly
             verify_pending_blocks(
-                &pending_block_store,
+                pending_block_store.clone(),
                 max_num_pending_blocks,
                 &new_pending_block,
             );
@@ -378,7 +390,8 @@ mod test {
             let oldest_block_round = oldest_block.first_block().round();
 
             // Verify that the oldest block was garbage collected
-            let blocks_without_payloads = pending_block_store.blocks_without_payloads.lock();
+            let blocks_without_payloads =
+                pending_block_store.lock().blocks_without_payloads.clone();
             assert!(!blocks_without_payloads.contains_key(&(current_epoch, oldest_block_round)));
         }
     }
@@ -391,13 +404,15 @@ mod test {
             max_num_pending_blocks: max_num_pending_blocks as u64,
             ..ConsensusObserverConfig::default()
         };
-        let pending_block_store = PendingBlockStore::new(consensus_observer_config);
+        let pending_block_store = Arc::new(Mutex::new(PendingBlockStore::new(
+            consensus_observer_config,
+        )));
 
         // Insert the maximum number of blocks into the store
         let current_epoch = 0;
         let starting_round = 0;
         let pending_blocks = create_and_add_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks,
             current_epoch,
             starting_round,
@@ -405,43 +420,45 @@ mod test {
         );
 
         // Create a new block payload store and insert payloads for the second block
-        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+        let block_payload_store = Arc::new(Mutex::new(BlockPayloadStore::new(
+            consensus_observer_config,
+        )));
         let second_block = pending_blocks[1].clone();
-        insert_payloads_for_ordered_block(&mut block_payload_store, &second_block);
+        insert_payloads_for_ordered_block(block_payload_store.clone(), &second_block);
 
         // Remove the second block (which is now ready)
         let payload_round = second_block.first_block().round();
-        let ready_block = pending_block_store.remove_ready_block(
+        let ready_block = pending_block_store.lock().remove_ready_block(
             current_epoch,
             payload_round,
-            &block_payload_store,
+            block_payload_store.clone(),
         );
         assert_eq!(ready_block, Some(second_block));
 
         // Verify that the first and second blocks were removed
         verify_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks - 2,
             &pending_blocks[2..].to_vec(),
         );
 
         // Insert payloads for the last block
         let last_block = pending_blocks.last().unwrap().clone();
-        insert_payloads_for_ordered_block(&mut block_payload_store, &last_block);
+        insert_payloads_for_ordered_block(block_payload_store.clone(), &last_block);
 
         // Remove the last block (which is now ready)
         let payload_round = last_block.first_block().round();
-        let ready_block = pending_block_store.remove_ready_block(
+        let ready_block = pending_block_store.lock().remove_ready_block(
             current_epoch,
             payload_round,
-            &block_payload_store,
+            block_payload_store.clone(),
         );
 
         // Verify that the last block was removed
         assert_eq!(ready_block, Some(last_block));
 
         // Verify that the store is empty
-        verify_pending_blocks(&pending_block_store, 0, &vec![]);
+        verify_pending_blocks(pending_block_store.clone(), 0, &vec![]);
     }
 
     #[test]
@@ -452,13 +469,15 @@ mod test {
             max_num_pending_blocks: max_num_pending_blocks as u64,
             ..ConsensusObserverConfig::default()
         };
-        let pending_block_store = PendingBlockStore::new(consensus_observer_config);
+        let pending_block_store = Arc::new(Mutex::new(PendingBlockStore::new(
+            consensus_observer_config,
+        )));
 
         // Insert the maximum number of blocks into the store
         let current_epoch = 10;
         let starting_round = 100;
         let pending_blocks = create_and_add_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks,
             current_epoch,
             starting_round,
@@ -466,7 +485,9 @@ mod test {
         );
 
         // Create an empty block payload store
-        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+        let block_payload_store = Arc::new(Mutex::new(BlockPayloadStore::new(
+            consensus_observer_config,
+        )));
 
         // Incrementally insert and process each payload for the first block
         let first_block = pending_blocks.first().unwrap().clone();
@@ -474,14 +495,16 @@ mod test {
             // Insert the block
             let block_payload =
                 BlockPayload::new(block.block_info(), BlockTransactionPayload::empty());
-            block_payload_store.insert_block_payload(block_payload, true);
+            block_payload_store
+                .lock()
+                .insert_block_payload(block_payload, true);
 
             // Attempt to remove the block (which might not be ready)
             let payload_round = block.round();
-            let ready_block = pending_block_store.remove_ready_block(
+            let ready_block = pending_block_store.lock().remove_ready_block(
                 current_epoch,
                 payload_round,
-                &block_payload_store,
+                block_payload_store.clone(),
             );
 
             // If the block is ready, verify that it was removed.
@@ -492,7 +515,7 @@ mod test {
 
                 // Verify that the block was removed
                 verify_pending_blocks(
-                    &pending_block_store,
+                    pending_block_store.clone(),
                     max_num_pending_blocks - 1,
                     &pending_blocks[1..].to_vec(),
                 );
@@ -502,7 +525,7 @@ mod test {
 
                 // Verify that the block still remains
                 verify_pending_blocks(
-                    &pending_block_store,
+                    pending_block_store.clone(),
                     max_num_pending_blocks,
                     &pending_blocks,
                 );
@@ -517,14 +540,16 @@ mod test {
             if payload_round != last_block.first_block().round() {
                 let block_payload =
                     BlockPayload::new(block.block_info(), BlockTransactionPayload::empty());
-                block_payload_store.insert_block_payload(block_payload, true);
+                block_payload_store
+                    .lock()
+                    .insert_block_payload(block_payload, true);
             }
 
             // Attempt to remove the block (which might not be ready)
-            let ready_block = pending_block_store.remove_ready_block(
+            let ready_block = pending_block_store.lock().remove_ready_block(
                 current_epoch,
                 payload_round,
-                &block_payload_store,
+                block_payload_store.clone(),
             );
 
             // The block should not be ready
@@ -532,14 +557,14 @@ mod test {
 
             // Verify that the block still remains or has been removed on the last insert
             if payload_round == last_block.last_block().round() {
-                verify_pending_blocks(&pending_block_store, 0, &vec![]);
+                verify_pending_blocks(pending_block_store.clone(), 0, &vec![]);
             } else {
-                verify_pending_blocks(&pending_block_store, 1, &vec![last_block.clone()]);
+                verify_pending_blocks(pending_block_store.clone(), 1, &vec![last_block.clone()]);
             }
         }
 
         // Verify that the store is now empty
-        verify_pending_blocks(&pending_block_store, 0, &vec![]);
+        verify_pending_blocks(pending_block_store.clone(), 0, &vec![]);
     }
 
     #[test]
@@ -550,13 +575,15 @@ mod test {
             max_num_pending_blocks: max_num_pending_blocks as u64,
             ..ConsensusObserverConfig::default()
         };
-        let pending_block_store = PendingBlockStore::new(consensus_observer_config);
+        let pending_block_store = Arc::new(Mutex::new(PendingBlockStore::new(
+            consensus_observer_config,
+        )));
 
         // Insert the maximum number of blocks into the store
         let current_epoch = 0;
         let starting_round = 0;
         let pending_blocks = create_and_add_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks,
             current_epoch,
             starting_round,
@@ -564,63 +591,65 @@ mod test {
         );
 
         // Create a new block payload store and insert payloads for the first block
-        let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+        let block_payload_store = Arc::new(Mutex::new(BlockPayloadStore::new(
+            consensus_observer_config,
+        )));
         let first_block = pending_blocks.first().unwrap().clone();
-        insert_payloads_for_ordered_block(&mut block_payload_store, &first_block);
+        insert_payloads_for_ordered_block(block_payload_store.clone(), &first_block);
 
         // Remove the first block (which is now ready)
         let payload_round = first_block.first_block().round();
-        let ready_block = pending_block_store.remove_ready_block(
+        let ready_block = pending_block_store.lock().remove_ready_block(
             current_epoch,
             payload_round,
-            &block_payload_store,
+            block_payload_store.clone(),
         );
         assert_eq!(ready_block, Some(first_block));
 
         // Verify that the first block was removed
         verify_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks - 1,
             &pending_blocks[1..].to_vec(),
         );
 
         // Insert payloads for the second block
         let second_block = pending_blocks[1].clone();
-        insert_payloads_for_ordered_block(&mut block_payload_store, &second_block);
+        insert_payloads_for_ordered_block(block_payload_store.clone(), &second_block);
 
         // Remove the second block (which is now ready)
         let payload_round = second_block.first_block().round();
-        let ready_block = pending_block_store.remove_ready_block(
+        let ready_block = pending_block_store.lock().remove_ready_block(
             current_epoch,
             payload_round,
-            &block_payload_store,
+            block_payload_store.clone(),
         );
         assert_eq!(ready_block, Some(second_block));
 
         // Verify that the first and second blocks were removed
         verify_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks - 2,
             &pending_blocks[2..].to_vec(),
         );
 
         // Insert payloads for the last block
         let last_block = pending_blocks.last().unwrap().clone();
-        insert_payloads_for_ordered_block(&mut block_payload_store, &last_block);
+        insert_payloads_for_ordered_block(block_payload_store.clone(), &last_block);
 
         // Remove the last block (which is now ready)
         let payload_round = last_block.first_block().round();
-        let ready_block = pending_block_store.remove_ready_block(
+        let ready_block = pending_block_store.lock().remove_ready_block(
             current_epoch,
             payload_round,
-            &block_payload_store,
+            block_payload_store.clone(),
         );
 
         // Verify that the last block was removed
         assert_eq!(ready_block, Some(last_block));
 
         // Verify that the store is empty
-        verify_pending_blocks(&pending_block_store, 0, &vec![]);
+        verify_pending_blocks(pending_block_store.clone(), 0, &vec![]);
     }
 
     #[test]
@@ -631,13 +660,15 @@ mod test {
             max_num_pending_blocks: max_num_pending_blocks as u64,
             ..ConsensusObserverConfig::default()
         };
-        let pending_block_store = PendingBlockStore::new(consensus_observer_config);
+        let pending_block_store = Arc::new(Mutex::new(PendingBlockStore::new(
+            consensus_observer_config,
+        )));
 
         // Insert the maximum number of blocks into the store
         let current_epoch = 10;
         let starting_round = 100;
         let pending_blocks = create_and_add_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks,
             current_epoch,
             starting_round,
@@ -645,21 +676,23 @@ mod test {
         );
 
         // Create an empty block payload store
-        let block_payload_store = BlockPayloadStore::new(consensus_observer_config);
+        let block_payload_store = Arc::new(Mutex::new(BlockPayloadStore::new(
+            consensus_observer_config,
+        )));
 
         // Remove the third block (which is not ready)
         let third_block = pending_blocks[2].clone();
         let third_block_round = third_block.first_block().round();
-        let ready_block = pending_block_store.remove_ready_block(
+        let ready_block = pending_block_store.lock().remove_ready_block(
             current_epoch,
             third_block_round,
-            &block_payload_store,
+            block_payload_store.clone(),
         );
         assert!(ready_block.is_none());
 
         // Verify that the first three blocks were removed
         verify_pending_blocks(
-            &pending_block_store,
+            pending_block_store.clone(),
             max_num_pending_blocks - 3,
             &pending_blocks[3..].to_vec(),
         );
@@ -667,20 +700,20 @@ mod test {
         // Remove the last block (which is not ready)
         let last_block = pending_blocks.last().unwrap().clone();
         let last_block_round = last_block.first_block().round();
-        let ready_block = pending_block_store.remove_ready_block(
+        let ready_block = pending_block_store.lock().remove_ready_block(
             current_epoch,
             last_block_round,
-            &block_payload_store,
+            block_payload_store.clone(),
         );
         assert!(ready_block.is_none());
 
         // Verify that the store is now empty
-        verify_pending_blocks(&pending_block_store, 0, &vec![]);
+        verify_pending_blocks(pending_block_store.clone(), 0, &vec![]);
     }
 
     /// Creates and adds the specified number of blocks to the pending block store
     fn create_and_add_pending_blocks(
-        pending_block_store: &PendingBlockStore,
+        pending_block_store: Arc<Mutex<PendingBlockStore>>,
         num_pending_blocks: usize,
         epoch: u64,
         starting_round: Round,
@@ -732,7 +765,9 @@ mod test {
             let ordered_block = OrderedBlock::new(pipelined_blocks, ordered_proof.clone());
 
             // Insert the ordered block into the pending block store
-            pending_block_store.insert_pending_block(ordered_block.clone());
+            pending_block_store
+                .lock()
+                .insert_pending_block(ordered_block.clone());
 
             // Add the ordered block to the pending blocks
             pending_blocks.push(ordered_block);
@@ -743,31 +778,37 @@ mod test {
 
     /// Inserts payloads into the payload store for the ordered block
     fn insert_payloads_for_ordered_block(
-        block_payload_store: &mut BlockPayloadStore,
+        block_payload_store: Arc<Mutex<BlockPayloadStore>>,
         ordered_block: &OrderedBlock,
     ) {
         for block in ordered_block.blocks() {
             let block_payload =
                 BlockPayload::new(block.block_info(), BlockTransactionPayload::empty());
-            block_payload_store.insert_block_payload(block_payload, true);
+            block_payload_store
+                .lock()
+                .insert_block_payload(block_payload, true);
         }
     }
 
     /// Verifies that the pending block store contains the expected blocks
     fn verify_pending_blocks(
-        pending_block_store: &PendingBlockStore,
+        pending_block_store: Arc<Mutex<PendingBlockStore>>,
         num_expected_blocks: usize,
         pending_blocks: &Vec<OrderedBlock>,
     ) {
         // Check the number of pending blocks
-        let blocks_without_payloads = pending_block_store.blocks_without_payloads.lock();
-        assert_eq!(blocks_without_payloads.len(), num_expected_blocks);
+        assert_eq!(
+            pending_block_store.lock().blocks_without_payloads.len(),
+            num_expected_blocks
+        );
 
         // Check that all pending blocks are in the store
         for pending_block in pending_blocks {
             let first_block = pending_block.first_block();
             assert_eq!(
-                blocks_without_payloads
+                pending_block_store
+                    .lock()
+                    .blocks_without_payloads
                     .get(&(first_block.epoch(), first_block.round()))
                     .unwrap(),
                 pending_block

--- a/consensus/src/consensus_observer/observer/subscription_manager.rs
+++ b/consensus/src/consensus_observer/observer/subscription_manager.rs
@@ -360,7 +360,7 @@ impl SubscriptionManager {
         );
 
         // Update the number of created subscriptions
-        metrics::increment_request_counter(
+        metrics::increment_counter(
             &metrics::OBSERVER_CREATED_SUBSCRIPTIONS,
             metrics::CREATED_SUBSCRIPTION_LABEL,
             &peer_network_id,
@@ -381,7 +381,7 @@ impl SubscriptionManager {
         );
 
         // Update the number of terminated subscriptions
-        metrics::increment_request_counter(
+        metrics::increment_counter(
             &metrics::OBSERVER_TERMINATED_SUBSCRIPTIONS,
             error.get_label(),
             &peer_network_id,

--- a/consensus/src/consensus_observer/publisher/consensus_publisher.rs
+++ b/consensus/src/consensus_observer/publisher/consensus_publisher.rs
@@ -150,7 +150,7 @@ impl ConsensusPublisher {
         let (peer_network_id, message, response_sender) = network_message.into_parts();
 
         // Update the RPC request counter
-        metrics::increment_request_counter(
+        metrics::increment_counter(
             &metrics::PUBLISHER_RECEIVED_REQUESTS,
             message.get_label(),
             &peer_network_id,

--- a/consensus/src/payload_manager.rs
+++ b/consensus/src/payload_manager.rs
@@ -471,7 +471,7 @@ async fn get_transactions_for_observer(
     };
 
     // If the payload is valid, publish it to any downstream observers
-    let transaction_payload = block_payload.transaction_payload;
+    let transaction_payload = block_payload.transaction_payload();
     if let Some(consensus_publisher) = consensus_publisher {
         let message = ConsensusObserverMessage::new_block_payload_message(
             block.gen_block_info(HashValue::zero(), 0, None),


### PR DESCRIPTION
Note: most of this PR is adding/updating unit tests.

## Description
This PR adds support to consensus observer (CO) for subscribing to multiple subscription streams (instead of just a single stream). To achieve this, the PR offers the following commits:

1. Wrap the block and payload stores in locks (e.g., Mutex's), so they can be thread safe.
1. Update CO to handle duplicate commit messages.
1. Update CO to handle duplicate block payload messages.
1. Update CO to handle duplicate ordered block messages.
1. Small renames and refactors.
1. Update CO to create and maintain multiple subscription streams.
    - Note: most of the code is in this commit, and a majority of the changes are simply adding/updating unit tests.

The next step is to parallelize subscription creation (so that it doesn't block the CO thread). But, I'll do this in the next PR.

## Testing Plan
Existing test infrastructure and manual verification.

Note: for manual verification I hacked the code so that it randomly drops messages and verified that maintaining multiple streams improves reliability 😄 