### PR TITLE
Add unit test for prologue speculation

### DIFF
--- a/aptos-move/e2e-move-tests/src/aggregator_v2.rs
+++ b/aptos-move/e2e-move-tests/src/aggregator_v2.rs
@@ -77,17 +77,25 @@ fn initialize_harness(
     let mut harness = MoveHarness::new_with_executor(executor);
     // Reduce gas scaling, so that smaller differences in gas are caught in comparison testing.
     harness.modify_gas_scaling(1000);
+
+    let common_features = vec![
+        FeatureFlag::AGGREGATOR_V2_API,
+        FeatureFlag::NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE,
+        FeatureFlag::OPERATIONS_DEFAULT_TO_FA_APT_STORE,
+        FeatureFlag::DEFAULT_TO_CONCURRENT_FUNGIBLE_BALANCE,
+    ];
+
     if aggregator_execution_enabled {
         harness.enable_features(
-            vec![
-                FeatureFlag::AGGREGATOR_V2_API,
+            [common_features, vec![
                 FeatureFlag::AGGREGATOR_V2_DELAYED_FIELDS,
                 FeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET,
-            ],
+            ]]
+            .concat(),
             vec![],
         );
     } else {
-        harness.enable_features(vec![FeatureFlag::AGGREGATOR_V2_API], vec![
+        harness.enable_features(common_features, vec![
             FeatureFlag::AGGREGATOR_V2_DELAYED_FIELDS,
             FeatureFlag::RESOURCE_GROUPS_SPLIT_IN_VM_CHANGE_SET,
         ]);

--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -9,7 +9,7 @@ use aptos_gas_schedule::{
     AptosGasParameters, FromOnChainGasSchedule, InitialGasSchedule, ToOnChainGasSchedule,
 };
 use aptos_language_e2e_tests::{
-    account::{Account, AccountData, TransactionBuilder},
+    account::{Account, TransactionBuilder},
     executor::FakeExecutor,
 };
 use aptos_types::{
@@ -155,8 +155,9 @@ impl MoveHarness {
     }
 
     pub fn store_and_fund_account(&mut self, acc: &Account, balance: u64, seq_num: u64) -> Account {
-        let data = AccountData::with_account(acc.clone(), balance, seq_num);
-        self.executor.add_account_data(&data);
+        let data = self
+            .executor
+            .store_and_fund_account(acc.clone(), balance, seq_num);
         self.txn_seq_no.insert(*acc.address(), seq_num);
         data.account().clone()
     }
@@ -254,8 +255,8 @@ impl MoveHarness {
         account: &Account,
         payload: TransactionPayload,
     ) -> TransactionBuilder {
-        let on_chain_seq_no = self.sequence_number(account.address());
-        let seq_no_ref = self.txn_seq_no.get_mut(account.address()).unwrap();
+        let on_chain_seq_no = self.sequence_number_opt(account.address()).unwrap_or(0);
+        let seq_no_ref = self.txn_seq_no.entry(*account.address()).or_insert(0);
         let seq_no = std::cmp::max(on_chain_seq_no, *seq_no_ref);
         *seq_no_ref = seq_no + 1;
         account
@@ -799,7 +800,7 @@ impl MoveHarness {
         .unwrap_or(0)
             + self
                 .read_resource_from_resource_group::<FungibleStoreResource>(
-                    &aptos_types::account_config::fungible_store::primary_store(addr),
+                    &aptos_types::account_config::fungible_store::primary_apt_store(*addr),
                     ObjectGroupResource::struct_tag(),
                     FungibleStoreResource::struct_tag(),
                 )
@@ -881,10 +882,14 @@ impl MoveHarness {
         self.override_one_gas_param("txn.max_transaction_size_in_bytes", 1000 * 1024);
     }
 
-    pub fn sequence_number(&self, addr: &AccountAddress) -> u64 {
+    pub fn sequence_number_opt(&self, addr: &AccountAddress) -> Option<u64> {
         self.read_resource::<AccountResource>(addr, AccountResource::struct_tag())
-            .unwrap()
-            .sequence_number()
+            .as_ref()
+            .map(AccountResource::sequence_number)
+    }
+
+    pub fn sequence_number(&self, addr: &AccountAddress) -> u64 {
+        self.sequence_number_opt(addr).unwrap()
     }
 
     fn chain_id_is_mainnet(&self, addr: &AccountAddress) -> bool {

--- a/aptos-move/e2e-tests/src/account.rs
+++ b/aptos-move/e2e-tests/src/account.rs
@@ -10,7 +10,11 @@ use aptos_keygen::KeyGen;
 use aptos_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
-    account_config::{self, AccountResource, CoinStoreResource},
+    account_config::{
+        self, primary_apt_store, AccountResource, CoinStoreResource,
+        ConcurrentFungibleBalanceResource, FungibleStoreResource, MigrationFlag,
+        ObjectCoreResource, ObjectGroupResource,
+    },
     chain_id::ChainId,
     event::{EventHandle, EventKey},
     keyless::KeylessPublicKey,
@@ -395,6 +399,77 @@ impl CoinStore {
     }
 }
 
+/// Struct that represents an account FungibleStore resource for tests.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FungibleStore {
+    pub owner: AccountAddress,
+    pub metadata: AccountAddress,
+    pub balance: u64,
+    pub frozen: bool,
+    pub concurrent_balance: bool,
+}
+
+impl FungibleStore {
+    pub fn new(
+        owner: AccountAddress,
+        metadata: AccountAddress,
+        balance: u64,
+        frozen: bool,
+        concurrent_balance: bool,
+    ) -> Self {
+        Self {
+            owner,
+            metadata,
+            balance,
+            frozen,
+            concurrent_balance,
+        }
+    }
+
+    /// Retrieve the balance inside of this
+    pub fn balance(&self) -> u64 {
+        self.balance
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let primary_store_object_address = primary_apt_store(self.owner);
+        let mut object_group = ObjectGroupResource::default();
+        object_group.insert(
+            ObjectCoreResource::struct_tag(),
+            bcs::to_bytes(&ObjectCoreResource::new(
+                self.owner,
+                false,
+                new_event_handle(0, primary_store_object_address),
+            ))
+            .unwrap(),
+        );
+        object_group.insert(
+            FungibleStoreResource::struct_tag(),
+            bcs::to_bytes(&FungibleStoreResource::new(
+                self.metadata,
+                if self.concurrent_balance {
+                    0
+                } else {
+                    self.balance
+                },
+                self.frozen,
+            ))
+            .unwrap(),
+        );
+        if self.concurrent_balance {
+            object_group.insert(
+                ConcurrentFungibleBalanceResource::struct_tag(),
+                bcs::to_bytes(&ConcurrentFungibleBalanceResource::new(self.balance)).unwrap(),
+            );
+        }
+        object_group.insert(
+            MigrationFlag::struct_tag(),
+            bcs::to_bytes(&MigrationFlag::default()).unwrap(),
+        );
+        bcs::to_bytes(&object_group).unwrap()
+    }
+}
+
 //---------------------------------------------------------------------------
 // Account resource representation
 //---------------------------------------------------------------------------
@@ -408,7 +483,8 @@ pub struct AccountData {
     sequence_number: u64,
     coin_register_events: EventHandle,
     key_rotation_events: EventHandle,
-    coin_store: CoinStore,
+    coin_store: Option<CoinStore>,
+    fungible_store: Option<FungibleStore>,
 }
 
 fn new_event_handle(count: u64, address: AccountAddress) -> EventHandle {
@@ -420,7 +496,7 @@ impl AccountData {
     ///
     /// This constructor is non-deterministic and should not be used against golden file.
     pub fn new(balance: u64, sequence_number: u64) -> Self {
-        Self::with_account(Account::new(), balance, sequence_number)
+        Self::with_account(Account::new(), balance, sequence_number, false, false)
     }
 
     pub fn increment_sequence_number(&mut self) {
@@ -431,12 +507,33 @@ impl AccountData {
     ///
     /// Most tests will want to use this constructor.
     pub fn new_from_seed(seed: &mut KeyGen, balance: u64, sequence_number: u64) -> Self {
-        Self::with_account(Account::new_from_seed(seed), balance, sequence_number)
+        Self::with_account(
+            Account::new_from_seed(seed),
+            balance,
+            sequence_number,
+            false,
+            false,
+        )
     }
 
     /// Creates a new `AccountData` with the provided account.
-    pub fn with_account(account: Account, balance: u64, sequence_number: u64) -> Self {
-        Self::with_account_and_event_counts(account, balance, sequence_number, 0, 0)
+    pub fn with_account(
+        account: Account,
+        balance: u64,
+        sequence_number: u64,
+        use_fa_apt: bool,
+        use_concurrent_balance: bool,
+    ) -> Self {
+        if use_fa_apt {
+            Self::with_account_and_fungible_store(
+                account,
+                balance,
+                sequence_number,
+                use_concurrent_balance,
+            )
+        } else {
+            Self::with_account_and_event_counts(account, balance, sequence_number, 0, 0)
+        }
     }
 
     /// Creates a new `AccountData` with the provided account.
@@ -447,7 +544,7 @@ impl AccountData {
         sequence_number: u64,
     ) -> Self {
         let account = Account::with_keypair(privkey, pubkey);
-        Self::with_account(account, balance, sequence_number)
+        Self::with_account(account, balance, sequence_number, false, false)
     }
 
     /// Creates a new `AccountData` with custom parameters.
@@ -461,11 +558,36 @@ impl AccountData {
         let addr = *account.address();
         Self {
             account,
-            coin_store: CoinStore::new(
+            coin_store: Some(CoinStore::new(
                 balance,
                 new_event_handle(received_events_count, addr),
                 new_event_handle(sent_events_count, addr),
-            ),
+            )),
+            fungible_store: None,
+            sequence_number,
+            coin_register_events: new_event_handle(0, addr),
+            key_rotation_events: new_event_handle(1, addr),
+        }
+    }
+
+    /// Creates a new `AccountData` with custom parameters.
+    pub fn with_account_and_fungible_store(
+        account: Account,
+        fungible_balance: u64,
+        sequence_number: u64,
+        use_concurrent_balance: bool,
+    ) -> Self {
+        let addr = *account.address();
+        Self {
+            account,
+            coin_store: None,
+            fungible_store: Some(FungibleStore::new(
+                addr,
+                AccountAddress::TEN,
+                fungible_balance,
+                false,
+                use_concurrent_balance,
+            )),
             sequence_number,
             coin_register_events: new_event_handle(0, addr),
             key_rotation_events: new_event_handle(1, addr),
@@ -505,17 +627,30 @@ impl AccountData {
     /// Creates a writeset that contains the account data and can be patched to the storage
     /// directly.
     pub fn to_writeset(&self) -> WriteSet {
-        let write_set = vec![
-            (
-                StateKey::resource_typed::<AccountResource>(self.address()).unwrap(),
-                WriteOp::legacy_modification(self.to_bytes().into()),
-            ),
-            (
+        let mut write_set = vec![(
+            StateKey::resource_typed::<AccountResource>(self.address()).unwrap(),
+            WriteOp::legacy_modification(self.to_bytes().into()),
+        )];
+
+        if let Some(coin_store) = &self.coin_store {
+            write_set.push((
                 StateKey::resource_typed::<CoinStoreResource<AptosCoinType>>(self.address())
                     .unwrap(),
-                WriteOp::legacy_modification(self.coin_store.to_bytes().into()),
-            ),
-        ];
+                WriteOp::legacy_modification(coin_store.to_bytes().into()),
+            ));
+        }
+
+        if let Some(fungible_store) = &self.fungible_store {
+            let primary_store_object_address = primary_apt_store(*self.address());
+
+            write_set.push((
+                StateKey::resource_group(
+                    &primary_store_object_address,
+                    &ObjectGroupResource::struct_tag(),
+                ),
+                WriteOp::legacy_modification(fungible_store.to_bytes().into()),
+            ));
+        }
 
         WriteSetMut::new(write_set).freeze().unwrap()
     }
@@ -539,8 +674,12 @@ impl AccountData {
     }
 
     /// Returns the initial balance.
-    pub fn balance(&self) -> u64 {
-        self.coin_store.coin()
+    pub fn coin_balance(&self) -> Option<u64> {
+        self.coin_store.as_ref().map(CoinStore::coin)
+    }
+
+    pub fn fungible_balance(&self) -> Option<u64> {
+        self.fungible_store.as_ref().map(FungibleStore::balance)
     }
 
     /// Returns the initial sequence number.
@@ -550,21 +689,21 @@ impl AccountData {
 
     /// Returns the unique key for this sent events stream.
     pub fn sent_events_key(&self) -> &EventKey {
-        self.coin_store.withdraw_events.key()
+        self.coin_store.as_ref().unwrap().withdraw_events.key()
     }
 
     /// Returns the initial sent events count.
     pub fn sent_events_count(&self) -> u64 {
-        self.coin_store.withdraw_events.count()
+        self.coin_store.as_ref().unwrap().withdraw_events.count()
     }
 
     /// Returns the unique key for this received events stream.
     pub fn received_events_key(&self) -> &EventKey {
-        self.coin_store.deposit_events.key()
+        self.coin_store.as_ref().unwrap().deposit_events.key()
     }
 
     /// Returns the initial received events count.
     pub fn received_events_count(&self) -> u64 {
-        self.coin_store.deposit_events.count()
+        self.coin_store.as_ref().unwrap().deposit_events.count()
     }
 }

--- a/aptos-move/e2e-tests/src/account_universe.rs
+++ b/aptos-move/e2e-tests/src/account_universe.rs
@@ -128,7 +128,7 @@ pub struct AccountCurrent {
 
 impl AccountCurrent {
     fn new(initial_data: AccountData) -> Self {
-        let balance = initial_data.balance();
+        let balance = initial_data.coin_balance().unwrap();
         let sequence_number = initial_data.sequence_number();
         let sent_events_count = initial_data.sent_events_count();
         let received_events_count = initial_data.received_events_count();

--- a/aptos-move/e2e-tests/src/account_universe/create_account.rs
+++ b/aptos-move/e2e-tests/src/account_universe/create_account.rs
@@ -59,6 +59,8 @@ impl AUTransactionGen for CreateAccountGen {
                 self.new_account.clone(),
                 self.amount,
                 0,
+                false,
+                false,
             ));
         } else {
             gas_used = 0;

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -24,8 +24,8 @@ use aptos_gas_schedule::{AptosGasParameters, InitialGasSchedule, LATEST_GAS_FEAT
 use aptos_keygen::KeyGen;
 use aptos_types::{
     account_config::{
-        new_block_event_key, AccountResource, CoinInfoResource, CoinStoreResource, NewBlockEvent,
-        CORE_CODE_ADDRESS,
+        new_block_event_key, AccountResource, CoinInfoResource, CoinStoreResource,
+        ConcurrentSupply, NewBlockEvent, ObjectGroupResource, CORE_CODE_ADDRESS,
     },
     block_executor::config::{
         BlockExecutorConfig, BlockExecutorConfigFromOnchain, BlockExecutorLocalConfig,
@@ -34,7 +34,7 @@ use aptos_types::{
     chain_id::ChainId,
     contract_event::ContractEvent,
     move_utils::MemberId,
-    on_chain_config::{AptosVersion, OnChainConfig, ValidatorSet},
+    on_chain_config::{AptosVersion, FeatureFlag, Features, OnChainConfig, ValidatorSet},
     state_store::{state_key::StateKey, state_value::StateValue, StateView, TStateView},
     transaction::{
         signature_verified_transaction::{
@@ -44,7 +44,7 @@ use aptos_types::{
         TransactionPayload, TransactionStatus, VMValidatorResult, ViewFunctionOutput,
     },
     vm_status::VMStatus,
-    write_set::WriteSet,
+    write_set::{WriteOp, WriteSet, WriteSetMut},
     AptosCoinType, CoinType,
 };
 use aptos_vm::{
@@ -64,14 +64,14 @@ use bytes::Bytes;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::Identifier,
-    language_storage::{ModuleId, TypeTag},
-    move_resource::MoveResource,
+    language_storage::{ModuleId, StructTag, TypeTag},
+    move_resource::{MoveResource, MoveStructType},
 };
 use move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage};
 use move_vm_types::gas::UnmeteredGasMeter;
 use serde::Serialize;
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     env,
     fs::{self, OpenOptions},
     io::Write,
@@ -368,8 +368,30 @@ impl FakeExecutor {
     pub fn new_account_data_at(&mut self, addr: AccountAddress) -> AccountData {
         // The below will use the genesis keypair but that should be fine.
         let acc = Account::new_genesis_account(addr);
+
         // Mint the account 10M Aptos coins (with 8 decimals).
-        let data = AccountData::with_account(acc, 1_000_000_000_000_000, 0);
+        self.store_and_fund_account(acc, 1_000_000_000_000_000, 0)
+    }
+
+    pub fn store_and_fund_account(
+        &mut self,
+        account: Account,
+        balance: u64,
+        seq_num: u64,
+    ) -> AccountData {
+        let features = Features::fetch_config(&self.data_store).unwrap_or_default();
+        let use_fa_balance = features.is_enabled(FeatureFlag::NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE);
+        let use_concurrent_balance =
+            features.is_enabled(FeatureFlag::DEFAULT_TO_CONCURRENT_FUNGIBLE_BALANCE);
+
+        // Mint the account 10M Aptos coins (with 8 decimals).
+        let data = AccountData::with_account(
+            account,
+            balance,
+            seq_num,
+            use_fa_balance,
+            use_concurrent_balance,
+        );
         self.add_account_data(&data);
         data
     }
@@ -386,20 +408,60 @@ impl FakeExecutor {
     /// Adds an account to this executor's data store.
     pub fn add_account_data(&mut self, account_data: &AccountData) {
         self.data_store.add_account_data(account_data);
-        let new_added_supply = account_data.balance();
         // When a new account data with balance is initialized. The total_supply should be updated
         // correspondingly to be consistent with the global state.
         // if new_added_supply = 0, it is a noop.
-        if new_added_supply != 0 {
-            let coin_info_resource = self
-                .read_apt_coin_info_resource()
-                .expect("coin info must exist in data store");
-            let old_supply = self.read_coin_supply().unwrap();
-            self.data_store.add_write_set(
-                &coin_info_resource
-                    .to_writeset(old_supply + (new_added_supply as u128))
+
+        if let Some(new_added_supply) = account_data.coin_balance() {
+            if new_added_supply != 0 {
+                let coin_info_resource = self
+                    .read_apt_coin_info_resource()
+                    .expect("coin info must exist in data store");
+                let old_supply = self.read_coin_supply().unwrap();
+                self.data_store.add_write_set(
+                    &coin_info_resource
+                        .to_writeset(old_supply + (new_added_supply as u128))
+                        .unwrap(),
+                )
+            }
+        }
+
+        if let Some(new_added_supply) = account_data.fungible_balance() {
+            if new_added_supply != 0 {
+                let mut fa_resource_group = self
+                    .read_resource_group::<ObjectGroupResource>(&AccountAddress::TEN)
+                    .expect("resource group must exist in data store");
+                let mut supply = bcs::from_bytes::<ConcurrentSupply>(
+                    fa_resource_group
+                        .group
+                        .get(&ConcurrentSupply::struct_tag())
+                        .unwrap(),
+                )
+                .unwrap();
+                supply
+                    .current
+                    .set(supply.current.get() + new_added_supply as u128);
+                fa_resource_group
+                    .group
+                    .insert(
+                        ConcurrentSupply::struct_tag(),
+                        bcs::to_bytes(&supply).unwrap(),
+                    )
+                    .unwrap();
+                self.data_store.add_write_set(
+                    &WriteSetMut::new(vec![(
+                        StateKey::resource_group(
+                            &AccountAddress::TEN,
+                            &ObjectGroupResource::struct_tag(),
+                        ),
+                        WriteOp::legacy_modification(
+                            bcs::to_bytes(&fa_resource_group).unwrap().into(),
+                        ),
+                    )])
+                    .freeze()
                     .unwrap(),
-            )
+                )
+            }
         }
     }
 
@@ -428,6 +490,37 @@ impl FakeExecutor {
         .expect("account must exist in data store")
         .unwrap_or_else(|| panic!("Can't fetch {} resource for {}", T::STRUCT_NAME, addr));
         bcs::from_bytes(&data_blob).ok()
+    }
+
+    pub fn read_resource_group<T: MoveResource>(&self, addr: &AccountAddress) -> Option<T> {
+        let data_blob = TStateView::get_state_value_bytes(
+            &self.data_store,
+            &StateKey::resource_group(addr, &T::struct_tag()),
+        )
+        .expect("account must exist in data store")
+        .unwrap_or_else(|| panic!("Can't fetch {} resource group for {}", T::STRUCT_NAME, addr));
+        bcs::from_bytes(&data_blob).ok()
+    }
+
+    pub fn read_resource_from_group<T: MoveResource>(
+        &self,
+        addr: &AccountAddress,
+        resource_group_tag: &StructTag,
+    ) -> Option<T> {
+        let bytes_opt = TStateView::get_state_value_bytes(
+            &self.data_store,
+            &StateKey::resource_group(addr, resource_group_tag),
+        )
+        .expect("account must exist in data store");
+
+        let group: Option<BTreeMap<StructTag, Vec<u8>>> = bytes_opt
+            .map(|bytes| bcs::from_bytes(&bytes))
+            .transpose()
+            .unwrap();
+        group
+            .and_then(|g| g.get(&T::struct_tag()).map(|b| bcs::from_bytes(b)))
+            .transpose()
+            .unwrap()
     }
 
     /// Reads the resource `Value` for an account under the given address from

--- a/types/src/account_config/resources/fungible_asset_metadata.rs
+++ b/types/src/account_config/resources/fungible_asset_metadata.rs
@@ -1,0 +1,22 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::aggregator::AggregatorResource;
+use move_core_types::{
+    ident_str,
+    identifier::IdentStr,
+    move_resource::{MoveResource, MoveStructType},
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ConcurrentSupply {
+    pub current: AggregatorResource<u128>,
+}
+
+impl MoveStructType for ConcurrentSupply {
+    const MODULE_NAME: &'static IdentStr = ident_str!("fungible_asset");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("ConcurrentSupply");
+}
+
+impl MoveResource for ConcurrentSupply {}

--- a/types/src/account_config/resources/mod.rs
+++ b/types/src/account_config/resources/mod.rs
@@ -8,6 +8,7 @@ pub mod challenge;
 pub mod coin_info;
 pub mod coin_store;
 pub mod core_account;
+pub mod fungible_asset_metadata;
 pub mod fungible_store;
 pub mod object;
 
@@ -16,4 +17,6 @@ pub use challenge::*;
 pub use coin_info::*;
 pub use coin_store::*;
 pub use core_account::*;
+pub use fungible_asset_metadata::*;
+pub use fungible_store::*;
 pub use object::*;

--- a/types/src/account_config/resources/object.rs
+++ b/types/src/account_config/resources/object.rs
@@ -1,19 +1,35 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::event::EventHandle;
 use move_core_types::{
+    account_address::AccountAddress,
     ident_str,
     identifier::IdentStr,
+    language_storage::StructTag,
     move_resource::{MoveResource, MoveStructType},
 };
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// A Rust representation of ObjectGroup.
-#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
-pub struct ObjectGroupResource {}
+pub struct ObjectGroupResource {
+    pub group: BTreeMap<StructTag, Vec<u8>>,
+}
+
+impl ObjectGroupResource {
+    pub fn insert(&mut self, key: StructTag, value: Vec<u8>) -> Option<Vec<u8>> {
+        self.group.insert(key, value)
+    }
+
+    pub fn to_bytes(&self) -> anyhow::Result<Vec<u8>> {
+        Ok(bcs::to_bytes(&self.group)?)
+    }
+}
 
 impl MoveStructType for ObjectGroupResource {
     const MODULE_NAME: &'static IdentStr = ident_str!("object");
@@ -21,3 +37,35 @@ impl MoveStructType for ObjectGroupResource {
 }
 
 impl MoveResource for ObjectGroupResource {}
+
+/// A Rust representation of ObjectCoreResource.
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+pub struct ObjectCoreResource {
+    guid_creation_num: u64,
+    owner: AccountAddress,
+    allow_ungated_transfer: bool,
+    transfer_events: EventHandle,
+}
+
+impl ObjectCoreResource {
+    pub fn new(
+        owner: AccountAddress,
+        allow_ungated_transfer: bool,
+        transfer_events: EventHandle,
+    ) -> Self {
+        Self {
+            guid_creation_num: 0,
+            owner,
+            allow_ungated_transfer,
+            transfer_events,
+        }
+    }
+}
+
+impl MoveStructType for ObjectCoreResource {
+    const MODULE_NAME: &'static IdentStr = ident_str!("object");
+    const STRUCT_NAME: &'static IdentStr = ident_str!("ObjectCore");
+}
+
+impl MoveResource for ObjectCoreResource {}


### PR DESCRIPTION
## Description
Add an unit test that fails before the fix (#14512) of propagation of prologue speculation.
When speculatively executing transaction, calls to view (i.e. storage) can return speculative errors if BlockSTM is aware transaction will need to be re-executed. BlockSTM then sees these errors and marks for re-execution accordingly.
But, if that happens in prologue or epilogue, we were transforming these errors into UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION, and so BlockSTM didn't know it should re-execute them.

Prologue and epilogue are very limited, and only existing way to trigger it there is by having concurrent fungible balance created and used in the same block, but in a way that there are expensive transactions before both - so that rolling commit couldn't pass over the first one. That is what the test checks for.

Additionally, support creating accounts with FA in move Harness (reusing a lot of code from @lightmark's PR #10780, that will take time to land)

## Type of Change
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## How Has This Been Tested?
provided unit test

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
