### PR TITLE
Comment out disabled fuzzers to prevent them from appearing in the list

### DIFF
--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -41,33 +41,33 @@ path = "fuzz_targets/move/bytecode_verifier_mixed.rs"
 test = false
 doc = false
 
-[[bin]]
-name = "move_value_deserialize"
-path = "fuzz_targets/move/value_deserialize.rs"
-test = false
-doc = false
-required-features = ["disabled"]
+#[[bin]]
+#name = "move_value_deserialize"
+#path = "fuzz_targets/move/value_deserialize.rs"
+#test = false
+#doc = false
+#required-features = ["disabled"]
 
-[[bin]]
-name = "move_move_value_deserialize"
-path = "fuzz_targets/move/move_value_deserialize.rs"
-test = false
-doc = false
-required-features = ["disabled"]
+#[[bin]]
+#name = "move_move_value_deserialize"
+#path = "fuzz_targets/move/move_value_deserialize.rs"
+#test = false
+#doc = false
+#required-features = ["disabled"]
 
-[[bin]]
-name = "move_move_value_decorate"
-path = "fuzz_targets/move/move_value_decorate.rs"
-test = false
-doc = false
-required-features = ["disabled"]
+#[[bin]]
+#name = "move_move_value_decorate"
+#path = "fuzz_targets/move/move_value_decorate.rs"
+#test = false
+#doc = false
+#required-features = ["disabled"]
 
-[[bin]]
-name = "signed_transaction_deserialize"
-path = "fuzz_targets/signed_transaction_deserialize.rs"
-test = false
-doc = false
-required-features = ["disabled"]
+#[[bin]]
+#name = "signed_transaction_deserialize"
+#path = "fuzz_targets/signed_transaction_deserialize.rs"
+#test = false
+#doc = false
+#required-features = ["disabled"]
 
 [[bin]]
 name = "move_aptosvm_publish_and_run"

--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -41,8 +41,25 @@ path = "fuzz_targets/move/bytecode_verifier_mixed.rs"
 test = false
 doc = false
 
-#[[bin]]
-#name = "move_value_deserialize"
+[[bin]]
+name = "move_aptosvm_publish_and_run"
+path = "fuzz_targets/move/aptosvm_publish_and_run.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "move_aptosvm_publish"
+path = "fuzz_targets/move/aptosvm_publish.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "move_aptosvm_authenticators"
+path = "fuzz_targets/move/aptosvm_authenticators.rs"
+test = false
+doc = false
+
+#[[bin]]#name = "move_value_deserialize"
 #path = "fuzz_targets/move/value_deserialize.rs"
 #test = false
 #doc = false
@@ -68,21 +85,3 @@ doc = false
 #test = false
 #doc = false
 #required-features = ["disabled"]
-
-[[bin]]
-name = "move_aptosvm_publish_and_run"
-path = "fuzz_targets/move/aptosvm_publish_and_run.rs"
-test = false
-doc = false
-
-[[bin]]
-name = "move_aptosvm_publish"
-path = "fuzz_targets/move/aptosvm_publish.rs"
-test = false
-doc = false
-
-[[bin]]
-name = "move_aptosvm_authenticators"
-path = "fuzz_targets/move/aptosvm_authenticators.rs"
-test = false
-doc = false


### PR DESCRIPTION
## Description
Workaround since `cargo fuzz list` return all the bins in the cargo toml.

## How Has This Been Tested?
N/A

## Key Areas to Review
N/A

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [X] Other (specify)

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X] I tested both happy and unhappy path of the functionality
- [X] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
