### PR TITLE
Internal indexer backup support

### DIFF
--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -177,11 +177,13 @@ pub fn new_test_context_inner(
     node_config
         .storage
         .set_data_dir(tmp_dir.path().to_path_buf());
+
     let mock_indexer_service = MockInternalIndexerDBService::new_for_test(
         db_rw.reader.clone(),
         &node_config,
         recver,
         end_version,
+        mempool.ac_client.clone(),
     );
 
     let context = Context::new(

--- a/aptos-node/src/services.rs
+++ b/aptos-node/src/services.rs
@@ -80,8 +80,10 @@ pub fn bootstrap_api_and_indexer(
     let (db_indexer_runtime, txn_event_reader) = match bootstrap_internal_indexer_db(
         node_config,
         db_rw.clone(),
+        chain_id,
         internal_indexer_db,
         update_receiver,
+        mempool_client_sender.clone(),
     ) {
         Some((runtime, db_indexer)) => (Some(runtime), Some(db_indexer)),
         None => (None, None),

--- a/config/src/config/test_data/validator.yaml
+++ b/config/src/config/test_data/validator.yaml
@@ -79,3 +79,16 @@ validator_network:
     max_frame_size: 4194304 # 4 MiB
 api:
     enabled: true
+
+indexer_db_config:
+    enable_event: true
+    enable_statekeys: true
+    enable_transaction: true
+    internal_indexer_service_mode:
+#        Disabled
+        Backup:
+            internal-indexer-db-bucket
+
+storage:
+    rocksdb_configs:
+        enable_storage_sharding: true

--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/src/lib.rs
@@ -15,3 +15,16 @@ pub fn snapshot_folder_prefix(chain_id: u64) -> String {
 pub fn snapshot_folder_name(chain_id: u64, epoch: u64) -> String {
     format!("snapshot_chain_{}_epoch_{}", chain_id, epoch)
 }
+
+/// Internal indexer snapshot folder prefix for a chain; this is used to identify the snapshot folder and backup.
+pub fn internal_indexer_snapshot_folder_prefix(chain_id: u64) -> String {
+    format!("internal_indexer_snapshot_chain_{}_epoch_", chain_id)
+}
+
+/// Internal indexer snapshot folder name for a chain and epoch.
+pub fn internal_indexer_snapshot_folder_name(chain_id: u64, epoch: u64) -> String {
+    format!(
+        "internal_indexer_snapshot_chain_{}_epoch_{}",
+        chain_id, epoch
+    )
+}

--- a/storage/indexer/src/db_indexer.rs
+++ b/storage/indexer/src/db_indexer.rs
@@ -33,6 +33,8 @@ use aptos_types::{
 };
 use std::{
     cmp::min,
+    fs,
+    path::PathBuf,
     sync::{
         mpsc::{self, Receiver, Sender},
         Arc,
@@ -272,6 +274,11 @@ impl InternalIndexerDB {
             .db
             .get::<InternalIndexerMetadataSchema>(key)?
             .map(|v| v.expect_version()))
+    }
+
+    pub fn create_checkpoint(&self, path: &PathBuf) -> Result<()> {
+        fs::remove_dir_all(path).unwrap_or(());
+        self.db.create_checkpoint(path)
     }
 }
 


### PR DESCRIPTION
## Description
This PR enables the backup support for the internal indexer DB. This enables the internal indexer db service take a series of snapshot of the DB every epoch and upload them on the GCS.

## How Has This Been Tested?
Tested on the localnet: https://console.cloud.google.com/storage/browser/internal-indexer-db-bucket/files;tab=objects?project=aptos-jpark-playground&prefix=&forceOnObjectsSortingFiltering=false&pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
