### PR TITLE
always trigger epoch switch in block prologue

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -131,6 +131,7 @@ pub enum FeatureFlag {
     FederatedKeyless,
     TransactionSimulationEnhancement,
     CollectionOwner,
+    AsyncReconfigFramework,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -347,6 +348,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
                 AptosFeatureFlag::TRANSACTION_SIMULATION_ENHANCEMENT
             },
             FeatureFlag::CollectionOwner => AptosFeatureFlag::COLLECTION_OWNER,
+            FeatureFlag::AsyncReconfigFramework => AptosFeatureFlag::ASYNC_RECONFIG_FRAMEWORK,
         }
     }
 }
@@ -490,6 +492,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::TransactionSimulationEnhancement
             },
             AptosFeatureFlag::COLLECTION_OWNER => FeatureFlag::CollectionOwner,
+            AptosFeatureFlag::ASYNC_RECONFIG_FRAMEWORK => FeatureFlag::AsyncReconfigFramework,
         }
     }
 }

--- a/aptos-move/aptos-vm/src/system_module_names.rs
+++ b/aptos-move/aptos-vm/src/system_module_names.rs
@@ -29,6 +29,15 @@ pub static BLOCK_MODULE: Lazy<ModuleId> = Lazy::new(|| {
 
 pub const BLOCK_PROLOGUE: &IdentStr = ident_str!("block_prologue");
 pub const BLOCK_PROLOGUE_EXT: &IdentStr = ident_str!("block_prologue_ext");
+pub const BLOCK_PROLOGUE_EXT_V2: &IdentStr = ident_str!("block_prologue_ext_v2");
+
+pub static DKG_MODULE: Lazy<ModuleId> = Lazy::new(|| {
+    ModuleId::new(
+        account_config::CORE_CODE_ADDRESS,
+        ident_str!("dkg").to_owned(),
+    )
+});
+pub const FINISH: &IdentStr = ident_str!("finish");
 
 pub static RECONFIGURATION_WITH_DKG_MODULE: Lazy<ModuleId> = Lazy::new(|| {
     ModuleId::new(

--- a/aptos-move/framework/aptos-framework/doc/async_reconfig.md
+++ b/aptos-move/framework/aptos-framework/doc/async_reconfig.md
@@ -1,0 +1,142 @@
+
+<a id="0x1_async_reconfig"></a>
+
+# Module `0x1::async_reconfig`
+
+Formal async reconfiguration state management to replace <code><a href="reconfiguration_with_dkg.md#0x1_reconfiguration_with_dkg">reconfiguration_with_dkg</a>.<b>move</b></code>.
+
+Every feature that requires end-of-epoch processing now has to specify the following procedures.
+- A function <code>on_async_reconfig_start()</code> to start the processing.
+- A function <code>ready_for_next_epoch()</code> to inform the framework whether the feature needs more time for processing.
+- A function  <code>on_new_epoch()</code> to clean things up right before epoch change.
+
+
+-  [Function `try_start`](#0x1_async_reconfig_try_start)
+-  [Function `force_finish`](#0x1_async_reconfig_force_finish)
+-  [Function `try_finish`](#0x1_async_reconfig_try_finish)
+
+
+<pre><code><b>use</b> <a href="consensus_config.md#0x1_consensus_config">0x1::consensus_config</a>;
+<b>use</b> <a href="dkg.md#0x1_dkg">0x1::dkg</a>;
+<b>use</b> <a href="execution_config.md#0x1_execution_config">0x1::execution_config</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
+<b>use</b> <a href="gas_schedule.md#0x1_gas_schedule">0x1::gas_schedule</a>;
+<b>use</b> <a href="jwk_consensus_config.md#0x1_jwk_consensus_config">0x1::jwk_consensus_config</a>;
+<b>use</b> <a href="jwks.md#0x1_jwks">0x1::jwks</a>;
+<b>use</b> <a href="keyless_account.md#0x1_keyless_account">0x1::keyless_account</a>;
+<b>use</b> <a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config">0x1::randomness_api_v0_config</a>;
+<b>use</b> <a href="randomness_config.md#0x1_randomness_config">0x1::randomness_config</a>;
+<b>use</b> <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum">0x1::randomness_config_seqnum</a>;
+<b>use</b> <a href="reconfiguration.md#0x1_reconfiguration">0x1::reconfiguration</a>;
+<b>use</b> <a href="reconfiguration_state.md#0x1_reconfiguration_state">0x1::reconfiguration_state</a>;
+<b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
+<b>use</b> <a href="version.md#0x1_version">0x1::version</a>;
+</code></pre>
+
+
+
+<a id="0x1_async_reconfig_try_start"></a>
+
+## Function `try_start`
+
+Trigger an async reconfig. More specifically,
+- for every feature that requires end-of-epoch processing, call its <code>on_async_reconfig_start()</code> hook.
+
+Do nothing if one is already in progress.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="async_reconfig.md#0x1_async_reconfig_try_start">try_start</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="async_reconfig.md#0x1_async_reconfig_try_start">try_start</a>() {
+    <b>if</b> (!<a href="reconfiguration_state.md#0x1_reconfiguration_state_is_in_progress">reconfiguration_state::is_in_progress</a>()) {
+        <a href="reconfiguration_state.md#0x1_reconfiguration_state_on_reconfig_start">reconfiguration_state::on_reconfig_start</a>();
+        <a href="dkg.md#0x1_dkg_on_async_reconfig_start">dkg::on_async_reconfig_start</a>();
+        // another_feature::on_async_reconfig_start();
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_async_reconfig_force_finish"></a>
+
+## Function `force_finish`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="async_reconfig.md#0x1_async_reconfig_force_finish">force_finish</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="async_reconfig.md#0x1_async_reconfig_force_finish">force_finish</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
+    <a href="dkg.md#0x1_dkg_on_new_epoch">dkg::on_new_epoch</a>(framework);
+    // another_feature::on_new_epoch(framework);
+
+    // Apply buffered config changes.
+    <a href="consensus_config.md#0x1_consensus_config_on_new_epoch">consensus_config::on_new_epoch</a>(framework);
+    <a href="execution_config.md#0x1_execution_config_on_new_epoch">execution_config::on_new_epoch</a>(framework);
+    <a href="gas_schedule.md#0x1_gas_schedule_on_new_epoch">gas_schedule::on_new_epoch</a>(framework);
+    std::version::on_new_epoch(framework);
+    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_on_new_epoch">features::on_new_epoch</a>(framework);
+    <a href="jwk_consensus_config.md#0x1_jwk_consensus_config_on_new_epoch">jwk_consensus_config::on_new_epoch</a>(framework);
+    <a href="jwks.md#0x1_jwks_on_new_epoch">jwks::on_new_epoch</a>(framework);
+    <a href="keyless_account.md#0x1_keyless_account_on_new_epoch">keyless_account::on_new_epoch</a>(framework);
+    <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_on_new_epoch">randomness_config_seqnum::on_new_epoch</a>(framework);
+    <a href="randomness_config.md#0x1_randomness_config_on_new_epoch">randomness_config::on_new_epoch</a>(framework);
+    <a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config_on_new_epoch">randomness_api_v0_config::on_new_epoch</a>(framework);
+    <a href="reconfiguration.md#0x1_reconfiguration_reconfigure">reconfiguration::reconfigure</a>();
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_async_reconfig_try_finish"></a>
+
+## Function `try_finish`
+
+Complete the current reconfiguration with DKG if possible.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="async_reconfig.md#0x1_async_reconfig_try_finish">try_finish</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="async_reconfig.md#0x1_async_reconfig_try_finish">try_finish</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
+    <b>let</b> ready_for_next_epoch = <b>true</b>;
+    ready_for_next_epoch = ready_for_next_epoch && <a href="dkg.md#0x1_dkg_ready_for_next_epoch">dkg::ready_for_next_epoch</a>();
+    // ready_for_next_epoch = ready_for_next_epoch && another_feature::ready_for_next_epoch();
+    <b>if</b> (ready_for_next_epoch) {
+        <a href="async_reconfig.md#0x1_async_reconfig_force_finish">force_finish</a>(framework);
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/overview.md
+++ b/aptos-move/framework/aptos-framework/doc/overview.md
@@ -19,6 +19,7 @@ This is the reference documentation of the Aptos framework.
 -  [`0x1::aptos_account`](aptos_account.md#0x1_aptos_account)
 -  [`0x1::aptos_coin`](aptos_coin.md#0x1_aptos_coin)
 -  [`0x1::aptos_governance`](aptos_governance.md#0x1_aptos_governance)
+-  [`0x1::async_reconfig`](async_reconfig.md#0x1_async_reconfig)
 -  [`0x1::block`](block.md#0x1_block)
 -  [`0x1::chain_id`](chain_id.md#0x1_chain_id)
 -  [`0x1::chain_status`](chain_status.md#0x1_chain_status)

--- a/aptos-move/framework/aptos-framework/sources/async_reconfig.move
+++ b/aptos-move/framework/aptos-framework/sources/async_reconfig.move
@@ -1,0 +1,68 @@
+/// Formal async reconfiguration state management to replace `reconfiguration_with_dkg.move`.
+///
+/// Every feature that requires end-of-epoch processing now has to specify the following procedures.
+/// - A function `on_async_reconfig_start()` to start the processing.
+/// - A function `ready_for_next_epoch()` to inform the framework whether the feature needs more time for processing.
+/// - A function  `on_new_epoch()` to clean things up right before epoch change.
+module aptos_framework::async_reconfig {
+    use std::features;
+    use aptos_framework::consensus_config;
+    use aptos_framework::dkg;
+    use aptos_framework::execution_config;
+    use aptos_framework::gas_schedule;
+    use aptos_framework::jwk_consensus_config;
+    use aptos_framework::jwks;
+    use aptos_framework::keyless_account;
+    use aptos_framework::randomness_api_v0_config;
+    use aptos_framework::randomness_config;
+    use aptos_framework::randomness_config_seqnum;
+    use aptos_framework::reconfiguration;
+    use aptos_framework::reconfiguration_state;
+    use aptos_framework::system_addresses;
+
+    friend aptos_framework::block;
+
+    /// Trigger an async reconfig. More specifically,
+    /// - for every feature that requires end-of-epoch processing, call its `on_async_reconfig_start()` hook.
+    ///
+    /// Do nothing if one is already in progress.
+    public(friend) fun try_start() {
+        if (!reconfiguration_state::is_in_progress()) {
+            reconfiguration_state::on_reconfig_start();
+            dkg::on_async_reconfig_start();
+            // another_feature::on_async_reconfig_start();
+        };
+    }
+
+    ///
+    public(friend) fun force_finish(framework: &signer) {
+        system_addresses::assert_aptos_framework(framework);
+        dkg::on_new_epoch(framework);
+        // another_feature::on_new_epoch(framework);
+
+        // Apply buffered config changes.
+        consensus_config::on_new_epoch(framework);
+        execution_config::on_new_epoch(framework);
+        gas_schedule::on_new_epoch(framework);
+        std::version::on_new_epoch(framework);
+        features::on_new_epoch(framework);
+        jwk_consensus_config::on_new_epoch(framework);
+        jwks::on_new_epoch(framework);
+        keyless_account::on_new_epoch(framework);
+        randomness_config_seqnum::on_new_epoch(framework);
+        randomness_config::on_new_epoch(framework);
+        randomness_api_v0_config::on_new_epoch(framework);
+        reconfiguration::reconfigure();
+    }
+
+    /// Complete the current reconfiguration with DKG if possible.
+    public(friend) fun try_finish(framework: &signer) {
+        system_addresses::assert_aptos_framework(framework);
+        let ready_for_next_epoch = true;
+        ready_for_next_epoch = ready_for_next_epoch && dkg::ready_for_next_epoch();
+        // ready_for_next_epoch = ready_for_next_epoch && another_feature::ready_for_next_epoch();
+        if (ready_for_next_epoch) {
+            force_finish(framework);
+        }
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/configs/consensus_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/consensus_config.move
@@ -11,6 +11,7 @@ module aptos_framework::consensus_config {
 
     friend aptos_framework::genesis;
     friend aptos_framework::reconfiguration_with_dkg;
+    friend aptos_framework::async_reconfig;
 
     struct ConsensusConfig has drop, key, store {
         config: vector<u8>,

--- a/aptos-move/framework/aptos-framework/sources/configs/execution_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/execution_config.move
@@ -10,6 +10,7 @@ module aptos_framework::execution_config {
     use aptos_framework::system_addresses;
     friend aptos_framework::genesis;
     friend aptos_framework::reconfiguration_with_dkg;
+    friend aptos_framework::async_reconfig;
 
     struct ExecutionConfig has drop, key, store {
         config: vector<u8>,

--- a/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.move
@@ -19,6 +19,7 @@ module aptos_framework::gas_schedule {
 
     friend aptos_framework::genesis;
     friend aptos_framework::reconfiguration_with_dkg;
+    friend aptos_framework::async_reconfig;
 
     /// The provided gas schedule bytes are empty or invalid
     const EINVALID_GAS_SCHEDULE: u64 = 1;

--- a/aptos-move/framework/aptos-framework/sources/configs/jwk_consensus_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/jwk_consensus_config.move
@@ -15,6 +15,7 @@ module aptos_framework::jwk_consensus_config {
     use std::string::utf8;
 
     friend aptos_framework::reconfiguration_with_dkg;
+    friend aptos_framework::async_reconfig;
 
     /// `ConfigV1` creation failed with duplicated providers given.
     const EDUPLICATE_PROVIDERS: u64 = 1;

--- a/aptos-move/framework/aptos-framework/sources/configs/randomness_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/randomness_config.move
@@ -6,6 +6,7 @@ module aptos_framework::randomness_config {
     use aptos_std::fixed_point64::FixedPoint64;
     use aptos_framework::config_buffer;
     use aptos_framework::system_addresses;
+    friend aptos_framework::async_reconfig;
 
     friend aptos_framework::reconfiguration_with_dkg;
 

--- a/aptos-move/framework/aptos-framework/sources/configs/randomness_config_seqnum.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/randomness_config_seqnum.move
@@ -12,6 +12,7 @@ module aptos_framework::randomness_config_seqnum {
     use aptos_framework::system_addresses;
 
     friend aptos_framework::reconfiguration_with_dkg;
+    friend aptos_framework::async_reconfig;
 
     /// If this seqnum is smaller than a validator local override, the on-chain `RandomnessConfig` will be ignored.
     /// Useful in a chain recovery from randomness stall.

--- a/aptos-move/framework/aptos-framework/sources/configs/version.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/version.move
@@ -10,6 +10,7 @@ module aptos_framework::version {
 
     friend aptos_framework::genesis;
     friend aptos_framework::reconfiguration_with_dkg;
+    friend aptos_framework::async_reconfig;
 
     struct Version has drop, key, store {
         major: u64,

--- a/aptos-move/framework/aptos-framework/sources/jwks.move
+++ b/aptos-move/framework/aptos-framework/sources/jwks.move
@@ -26,6 +26,7 @@ module aptos_framework::jwks {
 
     friend aptos_framework::genesis;
     friend aptos_framework::reconfiguration_with_dkg;
+    friend aptos_framework::async_reconfig;
 
     /// We limit the size of a `PatchedJWKs` resource installed by a dapp owner for federated keyless accounts.
     /// Note: If too large, validators waste work reading it for invalid TXN signatures.

--- a/aptos-move/framework/aptos-framework/sources/keyless_account.move
+++ b/aptos-move/framework/aptos-framework/sources/keyless_account.move
@@ -12,6 +12,7 @@ module aptos_framework::keyless_account {
     use aptos_std::ed25519;
     use aptos_framework::chain_status;
     use aptos_framework::system_addresses;
+    friend aptos_framework::async_reconfig;
 
     // The `aptos_framework::reconfiguration_with_dkg` module needs to be able to call `on_new_epoch`.
     friend aptos_framework::reconfiguration_with_dkg;

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -23,6 +23,7 @@ module aptos_framework::reconfiguration {
     friend aptos_framework::genesis;
     friend aptos_framework::version;
     friend aptos_framework::reconfiguration_with_dkg;
+    friend aptos_framework::async_reconfig;
 
     #[event]
     /// Event that signals consensus to start a new epoch,

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration_state.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration_state.move
@@ -12,6 +12,8 @@ module aptos_framework::reconfiguration_state {
     friend aptos_framework::reconfiguration;
     friend aptos_framework::reconfiguration_with_dkg;
     friend aptos_framework::stake;
+    friend aptos_framework::block;
+    friend aptos_framework::async_reconfig;
 
     const ERECONFIG_NOT_IN_PROGRESS: u64 = 1;
 

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -95,6 +95,7 @@ pub enum FeatureFlag {
     FEDERATED_KEYLESS = 77,
     TRANSACTION_SIMULATION_ENHANCEMENT = 78,
     COLLECTION_OWNER = 79,
+    ASYNC_RECONFIG_FRAMEWORK = 80,
 }
 
 impl FeatureFlag {
@@ -172,6 +173,7 @@ impl FeatureFlag {
             FeatureFlag::ENABLE_RESOURCE_ACCESS_CONTROL,
             FeatureFlag::REJECT_UNSTABLE_BYTECODE_FOR_SCRIPT,
             FeatureFlag::TRANSACTION_SIMULATION_ENHANCEMENT,
+            FeatureFlag::ASYNC_RECONFIG_FRAMEWORK,
         ]
     }
 }


### PR DESCRIPTION
## Description

### purpose of the change
- To move new epoch related system events (NewEpochEvent, RewardDistribution, etc.) back to block prologue txns.
- To make it easier to support 2+ features that require end-of-epoch processing.

### what's changed

No impact on existing features/ecosystem.

Here are the internal changes.
- Add a new feature flag: `ASYNC_RECONFIG_FRAMEWORK`.
- When `ASYNC_RECONFIG_FRAMEWORK` is enabled,
  - validator txn variant `DKGResult` only publishes DKG result but no longer triggers epoch change;
  - in BlockPrologue, if a reconfig is in progress and every end-of-epoch processing feature has done the processing, trigger epoch change.

## How Has This Been Tested?

Existing test suites.


## Key Areas to Review


## Type of Change
- [x] Breaking change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
