### PR TITLE
[Consensus Observer] Parallelize message processing logic.

### DIFF
--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -363,7 +363,10 @@ impl ProofOfStore {
         }
         let result = validator
             .verify_multi_signatures(&self.info, &self.multi_signature)
-            .context("Failed to verify ProofOfStore");
+            .context(format!(
+                "Failed to verify ProofOfStore for batch: {:?}",
+                self.info
+            ));
         if result.is_ok() {
             cache.insert(self.info.clone(), self.multi_signature.clone());
         }

--- a/consensus/src/consensus_observer/observer/payload_store.rs
+++ b/consensus/src/consensus_observer/observer/payload_store.rs
@@ -213,8 +213,7 @@ impl BlockPayloadStore {
     }
 
     /// Verifies the block payload signatures against the given epoch state.
-    /// If verification is successful, blocks are marked as verified. Each
-    /// new verified block is
+    /// If verification is successful, blocks are marked as verified.
     pub fn verify_payload_signatures(&mut self, epoch_state: &EpochState) -> Vec<Round> {
         // Get the current epoch
         let current_epoch = epoch_state.epoch;


### PR DESCRIPTION
## Description
This PR parallelizes message verification steps in consensus observer. Specifically, payload signature verification and payload digest verification. This should save about ~20ms in consensus observer lag for `realistic_env_max_load` (e.g., see: https://github.com/aptos-labs/aptos-core/pull/15002)

## Testing Plan
Existing test infrastructure.