### PR TITLE
[cli] Bumping to 4.2.6 to fix in issue with `--move-2` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "4.2.5"
+version = "4.2.6"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 ## Unreleased
 - [`Fix`] Remove unwraps to make outputs go through regular error handling
 
+## [4.2.6] - 2024/10/23
+- Fixing issue with `--move-2` flag which was still selecting language version 2.0 instead of 2.1.
+
 ## [4.2.5] - 2024/10/23
 - Bump to resolve issue with release version inconsistency.
 

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "4.2.5"
+version = "4.2.6"
 
 # Workspace inherited keys
 authors = { workspace = true }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1176,7 +1176,7 @@ pub struct MovePackageDir {
     /// Currently, defaults to `1`, unless `--move-2` is selected.
     #[clap(long, value_parser = clap::value_parser!(LanguageVersion),
            alias = "language",
-           default_value_if("move_2", "true", "2.0"),
+           default_value_if("move_2", "true", "2.1"),
            verbatim_doc_comment)]
     pub language_version: Option<LanguageVersion>,
 

--- a/third_party/move/move-prover/move-docgen/tests/testsuite.rs
+++ b/third_party/move/move-prover/move-docgen/tests/testsuite.rs
@@ -91,7 +91,7 @@ fn test_docgen(path: &Path, mut options: Options, suffix: &str) -> anyhow::Resul
 
     if path.to_str().is_some_and(|s| s.contains(V2_TEST_DIR)) {
         options.compiler_v2 = true;
-        options.language_version = Some(LanguageVersion::V2_0);
+        options.language_version = Some(LanguageVersion::latest_stable());
     }
 
     let mut error_writer = Buffer::no_color();


### PR DESCRIPTION
## Description

Bumping version of cli to fix a bug with move-2 flag

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
