### PR TITLE
[move-compiler-v2] Generate suitable error messages for current misuse of function-typed values, lay groundwork for implementing and testing more general lambdas.

### DIFF
--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -406,9 +406,12 @@ impl<'env> Generator<'env> {
                         ),
                     );
                 }
-                self.emit_call(*id, targets, BytecodeOperation::WriteRef, vec![
-                    lhs_temp, rhs_temp,
-                ])
+                self.emit_call(
+                    *id,
+                    targets,
+                    BytecodeOperation::WriteRef,
+                    vec![lhs_temp, rhs_temp],
+                )
             },
             ExpData::Assign(id, lhs, rhs) => self.gen_assign(*id, lhs, rhs, None),
             ExpData::Return(id, exp) => {
@@ -476,9 +479,16 @@ impl<'env> Generator<'env> {
                     .rewrite_spec_descent(&SpecBlockTarget::Inline, spec);
                 self.emit_with(*id, |attr| Bytecode::SpecBlock(attr, spec));
             },
-            ExpData::Invoke(id, _, _) | ExpData::Lambda(id, _, _) => {
-                self.internal_error(*id, format!("not yet implemented: {:?}", exp))
-            },
+            // TODO(LAMBDA)
+            ExpData::Lambda(id, _, _) => self.error(
+                *id,
+                "Function-typed values not yet supported except as parameters to calls to inline functions",
+            ),
+            // TODO(LAMBDA)
+            ExpData::Invoke(_, exp, _) => self.error(
+                exp.as_ref().node_id(),
+                "Calls to function values other than inline function parameters not yet supported",
+            ),
             ExpData::Quant(id, _, _, _, _, _) => {
                 self.internal_error(*id, "unsupported specification construct")
             },
@@ -803,7 +813,11 @@ impl<'env> Generator<'env> {
 
             Operation::NoOp => {}, // do nothing
 
-            Operation::Closure(..) => self.internal_error(id, "closure not yet implemented"),
+            // TODO(LAMBDA)
+            Operation::Closure(..) => self.error(
+                id,
+                "Function-typed values not yet supported except as parameters to calls to inline functions",
+            ),
 
             // Non-supported specification related operations
             Operation::Exists(Some(_))

--- a/third_party/move/move-compiler-v2/src/env_pipeline/lambda_lifter.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/lambda_lifter.rs
@@ -309,7 +309,7 @@ impl<'a> ExpRewriterFunctions for LambdaLifter<'a> {
                 env.error(
                     &loc,
                     &format!(
-                        "captured variable `{}` cannot be modified inside of a lambda",
+                        "captured variable `{}` cannot be modified inside of a lambda", // TODO(LAMBDA)
                         name.display(env.symbol_pool())
                     ),
                 );
@@ -327,7 +327,7 @@ impl<'a> ExpRewriterFunctions for LambdaLifter<'a> {
                 env.error(
                     &loc,
                     &format!(
-                        "captured variable `{}` cannot be modified inside of a lambda",
+                        "captured variable `{}` cannot be modified inside of a lambda", // TODO(LAMBDA)
                         name.display(env.symbol_pool())
                     ),
                 );

--- a/third_party/move/move-compiler-v2/src/env_pipeline/recursive_struct_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/recursive_struct_checker.rs
@@ -101,7 +101,7 @@ impl<'a> RecursiveStructChecker<'a> {
                         self.report_invalid_field(&struct_env, &field_env);
                     }
                 },
-                Type::Primitive(_) | Type::TypeParameter(_) => {},
+                Type::Primitive(_) | Type::TypeParameter(_) | Type::Fun(..) => {},
                 _ => unreachable!("invalid field type"),
             }
             path.pop();

--- a/third_party/move/move-compiler-v2/src/env_pipeline/unused_params_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/unused_params_checker.rs
@@ -55,12 +55,16 @@ fn used_type_parameters_in_fields(struct_env: &StructEnv) -> BTreeSet<u16> {
 fn used_type_parameters_in_ty(ty: &Type) -> BTreeSet<u16> {
     match ty {
         Type::Primitive(_) => BTreeSet::new(),
-        Type::Struct(_, _, tys) => tys.iter().flat_map(used_type_parameters_in_ty).collect(),
+        Type::Tuple(tys) | Type::Struct(_, _, tys) => {
+            tys.iter().flat_map(used_type_parameters_in_ty).collect()
+        },
         Type::TypeParameter(i) => BTreeSet::from([*i]),
         Type::Vector(ty) => used_type_parameters_in_ty(ty),
+        Type::Fun(t1, t2) => [t1, t2]
+            .iter()
+            .flat_map(|t| used_type_parameters_in_ty(t))
+            .collect(),
         Type::Reference(..)
-        | Type::Fun(..)
-        | Type::Tuple(..)
         | Type::TypeDomain(..)
         | Type::ResourceDomain(..)
         | Type::Error

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -112,8 +112,29 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             default: Given(false),
         },
         Experiment {
+            name: Experiment::LAMBDA_FIELDS.to_string(),
+            description: "Turns on or off function values in struct fields".to_string(),
+            default: Given(false),
+        },
+        Experiment {
             name: Experiment::LAMBDA_LIFTING.to_string(),
             description: "Turns on or off lambda lifting".to_string(),
+            default: Given(false),
+        },
+        Experiment {
+            name: Experiment::LAMBDA_PARAMS.to_string(),
+            description: "Turns on or off function values as parameters to non-inline functions"
+                .to_string(),
+            default: Given(false),
+        },
+        Experiment {
+            name: Experiment::LAMBDA_RESULTS.to_string(),
+            description: "Turns on or off function values in function results".to_string(),
+            default: Given(false),
+        },
+        Experiment {
+            name: Experiment::LAMBDA_VALUES.to_string(),
+            description: "Turns on or off first-class function values".to_string(),
             default: Given(false),
         },
         Experiment {
@@ -275,7 +296,11 @@ impl Experiment {
     pub const INLINING: &'static str = "inlining";
     pub const KEEP_INLINE_FUNS: &'static str = "keep-inline-funs";
     pub const KEEP_UNINIT_ANNOTATIONS: &'static str = "keep-uninit-annotations";
+    pub const LAMBDA_FIELDS: &'static str = "lambda-fields";
     pub const LAMBDA_LIFTING: &'static str = "lambda-lifting";
+    pub const LAMBDA_PARAMS: &'static str = "lambda-params";
+    pub const LAMBDA_RESULTS: &'static str = "lambda-results";
+    pub const LAMBDA_VALUES: &'static str = "lambda-values";
     pub const LINT_CHECKS: &'static str = "lint-checks";
     pub const OPTIMIZE: &'static str = "optimize";
     pub const OPTIMIZE_EXTRA: &'static str = "optimize-extra";

--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -365,7 +365,20 @@ impl ModuleGenerator {
                     ReferenceKind::Mutable => FF::SignatureToken::MutableReference(target_ty),
                 }
             },
-            Fun(_, _) | TypeDomain(_) | ResourceDomain(_, _, _) | Error | Var(_) => {
+            Fun(_param_ty, _result_ty) => {
+                // let _param_ty = Box::new(self.signature_token(ctx, loc, param_ty));
+                // let _result_ty = Box::new(self.signature_token(ctx, loc, result_ty));
+                // TODO(LAMBDA)
+                ctx.error(
+                    loc,
+                    format!(
+                        "Unexpected type: {}",
+                        ty.display(&ctx.env.get_type_display_ctx())
+                    ),
+                );
+                FF::SignatureToken::Bool
+            },
+            TypeDomain(_) | ResourceDomain(_, _, _) | Error | Var(_) => {
                 ctx.internal_error(
                     loc,
                     format!(

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_14471_receiver_inference.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_14471_receiver_inference.exp
@@ -4,8 +4,8 @@ module 0x815::m {
         table: m::Table<address, m::ValueWrap>,
     }
     struct Table {
-        x: #0,
-        y: #1,
+        x: T1,
+        y: T2,
     }
     struct ValueWrap {
         val: u64,

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/fields.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/fields.exp
@@ -4,7 +4,7 @@ module 0x42::fields {
         h: u64,
     }
     struct G {
-        f: #0,
+        f: X,
     }
     struct S {
         f: u64,

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_ok.exp
@@ -42,7 +42,7 @@ module 0xc0ffee::m {
     enum Option {
         None,
         Some {
-            value: #0,
+            value: A,
         }
     }
     enum Outer {

--- a/third_party/move/move-compiler-v2/tests/checking/abilities/v1/ability_constraints.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/abilities/v1/ability_constraints.exp
@@ -1,11 +1,11 @@
 // -- Model dump before bytecode pipeline
 module 0x42::M {
     struct Box {
-        f: #0,
+        f: T,
     }
     struct Pair {
-        f1: #0,
-        f2: #1,
+        f1: T1,
+        f2: T2,
     }
     struct R {
         dummy_field: bool,

--- a/third_party/move/move-compiler-v2/tests/checking/abilities/v1/phantom_param_op_abilities.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/abilities/v1/phantom_param_op_abilities.exp
@@ -1,22 +1,22 @@
 // -- Model dump before bytecode pipeline
 module 0x42::M {
     struct HasCopy {
-        a: #1,
+        a: T2,
     }
     struct HasDrop {
-        a: #1,
+        a: T2,
     }
     struct HasKey {
-        a: #1,
+        a: T2,
     }
     struct HasStore {
-        a: #1,
+        a: T2,
     }
     struct NoAbilities {
         dummy_field: bool,
     }
     struct RequireStore {
-        a: #0,
+        a: T,
     }
     private fun f1(ref: &mut M::HasDrop<M::NoAbilities, u64>) {
         ref = pack M::HasDrop<M::NoAbilities, u64>(1);

--- a/third_party/move/move-compiler-v2/tests/checking/abilities/v1/phantom_params_constraint_abilities.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/abilities/v1/phantom_params_constraint_abilities.exp
@@ -1,34 +1,34 @@
 // -- Model dump before bytecode pipeline
 module 0x42::M {
     struct HasAbilities {
-        a: #1,
+        a: T2,
     }
     struct HasCopy {
-        a: #1,
+        a: T2,
     }
     struct HasDrop {
-        a: #1,
+        a: T2,
     }
     struct HasKey {
-        a: #1,
+        a: T2,
     }
     struct HasStore {
-        a: #1,
+        a: T2,
     }
     struct NoAbilities {
         a: bool,
     }
     struct S1 {
-        a: #0,
+        a: T,
     }
     struct S2 {
         a: M::S1<M::HasAbilities<M::NoAbilities, u64>>,
     }
     struct S3 {
-        a: #0,
-        b: #1,
-        c: #2,
-        d: #3,
+        a: T1,
+        b: T2,
+        c: T3,
+        d: T4,
     }
     struct S4 {
         a: M::S3<M::HasDrop<M::NoAbilities, u64>, M::HasCopy<M::NoAbilities, u64>, M::HasStore<M::NoAbilities, u64>, M::HasKey<M::NoAbilities, u64>>,

--- a/third_party/move/move-compiler-v2/tests/checking/abilities/v1/phantom_params_field_abilities.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/abilities/v1/phantom_params_field_abilities.exp
@@ -1,16 +1,16 @@
 // -- Model dump before bytecode pipeline
 module 0x42::M {
     struct HasCopy {
-        a: #1,
+        a: T2,
     }
     struct HasDrop {
-        a: #1,
+        a: T2,
     }
     struct HasKey {
-        a: #1,
+        a: T2,
     }
     struct HasStore {
-        a: #1,
+        a: T2,
     }
     struct NoAbilities {
         dummy_field: bool,

--- a/third_party/move/move-compiler-v2/tests/checking/dotdot/dotdot_valid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/dotdot/dotdot_valid.exp
@@ -28,16 +28,16 @@ module 0x42::test {
         y: u8,
     }
     struct S4 {
-        x: #0,
+        x: T,
         y: test::S3,
     }
     struct S5 {
-        0: #0,
-        1: #1,
+        0: T,
+        1: U,
     }
     struct S6 {
-        x: #0,
-        y: #1,
+        x: T,
+        y: U,
     }
     struct S7 {
         0: u8,

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda3.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda3.exp
@@ -1,0 +1,17 @@
+// -- Model dump before bytecode pipeline
+module 0x8675309::M {
+    public fun lambda_not_allowed() {
+        {
+          let _x: |u64|u64 = |i: u64| Add<u64>(i, 1);
+          Tuple()
+        }
+    }
+} // end 0x8675309::M
+
+
+Diagnostics:
+error: Function-typed values not yet supported except as parameters to calls to inline functions
+   ┌─ tests/checking/inlining/lambda3.move:77:18
+   │
+77 │         let _x = |i| i + 1; // expected lambda not allowed
+   │                  ^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda3.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda3.move
@@ -1,0 +1,99 @@
+module 0x8675309::M {
+    // use 0x1::XVector;
+
+    // public inline fun foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         action(XVector::borrow(v, i));
+    //         i = i + 1;
+    //     }
+    // }
+
+    // public inline fun reduce<R, T>(v: vector<T>, accu: R, reducer: |T, R|R): R {
+    //     while (!XVector::is_empty(&v)) {
+    //         accu = reducer(XVector::pop_back(&mut v), accu);
+    //     };
+    //     accu
+    // }
+
+
+    // public fun correct_foreach() {
+    //     let v = vector[1, 2, 3];
+    //     let sum = 0;
+    //     foreach(&v, |e| sum = sum + *e) // expected to be not implemented
+    // }
+
+    // public fun correct_reduce(): u64 {
+    //     let v = vector[1, 2, 3];
+    //     reduce(v, 0, |t, r| t + r)
+    // }
+
+    // public fun corrected_nested() {
+    //     let v = vector[vector[1,2], vector[3]];
+    //     let sum = 0;
+    //     foreach(&v, |e| sum = sum + reduce!(*e, 0, |t, r| t + r));
+    // }
+
+    // public inline fun wrong_local_call_arg_count<T>(v: &vector<T>, action: |&T|) {
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         action(XVector::borrow(v, i), i); // expected to have wrong argument count
+    //         i = i + 1;
+    //     }
+    // }
+
+    // public inline fun wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         action(i); // expected to have wrong argument type
+    //         i = i + 1;
+    //     }
+    // }
+
+    // public inline fun wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
+    //     }
+    // }
+
+    // public fun wrong_local_call_no_fun(x: u64) {
+    //     x(1) // expected to be not a function
+    // }
+
+    // public fun wrong_lambda_inferred_type() {
+    //     let v = vector[1, 2, 3];
+    //     let sum = 0;
+    //     foreach(&v, |e| sum = sum + e) // expected to cannot infer type
+    // }
+
+    // public fun wrong_lambda_result_type() {
+    //     let v = vector[1, 2, 3];
+    //     let sum = 0;
+    //     foreach(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
+    // }
+
+    public fun lambda_not_allowed() {
+        let _x = |i| i + 1; // expected lambda not allowed
+    }
+
+    // struct FieldFunNotAllowed {
+    //     f: |u64|u64, // expected lambda not allowed
+    // }
+
+    // public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
+
+    // public inline fun macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+    //     abort (1)
+    // }
+    // public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+    //     abort (1)
+    // }
+}
+
+// module 0x1::XVector {
+//     public fun length<T>(v: &vector<T>): u64 { abort(1) }
+//     public fun is_empty<T>(v: &vector<T>): bool { abort(1) }
+//     public fun borrow<T>(v: &vector<T>, i: u64): &T { abort(1) }
+//     public fun pop_back<T>(v: &mut vector<T>): T { abort(1) }
+// }

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda4.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda4.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: Functions may not return function-typed values, but function `M::macro_result_lambda_not_allowed` return type is `|u64|`:
+   ┌─ tests/checking/inlining/lambda4.move:86:23
+   │
+86 │     public inline fun macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+   │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Functions may not return function-typed values, but function `M::fun_result_lambda_not_allowed` return type is `|u64|`:
+   ┌─ tests/checking/inlining/lambda4.move:89:16
+   │
+89 │     public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda4.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda4.move
@@ -1,0 +1,99 @@
+module 0x8675309::M {
+    // use 0x1::XVector;
+
+    // public inline fun foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         action(XVector::borrow(v, i));
+    //         i = i + 1;
+    //     }
+    // }
+
+    // public inline fun reduce<R, T>(v: vector<T>, accu: R, reducer: |T, R|R): R {
+    //     while (!XVector::is_empty(&v)) {
+    //         accu = reducer(XVector::pop_back(&mut v), accu);
+    //     };
+    //     accu
+    // }
+
+
+    // public fun correct_foreach() {
+    //     let v = vector[1, 2, 3];
+    //     let sum = 0;
+    //     foreach(&v, |e| sum = sum + *e) // expected to be not implemented
+    // }
+
+    // public fun correct_reduce(): u64 {
+    //     let v = vector[1, 2, 3];
+    //     reduce(v, 0, |t, r| t + r)
+    // }
+
+    // public fun corrected_nested() {
+    //     let v = vector[vector[1,2], vector[3]];
+    //     let sum = 0;
+    //     foreach(&v, |e| sum = sum + reduce!(*e, 0, |t, r| t + r));
+    // }
+
+    // public inline fun wrong_local_call_arg_count<T>(v: &vector<T>, action: |&T|) {
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         action(XVector::borrow(v, i), i); // expected to have wrong argument count
+    //         i = i + 1;
+    //     }
+    // }
+
+    // public inline fun wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         action(i); // expected to have wrong argument type
+    //         i = i + 1;
+    //     }
+    // }
+
+    // public inline fun wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
+    //     }
+    // }
+
+    // public fun wrong_local_call_no_fun(x: u64) {
+    //     x(1) // expected to be not a function
+    // }
+
+    // public fun wrong_lambda_inferred_type() {
+    //     let v = vector[1, 2, 3];
+    //     let sum = 0;
+    //     foreach(&v, |e| sum = sum + e) // expected to cannot infer type
+    // }
+
+    // public fun wrong_lambda_result_type() {
+    //     let v = vector[1, 2, 3];
+    //     let sum = 0;
+    //     foreach(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
+    // }
+
+    // public fun lambda_not_allowed() {
+    //     let _x = |i| i + 1; // expected lambda not allowed
+    // }
+
+    // struct FieldFunNotAllowed {
+    //     f: |u64|u64, // expected lambda not allowed
+    // }
+
+    // public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
+
+    public inline fun macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+        abort (1)
+    }
+    public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+        abort (1)
+    }
+}
+
+// module 0x1::XVector {
+//     public fun length<T>(v: &vector<T>): u64 { abort(1) }
+//     public fun is_empty<T>(v: &vector<T>): bool { abort(1) }
+//     public fun borrow<T>(v: &vector<T>, i: u64): &T { abort(1) }
+//     public fun pop_back<T>(v: &mut vector<T>): T { abort(1) }
+// }

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda5.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda5.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: Functions may not return function-typed values, but function `M::macro_result_lambda_not_allowed` return type is `|u64|`:
+   ┌─ tests/checking/inlining/lambda5.move:86:23
+   │
+86 │     public inline fun macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+   │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda5.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda5.move
@@ -1,0 +1,99 @@
+module 0x8675309::M {
+    // use 0x1::XVector;
+
+    // public inline fun foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         action(XVector::borrow(v, i));
+    //         i = i + 1;
+    //     }
+    // }
+
+    // public inline fun reduce<R, T>(v: vector<T>, accu: R, reducer: |T, R|R): R {
+    //     while (!XVector::is_empty(&v)) {
+    //         accu = reducer(XVector::pop_back(&mut v), accu);
+    //     };
+    //     accu
+    // }
+
+
+    // public fun correct_foreach() {
+    //     let v = vector[1, 2, 3];
+    //     let sum = 0;
+    //     foreach(&v, |e| sum = sum + *e) // expected to be not implemented
+    // }
+
+    // public fun correct_reduce(): u64 {
+    //     let v = vector[1, 2, 3];
+    //     reduce(v, 0, |t, r| t + r)
+    // }
+
+    // public fun corrected_nested() {
+    //     let v = vector[vector[1,2], vector[3]];
+    //     let sum = 0;
+    //     foreach(&v, |e| sum = sum + reduce!(*e, 0, |t, r| t + r));
+    // }
+
+    // public inline fun wrong_local_call_arg_count<T>(v: &vector<T>, action: |&T|) {
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         action(XVector::borrow(v, i), i); // expected to have wrong argument count
+    //         i = i + 1;
+    //     }
+    // }
+
+    // public inline fun wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         action(i); // expected to have wrong argument type
+    //         i = i + 1;
+    //     }
+    // }
+
+    // public inline fun wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
+    //     }
+    // }
+
+    // public fun wrong_local_call_no_fun(x: u64) {
+    //     x(1) // expected to be not a function
+    // }
+
+    // public fun wrong_lambda_inferred_type() {
+    //     let v = vector[1, 2, 3];
+    //     let sum = 0;
+    //     foreach(&v, |e| sum = sum + e) // expected to cannot infer type
+    // }
+
+    // public fun wrong_lambda_result_type() {
+    //     let v = vector[1, 2, 3];
+    //     let sum = 0;
+    //     foreach(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
+    // }
+
+    // public fun lambda_not_allowed() {
+    //     let _x = |i| i + 1; // expected lambda not allowed
+    // }
+
+    // struct FieldFunNotAllowed {
+    //     f: |u64|u64, // expected lambda not allowed
+    // }
+
+    // public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
+
+    public inline fun macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+        abort (1)
+    }
+    // public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+    //     abort (1)
+    // }
+}
+
+// module 0x1::XVector {
+//     public fun length<T>(v: &vector<T>): u64 { abort(1) }
+//     public fun is_empty<T>(v: &vector<T>): bool { abort(1) }
+//     public fun borrow<T>(v: &vector<T>, i: u64): &T { abort(1) }
+//     public fun pop_back<T>(v: &mut vector<T>): T { abort(1) }
+// }

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/non_lambda_arg.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/non_lambda_arg.exp
@@ -4,10 +4,10 @@ error: Only inline functions may have function-typed parameters, but non-inline 
   ┌─ tests/checking/inlining/non_lambda_arg.move:4:16
   │
 4 │     public fun incorrect_sort<T: copy>(arr: &mut vector<T>, a_less_b: |T, T| bool) {
-  │                ^^^^^^^^^^^^^^                               -------- Parameter `a_less_b` has a function type.
+  │                ^^^^^^^^^^^^^^                               -------- Parameter `a_less_b` has function-valued type `|(T, T)|bool`.
 
 error: Only inline functions may have function-typed parameters, but non-inline function `sort::incorrect_sort_recursive` has a function parameter:
   ┌─ tests/checking/inlining/non_lambda_arg.move:9:16
   │
 9 │     public fun incorrect_sort_recursive<T: copy>(arr: &mut vector<T>, low: u64, high: u64, a_less_b: |T, T| bool) {
-  │                ^^^^^^^^^^^^^^^^^^^^^^^^                                                    -------- Parameter `a_less_b` has a function type.
+  │                ^^^^^^^^^^^^^^^^^^^^^^^^                                                    -------- Parameter `a_less_b` has function-valued type `|(T, T)|bool`.

--- a/third_party/move/move-compiler-v2/tests/checking/naming/unused_type_parameter_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/unused_type_parameter_struct.exp
@@ -49,16 +49,16 @@ module 0x42::test {
         dummy_field: bool,
     }
     struct S2 {
-        f: test::S3<#1>,
+        f: test::S3<T2>,
     }
     struct S3 {
         dummy_field: bool,
     }
     struct S4 {
-        f: vector<#0>,
+        f: vector<T>,
     }
     struct S5 {
-        f: vector<#0>,
-        g: vector<#1>,
+        f: vector<T>,
+        g: vector<U>,
     }
 } // end 0x42::test

--- a/third_party/move/move-compiler-v2/tests/checking/naming/warning_dependency.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/warning_dependency.exp
@@ -18,16 +18,16 @@ module 0x42::test {
         dummy_field: bool,
     }
     struct S2 {
-        f: test::S3<#1>,
+        f: test::S3<T2>,
     }
     struct S3 {
         dummy_field: bool,
     }
     struct S4 {
-        f: vector<#0>,
+        f: vector<T>,
     }
     struct S5 {
-        f: vector<#0>,
-        g: vector<#1>,
+        f: vector<T>,
+        g: vector<U>,
     }
 } // end 0x42::test

--- a/third_party/move/move-compiler-v2/tests/checking/positional_fields/decl_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/positional_fields/decl_ok.exp
@@ -16,9 +16,9 @@ module 0x42::test {
         1: bool,
     }
     struct S3 {
-        0: #1,
+        0: T2,
         1: u8,
-        2: #0,
+        2: T1,
     }
     private fun bar(x: test::S2) {
         select test::S2.0<test::S2>(x);

--- a/third_party/move/move-compiler-v2/tests/checking/positional_fields/named_tuple_ability_decl_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/positional_fields/named_tuple_ability_decl_ok.exp
@@ -7,20 +7,20 @@ module 0x42::test {
         0: u8,
     }
     struct S2 {
-        0: #0,
+        0: T,
         1: u8,
     }
     struct S3 {
-        0: #0,
+        0: T,
         1: u8,
     }
     struct S4 {
         x: u8,
-        y: #0,
+        y: T,
     }
     struct S5 {
-        0: #0,
-        1: test::S3<#0>,
+        0: T,
+        1: test::S3<T>,
     }
     struct S6 {
         dummy_field: bool,

--- a/third_party/move/move-compiler-v2/tests/checking/positional_fields/named_tuple_construct_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/positional_fields/named_tuple_construct_ok.exp
@@ -19,14 +19,14 @@ module 0x42::test {
         1: bool,
     }
     struct S3 {
-        0: #0,
+        0: T,
         1: u8,
     }
     struct S4 {
         dummy_field: bool,
     }
     struct S5 {
-        x: #0,
+        x: T,
         y: u8,
     }
     private fun S0_inhabited(): test::S0 {

--- a/third_party/move/move-compiler-v2/tests/checking/positional_fields/variant_ability_decl_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/positional_fields/variant_ability_decl_ok.exp
@@ -2,7 +2,7 @@
 module 0x42::test {
     enum Bar {
         A {
-            0: #0,
+            0: T,
         }
         B {
             0: u8,
@@ -11,7 +11,7 @@ module 0x42::test {
     }
     enum Foo {
         A {
-            0: #0,
+            0: T,
         }
         B {
             0: u8,

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/decl_errors.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/decl_errors.exp
@@ -39,8 +39,8 @@ module 0x42::n {
 module 0x42::m {
     use 0x42::n::{T}; // resolved as: 0x42::n
     struct G {
-        x: #0,
-        y: #1,
+        x: T,
+        y: R,
     }
     struct S {
         x: u64,

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/generic_calls.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/generic_calls.exp
@@ -1,7 +1,7 @@
 // -- Model dump before bytecode pipeline
 module 0x42::m {
     struct S {
-        x: #0,
+        x: T,
     }
     private fun id<T>(self: m::S<#0>): m::S<#0> {
         self

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/generic_calls_typed.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/generic_calls_typed.exp
@@ -1,7 +1,7 @@
 // -- Model dump before bytecode pipeline
 module 0x42::m {
     struct S {
-        x: #0,
+        x: T,
     }
     private fun id<T>(self: m::S<#0>): m::S<#0> {
         self

--- a/third_party/move/move-compiler-v2/tests/checking/specs/schemas_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/schemas_ok.exp
@@ -53,7 +53,7 @@ note: unused schema M::SchemaExp
 // -- Model dump before bytecode pipeline
 module 0x42::M {
     struct S {
-        x: #0,
+        x: X,
     }
     private fun add(x: u64): u64 {
         Add<u64>(x, 1)

--- a/third_party/move/move-compiler-v2/tests/checking/specs/structs_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/specs/structs_ok.exp
@@ -4,7 +4,7 @@ module 0x42::M {
         x: u64,
     }
     struct G {
-        x: #0,
+        x: T,
         y: bool,
     }
     struct R {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/eq.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/eq.exp
@@ -1,7 +1,7 @@
 // -- Model dump before bytecode pipeline
 module 0x8675309::M {
     struct G {
-        f: #0,
+        f: T,
     }
     struct R {
         f: u64,

--- a/third_party/move/move-compiler-v2/tests/checking/typing/exp_list.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/exp_list.exp
@@ -1,7 +1,7 @@
 // -- Model dump before bytecode pipeline
 module 0x8675309::M {
     struct R {
-        f: #0,
+        f: T,
     }
     struct S {
         dummy_field: bool,

--- a/third_party/move/move-compiler-v2/tests/checking/typing/lambda.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/lambda.exp
@@ -48,3 +48,11 @@ error: tuple type `()` is not allowed as a type argument (type was inferred)
    │                                     ^
    │
    = required by instantiating type parameter `T` of function `foreach`
+
+error: function type `|u64|u64` is not allowed as a field type
+   ┌─ tests/checking/typing/lambda.move:81:12
+   │
+81 │         f: |u64|u64, // expected lambda not allowed
+   │            ^^^^^^^^
+   │
+   = required by declaration of field `f`

--- a/third_party/move/move-compiler-v2/tests/checking/typing/lambda2.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/lambda2.exp
@@ -1,0 +1,25 @@
+
+Diagnostics:
+error: Only inline functions may have function-typed parameters, but non-inline function `M::fun_arg_lambda_not_allowed` has a function parameter:
+   ┌─ tests/checking/typing/lambda2.move:84:16
+   │
+84 │     public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^ - Parameter `x` has function-valued type `|u64|`.
+
+warning: Unused parameter `x`. Consider removing or prefixing with an underscore: `_x`
+   ┌─ tests/checking/typing/lambda2.move:84:43
+   │
+84 │     public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
+   │                                           ^
+
+error: Functions may not return function-typed values, but function `M::macro_result_lambda_not_allowed` return type is `|u64|`:
+   ┌─ tests/checking/typing/lambda2.move:86:23
+   │
+86 │     public inline fun macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+   │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Functions may not return function-typed values, but function `M::fun_result_lambda_not_allowed` return type is `|u64|`:
+   ┌─ tests/checking/typing/lambda2.move:89:16
+   │
+89 │     public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/lambda2.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/lambda2.move
@@ -1,0 +1,100 @@
+module 0x8675309::M {
+    // use 0x1::XVector;
+
+    // public inline fun foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         action(XVector::borrow(v, i));
+    //         i = i + 1;
+    //     }
+    // }
+
+    // public inline fun reduce<R, T>(v: vector<T>, accu: R, reducer: |T, R|R): R {
+    //     while (!XVector::is_empty(&v)) {
+    //         accu = reducer(XVector::pop_back(&mut v), accu);
+    //     };
+    //     accu
+    // }
+
+
+    // public fun correct_foreach() {
+    //     let v = vector[1, 2, 3];
+    //     let sum = 0;
+    //     foreach(&v, |e| sum = sum + *e) // expected to be not implemented
+    // }
+
+    // public fun correct_reduce(): u64 {
+    //     let v = vector[1, 2, 3];
+    //     reduce(v, 0, |t, r| t + r)
+    // }
+
+    // public fun corrected_nested() {
+    //     let v = vector[vector[1,2], vector[3]];
+    //     let sum = 0;
+    //     foreach(&v, |e| sum = sum + reduce!(*e, 0, |t, r| t + r));
+    // }
+
+    // public inline fun wrong_local_call_arg_count<T>(v: &vector<T>, action: |&T|) {
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         action(XVector::borrow(v, i), i); // expected to have wrong argument count
+    //         i = i + 1;
+    //     }
+    // }
+
+    // public inline fun wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         action(i); // expected to have wrong argument type
+    //         i = i + 1;
+    //     }
+    // }
+
+    // public inline fun wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
+    //     }
+    // }
+
+    // public fun wrong_local_call_no_fun(x: u64) {
+    //     x(1) // expected to be not a function
+    // }
+
+    // public fun wrong_lambda_inferred_type() {
+    //     let v = vector[1, 2, 3];
+    //     let sum = 0;
+    //     foreach(&v, |e| sum = sum + e) // expected to cannot infer type
+    // }
+
+    // public fun wrong_lambda_result_type() {
+    //     let v = vector[1, 2, 3];
+    //     let sum = 0;
+    //     foreach(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
+    // }
+
+    public fun lambda_not_allowed() {
+        let _x = |i| i + 1; // expected lambda not allowed
+    }
+
+    // struct FieldFunNotAllowed {
+    //     f: |u64|u64, // expected lambda not allowed
+    // }
+
+    public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
+
+    public inline fun macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+        abort (1)
+    }
+    public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+        abort (1)
+    }
+
+}
+
+// module 0x1::XVector {
+//     public fun length<T>(v: &vector<T>): u64 { abort(1) }
+//     public fun is_empty<T>(v: &vector<T>): bool { abort(1) }
+//     public fun borrow<T>(v: &vector<T>, i: u64): &T { abort(1) }
+//     public fun pop_back<T>(v: &mut vector<T>): T { abort(1) }
+// }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/lambda_typed.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/lambda_typed.exp
@@ -35,3 +35,11 @@ error: cannot pass `|&u64|u64` to a function which expects argument of type `|&u
    │
 73 │         foreach(&v, |e: &u64| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: function type `|u64|u64` is not allowed as a field type
+   ┌─ tests/checking/typing/lambda_typed.move:81:12
+   │
+81 │         f: |u64|u64, // expected lambda not allowed
+   │            ^^^^^^^^
+   │
+   = required by declaration of field `f`

--- a/third_party/move/move-compiler-v2/tests/checking/typing/main_arguments_various_caes.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/main_arguments_various_caes.exp
@@ -1,7 +1,7 @@
 // -- Model dump before bytecode pipeline
 module 0x42::M {
     struct Cup {
-        f1: #0,
+        f1: T,
     }
     struct R {
         dummy_field: bool,

--- a/third_party/move/move-compiler-v2/tests/checking/typing/neq.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/neq.exp
@@ -1,7 +1,7 @@
 // -- Model dump before bytecode pipeline
 module 0x8675309::M {
     struct G {
-        f: #0,
+        f: T,
     }
     struct R {
         f: u64,

--- a/third_party/move/move-compiler-v2/tests/checking/typing/nested_post_process.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/nested_post_process.exp
@@ -4,11 +4,11 @@ module 0x42::simple_map {
     use std::option;
     use std::vector;
     struct Element {
-        key: #0,
-        value: #1,
+        key: Key,
+        value: Value,
     }
     struct SimpleMap {
-        data: vector<simple_map::Element<#0, #1>>,
+        data: vector<simple_map::Element<Key, Value>>,
     }
     public fun borrow<Key,Value>(map: &simple_map::SimpleMap<#0, #1>,key: &#0): &#1 {
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/phantom_param_struct_decl.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/phantom_param_struct_decl.exp
@@ -4,17 +4,17 @@ module 0x42::M1 {
         a: u64,
     }
     struct S2 {
-        a: M1::S1<#0>,
-        b: vector<M1::S1<#0>>,
+        a: M1::S1<T>,
+        b: vector<M1::S1<T>>,
     }
     struct S3 {
-        a: #1,
-        b: #3,
+        a: T2,
+        b: T4,
     }
     struct S4 {
         a: u64,
     }
     struct S5 {
-        a: M1::S4<#0>,
+        a: M1::S4<T>,
     }
 } // end 0x42::M1

--- a/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_single_pack.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_single_pack.exp
@@ -1,8 +1,8 @@
 // -- Model dump before bytecode pipeline
 module 0x42::M {
     struct Box {
-        f1: #0,
-        f2: #0,
+        f1: T,
+        f2: T,
     }
     private fun t0() {
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_single_unpack.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_single_unpack.exp
@@ -1,8 +1,8 @@
 // -- Model dump before bytecode pipeline
 module 0x8675309::M {
     struct Box {
-        f1: #0,
-        f2: #0,
+        f1: T,
+        f2: T,
     }
     private fun new<T>(): M::Box<#0> {
         Abort(0)

--- a/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_single_unpack_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_single_unpack_assign.exp
@@ -1,8 +1,8 @@
 // -- Model dump before bytecode pipeline
 module 0x8675309::M {
     struct Box {
-        f1: #0,
-        f2: #0,
+        f1: T,
+        f2: T,
     }
     private fun new<T>(): M::Box<#0> {
         Abort(0)

--- a/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_threaded_pack.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/type_variable_join_threaded_pack.exp
@@ -1,7 +1,7 @@
 // -- Model dump before bytecode pipeline
 module 0x2::Container {
     struct T {
-        f: #0,
+        f: V,
     }
     public fun get<V>(_self: &Container::T<#0>): #0 {
         Abort(0)
@@ -16,8 +16,8 @@ module 0x2::Container {
 module 0x2::M {
     use 0x2::Container; // resolved as: 0x2::Container
     struct Box {
-        f1: #0,
-        f2: #0,
+        f1: T,
+        f2: T,
     }
     private fun t0(): M::Box<u64> {
         {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/multi_pool_money_market_token.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/multi_pool_money_market_token.exp
@@ -19,7 +19,7 @@ warning: unused type parameter
 // -- Model dump before bytecode pipeline
 module 0x2::Token {
     struct Coin {
-        type: #0,
+        type: AssetType,
         value: u64,
     }
     public fun create<ATy>(type: #0,value: u64): Token::Coin<#0> {
@@ -91,7 +91,7 @@ module 0x3::OneToOneMarket {
         record: Map::T<address, u64>,
     }
     struct Pool {
-        coin: Token::Coin<#0>,
+        coin: Token::Coin<AssetType>,
     }
     struct Price {
         price: u64,

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/simple_money_market_token.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/simple_money_market_token.exp
@@ -1,7 +1,7 @@
 // -- Model dump before bytecode pipeline
 module 0x2::Token {
     struct Coin {
-        type: #0,
+        type: AssetType,
         value: u64,
     }
     public fun create<ATy>(type: #0,value: u64): Token::Coin<#0> {
@@ -93,7 +93,7 @@ module 0xb055::OneToOneMarket {
         record: u64,
     }
     struct Pool {
-        coin: Token::Coin<#0>,
+        coin: Token::Coin<AssetType>,
     }
     struct Price {
         price: u64,

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_no_parenthesis_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_no_parenthesis_ok.exp
@@ -11,7 +11,7 @@ module 0x815::m {
     }
     enum Generic {
         Foo {
-            0: #0,
+            0: T,
         }
         Bar {
             0: u64,

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_ok.exp
@@ -11,7 +11,7 @@ module 0x815::m {
     }
     enum Generic {
         Foo {
-            0: #0,
+            0: T,
         }
         Bar {
             0: u64,

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_non_generic_type_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_non_generic_type_ok.exp
@@ -1,7 +1,7 @@
 // -- Model dump before bytecode pipeline
 module 0x8675309::M {
     struct S {
-        f: #0,
+        f: T,
     }
     private fun f<T>() {
         M::g<M::S<T>>()

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_valid.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_valid.exp
@@ -1,7 +1,7 @@
 // -- Model dump before bytecode pipeline
 module 0x42::M {
     struct Box {
-        f: #0,
+        f: T,
     }
     public fun t0<T>() {
         M::t1<T>();

--- a/third_party/move/move-compiler-v2/tests/lambda-lifting/basic.exp
+++ b/third_party/move/move-compiler-v2/tests/lambda-lifting/basic.exp
@@ -18,7 +18,265 @@ module 0xcafe::m {
 } // end 0xcafe::m
 
 
+// -- Model dump after env processor unused checks:
+module 0xcafe::m {
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun no_name_clash(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| Add<u64>(y, c))
+    }
+    private fun with_name_clash1(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>(x, c))
+    }
+    private fun with_name_clash2(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>({
+          let x: u64 = Add<u64>(c, 1);
+          x
+        }, x))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor type parameter check:
+module 0xcafe::m {
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun no_name_clash(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| Add<u64>(y, c))
+    }
+    private fun with_name_clash1(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>(x, c))
+    }
+    private fun with_name_clash2(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>({
+          let x: u64 = Add<u64>(c, 1);
+          x
+        }, x))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor check recursive struct definition:
+module 0xcafe::m {
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun no_name_clash(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| Add<u64>(y, c))
+    }
+    private fun with_name_clash1(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>(x, c))
+    }
+    private fun with_name_clash2(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>({
+          let x: u64 = Add<u64>(c, 1);
+          x
+        }, x))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor check cyclic type instantiation:
+module 0xcafe::m {
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun no_name_clash(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| Add<u64>(y, c))
+    }
+    private fun with_name_clash1(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>(x, c))
+    }
+    private fun with_name_clash2(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>({
+          let x: u64 = Add<u64>(c, 1);
+          x
+        }, x))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor unused struct params check:
+module 0xcafe::m {
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun no_name_clash(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| Add<u64>(y, c))
+    }
+    private fun with_name_clash1(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>(x, c))
+    }
+    private fun with_name_clash2(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>({
+          let x: u64 = Add<u64>(c, 1);
+          x
+        }, x))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor access and use check before inlining:
+module 0xcafe::m {
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun no_name_clash(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| Add<u64>(y, c))
+    }
+    private fun with_name_clash1(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>(x, c))
+    }
+    private fun with_name_clash2(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>({
+          let x: u64 = Add<u64>(c, 1);
+          x
+        }, x))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor inlining:
+module 0xcafe::m {
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun no_name_clash(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| Add<u64>(y, c))
+    }
+    private fun with_name_clash1(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>(x, c))
+    }
+    private fun with_name_clash2(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>({
+          let x: u64 = Add<u64>(c, 1);
+          x
+        }, x))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor access and use check after inlining:
+module 0xcafe::m {
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun no_name_clash(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| Add<u64>(y, c))
+    }
+    private fun with_name_clash1(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>(x, c))
+    }
+    private fun with_name_clash2(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>({
+          let x: u64 = Add<u64>(c, 1);
+          x
+        }, x))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor acquires check:
+module 0xcafe::m {
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun no_name_clash(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| Add<u64>(y, c))
+    }
+    private fun with_name_clash1(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>(x, c))
+    }
+    private fun with_name_clash2(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>({
+          let x: u64 = Add<u64>(c, 1);
+          x
+        }, x))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor simplifier:
+module 0xcafe::m {
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun no_name_clash(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| Add<u64>(y, c))
+    }
+    private fun with_name_clash1(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>(x, c))
+    }
+    private fun with_name_clash2(x: u64,c: u64): u64 {
+        m::map(x, |x: u64| Add<u64>({
+          let x: u64 = Add<u64>(c, 1);
+          x
+        }, x))
+    }
+} // end 0xcafe::m
+
+
 // -- Model dump after env processor lambda-lifting:
+module 0xcafe::m {
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun no_name_clash(x: u64,c: u64): u64 {
+        m::map(x, closure m::no_name_clash$lambda$1(c))
+    }
+    private fun with_name_clash1(x: u64,c: u64): u64 {
+        m::map(x, closure m::with_name_clash1$lambda$1(c))
+    }
+    private fun with_name_clash2(x: u64,c: u64): u64 {
+        m::map(x, closure m::with_name_clash2$lambda$1(c))
+    }
+    private fun no_name_clash$lambda$1(c: u64,y: u64): u64 {
+        Add<u64>(y, c)
+    }
+    private fun with_name_clash1$lambda$1(c: u64,x: u64): u64 {
+        Add<u64>(x, c)
+    }
+    private fun with_name_clash2$lambda$1(c: u64,x: u64): u64 {
+        Add<u64>({
+          let x: u64 = Add<u64>(c, 1);
+          x
+        }, x)
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor specification checker:
+module 0xcafe::m {
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun no_name_clash(x: u64,c: u64): u64 {
+        m::map(x, closure m::no_name_clash$lambda$1(c))
+    }
+    private fun with_name_clash1(x: u64,c: u64): u64 {
+        m::map(x, closure m::with_name_clash1$lambda$1(c))
+    }
+    private fun with_name_clash2(x: u64,c: u64): u64 {
+        m::map(x, closure m::with_name_clash2$lambda$1(c))
+    }
+    private fun no_name_clash$lambda$1(c: u64,y: u64): u64 {
+        Add<u64>(y, c)
+    }
+    private fun with_name_clash1$lambda$1(c: u64,x: u64): u64 {
+        Add<u64>(x, c)
+    }
+    private fun with_name_clash2$lambda$1(c: u64,x: u64): u64 {
+        Add<u64>({
+          let x: u64 = Add<u64>(c, 1);
+          x
+        }, x)
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor specification rewriter:
 module 0xcafe::m {
     private fun map(x: u64,f: |u64|u64): u64 {
         (f)(x)

--- a/third_party/move/move-compiler-v2/tests/lambda-lifting/modify.exp
+++ b/third_party/move/move-compiler-v2/tests/lambda-lifting/modify.exp
@@ -44,6 +44,463 @@ module 0xcafe::m {
 } // end 0xcafe::m
 
 
+// -- Model dump after env processor unused checks:
+module 0xcafe::m {
+    struct S {
+        x: u64,
+    }
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun assigns_local(x: u64,c: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| z: u64 = 2;
+          Add<u64>(y, c))
+        }
+    }
+    private fun assigns_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| x: u64 = 2;
+        Add<u64>(y, c))
+    }
+    private fun borrows_local(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &mut u64 = Borrow(Mutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+    private fun borrows_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| {
+          let r: &mut u64 = Borrow(Mutable)(c);
+          Add<u64>(y, Deref(r))
+        })
+    }
+    private fun immutable_borrow_ok(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &u64 = Borrow(Immutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor type parameter check:
+module 0xcafe::m {
+    struct S {
+        x: u64,
+    }
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun assigns_local(x: u64,c: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| z: u64 = 2;
+          Add<u64>(y, c))
+        }
+    }
+    private fun assigns_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| x: u64 = 2;
+        Add<u64>(y, c))
+    }
+    private fun borrows_local(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &mut u64 = Borrow(Mutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+    private fun borrows_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| {
+          let r: &mut u64 = Borrow(Mutable)(c);
+          Add<u64>(y, Deref(r))
+        })
+    }
+    private fun immutable_borrow_ok(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &u64 = Borrow(Immutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor check recursive struct definition:
+module 0xcafe::m {
+    struct S {
+        x: u64,
+    }
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun assigns_local(x: u64,c: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| z: u64 = 2;
+          Add<u64>(y, c))
+        }
+    }
+    private fun assigns_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| x: u64 = 2;
+        Add<u64>(y, c))
+    }
+    private fun borrows_local(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &mut u64 = Borrow(Mutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+    private fun borrows_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| {
+          let r: &mut u64 = Borrow(Mutable)(c);
+          Add<u64>(y, Deref(r))
+        })
+    }
+    private fun immutable_borrow_ok(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &u64 = Borrow(Immutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor check cyclic type instantiation:
+module 0xcafe::m {
+    struct S {
+        x: u64,
+    }
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun assigns_local(x: u64,c: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| z: u64 = 2;
+          Add<u64>(y, c))
+        }
+    }
+    private fun assigns_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| x: u64 = 2;
+        Add<u64>(y, c))
+    }
+    private fun borrows_local(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &mut u64 = Borrow(Mutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+    private fun borrows_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| {
+          let r: &mut u64 = Borrow(Mutable)(c);
+          Add<u64>(y, Deref(r))
+        })
+    }
+    private fun immutable_borrow_ok(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &u64 = Borrow(Immutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor unused struct params check:
+module 0xcafe::m {
+    struct S {
+        x: u64,
+    }
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun assigns_local(x: u64,c: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| z: u64 = 2;
+          Add<u64>(y, c))
+        }
+    }
+    private fun assigns_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| x: u64 = 2;
+        Add<u64>(y, c))
+    }
+    private fun borrows_local(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &mut u64 = Borrow(Mutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+    private fun borrows_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| {
+          let r: &mut u64 = Borrow(Mutable)(c);
+          Add<u64>(y, Deref(r))
+        })
+    }
+    private fun immutable_borrow_ok(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &u64 = Borrow(Immutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor access and use check before inlining:
+module 0xcafe::m {
+    struct S {
+        x: u64,
+    }
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun assigns_local(x: u64,c: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| z: u64 = 2;
+          Add<u64>(y, c))
+        }
+    }
+    private fun assigns_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| x: u64 = 2;
+        Add<u64>(y, c))
+    }
+    private fun borrows_local(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &mut u64 = Borrow(Mutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+    private fun borrows_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| {
+          let r: &mut u64 = Borrow(Mutable)(c);
+          Add<u64>(y, Deref(r))
+        })
+    }
+    private fun immutable_borrow_ok(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &u64 = Borrow(Immutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor inlining:
+module 0xcafe::m {
+    struct S {
+        x: u64,
+    }
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun assigns_local(x: u64,c: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| z: u64 = 2;
+          Add<u64>(y, c))
+        }
+    }
+    private fun assigns_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| x: u64 = 2;
+        Add<u64>(y, c))
+    }
+    private fun borrows_local(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &mut u64 = Borrow(Mutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+    private fun borrows_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| {
+          let r: &mut u64 = Borrow(Mutable)(c);
+          Add<u64>(y, Deref(r))
+        })
+    }
+    private fun immutable_borrow_ok(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &u64 = Borrow(Immutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor access and use check after inlining:
+module 0xcafe::m {
+    struct S {
+        x: u64,
+    }
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun assigns_local(x: u64,c: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| z: u64 = 2;
+          Add<u64>(y, c))
+        }
+    }
+    private fun assigns_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| x: u64 = 2;
+        Add<u64>(y, c))
+    }
+    private fun borrows_local(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &mut u64 = Borrow(Mutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+    private fun borrows_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| {
+          let r: &mut u64 = Borrow(Mutable)(c);
+          Add<u64>(y, Deref(r))
+        })
+    }
+    private fun immutable_borrow_ok(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &u64 = Borrow(Immutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor acquires check:
+module 0xcafe::m {
+    struct S {
+        x: u64,
+    }
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun assigns_local(x: u64,c: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| z: u64 = 2;
+          Add<u64>(y, c))
+        }
+    }
+    private fun assigns_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| x: u64 = 2;
+        Add<u64>(y, c))
+    }
+    private fun borrows_local(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &mut u64 = Borrow(Mutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+    private fun borrows_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| {
+          let r: &mut u64 = Borrow(Mutable)(c);
+          Add<u64>(y, Deref(r))
+        })
+    }
+    private fun immutable_borrow_ok(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &u64 = Borrow(Immutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor simplifier:
+module 0xcafe::m {
+    struct S {
+        x: u64,
+    }
+    private fun map(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun assigns_local(x: u64,c: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| z: u64 = 2;
+          Add<u64>(y, c))
+        }
+    }
+    private fun assigns_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| x: u64 = 2;
+        Add<u64>(y, c))
+    }
+    private fun borrows_local(x: u64): u64 {
+        {
+          let z: u64 = 1;
+          m::map(x, |y: u64| {
+            let r: &mut u64 = Borrow(Mutable)(z);
+            Add<u64>(y, Deref(r))
+          })
+        }
+    }
+    private fun borrows_param(x: u64,c: u64): u64 {
+        m::map(x, |y: u64| {
+          let r: &mut u64 = Borrow(Mutable)(c);
+          Add<u64>(y, Deref(r))
+        })
+    }
+    private fun immutable_borrow_ok(x: u64): u64 {
+        m::map(x, |y: u64| {
+          let r: &u64 = Borrow(Immutable)(1);
+          Add<u64>(y, Deref(r))
+        })
+    }
+} // end 0xcafe::m
+
+
 
 Diagnostics:
 error: captured variable `x` cannot be modified inside of a lambda

--- a/third_party/move/move-compiler-v2/tests/lambda-lifting/nested.exp
+++ b/third_party/move/move-compiler-v2/tests/lambda-lifting/nested.exp
@@ -12,7 +12,187 @@ module 0xcafe::m {
 } // end 0xcafe::m
 
 
+// -- Model dump after env processor unused checks:
+module 0xcafe::m {
+    private fun map1(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun map2(x: u8,f: |u8|u8): u8 {
+        (f)(x)
+    }
+    private fun nested(x: u64,c: u64): u64 {
+        m::map1(x, |y: u64| Cast<u64>(m::map2(Cast<u8>(Sub<u64>(y, c)), |y: u8| Add<u8>(y, Cast<u8>(c)))))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor type parameter check:
+module 0xcafe::m {
+    private fun map1(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun map2(x: u8,f: |u8|u8): u8 {
+        (f)(x)
+    }
+    private fun nested(x: u64,c: u64): u64 {
+        m::map1(x, |y: u64| Cast<u64>(m::map2(Cast<u8>(Sub<u64>(y, c)), |y: u8| Add<u8>(y, Cast<u8>(c)))))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor check recursive struct definition:
+module 0xcafe::m {
+    private fun map1(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun map2(x: u8,f: |u8|u8): u8 {
+        (f)(x)
+    }
+    private fun nested(x: u64,c: u64): u64 {
+        m::map1(x, |y: u64| Cast<u64>(m::map2(Cast<u8>(Sub<u64>(y, c)), |y: u8| Add<u8>(y, Cast<u8>(c)))))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor check cyclic type instantiation:
+module 0xcafe::m {
+    private fun map1(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun map2(x: u8,f: |u8|u8): u8 {
+        (f)(x)
+    }
+    private fun nested(x: u64,c: u64): u64 {
+        m::map1(x, |y: u64| Cast<u64>(m::map2(Cast<u8>(Sub<u64>(y, c)), |y: u8| Add<u8>(y, Cast<u8>(c)))))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor unused struct params check:
+module 0xcafe::m {
+    private fun map1(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun map2(x: u8,f: |u8|u8): u8 {
+        (f)(x)
+    }
+    private fun nested(x: u64,c: u64): u64 {
+        m::map1(x, |y: u64| Cast<u64>(m::map2(Cast<u8>(Sub<u64>(y, c)), |y: u8| Add<u8>(y, Cast<u8>(c)))))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor access and use check before inlining:
+module 0xcafe::m {
+    private fun map1(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun map2(x: u8,f: |u8|u8): u8 {
+        (f)(x)
+    }
+    private fun nested(x: u64,c: u64): u64 {
+        m::map1(x, |y: u64| Cast<u64>(m::map2(Cast<u8>(Sub<u64>(y, c)), |y: u8| Add<u8>(y, Cast<u8>(c)))))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor inlining:
+module 0xcafe::m {
+    private fun map1(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun map2(x: u8,f: |u8|u8): u8 {
+        (f)(x)
+    }
+    private fun nested(x: u64,c: u64): u64 {
+        m::map1(x, |y: u64| Cast<u64>(m::map2(Cast<u8>(Sub<u64>(y, c)), |y: u8| Add<u8>(y, Cast<u8>(c)))))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor access and use check after inlining:
+module 0xcafe::m {
+    private fun map1(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun map2(x: u8,f: |u8|u8): u8 {
+        (f)(x)
+    }
+    private fun nested(x: u64,c: u64): u64 {
+        m::map1(x, |y: u64| Cast<u64>(m::map2(Cast<u8>(Sub<u64>(y, c)), |y: u8| Add<u8>(y, Cast<u8>(c)))))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor acquires check:
+module 0xcafe::m {
+    private fun map1(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun map2(x: u8,f: |u8|u8): u8 {
+        (f)(x)
+    }
+    private fun nested(x: u64,c: u64): u64 {
+        m::map1(x, |y: u64| Cast<u64>(m::map2(Cast<u8>(Sub<u64>(y, c)), |y: u8| Add<u8>(y, Cast<u8>(c)))))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor simplifier:
+module 0xcafe::m {
+    private fun map1(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun map2(x: u8,f: |u8|u8): u8 {
+        (f)(x)
+    }
+    private fun nested(x: u64,c: u64): u64 {
+        m::map1(x, |y: u64| Cast<u64>(m::map2(Cast<u8>(Sub<u64>(y, c)), |y: u8| Add<u8>(y, Cast<u8>(c)))))
+    }
+} // end 0xcafe::m
+
+
 // -- Model dump after env processor lambda-lifting:
+module 0xcafe::m {
+    private fun map1(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun map2(x: u8,f: |u8|u8): u8 {
+        (f)(x)
+    }
+    private fun nested(x: u64,c: u64): u64 {
+        m::map1(x, closure m::nested$lambda$2(c))
+    }
+    private fun nested$lambda$1(c: u64,y: u8): u8 {
+        Add<u8>(y, Cast<u8>(c))
+    }
+    private fun nested$lambda$2(c: u64,y: u64): u64 {
+        Cast<u64>(m::map2(Cast<u8>(Sub<u64>(y, c)), closure m::nested$lambda$1(c)))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor specification checker:
+module 0xcafe::m {
+    private fun map1(x: u64,f: |u64|u64): u64 {
+        (f)(x)
+    }
+    private fun map2(x: u8,f: |u8|u8): u8 {
+        (f)(x)
+    }
+    private fun nested(x: u64,c: u64): u64 {
+        m::map1(x, closure m::nested$lambda$2(c))
+    }
+    private fun nested$lambda$1(c: u64,y: u8): u8 {
+        Add<u8>(y, Cast<u8>(c))
+    }
+    private fun nested$lambda$2(c: u64,y: u64): u64 {
+        Cast<u64>(m::map2(Cast<u8>(Sub<u64>(y, c)), closure m::nested$lambda$1(c)))
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor specification rewriter:
 module 0xcafe::m {
     private fun map1(x: u64,f: |u64|u64): u64 {
         (f)(x)

--- a/third_party/move/move-compiler-v2/tests/lambda-lifting/pattern.exp
+++ b/third_party/move/move-compiler-v2/tests/lambda-lifting/pattern.exp
@@ -1,7 +1,177 @@
 // -- Model dump before env processor pipeline:
 module 0xcafe::m {
     struct S {
-        x: #0,
+        x: T,
+    }
+    private fun consume<T>(s: m::S<#0>,x: #0,f: |(m::S<#0>, #0)|#0): #0 {
+        (f)(s, x)
+    }
+    private fun pattern(s: m::S<u64>,x: u64): u64 {
+        m::consume<u64>(s, x, |(m::S<u64>{ x }, _y: u64): (m::S<u64>, u64)| {
+          let y: u64 = x;
+          Add<u64>(x, y)
+        })
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor unused checks:
+module 0xcafe::m {
+    struct S {
+        x: T,
+    }
+    private fun consume<T>(s: m::S<#0>,x: #0,f: |(m::S<#0>, #0)|#0): #0 {
+        (f)(s, x)
+    }
+    private fun pattern(s: m::S<u64>,x: u64): u64 {
+        m::consume<u64>(s, x, |(m::S<u64>{ x }, _y: u64): (m::S<u64>, u64)| {
+          let y: u64 = x;
+          Add<u64>(x, y)
+        })
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor type parameter check:
+module 0xcafe::m {
+    struct S {
+        x: T,
+    }
+    private fun consume<T>(s: m::S<#0>,x: #0,f: |(m::S<#0>, #0)|#0): #0 {
+        (f)(s, x)
+    }
+    private fun pattern(s: m::S<u64>,x: u64): u64 {
+        m::consume<u64>(s, x, |(m::S<u64>{ x }, _y: u64): (m::S<u64>, u64)| {
+          let y: u64 = x;
+          Add<u64>(x, y)
+        })
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor check recursive struct definition:
+module 0xcafe::m {
+    struct S {
+        x: T,
+    }
+    private fun consume<T>(s: m::S<#0>,x: #0,f: |(m::S<#0>, #0)|#0): #0 {
+        (f)(s, x)
+    }
+    private fun pattern(s: m::S<u64>,x: u64): u64 {
+        m::consume<u64>(s, x, |(m::S<u64>{ x }, _y: u64): (m::S<u64>, u64)| {
+          let y: u64 = x;
+          Add<u64>(x, y)
+        })
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor check cyclic type instantiation:
+module 0xcafe::m {
+    struct S {
+        x: T,
+    }
+    private fun consume<T>(s: m::S<#0>,x: #0,f: |(m::S<#0>, #0)|#0): #0 {
+        (f)(s, x)
+    }
+    private fun pattern(s: m::S<u64>,x: u64): u64 {
+        m::consume<u64>(s, x, |(m::S<u64>{ x }, _y: u64): (m::S<u64>, u64)| {
+          let y: u64 = x;
+          Add<u64>(x, y)
+        })
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor unused struct params check:
+module 0xcafe::m {
+    struct S {
+        x: T,
+    }
+    private fun consume<T>(s: m::S<#0>,x: #0,f: |(m::S<#0>, #0)|#0): #0 {
+        (f)(s, x)
+    }
+    private fun pattern(s: m::S<u64>,x: u64): u64 {
+        m::consume<u64>(s, x, |(m::S<u64>{ x }, _y: u64): (m::S<u64>, u64)| {
+          let y: u64 = x;
+          Add<u64>(x, y)
+        })
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor access and use check before inlining:
+module 0xcafe::m {
+    struct S {
+        x: T,
+    }
+    private fun consume<T>(s: m::S<#0>,x: #0,f: |(m::S<#0>, #0)|#0): #0 {
+        (f)(s, x)
+    }
+    private fun pattern(s: m::S<u64>,x: u64): u64 {
+        m::consume<u64>(s, x, |(m::S<u64>{ x }, _y: u64): (m::S<u64>, u64)| {
+          let y: u64 = x;
+          Add<u64>(x, y)
+        })
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor inlining:
+module 0xcafe::m {
+    struct S {
+        x: T,
+    }
+    private fun consume<T>(s: m::S<#0>,x: #0,f: |(m::S<#0>, #0)|#0): #0 {
+        (f)(s, x)
+    }
+    private fun pattern(s: m::S<u64>,x: u64): u64 {
+        m::consume<u64>(s, x, |(m::S<u64>{ x }, _y: u64): (m::S<u64>, u64)| {
+          let y: u64 = x;
+          Add<u64>(x, y)
+        })
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor access and use check after inlining:
+module 0xcafe::m {
+    struct S {
+        x: T,
+    }
+    private fun consume<T>(s: m::S<#0>,x: #0,f: |(m::S<#0>, #0)|#0): #0 {
+        (f)(s, x)
+    }
+    private fun pattern(s: m::S<u64>,x: u64): u64 {
+        m::consume<u64>(s, x, |(m::S<u64>{ x }, _y: u64): (m::S<u64>, u64)| {
+          let y: u64 = x;
+          Add<u64>(x, y)
+        })
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor acquires check:
+module 0xcafe::m {
+    struct S {
+        x: T,
+    }
+    private fun consume<T>(s: m::S<#0>,x: #0,f: |(m::S<#0>, #0)|#0): #0 {
+        (f)(s, x)
+    }
+    private fun pattern(s: m::S<u64>,x: u64): u64 {
+        m::consume<u64>(s, x, |(m::S<u64>{ x }, _y: u64): (m::S<u64>, u64)| {
+          let y: u64 = x;
+          Add<u64>(x, y)
+        })
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor simplifier:
+module 0xcafe::m {
+    struct S {
+        x: T,
     }
     private fun consume<T>(s: m::S<#0>,x: #0,f: |(m::S<#0>, #0)|#0): #0 {
         (f)(s, x)
@@ -18,7 +188,53 @@ module 0xcafe::m {
 // -- Model dump after env processor lambda-lifting:
 module 0xcafe::m {
     struct S {
-        x: #0,
+        x: T,
+    }
+    private fun consume<T>(s: m::S<#0>,x: #0,f: |(m::S<#0>, #0)|#0): #0 {
+        (f)(s, x)
+    }
+    private fun pattern(s: m::S<u64>,x: u64): u64 {
+        m::consume<u64>(s, x, closure m::pattern$lambda$1())
+    }
+    private fun pattern$lambda$1(param$0: m::S<u64>,_y: u64): u64 {
+        {
+          let m::S<u64>{ x } = param$0;
+          {
+            let y: u64 = x;
+            Add<u64>(x, y)
+          }
+        }
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor specification checker:
+module 0xcafe::m {
+    struct S {
+        x: T,
+    }
+    private fun consume<T>(s: m::S<#0>,x: #0,f: |(m::S<#0>, #0)|#0): #0 {
+        (f)(s, x)
+    }
+    private fun pattern(s: m::S<u64>,x: u64): u64 {
+        m::consume<u64>(s, x, closure m::pattern$lambda$1())
+    }
+    private fun pattern$lambda$1(param$0: m::S<u64>,_y: u64): u64 {
+        {
+          let m::S<u64>{ x } = param$0;
+          {
+            let y: u64 = x;
+            Add<u64>(x, y)
+          }
+        }
+    }
+} // end 0xcafe::m
+
+
+// -- Model dump after env processor specification rewriter:
+module 0xcafe::m {
+    struct S {
+        x: T,
     }
     private fun consume<T>(s: m::S<#0>,x: #0,f: |(m::S<#0>, #0)|#0): #0 {
         (f)(s, x)

--- a/third_party/move/move-compiler-v2/tests/more-v1/parser/spec_parsing_fun_type_fail.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/parser/spec_parsing_fun_type_fail.exp
@@ -4,7 +4,7 @@ error: Only inline functions may have function-typed parameters, but non-inline 
   ┌─ tests/more-v1/parser/spec_parsing_fun_type_fail.move:2:9
   │
 2 │     fun fun_type_in_prog(p: |u64|u64) {
-  │         ^^^^^^^^^^^^^^^^ - Parameter `p` has a function type.
+  │         ^^^^^^^^^^^^^^^^ - Parameter `p` has function-valued type `|u64|u64`.
 
 warning: Unused parameter `p`. Consider removing or prefixing with an underscore: `_p`
   ┌─ tests/more-v1/parser/spec_parsing_fun_type_fail.move:2:26

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -169,15 +169,10 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             exp_suffix: None,
             options: opts
                 .clone()
-                // Need to turn off usage checks because they complain about
-                // lambda parameters outside of inline functions. Other checks
-                // also turned off for now since they mess up baseline.
-                .set_experiment(Experiment::CHECKS, false)
-                .set_experiment(Experiment::OPTIMIZE, false)
-                .set_experiment(Experiment::OPTIMIZE_WAITING_FOR_COMPARE_TESTS, false)
-                .set_experiment(Experiment::INLINING, false)
-                .set_experiment(Experiment::RECURSIVE_TYPE_CHECK, false)
-                .set_experiment(Experiment::SPEC_REWRITE, false)
+                .set_experiment(Experiment::LAMBDA_FIELDS, true)
+                .set_experiment(Experiment::LAMBDA_PARAMS, true)
+                .set_experiment(Experiment::LAMBDA_RESULTS, true)
+                .set_experiment(Experiment::LAMBDA_VALUES, true)
                 .set_experiment(Experiment::LAMBDA_LIFTING, true),
             stop_after: StopAfter::AstPipeline,
             dump_ast: DumpLevel::AllStages,

--- a/third_party/move/move-compiler/tests/move_check/typing/lambda2.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/lambda2.exp
@@ -1,0 +1,30 @@
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda2.move:77:18
+   │
+77 │         let _x = |i| i + 1; // expected lambda not allowed
+   │                  ^^^^^^^^^ function type only allowed for inline function arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda2.move:81:12
+   │
+81 │         f: |u64|u64, // expected lambda not allowed
+   │            ^^^^^^^^ function type only allowed for inline function arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda2.move:84:46
+   │
+84 │     public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
+   │                                              ^^^^^ function type only allowed for inline function arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda2.move:86:58
+   │
+86 │     public inline fun macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+   │                                                          ^^^^^ function type only allowed for inline function arguments
+
+error[E04024]: invalid usage of function type
+   ┌─ tests/move_check/typing/lambda2.move:89:49
+   │
+89 │     public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+   │                                                 ^^^^^ function type only allowed for inline function arguments
+

--- a/third_party/move/move-compiler/tests/move_check/typing/lambda2.move
+++ b/third_party/move/move-compiler/tests/move_check/typing/lambda2.move
@@ -1,0 +1,100 @@
+module 0x8675309::M {
+    // use 0x1::XVector;
+
+    // public inline fun foreach<T>(v: &vector<T>, action: |&T|) { // expected to be not implemented
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         action(XVector::borrow(v, i));
+    //         i = i + 1;
+    //     }
+    // }
+
+    // public inline fun reduce<R, T>(v: vector<T>, accu: R, reducer: |T, R|R): R {
+    //     while (!XVector::is_empty(&v)) {
+    //         accu = reducer(XVector::pop_back(&mut v), accu);
+    //     };
+    //     accu
+    // }
+
+
+    // public fun correct_foreach() {
+    //     let v = vector[1, 2, 3];
+    //     let sum = 0;
+    //     foreach(&v, |e| sum = sum + *e) // expected to be not implemented
+    // }
+
+    // public fun correct_reduce(): u64 {
+    //     let v = vector[1, 2, 3];
+    //     reduce(v, 0, |t, r| t + r)
+    // }
+
+    // public fun corrected_nested() {
+    //     let v = vector[vector[1,2], vector[3]];
+    //     let sum = 0;
+    //     foreach(&v, |e| sum = sum + reduce!(*e, 0, |t, r| t + r));
+    // }
+
+    // public inline fun wrong_local_call_arg_count<T>(v: &vector<T>, action: |&T|) {
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         action(XVector::borrow(v, i), i); // expected to have wrong argument count
+    //         i = i + 1;
+    //     }
+    // }
+
+    // public inline fun wrong_local_call_arg_type<T>(v: &vector<T>, action: |&T|) {
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         action(i); // expected to have wrong argument type
+    //         i = i + 1;
+    //     }
+    // }
+
+    // public inline fun wrong_local_call_result_type<T>(v: &vector<T>, action: |&T|) {
+    //     let i = 0;
+    //     while (i < XVector::length(v)) {
+    //         i = i + action(XVector::borrow(v, i)); // expected to have wrong result type
+    //     }
+    // }
+
+    // public fun wrong_local_call_no_fun(x: u64) {
+    //     x(1) // expected to be not a function
+    // }
+
+    // public fun wrong_lambda_inferred_type() {
+    //     let v = vector[1, 2, 3];
+    //     let sum = 0;
+    //     foreach(&v, |e| sum = sum + e) // expected to cannot infer type
+    // }
+
+    // public fun wrong_lambda_result_type() {
+    //     let v = vector[1, 2, 3];
+    //     let sum = 0;
+    //     foreach(&v, |e| { sum = sum + *e; *e }) // expected to have wrong result type of lambda
+    // }
+
+    public fun lambda_not_allowed() {
+        let _x = |i| i + 1; // expected lambda not allowed
+    }
+
+    struct FieldFunNotAllowed {
+        f: |u64|u64, // expected lambda not allowed
+    }
+
+    public fun fun_arg_lambda_not_allowed(x: |u64|) {} // expected lambda not allowed
+
+    public inline fun macro_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+        abort (1)
+    }
+    public fun fun_result_lambda_not_allowed(): |u64| {  // expected lambda not allowed
+        abort (1)
+    }
+
+}
+
+// module 0x1::XVector {
+//     public fun length<T>(v: &vector<T>): u64 { abort(1) }
+//     public fun is_empty<T>(v: &vector<T>): bool { abort(1) }
+//     public fun borrow<T>(v: &vector<T>, i: u64): &T { abort(1) }
+//     public fun pop_back<T>(v: &mut vector<T>): T { abort(1) }
+// }

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -151,8 +151,9 @@ pub(crate) struct StructVariant {
 /// A declaration of a function.
 #[derive(Debug, Clone)]
 pub(crate) struct FunEntry {
-    pub loc: Loc,      // location of the entire function span
-    pub name_loc: Loc, // location of just the function name
+    pub loc: Loc,             // location of the entire function span
+    pub name_loc: Loc,        // location of just the function name
+    pub result_type_loc: Loc, // location of the result type declaration
     pub module_id: ModuleId,
     pub fun_id: FunId,
     pub visibility: Visibility,

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -568,9 +568,11 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         let is_native = matches!(def.body.value, EA::FunctionBody_::Native);
         let def_loc = et.to_loc(&def.loc);
         let name_loc = et.to_loc(&name.loc());
+        let result_type_loc = et.to_loc(&def.signature.return_type.loc);
         et.parent.parent.define_fun(qsym.clone(), FunEntry {
             loc: def_loc.clone(),
             name_loc,
+            result_type_loc,
             module_id: et.parent.module_id,
             fun_id,
             visibility,
@@ -3552,6 +3554,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 name: name.symbol,
                 loc: entry.loc.clone(),
                 id_loc: entry.name_loc.clone(),
+                result_type_loc: entry.result_type_loc.clone(),
                 def_idx: None,
                 handle_idx: None,
                 visibility: entry.visibility,

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -155,6 +155,9 @@ pub enum Constraint {
     /// a pseudo constraint which never fails, but used to generate a default for
     /// inference.
     WithDefault(Type),
+    /// The type must not be function because it is used as the type of some field or
+    /// as a type argument.
+    NoFunction,
 }
 
 /// A type to describe the context from where a constraint stems. Used for
@@ -384,7 +387,10 @@ impl Constraint {
     /// for internal constraints which would be mostly confusing to users.
     pub fn hidden(&self) -> bool {
         use Constraint::*;
-        matches!(self, NoPhantom | NoReference | NoTuple | WithDefault(..))
+        matches!(
+            self,
+            NoPhantom | NoReference | NoTuple | NoFunction | WithDefault(..)
+        )
     }
 
     /// Returns true if this context is accumulating. When adding a new constraint
@@ -402,6 +408,7 @@ impl Constraint {
                 | Constraint::NoPhantom
                 | Constraint::NoTuple
                 | Constraint::NoReference
+                | Constraint::NoFunction
         )
     }
 
@@ -420,7 +427,10 @@ impl Constraint {
     /// the same type.
     pub fn report_only_once(&self) -> bool {
         use Constraint::*;
-        matches!(self, HasAbilities(..) | NoReference | NoPhantom | NoTuple)
+        matches!(
+            self,
+            HasAbilities(..) | NoReference | NoFunction | NoPhantom | NoTuple
+        )
     }
 
     /// Joins the two constraints. If they are incompatible, produces a type unification error.
@@ -505,6 +515,7 @@ impl Constraint {
                     ))
                 }
             },
+            (Constraint::NoFunction, Constraint::NoFunction) => Ok(true),
             (Constraint::NoReference, Constraint::NoReference) => Ok(true),
             (Constraint::NoTuple, Constraint::NoTuple) => Ok(true),
             (Constraint::NoPhantom, Constraint::NoPhantom) => Ok(true),
@@ -528,7 +539,11 @@ impl Constraint {
     /// type parameter. This creates NoReference, NoTuple, NoPhantom unless the type parameter is
     /// phantom, and HasAbilities if any abilities need to be met.
     pub fn for_type_parameter(param: &TypeParameter) -> Vec<Constraint> {
-        let mut result = vec![Constraint::NoReference, Constraint::NoTuple];
+        let mut result = vec![
+            Constraint::NoReference,
+            Constraint::NoTuple,
+            Constraint::NoFunction,
+        ];
         let TypeParameter(
             _,
             TypeParameterKind {
@@ -552,6 +567,7 @@ impl Constraint {
             Constraint::NoPhantom,
             Constraint::NoReference,
             Constraint::NoTuple,
+            Constraint::NoFunction,
         ]
     }
 
@@ -562,6 +578,7 @@ impl Constraint {
             Constraint::NoPhantom,
             Constraint::NoTuple,
             Constraint::NoReference,
+            Constraint::NoFunction,
         ];
         let abilities = if !field_ty.depends_from_type_parameter() {
             if struct_abilities.has_ability(Ability::Key) {
@@ -632,6 +649,7 @@ impl Constraint {
                 )
             },
             Constraint::NoReference => "no-ref".to_string(),
+            Constraint::NoFunction => "no-func".to_string(),
             Constraint::NoTuple => "no-tuple".to_string(),
             Constraint::NoPhantom => "no-phantom".to_string(),
             Constraint::HasAbilities(required_abilities) => {
@@ -804,6 +822,11 @@ impl Type {
     /// Determines whether this is a reference.
     pub fn is_reference(&self) -> bool {
         matches!(self, Type::Reference(_, _))
+    }
+
+    /// Determines whether this is a function.
+    pub fn is_function(&self) -> bool {
+        matches!(self, Type::Fun(..))
     }
 
     /// If this is a reference, return the kind of the reference, otherwise None.
@@ -1769,6 +1792,13 @@ impl Substitution {
                 },
                 (Constraint::NoReference, ty) => {
                     if ty.is_reference() {
+                        constraint_unsatisfied_error()
+                    } else {
+                        Ok(())
+                    }
+                },
+                (Constraint::NoFunction, ty) => {
+                    if ty.is_function() {
                         constraint_unsatisfied_error()
                     } else {
                         Ok(())
@@ -2940,6 +2970,13 @@ impl TypeUnificationError {
                     Constraint::NoReference => {
                         format!(
                             "reference type `{}` is not allowed {}",
+                            ty.display(display_context),
+                            item_name()
+                        )
+                    },
+                    Constraint::NoFunction => {
+                        format!(
+                            "function type `{}` is not allowed {}",
                             ty.display(display_context),
                             item_name()
                         )


### PR DESCRIPTION
## Description

Catch all errors in `move-compiler-v2/tests/checking/typing/lambda.move` in Compiler V2,
after splitting and gradually commenting out code as `lambda[2-5].move`,
to avoid shadowing by other errors.  Lay groundwork for support of lambdas in various capacities.

Fixes #14633.

- add checking for function-typed function results in `function_checker`
- Change `internal_error` to `error` in `bytecode_generator` and `module_generator`
  to properly show "error" rather than "bug" if lambdas are mistakenly used as values today.
- tag some code to show where changes are needed to support lambda: // TODO(LAMBDA)
- fix unused_params_checker and recursive_struct_checker to tolerate lambda types
- add experiments to control enabling of various aspects of lambda support:
  - `LAMBDA_PARAMS`, `LAMBDA_RESULTS` to allow lambdas as general function params or results
  - `LAMBDA_FIELDS` - support lambdas in struct fields
  - `LAMBDA_VALUES` - support lambdas in general-purpose values
  - may add `LAMBDA_TYPE_PARAMS` later
- update lambda-lifting test config to use those flags rather than disabling checks
- add a `result_type_loc` field to move-model's `FunctionData` (and model-builder's `FunEntry`)
  to more precisely locate errors in function result types.
- Fix `GlobalEnv::internal_dump_env` to use function- and struct-specific type contexts
  so that types are shown with correct type parameter names.
- Check that struct fields are not functions.

## How Has This Been Tested?

Running the usual tests.

## Key Areas to Review

Note that a few errors are caught quite late, in `bytecode-generator`,
and the order in which we catch errors may be a bit surprising to
users (errors in `exp_builder` come first, then errors caught by
`function_checker`, then (much later) `bytecode_generator`.).
Actually supporting particular subsets of the "experiments" mentioned
above would be difficult, but it seems useful to have the labels to
help understand just what features are supported by the implementation
as we go.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [X] Move Compiler
- [ ] Other (specify)

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X] I tested both happy and unhappy path of the functionality
- [X] I have made corresponding changes to the documentation
