### PR TITLE
Slightly change build process to prevent OOM

### DIFF
--- a/testsuite/fuzzer/fuzz.sh
+++ b/testsuite/fuzzer/fuzz.sh
@@ -120,10 +120,18 @@ function build-oss-fuzz() {
     ld.lld --version
     clang --version
 
-    if ! build all ./target; then
-        env
-        error "Build failed. Exiting."
-    fi
+    # Limit the number of parallel jobs to avoid OOM
+    # export CARGO_BUILD_JOBS = 3
+
+    # Build the fuzz targets
+    # Doing one target at the time should prevent OOM, but use all thread while bulding dependecies
+    for fuzz_target in $(list); do
+        if ! build $fuzz_target ./target ; then
+            env
+            error "Build failed. Exiting."
+        fi
+    done
+
     find ./target/*/release/ -maxdepth 1 -type f -perm /111 -exec cp {} $oss_fuzz_out \;
 
     # Download corpus zip


### PR DESCRIPTION
## Description
Our long-lasting issue with OSS-Fuzz builds could be at an end without too many sacrifices. The idea is to build fuzzers one at a time instead of lowering Rust job cores. This trick will use all the cores to build dependencies, but during the linking phase, we have only one fuzzer (this is where we had issues with OOM). The next fuzzer to be built will benefit from already built dependencies of the previous one.
We can re-evaluate decommissioned fuzzer for improvements and re-enable them if everything works smoothly.

## How Has This Been Tested?
N/A

## Key Areas to Review
N/A

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [X] Other (specify)

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X] I tested both happy and unhappy path of the functionality
- [X] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
