### PR TITLE
[compiler-v2] Add loop labels to the language

### DIFF
--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -450,11 +450,11 @@ impl<'env> Generator<'env> {
                 self.emit_with(*id, |attr| Bytecode::Jump(attr, continue_label));
                 self.emit_with(*id, |attr| Bytecode::Label(attr, break_label));
             },
-            ExpData::LoopCont(id, 0, do_continue) => {
+            ExpData::LoopCont(id, nest, do_continue) => {
                 if let Some(LoopContext {
                     continue_label,
                     break_label,
-                }) = self.loops.last()
+                }) = self.loops.iter().rev().nth(*nest)
                 {
                     let target = if *do_continue {
                         *continue_label
@@ -465,9 +465,6 @@ impl<'env> Generator<'env> {
                 } else {
                     self.error(*id, "missing enclosing loop statement")
                 }
-            },
-            ExpData::LoopCont(_, _, _) => {
-                unimplemented!("continue/break with nesting")
             },
             ExpData::SpecBlock(id, spec) => {
                 // Map locals in spec to assigned temporaries.

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/loop_labels.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/loop_labels.exp
@@ -1,0 +1,78 @@
+// -- Model dump before bytecode pipeline
+module 0x815::test {
+    private fun f1() {
+        loop {
+          loop {
+            loop {
+              if true {
+                loop {
+                  if false {
+                    continue[3]
+                  } else {
+                    break[1]
+                  };
+                  break
+                }
+              } else {
+                continue[2]
+              }
+            }
+          };
+          break
+        }
+    }
+} // end 0x815::test
+
+// -- Sourcified model before bytecode pipeline
+module 0x815::test {
+    fun f1() {
+        'l0: loop {
+            loop 'l1: loop if (true) loop {
+                if (false) continue 'l0 else break 'l1;
+                break
+            } else continue 'l0;
+            break
+        }
+    }
+}
+
+============ initial bytecode ================
+
+[variant baseline]
+fun test::f1() {
+     var $t0: bool
+     var $t1: bool
+  0: label L0
+  1: label L2
+  2: label L4
+  3: $t0 := true
+  4: if ($t0) goto 5 else goto 19
+  5: label L6
+  6: label L9
+  7: $t1 := false
+  8: if ($t1) goto 9 else goto 12
+  9: label L11
+ 10: goto 0
+ 11: goto 14
+ 12: label L12
+ 13: goto 23
+ 14: label L13
+ 15: goto 17
+ 16: goto 6
+ 17: label L10
+ 18: goto 21
+ 19: label L7
+ 20: goto 0
+ 21: label L8
+ 22: goto 2
+ 23: label L5
+ 24: goto 1
+ 25: label L3
+ 26: goto 28
+ 27: goto 0
+ 28: label L1
+ 29: return ()
+}
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/loop_labels.move
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/loop_labels.move
@@ -1,0 +1,14 @@
+module 0x815::test {
+    fun f1() {
+        'outer: loop {
+            // unlabeled loop, but counts in nesting in AST
+            loop {
+                'inner: loop if (true) loop {
+                    if (false) continue 'outer else break 'inner;
+                    break
+                } else continue 'outer
+            };
+            break
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/loop_labels.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/loop_labels.exp
@@ -4,28 +4,28 @@ error: unsupported language construct
   ┌─ tests/checking-lang-v1/loop_labels.move:3:9
   │
 3 │         'outer: loop {
-  │         ^^^^^^ Move language construct `'outer` is not enabled until version 2.1
+  │         ^^^^^^ loop labels are not enabled before version 2.1
 
 error: unsupported language construct
   ┌─ tests/checking-lang-v1/loop_labels.move:6:17
   │
 6 │                 'inner: loop if (true) loop {
-  │                 ^^^^^^ Move language construct `'inner` is not enabled until version 2.1
+  │                 ^^^^^^ loop labels are not enabled before version 2.1
 
 error: unsupported language construct
   ┌─ tests/checking-lang-v1/loop_labels.move:7:41
   │
 7 │                     if (false) continue 'outer else break 'inner;
-  │                                         ^^^^^^ Move language construct `'outer` is not enabled until version 2.1
+  │                                         ^^^^^^ loop labels are not enabled before version 2.1
 
 error: unsupported language construct
   ┌─ tests/checking-lang-v1/loop_labels.move:7:59
   │
 7 │                     if (false) continue 'outer else break 'inner;
-  │                                                           ^^^^^^ Move language construct `'inner` is not enabled until version 2.1
+  │                                                           ^^^^^^ loop labels are not enabled before version 2.1
 
 error: unsupported language construct
   ┌─ tests/checking-lang-v1/loop_labels.move:9:33
   │
 9 │                 } else continue 'outer
-  │                                 ^^^^^^ Move language construct `'outer` is not enabled until version 2.1
+  │                                 ^^^^^^ loop labels are not enabled before version 2.1

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/loop_labels.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/loop_labels.exp
@@ -1,0 +1,31 @@
+
+Diagnostics:
+error: unsupported language construct
+  ┌─ tests/checking-lang-v1/loop_labels.move:3:9
+  │
+3 │         'outer: loop {
+  │         ^^^^^^ Move language construct `'outer` is not enabled until version 2.1
+
+error: unsupported language construct
+  ┌─ tests/checking-lang-v1/loop_labels.move:6:17
+  │
+6 │                 'inner: loop if (true) loop {
+  │                 ^^^^^^ Move language construct `'inner` is not enabled until version 2.1
+
+error: unsupported language construct
+  ┌─ tests/checking-lang-v1/loop_labels.move:7:41
+  │
+7 │                     if (false) continue 'outer else break 'inner;
+  │                                         ^^^^^^ Move language construct `'outer` is not enabled until version 2.1
+
+error: unsupported language construct
+  ┌─ tests/checking-lang-v1/loop_labels.move:7:59
+  │
+7 │                     if (false) continue 'outer else break 'inner;
+  │                                                           ^^^^^^ Move language construct `'inner` is not enabled until version 2.1
+
+error: unsupported language construct
+  ┌─ tests/checking-lang-v1/loop_labels.move:9:33
+  │
+9 │                 } else continue 'outer
+  │                                 ^^^^^^ Move language construct `'outer` is not enabled until version 2.1

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/loop_labels.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/loop_labels.move
@@ -1,0 +1,14 @@
+module 0x815::test {
+    fun f1() {
+        'outer: loop {
+            // unlabeled loop, but counts in nesting in AST
+            loop {
+                'inner: loop if (true) loop {
+                    if (false) continue 'outer else break 'inner;
+                    break
+                } else continue 'outer
+            };
+            break
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_check_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_check_err.exp
@@ -1,0 +1,21 @@
+
+Diagnostics:
+error: label `'outer` undefined
+  ┌─ tests/checking/control_flow/loop_labels_check_err.move:3:15
+  │
+3 │         break 'outer;
+  │               ^^^^^^
+
+error: label `'inner` undefined
+  ┌─ tests/checking/control_flow/loop_labels_check_err.move:5:19
+  │
+5 │             break 'inner
+  │                   ^^^^^^
+
+error: label `'l1` already used by outer loop
+   ┌─ tests/checking/control_flow/loop_labels_check_err.move:11:19
+   │
+11 │         'l1: loop 'l1: loop {};
+   │         ---       ^^^
+   │         │
+   │         outer definition of label

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_check_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_check_err.move
@@ -1,0 +1,14 @@
+module 0x815::test {
+    fun undefined_label() {
+        break 'outer;
+        'outer: loop {
+            break 'inner
+        }
+    }
+
+    fun duplicate_label() {
+        'l1: loop {};
+        'l1: loop 'l1: loop {};
+        'l1: loop {}
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_check_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_check_ok.exp
@@ -1,0 +1,37 @@
+// -- Model dump before bytecode pipeline
+module 0x815::test {
+    private fun f1() {
+        loop {
+          loop {
+            loop {
+              if true {
+                loop {
+                  if false {
+                    continue[3]
+                  } else {
+                    break[1]
+                  };
+                  break
+                }
+              } else {
+                continue[2]
+              }
+            }
+          };
+          break
+        }
+    }
+} // end 0x815::test
+
+// -- Sourcified model before bytecode pipeline
+module 0x815::test {
+    fun f1() {
+        'l0: loop {
+            loop 'l1: loop if (true) loop {
+                if (false) continue 'l0 else break 'l1;
+                break
+            } else continue 'l0;
+            break
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_check_ok.move
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_check_ok.move
@@ -1,0 +1,14 @@
+module 0x815::test {
+    fun f1() {
+        'outer: loop {
+            // unlabeled loop, but counts in nesting in AST
+            loop {
+                'inner: loop if (true) loop {
+                    if (false) continue 'outer else break 'inner;
+                    break
+                } else continue 'outer
+            };
+            break
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err1.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err1.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+error: unexpected token
+  ┌─ tests/checking/control_flow/loop_labels_parse_err1.move:3:13
+  │
+3 │         'a: if (true) false else true
+  │             ^^
+  │             │
+  │             Unexpected 'if'
+  │             Expected one of: 'while' or 'loop'

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err1.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err1.exp
@@ -7,4 +7,4 @@ error: unexpected token
   │             ^^
   │             │
   │             Unexpected 'if'
-  │             Expected one of: 'while' or 'loop'
+  │             Expected one of: `while` or `loop`

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err1.move
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err1.move
@@ -1,0 +1,5 @@
+module 0x815::test {
+    fun f1(): bool {
+        'a: if (true) false else true
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err2.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err2.exp
@@ -7,4 +7,4 @@ error: unexpected token
   │             ^^
   │             │
   │             Unexpected 'if'
-  │             Expected one of: 'while' or 'loop'
+  │             Expected one of: `while` or `loop`

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err2.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err2.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+error: unexpected token
+  ┌─ tests/checking/control_flow/loop_labels_parse_err2.move:3:13
+  │
+3 │         'a: if (true) false else true
+  │             ^^
+  │             │
+  │             Unexpected 'if'
+  │             Expected one of: 'while' or 'loop'

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err2.move
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err2.move
@@ -1,0 +1,5 @@
+module 0x815::test {
+    fun f1(): bool {
+        'a: if (true) false else true
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err3.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err3.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: invalid character
+  ┌─ tests/checking/control_flow/loop_labels_parse_err3.move:3:10
+  │
+3 │         ': if (true) false else true
+  │          ^ Label quote must be followed by 'A-Z', `a-z', or '_'

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err3.move
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err3.move
@@ -1,0 +1,9 @@
+module 0x815::test {
+    fun f1(): bool {
+        ': if (true) false else true
+    }
+
+    fun f1(): bool {
+        '0x: if (true) false else true
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err4.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err4.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: invalid character
+  ┌─ tests/checking/control_flow/loop_labels_parse_err4.move:3:10
+  │
+3 │         '0x: if (true) false else true
+  │          ^ Label quote must be followed by 'A-Z', `a-z', or '_'

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err4.move
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/loop_labels_parse_err4.move
@@ -1,0 +1,5 @@
+module 0x815::test {
+    fun f1(): bool {
+        '0x: if (true) false else true
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -106,7 +106,7 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
         // Turn optimization on by default. Some configs below may turn it off.
         .set_experiment(Experiment::OPTIMIZE, true)
         .set_experiment(Experiment::OPTIMIZE_WAITING_FOR_COMPARE_TESTS, true)
-        .set_language_version(LanguageVersion::V2_0);
+        .set_language_version(LanguageVersion::V2_1);
     opts.testing = true;
     let configs = vec![
         // --- Tests for checking and ast processing
@@ -718,7 +718,7 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             include: vec!["/op-equal/"],
             exclude: vec![],
             exp_suffix: None,
-            options: opts.clone().set_language_version(LanguageVersion::V2_1),
+            options: opts.clone(),
             // Run the entire compiler pipeline to double-check the result
             stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::EndStage,

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/loop_labels.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/loop_labels.exp
@@ -1,0 +1,1 @@
+processed 1 task

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/loop_labels.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/loop_labels.move
@@ -1,0 +1,18 @@
+//# run
+script {
+    fun main() {
+        let result = 0;
+        'outer: while (result < 100) {
+            while (result < 50) {
+                'inner: while (result < 30) {
+                    result += 1;
+                    continue 'outer
+               };
+               result += 10;
+               continue 'outer
+            };
+            result += 20
+        };
+        assert!(result == 110);
+    }
+}

--- a/third_party/move/move-compiler/src/expansion/dependency_ordering.rs
+++ b/third_party/move/move-compiler/src/expansion/dependency_ordering.rs
@@ -435,8 +435,8 @@ fn exp(context: &mut Context, sp!(_loc, e_): &E::Exp) {
 
         E::Unit { .. }
         | E::UnresolvedError
-        | E::Break
-        | E::Continue
+        | E::Break(_)
+        | E::Continue(_)
         | E::Spec(_, _, _)
         | E::Value(_)
         | E::Move(_)
@@ -478,7 +478,7 @@ fn exp(context: &mut Context, sp!(_loc, e_): &E::Exp) {
             }
         },
 
-        E::BinopExp(e1, _, e2) | E::Mutate(e1, e2) | E::While(e1, e2) | E::Index(e1, e2) => {
+        E::BinopExp(e1, _, e2) | E::Mutate(e1, e2) | E::While(_, e1, e2) | E::Index(e1, e2) => {
             exp(context, e1);
             exp(context, e2)
         },
@@ -492,7 +492,7 @@ fn exp(context: &mut Context, sp!(_loc, e_): &E::Exp) {
             exp(context, e);
         },
 
-        E::Loop(e)
+        E::Loop(_, e)
         | E::Return(e)
         | E::Abort(e)
         | E::Dereference(e)

--- a/third_party/move/move-compiler/src/expansion/translate.rs
+++ b/third_party/move/move-compiler/src/expansion/translate.rs
@@ -2611,8 +2611,8 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
                 .collect::<Vec<_>>();
             EE::Match(discriminator, match_arms)
         },
-        PE::While(pb, ploop) => EE::While(exp(context, *pb), exp(context, *ploop)),
-        PE::Loop(ploop) => EE::Loop(exp(context, *ploop)),
+        PE::While(label, pb, ploop) => EE::While(label, exp(context, *pb), exp(context, *ploop)),
+        PE::Loop(label, ploop) => EE::Loop(label, exp(context, *ploop)),
         PE::Block(seq) => EE::Block(sequence(context, loc, seq)),
         PE::Lambda(pbs, pe) => {
             let tbs_opt = typed_bind_list(context, pbs);
@@ -2767,8 +2767,8 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
             EE::Return(ev)
         },
         PE::Abort(pe) => EE::Abort(exp(context, *pe)),
-        PE::Break => EE::Break,
-        PE::Continue => EE::Continue,
+        PE::Break(l) => EE::Break(l),
+        PE::Continue(l) => EE::Continue(l),
         PE::Dereference(pe) => EE::Dereference(exp(context, *pe)),
         PE::UnaryExp(op, pe) => EE::UnaryExp(op, exp(context, *pe)),
         PE::BinopExp(pl, op, pr) => {
@@ -3294,8 +3294,8 @@ fn unbound_names_exp(unbound: &mut UnboundNames, sp!(_, e_): &E::Exp) {
     use E::Exp_ as EE;
     match e_ {
         EE::Value(_)
-        | EE::Break
-        | EE::Continue
+        | EE::Break(_)
+        | EE::Continue(_)
         | EE::UnresolvedError
         | EE::Name(sp!(_, E::ModuleAccess_::ModuleAccess(..)), _)
         | EE::Unit { .. } => (),
@@ -3334,11 +3334,11 @@ fn unbound_names_exp(unbound: &mut UnboundNames, sp!(_, e_): &E::Exp) {
                 unbound_names_exp(unbound, &arm.value.2)
             }
         },
-        EE::While(econd, eloop) => {
+        EE::While(_, econd, eloop) => {
             unbound_names_exp(unbound, eloop);
             unbound_names_exp(unbound, econd)
         },
-        EE::Loop(eloop) => unbound_names_exp(unbound, eloop),
+        EE::Loop(_, eloop) => unbound_names_exp(unbound, eloop),
 
         EE::Block(seq) => unbound_names_sequence(unbound, seq),
         EE::Lambda(ls, er) => {

--- a/third_party/move/move-compiler/src/naming/translate.rs
+++ b/third_party/move/move-compiler/src/naming/translate.rs
@@ -938,8 +938,8 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
         EE::IfElse(eb, et, ef) => {
             NE::IfElse(exp(context, *eb), exp(context, *et), exp(context, *ef))
         },
-        EE::While(eb, el) => NE::While(exp(context, *eb), exp(context, *el)),
-        EE::Loop(el) => NE::Loop(exp(context, *el)),
+        EE::While(_, eb, el) => NE::While(exp(context, *eb), exp(context, *el)),
+        EE::Loop(_, el) => NE::Loop(exp(context, *el)),
         EE::Block(seq) => NE::Block(sequence(context, seq)),
         EE::Lambda(args, body) => {
             let bind_opt = bind_typed_list(context, args);
@@ -981,8 +981,8 @@ fn exp_(context: &mut Context, e: E::Exp) -> N::Exp {
 
         EE::Return(es) => NE::Return(exp(context, *es)),
         EE::Abort(es) => NE::Abort(exp(context, *es)),
-        EE::Break => NE::Break,
-        EE::Continue => NE::Continue,
+        EE::Break(_) => NE::Break,
+        EE::Continue(_) => NE::Continue,
 
         EE::Dereference(e) => NE::Dereference(exp(context, *e)),
         EE::UnaryExp(uop, e) => NE::UnaryExp(uop, exp(context, *e)),

--- a/third_party/move/move-compiler/src/parser/ast.rs
+++ b/third_party/move/move-compiler/src/parser/ast.rs
@@ -502,6 +502,7 @@ pub type Type = Spanned<Type_>;
 //**************************************************************************************************
 
 new_name!(Var);
+new_name!(Label);
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Bind_ {
@@ -678,10 +679,10 @@ pub enum Exp_ {
 
     // if (eb) et else ef
     IfElse(Box<Exp>, Box<Exp>, Option<Box<Exp>>),
-    // while (eb) eloop
-    While(Box<Exp>, Box<Exp>),
-    // loop eloop
-    Loop(Box<Exp>),
+    // [label] while (eb) eloop
+    While(Option<Label>, Box<Exp>, Box<Exp>),
+    // [label] loop eloop
+    Loop(Option<Label>, Box<Exp>),
     // match (e) { b1 [ if c_1] => e1, ... }
     Match(Box<Exp>, Vec<Spanned<(BindList, Option<Exp>, Exp)>>),
 
@@ -710,9 +711,9 @@ pub enum Exp_ {
     // abort e
     Abort(Box<Exp>),
     // break
-    Break,
+    Break(Option<Label>),
     // continue
-    Continue,
+    Continue(Option<Label>),
 
     // *e
     Dereference(Box<Exp>),
@@ -1882,13 +1883,19 @@ impl AstDebug for Exp_ {
                     arm.value.2.ast_debug(w)
                 }
             },
-            E::While(b, e) => {
+            E::While(l, b, e) => {
+                if let Some(l) = l {
+                    w.write(&format!("{}: ", l.value().as_str()))
+                }
                 w.write("while (");
                 b.ast_debug(w);
                 w.write(")");
                 e.ast_debug(w);
             },
-            E::Loop(e) => {
+            E::Loop(l, e) => {
+                if let Some(l) = l {
+                    w.write(&format!("{}: ", l.value().as_str()))
+                }
                 w.write("loop ");
                 e.ast_debug(w);
             },
@@ -1936,8 +1943,18 @@ impl AstDebug for Exp_ {
                 w.write("abort ");
                 e.ast_debug(w);
             },
-            E::Break => w.write("break"),
-            E::Continue => w.write("continue"),
+            E::Break(l) => {
+                w.write("break");
+                if let Some(l) = l {
+                    w.write(format!(" {}", l.value().as_str()));
+                }
+            },
+            E::Continue(l) => {
+                w.write("continue");
+                if let Some(l) = l {
+                    w.write(format!(" {}", l.value().as_str()));
+                }
+            },
             E::Dereference(e) => {
                 w.write("*");
                 e.ast_debug(w)

--- a/third_party/move/move-compiler/src/parser/lexer.rs
+++ b/third_party/move/move-compiler/src/parser/lexer.rs
@@ -508,6 +508,15 @@ fn find_token(
             }
         },
         '\'' => {
+            if text.len() <= 1
+                || !matches!(text.chars().nth(1).unwrap(), 'A'..='Z' | 'a'..='z' | '_')
+            {
+                let loc = make_loc(file_hash, start_offset + 1, start_offset + 2);
+                return Err(Box::new(diag!(
+                    Syntax::InvalidCharacter,
+                    (loc, "Label quote must be followed by 'A-Z', `a-z', or '_'")
+                )));
+            }
             let len = get_name_len(&text[1..]);
             (Tok::Label, 1 + len)
         },

--- a/third_party/move/move-compiler/src/parser/lexer.rs
+++ b/third_party/move/move-compiler/src/parser/lexer.rs
@@ -92,6 +92,7 @@ pub enum Tok {
     NumSign,
     AtSign,
     Inline,
+    Label,
 }
 
 impl fmt::Display for Tok {
@@ -178,6 +179,7 @@ impl fmt::Display for Tok {
             Friend => "friend",
             NumSign => "#",
             AtSign => "@",
+            Label => "[Label]",
         };
         fmt::Display::fmt(s, formatter)
     }
@@ -504,6 +506,10 @@ fn find_token(
                 let len = get_name_len(text);
                 (get_name_token(&text[..len]), len)
             }
+        },
+        '\'' => {
+            let len = get_name_len(&text[1..]);
+            (Tok::Label, 1 + len)
         },
         '"' => {
             let line = &text.lines().next().unwrap()[1..];

--- a/third_party/move/move-compiler/src/parser/syntax.rs
+++ b/third_party/move/move-compiler/src/parser/syntax.rs
@@ -1402,7 +1402,7 @@ fn parse_control_exp(context: &mut Context) -> Result<(Exp, bool), Box<Diagnosti
         if !matches!(context.tokens.peek(), Tok::While | Tok::Loop) {
             return Err(unexpected_token_error(
                 context.tokens,
-                "one of: 'while' or 'loop'",
+                "one of: `while` or `loop`",
             ));
         }
     };

--- a/third_party/move/move-compiler/src/parser/syntax.rs
+++ b/third_party/move/move-compiler/src/parser/syntax.rs
@@ -101,7 +101,7 @@ fn require_language_version(
         loc,
         min_language_version,
         &format!(
-            "Move language construct `{}` is not enabled until version {}",
+            "{} not enabled before version {}",
             description, min_language_version
         ),
     )
@@ -1466,7 +1466,7 @@ fn parse_optional_label(context: &mut Context) -> Result<Option<Label>, Box<Diag
             context,
             current_token_loc(context.tokens),
             LanguageVersion::V2_1,
-            context.tokens.content(),
+            "loop labels are",
         );
         let label = Label(Name::new(
             current_token_loc(context.tokens),
@@ -1950,7 +1950,7 @@ fn parse_exp(context: &mut Context) -> Result<Exp, Box<Diagnostic>> {
                         context,
                         current_token_loc(context.tokens),
                         LanguageVersion::V2_1,
-                        &current_token.to_string(),
+                        "op-equal operators are",
                     );
                     let op_loc = context.tokens.advance_with_loc()?; // consume the "op="
                     let rhs = Box::new(parse_exp(context)?);

--- a/third_party/move/move-compiler/src/parser/syntax.rs
+++ b/third_party/move/move-compiler/src/parser/syntax.rs
@@ -1167,17 +1167,20 @@ fn parse_term(context: &mut Context) -> Result<Exp, Box<Diagnostic>> {
         },
         Tok::Break => {
             context.tokens.advance()?;
+            let label = parse_optional_label(context)?;
+
             if at_start_of_exp(context) {
                 let mut diag = unexpected_token_error(context.tokens, "the end of an expression");
                 diag.add_note("'break' with a value is not yet supported");
                 return Err(diag);
             }
-            Exp_::Break
+            Exp_::Break(label)
         },
 
         Tok::Continue => {
             context.tokens.advance()?;
-            Exp_::Continue
+            let label = parse_optional_label(context)?;
+            Exp_::Continue(label)
         },
 
         Tok::Identifier
@@ -1323,7 +1326,7 @@ fn parse_cast_or_test_exp(
 fn is_control_exp(tok: Tok) -> bool {
     matches!(
         tok,
-        Tok::If | Tok::While | Tok::Loop | Tok::Return | Tok::Abort
+        Tok::If | Tok::While | Tok::Loop | Tok::Return | Tok::Abort | Tok::Label
     )
 }
 
@@ -1392,6 +1395,17 @@ fn parse_spec_loop_invariant(context: &mut Context) -> Result<SequenceItem, Box<
 // should be,     if (cond) e1 else (e2 + 1)
 fn parse_control_exp(context: &mut Context) -> Result<(Exp, bool), Box<Diagnostic>> {
     let start_loc = context.tokens.start_loc();
+    let label = parse_optional_label(context)?;
+    if label.is_some() {
+        consume_token(context.tokens, Tok::Colon)?;
+        // Check here whether a label is actually allowed
+        if !matches!(context.tokens.peek(), Tok::While | Tok::Loop) {
+            return Err(unexpected_token_error(
+                context.tokens,
+                "one of: 'while' or 'loop'",
+            ));
+        }
+    };
     let (exp_, ends_in_block) = match context.tokens.peek() {
         Tok::If => {
             context.tokens.advance()?;
@@ -1414,12 +1428,15 @@ fn parse_control_exp(context: &mut Context) -> Result<(Exp, bool), Box<Diagnosti
             consume_token(context.tokens, Tok::RParen)?;
             let (eloop, ends_in_block) = parse_exp_or_control_sequence(context)?;
             let (econd, ends_in_block) = parse_spec_while_loop(context, econd, ends_in_block)?;
-            (Exp_::While(Box::new(econd), Box::new(eloop)), ends_in_block)
+            (
+                Exp_::While(label, Box::new(econd), Box::new(eloop)),
+                ends_in_block,
+            )
         },
         Tok::Loop => {
             context.tokens.advance()?;
             let (eloop, ends_in_block) = parse_exp_or_control_sequence(context)?;
-            (Exp_::Loop(Box::new(eloop)), ends_in_block)
+            (Exp_::Loop(label, Box::new(eloop)), ends_in_block)
         },
         Tok::Return => {
             context.tokens.advance()?;
@@ -1441,6 +1458,25 @@ fn parse_control_exp(context: &mut Context) -> Result<(Exp, bool), Box<Diagnosti
     let end_loc = context.tokens.previous_end_loc();
     let exp = spanned(context.tokens.file_hash(), start_loc, end_loc, exp_);
     Ok((exp, ends_in_block))
+}
+
+fn parse_optional_label(context: &mut Context) -> Result<Option<Label>, Box<Diagnostic>> {
+    if context.tokens.peek() == Tok::Label {
+        require_language_version(
+            context,
+            current_token_loc(context.tokens),
+            LanguageVersion::V2_1,
+            context.tokens.content(),
+        );
+        let label = Label(Name::new(
+            current_token_loc(context.tokens),
+            Symbol::from(context.tokens.content()),
+        ));
+        context.tokens.advance()?;
+        Ok(Some(label))
+    } else {
+        Ok(None)
+    }
 }
 
 // "for (iter in lower_bound..upper_bound) loop_body" transforms into
@@ -1601,7 +1637,7 @@ fn parse_for_loop(context: &mut Context) -> Result<(Exp, bool), Box<Diagnostic>>
     let loop_conditional = Exp_::IfElse(
         Box::new(loop_condition),
         Box::new(for_body),
-        Some(Box::new(sp(for_loc, Exp_::Break))),
+        Some(Box::new(sp(for_loc, Exp_::Break(None)))),
     );
     let loop_conditional = sp(
         for_loc,
@@ -1626,7 +1662,7 @@ fn parse_for_loop(context: &mut Context) -> Result<(Exp, bool), Box<Diagnostic>>
     );
     let loop_body = sp(
         for_loc,
-        Exp_::While(Box::new(while_condition), Box::new(body)),
+        Exp_::While(None, Box::new(while_condition), Box::new(body)),
     );
     let loop_body = sp(for_loc, SequenceItem_::Seq(Box::new(loop_body)));
 

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -92,6 +92,8 @@ pub(crate) struct ExpTranslator<'env, 'translator, 'module_translator> {
     pub placeholder_map: BTreeMap<NodeId, ExpPlaceholder>,
     /// A flag to indicate whether to insert freeze operation
     pub insert_freeze: bool,
+    /// A stack of open loops and their optional label
+    pub loop_stack: Vec<Option<PA::Label>>,
 }
 
 #[derive(Debug)]
@@ -159,6 +161,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             spec_block_map: BTreeMap::new(),
             placeholder_map: BTreeMap::new(),
             insert_freeze: true,
+            loop_stack: vec![],
         }
     }
 
@@ -1545,10 +1548,12 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             EA::Exp_::Match(discriminator, arms) => {
                 self.translate_match(loc, context, expected_type, discriminator, arms)
             },
-            EA::Exp_::While(cond, body) => {
+            EA::Exp_::While(label, cond, body) => {
                 let cond = self.translate_exp(cond, &Type::new_prim(PrimitiveType::Bool));
                 let body_type = self.check_type(&loc, &Type::unit(), expected_type, context);
+                self.push_loop_label(label);
                 let body = self.translate_exp(body, &body_type);
+                self.pop_loop_label();
                 let id = self.new_node_id_with_type_loc(&body_type, &loc);
                 ExpData::Loop(
                     id,
@@ -1561,8 +1566,10 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                     .into_exp(),
                 )
             },
-            EA::Exp_::Loop(body) => {
+            EA::Exp_::Loop(label, body) => {
+                self.push_loop_label(label);
                 let body = self.translate_exp(body, &Type::unit());
+                self.pop_loop_label();
                 // See the Move book for below treatment: if the loop has no exit, the type
                 // is arbitrary, otherwise `()`.
                 let loop_type = if body.has_loop_exit() {
@@ -1573,15 +1580,17 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 let id = self.new_node_id_with_type_loc(&loop_type, &loc);
                 ExpData::Loop(id, body.into_exp())
             },
-            EA::Exp_::Break => {
+            EA::Exp_::Break(label) => {
+                let nest = self.find_loop_nest(label);
                 // Type of `break` is arbitrary
                 let id = self.new_node_id_with_type_loc(expected_type, &loc);
-                ExpData::LoopCont(id, 0, false)
+                ExpData::LoopCont(id, nest, false)
             },
-            EA::Exp_::Continue => {
+            EA::Exp_::Continue(label) => {
+                let nest = self.find_loop_nest(label);
                 // Type of `continue` is arbitrary
                 let id = self.new_node_id_with_type_loc(expected_type, &loc);
-                ExpData::LoopCont(id, 0, true)
+                ExpData::LoopCont(id, nest, true)
             },
             EA::Exp_::Block(seq) => self.translate_seq(&loc, seq, expected_type, context),
             EA::Exp_::Lambda(bindings, exp) => {
@@ -1873,6 +1882,55 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 self.new_error_exp()
             },
         }
+    }
+
+    fn find_loop_nest(&self, label: &Option<PA::Label>) -> usize {
+        if let Some(label) = label {
+            let label_sym = label.value();
+            self.loop_stack
+                .iter()
+                .rev()
+                .position(|s| s.map(|s| s.value()) == Some(label_sym))
+                .unwrap_or_else(|| {
+                    self.error(
+                        &self.to_loc(&label.loc()),
+                        &format!("label `{}` undefined", label.value().as_str()),
+                    );
+                    0
+                })
+        } else {
+            0
+        }
+    }
+
+    fn push_loop_label(&mut self, label: &Option<PA::Label>) {
+        if let Some(label) = label {
+            let label_sym = label.value();
+            if let Some(Some(outer)) = self
+                .loop_stack
+                .iter()
+                .find(|s| s.map(|s| s.value()) == Some(label_sym))
+            {
+                self.error_with_labels(
+                    &self.to_loc(&label.loc()),
+                    &format!(
+                        "label `{}` already used by outer loop",
+                        label.value().as_str()
+                    ),
+                    vec![(
+                        self.to_loc(&outer.loc()),
+                        "outer definition of label".to_string(),
+                    )],
+                );
+            }
+        }
+        self.loop_stack.push(*label)
+    }
+
+    fn pop_loop_label(&mut self) {
+        self.loop_stack
+            .pop()
+            .expect("expected loop stack to be balanced");
     }
 
     /// Returns a map representing the current locals in scope and their associated declaration

--- a/third_party/move/move-model/src/lib.rs
+++ b/third_party/move/move-model/src/lib.rs
@@ -1169,14 +1169,15 @@ fn downgrade_exp_inlining_to_expansion(exp: &T::Exp) -> E::Exp {
             downgrade_exp_inlining_to_expansion(else_case).into(),
         ),
         UnannotatedExp_::While(cond, body) => Exp_::While(
+            None, // note that labels cannot be downgraded as they are not supported in v1
             downgrade_exp_inlining_to_expansion(cond).into(),
             downgrade_exp_inlining_to_expansion(body).into(),
         ),
         UnannotatedExp_::Loop { has_break: _, body } => {
-            Exp_::Loop(downgrade_exp_inlining_to_expansion(body).into())
+            Exp_::Loop(None, downgrade_exp_inlining_to_expansion(body).into())
         },
-        UnannotatedExp_::Break => Exp_::Break,
-        UnannotatedExp_::Continue => Exp_::Continue,
+        UnannotatedExp_::Break => Exp_::Break(None),
+        UnannotatedExp_::Continue => Exp_::Continue(None),
 
         UnannotatedExp_::Block(seq) => Exp_::Block(downgrade_sequence_inlining_to_expansion(seq)),
         UnannotatedExp_::Lambda(..) => {


### PR DESCRIPTION
## Description

Besides the user being able to describe complex algorithms more efficiently, loop labels are required to express aribtrary reducible control flow graphs in the AST language, and create parity of the AST with the bytecode level for this kind of code (which is also what can be generated from Move).

## How Has This Been Tested?

New baseline tests in checking, v1-checking, bytecode generation, and a transactional test.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)
