### PR TITLE
[Bugfix] Fix broken bytecode dependency

### DIFF
--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -63,6 +63,7 @@ aptos-aggregator = { workspace = true, features = ["testing"] }
 aptos-block-executor = { workspace = true, features = ["testing"] }
 aptos-language-e2e-tests = { workspace = true }
 aptos-types = { workspace = true, features = ["fuzzing"] }
+move-vm-types = { workspace = true, features = ["testing"] }
 claims = { workspace = true }
 proptest = { workspace = true }
 rand_core = { workspace = true }

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -63,8 +63,8 @@ aptos-aggregator = { workspace = true, features = ["testing"] }
 aptos-block-executor = { workspace = true, features = ["testing"] }
 aptos-language-e2e-tests = { workspace = true }
 aptos-types = { workspace = true, features = ["fuzzing"] }
-move-vm-types = { workspace = true, features = ["testing"] }
 claims = { workspace = true }
+move-vm-types = { workspace = true, features = ["testing"] }
 proptest = { workspace = true }
 rand_core = { workspace = true }
 

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -208,15 +208,12 @@ pub fn build_model(
     let compiler_version = compiler_version.unwrap_or_default();
     let language_version = language_version.unwrap_or_default();
     compiler_version.check_language_support(language_version)?;
-    build_config.move_model_for_package(
-        package_path,
-        ModelConfig {
-            target_filter,
-            all_files_as_targets: false,
-            compiler_version,
-            language_version,
-        },
-    )
+    build_config.move_model_for_package(package_path, ModelConfig {
+        target_filter,
+        all_files_as_targets: false,
+        compiler_version,
+        language_version,
+    })
 }
 
 impl BuiltPackage {

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -208,12 +208,15 @@ pub fn build_model(
     let compiler_version = compiler_version.unwrap_or_default();
     let language_version = language_version.unwrap_or_default();
     compiler_version.check_language_support(language_version)?;
-    build_config.move_model_for_package(package_path, ModelConfig {
+    build_config.move_model_for_package(
+        package_path,
+        ModelConfig {
             target_filter,
             all_files_as_targets: false,
             compiler_version,
             language_version,
-    })
+        },
+    )
 }
 
 impl BuiltPackage {

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -209,10 +209,10 @@ pub fn build_model(
     let language_version = language_version.unwrap_or_default();
     compiler_version.check_language_support(language_version)?;
     build_config.move_model_for_package(package_path, ModelConfig {
-        target_filter,
-        all_files_as_targets: false,
-        compiler_version,
-        language_version,
+            target_filter,
+            all_files_as_targets: false,
+            compiler_version,
+            language_version,
     })
 }
 
@@ -484,6 +484,15 @@ impl BuiltPackage {
                 },
                 CompiledUnit::Script(_) => None,
             })
+            .chain(
+                self.package
+                    .bytecode_deps
+                    .iter()
+                    .map(|(name, address)| PackageDep {
+                        account: address.into_inner(),
+                        package_name: name.as_str().to_string(),
+                    }),
+            )
             .collect::<BTreeSet<_>>()
             .into_iter()
             .collect();

--- a/third_party/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/third_party/move/tools/move-package/src/compilation/compiled_package.rs
@@ -657,7 +657,7 @@ impl CompiledPackage {
                     );
                     compiler_driver_v1(compiler)?
                 },
-                CompilerVersion::V2_0 | CompilerVersion::V2_1 => {
+                version @ CompilerVersion::V2_0 | version @ CompilerVersion::V2_1 => {
                     let to_str_vec = |ps: &[Symbol]| {
                         ps.iter()
                             .map(move |s| s.as_str().to_owned())
@@ -704,12 +704,11 @@ impl CompiledPackage {
                         skip_attribute_checks,
                         known_attributes: known_attributes.clone(),
                         language_version: Some(effective_language_version),
+                        compiler_version: Some(version),
                         compile_test_code: flags.keep_testing_functions(),
+                        experiments: config.experiments.clone(),
                         ..Default::default()
                     };
-                    for experiment in &config.experiments {
-                        options = options.set_experiment(experiment, true)
-                    }
                     options = options.set_experiment(Experiment::ATTACH_COMPILED_MODULE, true);
                     compiler_driver_v2(options)?
                 },
@@ -1176,7 +1175,7 @@ pub fn build_and_report_no_exit_v2_driver(
 fn get_module_addr(pkg_name: Symbol, pkg_path: &str) -> Result<NumericalAddress> {
     // Read the bytecode file
     let mut bytecode = Vec::new();
-    std::fs::File::open(&pkg_path.to_string())
+    std::fs::File::open(pkg_path)
         .context(format!("Failed to open bytecode file for {}", pkg_path))
         .and_then(|mut file| {
             // read contents of the file into bytecode

--- a/third_party/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/third_party/move/tools/move-package/src/compilation/compiled_package.rs
@@ -158,18 +158,15 @@ impl OnDiskCompiledPackage {
         }
         let mut bytecode_deps = vec![];
         for dep_name in self.package.bytecode_deps.iter().copied() {
-            let addr = self
-                .package
-                .compiled_package_info
-                .address_alias_instantiation
-                .get(&dep_name)
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "Dependency {} not found in address alias instantiation",
-                        dep_name
-                    )
-                })?;
-            bytecode_deps.push((dep_name, NumericalAddress::from_account_address(*addr)));
+            let bytecode_paths = self.get_compiled_units_paths(dep_name)?;
+            let mut addrs = BTreeSet::new();
+            for bytecode_path in bytecode_paths {
+                let addr = get_module_addr(dep_name, bytecode_path.as_str())?;
+                addrs.insert(addr);
+            }
+            for addr in addrs {
+                bytecode_deps.push((dep_name, addr));
+            }
         }
 
         let docs_path = self

--- a/third_party/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/third_party/move/tools/move-package/src/compilation/compiled_package.rs
@@ -820,27 +820,29 @@ impl CompiledPackage {
                 .iter()
                 .flat_map(|package| {
                     let name = package.name.unwrap();
-                    let pkg_path = package.paths.first().unwrap();
-                    // Read the bytecode file
-                    let mut bytecode = Vec::new();
-                    std::fs::File::open(&pkg_path.to_string())
-                        .context(format!("Failed to open bytecode file for {}", pkg_path))
-                        .and_then(|mut file| {
-                            // read contents of the file into bytecode
-                            std::io::Read::read_to_end(&mut file, &mut bytecode).context(format!("Failed to read bytecode file {}", pkg_path))
-                        })
-                        .and_then(|_| {
-                            CompiledModule::deserialize(&bytecode).context(format!(
-                                "Failed to deserialize bytecode file for {}",
-                                name
-                            ))
-                        })
-                        .map(|module| {
-                            (
-                                name,
-                                NumericalAddress::from_account_address(*module.self_addr()),
-                            )
-                        })
+                    package.paths.iter().map(move |pkg_path| {
+                        // Read the bytecode file
+                        let mut bytecode = Vec::new();
+                        std::fs::File::open(&pkg_path.to_string())
+                            .context(format!("Failed to open bytecode file for {}", pkg_path))
+                            .and_then(|mut file| {
+                                // read contents of the file into bytecode
+                                std::io::Read::read_to_end(&mut file, &mut bytecode)
+                                    .context(format!("Failed to read bytecode file {}", pkg_path))
+                            })
+                            .and_then(|_| {
+                                CompiledModule::deserialize(&bytecode).context(format!(
+                                    "Failed to deserialize bytecode file for {}",
+                                    name
+                                ))
+                            })
+                            .map(|module| {
+                                (
+                                    name,
+                                    NumericalAddress::from_account_address(*module.self_addr()),
+                                )
+                            })
+                    })
                 })
                 .try_collect()?,
             compiled_package_info: CompiledPackageInfo {

--- a/third_party/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/third_party/move/tools/move-package/src/compilation/compiled_package.rs
@@ -806,7 +806,8 @@ impl CompiledPackage {
                 .flat_map(|package| {
                     let name = package.name.unwrap();
                     package.paths.iter().map(move |pkg_path| {
-                        get_addr_from_module_in_package(name, pkg_path.as_str()).map(|addr| (name, addr))
+                        get_addr_from_module_in_package(name, pkg_path.as_str())
+                            .map(|addr| (name, addr))
                     })
                 })
                 .try_collect()?,
@@ -904,8 +905,8 @@ impl CompiledPackage {
                     .collect(),
                 bytecode_deps: self
                     .bytecode_deps
-                    .iter()
-                    .map(|(package_name, _)| *package_name)
+                    .keys()
+                    .copied()
                     .collect::<BTreeSet<_>>()
                     .into_iter()
                     .collect(),

--- a/third_party/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/third_party/move/tools/move-package/src/compilation/compiled_package.rs
@@ -81,6 +81,8 @@ pub struct CompiledPackage {
     pub root_compiled_units: Vec<CompiledUnitWithSource>,
     /// The output compiled bytecode for dependencies
     pub deps_compiled_units: Vec<(PackageName, CompiledUnitWithSource)>,
+    /// Bytecode dependencies of this compiled package
+    pub bytecode_deps: Vec<(PackageName, NumericalAddress)>,
 
     // Optional artifacts from compilation
     //
@@ -198,6 +200,7 @@ impl OnDiskCompiledPackage {
             compiled_package_info: self.package.compiled_package_info.clone(),
             root_compiled_units,
             deps_compiled_units,
+            bytecode_deps: Vec::new(), // TODO
             compiled_docs,
             compiled_abis,
         })
@@ -628,72 +631,76 @@ impl CompiledPackage {
         let effective_language_version = config.language_version.unwrap_or_default();
         effective_compiler_version.check_language_support(effective_language_version)?;
 
-        let (file_map, all_compiled_units, optional_global_env) = match config
-            .compiler_version
-            .unwrap_or_default()
-        {
-            CompilerVersion::V1 => {
-                let mut paths = src_deps;
-                paths.push(sources_package_paths.clone());
-                let compiler =
-                    Compiler::from_package_paths(paths, bytecode_deps, flags, &known_attributes);
-                compiler_driver_v1(compiler)?
-            },
-            version @ CompilerVersion::V2_0 | version @ CompilerVersion::V2_1 => {
-                let to_str_vec = |ps: &[Symbol]| {
-                    ps.iter()
-                        .map(move |s| s.as_str().to_owned())
-                        .collect::<Vec<_>>()
-                };
-                let mut global_address_map = BTreeMap::new();
-                for pack in std::iter::once(&sources_package_paths)
-                    .chain(src_deps.iter())
-                    .chain(bytecode_deps.iter())
-                {
-                    for (name, val) in &pack.named_address_map {
-                        if let Some(old) = global_address_map.insert(name.as_str().to_owned(), *val)
-                        {
-                            if old != *val {
-                                let pack_name = pack
-                                    .name
-                                    .map(|s| s.as_str().to_owned())
-                                    .unwrap_or_else(|| "<unnamed>".to_owned());
-                                bail!(
+        let (file_map, all_compiled_units, optional_global_env) =
+            match config.compiler_version.unwrap_or_default() {
+                CompilerVersion::V1 => {
+                    let mut paths = src_deps;
+                    paths.push(sources_package_paths.clone());
+                    let compiler = Compiler::from_package_paths(
+                        paths,
+                        bytecode_deps.clone(),
+                        flags,
+                        &known_attributes,
+                    );
+                    compiler_driver_v1(compiler)?
+                },
+                CompilerVersion::V2_0 => {
+                    let to_str_vec = |ps: &[Symbol]| {
+                        ps.iter()
+                            .map(move |s| s.as_str().to_owned())
+                            .collect::<Vec<_>>()
+                    };
+                    let mut global_address_map = BTreeMap::new();
+                    for pack in std::iter::once(&sources_package_paths)
+                        .chain(src_deps.iter())
+                        .chain(bytecode_deps.iter())
+                    {
+                        for (name, val) in &pack.named_address_map {
+                            if let Some(old) =
+                                global_address_map.insert(name.as_str().to_owned(), *val)
+                            {
+                                if old != *val {
+                                    let pack_name = pack
+                                        .name
+                                        .map(|s| s.as_str().to_owned())
+                                        .unwrap_or_else(|| "<unnamed>".to_owned());
+                                    bail!(
                                     "found remapped address alias `{}` (`{} != {}`) in package `{}`\
                                     , please use unique address aliases across dependencies",
                                     name, old, val, pack_name
                                 )
+                                }
                             }
                         }
                     }
-                }
-                let mut options = move_compiler_v2::Options {
-                    sources: sources_package_paths
-                        .paths
-                        .iter()
-                        .map(|path| path.as_str().to_owned())
-                        .collect(),
-                    sources_deps: src_deps.iter().flat_map(|x| to_str_vec(&x.paths)).collect(),
-                    dependencies: bytecode_deps
-                        .iter()
-                        .flat_map(|x| to_str_vec(&x.paths))
-                        .collect(),
-                    named_address_mapping: global_address_map
-                        .into_iter()
-                        .map(|(k, v)| format!("{}={}", k, v))
-                        .collect(),
-                    skip_attribute_checks,
-                    known_attributes: known_attributes.clone(),
-                    language_version: Some(effective_language_version),
-                    compiler_version: Some(version),
-                    compile_test_code: flags.keep_testing_functions(),
-                    experiments: config.experiments.clone(),
-                    ..Default::default()
-                };
-                options = options.set_experiment(Experiment::ATTACH_COMPILED_MODULE, true);
-                compiler_driver_v2(options)?
-            },
-        };
+                    let mut options = move_compiler_v2::Options {
+                        sources: sources_package_paths
+                            .paths
+                            .iter()
+                            .map(|path| path.as_str().to_owned())
+                            .collect(),
+                        sources_deps: src_deps.iter().flat_map(|x| to_str_vec(&x.paths)).collect(),
+                        dependencies: bytecode_deps
+                            .iter()
+                            .flat_map(|x| to_str_vec(&x.paths))
+                            .collect(),
+                        named_address_mapping: global_address_map
+                            .into_iter()
+                            .map(|(k, v)| format!("{}={}", k, v))
+                            .collect(),
+                        skip_attribute_checks,
+                        known_attributes: known_attributes.clone(),
+                        language_version: Some(effective_language_version),
+                        compile_test_code: flags.keep_testing_functions(),
+                        ..Default::default()
+                    };
+                    for experiment in &config.experiments {
+                        options = options.set_experiment(experiment, true)
+                    }
+                    options = options.set_experiment(Experiment::ATTACH_COMPILED_MODULE, true);
+                    compiler_driver_v2(options)?
+                },
+            };
         let mut root_compiled_units = vec![];
         let mut deps_compiled_units = vec![];
         let obtain_package_name =
@@ -799,6 +806,21 @@ impl CompiledPackage {
             },
             root_compiled_units,
             deps_compiled_units,
+            bytecode_deps: bytecode_deps
+                .iter()
+                .map(|package| {
+                    let name = package.name.unwrap();
+                    // Package address of the bytecode dep is required for publication. It must be
+                    // provided as a named address in the dep package's Move.toml or through CLI arg
+                    // `--named-addresses`, with the same name as the dep package.
+                    let address = package.named_address_map.get(&name).ok_or(anyhow::anyhow!(
+                        "address unknown for bytecode dependency {}",
+                        name
+                    ));
+
+                    address.map(|&a| (name, a))
+                })
+                .try_collect()?,
             compiled_docs,
             compiled_abis,
         };
@@ -878,6 +900,7 @@ impl CompiledPackage {
             root_path: under_path.join(root_package.as_str()),
             package: OnDiskPackage {
                 compiled_package_info: self.compiled_package_info.clone(),
+                // TODO - bytecode deps
                 dependencies: self
                     .deps_compiled_units
                     .iter()

--- a/third_party/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/third_party/move/tools/move-package/src/compilation/compiled_package.rs
@@ -810,11 +810,11 @@ impl CompiledPackage {
                 .iter()
                 .map(|package| {
                     let name = package.name.unwrap();
-                    // Package address of the bytecode dep is required for publication. It must be
-                    // provided as a named address in the dep package's Move.toml or through CLI arg
-                    // `--named-addresses`, with the same name as the dep package.
+                    // Package address of the bytecode dep is required for publication.
                     let address = package.named_address_map.get(&name).ok_or(anyhow::anyhow!(
-                        "address unknown for bytecode dependency {}",
+                        "address unknown for bytecode dependency {}. It must be provided as a named \
+                        address in the dependency's Move.toml or through CLI arg --named-addresses, \
+                        with name {0}",
                         name
                     ));
 


### PR DESCRIPTION
## Description

Fixed #14311. This PR continues the partial fix from @jasonxh https://github.com/aptos-labs/aptos-core/pull/14340 by
- extending `OnDiskPackage`
- fix the way package metadata is extracted from the bytecode dependency in the original pr

The original issue is caused by `CompiledPackage` missing information for bytecode dependencies, which propagates to `PackageMetadata` when constructing transaction payloads.

## How Has This Been Tested?

This is manually tested on the #14311

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

