### PR TITLE
mutation-tool: add mutation::skip attribute

### DIFF
--- a/third_party/move/move-compiler/src/unit_test/filter_test_members.rs
+++ b/third_party/move/move-compiler/src/unit_test/filter_test_members.rs
@@ -245,7 +245,8 @@ fn test_attributes(attrs: &P::Attributes) -> Vec<(Loc, known_attributes::Testing
                 KnownAttribute::Verification(_)
                 | KnownAttribute::Native(_)
                 | KnownAttribute::Deprecation(_)
-                | KnownAttribute::Lint(_) => None,
+                | KnownAttribute::Lint(_)
+                | KnownAttribute::Mutation(_) => None,
             },
         )
         .collect()

--- a/third_party/move/move-compiler/src/verification/ast_filter.rs
+++ b/third_party/move/move-compiler/src/verification/ast_filter.rs
@@ -69,7 +69,8 @@ fn verification_attributes(
                 KnownAttribute::Testing(_)
                 | KnownAttribute::Native(_)
                 | KnownAttribute::Deprecation(_)
-                | KnownAttribute::Lint(_) => None,
+                | KnownAttribute::Lint(_)
+                | KnownAttribute::Mutation(_) => None,
             },
         )
         .collect()

--- a/third_party/move/move-compiler/tests/move_check/mutation/no_warnings_for_skip_mutating_functions_and_modules.move
+++ b/third_party/move/move-compiler/tests/move_check/mutation/no_warnings_for_skip_mutating_functions_and_modules.move
@@ -1,0 +1,17 @@
+#[mutation::skip]
+module 0x41::DoNotMutateThisModule {
+    public fun sum(a: u32, b: u32): u32 {
+        a + b
+    }
+}
+
+module 0x42::MutatingAllowed {
+    public fun sum(a: u32, b: u32): u32 {
+        a + b
+    }
+
+    #[mutation::skip]
+    public fun sum_no_mutation(a: u32, b: u32): u32 {
+        a + b
+    }
+}


### PR DESCRIPTION
## Description
The new `mutation::skip` attribute can be applied to functions and modules in order to avoid generating mutants for specified code blocks.
This attribute can be used by the `move-mutator`, `move-spec-test` and `move-mutation-test` tools. For more info, check the repository here:
https://github.com/eigerco/move-spec-testing


## How Has This Been Tested?
This new attribute shouldn't have an impact on existing `move-compiler` functionality.
A new unit test has been written that shows that when the new attribute is used, no errors are produced by the compiler.

## Key Areas to Review
It's a new attribute in the `move-compiler` within the `shared/mod.rs` file.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
