### PR TITLE
[indexer grpc] Improve the read consistency for fullnode GRPC. 

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/stream_coordinator.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/stream_coordinator.rs
@@ -500,7 +500,17 @@ impl IndexerStreamCoordinator {
 
     pub fn set_highest_known_version(&mut self) -> anyhow::Result<()> {
         let info = self.context.get_latest_ledger_info_wrapped()?;
-        self.highest_known_version = info.ledger_version.0;
+        let latest_table_info_version = self
+            .context
+            .indexer_reader
+            .as_ref()
+            .expect("Table info reader not set")
+            .get_latest_table_info_ledger_version()?
+            .expect("Table info ledger version not set");
+
+        self.highest_known_version =
+            std::cmp::min(info.ledger_version.0, latest_table_info_version);
+
         Ok(())
     }
 

--- a/storage/indexer/src/indexer_reader.rs
+++ b/storage/indexer/src/indexer_reader.rs
@@ -58,6 +58,13 @@ impl IndexerReader for IndexerReaders {
         anyhow::bail!("DB indexer reader is not available")
     }
 
+    fn get_latest_table_info_ledger_version(&self) -> anyhow::Result<Option<Version>> {
+        if let Some(table_info_reader) = &self.table_info_reader {
+            return Ok(Some(table_info_reader.next_version()));
+        }
+        anyhow::bail!("Table info reader is not available")
+    }
+
     fn get_events(
         &self,
         event_key: &EventKey,

--- a/types/src/indexer/indexer_db_reader.rs
+++ b/types/src/indexer/indexer_db_reader.rs
@@ -60,6 +60,7 @@ pub trait IndexerReader: Send + Sync {
     ) -> Result<Box<dyn Iterator<Item = Result<(StateKey, StateValue)>> + '_>>;
 
     fn get_latest_internal_indexer_ledger_version(&self) -> Result<Option<Version>>;
+    fn get_latest_table_info_ledger_version(&self) -> Result<Option<Version>>;
 
     #[cfg(any(test, feature = "fuzzing"))]
     fn wait_for_internal_indexer(&self, version: Version) -> Result<()> {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

In this PR, fullnode will serve data based on the ledger and table info versions. With this change, the API result would be consistent since ledger db and table info are consistent for requested version. 

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

* Tested in forge and looks good: processing is tightly bounded by fullnode version. 

![image](https://github.com/user-attachments/assets/99d9a406-2b96-4450-8a9b-5098e01be2a8)


## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
