### PR TITLE
[release builder] fix framework upgrade ordering (main)

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/framework.rs
+++ b/aptos-move/aptos-release-builder/src/components/framework.rs
@@ -61,7 +61,7 @@ pub fn generate_upgrade_proposals(
     // For generating multi-step proposal files, we need to generate them in the reverse order since
     // we need the hash of the next script.
     // We will reverse the order back when writing the files into a directory.
-    if next_execution_hash.is_some() {
+    if is_multi_step {
         package_path_list.reverse();
     }
 


### PR DESCRIPTION
This fixes a bug in the release builder that results in the framework upgrade scripts being generated in reverse order.