### PR TITLE
[Consensus] Make consensus pipeline self-sending optional.

### DIFF
--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -90,7 +90,7 @@ pub fn start_consensus(
         node_config.consensus.clone(),
         Arc::new(execution_proxy),
         node_config.validator_network.as_ref().unwrap().peer_id(),
-        self_sender.clone(),
+        Some(self_sender.clone()),
         consensus_network_client.clone(),
         bounded_executor.clone(),
         rand_storage.clone(),
@@ -101,7 +101,7 @@ pub fn start_consensus(
     let epoch_mgr = EpochManager::new(
         node_config,
         time_service,
-        self_sender,
+        Some(self_sender),
         consensus_network_client,
         timeout_sender,
         consensus_to_mempool_sender,
@@ -140,8 +140,6 @@ pub fn start_consensus_observer(
     reconfig_events: Option<ReconfigNotificationListener<DbBackedOnChainConfig>>,
 ) {
     // Create the (dummy) consensus network client
-    let (self_sender, _self_receiver) =
-        aptos_channels::new_unbounded(&counters::PENDING_SELF_MESSAGES);
     let consensus_network_client = ConsensusNetworkClient::new(NetworkClient::new(
         vec![],
         vec![],
@@ -174,7 +172,7 @@ pub fn start_consensus_observer(
             node_config.consensus.clone(),
             Arc::new(execution_proxy),
             AccountAddress::ONE,
-            self_sender.clone(),
+            None,
             consensus_network_client,
             bounded_executor,
             rand_storage.clone(),

--- a/consensus/src/dag/tests/integration_tests.rs
+++ b/consensus/src/dag/tests/integration_tests.rs
@@ -161,7 +161,12 @@ fn create_network(
     let network_events = NetworkEvents::new(consensus_rx, None, true);
 
     let (self_sender, self_receiver) = aptos_channels::new_unbounded_test();
-    let network = NetworkSender::new(author, consensus_network_client, self_sender, validators);
+    let network = NetworkSender::new(
+        author,
+        consensus_network_client,
+        Some(self_sender),
+        validators,
+    );
 
     let twin_id = TwinId { id, author };
 

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -137,7 +137,7 @@ pub struct EpochManager<P: OnChainConfigProvider> {
     execution_config: ExecutionConfig,
     randomness_override_seq_num: u64,
     time_service: Arc<dyn TimeService>,
-    self_sender: aptos_channels::UnboundedSender<Event<ConsensusMsg>>,
+    self_sender: Option<aptos_channels::UnboundedSender<Event<ConsensusMsg>>>,
     network_sender: ConsensusNetworkClient<NetworkClient<ConsensusMsg>>,
     timeout_sender: aptos_channels::Sender<Round>,
     quorum_store_enabled: bool,
@@ -184,7 +184,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
     pub(crate) fn new(
         node_config: &NodeConfig,
         time_service: Arc<dyn TimeService>,
-        self_sender: aptos_channels::UnboundedSender<Event<ConsensusMsg>>,
+        self_sender: Option<aptos_channels::UnboundedSender<Event<ConsensusMsg>>>,
         network_sender: ConsensusNetworkClient<NetworkClient<ConsensusMsg>>,
         timeout_sender: aptos_channels::Sender<Round>,
         quorum_store_to_mempool_sender: Sender<QuorumStoreRequest>,

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -662,7 +662,7 @@ mod tests {
             let node = NetworkSender::new(
                 *peer,
                 consensus_network_client,
-                self_sender,
+                Some(self_sender),
                 validator_verifier.clone(),
             );
 
@@ -778,7 +778,7 @@ mod tests {
             let node = NetworkSender::new(
                 *peer,
                 consensus_network_client.clone(),
-                self_sender,
+                Some(self_sender),
                 validator_verifier.clone(),
             );
 

--- a/consensus/src/pipeline/execution_client.rs
+++ b/consensus/src/pipeline/execution_client.rs
@@ -146,7 +146,7 @@ pub struct ExecutionProxyClient {
     consensus_config: ConsensusConfig,
     execution_proxy: Arc<ExecutionProxy>,
     author: Author,
-    self_sender: aptos_channels::UnboundedSender<Event<ConsensusMsg>>,
+    self_sender: Option<aptos_channels::UnboundedSender<Event<ConsensusMsg>>>,
     network_sender: ConsensusNetworkClient<NetworkClient<ConsensusMsg>>,
     bounded_executor: BoundedExecutor,
     // channels to buffer manager
@@ -161,7 +161,7 @@ impl ExecutionProxyClient {
         consensus_config: ConsensusConfig,
         execution_proxy: Arc<ExecutionProxy>,
         author: Author,
-        self_sender: aptos_channels::UnboundedSender<Event<ConsensusMsg>>,
+        self_sender: Option<aptos_channels::UnboundedSender<Event<ConsensusMsg>>>,
         network_sender: ConsensusNetworkClient<NetworkClient<ConsensusMsg>>,
         bounded_executor: BoundedExecutor,
         rand_storage: Arc<dyn RandStorage<AugmentedData>>,

--- a/consensus/src/pipeline/tests/buffer_manager_tests.rs
+++ b/consensus/src/pipeline/tests/buffer_manager_tests.rs
@@ -117,7 +117,7 @@ pub fn prepare_buffer_manager(
     let network = NetworkSender::new(
         author,
         consensus_network_client,
-        self_loop_tx,
+        Some(self_loop_tx),
         validators.clone(),
     );
 

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -157,8 +157,6 @@ fn create_node_for_fuzzing() -> RoundManager {
     );
     let consensus_network_client = ConsensusNetworkClient::new(network_client);
 
-    let (self_sender, _self_receiver) = aptos_channels::new_unbounded_test();
-
     let epoch_state = Arc::new(EpochState {
         epoch: 1,
         verifier: storage.get_validator_set().into(),
@@ -166,7 +164,7 @@ fn create_node_for_fuzzing() -> RoundManager {
     let network = Arc::new(NetworkSender::new(
         signer.author(),
         consensus_network_client,
-        self_sender,
+        None,
         epoch_state.verifier.clone(),
     ));
 

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -270,7 +270,7 @@ impl NodeSetup {
         let network = Arc::new(NetworkSender::new(
             author,
             consensus_network_client,
-            self_sender,
+            Some(self_sender),
             validators,
         ));
 

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -151,7 +151,7 @@ impl SMRNode {
         let epoch_mgr = EpochManager::new(
             &config,
             time_service,
-            self_sender,
+            Some(self_sender),
             consensus_network_client,
             timeout_sender,
             quorum_store_to_mempool_sender,


### PR DESCRIPTION
## Description
This PR makes self-sending in the consensus pipeline optional, such that it does not occur for consensus observer (CO). This is prompted by a spurious error log for CO that self sends are failing (see: https://github.com/aptos-labs/aptos-core/pull/14559), however, self-sends are not required for CO.

## Testing Plan
Existing test infrastructure.
