### PR TITLE
Create benchmark

### DIFF
--- a/crates/transaction-workloads-lib/src/args.rs
+++ b/crates/transaction-workloads-lib/src/args.rs
@@ -78,6 +78,8 @@ pub enum TransactionTypeArg {
     SmartTablePicture1MWith1KChangeExceedsLimit,
     DeserializeU256,
     SimpleScript,
+    APTTransferWithPermissionedSigner,
+    APTTransferWithMasterSigner,
 }
 
 impl TransactionTypeArg {
@@ -351,6 +353,12 @@ impl TransactionTypeArg {
             },
             TransactionTypeArg::DeserializeU256 => call_custom_module(EntryPoints::DeserializeU256),
             TransactionTypeArg::SimpleScript => call_custom_module(EntryPoints::SimpleScript),
+            TransactionTypeArg::APTTransferWithPermissionedSigner => {
+                call_custom_module(EntryPoints::APTTransferWithPermissionedSigner)
+            },
+            TransactionTypeArg::APTTransferWithMasterSigner => {
+                call_custom_module(EntryPoints::APTTransferWithMasterSigner)
+            },
         }
     }
 

--- a/crates/transaction-workloads-lib/src/move_workloads.rs
+++ b/crates/transaction-workloads-lib/src/move_workloads.rs
@@ -232,6 +232,10 @@ pub enum EntryPoints {
     /// there to slow down deserialization & verification, effectively making it more expensive to
     /// load it into code cache.
     SimpleScript,
+    /// Set up an APT transfer permission and transfering APT by using that permissioned signer.
+    APTTransferWithPermissionedSigner,
+    /// Transfer APT using vanilla master signer to compare the performance.
+    APTTransferWithMasterSigner,
 }
 
 impl EntryPointTrait for EntryPoints {
@@ -284,7 +288,9 @@ impl EntryPointTrait for EntryPoints {
             | EntryPoints::ResourceGroupsSenderWriteTag { .. }
             | EntryPoints::ResourceGroupsSenderMultiChange { .. }
             | EntryPoints::CoinInitAndMint
-            | EntryPoints::FungibleAssetMint => "framework_usecases",
+            | EntryPoints::FungibleAssetMint
+            | EntryPoints::APTTransferWithPermissionedSigner
+            | EntryPoints::APTTransferWithMasterSigner => "framework_usecases",
             EntryPoints::TokenV2AmbassadorMint { .. } | EntryPoints::TokenV2AmbassadorBurn => {
                 "ambassador_token"
             },
@@ -363,6 +369,8 @@ impl EntryPointTrait for EntryPoints {
             EntryPoints::IncGlobalMilestoneAggV2 { .. }
             | EntryPoints::CreateGlobalMilestoneAggV2 { .. } => "counter_with_milestone",
             EntryPoints::DeserializeU256 => "bcs_stream",
+            EntryPoints::APTTransferWithPermissionedSigner
+            | EntryPoints::APTTransferWithMasterSigner => "permissioned_transfer",
         }
     }
 
@@ -781,6 +789,20 @@ impl EntryPointTrait for EntryPoints {
                     ],
                 )
             },
+            EntryPoints::APTTransferWithPermissionedSigner => get_payload(
+                module_id,
+                ident_str!("transfer_permissioned").to_owned(),
+                vec![
+                    bcs::to_bytes(&other.expect("Must provide other")).unwrap(),
+                    bcs::to_bytes(&1u64).unwrap(),
+                ],
+            ),
+            EntryPoints::APTTransferWithMasterSigner => {
+                get_payload(module_id, ident_str!("transfer").to_owned(), vec![
+                    bcs::to_bytes(&other.expect("Must provide other")).unwrap(),
+                    bcs::to_bytes(&1u64).unwrap(),
+                ])
+            },
         }
     }
 
@@ -899,6 +921,8 @@ impl EntryPointTrait for EntryPoints {
             EntryPoints::DeserializeU256 => AutomaticArgs::None,
             EntryPoints::IncGlobalMilestoneAggV2 { .. } => AutomaticArgs::None,
             EntryPoints::CreateGlobalMilestoneAggV2 { .. } => AutomaticArgs::Signer,
+            EntryPoints::APTTransferWithPermissionedSigner
+            | EntryPoints::APTTransferWithMasterSigner => AutomaticArgs::Signer,
         }
     }
 }

--- a/testsuite/module-publish/src/packages/framework_usecases/sources/permissioned_transfer.move
+++ b/testsuite/module-publish/src/packages/framework_usecases/sources/permissioned_transfer.move
@@ -1,0 +1,24 @@
+
+module 0xABCD::permissioned_transfer {
+    use aptos_framework::aptos_account;
+    use aptos_framework::permissioned_signer;
+    use aptos_framework::primary_fungible_store;
+
+    public entry fun transfer_permissioned(
+        source: &signer, to: address, amount: u64
+    ) {
+        let handle = permissioned_signer::create_permissioned_handle(source);
+        let permissioned_signer = permissioned_signer::signer_from_permissioned_handle(&handle);
+
+        primary_fungible_store::grant_apt_permission(source, &permissioned_signer, amount);
+        aptos_account::transfer(&permissioned_signer, to, amount);
+
+        permissioned_signer::destroy_permissioned_handle(handle);
+    }
+
+    public entry fun transfer(
+        source: &signer, to: address, amount: u64
+    ) {
+        aptos_account::transfer(source, to, amount);
+    }
+}


### PR DESCRIPTION
## Description
Added new transaction types for APT token transfers, including a permissioned transfer option that uses the permissioned signer framework. This enables both standard APT transfers and permissioned transfers through the transaction generator and e2e benchmark framework.

## How Has This Been Tested?
The functionality is integrated into the existing e2e benchmark framework and transaction generator test infrastructure. The new transfer types are added to the test suite alongside other transaction types.

## Key Areas to Review
- New Move module `permissioned_transfer.move` implementing both standard and permissioned transfer functions
- Integration of new transaction types into the entry points enum and transaction type arguments
- Permissioned transfer implementation using the permissioned signer framework

## Type of Change
- [x] New feature
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Testing Infrastructure

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation