### PR TITLE
[Prover][trivial] Add support of operation `vector[]` to spec

### DIFF
--- a/third_party/move/move-prover/tests/sources/functional/verify_vector.move
+++ b/third_party/move/move-prover/tests/sources/functional/verify_vector.move
@@ -88,7 +88,7 @@ module 0x42::VerifyVector {
     spec verify_singleton {
         aborts_if false;
         ensures len(result) == 1;
-        ensures result[0] == e;
+        ensures result == vector[e];
     }
 
     // Reverses the order of the elements in the vector in place.
@@ -408,5 +408,39 @@ module 0x42::VerifyVector {
         ensures len(v) == len(old(v)) - 1;
         ensures v == old(update(v,i,v[len(v)-1])[0..len(v)-1]);
         ensures old(v[i]) == result;
+    }
+
+    fun vector_operator_in_function<Element: copy + drop>(e1: Element, e2: Element, e3: Element): vector<Element> {
+        vector[e1, e2, e3]
+    }
+
+    fun spec_with_vector_operator<Element: copy + drop>(e1: Element, e2: Element, e3: Element): (vector<Element>, vector<Element>) {
+        let v0 = vector::empty();
+        let v3 = vector::empty();
+        vector::push_back(&mut v3, e1);
+        spec {
+            assert v3 == vector[e1];
+        };
+        vector::push_back(&mut v3, e2);
+        spec {
+            assert v3 == vector[e1, e2];
+        };
+        vector::push_back(&mut v3, e3);
+        spec {
+            assert v3 == vector_operator_in_function(e1, e2, e3);
+        };
+        vector::push_back(&mut v3, e1);
+        spec {
+            assert v3 == vector[e1, e2, e3, e1];
+        };
+        vector::push_back(&mut v3, e2);
+        spec {
+            assert v3 == vector[e1, e2, e3, e1, e2];
+        };
+        (v3, v0)
+    }
+    spec spec_with_vector_operator {
+        ensures result_2 == vector[];
+        ensures result_1 == concat(vector_operator_in_function(e1, e2, e3), vector[e1, e2]);
     }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR allows use of `vector[...]` in specifications by:

1) converting `vector[]` into `$EmptyVec` when the vector is empty;
2) converting `vector[]` into `MakeVec1`, `MakeVec2`, `MakeVec3` and `MakeVec4`  when the vector has 1, 2, 3 and 4 elements;
3) converting `vector[x1, x2...]` into `ConcatVec(MakeVec1(x1), ConcatVec(...))` when the vector has more than 4 elements.

close #14790

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

New test cases with `vector[...]` used in the spec.


## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Prover

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
