### PR TITLE
Fix Forge default arguments to the aptos-node Helm chart

### DIFF
--- a/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml
+++ b/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml
@@ -5,6 +5,12 @@ validator:
   rust_log: info,hyper=off
   # force enable the telemetry service to try to send telemetry
   force_enable_telemetry: true
+  config:
+    storage:
+      rocksdb_configs:
+        enable_storage_sharding: true
+    indexer_db_config:
+      enable_event: true
 
 fullnode:
   # at most one VFN per validator, depending on numFullnodeGroups
@@ -16,6 +22,12 @@ fullnode:
   rust_log: info,hyper=off
   # force enable the telemetry service to try to send telemetry
   force_enable_telemetry: true
+  config:
+    storage:
+      rocksdb_configs:
+        enable_storage_sharding: true
+    indexer_db_config:
+      enable_event: true
 
 service:
   validator:
@@ -25,12 +37,6 @@ service:
       type: "ClusterIP"
     enableRestApi: true
     enableMetricsPort: true
-    config:
-      storage:
-        rocksdb_configs:
-          enable_storage_sharding: true
-      indexer_db_config:
-        enable_event: true
 
   fullnode:
     external:
@@ -39,12 +45,6 @@ service:
       type: "ClusterIP"
     enableRestApi: true
     enableMetricsPort: true
-    config:
-      storage:
-        rocksdb_configs:
-          enable_storage_sharding: true
-      indexer_db_config:
-        enable_event: true
 
 # always assume we're spinning up a testnet and doing genesis rather than using the single validator test mode
 loadTestGenesis: false


### PR DESCRIPTION
## Description

Fix default arguments for the `aptos-node` Helm chart when initialized by Forge.
Previously changed in https://github.com/aptos-labs/aptos-core/pull/14547.