### PR TITLE
[State Sync] Remove clone() calls for storage synchronizer.

### DIFF
--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -1177,7 +1177,7 @@ impl<
             BootstrappingMode::ApplyTransactionOutputsFromGenesis => {
                 if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof {
                     utils::apply_transaction_outputs(
-                        self.storage_synchronizer.clone(),
+                        &mut self.storage_synchronizer,
                         notification_metadata,
                         proof_ledger_info,
                         end_of_epoch_ledger_info,
@@ -1198,7 +1198,7 @@ impl<
             BootstrappingMode::ExecuteTransactionsFromGenesis => {
                 if let Some(transaction_list_with_proof) = transaction_list_with_proof {
                     utils::execute_transactions(
-                        self.storage_synchronizer.clone(),
+                        &mut self.storage_synchronizer,
                         notification_metadata,
                         proof_ledger_info,
                         end_of_epoch_ledger_info,
@@ -1219,7 +1219,7 @@ impl<
             BootstrappingMode::ExecuteOrApplyFromGenesis => {
                 if let Some(transaction_list_with_proof) = transaction_list_with_proof {
                     utils::execute_transactions(
-                        self.storage_synchronizer.clone(),
+                        &mut self.storage_synchronizer,
                         notification_metadata,
                         proof_ledger_info,
                         end_of_epoch_ledger_info,
@@ -1229,7 +1229,7 @@ impl<
                 } else if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof
                 {
                     utils::apply_transaction_outputs(
-                        self.storage_synchronizer.clone(),
+                        &mut self.storage_synchronizer,
                         notification_metadata,
                         proof_ledger_info,
                         end_of_epoch_ledger_info,

--- a/state-sync/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-driver/src/continuous_syncer.rs
@@ -302,7 +302,7 @@ impl<
             ContinuousSyncingMode::ApplyTransactionOutputs => {
                 if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof {
                     utils::apply_transaction_outputs(
-                        self.storage_synchronizer.clone(),
+                        &mut self.storage_synchronizer,
                         notification_metadata,
                         ledger_info_with_signatures.clone(),
                         None,
@@ -323,7 +323,7 @@ impl<
             ContinuousSyncingMode::ExecuteTransactions => {
                 if let Some(transaction_list_with_proof) = transaction_list_with_proof {
                     utils::execute_transactions(
-                        self.storage_synchronizer.clone(),
+                        &mut self.storage_synchronizer,
                         notification_metadata,
                         ledger_info_with_signatures.clone(),
                         None,
@@ -344,7 +344,7 @@ impl<
             ContinuousSyncingMode::ExecuteTransactionsOrApplyOutputs => {
                 if let Some(transaction_list_with_proof) = transaction_list_with_proof {
                     utils::execute_transactions(
-                        self.storage_synchronizer.clone(),
+                        &mut self.storage_synchronizer,
                         notification_metadata,
                         ledger_info_with_signatures.clone(),
                         None,
@@ -354,7 +354,7 @@ impl<
                 } else if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof
                 {
                     utils::apply_transaction_outputs(
-                        self.storage_synchronizer.clone(),
+                        &mut self.storage_synchronizer,
                         notification_metadata,
                         ledger_info_with_signatures.clone(),
                         None,

--- a/state-sync/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-driver/src/utils.rs
@@ -376,8 +376,8 @@ pub fn update_new_epoch_metrics() {
 
 /// Executes the given list of transactions and
 /// returns the number of transactions in the list.
-pub async fn execute_transactions<StorageSyncer: StorageSynchronizerInterface + Clone>(
-    mut storage_synchronizer: StorageSyncer,
+pub async fn execute_transactions<StorageSyncer: StorageSynchronizerInterface>(
+    storage_synchronizer: &mut StorageSyncer,
     notification_metadata: NotificationMetadata,
     proof_ledger_info: LedgerInfoWithSignatures,
     end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
@@ -397,8 +397,8 @@ pub async fn execute_transactions<StorageSyncer: StorageSynchronizerInterface + 
 
 /// Applies the given list of transaction outputs and
 /// returns the number of outputs in the list.
-pub async fn apply_transaction_outputs<StorageSyncer: StorageSynchronizerInterface + Clone>(
-    mut storage_synchronizer: StorageSyncer,
+pub async fn apply_transaction_outputs<StorageSyncer: StorageSynchronizerInterface>(
+    storage_synchronizer: &mut StorageSyncer,
     notification_metadata: NotificationMetadata,
     proof_ledger_info: LedgerInfoWithSignatures,
     end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,


### PR DESCRIPTION
## Description
This PR removes unnecessary `clone()` calls for the storage synchronizer.

## Testing Plan
Existing test infrastructure.
