### PR TITLE
[movefmt][trivial] format move files in the `tests` and `examples` folder

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- `aptos move fmt` formats move files inside the `tests` and `examples` directory of a package.
 
 ## [4.2.3] - 2024/09/20
 - Fix the broken indexer in localnet in 4.2.2, which migrates table info from sycn to async ways.

--- a/crates/aptos/src/move_tool/fmt.rs
+++ b/crates/aptos/src/move_tool/fmt.rs
@@ -125,6 +125,14 @@ impl FmtCommand {
             if scripts_path.exists() {
                 path_vec.push(scripts_path.clone());
             }
+            let tests_path = root_package_path.join(SourcePackageLayout::Tests.path());
+            if tests_path.exists() {
+                path_vec.push(tests_path.clone());
+            }
+            let examples_path = root_package_path.join(SourcePackageLayout::Examples.path());
+            if examples_path.exists() {
+                path_vec.push(examples_path.clone());
+            }
             if let Ok(move_sources) = find_move_filenames(&path_vec, false) {
                 for source in &move_sources {
                     let mut cur_cmd = create_cmd();


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR includes move files inside `tests` and `examples` as the format target when executing `aptos move fmt`.
Close #14776

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Manual test


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
