### PR TITLE
[Consensus Observer] Disable CO for VFNs.

### DIFF
--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 
 // Useful constants for enabling consensus observer on different node types
-const ENABLE_ON_VALIDATORS: bool = true;
-const ENABLE_ON_VALIDATOR_FULLNODES: bool = true;
+const ENABLE_ON_VALIDATORS: bool = false;
+const ENABLE_ON_VALIDATOR_FULLNODES: bool = false;
 const ENABLE_ON_PUBLIC_FULLNODES: bool = false;
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]


### PR DESCRIPTION
## Description
This PR disables consensus observer (CO) for VFNs (by default).

## Testing Plan
Existing test infrastructure.
