### PR TITLE
[simple] remove backtrace from common warn logs

### DIFF
--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -1535,7 +1535,7 @@ impl RoundManager {
                             Ok(_) => trace!(RoundStateLogSchema::new(round_state)),
                             Err(e) => {
                                 counters::ERROR_COUNT.inc();
-                                warn!(error = ?e, kind = error_kind(&e), RoundStateLogSchema::new(round_state));
+                                warn!(kind = error_kind(&e), RoundStateLogSchema::new(round_state), "Error: {:#}", e);
                             }
                         }
                     }
@@ -1583,7 +1583,7 @@ impl RoundManager {
                         Ok(_) => trace!(RoundStateLogSchema::new(round_state)),
                         Err(e) => {
                             counters::ERROR_COUNT.inc();
-                            warn!(error = ?e, kind = error_kind(&e), RoundStateLogSchema::new(round_state));
+                            warn!(kind = error_kind(&e), RoundStateLogSchema::new(round_state), "Error: {:#}", e);
                         }
                     }
                 },

--- a/crates/reliable-broadcast/src/lib.rs
+++ b/crates/reliable-broadcast/src/lib.rs
@@ -211,12 +211,12 @@ fn log_rpc_failure(error: anyhow::Error, receiver: Author) {
     // Log a sampled warning (to prevent spam)
     sample!(
         SampleRate::Duration(Duration::from_secs(30)),
-        warn!(error = ?error, "[sampled] rpc to {} failed, error {}", receiver, error)
+        warn!("[sampled] rpc to {} failed, error {:#}", receiver, error)
     );
 
     // Log at the debug level (this is useful for debugging
     // and won't spam the logs in a production environment).
-    debug!(error = ?error, "rpc to {} failed, error {}", receiver, error);
+    debug!("rpc to {} failed, error {:#}", receiver, error);
 }
 
 pub struct DropGuard {

--- a/network/framework/src/protocols/health_checker/mod.rs
+++ b/network/framework/src/protocols/health_checker/mod.rs
@@ -342,11 +342,9 @@ impl<NetworkClient: NetworkClientInterface<HealthCheckerMsg> + Unpin> HealthChec
             },
             Err(err) => {
                 warn!(
-                    NetworkSchema::new(&self.network_context)
-                        .remote_peer(&peer_id),
-                    error = ?err,
+                    NetworkSchema::new(&self.network_context).remote_peer(&peer_id),
                     round = round,
-                    "{} Ping failed for peer: {} round: {} with error: {:?}",
+                    "{} Ping failed for peer: {} round: {} with error: {:#}",
                     self.network_context,
                     peer_id.short_str(),
                     round,


### PR DESCRIPTION
## Description

Use {:#} from https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations, to keep all reasons, but no stack trace, as they are generally not useful here.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
