### PR TITLE
[move-vm] Fix a bug in order of bounds checking

### DIFF
--- a/third_party/move/move-binary-format/src/check_bounds.rs
+++ b/third_party/move/move-binary-format/src/check_bounds.rs
@@ -97,8 +97,6 @@ impl<'a> BoundsChecker<'a> {
         self.check_function_instantiations()?;
         self.check_field_instantiations()?;
         self.check_struct_defs()?;
-        self.check_function_defs()?;
-        // Since bytecode version 7
         self.check_table(
             self.view.variant_field_handles(),
             Self::check_variant_field_handle,
@@ -115,6 +113,7 @@ impl<'a> BoundsChecker<'a> {
             self.view.struct_variant_instantiations(),
             Self::check_struct_variant_instantiation,
         )?;
+        self.check_function_defs()?;
         Ok(())
     }
 

--- a/third_party/move/move-bytecode-verifier/src/check_duplication.rs
+++ b/third_party/move/move-bytecode-verifier/src/check_duplication.rs
@@ -30,12 +30,7 @@ pub struct DuplicationChecker<'a> {
 
 impl<'a> DuplicationChecker<'a> {
     pub fn verify_module(module: &'a CompiledModule) -> VMResult<()> {
-        let res = Self::verify_module_impl(module)
-            .map_err(|e| e.finish(Location::Module(module.self_id())));
-        if let Err(e) = res.clone() {
-            println!("error: {}", e)
-        }
-        res
+        Self::verify_module_impl(module).map_err(|e| e.finish(Location::Module(module.self_id())))
     }
 
     fn verify_module_impl(module: &'a CompiledModule) -> PartialVMResult<()> {


### PR DESCRIPTION
## Description

Fixed ordering of bounds checking, remove obsolete debug print.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

