### PR TITLE
[aptos-workspace-server] service-startup using shared futures

### DIFF
--- a/aptos-move/aptos-workspace-server/src/main.rs
+++ b/aptos-move/aptos-workspace-server/src/main.rs
@@ -1,22 +1,36 @@
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use aptos::node::local_testnet::HealthChecker;
 use aptos_config::config::{NodeConfig, TableInfoServiceMode};
 use aptos_faucet_core::server::{FunderKeyEnum, RunConfig};
 use aptos_node::{load_node_config, start_and_report_ports};
 use aptos_types::network_address::{NetworkAddress, Protocol};
-use futures::channel::oneshot;
+use futures::{channel::oneshot, future::Shared, FutureExt};
 use rand::{rngs::StdRng, SeedableRng};
 use std::{
+    future::Future,
     net::{IpAddr, Ipv4Addr},
     path::Path,
+    sync::Arc,
     thread,
     time::Duration,
 };
 use url::Url;
 
+const IP_LOCAL_HOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+
+/// Converts a future into a shared one by putting the error into an Arc.
+fn make_shared<F, T, E>(fut: F) -> Shared<impl Future<Output = Result<T, Arc<E>>>>
+where
+    T: Clone,
+    F: Future<Output = Result<T, E>>,
+{
+    fut.map(|r| r.map_err(|err| Arc::new(err))).shared()
+}
+
+/// Sets all ports in the node config to zero so the OS can assign them random ones.
 pub fn zero_all_ports(config: &mut NodeConfig) {
     // TODO: Double check if all ports are covered.
 
@@ -42,7 +56,15 @@ pub fn zero_all_ports(config: &mut NodeConfig) {
     }
 }
 
-async fn spawn_node(test_dir: &Path) -> Result<()> {
+/// Starts a local node and returns two futures:
+/// 1. A future for the node API, which resolves to the port number once the service is fully up.
+/// 2. A future for the indexer gRPC, which resolves to the port number once the service is fully up.
+fn start_node(
+    test_dir: &Path,
+) -> Result<(
+    impl Future<Output = Result<u16>>,
+    impl Future<Output = Result<u16>>,
+)> {
     let rng = StdRng::from_entropy();
 
     let mut node_config = load_node_config(
@@ -62,17 +84,11 @@ async fn spawn_node(test_dir: &Path) -> Result<()> {
 
     node_config.indexer_table_info.table_info_service_mode = TableInfoServiceMode::IndexingOnly;
 
-    node_config
-        .api
-        .address
-        .set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
-    node_config
-        .indexer_grpc
-        .address
-        .set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+    node_config.api.address.set_ip(IP_LOCAL_HOST);
+    node_config.indexer_grpc.address.set_ip(IP_LOCAL_HOST);
 
-    node_config.admin_service.address = "127.0.0.1".to_string();
-    node_config.inspection_service.address = "127.0.0.1".to_string();
+    node_config.admin_service.address = IP_LOCAL_HOST.to_string();
+    node_config.inspection_service.address = IP_LOCAL_HOST.to_string();
 
     let (api_port_tx, api_port_rx) = oneshot::channel();
     let (indexer_grpc_port_tx, indexer_grpc_port_rx) = oneshot::channel();
@@ -99,46 +115,61 @@ async fn spawn_node(test_dir: &Path) -> Result<()> {
         }
     });
 
-    let api_port = api_port_rx.await?;
-    let indexer_grpc_port = indexer_grpc_port_rx.await?;
+    let fut_api = async move {
+        let api_port = api_port_rx.await?;
 
-    let api_health_checker = HealthChecker::NodeApi(
-        Url::parse(&format!(
-            "http://{}:{}",
-            node_config.api.address.ip(),
-            api_port
-        ))
-        .unwrap(),
-    );
-    let indexer_grpc_health_checker = HealthChecker::DataServiceGrpc(
-        Url::parse(&format!(
-            "http://{}:{}",
-            node_config.indexer_grpc.address.ip(),
-            indexer_grpc_port
-        ))
-        .unwrap(),
-    );
+        let api_health_checker = HealthChecker::NodeApi(
+            Url::parse(&format!("http://{}:{}", IP_LOCAL_HOST, api_port)).unwrap(),
+        );
+        api_health_checker.wait(None).await?;
 
-    api_health_checker.wait(None).await?;
-    eprintln!(
-        "Node API is ready. Endpoint: http://127.0.0.1:{}/",
-        api_port
-    );
+        println!(
+            "Node API is ready. Endpoint: http://{}:{}/",
+            IP_LOCAL_HOST, api_port
+        );
 
-    indexer_grpc_health_checker.wait(None).await?;
-    eprintln!(
-        "Transaction stream is ready. Endpoint: http://127.0.0.1:{}/",
-        indexer_grpc_port
-    );
+        Ok(api_port)
+    };
+
+    let fut_indexer_grpc = async move {
+        let indexer_grpc_port = indexer_grpc_port_rx.await?;
+
+        let indexer_grpc_health_checker = HealthChecker::DataServiceGrpc(
+            Url::parse(&format!("http://{}:{}", IP_LOCAL_HOST, indexer_grpc_port)).unwrap(),
+        );
+
+        indexer_grpc_health_checker.wait(None).await?;
+        println!(
+            "Transaction stream is ready. Endpoint: http://{}:{}/",
+            IP_LOCAL_HOST, indexer_grpc_port
+        );
+
+        Ok(indexer_grpc_port)
+    };
+
+    Ok((fut_api, fut_indexer_grpc))
+}
+
+/// Starts the faucet service.
+/// The port used will be returned once the service is fully up.
+async fn start_faucet(
+    test_dir: &Path,
+    fut_node_api: impl Future<Output = Result<u16, Arc<anyhow::Error>>>,
+    fut_indexer_grpc: impl Future<Output = Result<u16, Arc<anyhow::Error>>>,
+) -> Result<u16> {
+    let api_port = fut_node_api
+        .await
+        .map_err(anyhow::Error::msg)
+        .context("failed to start faucet: node api did not start successfully")?;
+
+    fut_indexer_grpc
+        .await
+        .map_err(anyhow::Error::msg)
+        .context("failed to start faucet: indexer grpc did not start successfully")?;
 
     let faucet_run_config = RunConfig::build_for_cli(
-        Url::parse(&format!(
-            "http://{}:{}",
-            node_config.api.address.ip(),
-            api_port
-        ))
-        .unwrap(),
-        "127.0.0.1".to_string(),
+        Url::parse(&format!("http://{}:{}", IP_LOCAL_HOST, api_port)).unwrap(),
+        IP_LOCAL_HOST.to_string(),
         0,
         FunderKeyEnum::KeyFile(test_dir.join("mint.key")),
         false,
@@ -146,19 +177,50 @@ async fn spawn_node(test_dir: &Path) -> Result<()> {
     );
 
     let (faucet_port_tx, faucet_port_rx) = oneshot::channel();
-    tokio::spawn(faucet_run_config.run_and_report_port(faucet_port_tx));
+    tokio::spawn(async move {
+        if let Err(err) = faucet_run_config.run_and_report_port(faucet_port_tx).await {
+            eprintln!("Faucet exited with error {:?}", err)
+        }
+    });
 
-    let faucet_port = faucet_port_rx.await?;
+    let faucet_port = faucet_port_rx
+        .await
+        .context("failed to receive faucet port")?;
 
     let faucet_health_checker =
         HealthChecker::http_checker_from_port(faucet_port, "Faucet".to_string());
     faucet_health_checker.wait(None).await?;
-    eprintln!(
-        "Faucet is ready. Endpoint: http://127.0.0.1:{}",
-        faucet_port
+
+    println!(
+        "Faucet is ready. Endpoint: http://{}:{}",
+        IP_LOCAL_HOST, faucet_port
     );
 
-    eprintln!("Indexer API is ready. Endpoint: http://127.0.0.1:0/");
+    Ok(faucet_port)
+}
+
+async fn start_all_services(test_dir: &Path) -> Result<()> {
+    let (fut_node_api, fut_indexer_grpc) = start_node(test_dir)?;
+
+    let fut_node_api = make_shared(fut_node_api);
+    let fut_indexer_grpc = make_shared(fut_indexer_grpc);
+    let fut_faucet = start_faucet(test_dir, fut_node_api.clone(), fut_indexer_grpc.clone());
+
+    let (res_node_api, res_indexer_grpc, res_faucet) =
+        tokio::join!(fut_node_api, fut_indexer_grpc, fut_faucet);
+
+    res_node_api
+        .map_err(anyhow::Error::msg)
+        .context("failed to start node api")?;
+    res_indexer_grpc
+        .map_err(anyhow::Error::msg)
+        .context("failed to start node api")?;
+    res_faucet.context("failed to start faucet")?;
+
+    println!(
+        "Indexer API is ready. Endpoint: http://{}:0/",
+        IP_LOCAL_HOST
+    );
 
     Ok(())
 }
@@ -169,7 +231,7 @@ async fn main() -> Result<()> {
 
     println!("Test directory: {}", test_dir.path().display());
 
-    spawn_node(test_dir.path()).await?;
+    start_all_services(test_dir.path()).await?;
 
     loop {
         tokio::time::sleep(Duration::from_millis(200)).await;

--- a/aptos-move/aptos-workspace-server/src/main.rs
+++ b/aptos-move/aptos-workspace-server/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use aptos::node::local_testnet::HealthChecker;
 use aptos_config::config::{NodeConfig, TableInfoServiceMode};
 use aptos_faucet_core::server::{FunderKeyEnum, RunConfig};
@@ -12,10 +12,9 @@ use rand::{rngs::StdRng, SeedableRng};
 use std::{
     future::Future,
     net::{IpAddr, Ipv4Addr},
-    path::Path,
+    path::{Path, PathBuf},
     sync::Arc,
     thread,
-    time::Duration,
 };
 use url::Url;
 
@@ -56,14 +55,16 @@ pub fn zero_all_ports(config: &mut NodeConfig) {
     }
 }
 
-/// Starts a local node and returns two futures:
+/// Starts a local node and returns three futures:
 /// 1. A future for the node API, which resolves to the port number once the service is fully up.
 /// 2. A future for the indexer gRPC, which resolves to the port number once the service is fully up.
+/// 3. A final future that resolves when the node stops.
 fn start_node(
     test_dir: &Path,
 ) -> Result<(
     impl Future<Output = Result<u16>>,
     impl Future<Output = Result<u16>>,
+    impl Future<Output = Result<()>>,
 )> {
     let rng = StdRng::from_entropy();
 
@@ -107,13 +108,19 @@ fn start_node(
         }
     };
 
-    let _node_thread_handle = thread::spawn(move || {
-        let res = run_node();
+    let node_thread_handle = thread::spawn(run_node);
 
-        if let Err(err) = res {
-            println!("Node stopped unexpectedly {:?}", err);
-        }
-    });
+    let fut_node_finish = async {
+        let join_handle = tokio::task::spawn_blocking(move || -> Result<()> {
+            node_thread_handle
+                .join()
+                .map_err(|_err| anyhow!("failed to wait for node thread"))?
+        });
+
+        join_handle
+            .await
+            .map_err(|err| anyhow!("failed to join node task: {}", err))?
+    };
 
     let fut_api = async move {
         let api_port = api_port_rx.await?;
@@ -147,68 +154,87 @@ fn start_node(
         Ok(indexer_grpc_port)
     };
 
-    Ok((fut_api, fut_indexer_grpc))
+    Ok((fut_api, fut_indexer_grpc, fut_node_finish))
 }
 
-/// Starts the faucet service.
-/// The port used will be returned once the service is fully up.
-async fn start_faucet(
-    test_dir: &Path,
-    fut_node_api: impl Future<Output = Result<u16, Arc<anyhow::Error>>>,
-    fut_indexer_grpc: impl Future<Output = Result<u16, Arc<anyhow::Error>>>,
-) -> Result<u16> {
-    let api_port = fut_node_api
-        .await
-        .map_err(anyhow::Error::msg)
-        .context("failed to start faucet: node api did not start successfully")?;
-
-    fut_indexer_grpc
-        .await
-        .map_err(anyhow::Error::msg)
-        .context("failed to start faucet: indexer grpc did not start successfully")?;
-
-    let faucet_run_config = RunConfig::build_for_cli(
-        Url::parse(&format!("http://{}:{}", IP_LOCAL_HOST, api_port)).unwrap(),
-        IP_LOCAL_HOST.to_string(),
-        0,
-        FunderKeyEnum::KeyFile(test_dir.join("mint.key")),
-        false,
-        None,
-    );
-
+/// Starts the faucet service and returns two futures.
+/// 1. A future that resolves to the port used, once the faucet service is fully up.
+/// 2. A future that resolves, when the service stops.
+fn start_faucet(
+    test_dir: PathBuf,
+    fut_node_api: impl Future<Output = Result<u16, Arc<anyhow::Error>>> + Send + 'static,
+    fut_indexer_grpc: impl Future<Output = Result<u16, Arc<anyhow::Error>>> + Send + 'static,
+) -> (
+    impl Future<Output = Result<u16>>,
+    impl Future<Output = Result<()>> + 'static,
+) {
     let (faucet_port_tx, faucet_port_rx) = oneshot::channel();
-    tokio::spawn(async move {
-        if let Err(err) = faucet_run_config.run_and_report_port(faucet_port_tx).await {
-            eprintln!("Faucet exited with error {:?}", err)
-        }
+
+    let handle_faucet = tokio::spawn(async move {
+        let api_port = fut_node_api
+            .await
+            .map_err(anyhow::Error::msg)
+            .context("failed to start faucet: node api did not start successfully")?;
+
+        fut_indexer_grpc
+            .await
+            .map_err(anyhow::Error::msg)
+            .context("failed to start faucet: indexer grpc did not start successfully")?;
+
+        let faucet_run_config = RunConfig::build_for_cli(
+            Url::parse(&format!("http://{}:{}", IP_LOCAL_HOST, api_port)).unwrap(),
+            IP_LOCAL_HOST.to_string(),
+            0,
+            FunderKeyEnum::KeyFile(test_dir.join("mint.key")),
+            false,
+            None,
+        );
+
+        faucet_run_config.run_and_report_port(faucet_port_tx).await
     });
 
-    let faucet_port = faucet_port_rx
-        .await
-        .context("failed to receive faucet port")?;
+    let fut_faucet_finish = async move {
+        handle_faucet
+            .await
+            .map_err(|err| anyhow!("failed to join handle task: {}", err))?
+    };
 
-    let faucet_health_checker =
-        HealthChecker::http_checker_from_port(faucet_port, "Faucet".to_string());
-    faucet_health_checker.wait(None).await?;
+    let fut_faucet_port = async move {
+        let faucet_port = faucet_port_rx
+            .await
+            .context("failed to receive faucet port")?;
 
-    println!(
-        "Faucet is ready. Endpoint: http://{}:{}",
-        IP_LOCAL_HOST, faucet_port
-    );
+        let faucet_health_checker =
+            HealthChecker::http_checker_from_port(faucet_port, "Faucet".to_string());
+        faucet_health_checker.wait(None).await?;
 
-    Ok(faucet_port)
+        println!(
+            "Faucet is ready. Endpoint: http://{}:{}",
+            IP_LOCAL_HOST, faucet_port
+        );
+
+        Ok(faucet_port)
+    };
+
+    (fut_faucet_port, fut_faucet_finish)
 }
 
 async fn start_all_services(test_dir: &Path) -> Result<()> {
-    let (fut_node_api, fut_indexer_grpc) = start_node(test_dir)?;
+    // Step 1: spawn all services.
+    let (fut_node_api, fut_indexer_grpc, fut_node_finish) = start_node(test_dir)?;
 
     let fut_node_api = make_shared(fut_node_api);
     let fut_indexer_grpc = make_shared(fut_indexer_grpc);
-    let fut_faucet = start_faucet(test_dir, fut_node_api.clone(), fut_indexer_grpc.clone());
+    let (fut_faucet, fut_faucet_finish) = start_faucet(
+        test_dir.to_owned(),
+        fut_node_api.clone(),
+        fut_indexer_grpc.clone(),
+    );
 
     let (res_node_api, res_indexer_grpc, res_faucet) =
         tokio::join!(fut_node_api, fut_indexer_grpc, fut_faucet);
 
+    // Step 2: wait for all services to be up.
     res_node_api
         .map_err(anyhow::Error::msg)
         .context("failed to start node api")?;
@@ -222,6 +248,30 @@ async fn start_all_services(test_dir: &Path) -> Result<()> {
         IP_LOCAL_HOST
     );
 
+    println!("ALL SERVICES STARTED SUCCESSFULLY");
+
+    // Step 3: wait for services to stop.
+    tokio::pin!(fut_node_finish);
+    tokio::pin!(fut_faucet_finish);
+
+    let mut finished: u64 = 0;
+    while finished < 2 {
+        tokio::select! {
+            res = &mut fut_node_finish => {
+                if let Err(err) = res {
+                    eprintln!("Node existed with error: {}", err);
+                }
+                finished += 1;
+            }
+            res = &mut fut_faucet_finish => {
+                if let Err(err) = res {
+                    eprintln!("Faucet existed with error: {}", err);
+                }
+                finished += 1;
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -233,7 +283,5 @@ async fn main() -> Result<()> {
 
     start_all_services(test_dir.path()).await?;
 
-    loop {
-        tokio::time::sleep(Duration::from_millis(200)).await;
-    }
+    Ok(())
 }


### PR DESCRIPTION
## Description
This refactors the existing `aptos-workspace-server` implementation to make use of shared futures. This shift of paradigm will give us great flexibility and scalability when it comes to managing complex service startup sequences, paving the road for supporting the indexer components.

## How Has This Been Tested?
Manually tested. Automated tests will be set up later as planned

## Key Areas to Review
The use of shared futures

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (Aptos Workspace)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

