### PR TITLE
separate state sync notifications to pre-commit and commit

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -955,6 +955,14 @@ pub static PENDING_STATE_SYNC_NOTIFICATION: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static PENDING_COMMIT_NOTIFICATION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_consensus_pending_commit_notification",
+        "Count of the pending commit notification"
+    )
+    .unwrap()
+});
+
 /// Count of the pending quorum store commit notification.
 pub static PENDING_QUORUM_STORE_COMMIT_NOTIFICATION: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(

--- a/consensus/src/execution_pipeline.rs
+++ b/consensus/src/execution_pipeline.rs
@@ -14,7 +14,7 @@ use aptos_consensus_types::{block::Block, pipeline_execution_result::PipelineExe
 use aptos_crypto::HashValue;
 use aptos_executor_types::{
     state_checkpoint_output::StateCheckpointOutput, BlockExecutorTrait, ExecutorError,
-    ExecutorResult,
+    ExecutorResult, StateComputeResult,
 };
 use aptos_experimental_runtimes::thread_manager::optimal_min_len;
 use aptos_logger::{debug, warn};
@@ -34,6 +34,12 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::sync::{mpsc, oneshot};
+
+pub type PreCommitHook = Box<
+    dyn 'static
+        + FnOnce(&[SignedTransaction], &StateComputeResult) -> BoxFuture<'static, ()>
+        + Send,
+>;
 
 #[allow(clippy::unwrap_used)]
 pub static SIG_VERIFY_POOL: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
@@ -88,6 +94,7 @@ impl ExecutionPipeline {
         parent_block_id: HashValue,
         txn_generator: BlockPreparer,
         block_executor_onchain_config: BlockExecutorConfigFromOnchain,
+        pre_commit_hook: PreCommitHook,
         lifetime_guard: CountedRequest<()>,
     ) -> StateComputeResultFut {
         let (result_tx, result_rx) = oneshot::channel();
@@ -101,6 +108,7 @@ impl ExecutionPipeline {
                 block_preparer: txn_generator,
                 result_tx,
                 command_creation_time: Instant::now(),
+                pre_commit_hook,
                 lifetime_guard,
             })
             .expect("Failed to send block to execution pipeline.");
@@ -127,6 +135,7 @@ impl ExecutionPipeline {
             block_executor_onchain_config,
             parent_block_id,
             block_preparer,
+            pre_commit_hook,
             result_tx,
             command_creation_time,
             lifetime_guard,
@@ -163,6 +172,7 @@ impl ExecutionPipeline {
                     block: (block.id(), sig_verified_txns).into(),
                     parent_block_id,
                     block_executor_onchain_config,
+                    pre_commit_hook,
                     result_tx,
                     command_creation_time: Instant::now(),
                     lifetime_guard,
@@ -196,6 +206,7 @@ impl ExecutionPipeline {
             block,
             parent_block_id,
             block_executor_onchain_config,
+            pre_commit_hook,
             result_tx,
             command_creation_time,
             lifetime_guard,
@@ -232,6 +243,7 @@ impl ExecutionPipeline {
                     block_id,
                     parent_block_id,
                     state_checkpoint_output,
+                    pre_commit_hook,
                     result_tx,
                     command_creation_time: Instant::now(),
                     lifetime_guard,
@@ -252,6 +264,7 @@ impl ExecutionPipeline {
             block_id,
             parent_block_id,
             state_checkpoint_output: execution_result,
+            pre_commit_hook,
             result_tx,
             command_creation_time,
             lifetime_guard,
@@ -274,6 +287,7 @@ impl ExecutionPipeline {
             }
             .await;
             let pipeline_res = res.map(|(output, execution_duration)| {
+                let pre_commit_hook_fut = pre_commit_hook(&input_txns, &output);
                 let pre_commit_fut: BoxFuture<'static, ExecutorResult<()>> =
                     if output.epoch_state().is_some() || !enable_pre_commit {
                         // hack: it causes issue if pre-commit is finished at an epoch ending, and
@@ -285,7 +299,9 @@ impl ExecutionPipeline {
                                 executor.pre_commit_block(block_id, parent_block_id)
                             })
                             .await
-                            .expect("failed to spawn_blocking")
+                            .expect("failed to spawn_blocking")?;
+                            pre_commit_hook_fut.await;
+                            Ok(())
                         })
                     } else {
                         // kick off pre-commit right away
@@ -295,6 +311,7 @@ impl ExecutionPipeline {
                             .send(PreCommitCommand {
                                 block_id,
                                 parent_block_id,
+                                pre_commit_hook_fut,
                                 result_tx: pre_commit_result_tx,
                                 lifetime_guard,
                             })
@@ -322,6 +339,7 @@ impl ExecutionPipeline {
         while let Some(PreCommitCommand {
             block_id,
             parent_block_id,
+            pre_commit_hook_fut,
             result_tx,
             lifetime_guard,
         }) = block_rx.recv().await
@@ -336,7 +354,9 @@ impl ExecutionPipeline {
                     })
                 )
                 .await
-                .expect("Failed to spawn_blocking().")
+                .expect("Failed to spawn_blocking().")?;
+                pre_commit_hook_fut.await;
+                Ok(())
             }
             .await;
             result_tx
@@ -355,6 +375,7 @@ struct PrepareBlockCommand {
     // The parent block id.
     parent_block_id: HashValue,
     block_preparer: BlockPreparer,
+    pre_commit_hook: PreCommitHook,
     result_tx: oneshot::Sender<ExecutorResult<PipelineExecutionResult>>,
     command_creation_time: Instant,
     lifetime_guard: CountedRequest<()>,
@@ -365,6 +386,7 @@ struct ExecuteBlockCommand {
     block: ExecutableBlock,
     parent_block_id: HashValue,
     block_executor_onchain_config: BlockExecutorConfigFromOnchain,
+    pre_commit_hook: PreCommitHook,
     result_tx: oneshot::Sender<ExecutorResult<PipelineExecutionResult>>,
     command_creation_time: Instant,
     lifetime_guard: CountedRequest<()>,
@@ -375,6 +397,7 @@ struct LedgerApplyCommand {
     block_id: HashValue,
     parent_block_id: HashValue,
     state_checkpoint_output: ExecutorResult<(StateCheckpointOutput, Duration)>,
+    pre_commit_hook: PreCommitHook,
     result_tx: oneshot::Sender<ExecutorResult<PipelineExecutionResult>>,
     command_creation_time: Instant,
     lifetime_guard: CountedRequest<()>,
@@ -383,6 +406,7 @@ struct LedgerApplyCommand {
 struct PreCommitCommand {
     block_id: HashValue,
     parent_block_id: HashValue,
+    pre_commit_hook_fut: BoxFuture<'static, ()>,
     result_tx: oneshot::Sender<ExecutorResult<()>>,
     lifetime_guard: CountedRequest<()>,
 }

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -7,7 +7,7 @@ use crate::{
     block_storage::tracing::{observe_block, BlockStage},
     counters,
     error::StateSyncError,
-    execution_pipeline::ExecutionPipeline,
+    execution_pipeline::{ExecutionPipeline, PreCommitHook},
     monitor,
     payload_manager::TPayloadManager,
     pipeline::pipeline_phase::CountedRequest,
@@ -24,13 +24,14 @@ use aptos_consensus_types::{
     pipelined_block::PipelinedBlock,
 };
 use aptos_crypto::HashValue;
-use aptos_executor_types::{BlockExecutorTrait, ExecutorResult};
+use aptos_executor_types::{BlockExecutorTrait, ExecutorResult, StateComputeResult};
 use aptos_infallible::RwLock;
 use aptos_logger::prelude::*;
+use aptos_metrics_core::IntGauge;
 use aptos_types::{
     account_address::AccountAddress, block_executor::config::BlockExecutorConfigFromOnchain,
-    contract_event::ContractEvent, epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
-    randomness::Randomness, transaction::Transaction,
+    block_metadata_ext::BlockMetadataExt, epoch_state::EpochState,
+    ledger_info::LedgerInfoWithSignatures, randomness::Randomness, transaction::SignedTransaction,
 };
 use fail::fail_point;
 use futures::{future::BoxFuture, SinkExt, StreamExt};
@@ -39,11 +40,7 @@ use tokio::sync::Mutex as AsyncMutex;
 
 pub type StateComputeResultFut = BoxFuture<'static, ExecutorResult<PipelineExecutionResult>>;
 
-type NotificationType = (
-    Box<dyn FnOnce() + Send + Sync>,
-    Vec<Transaction>,
-    Vec<ContractEvent>, // Subscribable events, e.g. NewEpochEvent, DKGStartEvent
-);
+type NotificationType = BoxFuture<'static, ()>;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
 struct LogicalTime {
@@ -73,7 +70,8 @@ pub struct ExecutionProxy {
     executor: Arc<dyn BlockExecutorTrait>,
     txn_notifier: Arc<dyn TxnNotifier>,
     state_sync_notifier: Arc<dyn ConsensusNotificationSender>,
-    async_state_sync_notifier: aptos_channels::Sender<NotificationType>,
+    pre_commit_notifier: aptos_channels::Sender<NotificationType>,
+    commit_notifier: aptos_channels::Sender<NotificationType>,
     write_mutex: AsyncMutex<LogicalTime>,
     transaction_filter: Arc<TransactionFilter>,
     execution_pipeline: ExecutionPipeline,
@@ -89,28 +87,22 @@ impl ExecutionProxy {
         txn_filter: TransactionFilter,
         enable_pre_commit: bool,
     ) -> Self {
-        let (tx, mut rx) =
-            aptos_channels::new::<NotificationType>(10, &counters::PENDING_STATE_SYNC_NOTIFICATION);
-        let notifier = state_sync_notifier.clone();
-        handle.spawn(async move {
-            while let Some((callback, txns, subscribable_events)) = rx.next().await {
-                if let Err(e) = monitor!(
-                    "notify_state_sync",
-                    notifier.notify_new_commit(txns, subscribable_events).await
-                ) {
-                    error!(error = ?e, "Failed to notify state synchronizer");
-                }
+        let pre_commit_notifier = Self::spawn_future_runner(
+            handle,
+            "pre-commit",
+            &counters::PENDING_STATE_SYNC_NOTIFICATION,
+        );
+        let commit_notifier =
+            Self::spawn_future_runner(handle, "commit", &counters::PENDING_COMMIT_NOTIFICATION);
 
-                callback();
-            }
-        });
         let execution_pipeline =
             ExecutionPipeline::spawn(executor.clone(), handle, enable_pre_commit);
         Self {
             executor,
             txn_notifier,
             state_sync_notifier,
-            async_state_sync_notifier: tx,
+            pre_commit_notifier,
+            commit_notifier,
             write_mutex: AsyncMutex::new(LogicalTime::new(0, 0)),
             transaction_filter: Arc::new(txn_filter),
             execution_pipeline,
@@ -118,33 +110,62 @@ impl ExecutionProxy {
         }
     }
 
-    fn transactions_to_commit(
+    fn spawn_future_runner(
+        handle: &tokio::runtime::Handle,
+        name: &'static str,
+        pending_notifications_gauge: &IntGauge,
+    ) -> aptos_channels::Sender<NotificationType> {
+        let (tx, mut rx) = aptos_channels::new::<NotificationType>(10, pending_notifications_gauge);
+        let _join_handle = handle.spawn(async move {
+            while let Some(fut) = rx.next().await {
+                fut.await
+            }
+            info!(name = name, "Future runner stopped.")
+        });
+        tx
+    }
+
+    fn pre_commit_hook(
         &self,
-        executed_block: &PipelinedBlock,
-        validators: &[AccountAddress],
-        randomness_enabled: bool,
-    ) -> Vec<Transaction> {
-        // reconfiguration suffix don't execute
-        if executed_block.is_reconfiguration_suffix() {
-            return vec![];
-        }
+        block: &Block,
+        metadata: BlockMetadataExt,
+        payload_manager: Arc<dyn TPayloadManager>,
+    ) -> PreCommitHook {
+        let mut pre_commit_notifier = self.pre_commit_notifier.clone();
+        let state_sync_notifier = self.state_sync_notifier.clone();
+        let payload = block.payload().cloned();
+        let timestamp = block.timestamp_usecs();
+        let validator_txns = block.validator_txns().cloned().unwrap_or_default();
+        let block_id = block.id();
+        Box::new(
+            move |user_txns: &[SignedTransaction], state_compute_result: &StateComputeResult| {
+                let input_txns = Block::combine_to_input_transactions(
+                    validator_txns,
+                    user_txns.to_vec(),
+                    metadata,
+                );
+                let txns = state_compute_result.transactions_to_commit(input_txns, block_id);
+                let subscribable_events = state_compute_result.subscribable_events().to_vec();
+                Box::pin(async move {
+                    pre_commit_notifier
+                        .send(Box::pin(async move {
+                            if let Err(e) = monitor!(
+                                "notify_state_sync",
+                                state_sync_notifier
+                                    .notify_new_commit(txns, subscribable_events)
+                                    .await
+                            ) {
+                                error!(error = ?e, "Failed to notify state synchronizer");
+                            }
 
-        let user_txns = executed_block.input_transactions().clone();
-        let validator_txns = executed_block.validator_txns().cloned().unwrap_or_default();
-        let metadata = if randomness_enabled {
-            executed_block
-                .block()
-                .new_metadata_with_randomness(validators, executed_block.randomness().cloned())
-        } else {
-            executed_block.block().new_block_metadata(validators).into()
-        };
-
-        let input_txns = Block::combine_to_input_transactions(validator_txns, user_txns, metadata);
-
-        // Adds StateCheckpoint/BlockEpilogue transaction if needed.
-        executed_block
-            .compute_result()
-            .transactions_to_commit(input_txns, executed_block.id())
+                            let payload_vec = payload.into_iter().collect();
+                            payload_manager.notify_commit(timestamp, payload_vec);
+                        }))
+                        .await
+                        .expect("Failed to send pre-commit notification");
+                })
+            },
+        )
     }
 }
 
@@ -201,10 +222,11 @@ impl StateComputer for ExecutionProxy {
             .execution_pipeline
             .queue(
                 block.clone(),
-                metadata,
+                metadata.clone(),
                 parent_block_id,
                 transaction_generator,
                 block_executor_onchain_config,
+                self.pre_commit_hook(block, metadata, payload_manager),
                 lifetime_guard,
             )
             .await;
@@ -264,40 +286,14 @@ impl StateComputer for ExecutionProxy {
         callback: StateComputerCommitCallBackType,
     ) -> ExecutorResult<()> {
         let mut latest_logical_time = self.write_mutex.lock().await;
-        let mut txns = Vec::new();
-        let mut subscribable_txn_events = Vec::new();
-        let mut payloads = Vec::new();
         let logical_time = LogicalTime::new(
             finality_proof.ledger_info().epoch(),
             finality_proof.ledger_info().round(),
         );
-        let block_timestamp = finality_proof.commit_info().timestamp_usecs();
-
-        let MutableState {
-            payload_manager,
-            validators,
-            is_randomness_enabled,
-            ..
-        } = self
-            .state
-            .read()
-            .as_ref()
-            .cloned()
-            .expect("must be set within an epoch");
-        let mut pre_commit_futs = Vec::with_capacity(blocks.len());
-        for block in blocks {
-            if let Some(payload) = block.block().payload() {
-                payloads.push(payload.clone());
-            }
-
-            txns.extend(self.transactions_to_commit(block, &validators, is_randomness_enabled));
-            subscribable_txn_events.extend(block.subscribable_events());
-            pre_commit_futs.push(block.take_pre_commit_fut());
-        }
 
         // wait until all blocks are committed
-        for pre_commit_fut in pre_commit_futs {
-            pre_commit_fut.await?
+        for block in blocks {
+            block.take_pre_commit_fut().await?
         }
 
         let executor = self.executor.clone();
@@ -314,15 +310,15 @@ impl StateComputer for ExecutionProxy {
         .expect("spawn_blocking failed");
 
         let blocks = blocks.to_vec();
-        let wrapped_callback = move || {
-            payload_manager.notify_commit(block_timestamp, payloads);
+        let callback_fut = Box::pin(async move {
             callback(&blocks, finality_proof);
-        };
-        self.async_state_sync_notifier
+        });
+
+        self.commit_notifier
             .clone()
-            .send((Box::new(wrapped_callback), txns, subscribable_txn_events))
+            .send(callback_fut)
             .await
-            .expect("Failed to send async state sync notification");
+            .expect("Failed to send commit notification");
 
         *latest_logical_time = logical_time;
         Ok(())
@@ -428,9 +424,10 @@ async fn test_commit_sync_race() {
         aggregate_signature::AggregateSignature,
         block_executor::partitioner::ExecutableBlock,
         block_info::BlockInfo,
+        contract_event::ContractEvent,
         ledger_info::LedgerInfo,
         on_chain_config::{TransactionDeduperType, TransactionShufflerType},
-        transaction::{SignedTransaction, TransactionStatus},
+        transaction::{SignedTransaction, Transaction, TransactionStatus},
     };
 
     struct RecordedCommit {

--- a/consensus/src/state_computer_tests.rs
+++ b/consensus/src/state_computer_tests.rs
@@ -2,15 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    error::MempoolError, payload_manager::DirectMempoolPayloadManager,
-    pipeline::pipeline_phase::CountedRequest, state_computer::ExecutionProxy,
+    error::MempoolError, pipeline::pipeline_phase::CountedRequest, state_computer::ExecutionProxy,
     state_replication::StateComputer, transaction_deduper::NoOpDeduper,
     transaction_filter::TransactionFilter, transaction_shuffler::NoOpShuffler,
     txn_notifier::TxnNotifier,
 };
 use aptos_config::config::transaction_filter_type::Filter;
 use aptos_consensus_notifications::{ConsensusNotificationSender, Error};
-use aptos_consensus_types::{block::Block, block_data::BlockData, pipelined_block::PipelinedBlock};
+use aptos_consensus_types::{block::Block, block_data::BlockData};
 use aptos_crypto::HashValue;
 use aptos_executor_types::{
     state_checkpoint_output::StateCheckpointOutput, BlockExecutorTrait, ExecutorResult,
@@ -18,27 +17,34 @@ use aptos_executor_types::{
 };
 use aptos_infallible::Mutex;
 use aptos_types::{
-    aggregate_signature::AggregateSignature,
     block_executor::{config::BlockExecutorConfigFromOnchain, partitioner::ExecutableBlock},
     contract_event::ContractEvent,
     epoch_state::EpochState,
-    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    ledger_info::LedgerInfoWithSignatures,
     transaction::{ExecutionStatus, SignedTransaction, Transaction, TransactionStatus},
     validator_txn::ValidatorTransaction,
 };
-use futures_channel::oneshot;
 use std::sync::{atomic::AtomicU64, Arc};
-use tokio::runtime::Handle;
+use tokio::{runtime::Handle, sync::Mutex as AsyncMutex};
 
 struct DummyStateSyncNotifier {
     invocations: Mutex<Vec<(Vec<Transaction>, Vec<ContractEvent>)>>,
+    tx: tokio::sync::mpsc::Sender<()>,
+    rx: AsyncMutex<tokio::sync::mpsc::Receiver<()>>,
 }
 
 impl DummyStateSyncNotifier {
     fn new() -> Self {
+        let (tx, rx) = tokio::sync::mpsc::channel(10);
         Self {
             invocations: Mutex::new(vec![]),
+            tx,
+            rx: AsyncMutex::new(rx),
         }
+    }
+
+    async fn wait_for_notification(&self) {
+        self.rx.lock().await.recv().await;
     }
 }
 
@@ -52,6 +58,7 @@ impl ConsensusNotificationSender for DummyStateSyncNotifier {
         self.invocations
             .lock()
             .push((transactions, subscribable_events));
+        self.tx.send(()).await.unwrap();
         Ok(())
     }
 
@@ -94,15 +101,6 @@ impl BlockExecutorTrait for DummyBlockExecutor {
         Ok(())
     }
 
-    fn execute_block(
-        &self,
-        _block: ExecutableBlock,
-        _parent_block_id: HashValue,
-        _onchain_config: BlockExecutorConfigFromOnchain,
-    ) -> ExecutorResult<StateComputeResult> {
-        Ok(StateComputeResult::new_dummy())
-    }
-
     fn execute_and_state_checkpoint(
         &self,
         block: ExecutableBlock,
@@ -119,7 +117,18 @@ impl BlockExecutorTrait for DummyBlockExecutor {
         _parent_block_id: HashValue,
         _state_checkpoint_output: StateCheckpointOutput,
     ) -> ExecutorResult<StateComputeResult> {
-        Ok(StateComputeResult::new_dummy())
+        let num_txns = self
+            .blocks_received
+            .lock()
+            .last()
+            .unwrap()
+            .transactions
+            .num_transactions();
+
+        Ok(StateComputeResult::new_dummy_with_compute_status(vec![
+            TransactionStatus::Keep(ExecutionStatus::Success);
+            num_txns
+        ]))
     }
 
     fn pre_commit_block(
@@ -142,15 +151,16 @@ impl BlockExecutorTrait for DummyBlockExecutor {
 
 #[tokio::test]
 #[cfg(test)]
-async fn schedule_compute_should_discover_validator_txns() {
+async fn should_see_and_notify_validator_txns() {
     use crate::payload_manager::DirectMempoolPayloadManager;
 
     let executor = Arc::new(DummyBlockExecutor::new());
 
+    let state_sync_notifier = Arc::new(DummyStateSyncNotifier::new());
     let execution_policy = ExecutionProxy::new(
         executor.clone(),
         Arc::new(DummyTxnNotifier {}),
-        Arc::new(DummyStateSyncNotifier::new()),
+        state_sync_notifier.clone(),
         &Handle::current(),
         TransactionFilter::new(Filter::empty()),
         true,
@@ -183,7 +193,8 @@ async fn schedule_compute_should_discover_validator_txns() {
     let _ = execution_policy
         .schedule_compute(&block, HashValue::zero(), None, dummy_guard())
         .await
-        .await;
+        .await
+        .unwrap();
 
     // Get the txns from the view of the dummy executor.
     let txns = executor.blocks_received.lock()[0]
@@ -195,78 +206,9 @@ async fn schedule_compute_should_discover_validator_txns() {
     let supposed_validator_txn_1 = txns[2].expect_valid().try_as_validator_txn().unwrap();
     assert_eq!(&validator_txn_0, supposed_validator_txn_0);
     assert_eq!(&validator_txn_1, supposed_validator_txn_1);
-}
 
-#[tokio::test]
-async fn commit_should_discover_validator_txns() {
-    let state_sync_notifier = Arc::new(DummyStateSyncNotifier::new());
-
-    let execution_policy = ExecutionProxy::new(
-        Arc::new(DummyBlockExecutor::new()),
-        Arc::new(DummyTxnNotifier {}),
-        state_sync_notifier.clone(),
-        &Handle::current(),
-        TransactionFilter::new(Filter::empty()),
-        true,
-    );
-
-    let validator_txn_0 = ValidatorTransaction::dummy(vec![0xFF; 99]);
-    let validator_txn_1 = ValidatorTransaction::dummy(vec![0xFF; 999]);
-
-    let block = Block::new_for_testing(
-        HashValue::zero(),
-        BlockData::dummy_with_validator_txns(vec![
-            validator_txn_0.clone(),
-            validator_txn_1.clone(),
-        ]),
-        None,
-    );
-
-    // Eventually 3 txns: block metadata, validator txn 0, validator txn 1.
-    let state_compute_result = StateComputeResult::new_dummy_with_compute_status(vec![
-            TransactionStatus::Keep(
-                ExecutionStatus::Success
-            );
-            3
-        ]);
-
-    let blocks = vec![Arc::new(PipelinedBlock::new(
-        block,
-        vec![],
-        state_compute_result,
-    ))];
-    blocks[0].mark_successful_pre_commit_for_test();
-    let epoch_state = EpochState::empty();
-
-    execution_policy.new_epoch(
-        &epoch_state,
-        Arc::new(DirectMempoolPayloadManager::new()),
-        Arc::new(NoOpShuffler {}),
-        BlockExecutorConfigFromOnchain::new_no_block_limit(),
-        Arc::new(NoOpDeduper {}),
-        false,
-    );
-
-    let (tx, rx) = oneshot::channel::<()>();
-
-    let callback = Box::new(
-        move |_a: &[Arc<PipelinedBlock>], _b: LedgerInfoWithSignatures| {
-            tx.send(()).unwrap();
-        },
-    );
-
-    let _ = execution_policy
-        .commit(
-            blocks.as_slice(),
-            LedgerInfoWithSignatures::new(LedgerInfo::dummy(), AggregateSignature::empty()),
-            callback,
-        )
-        .await;
-
-    // Wait until state sync is notified.
-    let _ = rx.await;
-
-    // Get all txns that state sync was notified with.
+    // Get all txns that state sync was notified with (when pre-commit finishes)
+    state_sync_notifier.wait_for_notification().await;
     let (txns, _) = state_sync_notifier.invocations.lock()[0].clone();
 
     let supposed_validator_txn_0 = txns[1].try_as_validator_txn().unwrap();

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -434,6 +434,10 @@ impl StateComputeResult {
         input_txns: Vec<Transaction>,
         block_id: HashValue,
     ) -> Vec<Transaction> {
+        if self.is_reconfiguration_suffix() {
+            return vec![];
+        }
+
         assert_eq!(
             input_txns.len(),
             self.compute_status_for_input_txns().len(),
@@ -517,6 +521,10 @@ impl StateComputeResult {
 
     pub fn subscribable_events(&self) -> &[ContractEvent] {
         &self.subscribable_events
+    }
+
+    pub fn is_reconfiguration_suffix(&self) -> bool {
+        self.has_reconfiguration() && self.compute_status_for_input_txns().is_empty()
     }
 }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

separate state sync notifications to pre-commit and commit, so that state sync always receives notification even if consensus switches with pre-committed-but-not-committed blocks.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

existing coverage 

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Validator Node

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
