### PR TITLE
Improve the storage code for table info indexing.

### DIFF
--- a/storage/indexer/src/db_v2.rs
+++ b/storage/indexer/src/db_v2.rs
@@ -187,11 +187,12 @@ impl IndexerAsyncV2 {
         self.db.get::<TableInfoSchema>(&handle).map_err(Into::into)
     }
 
-    pub fn get_table_info_with_retry(&self, handle: TableHandle) -> Result<Option<TableInfo>> {
+    /// Get table info with retry: until the table info is available without error.
+    pub fn get_table_info_with_retry(&self, handle: TableHandle) -> TableInfo {
         let mut retried = 0;
         loop {
             if let Ok(Some(table_info)) = self.get_table_info(handle) {
-                return Ok(Some(table_info));
+                return table_info;
             }
             retried += 1;
             info!(

--- a/storage/indexer/src/indexer_reader.rs
+++ b/storage/indexer/src/indexer_reader.rs
@@ -44,9 +44,11 @@ impl IndexerReader for IndexerReaders {
         self.db_indexer_reader.is_some()
     }
 
+    /// A blocking call that waits for the internal indexer to catch up to the given version
+    /// if requested handle is ahead of the internal indexer.
     fn get_table_info(&self, handle: TableHandle) -> anyhow::Result<Option<TableInfo>> {
         if let Some(table_info_reader) = &self.table_info_reader {
-            return Ok(table_info_reader.get_table_info_with_retry(handle)?);
+            return Ok(Some(table_info_reader.get_table_info_with_retry(handle)));
         }
         anyhow::bail!("Table info reader is not available")
     }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This is a pure refactor of the code: table info db `get_table_info` is internalized and all errors are swallowed. Flatten the structure to make this more clear.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
linter + ut
## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
