### PR TITLE
Fix potential deadlock in state_key::Entry::drop

### DIFF
--- a/types/src/state_store/state_key/registry.rs
+++ b/types/src/state_store/state_key/registry.rs
@@ -152,12 +152,12 @@ where
         let mut locked = self.inner.write();
         if let Some(map2) = locked.get_mut(key1) {
             if let Some(entry) = map2.get(key2) {
-                if entry.upgrade().is_none() {
+                if entry.strong_count() == 0 {
                     map2.remove(key2);
+                    if map2.is_empty() {
+                        locked.remove(key1);
+                    }
                 }
-            }
-            if map2.is_empty() {
-                locked.remove(key1);
             }
         }
     }


### PR DESCRIPTION

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

If before Entry::drop() calls Registry::maybe_remove, the weak ref under the same key1 and key2 is replaced, Entry::drop can be called recursively resulting in a deadlock. The crux is we try to see if the entry has been replaced by trying to upgrading it to a strong ref, and it possible that the upgrade is successful and the result becomes a only ref to the new entry.

This tries to fix it by determining the same thing by seeing if Weak::strong_count() is 0 instead of upgrading the weak ref.


## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Validator Node

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

eyes of hackers