### PR TITLE
[Consensus Observer] Add state sync fallback mode.

### DIFF
--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -9,8 +9,8 @@ use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 
 // Useful constants for enabling consensus observer on different node types
-const ENABLE_ON_VALIDATORS: bool = false;
-const ENABLE_ON_VALIDATOR_FULLNODES: bool = false;
+const ENABLE_ON_VALIDATORS: bool = true;
+const ENABLE_ON_VALIDATOR_FULLNODES: bool = true;
 const ENABLE_ON_PUBLIC_FULLNODES: bool = false;
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]

--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -18,7 +18,7 @@ const ENABLE_ON_PUBLIC_FULLNODES: bool = false;
 pub struct ConsensusObserverConfig {
     /// Whether the consensus observer is enabled
     pub observer_enabled: bool,
-    /// Whether the consensus observer publisher is enabled
+    /// Whether the consensus publisher is enabled
     pub publisher_enabled: bool,
 
     /// Maximum number of pending network messages
@@ -30,21 +30,27 @@ pub struct ConsensusObserverConfig {
 
     /// Interval (in milliseconds) to garbage collect peer state
     pub garbage_collection_interval_ms: u64,
-    /// The maximum number of concurrent subscriptions
-    pub max_concurrent_subscriptions: u64,
     /// Maximum number of blocks to keep in memory (e.g., pending blocks, ordered blocks, etc.)
     pub max_num_pending_blocks: u64,
-    /// Maximum timeout (in milliseconds) for active subscriptions
-    pub max_subscription_timeout_ms: u64,
-    /// Maximum timeout (in milliseconds) we'll wait for the synced version to
-    /// increase before terminating the active subscription.
-    pub max_synced_version_timeout_ms: u64,
     /// Interval (in milliseconds) to check progress of the consensus observer
     pub progress_check_interval_ms: u64,
+
+    /// The maximum number of concurrent subscriptions
+    pub max_concurrent_subscriptions: u64,
+    /// Maximum timeout (in milliseconds) we'll wait for the synced version to
+    /// increase before terminating the active subscription.
+    pub max_subscription_sync_timeout_ms: u64,
+    /// Maximum message timeout (in milliseconds) for active subscriptions
+    pub max_subscription_timeout_ms: u64,
     /// Interval (in milliseconds) to check for subscription related peer changes
     pub subscription_peer_change_interval_ms: u64,
     /// Interval (in milliseconds) to refresh the subscription
     pub subscription_refresh_interval_ms: u64,
+
+    /// Duration (in milliseconds) to require state sync to synchronize when in fallback mode
+    pub observer_fallback_duration_ms: u64,
+    /// Duration (in milliseconds) we'll wait for syncing progress before entering fallback mode
+    pub observer_fallback_sync_threshold_ms: u64,
 }
 
 impl Default for ConsensusObserverConfig {
@@ -56,13 +62,15 @@ impl Default for ConsensusObserverConfig {
             max_parallel_serialization_tasks: num_cpus::get(), // Default to the number of CPUs
             network_request_timeout_ms: 5_000,                 // 5 seconds
             garbage_collection_interval_ms: 60_000,            // 60 seconds
-            max_concurrent_subscriptions: 2,                   // 2 streams should be sufficient
             max_num_pending_blocks: 100,                       // 100 blocks
-            max_subscription_timeout_ms: 30_000,               // 30 seconds
-            max_synced_version_timeout_ms: 60_000,             // 60 seconds
             progress_check_interval_ms: 5_000,                 // 5 seconds
+            max_concurrent_subscriptions: 2,                   // 2 streams should be sufficient
+            max_subscription_sync_timeout_ms: 15_000,          // 15 seconds
+            max_subscription_timeout_ms: 15_000,               // 15 seconds
             subscription_peer_change_interval_ms: 60_000,      // 1 minute
             subscription_refresh_interval_ms: 300_000,         // 5 minutes
+            observer_fallback_duration_ms: 600_000,            // 10 minutes
+            observer_fallback_sync_threshold_ms: 30_000,       // 30 seconds
         }
     }
 }

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -432,7 +432,7 @@ impl BlockStore {
         storage.save_tree(blocks.clone(), quorum_certs.clone())?;
 
         execution_client
-            .sync_to(highest_commit_cert.ledger_info().clone())
+            .sync_to_target(highest_commit_cert.ledger_info().clone())
             .await?;
 
         // we do not need to update block_tree.highest_commit_decision_ledger_info here

--- a/consensus/src/consensus_observer/common/error.rs
+++ b/consensus/src/consensus_observer/common/error.rs
@@ -12,6 +12,9 @@ pub enum Error {
     #[error("Network error: {0}")]
     NetworkError(String),
 
+    #[error("Consensus observer progress stopped: {0}")]
+    ObserverProgressStopped(String),
+
     #[error("Aptos network rpc error: {0}")]
     RpcError(#[from] RpcError),
 
@@ -40,6 +43,7 @@ impl Error {
         match self {
             Self::InvalidMessageError(_) => "invalid_message_error",
             Self::NetworkError(_) => "network_error",
+            Self::ObserverProgressStopped(_) => "observer_progress_stopped",
             Self::RpcError(_) => "rpc_error",
             Self::SubscriptionDisconnected(_) => "subscription_disconnected",
             Self::SubscriptionProgressStopped(_) => "subscription_progress_stopped",

--- a/consensus/src/consensus_observer/common/metrics.rs
+++ b/consensus/src/consensus_observer/common/metrics.rs
@@ -10,7 +10,7 @@ use aptos_metrics_core::{
 };
 use once_cell::sync::Lazy;
 
-// Useful metric labels
+// Useful observer metric labels
 pub const BLOCK_PAYLOAD_LABEL: &str = "block_payload";
 pub const COMMIT_DECISION_LABEL: &str = "commit_decision";
 pub const COMMITTED_BLOCKS_LABEL: &str = "committed_blocks";
@@ -20,6 +20,10 @@ pub const ORDERED_BLOCK_LABEL: &str = "ordered_block";
 pub const PENDING_BLOCK_ENTRIES_LABEL: &str = "pending_block_entries";
 pub const PENDING_BLOCKS_LABEL: &str = "pending_blocks";
 pub const STORED_PAYLOADS_LABEL: &str = "stored_payloads";
+
+// Useful state sync metric labels
+pub const STATE_SYNCING_FOR_FALLBACK: &str = "sync_for_fallback";
+pub const STATE_SYNCING_TO_COMMIT: &str = "sync_to_commit";
 
 /// Counter for tracking created subscriptions for the consensus observer
 pub static OBSERVER_CREATED_SUBSCRIPTIONS: Lazy<IntCounterVec> = Lazy::new(|| {
@@ -145,6 +149,16 @@ pub static OBSERVER_SENT_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
         "consensus_observer_sent_requests",
         "Counters related to sent RPC requests by the consensus observer",
         &["request_type", "network_id"]
+    )
+    .unwrap()
+});
+
+/// Gauge for tracking when consensus observer has invoked state sync
+pub static OBSERVER_STATE_SYNC_EXECUTING: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "consensus_observer_state_sync_executing",
+        "Gauge for tracking when consensus observer has invoked state sync",
+        &["syncing_mode"]
     )
     .unwrap()
 });

--- a/consensus/src/consensus_observer/observer/consensus_observer.rs
+++ b/consensus/src/consensus_observer/observer/consensus_observer.rs
@@ -881,7 +881,7 @@ fn sync_to_commit_decision(
             // Sync to the commit decision
             if let Err(error) = execution_client
                 .clone()
-                .sync_to(commit_decision.commit_proof().clone())
+                .sync_to_target(commit_decision.commit_proof().clone())
                 .await
             {
                 warn!(

--- a/consensus/src/consensus_observer/observer/fallback_manager.rs
+++ b/consensus/src/consensus_observer/observer/fallback_manager.rs
@@ -1,0 +1,241 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::consensus_observer::common::error::Error;
+use aptos_config::config::ConsensusObserverConfig;
+use aptos_storage_interface::DbReader;
+use aptos_time_service::{TimeService, TimeServiceTrait};
+use aptos_types::ledger_info::LedgerInfoWithSignatures;
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+/// The manager for fallback mode in consensus observer
+pub struct ObserverFallbackManager {
+    // The configuration of the consensus observer
+    consensus_observer_config: ConsensusObserverConfig,
+
+    // A handle to storage (used to read the latest state and check progress)
+    db_reader: Arc<dyn DbReader>,
+
+    // The highest synced version we've seen from storage, along with the time at which it was seen
+    highest_synced_version_and_time: (u64, Instant),
+
+    // The time service (used to check the storage update time)
+    time_service: TimeService,
+}
+
+impl ObserverFallbackManager {
+    pub fn new(
+        consensus_observer_config: ConsensusObserverConfig,
+        db_reader: Arc<dyn DbReader>,
+        time_service: TimeService,
+    ) -> Self {
+        // Get the current time
+        let time_now = time_service.now();
+
+        // Create a new fallback manager
+        Self {
+            consensus_observer_config,
+            db_reader,
+            highest_synced_version_and_time: (0, time_now),
+            time_service,
+        }
+    }
+
+    /// Verifies that the DB is continuing to sync and commit new data.
+    /// If not, an error is returned, indicating that we should enter fallback mode.
+    pub fn check_syncing_progress(&mut self) -> Result<(), Error> {
+        // Get the current time and synced version from storage
+        let time_now = self.time_service.now();
+        let current_synced_version =
+            self.db_reader
+                .get_latest_ledger_info_version()
+                .map_err(|error| {
+                    Error::UnexpectedError(format!(
+                        "Failed to read highest synced version: {:?}",
+                        error
+                    ))
+                })?;
+
+        // Verify that the synced version is increasing appropriately
+        let (highest_synced_version, highest_version_timestamp) =
+            self.highest_synced_version_and_time;
+        if current_synced_version <= highest_synced_version {
+            // The synced version hasn't increased. Check if we should enter fallback mode.
+            let duration_since_highest_seen = time_now.duration_since(highest_version_timestamp);
+            let fallback_threshold = Duration::from_millis(
+                self.consensus_observer_config
+                    .observer_fallback_sync_threshold_ms,
+            );
+            if duration_since_highest_seen > fallback_threshold {
+                return Err(Error::ObserverProgressStopped(format!(
+                    "Consensus observer is not making progress! Highest synced version: {}, elapsed: {:?}",
+                    highest_synced_version, duration_since_highest_seen
+                )));
+            }
+            return Ok(()); // We haven't passed the fallback threshold yet
+        }
+
+        // Update the highest synced version and time
+        self.highest_synced_version_and_time = (current_synced_version, time_now);
+
+        Ok(())
+    }
+
+    /// Resets the syncing progress to the latest synced ledger info and current time
+    pub fn reset_syncing_progress(&mut self, latest_synced_ledger_info: &LedgerInfoWithSignatures) {
+        // Get the current time and highest synced version
+        let time_now = self.time_service.now();
+        let highest_synced_version = latest_synced_ledger_info.ledger_info().version();
+
+        // Update the highest synced version and time
+        self.highest_synced_version_and_time = (highest_synced_version, time_now);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use aptos_crypto::HashValue;
+    use aptos_storage_interface::Result;
+    use aptos_types::{
+        aggregate_signature::AggregateSignature, block_info::BlockInfo, ledger_info::LedgerInfo,
+        transaction::Version,
+    };
+    use claims::assert_matches;
+    use mockall::mock;
+
+    // This is a simple mock of the DbReader (it generates a MockDatabaseReader)
+    mock! {
+        pub DatabaseReader {}
+        impl DbReader for DatabaseReader {
+            fn get_latest_ledger_info_version(&self) -> Result<Version>;
+        }
+    }
+
+    #[test]
+    fn test_check_syncing_progress() {
+        // Create a consensus observer config
+        let observer_fallback_sync_threshold_ms = 10_000;
+        let consensus_observer_config = ConsensusObserverConfig {
+            observer_fallback_sync_threshold_ms,
+            ..ConsensusObserverConfig::default()
+        };
+
+        // Create a mock DB reader with expectations
+        let first_synced_version = 1;
+        let second_synced_version = 2;
+        let mut mock_db_reader = MockDatabaseReader::new();
+        mock_db_reader
+            .expect_get_latest_ledger_info_version()
+            .returning(move || Ok(first_synced_version))
+            .times(1); // Only allow one call for the first version
+        mock_db_reader
+            .expect_get_latest_ledger_info_version()
+            .returning(move || Ok(second_synced_version)); // Allow multiple calls for the second version
+
+        // Create a new fallback manager
+        let time_service = TimeService::mock();
+        let mut fallback_manager = ObserverFallbackManager::new(
+            consensus_observer_config,
+            Arc::new(mock_db_reader),
+            time_service.clone(),
+        );
+
+        // Verify that the DB is making sync progress and that the highest synced version is updated
+        let mock_time_service = time_service.into_mock();
+        assert!(fallback_manager.check_syncing_progress().is_ok());
+        assert_eq!(
+            fallback_manager.highest_synced_version_and_time,
+            (first_synced_version, mock_time_service.now())
+        );
+
+        // Elapse enough time to bypass the fallback threshold
+        mock_time_service.advance(Duration::from_millis(
+            observer_fallback_sync_threshold_ms + 1,
+        ));
+
+        // Verify that the DB is still making sync progress (the next DB version is higher)
+        let time_now = mock_time_service.now();
+        assert!(fallback_manager.check_syncing_progress().is_ok());
+        assert_eq!(
+            fallback_manager.highest_synced_version_and_time,
+            (second_synced_version, time_now)
+        );
+
+        // Elapse some amount of time (but not enough to bypass the fallback threshold)
+        mock_time_service.advance(Duration::from_millis(
+            observer_fallback_sync_threshold_ms - 1,
+        ));
+
+        // Verify that the DB is still making sync progress (the threshold hasn't been reached)
+        assert!(fallback_manager.check_syncing_progress().is_ok());
+        assert_eq!(
+            fallback_manager.highest_synced_version_and_time,
+            (second_synced_version, time_now)
+        );
+
+        // Elapse enough time to bypass the fallback threshold
+        mock_time_service.advance(Duration::from_millis(
+            observer_fallback_sync_threshold_ms + 1,
+        ));
+
+        // Verify that the DB is not making sync progress and that fallback mode should be entered
+        assert_matches!(
+            fallback_manager.check_syncing_progress(),
+            Err(Error::ObserverProgressStopped(_))
+        );
+        assert_eq!(
+            fallback_manager.highest_synced_version_and_time,
+            (second_synced_version, time_now)
+        );
+    }
+
+    #[test]
+    fn test_reset_syncing_progress() {
+        // Create a new fallback manager
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let mock_db_reader = MockDatabaseReader::new();
+        let time_service = TimeService::mock();
+        let mut fallback_manager = ObserverFallbackManager::new(
+            consensus_observer_config,
+            Arc::new(mock_db_reader),
+            time_service.clone(),
+        );
+
+        // Verify the initial state of the highest synced version and time
+        let mock_time_service = time_service.into_mock();
+        assert_eq!(
+            fallback_manager.highest_synced_version_and_time,
+            (0, mock_time_service.now())
+        );
+
+        // Elapse some amount of time
+        mock_time_service.advance(Duration::from_secs(10));
+
+        // Reset the syncing progress to a new synced ledger info
+        let block_version = 100;
+        let block_info = BlockInfo::new(
+            0,
+            0,
+            HashValue::zero(),
+            HashValue::zero(),
+            block_version,
+            0,
+            None,
+        );
+        let latest_synced_ledger_info = LedgerInfoWithSignatures::new(
+            LedgerInfo::new(block_info, HashValue::zero()),
+            AggregateSignature::empty(),
+        );
+        fallback_manager.reset_syncing_progress(&latest_synced_ledger_info);
+
+        // Verify that the highest synced version and time have been updated
+        assert_eq!(
+            fallback_manager.highest_synced_version_and_time,
+            (block_version, mock_time_service.now())
+        );
+    }
+}

--- a/consensus/src/consensus_observer/observer/mod.rs
+++ b/consensus/src/consensus_observer/observer/mod.rs
@@ -3,9 +3,11 @@
 
 pub mod active_state;
 pub mod consensus_observer;
+pub mod fallback_manager;
 pub mod ordered_blocks;
 pub mod payload_store;
 pub mod pending_blocks;
+pub mod state_sync_manager;
 pub mod subscription;
 pub mod subscription_manager;
 pub mod subscription_utils;

--- a/consensus/src/consensus_observer/observer/ordered_blocks.rs
+++ b/consensus/src/consensus_observer/observer/ordered_blocks.rs
@@ -339,8 +339,15 @@ mod test {
 
     #[test]
     fn test_get_last_ordered_block() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 100;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
         // Create a new ordered block store
-        let mut ordered_block_store = OrderedBlockStore::new(ConsensusObserverConfig::default());
+        let mut ordered_block_store = OrderedBlockStore::new(consensus_observer_config);
 
         // Verify that we have no last ordered block
         assert!(ordered_block_store.get_last_ordered_block().is_none());
@@ -379,8 +386,15 @@ mod test {
 
     #[test]
     fn test_get_ordered_block() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 100;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
         // Create a new ordered block store
-        let mut ordered_block_store = OrderedBlockStore::new(ConsensusObserverConfig::default());
+        let mut ordered_block_store = OrderedBlockStore::new(consensus_observer_config);
 
         // Insert several ordered blocks for the current epoch
         let current_epoch = 0;
@@ -456,8 +470,15 @@ mod test {
 
     #[test]
     fn test_remove_blocks_for_commit() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 100;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
         // Create a new ordered block store
-        let mut ordered_block_store = OrderedBlockStore::new(ConsensusObserverConfig::default());
+        let mut ordered_block_store = OrderedBlockStore::new(consensus_observer_config);
 
         // Insert several ordered blocks for the current epoch
         let current_epoch = 10;
@@ -553,8 +574,15 @@ mod test {
 
     #[test]
     fn test_update_commit_decision() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 100;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
         // Create a new ordered block store
-        let mut ordered_block_store = OrderedBlockStore::new(ConsensusObserverConfig::default());
+        let mut ordered_block_store = OrderedBlockStore::new(consensus_observer_config);
 
         // Insert several ordered blocks for the current epoch
         let current_epoch = 0;

--- a/consensus/src/consensus_observer/observer/payload_store.rs
+++ b/consensus/src/consensus_observer/observer/payload_store.rs
@@ -379,8 +379,14 @@ mod test {
 
     #[test]
     fn test_clear_all_payloads() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 100;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
         // Create a new block payload store
-        let consensus_observer_config = ConsensusObserverConfig::default();
         let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
         // Add some unverified blocks to the payload store
@@ -446,8 +452,14 @@ mod test {
 
     #[test]
     fn test_insert_block_payload() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 100;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
         // Create a new block payload store
-        let consensus_observer_config = ConsensusObserverConfig::default();
         let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
         // Add some verified blocks to the payload store
@@ -556,8 +568,14 @@ mod test {
 
     #[test]
     fn test_remove_blocks_for_epoch_round_verified() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 100;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
         // Create a new block payload store
-        let consensus_observer_config = ConsensusObserverConfig::default();
         let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
         // Add some verified blocks to the payload store for the current epoch
@@ -614,8 +632,14 @@ mod test {
 
     #[test]
     fn test_remove_blocks_for_epoch_round_unverified() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 100;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
         // Create a new block payload store
-        let consensus_observer_config = ConsensusObserverConfig::default();
         let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
         // Add some unverified blocks to the payload store for the current epoch
@@ -671,8 +695,14 @@ mod test {
 
     #[test]
     fn test_remove_committed_blocks_verified() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 100;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
         // Create a new block payload store
-        let consensus_observer_config = ConsensusObserverConfig::default();
         let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
         // Add some blocks to the payload store for the current epoch
@@ -740,8 +770,14 @@ mod test {
 
     #[test]
     fn test_remove_committed_blocks_unverified() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 100;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
         // Create a new block payload store
-        let consensus_observer_config = ConsensusObserverConfig::default();
         let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
         // Add some blocks to the payload store for the current epoch
@@ -808,8 +844,14 @@ mod test {
 
     #[test]
     fn test_verify_payload_signatures() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 100;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
         // Create a new block payload store
-        let consensus_observer_config = ConsensusObserverConfig::default();
         let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
         // Add some verified blocks for the current epoch
@@ -940,8 +982,14 @@ mod test {
 
     #[test]
     fn test_verify_payload_signatures_failure() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 100;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            ..ConsensusObserverConfig::default()
+        };
+
         // Create a new block payload store
-        let consensus_observer_config = ConsensusObserverConfig::default();
         let mut block_payload_store = BlockPayloadStore::new(consensus_observer_config);
 
         // Add some verified blocks for the current epoch

--- a/consensus/src/consensus_observer/observer/state_sync_manager.rs
+++ b/consensus/src/consensus_observer/observer/state_sync_manager.rs
@@ -1,0 +1,346 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    consensus_observer::{
+        common::{
+            logging::{LogEntry, LogSchema},
+            metrics,
+        },
+        network::observer_message::CommitDecision,
+    },
+    pipeline::execution_client::TExecutionClient,
+};
+use aptos_config::config::ConsensusObserverConfig;
+use aptos_logger::{error, info};
+use aptos_reliable_broadcast::DropGuard;
+use aptos_types::ledger_info::LedgerInfoWithSignatures;
+use futures::future::{AbortHandle, Abortable};
+use std::{sync::Arc, time::Duration};
+use tokio::sync::mpsc::UnboundedSender;
+
+/// A simple state sync notification to notify consensus
+/// observer that state syncing has completed.
+pub enum StateSyncNotification {
+    FallbackSyncCompleted(LedgerInfoWithSignatures),
+    CommitSyncCompleted(LedgerInfoWithSignatures),
+}
+
+impl StateSyncNotification {
+    /// Returns a new state sync notification that fallback syncing has completed
+    pub fn fallback_sync_completed(ledger_info: LedgerInfoWithSignatures) -> Self {
+        Self::FallbackSyncCompleted(ledger_info)
+    }
+
+    /// Returns a new state sync notification that syncing to a commit has completed
+    pub fn commit_sync_completed(ledger_info: LedgerInfoWithSignatures) -> Self {
+        Self::CommitSyncCompleted(ledger_info)
+    }
+}
+
+/// The manager for interacting with state sync
+pub struct StateSyncManager {
+    // The configuration of the consensus observer
+    consensus_observer_config: ConsensusObserverConfig,
+
+    // The execution client to the buffer manager
+    execution_client: Arc<dyn TExecutionClient>,
+
+    // The sender to notify consensus observer that state syncing to
+    // the specified ledger info has completed.
+    state_sync_notification_sender: UnboundedSender<StateSyncNotification>,
+
+    // The active fallback sync handle. If this is set, it means that
+    // we've fallen back to state sync, and we should wait for it to complete.
+    fallback_sync_handle: Option<DropGuard>,
+
+    // The active sync to commit handle. If this is set, it means that
+    // we're waiting for state sync to synchronize to a known commit decision.
+    // The flag indicates if the commit will transition us to a new epoch.
+    sync_to_commit_handle: Option<(DropGuard, bool)>,
+}
+
+impl StateSyncManager {
+    pub fn new(
+        consensus_observer_config: ConsensusObserverConfig,
+        execution_client: Arc<dyn TExecutionClient>,
+        state_sync_notification_sender: UnboundedSender<StateSyncNotification>,
+    ) -> Self {
+        Self {
+            consensus_observer_config,
+            execution_client,
+            state_sync_notification_sender,
+            fallback_sync_handle: None,
+            sync_to_commit_handle: None,
+        }
+    }
+
+    /// Resets the handle for any active sync to a commit decision
+    pub fn clear_active_commit_sync(&mut self) {
+        // If we're not actively syncing to a commit, log an error
+        if !self.is_syncing_to_commit() {
+            error!(LogSchema::new(LogEntry::ConsensusObserver)
+                .message("Failed to clear sync to commit decision! No active sync handle found!"));
+        }
+
+        self.sync_to_commit_handle = None;
+    }
+
+    /// Resets the handle for any active fallback sync
+    pub fn clear_active_fallback_sync(&mut self) {
+        // If we're not actively syncing in fallback mode, log an error
+        if !self.in_fallback_mode() {
+            error!(LogSchema::new(LogEntry::ConsensusObserver)
+                .message("Failed to clear fallback sync! No active sync handle found!"));
+        }
+
+        self.fallback_sync_handle = None;
+    }
+
+    /// Returns true iff state sync is currently executing in fallback mode
+    pub fn in_fallback_mode(&self) -> bool {
+        self.fallback_sync_handle.is_some()
+    }
+
+    /// Returns true iff we are waiting for state sync to synchronize
+    /// to a commit decision that will transition us to a new epoch
+    pub fn is_syncing_through_epoch(&self) -> bool {
+        matches!(self.sync_to_commit_handle, Some((_, true)))
+    }
+
+    /// Returns true iff state sync is currently syncing to a commit decision
+    pub fn is_syncing_to_commit(&self) -> bool {
+        self.sync_to_commit_handle.is_some()
+    }
+
+    /// Invokes state sync to synchronize in fallback mode
+    pub fn sync_for_fallback(&mut self) {
+        // Log that we're starting to sync in fallback mode
+        info!(
+            LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                "Started syncing in fallback mode! Syncing duration: {:?} ms!",
+                self.consensus_observer_config.observer_fallback_duration_ms
+            ))
+        );
+
+        // Clone the required components for the state sync task
+        let consensus_observer_config = self.consensus_observer_config;
+        let execution_client = self.execution_client.clone();
+        let sync_notification_sender = self.state_sync_notification_sender.clone();
+
+        // Spawn a task to sync for the fallback
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
+        tokio::spawn(Abortable::new(
+            async move {
+                // Update the state sync metrics now that we're syncing for the fallback
+                metrics::set_gauge_with_label(
+                    &metrics::OBSERVER_STATE_SYNC_EXECUTING,
+                    metrics::STATE_SYNCING_FOR_FALLBACK,
+                    1, // We're syncing for the fallback
+                );
+
+                // Get the fallback duration
+                let fallback_duration =
+                    Duration::from_millis(consensus_observer_config.observer_fallback_duration_ms);
+
+                // Sync for the fallback duration
+                let latest_synced_ledger_info = match execution_client
+                    .clone()
+                    .sync_for_duration(fallback_duration)
+                    .await
+                {
+                    Ok(latest_synced_ledger_info) => latest_synced_ledger_info,
+                    Err(error) => {
+                        error!(LogSchema::new(LogEntry::ConsensusObserver)
+                            .message(&format!("Failed to sync for fallback! Error: {:?}", error)));
+                        return;
+                    },
+                };
+
+                // Notify consensus observer that we've synced for the fallback
+                let state_sync_notification =
+                    StateSyncNotification::fallback_sync_completed(latest_synced_ledger_info);
+                if let Err(error) = sync_notification_sender.send(state_sync_notification) {
+                    error!(
+                        LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                            "Failed to send state sync notification for fallback! Error: {:?}",
+                            error
+                        ))
+                    );
+                }
+
+                // Clear the state sync metrics now that we're done syncing
+                metrics::set_gauge_with_label(
+                    &metrics::OBSERVER_STATE_SYNC_EXECUTING,
+                    metrics::STATE_SYNCING_FOR_FALLBACK,
+                    0, // We're no longer syncing for the fallback
+                );
+            },
+            abort_registration,
+        ));
+
+        // Save the sync task handle
+        self.fallback_sync_handle = Some(DropGuard::new(abort_handle));
+    }
+
+    /// Invokes state sync to synchronize to a new commit decision
+    pub fn sync_to_commit(&mut self, commit_decision: CommitDecision, epoch_changed: bool) {
+        // Log that we're starting to sync to the commit decision
+        info!(
+            LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                "Started syncing to commit: {}!",
+                commit_decision.proof_block_info()
+            ))
+        );
+
+        // Get the commit decision epoch and round
+        let commit_epoch = commit_decision.epoch();
+        let commit_round = commit_decision.round();
+
+        // Clone the required components for the state sync task
+        let execution_client = self.execution_client.clone();
+        let sync_notification_sender = self.state_sync_notification_sender.clone();
+
+        // Spawn a task to sync to the commit decision
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
+        tokio::spawn(Abortable::new(
+            async move {
+                // Update the state sync metrics now that we're syncing to a commit
+                metrics::set_gauge_with_label(
+                    &metrics::OBSERVER_STATE_SYNC_EXECUTING,
+                    metrics::STATE_SYNCING_TO_COMMIT,
+                    1, // We're syncing to a commit decision
+                );
+
+                // Sync to the commit decision
+                if let Err(error) = execution_client
+                    .clone()
+                    .sync_to_target(commit_decision.commit_proof().clone())
+                    .await
+                {
+                    error!(
+                        LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                            "Failed to sync to commit decision: {:?}! Error: {:?}",
+                            commit_decision, error
+                        ))
+                    );
+                    return;
+                }
+
+                // Notify consensus observer that we've synced to the commit decision
+                let state_sync_notification = StateSyncNotification::commit_sync_completed(
+                    commit_decision.commit_proof().clone(),
+                );
+                if let Err(error) = sync_notification_sender.send(state_sync_notification) {
+                    error!(
+                        LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                            "Failed to send state sync notification for commit decision epoch: {:?}, round: {:?}! Error: {:?}",
+                            commit_epoch, commit_round, error
+                        ))
+                    );
+                }
+
+                // Clear the state sync metrics now that we're done syncing
+                metrics::set_gauge_with_label(
+                    &metrics::OBSERVER_STATE_SYNC_EXECUTING,
+                    metrics::STATE_SYNCING_TO_COMMIT,
+                    0, // We're no longer syncing to a commit decision
+                );
+            },
+            abort_registration,
+        ));
+
+        // Save the sync task handle
+        self.sync_to_commit_handle = Some((DropGuard::new(abort_handle), epoch_changed));
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::pipeline::execution_client::DummyExecutionClient;
+    use aptos_types::{aggregate_signature::AggregateSignature, ledger_info::LedgerInfo};
+
+    #[tokio::test]
+    async fn test_clear_active_sync() {
+        // Create a new state sync manager
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let (state_sync_notification_sender, _) = tokio::sync::mpsc::unbounded_channel();
+        let mut state_sync_manager = StateSyncManager::new(
+            consensus_observer_config,
+            Arc::new(DummyExecutionClient),
+            state_sync_notification_sender,
+        );
+
+        // Verify that there are no active sync handles
+        assert!(!state_sync_manager.in_fallback_mode());
+        assert!(!state_sync_manager.is_syncing_to_commit());
+
+        // Sync to a commit and verify that the active sync handle is set
+        let commit_decision = CommitDecision::new(LedgerInfoWithSignatures::new(
+            LedgerInfo::dummy(),
+            AggregateSignature::empty(),
+        ));
+        state_sync_manager.sync_to_commit(commit_decision, false);
+        assert!(state_sync_manager.is_syncing_to_commit());
+
+        // Clear the active sync handle and verify that it's reset
+        state_sync_manager.clear_active_commit_sync();
+        assert!(!state_sync_manager.is_syncing_to_commit());
+
+        // Sync for the fallback and verify that the active sync handle is set
+        state_sync_manager.sync_for_fallback();
+        assert!(state_sync_manager.in_fallback_mode());
+
+        // Clear the active sync handle and verify that it's reset
+        state_sync_manager.clear_active_fallback_sync();
+        assert!(!state_sync_manager.in_fallback_mode());
+    }
+
+    #[tokio::test]
+    async fn test_is_syncing_through_epoch() {
+        // Create a new state sync manager
+        let consensus_observer_config = ConsensusObserverConfig::default();
+        let (state_sync_notification_sender, _) = tokio::sync::mpsc::unbounded_channel();
+        let mut state_sync_manager = StateSyncManager::new(
+            consensus_observer_config,
+            Arc::new(DummyExecutionClient),
+            state_sync_notification_sender,
+        );
+
+        // Verify that we're not syncing through an epoch
+        assert!(!state_sync_manager.is_syncing_through_epoch());
+
+        // Sync to a commit that doesn't transition us to a new epoch
+        let commit_decision = CommitDecision::new(LedgerInfoWithSignatures::new(
+            LedgerInfo::dummy(),
+            AggregateSignature::empty(),
+        ));
+        state_sync_manager.sync_to_commit(commit_decision, false);
+
+        // Verify that we're not syncing through an epoch
+        assert!(!state_sync_manager.is_syncing_through_epoch());
+
+        // Clear the active sync handle and verify that it's reset
+        state_sync_manager.clear_active_commit_sync();
+        assert!(!state_sync_manager.is_syncing_through_epoch());
+
+        // Sync to a commit that transitions us to a new epoch
+        let commit_decision = CommitDecision::new(LedgerInfoWithSignatures::new(
+            LedgerInfo::dummy(),
+            AggregateSignature::empty(),
+        ));
+        state_sync_manager.sync_to_commit(commit_decision, true);
+
+        // Verify that we're syncing through an epoch
+        assert!(state_sync_manager.is_syncing_through_epoch());
+
+        // Clear the active sync handle and verify that it's reset
+        state_sync_manager.clear_active_commit_sync();
+        assert!(!state_sync_manager.is_syncing_through_epoch());
+
+        // Sync for the fallback and verify that we're not syncing through an epoch
+        state_sync_manager.sync_for_fallback();
+        assert!(!state_sync_manager.is_syncing_through_epoch());
+    }
+}

--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -187,14 +187,14 @@ pub fn start_consensus_observer(
     };
 
     // Create the consensus observer
-    let (sync_notification_sender, sync_notification_listener) =
+    let (state_sync_notification_sender, state_sync_notification_listener) =
         tokio::sync::mpsc::unbounded_channel();
     let consensus_observer = ConsensusObserver::new(
         node_config.clone(),
         consensus_observer_client,
         aptos_db.reader.clone(),
         execution_client,
-        sync_notification_sender,
+        state_sync_notification_sender,
         reconfig_events,
         consensus_publisher,
         TimeService::real(),
@@ -204,6 +204,6 @@ pub fn start_consensus_observer(
     consensus_observer_runtime.spawn(consensus_observer.start(
         node_config.consensus_observer,
         consensus_observer_message_receiver,
-        sync_notification_listener,
+        state_sync_notification_listener,
     ));
 }

--- a/consensus/src/dag/dag_state_sync.rs
+++ b/consensus/src/dag/dag_state_sync.rs
@@ -254,7 +254,7 @@ impl DagStateSynchronizer {
             },
         }
 
-        self.execution_client.sync_to(commit_li).await?;
+        self.execution_client.sync_to_target(commit_li).await?;
 
         let inner =
             Arc::into_inner(sync_dag_store).expect("Only one strong reference should exists");

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -541,7 +541,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         // make sure storage is on this ledger_info too, it should be no-op if it's already committed
         // panic if this doesn't succeed since the current processors are already shutdown.
         self.execution_client
-            .sync_to(ledger_info.clone())
+            .sync_to_target(ledger_info.clone())
             .await
             .context(format!(
                 "[EpochManager] State sync to new epoch {}",

--- a/consensus/src/pipeline/execution_client.rs
+++ b/consensus/src/pipeline/execution_client.rs
@@ -88,8 +88,8 @@ pub trait TExecutionClient: Send + Sync {
         commit_msg: IncomingCommitRequest,
     ) -> Result<()>;
 
-    /// Synchronize to a commit that not present locally.
-    async fn sync_to(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError>;
+    /// Synchronize to a commit that is not present locally.
+    async fn sync_to_target(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError>;
 
     /// Resets the internal state of the rand and buffer managers.
     async fn reset(&self, target: &LedgerInfoWithSignatures) -> Result<()>;
@@ -400,9 +400,9 @@ impl TExecutionClient for ExecutionProxyClient {
         }
     }
 
-    async fn sync_to(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
-        fail_point!("consensus::sync_to", |_| {
-            Err(anyhow::anyhow!("Injected error in sync_to").into())
+    async fn sync_to_target(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
+        fail_point!("consensus::sync_to_target", |_| {
+            Err(anyhow::anyhow!("Injected error in sync_to_target").into())
         });
 
         // Reset the rand and buffer managers to the target round
@@ -410,7 +410,7 @@ impl TExecutionClient for ExecutionProxyClient {
 
         // TODO: handle the sync error, should re-push the ordered blocks to buffer manager
         // when it's reset but sync fails.
-        self.execution_proxy.sync_to(target).await?;
+        self.execution_proxy.sync_to_target(target).await?;
         Ok(())
     }
 
@@ -523,7 +523,7 @@ impl TExecutionClient for DummyExecutionClient {
         Ok(())
     }
 
-    async fn sync_to(&self, _: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
+    async fn sync_to_target(&self, _: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
         Ok(())
     }
 

--- a/consensus/src/pipeline/execution_client.rs
+++ b/consensus/src/pipeline/execution_client.rs
@@ -25,7 +25,7 @@ use crate::{
     transaction_deduper::create_transaction_deduper,
     transaction_shuffler::create_transaction_shuffler,
 };
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use aptos_bounded_executor::BoundedExecutor;
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::{ConsensusConfig, ConsensusObserverConfig};
@@ -51,7 +51,7 @@ use futures::{
 };
 use futures_channel::mpsc::unbounded;
 use move_core_types::account_address::AccountAddress;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 #[async_trait::async_trait]
 pub trait TExecutionClient: Send + Sync {
@@ -87,6 +87,14 @@ pub trait TExecutionClient: Send + Sync {
         peer_id: AccountAddress,
         commit_msg: IncomingCommitRequest,
     ) -> Result<()>;
+
+    /// Synchronizes for the specified duration and returns the latest synced
+    /// ledger info. Note: it is possible that state sync may run longer than
+    /// the specified duration (e.g., if the node is very far behind).
+    async fn sync_for_duration(
+        &self,
+        duration: Duration,
+    ) -> Result<LedgerInfoWithSignatures, StateSyncError>;
 
     /// Synchronize to a commit that is not present locally.
     async fn sync_to_target(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError>;
@@ -400,6 +408,25 @@ impl TExecutionClient for ExecutionProxyClient {
         }
     }
 
+    async fn sync_for_duration(
+        &self,
+        duration: Duration,
+    ) -> Result<LedgerInfoWithSignatures, StateSyncError> {
+        fail_point!("consensus::sync_for_duration", |_| {
+            Err(anyhow::anyhow!("Injected error in sync_for_duration").into())
+        });
+
+        // Sync for the specified duration
+        let result = self.execution_proxy.sync_for_duration(duration).await;
+
+        // Reset the rand and buffer managers to the new synced round
+        if let Ok(latest_synced_ledger_info) = &result {
+            self.reset(latest_synced_ledger_info).await?;
+        }
+
+        result
+    }
+
     async fn sync_to_target(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
         fail_point!("consensus::sync_to_target", |_| {
             Err(anyhow::anyhow!("Injected error in sync_to_target").into())
@@ -408,10 +435,9 @@ impl TExecutionClient for ExecutionProxyClient {
         // Reset the rand and buffer managers to the target round
         self.reset(&target).await?;
 
-        // TODO: handle the sync error, should re-push the ordered blocks to buffer manager
-        // when it's reset but sync fails.
-        self.execution_proxy.sync_to_target(target).await?;
-        Ok(())
+        // TODO: handle the state sync error (e.g., re-push the ordered
+        // blocks to the buffer manager when it's reset but sync fails).
+        self.execution_proxy.sync_to_target(target).await
     }
 
     async fn reset(&self, target: &LedgerInfoWithSignatures) -> Result<()> {
@@ -521,6 +547,15 @@ impl TExecutionClient for DummyExecutionClient {
 
     fn send_commit_msg(&self, _: AccountAddress, _: IncomingCommitRequest) -> Result<()> {
         Ok(())
+    }
+
+    async fn sync_for_duration(
+        &self,
+        _: Duration,
+    ) -> Result<LedgerInfoWithSignatures, StateSyncError> {
+        Err(StateSyncError::from(anyhow!(
+            "sync_for_duration() is not supported by the DummyExecutionClient!"
+        )))
     }
 
     async fn sync_to_target(&self, _: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -325,7 +325,7 @@ impl StateComputer for ExecutionProxy {
     }
 
     /// Synchronize to a commit that not present locally.
-    async fn sync_to(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
+    async fn sync_to_target(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
         let mut latest_logical_time = self.write_mutex.lock().await;
         let logical_time =
             LogicalTime::new(target.ledger_info().epoch(), target.ledger_info().round());
@@ -353,8 +353,8 @@ impl StateComputer for ExecutionProxy {
                 .notify_commit(block_timestamp, Vec::new());
         }
 
-        fail_point!("consensus::sync_to", |_| {
-            Err(anyhow::anyhow!("Injected error in sync_to").into())
+        fail_point!("consensus::sync_to_target", |_| {
+            Err(anyhow::anyhow!("Injected error in sync_to_target").into())
         });
         // Here to start to do state synchronization where ChunkExecutor inside will
         // process chunks and commit to Storage. However, after block execution and
@@ -362,7 +362,7 @@ impl StateComputer for ExecutionProxy {
         // it is required to reset the cache of ChunkExecutor in State Sync
         // when requested to sync.
         let res = monitor!(
-            "sync_to",
+            "sync_to_target",
             self.state_sync_notifier.sync_to_target(target).await
         );
         *latest_logical_time = logical_time;
@@ -574,8 +574,8 @@ async fn test_commit_sync_race() {
         .commit(&[], generate_li(1, 10), callback)
         .await
         .unwrap();
-    assert!(executor.sync_to(generate_li(1, 8)).await.is_ok());
+    assert!(executor.sync_to_target(generate_li(1, 8)).await.is_ok());
     assert_eq!(*recorded_commit.time.lock(), LogicalTime::new(1, 10));
-    assert!(executor.sync_to(generate_li(2, 8)).await.is_ok());
+    assert!(executor.sync_to_target(generate_li(2, 8)).await.is_ok());
     assert_eq!(*recorded_commit.time.lock(), LogicalTime::new(2, 8));
 }

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -35,7 +35,11 @@ use aptos_types::{
 };
 use fail::fail_point;
 use futures::{future::BoxFuture, SinkExt, StreamExt};
-use std::{boxed::Box, sync::Arc, time::Instant};
+use std::{
+    boxed::Box,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tokio::sync::Mutex as AsyncMutex;
 
 pub type StateComputeResultFut = BoxFuture<'static, ExecutorResult<PipelineExecutionResult>>;
@@ -324,22 +328,67 @@ impl StateComputer for ExecutionProxy {
         Ok(())
     }
 
-    /// Synchronize to a commit that not present locally.
-    async fn sync_to_target(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
+    /// Best effort state synchronization for the specified duration
+    async fn sync_for_duration(
+        &self,
+        duration: Duration,
+    ) -> Result<LedgerInfoWithSignatures, StateSyncError> {
+        // Grab the logical time lock
         let mut latest_logical_time = self.write_mutex.lock().await;
-        let logical_time =
-            LogicalTime::new(target.ledger_info().epoch(), target.ledger_info().round());
-        let block_timestamp = target.commit_info().timestamp_usecs();
 
-        // Before the state synchronization, we have to call finish() to free the in-memory SMT
-        // held by BlockExecutor to prevent memory leak.
+        // Before state synchronization, we have to call finish() to free the
+        // in-memory SMT held by the BlockExecutor to prevent a memory leak.
+        self.executor.finish();
+
+        // Inject an error for fail point testing
+        fail_point!("consensus::sync_for_duration", |_| {
+            Err(anyhow::anyhow!("Injected error in sync_for_duration").into())
+        });
+
+        // Invoke state sync to synchronize for the specified duration. Here, the
+        // ChunkExecutor will process chunks and commit to storage. However, after
+        // block execution and commits, the internal state of the ChunkExecutor may
+        // not be up to date. So, it is required to reset the cache of the
+        // ChunkExecutor in state sync when requested to sync.
+        let result = monitor!(
+            "sync_for_duration",
+            self.state_sync_notifier.sync_for_duration(duration).await
+        );
+
+        // Update the latest logical time
+        if let Ok(latest_synced_ledger_info) = &result {
+            let ledger_info = latest_synced_ledger_info.ledger_info();
+            let synced_logical_time = LogicalTime::new(ledger_info.epoch(), ledger_info.round());
+            *latest_logical_time = synced_logical_time;
+        }
+
+        // Similarly, after state synchronization, we have to reset the cache of
+        // the BlockExecutor to guarantee the latest committed state is up to date.
+        self.executor.reset()?;
+
+        // Return the result
+        result.map_err(|error| {
+            let anyhow_error: anyhow::Error = error.into();
+            anyhow_error.into()
+        })
+    }
+
+    /// Synchronize to a commit that is not present locally.
+    async fn sync_to_target(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
+        // Grab the logical time lock and calculate the target logical time
+        let mut latest_logical_time = self.write_mutex.lock().await;
+        let target_logical_time =
+            LogicalTime::new(target.ledger_info().epoch(), target.ledger_info().round());
+
+        // Before state synchronization, we have to call finish() to free the
+        // in-memory SMT held by BlockExecutor to prevent a memory leak.
         self.executor.finish();
 
         // The pipeline phase already committed beyond the target block timestamp, just return.
-        if *latest_logical_time >= logical_time {
+        if *latest_logical_time >= target_logical_time {
             warn!(
                 "State sync target {:?} is lower than already committed logical time {:?}",
-                logical_time, *latest_logical_time
+                target_logical_time, *latest_logical_time
             );
             return Ok(());
         }
@@ -348,30 +397,36 @@ impl StateComputer for ExecutionProxy {
         // so it can set batches expiration accordingly.
         // Might be none if called in the recovery path, or between epoch stop and start.
         if let Some(inner) = self.state.read().as_ref() {
+            let block_timestamp = target.commit_info().timestamp_usecs();
             inner
                 .payload_manager
                 .notify_commit(block_timestamp, Vec::new());
         }
 
+        // Inject an error for fail point testing
         fail_point!("consensus::sync_to_target", |_| {
             Err(anyhow::anyhow!("Injected error in sync_to_target").into())
         });
-        // Here to start to do state synchronization where ChunkExecutor inside will
-        // process chunks and commit to Storage. However, after block execution and
-        // commitments, the sync state of ChunkExecutor may be not up to date so
-        // it is required to reset the cache of ChunkExecutor in State Sync
-        // when requested to sync.
-        let res = monitor!(
+
+        // Invoke state sync to synchronize to the specified target. Here, the
+        // ChunkExecutor will process chunks and commit to storage. However, after
+        // block execution and commits, the internal state of the ChunkExecutor may
+        // not be up to date. So, it is required to reset the cache of the
+        // ChunkExecutor in state sync when requested to sync.
+        let result = monitor!(
             "sync_to_target",
             self.state_sync_notifier.sync_to_target(target).await
         );
-        *latest_logical_time = logical_time;
 
-        // Similarly, after the state synchronization, we have to reset the cache
-        // of BlockExecutor to guarantee the latest committed state is up to date.
+        // Update the latest logical time
+        *latest_logical_time = target_logical_time;
+
+        // Similarly, after state synchronization, we have to reset the cache of
+        // the BlockExecutor to guarantee the latest committed state is up to date.
         self.executor.reset()?;
 
-        res.map_err(|error| {
+        // Return the result
+        result.map_err(|error| {
             let anyhow_error: anyhow::Error = error.into();
             anyhow_error.into()
         })
@@ -517,7 +572,9 @@ async fn test_commit_sync_race() {
             &self,
             _duration: std::time::Duration,
         ) -> std::result::Result<LedgerInfoWithSignatures, Error> {
-            unreachable!()
+            Err(Error::UnexpectedErrorEncountered(
+                "sync_for_duration() is not supported by the RecordedCommit!".into(),
+            ))
         }
 
         async fn sync_to_target(

--- a/consensus/src/state_computer_tests.rs
+++ b/consensus/src/state_computer_tests.rs
@@ -69,7 +69,9 @@ impl ConsensusNotificationSender for DummyStateSyncNotifier {
         &self,
         _duration: Duration,
     ) -> Result<LedgerInfoWithSignatures, Error> {
-        unreachable!()
+        Err(Error::UnexpectedErrorEncountered(
+            "sync_for_duration() is not supported by the DummyStateSyncNotifier!".into(),
+        ))
     }
 
     async fn sync_to_target(&self, _target: LedgerInfoWithSignatures) -> Result<(), Error> {

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -49,7 +49,7 @@ pub trait StateComputer: Send + Sync {
     /// In case of success (`Result::Ok`) the LI of storage is at the given target.
     /// In case of failure (`Result::Error`) the LI of storage remains unchanged, and the validator
     /// can assume there were no modifications to the storage made.
-    async fn sync_to(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError>;
+    async fn sync_to_target(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError>;
 
     // Reconfigure to execute transactions for a new epoch.
     fn new_epoch(

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -15,7 +15,7 @@ use aptos_types::{
     block_executor::config::BlockExecutorConfigFromOnchain, epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures, randomness::Randomness,
 };
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 pub type StateComputerCommitCallBackType =
     Box<dyn FnOnce(&[Arc<PipelinedBlock>], LedgerInfoWithSignatures) + Send + Sync>;
@@ -44,6 +44,15 @@ pub trait StateComputer: Send + Sync {
         finality_proof: LedgerInfoWithSignatures,
         callback: StateComputerCommitCallBackType,
     ) -> ExecutorResult<()>;
+
+    /// Best effort state synchronization for the specified duration.
+    /// This function returns the latest synced ledger info after state syncing.
+    /// Note: it is possible that state sync may run longer than the specified
+    /// duration (e.g., if the node is very far behind).
+    async fn sync_for_duration(
+        &self,
+        duration: Duration,
+    ) -> Result<LedgerInfoWithSignatures, StateSyncError>;
 
     /// Best effort state synchronization to the given target LedgerInfo.
     /// In case of success (`Result::Ok`) the LI of storage is at the given target.

--- a/consensus/src/test_utils/mock_execution_client.rs
+++ b/consensus/src/test_utils/mock_execution_client.rs
@@ -14,7 +14,7 @@ use crate::{
     state_replication::StateComputerCommitCallBackType,
     test_utils::mock_storage::MockStorage,
 };
-use anyhow::{format_err, Result};
+use anyhow::{anyhow, format_err, Result};
 use aptos_channels::aptos_channel;
 use aptos_consensus_types::{
     common::{Payload, Round},
@@ -33,7 +33,7 @@ use aptos_types::{
 use futures::{channel::mpsc, SinkExt};
 use futures_channel::mpsc::UnboundedSender;
 use move_core_types::account_address::AccountAddress;
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 pub struct MockExecutionClient {
     state_sync_client: mpsc::UnboundedSender<Vec<SignedTransaction>>,
@@ -160,6 +160,15 @@ impl TExecutionClient for MockExecutionClient {
         _commit_msg: IncomingCommitRequest,
     ) -> Result<()> {
         Ok(())
+    }
+
+    async fn sync_for_duration(
+        &self,
+        _duration: Duration,
+    ) -> Result<LedgerInfoWithSignatures, StateSyncError> {
+        Err(StateSyncError::from(anyhow!(
+            "sync_for_duration() is not supported by the MockExecutionClient!"
+        )))
     }
 
     async fn sync_to_target(&self, commit: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {

--- a/consensus/src/test_utils/mock_execution_client.rs
+++ b/consensus/src/test_utils/mock_execution_client.rs
@@ -162,7 +162,7 @@ impl TExecutionClient for MockExecutionClient {
         Ok(())
     }
 
-    async fn sync_to(&self, commit: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
+    async fn sync_to_target(&self, commit: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
         debug!(
             "Fake sync to block id {}",
             commit.ledger_info().consensus_block_id()

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -11,7 +11,7 @@ use crate::{
     transaction_deduper::TransactionDeduper,
     transaction_shuffler::TransactionShuffler,
 };
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use aptos_consensus_types::{
     block::Block, pipeline_execution_result::PipelineExecutionResult,
     pipelined_block::PipelinedBlock,
@@ -65,6 +65,15 @@ impl StateComputer for EmptyStateComputer {
         }
 
         Ok(())
+    }
+
+    async fn sync_for_duration(
+        &self,
+        _duration: Duration,
+    ) -> Result<LedgerInfoWithSignatures, StateSyncError> {
+        Err(StateSyncError::from(anyhow!(
+            "sync_for_duration() is not supported by the EmptyStateComputer!"
+        )))
     }
 
     async fn sync_to_target(
@@ -142,6 +151,15 @@ impl StateComputer for RandomComputeResultStateComputer {
         _call_back: StateComputerCommitCallBackType,
     ) -> ExecutorResult<()> {
         Ok(())
+    }
+
+    async fn sync_for_duration(
+        &self,
+        _duration: Duration,
+    ) -> Result<LedgerInfoWithSignatures, StateSyncError> {
+        Err(StateSyncError::from(anyhow!(
+            "sync_for_duration() is not supported by the RandomComputeResultStateComputer!"
+        )))
     }
 
     async fn sync_to_target(

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -67,7 +67,10 @@ impl StateComputer for EmptyStateComputer {
         Ok(())
     }
 
-    async fn sync_to(&self, _commit: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
+    async fn sync_to_target(
+        &self,
+        _target: LedgerInfoWithSignatures,
+    ) -> Result<(), StateSyncError> {
         Ok(())
     }
 
@@ -141,7 +144,10 @@ impl StateComputer for RandomComputeResultStateComputer {
         Ok(())
     }
 
-    async fn sync_to(&self, _commit: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
+    async fn sync_to_target(
+        &self,
+        _target: LedgerInfoWithSignatures,
+    ) -> Result<(), StateSyncError> {
         Ok(())
     }
 

--- a/state-sync/inter-component/event-notifications/src/lib.rs
+++ b/state-sync/inter-component/event-notifications/src/lib.rs
@@ -36,7 +36,7 @@ mod tests;
 // consumed, they will be dropped (oldest messages first). The remaining messages
 // will be retrieved using FIFO ordering.
 const EVENT_NOTIFICATION_CHANNEL_SIZE: usize = 100;
-const RECONFIG_NOTIFICATION_CHANNEL_SIZE: usize = 1;
+const RECONFIG_NOTIFICATION_CHANNEL_SIZE: usize = 1; // Note: this should be 1 to ensure only the latest reconfig is consumed
 
 #[derive(Clone, Debug, Deserialize, Error, PartialEq, Eq, Serialize)]
 pub enum Error {


### PR DESCRIPTION
## Description
This PR adds a "state sync fallback" mode to consensus observer (CO). If CO does not make progress for some time (e.g., no increase in synced version for 30 seconds), it will fallback to state sync for a while (e.g., 10 minutes). After which, CO will regain control and attempt to make progress.

The PR offers the following commits:
1. Rename `sync_to()` to `sync_to_target()`
1. Add the state sync fallback mode to CO. For this, we introduce two new components to help manage state sync interaction: (i) the state sync manager; and (ii) the observer fallback manager.
1. Enable CO for all validators and VFNs (by default).

## Testing Plan
New and existing test infrastructure, including manual verification, e.g., see https://github.com/aptos-labs/aptos-core/pull/14960.