### PR TITLE
fix that DB::open_readonly not using the same cf options

### DIFF
--- a/storage/aptosdb/src/ledger_db/mod.rs
+++ b/storage/aptosdb/src/ledger_db/mod.rs
@@ -364,7 +364,7 @@ impl LedgerDb {
                 &gen_rocksdb_options(db_config, true),
                 path.clone(),
                 name,
-                Self::get_column_families_by_name(name),
+                Self::gen_cfds_by_name(db_config, name),
             )?
         } else {
             DB::open_cf(

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -5,9 +5,7 @@
 
 use crate::{
     common::NUM_STATE_SHARDS,
-    db_options::{
-        gen_state_kv_cfds, state_kv_db_column_families, state_kv_db_new_key_column_families,
-    },
+    db_options::gen_state_kv_cfds,
     metrics::OTHER_TIMERS_SECONDS,
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
@@ -268,11 +266,7 @@ impl StateKvDb {
                 &gen_rocksdb_options(state_kv_db_config, true),
                 path,
                 name,
-                if enable_sharding {
-                    state_kv_db_new_key_column_families()
-                } else {
-                    state_kv_db_column_families()
-                },
+                gen_state_kv_cfds(state_kv_db_config, enable_sharding),
             )?
         } else {
             DB::open_cf(

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     common::NUM_STATE_SHARDS,
-    db_options::{gen_state_merkle_cfds, state_merkle_db_column_families},
+    db_options::gen_state_merkle_cfds,
     lru_node_cache::LruNodeCache,
     metrics::{NODE_CACHE_SECONDS, OTHER_TIMERS_SECONDS},
     schema::{
@@ -638,7 +638,7 @@ impl StateMerkleDb {
                 &gen_rocksdb_options(state_merkle_db_config, true),
                 path,
                 name,
-                state_merkle_db_column_families(),
+                gen_state_merkle_cfds(state_merkle_db_config),
             )?
         } else {
             DB::open_cf(

--- a/storage/schemadb/tests/db.rs
+++ b/storage/schemadb/tests/db.rs
@@ -10,7 +10,7 @@ use aptos_schemadb::{
 };
 use aptos_storage_interface::AptosDbError;
 use byteorder::{LittleEndian, ReadBytesExt};
-use rocksdb::DEFAULT_COLUMN_FAMILY_NAME;
+use rocksdb::{ColumnFamilyDescriptor, DEFAULT_COLUMN_FAMILY_NAME};
 
 // Creating two schemas that share exactly the same structure but are stored in different column
 // families. Also note that the key and value are of the same type `TestField`. By implementing
@@ -81,6 +81,13 @@ fn get_column_families() -> Vec<ColumnFamilyName> {
     ]
 }
 
+fn get_cfds() -> Vec<ColumnFamilyDescriptor> {
+    get_column_families()
+        .iter()
+        .map(|cf_name| ColumnFamilyDescriptor::new(*cf_name, rocksdb::Options::default()))
+        .collect()
+}
+
 fn open_db(dir: &aptos_temppath::TempPath) -> DB {
     let mut db_opts = rocksdb::Options::default();
     db_opts.create_if_missing(true);
@@ -89,13 +96,8 @@ fn open_db(dir: &aptos_temppath::TempPath) -> DB {
 }
 
 fn open_db_read_only(dir: &aptos_temppath::TempPath) -> DB {
-    DB::open_cf_readonly(
-        &rocksdb::Options::default(),
-        dir.path(),
-        "test",
-        get_column_families(),
-    )
-    .expect("Failed to open DB.")
+    DB::open_cf_readonly(&rocksdb::Options::default(), dir.path(), "test", get_cfds())
+        .expect("Failed to open DB.")
 }
 
 fn open_db_as_secondary(dir: &aptos_temppath::TempPath, dir_sec: &aptos_temppath::TempPath) -> DB {
@@ -104,7 +106,7 @@ fn open_db_as_secondary(dir: &aptos_temppath::TempPath, dir_sec: &aptos_temppath
         dir.path(),
         dir_sec.path(),
         "test",
-        get_column_families(),
+        get_cfds(),
     )
     .expect("Failed to open DB.")
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

DB::open_readonly used not to accept cfds, resulting in different options being used compared to a normal open. This is particularly an issue where the prefix_extractor being missed for the KV DBs.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Other (specify) -- tooling, aptos-debugger

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

unittests and local runs 
