### PR TITLE
[Compiler-v2] Check recursive definition for constants

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/v1-typing/refer_other_constants.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/v1-typing/refer_other_constants.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: not supported before language version `2.0`: constant definitions referring to other constants
+  ┌─ tests/checking-lang-v1/v1-typing/refer_other_constants.move:3:5
+  │
+3 │     const X: u64 = Y;
+  │     ^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/v1-typing/refer_other_constants.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/v1-typing/refer_other_constants.move
@@ -1,0 +1,14 @@
+address 0x42 {
+module M {
+    const X: u64 = Y;
+    const Y: u64 = 0;
+
+    public fun get_x(): u64 {
+        X
+    }
+
+    public fun get_y(): u64 {
+        Y
+    }
+}
+}

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_all_valid_types.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_all_valid_types.exp
@@ -24,6 +24,9 @@ module 0x42::M {
     private fun t8(): vector<address> {
         [Address(Numerical(0000000000000000000000000000000000000000000000000000000000000000)), Address(Numerical(0000000000000000000000000000000000000000000000000000000000000001))]
     }
+    private fun t9(): u8 {
+        0
+    }
 } // end 0x42::M
 module <SELF>_0 {
     private fun t() {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_all_valid_types.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_all_valid_types.move
@@ -1,5 +1,6 @@
 address 0x42 {
 module M {
+    const B: u8 = C1;
     const C1: u8 = 0;
     const C2: u64 = 0;
     const C3: u128 = 0;
@@ -17,6 +18,7 @@ module M {
     fun t6(): vector<u8> { C6 }
     fun t7(): vector<u8> { C7 }
     fun t8(): vector<address> { C8 }
+    fun t9(): u8 { B }
 }
 }
 

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_duplicate.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_duplicate.exp
@@ -1,0 +1,9 @@
+
+Diagnostics:
+error: duplicate declaration, item, or annotation
+  ┌─ tests/checking/typing/constant_duplicate.move:3:11
+  │
+2 │     const LN2_X_32: u64 = 32 * 2977044472;
+  │           -------- Alias previously defined here
+3 │     const LN2_X_32: u64 = 32 * 2977044472;
+  │           ^^^^^^^^ Duplicate module member or alias 'LN2_X_32'. Top level names in a namespace must be unique

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_duplicate.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_duplicate.move
@@ -1,0 +1,4 @@
+module 0x42::constant_duplicate {
+    const LN2_X_32: u64 = 32 * 2977044472;
+    const LN2_X_32: u64 = 32 * 2977044472;
+}

--- a/third_party/move/move-compiler-v2/tests/checking/typing/recursive_constant.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/recursive_constant.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: Found recursive definition of a constant `X`
+error: Found recursive definition of a constant `X`; cycle formed by definitions below
   ┌─ tests/checking/typing/recursive_constant.move:3:5
   │
 3 │     const X: u64 = Y;
@@ -10,7 +10,7 @@ error: Found recursive definition of a constant `X`
 4 │     const Y: u64 = X;
   │     ----------------- `Y` is defined here
 
-error: Found recursive definition of a constant `F`
+error: Found recursive definition of a constant `F`; cycle formed by definitions below
   ┌─ tests/checking/typing/recursive_constant.move:6:5
   │
 6 │     const F: u64 = F;
@@ -30,7 +30,7 @@ error: Invalid expression in `const`. Constant folding failed due to incomplete 
 10 │     const A: u64 = B + C;
    │                    ^^^^^
 
-error: Found recursive definition of a constant `A`
+error: Found recursive definition of a constant `A`; cycle formed by definitions below
    ┌─ tests/checking/typing/recursive_constant.move:10:5
    │
  7 │ ╭     const X1: u64 = {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/recursive_constant.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/recursive_constant.exp
@@ -1,9 +1,7 @@
-// -- Model dump before bytecode pipeline
-module 0x42::M {
-    public fun get_x(): u64 {
-        false
-    }
-    public fun get_y(): u64 {
-        false
-    }
-} // end 0x42::M
+
+Diagnostics:
+error: Found recursive definition of a constant
+  ┌─ tests/checking/typing/recursive_constant.move:4:5
+  │
+4 │     const Y: u64 = X;
+  │     ^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/recursive_constant.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/recursive_constant.exp
@@ -1,7 +1,51 @@
 
 Diagnostics:
-error: Found recursive definition of a constant
-  ┌─ tests/checking/typing/recursive_constant.move:4:5
+error: Found recursive definition of a constant `X`
+  ┌─ tests/checking/typing/recursive_constant.move:3:5
   │
-4 │     const Y: u64 = X;
+3 │     const X: u64 = Y;
   │     ^^^^^^^^^^^^^^^^^
+  │     │
+  │     `X` is defined here
+4 │     const Y: u64 = X;
+  │     ----------------- `Y` is defined here
+
+error: Found recursive definition of a constant `F`
+  ┌─ tests/checking/typing/recursive_constant.move:6:5
+  │
+6 │     const F: u64 = F;
+  │     ^^^^^^^^^^^^^^^^^
+  │     │
+  │     `F` is defined here
+
+error: Invalid expression in `const`. Constant folding failed due to incomplete evaluation
+  ┌─ tests/checking/typing/recursive_constant.move:8:8
+  │
+8 │        Z + A
+  │        ^^^^^
+
+error: Invalid expression in `const`. Constant folding failed due to incomplete evaluation
+   ┌─ tests/checking/typing/recursive_constant.move:10:20
+   │
+10 │     const A: u64 = B + C;
+   │                    ^^^^^
+
+error: Found recursive definition of a constant `A`
+   ┌─ tests/checking/typing/recursive_constant.move:10:5
+   │
+ 7 │ ╭     const X1: u64 = {
+ 8 │ │        Z + A
+ 9 │ │     };
+   │ ╰──────' `X1` is defined here
+10 │       const A: u64 = B + C;
+   │       ^^^^^^^^^^^^^^^^^^^^^
+   │       │
+   │       `A` is defined here
+11 │       const B: u64 = X1;
+   │       ------------------ `B` is defined here
+
+error: Invalid expression in `const`. Constant folding failed due to incomplete evaluation
+   ┌─ tests/checking/typing/recursive_constant.move:12:20
+   │
+12 │     const C: u64 = Z + B;
+   │                    ^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/recursive_constant.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/recursive_constant.move
@@ -3,6 +3,13 @@ module M {
     const X: u64 = Y;
     const Y: u64 = X;
     const Z: u64 = 0;
+    const F: u64 = F;
+    const X1: u64 = {
+       Z + A
+    };
+    const A: u64 = B + C;
+    const B: u64 = X1;
+    const C: u64 = Z + B;
 
     public fun get_x(): u64 {
         X

--- a/third_party/move/move-compiler/src/expansion/ast.rs
+++ b/third_party/move/move-compiler/src/expansion/ast.rs
@@ -21,7 +21,7 @@ use move_binary_format::file_format;
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     fmt,
     hash::Hash,
 };
@@ -382,7 +382,7 @@ pub enum ModuleAccess_ {
 }
 
 impl ModuleAccess_ {
-    fn get_name(&self) -> &Name {
+    pub fn get_name(&self) -> &Name {
         match self {
             ModuleAccess_::Name(n) | ModuleAccess_::ModuleAccess(_, n, _) => n,
         }
@@ -547,44 +547,6 @@ pub enum Exp_ {
     UnresolvedError,
 }
 pub type Exp = Spanned<Exp_>;
-
-impl Exp_ {
-    /// Get all names from an expression
-    /// only perform on expression supported in constant definition.
-    pub fn get_names_for_const_exp(&self) -> HashSet<Name> {
-        let mut names = HashSet::new();
-        let mut add_names = |v: &Exp| {
-            let set = v.value.get_names_for_const_exp();
-            for n in set.iter() {
-                names.insert(*n);
-            }
-        };
-        match self {
-            Self::Name(access, _) => {
-                names.insert(*access.value.get_name());
-            },
-            Self::Call(_, _, _, exp_vec) | Self::Vector(_, _, exp_vec) => {
-                let _ = exp_vec.value.iter().map(&mut add_names);
-            },
-            Self::UnaryExp(_, exp) => {
-                add_names(exp);
-            },
-            Self::BinopExp(exp1, _, exp2) => {
-                add_names(exp1);
-                add_names(exp2);
-            },
-            Self::Block(seq) => {
-                for s in seq.iter() {
-                    if let SequenceItem_::Seq(exp) = &s.value {
-                        add_names(exp);
-                    }
-                }
-            },
-            _ => {},
-        }
-        names
-    }
-}
 
 pub type Sequence = VecDeque<SequenceItem>;
 #[derive(Debug, Clone, PartialEq)]

--- a/third_party/move/move-compiler/tests/move_check/typing/constant_duplicate.exp
+++ b/third_party/move/move-compiler/tests/move_check/typing/constant_duplicate.exp
@@ -1,0 +1,8 @@
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ tests/move_check/typing/constant_duplicate.move:3:11
+  │
+2 │     const LN2_X_32: u64 = 32 * 2977044472;
+  │           -------- Alias previously defined here
+3 │     const LN2_X_32: u64 = 32 * 2977044472;
+  │           ^^^^^^^^ Duplicate module member or alias 'LN2_X_32'. Top level names in a namespace must be unique
+

--- a/third_party/move/move-compiler/tests/move_check/typing/constant_duplicate.move
+++ b/third_party/move/move-compiler/tests/move_check/typing/constant_duplicate.move
@@ -1,0 +1,4 @@
+module 0x42::constant_duplicate {
+    const LN2_X_32: u64 = 32 * 2977044472;
+    const LN2_X_32: u64 = 32 * 2977044472;
+}

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -176,15 +176,8 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
     }
 
     pub fn check_language_version(&self, loc: &Loc, feature: &str, version_min: LanguageVersion) {
-        if !self.env().language_version().is_at_least(version_min) {
-            self.env().error(
-                loc,
-                &format!(
-                    "not supported before language version `{}`: {}",
-                    version_min, feature
-                ),
-            )
-        }
+        self.parent
+            .check_language_version(loc, feature, version_min);
     }
 
     pub fn set_spec_block_map(&mut self, map: BTreeMap<EA::SpecId, EA::SpecBlock>) {

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -887,14 +887,58 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         }
     }
 
-    fn analyze_constant(
+    /// Evaluation of constant `key`
+    /// Performed in depth-first way to detect cyclic dependency
+    /// and constants are evaluated according to dependency relation
+    fn eval_constant(
         &mut self,
         key: &PA::ConstantName,
         constant_map: &UniqueMap<PA::ConstantName, EA::Constant>,
-        visiting: &mut HashSet<PA::ConstantName>,
-        visited: &mut HashSet<PA::ConstantName>,
+        visiting: &mut Vec<(PA::ConstantName, Loc)>, // constants that are being traversed during dfs
+        visited: &mut HashSet<PA::ConstantName>, // constants that are already visited during dfs
         compiled_module: &Option<BytecodeModule>,
     ) {
+        // Get all names from an expression
+        // only recursively check on expression types supported in constant definition.
+        fn get_names_from_const_exp(exp: &EA::Exp_) -> BTreeSet<Name> {
+            let mut names = BTreeSet::new();
+            let mut add_names = |v: &EA::Exp| {
+                let set = get_names_from_const_exp(&v.value);
+                for n in set.iter() {
+                    names.insert(*n);
+                }
+            };
+            match exp {
+                EA::Exp_::Name(access, _) => {
+                    names.insert(*access.value.get_name());
+                },
+                EA::Exp_::Call(_, _, _, exp_vec) | EA::Exp_::Vector(_, _, exp_vec) => {
+                    exp_vec.value.iter().for_each(&mut add_names);
+                },
+                EA::Exp_::UnaryExp(_, exp) => {
+                    add_names(exp);
+                },
+                EA::Exp_::BinopExp(exp1, _, exp2) => {
+                    add_names(exp1);
+                    add_names(exp2);
+                },
+                EA::Exp_::Block(seq) => {
+                    for s in seq.iter() {
+                        match &s.value {
+                            EA::SequenceItem_::Seq(exp) | EA::SequenceItem_::Bind(_, exp) => {
+                                add_names(exp);
+                            },
+                            _ => {},
+                        }
+                    }
+                },
+                _ => {},
+            }
+            names
+        }
+        if visited.contains(key) {
+            return;
+        }
         let qsym = self.qualified_by_module_from_name(&key.0);
         let loc = self
             .parent
@@ -903,15 +947,22 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             .expect("constant declared")
             .loc
             .clone();
-        if visited.contains(key) {
+        if let Some(index) = visiting.iter().position(|r| r.0 == *key) {
+            self.parent.env.diag_with_labels(
+                Severity::Error,
+                &loc,
+                &format!("Found recursive definition of a constant `{}`", key),
+                visiting[index..]
+                    .to_vec()
+                    .iter()
+                    .map(|(name, loc)| (loc.clone(), format!("`{}` is defined here", name)))
+                    .collect_vec(),
+            );
             return;
         }
-        if visiting.contains(key) {
-            return;
-        }
-        visiting.insert(*key);
+        visiting.push((*key, loc.clone()));
         if let Some(exp) = constant_map.get(key) {
-            let names = exp.value.value.get_names_for_const_exp();
+            let names = get_names_from_const_exp(&exp.value.value);
             for name in names {
                 let const_name = PA::ConstantName(name);
                 let qsym = self.qualified_by_module_from_name(&name);
@@ -920,19 +971,13 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 }
                 self.check_language_version(
                     &loc,
-                    "Referring to other constants",
+                    "constant definitions referring to other constants",
                     LanguageVersion::V2_0,
                 );
                 if visited.contains(&const_name) {
-                    return;
+                    continue;
                 }
-                if visiting.contains(&const_name) {
-                    self.parent
-                        .env
-                        .error(&loc, "Found recursive definition of a constant");
-                    return;
-                }
-                self.analyze_constant(
+                self.eval_constant(
                     &const_name,
                     constant_map,
                     visiting,
@@ -941,20 +986,21 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 );
             }
             self.def_ana_constant(key, exp, compiled_module);
-            visited.insert(*key);
-            visiting.remove(key);
         }
+        visited.insert(*key);
+        visiting.pop();
     }
 
+    /// Evaluation of constants in the module
     fn analyze_constants(
         &mut self,
         module_def: &EA::ModuleDefinition,
         compiled_module: &Option<BytecodeModule>,
     ) {
         let mut visited = HashSet::new();
-        let mut visiting = HashSet::new();
+        let mut visiting = vec![];
         for (name, _) in module_def.constants.key_cloned_iter() {
-            self.analyze_constant(
+            self.eval_constant(
                 &name,
                 &module_def.constants,
                 &mut visiting,

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -52,7 +52,7 @@ use move_ir_types::{ast::ConstantName, location::Spanned};
 use regex::Regex;
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, BTreeSet, HashSet},
+    collections::{BTreeMap, BTreeSet},
     default::Default,
     fmt,
 };
@@ -895,7 +895,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         key: &PA::ConstantName,
         constant_map: &UniqueMap<PA::ConstantName, EA::Constant>,
         visiting: &mut Vec<(PA::ConstantName, Loc)>, // constants that are being traversed during dfs
-        visited: &mut HashSet<PA::ConstantName>, // constants that are already visited during dfs
+        visited: &mut BTreeSet<PA::ConstantName>, // constants that are already visited during dfs
         compiled_module: &Option<BytecodeModule>,
     ) {
         // Get all names from an expression
@@ -951,7 +951,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             self.parent.env.diag_with_labels(
                 Severity::Error,
                 &loc,
-                &format!("Found recursive definition of a constant `{}`", key),
+                &format!("Found recursive definition of a constant `{}`; cycle formed by definitions below", key),
                 visiting[index..]
                     .to_vec()
                     .iter()
@@ -997,7 +997,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
         module_def: &EA::ModuleDefinition,
         compiled_module: &Option<BytecodeModule>,
     ) {
-        let mut visited = HashSet::new();
+        let mut visited = BTreeSet::new();
         let mut visiting = vec![];
         for (name, _) in module_def.constants.key_cloned_iter() {
             self.eval_constant(

--- a/third_party/move/move-model/src/constant_folder.rs
+++ b/third_party/move/move-model/src/constant_folder.rs
@@ -328,9 +328,17 @@ impl<'env> ConstantFolder<'env> {
                     O::Neq => val0
                         .equivalent(val1)
                         .map(|equivalence| V(id, Bool(!equivalence)).into_exp()),
-                    _ => self.constant_folding_error(id, |_| {
-                        "Unknown binary expression in `const`".to_owned()
-                    }),
+                    _ => {
+                        if oper.is_binop() {
+                            self.constant_folding_error(id, |_| {
+                                "Constant folding failed due to incomplete evaluation".to_owned()
+                            })
+                        } else {
+                            self.constant_folding_error(id, |_| {
+                                "Unknown binary expression in `const`".to_owned()
+                            })
+                        }
+                    },
                 }
             }
         } else {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR

1) adds checks to only allow referring other constants in constant definition when the language version is at least 2.0.
2) rejects recursive definition of constants.

close #14648

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Other (specify)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

1) Update existing test cases;
2) Add a new test to `checking-lang-v1`

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
