### PR TITLE
Break lock reentrancy in StateKey registry

### DIFF
--- a/types/src/state_store/state_key/registry.rs
+++ b/types/src/state_store/state_key/registry.rs
@@ -158,8 +158,7 @@ where
             if let Some(map2) = locked.get_mut(key1) {
                 if let Some(entry) = map2.get(key2) {
                     if entry.strong_count() == 0 {
-                        removed_entry = Some(entry.clone());
-                        map2.remove(key2);
+                        removed_entry = map2.remove(key2);
                         if map2.is_empty() {
                             locked.remove(key1);
                         }

--- a/types/src/state_store/state_key/registry.rs
+++ b/types/src/state_store/state_key/registry.rs
@@ -20,6 +20,7 @@ use move_core_types::{
 };
 use once_cell::sync::Lazy;
 use std::{
+    mem,
     borrow::Borrow,
     hash::{Hash, Hasher},
     sync::{Arc, Weak},
@@ -149,17 +150,24 @@ where
     }
 
     fn maybe_remove(&self, key1: &Key1, key2: &Key2) {
-        let mut locked = self.inner.write();
-        if let Some(map2) = locked.get_mut(key1) {
-            if let Some(entry) = map2.get(key2) {
-                if entry.strong_count() == 0 {
-                    map2.remove(key2);
-                    if map2.is_empty() {
-                        locked.remove(key1);
+        // If the entry is removed, it must be dropped outside of the lock
+        // to prevent lock reentrancy
+        let mut removed_entry = None;
+        {
+            let mut locked = self.inner.write();
+            if let Some(map2) = locked.get_mut(key1) {
+                if let Some(entry) = map2.get(key2) {
+                    if entry.strong_count() == 0 {
+                        removed_entry = Some(entry.clone());
+                        map2.remove(key2);
+                        if map2.is_empty() {
+                            locked.remove(key1);
+                        }
                     }
                 }
             }
         }
+        mem::drop(removed_entry);
     }
 
     pub fn get_or_add<Ref1, Ref2, Gen>(


### PR DESCRIPTION
## Description

When removing an entry from the registry, defer drop of the removed entry to after the lock is released.

If the entry refers to another resource on the same registry shard and that entry gets dropped in turn, the lock in the TwoKeyRegistry is attempted to be acquired by this thread again, which results in a deadlock.

<details>
<summary>Stack trace showing the problem</summary>

I have observed the reentrancy in a stack trace like the following (sorry for the lack of demangling and file paths):

```
    frame #10: 0x0000000104ce1ea0 maptos_opt_executor-753cc2b89641a4d9`aptos_types::state_store::state_key::registry::TwoKeyRegistry$LT$Key1$C$Key2$GT$::maybe_remove::h41f7928449542812 at registry.rs:152:26
    frame #11: 0x0000000104cdeedc maptos_opt_executor-753cc2b89641a4d9`_$LT$aptos_types..state_store..state_key..registry..Entry$u20$as$u20$core..ops..drop..Drop$GT$::drop::h7a7439bf6bc9289e at registry.rs:55:51
    frame #12: 0x0000000104b96b28 maptos_opt_executor-753cc2b89641a4d9`core::ptr::drop_in_place$LT$aptos_types..state_store..state_key..registry..Entry$GT$::h38223251290fbec3 at mod.rs:514:1
    frame #13: 0x0000000104a8d3c0 maptos_opt_executor-753cc2b89641a4d9`alloc::sync::Arc$LT$T$C$A$GT$::drop_slow::h82f63e5833020f3d at sync.rs:1812:18
    frame #14: 0x0000000104a8d6b0 maptos_opt_executor-753cc2b89641a4d9`_$LT$alloc..sync..Arc$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$::drop::h3e979cf651f06eaa at sync.rs:2470:13
    frame #15: 0x0000000104b9a830 maptos_opt_executor-753cc2b89641a4d9`core::ptr::drop_in_place$LT$alloc..sync..Arc$LT$aptos_types..state_store..state_key..registry..Entry$GT$$GT$::h5e81035a5d801980 at mod.rs:514:1
    frame #16: 0x0000000104b8c384 maptos_opt_executor-753cc2b89641a4d9`core::ptr::drop_in_place$LT$core..option..Option$LT$alloc..sync..Arc$LT$aptos_types..state_store..state_key..registry..Entry$GT$$GT$$GT$::h3e7c3ab3881102e5 at mod.rs:514:1
    frame #17: 0x0000000104ce1fcc maptos_opt_executor-753cc2b89641a4d9`aptos_types::state_store::state_key::registry::TwoKeyRegistry$LT$Key1$C$Key2$GT$::maybe_remove::h41f7928449542812 at registry.rs:155:44
    frame #18: 0x0000000104cdeedc maptos_opt_executor-753cc2b89641a4d9`_$LT$aptos_types..state_store..state_key..registry..Entry$u20$as$u20$core..ops..drop..Drop$GT$::drop::h7a7439bf6bc9289e at registry.rs:55:51
    frame #19: 0x0000000104b96b28 maptos_opt_executor-753cc2b89641a4d9`core::ptr::drop_in_place$LT$aptos_types..state_store..state_key..registry..Entry$GT$::h38223251290fbec3 at mod.rs:514:1
    frame #20: 0x0000000104a8d3c0 maptos_opt_executor-753cc2b89641a4d9`alloc::sync::Arc$LT$T$C$A$GT$::drop_slow::h82f63e5833020f3d at sync.rs:1812:18
    frame #21: 0x0000000104a8d6b0 maptos_opt_executor-753cc2b89641a4d9`_$LT$alloc..sync..Arc$LT$T$C$A$GT$$u20$as$u20$core..ops..drop..Drop$GT$::drop::h3e979cf651f06eaa at sync.rs:2470:13
    frame #22: 0x0000000104b9a830 maptos_opt_executor-753cc2b89641a4d9`core::ptr::drop_in_place$LT$alloc..sync..Arc$LT$aptos_types..state_store..state_key..registry..Entry$GT$$GT$::h5e81035a5d801980 at mod.rs:514:1
    frame #23: 0x0000000104b95860 maptos_opt_executor-753cc2b89641a4d9`core::ptr::drop_in_place$LT$aptos_types..state_store..state_key..StateKey$GT$::h3509e573628e3275 at mod.rs:514:1
    frame #24: 0x0000000104287450 maptos_opt_executor-753cc2b89641a4d9`aptos_types::on_chain_config::OnChainConfig::fetch_config::hc94889aaa8fcc584 at mod.rs:184:5
    frame #25: 0x000000010426c180 maptos_opt_executor-753cc2b89641a4d9`aptos_vm::move_vm_ext::write_op_converter::WriteOpConverter::new::he2c2f575f498f860 at write_op_converter.rs:151:41
```

</details>

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?

No isolated tests as of yet, I have only observed the occasional deadlock while testing with a complex genesis setup in https://github.com/movementlabsxyz/movement/pull/576

## Key Areas to Review
- Drop of a possibly existing entry in `TwoKeyRegistry::maybe_remove` has been taken out of the lock scope.
- `std::mem::drop` has been used both for clarity and to prevent a warning about an unused value.

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
