### PR TITLE
[compiler-v2] Make flush writes optimization a default optimization

### DIFF
--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -222,7 +222,7 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
         Experiment {
             name: Experiment::FLUSH_WRITES_OPTIMIZATION.to_string(),
             description: "Whether to run flush writes processor and optimization".to_string(),
-            default: Inherited(Experiment::OPTIMIZE_WAITING_FOR_COMPARE_TESTS.to_string()),
+            default: Inherited(Experiment::OPTIMIZE.to_string()),
         },
         Experiment {
             name: Experiment::STOP_BEFORE_STACKLESS_BYTECODE.to_string(),

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
@@ -43,44 +43,53 @@ B0:
 	2: Ret
 }
 mut_field(Arg0: &mut S): u64 /* def_idx: 3 */ {
-L1:	loc0: &mut u64
+L1:	loc0: u64
+L2:	loc1: &mut u64
 B0:
 	0: MoveLoc[0](Arg0: &mut S)
 	1: MutBorrowField[0](S.f: u64)
-	2: StLoc[1](loc0: &mut u64)
-	3: LdU64(22)
-	4: CopyLoc[1](loc0: &mut u64)
-	5: WriteRef
-	6: MoveLoc[1](loc0: &mut u64)
-	7: ReadRef
-	8: Ret
+	2: LdU64(22)
+	3: StLoc[1](loc0: u64)
+	4: StLoc[2](loc1: &mut u64)
+	5: MoveLoc[1](loc0: u64)
+	6: CopyLoc[2](loc1: &mut u64)
+	7: WriteRef
+	8: MoveLoc[2](loc1: &mut u64)
+	9: ReadRef
+	10: Ret
 }
 mut_local(Arg0: u64): u64 /* def_idx: 4 */ {
 L1:	loc0: u64
-L2:	loc1: &mut u64
+L2:	loc1: u64
+L3:	loc2: &mut u64
 B0:
 	0: LdU64(33)
 	1: StLoc[1](loc0: u64)
 	2: MutBorrowLoc[1](loc0: u64)
+	3: LdU64(22)
+	4: StLoc[2](loc1: u64)
+	5: StLoc[3](loc2: &mut u64)
+	6: MoveLoc[2](loc1: u64)
+	7: CopyLoc[3](loc2: &mut u64)
+	8: WriteRef
+	9: MoveLoc[3](loc2: &mut u64)
+	10: ReadRef
+	11: Ret
+}
+mut_param(Arg0: u64): u64 /* def_idx: 5 */ {
+L1:	loc0: u64
+L2:	loc1: &mut u64
+B0:
+	0: MutBorrowLoc[0](Arg0: u64)
+	1: LdU64(22)
+	2: StLoc[1](loc0: u64)
 	3: StLoc[2](loc1: &mut u64)
-	4: LdU64(22)
+	4: MoveLoc[1](loc0: u64)
 	5: CopyLoc[2](loc1: &mut u64)
 	6: WriteRef
 	7: MoveLoc[2](loc1: &mut u64)
 	8: ReadRef
 	9: Ret
-}
-mut_param(Arg0: u64): u64 /* def_idx: 5 */ {
-L1:	loc0: &mut u64
-B0:
-	0: MutBorrowLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: &mut u64)
-	2: LdU64(22)
-	3: CopyLoc[1](loc0: &mut u64)
-	4: WriteRef
-	5: MoveLoc[1](loc0: &mut u64)
-	6: ReadRef
-	7: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance.exp
@@ -14,25 +14,25 @@ B0:
 	0: ImmBorrowLoc[0](Arg0: bool)
 	1: StLoc[2](loc0: &bool)
 	2: CopyLoc[0](Arg0: bool)
-	3: BrFalse(16)
+	3: BrFalse(7)
 B1:
 	4: LdTrue
 	5: StLoc[3](loc1: bool)
+	6: Branch(9)
 B2:
-	6: ImmBorrowLoc[3](loc1: bool)
-	7: StLoc[4](loc2: &bool)
-	8: MoveLoc[2](loc0: &bool)
-	9: MoveLoc[4](loc2: &bool)
-	10: Neq
-	11: Pop
-	12: MoveLoc[0](Arg0: bool)
-	13: Pack[0](Struct0)
-	14: Pop
-	15: Ret
+	7: MoveLoc[1](Arg1: bool)
+	8: StLoc[3](loc1: bool)
 B3:
-	16: MoveLoc[1](Arg1: bool)
-	17: StLoc[3](loc1: bool)
-	18: Branch(6)
+	9: ImmBorrowLoc[3](loc1: bool)
+	10: StLoc[4](loc2: &bool)
+	11: MoveLoc[2](loc0: &bool)
+	12: MoveLoc[4](loc2: &bool)
+	13: Neq
+	14: MoveLoc[0](Arg0: bool)
+	15: Pack[0](Struct0)
+	16: Pop
+	17: Pop
+	18: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance_regression.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance_regression.exp
@@ -17,13 +17,19 @@ enum Data has drop {
 
 test_v1(): bool /* def_idx: 0 */ {
 L0:	loc0: Data
+L1:	loc1: bool
 B0:
 	0: LdU64(43)
 	1: PackVariant[0](Data/V1)
 	2: StLoc[0](loc0: Data)
 	3: ImmBorrowLoc[0](loc0: Data)
 	4: TestVariant[0](Data/V1)
-	5: Ret
+	5: StLoc[1](loc1: bool)
+	6: CopyLoc[1](loc1: bool)
+	7: BrTrue(8)
+B1:
+	8: MoveLoc[1](loc1: bool)
+	9: Ret
 }
 test_v1v3(): bool /* def_idx: 1 */ {
 L0:	loc0: Data
@@ -42,35 +48,40 @@ B0:
 	6: TestVariant[0](Data/V1)
 	7: StLoc[2](loc2: bool)
 	8: CopyLoc[2](loc2: bool)
-	9: BrTrue(13)
+	9: BrTrue(15)
 B1:
 	10: MoveLoc[1](loc1: &Data)
 	11: TestVariant[1](Data/V3)
 	12: StLoc[2](loc2: bool)
+	13: CopyLoc[2](loc2: bool)
+	14: BrTrue(15)
 B2:
-	13: PackVariant[1](Data/V3)
-	14: StLoc[3](loc3: Data)
-	15: MoveLoc[2](loc2: bool)
-	16: BrFalse(29)
+	15: PackVariant[1](Data/V3)
+	16: StLoc[3](loc3: Data)
+	17: MoveLoc[2](loc2: bool)
+	18: BrFalse(32)
 B3:
-	17: ImmBorrowLoc[3](loc3: Data)
-	18: StLoc[4](loc4: &Data)
-	19: CopyLoc[4](loc4: &Data)
-	20: TestVariant[0](Data/V1)
-	21: StLoc[5](loc5: bool)
-	22: CopyLoc[5](loc5: bool)
-	23: BrTrue(27)
+	19: ImmBorrowLoc[3](loc3: Data)
+	20: StLoc[4](loc4: &Data)
+	21: CopyLoc[4](loc4: &Data)
+	22: TestVariant[0](Data/V1)
+	23: StLoc[5](loc5: bool)
+	24: CopyLoc[5](loc5: bool)
+	25: BrTrue(31)
 B4:
-	24: MoveLoc[4](loc4: &Data)
-	25: TestVariant[1](Data/V3)
-	26: StLoc[5](loc5: bool)
+	26: MoveLoc[4](loc4: &Data)
+	27: TestVariant[1](Data/V3)
+	28: StLoc[5](loc5: bool)
+	29: CopyLoc[5](loc5: bool)
+	30: BrTrue(31)
 B5:
-	27: MoveLoc[5](loc5: bool)
-	28: Ret
+	31: Branch(34)
 B6:
-	29: LdFalse
-	30: StLoc[5](loc5: bool)
-	31: Branch(27)
+	32: LdFalse
+	33: StLoc[5](loc5: bool)
+B7:
+	34: MoveLoc[5](loc5: bool)
+	35: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
@@ -144,36 +144,36 @@ test_constans() /* def_idx: 0 */ {
 B0:
 	0: LdTrue
 	1: Call u<bool>(bool): bool
-	2: Pop
-	3: LdFalse
-	4: Call u<bool>(bool): bool
-	5: Pop
-	6: LdU8(1)
-	7: Call u<u8>(u8): u8
-	8: Pop
-	9: LdU16(7086)
-	10: Call u<u16>(u16): u16
-	11: Pop
-	12: LdU32(14593408)
-	13: Call u<u32>(u32): u32
-	14: Pop
-	15: LdU64(51966)
-	16: Call u<u64>(u64): u64
-	17: Pop
-	18: LdU128(3735928559)
-	19: Call u<u128>(u128): u128
-	20: Pop
-	21: LdU256(301490978409967)
-	22: Call u<u256>(u256): u256
+	2: LdFalse
+	3: Call u<bool>(bool): bool
+	4: LdU8(1)
+	5: Call u<u8>(u8): u8
+	6: LdU16(7086)
+	7: Call u<u16>(u16): u16
+	8: LdU32(14593408)
+	9: Call u<u32>(u32): u32
+	10: LdU64(51966)
+	11: Call u<u64>(u64): u64
+	12: LdU128(3735928559)
+	13: Call u<u128>(u128): u128
+	14: LdU256(301490978409967)
+	15: Call u<u256>(u256): u256
+	16: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66])
+	17: Call u<address>(address): address
+	18: LdConst[1](Vector(U64): [3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0])
+	19: Call u<vector<u64>>(vector<u64>): vector<u64>
+	20: LdConst[2](Vector(U8): [7, 72, 101, 108, 108, 111, 33, 10])
+	21: Call u<vector<u8>>(vector<u8>): vector<u8>
+	22: Pop
 	23: Pop
-	24: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 66])
-	25: Call u<address>(address): address
+	24: Pop
+	25: Pop
 	26: Pop
-	27: LdConst[1](Vector(U64): [3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0])
-	28: Call u<vector<u64>>(vector<u64>): vector<u64>
+	27: Pop
+	28: Pop
 	29: Pop
-	30: LdConst[2](Vector(U8): [7, 72, 101, 108, 108, 111, 33, 10])
-	31: Call u<vector<u8>>(vector<u8>): vector<u8>
+	30: Pop
+	31: Pop
 	32: Pop
 	33: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/has_script.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/has_script.exp
@@ -9,10 +9,12 @@ B0:
 	0: LdTrue
 	1: BrFalse(3)
 B1:
-	2: Ret
+	2: Branch(5)
 B2:
 	3: LdU64(1)
 	4: Abort
+B3:
+	5: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.exp
@@ -10,7 +10,7 @@ L3:	loc1: u64
 L4:	loc2: u64
 B0:
 	0: MoveLoc[0](Arg0: bool)
-	1: BrFalse(10)
+	1: BrFalse(9)
 B1:
 	2: LdU64(1)
 	3: StLoc[2](loc0: u64)
@@ -18,17 +18,17 @@ B1:
 	5: MoveLoc[2](loc0: u64)
 	6: Add
 	7: StLoc[3](loc1: u64)
+	8: Branch(15)
 B2:
-	8: MoveLoc[3](loc1: u64)
-	9: Ret
+	9: LdU64(1)
+	10: StLoc[4](loc2: u64)
+	11: MoveLoc[1](Arg1: u64)
+	12: MoveLoc[4](loc2: u64)
+	13: Sub
+	14: StLoc[3](loc1: u64)
 B3:
-	10: LdU64(1)
-	11: StLoc[4](loc2: u64)
-	12: MoveLoc[1](Arg1: u64)
-	13: MoveLoc[4](loc2: u64)
-	14: Sub
-	15: StLoc[3](loc1: u64)
-	16: Branch(8)
+	15: MoveLoc[3](loc1: u64)
+	16: Ret
 }
 if_else_nested(Arg0: bool, Arg1: u64): u64 /* def_idx: 1 */ {
 L2:	loc0: u64
@@ -40,7 +40,7 @@ L7:	loc5: u64
 L8:	loc6: u64
 B0:
 	0: MoveLoc[0](Arg0: bool)
-	1: BrFalse(29)
+	1: BrFalse(9)
 B1:
 	2: LdU64(1)
 	3: StLoc[2](loc0: u64)
@@ -48,39 +48,39 @@ B1:
 	5: MoveLoc[2](loc0: u64)
 	6: Add
 	7: StLoc[3](loc1: u64)
+	8: Branch(15)
 B2:
-	8: LdU64(10)
-	9: StLoc[4](loc2: u64)
-	10: MoveLoc[3](loc1: u64)
-	11: MoveLoc[4](loc2: u64)
-	12: Gt
-	13: BrFalse(22)
+	9: LdU64(1)
+	10: StLoc[4](loc2: u64)
+	11: CopyLoc[1](Arg1: u64)
+	12: MoveLoc[4](loc2: u64)
+	13: Sub
+	14: StLoc[3](loc1: u64)
 B3:
-	14: LdU64(2)
-	15: StLoc[5](loc3: u64)
-	16: MoveLoc[1](Arg1: u64)
-	17: MoveLoc[5](loc3: u64)
-	18: Mul
-	19: StLoc[6](loc4: u64)
+	15: LdU64(10)
+	16: StLoc[5](loc3: u64)
+	17: MoveLoc[3](loc1: u64)
+	18: MoveLoc[5](loc3: u64)
+	19: Gt
+	20: BrFalse(28)
 B4:
-	20: MoveLoc[6](loc4: u64)
-	21: Ret
+	21: LdU64(2)
+	22: StLoc[6](loc4: u64)
+	23: MoveLoc[1](Arg1: u64)
+	24: MoveLoc[6](loc4: u64)
+	25: Mul
+	26: StLoc[7](loc5: u64)
+	27: Branch(34)
 B5:
-	22: LdU64(2)
-	23: StLoc[7](loc5: u64)
-	24: MoveLoc[1](Arg1: u64)
-	25: MoveLoc[7](loc5: u64)
-	26: Div
-	27: StLoc[6](loc4: u64)
-	28: Branch(20)
+	28: LdU64(2)
+	29: StLoc[8](loc6: u64)
+	30: MoveLoc[1](Arg1: u64)
+	31: MoveLoc[8](loc6: u64)
+	32: Div
+	33: StLoc[7](loc5: u64)
 B6:
-	29: LdU64(1)
-	30: StLoc[8](loc6: u64)
-	31: CopyLoc[1](Arg1: u64)
-	32: MoveLoc[8](loc6: u64)
-	33: Sub
-	34: StLoc[3](loc1: u64)
-	35: Branch(8)
+	34: MoveLoc[7](loc5: u64)
+	35: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
@@ -16,14 +16,14 @@ B0:
 	2: CopyLoc[0](Arg0: u64)
 	3: MoveLoc[1](loc0: u64)
 	4: Gt
-	5: BrFalse(25)
+	5: BrFalse(30)
 B1:
 	6: LdU64(10)
 	7: StLoc[2](loc1: u64)
 	8: CopyLoc[0](Arg0: u64)
 	9: MoveLoc[2](loc1: u64)
 	10: Gt
-	11: BrFalse(18)
+	11: BrFalse(20)
 B2:
 	12: LdU64(1)
 	13: StLoc[3](loc2: u64)
@@ -31,19 +31,32 @@ B2:
 	15: MoveLoc[3](loc2: u64)
 	16: Sub
 	17: StLoc[0](Arg0: u64)
+	18: Branch(22)
 B3:
-	18: LdU64(1)
-	19: StLoc[4](loc3: u64)
-	20: MoveLoc[0](Arg0: u64)
-	21: MoveLoc[4](loc3: u64)
-	22: Sub
-	23: StLoc[0](Arg0: u64)
-	24: Branch(0)
+	19: Branch(21)
 B4:
-	25: MoveLoc[0](Arg0: u64)
-	26: StLoc[5](loc4: u64)
-	27: MoveLoc[5](loc4: u64)
-	28: Ret
+	20: Branch(22)
+B5:
+	21: Branch(6)
+B6:
+	22: LdU64(1)
+	23: StLoc[4](loc3: u64)
+	24: MoveLoc[0](Arg0: u64)
+	25: MoveLoc[4](loc3: u64)
+	26: Sub
+	27: StLoc[0](Arg0: u64)
+	28: Branch(0)
+B7:
+	29: Branch(31)
+B8:
+	30: Branch(32)
+B9:
+	31: Branch(0)
+B10:
+	32: MoveLoc[0](Arg0: u64)
+	33: StLoc[5](loc4: u64)
+	34: MoveLoc[5](loc4: u64)
+	35: Ret
 }
 while_loop(Arg0: u64): u64 /* def_idx: 1 */ {
 L1:	loc0: u64
@@ -63,12 +76,16 @@ B1:
 	9: MoveLoc[2](loc1: u64)
 	10: Sub
 	11: StLoc[0](Arg0: u64)
-	12: Branch(0)
+	12: Branch(14)
 B2:
-	13: MoveLoc[0](Arg0: u64)
-	14: StLoc[3](loc2: u64)
-	15: MoveLoc[3](loc2: u64)
-	16: Ret
+	13: Branch(15)
+B3:
+	14: Branch(0)
+B4:
+	15: MoveLoc[0](Arg0: u64)
+	16: StLoc[3](loc2: u64)
+	17: MoveLoc[3](loc2: u64)
+	18: Ret
 }
 while_loop_with_break_and_continue(Arg0: u64): u64 /* def_idx: 2 */ {
 L1:	loc0: u64
@@ -82,34 +99,46 @@ B0:
 	2: CopyLoc[0](Arg0: u64)
 	3: MoveLoc[1](loc0: u64)
 	4: Gt
-	5: BrFalse(12)
+	5: BrFalse(29)
 B1:
 	6: LdU64(42)
 	7: StLoc[2](loc1: u64)
 	8: CopyLoc[0](Arg0: u64)
 	9: MoveLoc[2](loc1: u64)
 	10: Eq
-	11: BrFalse(16)
+	11: BrFalse(14)
 B2:
-	12: MoveLoc[0](Arg0: u64)
-	13: StLoc[3](loc2: u64)
-	14: MoveLoc[3](loc2: u64)
-	15: Ret
+	12: Branch(31)
 B3:
-	16: LdU64(21)
-	17: StLoc[4](loc3: u64)
-	18: CopyLoc[0](Arg0: u64)
-	19: MoveLoc[4](loc3: u64)
-	20: Eq
-	21: BrTrue(0)
+	13: Branch(14)
 B4:
+	14: LdU64(21)
+	15: StLoc[3](loc2: u64)
+	16: CopyLoc[0](Arg0: u64)
+	17: MoveLoc[3](loc2: u64)
+	18: Eq
+	19: BrFalse(22)
+B5:
+	20: Branch(0)
+B6:
+	21: Branch(22)
+B7:
 	22: LdU64(1)
-	23: StLoc[5](loc4: u64)
+	23: StLoc[4](loc3: u64)
 	24: MoveLoc[0](Arg0: u64)
-	25: MoveLoc[5](loc4: u64)
+	25: MoveLoc[4](loc3: u64)
 	26: Sub
 	27: StLoc[0](Arg0: u64)
-	28: Branch(0)
+	28: Branch(30)
+B8:
+	29: Branch(31)
+B9:
+	30: Branch(0)
+B10:
+	31: MoveLoc[0](Arg0: u64)
+	32: StLoc[5](loc4: u64)
+	33: MoveLoc[5](loc4: u64)
+	34: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
@@ -47,72 +47,72 @@ L4:	loc2: bool
 L5:	loc3: bool
 B0:
 	0: CopyLoc[0](Arg0: bool)
-	1: BrFalse(46)
+	1: BrFalse(5)
 B1:
 	2: CopyLoc[1](Arg1: bool)
 	3: StLoc[2](loc0: bool)
+	4: Branch(7)
 B2:
-	4: MoveLoc[2](loc0: bool)
-	5: BrFalse(37)
+	5: LdFalse
+	6: StLoc[2](loc0: bool)
 B3:
-	6: LdTrue
-	7: StLoc[3](loc1: bool)
+	7: MoveLoc[2](loc0: bool)
+	8: BrFalse(12)
 B4:
-	8: MoveLoc[3](loc1: bool)
-	9: BrFalse(28)
+	9: LdTrue
+	10: StLoc[3](loc1: bool)
+	11: Branch(20)
 B5:
-	10: LdTrue
-	11: StLoc[4](loc2: bool)
-B6:
-	12: MoveLoc[4](loc2: bool)
+	12: CopyLoc[0](Arg0: bool)
 	13: BrFalse(18)
+B6:
+	14: CopyLoc[1](Arg1: bool)
+	15: Not
+	16: StLoc[3](loc1: bool)
+	17: Branch(20)
 B7:
-	14: LdTrue
-	15: StLoc[5](loc3: bool)
+	18: LdFalse
+	19: StLoc[3](loc1: bool)
 B8:
-	16: MoveLoc[5](loc3: bool)
-	17: Ret
+	20: MoveLoc[3](loc1: bool)
+	21: BrFalse(25)
 B9:
-	18: MoveLoc[0](Arg0: bool)
-	19: Not
-	20: BrFalse(25)
+	22: LdTrue
+	23: StLoc[4](loc2: bool)
+	24: Branch(33)
 B10:
-	21: MoveLoc[1](Arg1: bool)
-	22: Not
-	23: StLoc[5](loc3: bool)
-	24: Branch(16)
+	25: CopyLoc[0](Arg0: bool)
+	26: Not
+	27: BrFalse(31)
 B11:
-	25: LdFalse
-	26: StLoc[5](loc3: bool)
-	27: Branch(16)
+	28: CopyLoc[1](Arg1: bool)
+	29: StLoc[4](loc2: bool)
+	30: Branch(33)
 B12:
-	28: CopyLoc[0](Arg0: bool)
-	29: Not
-	30: BrFalse(34)
-B13:
-	31: CopyLoc[1](Arg1: bool)
+	31: LdFalse
 	32: StLoc[4](loc2: bool)
-	33: Branch(12)
+B13:
+	33: MoveLoc[4](loc2: bool)
+	34: BrFalse(38)
 B14:
-	34: LdFalse
-	35: StLoc[4](loc2: bool)
-	36: Branch(12)
+	35: LdTrue
+	36: StLoc[5](loc3: bool)
+	37: Branch(47)
 B15:
-	37: CopyLoc[0](Arg0: bool)
-	38: BrFalse(43)
+	38: MoveLoc[0](Arg0: bool)
+	39: Not
+	40: BrFalse(45)
 B16:
-	39: CopyLoc[1](Arg1: bool)
-	40: Not
-	41: StLoc[3](loc1: bool)
-	42: Branch(8)
+	41: MoveLoc[1](Arg1: bool)
+	42: Not
+	43: StLoc[5](loc3: bool)
+	44: Branch(47)
 B17:
-	43: LdFalse
-	44: StLoc[3](loc1: bool)
-	45: Branch(8)
+	45: LdFalse
+	46: StLoc[5](loc3: bool)
 B18:
-	46: LdFalse
-	47: StLoc[2](loc0: bool)
-	48: Branch(4)
+	47: MoveLoc[5](loc3: bool)
+	48: Ret
 }
 equality<Ty0: drop>(Arg0: Ty0, Arg1: Ty0): bool /* def_idx: 3 */ {
 B0:
@@ -136,45 +136,45 @@ B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: CopyLoc[1](Arg1: u64)
 	2: Lt
-	3: BrFalse(30)
+	3: BrFalse(9)
 B1:
 	4: CopyLoc[0](Arg0: u64)
 	5: CopyLoc[1](Arg1: u64)
 	6: Le
 	7: StLoc[2](loc0: bool)
+	8: Branch(11)
 B2:
-	8: MoveLoc[2](loc0: bool)
-	9: BrFalse(27)
+	9: LdFalse
+	10: StLoc[2](loc0: bool)
 B3:
-	10: CopyLoc[0](Arg0: u64)
-	11: CopyLoc[1](Arg1: u64)
-	12: Gt
-	13: Not
-	14: StLoc[3](loc1: bool)
+	11: MoveLoc[2](loc0: bool)
+	12: BrFalse(19)
 B4:
-	15: MoveLoc[3](loc1: bool)
-	16: BrFalse(24)
+	13: CopyLoc[0](Arg0: u64)
+	14: CopyLoc[1](Arg1: u64)
+	15: Gt
+	16: Not
+	17: StLoc[3](loc1: bool)
+	18: Branch(21)
 B5:
-	17: MoveLoc[0](Arg0: u64)
-	18: MoveLoc[1](Arg1: u64)
-	19: Ge
-	20: Not
-	21: StLoc[4](loc2: bool)
+	19: LdFalse
+	20: StLoc[3](loc1: bool)
 B6:
-	22: MoveLoc[4](loc2: bool)
-	23: Ret
+	21: MoveLoc[3](loc1: bool)
+	22: BrFalse(29)
 B7:
-	24: LdFalse
-	25: StLoc[4](loc2: bool)
-	26: Branch(22)
+	23: MoveLoc[0](Arg0: u64)
+	24: MoveLoc[1](Arg1: u64)
+	25: Ge
+	26: Not
+	27: StLoc[4](loc2: bool)
+	28: Branch(31)
 B8:
-	27: LdFalse
-	28: StLoc[3](loc1: bool)
-	29: Branch(15)
+	29: LdFalse
+	30: StLoc[4](loc2: bool)
 B9:
-	30: LdFalse
-	31: StLoc[2](loc0: bool)
-	32: Branch(8)
+	31: MoveLoc[4](loc2: bool)
+	32: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.exp
@@ -70,29 +70,30 @@ B0:
 	1: StLoc[1](loc0: &Inner)
 	2: CopyLoc[1](loc0: &Inner)
 	3: TestVariant[0](Inner/Inner1)
-	4: BrFalse(12)
+	4: BrFalse(11)
 B1:
 	5: MoveLoc[1](loc0: &Inner)
 	6: Pop
 	7: MoveLoc[0](Arg0: Inner)
 	8: UnpackVariant[0](Inner/Inner1)
 	9: StLoc[2](loc1: u64)
+	10: Branch(21)
 B2:
-	10: MoveLoc[2](loc1: u64)
-	11: Ret
+	11: MoveLoc[1](loc0: &Inner)
+	12: TestVariant[1](Inner/Inner2)
+	13: BrFalse(19)
 B3:
-	12: MoveLoc[1](loc0: &Inner)
-	13: TestVariant[1](Inner/Inner2)
-	14: BrFalse(20)
+	14: MoveLoc[0](Arg0: Inner)
+	15: UnpackVariant[1](Inner/Inner2)
+	16: Add
+	17: StLoc[2](loc1: u64)
+	18: Branch(21)
 B4:
-	15: MoveLoc[0](Arg0: Inner)
-	16: UnpackVariant[1](Inner/Inner2)
-	17: Add
-	18: StLoc[2](loc1: u64)
-	19: Branch(10)
+	19: LdU64(14566554180833181697)
+	20: Abort
 B5:
-	20: LdU64(14566554180833181697)
-	21: Abort
+	21: MoveLoc[2](loc1: u64)
+	22: Ret
 }
 public is_inner1(Arg0: &Inner): bool /* def_idx: 1 */ {
 L1:	loc0: bool
@@ -100,49 +101,54 @@ L2:	loc1: &Inner
 B0:
 	0: CopyLoc[0](Arg0: &Inner)
 	1: TestVariant[0](Inner/Inner1)
-	2: BrFalse(9)
+	2: BrFalse(8)
 B1:
 	3: MoveLoc[0](Arg0: &Inner)
 	4: Pop
 	5: LdTrue
 	6: StLoc[1](loc0: bool)
+	7: Branch(17)
 B2:
-	7: MoveLoc[1](loc0: bool)
-	8: Ret
+	8: MoveLoc[0](Arg0: &Inner)
+	9: StLoc[2](loc1: &Inner)
+	10: MoveLoc[2](loc1: &Inner)
+	11: Pop
+	12: LdFalse
+	13: StLoc[1](loc0: bool)
+	14: Branch(17)
 B3:
-	9: MoveLoc[0](Arg0: &Inner)
-	10: StLoc[2](loc1: &Inner)
-	11: MoveLoc[2](loc1: &Inner)
-	12: Pop
-	13: LdFalse
-	14: StLoc[1](loc0: bool)
-	15: Branch(7)
+	15: LdU64(14566554180833181697)
+	16: Abort
+B4:
+	17: MoveLoc[1](loc0: bool)
+	18: Ret
 }
 public is_some<Ty0>(Arg0: &Option<Ty0>): bool /* def_idx: 2 */ {
 L1:	loc0: bool
 B0:
 	0: CopyLoc[0](Arg0: &Option<Ty0>)
 	1: TestVariantGeneric[0](Option/None<Ty0>)
-	2: BrFalse(9)
+	2: BrFalse(8)
 B1:
 	3: MoveLoc[0](Arg0: &Option<Ty0>)
 	4: Pop
 	5: LdFalse
 	6: StLoc[1](loc0: bool)
+	7: Branch(16)
 B2:
-	7: MoveLoc[1](loc0: bool)
-	8: Ret
+	8: MoveLoc[0](Arg0: &Option<Ty0>)
+	9: TestVariantGeneric[1](Option/Some<Ty0>)
+	10: BrFalse(14)
 B3:
-	9: MoveLoc[0](Arg0: &Option<Ty0>)
-	10: TestVariantGeneric[1](Option/Some<Ty0>)
-	11: BrFalse(15)
+	11: LdTrue
+	12: StLoc[1](loc0: bool)
+	13: Branch(16)
 B4:
-	12: LdTrue
-	13: StLoc[1](loc0: bool)
-	14: Branch(7)
+	14: LdU64(14566554180833181697)
+	15: Abort
 B5:
-	15: LdU64(14566554180833181697)
-	16: Abort
+	16: MoveLoc[1](loc0: bool)
+	17: Ret
 }
 public is_some_dropped<Ty0: drop>(Arg0: Option<Ty0>): bool /* def_idx: 3 */ {
 L1:	loc0: bool
@@ -150,67 +156,72 @@ L2:	loc1: Option<Ty0>
 B0:
 	0: ImmBorrowLoc[0](Arg0: Option<Ty0>)
 	1: TestVariantGeneric[0](Option/None<Ty0>)
-	2: BrFalse(9)
+	2: BrFalse(8)
 B1:
 	3: MoveLoc[0](Arg0: Option<Ty0>)
 	4: UnpackVariantGeneric[0](Option/None<Ty0>)
 	5: LdFalse
 	6: StLoc[1](loc0: bool)
+	7: Branch(15)
 B2:
-	7: MoveLoc[1](loc0: bool)
-	8: Ret
+	8: MoveLoc[0](Arg0: Option<Ty0>)
+	9: StLoc[2](loc1: Option<Ty0>)
+	10: LdTrue
+	11: StLoc[1](loc0: bool)
+	12: Branch(15)
 B3:
-	9: MoveLoc[0](Arg0: Option<Ty0>)
-	10: StLoc[2](loc1: Option<Ty0>)
-	11: LdTrue
-	12: StLoc[1](loc0: bool)
-	13: Branch(7)
+	13: LdU64(14566554180833181697)
+	14: Abort
+B4:
+	15: MoveLoc[1](loc0: bool)
+	16: Ret
 }
 public is_some_specialized(Arg0: &Option<Option<u64>>): bool /* def_idx: 4 */ {
 L1:	loc0: bool
 B0:
 	0: CopyLoc[0](Arg0: &Option<Option<u64>>)
 	1: TestVariantGeneric[2](Option/None<Option<u64>>)
-	2: BrFalse(9)
+	2: BrFalse(8)
 B1:
 	3: MoveLoc[0](Arg0: &Option<Option<u64>>)
 	4: Pop
 	5: LdFalse
 	6: StLoc[1](loc0: bool)
+	7: Branch(32)
 B2:
-	7: MoveLoc[1](loc0: bool)
-	8: Ret
+	8: CopyLoc[0](Arg0: &Option<Option<u64>>)
+	9: TestVariantGeneric[3](Option/Some<Option<u64>>)
+	10: BrFalse(20)
 B3:
-	9: CopyLoc[0](Arg0: &Option<Option<u64>>)
-	10: TestVariantGeneric[3](Option/Some<Option<u64>>)
-	11: BrFalse(21)
+	11: CopyLoc[0](Arg0: &Option<Option<u64>>)
+	12: ImmBorrowVariantFieldGeneric[0](Some.value: Ty0)
+	13: TestVariantGeneric[4](Option/None<u64>)
+	14: BrFalse(20)
 B4:
-	12: CopyLoc[0](Arg0: &Option<Option<u64>>)
-	13: ImmBorrowVariantFieldGeneric[0](Some.value: Ty0)
-	14: TestVariantGeneric[4](Option/None<u64>)
-	15: BrFalse(21)
+	15: MoveLoc[0](Arg0: &Option<Option<u64>>)
+	16: Pop
+	17: LdFalse
+	18: StLoc[1](loc0: bool)
+	19: Branch(32)
 B5:
-	16: MoveLoc[0](Arg0: &Option<Option<u64>>)
-	17: Pop
-	18: LdFalse
-	19: StLoc[1](loc0: bool)
-	20: Branch(7)
+	20: CopyLoc[0](Arg0: &Option<Option<u64>>)
+	21: TestVariantGeneric[3](Option/Some<Option<u64>>)
+	22: BrFalse(30)
 B6:
-	21: CopyLoc[0](Arg0: &Option<Option<u64>>)
-	22: TestVariantGeneric[3](Option/Some<Option<u64>>)
-	23: BrFalse(31)
+	23: MoveLoc[0](Arg0: &Option<Option<u64>>)
+	24: ImmBorrowVariantFieldGeneric[0](Some.value: Ty0)
+	25: TestVariantGeneric[5](Option/Some<u64>)
+	26: BrFalse(30)
 B7:
-	24: MoveLoc[0](Arg0: &Option<Option<u64>>)
-	25: ImmBorrowVariantFieldGeneric[0](Some.value: Ty0)
-	26: TestVariantGeneric[5](Option/Some<u64>)
-	27: BrFalse(31)
+	27: LdTrue
+	28: StLoc[1](loc0: bool)
+	29: Branch(32)
 B8:
-	28: LdTrue
-	29: StLoc[1](loc0: bool)
-	30: Branch(7)
+	30: LdU64(14566554180833181697)
+	31: Abort
 B9:
-	31: LdU64(14566554180833181697)
-	32: Abort
+	32: MoveLoc[1](loc0: bool)
+	33: Ret
 }
 public outer_value(Arg0: Outer): u64 /* def_idx: 5 */ {
 L1:	loc0: &Outer
@@ -221,7 +232,7 @@ B0:
 	1: StLoc[1](loc0: &Outer)
 	2: CopyLoc[1](loc0: &Outer)
 	3: TestVariant[4](Outer/None)
-	4: BrFalse(13)
+	4: BrFalse(12)
 B1:
 	5: MoveLoc[1](loc0: &Outer)
 	6: Pop
@@ -229,39 +240,40 @@ B1:
 	8: UnpackVariant[4](Outer/None)
 	9: LdU64(0)
 	10: StLoc[2](loc1: u64)
+	11: Branch(37)
 B2:
-	11: MoveLoc[2](loc1: u64)
-	12: Ret
+	12: CopyLoc[1](loc0: &Outer)
+	13: TestVariant[5](Outer/One)
+	14: BrFalse(22)
 B3:
-	13: CopyLoc[1](loc0: &Outer)
-	14: TestVariant[5](Outer/One)
-	15: BrFalse(23)
+	15: MoveLoc[1](loc0: &Outer)
+	16: Pop
+	17: MoveLoc[0](Arg0: Outer)
+	18: UnpackVariant[5](Outer/One)
+	19: Call inner_value(Inner): u64
+	20: StLoc[2](loc1: u64)
+	21: Branch(37)
 B4:
-	16: MoveLoc[1](loc0: &Outer)
-	17: Pop
-	18: MoveLoc[0](Arg0: Outer)
-	19: UnpackVariant[5](Outer/One)
-	20: Call inner_value(Inner): u64
-	21: StLoc[2](loc1: u64)
-	22: Branch(11)
+	22: MoveLoc[1](loc0: &Outer)
+	23: TestVariant[6](Outer/Two)
+	24: BrFalse(35)
 B5:
-	23: MoveLoc[1](loc0: &Outer)
-	24: TestVariant[6](Outer/Two)
-	25: BrFalse(36)
+	25: MoveLoc[0](Arg0: Outer)
+	26: UnpackVariant[6](Outer/Two)
+	27: StLoc[3](loc2: Box)
+	28: Call inner_value(Inner): u64
+	29: ImmBorrowLoc[3](loc2: Box)
+	30: ImmBorrowField[0](Box.x: u64)
+	31: ReadRef
+	32: Add
+	33: StLoc[2](loc1: u64)
+	34: Branch(37)
 B6:
-	26: MoveLoc[0](Arg0: Outer)
-	27: UnpackVariant[6](Outer/Two)
-	28: StLoc[3](loc2: Box)
-	29: Call inner_value(Inner): u64
-	30: ImmBorrowLoc[3](loc2: Box)
-	31: ImmBorrowField[0](Box.x: u64)
-	32: ReadRef
-	33: Add
-	34: StLoc[2](loc1: u64)
-	35: Branch(11)
+	35: LdU64(14566554180833181697)
+	36: Abort
 B7:
-	36: LdU64(14566554180833181697)
-	37: Abort
+	37: MoveLoc[2](loc1: u64)
+	38: Ret
 }
 public outer_value_nested(Arg0: Outer): u64 /* def_idx: 6 */ {
 L1:	loc0: &Outer
@@ -272,7 +284,7 @@ B0:
 	1: StLoc[1](loc0: &Outer)
 	2: CopyLoc[1](loc0: &Outer)
 	3: TestVariant[4](Outer/None)
-	4: BrFalse(13)
+	4: BrFalse(12)
 B1:
 	5: MoveLoc[1](loc0: &Outer)
 	6: Pop
@@ -280,56 +292,57 @@ B1:
 	8: UnpackVariant[4](Outer/None)
 	9: LdU64(0)
 	10: StLoc[2](loc1: u64)
+	11: Branch(51)
 B2:
-	11: MoveLoc[2](loc1: u64)
-	12: Ret
+	12: CopyLoc[1](loc0: &Outer)
+	13: TestVariant[5](Outer/One)
+	14: BrFalse(26)
 B3:
-	13: CopyLoc[1](loc0: &Outer)
-	14: TestVariant[5](Outer/One)
-	15: BrFalse(27)
+	15: CopyLoc[1](loc0: &Outer)
+	16: ImmBorrowVariantField[1](One.i: Inner)
+	17: TestVariant[0](Inner/Inner1)
+	18: BrFalse(26)
 B4:
-	16: CopyLoc[1](loc0: &Outer)
-	17: ImmBorrowVariantField[1](One.i: Inner)
-	18: TestVariant[0](Inner/Inner1)
-	19: BrFalse(27)
+	19: MoveLoc[1](loc0: &Outer)
+	20: Pop
+	21: MoveLoc[0](Arg0: Outer)
+	22: UnpackVariant[5](Outer/One)
+	23: UnpackVariant[0](Inner/Inner1)
+	24: StLoc[2](loc1: u64)
+	25: Branch(51)
 B5:
-	20: MoveLoc[1](loc0: &Outer)
-	21: Pop
-	22: MoveLoc[0](Arg0: Outer)
-	23: UnpackVariant[5](Outer/One)
-	24: UnpackVariant[0](Inner/Inner1)
-	25: StLoc[2](loc1: u64)
-	26: Branch(11)
+	26: CopyLoc[1](loc0: &Outer)
+	27: TestVariant[5](Outer/One)
+	28: BrFalse(36)
 B6:
-	27: CopyLoc[1](loc0: &Outer)
-	28: TestVariant[5](Outer/One)
-	29: BrFalse(37)
+	29: MoveLoc[1](loc0: &Outer)
+	30: Pop
+	31: MoveLoc[0](Arg0: Outer)
+	32: UnpackVariant[5](Outer/One)
+	33: Call inner_value(Inner): u64
+	34: StLoc[2](loc1: u64)
+	35: Branch(51)
 B7:
-	30: MoveLoc[1](loc0: &Outer)
-	31: Pop
-	32: MoveLoc[0](Arg0: Outer)
-	33: UnpackVariant[5](Outer/One)
-	34: Call inner_value(Inner): u64
-	35: StLoc[2](loc1: u64)
-	36: Branch(11)
+	36: MoveLoc[1](loc0: &Outer)
+	37: TestVariant[6](Outer/Two)
+	38: BrFalse(49)
 B8:
-	37: MoveLoc[1](loc0: &Outer)
-	38: TestVariant[6](Outer/Two)
-	39: BrFalse(50)
+	39: MoveLoc[0](Arg0: Outer)
+	40: UnpackVariant[6](Outer/Two)
+	41: StLoc[3](loc2: Box)
+	42: Call inner_value(Inner): u64
+	43: ImmBorrowLoc[3](loc2: Box)
+	44: ImmBorrowField[0](Box.x: u64)
+	45: ReadRef
+	46: Add
+	47: StLoc[2](loc1: u64)
+	48: Branch(51)
 B9:
-	40: MoveLoc[0](Arg0: Outer)
-	41: UnpackVariant[6](Outer/Two)
-	42: StLoc[3](loc2: Box)
-	43: Call inner_value(Inner): u64
-	44: ImmBorrowLoc[3](loc2: Box)
-	45: ImmBorrowField[0](Box.x: u64)
-	46: ReadRef
-	47: Add
-	48: StLoc[2](loc1: u64)
-	49: Branch(11)
+	49: LdU64(14566554180833181697)
+	50: Abort
 B10:
-	50: LdU64(14566554180833181697)
-	51: Abort
+	51: MoveLoc[2](loc1: u64)
+	52: Ret
 }
 public outer_value_with_cond(Arg0: Outer): u64 /* def_idx: 7 */ {
 L1:	loc0: &Outer
@@ -341,7 +354,7 @@ B0:
 	1: StLoc[1](loc0: &Outer)
 	2: CopyLoc[1](loc0: &Outer)
 	3: TestVariant[4](Outer/None)
-	4: BrFalse(13)
+	4: BrFalse(12)
 B1:
 	5: MoveLoc[1](loc0: &Outer)
 	6: Pop
@@ -349,155 +362,161 @@ B1:
 	8: UnpackVariant[4](Outer/None)
 	9: LdU64(0)
 	10: StLoc[2](loc1: u64)
+	11: Branch(55)
 B2:
-	11: MoveLoc[2](loc1: u64)
-	12: Ret
+	12: CopyLoc[1](loc0: &Outer)
+	13: TestVariant[5](Outer/One)
+	14: BrFalse(30)
 B3:
-	13: CopyLoc[1](loc0: &Outer)
-	14: TestVariant[5](Outer/One)
-	15: BrFalse(31)
+	15: CopyLoc[1](loc0: &Outer)
+	16: ImmBorrowVariantField[1](One.i: Inner)
+	17: StLoc[3](loc2: &Inner)
+	18: MoveLoc[3](loc2: &Inner)
+	19: Call is_inner1(&Inner): bool
+	20: BrFalse(30)
 B4:
-	16: CopyLoc[1](loc0: &Outer)
-	17: ImmBorrowVariantField[1](One.i: Inner)
-	18: StLoc[3](loc2: &Inner)
-	19: MoveLoc[3](loc2: &Inner)
-	20: Call is_inner1(&Inner): bool
-	21: BrFalse(31)
+	21: MoveLoc[1](loc0: &Outer)
+	22: Pop
+	23: MoveLoc[0](Arg0: Outer)
+	24: UnpackVariant[5](Outer/One)
+	25: Call inner_value(Inner): u64
+	26: LdU64(2)
+	27: Mod
+	28: StLoc[2](loc1: u64)
+	29: Branch(55)
 B5:
-	22: MoveLoc[1](loc0: &Outer)
-	23: Pop
-	24: MoveLoc[0](Arg0: Outer)
-	25: UnpackVariant[5](Outer/One)
-	26: Call inner_value(Inner): u64
-	27: LdU64(2)
-	28: Mod
-	29: StLoc[2](loc1: u64)
-	30: Branch(11)
+	30: CopyLoc[1](loc0: &Outer)
+	31: TestVariant[5](Outer/One)
+	32: BrFalse(40)
 B6:
-	31: CopyLoc[1](loc0: &Outer)
-	32: TestVariant[5](Outer/One)
-	33: BrFalse(41)
+	33: MoveLoc[1](loc0: &Outer)
+	34: Pop
+	35: MoveLoc[0](Arg0: Outer)
+	36: UnpackVariant[5](Outer/One)
+	37: Call inner_value(Inner): u64
+	38: StLoc[2](loc1: u64)
+	39: Branch(55)
 B7:
-	34: MoveLoc[1](loc0: &Outer)
-	35: Pop
-	36: MoveLoc[0](Arg0: Outer)
-	37: UnpackVariant[5](Outer/One)
-	38: Call inner_value(Inner): u64
-	39: StLoc[2](loc1: u64)
-	40: Branch(11)
+	40: MoveLoc[1](loc0: &Outer)
+	41: TestVariant[6](Outer/Two)
+	42: BrFalse(53)
 B8:
-	41: MoveLoc[1](loc0: &Outer)
-	42: TestVariant[6](Outer/Two)
-	43: BrFalse(54)
+	43: MoveLoc[0](Arg0: Outer)
+	44: UnpackVariant[6](Outer/Two)
+	45: StLoc[4](loc3: Box)
+	46: Call inner_value(Inner): u64
+	47: ImmBorrowLoc[4](loc3: Box)
+	48: ImmBorrowField[0](Box.x: u64)
+	49: ReadRef
+	50: Add
+	51: StLoc[2](loc1: u64)
+	52: Branch(55)
 B9:
-	44: MoveLoc[0](Arg0: Outer)
-	45: UnpackVariant[6](Outer/Two)
-	46: StLoc[4](loc3: Box)
-	47: Call inner_value(Inner): u64
-	48: ImmBorrowLoc[4](loc3: Box)
-	49: ImmBorrowField[0](Box.x: u64)
-	50: ReadRef
-	51: Add
-	52: StLoc[2](loc1: u64)
-	53: Branch(11)
+	53: LdU64(14566554180833181697)
+	54: Abort
 B10:
-	54: LdU64(14566554180833181697)
-	55: Abort
+	55: MoveLoc[2](loc1: u64)
+	56: Ret
 }
 public outer_value_with_cond_ref(Arg0: &Outer): bool /* def_idx: 8 */ {
 L1:	loc0: bool
 B0:
 	0: CopyLoc[0](Arg0: &Outer)
 	1: TestVariant[4](Outer/None)
-	2: BrFalse(9)
+	2: BrFalse(8)
 B1:
 	3: MoveLoc[0](Arg0: &Outer)
 	4: Pop
 	5: LdFalse
 	6: StLoc[1](loc0: bool)
+	7: Branch(40)
 B2:
-	7: MoveLoc[1](loc0: bool)
-	8: Ret
+	8: CopyLoc[0](Arg0: &Outer)
+	9: TestVariant[5](Outer/One)
+	10: BrFalse(20)
 B3:
-	9: CopyLoc[0](Arg0: &Outer)
-	10: TestVariant[5](Outer/One)
-	11: BrFalse(21)
+	11: CopyLoc[0](Arg0: &Outer)
+	12: ImmBorrowVariantField[1](One.i: Inner)
+	13: Call is_inner1(&Inner): bool
+	14: BrFalse(20)
 B4:
-	12: CopyLoc[0](Arg0: &Outer)
-	13: ImmBorrowVariantField[1](One.i: Inner)
-	14: Call is_inner1(&Inner): bool
-	15: BrFalse(21)
+	15: MoveLoc[0](Arg0: &Outer)
+	16: Pop
+	17: LdTrue
+	18: StLoc[1](loc0: bool)
+	19: Branch(40)
 B5:
-	16: MoveLoc[0](Arg0: &Outer)
-	17: Pop
-	18: LdTrue
-	19: StLoc[1](loc0: bool)
-	20: Branch(7)
+	20: CopyLoc[0](Arg0: &Outer)
+	21: TestVariant[5](Outer/One)
+	22: BrFalse(28)
 B6:
-	21: CopyLoc[0](Arg0: &Outer)
-	22: TestVariant[5](Outer/One)
-	23: BrFalse(29)
+	23: MoveLoc[0](Arg0: &Outer)
+	24: ImmBorrowVariantField[1](One.i: Inner)
+	25: Call is_inner1(&Inner): bool
+	26: StLoc[1](loc0: bool)
+	27: Branch(40)
 B7:
-	24: MoveLoc[0](Arg0: &Outer)
-	25: ImmBorrowVariantField[1](One.i: Inner)
-	26: Call is_inner1(&Inner): bool
-	27: StLoc[1](loc0: bool)
-	28: Branch(7)
+	28: CopyLoc[0](Arg0: &Outer)
+	29: TestVariant[6](Outer/Two)
+	30: BrFalse(36)
 B8:
-	29: CopyLoc[0](Arg0: &Outer)
-	30: TestVariant[6](Outer/Two)
-	31: BrFalse(37)
+	31: MoveLoc[0](Arg0: &Outer)
+	32: ImmBorrowVariantField[2](Two.i: Inner)
+	33: Call is_inner1(&Inner): bool
+	34: StLoc[1](loc0: bool)
+	35: Branch(40)
 B9:
-	32: MoveLoc[0](Arg0: &Outer)
-	33: ImmBorrowVariantField[2](Two.i: Inner)
-	34: Call is_inner1(&Inner): bool
-	35: StLoc[1](loc0: bool)
-	36: Branch(7)
+	36: MoveLoc[0](Arg0: &Outer)
+	37: Pop
+	38: LdU64(14566554180833181697)
+	39: Abort
 B10:
-	37: MoveLoc[0](Arg0: &Outer)
-	38: Pop
-	39: LdU64(14566554180833181697)
-	40: Abort
+	40: MoveLoc[1](loc0: bool)
+	41: Ret
 }
 select_common_fields(Arg0: CommonFields): u64 /* def_idx: 9 */ {
-L1:	loc0: u64
-L2:	loc1: &CommonFields
+L1:	loc0: &CommonFields
+L2:	loc1: bool
 L3:	loc2: u64
+L4:	loc3: u64
 B0:
 	0: ImmBorrowLoc[0](Arg0: CommonFields)
 	1: ImmBorrowVariantField[3](Foo.x|Bar.x: u64)
 	2: ReadRef
-	3: StLoc[1](loc0: u64)
-	4: ImmBorrowLoc[0](Arg0: CommonFields)
-	5: StLoc[2](loc1: &CommonFields)
-	6: CopyLoc[2](loc1: &CommonFields)
-	7: TestVariant[7](CommonFields/Foo)
-	8: BrFalse(19)
+	3: ImmBorrowLoc[0](Arg0: CommonFields)
+	4: StLoc[1](loc0: &CommonFields)
+	5: CopyLoc[1](loc0: &CommonFields)
+	6: TestVariant[7](CommonFields/Foo)
+	7: StLoc[2](loc1: bool)
+	8: StLoc[3](loc2: u64)
+	9: MoveLoc[2](loc1: bool)
+	10: BrFalse(18)
 B1:
-	9: MoveLoc[2](loc1: &CommonFields)
-	10: Pop
-	11: MoveLoc[0](Arg0: CommonFields)
-	12: UnpackVariant[7](CommonFields/Foo)
-	13: StLoc[3](loc2: u64)
-	14: Pop
+	11: MoveLoc[1](loc0: &CommonFields)
+	12: Pop
+	13: MoveLoc[0](Arg0: CommonFields)
+	14: UnpackVariant[7](CommonFields/Foo)
+	15: StLoc[4](loc3: u64)
+	16: Pop
+	17: Branch(28)
 B2:
-	15: MoveLoc[1](loc0: u64)
-	16: MoveLoc[3](loc2: u64)
-	17: Add
-	18: Ret
+	18: MoveLoc[1](loc0: &CommonFields)
+	19: TestVariant[8](CommonFields/Bar)
+	20: BrFalse(26)
 B3:
-	19: MoveLoc[2](loc1: &CommonFields)
-	20: TestVariant[8](CommonFields/Bar)
-	21: BrFalse(27)
+	21: MoveLoc[0](Arg0: CommonFields)
+	22: UnpackVariant[8](CommonFields/Bar)
+	23: StLoc[4](loc3: u64)
+	24: Pop
+	25: Branch(28)
 B4:
-	22: MoveLoc[0](Arg0: CommonFields)
-	23: UnpackVariant[8](CommonFields/Bar)
-	24: StLoc[3](loc2: u64)
-	25: Pop
-	26: Branch(15)
+	26: LdU64(14566554180833181697)
+	27: Abort
 B5:
-	27: LdU64(14566554180833181697)
-	28: Abort
+	28: MoveLoc[3](loc2: u64)
+	29: MoveLoc[4](loc3: u64)
+	30: Add
+	31: Ret
 }
 select_common_fields_different_offset(Arg0: CommonFieldsAtDifferentOffset): u64 /* def_idx: 10 */ {
 L1:	loc0: &CommonFieldsAtDifferentOffset
@@ -507,24 +526,26 @@ B0:
 	1: StLoc[1](loc0: &CommonFieldsAtDifferentOffset)
 	2: CopyLoc[1](loc0: &CommonFieldsAtDifferentOffset)
 	3: TestVariant[9](CommonFieldsAtDifferentOffset/Bar)
-	4: BrTrue(14)
+	4: BrTrue(9)
 B1:
 	5: CopyLoc[1](loc0: &CommonFieldsAtDifferentOffset)
 	6: TestVariant[10](CommonFieldsAtDifferentOffset/Balt)
-	7: BrTrue(14)
+	7: BrTrue(9)
 B2:
-	8: MoveLoc[1](loc0: &CommonFieldsAtDifferentOffset)
-	9: ImmBorrowVariantField[4](Baz.z: u64)
-	10: StLoc[2](loc1: &u64)
+	8: Branch(13)
 B3:
-	11: MoveLoc[2](loc1: &u64)
-	12: ReadRef
-	13: Ret
+	9: MoveLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	10: ImmBorrowVariantField[4](Bar.z|Balt.z: u64)
+	11: StLoc[2](loc1: &u64)
+	12: Branch(16)
 B4:
-	14: MoveLoc[1](loc0: &CommonFieldsAtDifferentOffset)
-	15: ImmBorrowVariantField[5](Bar.z|Balt.z: u64)
-	16: StLoc[2](loc1: &u64)
-	17: Branch(11)
+	13: MoveLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	14: ImmBorrowVariantField[5](Baz.z: u64)
+	15: StLoc[2](loc1: &u64)
+B5:
+	16: MoveLoc[2](loc1: &u64)
+	17: ReadRef
+	18: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.exp
@@ -16,15 +16,17 @@ public destroy_none<Ty0>(Arg0: Option<Ty0>) /* def_idx: 0 */ {
 B0:
 	0: ImmBorrowLoc[0](Arg0: Option<Ty0>)
 	1: Call is_none<Ty0>(&Option<Ty0>): bool
-	2: BrFalse(7)
+	2: BrFalse(4)
 B1:
-	3: MoveLoc[0](Arg0: Option<Ty0>)
-	4: UnpackGeneric[0](Option<Ty0>)
-	5: VecUnpack(2, 0)
-	6: Ret
+	3: Branch(6)
 B2:
-	7: LdU64(262144)
-	8: Abort
+	4: LdU64(262144)
+	5: Abort
+B3:
+	6: MoveLoc[0](Arg0: Option<Ty0>)
+	7: UnpackGeneric[0](Option<Ty0>)
+	8: VecUnpack(2, 0)
+	9: Ret
 }
 public foo<Ty0: drop + store>(Arg0: E<Ty0>, Arg1: &mut Ty0) /* def_idx: 1 */ {
 L2:	loc0: E<Ty0>

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
@@ -22,46 +22,52 @@ B0:
 	4: CopyLoc[1](Arg1: u64)
 	5: CopyLoc[2](loc0: u64)
 	6: Ge
-	7: BrFalse(12)
+	7: BrFalse(13)
 B1:
 	8: MoveLoc[0](Arg0: &mut vector<Ty0>)
 	9: Pop
 	10: LdU64(1)
 	11: Abort
 B2:
-	12: LdU64(1)
-	13: StLoc[3](loc1: u64)
-	14: MoveLoc[2](loc0: u64)
-	15: MoveLoc[3](loc1: u64)
-	16: Sub
-	17: StLoc[2](loc0: u64)
+	12: Branch(13)
 B3:
-	18: CopyLoc[1](Arg1: u64)
-	19: CopyLoc[2](loc0: u64)
-	20: Lt
-	21: BrFalse(39)
+	13: LdU64(1)
+	14: StLoc[3](loc1: u64)
+	15: MoveLoc[2](loc0: u64)
+	16: MoveLoc[3](loc1: u64)
+	17: Sub
+	18: StLoc[2](loc0: u64)
 B4:
-	22: CopyLoc[0](Arg0: &mut vector<Ty0>)
-	23: StLoc[4](loc2: &mut vector<Ty0>)
-	24: CopyLoc[1](Arg1: u64)
-	25: StLoc[5](loc3: u64)
-	26: LdU64(1)
-	27: StLoc[6](loc4: u64)
-	28: MoveLoc[1](Arg1: u64)
-	29: MoveLoc[6](loc4: u64)
-	30: Add
-	31: StLoc[1](Arg1: u64)
-	32: CopyLoc[1](Arg1: u64)
-	33: StLoc[7](loc5: u64)
-	34: MoveLoc[4](loc2: &mut vector<Ty0>)
-	35: MoveLoc[5](loc3: u64)
-	36: MoveLoc[7](loc5: u64)
-	37: VecSwap(1)
-	38: Branch(18)
+	19: CopyLoc[1](Arg1: u64)
+	20: CopyLoc[2](loc0: u64)
+	21: Lt
+	22: BrFalse(40)
 B5:
-	39: MoveLoc[0](Arg0: &mut vector<Ty0>)
-	40: VecPopBack(1)
-	41: Ret
+	23: CopyLoc[0](Arg0: &mut vector<Ty0>)
+	24: StLoc[4](loc2: &mut vector<Ty0>)
+	25: CopyLoc[1](Arg1: u64)
+	26: StLoc[5](loc3: u64)
+	27: LdU64(1)
+	28: StLoc[6](loc4: u64)
+	29: MoveLoc[1](Arg1: u64)
+	30: MoveLoc[6](loc4: u64)
+	31: Add
+	32: StLoc[1](Arg1: u64)
+	33: CopyLoc[1](Arg1: u64)
+	34: StLoc[7](loc5: u64)
+	35: MoveLoc[4](loc2: &mut vector<Ty0>)
+	36: MoveLoc[5](loc3: u64)
+	37: MoveLoc[7](loc5: u64)
+	38: VecSwap(1)
+	39: Branch(41)
+B6:
+	40: Branch(42)
+B7:
+	41: Branch(19)
+B8:
+	42: MoveLoc[0](Arg0: &mut vector<Ty0>)
+	43: VecPopBack(1)
+	44: Ret
 }
 create(): vector<u64> /* def_idx: 1 */ {
 B0:
@@ -69,8 +75,8 @@ B0:
 	1: Ret
 }
 test_fold() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: vector<u64>
+L0:	loc0: vector<u64>
+L1:	loc1: u64
 L2:	loc2: u64
 L3:	loc3: u64
 L4:	loc4: u64
@@ -78,41 +84,47 @@ L5:	loc5: u64
 L6:	loc6: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[0](loc0: u64)
-	2: LdConst[1](Vector(U64): [1, 1, 0, 0, 0, 0, 0, 0, 0])
-	3: StLoc[1](loc1: vector<u64>)
-	4: MutBorrowLoc[1](loc1: vector<u64>)
-	5: Call 1vector::reverse<u64>(&mut vector<u64>)
+	1: LdConst[1](Vector(U64): [1, 1, 0, 0, 0, 0, 0, 0, 0])
+	2: StLoc[0](loc0: vector<u64>)
+	3: MutBorrowLoc[0](loc0: vector<u64>)
+	4: Call 1vector::reverse<u64>(&mut vector<u64>)
+	5: StLoc[1](loc1: u64)
 B1:
-	6: ImmBorrowLoc[1](loc1: vector<u64>)
+	6: ImmBorrowLoc[0](loc0: vector<u64>)
 	7: Call 1vector::is_empty<u64>(&vector<u64>): bool
 	8: Not
 	9: BrFalse(20)
 B2:
-	10: MutBorrowLoc[1](loc1: vector<u64>)
+	10: MutBorrowLoc[0](loc0: vector<u64>)
 	11: VecPopBack(5)
 	12: StLoc[2](loc2: u64)
-	13: MoveLoc[0](loc0: u64)
+	13: MoveLoc[1](loc1: u64)
 	14: StLoc[3](loc3: u64)
 	15: MoveLoc[2](loc2: u64)
 	16: StLoc[4](loc4: u64)
 	17: LdU64(0)
-	18: StLoc[0](loc0: u64)
-	19: Branch(6)
+	18: StLoc[1](loc1: u64)
+	19: Branch(21)
 B3:
-	20: MoveLoc[0](loc0: u64)
-	21: StLoc[5](loc5: u64)
-	22: LdU64(0)
-	23: StLoc[6](loc6: u64)
-	24: MoveLoc[5](loc5: u64)
-	25: MoveLoc[6](loc6: u64)
-	26: Eq
-	27: BrFalse(29)
+	20: Branch(22)
 B4:
-	28: Ret
+	21: Branch(6)
 B5:
-	29: LdU64(0)
-	30: Abort
+	22: MoveLoc[1](loc1: u64)
+	23: StLoc[5](loc5: u64)
+	24: LdU64(0)
+	25: StLoc[6](loc6: u64)
+	26: MoveLoc[5](loc5: u64)
+	27: MoveLoc[6](loc6: u64)
+	28: Eq
+	29: BrFalse(31)
+B6:
+	30: Branch(33)
+B7:
+	31: LdU64(0)
+	32: Abort
+B8:
+	33: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -174,6 +174,7 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
                 // also turned off for now since they mess up baseline.
                 .set_experiment(Experiment::CHECKS, false)
                 .set_experiment(Experiment::OPTIMIZE, false)
+                .set_experiment(Experiment::OPTIMIZE_WAITING_FOR_COMPARE_TESTS, false)
                 .set_experiment(Experiment::INLINING, false)
                 .set_experiment(Experiment::RECURSIVE_TYPE_CHECK, false)
                 .set_experiment(Experiment::SPEC_REWRITE, false)
@@ -324,6 +325,7 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             // known without optimizations, so we need to have a different exp file
             exp_suffix: Some("no-opt.exp"),
             options: opts.clone().set_experiment(Experiment::OPTIMIZE, false)
+                .set_experiment(Experiment::OPTIMIZE_WAITING_FOR_COMPARE_TESTS, false)
                 .set_experiment(Experiment::ACQUIRES_CHECK, false),
             stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::None,
@@ -556,6 +558,7 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             options: opts
                 .clone()
                 .set_experiment(Experiment::OPTIMIZE, false)
+                .set_experiment(Experiment::OPTIMIZE_WAITING_FOR_COMPARE_TESTS, false)
                 .set_experiment(Experiment::AST_SIMPLIFY, true),
             stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::None,

--- a/third_party/move/move-prover/tests/sources/functional/choice.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/choice.v2_exp
@@ -45,13 +45,12 @@ error: post-condition does not hold
    =     at tests/sources/functional/choice.move:76: test_not_using_min_incorrect
    =         v = <redacted>
    =     at tests/sources/functional/choice.move:77: test_not_using_min_incorrect
-   =     at tests/sources/functional/choice.move:78: test_not_using_min_incorrect
-   =         <redacted> = <redacted>
    =         v_ref = <redacted>
+   =     at tests/sources/functional/choice.move:78: test_not_using_min_incorrect
    =     at tests/sources/functional/choice.move:79: test_not_using_min_incorrect
    =     at tests/sources/functional/choice.move:80: test_not_using_min_incorrect
-   =     at tests/sources/functional/choice.move:81: test_not_using_min_incorrect
    =         v = <redacted>
+   =     at tests/sources/functional/choice.move:81: test_not_using_min_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/choice.move:84: test_not_using_min_incorrect
    =     at tests/sources/functional/choice.move:87: test_not_using_min_incorrect (spec)

--- a/third_party/move/move-prover/tests/sources/functional/enum.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/enum.v2_exp
@@ -33,7 +33,6 @@ error: data invariant does not hold
    =     at tests/sources/functional/enum.move:29: test_data_invariant
    =         <redacted> = <redacted>
    =         z = <redacted>
-   =     at tests/sources/functional/enum.move:30: test_data_invariant
    =     at tests/sources/functional/enum.move:9
    =     at tests/sources/functional/enum.move:10
 
@@ -52,13 +51,12 @@ error: unknown assertion failed
    =     at tests/sources/functional/enum.move:58: test_enum_vector
    =     at tests/sources/functional/enum.move:9
    =     at tests/sources/functional/enum.move:10
+   =     at tests/sources/functional/enum.move:58: test_enum_vector
+   =         _common_fields = <redacted>
    =     at tests/sources/functional/enum.move:64: test_enum_vector
    =     at tests/sources/functional/enum.move:65: test_enum_vector
-   =         <redacted> = <redacted>
-   =         _common_fields = <redacted>
    =     at tests/sources/functional/enum.move:9
    =     at tests/sources/functional/enum.move:65: test_enum_vector
    =     at tests/sources/functional/enum.move:63: test_enum_vector
-   =         <redacted> = <redacted>
    =         _common_vector_2 = <redacted>
    =     at tests/sources/functional/enum.move:68: test_enum_vector

--- a/third_party/move/move-prover/tests/sources/functional/enum_abort.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/enum_abort.v2_exp
@@ -74,6 +74,7 @@ error: abort not covered by any of the `aborts_if` clauses
     =         common = <redacted>
     =     at tests/sources/functional/enum_abort.move:98: test_get_field_abort
     =         <redacted> = <redacted>
+    =     at tests/sources/functional/enum_abort.move:98: test_get_field_abort
     =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
@@ -91,14 +92,15 @@ error: abort not covered by any of the `aborts_if` clauses
     =     at tests/sources/functional/enum_abort.move:114: test_match_abort
     =     at tests/sources/functional/enum_abort.move:115: test_match_abort
     =     at tests/sources/functional/enum_abort.move:112: test_match_abort
+    =         common = <redacted>
     =     at tests/sources/functional/enum_abort.move:118: test_match_abort
     =     at tests/sources/functional/enum_abort.move:117: test_match_abort
-    =         <redacted> = <redacted>
-    =         common = <redacted>
     =         _common_vector_2 = <redacted>
-    =     at tests/sources/functional/enum_abort.move:122: test_match_abort
+    =     at tests/sources/functional/enum_abort.move:121: test_match_abort
     =         <redacted> = <redacted>
+    =     at tests/sources/functional/enum_abort.move:122: test_match_abort
     =         _x = <redacted>
+    =         <redacted> = <redacted>
     =     at tests/sources/functional/enum_abort.move:122: test_match_abort
     =         _z = <redacted>
     =         <redacted> = <redacted>

--- a/third_party/move/move-prover/tests/sources/functional/enum_generic.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/enum_generic.v2_exp
@@ -12,11 +12,9 @@ error: unknown assertion failed
    =     at tests/sources/functional/enum_generic.move:19: test_enum_vector
    =     at tests/sources/functional/enum_generic.move:20: test_enum_vector
    =     at tests/sources/functional/enum_generic.move:17: test_enum_vector
+   =         _common_fields = <redacted>
    =     at tests/sources/functional/enum_generic.move:23: test_enum_vector
    =     at tests/sources/functional/enum_generic.move:24: test_enum_vector
-   =         <redacted> = <redacted>
-   =         _common_fields = <redacted>
    =     at tests/sources/functional/enum_generic.move:22: test_enum_vector
-   =         <redacted> = <redacted>
    =         _common_vector_2 = <redacted>
    =     at tests/sources/functional/enum_generic.move:27: test_enum_vector

--- a/third_party/move/move-prover/tests/sources/functional/enum_positional.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/enum_positional.v2_exp
@@ -13,6 +13,5 @@ error: data invariant does not hold
   =     at tests/sources/functional/enum_positional.move:17: test_positional_incorrect
   =         <redacted> = <redacted>
   =     at tests/sources/functional/enum_positional.move:18: test_positional_incorrect
-  =         <redacted> = <redacted>
   =         y = <redacted>
   =     at tests/sources/functional/enum_positional.move:9

--- a/third_party/move/move-prover/tests/sources/functional/enum_self.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/enum_self.v2_exp
@@ -12,7 +12,6 @@ error: data invariant does not hold
    =     at tests/sources/functional/enum_self.move:19: test_enum_self
    =         self_s = <redacted>
    =     at tests/sources/functional/enum_self.move:22: test_enum_self
-   =     at tests/sources/functional/enum_self.move:23: test_enum_self
-   =         <redacted> = <redacted>
    =         self = <redacted>
+   =     at tests/sources/functional/enum_self.move:23: test_enum_self
    =     at tests/sources/functional/enum_self.move:12

--- a/third_party/move/move-prover/tests/sources/functional/fixed_point_arithm.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/fixed_point_arithm.v2_exp
@@ -78,8 +78,8 @@ error: post-condition does not hold
     =     at ../move-stdlib/sources/fixed_point32.move:150: get_raw_value
     =         result = <redacted>
     =     at ../move-stdlib/sources/fixed_point32.move:151: get_raw_value
-    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =         y_raw_val = <redacted>
+    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =         y = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect
@@ -102,8 +102,8 @@ error: post-condition does not hold
     =     at ../move-stdlib/sources/fixed_point32.move:150: get_raw_value
     =         result = <redacted>
     =     at ../move-stdlib/sources/fixed_point32.move:151: get_raw_value
-    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =         y_raw_val = <redacted>
+    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =         y = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect

--- a/third_party/move/move-prover/tests/sources/functional/invariants.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/invariants.v2_exp
@@ -20,9 +20,8 @@ error: data invariant does not hold
    =         r = <redacted>
    =     at tests/sources/functional/invariants.move:114: lifetime_invalid_R
    =     at tests/sources/functional/invariants.move:115: lifetime_invalid_R
-   =     at tests/sources/functional/invariants.move:116: lifetime_invalid_R
-   =         <redacted> = <redacted>
    =         x_ref = <redacted>
+   =     at tests/sources/functional/invariants.move:116: lifetime_invalid_R
    =     at tests/sources/functional/invariants.move:15
 
 error: data invariant does not hold

--- a/third_party/move/move-prover/tests/sources/functional/is_txn_signer.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/is_txn_signer.v2_exp
@@ -55,8 +55,8 @@ error: global memory invariant does not hold
    =     at tests/sources/functional/is_txn_signer.move:60: ADMIN_ADDRESS
    =         result = <redacted>
    =     at tests/sources/functional/is_txn_signer.move:61: ADMIN_ADDRESS
-   =     at tests/sources/functional/is_txn_signer.move:85: increment_incorrect
    =         c_ref = <redacted>
+   =     at tests/sources/functional/is_txn_signer.move:85: increment_incorrect
    =     at tests/sources/functional/is_txn_signer.move:83: increment_incorrect
    =     at tests/sources/functional/is_txn_signer.move:85: increment_incorrect
    =     at tests/sources/functional/is_txn_signer.move:90

--- a/third_party/move/move-prover/tests/sources/functional/mut_ref.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/mut_ref.v2_exp
@@ -40,8 +40,6 @@ error: data invariant does not hold
   =         result = <redacted>
   =         x = <redacted>
   =     at tests/sources/functional/mut_ref.move:92: return_ref_different_path_vec2
-  =     at tests/sources/functional/mut_ref.move:122: call_return_ref_different_path_vec2_incorrect
-  =         <redacted> = <redacted>
   =         r = <redacted>
   =     at tests/sources/functional/mut_ref.move:122: call_return_ref_different_path_vec2_incorrect
   =     at tests/sources/functional/mut_ref.move:8

--- a/third_party/move/move-prover/tests/sources/functional/references.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/references.v2_exp
@@ -8,8 +8,8 @@ error: function does not abort under this condition
    =     at tests/sources/functional/references.move:69: mut_ref_incorrect
    =         b = <redacted>
    =     at tests/sources/functional/references.move:70: mut_ref_incorrect
-   =     at tests/sources/functional/references.move:71: mut_ref_incorrect
    =         b_ref = <redacted>
+   =     at tests/sources/functional/references.move:71: mut_ref_incorrect
    =     at tests/sources/functional/references.move:50: mut_b
    =         b = <redacted>
    =     at tests/sources/functional/references.move:51: mut_b

--- a/third_party/move/move-prover/tests/sources/functional/strong_edges.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/strong_edges.v2_exp
@@ -25,8 +25,7 @@ error: unknown assertion failed
    =     at tests/sources/functional/strong_edges.move:60: loc__edge_incorrect
    =         r = <redacted>
    =     at tests/sources/functional/strong_edges.move:61: loc__edge_incorrect
-   =     at tests/sources/functional/strong_edges.move:62: loc__edge_incorrect
-   =         <redacted> = <redacted>
    =         r_ref = <redacted>
+   =     at tests/sources/functional/strong_edges.move:62: loc__edge_incorrect
    =         r = <redacted>
    =     at tests/sources/functional/strong_edges.move:64: loc__edge_incorrect


### PR DESCRIPTION
## Description

In this PR, we make "flush writes optimization" a default optimization (derives from the `OPTIMIZE` experiment), after having successfully run the compare testing with it being on.

In addition, I am turning off the experiment `OPTIMIZE_WAITING_FOR_COMPARE_TESTS` in all those test configs where `OPTIMIZE` was turned off, as the expectation in those test configs is that no optimizations are run.

## Type of Change
- [x] Performance improvement

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## How Has This Been Tested?
Existing tests, with baseline updates that were reviewed and considered okay.
