### PR TITLE
[State Sync] Update synced version and synced epoch metrics.

### DIFF
--- a/state-sync/state-sync-driver/src/metrics.rs
+++ b/state-sync/state-sync-driver/src/metrics.rs
@@ -60,13 +60,16 @@ impl ExecutingComponent {
     }
 }
 
-/// An enum of storage synchronizer operations performed by state sync
+/// An enum of storage synchronizer operations performed by
+/// state sync. Each of these is a metric label to track.
 pub enum StorageSynchronizerOperations {
-    AppliedTransactionOutputs, // Applied a chunk of transactions outputs.
-    ExecutedTransactions,      // Executed a chunk of transactions.
-    Synced,                    // Wrote a chunk of transactions and outputs to storage.
-    SyncedStates,              // Wrote a chunk of state values to storage.
-    SyncedEpoch, // Wrote a chunk of transactions and outputs to storage that resulted in a new epoch.
+    AppliedTransactionOutputs, // The total number of applied transaction outputs
+    ExecutedTransactions,      // The total number of executed transactions
+    Synced,                    // The latest synced version (as read from storage)
+    SyncedIncremental, // The latest synced version (calculated as the sum of all processed transactions)
+    SyncedStates,      // The total number of synced states
+    SyncedEpoch,       // The latest synced epoch (as read from storage)
+    SyncedEpochIncremental, // The latest synced epoch (calculated as the sum of all processed epochs)
 }
 
 impl StorageSynchronizerOperations {
@@ -77,8 +80,10 @@ impl StorageSynchronizerOperations {
             },
             StorageSynchronizerOperations::ExecutedTransactions => "executed_transactions",
             StorageSynchronizerOperations::Synced => "synced",
-            StorageSynchronizerOperations::SyncedEpoch => "synced_epoch",
+            StorageSynchronizerOperations::SyncedIncremental => "synced_incremental",
             StorageSynchronizerOperations::SyncedStates => "synced_states",
+            StorageSynchronizerOperations::SyncedEpoch => "synced_epoch",
+            StorageSynchronizerOperations::SyncedEpochIncremental => "synced_epoch_incremental",
         }
     }
 }

--- a/state-sync/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-driver/src/utils.rs
@@ -293,6 +293,7 @@ pub fn initialize_sync_gauges(storage: Arc<dyn DbReader>) -> Result<(), Error> {
         metrics::StorageSynchronizerOperations::AppliedTransactionOutputs,
         metrics::StorageSynchronizerOperations::ExecutedTransactions,
         metrics::StorageSynchronizerOperations::Synced,
+        metrics::StorageSynchronizerOperations::SyncedIncremental,
     ];
     for metric in metrics {
         metrics::set_gauge(
@@ -302,13 +303,19 @@ pub fn initialize_sync_gauges(storage: Arc<dyn DbReader>) -> Result<(), Error> {
         );
     }
 
-    // Update the latest synced epoch
+    // Update the latest synced epochs
     let highest_synced_epoch = fetch_latest_epoch_state(storage)?.epoch;
-    metrics::set_gauge(
-        &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
-        metrics::StorageSynchronizerOperations::SyncedEpoch.get_label(),
-        highest_synced_epoch,
-    );
+    let metrics = [
+        metrics::StorageSynchronizerOperations::SyncedEpoch,
+        metrics::StorageSynchronizerOperations::SyncedEpochIncremental,
+    ];
+    for metric in metrics {
+        metrics::set_gauge(
+            &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
+            metric.get_label(),
+            highest_synced_epoch,
+        );
+    }
 
     Ok(())
 }
@@ -365,12 +372,58 @@ pub async fn handle_committed_transactions<
 }
 
 /// Updates the metrics to handle an epoch change event
-pub fn update_new_epoch_metrics() {
-    // Increment the epoch
-    metrics::increment_gauge(
+pub fn update_new_epoch_metrics(storage: Arc<dyn DbReader>, reconfiguration_occurred: bool) {
+    // Update the epoch metric (by reading directly from storage)
+    let highest_synced_epoch = match fetch_latest_epoch_state(storage.clone()) {
+        Ok(epoch_state) => epoch_state.epoch,
+        Err(error) => {
+            error!(LogSchema::new(LogEntry::Driver).message(&format!(
+                "Failed to fetch the latest epoch state from storage! Error: {:?}",
+                error
+            )));
+            return;
+        },
+    };
+    metrics::set_gauge(
         &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
         metrics::StorageSynchronizerOperations::SyncedEpoch.get_label(),
-        1,
+        highest_synced_epoch,
+    );
+
+    // Update the incremental epoch metric (by incrementing the current value)
+    if reconfiguration_occurred {
+        metrics::increment_gauge(
+            &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
+            metrics::StorageSynchronizerOperations::SyncedEpochIncremental.get_label(),
+            1,
+        );
+    }
+}
+
+/// Updates the metrics to handle newly synced transactions
+pub fn update_new_synced_metrics(storage: Arc<dyn DbReader>, num_synced_transactions: usize) {
+    // Update the version metric (by reading directly from storage)
+    let highest_synced_version = match fetch_pre_committed_version(storage.clone()) {
+        Ok(highest_synced_version) => highest_synced_version,
+        Err(error) => {
+            error!(LogSchema::new(LogEntry::Driver).message(&format!(
+                "Failed to fetch the pre committed version from storage! Error: {:?}",
+                error
+            )));
+            return;
+        },
+    };
+    metrics::set_gauge(
+        &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
+        metrics::StorageSynchronizerOperations::Synced.get_label(),
+        highest_synced_version,
+    );
+
+    // Update the incremental version metric (by incrementing the current value)
+    metrics::increment_gauge(
+        &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
+        metrics::StorageSynchronizerOperations::SyncedIncremental.get_label(),
+        num_synced_transactions as u64,
     );
 }
 


### PR DESCRIPTION
## Description
This PR updates the synced version and synced epoch metrics. We now track these metrics in two ways: (i) by reading the values directly from storage; and (ii) by incrementally summing up all processed transactions and epochs. 

The first metric will be used as the "official" metric, and the second as a sanity check to ensure that there are no gaps in transaction and/or epoch processing (e.g., consensus dropping notifications meant for state sync).

## Testing Plan
Existing test infrastructure.
