### PR TITLE
block metadata txn api update

### DIFF
--- a/api/doc/spec.json
+++ b/api/doc/spec.json
@@ -14269,6 +14269,79 @@
           }
         }
       },
+      "BlockMetadataExtension": {
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionEmpty"
+          },
+          {
+            "$ref": "#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionRandomness"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "v0": "#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionEmpty",
+            "v1": "#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionRandomness"
+          }
+        }
+      },
+      "BlockMetadataExtensionEmpty": {
+        "type": "object"
+      },
+      "BlockMetadataExtensionRandomness": {
+        "type": "object",
+        "properties": {
+          "randomness": {
+            "$ref": "#/components/schemas/HexEncodedBytes"
+          }
+        }
+      },
+      "BlockMetadataExtension_BlockMetadataExtensionEmpty": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "v0"
+                ],
+                "example": "v0"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/BlockMetadataExtensionEmpty"
+          }
+        ]
+      },
+      "BlockMetadataExtension_BlockMetadataExtensionRandomness": {
+        "allOf": [
+          {
+            "type": "object",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "v1"
+                ],
+                "example": "v1"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/BlockMetadataExtensionRandomness"
+          }
+        ]
+      },
       "BlockMetadataTransaction": {
         "type": "object",
         "description": "A block metadata transaction\n\nThis signifies the beginning of a block, and contains information\nabout the specific block",
@@ -14365,6 +14438,17 @@
           },
           "timestamp": {
             "$ref": "#/components/schemas/U64"
+          },
+          "block_metadata_extension": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BlockMetadataExtension"
+              },
+              {
+                "description": "If some, it means the internal txn type is `aptos_types::transaction::Transaction::BlockMetadataExt`.\nOtherwise, it is `aptos_types::transaction::Transaction::BlockMetadata`.\n\nNOTE: we could have introduced a new APT txn type to represent the corresponding internal type,\nbut that is a breaking change to the ecosystem.\n\nNOTE: `oai` does not support `flatten` together with `skip_serializing_if`.",
+                "default": null
+              }
+            ]
           }
         }
       },

--- a/api/doc/spec.yaml
+++ b/api/doc/spec.yaml
@@ -10669,6 +10669,47 @@ components:
           $ref: '#/components/schemas/U64'
         block_end_info:
           $ref: '#/components/schemas/BlockEndInfo'
+    BlockMetadataExtension:
+      type: object
+      oneOf:
+      - $ref: '#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionEmpty'
+      - $ref: '#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionRandomness'
+      discriminator:
+        propertyName: type
+        mapping:
+          v0: '#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionEmpty'
+          v1: '#/components/schemas/BlockMetadataExtension_BlockMetadataExtensionRandomness'
+    BlockMetadataExtensionEmpty:
+      type: object
+    BlockMetadataExtensionRandomness:
+      type: object
+      properties:
+        randomness:
+          $ref: '#/components/schemas/HexEncodedBytes'
+    BlockMetadataExtension_BlockMetadataExtensionEmpty:
+      allOf:
+      - type: object
+        required:
+        - type
+        properties:
+          type:
+            type: string
+            enum:
+            - v0
+            example: v0
+      - $ref: '#/components/schemas/BlockMetadataExtensionEmpty'
+    BlockMetadataExtension_BlockMetadataExtensionRandomness:
+      allOf:
+      - type: object
+        required:
+        - type
+        properties:
+          type:
+            type: string
+            enum:
+            - v1
+            example: v1
+      - $ref: '#/components/schemas/BlockMetadataExtensionRandomness'
     BlockMetadataTransaction:
       type: object
       description: |-
@@ -10747,6 +10788,18 @@ components:
             format: uint32
         timestamp:
           $ref: '#/components/schemas/U64'
+        block_metadata_extension:
+          allOf:
+          - $ref: '#/components/schemas/BlockMetadataExtension'
+          - description: |-
+              If some, it means the internal txn type is `aptos_types::transaction::Transaction::BlockMetadataExt`.
+              Otherwise, it is `aptos_types::transaction::Transaction::BlockMetadata`.
+
+              NOTE: we could have introduced a new APT txn type to represent the corresponding internal type,
+              but that is a breaking change to the ecosystem.
+
+              NOTE: `oai` does not support `flatten` together with `skip_serializing_if`.
+            default: null
     DKGResultTransaction:
       type: object
       required:

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -4,9 +4,10 @@
 
 use crate::{
     transaction::{
-        BlockEpilogueTransaction, DecodedTableData, DeleteModule, DeleteResource, DeleteTableItem,
-        DeletedTableData, MultisigPayload, MultisigTransactionPayload, StateCheckpointTransaction,
-        UserTransactionRequestInner, WriteModule, WriteResource, WriteTableItem,
+        BlockEpilogueTransaction, BlockMetadataTransaction, DecodedTableData, DeleteModule,
+        DeleteResource, DeleteTableItem, DeletedTableData, MultisigPayload,
+        MultisigTransactionPayload, StateCheckpointTransaction, UserTransactionRequestInner,
+        WriteModule, WriteResource, WriteTableItem,
     },
     view::{ViewFunction, ViewRequest},
     Address, Bytecode, DirectWriteSet, EntryFunctionId, EntryFunctionPayload, Event,
@@ -204,8 +205,12 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                 let payload = self.try_into_write_set_payload(write_set)?;
                 (info, payload, events).into()
             },
-            BlockMetadata(txn) => (&txn, info, events).into(),
-            BlockMetadataExt(txn) => (&txn, info, events).into(),
+            BlockMetadata(txn) => Transaction::BlockMetadataTransaction(
+                BlockMetadataTransaction::from_internal(txn, info, events),
+            ),
+            BlockMetadataExt(txn) => Transaction::BlockMetadataTransaction(
+                BlockMetadataTransaction::from_internal_ext(txn, info, events),
+            ),
             StateCheckpoint(_) => {
                 Transaction::StateCheckpointTransaction(StateCheckpointTransaction {
                     info,

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -579,7 +579,7 @@ pub struct BlockMetadataExtensionRandomness {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Union)]
-#[serde(tag = "extension_type", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case")]
 #[oai(one_of, discriminator_name = "type", rename_all = "snake_case")]
 pub enum BlockMetadataExtension {
     V0(BlockMetadataExtensionEmpty),

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -572,11 +572,7 @@ pub struct BlockMetadataExtensionRandomness {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Union)]
 #[serde(tag = "extension_type", rename_all = "snake_case")]
-#[oai(
-    one_of,
-    discriminator_name = "type",
-    rename_all = "snake_case"
-)]
+#[oai(one_of, discriminator_name = "type", rename_all = "snake_case")]
 pub enum BlockMetadataExtension {
     V0(BlockMetadataExtensionEmpty),
     V1(BlockMetadataExtensionRandomness),

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -557,6 +557,14 @@ pub struct BlockMetadataTransaction {
     /// The indices of the proposers who failed to propose
     pub failed_proposer_indices: Vec<u32>,
     pub timestamp: U64,
+
+    /// If some, it means the internal txn type is `aptos_types::transaction::Transaction::BlockMetadataExt`.
+    /// Otherwise, it is `aptos_types::transaction::Transaction::BlockMetadata`.
+    ///
+    /// NOTE: we could have introduced a new APT txn type to represent the corresponding internal type,
+    /// but that is a breaking change to the ecosystem.
+    ///
+    /// NOTE: `oai` does not support `flatten` together with `skip_serializing_if`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[oai(default, skip_serializing_if = "Option::is_none")]
     pub block_metadata_extension: Option<BlockMetadataExtension>,

--- a/types/src/block_metadata_ext.rs
+++ b/types/src/block_metadata_ext.rs
@@ -104,6 +104,13 @@ impl BlockMetadataExt {
             BlockMetadataExt::V1(obj) => obj.round,
         }
     }
+
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            BlockMetadataExt::V0(_) => "block_metadata_ext_transaction__v0",
+            BlockMetadataExt::V1(_) => "block_metadata_ext_transaction__v1",
+        }
+    }
 }
 
 impl From<BlockMetadata> for BlockMetadataExt {

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -2027,7 +2027,7 @@ impl Transaction {
             Transaction::StateCheckpoint(_) => "state_checkpoint",
             Transaction::BlockEpilogue(_) => "block_epilogue",
             Transaction::ValidatorTransaction(vt) => vt.type_name(),
-            Transaction::BlockMetadataExt(_) => "block_metadata_ext",
+            Transaction::BlockMetadataExt(bmet) => bmet.type_name(),
         }
     }
 


### PR DESCRIPTION
## Description

(Validator txn had the same problem, fixed in #13718 .)

Txn API currently doesn't return anything to help distinguish between the following BlockMetadata txn variants (depending on the status of randomness feature and randomness seed availability).
- (A) `BlockMetadataExt::V1 { seed: Some(...) }`, used when the feature is enabled and the seed is available.
- (B) `BlockMetadataExt::V1 { seed: None }`, used when the feature is enabled but the seed is unavailable.
- (C) `BlockMetadataExt::V0`, never used.
- (D) `BlockMetadata`, used when the randomness feature is disabled.

This change adds distinguishing fields to the txn API return values. Hopefully this doesn't break anyone since we are only adding fields.

NOTE: no change to indexer, **assuming the variant info should still be ignored**.

Here is an example of new A with this change.
```json
{
    "version": "7",
    "hash": "0xb6df477fc89fea0a2ee1e91f380dfbc8fab0ec17621c67887c4e160ca99e39a5",
    "state_change_hash": "0xe20b184595ddfc4770ebf3c88f961ceac50055ef5fb419f74eea437e9b735190",
    "event_root_hash": "0x4a3c7769ff77f8f49df8a63a6054c670654a765eebb753bf6f5faae3cf464678",
    "state_checkpoint_hash": null,
    "gas_used": "0",
    "success": true,
    "vm_status": "Executed successfully",
    "accumulator_root_hash": "0x59ce4d194712a90f337bc1c5fd20624ec90593cdabbe948cd402d8d1f841aefb",
    "changes": [],
    "id": "0x4c87e957f0922da125d63e2581218bfeda4da153c15a6bb341f47f1042c95b56",
    "epoch": "2",
    "round": "1",
    "events": [],
    "previous_block_votes_bitvec": [
        0
    ],
    "proposer": "0x726281301ff21e554010a8a0900346a94873c009e31b00aee09bc5ca293d3bf0",
    "failed_proposer_indices": [],
    "timestamp": "1727903189064629",
    "block_metadata_extension": { // new!
        "randomness": "0x3d3621c7603b2d2b8e98ecf1777f6c31cdbc2b973a7a8a621746667f4909481f",
        "type": "v1"
    },
    "type": "block_metadata_transaction"
}
```

And an example of new B with this change.
```json
{
    "version": "1",
    "hash": "0xd0c6748ccba4ffa636db8ba8bfb8ef0b589575563fa4de6a7494858fdfb92b7c",
    "state_change_hash": "0xc7bc6d5a9deeb398e5dbdbb9ca68632d4ee5ac3f6c999d3818abc5d8e21d30c6",
    "event_root_hash": "0xdd6660deaf779f12af9116ba8460e9d0efe624212330e701133f3c44bfed6229",
    "state_checkpoint_hash": null,
    "gas_used": "0",
    "success": true,
    "vm_status": "Executed successfully",
    "accumulator_root_hash": "0xc0ad2d5721961035703ae283035832db146f3e78ae8ed377f4607b9a7f5cc61f",
    "changes": [],
    "id": "0x6dfbaab81e094f6f6ffdf7b3092d0a2695e6bae0d07470fb1cf4aa435c3e3b76",
    "epoch": "1",
    "round": "1",
    "events": [],
    "previous_block_votes_bitvec": [
        0
    ],
    "proposer": "0x972766e48ab4e27cd3a75fbbf57e292e4c8edbf21322b084c31ea27698a8c28c",
    "failed_proposer_indices": [],
    "timestamp": "1727904571696488",
    "block_metadata_extension": { // new!
        "randomness": null,
        "type": "v1"
    },
    "type": "block_metadata_transaction"
}
```

An example of new C.
```json
{
    "version": "1",
    "hash": "0xd0c6748ccba4ffa636db8ba8bfb8ef0b589575563fa4de6a7494858fdfb92b7c",
    "state_change_hash": "0xc7bc6d5a9deeb398e5dbdbb9ca68632d4ee5ac3f6c999d3818abc5d8e21d30c6",
    "event_root_hash": "0xdd6660deaf779f12af9116ba8460e9d0efe624212330e701133f3c44bfed6229",
    "state_checkpoint_hash": null,
    "gas_used": "0",
    "success": true,
    "vm_status": "Executed successfully",
    "accumulator_root_hash": "0xc0ad2d5721961035703ae283035832db146f3e78ae8ed377f4607b9a7f5cc61f",
    "changes": [],
    "id": "0x6dfbaab81e094f6f6ffdf7b3092d0a2695e6bae0d07470fb1cf4aa435c3e3b76",
    "epoch": "1",
    "round": "1",
    "events": [],
    "previous_block_votes_bitvec": [
        0
    ],
    "proposer": "0x972766e48ab4e27cd3a75fbbf57e292e4c8edbf21322b084c31ea27698a8c28c",
    "failed_proposer_indices": [],
    "timestamp": "1727904571696488",
    "block_metadata_extension": { // new!
        "type": "v0"
    },
    "type": "block_metadata_transaction"
}
```

No change to D.
```json
{
    "version": "1",
    "hash": "0x4cf8a37121ea3121defe3fafd618f3ab968d02f0eb924f2c015df9056dad8d1a",
    "state_change_hash": "0x554255d7a035d701c0394522dc8ace803b1aa0569863b6775ef772c18d9ed707",
    "event_root_hash": "0x80c53529f63b485d26ce7a14157cd6fe97a0f333b1ab7677cb9fb2f8ed3220f4",
    "state_checkpoint_hash": "0x17f8678c45980bb6eb8b19ac7d30c341c77c576d5dfd6a9b634d4e4d578b679e",
    "gas_used": "0",
    "success": true,
    "vm_status": "Executed successfully",
    "accumulator_root_hash": "0x79ffce0a9053b71617006e9fdc5e5240403644e44bdf35d065a37aee9f825c59",
    "changes": [],
    "id": "0xf411e31569704a38553b134dfff4e32d9c9dbbb5fe327315f8e25a70656ec17a",
    "epoch": "1",
    "round": "1",
    "events": [],
    "previous_block_votes_bitvec": [
    0
    ],
    "proposer": "0x937ac0c8b3a4a1856306a012174560a730ba3b8e28e58afc0e92390075186bc9",
    "failed_proposer_indices": [],
    "timestamp": "1727905079538104",
    "type": "block_metadata_transaction"
}
```

## How Has This Been Tested?
Local manual testing.

## Key Areas to Review
n/a

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Full Node (API, Indexer, etc.)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
