### PR TITLE
[compiler-v2] Avoid infinite recursion showing types with receiver functions in presence of errors

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/receiver/bad_receiver.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/bad_receiver.exp
@@ -23,9 +23,3 @@ error: undeclared `0x1::ordered_map::OrderedMao`
    │
 39 │     public fun borrow<K, V>(self: &OrderedMao<K, V>, key: &K): &V {
    │                                    ^^^^^^^^^^
-
-error: unable to infer instantiation of type `fun self.iter_borrow(Self,&*error*):&V` (consider providing type arguments or annotating the type)
-   ┌─ tests/checking/receiver/bad_receiver.move:40:9
-   │
-40 │         self.find(key).iter_borrow(self)
-   │         ^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/bad_receiver.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/bad_receiver.exp
@@ -1,0 +1,31 @@
+
+Diagnostics:
+error: undeclared receiver function `borrow` for type `vector<Entry<K, V>>`
+   ┌─ tests/checking/receiver/bad_receiver.move:25:10
+   │
+25 │         &map.entries.borrow(self.index).key
+   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: undeclared receiver function `lower_bound` for type `OrderedMap<K, V>`
+   ┌─ tests/checking/receiver/bad_receiver.move:29:27
+   │
+29 │         let lower_bound = self.lower_bound(key);
+   │                           ^^^^^^^^^^^^^^^^^^^^^
+
+error: type cannot have type arguments
+   ┌─ tests/checking/receiver/bad_receiver.move:39:36
+   │
+39 │     public fun borrow<K, V>(self: &OrderedMao<K, V>, key: &K): &V {
+   │                                    ^^^^^^^^^^
+
+error: undeclared `0x1::ordered_map::OrderedMao`
+   ┌─ tests/checking/receiver/bad_receiver.move:39:36
+   │
+39 │     public fun borrow<K, V>(self: &OrderedMao<K, V>, key: &K): &V {
+   │                                    ^^^^^^^^^^
+
+error: unable to infer instantiation of type `fun self.iter_borrow(Self,&*error*):&V` (consider providing type arguments or annotating the type)
+   ┌─ tests/checking/receiver/bad_receiver.move:40:9
+   │
+40 │         self.find(key).iter_borrow(self)
+   │         ^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/bad_receiver.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/bad_receiver.move
@@ -1,0 +1,50 @@
+module aptos_std::ordered_map {
+    const EITER_OUT_OF_BOUNDS: u64 = 3;
+
+    struct Entry<K, V> has drop, copy, store {
+        key: K,
+        value: V,
+    }
+
+    enum OrderedMap<K, V> has drop, copy, store {
+        SortedVectorMap {
+            entries: vector<Entry<K, V>>,
+        }
+    }
+    
+    enum Iterator has copy, drop {
+        End,
+        Position {
+            index: u64,
+        },
+    }
+
+    public fun iter_borrow_key<K, V>(self: &Iterator, map: &OrderedMap<K, V>): &K {
+        assert!(!(self is Iterator::End), EITER_OUT_OF_BOUNDS);
+
+        &map.entries.borrow(self.index).key
+    }
+    
+    public fun find<K, V>(self: &OrderedMap<K, V>, key: &K): Iterator {
+        let lower_bound = self.lower_bound(key);
+        if (lower_bound.iter_is_end(self)) {
+            lower_bound
+        } else if (lower_bound.iter_borrow_key(self) == key) {
+            lower_bound
+        } else {
+            self.new_end_iter()
+        }
+    }
+
+    public fun borrow<K, V>(self: &OrderedMao<K, V>, key: &K): &V {
+        self.find(key).iter_borrow(self)
+    }
+
+    public fun new_end_iter<K, V>(self: &OrderedMap<K, V>): Iterator {
+        Iterator::End
+    }
+
+    public fun iter_is_end<K, V>(self: &Iterator, _map: &OrderedMap<K, V>): bool {
+        self is Iterator::End
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/bad_receiver.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/bad_receiver.move
@@ -11,7 +11,7 @@ module aptos_std::ordered_map {
             entries: vector<Entry<K, V>>,
         }
     }
-    
+
     enum Iterator has copy, drop {
         End,
         Position {
@@ -24,7 +24,7 @@ module aptos_std::ordered_map {
 
         &map.entries.borrow(self.index).key
     }
-    
+
     public fun find<K, V>(self: &OrderedMap<K, V>, key: &K): Iterator {
         let lower_bound = self.lower_bound(key);
         if (lower_bound.iter_is_end(self)) {

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -420,13 +420,17 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         };
         ty.visit(&mut visitor);
         if incomplete {
-            self.error(
-                &loc,
-                &format!(
-                    "unable to infer instantiation of type `{}` (consider providing type arguments or annotating the type)",
-                    ty.display(&self.type_display_context())
-                ),
-            );
+            let displayed_ty = format!("{}", ty.display(&self.type_display_context()));
+            // Skip displaying the error message if there is already an error in the type; we must have another message about it already.
+            if !displayed_ty.contains("*error*") {
+                self.error(
+                    &loc,
+                    &format!(
+                        "unable to infer instantiation of type `{}` (consider providing type arguments or annotating the type)",
+                        displayed_ty
+                    ),
+                );
+            }
         }
         ty
     }

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -271,6 +271,7 @@ impl<'env> ModelBuilder<'env> {
             display_type_vars: false,
             used_modules: BTreeSet::new(),
             use_module_qualification: false,
+            opt_self_var: None,
         }
     }
 
@@ -464,6 +465,9 @@ impl<'env> ModelBuilder<'env> {
                             self.vector_receiver_functions
                                 .insert(name.symbol, name.clone());
                         }
+                    },
+                    Type::Error => {
+                        // Ignore this, there will be a message where the error type is generated.
                     },
                     _ => diag(
                         "is not suitable for receiver functions. \

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -271,7 +271,7 @@ impl<'env> ModelBuilder<'env> {
             display_type_vars: false,
             used_modules: BTreeSet::new(),
             use_module_qualification: false,
-            opt_self_var: None,
+            recursive_vars: None,
         }
     }
 
@@ -400,7 +400,7 @@ impl<'env> ModelBuilder<'env> {
                         &entry.name_loc,
                         &format!(
                             "parameter name `{}` indicates a receiver function but \
-                        the type `{}` {}. Consider using a different name.",
+                             the type `{}` {}. Consider using a different name.",
                             well_known::RECEIVER_PARAM_NAME,
                             base_type.display(&type_ctx()),
                             reason
@@ -414,7 +414,7 @@ impl<'env> ModelBuilder<'env> {
                         if !matches!(ty, Type::TypeParameter(_)) {
                             diag(&format!(
                                 "must only use type parameters \
-                            but instead uses `{}`",
+                                 but instead uses `{}`",
                                 ty.display(&type_ctx())
                             ))
                         } else if !seen.insert(ty) {
@@ -434,7 +434,7 @@ impl<'env> ModelBuilder<'env> {
                         if &entry.module_id != mid {
                             diag(
                                 "is declared outside of this module \
-                            and new receiver functions cannot be added",
+                                 and new receiver functions cannot be added",
                             )
                         } else {
                             // The instantiation must be fully generic.
@@ -457,7 +457,7 @@ impl<'env> ModelBuilder<'env> {
                         {
                             diag(
                                 "is associated with the standard vector module \
-                                and new receiver functions cannot be added",
+                                 and new receiver functions cannot be added",
                             )
                         } else {
                             // See above  for structs
@@ -471,7 +471,7 @@ impl<'env> ModelBuilder<'env> {
                     },
                     _ => diag(
                         "is not suitable for receiver functions. \
-                    Only structs and vectors can have receiver functions",
+                         Only structs and vectors can have receiver functions",
                     ),
                 }
             }

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -3311,6 +3311,8 @@ pub struct TypeDisplayContext<'a> {
     pub used_modules: BTreeSet<ModuleId>,
     /// Whether to use `m::T` for representing types, for stable output in docgen
     pub use_module_qualification: bool,
+    /// Var type that should appear as Self in display
+    pub opt_self_var: Option<u32>,
 }
 
 impl<'a> TypeDisplayContext<'a> {
@@ -3324,6 +3326,7 @@ impl<'a> TypeDisplayContext<'a> {
             display_type_vars: false,
             used_modules: BTreeSet::new(),
             use_module_qualification: false,
+            opt_self_var: None,
         }
     }
 
@@ -3347,6 +3350,7 @@ impl<'a> TypeDisplayContext<'a> {
             display_type_vars: false,
             used_modules: BTreeSet::new(),
             use_module_qualification: false,
+            opt_self_var: None,
         }
     }
 
@@ -3354,6 +3358,13 @@ impl<'a> TypeDisplayContext<'a> {
         Self {
             subs_opt: Some(subs),
             ..self
+        }
+    }
+
+    pub fn map_var_to_self(&self, idx: u32) -> Self {
+        Self {
+            opt_self_var: Some(idx),
+            ..self.clone()
         }
     }
 }
@@ -3447,6 +3458,11 @@ impl<'a> fmt::Display for TypeDisplay<'a> {
                 }
             },
             Var(idx) => {
+                if let Some(idx2) = self.context.opt_self_var {
+                    if *idx == idx2 {
+                        return f.write_str("Self");
+                    }
+                }
                 if let Some(ty) = self.context.subs_opt.and_then(|s| s.subs.get(idx)) {
                     write!(f, "{}", ty.display(self.context))
                 } else if let Some(ctrs) =
@@ -3456,9 +3472,10 @@ impl<'a> fmt::Display for TypeDisplay<'a> {
                     if ctrs.is_empty() {
                         f.write_str(&self.type_var_str(*idx))
                     } else {
+                        let recursive_context = self.context.map_var_to_self(*idx);
                         let out = ctrs
                             .iter()
-                            .map(|(_, _, c)| c.display(self.context).to_string())
+                            .map(|(_, _, c)| c.display(&recursive_context).to_string())
                             .join(" + ");
                         f.write_str(&out)
                     }


### PR DESCRIPTION
## Description

When displaying a "receiver function" type in the presence of errors,
a type variable may be shown by showing the receiver function type,
which includes the type variable itself.  We break the recursion by
introducing an `opt_self_var` field in `TypeDisplayContext` which
is used to recognize the type variable and display "Self" instead
of recursing.

Fixes #14913 

## How Has This Been Tested?

Added a reduced test based on Igor's finding.

## Key Areas to Review

If we allow more recursive types/constraint in the future then we
may want a more general mechanism.  I think we should punt for now,
but others may disagree.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
