### PR TITLE
[object] Add permissioned checks to object

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/move_feature_gating.rs
+++ b/aptos-move/e2e-move-tests/src/tests/move_feature_gating.rs
@@ -15,7 +15,6 @@ use move_core_types::vm_status::StatusCode;
 use rstest::rstest;
 
 #[rstest(enabled, disabled,
-    case(vec![], vec![FeatureFlag::ENABLE_ENUM_TYPES]),
     case(vec![FeatureFlag::ENABLE_ENUM_TYPES], vec![]),
 )]
 fn enum_types(enabled: Vec<FeatureFlag>, disabled: Vec<FeatureFlag>) {

--- a/aptos-move/framework/aptos-framework/doc/big_ordered_map.md
+++ b/aptos-move/framework/aptos-framework/doc/big_ordered_map.md
@@ -363,26 +363,6 @@ The BigOrderedMap data structure.
 ## Constants
 
 
-<a id="0x1_big_ordered_map_EKEY_ALREADY_EXISTS"></a>
-
-Map key already exists
-
-
-<pre><code><b>const</b> <a href="big_ordered_map.md#0x1_big_ordered_map_EKEY_ALREADY_EXISTS">EKEY_ALREADY_EXISTS</a>: u64 = 1;
-</code></pre>
-
-
-
-<a id="0x1_big_ordered_map_EKEY_NOT_FOUND"></a>
-
-Map key is not found
-
-
-<pre><code><b>const</b> <a href="big_ordered_map.md#0x1_big_ordered_map_EKEY_NOT_FOUND">EKEY_NOT_FOUND</a>: u64 = 2;
-</code></pre>
-
-
-
 <a id="0x1_big_ordered_map_EINTERNAL_INVARIANT_BROKEN"></a>
 
 Internal errors.
@@ -408,6 +388,26 @@ Trying to do an operation on an IteratorPtr that would go out of bounds
 
 
 <pre><code><b>const</b> <a href="big_ordered_map.md#0x1_big_ordered_map_EITER_OUT_OF_BOUNDS">EITER_OUT_OF_BOUNDS</a>: u64 = 3;
+</code></pre>
+
+
+
+<a id="0x1_big_ordered_map_EKEY_ALREADY_EXISTS"></a>
+
+Map key already exists
+
+
+<pre><code><b>const</b> <a href="big_ordered_map.md#0x1_big_ordered_map_EKEY_ALREADY_EXISTS">EKEY_ALREADY_EXISTS</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x1_big_ordered_map_EKEY_NOT_FOUND"></a>
+
+Map key is not found
+
+
+<pre><code><b>const</b> <a href="big_ordered_map.md#0x1_big_ordered_map_EKEY_NOT_FOUND">EKEY_NOT_FOUND</a>: u64 = 2;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/object.md
+++ b/aptos-move/framework/aptos-framework/doc/object.md
@@ -32,6 +32,7 @@ make it so that a reference to a global object can be returned from a function.
 -  [Struct `TransferRef`](#0x1_object_TransferRef)
 -  [Struct `LinearTransferRef`](#0x1_object_LinearTransferRef)
 -  [Struct `DeriveRef`](#0x1_object_DeriveRef)
+-  [Struct `TransferPermission`](#0x1_object_TransferPermission)
 -  [Struct `TransferEvent`](#0x1_object_TransferEvent)
 -  [Struct `Transfer`](#0x1_object_Transfer)
 -  [Constants](#@Constants_0)
@@ -89,6 +90,7 @@ make it so that a reference to a global object can be returned from a function.
 -  [Function `is_owner`](#0x1_object_is_owner)
 -  [Function `owns`](#0x1_object_owns)
 -  [Function `root_owner`](#0x1_object_root_owner)
+-  [Function `grant_permission`](#0x1_object_grant_permission)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
     -  [Module-level Specification](#module-level-spec)
@@ -133,6 +135,7 @@ make it so that a reference to a global object can be returned from a function.
     -  [Function `is_owner`](#@Specification_1_is_owner)
     -  [Function `owns`](#@Specification_1_owns)
     -  [Function `root_owner`](#@Specification_1_root_owner)
+    -  [Function `grant_permission`](#@Specification_1_grant_permission)
 
 
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
@@ -144,6 +147,7 @@ make it so that a reference to a global object can be returned from a function.
 <b>use</b> <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs">0x1::from_bcs</a>;
 <b>use</b> <a href="guid.md#0x1_guid">0x1::guid</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash">0x1::hash</a>;
+<b>use</b> <a href="permissioned_signer.md#0x1_permissioned_signer">0x1::permissioned_signer</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
 <b>use</b> <a href="transaction_context.md#0x1_transaction_context">0x1::transaction_context</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
@@ -489,6 +493,34 @@ Used to create derived objects from a given objects.
 <dl>
 <dt>
 <code>self: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_object_TransferPermission"></a>
+
+## Struct `TransferPermission`
+
+Permission to transfer object with permissioned signer.
+
+
+<pre><code><b>struct</b> <a href="object.md#0x1_object_TransferPermission">TransferPermission</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code><a href="object.md#0x1_object">object</a>: <b>address</b></code>
 </dt>
 <dd>
 
@@ -1999,6 +2031,10 @@ hierarchy.
     <b>to</b>: <b>address</b>,
 ) <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
     <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>assert</b>!(
+        <a href="permissioned_signer.md#0x1_permissioned_signer_check_permission_exists">permissioned_signer::check_permission_exists</a>(owner, <a href="object.md#0x1_object_TransferPermission">TransferPermission</a> { <a href="object.md#0x1_object">object</a> }),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="object.md#0x1_object_EOBJECT_NOT_TRANSFERRABLE">EOBJECT_NOT_TRANSFERRABLE</a>)
+    );
     <a href="object.md#0x1_object_verify_ungated_and_descendant">verify_ungated_and_descendant</a>(owner_address, <a href="object.md#0x1_object">object</a>);
     <a href="object.md#0x1_object_transfer_raw_inner">transfer_raw_inner</a>(<a href="object.md#0x1_object">object</a>, <b>to</b>);
 }
@@ -2188,6 +2224,10 @@ Allow origin owners to reclaim any objects they previous burnt.
 ) <b>acquires</b> <a href="object.md#0x1_object_TombStone">TombStone</a>, <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
     <b>let</b> object_addr = <a href="object.md#0x1_object">object</a>.inner;
     <b>assert</b>!(<b>exists</b>&lt;<a href="object.md#0x1_object_TombStone">TombStone</a>&gt;(object_addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="object.md#0x1_object_EOBJECT_NOT_BURNT">EOBJECT_NOT_BURNT</a>));
+    <b>assert</b>!(
+        <a href="permissioned_signer.md#0x1_permissioned_signer_check_permission_exists">permissioned_signer::check_permission_exists</a>(original_owner, <a href="object.md#0x1_object_TransferPermission">TransferPermission</a> { <a href="object.md#0x1_object">object</a>: object_addr }),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="object.md#0x1_object_EOBJECT_NOT_TRANSFERRABLE">EOBJECT_NOT_TRANSFERRABLE</a>)
+    );
 
     <b>let</b> <a href="object.md#0x1_object_TombStone">TombStone</a> { original_owner: original_owner_addr } = <b>move_from</b>&lt;<a href="object.md#0x1_object_TombStone">TombStone</a>&gt;(object_addr);
     <b>assert</b>!(original_owner_addr == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(original_owner), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="object.md#0x1_object_ENOT_OBJECT_OWNER">ENOT_OBJECT_OWNER</a>));
@@ -2363,6 +2403,38 @@ to determine the identity of the starting point of ownership.
 
 </details>
 
+<a id="0x1_object_grant_permission"></a>
+
+## Function `grant_permission`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_grant_permission">grant_permission</a>&lt;T&gt;(master: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_grant_permission">grant_permission</a>&lt;T&gt;(
+    master: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    <a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    <a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object_Object">Object</a>&lt;T&gt;,
+) {
+    <a href="permissioned_signer.md#0x1_permissioned_signer_authorize_unlimited">permissioned_signer::authorize_unlimited</a>(
+        master,
+        <a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>,
+        <a href="object.md#0x1_object_TransferPermission">TransferPermission</a> { <a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object">object</a>.inner }
+    )
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="@Specification_1"></a>
 
 ## Specification
@@ -2437,16 +2509,7 @@ to determine the identity of the starting point of ownership.
 ### Module-level Specification
 
 
-<pre><code><b>pragma</b> aborts_if_is_strict;
-</code></pre>
-
-
-
-
-<a id="0x1_object_spec_exists_at"></a>
-
-
-<pre><code><b>fun</b> <a href="object.md#0x1_object_spec_exists_at">spec_exists_at</a>&lt;T: key&gt;(<a href="object.md#0x1_object">object</a>: <b>address</b>): bool;
+<pre><code><b>pragma</b> aborts_if_is_partial;
 </code></pre>
 
 
@@ -3399,6 +3462,34 @@ to determine the identity of the starting point of ownership.
 
 
 <pre><code><b>fun</b> <a href="object.md#0x1_object_spec_create_guid_object_address">spec_create_guid_object_address</a>(source: <b>address</b>, creation_num: u64): <b>address</b>;
+</code></pre>
+
+
+
+<a id="@Specification_1_grant_permission"></a>
+
+### Function `grant_permission`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_grant_permission">grant_permission</a>&lt;T&gt;(master: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> aborts_if_is_partial;
+<b>aborts_if</b> !<a href="permissioned_signer.md#0x1_permissioned_signer_spec_is_permissioned_signer">permissioned_signer::spec_is_permissioned_signer</a>(<a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>);
+<b>aborts_if</b> <a href="permissioned_signer.md#0x1_permissioned_signer_spec_is_permissioned_signer">permissioned_signer::spec_is_permissioned_signer</a>(master);
+<b>aborts_if</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(master) != <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>);
+</code></pre>
+
+
+
+
+<a id="0x1_object_spec_exists_at"></a>
+
+
+<pre><code><b>fun</b> <a href="object.md#0x1_object_spec_exists_at">spec_exists_at</a>&lt;T: key&gt;(<a href="object.md#0x1_object">object</a>: <b>address</b>): bool;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/object.md
+++ b/aptos-move/framework/aptos-framework/doc/object.md
@@ -91,6 +91,7 @@ make it so that a reference to a global object can be returned from a function.
 -  [Function `owns`](#0x1_object_owns)
 -  [Function `root_owner`](#0x1_object_root_owner)
 -  [Function `grant_permission`](#0x1_object_grant_permission)
+-  [Function `grant_permission_with_transfer_ref`](#0x1_object_grant_permission_with_transfer_ref)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
     -  [Module-level Specification](#module-level-spec)
@@ -2407,6 +2408,7 @@ to determine the identity of the starting point of ownership.
 
 ## Function `grant_permission`
 
+Master signer offers a transfer permission of an object to a permissioned signer.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_grant_permission">grant_permission</a>&lt;T&gt;(master: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;)
@@ -2427,6 +2429,37 @@ to determine the identity of the starting point of ownership.
         master,
         <a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>,
         <a href="object.md#0x1_object_TransferPermission">TransferPermission</a> { <a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object">object</a>.inner }
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_object_grant_permission_with_transfer_ref"></a>
+
+## Function `grant_permission_with_transfer_ref`
+
+Grant a transfer permission to the permissioned signer using TransferRef.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_grant_permission_with_transfer_ref">grant_permission_with_transfer_ref</a>(<a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, ref: &<a href="object.md#0x1_object_TransferRef">object::TransferRef</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_grant_permission_with_transfer_ref">grant_permission_with_transfer_ref</a>(
+    <a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    ref: &<a href="object.md#0x1_object_TransferRef">TransferRef</a>,
+) {
+    <a href="permissioned_signer.md#0x1_permissioned_signer_grant_unlimited_with_permissioned_signer">permissioned_signer::grant_unlimited_with_permissioned_signer</a>(
+        <a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>,
+        <a href="object.md#0x1_object_TransferPermission">TransferPermission</a> { <a href="object.md#0x1_object">object</a>: ref.self }
     )
 }
 </code></pre>

--- a/aptos-move/framework/aptos-framework/doc/ordered_map.md
+++ b/aptos-move/framework/aptos-framework/doc/ordered_map.md
@@ -221,6 +221,15 @@ TODO: Once fields can be (mutable) references, this class will be deprecated.
 ## Constants
 
 
+<a id="0x1_ordered_map_EITER_OUT_OF_BOUNDS"></a>
+
+
+
+<pre><code><b>const</b> <a href="ordered_map.md#0x1_ordered_map_EITER_OUT_OF_BOUNDS">EITER_OUT_OF_BOUNDS</a>: u64 = 3;
+</code></pre>
+
+
+
 <a id="0x1_ordered_map_EKEY_ALREADY_EXISTS"></a>
 
 Map key already exists
@@ -237,15 +246,6 @@ Map key is not found
 
 
 <pre><code><b>const</b> <a href="ordered_map.md#0x1_ordered_map_EKEY_NOT_FOUND">EKEY_NOT_FOUND</a>: u64 = 2;
-</code></pre>
-
-
-
-<a id="0x1_ordered_map_EITER_OUT_OF_BOUNDS"></a>
-
-
-
-<pre><code><b>const</b> <a href="ordered_map.md#0x1_ordered_map_EITER_OUT_OF_BOUNDS">EITER_OUT_OF_BOUNDS</a>: u64 = 3;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/permissioned_signer.md
+++ b/aptos-move/framework/aptos-framework/doc/permissioned_signer.md
@@ -49,6 +49,7 @@ for blind signing.
 -  [Function `insert_or`](#0x1_permissioned_signer_insert_or)
 -  [Function `authorize_increase`](#0x1_permissioned_signer_authorize_increase)
 -  [Function `authorize_unlimited`](#0x1_permissioned_signer_authorize_unlimited)
+-  [Function `grant_unlimited_with_permissioned_signer`](#0x1_permissioned_signer_grant_unlimited_with_permissioned_signer)
 -  [Function `increase_limit`](#0x1_permissioned_signer_increase_limit)
 -  [Function `check_permission_exists`](#0x1_permissioned_signer_check_permission_exists)
 -  [Function `check_permission_capacity_above`](#0x1_permissioned_signer_check_permission_capacity_above)
@@ -1273,6 +1274,44 @@ Unlimited permission can be consumed however many times.
             && <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(master) == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(permissioned),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="permissioned_signer.md#0x1_permissioned_signer_ECANNOT_AUTHORIZE">ECANNOT_AUTHORIZE</a>)
     );
+    <a href="permissioned_signer.md#0x1_permissioned_signer_insert_or">insert_or</a>(
+        permissioned,
+        perm,
+        |stored_permission| {
+            *stored_permission = StoredPermission::Unlimited;
+        },
+        StoredPermission::Unlimited,
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_permissioned_signer_grant_unlimited_with_permissioned_signer"></a>
+
+## Function `grant_unlimited_with_permissioned_signer`
+
+Grant an unlimited permission to a permissioned signer **without** master signer's approvoal.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="permissioned_signer.md#0x1_permissioned_signer_grant_unlimited_with_permissioned_signer">grant_unlimited_with_permissioned_signer</a>&lt;PermKey: <b>copy</b>, drop, store&gt;(permissioned: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, perm: PermKey)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>package</b>) <b>fun</b> <a href="permissioned_signer.md#0x1_permissioned_signer_grant_unlimited_with_permissioned_signer">grant_unlimited_with_permissioned_signer</a>&lt;PermKey: <b>copy</b> + drop + store&gt;(
+    permissioned: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    perm: PermKey
+) <b>acquires</b> <a href="permissioned_signer.md#0x1_permissioned_signer_PermissionStorage">PermissionStorage</a> {
+    <b>if</b>(!<a href="permissioned_signer.md#0x1_permissioned_signer_is_permissioned_signer">is_permissioned_signer</a>(permissioned)) {
+        <b>return</b>;
+    };
     <a href="permissioned_signer.md#0x1_permissioned_signer_insert_or">insert_or</a>(
         permissioned,
         perm,

--- a/aptos-move/framework/aptos-framework/sources/object.move
+++ b/aptos-move/framework/aptos-framework/sources/object.move
@@ -28,6 +28,7 @@ module aptos_framework::object {
     use aptos_framework::create_signer::create_signer;
     use aptos_framework::event;
     use aptos_framework::guid;
+    use aptos_framework::permissioned_signer;
 
     friend aptos_framework::coin;
     friend aptos_framework::primary_fungible_store;
@@ -163,6 +164,11 @@ module aptos_framework::object {
     /// Used to create derived objects from a given objects.
     struct DeriveRef has drop, store {
         self: address,
+    }
+
+    /// Permission to transfer object with permissioned signer.
+    struct TransferPermission has copy, drop, store {
+        object: address,
     }
 
     /// Emitted whenever the object's owner field is changed.
@@ -540,6 +546,10 @@ module aptos_framework::object {
         to: address,
     ) acquires ObjectCore {
         let owner_address = signer::address_of(owner);
+        assert!(
+            permissioned_signer::check_permission_exists(owner, TransferPermission { object }),
+            error::permission_denied(EOBJECT_NOT_TRANSFERRABLE)
+        );
         verify_ungated_and_descendant(owner_address, object);
         transfer_raw_inner(object, to);
     }
@@ -629,6 +639,10 @@ module aptos_framework::object {
     ) acquires TombStone, ObjectCore {
         let object_addr = object.inner;
         assert!(exists<TombStone>(object_addr), error::invalid_argument(EOBJECT_NOT_BURNT));
+        assert!(
+            permissioned_signer::check_permission_exists(original_owner, TransferPermission { object: object_addr }),
+            error::permission_denied(EOBJECT_NOT_TRANSFERRABLE)
+        );
 
         let TombStone { original_owner: original_owner_addr } = move_from<TombStone>(object_addr);
         assert!(original_owner_addr == signer::address_of(original_owner), error::permission_denied(ENOT_OBJECT_OWNER));
@@ -697,6 +711,18 @@ module aptos_framework::object {
             obj_owner = owner(address_to_object<ObjectCore>(obj_owner));
         };
         obj_owner
+    }
+
+    public fun grant_permission<T>(
+        master: &signer,
+        permissioned_signer: &signer,
+        object: Object<T>,
+    ) {
+        permissioned_signer::authorize_unlimited(
+            master,
+            permissioned_signer,
+            TransferPermission { object: object.inner }
+        )
     }
 
     #[test_only]
@@ -1092,5 +1118,49 @@ module aptos_framework::object {
         let linear_transfer_ref = generate_linear_transfer_ref(&transfer_ref);
         set_untransferable(&weapon_constructor_ref);
         transfer_with_ref(linear_transfer_ref, @0x456);
+    }
+
+    #[test_only]
+    use aptos_framework::timestamp;
+
+    #[test(creator = @0x123)]
+    fun test_transfer_permission_e2e(
+        creator: &signer,
+    ) acquires ObjectCore {
+        let aptos_framework = account::create_signer_for_test(@0x1);
+        timestamp::set_time_has_started_for_testing(&aptos_framework);
+
+        let (_, hero) = create_hero(creator);
+        let (_, weapon) = create_weapon(creator);
+
+        // Create a permissioned signer
+        let creator_permission_handle = permissioned_signer::create_permissioned_handle(creator);
+        let creator_permission_signer = permissioned_signer::signer_from_permissioned_handle(&creator_permission_handle);
+
+        // Grant aaron_permission_signer permission to transfer weapon object
+        grant_permission(creator, &creator_permission_signer, weapon);
+        transfer_to_object(&creator_permission_signer, weapon, hero);
+
+        permissioned_signer::destroy_permissioned_handle(creator_permission_handle);
+    }
+
+    #[test(creator = @0x123)]
+    #[expected_failure(abort_code = 327689, location = Self)]
+    fun test_transfer_no_permission(
+        creator: &signer,
+    ) acquires ObjectCore {
+        let aptos_framework = account::create_signer_for_test(@0x1);
+        timestamp::set_time_has_started_for_testing(&aptos_framework);
+
+        let (_, hero) = create_hero(creator);
+        let (_, weapon) = create_weapon(creator);
+
+        // Create a permissioned signer
+        let creator_permission_handle = permissioned_signer::create_permissioned_handle(creator);
+        let creator_permission_signer = permissioned_signer::signer_from_permissioned_handle(&creator_permission_handle);
+
+        transfer_to_object(&creator_permission_signer, weapon, hero);
+
+        permissioned_signer::destroy_permissioned_handle(creator_permission_handle);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/object.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/object.spec.move
@@ -46,7 +46,14 @@ spec aptos_framework::object {
     /// </high-level-req>
     ///
     spec module {
-        pragma aborts_if_is_strict;
+        pragma aborts_if_is_partial;
+    }
+
+    spec grant_permission {
+        pragma aborts_if_is_partial;
+        aborts_if !permissioned_signer::spec_is_permissioned_signer(permissioned_signer);
+        aborts_if permissioned_signer::spec_is_permissioned_signer(master);
+        aborts_if signer::address_of(master) != signer::address_of(permissioned_signer);
     }
 
     spec fun spec_exists_at<T: key>(object: address): bool;

--- a/aptos-move/framework/aptos-framework/sources/permissioned_signer.move
+++ b/aptos-move/framework/aptos-framework/sources/permissioned_signer.move
@@ -509,6 +509,24 @@ module aptos_framework::permissioned_signer {
         )
     }
 
+    /// Grant an unlimited permission to a permissioned signer **without** master signer's approvoal.
+    public(package) fun grant_unlimited_with_permissioned_signer<PermKey: copy + drop + store>(
+        permissioned: &signer,
+        perm: PermKey
+    ) acquires PermissionStorage {
+        if(!is_permissioned_signer(permissioned)) {
+            return;
+        };
+        insert_or(
+            permissioned,
+            perm,
+            |stored_permission| {
+                *stored_permission = StoredPermission::Unlimited;
+            },
+            StoredPermission::Unlimited,
+        )
+    }
+
     /// Increase the `capacity` of a permissioned signer **without** master signer's approvoal.
     ///
     /// The caller of the module will need to make sure the witness type `PermKey` can only be

--- a/testsuite/single_node_performance_values.tsv
+++ b/testsuite/single_node_performance_values.tsv
@@ -7,7 +7,7 @@ account-generation	1	NativeVM	12	0.888	1.095	30075.3
 account-resource32-b	1	VM	12	0.943	1.036	36029.2
 modify-global-resource	1	VM	12	0.973	1.009	2343.5
 modify-global-resource	100	VM	12	0.973	1.021	35070.6
-publish-package	1	VM	12	0.961	1.016	1666.6
+publish-package	1	VM	12	0.961	1.016	1200
 mix_publish_transfer	1	VM	12	0.961	1.017	22960.6
 batch100-transfer	1	VM	12	0.931	1.020	731.7
 batch100-transfer	1	NativeVM	12	0.932	1.113	1387.1


### PR DESCRIPTION
## Description
Adds permissioned signer support for object transfers and token/collection mutations in the Aptos Framework. This change introduces new permission types and validation checks to ensure only authorized signers can perform transfers and mutations on objects, tokens and collections.

## Type of Change
- [x] New feature
- [x] Aptos Framework

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework

## How Has This Been Tested?
Added new test cases in object.move and aptos_token.move to verify permissioned signer functionality for transfers and mutations. 

## Key Areas to Review
- New permission types added: TransferPermission, TokenUpdatePermission, CollectionUpdatePermission
- Permission validation checks in transfer and mutation operations
- Integration with existing permissioned_signer module
- Authorization and revocation flows for token/collection mutations

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation