### PR TITLE
improve internal_indexer_test.rs and error it gives

### DIFF
--- a/execution/executor/tests/internal_indexer_test.rs
+++ b/execution/executor/tests/internal_indexer_test.rs
@@ -20,7 +20,7 @@ use aptos_types::{
     account_config::aptos_test_root_address,
     block_metadata::BlockMetadata,
     chain_id::ChainId,
-    state_store::state_key::prefix::StateKeyPrefix,
+    state_store::state_key::{prefix::StateKeyPrefix, StateKey},
     test_helpers::transaction_test_helpers::TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
     transaction::{
         signature_verified_transaction::into_signature_verified_block,
@@ -28,8 +28,9 @@ use aptos_types::{
         WriteSetPayload,
     },
 };
+use move_core_types::{ident_str, language_storage::StructTag};
 use rand::SeedableRng;
-use std::sync::Arc;
+use std::{fmt::Debug, str::FromStr, sync::Arc};
 
 const B: u64 = 1_000_000_000;
 
@@ -192,6 +193,207 @@ fn test_db_indexer_data() {
             total_version,
         )
         .unwrap();
-    let address_one_kv_res: Vec<_> = address_one_kv_iter.collect();
-    assert_eq!(address_one_kv_res.len(), 152);
+    let address_one_kv_res = address_one_kv_iter.collect::<Result<Vec<_>, _>>().unwrap();
+
+    let (code, resources): (Vec<_>, Vec<_>) = address_one_kv_res
+        .into_iter()
+        .map(|(s, _)| s)
+        .partition(|s| s.is_aptos_code());
+
+    let expected_code = vec![
+        ident_str!("acl"),
+        ident_str!("any"),
+        ident_str!("bcs"),
+        ident_str!("dkg"),
+        ident_str!("code"),
+        ident_str!("coin"),
+        ident_str!("guid"),
+        ident_str!("hash"),
+        ident_str!("jwks"),
+        ident_str!("util"),
+        ident_str!("block"),
+        ident_str!("debug"),
+        ident_str!("error"),
+        ident_str!("event"),
+        ident_str!("stake"),
+        ident_str!("table"),
+        ident_str!("math64"),
+        ident_str!("object"),
+        ident_str!("option"),
+        ident_str!("signer"),
+        ident_str!("string"),
+        ident_str!("vector"),
+        ident_str!("voting"),
+        ident_str!("account"),
+        ident_str!("ed25519"),
+        ident_str!("genesis"),
+        ident_str!("math128"),
+        ident_str!("version"),
+        ident_str!("vesting"),
+        ident_str!("bls12381"),
+        ident_str!("chain_id"),
+        ident_str!("features"),
+        ident_str!("from_bcs"),
+        ident_str!("pool_u64"),
+        ident_str!("secp256k1"),
+        ident_str!("timestamp"),
+        ident_str!("type_info"),
+        ident_str!("aggregator"),
+        ident_str!("aptos_coin"),
+        ident_str!("aptos_hash"),
+        ident_str!("big_vector"),
+        ident_str!("bit_vector"),
+        ident_str!("capability"),
+        ident_str!("comparator"),
+        ident_str!("math_fixed"),
+        ident_str!("randomness"),
+        ident_str!("simple_map"),
+        ident_str!("smart_table"),
+        ident_str!("storage_gas"),
+        ident_str!("chain_status"),
+        ident_str!("copyable_any"),
+        ident_str!("gas_schedule"),
+        ident_str!("managed_coin"),
+        ident_str!("math_fixed64"),
+        ident_str!("ristretto255"),
+        ident_str!("smart_vector"),
+        ident_str!("string_utils"),
+        ident_str!("aggregator_v2"),
+        ident_str!("aptos_account"),
+        ident_str!("bn254_algebra"),
+        ident_str!("config_buffer"),
+        ident_str!("create_signer"),
+        ident_str!("fixed_point32"),
+        ident_str!("fixed_point64"),
+        ident_str!("function_info"),
+        ident_str!("multi_ed25519"),
+        ident_str!("staking_proxy"),
+        ident_str!("state_storage"),
+        ident_str!("crypto_algebra"),
+        ident_str!("fungible_asset"),
+        ident_str!("staking_config"),
+        ident_str!("delegation_pool"),
+        ident_str!("keyless_account"),
+        ident_str!("reconfiguration"),
+        ident_str!("transaction_fee"),
+        ident_str!("aptos_governance"),
+        ident_str!("bls12381_algebra"),
+        ident_str!("consensus_config"),
+        ident_str!("execution_config"),
+        ident_str!("multisig_account"),
+        ident_str!("pool_u64_unbound"),
+        ident_str!("resource_account"),
+        ident_str!("staking_contract"),
+        ident_str!("system_addresses"),
+        ident_str!("randomness_config"),
+        ident_str!("table_with_length"),
+        ident_str!("aggregator_factory"),
+        ident_str!("governance_proposal"),
+        ident_str!("optional_aggregator"),
+        ident_str!("transaction_context"),
+        ident_str!("jwk_consensus_config"),
+        ident_str!("ristretto255_elgamal"),
+        ident_str!("reconfiguration_state"),
+        ident_str!("ristretto255_pedersen"),
+        ident_str!("object_code_deployment"),
+        ident_str!("primary_fungible_store"),
+        ident_str!("transaction_validation"),
+        ident_str!("randomness_api_v0_config"),
+        ident_str!("randomness_config_seqnum"),
+        ident_str!("reconfiguration_with_dkg"),
+        ident_str!("validator_consensus_info"),
+        ident_str!("ristretto255_bulletproofs"),
+        ident_str!("dispatchable_fungible_asset"),
+    ]
+    .into_iter()
+    .map(|module| StateKey::module(&AccountAddress::ONE, module))
+    .collect::<Vec<_>>();
+
+    assert_vec_eq(&code, &expected_code);
+
+    let expected_resources = vec![
+        (false, "0x1::dkg::DKGState"),
+        (false, "0x1::jwks::Patches"),
+        (false, "0x1::account::Account"),
+        (false, "0x1::version::Version"),
+        (false, "0x1::jwks::PatchedJWKs"),
+        (false, "0x1::chain_id::ChainId"),
+        (false, "0x1::coin::SupplyConfig"),
+        (false, "0x1::jwks::ObservedJWKs"),
+        (false, "0x1::features::Features"),
+        (false, "0x1::stake::ValidatorSet"),
+        (false, "0x1::block::BlockResource"),
+        (false, "0x1::block::CommitHistory"),
+        (false, "0x1::code::PackageRegistry"),
+        (true, "0x1::keyless_account::Group"),
+        (false, "0x1::coin::CoinConversionMap"),
+        (false, "0x1::storage_gas::StorageGas"),
+        (false, "0x1::stake::ValidatorPerformance"),
+        (false, "0x1::account::OriginatingAddress"),
+        (false, "0x1::gas_schedule::GasScheduleV2"),
+        (false, "0x1::jwks::SupportedOIDCProviders"),
+        (false, "0x1::stake::AptosCoinCapabilities"),
+        (false, "0x1::reconfiguration_state::State"),
+        (false, "0x1::version::SetVersionCapability"),
+        (false, "0x1::storage_gas::StorageGasConfig"),
+        (false, "0x1::config_buffer::PendingConfigs"),
+        (false, "0x1::staking_config::StakingConfig"),
+        (false, "0x1::randomness::PerBlockRandomness"),
+        (false, "0x1::chain_status::GenesisEndMarker"),
+        (false, "0x1::reconfiguration::Configuration"),
+        (false, "0x1::aptos_governance::VotingRecords"),
+        (false, "0x1::state_storage::StateStorageUsage"),
+        (false, "0x1::consensus_config::ConsensusConfig"),
+        (false, "0x1::execution_config::ExecutionConfig"),
+        (false, "0x1::timestamp::CurrentTimeMicroseconds"),
+        (false, "0x1::aptos_governance::GovernanceConfig"),
+        (false, "0x1::aptos_governance::GovernanceEvents"),
+        (false, "0x1::randomness_config::RandomnessConfig"),
+        (false, "0x1::aggregator_factory::AggregatorFactory"),
+        (false, "0x1::transaction_fee::AptosCoinCapabilities"),
+        (false, "0x1::transaction_fee::AptosCoinMintCapability"),
+        (false, "0x1::jwk_consensus_config::JWKConsensusConfig"),
+        (false, "0x1::aptos_governance::ApprovedExecutionHashes"),
+        (false, "0x1::aptos_governance::GovernanceResponsbility"),
+        (false, "0x1::randomness_api_v0_config::RequiredGasDeposit"),
+        (false, "0x1::transaction_validation::TransactionValidation"),
+        (
+            false,
+            "0x1::randomness_api_v0_config::AllowCustomMaxGasFlag",
+        ),
+        (
+            false,
+            "0x1::randomness_config_seqnum::RandomnessConfigSeqNum",
+        ),
+        (false, "0x1::coin::CoinInfo<0x1::aptos_coin::AptosCoin>"),
+        (
+            false,
+            "0x1::voting::VotingForum<0x1::governance_proposal::GovernanceProposal>",
+        ),
+    ]
+    .into_iter()
+    .map(|(rg, struct_tag)| {
+        if rg {
+            StateKey::resource_group(
+                &AccountAddress::ONE,
+                &StructTag::from_str(struct_tag).unwrap(),
+            )
+        } else {
+            StateKey::resource(
+                &AccountAddress::ONE,
+                &StructTag::from_str(struct_tag).unwrap(),
+            )
+            .unwrap()
+        }
+    })
+    .collect::<Vec<_>>();
+
+    assert_vec_eq(&resources, &expected_resources);
+}
+
+fn assert_vec_eq<T: Eq + Debug>(left: &[T], right: &[T]) {
+    for i in 0..left.len().min(right.len()) {
+        assert_eq!(left[i], right[i], "difference at position {}", i);
+    }
+    assert_eq!(left.len(), right.len(), "difference at last element");
 }


### PR DESCRIPTION
## Description
When changing something in the framework, that changes genesis (even new stdlib module), this test fails cryptically:

```
thread 'test_db_indexer_data' panicked at execution/executor/tests/internal_indexer_test.rs:196:5:
assertion `left == right` failed
  left: 151
 right: 152
```

Changing it so that:
- error message is clearer
- fixing it is clearer (instead of just changing number - you modify the key that your PR changes)

## How Has This Been Tested?
unit tested on PRs changing genesis


## Type of Change
- [x] Tests
