### PR TITLE
[compiler-v2] Fix type constraint display infinite recursion

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/receiver/bug_14913_constraint_infinite_recursion.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/bug_14913_constraint_infinite_recursion.exp
@@ -1,0 +1,37 @@
+
+Diagnostics:
+error: undeclared receiver function `borrow` for type `vector<Entry<K, V>>`
+   ┌─ tests/checking/receiver/bug_14913_constraint_infinite_recursion.move:20:10
+   │
+20 │         &map.entries.borrow(self.index).key
+   │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: undeclared receiver function `lower_bound` for type `OrderedMap<K, V>`
+   ┌─ tests/checking/receiver/bug_14913_constraint_infinite_recursion.move:23:27
+   │
+23 │         let lower_bound = self.lower_bound(key);
+   │                           ^^^^^^^^^^^^^^^^^^^^^
+
+warning: parameter name `self` indicates a receiver function but the type `*error*` is not suitable for receiver functions. Only structs and vectors can have receiver functions. Consider using a different name.
+   ┌─ tests/checking/receiver/bug_14913_constraint_infinite_recursion.move:32:16
+   │
+32 │     public fun borrow<K, V>(self: &OrderedMao<K, V>, key: &K): &V {
+   │                ^^^^^^
+
+error: type cannot have type arguments
+   ┌─ tests/checking/receiver/bug_14913_constraint_infinite_recursion.move:32:36
+   │
+32 │     public fun borrow<K, V>(self: &OrderedMao<K, V>, key: &K): &V {
+   │                                    ^^^^^^^^^^
+
+error: undeclared `0x815::ordered_map::OrderedMao`
+   ┌─ tests/checking/receiver/bug_14913_constraint_infinite_recursion.move:32:36
+   │
+32 │     public fun borrow<K, V>(self: &OrderedMao<K, V>, key: &K): &V {
+   │                                    ^^^^^^^^^^
+
+error: unable to infer instantiation of type `fun self.iter_borrow(_,&*error*):&V` (consider providing type arguments or annotating the type)
+   ┌─ tests/checking/receiver/bug_14913_constraint_infinite_recursion.move:33:9
+   │
+33 │         self.find(key).iter_borrow(self)
+   │         ^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/bug_14913_constraint_infinite_recursion.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/bug_14913_constraint_infinite_recursion.move
@@ -1,0 +1,41 @@
+module 0x815::ordered_map {
+    const EITER_OUT_OF_BOUNDS: u64 = 3;
+    struct Entry<K, V> has drop, copy, store {
+        key: K,
+        value: V,
+    }
+    enum OrderedMap<K, V> has drop, copy, store {
+        SortedVectorMap {
+            entries: vector<Entry<K, V>>,
+        }
+    }
+    enum Iterator has copy, drop {
+        End,
+        Position {
+            index: u64,
+        },
+    }
+    public fun iter_borrow_key<K, V>(self: &Iterator, map: &OrderedMap<K, V>): &K {
+        assert!(!(self is Iterator::End), EITER_OUT_OF_BOUNDS);
+        &map.entries.borrow(self.index).key
+    }
+    public fun find<K, V>(self: &OrderedMap<K, V>, key: &K): Iterator {
+        let lower_bound = self.lower_bound(key);
+        if (lower_bound.iter_is_end(self)) {
+            lower_bound
+        } else if (lower_bound.iter_borrow_key(self) == key) {
+            lower_bound
+        } else {
+            self.new_end_iter()
+        }
+    }
+    public fun borrow<K, V>(self: &OrderedMao<K, V>, key: &K): &V {
+        self.find(key).iter_borrow(self)
+    }
+    public fun new_end_iter<K, V>(self: &OrderedMap<K, V>): Iterator {
+        Iterator::End
+    }
+    public fun iter_is_end<K, V>(self: &Iterator, _map: &OrderedMap<K, V>): bool {
+        self is Iterator::End
+    }
+}


### PR DESCRIPTION
## Description

Type constraints can be self-referring, as in `x is ReceiverFunction(x, ...)`, so we need to avoid to run into endless recursion when displaying them. This adds a "visting" set to the display logic.

Closes #14913

## How Has This Been Tested?

New baseline test


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)
