### PR TITLE
Replace EpochState with Arc<EpochState>

### DIFF
--- a/consensus/src/block_storage/block_store_test.rs
+++ b/consensus/src/block_storage/block_store_test.rs
@@ -23,10 +23,11 @@ use aptos_consensus_types::{
 };
 use aptos_crypto::{HashValue, PrivateKey};
 use aptos_types::{
-    validator_signer::ValidatorSigner, validator_verifier::random_validator_verifier,
+    epoch_state::EpochState, validator_signer::ValidatorSigner,
+    validator_verifier::random_validator_verifier,
 };
 use proptest::prelude::*;
-use std::{cmp::min, collections::HashSet};
+use std::{cmp::min, collections::HashSet, sync::Arc};
 
 #[tokio::test]
 async fn test_highest_block_and_quorum_cert() {
@@ -274,6 +275,7 @@ async fn test_insert_vote() {
     ::aptos_logger::Logger::init_for_testing();
     // Set up enough different authors to support different votes for the same block.
     let (signers, validator_verifier) = random_validator_verifier(11, Some(10), false);
+    let epoch_state = Arc::new(EpochState::new(1, validator_verifier));
     let my_signer = signers[10].clone();
     let mut inserter = TreeInserter::new(my_signer);
     let block_store = inserter.block_store();
@@ -300,13 +302,13 @@ async fn test_insert_vote() {
             voter,
         )
         .unwrap();
-        let vote_res = pending_votes.insert_vote(&vote, &validator_verifier);
+        let vote_res = pending_votes.insert_vote(&vote, epoch_state.clone());
 
         // first vote of an author is accepted
         assert_eq!(vote_res, VoteReceptionResult::VoteAdded(i as u128));
         // filter out duplicates
         assert_eq!(
-            pending_votes.insert_vote(&vote, &validator_verifier),
+            pending_votes.insert_vote(&vote, epoch_state.clone()),
             VoteReceptionResult::DuplicateVote,
         );
         // qc is still not there
@@ -329,7 +331,7 @@ async fn test_insert_vote() {
         final_voter,
     )
     .unwrap();
-    match pending_votes.insert_vote(&vote, &validator_verifier) {
+    match pending_votes.insert_vote(&vote, epoch_state.clone()) {
         VoteReceptionResult::NewQuorumCertificate(qc) => {
             assert_eq!(qc.certified_block().id(), block.id());
             block_store

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -244,9 +244,9 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         }
     }
 
-    fn epoch_state(&self) -> &EpochState {
+    fn epoch_state(&self) -> Arc<EpochState> {
         self.epoch_state
-            .as_ref()
+            .clone()
             .expect("EpochManager not started yet")
     }
 
@@ -270,7 +270,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
     /// Create a proposer election handler based on proposers
     fn create_proposer_election(
         &self,
-        epoch_state: &EpochState,
+        epoch_state: Arc<EpochState>,
         onchain_config: &OnChainConsensusConfig,
     ) -> Arc<dyn ProposerElection + Send + Sync> {
         let proposers = epoch_state
@@ -343,7 +343,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 };
 
                 let epoch_to_proposers = self.extract_epoch_proposers(
-                    epoch_state,
+                    epoch_state.clone(),
                     use_history_from_previous_epoch_max_count,
                     proposers,
                     (window_size + seek_len) as u64,
@@ -392,7 +392,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
     fn extract_epoch_proposers(
         &self,
-        epoch_state: &EpochState,
+        epoch_state: Arc<EpochState>,
         use_history_from_previous_epoch_max_count: u32,
         proposers: Vec<AccountAddress>,
         needed_rounds: u64,
@@ -527,7 +527,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
     async fn initiate_new_epoch(&mut self, proof: EpochChangeProof) -> anyhow::Result<()> {
         let ledger_info = proof
-            .verify(self.epoch_state())
+            .verify(self.epoch_state().as_ref())
             .context("[EpochManager] Invalid EpochChangeProof")?;
         info!(
             LogSchema::new(LogEvent::NewEpoch).epoch(ledger_info.ledger_info().next_block_epoch()),
@@ -663,7 +663,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
     async fn init_payload_provider(
         &mut self,
-        epoch_state: &EpochState,
+        epoch_state: Arc<EpochState>,
         network_sender: NetworkSender,
         consensus_config: &OnChainConsensusConfig,
     ) -> (
@@ -684,16 +684,14 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         let mut quorum_store_builder = if self.quorum_store_enabled {
             info!("Building QuorumStore");
             QuorumStoreBuilder::QuorumStore(InnerBuilder::new(
-                self.epoch(),
                 self.author,
-                epoch_state.verifier.len() as u64,
                 quorum_store_config,
                 consensus_to_quorum_store_rx,
                 self.quorum_store_to_mempool_sender.clone(),
                 self.config.mempool_txn_pull_timeout_ms,
                 self.storage.aptos_db().clone(),
                 network_sender,
-                epoch_state.verifier.clone(),
+                epoch_state.clone(),
                 self.proof_cache.clone(),
                 self.config.safety_rules.backend.clone(),
                 self.quorum_store_storage.clone(),
@@ -722,7 +720,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         (payload_manager, payload_client, quorum_store_builder)
     }
 
-    fn set_epoch_start_metrics(&self, epoch_state: &EpochState) {
+    fn set_epoch_start_metrics(&self, epoch_state: Arc<EpochState>) {
         counters::EPOCH.set(epoch_state.epoch as i64);
         counters::CURRENT_EPOCH_VALIDATORS.set(epoch_state.verifier.len() as i64);
 
@@ -785,7 +783,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
         info!(epoch = epoch, "Create ProposerElection");
         let proposer_election =
-            self.create_proposer_election(&epoch_state, &onchain_consensus_config);
+            self.create_proposer_election(epoch_state.clone(), &onchain_consensus_config);
         let chain_health_backoff_config =
             ChainHealthBackoffConfig::new(self.config.chain_health_backoff.clone());
         let pipeline_backpressure_config = PipelineBackpressureConfig::new(
@@ -907,7 +905,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         }
     }
 
-    fn create_network_sender(&mut self, epoch_state: &EpochState) -> NetworkSender {
+    fn create_network_sender(&mut self, epoch_state: Arc<EpochState>) -> NetworkSender {
         NetworkSender::new(
             self.author,
             self.network_sender.clone(),
@@ -919,7 +917,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
     fn try_get_rand_config_for_new_epoch(
         &self,
         maybe_consensus_key: Option<Arc<PrivateKey>>,
-        new_epoch_state: &EpochState,
+        new_epoch_state: Arc<EpochState>,
         onchain_randomness_config: &OnChainRandomnessConfig,
         maybe_dkg_state: anyhow::Result<DKGState>,
         consensus_config: &OnChainConsensusConfig,
@@ -1130,7 +1128,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
         let rand_configs = self.try_get_rand_config_for_new_epoch(
             loaded_consensus_key.clone(),
-            &epoch_state,
+            epoch_state.clone(),
             &onchain_randomness_config,
             dkg_state,
             &consensus_config,
@@ -1162,7 +1160,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         );
 
         let (network_sender, payload_client, payload_manager) = self
-            .initialize_shared_component(&epoch_state, &consensus_config)
+            .initialize_shared_component(epoch_state.clone(), &consensus_config)
             .await;
 
         let (rand_msg_tx, rand_msg_rx) = aptos_channel::new::<AccountAddress, IncomingRandGenRequest>(
@@ -1175,7 +1173,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
         if consensus_config.is_dag_enabled() {
             self.start_new_epoch_with_dag(
-                epoch_state,
+                epoch_state.clone(),
                 loaded_consensus_key.clone(),
                 consensus_config,
                 execution_config,
@@ -1210,16 +1208,16 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
     async fn initialize_shared_component(
         &mut self,
-        epoch_state: &EpochState,
+        epoch_state: Arc<EpochState>,
         consensus_config: &OnChainConsensusConfig,
     ) -> (
         NetworkSender,
         Arc<dyn PayloadClient>,
         Arc<dyn TPayloadManager>,
     ) {
-        self.set_epoch_start_metrics(epoch_state);
+        self.set_epoch_start_metrics(epoch_state.clone());
         self.quorum_store_enabled = self.enable_quorum_store(consensus_config);
-        let network_sender = self.create_network_sender(epoch_state);
+        let network_sender = self.create_network_sender(epoch_state.clone());
         let (payload_manager, quorum_store_client, quorum_store_builder) = self
             .init_payload_provider(epoch_state, network_sender.clone(), consensus_config)
             .await;
@@ -1340,7 +1338,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
 
         let onchain_dag_consensus_config = onchain_consensus_config.unwrap_dag_config_v1();
         let epoch_to_validators = self.extract_epoch_proposers(
-            &epoch_state,
+            epoch_state.clone(),
             onchain_dag_consensus_config.dag_ordering_causal_history_window as u32,
             epoch_state.verifier.get_ordered_account_addresses(),
             onchain_dag_consensus_config.dag_ordering_causal_history_window as u64,

--- a/consensus/src/liveness/round_state.rs
+++ b/consensus/src/liveness/round_state.rs
@@ -13,9 +13,7 @@ use aptos_consensus_types::{
 };
 use aptos_crypto::HashValue;
 use aptos_logger::{prelude::*, Schema};
-use aptos_types::{
-    ledger_info::LedgerInfoWithVerifiedSignatures, validator_verifier::ValidatorVerifier,
-};
+use aptos_types::{epoch_state::EpochState, ledger_info::LedgerInfoWithVerifiedSignatures};
 use futures::future::AbortHandle;
 use serde::Serialize;
 use std::{fmt, sync::Arc, time::Duration};
@@ -275,10 +273,10 @@ impl RoundState {
     pub fn insert_vote(
         &mut self,
         vote: &Vote,
-        verifier: &ValidatorVerifier,
+        epoch_state: Arc<EpochState>,
     ) -> VoteReceptionResult {
         if vote.vote_data().proposed().round() == self.current_round {
-            self.pending_votes.insert_vote(vote, verifier)
+            self.pending_votes.insert_vote(vote, epoch_state)
         } else {
             VoteReceptionResult::UnexpectedRound(
                 vote.vote_data().proposed().round(),

--- a/consensus/src/pending_order_votes.rs
+++ b/consensus/src/pending_order_votes.rs
@@ -7,8 +7,9 @@ use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_logger::prelude::*;
 use aptos_types::{
     aggregate_signature::PartialSignatures,
+    epoch_state::EpochState,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures, LedgerInfoWithVerifiedSignatures},
-    validator_verifier::{ValidatorVerifier, VerifyError},
+    validator_verifier::VerifyError,
 };
 use std::{collections::HashMap, sync::Arc};
 
@@ -62,7 +63,7 @@ impl PendingOrderVotes {
     pub fn insert_order_vote(
         &mut self,
         order_vote: &OrderVote,
-        validator_verifier: &ValidatorVerifier,
+        epoch_state: Arc<EpochState>,
         verified_quorum_cert: Option<QuorumCert>,
     ) -> OrderVoteReceptionResult {
         // derive data from order vote
@@ -93,7 +94,7 @@ impl PendingOrderVotes {
             OrderVoteStatus::NotEnoughVotes(li_with_sig) => {
                 // we don't have enough votes for this ledger info yet
                 let validator_voting_power =
-                    validator_verifier.get_voting_power(&order_vote.author());
+                    epoch_state.verifier.get_voting_power(&order_vote.author());
                 if validator_voting_power.is_none() {
                     warn!(
                         "Received order vote from an unknown author: {}",
@@ -112,14 +113,17 @@ impl PendingOrderVotes {
                 }
                 li_with_sig.add_signature(order_vote.author(), order_vote.signature().clone());
                 // check if we have enough signatures to create a QC
-                match validator_verifier.check_voting_power(li_with_sig.signatures().keys(), true) {
+                match epoch_state
+                    .verifier
+                    .check_voting_power(li_with_sig.signatures().keys(), true)
+                {
                     // a quorum of signature was reached, a new QC is formed
                     Ok(aggregated_voting_power) => {
                         assert!(
-                            aggregated_voting_power >= validator_verifier.quorum_voting_power(),
+                            aggregated_voting_power >= epoch_state.verifier.quorum_voting_power(),
                             "QC aggregation should not be triggered if we don't have enough votes to form a QC"
                         );
-                        match li_with_sig.aggregate_signatures(validator_verifier) {
+                        match li_with_sig.aggregate_signatures(&epoch_state.verifier) {
                             Ok(ledger_info_with_sig) => {
                                 *status =
                                     OrderVoteStatus::EnoughVotes(ledger_info_with_sig.clone());
@@ -179,9 +183,10 @@ mod tests {
     use aptos_consensus_types::{order_vote::OrderVote, quorum_cert::QuorumCert};
     use aptos_crypto::HashValue;
     use aptos_types::{
-        block_info::BlockInfo, ledger_info::LedgerInfo,
+        block_info::BlockInfo, epoch_state::EpochState, ledger_info::LedgerInfo,
         validator_verifier::random_validator_verifier,
     };
+    use std::sync::Arc;
 
     /// Creates a random ledger info for epoch 1 and round 1.
     fn random_ledger_info() -> LedgerInfo {
@@ -196,7 +201,7 @@ mod tests {
         ::aptos_logger::Logger::init_for_testing();
         // set up 4 validators
         let (signers, validator) = random_validator_verifier(4, Some(2), false);
-
+        let epoch_state = Arc::new(EpochState::new(1, validator.clone()));
         let mut pending_order_votes = PendingOrderVotes::new();
 
         // create random vote from validator[0]
@@ -212,7 +217,7 @@ mod tests {
         assert_eq!(
             pending_order_votes.insert_order_vote(
                 &order_vote_1_author_0,
-                &validator,
+                epoch_state.clone(),
                 Some(qc.clone())
             ),
             OrderVoteReceptionResult::VoteAdded(1),
@@ -222,7 +227,7 @@ mod tests {
         assert_eq!(
             pending_order_votes.insert_order_vote(
                 &order_vote_1_author_0,
-                &validator,
+                epoch_state.clone(),
                 Some(qc.clone())
             ),
             OrderVoteReceptionResult::VoteAdded(1)
@@ -238,7 +243,7 @@ mod tests {
         assert_eq!(
             pending_order_votes.insert_order_vote(
                 &order_vote_2_author_1,
-                &validator,
+                epoch_state.clone(),
                 Some(qc.clone())
             ),
             OrderVoteReceptionResult::VoteAdded(1),
@@ -254,11 +259,13 @@ mod tests {
         );
         match pending_order_votes.insert_order_vote(
             &order_vote_2_author_2,
-            &validator,
+            epoch_state.clone(),
             Some(qc.clone()),
         ) {
             OrderVoteReceptionResult::NewLedgerInfoWithSignatures((_, li_with_sig)) => {
-                assert!(li_with_sig.check_voting_power(&validator).is_ok());
+                assert!(li_with_sig
+                    .check_voting_power(&epoch_state.verifier)
+                    .is_ok());
             },
             _ => {
                 panic!("No QC formed.");

--- a/consensus/src/quorum_store/batch_requester.rs
+++ b/consensus/src/quorum_store/batch_requester.rs
@@ -13,7 +13,7 @@ use aptos_consensus_types::proof_of_store::BatchInfo;
 use aptos_crypto::HashValue;
 use aptos_executor_types::*;
 use aptos_logger::prelude::*;
-use aptos_types::{transaction::SignedTransaction, validator_verifier::ValidatorVerifier, PeerId};
+use aptos_types::{epoch_state::EpochState, transaction::SignedTransaction, PeerId};
 use futures::{stream::FuturesUnordered, StreamExt};
 use rand::Rng;
 use std::{sync::Arc, time::Duration};
@@ -95,36 +95,33 @@ impl BatchRequesterState {
 }
 
 pub(crate) struct BatchRequester<T> {
-    epoch: u64,
     my_peer_id: PeerId,
     request_num_peers: usize,
     retry_limit: usize,
     retry_interval_ms: usize,
     rpc_timeout_ms: usize,
     network_sender: T,
-    validator_verifier: Arc<ValidatorVerifier>,
+    epoch_state: Arc<EpochState>,
 }
 
 impl<T: QuorumStoreSender + Sync + 'static> BatchRequester<T> {
     pub(crate) fn new(
-        epoch: u64,
         my_peer_id: PeerId,
         request_num_peers: usize,
         retry_limit: usize,
         retry_interval_ms: usize,
         rpc_timeout_ms: usize,
         network_sender: T,
-        validator_verifier: ValidatorVerifier,
+        epoch_state: Arc<EpochState>,
     ) -> Self {
         Self {
-            epoch,
             my_peer_id,
             request_num_peers,
             retry_limit,
             retry_interval_ms,
             rpc_timeout_ms,
             network_sender,
-            validator_verifier: Arc::new(validator_verifier),
+            epoch_state,
         }
     }
 
@@ -136,12 +133,12 @@ impl<T: QuorumStoreSender + Sync + 'static> BatchRequester<T> {
         ret_tx: oneshot::Sender<ExecutorResult<Vec<SignedTransaction>>>,
         mut subscriber_rx: oneshot::Receiver<PersistedValue>,
     ) -> Option<(BatchInfo, Vec<SignedTransaction>)> {
-        let validator_verifier = self.validator_verifier.clone();
+        let epoch_state = self.epoch_state.clone();
         let mut request_state = BatchRequesterState::new(responders, ret_tx, self.retry_limit);
         let network_sender = self.network_sender.clone();
         let request_num_peers = self.request_num_peers;
         let my_peer_id = self.my_peer_id;
-        let epoch = self.epoch;
+        let epoch = self.epoch_state.epoch;
         let retry_interval = Duration::from_millis(self.retry_interval_ms as u64);
         let rpc_timeout = Duration::from_millis(self.rpc_timeout_ms as u64);
 
@@ -177,7 +174,7 @@ impl<T: QuorumStoreSender + Sync + 'static> BatchRequester<T> {
                                 counters::RECEIVED_BATCH_NOT_FOUND_COUNT.inc();
                                 if ledger_info.commit_info().epoch() == epoch
                                     && ledger_info.commit_info().timestamp_usecs() > expiration
-                                    && ledger_info.verify_signatures(&validator_verifier).is_ok()
+                                    && ledger_info.verify_signatures(&epoch_state.verifier).is_ok()
                                 {
                                     counters::RECEIVED_BATCH_EXPIRED_COUNT.inc();
                                     debug!("QS: batch request expired, digest:{}", digest);

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -34,8 +34,7 @@ use aptos_mempool::QuorumStoreRequest;
 use aptos_secure_storage::{KVStorage, Storage};
 use aptos_storage_interface::DbReader;
 use aptos_types::{
-    account_address::AccountAddress, validator_signer::ValidatorSigner,
-    validator_verifier::ValidatorVerifier,
+    account_address::AccountAddress, epoch_state::EpochState, validator_signer::ValidatorSigner,
 };
 use futures::StreamExt;
 use futures_channel::mpsc::{Receiver, Sender};
@@ -118,16 +117,14 @@ impl DirectMempoolInnerBuilder {
 
 // TODO: push most things to config
 pub struct InnerBuilder {
-    epoch: u64,
     author: Author,
-    num_validators: u64,
     config: QuorumStoreConfig,
     consensus_to_quorum_store_receiver: Receiver<GetPayloadCommand>,
     quorum_store_to_mempool_sender: Sender<QuorumStoreRequest>,
     mempool_txn_pull_timeout_ms: u64,
     aptos_db: Arc<dyn DbReader>,
     network_sender: NetworkSender,
-    verifier: ValidatorVerifier,
+    epoch_state: Arc<EpochState>,
     proof_cache: ProofCache,
     backend: SecureBackend,
     coordinator_tx: Sender<CoordinatorCommand>,
@@ -152,16 +149,14 @@ pub struct InnerBuilder {
 
 impl InnerBuilder {
     pub(crate) fn new(
-        epoch: u64,
         author: Author,
-        num_validators: u64,
         config: QuorumStoreConfig,
         consensus_to_quorum_store_receiver: Receiver<GetPayloadCommand>,
         quorum_store_to_mempool_sender: Sender<QuorumStoreRequest>,
         mempool_txn_pull_timeout_ms: u64,
         aptos_db: Arc<dyn DbReader>,
         network_sender: NetworkSender,
-        verifier: ValidatorVerifier,
+        epoch_state: Arc<EpochState>,
         proof_cache: ProofCache,
         backend: SecureBackend,
         quorum_store_storage: Arc<dyn QuorumStoreStorage>,
@@ -191,16 +186,14 @@ impl InnerBuilder {
         }
 
         Self {
-            epoch,
             author,
-            num_validators,
             config,
             consensus_to_quorum_store_receiver,
             quorum_store_to_mempool_sender,
             mempool_txn_pull_timeout_ms,
             aptos_db,
             network_sender,
-            verifier,
+            epoch_state,
             proof_cache,
             backend,
             coordinator_tx,
@@ -243,17 +236,16 @@ impl InnerBuilder {
         let last_committed_timestamp = latest_ledger_info_with_sigs.commit_info().timestamp_usecs();
 
         let batch_requester = BatchRequester::new(
-            self.epoch,
             self.author,
             self.config.batch_request_num_peers,
             self.config.batch_request_retry_limit,
             self.config.batch_request_retry_interval_ms,
             self.config.batch_request_rpc_timeout_ms,
             self.network_sender.clone(),
-            self.verifier.clone(),
+            self.epoch_state.clone(),
         );
         let batch_store = Arc::new(BatchStore::new(
-            self.epoch,
+            self.epoch_state.epoch,
             last_committed_timestamp,
             self.quorum_store_storage.clone(),
             self.config.memory_quota,
@@ -297,7 +289,7 @@ impl InnerBuilder {
         let batch_generator_cmd_rx = self.batch_generator_cmd_rx.take().unwrap();
         let back_pressure_rx = self.back_pressure_rx.take().unwrap();
         let batch_generator = BatchGenerator::new(
-            self.epoch,
+            self.epoch_state.epoch,
             self.author,
             self.config.clone(),
             self.quorum_store_storage.clone(),
@@ -351,7 +343,7 @@ impl InnerBuilder {
             proof_coordinator.start(
                 proof_coordinator_cmd_rx,
                 self.network_sender.clone(),
-                self.verifier.clone(),
+                self.epoch_state.clone(),
             )
         );
 
@@ -362,7 +354,7 @@ impl InnerBuilder {
             self.config
                 .back_pressure
                 .backlog_per_validator_batch_limit_count
-                * self.num_validators,
+                * (self.epoch_state.verifier.len() as u64),
             self.batch_store.clone().unwrap(),
             self.config.allow_batches_without_pos_in_proposal,
             self.config.enable_opt_quorum_store,
@@ -386,7 +378,7 @@ impl InnerBuilder {
         spawn_named!("network_listener", net.start());
 
         let batch_store = self.batch_store.clone().unwrap();
-        let epoch = self.epoch;
+        let epoch = self.epoch_state.epoch;
         let (batch_retrieval_tx, mut batch_retrieval_rx) =
             aptos_channel::new::<AccountAddress, IncomingBatchRetrievalRequest>(
                 QueueStyle::LIFO,
@@ -445,7 +437,7 @@ impl InnerBuilder {
                 // TODO: remove after splitting out clean requests
                 self.coordinator_tx.clone(),
                 consensus_publisher,
-                self.verifier.get_ordered_account_addresses(),
+                self.epoch_state.verifier.get_ordered_account_addresses(),
             )),
             Some(self.quorum_store_msg_tx.clone()),
         )

--- a/consensus/src/quorum_store/tests/batch_requester_test.rs
+++ b/consensus/src/quorum_store/tests/batch_requester_test.rs
@@ -16,12 +16,16 @@ use aptos_crypto::HashValue;
 use aptos_types::{
     aggregate_signature::PartialSignatures,
     block_info::BlockInfo,
+    epoch_state::EpochState,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     validator_signer::ValidatorSigner,
     validator_verifier::{ValidatorConsensusInfo, ValidatorVerifier},
 };
 use move_core_types::account_address::AccountAddress;
-use std::time::{Duration, Instant};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tokio::sync::oneshot;
 
 #[derive(Clone)]
@@ -81,15 +85,18 @@ async fn test_batch_request_exists() {
 
     let validator_signer = ValidatorSigner::random(None);
     let (tx, mut rx) = tokio::sync::oneshot::channel();
-    let batch_requester = BatchRequester::new(
+    let epoch_state = Arc::new(EpochState::new(
         1,
+        ValidatorVerifier::new_single(validator_signer.author(), validator_signer.public_key()),
+    ));
+    let batch_requester = BatchRequester::new(
         AccountAddress::random(),
         1,
         2,
         1_000,
         1_000,
         MockBatchRequester::new(batch_response),
-        ValidatorVerifier::new_single(validator_signer.author(), validator_signer.public_key()),
+        epoch_state,
     );
 
     let (_, subscriber_rx) = oneshot::channel();
@@ -176,15 +183,15 @@ async fn test_batch_request_not_exists_not_expired() {
     );
     let (tx, mut rx) = tokio::sync::oneshot::channel();
     let batch_response = BatchResponse::NotFound(ledger_info_with_signatures);
+    let epoch_state = Arc::new(EpochState::new(1, validator_verifier));
     let batch_requester = BatchRequester::new(
-        1,
         AccountAddress::random(),
         1,
         2,
         retry_interval_ms,
         1_000,
         MockBatchRequester::new(batch_response),
-        validator_verifier,
+        epoch_state,
     );
 
     let request_start = Instant::now();
@@ -224,15 +231,15 @@ async fn test_batch_request_not_exists_expired() {
     );
     let (tx, mut rx) = tokio::sync::oneshot::channel();
     let batch_response = BatchResponse::NotFound(ledger_info_with_signatures);
+    let epoch_state = Arc::new(EpochState::new(1, validator_verifier));
     let batch_requester = BatchRequester::new(
-        1,
         AccountAddress::random(),
         1,
         2,
         retry_interval_ms,
         1_000,
         MockBatchRequester::new(batch_response),
-        validator_verifier,
+        epoch_state,
     );
 
     let request_start = Instant::now();

--- a/consensus/src/quorum_store/tests/proof_coordinator_test.rs
+++ b/consensus/src/quorum_store/tests/proof_coordinator_test.rs
@@ -14,7 +14,8 @@ use aptos_consensus_types::proof_of_store::{BatchId, SignedBatchInfo, SignedBatc
 use aptos_crypto::HashValue;
 use aptos_executor_types::ExecutorResult;
 use aptos_types::{
-    transaction::SignedTransaction, validator_verifier::random_validator_verifier, PeerId,
+    epoch_state::EpochState, transaction::SignedTransaction,
+    validator_verifier::random_validator_verifier, PeerId,
 };
 use mini_moka::sync::Cache;
 use std::sync::Arc;
@@ -47,6 +48,7 @@ impl BatchReader for MockBatchReader {
 async fn test_proof_coordinator_basic() {
     aptos_logger::Logger::init_for_testing();
     let (signers, verifier) = random_validator_verifier(4, None, true);
+    let epoch_state = Arc::new(EpochState::new(1, verifier));
     let (tx, _rx) = channel(100);
     let proof_cache = Cache::builder().build();
     let proof_coordinator = ProofCoordinator::new(
@@ -62,7 +64,11 @@ async fn test_proof_coordinator_basic() {
     let (proof_coordinator_tx, proof_coordinator_rx) = channel(100);
     let (tx, mut rx) = channel(100);
     let network_sender = MockQuorumStoreSender::new(tx);
-    tokio::spawn(proof_coordinator.start(proof_coordinator_rx, network_sender, verifier.clone()));
+    tokio::spawn(proof_coordinator.start(
+        proof_coordinator_rx,
+        network_sender,
+        epoch_state.clone(),
+    ));
 
     let batch_author = signers[0].author();
     let batch_id = BatchId::new_for_test(1);
@@ -85,7 +91,9 @@ async fn test_proof_coordinator_basic() {
         msg => panic!("Expected LocalProof but received: {:?}", msg),
     };
     // check normal path
-    assert!(proof_msg.verify(100, &verifier, &proof_cache).is_ok());
+    assert!(proof_msg
+        .verify(100, &epoch_state.verifier, &proof_cache)
+        .is_ok());
     let proofs = proof_msg.take();
     assert_eq!(proofs[0].digest(), digest);
 }

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -1104,13 +1104,13 @@ impl RoundManager {
                         .observe(start.elapsed().as_secs_f64());
                     self.pending_order_votes.insert_order_vote(
                         order_vote_msg.order_vote(),
-                        &self.epoch_state.verifier,
+                        self.epoch_state.clone(),
                         Some(order_vote_msg.quorum_cert().clone()),
                     )
                 } else {
                     self.pending_order_votes.insert_order_vote(
                         order_vote_msg.order_vote(),
-                        &self.epoch_state.verifier,
+                        self.epoch_state.clone(),
                         None,
                     )
                 };
@@ -1248,9 +1248,7 @@ impl RoundManager {
         {
             return Ok(());
         }
-        let vote_reception_result = self
-            .round_state
-            .insert_vote(vote, &self.epoch_state.verifier);
+        let vote_reception_result = self.round_state.insert_vote(vote, self.epoch_state.clone());
         self.process_vote_reception_result(vote, vote_reception_result)
             .await
     }


### PR DESCRIPTION
## Description
In the optimistic signature verification feature, we add the list of malicious authors to validator verifier when a signature verification fails. The other components utilize this data. We need to make sure different components see the same version of validator verifier. Using Arc<EpochState> instead of EpochState to achieve this.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
