### PR TITLE
[BlockSTM] Lazy (potentially iterable) txns input to BlockSTM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,6 +813,7 @@ name = "aptos-comparison-testing"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-block-executor",
  "aptos-framework",
  "aptos-language-e2e-tests",
  "aptos-rest-client",
@@ -1262,6 +1263,7 @@ dependencies = [
  "anyhow",
  "aptos-backup-cli",
  "aptos-backup-service",
+ "aptos-block-executor",
  "aptos-config",
  "aptos-db",
  "aptos-executor",
@@ -1452,6 +1454,7 @@ name = "aptos-executor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-block-executor",
  "aptos-cached-packages",
  "aptos-config",
  "aptos-consensus-types",
@@ -1542,6 +1545,7 @@ dependencies = [
 name = "aptos-executor-service"
 version = "0.1.0"
 dependencies = [
+ "aptos-block-executor",
  "aptos-block-partitioner",
  "aptos-config",
  "aptos-infallible",
@@ -1649,6 +1653,7 @@ dependencies = [
 name = "aptos-experimental-ptx-executor"
 version = "0.1.0"
 dependencies = [
+ "aptos-block-executor",
  "aptos-experimental-runtimes",
  "aptos-infallible",
  "aptos-logger",
@@ -4289,6 +4294,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-api-types",
+ "aptos-block-executor",
  "aptos-cached-packages",
  "aptos-crypto",
  "aptos-framework",
@@ -4586,6 +4592,7 @@ name = "aptos-vm-profiling"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-block-executor",
  "aptos-cached-packages",
  "aptos-gas-schedule",
  "aptos-language-e2e-tests",

--- a/aptos-move/aptos-debugger/src/aptos_debugger.rs
+++ b/aptos-move/aptos-debugger/src/aptos_debugger.rs
@@ -361,7 +361,7 @@ impl AptosDebugger {
     }
 }
 
-fn print_transaction_stats(sig_verified_txns: &[Arc<SignatureVerifiedTransaction>], version: u64) {
+fn print_transaction_stats(sig_verified_txns: &[SignatureVerifiedTransaction], version: u64) {
     let transaction_types = sig_verified_txns
         .iter()
         .map(|txn| txn.expect_valid().type_name().to_string())

--- a/aptos-move/aptos-debugger/src/aptos_debugger.rs
+++ b/aptos-move/aptos-debugger/src/aptos_debugger.rs
@@ -3,7 +3,9 @@
 
 use anyhow::{bail, format_err, Result};
 use aptos_block_executor::{
-    code_cache_global_manager::AptosModuleCacheManager, txn_commit_hook::NoOpTransactionCommitHook,
+    code_cache_global_manager::AptosModuleCacheManager,
+    txn_commit_hook::NoOpTransactionCommitHook,
+    txn_provider::{default::DefaultTxnProvider, TxnProvider},
 };
 use aptos_gas_profiling::{GasProfiler, TransactionGasLog};
 use aptos_rest_client::Client;
@@ -64,9 +66,10 @@ impl AptosDebugger {
     ) -> Result<Vec<TransactionOutput>> {
         let sig_verified_txns: Vec<SignatureVerifiedTransaction> =
             txns.into_iter().map(|x| x.into()).collect::<Vec<_>>();
+        let txn_provider = DefaultTxnProvider::new(sig_verified_txns);
         let state_view = DebuggerStateView::new(self.debugger.clone(), version);
 
-        print_transaction_stats(&sig_verified_txns, version);
+        print_transaction_stats(txn_provider.get_txns(), version);
 
         let mut result = None;
 
@@ -74,12 +77,12 @@ impl AptosDebugger {
             for i in 0..repeat_execution_times {
                 let start_time = Instant::now();
                 let cur_result =
-                    execute_block_no_limit(&sig_verified_txns, &state_view, *concurrency_level)
+                    execute_block_no_limit(&txn_provider, &state_view, *concurrency_level)
                         .map_err(|err| format_err!("Unexpected VM Error: {:?}", err))?;
 
                 println!(
                     "[{} txns from {}] Finished execution round {}/{} with concurrency_level={} in {}ms",
-                    sig_verified_txns.len(),
+                    txn_provider.num_txns(),
                     version,
                     i + 1,
                     repeat_execution_times,
@@ -103,7 +106,7 @@ impl AptosDebugger {
         }
 
         let result = result.unwrap();
-        assert_eq!(sig_verified_txns.len(), result.len());
+        assert_eq!(txn_provider.num_txns(), result.len());
         Ok(result)
     }
 
@@ -358,7 +361,7 @@ impl AptosDebugger {
     }
 }
 
-fn print_transaction_stats(sig_verified_txns: &[SignatureVerifiedTransaction], version: u64) {
+fn print_transaction_stats(sig_verified_txns: &[Arc<SignatureVerifiedTransaction>], version: u64) {
     let transaction_types = sig_verified_txns
         .iter()
         .map(|txn| txn.expect_valid().type_name().to_string())
@@ -427,12 +430,16 @@ fn is_reconfiguration(vm_output: &TransactionOutput) -> bool {
 }
 
 fn execute_block_no_limit(
-    sig_verified_txns: &[SignatureVerifiedTransaction],
+    txn_provider: &DefaultTxnProvider<SignatureVerifiedTransaction>,
     state_view: &DebuggerStateView,
     concurrency_level: usize,
 ) -> Result<Vec<TransactionOutput>, VMStatus> {
-    BlockAptosVM::execute_block::<_, NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>>(
-        sig_verified_txns,
+    BlockAptosVM::execute_block::<
+        _,
+        NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
+        DefaultTxnProvider<SignatureVerifiedTransaction>,
+    >(
+        txn_provider,
         state_view,
         &AptosModuleCacheManager::new(),
         BlockExecutorConfig {

--- a/aptos-move/aptos-e2e-comparison-testing/Cargo.toml
+++ b/aptos-move/aptos-e2e-comparison-testing/Cargo.toml
@@ -12,6 +12,7 @@ default-run = "aptos-comparison-testing"
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-block-executor = { workspace = true }
 aptos-framework = { workspace = true }
 aptos-language-e2e-tests = { workspace = true }
 aptos-rest-client = { workspace = true }

--- a/aptos-move/aptos-e2e-comparison-testing/src/data_collection.rs
+++ b/aptos-move/aptos-e2e-comparison-testing/src/data_collection.rs
@@ -6,6 +6,7 @@ use crate::{
     CompilationCache, DataManager, IndexWriter, PackageInfo, TxnIndex,
 };
 use anyhow::{format_err, Result};
+use aptos_block_executor::txn_provider::default::DefaultTxnProvider;
 use aptos_framework::natives::code::PackageMetadata;
 use aptos_rest_client::Client;
 use aptos_types::{
@@ -92,8 +93,9 @@ impl DataCollection {
         // FIXME(#10412): remove the assert
         let val = debugger_state_view.get_state_value(TOTAL_SUPPLY_STATE_KEY.deref());
         assert!(val.is_ok() && val.unwrap().is_some());
+        let txn_provider = DefaultTxnProvider::new(sig_verified_txns);
         AptosVMBlockExecutor::new()
-            .execute_block_no_limit(&sig_verified_txns, debugger_state_view)
+            .execute_block_no_limit(&txn_provider, debugger_state_view)
             .map_err(|err| format_err!("Unexpected VM Error: {:?}", err))
     }
 

--- a/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/transaction_bench_state.rs
@@ -4,7 +4,9 @@
 use crate::transactions;
 use aptos_bitvec::BitVec;
 use aptos_block_executor::{
-    code_cache_global_manager::AptosModuleCacheManager, txn_commit_hook::NoOpTransactionCommitHook,
+    code_cache_global_manager::AptosModuleCacheManager,
+    txn_commit_hook::NoOpTransactionCommitHook,
+    txn_provider::{default::DefaultTxnProvider, TxnProvider},
 };
 use aptos_block_partitioner::{
     v2::config::PartitionerV2Config, BlockPartitioner, PartitionerConfig,
@@ -192,16 +194,16 @@ where
     pub(crate) fn execute_sequential(mut self) {
         // The output is ignored here since we're just testing transaction performance, not trying
         // to assert correctness.
-        let txns = self.gen_transaction();
-        self.execute_benchmark_sequential(&txns, None);
+        let txn_provider = DefaultTxnProvider::new(self.gen_transaction());
+        self.execute_benchmark_sequential(&txn_provider, None);
     }
 
     /// Executes this state in a single block.
     pub(crate) fn execute_parallel(mut self) {
         // The output is ignored here since we're just testing transaction performance, not trying
         // to assert correctness.
-        let txns = self.gen_transaction();
-        self.execute_benchmark_parallel(&txns, num_cpus::get(), None);
+        let txn_provider = DefaultTxnProvider::new(self.gen_transaction());
+        self.execute_benchmark_parallel(&txn_provider, num_cpus::get(), None);
     }
 
     fn is_shareded(&self) -> bool {
@@ -210,16 +212,17 @@ where
 
     fn execute_benchmark_sequential(
         &self,
-        transactions: &[SignatureVerifiedTransaction],
+        txn_provider: &DefaultTxnProvider<SignatureVerifiedTransaction>,
         maybe_block_gas_limit: Option<u64>,
     ) -> (Vec<TransactionOutput>, usize) {
-        let block_size = transactions.len();
+        let block_size = txn_provider.num_txns();
         let timer = Instant::now();
         let output = BlockAptosVM::execute_block::<
             _,
             NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
+            DefaultTxnProvider<SignatureVerifiedTransaction>,
         >(
-            transactions,
+            txn_provider,
             self.state_view.as_ref(),
             &AptosModuleCacheManager::new(),
             BlockExecutorConfig::new_maybe_block_limit(1, maybe_block_gas_limit),
@@ -259,17 +262,18 @@ where
 
     fn execute_benchmark_parallel(
         &self,
-        transactions: &[SignatureVerifiedTransaction],
+        txn_provider: &DefaultTxnProvider<SignatureVerifiedTransaction>,
         concurrency_level_per_shard: usize,
         maybe_block_gas_limit: Option<u64>,
     ) -> (Vec<TransactionOutput>, usize) {
-        let block_size = transactions.len();
+        let block_size = txn_provider.num_txns();
         let timer = Instant::now();
         let output = BlockAptosVM::execute_block::<
             _,
             NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
+            DefaultTxnProvider<SignatureVerifiedTransaction>,
         >(
-            transactions,
+            txn_provider,
             self.state_view.as_ref(),
             &AptosModuleCacheManager::new(),
             BlockExecutorConfig::new_maybe_block_limit(
@@ -295,6 +299,7 @@ where
         concurrency_level_per_shard: usize,
         maybe_block_gas_limit: Option<u64>,
     ) -> (usize, usize) {
+        let txn_provider = DefaultTxnProvider::new(transactions);
         let (output, par_tps) = if run_par {
             println!("Parallel execution starts...");
             let (output, tps) = if self.is_shareded() {
@@ -305,7 +310,7 @@ where
                 )
             } else {
                 self.execute_benchmark_parallel(
-                    &transactions,
+                    &txn_provider,
                     concurrency_level_per_shard,
                     maybe_block_gas_limit,
                 )
@@ -324,7 +329,7 @@ where
         let (output, seq_tps) = if run_seq {
             println!("Sequential execution starts...");
             let (output, tps) =
-                self.execute_benchmark_sequential(&transactions, maybe_block_gas_limit);
+                self.execute_benchmark_sequential(&txn_provider, maybe_block_gas_limit);
             println!("Sequential execution finishes, TPS = {}", tps);
             (output, tps)
         } else {

--- a/aptos-move/aptos-transactional-test-harness/Cargo.toml
+++ b/aptos-move/aptos-transactional-test-harness/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-api-types = { workspace = true }
+aptos-block-executor = { workspace = true }
 aptos-cached-packages = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-framework = { workspace = true }

--- a/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
+++ b/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{bail, format_err, Result};
 use aptos_api_types::AsConverter;
+use aptos_block_executor::txn_provider::default::DefaultTxnProvider;
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     hash::HashValue,
@@ -515,8 +516,9 @@ impl<'a> AptosTestAdapter<'a> {
     fn run_transaction(&mut self, txn: Transaction) -> Result<TransactionOutput> {
         let txn_block = vec![txn];
         let sig_verified_block = into_signature_verified_block(txn_block);
+        let txn_provider = DefaultTxnProvider::new(sig_verified_block);
         let mut outputs = AptosVMBlockExecutor::new()
-            .execute_block_no_limit(&sig_verified_block, &self.storage.clone())?;
+            .execute_block_no_limit(&txn_provider, &self.storage.clone())?;
 
         assert_eq!(outputs.len(), 1);
 

--- a/aptos-move/aptos-vm-profiling/Cargo.toml
+++ b/aptos-move/aptos-vm-profiling/Cargo.toml
@@ -17,6 +17,7 @@ glob = { workspace = true }
 once_cell = { workspace = true }
 smallvec = { workspace = true }
 
+aptos-block-executor = { workspace = true }
 aptos-cached-packages = { workspace = true }
 aptos-gas-schedule = { workspace = true }
 aptos-language-e2e-tests = { workspace = true }

--- a/aptos-move/aptos-vm-profiling/src/bins/run_aptos_p2p.rs
+++ b/aptos-move/aptos-vm-profiling/src/bins/run_aptos_p2p.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use aptos_block_executor::txn_provider::default::DefaultTxnProvider;
 use aptos_language_e2e_tests::{account::AccountData, data_store::FakeDataStore};
 use aptos_types::{
     transaction::{signature_verified_transaction::SignatureVerifiedTransaction, Transaction},
@@ -48,7 +49,9 @@ fn main() -> Result<()> {
         })
         .collect();
 
-    let outputs = AptosVMBlockExecutor::new().execute_block_no_limit(&txns, &state_store)?;
+    let txn_provider = DefaultTxnProvider::new(txns);
+    let outputs =
+        AptosVMBlockExecutor::new().execute_block_no_limit(&txn_provider, &state_store)?;
     for i in 0..NUM_TXNS {
         assert!(outputs[i as usize].status().status().unwrap().is_success());
     }

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -14,7 +14,7 @@ use aptos_aggregator::{
 use aptos_block_executor::{
     code_cache_global_manager::AptosModuleCacheManager, errors::BlockExecutionError,
     executor::BlockExecutor, task::TransactionOutput as BlockExecutorTransactionOutput,
-    txn_commit_hook::TransactionCommitHook, types::InputOutputKey,
+    txn_commit_hook::TransactionCommitHook, txn_provider::TxnProvider, types::InputOutputKey,
 };
 use aptos_infallible::Mutex;
 use aptos_types::{
@@ -391,9 +391,10 @@ impl BlockAptosVM {
     pub fn execute_block_on_thread_pool<
         S: StateView + Sync,
         L: TransactionCommitHook<Output = AptosTransactionOutput>,
+        TP: TxnProvider<SignatureVerifiedTransaction> + Sync,
     >(
         executor_thread_pool: Arc<rayon::ThreadPool>,
-        signature_verified_block: &[SignatureVerifiedTransaction],
+        signature_verified_block: &TP,
         state_view: &S,
         module_cache_manager: &AptosModuleCacheManager,
         config: BlockExecutorConfig,
@@ -402,7 +403,7 @@ impl BlockAptosVM {
     ) -> Result<BlockOutput<TransactionOutput>, VMStatus> {
         let _timer = BLOCK_EXECUTOR_EXECUTE_BLOCK_SECONDS.start_timer();
 
-        let num_txns = signature_verified_block.len();
+        let num_txns = signature_verified_block.num_txns();
         if state_view.id() != StateViewId::Miscellaneous {
             // Speculation is disabled in Miscellaneous context, which is used by testing and
             // can even lead to concurrent execute_block invocations, leading to errors on flush.
@@ -423,6 +424,7 @@ impl BlockAptosVM {
             S,
             L,
             ExecutableTestType,
+            TP,
         >::new(config, executor_thread_pool, transaction_commit_listener);
 
         let ret = executor.execute_block(
@@ -464,15 +466,16 @@ impl BlockAptosVM {
     pub fn execute_block<
         S: StateView + Sync,
         L: TransactionCommitHook<Output = AptosTransactionOutput>,
+        TP: TxnProvider<SignatureVerifiedTransaction> + Sync,
     >(
-        signature_verified_block: &[SignatureVerifiedTransaction],
+        signature_verified_block: &TP,
         state_view: &S,
         module_cache_manager: &AptosModuleCacheManager,
         config: BlockExecutorConfig,
         transaction_slice_metadata: TransactionSliceMetadata,
         transaction_commit_listener: Option<L>,
     ) -> Result<BlockOutput<TransactionOutput>, VMStatus> {
-        Self::execute_block_on_thread_pool::<S, L>(
+        Self::execute_block_on_thread_pool::<S, L, TP>(
             Arc::clone(&RAYON_EXEC_POOL),
             signature_verified_block,
             state_view,

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -126,6 +126,7 @@ pub mod verifier;
 
 pub use crate::aptos_vm::{AptosSimulationVM, AptosVM};
 use crate::sharded_block_executor::{executor_client::ExecutorClient, ShardedBlockExecutor};
+use aptos_block_executor::txn_provider::default::DefaultTxnProvider;
 use aptos_types::{
     block_executor::{
         config::BlockExecutorConfigFromOnchain, execution_state::TransactionSliceMetadata,
@@ -168,7 +169,7 @@ pub trait VMBlockExecutor: Send + Sync {
     /// Executes a block of transactions and returns output for each one of them.
     fn execute_block(
         &self,
-        transactions: &[SignatureVerifiedTransaction],
+        txn_provider: &DefaultTxnProvider<SignatureVerifiedTransaction>,
         state_view: &(impl StateView + Sync),
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
@@ -178,11 +179,11 @@ pub trait VMBlockExecutor: Send + Sync {
     /// any block limit.
     fn execute_block_no_limit(
         &self,
-        transactions: &[SignatureVerifiedTransaction],
+        txn_provider: &DefaultTxnProvider<SignatureVerifiedTransaction>,
         state_view: &(impl StateView + Sync),
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         self.execute_block(
-            transactions,
+            txn_provider,
             state_view,
             BlockExecutorConfigFromOnchain::new_no_block_limit(),
             // For all use cases, we run on an unknown state.

--- a/aptos-move/aptos-vm/tests/sharded_block_executor.rs
+++ b/aptos-move/aptos-vm/tests/sharded_block_executor.rs
@@ -186,6 +186,7 @@ fn test_partitioner_v2_connected_component_sharded_block_executor_with_random_tr
 }
 
 mod test_utils {
+    use aptos_block_executor::txn_provider::default::DefaultTxnProvider;
     use aptos_block_partitioner::BlockPartitioner;
     use aptos_language_e2e_tests::{
         account::AccountData, common_transactions::peer_to_peer_txn, data_store::FakeDataStore,
@@ -308,8 +309,9 @@ mod test_utils {
                 .into_iter()
                 .map(|t| t.into_txn())
                 .collect();
+        let txn_provider = DefaultTxnProvider::new(ordered_txns);
         let unsharded_txn_output = AptosVMBlockExecutor::new()
-            .execute_block_no_limit(&ordered_txns, executor.data_store())
+            .execute_block_no_limit(&txn_provider, executor.data_store())
             .unwrap();
         compare_txn_outputs(unsharded_txn_output, sharded_txn_output);
     }
@@ -358,8 +360,9 @@ mod test_utils {
             )
             .unwrap();
 
+        let txn_provider = DefaultTxnProvider::new(execution_ordered_txns);
         let unsharded_txn_output = AptosVMBlockExecutor::new()
-            .execute_block_no_limit(&execution_ordered_txns, executor.data_store())
+            .execute_block_no_limit(&txn_provider, executor.data_store())
             .unwrap();
         compare_txn_outputs(unsharded_txn_output, sharded_txn_output);
     }
@@ -412,8 +415,9 @@ mod test_utils {
             )
             .unwrap();
 
+        let txn_provider = DefaultTxnProvider::new(execution_ordered_txns);
         let unsharded_txn_output = AptosVMBlockExecutor::new()
-            .execute_block_no_limit(&execution_ordered_txns, executor.data_store())
+            .execute_block_no_limit(&txn_provider, executor.data_store())
             .unwrap();
         compare_txn_outputs(unsharded_txn_output, sharded_txn_output);
     }

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -128,7 +128,7 @@ where
         parallel_state: ParallelState<T, X>,
     ) -> Result<bool, PanicOr<ParallelBlockExecutionError>> {
         let _timer = TASK_EXECUTE_SECONDS.start_timer();
-        let txn = &signature_verified_block.get_txn(idx_to_execute);
+        let txn = signature_verified_block.get_txn(idx_to_execute);
 
         // VM execution.
         let sync_view = LatestView::new(
@@ -1393,7 +1393,7 @@ where
                 ViewState::Unsync(SequentialState::new(&unsync_map, start_counter, &counter)),
                 idx as TxnIndex,
             );
-            let res = executor.execute_transaction(&latest_view, txn.as_ref(), idx as TxnIndex);
+            let res = executor.execute_transaction(&latest_view, txn, idx as TxnIndex);
             let must_skip = matches!(res, ExecutionStatus::SkipRest(_));
             match res {
                 ExecutionStatus::Abort(err) => {

--- a/aptos-move/block-executor/src/lib.rs
+++ b/aptos-move/block-executor/src/lib.rs
@@ -155,6 +155,7 @@ mod scheduler;
 pub mod task;
 pub mod txn_commit_hook;
 pub mod txn_last_input_output;
+pub mod txn_provider;
 pub mod types;
 #[cfg(test)]
 mod unit_tests;

--- a/aptos-move/block-executor/src/proptest_types/baseline.rs
+++ b/aptos-move/block-executor/src/proptest_types/baseline.rs
@@ -27,13 +27,7 @@ use aptos_vm_types::resource_group_adapter::group_size_as_sum;
 use bytes::Bytes;
 use claims::{assert_matches, assert_none, assert_some, assert_some_eq};
 use itertools::izip;
-use std::{
-    collections::HashMap,
-    fmt::Debug,
-    hash::Hash,
-    result::Result,
-    sync::{atomic::Ordering, Arc},
-};
+use std::{collections::HashMap, fmt::Debug, hash::Hash, result::Result, sync::atomic::Ordering};
 
 // TODO: extend to derived values, and code.
 #[derive(Clone)]
@@ -103,7 +97,7 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
     /// Must be invoked after parallel execution to have incarnation information set and
     /// work with dynamic read/writes.
     pub(crate) fn generate<E: Debug + Clone + TransactionEvent>(
-        txns: &[Arc<MockTransaction<K, E>>],
+        txns: &[MockTransaction<K, E>],
         maybe_block_gas_limit: Option<u64>,
     ) -> Self {
         let mut current_world = HashMap::<K, BaselineValue>::new();
@@ -115,7 +109,6 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
         let mut group_reads = vec![];
 
         for txn in txns.iter() {
-            let txn = txn.as_ref();
             match txn {
                 MockTransaction::Abort => {
                     status = BaselineStatus::Aborted;

--- a/aptos-move/block-executor/src/proptest_types/baseline.rs
+++ b/aptos-move/block-executor/src/proptest_types/baseline.rs
@@ -27,7 +27,13 @@ use aptos_vm_types::resource_group_adapter::group_size_as_sum;
 use bytes::Bytes;
 use claims::{assert_matches, assert_none, assert_some, assert_some_eq};
 use itertools::izip;
-use std::{collections::HashMap, fmt::Debug, hash::Hash, result::Result, sync::atomic::Ordering};
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    hash::Hash,
+    result::Result,
+    sync::{atomic::Ordering, Arc},
+};
 
 // TODO: extend to derived values, and code.
 #[derive(Clone)]
@@ -97,7 +103,7 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
     /// Must be invoked after parallel execution to have incarnation information set and
     /// work with dynamic read/writes.
     pub(crate) fn generate<E: Debug + Clone + TransactionEvent>(
-        txns: &[MockTransaction<K, E>],
+        txns: &[Arc<MockTransaction<K, E>>],
         maybe_block_gas_limit: Option<u64>,
     ) -> Self {
         let mut current_world = HashMap::<K, BaselineValue>::new();
@@ -109,6 +115,7 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
         let mut group_reads = vec![];
 
         for txn in txns.iter() {
+            let txn = txn.as_ref();
             match txn {
                 MockTransaction::Abort => {
                     status = BaselineStatus::Aborted;

--- a/aptos-move/block-executor/src/proptest_types/bencher.rs
+++ b/aptos-move/block-executor/src/proptest_types/bencher.rs
@@ -12,6 +12,7 @@ use crate::{
         },
     },
     txn_commit_hook::NoOpTransactionCommitHook,
+    txn_provider::default::DefaultTxnProvider,
 };
 use aptos_types::{
     block_executor::config::BlockExecutorConfig, contract_event::TransactionEvent,
@@ -36,10 +37,10 @@ pub struct Bencher<K, V, E> {
 }
 
 pub(crate) struct BencherState<
-    K: Hash + Clone + Debug + Eq + PartialOrd + Ord,
-    E: Send + Sync + Debug + Clone + TransactionEvent,
+    K: Hash + Clone + Debug + Eq + PartialOrd + Ord + Send + Sync + 'static,
+    E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
 > {
-    transactions: Vec<MockTransaction<KeyType<K>, E>>,
+    txns_provider: DefaultTxnProvider<MockTransaction<KeyType<K>, E>>,
     baseline_output: BaselineOutput<KeyType<K>>,
 }
 
@@ -107,11 +108,12 @@ where
             .into_iter()
             .map(|txn_gen| txn_gen.materialize(&key_universe, (false, false)))
             .collect();
+        let txns_provider = DefaultTxnProvider::new(transactions.clone());
 
-        let baseline_output = BaselineOutput::generate(&transactions, None);
+        let baseline_output = BaselineOutput::generate(txns_provider.get_txns(), None);
 
         Self {
-            transactions,
+            txns_provider: DefaultTxnProvider::new(transactions),
             baseline_output,
         }
     }
@@ -135,8 +137,9 @@ where
             MockStateView<KeyType<K>>,
             NoOpTransactionCommitHook<MockOutput<KeyType<K>, E>, usize>,
             ExecutableTestType,
+            DefaultTxnProvider<MockTransaction<KeyType<K>, E>>,
         >::new(config, executor_thread_pool, None)
-        .execute_transactions_parallel(&self.transactions, &state_view, &mut guard);
+        .execute_transactions_parallel(&self.txns_provider, &state_view, &mut guard);
 
         self.baseline_output.assert_parallel_output(&output);
     }

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -14,6 +14,7 @@ use crate::{
         },
     },
     txn_commit_hook::NoOpTransactionCommitHook,
+    txn_provider::default::DefaultTxnProvider,
 };
 use aptos_types::{
     block_executor::config::BlockExecutorConfig, contract_event::TransactionEvent,
@@ -68,6 +69,7 @@ fn run_transactions<K, V, E>(
             .unwrap(),
     );
 
+    let txn_provider = DefaultTxnProvider::new(transactions);
     for _ in 0..num_repeat {
         let mut guard = AptosModuleCacheManagerGuard::none();
 
@@ -77,19 +79,20 @@ fn run_transactions<K, V, E>(
             MockStateView<KeyType<K>>,
             NoOpTransactionCommitHook<MockOutput<KeyType<K>, E>, usize>,
             ExecutableTestType,
+            DefaultTxnProvider<MockTransaction<KeyType<K>, E>>,
         >::new(
             BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), maybe_block_gas_limit),
             executor_thread_pool.clone(),
             None,
         )
-        .execute_transactions_parallel(&transactions, &state_view, &mut guard);
+        .execute_transactions_parallel(&txn_provider, &state_view, &mut guard);
 
         if module_access.0 && module_access.1 {
             assert_matches!(output, Err(()));
             continue;
         }
 
-        BaselineOutput::generate(&transactions, maybe_block_gas_limit)
+        BaselineOutput::generate(txn_provider.get_txns(), maybe_block_gas_limit)
             .assert_parallel_output(&output);
     }
 }
@@ -193,6 +196,7 @@ fn deltas_writes_mixed_with_block_gas_limit(num_txns: usize, maybe_block_gas_lim
         .into_iter()
         .map(|txn_gen| txn_gen.materialize_with_deltas(&universe, 15, false))
         .collect();
+    let txn_provider = DefaultTxnProvider::new(transactions);
 
     let data_view = DeltaDataView::<KeyType<[u8; 32]>> {
         phantom: PhantomData,
@@ -214,14 +218,15 @@ fn deltas_writes_mixed_with_block_gas_limit(num_txns: usize, maybe_block_gas_lim
             DeltaDataView<KeyType<[u8; 32]>>,
             NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
             ExecutableTestType,
+            DefaultTxnProvider<MockTransaction<KeyType<[u8; 32]>, MockEvent>>,
         >::new(
             BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), maybe_block_gas_limit),
             executor_thread_pool.clone(),
             None,
         )
-        .execute_transactions_parallel(&transactions, &data_view, &mut guard);
+        .execute_transactions_parallel(&txn_provider, &data_view, &mut guard);
 
-        BaselineOutput::generate(&transactions, maybe_block_gas_limit)
+        BaselineOutput::generate(txn_provider.get_txns(), maybe_block_gas_limit)
             .assert_parallel_output(&output);
     }
 }
@@ -250,6 +255,7 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
         .into_iter()
         .map(|txn_gen| txn_gen.materialize_with_deltas(&universe, 15, false))
         .collect();
+    let txn_provider = DefaultTxnProvider::new(transactions);
 
     let executor_thread_pool = Arc::new(
         rayon::ThreadPoolBuilder::new()
@@ -267,14 +273,15 @@ fn deltas_resolver_with_block_gas_limit(num_txns: usize, maybe_block_gas_limit: 
             DeltaDataView<KeyType<[u8; 32]>>,
             NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
             ExecutableTestType,
+            DefaultTxnProvider<MockTransaction<KeyType<[u8; 32]>, MockEvent>>,
         >::new(
             BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), maybe_block_gas_limit),
             executor_thread_pool.clone(),
             None,
         )
-        .execute_transactions_parallel(&transactions, &data_view, &mut guard);
+        .execute_transactions_parallel(&txn_provider, &data_view, &mut guard);
 
-        BaselineOutput::generate(&transactions, maybe_block_gas_limit)
+        BaselineOutput::generate(txn_provider.get_txns(), maybe_block_gas_limit)
             .assert_parallel_output(&output);
     }
 }
@@ -416,6 +423,7 @@ fn publishing_fixed_params_with_block_gas_limit(
             .unwrap(),
     );
 
+    let txn_provider = DefaultTxnProvider::new(transactions.clone());
     // Confirm still no intersection
     let mut guard = AptosModuleCacheManagerGuard::none();
     let output = BlockExecutor::<
@@ -424,12 +432,13 @@ fn publishing_fixed_params_with_block_gas_limit(
         DeltaDataView<KeyType<[u8; 32]>>,
         NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
         ExecutableTestType,
+        DefaultTxnProvider<MockTransaction<KeyType<[u8; 32]>, MockEvent>>,
     >::new(
         BlockExecutorConfig::new_maybe_block_limit(num_cpus::get(), maybe_block_gas_limit),
         executor_thread_pool,
         None,
     )
-    .execute_transactions_parallel(&transactions, &data_view, &mut guard);
+    .execute_transactions_parallel(&txn_provider, &data_view, &mut guard);
     assert_ok!(output);
 
     // Adjust the reads of txn indices[2] to contain module read to key 42.
@@ -459,6 +468,7 @@ fn publishing_fixed_params_with_block_gas_limit(
             .unwrap(),
     );
 
+    let txn_provider = DefaultTxnProvider::new(transactions);
     for _ in 0..200 {
         let mut guard = AptosModuleCacheManagerGuard::none();
 
@@ -468,6 +478,7 @@ fn publishing_fixed_params_with_block_gas_limit(
             DeltaDataView<KeyType<[u8; 32]>>,
             NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
             ExecutableTestType,
+            DefaultTxnProvider<MockTransaction<KeyType<[u8; 32]>, MockEvent>>,
         >::new(
             BlockExecutorConfig::new_maybe_block_limit(
                 num_cpus::get(),
@@ -476,7 +487,7 @@ fn publishing_fixed_params_with_block_gas_limit(
             executor_thread_pool.clone(),
             None,
         ) // Ensure enough gas limit to commit the module txns (4 is maximum gas per txn)
-        .execute_transactions_parallel(&transactions, &data_view, &mut guard);
+        .execute_transactions_parallel(&txn_provider, &data_view, &mut guard);
 
         assert_matches!(output, Err(()));
     }
@@ -528,6 +539,7 @@ fn non_empty_group(
             txn_gen.materialize_groups::<[u8; 32], MockEvent>(&key_universe, group_size_pcts)
         })
         .collect();
+    let txn_provider = DefaultTxnProvider::new(transactions);
 
     let data_view = NonEmptyGroupDataView::<KeyType<[u8; 32]>> {
         group_keys: key_universe[(key_universe_len - 3)..key_universe_len]
@@ -552,14 +564,15 @@ fn non_empty_group(
             NonEmptyGroupDataView<KeyType<[u8; 32]>>,
             NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
             ExecutableTestType,
+            DefaultTxnProvider<MockTransaction<KeyType<[u8; 32]>, MockEvent>>,
         >::new(
             BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
             executor_thread_pool.clone(),
             None,
         )
-        .execute_transactions_parallel(&transactions, &data_view, &mut guard);
+        .execute_transactions_parallel(&txn_provider, &data_view, &mut guard);
 
-        BaselineOutput::generate(&transactions, None).assert_parallel_output(&output);
+        BaselineOutput::generate(txn_provider.get_txns(), None).assert_parallel_output(&output);
     }
 
     for _ in 0..num_repeat_sequential {
@@ -571,20 +584,23 @@ fn non_empty_group(
             NonEmptyGroupDataView<KeyType<[u8; 32]>>,
             NoOpTransactionCommitHook<MockOutput<KeyType<[u8; 32]>, MockEvent>, usize>,
             ExecutableTestType,
+            DefaultTxnProvider<MockTransaction<KeyType<[u8; 32]>, MockEvent>>,
         >::new(
             BlockExecutorConfig::new_no_block_limit(num_cpus::get()),
             executor_thread_pool.clone(),
             None,
         )
-        .execute_transactions_sequential(&transactions, &data_view, &mut guard, false);
+        .execute_transactions_sequential(&txn_provider, &data_view, &mut guard, false);
         // TODO: test dynamic disabled as well.
 
-        BaselineOutput::generate(&transactions, None).assert_output(&output.map_err(|e| match e {
-            SequentialBlockExecutionError::ResourceGroupSerializationError => {
-                panic!("Unexpected error")
+        BaselineOutput::generate(txn_provider.get_txns(), None).assert_output(&output.map_err(
+            |e| match e {
+                SequentialBlockExecutionError::ResourceGroupSerializationError => {
+                    panic!("Unexpected error")
+                },
+                SequentialBlockExecutionError::ErrorToReturn(err) => err,
             },
-            SequentialBlockExecutionError::ErrorToReturn(err) => err,
-        }));
+        ));
     }
 }
 

--- a/aptos-move/block-executor/src/txn_provider/blocking_txns_provider.rs
+++ b/aptos-move/block-executor/src/txn_provider/blocking_txns_provider.rs
@@ -4,69 +4,45 @@
 use crate::txn_provider::TxnProvider;
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::transaction::BlockExecutableTransaction as Transaction;
-use std::sync::{Arc, Condvar, Mutex};
+use once_cell::sync::OnceCell;
 
-#[allow(dead_code)]
-pub enum BlockingTransactionStatus<T: Transaction> {
-    Ready(Arc<T>),
-    Waiting,
-}
-
-pub struct BlockingTransaction<T: Transaction> {
-    pub txn: Mutex<BlockingTransactionStatus<T>>,
-    pub cvar: Condvar,
+pub struct BlockingTransaction<T: Transaction + std::fmt::Debug> {
+    pub txn: OnceCell<T>,
 }
 
 #[allow(dead_code)]
-impl<T: Transaction> BlockingTransaction<T> {
+impl<T: Transaction + std::fmt::Debug> BlockingTransaction<T> {
     pub fn new() -> Self {
         Self {
-            txn: Mutex::new(BlockingTransactionStatus::Waiting),
-            cvar: Condvar::new(),
+            txn: OnceCell::new(),
         }
     }
 }
 
-pub struct BlockingTxnsProvider<T: Transaction> {
+pub struct BlockingTxnsProvider<T: Transaction + std::fmt::Debug> {
     txns: Vec<BlockingTransaction<T>>,
 }
 
 #[allow(dead_code)]
-impl<T: Transaction> BlockingTxnsProvider<T> {
+impl<T: Transaction + std::fmt::Debug> BlockingTxnsProvider<T> {
     pub fn new(txns: Vec<BlockingTransaction<T>>) -> Self {
         Self { txns }
     }
 
     pub fn set_txn(&self, idx: TxnIndex, txn: T) {
-        let blocking_txn = &self.txns[idx as usize];
-        let (lock, cvar) = (&blocking_txn.txn, &blocking_txn.cvar);
-        let mut status = lock.lock().unwrap();
-        match &*status {
-            BlockingTransactionStatus::Waiting => {
-                *status = BlockingTransactionStatus::Ready(Arc::new(txn));
-                cvar.notify_all();
-            },
-            BlockingTransactionStatus::Ready(_) => {
-                panic!("Trying to add a txn that is already present");
-            },
-        }
+        self.txns[idx as usize]
+            .txn
+            .set(txn)
+            .expect("Trying to set a txn that is already present");
     }
 }
 
-impl<T: Transaction> TxnProvider<T> for BlockingTxnsProvider<T> {
+impl<T: Transaction + std::fmt::Debug> TxnProvider<T> for BlockingTxnsProvider<T> {
     fn num_txns(&self) -> usize {
         self.txns.len()
     }
 
-    fn get_txn(&self, idx: TxnIndex) -> Arc<T> {
-        let txn = &self.txns[idx as usize];
-        let mut status = txn.txn.lock().unwrap();
-        while let BlockingTransactionStatus::Waiting = *status {
-            status = txn.cvar.wait(status).unwrap();
-        }
-        match *status {
-            BlockingTransactionStatus::Ready(ref txn) => txn.clone(),
-            BlockingTransactionStatus::Waiting => panic!("Unexpected status"),
-        }
+    fn get_txn(&self, idx: TxnIndex) -> &T {
+        self.txns[idx as usize].txn.wait()
     }
 }

--- a/aptos-move/block-executor/src/txn_provider/blocking_txns_provider.rs
+++ b/aptos-move/block-executor/src/txn_provider/blocking_txns_provider.rs
@@ -19,13 +19,17 @@ impl<T: Transaction + std::fmt::Debug> BlockingTransaction<T> {
     }
 }
 
-pub struct BlockingTxnsProvider<T: Transaction + std::fmt::Debug> {
+pub struct BlockingTxnProvider<T: Transaction + std::fmt::Debug> {
     txns: Vec<BlockingTransaction<T>>,
 }
 
 #[allow(dead_code)]
-impl<T: Transaction + std::fmt::Debug> BlockingTxnsProvider<T> {
-    pub fn new(txns: Vec<BlockingTransaction<T>>) -> Self {
+impl<T: Transaction + std::fmt::Debug> BlockingTxnProvider<T> {
+    pub fn new(num_txns: usize) -> Self {
+        let mut txns = Vec::with_capacity(num_txns);
+        for _ in 0..num_txns {
+            txns.push(BlockingTransaction::new());
+        }
         Self { txns }
     }
 
@@ -37,7 +41,7 @@ impl<T: Transaction + std::fmt::Debug> BlockingTxnsProvider<T> {
     }
 }
 
-impl<T: Transaction + std::fmt::Debug> TxnProvider<T> for BlockingTxnsProvider<T> {
+impl<T: Transaction + std::fmt::Debug> TxnProvider<T> for BlockingTxnProvider<T> {
     fn num_txns(&self) -> usize {
         self.txns.len()
     }

--- a/aptos-move/block-executor/src/txn_provider/blocking_txns_provider.rs
+++ b/aptos-move/block-executor/src/txn_provider/blocking_txns_provider.rs
@@ -1,0 +1,75 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::txn_provider::TxnProvider;
+use aptos_mvhashmap::types::TxnIndex;
+use aptos_types::transaction::BlockExecutableTransaction as Transaction;
+use std::sync::{Arc, Condvar, Mutex};
+
+#[allow(dead_code)]
+pub enum BlockingTransactionStatus<T: Transaction> {
+    Ready(Arc<T>),
+    Waiting,
+}
+
+pub struct BlockingTransaction<T: Transaction> {
+    pub txn: Mutex<BlockingTransactionStatus<T>>,
+    pub cvar: Condvar,
+}
+
+#[allow(dead_code)]
+impl<T: Transaction> BlockingTransaction<T> {
+    pub fn new() -> Self {
+        Self {
+            txn: Mutex::new(BlockingTransactionStatus::Waiting),
+            cvar: Condvar::new(),
+        }
+    }
+}
+
+pub struct BlockingTxnsProvider<T: Transaction> {
+    txns: Vec<BlockingTransaction<T>>,
+}
+
+#[allow(dead_code)]
+impl<T: Transaction> BlockingTxnsProvider<T> {
+    pub fn new(txns: Vec<BlockingTransaction<T>>) -> Self {
+        Self { txns }
+    }
+
+    pub fn set_txn(&self, idx: TxnIndex, txn: T) {
+        let blocking_txn = &self.txns[idx as usize];
+        let (lock, cvar) = (&blocking_txn.txn, &blocking_txn.cvar);
+        let mut status = lock.lock().unwrap();
+        match &*status {
+            BlockingTransactionStatus::Waiting => {
+                *status = BlockingTransactionStatus::Ready(Arc::new(txn));
+                cvar.notify_all();
+            },
+            BlockingTransactionStatus::Ready(_) => {
+                panic!("Trying to add a txn that is already present");
+            },
+        }
+    }
+}
+
+impl<T: Transaction> TxnProvider<T> for BlockingTxnsProvider<T> {
+    fn num_txns(&self) -> usize {
+        self.txns.len()
+    }
+
+    fn get_txn(&self, idx: TxnIndex) -> Arc<T> {
+        let txn = &self.txns[idx as usize];
+        let mut status = txn.txn.lock().unwrap();
+        match *status {
+            BlockingTransactionStatus::Ready(ref txn) => txn.clone(),
+            BlockingTransactionStatus::Waiting => {
+                status = txn.cvar.wait(status).unwrap();
+                match *status {
+                    BlockingTransactionStatus::Ready(ref txn) => txn.clone(),
+                    BlockingTransactionStatus::Waiting => panic!("Unexpected status"),
+                }
+            },
+        }
+    }
+}

--- a/aptos-move/block-executor/src/txn_provider/default.rs
+++ b/aptos-move/block-executor/src/txn_provider/default.rs
@@ -4,19 +4,17 @@
 use crate::txn_provider::TxnProvider;
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::transaction::BlockExecutableTransaction as Transaction;
-use std::sync::Arc;
 
 pub struct DefaultTxnProvider<T: Transaction> {
-    pub txns: Vec<Arc<T>>,
+    pub txns: Vec<T>,
 }
 
 impl<T: Transaction> DefaultTxnProvider<T> {
     pub fn new(txns: Vec<T>) -> Self {
-        let txns = txns.into_iter().map(|txn| Arc::new(txn)).collect();
         Self { txns }
     }
 
-    pub fn get_txns(&self) -> &Vec<Arc<T>> {
+    pub fn get_txns(&self) -> &Vec<T> {
         &self.txns
     }
 }
@@ -26,13 +24,13 @@ impl<T: Transaction> TxnProvider<T> for DefaultTxnProvider<T> {
         self.txns.len()
     }
 
-    fn get_txn(&self, idx: TxnIndex) -> Arc<T> {
-        self.txns[idx as usize].clone()
+    fn get_txn(&self, idx: TxnIndex) -> &T {
+        &self.txns[idx as usize]
     }
 }
 
 impl<T: Transaction> Iterator for DefaultTxnProvider<T> {
-    type Item = Arc<T>;
+    type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.txns.pop()

--- a/aptos-move/block-executor/src/txn_provider/default.rs
+++ b/aptos-move/block-executor/src/txn_provider/default.rs
@@ -1,0 +1,40 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::txn_provider::TxnProvider;
+use aptos_mvhashmap::types::TxnIndex;
+use aptos_types::transaction::BlockExecutableTransaction as Transaction;
+use std::sync::Arc;
+
+pub struct DefaultTxnProvider<T: Transaction> {
+    pub txns: Vec<Arc<T>>,
+}
+
+impl<T: Transaction> DefaultTxnProvider<T> {
+    pub fn new(txns: Vec<T>) -> Self {
+        let txns = txns.into_iter().map(|txn| Arc::new(txn)).collect();
+        Self { txns }
+    }
+
+    pub fn get_txns(&self) -> &Vec<Arc<T>> {
+        &self.txns
+    }
+}
+
+impl<T: Transaction> TxnProvider<T> for DefaultTxnProvider<T> {
+    fn num_txns(&self) -> usize {
+        self.txns.len()
+    }
+
+    fn get_txn(&self, idx: TxnIndex) -> Arc<T> {
+        self.txns[idx as usize].clone()
+    }
+}
+
+impl<T: Transaction> Iterator for DefaultTxnProvider<T> {
+    type Item = Arc<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.txns.pop()
+    }
+}

--- a/aptos-move/block-executor/src/txn_provider/mod.rs
+++ b/aptos-move/block-executor/src/txn_provider/mod.rs
@@ -1,0 +1,17 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+mod blocking_txns_provider;
+pub mod default;
+
+use aptos_mvhashmap::types::TxnIndex;
+use aptos_types::transaction::BlockExecutableTransaction as Transaction;
+use std::sync::Arc;
+
+pub trait TxnProvider<T: Transaction> {
+    /// Get total number of transactions
+    fn num_txns(&self) -> usize;
+
+    /// Get a reference of the txn object by its index.
+    fn get_txn(&self, idx: TxnIndex) -> Arc<T>;
+}

--- a/aptos-move/block-executor/src/txn_provider/mod.rs
+++ b/aptos-move/block-executor/src/txn_provider/mod.rs
@@ -6,12 +6,11 @@ pub mod default;
 
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::transaction::BlockExecutableTransaction as Transaction;
-use std::sync::Arc;
 
 pub trait TxnProvider<T: Transaction> {
     /// Get total number of transactions
     fn num_txns(&self) -> usize;
 
     /// Get a reference of the txn object by its index.
-    fn get_txn(&self, idx: TxnIndex) -> Arc<T>;
+    fn get_txn(&self, idx: TxnIndex) -> &T;
 }

--- a/execution/executor-service/Cargo.toml
+++ b/execution/executor-service/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+aptos-block-executor = { workspace = true }
 aptos-block-partitioner = { workspace = true }
 aptos-config = { workspace = true }
 aptos-infallible = { workspace = true }

--- a/execution/executor-service/src/test_utils.rs
+++ b/execution/executor-service/src/test_utils.rs
@@ -1,6 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_block_executor::txn_provider::default::DefaultTxnProvider;
 use aptos_block_partitioner::{v2::config::PartitionerV2Config, PartitionerConfig};
 use aptos_language_e2e_tests::{
     account::AccountData, common_transactions::peer_to_peer_txn, data_store::FakeDataStore,
@@ -137,8 +138,9 @@ pub fn test_sharded_block_executor_no_conflict<E: ExecutorClient<FakeDataStore>>
             .into_iter()
             .map(|t| t.into_txn())
             .collect();
+    let txn_provider = DefaultTxnProvider::new(txns);
     let unsharded_txn_output = AptosVMBlockExecutor::new()
-        .execute_block_no_limit(&txns, executor.data_store())
+        .execute_block_no_limit(&txn_provider, executor.data_store())
         .unwrap();
     compare_txn_outputs(unsharded_txn_output, sharded_txn_output);
     sharded_block_executor.shutdown();
@@ -192,8 +194,9 @@ pub fn sharded_block_executor_with_conflict<E: ExecutorClient<FakeDataStore>>(
         )
         .unwrap();
 
+    let txn_provider = DefaultTxnProvider::new(execution_ordered_txns);
     let unsharded_txn_output = AptosVMBlockExecutor::new()
-        .execute_block_no_limit(&execution_ordered_txns, executor.data_store())
+        .execute_block_no_limit(&txn_provider, executor.data_store())
         .unwrap();
     compare_txn_outputs(unsharded_txn_output, sharded_txn_output);
     sharded_block_executor.shutdown();

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-block-executor = { workspace = true }
 aptos-consensus-types = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-drop-helper = { workspace = true }

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -4,6 +4,7 @@
 
 use crate::block_executor::BlockExecutor;
 use anyhow::Result;
+use aptos_block_executor::txn_provider::default::DefaultTxnProvider;
 use aptos_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
 use aptos_executor_types::BlockExecutorTrait;
 use aptos_storage_interface::{chunk_to_commit::ChunkToCommit, DbReader, DbReaderWriter, DbWriter};
@@ -77,7 +78,7 @@ impl VMBlockExecutor for FakeVM {
 
     fn execute_block(
         &self,
-        _transactions: &[SignatureVerifiedTransaction],
+        _txn_provider: &DefaultTxnProvider<SignatureVerifiedTransaction>,
         _state_view: &impl StateView,
         _onchain_config: BlockExecutorConfigFromOnchain,
         _transaction_slice_metadata: TransactionSliceMetadata,

--- a/execution/executor/src/tests/mock_vm/mock_vm_test.rs
+++ b/execution/executor/src/tests/mock_vm/mock_vm_test.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{balance_ap, encode_mint_transaction, encode_transfer_transaction, seqnum_ap, MockVM};
+use aptos_block_executor::txn_provider::default::DefaultTxnProvider;
 use aptos_types::{
     account_address::AccountAddress,
     bytes::NumToBytes,
@@ -25,11 +26,9 @@ fn test_mock_vm_different_senders() {
         txns.push(encode_mint_transaction(gen_address(i), amount));
     }
 
+    let txn_provider = DefaultTxnProvider::new(into_signature_verified_block(txns.clone()));
     let outputs = MockVM::new()
-        .execute_block_no_limit(
-            &into_signature_verified_block(txns.clone()),
-            &MockStateView::empty(),
-        )
+        .execute_block_no_limit(&txn_provider, &MockStateView::empty())
         .expect("MockVM should not fail to start");
 
     for (output, txn) in itertools::zip_eq(outputs.iter(), txns.iter()) {
@@ -65,11 +64,9 @@ fn test_mock_vm_same_sender() {
         txns.push(encode_mint_transaction(sender, amount));
     }
 
+    let txn_provider = DefaultTxnProvider::new(into_signature_verified_block(txns));
     let outputs = MockVM::new()
-        .execute_block_no_limit(
-            &into_signature_verified_block(txns),
-            &MockStateView::empty(),
-        )
+        .execute_block_no_limit(&txn_provider, &MockStateView::empty())
         .expect("MockVM should not fail to start");
 
     for (i, output) in outputs.iter().enumerate() {
@@ -103,11 +100,9 @@ fn test_mock_vm_payment() {
         encode_transfer_transaction(gen_address(0), gen_address(1), 50),
     ];
 
+    let txn_provider = DefaultTxnProvider::new(into_signature_verified_block(txns));
     let output = MockVM::new()
-        .execute_block_no_limit(
-            &into_signature_verified_block(txns),
-            &MockStateView::empty(),
-        )
+        .execute_block_no_limit(&txn_provider, &MockStateView::empty())
         .expect("MockVM should not fail to start");
 
     let mut output_iter = output.iter();

--- a/execution/executor/src/tests/mock_vm/mod.rs
+++ b/execution/executor/src/tests/mock_vm/mod.rs
@@ -77,8 +77,7 @@ impl VMBlockExecutor for MockVM {
         let mut outputs = vec![];
 
         for idx in 0..txn_provider.num_txns() {
-            let txn_arc = txn_provider.get_txn(idx as u32);
-            let txn = txn_arc.expect_valid();
+            let txn = txn_provider.get_txn(idx as u32).expect_valid();
             if matches!(txn, Transaction::StateCheckpoint(_)) {
                 outputs.push(TransactionOutput::new(
                     WriteSet::default(),

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -114,7 +114,7 @@ impl DoGetExecutionOutput {
             txn_provider
                 .txns
                 .into_iter()
-                .map(|t| Arc::into_inner(t).unwrap().into_inner())
+                .map(|t| t.into_inner())
                 .collect(),
             transaction_outputs,
             state_view.into_state_cache(),

--- a/experimental/execution/ptx-executor/Cargo.toml
+++ b/experimental/execution/ptx-executor/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
+aptos-block-executor = { workspace = true }
 aptos-experimental-runtimes = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-logger = { workspace = true }

--- a/storage/db-tool/Cargo.toml
+++ b/storage/db-tool/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-backup-cli = { workspace = true }
+aptos-block-executor = { workspace = true }
 aptos-config = { workspace = true }
 aptos-db = { workspace = true, features = ["db-debugger"] }
 aptos-executor = { workspace = true }


### PR DESCRIPTION
Currently BlockSTM takes in a block (vec) of txns and executes them.
This commits adds a capability where we don't need to provide all the
txns in the block upfront, rather provide them as per any desired logic
in the system.

The commit has a default implementation 'DefaultTxnProvider' where all
txns are provided upfront as per current logic, and also a reference
implementation of 'BlockingTxnsProvider' where txns can be provided
after BlockSTM starts execution.

Note: One should be careful while using 'BlockingTxnsProvider' because
if BlockSTM chooses to execute a txn that is not yet provided, then that
thread gets blocked until such a txn is provided. This could lead to
performance degradation.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
