### PR TITLE
Fixed possible double insertion in loader

### DIFF
--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -141,7 +141,14 @@ impl StructNameCache {
         if let Some(idx) = self.data.read().0.get(&name) {
             return *idx;
         }
+
         let mut inner_data = self.data.write();
+
+        // Check again to avoid double insertion.
+        if let Some(idx) = inner_data.0.get(&name) {
+            return *idx;
+        }
+
         let idx = StructNameIndex(inner_data.1.len());
         inner_data.0.insert(name.clone(), idx);
         inner_data.1.push(name);


### PR DESCRIPTION
## Description
There was a possibility of double insertion to StructNameCache, fixed by checking for the existence of the key againunder the write lock.

## How Has This Been Tested?
Reviewer's sharp eyes

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)
