### PR TITLE
[State Sync] Add sync_for_duration() support.

### DIFF
--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -513,6 +513,13 @@ async fn test_commit_sync_race() {
             Ok(())
         }
 
+        async fn sync_for_duration(
+            &self,
+            _duration: std::time::Duration,
+        ) -> std::result::Result<(), Error> {
+            Ok(())
+        }
+
         async fn sync_to_target(
             &self,
             target: LedgerInfoWithSignatures,

--- a/consensus/src/state_computer_tests.rs
+++ b/consensus/src/state_computer_tests.rs
@@ -24,7 +24,10 @@ use aptos_types::{
     transaction::{ExecutionStatus, SignedTransaction, Transaction, TransactionStatus},
     validator_txn::ValidatorTransaction,
 };
-use std::sync::{atomic::AtomicU64, Arc};
+use std::{
+    sync::{atomic::AtomicU64, Arc},
+    time::Duration,
+};
 use tokio::{runtime::Handle, sync::Mutex as AsyncMutex};
 
 struct DummyStateSyncNotifier {
@@ -60,6 +63,10 @@ impl ConsensusNotificationSender for DummyStateSyncNotifier {
             .push((transactions, subscribable_events));
         self.tx.send(()).await.unwrap();
         Ok(())
+    }
+
+    async fn sync_for_duration(&self, _duration: Duration) -> Result<(), Error> {
+        unreachable!()
     }
 
     async fn sync_to_target(&self, _target: LedgerInfoWithSignatures) -> Result<(), Error> {

--- a/state-sync/inter-component/consensus-notifications/src/lib.rs
+++ b/state-sync/inter-component/consensus-notifications/src/lib.rs
@@ -43,6 +43,9 @@ pub trait ConsensusNotificationSender: Send + Sync {
         subscribable_events: Vec<ContractEvent>,
     ) -> Result<(), Error>;
 
+    // Notifies state sync to synchronize storage for the specified duration.
+    async fn sync_for_duration(&self, duration: Duration) -> Result<(), Error>;
+
     /// Notify state sync to synchronize storage to the specified target.
     async fn sync_to_target(&self, target: LedgerInfoWithSignatures) -> Result<(), Error>;
 }
@@ -93,14 +96,10 @@ impl ConsensusNotificationSender for ConsensusNotifier {
             return Ok(());
         }
 
-        // Construct a channel to receive a state sync response
-        let (callback, callback_receiver) = oneshot::channel();
-        let commit_notification =
-            ConsensusNotification::NotifyCommit(ConsensusCommitNotification {
-                transactions,
-                subscribable_events,
-                callback,
-            });
+        // Create a consensus commit notification
+        let (notification, callback_receiver) =
+            ConsensusCommitNotification::new(transactions, subscribable_events);
+        let commit_notification = ConsensusNotification::NotifyCommit(notification);
 
         // Send the notification to state sync
         if let Err(error) = self
@@ -124,24 +123,54 @@ impl ConsensusNotificationSender for ConsensusNotifier {
         {
             match response {
                 Ok(consensus_notification_response) => consensus_notification_response.result,
-                Err(error) => Err(Error::UnexpectedErrorEncountered(format!("{:?}", error))),
+                Err(error) => Err(Error::UnexpectedErrorEncountered(format!(
+                    "Consensus commit notification failure: {:?}",
+                    error
+                ))),
             }
         } else {
             Err(Error::TimeoutWaitingForStateSync)
         }
     }
 
-    async fn sync_to_target(&self, target: LedgerInfoWithSignatures) -> Result<(), Error> {
-        // Construct a channel to receive a state sync response
-        let (callback, callback_receiver) = oneshot::channel();
-        let sync_notification =
-            ConsensusNotification::SyncToTarget(ConsensusSyncNotification { target, callback });
+    async fn sync_for_duration(&self, duration: Duration) -> Result<(), Error> {
+        // Create a consensus sync duration notification
+        let (notification, callback_receiver) = ConsensusSyncDurationNotification::new(duration);
+        let sync_duration_notification = ConsensusNotification::SyncForDuration(notification);
 
         // Send the notification to state sync
         if let Err(error) = self
             .notification_sender
             .clone()
-            .send(sync_notification)
+            .send(sync_duration_notification)
+            .await
+        {
+            return Err(Error::NotificationError(format!(
+                "Failed to notify state sync of sync duration! Error: {:?}",
+                error
+            )));
+        }
+
+        // Process the response
+        match callback_receiver.await {
+            Ok(response) => response.result,
+            Err(error) => Err(Error::UnexpectedErrorEncountered(format!(
+                "Sync for duration failure: {:?}",
+                error
+            ))),
+        }
+    }
+
+    async fn sync_to_target(&self, target: LedgerInfoWithSignatures) -> Result<(), Error> {
+        // Create a consensus sync target notification
+        let (notification, callback_receiver) = ConsensusSyncTargetNotification::new(target);
+        let sync_target_notification = ConsensusNotification::SyncToTarget(notification);
+
+        // Send the notification to state sync
+        if let Err(error) = self
+            .notification_sender
+            .clone()
+            .send(sync_target_notification)
             .await
         {
             return Err(Error::NotificationError(format!(
@@ -153,7 +182,10 @@ impl ConsensusNotificationSender for ConsensusNotifier {
         // Process the response
         match callback_receiver.await {
             Ok(response) => response.result,
-            Err(error) => Err(Error::UnexpectedErrorEncountered(format!("{:?}", error))),
+            Err(error) => Err(Error::UnexpectedErrorEncountered(format!(
+                "Sync to target failure: {:?}",
+                error
+            ))),
         }
     }
 }
@@ -171,28 +203,42 @@ impl ConsensusNotificationListener {
         }
     }
 
-    /// Respond to the commit notification
-    pub async fn respond_to_commit_notification(
-        &mut self,
-        consensus_commit_notification: ConsensusCommitNotification,
+    /// Sends the specified result to the given callback
+    fn send_result_to_callback(
+        &self,
+        callback: oneshot::Sender<ConsensusNotificationResponse>,
         result: Result<(), Error>,
     ) -> Result<(), Error> {
-        consensus_commit_notification
-            .callback
+        callback
             .send(ConsensusNotificationResponse { result })
             .map_err(|error| Error::UnexpectedErrorEncountered(format!("{:?}", error)))
     }
 
-    /// Respond to the sync notification
-    pub async fn respond_to_sync_notification(
-        &mut self,
-        consensus_sync_notification: ConsensusSyncNotification,
+    /// Respond to the commit notification
+    pub async fn respond_to_commit_notification(
+        &self,
+        consensus_commit_notification: ConsensusCommitNotification,
         result: Result<(), Error>,
     ) -> Result<(), Error> {
-        consensus_sync_notification
-            .callback
-            .send(ConsensusNotificationResponse { result })
-            .map_err(|error| Error::UnexpectedErrorEncountered(format!("{:?}", error)))
+        self.send_result_to_callback(consensus_commit_notification.callback, result)
+    }
+
+    /// Respond to the sync duration notification
+    pub async fn respond_to_sync_duration_notification(
+        &self,
+        sync_duration_notification: ConsensusSyncDurationNotification,
+        result: Result<(), Error>,
+    ) -> Result<(), Error> {
+        self.send_result_to_callback(sync_duration_notification.callback, result)
+    }
+
+    /// Respond to the sync target notification
+    pub async fn respond_to_sync_target_notification(
+        &self,
+        sync_target_notification: ConsensusSyncTargetNotification,
+        result: Result<(), Error>,
+    ) -> Result<(), Error> {
+        self.send_result_to_callback(sync_target_notification.callback, result)
     }
 }
 
@@ -213,15 +259,16 @@ impl FusedStream for ConsensusNotificationListener {
 #[derive(Debug)]
 pub enum ConsensusNotification {
     NotifyCommit(ConsensusCommitNotification),
-    SyncToTarget(ConsensusSyncNotification),
+    SyncForDuration(ConsensusSyncDurationNotification),
+    SyncToTarget(ConsensusSyncTargetNotification),
 }
 
 /// A commit notification to notify state sync of new commits
 #[derive(Debug)]
 pub struct ConsensusCommitNotification {
-    pub transactions: Vec<Transaction>,
-    pub subscribable_events: Vec<ContractEvent>,
-    pub(crate) callback: oneshot::Sender<ConsensusNotificationResponse>,
+    transactions: Vec<Transaction>,
+    subscribable_events: Vec<ContractEvent>,
+    callback: oneshot::Sender<ConsensusNotificationResponse>,
 }
 
 impl ConsensusCommitNotification {
@@ -238,6 +285,16 @@ impl ConsensusCommitNotification {
 
         (commit_notification, callback_receiver)
     }
+
+    /// Returns a reference to the transactions
+    pub fn get_transactions(&self) -> &Vec<Transaction> {
+        &self.transactions
+    }
+
+    /// Returns a reference to the subscribable events
+    pub fn get_subscribable_events(&self) -> &Vec<ContractEvent> {
+        &self.subscribable_events
+    }
 }
 
 /// The result returned by state sync for a consensus or consensus observer notification
@@ -246,21 +303,47 @@ pub struct ConsensusNotificationResponse {
     pub result: Result<(), Error>,
 }
 
-/// A notification for state sync to synchronize to the given target
+/// A notification for state sync to synchronize for the specified duration
 #[derive(Debug)]
-pub struct ConsensusSyncNotification {
-    pub target: LedgerInfoWithSignatures,
-    pub(crate) callback: oneshot::Sender<ConsensusNotificationResponse>,
+pub struct ConsensusSyncDurationNotification {
+    duration: Duration,
+    callback: oneshot::Sender<ConsensusNotificationResponse>,
 }
 
-impl ConsensusSyncNotification {
+impl ConsensusSyncDurationNotification {
+    pub fn new(duration: Duration) -> (Self, oneshot::Receiver<ConsensusNotificationResponse>) {
+        let (callback, callback_receiver) = oneshot::channel();
+        let notification = ConsensusSyncDurationNotification { duration, callback };
+
+        (notification, callback_receiver)
+    }
+
+    /// Returns the duration of the notification
+    pub fn get_duration(&self) -> Duration {
+        self.duration
+    }
+}
+
+/// A notification for state sync to synchronize to the given target
+#[derive(Debug)]
+pub struct ConsensusSyncTargetNotification {
+    target: LedgerInfoWithSignatures,
+    callback: oneshot::Sender<ConsensusNotificationResponse>,
+}
+
+impl ConsensusSyncTargetNotification {
     pub fn new(
         target: LedgerInfoWithSignatures,
     ) -> (Self, oneshot::Receiver<ConsensusNotificationResponse>) {
         let (callback, callback_receiver) = oneshot::channel();
-        let sync_notification = ConsensusSyncNotification { target, callback };
+        let notification = ConsensusSyncTargetNotification { target, callback };
 
-        (sync_notification, callback_receiver)
+        (notification, callback_receiver)
+    }
+
+    /// Returns a reference to the target of the notification
+    pub fn get_target(&self) -> &LedgerInfoWithSignatures {
+        &self.target
     }
 }
 
@@ -338,8 +421,11 @@ mod tests {
         match consensus_listener.select_next_some().now_or_never() {
             Some(consensus_notification) => match consensus_notification {
                 ConsensusNotification::NotifyCommit(commit_notification) => {
-                    assert_eq!(transactions, commit_notification.transactions);
-                    assert_eq!(subscribable_events, commit_notification.subscribable_events);
+                    assert_eq!(transactions, commit_notification.get_transactions().clone());
+                    assert_eq!(
+                        subscribable_events,
+                        commit_notification.get_subscribable_events().clone()
+                    );
                 },
                 result => panic!(
                     "Expected consensus commit notification but got: {:?}",
@@ -349,9 +435,10 @@ mod tests {
             result => panic!("Expected consensus notification but got: {:?}", result),
         };
 
-        // Send a sync notification
+        // Send a sync target notification
+        let notifier = consensus_notifier.clone();
         let _thread = std::thread::spawn(move || {
-            let _result = block_on(consensus_notifier.sync_to_target(create_ledger_info()));
+            let _result = block_on(notifier.sync_to_target(create_ledger_info()));
         });
 
         // Give the thread enough time to spawn and send the notification
@@ -361,9 +448,34 @@ mod tests {
         match consensus_listener.select_next_some().now_or_never() {
             Some(consensus_notification) => match consensus_notification {
                 ConsensusNotification::SyncToTarget(sync_notification) => {
-                    assert_eq!(create_ledger_info(), sync_notification.target);
+                    assert_eq!(create_ledger_info(), sync_notification.get_target().clone());
                 },
-                result => panic!("Expected consensus sync notification but got: {:?}", result),
+                result => panic!(
+                    "Expected consensus sync target notification but got: {:?}",
+                    result
+                ),
+            },
+            result => panic!("Expected consensus notification but got: {:?}", result),
+        };
+
+        // Send a sync duration notification
+        let _thread = std::thread::spawn(move || {
+            let _result = block_on(consensus_notifier.sync_for_duration(Duration::from_secs(10)));
+        });
+
+        // Give the thread enough time to spawn and send the notification
+        std::thread::sleep(Duration::from_millis(1000));
+
+        // Verify the notification arrives at the receiver
+        match consensus_listener.select_next_some().now_or_never() {
+            Some(consensus_notification) => match consensus_notification {
+                ConsensusNotification::SyncForDuration(sync_notification) => {
+                    assert_eq!(Duration::from_secs(10), sync_notification.duration);
+                },
+                result => panic!(
+                    "Expected consensus sync duration notification but got: {:?}",
+                    result
+                ),
             },
             result => panic!("Expected consensus notification but got: {:?}", result),
         };
@@ -387,10 +499,21 @@ mod tests {
                     );
                 },
                 Some(ConsensusNotification::SyncToTarget(sync_notification)) => {
-                    let _result = block_on(consensus_listener.respond_to_sync_notification(
+                    let _result = block_on(consensus_listener.respond_to_sync_target_notification(
                         sync_notification,
-                        Err(Error::UnexpectedErrorEncountered("Oops?".into())),
+                        Err(Error::UnexpectedErrorEncountered(
+                            "Oops! Sync to target failed!".into(),
+                        )),
                     ));
+                },
+                Some(ConsensusNotification::SyncForDuration(sync_notification)) => {
+                    let _result =
+                        block_on(consensus_listener.respond_to_sync_duration_notification(
+                            sync_notification,
+                            Err(Error::UnexpectedErrorEncountered(
+                                "Oops! Sync for duration failed!".into(),
+                            )),
+                        ));
                 },
                 _ => { /* Do nothing */ },
             }
@@ -401,8 +524,12 @@ mod tests {
             block_on(consensus_notifier.notify_new_commit(vec![create_user_transaction()], vec![]));
         assert_ok!(notify_result);
 
-        // Send a sync notification and very an error response
+        // Send a sync target notification and verify an error response
         let notify_result = block_on(consensus_notifier.sync_to_target(create_ledger_info()));
+        assert_err!(notify_result);
+
+        // Send a sync duration notification and verify an error response
+        let notify_result = block_on(consensus_notifier.sync_for_duration(Duration::from_secs(10)));
         assert_err!(notify_result);
     }
 

--- a/state-sync/inter-component/consensus-notifications/src/lib.rs
+++ b/state-sync/inter-component/consensus-notifications/src/lib.rs
@@ -215,7 +215,7 @@ impl ConsensusNotificationListener {
     }
 
     /// Respond to the commit notification
-    pub async fn respond_to_commit_notification(
+    pub fn respond_to_commit_notification(
         &self,
         consensus_commit_notification: ConsensusCommitNotification,
         result: Result<(), Error>,
@@ -224,7 +224,7 @@ impl ConsensusNotificationListener {
     }
 
     /// Respond to the sync duration notification
-    pub async fn respond_to_sync_duration_notification(
+    pub fn respond_to_sync_duration_notification(
         &self,
         sync_duration_notification: ConsensusSyncDurationNotification,
         result: Result<(), Error>,
@@ -233,7 +233,7 @@ impl ConsensusNotificationListener {
     }
 
     /// Respond to the sync target notification
-    pub async fn respond_to_sync_target_notification(
+    pub fn respond_to_sync_target_notification(
         &self,
         sync_target_notification: ConsensusSyncTargetNotification,
         result: Result<(), Error>,
@@ -493,27 +493,24 @@ mod tests {
         let _handler = std::thread::spawn(move || loop {
             match consensus_listener.select_next_some().now_or_never() {
                 Some(ConsensusNotification::NotifyCommit(commit_notification)) => {
-                    let _result = block_on(
-                        consensus_listener
-                            .respond_to_commit_notification(commit_notification, Ok(())),
-                    );
+                    let _result = consensus_listener
+                        .respond_to_commit_notification(commit_notification, Ok(()));
                 },
                 Some(ConsensusNotification::SyncToTarget(sync_notification)) => {
-                    let _result = block_on(consensus_listener.respond_to_sync_target_notification(
+                    let _result = consensus_listener.respond_to_sync_target_notification(
                         sync_notification,
                         Err(Error::UnexpectedErrorEncountered(
                             "Oops! Sync to target failed!".into(),
                         )),
-                    ));
+                    );
                 },
                 Some(ConsensusNotification::SyncForDuration(sync_notification)) => {
-                    let _result =
-                        block_on(consensus_listener.respond_to_sync_duration_notification(
-                            sync_notification,
-                            Err(Error::UnexpectedErrorEncountered(
-                                "Oops! Sync for duration failed!".into(),
-                            )),
-                        ));
+                    let _result = consensus_listener.respond_to_sync_duration_notification(
+                        sync_notification,
+                        Err(Error::UnexpectedErrorEncountered(
+                            "Oops! Sync for duration failed!".into(),
+                        )),
+                    );
                 },
                 _ => { /* Do nothing */ },
             }

--- a/state-sync/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-driver/src/continuous_syncer.rs
@@ -116,7 +116,7 @@ impl<
         let sync_request_target = consensus_sync_request
             .lock()
             .as_ref()
-            .map(|sync_request| sync_request.get_sync_target());
+            .and_then(|sync_request| sync_request.get_sync_target());
 
         // Initialize a new active data stream
         let active_data_stream = match self.get_continuous_syncing_mode() {
@@ -432,7 +432,7 @@ impl<
         let sync_request_target = consensus_sync_request
             .lock()
             .as_ref()
-            .map(|sync_request| sync_request.get_sync_target());
+            .and_then(|sync_request| sync_request.get_sync_target());
         if let Some(sync_request_target) = sync_request_target {
             let sync_request_version = sync_request_target.ledger_info().version();
             let proof_version = ledger_info_with_signatures.ledger_info().version();

--- a/state-sync/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-driver/src/driver.rs
@@ -22,7 +22,8 @@ use crate::{
 };
 use aptos_config::config::{ConsensusObserverConfig, RoleType, StateSyncDriverConfig};
 use aptos_consensus_notifications::{
-    ConsensusCommitNotification, ConsensusNotification, ConsensusSyncTargetNotification,
+    ConsensusCommitNotification, ConsensusNotification, ConsensusSyncDurationNotification,
+    ConsensusSyncTargetNotification,
 };
 use aptos_data_client::interface::AptosDataClientInterface;
 use aptos_data_streaming_service::streaming_client::{
@@ -264,19 +265,20 @@ impl<
                 ConsensusNotification::NotifyCommit(commit_notification) => {
                     let _ = self
                         .consensus_notification_handler
-                        .respond_to_commit_notification(commit_notification, Err(error.clone()))
-                        .await;
+                        .respond_to_commit_notification(commit_notification, Err(error.clone()));
                 },
                 ConsensusNotification::SyncToTarget(sync_notification) => {
                     let _ = self
                         .consensus_notification_handler
-                        .respond_to_sync_target_notification(sync_notification, Err(error.clone()))
-                        .await;
+                        .respond_to_sync_target_notification(sync_notification, Err(error.clone()));
                 },
-                ConsensusNotification::SyncForDuration(_) => {
-                    warn!(LogSchema::new(LogEntry::ConsensusNotification)
-                        .error(&error)
-                        .message("Received an invalid sync for duration notification!"));
+                ConsensusNotification::SyncForDuration(sync_notification) => {
+                    let _ = self
+                        .consensus_notification_handler
+                        .respond_to_sync_duration_notification(
+                            sync_notification,
+                            Err(error.clone()),
+                        );
                 },
             }
             warn!(LogSchema::new(LogEntry::ConsensusNotification)
@@ -296,10 +298,8 @@ impl<
                     .await
             },
             ConsensusNotification::SyncForDuration(sync_notification) => {
-                Err(Error::UnexpectedError(format!(
-                    "Received an unexpected sync for duration notification: {:?}",
-                    sync_notification
-                )))
+                self.handle_consensus_sync_duration_notification(sync_notification)
+                    .await
             },
         };
 
@@ -341,8 +341,7 @@ impl<
 
         // Respond successfully
         self.consensus_notification_handler
-            .respond_to_commit_notification(commit_notification, Ok(()))
-            .await?;
+            .respond_to_commit_notification(commit_notification, Ok(()))?;
 
         // Check the progress of any sync requests. We need this here because
         // consensus might issue a sync request and then commit (asynchronously).
@@ -384,11 +383,36 @@ impl<
         }
     }
 
+    /// Handles a consensus or consensus observer request to sync for a specified duration
+    async fn handle_consensus_sync_duration_notification(
+        &mut self,
+        sync_duration_notification: ConsensusSyncDurationNotification,
+    ) -> Result<(), Error> {
+        // Update the sync duration notification metrics
+        let latest_synced_version = utils::fetch_pre_committed_version(self.storage.clone())?;
+        info!(
+            LogSchema::new(LogEntry::ConsensusNotification).message(&format!(
+                "Received a consensus sync duration notification! Duration: {:?}. Latest synced version: {:?}",
+                sync_duration_notification.get_duration(), latest_synced_version,
+            ))
+        );
+        metrics::increment_counter(
+            &metrics::DRIVER_COUNTERS,
+            metrics::DRIVER_CONSENSUS_SYNC_DURATION_NOTIFICATION,
+        );
+
+        // Initialize a new sync request
+        self.consensus_notification_handler
+            .initialize_sync_duration_request(sync_duration_notification)
+            .await
+    }
+
     /// Handles a consensus or consensus observer request to sync to a specified target
     async fn handle_consensus_sync_target_notification(
         &mut self,
         sync_target_notification: ConsensusSyncTargetNotification,
     ) -> Result<(), Error> {
+        // Update the sync target notification metrics
         let latest_synced_version = utils::fetch_pre_committed_version(self.storage.clone())?;
         info!(
             LogSchema::new(LogEntry::ConsensusNotification).message(&format!(
@@ -398,7 +422,7 @@ impl<
         );
         metrics::increment_counter(
             &metrics::DRIVER_COUNTERS,
-            metrics::DRIVER_CONSENSUS_SYNC_NOTIFICATION,
+            metrics::DRIVER_CONSENSUS_SYNC_TARGET_NOTIFICATION,
         );
 
         // Initialize a new sync request
@@ -500,31 +524,27 @@ impl<
         };
     }
 
-    /// Checks if the node has successfully reached the sync target
+    /// Checks if the node has successfully reached the sync target or duration
     async fn check_sync_request_progress(&mut self) -> Result<(), Error> {
-        if !self.active_sync_request() {
-            return Ok(()); // There's no pending sync request
+        // Check if the sync request has been satisfied
+        let consensus_sync_request = self.consensus_notification_handler.get_sync_request();
+        match consensus_sync_request.lock().as_ref() {
+            Some(consensus_sync_request) => {
+                let latest_synced_ledger_info =
+                    utils::fetch_latest_synced_ledger_info(self.storage.clone())?;
+                if !consensus_sync_request
+                    .sync_request_satisfied(&latest_synced_ledger_info, self.time_service.clone())
+                {
+                    return Ok(()); // The sync request hasn't been satisfied yet
+                }
+            },
+            None => {
+                return Ok(()); // There's no active sync request
+            },
         }
 
-        // There's a sync request. Fetch it and check if we're still behind the target.
-        let sync_request = self.consensus_notification_handler.get_sync_request();
-        let sync_target_version = sync_request
-            .lock()
-            .as_ref()
-            .ok_or_else(|| {
-                Error::UnexpectedError(
-                    "We've already verified there is an active sync request!".into(),
-                )
-            })?
-            .get_sync_target_version();
-        let latest_synced_ledger_info =
-            utils::fetch_latest_synced_ledger_info(self.storage.clone())?;
-        if latest_synced_ledger_info.ledger_info().version() < sync_target_version {
-            return Ok(());
-        }
-
-        // Wait for the storage synchronizer to drain (if it hasn't already).
-        // This prevents notifying consensus prematurely.
+        // The sync request has been satisfied. Wait for the storage synchronizer to drain
+        // (if it hasn't already). This prevents notifying consensus prematurely.
         while self.storage_synchronizer.pending_storage_data() {
             sample!(
                 SampleRate::Duration(Duration::from_secs(PENDING_DATA_LOG_FREQ_SECS)),
@@ -539,7 +559,7 @@ impl<
         let latest_synced_ledger_info =
             utils::fetch_latest_synced_ledger_info(self.storage.clone())?;
         self.consensus_notification_handler
-            .check_sync_request_progress(latest_synced_ledger_info)
+            .handle_satisfied_sync_request(latest_synced_ledger_info)
             .await?;
 
         // If the sync request was successfully handled, reset the continuous syncer
@@ -548,6 +568,7 @@ impl<
             self.continuous_syncer.reset_active_stream(None).await?;
             self.storage_synchronizer.finish_chunk_executor(); // Consensus or consensus observer is now in control
         }
+
         Ok(())
     }
 

--- a/state-sync/state-sync-driver/src/driver_factory.rs
+++ b/state-sync/state-sync-driver/src/driver_factory.rs
@@ -124,7 +124,8 @@ impl DriverFactory {
             ClientNotificationListener::new(client_notification_receiver);
         let (commit_notification_sender, commit_notification_listener) =
             CommitNotificationListener::new();
-        let consensus_notification_handler = ConsensusNotificationHandler::new(consensus_listener);
+        let consensus_notification_handler =
+            ConsensusNotificationHandler::new(consensus_listener, time_service.clone());
         let (error_notification_sender, error_notification_listener) =
             ErrorNotificationListener::new();
         let mempool_notification_handler =

--- a/state-sync/state-sync-driver/src/metrics.rs
+++ b/state-sync/state-sync-driver/src/metrics.rs
@@ -11,7 +11,10 @@ use std::time::Instant;
 /// Driver metric labels
 pub const DRIVER_CLIENT_NOTIFICATION: &str = "driver_client_notification";
 pub const DRIVER_CONSENSUS_COMMIT_NOTIFICATION: &str = "driver_consensus_commit_notification";
-pub const DRIVER_CONSENSUS_SYNC_NOTIFICATION: &str = "driver_consensus_sync_notification";
+pub const DRIVER_CONSENSUS_SYNC_DURATION_NOTIFICATION: &str =
+    "driver_consensus_sync_duration_notification";
+pub const DRIVER_CONSENSUS_SYNC_TARGET_NOTIFICATION: &str =
+    "driver_consensus_sync_target_notification";
 
 /// Data notification metric labels
 pub const NOTIFICATION_CREATE_TO_APPLY: &str = "notification_create_to_apply";

--- a/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
+++ b/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
@@ -19,7 +19,7 @@ use crate::{
     utils::OutputFallbackHandler,
 };
 use aptos_config::config::ContinuousSyncingMode;
-use aptos_consensus_notifications::ConsensusSyncNotification;
+use aptos_consensus_notifications::ConsensusSyncTargetNotification;
 use aptos_data_streaming_service::{
     data_notification::{DataNotification, DataPayload, NotificationId},
     streaming_client::{NotificationAndFeedback, NotificationFeedback},
@@ -164,9 +164,9 @@ async fn test_data_stream_transactions_with_target() {
     );
 
     // Drive progress to initialize the transaction output stream
-    let (consensus_sync_notification, _) = ConsensusSyncNotification::new(target_ledger_info);
+    let (sync_target_notification, _) = ConsensusSyncTargetNotification::new(target_ledger_info);
     let sync_request = Arc::new(Mutex::new(Some(ConsensusSyncRequest::new(
-        consensus_sync_notification,
+        sync_target_notification,
     ))));
     drive_progress(&mut continuous_syncer, &sync_request).await;
 
@@ -324,9 +324,9 @@ async fn test_data_stream_transactions_or_outputs_with_target() {
     );
 
     // Drive progress to initialize the transaction output stream
-    let (consensus_sync_notification, _) = ConsensusSyncNotification::new(target_ledger_info);
+    let (sync_target_notification, _) = ConsensusSyncTargetNotification::new(target_ledger_info);
     let sync_request = Arc::new(Mutex::new(Some(ConsensusSyncRequest::new(
-        consensus_sync_notification,
+        sync_target_notification,
     ))));
     drive_progress(&mut continuous_syncer, &sync_request).await;
 
@@ -444,9 +444,9 @@ async fn test_data_stream_transactions_or_outputs_with_target_fallback() {
     assert!(!output_fallback_handler.in_fallback_mode());
 
     // Drive progress to initialize the transactions or output stream
-    let (consensus_sync_notification, _) = ConsensusSyncNotification::new(target_ledger_info);
+    let (sync_target_notification, _) = ConsensusSyncTargetNotification::new(target_ledger_info);
     let sync_request = Arc::new(Mutex::new(Some(ConsensusSyncRequest::new(
-        consensus_sync_notification,
+        sync_target_notification,
     ))));
     drive_progress(&mut continuous_syncer, &sync_request).await;
 

--- a/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
+++ b/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
@@ -19,7 +19,9 @@ use crate::{
     utils::OutputFallbackHandler,
 };
 use aptos_config::config::ContinuousSyncingMode;
-use aptos_consensus_notifications::ConsensusSyncTargetNotification;
+use aptos_consensus_notifications::{
+    ConsensusSyncDurationNotification, ConsensusSyncTargetNotification,
+};
 use aptos_data_streaming_service::{
     data_notification::{DataNotification, DataPayload, NotificationId},
     streaming_client::{NotificationAndFeedback, NotificationFeedback},
@@ -31,7 +33,10 @@ use aptos_types::transaction::{TransactionOutputListWithProof, Version};
 use claims::assert_matches;
 use futures::SinkExt;
 use mockall::{predicate::eq, Sequence};
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 #[tokio::test]
 async fn test_critical_timeout() {
@@ -111,7 +116,89 @@ async fn test_critical_timeout() {
 }
 
 #[tokio::test]
-async fn test_data_stream_transactions_with_target() {
+async fn test_data_stream_transactions_with_sync_duration() {
+    // Create test data
+    let current_synced_epoch = 10;
+    let current_synced_version = 1000;
+    let notification_id = 900;
+
+    // Create a driver configuration
+    let mut driver_configuration = create_full_node_driver_configuration();
+    driver_configuration.config.continuous_syncing_mode =
+        ContinuousSyncingMode::ExecuteTransactions;
+
+    // Create the mock streaming client
+    let mut mock_streaming_client = create_mock_streaming_client();
+    let mut expectation_sequence = Sequence::new();
+    let (mut notification_sender_1, data_stream_listener_1) = create_data_stream_listener();
+    let (_notification_sender_2, data_stream_listener_2) = create_data_stream_listener();
+    let data_stream_id_1 = data_stream_listener_1.data_stream_id;
+    for data_stream_listener in [data_stream_listener_1, data_stream_listener_2] {
+        mock_streaming_client
+            .expect_continuously_stream_transactions()
+            .times(1)
+            .with(
+                eq(current_synced_version),
+                eq(current_synced_epoch),
+                eq(false),
+                eq(None),
+            )
+            .return_once(move |_, _, _, _| Ok(data_stream_listener))
+            .in_sequence(&mut expectation_sequence);
+    }
+    mock_streaming_client
+        .expect_terminate_stream_with_feedback()
+        .with(
+            eq(data_stream_id_1),
+            eq(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::EmptyPayloadData,
+            ))),
+        )
+        .return_const(Ok(()));
+
+    // Create the continuous syncer
+    let (mut continuous_syncer, _) = create_continuous_syncer(
+        driver_configuration,
+        mock_streaming_client,
+        None,
+        true,
+        current_synced_version,
+        current_synced_epoch,
+    );
+
+    // Drive progress to initialize the transaction output stream for the sync duration
+    let (sync_duration_notification, _) =
+        ConsensusSyncDurationNotification::new(Duration::from_secs(1));
+    let sync_request = Arc::new(Mutex::new(Some(ConsensusSyncRequest::new_with_duration(
+        Instant::now(),
+        sync_duration_notification,
+    ))));
+    drive_progress(&mut continuous_syncer, &sync_request).await;
+
+    // Send an invalid output along the stream
+    let data_notification = DataNotification::new(
+        notification_id,
+        DataPayload::ContinuousTransactionOutputsWithProof(
+            create_epoch_ending_ledger_info(),
+            TransactionOutputListWithProof::new_empty(),
+        ),
+    );
+    notification_sender_1.send(data_notification).await.unwrap();
+
+    // Drive progress again and ensure we get a verification error
+    let error = continuous_syncer
+        .drive_progress(sync_request.clone())
+        .await
+        .unwrap_err();
+    assert_matches!(error, Error::VerificationError(_));
+
+    // Drive progress to initialize the transaction output stream.
+    drive_progress(&mut continuous_syncer, &sync_request).await;
+}
+
+#[tokio::test]
+async fn test_data_stream_transactions_with_sync_target() {
     // Create test data
     let current_synced_epoch = 5;
     let current_synced_version = 234;
@@ -163,9 +250,9 @@ async fn test_data_stream_transactions_with_target() {
         current_synced_epoch,
     );
 
-    // Drive progress to initialize the transaction output stream
+    // Drive progress to initialize the transaction output stream for the sync target
     let (sync_target_notification, _) = ConsensusSyncTargetNotification::new(target_ledger_info);
-    let sync_request = Arc::new(Mutex::new(Some(ConsensusSyncRequest::new(
+    let sync_request = Arc::new(Mutex::new(Some(ConsensusSyncRequest::new_with_target(
         sync_target_notification,
     ))));
     drive_progress(&mut continuous_syncer, &sync_request).await;
@@ -187,7 +274,7 @@ async fn test_data_stream_transactions_with_target() {
         .unwrap_err();
     assert_matches!(error, Error::VerificationError(_));
 
-    // Drive progress to initialize the transaction output stream.
+    // Drive progress to initialize the transaction output stream
     drive_progress(&mut continuous_syncer, &sync_request).await;
 }
 
@@ -242,7 +329,7 @@ async fn test_data_stream_transaction_outputs() {
         current_synced_epoch,
     );
 
-    // Drive progress to initialize the transaction output stream
+    // Drive progress to initialize the transaction output stream (without a sync target)
     let no_sync_request = Arc::new(Mutex::new(None));
     drive_progress(&mut continuous_syncer, &no_sync_request).await;
 
@@ -271,7 +358,89 @@ async fn test_data_stream_transaction_outputs() {
 }
 
 #[tokio::test]
-async fn test_data_stream_transactions_or_outputs_with_target() {
+async fn test_data_stream_transactions_or_outputs_with_sync_duration() {
+    // Create test data
+    let current_synced_epoch = 100;
+    let current_synced_version = 1000;
+    let notification_id = 100;
+
+    // Create a driver configuration with a genesis waypoint and transactions or output syncing
+    let mut driver_configuration = create_full_node_driver_configuration();
+    driver_configuration.config.continuous_syncing_mode =
+        ContinuousSyncingMode::ExecuteTransactionsOrApplyOutputs;
+
+    // Create the mock streaming client
+    let mut mock_streaming_client = create_mock_streaming_client();
+    let mut expectation_sequence = Sequence::new();
+    let (mut notification_sender_1, data_stream_listener_1) = create_data_stream_listener();
+    let (_notification_sender_2, data_stream_listener_2) = create_data_stream_listener();
+    let data_stream_id_1 = data_stream_listener_1.data_stream_id;
+    for data_stream_listener in [data_stream_listener_1, data_stream_listener_2] {
+        mock_streaming_client
+            .expect_continuously_stream_transactions_or_outputs()
+            .times(1)
+            .with(
+                eq(current_synced_version),
+                eq(current_synced_epoch),
+                eq(false),
+                eq(None),
+            )
+            .return_once(move |_, _, _, _| Ok(data_stream_listener))
+            .in_sequence(&mut expectation_sequence);
+    }
+    mock_streaming_client
+        .expect_terminate_stream_with_feedback()
+        .with(
+            eq(data_stream_id_1),
+            eq(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::EmptyPayloadData,
+            ))),
+        )
+        .return_const(Ok(()));
+
+    // Create the continuous syncer
+    let (mut continuous_syncer, _) = create_continuous_syncer(
+        driver_configuration,
+        mock_streaming_client,
+        None,
+        true,
+        current_synced_version,
+        current_synced_epoch,
+    );
+
+    // Drive progress to initialize the transaction output stream for the sync duration
+    let (sync_duration_notification, _) =
+        ConsensusSyncDurationNotification::new(Duration::from_secs(1));
+    let sync_request = Arc::new(Mutex::new(Some(ConsensusSyncRequest::new_with_duration(
+        Instant::now(),
+        sync_duration_notification,
+    ))));
+    drive_progress(&mut continuous_syncer, &sync_request).await;
+
+    // Send an invalid output along the stream
+    let data_notification = DataNotification::new(
+        notification_id,
+        DataPayload::ContinuousTransactionOutputsWithProof(
+            create_epoch_ending_ledger_info(),
+            TransactionOutputListWithProof::new_empty(),
+        ),
+    );
+    notification_sender_1.send(data_notification).await.unwrap();
+
+    // Drive progress again and ensure we get a verification error
+    let error = continuous_syncer
+        .drive_progress(sync_request.clone())
+        .await
+        .unwrap_err();
+    assert_matches!(error, Error::VerificationError(_));
+
+    // Drive progress to initialize the transaction output stream
+    drive_progress(&mut continuous_syncer, &sync_request).await;
+}
+
+#[tokio::test]
+async fn test_data_stream_transactions_or_outputs_with_sync_target() {
     // Create test data
     let current_synced_epoch = 5;
     let current_synced_version = 234;
@@ -323,9 +492,9 @@ async fn test_data_stream_transactions_or_outputs_with_target() {
         current_synced_epoch,
     );
 
-    // Drive progress to initialize the transaction output stream
+    // Drive progress to initialize the transaction output stream for the sync target
     let (sync_target_notification, _) = ConsensusSyncTargetNotification::new(target_ledger_info);
-    let sync_request = Arc::new(Mutex::new(Some(ConsensusSyncRequest::new(
+    let sync_request = Arc::new(Mutex::new(Some(ConsensusSyncRequest::new_with_target(
         sync_target_notification,
     ))));
     drive_progress(&mut continuous_syncer, &sync_request).await;
@@ -352,7 +521,138 @@ async fn test_data_stream_transactions_or_outputs_with_target() {
 }
 
 #[tokio::test]
-async fn test_data_stream_transactions_or_outputs_with_target_fallback() {
+async fn test_data_stream_transactions_or_outputs_with_sync_duration_fallback() {
+    // Create test data
+    let current_synced_epoch = 50;
+    let current_synced_version = 1234;
+    let notification_id = 101;
+
+    // Create a driver configuration with a genesis waypoint and transactions or output syncing
+    let mut driver_configuration = create_full_node_driver_configuration();
+    driver_configuration.config.continuous_syncing_mode =
+        ContinuousSyncingMode::ExecuteTransactionsOrApplyOutputs;
+
+    // Create the mock streaming client
+    let mut mock_streaming_client = create_mock_streaming_client();
+
+    // Set expectations for stream creations and terminations
+    let mut expectation_sequence = Sequence::new();
+    let (_notification_sender_1, data_stream_listener_1) = create_data_stream_listener();
+    let data_stream_id_1 = data_stream_listener_1.data_stream_id;
+    let (_notification_sender_2, data_stream_listener_2) = create_data_stream_listener();
+    let data_stream_id_2 = data_stream_listener_2.data_stream_id;
+    let (_notification_sender_3, data_stream_listener_3) = create_data_stream_listener();
+    mock_streaming_client
+        .expect_continuously_stream_transactions_or_outputs()
+        .times(1)
+        .with(
+            eq(current_synced_version),
+            eq(current_synced_epoch),
+            eq(false),
+            eq(None),
+        )
+        .return_once(move |_, _, _, _| Ok(data_stream_listener_1))
+        .in_sequence(&mut expectation_sequence);
+    mock_streaming_client
+        .expect_terminate_stream_with_feedback()
+        .times(1)
+        .with(
+            eq(data_stream_id_1),
+            eq(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::PayloadProofFailed,
+            ))),
+        )
+        .return_const(Ok(()))
+        .in_sequence(&mut expectation_sequence);
+    mock_streaming_client
+        .expect_continuously_stream_transaction_outputs()
+        .times(1)
+        .with(
+            eq(current_synced_version),
+            eq(current_synced_epoch),
+            eq(None),
+        )
+        .return_once(move |_, _, _| Ok(data_stream_listener_2))
+        .in_sequence(&mut expectation_sequence);
+    mock_streaming_client
+        .expect_terminate_stream_with_feedback()
+        .times(1)
+        .with(
+            eq(data_stream_id_2),
+            eq(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::InvalidPayloadData,
+            ))),
+        )
+        .return_const(Ok(()))
+        .in_sequence(&mut expectation_sequence);
+    mock_streaming_client
+        .expect_continuously_stream_transactions_or_outputs()
+        .times(1)
+        .with(
+            eq(current_synced_version),
+            eq(current_synced_epoch),
+            eq(false),
+            eq(None),
+        )
+        .return_once(move |_, _, _, _| Ok(data_stream_listener_3))
+        .in_sequence(&mut expectation_sequence);
+
+    // Create the continuous syncer
+    let time_service = TimeService::mock();
+    let (mut continuous_syncer, mut output_fallback_handler) = create_continuous_syncer(
+        driver_configuration.clone(),
+        mock_streaming_client,
+        Some(time_service.clone()),
+        true,
+        current_synced_version,
+        current_synced_epoch,
+    );
+    assert!(!output_fallback_handler.in_fallback_mode());
+
+    // Drive progress to initialize the transactions or output stream for the sync duration
+    let (sync_duration_notification, _) =
+        ConsensusSyncDurationNotification::new(Duration::from_secs(1));
+    let sync_request = Arc::new(Mutex::new(Some(ConsensusSyncRequest::new_with_duration(
+        Instant::now(),
+        sync_duration_notification,
+    ))));
+    drive_progress(&mut continuous_syncer, &sync_request).await;
+
+    // Send a storage synchronizer error to the continuous syncer so that it falls back
+    // to output syncing and drive progress for the new stream type.
+    handle_storage_synchronizer_error(
+        &mut continuous_syncer,
+        notification_id,
+        NotificationFeedback::PayloadProofFailed,
+    )
+    .await;
+    drive_progress(&mut continuous_syncer, &sync_request).await;
+    assert!(output_fallback_handler.in_fallback_mode());
+
+    // Elapse enough time so that fallback mode is now disabled
+    time_service
+        .into_mock()
+        .advance_async(Duration::from_secs(
+            driver_configuration.config.fallback_to_output_syncing_secs,
+        ))
+        .await;
+
+    // Send another storage synchronizer error to the bootstrapper and drive progress
+    // so that a regular stream is created.
+    handle_storage_synchronizer_error(
+        &mut continuous_syncer,
+        notification_id,
+        NotificationFeedback::InvalidPayloadData,
+    )
+    .await;
+    drive_progress(&mut continuous_syncer, &sync_request).await;
+    assert!(!output_fallback_handler.in_fallback_mode());
+}
+
+#[tokio::test]
+async fn test_data_stream_transactions_or_outputs_with_sync_target_fallback() {
     // Create test data
     let current_synced_epoch = 5;
     let current_synced_version = 234;
@@ -445,7 +745,7 @@ async fn test_data_stream_transactions_or_outputs_with_target_fallback() {
 
     // Drive progress to initialize the transactions or output stream
     let (sync_target_notification, _) = ConsensusSyncTargetNotification::new(target_ledger_info);
-    let sync_request = Arc::new(Mutex::new(Some(ConsensusSyncRequest::new(
+    let sync_request = Arc::new(Mutex::new(Some(ConsensusSyncRequest::new_with_target(
         sync_target_notification,
     ))));
     drive_progress(&mut continuous_syncer, &sync_request).await;


### PR DESCRIPTION
## Description
This PR adds basic `sync_for_duration()` support to state sync, allowing callers to block while state sync synchronizes the node for the specified duration. This will be required by consensus observer (CO), to implement a smarter fallback mechanism on failures to stay up-to-date. Integration with CO will happen in the next PR.

The PR offers the following commits:
1. Add a `sync_for_duration()` function to the consensus notifier.
1. Update state sync to handle the `sync_for_duration()` request.

## Testing Plan
New and existing test infrastructure. More will be added upon integration with CO.

