### PR TITLE
add governance proposal to enable federated keyless accounts

### DIFF
--- a/aptos-move/aptos-release-builder/data/federated_keyless.yaml
+++ b/aptos-move/aptos-release-builder/data/federated_keyless.yaml
@@ -1,0 +1,14 @@
+---
+remote_endpoint: ~
+name: federated_keyless
+proposals:
+  - name: enable_federated_keyless
+    metadata:
+      title: "Enable the federated Keyless account feature"
+      description: "Enables the federated Keyless feature in AIP-96 (https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-96.md)"
+      discussion_url: "https://github.com/aptos-foundation/AIPs/issues/490"
+    execution_mode: MultiStep
+    update_sequence:
+      - FeatureFlag:
+          enabled:
+            - federated_keyless


### PR DESCRIPTION
## Description

Adds the governance proposal to enable federated keyless accounts.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

It has not.

## Key Areas to Review

That the YAML is correct & the feature flag name is good.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
