### PR TITLE
[mempool] move the qs callback to be after mempool

### DIFF
--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -315,6 +315,7 @@ impl StateComputer for ExecutionProxy {
 
         let blocks = blocks.to_vec();
         let wrapped_callback = move || {
+            payload_manager.notify_commit(block_timestamp, payloads);
             callback(&blocks, finality_proof);
         };
         self.async_state_sync_notifier
@@ -324,7 +325,6 @@ impl StateComputer for ExecutionProxy {
             .expect("Failed to send async state sync notification");
 
         *latest_logical_time = logical_time;
-        payload_manager.notify_commit(block_timestamp, payloads);
         Ok(())
     }
 


### PR DESCRIPTION
this commit guarantees the garbage collection order of mempool -> quorum store -> block store.