### PR TITLE
[move][stdlib] Add vector::split_off and vector::replace library methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5151,9 +5151,9 @@ checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/move_stdlib.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/move_stdlib.rs
@@ -3,8 +3,11 @@
 
 //! This module defines the gas parameters for Move Stdlib.
 
-use crate::{gas_feature_versions::RELEASE_V1_18, gas_schedule::NativeGasParameters};
-use aptos_gas_algebra::{InternalGas, InternalGasPerByte};
+use crate::{
+    gas_feature_versions::{RELEASE_V1_18, RELEASE_V1_22},
+    gas_schedule::NativeGasParameters,
+};
+use aptos_gas_algebra::{InternalGas, InternalGasPerAbstractValueUnit, InternalGasPerByte};
 
 crate::gas_schedule::macros::define_gas_parameters!(
     MoveStdlibGasParameters,
@@ -36,5 +39,8 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [bcs_serialized_size_base: InternalGas, { RELEASE_V1_18.. => "bcs.serialized_size.base" }, 735],
         [bcs_serialized_size_per_byte_serialized: InternalGasPerByte, { RELEASE_V1_18.. => "bcs.serialized_size.per_byte_serialized" }, 36],
         [bcs_serialized_size_failure: InternalGas, { RELEASE_V1_18.. => "bcs.serialized_size.failure" }, 3676],
+
+        [mem_swap_base: InternalGas, { RELEASE_V1_22.. => "mem.swap.base" }, 367],
+        [mem_swap_per_abs_val_unit: InternalGasPerAbstractValueUnit, { RELEASE_V1_22.. => "mem.swap.per_abs_val_unit"}, 14],
     ]
 );

--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -69,7 +69,7 @@
 ///       global operations.
 /// - V1
 ///   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_21;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_22;
 
 pub mod gas_feature_versions {
     pub const RELEASE_V1_8: u64 = 11;
@@ -86,4 +86,5 @@ pub mod gas_feature_versions {
     pub const RELEASE_V1_19: u64 = 23;
     pub const RELEASE_V1_20: u64 = 24;
     pub const RELEASE_V1_21: u64 = 25;
+    pub const RELEASE_V1_22: u64 = 26;
 }

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib/sources/mem.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib/sources/mem.move
@@ -1,0 +1,1 @@
+../../../../../../framework/move-stdlib/sources/mem.move

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib_incompat/sources/mem.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib_incompat/sources/mem.move
@@ -1,0 +1,1 @@
+../../../../../../framework/move-stdlib/sources/mem.move

--- a/aptos-move/framework/move-stdlib/doc/mem.md
+++ b/aptos-move/framework/move-stdlib/doc/mem.md
@@ -1,0 +1,113 @@
+
+<a id="0x1_mem"></a>
+
+# Module `0x1::mem`
+
+Module with methods for safe memory manipulation.
+I.e. swapping/replacing non-copyable/non-droppable types.
+
+
+-  [Function `swap`](#0x1_mem_swap)
+-  [Function `replace`](#0x1_mem_replace)
+-  [Specification](#@Specification_0)
+    -  [Function `swap`](#@Specification_0_swap)
+    -  [Function `replace`](#@Specification_0_replace)
+
+
+<pre><code></code></pre>
+
+
+
+<a id="0x1_mem_swap"></a>
+
+## Function `swap`
+
+Swap contents of two passed mutable references.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="mem.md#0x1_mem_swap">swap</a>&lt;T&gt;(left: &<b>mut</b> T, right: &<b>mut</b> T)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="mem.md#0x1_mem_swap">swap</a>&lt;T&gt;(left: &<b>mut</b> T, right: &<b>mut</b> T);
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_mem_replace"></a>
+
+## Function `replace`
+
+Replace value reference points to with the given new value,
+and return value it had before.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="mem.md#0x1_mem_replace">replace</a>&lt;T&gt;(ref: &<b>mut</b> T, new: T): T
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="mem.md#0x1_mem_replace">replace</a>&lt;T&gt;(ref: &<b>mut</b> T, new: T): T {
+    <a href="mem.md#0x1_mem_swap">swap</a>(ref, &<b>mut</b> new);
+    new
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="@Specification_0"></a>
+
+## Specification
+
+
+<a id="@Specification_0_swap"></a>
+
+### Function `swap`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="mem.md#0x1_mem_swap">swap</a>&lt;T&gt;(left: &<b>mut</b> T, right: &<b>mut</b> T)
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> right == <b>old</b>(left);
+<b>ensures</b> left == <b>old</b>(right);
+</code></pre>
+
+
+
+<a id="@Specification_0_replace"></a>
+
+### Function `replace`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="mem.md#0x1_mem_replace">replace</a>&lt;T&gt;(ref: &<b>mut</b> T, new: T): T
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == <b>old</b>(ref);
+<b>ensures</b> ref == new;
+</code></pre>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc/overview.md
+++ b/aptos-move/framework/move-stdlib/doc/overview.md
@@ -20,6 +20,7 @@ For on overview of the Move language, see the [Move Book][move-book].
 -  [`0x1::features`](features.md#0x1_features)
 -  [`0x1::fixed_point32`](fixed_point32.md#0x1_fixed_point32)
 -  [`0x1::hash`](hash.md#0x1_hash)
+-  [`0x1::mem`](mem.md#0x1_mem)
 -  [`0x1::option`](option.md#0x1_option)
 -  [`0x1::signer`](signer.md#0x1_signer)
 -  [`0x1::string`](string.md#0x1_string)

--- a/aptos-move/framework/move-stdlib/doc/vector.md
+++ b/aptos-move/framework/move-stdlib/doc/vector.md
@@ -29,6 +29,7 @@ the return on investment didn't seem worth it for these simple functions.
 -  [Function `reverse_slice`](#0x1_vector_reverse_slice)
 -  [Function `append`](#0x1_vector_append)
 -  [Function `reverse_append`](#0x1_vector_reverse_append)
+-  [Function `split_off`](#0x1_vector_split_off)
 -  [Function `trim`](#0x1_vector_trim)
 -  [Function `trim_reverse`](#0x1_vector_trim_reverse)
 -  [Function `is_empty`](#0x1_vector_is_empty)
@@ -39,6 +40,7 @@ the return on investment didn't seem worth it for these simple functions.
 -  [Function `remove`](#0x1_vector_remove)
 -  [Function `remove_value`](#0x1_vector_remove_value)
 -  [Function `swap_remove`](#0x1_vector_swap_remove)
+-  [Function `replace`](#0x1_vector_replace)
 -  [Function `for_each`](#0x1_vector_for_each)
 -  [Function `for_each_reverse`](#0x1_vector_for_each_reverse)
 -  [Function `for_each_ref`](#0x1_vector_for_each_ref)
@@ -483,6 +485,42 @@ Pushes all of the elements of the <code>other</code> vector into the <code>self<
 
 </details>
 
+<a id="0x1_vector_split_off"></a>
+
+## Function `split_off`
+
+Splits the collection into two at the given index.
+Returns a newly allocated vector containing the elements in the range [at, len).
+After the call, the original vector will be left containing the elements [0, at)
+with its previous capacity unchanged.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_split_off">split_off</a>&lt;Element&gt;(self: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, at: u64): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_split_off">split_off</a>&lt;Element&gt;(self: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, at: u64): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt; {
+    <b>let</b> len = <a href="vector.md#0x1_vector_length">length</a>(self);
+    <b>assert</b>!(at &lt;= len, <a href="vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>);
+    <b>let</b> other = <a href="vector.md#0x1_vector_empty">empty</a>();
+    <b>while</b> (len &gt; at) {
+        <a href="vector.md#0x1_vector_push_back">push_back</a>(&<b>mut</b> other, <a href="vector.md#0x1_vector_pop_back">pop_back</a>(self));
+        len = len - 1;
+    };
+    <a href="vector.md#0x1_vector_reverse">reverse</a>(&<b>mut</b> other);
+    other
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_vector_trim"></a>
 
 ## Function `trim`
@@ -793,6 +831,37 @@ Aborts if <code>i</code> is out of bounds.
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_swap_remove">swap_remove</a>&lt;Element&gt;(self: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64): Element {
     <b>assert</b>!(!<a href="vector.md#0x1_vector_is_empty">is_empty</a>(self), <a href="vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>);
     <b>let</b> last_idx = <a href="vector.md#0x1_vector_length">length</a>(self) - 1;
+    <a href="vector.md#0x1_vector_swap">swap</a>(self, i, last_idx);
+    <a href="vector.md#0x1_vector_pop_back">pop_back</a>(self)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_vector_replace"></a>
+
+## Function `replace`
+
+Replace the <code>i</code>th element of the vector <code>self</code> with the given value, and return
+to the caller the value that was there before.
+Aborts if <code>i</code> is out of bounds.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_replace">replace</a>&lt;Element&gt;(self: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64, val: Element): Element
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_replace">replace</a>&lt;Element&gt;(self: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64, val: Element): Element {
+    <b>let</b> last_idx = <a href="vector.md#0x1_vector_length">length</a>(self);
+    <b>assert</b>!(i &lt; last_idx, <a href="vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>);
+    <a href="vector.md#0x1_vector_push_back">push_back</a>(self, val);
     <a href="vector.md#0x1_vector_swap">swap</a>(self, i, last_idx);
     <a href="vector.md#0x1_vector_pop_back">pop_back</a>(self)
 }

--- a/aptos-move/framework/move-stdlib/sources/mem.move
+++ b/aptos-move/framework/move-stdlib/sources/mem.move
@@ -1,0 +1,27 @@
+/// Module with methods for safe memory manipulation.
+/// I.e. swapping/replacing non-copyable/non-droppable types.
+module std::mem {
+    /// Swap contents of two passed mutable references.
+    public native fun swap<T>(left: &mut T, right: &mut T);
+
+    /// Replace value reference points to with the given new value,
+    /// and return value it had before.
+    public fun replace<T>(ref: &mut T, new: T): T {
+        swap(ref, &mut new);
+        new
+    }
+
+   spec swap<T>(left: &mut T, right: &mut T) {
+        pragma opaque;
+        aborts_if false;
+        ensures right == old(left);
+        ensures left == old(right);
+    }
+
+    spec replace<T>(ref: &mut T, new: T): T {
+        pragma opaque;
+        aborts_if false;
+        ensures result == old(ref);
+        ensures ref == new;
+    }
+}

--- a/aptos-move/framework/move-stdlib/sources/vector.move
+++ b/aptos-move/framework/move-stdlib/sources/vector.move
@@ -122,6 +122,22 @@ module std::vector {
         pragma intrinsic = true;
     }
 
+    /// Splits the collection into two at the given index.
+    /// Returns a newly allocated vector containing the elements in the range [at, len).
+    /// After the call, the original vector will be left containing the elements [0, at)
+    /// with its previous capacity unchanged.
+    public fun split_off<Element>(self: &mut vector<Element>, at: u64): vector<Element> {
+        let len = length(self);
+        assert!(at <= len, EINDEX_OUT_OF_BOUNDS);
+        let other = empty();
+        while (len > at) {
+            push_back(&mut other, pop_back(self));
+            len = len - 1;
+        };
+        reverse(&mut other);
+        other
+    }
+
     /// Trim a vector to a smaller size, returning the evicted elements in order
     public fun trim<Element>(self: &mut vector<Element>, new_len: u64): vector<Element> {
         let res = trim_reverse(self, new_len);
@@ -264,6 +280,17 @@ module std::vector {
     }
     spec swap_remove {
         pragma intrinsic = true;
+    }
+
+    /// Replace the `i`th element of the vector `self` with the given value, and return
+    /// to the caller the value that was there before.
+    /// Aborts if `i` is out of bounds.
+    public fun replace<Element>(self: &mut vector<Element>, i: u64, val: Element): Element {
+        let last_idx = length(self);
+        assert!(i < last_idx, EINDEX_OUT_OF_BOUNDS);
+        push_back(self, val);
+        swap(self, i, last_idx);
+        pop_back(self)
     }
 
     /// Apply the function to each element in the vector, consuming it.

--- a/aptos-move/framework/move-stdlib/src/natives/mem.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/mem.rs
@@ -1,0 +1,75 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementation of native functions for utf8 strings.
+
+use aptos_gas_schedule::gas_params::natives::move_stdlib::{
+    MEM_SWAP_BASE, MEM_SWAP_PER_ABS_VAL_UNIT,
+};
+use aptos_native_interface::{
+    safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeError,
+    SafeNativeResult,
+};
+use move_core_types::vm_status::StatusCode;
+use move_vm_runtime::native_functions::NativeFunction;
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::PartialVMError,
+    values::{Reference, Value},
+};
+use smallvec::{smallvec, SmallVec};
+use std::collections::VecDeque;
+
+/***************************************************************************************************
+ * native fun native_swap
+ *
+ *   gas cost: MEM_SWAP_BASE + MEM_SWAP_PER_ABS_VAL_UNIT * abstract_size_of_arguments
+ *
+ **************************************************************************************************/
+fn native_swap(
+    context: &mut SafeNativeContext,
+    _ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    debug_assert!(args.len() == 2);
+
+    if args.len() != 2 {
+        return Err(SafeNativeError::InvariantViolation(PartialVMError::new(
+            StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
+        )));
+    }
+
+    let cost = MEM_SWAP_BASE
+        + MEM_SWAP_PER_ABS_VAL_UNIT
+            * (context.abs_val_size(&args[0]) + context.abs_val_size(&args[1]));
+    context.charge(cost)?;
+
+    let ref1 = safely_pop_arg!(args, Reference);
+    let ref0 = safely_pop_arg!(args, Reference);
+
+    ref0.swap_ref(|value0| {
+        let mut value1_opt = Option::None;
+        ref1.swap_ref(|value1| {
+            value1_opt = Option::Some(value1);
+            Ok(value0)
+        })?;
+        Ok(value1_opt.unwrap())
+    })?;
+
+    Ok(smallvec![])
+}
+
+/***************************************************************************************************
+ * module
+ **************************************************************************************************/
+pub fn make_all(
+    builder: &SafeNativeBuilder,
+) -> impl Iterator<Item = (String, NativeFunction)> + '_ {
+    let natives = [("swap", native_swap as RawSafeNative)];
+
+    builder.make_named_natives(natives)
+}

--- a/aptos-move/framework/move-stdlib/src/natives/mod.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod bcs;
 pub mod hash;
+pub mod mem;
 pub mod signer;
 pub mod string;
 #[cfg(feature = "testing")]
@@ -33,6 +34,7 @@ pub fn all_natives(
     builder.with_incremental_gas_charging(false, |builder| {
         add_natives!("bcs", bcs::make_all(builder));
         add_natives!("hash", hash::make_all(builder));
+        add_natives!("mem", mem::make_all(builder));
         add_natives!("signer", signer::make_all(builder));
         add_natives!("string", string::make_all(builder));
         #[cfg(feature = "testing")]

--- a/aptos-move/framework/move-stdlib/tests/mem_tests.move
+++ b/aptos-move/framework/move-stdlib/tests/mem_tests.move
@@ -1,0 +1,65 @@
+#[test_only]
+module std::mem_tests {
+    use std::vector;
+    use std::mem::{swap, replace};
+
+    #[test]
+    fun test_swap_ints() {
+        let a = 1;
+        let b = 2;
+        let v = vector[3, 4, 5, 6];
+
+        swap(&mut a, &mut b);
+        assert!(a == 2, 0);
+        assert!(b == 1, 1);
+
+        swap(&mut a, vector::borrow_mut(&mut v, 0));
+        assert!(a == 3, 0);
+        assert!(vector::borrow(&v, 0) == &2, 1);
+
+        swap(vector::borrow_mut(&mut v, 2), &mut a);
+        assert!(a == 5, 0);
+        assert!(vector::borrow(&v, 2) == &3, 1);
+    }
+
+
+    #[test]
+    fun test_replace_ints() {
+        let a = 1;
+        let b = 2;
+
+        assert!(replace(&mut a, b) == 1, 0);
+        assert!(a == 2, 1);
+    }
+
+    #[test_only]
+    struct SomeStruct has drop {
+        f: u64,
+        v: vector<u64>,
+    }
+
+    #[test]
+    fun test_swap_struct() {
+        let a = 1;
+        let s1 = SomeStruct { f: 2, v: vector[3, 4]};
+        let s2 = SomeStruct { f: 5, v: vector[6, 7]};
+        let vs = vector[SomeStruct { f: 8, v: vector[9, 10]}, SomeStruct { f: 11, v: vector[12, 13]}];
+
+
+        swap(&mut s1, &mut s2);
+        assert!(&s1 == &SomeStruct { f: 5, v: vector[6, 7]}, 0);
+        assert!(&s2 == &SomeStruct { f: 2, v: vector[3, 4]}, 1);
+
+        swap(&mut s1.f, &mut a);
+        assert!(s1.f == 1, 2);
+        assert!(a == 5, 3);
+
+        swap(&mut s1.f, vector::borrow_mut(&mut s1.v, 0));
+        assert!(s1.f == 6, 4);
+        assert!(vector::borrow(&s1.v, 0) == &1, 5);
+
+        swap(&mut s2, vector::borrow_mut(&mut vs, 0));
+        assert!(&s2 == &SomeStruct { f: 8, v: vector[9, 10]}, 6);
+        assert!(vector::borrow(&vs, 0) == &SomeStruct { f: 2, v: vector[3, 4]}, 7);
+    }
+}

--- a/aptos-move/framework/move-stdlib/tests/vector_tests.move
+++ b/aptos-move/framework/move-stdlib/tests/vector_tests.move
@@ -954,4 +954,39 @@ module std::vector_tests {
         let v = vector[MoveOnly {}];
         vector::destroy(v, |m| { let MoveOnly {} = m; })
     }
+
+    #[test]
+    #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
+    fun test_replace_empty_abort() {
+        let v = vector[];
+        let MoveOnly {} = vector::replace(&mut v, 0, MoveOnly {});
+        vector::destroy_empty(v);
+    }
+
+    #[test]
+    fun test_replace() {
+        let v = vector[1, 2, 3, 4];
+        vector::replace(&mut v, 1, 17);
+        assert!(v == vector[1, 17, 3, 4], 0);
+    }
+
+    #[test]
+    fun test_split_off() {
+        let v = vector[1, 2, 3, 4, 5, 6];
+        let other = vector::split_off(&mut v, 4);
+        assert!(v == vector[1, 2, 3, 4], 0);
+        assert!(other == vector[5, 6], 1);
+
+        let other_empty = vector::split_off(&mut v, 4);
+        assert!(v == vector[1, 2, 3, 4], 2);
+        assert!(other_empty == vector[], 3);
+
+    }
+
+    #[test]
+    #[expected_failure(abort_code = V::EINDEX_OUT_OF_BOUNDS)]
+    fun test_split_off_abort() {
+        let v = vector[1, 2, 3];
+        vector::split_off(&mut v, 4);
+    }
 }


### PR DESCRIPTION
## Description
When we store un-drop-able objects in a vector, handling changes to vector needs to be done without dropping any elements in the process (or creating temporary ones).

Adding two missing utilities to help with that:
* split_off - which moves part of the vector into a new vector
* replace - which replaces value at particular index. 

Both could have more efficient implementations, if implemented in rust. But seems like that is the case for many functions in vector.move, so starting with straightforward implementation.

## How Has This Been Tested?
provided unit tests

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Aptos Framework

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
