### PR TITLE
[forge] indexer SuccessCriteria and new test

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -603,6 +603,8 @@ fn get_test_suite(
         return Ok(test_suite);
     } else if let Some(test_suite) = get_dag_test(test_name, duration, test_cmd) {
         return Ok(test_suite);
+    } else if let Some(test_suite) = get_indexer_test(test_name) {
+        return Ok(test_suite);
     }
 
     // Otherwise, check the test name against the ungrouped test suites
@@ -687,6 +689,15 @@ fn get_land_blocking_test(
         "compat" => compat(),
         "framework_upgrade" => framework_upgrade(),
         _ => return None, // The test name does not match a land-blocking test
+    };
+    Some(test)
+}
+
+/// Attempts to match the test name to an indexer test
+fn get_indexer_test(test_name: &str) -> Option<ForgeConfig> {
+    let test = match test_name {
+        "indexer_test" => indexer_test(),
+        _ => return None, // The test name does not match an indexer test
     };
     Some(test)
 }
@@ -2365,6 +2376,99 @@ fn multiregion_benchmark_test() -> ForgeConfig {
                 .add_system_metrics_threshold(SYSTEM_12_CORES_10GB_THRESHOLD.clone())
                 .add_chain_progress(RELIABLE_PROGRESS_THRESHOLD.clone()),
         )
+}
+
+/// Workload sweep with multiple stressful workloads for indexer
+fn indexer_test() -> ForgeConfig {
+    // Define all the workloads and their corresponding success criteria upfront
+    // The TransactionTypeArg is the workload per phase
+    // The structure of the success criteria is generally (min_tps, latencies...). See below for the exact definition.
+    let workloads_and_criteria = vec![
+        (
+            TransactionWorkload::new(TransactionTypeArg::CoinTransfer, 20000),
+            (7000, 0.5, 0.5, 0.5),
+        ),
+        (
+            TransactionWorkload::new(TransactionTypeArg::NoOp, 20000).with_num_modules(100),
+            (8500, 0.5, 0.5, 0.5),
+        ),
+        (
+            TransactionWorkload::new(TransactionTypeArg::ModifyGlobalResource, 6000)
+                .with_transactions_per_account(1),
+            (2000, 0.5, 0.5, 0.5),
+        ),
+        (
+            TransactionWorkload::new(TransactionTypeArg::TokenV2AmbassadorMint, 20000)
+                .with_unique_senders(),
+            (3200, 0.5, 0.5, 0.5),
+        ),
+        (
+            TransactionWorkload::new(TransactionTypeArg::PublishPackage, 200)
+                .with_transactions_per_account(1),
+            (28, 0.5, 0.5, 0.5),
+        ),
+        (
+            TransactionWorkload::new(TransactionTypeArg::VectorPicture30k, 100),
+            (100, 0.5, 0.5, 0.5),
+        ),
+        (
+            TransactionWorkload::new(TransactionTypeArg::SmartTablePicture30KWith200Change, 100),
+            (100, 0.5, 0.5, 0.5),
+        ),
+        (
+            TransactionWorkload::new(
+                TransactionTypeArg::TokenV1NFTMintAndTransferSequential,
+                1000,
+            ),
+            (500, 0.5, 0.5, 0.5),
+        ),
+        (
+            TransactionWorkload::new(TransactionTypeArg::TokenV1FTMintAndTransfer, 1000),
+            (500, 0.5, 0.5, 0.5),
+        ),
+    ];
+    let num_sweep = workloads_and_criteria.len();
+
+    let workloads = Workloads::TRANSACTIONS(
+        workloads_and_criteria
+            .iter()
+            .map(|(w, _)| w.clone())
+            .collect(),
+    );
+    let criteria = workloads_and_criteria
+        .iter()
+        .map(|(_, c)| {
+            let (
+                min_tps,
+                indexer_fullnode_processed_batch,
+                indexer_cache_worker_processed_batch,
+                indexer_data_service_all_chunks_sent,
+            ) = c.to_owned();
+            SuccessCriteria::new(min_tps).add_latency_breakdown_threshold(
+                LatencyBreakdownThreshold::new_strict(vec![
+                    (
+                        LatencyBreakdownSlice::IndexerFullnodeProcessedBatch,
+                        indexer_fullnode_processed_batch,
+                    ),
+                    (
+                        LatencyBreakdownSlice::IndexerCacheWorkerProcessedBatch,
+                        indexer_cache_worker_processed_batch,
+                    ),
+                    (
+                        LatencyBreakdownSlice::IndexerDataServiceAllChunksSent,
+                        indexer_data_service_all_chunks_sent,
+                    ),
+                ]),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    realistic_env_sweep_wrap(4, 4, LoadVsPerfBenchmark {
+        test: Box::new(PerformanceBenchmark),
+        workloads,
+        criteria,
+        background_traffic: background_traffic_for_sweep(num_sweep),
+    })
 }
 
 /// This test runs a constant-TPS benchmark where the network includes

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -2409,11 +2409,11 @@ fn indexer_test() -> ForgeConfig {
         ),
         (
             TransactionWorkload::new(TransactionTypeArg::VectorPicture30k, 100),
-            (100, 0.5, 0.5, 0.5),
+            (100, 1.0, 1.0, 1.0),
         ),
         (
             TransactionWorkload::new(TransactionTypeArg::SmartTablePicture30KWith200Change, 100),
-            (100, 0.5, 0.5, 0.5),
+            (100, 1.0, 1.0, 1.0),
         ),
         (
             TransactionWorkload::new(

--- a/testsuite/forge/src/backend/k8s/mod.rs
+++ b/testsuite/forge/src/backend/k8s/mod.rs
@@ -245,6 +245,7 @@ impl Factory for K8sFactory {
             self.keep,
             new_era,
             self.use_port_forward,
+            self.enable_indexer,
         )
         .await
         .unwrap();

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -62,6 +62,7 @@ pub struct K8sSwarm {
     era: Option<String>,
     use_port_forward: bool,
     chaos_experiment_ops: Box<dyn ChaosExperimentOps + Send + Sync>,
+    has_indexer: bool,
 }
 
 impl K8sSwarm {
@@ -75,6 +76,7 @@ impl K8sSwarm {
         keep: bool,
         era: Option<String>,
         use_port_forward: bool,
+        has_indexer: bool,
     ) -> Result<Self> {
         let kube_client = create_k8s_client().await?;
 
@@ -123,6 +125,7 @@ impl K8sSwarm {
                 kube_client: kube_client.clone(),
                 kube_namespace: kube_namespace.to_string(),
             }),
+            has_indexer,
         };
 
         // test hitting the configured prometheus endpoint
@@ -445,6 +448,10 @@ impl Swarm for K8sSwarm {
 
     fn get_default_pfn_node_config(&self) -> NodeConfig {
         get_default_pfn_node_config()
+    }
+
+    fn has_indexer(&self) -> bool {
+        self.has_indexer
     }
 }
 

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -650,6 +650,10 @@ impl Swarm for LocalSwarm {
     fn get_default_pfn_node_config(&self) -> NodeConfig {
         todo!()
     }
+
+    fn has_indexer(&self) -> bool {
+        false
+    }
 }
 
 #[derive(Debug)]

--- a/testsuite/forge/src/interface/prometheus_metrics.rs
+++ b/testsuite/forge/src/interface/prometheus_metrics.rs
@@ -43,6 +43,12 @@ impl fmt::Debug for MetricSamples {
     }
 }
 
+impl Default for MetricSamples {
+    fn default() -> Self {
+        Self::new(vec![])
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct SystemMetrics {
     pub cpu_core_metrics: MetricSamples,
@@ -124,10 +130,8 @@ impl LatencyBreakdown {
         self.0.keys().cloned().collect()
     }
 
-    pub fn get_samples(&self, slice: &LatencyBreakdownSlice) -> &MetricSamples {
-        self.0
-            .get(slice)
-            .unwrap_or_else(|| panic!("Missing latency breakdown for {:?}", slice))
+    pub fn get_samples(&self, slice: &LatencyBreakdownSlice) -> Option<&MetricSamples> {
+        self.0.get(slice)
     }
 
     pub fn join(&self, other: &LatencyBreakdown) -> LatencyBreakdown {

--- a/testsuite/forge/src/interface/prometheus_metrics.rs
+++ b/testsuite/forge/src/interface/prometheus_metrics.rs
@@ -105,6 +105,11 @@ pub enum LatencyBreakdownSlice {
     ConsensusProposalToOrdered,
     ConsensusOrderedToCommit,
     ConsensusProposalToCommit,
+    // each of the indexer grpc steps in order
+    IndexerFullnodeProcessedBatch,
+    IndexerCacheWorkerProcessedBatch,
+    IndexerDataServiceAllChunksSent,
+    // TODO: add processor insertion into DB latency
 }
 
 #[derive(Clone, Debug)]
@@ -123,6 +128,14 @@ impl LatencyBreakdown {
         self.0
             .get(slice)
             .unwrap_or_else(|| panic!("Missing latency breakdown for {:?}", slice))
+    }
+
+    pub fn join(&self, other: &LatencyBreakdown) -> LatencyBreakdown {
+        let mut ret_latency = self.0.clone();
+        for (slice, samples) in other.0.iter() {
+            ret_latency.insert(slice.clone(), samples.clone());
+        }
+        LatencyBreakdown::new(ret_latency)
     }
 }
 
@@ -210,5 +223,54 @@ pub async fn fetch_latency_breakdown(
         MetricSamples::new(consensus_proposal_to_commit_samples),
     );
 
+    if swarm.has_indexer() {
+        // These counters are defined in ecosystem/indexer-grpc/indexer-grpc-utils/src/counters.rs
+        let indexer_fullnode_processed_batch_query =
+            r#"max(indexer_grpc_duration_in_secs{step="4", service_type="indexer_fullnode"})"#;
+        let indexer_cache_worker_processed_batch_query =
+            r#"max(indexer_grpc_duration_in_secs{step="4", service_type="cache_worker"})"#;
+        let indexer_data_service_all_chunks_sent_query =
+            r#"max(indexer_grpc_duration_in_secs{step="4", service_type="data_service"})"#;
+
+        let indexer_fullnode_processed_batch_samples = swarm
+            .query_range_metrics(
+                indexer_fullnode_processed_batch_query,
+                start_time as i64,
+                end_time as i64,
+                None,
+            )
+            .await?;
+
+        let indexer_cache_worker_processed_batch_samples = swarm
+            .query_range_metrics(
+                indexer_cache_worker_processed_batch_query,
+                start_time as i64,
+                end_time as i64,
+                None,
+            )
+            .await?;
+
+        let indexer_data_service_all_chunks_sent_samples = swarm
+            .query_range_metrics(
+                indexer_data_service_all_chunks_sent_query,
+                start_time as i64,
+                end_time as i64,
+                None,
+            )
+            .await?;
+
+        samples.insert(
+            LatencyBreakdownSlice::IndexerFullnodeProcessedBatch,
+            MetricSamples::new(indexer_fullnode_processed_batch_samples),
+        );
+        samples.insert(
+            LatencyBreakdownSlice::IndexerCacheWorkerProcessedBatch,
+            MetricSamples::new(indexer_cache_worker_processed_batch_samples),
+        );
+        samples.insert(
+            LatencyBreakdownSlice::IndexerDataServiceAllChunksSent,
+            MetricSamples::new(indexer_data_service_all_chunks_sent_samples),
+        );
+    }
     Ok(LatencyBreakdown::new(samples))
 }

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -105,6 +105,10 @@ pub trait Swarm: Sync + Send {
     }
 
     fn get_default_pfn_node_config(&self) -> NodeConfig;
+
+    /// Check if the swarm has an indexer. NOTE: in the future we should make this more rich, and include
+    /// indexer endpoints, similar to how we collect validator and fullnode endpoints.
+    fn has_indexer(&self) -> bool;
 }
 
 impl<T: ?Sized> SwarmExt for T where T: Swarm {}

--- a/testsuite/forge/src/success_criteria.rs
+++ b/testsuite/forge/src/success_criteria.rs
@@ -150,7 +150,9 @@ impl LatencyBreakdownThreshold {
         traffic_name_addition: &String,
     ) -> anyhow::Result<()> {
         for (slice, threshold) in &self.thresholds {
-            let samples = metrics.get_samples(slice);
+            let samples = metrics
+                .get_samples(slice)
+                .expect("Could not get metric samples");
             threshold.ensure_metrics_threshold(
                 &format!("{:?}{}", slice, traffic_name_addition),
                 samples.get(),

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -283,7 +283,10 @@ impl NetworkTest for dyn NetworkLoadTest {
                     .keys()
                     .into_iter()
                     .map(|slice| {
-                        let slice_samples = phase_stats.latency_breakdown.get_samples(&slice);
+                        let slice_samples = phase_stats
+                            .latency_breakdown
+                            .get_samples(&slice)
+                            .expect("Could not get samples");
                         format!(
                             "{:?}: max: {:.3}, avg: {:.3}",
                             slice,


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Adds some latency-based success criteria to Forge runs with the indexer.

Also start to add a new class of `indexer_*` test suites

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

CI. Also run it ad-hoc many times. Use this to calibrate some of the latency criteria: https://github.com/aptos-labs/aptos-core/actions/runs/11185219106 (see the run history on GHA)
1. [run1](https://grafana.aptoslabs.com/d/fdr6l9zgfzncwf/indexer-testing-overview-ephemeral-forge?from=1728067246000&to=1728068660000&var-Datasource=fHo-R604z&var-BigQuery=axNEitxVz&var-metrics_source=All&var-chain_name=forge-0&var-cluster=All&var-namespace=forge-runner-1728067241&var-kubernetes_pod_name=All&orgId=1)
2. [run2](https://grafana.aptoslabs.com/d/fdr6l9zgfzncwf/indexer-testing-overview-ephemeral-forge?from=1728070813000&to=1728071720000&var-Datasource=fHo-R604z&var-BigQuery=axNEitxVz&var-metrics_source=All&var-chain_name=forge-0&var-cluster=All&var-namespace=forge-runner-1728070808&var-kubernetes_pod_name=All&orgId=1)
3. [run3](https://grafana.aptoslabs.com/d/fdr6l9zgfzncwf/indexer-testing-overview-ephemeral-forge?from=1728073682000&to=1728074733000&var-Datasource=fHo-R604z&var-BigQuery=axNEitxVz&var-metrics_source=All&var-chain_name=forge-0&var-cluster=All&var-namespace=forge-runner-1728073677&var-kubernetes_pod_name=All&orgId=1)
4. [run4](https://grafana.aptoslabs.com/d/fdr6l9zgfzncwf/indexer-testing-overview-ephemeral-forge?from=1728075104000&to=1728076269000&var-Datasource=fHo-R604z&var-BigQuery=axNEitxVz&var-metrics_source=All&var-chain_name=forge-0&var-cluster=All&var-namespace=forge-runner-1728075099&var-kubernetes_pod_name=All&orgId=1)
5. [run5](https://grafana.aptoslabs.com/d/fdr6l9zgfzncwf/indexer-testing-overview-ephemeral-forge?from=1728079272000&to=1728080409000&var-Datasource=fHo-R604z&var-BigQuery=axNEitxVz&var-metrics_source=All&var-chain_name=forge-0&var-cluster=All&var-namespace=forge-runner-1728079267&var-kubernetes_pod_name=All&orgId=1)
6. [run6](https://grafana.aptoslabs.com/d/fdr6l9zgfzncwf/indexer-testing-overview-ephemeral-forge?from=1728082112000&to=1728083180000&var-Datasource=fHo-R604z&var-BigQuery=axNEitxVz&var-metrics_source=All&var-chain_name=forge-0&var-cluster=All&var-namespace=forge-runner-1728082107&var-kubernetes_pod_name=All&orgId=1)
7. [run7](https://grafana.aptoslabs.com/d/fdr6l9zgfzncwf/indexer-testing-overview-ephemeral-forge?from=1728084199000&to=1728085171000&var-Datasource=fHo-R604z&var-BigQuery=axNEitxVz&var-metrics_source=All&var-chain_name=forge-0&var-cluster=All&var-namespace=forge-runner-1728084193&var-kubernetes_pod_name=All&orgId=1)

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

Metrics used for the success criteria; new test suite workloads

For the success criteria thresholds, based on some numbers from:
* [last 30d devnet data (under load)](https://grafana.aptoslabs.com/explore?schemaVersion=1&panes=%7B%2215u%22%3A%7B%22datasource%22%3A%22fHo-R604z%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22quantile%280.75%2C+indexer_grpc_duration_in_secs%7Bstep%3D%5C%224%5C%22%2C+service_type%3D%5C%22indexer_fullnode%5C%22%2C+namespace%3D%5C%22indexer-grpc-devnet%5C%22%7D%29%22%2C%22range%22%3Atrue%2C%22instant%22%3Atrue%2C%22datasource%22%3A%7B%22type%22%3A%22prometheus%22%2C%22uid%22%3A%22fHo-R604z%22%7D%2C%22editorMode%22%3A%22code%22%2C%22legendFormat%22%3A%22__auto%22%7D%2C%7B%22refId%22%3A%22B%22%2C%22expr%22%3A%22quantile%280.75%2C+indexer_grpc_duration_in_secs%7Bstep%3D%5C%224%5C%22%2C+service_type%3D%5C%22cache_worker%5C%22%2C+namespace%3D%5C%22indexer-grpc-devnet%5C%22%7D%29%22%2C%22range%22%3Atrue%2C%22instant%22%3Atrue%2C%22datasource%22%3A%7B%22type%22%3A%22prometheus%22%2C%22uid%22%3A%22fHo-R604z%22%7D%2C%22editorMode%22%3A%22code%22%2C%22legendFormat%22%3A%22__auto%22%7D%2C%7B%22refId%22%3A%22C%22%2C%22expr%22%3A%22quantile%280.75%2C+indexer_grpc_duration_in_secs%7Bstep%3D%5C%224%5C%22%2C+service_type%3D%5C%22data_service%5C%22%2C+namespace%3D%5C%22indexer-grpc-devnet%5C%22%7D%29%22%2C%22range%22%3Atrue%2C%22instant%22%3Atrue%2C%22datasource%22%3A%7B%22type%22%3A%22prometheus%22%2C%22uid%22%3A%22fHo-R604z%22%7D%2C%22editorMode%22%3A%22code%22%2C%22legendFormat%22%3A%22__auto%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-30d%22%2C%22to%22%3A%22now%22%7D%7D%7D&orgId=1)
* [last 30d testnet data](https://grafana.aptoslabs.com/explore?schemaVersion=1&panes=%7B%2215u%22:%7B%22datasource%22:%22fHo-R604z%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22quantile%280.75,%20indexer_grpc_duration_in_secs%7Bstep%3D%5C%224%5C%22,%20service_type%3D%5C%22indexer_fullnode%5C%22,%20namespace%3D%5C%22indexer-grpc-testnet%5C%22%7D%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22fHo-R604z%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D,%7B%22refId%22:%22B%22,%22expr%22:%22quantile%280.75,%20indexer_grpc_duration_in_secs%7Bstep%3D%5C%224%5C%22,%20service_type%3D%5C%22cache_worker%5C%22,%20namespace%3D%5C%22indexer-grpc-testnet%5C%22%7D%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22fHo-R604z%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D,%7B%22refId%22:%22C%22,%22expr%22:%22quantile%280.75,%20indexer_grpc_duration_in_secs%7Bstep%3D%5C%224%5C%22,%20service_type%3D%5C%22data_service%5C%22,%20namespace%3D%5C%22indexer-grpc-testnet%5C%22%7D%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22fHo-R604z%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%22now-30d%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)
*  [last 30d mainnet data](https://grafana.aptoslabs.com/explore?schemaVersion=1&panes=%7B%2215u%22:%7B%22datasource%22:%22vU-Lwva4k%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22quantile%280.75,%20indexer_grpc_duration_in_secs%7Bstep%3D%5C%224%5C%22,%20service_type%3D%5C%22indexer_fullnode%5C%22,%20namespace%3D%5C%22indexer-grpc-mainnet%5C%22%7D%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22vU-Lwva4k%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D,%7B%22refId%22:%22B%22,%22expr%22:%22quantile%280.75,%20indexer_grpc_duration_in_secs%7Bstep%3D%5C%224%5C%22,%20service_type%3D%5C%22cache_worker%5C%22,%20namespace%3D%5C%22indexer-grpc-mainnet%5C%22%7D%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22vU-Lwva4k%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D,%7B%22refId%22:%22C%22,%22expr%22:%22quantile%280.75,%20indexer_grpc_duration_in_secs%7Bstep%3D%5C%224%5C%22,%20service_type%3D%5C%22data_service%5C%22,%20namespace%3D%5C%22indexer-grpc-mainnet%5C%22%7D%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22vU-Lwva4k%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%22now-30d%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)

For example: 
![image](https://github.com/user-attachments/assets/632c16d4-ffa8-4bee-9be7-11c770d563fc)


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
