### PR TITLE
[Framework][Minor] Add _ before unused self variables to avoid compiler warnings

### DIFF
--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64.move
@@ -258,7 +258,7 @@ module aptos_std::pool_u64 {
         }
     }
 
-    public fun multiply_then_divide(self: &Pool, x: u64, y: u64, z: u64): u64 {
+    public fun multiply_then_divide(_self: &Pool, x: u64, y: u64, z: u64): u64 {
         let result = (to_u128(x) * to_u128(y)) / to_u128(z);
         (result as u64)
     }

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.move
@@ -255,7 +255,7 @@ module aptos_std::pool_u64_unbound {
         }
     }
 
-    public fun multiply_then_divide(self: &Pool, x: u128, y: u128, z: u128): u128 {
+    public fun multiply_then_divide(_self: &Pool, x: u128, y: u128, z: u128): u128 {
         let result = (to_u256(x) * to_u256(y)) / to_u256(z);
         (result as u128)
     }


### PR DESCRIPTION
## Description
self is not actually used in pool_u64::multiply_then_divide or pool_u64_unbounded::multiply_then_divide. This is currently generating compiler warnings every time a package is compiled against the framework. This PR adds _ prefix to avoid these warnings.

## How Has This Been Tested?
Compilation

## Key Areas to Review
Minor changes

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
