### PR TITLE
[forge] Add metrics for insertion_to_block and block_creation_to_commit

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -1178,12 +1178,12 @@ fn realistic_env_load_sweep_test() -> ForgeConfig {
         test: Box::new(PerformanceBenchmark),
         workloads: Workloads::TPS(vec![10, 100, 1000, 3000, 5000, 7000]),
         criteria: [
-            (9, 0.9, 0.9, 1.2, 0),
-            (95, 0.9, 1.0, 1.2, 0),
-            (950, 1.2, 1.3, 2.0, 0),
-            (2900, 1.4, 2.2, 2.5, 0),
-            (4800, 2.0, 2.5, 3.0, 0),
-            (6700, 2.5, 3.5, 5.0, 0),
+            (9, 1.0, 1.1, 1.2, 0),
+            (95, 1.0, 1.1, 1.2, 0),
+            (950, 1.3, 1.5, 2.0, 0),
+            (2900, 1.8, 2.2, 2.5, 0),
+            (4800, 2.3, 2.5, 3.0, 0),
+            (6700, 2.8, 3.5, 5.0, 0),
             // TODO add 9k or 10k. Allow some expired transactions (high-load)
         ]
         .into_iter()

--- a/testsuite/testcases/src/load_vs_perf_benchmark.rs
+++ b/testsuite/testcases/src/load_vs_perf_benchmark.rs
@@ -471,7 +471,7 @@ fn to_table(type_name: String, results: &[Vec<SingleRunStats>]) -> Vec<String> {
 
     let mut table = Vec::new();
     table.push(format!(
-        "{: <name_width$} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12}",
+        "{: <name_width$} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <16} | {: <13} | {: <12} | {: <12} | {: <12} | {: <12}",
         type_name,
         "submitted/s",
         "committed/s",
@@ -495,7 +495,7 @@ fn to_table(type_name: String, results: &[Vec<SingleRunStats>]) -> Vec<String> {
         for result in run_results {
             let rate = result.stats.rate();
             table.push(format!(
-                "{: <name_width$} | {: <12.2} | {: <12.2} | {: <12.2} | {: <12.2} | {: <12.2} | {: <12.3} | {: <12.3} | {: <12.3} | {: <12.3} | {: <12.3} | {: <12.3} | {: <12} | {: <12.3} | {: <12.3} | {: <12.3}",
+                "{: <name_width$} | {: <12.2} | {: <12.2} | {: <12.2} | {: <12.2} | {: <12.2} | {: <12.3} | {: <12.3} | {: <12.3} | {: <12.3} | {: <16.3} | {: <13.3} | {: <12} | {: <12.3} | {: <12.3} | {: <12.3}",
                 result.name,
                 rate.submitted,
                 rate.committed,

--- a/testsuite/testcases/src/load_vs_perf_benchmark.rs
+++ b/testsuite/testcases/src/load_vs_perf_benchmark.rs
@@ -471,7 +471,7 @@ fn to_table(type_name: String, results: &[Vec<SingleRunStats>]) -> Vec<String> {
 
     let mut table = Vec::new();
     table.push(format!(
-        "{: <name_width$} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12}",
+        "{: <name_width$} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12} | {: <12}",
         type_name,
         "submitted/s",
         "committed/s",
@@ -482,10 +482,8 @@ fn to_table(type_name: String, results: &[Vec<SingleRunStats>]) -> Vec<String> {
         "p50 lat",
         "p90 lat",
         "p99 lat",
-        "batch->pos",
-        "pos->prop",
-        "prop->order",
-        "order->commit",
+        "insertion->block",
+        "block->commit",
         "actual dur",
         // optional indexer metrics
         "idx_fn",
@@ -497,7 +495,7 @@ fn to_table(type_name: String, results: &[Vec<SingleRunStats>]) -> Vec<String> {
         for result in run_results {
             let rate = result.stats.rate();
             table.push(format!(
-                "{: <name_width$} | {: <12.2} | {: <12.2} | {: <12.2} | {: <12.2} | {: <12.2} | {: <12.3} | {: <12.3} | {: <12.3} | {: <12.3} | {: <12.3} | {: <12.3} | {: <12.3} | {: <12.3} | {: <12} | {: <12.3} | {: <12.3} | {: <12.3}",
+                "{: <name_width$} | {: <12.2} | {: <12.2} | {: <12.2} | {: <12.2} | {: <12.2} | {: <12.3} | {: <12.3} | {: <12.3} | {: <12.3} | {: <12.3} | {: <12.3} | {: <12} | {: <12.3} | {: <12.3} | {: <12.3}",
                 result.name,
                 rate.submitted,
                 rate.committed,
@@ -508,10 +506,8 @@ fn to_table(type_name: String, results: &[Vec<SingleRunStats>]) -> Vec<String> {
                 rate.p50_latency as f64 / 1000.0,
                 rate.p90_latency as f64 / 1000.0,
                 rate.p99_latency as f64 / 1000.0,
-                result.latency_breakdown.get_samples(&LatencyBreakdownSlice::QsBatchToPos).unwrap_or(&MetricSamples::default()).max_sample(),
-                result.latency_breakdown.get_samples(&LatencyBreakdownSlice::QsPosToProposal).unwrap_or(&MetricSamples::default()).max_sample(),
-                result.latency_breakdown.get_samples(&LatencyBreakdownSlice::ConsensusProposalToOrdered).unwrap_or(&MetricSamples::default()).max_sample(),
-                result.latency_breakdown.get_samples(&LatencyBreakdownSlice::ConsensusOrderedToCommit).unwrap_or(&MetricSamples::default()).max_sample(),
+                result.latency_breakdown.get_samples(&LatencyBreakdownSlice::InsertionToBlock).unwrap_or(&MetricSamples::default()).max_sample(),
+                result.latency_breakdown.get_samples(&LatencyBreakdownSlice::BlockCreationToCommit).unwrap_or(&MetricSamples::default()).max_sample(),
                 result.actual_duration.as_secs(),
                 // optional indexer metrics
                 result.latency_breakdown.get_samples(&LatencyBreakdownSlice::IndexerFullnodeProcessedBatch).unwrap_or(&MetricSamples::default()).max_sample(),


### PR DESCRIPTION
## Description

Forge provides too much granularity with 4 columns capturing metrics for all parts the blockchain latency in 4 components. The goal of this PR is to simplify this into 2 columns capturing 

1. `InsertionToBlock` -> Time from getting into the node to getting into a block
2. `BlockCreationToCommit` -> Time from getting into the block to getting into storage

### OLD
![batch-pos](https://github.com/user-attachments/assets/64a4320c-cc7c-497b-a943-ffa7a94cd342)

### New

![Screenshot 2024-10-17 at 2 00 17 PM](https://github.com/user-attachments/assets/affd7c2c-b372-45b4-af37-80bc60960d9d)

## How Has This Been Tested?

Tested queries on grafana 👍 

- [Adhoc Forge Run before](https://github.com/aptos-labs/aptos-core/actions/runs/11264334213)
- [SUCCESS] [Adhoc Forge Run after (with `realistic_env_load_sweep`)](https://github.com/aptos-labs/aptos-core/actions/runs/11283913429)

## Evidence for latency limit changes (non-exhaustive)
- [FAILURE] [`Failed latency check, for \["P90 latency for 10 is 0.9s and exceeds limit of 0.9s"\]`](https://github.com/aptos-labs/aptos-core/actions/runs/11280108671)
- [FAILURE] [`Failed latency check, for \["P50 latency for 100 is 0.9s and exceeds limit of 0.9s"\]`](https://github.com/aptos-labs/aptos-core/actions/runs/11282998408)
- [FAILURE] [`Failed latency check, for \["P90 latency for 1000 is 1.3s and exceeds limit of 1.3s"\]`](https://github.com/aptos-labs/aptos-core/actions/runs/11282080946)