### PR TITLE
test w/o verify

### DIFF
--- a/consensus/src/consensus_observer/network/observer_message.rs
+++ b/consensus/src/consensus_observer/network/observer_message.rs
@@ -663,6 +663,7 @@ impl BlockPayload {
 
     /// Verifies the block payload digests and returns an error if the data is invalid
     pub fn verify_payload_digests(&self) -> Result<(), Error> {
+        return Ok(());
         // Get the transactions, payload proofs and inline batches
         let transactions = self.transaction_payload.transactions();
         let payload_proofs = self.transaction_payload.payload_proofs();
@@ -718,21 +719,21 @@ impl BlockPayload {
     /// to the current epoch state. Returns an error if the data is invalid.
     pub fn verify_payload_signatures(&self, epoch_state: &EpochState) -> Result<(), Error> {
         // Create a dummy proof cache to verify the proofs
-        let proof_cache = ProofCache::new(1);
+        // let proof_cache = ProofCache::new(1);
 
         // TODO: parallelize the verification of the proof signatures!
 
         // Verify each of the proof signatures
-        let validator_verifier = &epoch_state.verifier;
-        for proof_of_store in &self.transaction_payload.payload_proofs() {
-            if let Err(error) = proof_of_store.verify(validator_verifier, &proof_cache) {
-                return Err(Error::InvalidMessageError(format!(
-                    "Failed to verify the proof of store for batch: {:?}, Error: {:?}",
-                    proof_of_store.info(),
-                    error
-                )));
-            }
-        }
+        // let validator_verifier = &epoch_state.verifier;
+        // for proof_of_store in &self.transaction_payload.payload_proofs() {
+        // if let Err(error) = proof_of_store.verify(validator_verifier, &proof_cache) {
+        //     return Err(Error::InvalidMessageError(format!(
+        //         "Failed to verify the proof of store for batch: {:?}, Error: {:?}",
+        //         proof_of_store.info(),
+        //         error
+        //     )));
+        // }
+        // }
 
         Ok(()) // All proofs are correctly signed
     }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
