### PR TITLE
[move-stdlib] Implement bcs::constant_serialized_size<T>(): Option<u64>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2889,6 +2889,7 @@ dependencies = [
  "aptos-gas-schedule",
  "aptos-native-interface",
  "aptos-types",
+ "bcs 0.1.4",
  "dir-diff",
  "file_diff",
  "move-cli",

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/move_stdlib.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/move_stdlib.rs
@@ -8,7 +8,7 @@ use crate::{
     gas_schedule::NativeGasParameters,
 };
 use aptos_gas_algebra::{
-    InternalGas, InternalGasPerAbstractValueUnit, InternalGasPerArg, InternalGasPerByte,
+    InternalGas, InternalGasPerAbstractValueUnit, InternalGasPerTypeNode, InternalGasPerArg, InternalGasPerByte,
 };
 
 crate::gas_schedule::macros::define_gas_parameters!(
@@ -41,6 +41,8 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [bcs_serialized_size_base: InternalGas, { RELEASE_V1_18.. => "bcs.serialized_size.base" }, 735],
         [bcs_serialized_size_per_byte_serialized: InternalGasPerByte, { RELEASE_V1_18.. => "bcs.serialized_size.per_byte_serialized" }, 36],
         [bcs_serialized_size_failure: InternalGas, { RELEASE_V1_18.. => "bcs.serialized_size.failure" }, 3676],
+        [bcs_constant_serialized_size_base: InternalGas, { RELEASE_V1_24.. => "bcs.constant_serialized_size.base" }, 735],
+        [bcs_constant_serialized_size_per_type_node: InternalGasPerTypeNode, { RELEASE_V1_24.. => "bcs.constant_serialized_size.per_type_node" }, 40],
 
         [cmp_compare_base: InternalGas, { RELEASE_V1_24.. => "cmp.compare.base" }, 367],
         [cmp_compare_per_abs_val_unit: InternalGasPerAbstractValueUnit, { RELEASE_V1_24.. => "cmp.compare.per_abs_val_unit"}, 14],

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/move_stdlib.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/move_stdlib.rs
@@ -8,7 +8,8 @@ use crate::{
     gas_schedule::NativeGasParameters,
 };
 use aptos_gas_algebra::{
-    InternalGas, InternalGasPerAbstractValueUnit, InternalGasPerTypeNode, InternalGasPerArg, InternalGasPerByte,
+    InternalGas, InternalGasPerAbstractValueUnit, InternalGasPerArg, InternalGasPerByte,
+    InternalGasPerTypeNode,
 };
 
 crate::gas_schedule::macros::define_gas_parameters!(

--- a/aptos-move/e2e-move-tests/src/tests/transaction_context.data/pack/sources/transaction_context_test.move
+++ b/aptos-move/e2e-move-tests/src/tests/transaction_context.data/pack/sources/transaction_context_test.move
@@ -110,6 +110,10 @@ module admin::transaction_context_test {
                 ), type_info::type_name<T3>()],
                 13
             );
+
+            assert!(option::some(option::destroy_some(payload_opt)) == transaction_context::entry_function_payload(), 13);
+        } else {
+            assert!(option::none() == payload_opt, 14);
         }
     }
 
@@ -128,7 +132,10 @@ module admin::transaction_context_test {
                 store.function_name = transaction_context::function_name(entry);
                 store.type_arg_names = transaction_context::type_arg_names(entry);
                 store.args = transaction_context::args(entry);
-            }
+            };
+            assert!(option::some(option::destroy_some(multisig_opt)) == transaction_context::multisig_payload(), 1);
+        } else {
+            assert!(option::none() == multisig_opt, 2);
         }
     }
 

--- a/aptos-move/framework/move-stdlib/Cargo.toml
+++ b/aptos-move/framework/move-stdlib/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 aptos-gas-schedule = { workspace = true }
 aptos-native-interface = { workspace = true }
 aptos-types = { workspace = true }
+bcs = { workspace = true }
 move-core-types = { path = "../../../third_party/move/move-core/types" }
 move-vm-runtime = { path = "../../../third_party/move/move-vm/runtime" }
 move-vm-types = { path = "../../../third_party/move/move-vm/types" }

--- a/aptos-move/framework/move-stdlib/doc/bcs.md
+++ b/aptos-move/framework/move-stdlib/doc/bcs.md
@@ -11,11 +11,13 @@ details on BCS.
 
 -  [Function `to_bytes`](#0x1_bcs_to_bytes)
 -  [Function `serialized_size`](#0x1_bcs_serialized_size)
+-  [Function `constant_serialized_size`](#0x1_bcs_constant_serialized_size)
 -  [Specification](#@Specification_0)
     -  [Function `serialized_size`](#@Specification_0_serialized_size)
 
 
-<pre><code></code></pre>
+<pre><code><b>use</b> <a href="option.md#0x1_option">0x1::option</a>;
+</code></pre>
 
 
 
@@ -61,6 +63,38 @@ Aborts with <code>0x1c5</code> error code if there is a failure when calculating
 
 
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="bcs.md#0x1_bcs_serialized_size">serialized_size</a>&lt;MoveValue&gt;(v: &MoveValue): u64;
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_bcs_constant_serialized_size"></a>
+
+## Function `constant_serialized_size`
+
+If the type has known constant (always the same, independent of instance) serialized size
+in BCS (Binary Canonical Serialization) format, returns it, otherwise returns None.
+Aborts with <code>0x1c5</code> error code if there is a failure when calculating serialized size.
+
+Note:
+For some types it might not be known they have constant size, and function might return None.
+For example, signer appears to have constant size, but it's size might change.
+If this function returned Some() for some type before - it is guaranteed to continue returning Some()
+On the other hand, if function has returned None for some type,
+it might change in the future to return Some() instead, if size becomes "known".
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="bcs.md#0x1_bcs_constant_serialized_size">constant_serialized_size</a>&lt;MoveValue&gt;(): <a href="option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>public</b>(<b>friend</b>) <b>fun</b> <a href="bcs.md#0x1_bcs_constant_serialized_size">constant_serialized_size</a>&lt;MoveValue&gt;(): std::option::Option&lt;u64&gt;;
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/doc/bcs.md
+++ b/aptos-move/framework/move-stdlib/doc/bcs.md
@@ -80,7 +80,7 @@ Aborts with <code>0x1c5</code> error code if there is a failure when calculating
 Note:
 For some types it might not be known they have constant size, and function might return None.
 For example, signer appears to have constant size, but it's size might change.
-If this function returned Some() for some type before - it is guaranteed to continue returning Some()
+If this function returned Some() for some type before - it is guaranteed to continue returning Some().
 On the other hand, if function has returned None for some type,
 it might change in the future to return Some() instead, if size becomes "known".
 
@@ -94,7 +94,7 @@ it might change in the future to return Some() instead, if size becomes "known".
 <summary>Implementation</summary>
 
 
-<pre><code><b>native</b> <b>public</b>(<b>friend</b>) <b>fun</b> <a href="bcs.md#0x1_bcs_constant_serialized_size">constant_serialized_size</a>&lt;MoveValue&gt;(): std::option::Option&lt;u64&gt;;
+<pre><code><b>native</b> <b>public</b>(<b>friend</b>) <b>fun</b> <a href="bcs.md#0x1_bcs_constant_serialized_size">constant_serialized_size</a>&lt;MoveValue&gt;(): Option&lt;u64&gt;;
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/sources/bcs.move
+++ b/aptos-move/framework/move-stdlib/sources/bcs.move
@@ -11,6 +11,23 @@ module std::bcs {
     /// Aborts with `0x1c5` error code if there is a failure when calculating serialized size.
     native public fun serialized_size<MoveValue>(v: &MoveValue): u64;
 
+    // TODO - function `constant_serialized_size1 is `public(friend)` here for one release,
+    // and to be changed to `public` one release later.
+    #[test_only]
+    friend std::bcs_tests;
+
+    /// If the type has known constant (always the same, independent of instance) serialized size
+    /// in BCS (Binary Canonical Serialization) format, returns it, otherwise returns None.
+    /// Aborts with `0x1c5` error code if there is a failure when calculating serialized size.
+    ///
+    /// Note:
+    /// For some types it might not be known they have constant size, and function might return None.
+    /// For example, signer appears to have constant size, but it's size might change.
+    /// If this function returned Some() for some type before - it is guaranteed to continue returning Some()
+    /// On the other hand, if function has returned None for some type,
+    /// it might change in the future to return Some() instead, if size becomes "known".
+    native public(friend) fun constant_serialized_size<MoveValue>(): std::option::Option<u64>;
+
     // ==============================
     // Module Specification
     spec module {} // switch to module documentation context

--- a/aptos-move/framework/move-stdlib/sources/bcs.move
+++ b/aptos-move/framework/move-stdlib/sources/bcs.move
@@ -3,6 +3,8 @@
 /// published on-chain. See https://github.com/aptos-labs/bcs#binary-canonical-serialization-bcs for more
 /// details on BCS.
 module std::bcs {
+    use std::option::Option;
+
     /// Returns the binary representation of `v` in BCS (Binary Canonical Serialization) format.
     /// Aborts with `0x1c5` error code if serialization fails.
     native public fun to_bytes<MoveValue>(v: &MoveValue): vector<u8>;
@@ -23,10 +25,10 @@ module std::bcs {
     /// Note:
     /// For some types it might not be known they have constant size, and function might return None.
     /// For example, signer appears to have constant size, but it's size might change.
-    /// If this function returned Some() for some type before - it is guaranteed to continue returning Some()
+    /// If this function returned Some() for some type before - it is guaranteed to continue returning Some().
     /// On the other hand, if function has returned None for some type,
     /// it might change in the future to return Some() instead, if size becomes "known".
-    native public(friend) fun constant_serialized_size<MoveValue>(): std::option::Option<u64>;
+    native public(friend) fun constant_serialized_size<MoveValue>(): Option<u64>;
 
     // ==============================
     // Module Specification

--- a/aptos-move/framework/move-stdlib/tests/bcs_tests.move
+++ b/aptos-move/framework/move-stdlib/tests/bcs_tests.move
@@ -2,6 +2,8 @@
 module std::bcs_tests {
     use std::bcs;
     use std::vector;
+    use std::option;
+    use std::signer;
 
     struct Box<T> has copy, drop, store { x: T }
     struct Box3<T> has copy, drop, store { x: Box<Box<T>> }
@@ -20,6 +22,8 @@ module std::bcs_tests {
         let expected_size = vector::length(&actual_bytes);
         let actual_size = bcs::serialized_size(&true);
         assert!(actual_size == expected_size, 1);
+
+        assert!(option::some(actual_size) == bcs::constant_serialized_size<bool>(), 2);
     }
 
     #[test]
@@ -31,6 +35,8 @@ module std::bcs_tests {
         let expected_size = vector::length(&actual_bytes);
         let actual_size = bcs::serialized_size(&1u8);
         assert!(actual_size == expected_size, 1);
+
+        assert!(option::some(actual_size) == bcs::constant_serialized_size<u8>(), 2);
     }
 
     #[test]
@@ -42,6 +48,8 @@ module std::bcs_tests {
         let expected_size = vector::length(&actual_bytes);
         let actual_size = bcs::serialized_size(&1);
         assert!(actual_size == expected_size, 1);
+
+        assert!(option::some(actual_size) == bcs::constant_serialized_size<u64>(), 2);
     }
 
     #[test]
@@ -53,6 +61,8 @@ module std::bcs_tests {
         let expected_size = vector::length(&actual_bytes);
         let actual_size = bcs::serialized_size(&1u128);
         assert!(actual_size == expected_size, 1);
+
+        assert!(option::some(actual_size) == bcs::constant_serialized_size<u128>(), 2);
     }
 
     #[test]
@@ -66,6 +76,23 @@ module std::bcs_tests {
         let expected_size = vector::length(&actual_bytes);
         let actual_size = bcs::serialized_size(&v);
         assert!(actual_size == expected_size, 1);
+
+        assert!(option::none() == bcs::constant_serialized_size<vector<u8>>(), 2);
+    }
+
+    #[test(creator = @0xcafe)]
+    fun bcs_address(creator: &signer) {
+        let v = signer::address_of(creator);
+
+        let expected_bytes = x"000000000000000000000000000000000000000000000000000000000000CAFE";
+        let actual_bytes = bcs::to_bytes(&v);
+        assert!(actual_bytes == expected_bytes, 0);
+
+        let expected_size = vector::length(&actual_bytes);
+        let actual_size = bcs::serialized_size(&v);
+        assert!(actual_size == expected_size, 1);
+
+        assert!(option::some(actual_size) == bcs::constant_serialized_size<address>(), 2);
     }
 
     fun box3<T>(x: T): Box3<T> {
@@ -101,5 +128,18 @@ module std::bcs_tests {
 
         let actual_size = bcs::serialized_size(&box);
         assert!(actual_size == expected_size, 0);
+
+        assert!(option::some(actual_size) == bcs::constant_serialized_size<Box127<bool>>(), 1);
+        assert!(option::none() == bcs::constant_serialized_size<Box63<vector<bool>>>(), 2);
+        assert!(option::none() == bcs::constant_serialized_size<Box63<option::Option<bool>>>(), 3);
     }
+
+    // enum Singleton {
+    //     V1(u64),
+    // }
+
+    // fun encode_enum() {
+    //     assert!(option::none() == bcs::constant_serialized_size<Singleton>());
+    //     assert!(option::none() == bcs::constant_serialized_size<Box3<Singleton>>());
+    // }
 }

--- a/third_party/move/move-vm/types/src/value_serde.rs
+++ b/third_party/move/move-vm/types/src/value_serde.rs
@@ -9,7 +9,9 @@ use crate::{
 };
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
-    value::{IdentifierMappingKind, MoveTypeLayout},
+    account_address::AccountAddress,
+    u256,
+    value::{IdentifierMappingKind, MoveStructLayout, MoveTypeLayout},
     vm_status::StatusCode,
 };
 use serde::{
@@ -165,6 +167,112 @@ pub fn serialized_size_allowing_delayed_values(
         value: &value.0,
     };
     bcs::serialized_size(&value).map_err(|e| {
+        PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR).with_message(format!(
+            "failed to compute serialized size of a value: {:?}",
+            e
+        ))
+    })
+}
+
+/// Count number of types constant_serialized_size would visit, used for gas charging.
+/// This is different done type.num_nodes(), as some types are not traversed (i.e. vector),
+/// and for structs types and number of fields matter as well.
+///
+/// Unclear if type_visit_count would be the same for other usages
+/// (for example, whether vector types need to be traversed),
+/// so name it very specifically, and on future usages see how it generalizes.
+pub fn type_visit_count_for_constant_serialized_size(ty_layout: &MoveTypeLayout) -> u64 {
+    match ty_layout {
+        MoveTypeLayout::Bool
+        | MoveTypeLayout::U8
+        | MoveTypeLayout::U16
+        | MoveTypeLayout::U32
+        | MoveTypeLayout::U128
+        | MoveTypeLayout::U256
+        | MoveTypeLayout::U64
+        | MoveTypeLayout::Address
+        | MoveTypeLayout::Signer => 1,
+        // non-recursed:
+        MoveTypeLayout::Struct(
+            MoveStructLayout::RuntimeVariants(_) | MoveStructLayout::WithVariants(_),
+        )
+        | MoveTypeLayout::Vector(_) => 1,
+        // recursed:
+        MoveTypeLayout::Struct(MoveStructLayout::Runtime(fields)) => {
+            let mut total = 1; // Count the current visit, and aggregate all children
+            for field in fields {
+                total += type_visit_count_for_constant_serialized_size(field);
+            }
+            total
+        },
+        MoveTypeLayout::Struct(MoveStructLayout::WithFields(fields))
+        | MoveTypeLayout::Struct(MoveStructLayout::WithTypes { fields, .. }) => {
+            let mut total = 1; // Count the current visit, and aggregate all children
+            for field in fields {
+                total += type_visit_count_for_constant_serialized_size(&field.layout);
+            }
+            total
+        },
+        // Count the current visit, and inner visits
+        MoveTypeLayout::Native(_, inner) => {
+            1 + type_visit_count_for_constant_serialized_size(inner)
+        },
+    }
+}
+
+/// If given type has a constant serialized size (irrespective of the instance), it returns the serialized
+/// size in bytes any value would have.
+/// Otherwise it returns None.
+pub fn constant_serialized_size(ty_layout: &MoveTypeLayout) -> PartialVMResult<Option<usize>> {
+    let bcs_size_result = match ty_layout {
+        MoveTypeLayout::Bool => bcs::serialized_size(&false).map(Some),
+        MoveTypeLayout::U8 => bcs::serialized_size(&0u8).map(Some),
+        MoveTypeLayout::U16 => bcs::serialized_size(&0u16).map(Some),
+        MoveTypeLayout::U32 => bcs::serialized_size(&0u32).map(Some),
+        MoveTypeLayout::U64 => bcs::serialized_size(&0u64).map(Some),
+        MoveTypeLayout::U128 => bcs::serialized_size(&0u128).map(Some),
+        MoveTypeLayout::U256 => bcs::serialized_size(&u256::U256::zero()).map(Some),
+        MoveTypeLayout::Address => bcs::serialized_size(&AccountAddress::ZERO).map(Some),
+        // signer's size is VM implementation detail, and can change at will.
+        MoveTypeLayout::Signer => Ok(None),
+        // vectors have no constant size
+        MoveTypeLayout::Vector(_) => Ok(None),
+        // enums have no constant size
+        MoveTypeLayout::Struct(
+            MoveStructLayout::RuntimeVariants(_) | MoveStructLayout::WithVariants(_),
+        ) => Ok(None),
+        MoveTypeLayout::Struct(MoveStructLayout::Runtime(fields)) => {
+            let mut total = Some(0);
+            for field in fields {
+                let cur = constant_serialized_size(field)?;
+                match cur {
+                    Some(cur_value) => total = total.map(|v| v + cur_value),
+                    None => {
+                        total = None;
+                        break;
+                    },
+                }
+            }
+            Ok(total)
+        },
+        MoveTypeLayout::Struct(MoveStructLayout::WithFields(fields))
+        | MoveTypeLayout::Struct(MoveStructLayout::WithTypes { fields, .. }) => {
+            let mut total = Some(0);
+            for field in fields {
+                let cur = constant_serialized_size(&field.layout)?;
+                match cur {
+                    Some(cur_value) => total = total.map(|v| v + cur_value),
+                    None => {
+                        total = None;
+                        break;
+                    },
+                }
+            }
+            Ok(total)
+        },
+        MoveTypeLayout::Native(_, inner) => Ok(constant_serialized_size(inner)?),
+    };
+    bcs_size_result.map_err(|e| {
         PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR).with_message(format!(
             "failed to compute serialized size of a value: {:?}",
             e

--- a/third_party/move/move-vm/types/src/value_serde.rs
+++ b/third_party/move/move-vm/types/src/value_serde.rs
@@ -9,9 +9,7 @@ use crate::{
 };
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
-    account_address::AccountAddress,
-    u256,
-    value::{IdentifierMappingKind, MoveStructLayout, MoveTypeLayout},
+    value::{IdentifierMappingKind, MoveTypeLayout},
     vm_status::StatusCode,
 };
 use serde::{
@@ -167,112 +165,6 @@ pub fn serialized_size_allowing_delayed_values(
         value: &value.0,
     };
     bcs::serialized_size(&value).map_err(|e| {
-        PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR).with_message(format!(
-            "failed to compute serialized size of a value: {:?}",
-            e
-        ))
-    })
-}
-
-/// Count number of types constant_serialized_size would visit, used for gas charging.
-/// This is different done type.num_nodes(), as some types are not traversed (i.e. vector),
-/// and for structs types and number of fields matter as well.
-///
-/// Unclear if type_visit_count would be the same for other usages
-/// (for example, whether vector types need to be traversed),
-/// so name it very specifically, and on future usages see how it generalizes.
-pub fn type_visit_count_for_constant_serialized_size(ty_layout: &MoveTypeLayout) -> u64 {
-    match ty_layout {
-        MoveTypeLayout::Bool
-        | MoveTypeLayout::U8
-        | MoveTypeLayout::U16
-        | MoveTypeLayout::U32
-        | MoveTypeLayout::U128
-        | MoveTypeLayout::U256
-        | MoveTypeLayout::U64
-        | MoveTypeLayout::Address
-        | MoveTypeLayout::Signer => 1,
-        // non-recursed:
-        MoveTypeLayout::Struct(
-            MoveStructLayout::RuntimeVariants(_) | MoveStructLayout::WithVariants(_),
-        )
-        | MoveTypeLayout::Vector(_) => 1,
-        // recursed:
-        MoveTypeLayout::Struct(MoveStructLayout::Runtime(fields)) => {
-            let mut total = 1; // Count the current visit, and aggregate all children
-            for field in fields {
-                total += type_visit_count_for_constant_serialized_size(field);
-            }
-            total
-        },
-        MoveTypeLayout::Struct(MoveStructLayout::WithFields(fields))
-        | MoveTypeLayout::Struct(MoveStructLayout::WithTypes { fields, .. }) => {
-            let mut total = 1; // Count the current visit, and aggregate all children
-            for field in fields {
-                total += type_visit_count_for_constant_serialized_size(&field.layout);
-            }
-            total
-        },
-        // Count the current visit, and inner visits
-        MoveTypeLayout::Native(_, inner) => {
-            1 + type_visit_count_for_constant_serialized_size(inner)
-        },
-    }
-}
-
-/// If given type has a constant serialized size (irrespective of the instance), it returns the serialized
-/// size in bytes any value would have.
-/// Otherwise it returns None.
-pub fn constant_serialized_size(ty_layout: &MoveTypeLayout) -> PartialVMResult<Option<usize>> {
-    let bcs_size_result = match ty_layout {
-        MoveTypeLayout::Bool => bcs::serialized_size(&false).map(Some),
-        MoveTypeLayout::U8 => bcs::serialized_size(&0u8).map(Some),
-        MoveTypeLayout::U16 => bcs::serialized_size(&0u16).map(Some),
-        MoveTypeLayout::U32 => bcs::serialized_size(&0u32).map(Some),
-        MoveTypeLayout::U64 => bcs::serialized_size(&0u64).map(Some),
-        MoveTypeLayout::U128 => bcs::serialized_size(&0u128).map(Some),
-        MoveTypeLayout::U256 => bcs::serialized_size(&u256::U256::zero()).map(Some),
-        MoveTypeLayout::Address => bcs::serialized_size(&AccountAddress::ZERO).map(Some),
-        // signer's size is VM implementation detail, and can change at will.
-        MoveTypeLayout::Signer => Ok(None),
-        // vectors have no constant size
-        MoveTypeLayout::Vector(_) => Ok(None),
-        // enums have no constant size
-        MoveTypeLayout::Struct(
-            MoveStructLayout::RuntimeVariants(_) | MoveStructLayout::WithVariants(_),
-        ) => Ok(None),
-        MoveTypeLayout::Struct(MoveStructLayout::Runtime(fields)) => {
-            let mut total = Some(0);
-            for field in fields {
-                let cur = constant_serialized_size(field)?;
-                match cur {
-                    Some(cur_value) => total = total.map(|v| v + cur_value),
-                    None => {
-                        total = None;
-                        break;
-                    },
-                }
-            }
-            Ok(total)
-        },
-        MoveTypeLayout::Struct(MoveStructLayout::WithFields(fields))
-        | MoveTypeLayout::Struct(MoveStructLayout::WithTypes { fields, .. }) => {
-            let mut total = Some(0);
-            for field in fields {
-                let cur = constant_serialized_size(&field.layout)?;
-                match cur {
-                    Some(cur_value) => total = total.map(|v| v + cur_value),
-                    None => {
-                        total = None;
-                        break;
-                    },
-                }
-            }
-            Ok(total)
-        },
-        MoveTypeLayout::Native(_, inner) => Ok(constant_serialized_size(inner)?),
-    };
-    bcs_size_result.map_err(|e| {
         PartialVMError::new(StatusCode::VALUE_SERIALIZATION_ERROR).with_message(format!(
             "failed to compute serialized size of a value: {:?}",
             e

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -97,6 +97,7 @@ pub enum FeatureFlag {
     TRANSACTION_SIMULATION_ENHANCEMENT = 78,
     COLLECTION_OWNER = 79,
     /// covers mem::swap and vector::move_range
+    /// AIP-105 (https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-105.md)
     NATIVE_MEMORY_OPERATIONS = 80,
     ENABLE_LOADER_V2 = 81,
 }


### PR DESCRIPTION
## Description
It is sometimes useful to know if type has constants serialized size, and for example perform some optimization based on it. 

## How Has This Been Tested?
provided unit tests

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
