### PR TITLE
Add GasEstimation based on actual transaction block inclusion latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "aptos-vm",
  "bcs 0.1.4",
  "bytes",
+ "claims",
  "fail",
  "futures",
  "hex",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -56,6 +56,7 @@ aptos-gas-schedule = { workspace = true, features = ["testing"] }
 aptos-move-stdlib = { workspace = true }
 aptos-proptest-helpers = { workspace = true }
 aptos-sdk = { workspace = true }
+claims = { workspace = true }
 move-package = { workspace = true }
 passkey-types = { workspace = true }
 percent-encoding = { workspace = true }

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     accept_type::AcceptType,
+    gas_estimation::GasEstimator,
     metrics,
     response::{
         bcs_api_disabled, block_not_found_by_height, block_not_found_by_version,
@@ -16,7 +17,7 @@ use aptos_api_types::{
     AptosErrorCode, AsConverter, BcsBlock, GasEstimation, LedgerInfo, ResourceGroup,
     TransactionOnChainData,
 };
-use aptos_config::config::{GasEstimationConfig, NodeConfig, RoleType};
+use aptos_config::config::{NodeConfig, RoleType};
 use aptos_crypto::HashValue;
 use aptos_gas_schedule::{AptosGasParameters, FromOnChainGasSchedule};
 use aptos_logger::{error, info, Schema};
@@ -40,11 +41,7 @@ use aptos_types::{
         state_value::StateValue,
         TStateView,
     },
-    transaction::{
-        block_epilogue::BlockEndInfo,
-        use_case::{UseCaseAwareTransaction, UseCaseKey},
-        SignedTransaction, Transaction, TransactionWithProof, Version,
-    },
+    transaction::{SignedTransaction, TransactionWithProof, Version},
 };
 use futures::{channel::oneshot, SinkExt};
 use mini_moka::sync::Cache;
@@ -56,13 +53,11 @@ use move_core_types::{
 use serde::Serialize;
 use std::{
     cmp::Reverse,
-    collections::{BTreeMap, HashMap},
-    ops::{Bound::Included, Deref},
+    collections::HashMap,
     sync::{
         atomic::{AtomicU64, AtomicUsize, Ordering},
-        Arc, RwLock, RwLockWriteGuard,
+        Arc, RwLock,
     },
-    time::Instant,
 };
 
 // Context holds application scope context
@@ -73,7 +68,7 @@ pub struct Context {
     mp_sender: MempoolClientSender,
     pub node_config: Arc<NodeConfig>,
     gas_schedule_cache: Arc<RwLock<GasScheduleCache>>,
-    gas_estimation_cache: Arc<RwLock<GasEstimationCache>>,
+    gas_estimator: Arc<GasEstimator>,
     gas_limit_cache: Arc<RwLock<GasLimitCache>>,
     view_function_stats: Arc<FunctionStats>,
     simulate_txn_stats: Arc<FunctionStats>,
@@ -108,6 +103,12 @@ impl Context {
                 )),
             )
         };
+        let gas_estimator = Arc::new(GasEstimator::new(
+            node_config.api.gas_estimation.clone(),
+            node_config.mempool.broadcast_buckets.clone(),
+            db.clone(),
+            mp_sender.clone(),
+        ));
         Self {
             chain_id,
             db,
@@ -117,12 +118,7 @@ impl Context {
                 last_updated_epoch: None,
                 gas_schedule_params: None,
             })),
-            gas_estimation_cache: Arc::new(RwLock::new(GasEstimationCache {
-                last_updated_epoch: None,
-                last_updated_time: None,
-                estimation: None,
-                min_inclusion_prices: BTreeMap::new(),
-            })),
+            gas_estimator,
             gas_limit_cache: Arc::new(RwLock::new(GasLimitCache {
                 last_updated_epoch: None,
                 execution_onchain_config: OnChainExecutionConfig::default_if_missing(),
@@ -936,341 +932,15 @@ impl Context {
         }
     }
 
-    fn next_bucket(&self, gas_unit_price: u64) -> u64 {
-        match self
-            .node_config
-            .mempool
-            .broadcast_buckets
-            .iter()
-            .find(|bucket| **bucket > gas_unit_price)
-        {
-            None => gas_unit_price,
-            Some(bucket) => *bucket,
-        }
-    }
-
-    fn default_gas_estimation(&self, min_gas_unit_price: u64) -> GasEstimation {
-        GasEstimation {
-            deprioritized_gas_estimate: Some(min_gas_unit_price),
-            gas_estimate: min_gas_unit_price,
-            prioritized_gas_estimate: Some(self.next_bucket(min_gas_unit_price)),
-        }
-    }
-
-    fn cached_gas_estimation<T>(&self, cache: &T, current_epoch: u64) -> Option<GasEstimation>
-    where
-        T: Deref<Target = GasEstimationCache>,
-    {
-        if let Some(epoch) = cache.last_updated_epoch {
-            if let Some(time) = cache.last_updated_time {
-                if let Some(estimation) = cache.estimation {
-                    if epoch == current_epoch
-                        && (time.elapsed().as_millis() as u64)
-                            < self.node_config.api.gas_estimation.cache_expiration_ms
-                    {
-                        return Some(estimation);
-                    }
-                }
-            }
-        }
-        None
-    }
-
-    fn update_cached_gas_estimation(
-        &self,
-        cache: &mut RwLockWriteGuard<GasEstimationCache>,
-        epoch: u64,
-        estimation: GasEstimation,
-    ) {
-        cache.last_updated_epoch = Some(epoch);
-        cache.estimation = Some(estimation);
-        cache.last_updated_time = Some(Instant::now());
-    }
-
-    fn get_gas_prices_and_used(
-        &self,
-        start_version: Version,
-        limit: u64,
-        ledger_version: Version,
-        count_majority_usecase: bool,
-    ) -> Result<(Vec<(u64, u64)>, Vec<BlockEndInfo>, Option<f32>)> {
-        if start_version > ledger_version || limit == 0 {
-            return Ok((vec![], vec![], None));
-        }
-
-        // This is just an estimation, so we can just skip over errors
-        let limit = std::cmp::min(limit, ledger_version - start_version + 1);
-        let txns = self.db.get_transaction_iterator(start_version, limit)?;
-        let infos = self
-            .db
-            .get_transaction_info_iterator(start_version, limit)?;
-
-        let mut gas_prices = Vec::new();
-        let mut block_end_infos = Vec::new();
-        let mut count_by_usecase = HashMap::new();
-        for (txn, info) in txns.zip(infos) {
-            match txn.as_ref() {
-                Ok(Transaction::UserTransaction(txn)) => {
-                    if let Ok(info) = info.as_ref() {
-                        gas_prices.push((txn.gas_unit_price(), info.gas_used()));
-                        if count_majority_usecase {
-                            let use_case_key = txn.parse_use_case();
-                            *count_by_usecase.entry(use_case_key).or_insert(0) += 1;
-                        }
-                    }
-                },
-                Ok(Transaction::BlockEpilogue(txn)) => {
-                    if let Some(block_end_info) = txn.try_as_block_end_info() {
-                        block_end_infos.push(block_end_info.clone());
-                    }
-                },
-                _ => {},
-            }
-        }
-
-        let majority_usecase_fraction = if count_majority_usecase {
-            count_by_usecase
-                .iter()
-                .max_by_key(|(_, v)| *v)
-                .and_then(|(max_usecase, max_value)| {
-                    if let UseCaseKey::ContractAddress(_) = max_usecase {
-                        Some(*max_value as f32 / count_by_usecase.values().sum::<u64>() as f32)
-                    } else {
-                        None
-                    }
-                })
-        } else {
-            None
-        };
-        Ok((gas_prices, block_end_infos, majority_usecase_fraction))
-    }
-
-    fn block_min_inclusion_price(
-        &self,
-        ledger_info: &LedgerInfo,
-        first: Version,
-        last: Version,
-        gas_estimation_config: &GasEstimationConfig,
-        execution_config: &OnChainExecutionConfig,
-    ) -> Option<u64> {
-        let user_use_case_spread_factor = execution_config
-            .transaction_shuffler_type()
-            .user_use_case_spread_factor();
-
-        match self.get_gas_prices_and_used(
-            first,
-            last - first,
-            ledger_info.ledger_version.0,
-            user_use_case_spread_factor.is_some(),
-        ) {
-            Ok((prices_and_used, block_end_infos, majority_usecase_fraction)) => {
-                let is_full_block =
-                    if majority_usecase_fraction.map_or(false, |fraction| fraction > 0.5) {
-                        // If majority usecase is above half of transactions, UseCaseAware block reordering
-                        // will allow other transactions to get in the block (AIP-68)
-                        false
-                    } else if prices_and_used.len() >= gas_estimation_config.full_block_txns {
-                        true
-                    } else if !block_end_infos.is_empty() {
-                        assert_eq!(1, block_end_infos.len());
-                        block_end_infos.first().unwrap().limit_reached()
-                    } else if let Some(block_gas_limit) =
-                        execution_config.block_gas_limit_type().block_gas_limit()
-                    {
-                        let gas_used = prices_and_used.iter().map(|(_, used)| *used).sum::<u64>();
-                        gas_used >= block_gas_limit
-                    } else {
-                        false
-                    };
-
-                if is_full_block {
-                    Some(
-                        self.next_bucket(
-                            prices_and_used
-                                .iter()
-                                .map(|(price, _)| *price)
-                                .min()
-                                .unwrap(),
-                        ),
-                    )
-                } else {
-                    None
-                }
-            },
-            Err(_) => None,
-        }
-    }
-
     pub fn estimate_gas_price<E: InternalError>(
         &self,
         ledger_info: &LedgerInfo,
     ) -> Result<GasEstimation, E> {
-        let config = &self.node_config.api.gas_estimation;
-        let min_gas_unit_price = self.min_gas_unit_price(ledger_info)?;
-        let execution_config = self.execution_onchain_config(ledger_info)?;
-        if !config.enabled {
-            return Ok(self.default_gas_estimation(min_gas_unit_price));
-        }
-        if let Some(static_override) = &config.static_override {
-            return Ok(GasEstimation {
-                deprioritized_gas_estimate: Some(static_override.low),
-                gas_estimate: static_override.market,
-                prioritized_gas_estimate: Some(static_override.aggressive),
-            });
-        }
-
-        let epoch = ledger_info.epoch.0;
-
-        // 0. (0) Return cached result if it exists
-        let cache = self.gas_estimation_cache.read().unwrap();
-        if let Some(cached_gas_estimation) = self.cached_gas_estimation(&cache, epoch) {
-            return Ok(cached_gas_estimation);
-        }
-        drop(cache);
-
-        // 0. (1) Write lock and prepare cache
-        let mut cache = self.gas_estimation_cache.write().unwrap();
-        // Retry cached result after acquiring write lock
-        if let Some(cached_gas_estimation) = self.cached_gas_estimation(&cache, epoch) {
-            return Ok(cached_gas_estimation);
-        }
-        // Clear the cache if the epoch has changed
-        if let Some(cached_epoch) = cache.last_updated_epoch {
-            if cached_epoch != epoch {
-                cache.min_inclusion_prices.clear();
-            }
-        }
-
-        let max_block_history = config.aggressive_block_history;
-        // 1. Get the block metadata txns
-        let mut lookup_version = ledger_info.ledger_version.0;
-        let mut blocks = vec![];
-        // Skip the first block, which may be partial
-        if let Ok((first, _, block)) = self.db.get_block_info_by_version(lookup_version) {
-            if block.epoch() == epoch {
-                lookup_version = first.saturating_sub(1);
-            }
-        }
-        let mut cached_blocks_hit = false;
-        for _i in 0..max_block_history {
-            if cache
-                .min_inclusion_prices
-                .contains_key(&(epoch, lookup_version))
-            {
-                cached_blocks_hit = true;
-                break;
-            }
-            match self.db.get_block_info_by_version(lookup_version) {
-                Ok((first, last, block)) => {
-                    if block.epoch() != epoch {
-                        break;
-                    }
-                    lookup_version = first.saturating_sub(1);
-                    blocks.push((first, last));
-                    if lookup_version == 0 {
-                        break;
-                    }
-                },
-                Err(_) => {
-                    break;
-                },
-            }
-        }
-        if blocks.is_empty() && !cached_blocks_hit {
-            let estimation = self.default_gas_estimation(min_gas_unit_price);
-            self.update_cached_gas_estimation(&mut cache, epoch, estimation);
-            return Ok(estimation);
-        }
-        let blocks_len = blocks.len();
-        let remaining = max_block_history - blocks_len;
-
-        // 2. Get gas prices per block
-        let mut min_inclusion_prices = vec![];
-        // TODO: if multiple calls to db is a perf issue, combine into a single call and then split
-        for (first, last) in blocks {
-            let min_inclusion_price = self
-                .block_min_inclusion_price(ledger_info, first, last, config, &execution_config)
-                .unwrap_or(min_gas_unit_price);
-            min_inclusion_prices.push(min_inclusion_price);
-            cache
-                .min_inclusion_prices
-                .insert((epoch, last), min_inclusion_price);
-        }
-        if cached_blocks_hit {
-            for (_, v) in cache
-                .min_inclusion_prices
-                .range((Included(&(epoch, 0)), Included(&(epoch, lookup_version))))
-                .rev()
-                .take(remaining)
-            {
-                min_inclusion_prices.push(*v);
-            }
-        }
-
-        // 3. Get values
-        // (1) low
-        let low_price = match min_inclusion_prices
-            .iter()
-            .take(config.low_block_history)
-            .min()
-        {
-            Some(price) => *price,
-            None => min_gas_unit_price,
-        };
-
-        // (2) market
-        let mut latest_prices: Vec<_> = min_inclusion_prices
-            .iter()
-            .take(config.market_block_history)
-            .cloned()
-            .collect();
-        latest_prices.sort();
-        let market_price = match latest_prices.get(latest_prices.len() / 2) {
-            None => {
-                error!(
-                    "prices empty, blocks.len={}, cached_blocks_hit={}, epoch={}, version={}",
-                    blocks_len,
-                    cached_blocks_hit,
-                    ledger_info.epoch.0,
-                    ledger_info.ledger_version.0
-                );
-                return Ok(self.default_gas_estimation(min_gas_unit_price));
-            },
-            Some(price) => low_price.max(*price),
-        };
-
-        // (3) aggressive
-        min_inclusion_prices.sort();
-        let p90_price = match min_inclusion_prices.get(min_inclusion_prices.len() * 9 / 10) {
-            None => {
-                error!(
-                    "prices empty, blocks.len={}, cached_blocks_hit={}, epoch={}, version={}",
-                    blocks_len,
-                    cached_blocks_hit,
-                    ledger_info.epoch.0,
-                    ledger_info.ledger_version.0
-                );
-                return Ok(self.default_gas_estimation(min_gas_unit_price));
-            },
-            Some(price) => market_price.max(*price),
-        };
-        // round up to next bucket
-        let aggressive_price = self.next_bucket(p90_price);
-
-        let estimation = GasEstimation {
-            deprioritized_gas_estimate: Some(low_price),
-            gas_estimate: market_price,
-            prioritized_gas_estimate: Some(aggressive_price),
-        };
-        // 4. Update cache
-        // GC old entries
-        if cache.min_inclusion_prices.len() > max_block_history {
-            for _i in max_block_history..cache.min_inclusion_prices.len() {
-                cache.min_inclusion_prices.pop_first();
-            }
-        }
-        self.update_cached_gas_estimation(&mut cache, epoch, estimation);
-        Ok(estimation)
+        self.gas_estimator.estimate_gas_price(
+            self.min_gas_unit_price(ledger_info)?,
+            self.execution_onchain_config(ledger_info)?,
+            ledger_info,
+        )
     }
 
     fn min_gas_unit_price<E: InternalError>(&self, ledger_info: &LedgerInfo) -> Result<u64, E> {
@@ -1425,11 +1095,7 @@ impl Context {
     }
 
     pub fn last_updated_gas_estimation_cache_size(&self) -> usize {
-        self.gas_estimation_cache
-            .read()
-            .unwrap()
-            .min_inclusion_prices
-            .len()
+        self.gas_estimator.last_updated_gas_estimation_cache_size()
     }
 
     pub fn view_function_stats(&self) -> &FunctionStats {
@@ -1444,14 +1110,6 @@ impl Context {
 pub struct GasScheduleCache {
     last_updated_epoch: Option<u64>,
     gas_schedule_params: Option<AptosGasParameters>,
-}
-
-pub struct GasEstimationCache {
-    last_updated_epoch: Option<u64>,
-    last_updated_time: Option<Instant>,
-    estimation: Option<GasEstimation>,
-    /// (epoch, lookup_version) -> min_inclusion_price
-    min_inclusion_prices: BTreeMap<(u64, u64), u64>,
 }
 
 pub struct GasLimitCache {

--- a/api/src/gas_estimation.rs
+++ b/api/src/gas_estimation.rs
@@ -1,0 +1,593 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::response::InternalError;
+use aptos_api_types::{AptosErrorCode, GasEstimation, LedgerInfo};
+use aptos_config::config::{
+    FromLocalHistoryGasEstimationMode, FromOnChainGasEstimationMode, GasEstimationConfig,
+    GasEstimationMode,
+};
+use aptos_logger::error;
+use aptos_mempool::{
+    GetLatencySummaryRequest, IndividualLatencyStat, MempoolClientRequest, MempoolClientSender,
+    MempoolLatencySummary,
+};
+use aptos_storage_interface::DbReader;
+use aptos_types::{
+    on_chain_config::OnChainExecutionConfig,
+    transaction::{
+        use_case::{UseCaseAwareTransaction, UseCaseKey},
+        BlockEndInfo, Transaction, Version,
+    },
+};
+use futures::{channel::oneshot, SinkExt};
+use itertools::Itertools;
+use std::{
+    collections::{BTreeMap, HashMap},
+    ops::{Bound::Included, Deref},
+    sync::{Arc, RwLock, RwLockWriteGuard},
+    time::Instant,
+};
+
+pub struct GasEstimationCache {
+    last_updated_epoch: Option<u64>,
+    last_updated_time: Option<Instant>,
+    estimation: Option<GasEstimation>,
+    /// (epoch, lookup_version) -> min_inclusion_price
+    min_inclusion_prices: BTreeMap<(u64, u64), u64>,
+}
+
+struct GasBuckets {
+    gas_buckets: Vec<u64>,
+}
+
+impl GasBuckets {
+    fn new(gas_buckets: Vec<u64>) -> Self {
+        Self { gas_buckets }
+    }
+
+    fn next_bucket(&self, gas_unit_price: u64) -> u64 {
+        match self
+            .gas_buckets
+            .iter()
+            .find(|bucket| **bucket > gas_unit_price)
+        {
+            None => gas_unit_price,
+            Some(bucket) => *bucket,
+        }
+    }
+}
+
+pub struct GasEstimator {
+    config: GasEstimationConfig,
+    gas_buckets: GasBuckets,
+    gas_estimation_cache: Arc<RwLock<GasEstimationCache>>,
+
+    db: Arc<dyn DbReader>,
+    mp_sender: MempoolClientSender,
+}
+
+impl GasEstimator {
+    pub(crate) fn new(
+        config: GasEstimationConfig,
+        gas_buckets: Vec<u64>,
+        db: Arc<dyn DbReader>,
+        mp_sender: MempoolClientSender,
+    ) -> Self {
+        Self {
+            config,
+            gas_buckets: GasBuckets::new(gas_buckets),
+            gas_estimation_cache: Arc::new(RwLock::new(GasEstimationCache {
+                last_updated_epoch: None,
+                last_updated_time: None,
+                estimation: None,
+                min_inclusion_prices: BTreeMap::new(),
+            })),
+            db,
+            mp_sender,
+        }
+    }
+
+    fn default_gas_estimation(&self, min_gas_unit_price: u64) -> GasEstimation {
+        GasEstimation {
+            deprioritized_gas_estimate: Some(min_gas_unit_price),
+            gas_estimate: min_gas_unit_price,
+            prioritized_gas_estimate: Some(self.gas_buckets.next_bucket(min_gas_unit_price)),
+        }
+    }
+
+    fn cached_gas_estimation<T>(&self, cache: &T, current_epoch: u64) -> Option<GasEstimation>
+    where
+        T: Deref<Target = GasEstimationCache>,
+    {
+        if let Some(epoch) = cache.last_updated_epoch {
+            if let Some(time) = cache.last_updated_time {
+                if let Some(estimation) = cache.estimation {
+                    if epoch == current_epoch
+                        && (time.elapsed().as_millis() as u64) < self.config.cache_expiration_ms
+                    {
+                        return Some(estimation);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn update_cached_gas_estimation(
+        cache: &mut RwLockWriteGuard<GasEstimationCache>,
+        epoch: u64,
+        estimation: GasEstimation,
+    ) {
+        cache.last_updated_epoch = Some(epoch);
+        cache.estimation = Some(estimation);
+        cache.last_updated_time = Some(Instant::now());
+    }
+
+    pub fn last_updated_gas_estimation_cache_size(&self) -> usize {
+        self.gas_estimation_cache
+            .read()
+            .unwrap()
+            .min_inclusion_prices
+            .len()
+    }
+
+    fn get_gas_prices_and_used(
+        &self,
+        start_version: Version,
+        limit: u64,
+        ledger_version: Version,
+        count_majority_usecase: bool,
+    ) -> anyhow::Result<(Vec<(u64, u64)>, Vec<BlockEndInfo>, Option<f32>)> {
+        if start_version > ledger_version || limit == 0 {
+            return Ok((vec![], vec![], None));
+        }
+
+        // This is just an estimation, so we can just skip over errors
+        let limit = std::cmp::min(limit, ledger_version - start_version + 1);
+        let txns = self.db.get_transaction_iterator(start_version, limit)?;
+        let infos = self
+            .db
+            .get_transaction_info_iterator(start_version, limit)?;
+
+        let mut gas_prices = Vec::new();
+        let mut block_end_infos = Vec::new();
+        let mut count_by_usecase = HashMap::new();
+        for (txn, info) in txns.zip(infos) {
+            match txn.as_ref() {
+                Ok(Transaction::UserTransaction(txn)) => {
+                    if let Ok(info) = info.as_ref() {
+                        gas_prices.push((txn.gas_unit_price(), info.gas_used()));
+                        if count_majority_usecase {
+                            let use_case_key = txn.parse_use_case();
+                            *count_by_usecase.entry(use_case_key).or_insert(0) += 1;
+                        }
+                    }
+                },
+                Ok(Transaction::BlockEpilogue(txn)) => {
+                    if let Some(block_end_info) = txn.try_as_block_end_info() {
+                        block_end_infos.push(block_end_info.clone());
+                    }
+                },
+                _ => {},
+            }
+        }
+
+        let majority_usecase_fraction = if count_majority_usecase {
+            count_by_usecase
+                .iter()
+                .max_by_key(|(_, v)| *v)
+                .and_then(|(max_usecase, max_value)| {
+                    if let UseCaseKey::ContractAddress(_) = max_usecase {
+                        Some(*max_value as f32 / count_by_usecase.values().sum::<u64>() as f32)
+                    } else {
+                        None
+                    }
+                })
+        } else {
+            None
+        };
+        Ok((gas_prices, block_end_infos, majority_usecase_fraction))
+    }
+
+    fn block_min_inclusion_price(
+        &self,
+        ledger_info: &LedgerInfo,
+        first: Version,
+        last: Version,
+        gas_estimation_config: &FromOnChainGasEstimationMode,
+        execution_config: &OnChainExecutionConfig,
+    ) -> Option<u64> {
+        let user_use_case_spread_factor = execution_config
+            .transaction_shuffler_type()
+            .user_use_case_spread_factor();
+
+        match self.get_gas_prices_and_used(
+            first,
+            last - first,
+            ledger_info.ledger_version.0,
+            user_use_case_spread_factor.is_some(),
+        ) {
+            Ok((prices_and_used, block_end_infos, majority_usecase_fraction)) => {
+                let is_full_block =
+                    if majority_usecase_fraction.map_or(false, |fraction| fraction > 0.5) {
+                        // If majority usecase is above half of transactions, UseCaseAware block reordering
+                        // will allow other transactions to get in the block (AIP-68)
+                        false
+                    } else if prices_and_used.len() >= gas_estimation_config.full_block_txns {
+                        true
+                    } else if !block_end_infos.is_empty() {
+                        assert_eq!(1, block_end_infos.len());
+                        block_end_infos.first().unwrap().limit_reached()
+                    } else if let Some(block_gas_limit) =
+                        execution_config.block_gas_limit_type().block_gas_limit()
+                    {
+                        let gas_used = prices_and_used.iter().map(|(_, used)| *used).sum::<u64>();
+                        gas_used >= block_gas_limit
+                    } else {
+                        false
+                    };
+
+                if is_full_block {
+                    Some(
+                        self.gas_buckets.next_bucket(
+                            prices_and_used
+                                .iter()
+                                .map(|(price, _)| *price)
+                                .min()
+                                .unwrap(),
+                        ),
+                    )
+                } else {
+                    None
+                }
+            },
+            Err(_) => None,
+        }
+    }
+
+    pub(crate) fn estimate_gas_price_based_on_onchain(
+        &self,
+        min_gas_unit_price: u64,
+        ledger_info: &LedgerInfo,
+        config: &FromOnChainGasEstimationMode,
+        execution_config: OnChainExecutionConfig,
+        cache: &mut GasEstimationCache,
+    ) -> GasEstimation {
+        let epoch = ledger_info.epoch.0;
+        // Clear the cache if the epoch has changed
+        if let Some(cached_epoch) = cache.last_updated_epoch {
+            if cached_epoch != epoch {
+                cache.min_inclusion_prices.clear();
+            }
+        }
+
+        let max_block_history = config.aggressive_block_history;
+        // 1. Get the block metadata txns
+        let mut lookup_version = ledger_info.ledger_version.0;
+        let mut blocks = vec![];
+        // Skip the first block, which may be partial
+        if let Ok((first, _, block)) = self.db.get_block_info_by_version(lookup_version) {
+            if block.epoch() == epoch {
+                lookup_version = first.saturating_sub(1);
+            }
+        }
+        let mut cached_blocks_hit = false;
+        for _i in 0..max_block_history {
+            if cache
+                .min_inclusion_prices
+                .contains_key(&(epoch, lookup_version))
+            {
+                cached_blocks_hit = true;
+                break;
+            }
+            match self.db.get_block_info_by_version(lookup_version) {
+                Ok((first, last, block)) => {
+                    if block.epoch() != epoch {
+                        break;
+                    }
+                    lookup_version = first.saturating_sub(1);
+                    blocks.push((first, last));
+                    if lookup_version == 0 {
+                        break;
+                    }
+                },
+                Err(_) => {
+                    break;
+                },
+            }
+        }
+        if blocks.is_empty() && !cached_blocks_hit {
+            let estimation = self.default_gas_estimation(min_gas_unit_price);
+            return estimation;
+        }
+        let blocks_len = blocks.len();
+        let remaining = max_block_history - blocks_len;
+
+        // 2. Get gas prices per block
+        let mut min_inclusion_prices = vec![];
+        // TODO: if multiple calls to db is a perf issue, combine into a single call and then split
+        for (first, last) in blocks {
+            let min_inclusion_price = self
+                .block_min_inclusion_price(ledger_info, first, last, config, &execution_config)
+                .unwrap_or(min_gas_unit_price);
+            min_inclusion_prices.push(min_inclusion_price);
+            cache
+                .min_inclusion_prices
+                .insert((epoch, last), min_inclusion_price);
+        }
+        if cached_blocks_hit {
+            for (_, v) in cache
+                .min_inclusion_prices
+                .range((Included(&(epoch, 0)), Included(&(epoch, lookup_version))))
+                .rev()
+                .take(remaining)
+            {
+                min_inclusion_prices.push(*v);
+            }
+        }
+
+        // 3. Get values
+        // (1) low
+        let low_price = match min_inclusion_prices
+            .iter()
+            .take(config.low_block_history)
+            .min()
+        {
+            Some(price) => *price,
+            None => min_gas_unit_price,
+        };
+
+        // (2) market
+        let mut latest_prices: Vec<_> = min_inclusion_prices
+            .iter()
+            .take(config.market_block_history)
+            .cloned()
+            .collect();
+        latest_prices.sort();
+        let market_price = match latest_prices.get(latest_prices.len() / 2) {
+            None => {
+                error!(
+                    "prices empty, blocks.len={}, cached_blocks_hit={}, epoch={}, version={}",
+                    blocks_len,
+                    cached_blocks_hit,
+                    ledger_info.epoch.0,
+                    ledger_info.ledger_version.0
+                );
+                return self.default_gas_estimation(min_gas_unit_price);
+            },
+            Some(price) => low_price.max(*price),
+        };
+
+        // (3) aggressive
+        min_inclusion_prices.sort();
+        let p90_price = match min_inclusion_prices.get(min_inclusion_prices.len() * 9 / 10) {
+            None => {
+                error!(
+                    "prices empty, blocks.len={}, cached_blocks_hit={}, epoch={}, version={}",
+                    blocks_len,
+                    cached_blocks_hit,
+                    ledger_info.epoch.0,
+                    ledger_info.ledger_version.0
+                );
+                return self.default_gas_estimation(min_gas_unit_price);
+            },
+            Some(price) => market_price.max(*price),
+        };
+        // round up to next bucket
+        let aggressive_price = self.gas_buckets.next_bucket(p90_price);
+
+        let estimation = GasEstimation {
+            deprioritized_gas_estimate: Some(low_price),
+            gas_estimate: market_price,
+            prioritized_gas_estimate: Some(aggressive_price),
+        };
+        // 4. Update cache
+        // GC old entries
+        if cache.min_inclusion_prices.len() > max_block_history {
+            for _i in max_block_history..cache.min_inclusion_prices.len() {
+                cache.min_inclusion_prices.pop_first();
+            }
+        }
+
+        estimation
+    }
+
+    fn get_mempool_latency_summary<E: InternalError>(
+        &self,
+        target_samples: usize,
+    ) -> Result<MempoolLatencySummary, E> {
+        let (req_sender, callback) = oneshot::channel();
+
+        futures::executor::block_on(self.mp_sender.clone().send(
+            MempoolClientRequest::GetLatencySummary(
+                GetLatencySummaryRequest { target_samples },
+                req_sender,
+            ),
+        ))
+        .map_err(|e| E::internal_with_code_no_info(e, AptosErrorCode::InternalError))?;
+
+        futures::executor::block_on(callback)
+            .map_err(|e| E::internal_with_code_no_info(e, AptosErrorCode::InternalError))
+    }
+
+    fn compute_gas_estimate_from_bottom(
+        gas_buckets: &GasBuckets,
+        sorted: &[(u64, IndividualLatencyStat)],
+        target_inclusion_latency_s: f64,
+    ) -> Option<u64> {
+        let mut last_over = None;
+        for (gas, stat) in sorted.iter() {
+            if stat.avg_s() < target_inclusion_latency_s {
+                return last_over.map(|gas| gas_buckets.next_bucket(gas));
+            }
+            last_over = Some(*gas);
+        }
+        Some(gas_buckets.next_bucket(sorted.last().unwrap().0))
+    }
+
+    fn compute_gas_estimate_from_top(
+        gas_buckets: &GasBuckets,
+        sorted: &[(u64, IndividualLatencyStat)],
+        target_inclusion_latency_s: f64,
+    ) -> Option<u64> {
+        for (gas, stat) in sorted.iter().rev() {
+            if stat.avg_s() > target_inclusion_latency_s {
+                return Some(gas_buckets.next_bucket(*gas));
+            }
+        }
+
+        None
+    }
+
+    fn estimate_gas_price_based_on_local_history<E: InternalError>(
+        &self,
+        config: &FromLocalHistoryGasEstimationMode,
+        min_gas_unit_price: u64,
+    ) -> Result<GasEstimation, E> {
+        let latency_summary = self.get_mempool_latency_summary(config.target_samples)?;
+
+        if latency_summary.count < config.min_samples_needed {
+            return Ok(self.default_gas_estimation(min_gas_unit_price));
+        }
+
+        Ok(Self::estimate_gas_price_based_on_local_history_impl(
+            &self.gas_buckets,
+            latency_summary,
+            min_gas_unit_price,
+            config,
+        ))
+    }
+
+    fn estimate_gas_price_based_on_local_history_impl(
+        gas_buckets: &GasBuckets,
+        latency_summary: MempoolLatencySummary,
+        min_gas_unit_price: u64,
+        config: &FromLocalHistoryGasEstimationMode,
+    ) -> GasEstimation {
+        let sorted = latency_summary
+            .inclusion_latency
+            .into_iter()
+            .sorted_by_key(|(gas, _stat)| *gas)
+            .collect::<Vec<_>>();
+
+        GasEstimation {
+            deprioritized_gas_estimate: Some(min_gas_unit_price),
+            gas_estimate: Self::compute_gas_estimate_from_bottom(
+                gas_buckets,
+                &sorted,
+                config.target_inclusion_latency_s,
+            )
+            .unwrap_or(min_gas_unit_price),
+            prioritized_gas_estimate: Some(
+                Self::compute_gas_estimate_from_top(
+                    gas_buckets,
+                    &sorted,
+                    config.prioritized_target_inclusion_latency_s,
+                )
+                .unwrap_or(min_gas_unit_price),
+            ),
+        }
+    }
+
+    pub(crate) fn estimate_gas_price<E: InternalError>(
+        &self,
+        min_gas_unit_price: u64,
+        execution_config: OnChainExecutionConfig,
+        ledger_info: &LedgerInfo,
+    ) -> Result<GasEstimation, E> {
+        if !self.config.enabled {
+            return Ok(self.default_gas_estimation(min_gas_unit_price));
+        }
+        if let Some(static_override) = &self.config.static_override {
+            return Ok(GasEstimation {
+                deprioritized_gas_estimate: Some(static_override.low),
+                gas_estimate: static_override.market,
+                prioritized_gas_estimate: Some(static_override.aggressive),
+            });
+        }
+
+        let epoch = ledger_info.epoch.0;
+
+        // 0. (0) Return cached result if it exists
+        let cache = self.gas_estimation_cache.read().unwrap();
+        if let Some(cached_gas_estimation) = self.cached_gas_estimation(&cache, epoch) {
+            return Ok(cached_gas_estimation);
+        }
+        drop(cache);
+
+        // 0. (1) Write lock and prepare cache
+        let mut cache = self.gas_estimation_cache.write().unwrap();
+        // Retry cached result after acquiring write lock
+        if let Some(cached_gas_estimation) = self.cached_gas_estimation(&cache, epoch) {
+            return Ok(cached_gas_estimation);
+        }
+
+        let estimation = match &self.config.mode {
+            GasEstimationMode::OnChainEstimation(from_onchain_config) => self
+                .estimate_gas_price_based_on_onchain(
+                    min_gas_unit_price,
+                    ledger_info,
+                    from_onchain_config,
+                    execution_config,
+                    &mut cache,
+                ),
+            GasEstimationMode::LocalHistory(local_history_config) => self
+                .estimate_gas_price_based_on_local_history(
+                    local_history_config,
+                    min_gas_unit_price,
+                )?,
+        };
+
+        Self::update_cached_gas_estimation(&mut cache, epoch, estimation);
+        Ok(estimation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::gas_estimation::{GasBuckets, GasEstimator};
+    use aptos_mempool::IndividualLatencyStat;
+    use claims::assert_le;
+    use proptest::prelude::*;
+
+    prop_compose! {
+        #[cfg(test)]
+        fn arb_latencies(len: usize)
+                        (bits in 1..(1<<len), latencies in prop::collection::vec(0.0..1.0, len))
+                        -> Vec<(u64, IndividualLatencyStat)> {
+            let mut result = Vec::new();
+            for idx in 0..len {
+                if bits & (1<<idx) != 0 {
+                    result.push((((idx + 1) * 10) as u64, IndividualLatencyStat::new(1, latencies[result.len()])))
+                }
+            }
+            result
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_bottom_estimate_below_top(sorted in arb_latencies(5)) {
+            let target_inclusion_latency_s = 0.5;
+            let gas_buckets = GasBuckets::new(vec![10, 20, 30, 40, 50, 60]);
+
+            let bottom = GasEstimator::compute_gas_estimate_from_bottom(
+                &gas_buckets,
+                &sorted,
+                target_inclusion_latency_s,
+            );
+
+            let top = GasEstimator::compute_gas_estimate_from_top(
+                &gas_buckets,
+                &sorted,
+                target_inclusion_latency_s,
+            );
+
+            if bottom.is_some() {
+                assert!(top.is_some());
+                assert_le!(bottom.unwrap(), top.unwrap());
+            }
+        }
+    }
+}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -14,6 +14,7 @@ pub mod context;
 mod error_converter;
 mod events;
 mod failpoint;
+mod gas_estimation;
 mod index;
 mod log;
 pub mod metrics;

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -7,7 +7,9 @@ use crate::tests::{
     new_test_context_with_config, new_test_context_with_db_sharding_and_internal_indexer,
 };
 use aptos_api_test_context::{assert_json, current_function_name, pretty, TestContext};
-use aptos_config::config::{GasEstimationStaticOverride, NodeConfig};
+use aptos_config::config::{
+    FromOnChainGasEstimationMode, GasEstimationMode, GasEstimationStaticOverride, NodeConfig,
+};
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519Signature},
     multi_ed25519::{MultiEd25519PrivateKey, MultiEd25519PublicKey},
@@ -1376,9 +1378,13 @@ async fn test_gas_estimation_cache() {
     node_config.api.gas_estimation.enabled = true;
     // Sets max cache size to 10
     let max_block_history = 10;
-    node_config.api.gas_estimation.low_block_history = max_block_history;
-    node_config.api.gas_estimation.market_block_history = max_block_history;
-    node_config.api.gas_estimation.aggressive_block_history = max_block_history;
+    node_config.api.gas_estimation.mode =
+        GasEstimationMode::OnChainEstimation(FromOnChainGasEstimationMode {
+            low_block_history: max_block_history,
+            market_block_history: max_block_history,
+            aggressive_block_history: max_block_history,
+            ..Default::default()
+        });
     let sleep_duration =
         Duration::from_millis(node_config.api.gas_estimation.cache_expiration_ms * 2);
     let mut context = new_test_context_with_config(current_function_name!(), node_config);

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -14,7 +14,7 @@ use aptos_types::{account_address::AccountAddress, chain_id::ChainId};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ApiConfig {
     /// Enables the REST API endpoint

--- a/config/src/config/gas_estimation_config.rs
+++ b/config/src/config/gas_estimation_config.rs
@@ -9,19 +9,23 @@ use aptos_types::chain_id::ChainId;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GasEstimationStaticOverride {
     pub low: u64,
     pub market: u64,
     pub aggressive: u64,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub enum GasEstimationMode {
+    OnChainEstimation(FromOnChainGasEstimationMode),
+    LocalHistory(FromLocalHistoryGasEstimationMode),
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
-pub struct GasEstimationConfig {
-    /// A gate for computing GasEstimation. If false, just returns the default.
-    pub enabled: bool,
-    /// Static values to override. If set, use these values instead of computing a GasEstimation.
-    pub static_override: Option<GasEstimationStaticOverride>,
+pub struct FromOnChainGasEstimationMode {
     /// Number of transactions for blocks to be classified as full for gas estimation
     pub full_block_txns: usize,
     /// Maximum number of blocks read for low gas estimation
@@ -30,19 +34,60 @@ pub struct GasEstimationConfig {
     pub market_block_history: usize,
     /// Maximum number of blocks read for aggressive gas estimation
     pub aggressive_block_history: usize,
+}
+
+impl Default for FromOnChainGasEstimationMode {
+    fn default() -> Self {
+        Self {
+            full_block_txns: 250,
+            low_block_history: 10,
+            market_block_history: 30,
+            aggressive_block_history: 120,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct FromLocalHistoryGasEstimationMode {
+    pub target_samples: usize,
+    pub min_samples_needed: usize,
+
+    pub target_inclusion_latency_s: f64,
+    pub prioritized_target_inclusion_latency_s: f64,
+}
+
+impl Default for FromLocalHistoryGasEstimationMode {
+    fn default() -> Self {
+        Self {
+            target_samples: 100,
+            min_samples_needed: 10,
+            target_inclusion_latency_s: 1.0,
+            prioritized_target_inclusion_latency_s: 0.7,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct GasEstimationConfig {
+    /// A gate for computing GasEstimation. If false, just returns the default.
+    pub enabled: bool,
+    /// Static values to override. If set, use these values instead of computing a GasEstimation.
+    pub static_override: Option<GasEstimationStaticOverride>,
+
+    pub mode: GasEstimationMode,
+
     /// Time after write when previous value is returned without recomputing
     pub cache_expiration_ms: u64,
 }
 
 impl Default for GasEstimationConfig {
-    fn default() -> GasEstimationConfig {
-        GasEstimationConfig {
+    fn default() -> Self {
+        Self {
             enabled: true,
             static_override: None,
-            full_block_txns: 250,
-            low_block_history: 10,
-            market_block_history: 30,
-            aggressive_block_history: 120,
+            mode: GasEstimationMode::OnChainEstimation(FromOnChainGasEstimationMode::default()),
             cache_expiration_ms: 500,
         }
     }
@@ -57,37 +102,42 @@ impl ConfigSanitizer for GasEstimationConfig {
         let sanitizer_name = Self::get_sanitizer_name();
         let gas_estimation_config = &node_config.api.gas_estimation;
 
-        // Validate aggressive price takes the most history
-        if gas_estimation_config.low_block_history > gas_estimation_config.aggressive_block_history
-            || gas_estimation_config.market_block_history
-                > gas_estimation_config.aggressive_block_history
-        {
-            return Err(Error::ConfigSanitizerFailed(
-                sanitizer_name,
-                format!(
-                    "aggressive block history {} must be > low {}, market {}",
-                    gas_estimation_config.aggressive_block_history,
-                    gas_estimation_config.low_block_history,
-                    gas_estimation_config.market_block_history
-                ),
-            ));
-        }
+        match &gas_estimation_config.mode {
+            GasEstimationMode::OnChainEstimation(from_onchain) => {
+                // Validate aggressive price takes the most history
+                if from_onchain.low_block_history > from_onchain.aggressive_block_history
+                    || from_onchain.market_block_history > from_onchain.aggressive_block_history
+                {
+                    return Err(Error::ConfigSanitizerFailed(
+                        sanitizer_name,
+                        format!(
+                            "aggressive block history {} must be > low {}, market {}",
+                            from_onchain.aggressive_block_history,
+                            from_onchain.low_block_history,
+                            from_onchain.market_block_history
+                        ),
+                    ));
+                }
 
-        if gas_estimation_config.low_block_history == 0
-            || gas_estimation_config.market_block_history == 0
-            || gas_estimation_config.aggressive_block_history == 0
-        {
-            return Err(Error::ConfigSanitizerFailed(
-                sanitizer_name,
-                format!(
-                    "low {}, market {}, aggressive {} block history must be > 0",
-                    gas_estimation_config.low_block_history,
-                    gas_estimation_config.market_block_history,
-                    gas_estimation_config.aggressive_block_history
-                ),
-            ));
+                if from_onchain.low_block_history == 0
+                    || from_onchain.market_block_history == 0
+                    || from_onchain.aggressive_block_history == 0
+                {
+                    return Err(Error::ConfigSanitizerFailed(
+                        sanitizer_name,
+                        format!(
+                            "low {}, market {}, aggressive {} block history must be > 0",
+                            from_onchain.low_block_history,
+                            from_onchain.market_block_history,
+                            from_onchain.aggressive_block_history
+                        ),
+                    ));
+                }
+            },
+            GasEstimationMode::LocalHistory(_from_local_history) => {
+                // TODO add sanitize
+            },
         }
-
         Ok(())
     }
 }
@@ -103,8 +153,11 @@ mod tests {
         let node_config = NodeConfig {
             api: ApiConfig {
                 gas_estimation: GasEstimationConfig {
-                    low_block_history: 11,
-                    aggressive_block_history: 10,
+                    mode: GasEstimationMode::OnChainEstimation(FromOnChainGasEstimationMode {
+                        low_block_history: 11,
+                        aggressive_block_history: 10,
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -128,8 +181,11 @@ mod tests {
         let node_config = NodeConfig {
             api: ApiConfig {
                 gas_estimation: GasEstimationConfig {
-                    market_block_history: 31,
-                    aggressive_block_history: 30,
+                    mode: GasEstimationMode::OnChainEstimation(FromOnChainGasEstimationMode {
+                        market_block_history: 31,
+                        aggressive_block_history: 30,
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -153,7 +209,10 @@ mod tests {
         let node_config = NodeConfig {
             api: ApiConfig {
                 gas_estimation: GasEstimationConfig {
-                    low_block_history: 0,
+                    mode: GasEstimationMode::OnChainEstimation(FromOnChainGasEstimationMode {
+                        low_block_history: 0,
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -177,7 +236,10 @@ mod tests {
         let node_config = NodeConfig {
             api: ApiConfig {
                 gas_estimation: GasEstimationConfig {
-                    market_block_history: 0,
+                    mode: GasEstimationMode::OnChainEstimation(FromOnChainGasEstimationMode {
+                        market_block_history: 0,
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -201,7 +263,10 @@ mod tests {
         let node_config = NodeConfig {
             api: ApiConfig {
                 gas_estimation: GasEstimationConfig {
-                    aggressive_block_history: 0,
+                    mode: GasEstimationMode::OnChainEstimation(FromOnChainGasEstimationMode {
+                        aggressive_block_history: 0,
+                        ..Default::default()
+                    }),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -28,8 +28,8 @@ pub struct LoadBalancingThresholdConfig {
 }
 
 impl Default for LoadBalancingThresholdConfig {
-    fn default() -> LoadBalancingThresholdConfig {
-        LoadBalancingThresholdConfig {
+    fn default() -> Self {
+        Self {
             avg_mempool_traffic_threshold_in_tps: 0,
             latency_slack_between_top_upstream_peers: 50,
             max_number_of_upstream_peers: 1,
@@ -37,7 +37,23 @@ impl Default for LoadBalancingThresholdConfig {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct LatencyStatsTrackingConfig {
+    pub num_intervals: usize,
+    pub time_per_interval_s: f32,
+}
+
+impl Default for LatencyStatsTrackingConfig {
+    fn default() -> Self {
+        Self {
+            num_intervals: 60,
+            time_per_interval_s: 1.0,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct MempoolConfig {
     /// Maximum number of transactions allowed in the Mempool
@@ -100,6 +116,8 @@ pub struct MempoolConfig {
     /// up to 10 minutes (shared_mempool_priority_update_interval_secs) to enable the load balancing. If this flag is enabled,
     /// then the PFNs will always do load balancing irrespective of the load.
     pub enable_max_load_balancing_at_any_load: bool,
+
+    pub latency_stats_tracking_config: LatencyStatsTrackingConfig,
 }
 
 impl Default for MempoolConfig {
@@ -164,6 +182,7 @@ impl Default for MempoolConfig {
                 },
             ],
             enable_max_load_balancing_at_any_load: false,
+            latency_stats_tracking_config: LatencyStatsTrackingConfig::default(),
         }
     }
 }

--- a/mempool/src/core_mempool/index.rs
+++ b/mempool/src/core_mempool/index.rs
@@ -400,6 +400,18 @@ impl MultiBucketTimelineIndex {
     }
 
     #[inline]
+    pub(crate) fn get_bucket_and_floor(&self, ranking_score: u64) -> (&str, u64) {
+        let index = self
+            .bucket_mins
+            .binary_search(&ranking_score)
+            .unwrap_or_else(|i| i - 1);
+        (
+            self.bucket_mins_to_string[index].as_str(),
+            self.bucket_mins[index],
+        )
+    }
+
+    #[inline]
     pub(crate) fn get_bucket(&self, ranking_score: u64) -> &str {
         let index = self
             .bucket_mins

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -69,6 +69,7 @@ pub const CLIENT_EVENT_LABEL: &str = "client_event";
 pub const CLIENT_EVENT_GET_TXN_LABEL: &str = "client_event_get_txn";
 pub const RECONFIG_EVENT_LABEL: &str = "reconfig";
 pub const PEER_BROADCAST_EVENT_LABEL: &str = "peer_broadcast";
+pub const CLIENT_EVENT_GET_LATENCY_SUMMARY_LABEL: &str = "client_event_get_latency_summary";
 
 // task spawn stage labels
 pub const SPAWN_LABEL: &str = "spawn";

--- a/mempool/src/lib.rs
+++ b/mempool/src/lib.rs
@@ -62,8 +62,9 @@ pub use shared_mempool::{
     bootstrap, network,
     network::MempoolSyncMsg,
     types::{
-        MempoolClientRequest, MempoolClientSender, MempoolEventsReceiver, QuorumStoreRequest,
-        QuorumStoreResponse, SubmissionStatus,
+        GetLatencySummaryRequest, IndividualLatencyStat, MempoolClientRequest, MempoolClientSender,
+        MempoolEventsReceiver, MempoolLatencySummary, QuorumStoreRequest, QuorumStoreResponse,
+        SubmissionStatus,
     },
 };
 #[cfg(any(test, feature = "fuzzing"))]

--- a/mempool/src/logging.rs
+++ b/mempool/src/logging.rs
@@ -157,6 +157,7 @@ pub enum LogEntry {
     JsonRpc,
     GetTransaction,
     GetBlock,
+    GetLatencySummary,
     QuorumStore,
     StateSyncCommit,
     BroadcastTransaction,

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -217,6 +217,26 @@ async fn handle_client_request<NetworkClient, TransactionValidator>(
                 ))
                 .await;
         },
+        MempoolClientRequest::GetLatencySummary(callback) => {
+            // This timer measures how long it took for the bounded executor to *schedule* the
+            // task.
+            let _timer = counters::task_spawn_latency_timer(
+                counters::CLIENT_EVENT_GET_LATENCY_SUMMARY_LABEL,
+                counters::SPAWN_LABEL,
+            );
+            // This timer measures how long it took for the task to go from scheduled to started.
+            let task_start_timer = counters::task_spawn_latency_timer(
+                counters::CLIENT_EVENT_GET_LATENCY_SUMMARY_LABEL,
+                counters::START_LABEL,
+            );
+            bounded_executor
+                .spawn(tasks::process_client_get_latency_summary(
+                    smp.clone(),
+                    callback,
+                    task_start_timer,
+                ))
+                .await;
+        },
     }
 }
 

--- a/mempool/src/shared_mempool/latency_tracking.rs
+++ b/mempool/src/shared_mempool/latency_tracking.rs
@@ -1,7 +1,16 @@
-
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use super::types::MempoolLatencySummary;
+
+
 pub struct MempoolLatencyStatsTracking {
 
+
+}
+
+impl MempoolLatencyStatsTracking {
+    pub fn get_latency_summary(&self) -> MempoolLatencySummary {
+        MempoolLatencySummary {}
+    }
 }

--- a/mempool/src/shared_mempool/latency_tracking.rs
+++ b/mempool/src/shared_mempool/latency_tracking.rs
@@ -2,15 +2,50 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::types::MempoolLatencySummary;
-
+use std::{
+    collections::VecDeque,
+    time::{Duration, Instant},
+};
 
 pub struct MempoolLatencyStatsTracking {
-
-
+    stats: VecDeque<MempoolLatencySummary>,
+    cur_time_start: Instant,
+    num_intervals: usize,
+    time_per_interval: Duration,
 }
 
 impl MempoolLatencyStatsTracking {
-    pub fn get_latency_summary(&self) -> MempoolLatencySummary {
-        MempoolLatencySummary {}
+    pub fn new(num_intervals: usize, time_per_interval: Duration) -> Self {
+        Self {
+            stats: VecDeque::from(vec![MempoolLatencySummary::empty()]),
+            cur_time_start: Instant::now(),
+            num_intervals,
+            time_per_interval,
+        }
+    }
+
+    pub fn get_latency_summary(&self, target_samples: usize) -> MempoolLatencySummary {
+        let mut total = MempoolLatencySummary::empty();
+        for stat in self.stats.iter().rev() {
+            total.aggregate(stat);
+            if total.count >= target_samples {
+                break;
+            }
+        }
+
+        total
+    }
+
+    pub fn check_rollover(&mut self) {
+        if self.cur_time_start.elapsed() > self.time_per_interval {
+            if self.stats.len() >= self.num_intervals {
+                self.stats.pop_front();
+            }
+            self.stats.push_back(MempoolLatencySummary::empty())
+        }
+    }
+
+    pub fn get_current_mut(&mut self) -> &mut MempoolLatencySummary {
+        self.stats.back_mut().unwrap()
     }
 }

--- a/mempool/src/shared_mempool/latency_tracking.rs
+++ b/mempool/src/shared_mempool/latency_tracking.rs
@@ -1,0 +1,7 @@
+
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+pub struct MempoolLatencyStatsTracking {
+
+}

--- a/mempool/src/shared_mempool/mod.rs
+++ b/mempool/src/shared_mempool/mod.rs
@@ -10,5 +10,6 @@ pub use runtime::bootstrap;
 #[cfg(any(test, feature = "fuzzing"))]
 pub(crate) use runtime::start_shared_mempool;
 mod coordinator;
+pub(crate) mod latency_tracking;
 pub(crate) mod tasks;
 pub(crate) mod use_case_history;

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Objects used by/related to shared mempool
+use super::latency_tracking::MempoolLatencyStatsTracking;
 use crate::{
     core_mempool::CoreMempool,
     network::{MempoolNetworkInterface, MempoolSyncMsg},
@@ -44,7 +45,6 @@ use super::latency_tracking::MempoolLatencyStatsTracking;
 
 pub type MempoolSenderBucket = u8;
 pub type TimelineIndexIdentifier = u8;
-
 
 /// Struct that owns all dependencies required by shared mempool routines.
 #[derive(Clone)]
@@ -242,15 +242,13 @@ pub type SubmissionStatusBundle = (SignedTransaction, SubmissionStatus);
 pub enum MempoolClientRequest {
     SubmitTransaction(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>),
     GetTransactionByHash(HashValue, oneshot::Sender<Option<SignedTransaction>>),
-    GetLatencySummary(MempoolLatencySummary),
+    GetLatencySummary(oneshot::Sender<MempoolLatencySummary>),
 }
 
 pub type MempoolClientSender = mpsc::Sender<MempoolClientRequest>;
 pub type MempoolEventsReceiver = mpsc::Receiver<MempoolClientRequest>;
 
-pub struct MempoolLatencySummary {
-
-}
+pub struct MempoolLatencySummary {}
 
 /// State of last sync with peer:
 /// `timeline_id` is position in log of ready transactions

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -102,20 +102,20 @@ fn test_transaction_metrics() {
     );
 
     // Check timestamp returned as end-to-end for broadcast-able transaction
-    let (insertion_info, _bucket, _priority) = mempool
+    let (insertion_info, _bucket, _priority, _bucket_floor) = mempool
         .get_transaction_store()
         .get_insertion_info_and_bucket(&TestTransaction::get_address(0), 0)
         .unwrap();
     assert_eq!(insertion_info.submitted_by, SubmittedBy::Downstream);
 
     // Check timestamp returned as not end-to-end for non-broadcast-able transaction
-    let (insertion_info, _bucket, _priority) = mempool
+    let (insertion_info, _bucket, _priority, _bucket_floor) = mempool
         .get_transaction_store()
         .get_insertion_info_and_bucket(&TestTransaction::get_address(1), 0)
         .unwrap();
     assert_eq!(insertion_info.submitted_by, SubmittedBy::PeerValidator);
 
-    let (insertion_info, _bucket, _priority) = mempool
+    let (insertion_info, _bucket, _priority, _bucket_floor) = mempool
         .get_transaction_store()
         .get_insertion_info_and_bucket(&TestTransaction::get_address(2), 0)
         .unwrap();

--- a/state-sync/state-sync-driver/src/notification_handlers.rs
+++ b/state-sync/state-sync-driver/src/notification_handlers.rs
@@ -407,11 +407,11 @@ impl<M: MempoolNotificationSender> MempoolNotificationHandler<M> {
     pub async fn notify_mempool_of_committed_transactions(
         &mut self,
         committed_transactions: Vec<Transaction>,
-        block_timestamp_usecs: u64,
+        latest_chain_timestamp_usecs: u64,
     ) -> Result<(), Error> {
         let result = self
             .mempool_notification_sender
-            .notify_new_commit(committed_transactions, block_timestamp_usecs)
+            .notify_new_commit(committed_transactions, latest_chain_timestamp_usecs)
             .await;
 
         if let Err(error) = result {

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -168,6 +168,19 @@ impl TransactionShufflerType {
             user_use_case_spread_factor: 4,
         }
     }
+
+    pub fn user_use_case_spread_factor(&self) -> Option<usize> {
+        match self {
+            TransactionShufflerType::NoShuffling
+            | TransactionShufflerType::DeprecatedSenderAwareV1(_)
+            | TransactionShufflerType::SenderAwareV2(_)
+            | TransactionShufflerType::DeprecatedFairness { .. } => None,
+            TransactionShufflerType::UseCaseAware {
+                user_use_case_spread_factor,
+                ..
+            } => Some(*user_use_case_spread_factor),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]


### PR DESCRIPTION
## Description
There are various different components that affect transaction inclusion in the block - backpressures, block gas limit, reordering, etc. It is very hard and fragile (in some cases impossible) to reverse-engineer all that form onchain information, and provide appropriate gas estimation.

Much more robust way is to use actual latency from transaction being ready in mempool (i.e. not being parked) to the time it is included in the block that commits it (as that is the part that gas price affects)

So add logic to track such information and provide it to the API implementation, which can then use it to produce better gas estimation.

One negative is that enough traffic needs to go through a particular endpoint for it to have enough information to use it for the gas estimation. So making it configurable in the node config, so that only nodes receiving enough traffic can enable it for better estimation. 

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Full Node (API, Indexer, etc.)

## How Has This Been Tested?
will enable and test on forge workload sweep

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
