### PR TITLE
[move-vm] Check for empty field variant list

### DIFF
--- a/third_party/move/move-binary-format/src/check_bounds.rs
+++ b/third_party/move/move-binary-format/src/check_bounds.rs
@@ -271,6 +271,13 @@ impl<'a> BoundsChecker<'a> {
 
     fn check_variant_field_handle(&self, field_handle: &VariantFieldHandle) -> PartialVMResult<()> {
         check_bounds_impl_opt(&self.view.struct_defs(), field_handle.struct_index)?;
+        if field_handle.variants.is_empty() {
+            return Err(verification_error(
+                StatusCode::ZERO_VARIANTS_ERROR,
+                IndexKind::MemberCount,
+                field_handle.field,
+            ));
+        }
         let struct_def = self.view.struct_def_at(field_handle.struct_index)?;
         for variant in &field_handle.variants {
             Self::check_variant_index(struct_def, *variant)?;


### PR DESCRIPTION
## Description

Add a check to bounds_checker for empty variant field handle lists


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)
