### PR TITLE
[cli] Replace unwraps with better error handling

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- [`Fix`] Remove unwraps to make outputs go through regular error handling
 
 ## [4.2.5] - 2024/10/23
 - Bump to resolve issue with release version inconsistency.

--- a/crates/aptos/src/move_tool/fmt.rs
+++ b/crates/aptos/src/move_tool/fmt.rs
@@ -113,7 +113,7 @@ impl FmtCommand {
         } else {
             None
         };
-        let package_path = dir_default_to_current(package_opt.clone()).unwrap();
+        let package_path = dir_default_to_current(package_opt.clone())?;
         let root_res = SourcePackageLayout::try_find_root(&package_path.clone());
         if let Ok(root_package_path) = root_res {
             let mut path_vec = vec![];

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -784,8 +784,7 @@ impl TryInto<PackagePublicationData> for &PublishPackage {
     type Error = CliError;
 
     fn try_into(self) -> Result<PackagePublicationData, Self::Error> {
-        let package =
-            build_package_options(&self.move_options, &self.included_artifacts_args).unwrap();
+        let package = build_package_options(&self.move_options, &self.included_artifacts_args)?;
 
         let package_publication_data =
             create_package_publication_data(package, PublishType::AccountDeploy, None)?;
@@ -815,8 +814,7 @@ impl AsyncTryInto<ChunkedPublishPayloads> for &PublishPackage {
     type Error = CliError;
 
     async fn async_try_into(self) -> Result<ChunkedPublishPayloads, Self::Error> {
-        let package =
-            build_package_options(&self.move_options, &self.included_artifacts_args).unwrap();
+        let package = build_package_options(&self.move_options, &self.included_artifacts_args)?;
 
         let chunked_publish_payloads =
             create_chunked_publish_payloads(package, PublishType::AccountDeploy, None)?;
@@ -1146,8 +1144,7 @@ impl CliCommand<TransactionSummary> for CreateObjectAndPublishPackage {
             let mock_object_address = AccountAddress::from_hex_literal("0xcafe").unwrap();
             self.move_options
                 .add_named_address(self.address_name.clone(), mock_object_address.to_string());
-            let package =
-                build_package_options(&self.move_options, &self.included_artifacts_args).unwrap();
+            let package = build_package_options(&self.move_options, &self.included_artifacts_args)?;
             let mock_payloads =
                 create_chunked_publish_payloads(package, PublishType::AccountDeploy, None)?
                     .payloads;
@@ -1162,8 +1159,7 @@ impl CliCommand<TransactionSummary> for CreateObjectAndPublishPackage {
         self.move_options
             .add_named_address(self.address_name, object_address.to_string());
 
-        let package =
-            build_package_options(&self.move_options, &self.included_artifacts_args).unwrap();
+        let package = build_package_options(&self.move_options, &self.included_artifacts_args)?;
         let message = format!(
             "Do you want to publish this package at object address {}",
             object_address
@@ -1246,7 +1242,7 @@ impl CliCommand<TransactionSummary> for UpgradeObjectPackage {
 
     async fn execute(self) -> CliTypedResult<TransactionSummary> {
         let built_package =
-            build_package_options(&self.move_options, &self.included_artifacts_args).unwrap();
+            build_package_options(&self.move_options, &self.included_artifacts_args)?;
         let url = self
             .txn_options
             .rest_options
@@ -1357,8 +1353,7 @@ impl CliCommand<TransactionSummary> for DeployObjectCode {
             let mock_object_address = AccountAddress::from_hex_literal("0xcafe").unwrap();
             self.move_options
                 .add_named_address(self.address_name.clone(), mock_object_address.to_string());
-            let package =
-                build_package_options(&self.move_options, &self.included_artifacts_args).unwrap();
+            let package = build_package_options(&self.move_options, &self.included_artifacts_args)?;
             let mock_payloads =
                 create_chunked_publish_payloads(package, PublishType::AccountDeploy, None)?
                     .payloads;
@@ -1373,8 +1368,7 @@ impl CliCommand<TransactionSummary> for DeployObjectCode {
         self.move_options
             .add_named_address(self.address_name, object_address.to_string());
 
-        let package =
-            build_package_options(&self.move_options, &self.included_artifacts_args).unwrap();
+        let package = build_package_options(&self.move_options, &self.included_artifacts_args)?;
         let message = format!(
             "Do you want to deploy this package at object address {}",
             object_address
@@ -1463,8 +1457,7 @@ impl CliCommand<TransactionSummary> for UpgradeCodeObject {
         self.move_options
             .add_named_address(self.address_name, self.object_address.to_string());
 
-        let package =
-            build_package_options(&self.move_options, &self.included_artifacts_args).unwrap();
+        let package = build_package_options(&self.move_options, &self.included_artifacts_args)?;
         let url = self
             .txn_options
             .rest_options


### PR DESCRIPTION
## Description
Makes error handling come out of stderr instead of relying on panics.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
