### PR TITLE
[cli] Make large packages module address configurable

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/large_package_publishing.rs
+++ b/aptos-move/e2e-move-tests/src/tests/large_package_publishing.rs
@@ -143,6 +143,7 @@ impl LargePackageTestContext {
             package_code,
             publish_type,
             Some(self.object_address),
+            LARGE_PACKAGES_MODULE_ADDRESS,
         )
     }
 }

--- a/aptos-move/framework/src/chunked_publish.rs
+++ b/aptos-move/framework/src/chunked_publish.rs
@@ -4,8 +4,10 @@
 use aptos_types::transaction::{EntryFunction, TransactionPayload};
 use move_core_types::{account_address::AccountAddress, ident_str, language_storage::ModuleId};
 
+/// The default address where the `large_packages.move` module is deployed.
+/// This address is used on both mainnet and testnet.
 pub const LARGE_PACKAGES_MODULE_ADDRESS: &str =
-    "0x0e1ca3011bdd07246d4d16d909dbb2d6953a86c4735d5acf5865d962c630cce7"; // mainnet and testnet
+    "0x0e1ca3011bdd07246d4d16d909dbb2d6953a86c4735d5acf5865d962c630cce7";
 
 /// Maximum code & metadata chunk size to be included in a transaction
 pub const MAX_CHUNK_SIZE_IN_BYTES: usize = 60_000;
@@ -21,6 +23,7 @@ pub fn chunk_package_and_create_payloads(
     package_code: Vec<Vec<u8>>,
     publish_type: PublishType,
     object_address: Option<AccountAddress>,
+    large_packages_module_address: &str,
 ) -> Vec<TransactionPayload> {
     // Chunk the metadata
     let mut metadata_chunks = create_chunks(metadata);
@@ -30,7 +33,9 @@ pub fn chunk_package_and_create_payloads(
     let mut taken_size = metadata_chunk.len();
     let mut payloads = metadata_chunks
         .into_iter()
-        .map(|chunk| large_packages_stage_code_chunk(chunk, vec![], vec![]))
+        .map(|chunk| {
+            large_packages_stage_code_chunk(chunk, vec![], vec![], large_packages_module_address)
+        })
         .collect::<Vec<_>>();
 
     let mut code_indices: Vec<u16> = vec![];
@@ -45,6 +50,7 @@ pub fn chunk_package_and_create_payloads(
                     metadata_chunk,
                     code_indices.clone(),
                     code_chunks.clone(),
+                    large_packages_module_address,
                 );
                 payloads.push(payload);
 
@@ -66,17 +72,20 @@ pub fn chunk_package_and_create_payloads(
             metadata_chunk,
             code_indices,
             code_chunks,
+            large_packages_module_address,
         ),
         PublishType::ObjectDeploy => large_packages_stage_code_chunk_and_publish_to_object(
             metadata_chunk,
             code_indices,
             code_chunks,
+            large_packages_module_address,
         ),
         PublishType::ObjectUpgrade => large_packages_stage_code_chunk_and_upgrade_object_code(
             metadata_chunk,
             code_indices,
             code_chunks,
             object_address.expect("ObjectAddress is missing"),
+            large_packages_module_address,
         ),
     };
     payloads.push(payload);
@@ -96,10 +105,11 @@ fn large_packages_stage_code_chunk(
     metadata_chunk: Vec<u8>,
     code_indices: Vec<u16>,
     code_chunks: Vec<Vec<u8>>,
+    large_packages_module_address: &str,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
-            AccountAddress::from_hex_literal(LARGE_PACKAGES_MODULE_ADDRESS).unwrap(),
+            AccountAddress::from_hex_literal(large_packages_module_address).unwrap(),
             ident_str!("large_packages").to_owned(),
         ),
         ident_str!("stage_code_chunk").to_owned(),
@@ -117,10 +127,11 @@ fn large_packages_stage_code_chunk_and_publish_to_account(
     metadata_chunk: Vec<u8>,
     code_indices: Vec<u16>,
     code_chunks: Vec<Vec<u8>>,
+    large_packages_module_address: &str,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
-            AccountAddress::from_hex_literal(LARGE_PACKAGES_MODULE_ADDRESS).unwrap(),
+            AccountAddress::from_hex_literal(large_packages_module_address).unwrap(),
             ident_str!("large_packages").to_owned(),
         ),
         ident_str!("stage_code_chunk_and_publish_to_account").to_owned(),
@@ -138,10 +149,11 @@ fn large_packages_stage_code_chunk_and_publish_to_object(
     metadata_chunk: Vec<u8>,
     code_indices: Vec<u16>,
     code_chunks: Vec<Vec<u8>>,
+    large_packages_module_address: &str,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
-            AccountAddress::from_hex_literal(LARGE_PACKAGES_MODULE_ADDRESS).unwrap(),
+            AccountAddress::from_hex_literal(large_packages_module_address).unwrap(),
             ident_str!("large_packages").to_owned(),
         ),
         ident_str!("stage_code_chunk_and_publish_to_object").to_owned(),
@@ -160,10 +172,11 @@ fn large_packages_stage_code_chunk_and_upgrade_object_code(
     code_indices: Vec<u16>,
     code_chunks: Vec<Vec<u8>>,
     code_object: AccountAddress,
+    large_packages_module_address: &str,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
-            AccountAddress::from_hex_literal(LARGE_PACKAGES_MODULE_ADDRESS).unwrap(),
+            AccountAddress::from_hex_literal(large_packages_module_address).unwrap(),
             ident_str!("large_packages").to_owned(),
         ),
         ident_str!("stage_code_chunk_and_upgrade_object_code").to_owned(),
@@ -178,10 +191,12 @@ fn large_packages_stage_code_chunk_and_upgrade_object_code(
 }
 
 // Cleanup account's `StagingArea` resource.
-pub fn large_packages_cleanup_staging_area() -> TransactionPayload {
+pub fn large_packages_cleanup_staging_area(
+    large_packages_module_address: &str,
+) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
-            AccountAddress::from_hex_literal(LARGE_PACKAGES_MODULE_ADDRESS).unwrap(),
+            AccountAddress::from_hex_literal(large_packages_module_address).unwrap(),
             ident_str!("large_packages").to_owned(),
         ),
         ident_str!("cleanup_staging_area").to_owned(),

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -25,6 +25,7 @@ use aptos_crypto::{
     encoding_type::{EncodingError, EncodingType},
     x25519, PrivateKey, ValidCryptoMaterialStringExt,
 };
+use aptos_framework::chunked_publish::LARGE_PACKAGES_MODULE_ADDRESS;
 use aptos_global_constants::adjust_gas_headroom;
 use aptos_keygen::KeyGen;
 use aptos_logger::Level;
@@ -2350,4 +2351,16 @@ pub struct ChunkedPublishOption {
     /// Use this option for publishing large packages exceeding `MAX_PUBLISH_PACKAGE_SIZE`.
     #[clap(long)]
     pub(crate) chunked_publish: bool,
+
+    /// Address of the `large_packages` move module for chunked publishing
+    #[clap(long)]
+    pub(crate) large_packages_module_address: Option<String>,
+}
+
+impl ChunkedPublishOption {
+    pub fn large_packages_module_address(&self) -> &str {
+        self.large_packages_module_address
+            .as_deref()
+            .unwrap_or(LARGE_PACKAGES_MODULE_ADDRESS)
+    }
 }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -2353,14 +2353,6 @@ pub struct ChunkedPublishOption {
     pub(crate) chunked_publish: bool,
 
     /// Address of the `large_packages` move module for chunked publishing
-    #[clap(long)]
-    pub(crate) large_packages_module_address: Option<String>,
-}
-
-impl ChunkedPublishOption {
-    pub fn large_packages_module_address(&self) -> &str {
-        self.large_packages_module_address
-            .as_deref()
-            .unwrap_or(LARGE_PACKAGES_MODULE_ADDRESS)
-    }
+    #[clap(long, default_value = LARGE_PACKAGES_MODULE_ADDRESS)]
+    pub(crate) large_packages_module_address: String,
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -820,7 +820,7 @@ impl AsyncTryInto<ChunkedPublishPayloads> for &PublishPackage {
             package,
             PublishType::AccountDeploy,
             None,
-            self.chunked_publish_option.large_packages_module_address(),
+            &self.chunked_publish_option.large_packages_module_address,
         )?;
 
         let size = &chunked_publish_payloads
@@ -1050,7 +1050,7 @@ impl CliCommand<TransactionSummary> for PublishPackage {
             submit_chunked_publish_transactions(
                 chunked_package_payloads.payloads,
                 &self.txn_options,
-                self.chunked_publish_option.large_packages_module_address(),
+                &self.chunked_publish_option.large_packages_module_address,
             )
             .await
         } else {
@@ -1156,7 +1156,7 @@ impl CliCommand<TransactionSummary> for CreateObjectAndPublishPackage {
                 package,
                 PublishType::AccountDeploy,
                 None,
-                self.chunked_publish_option.large_packages_module_address(),
+                &self.chunked_publish_option.large_packages_module_address,
             )?
             .payloads;
             let staging_tx_count = (mock_payloads.len() - 1) as u64;
@@ -1182,7 +1182,7 @@ impl CliCommand<TransactionSummary> for CreateObjectAndPublishPackage {
                 package,
                 PublishType::ObjectDeploy,
                 None,
-                self.chunked_publish_option.large_packages_module_address(),
+                &self.chunked_publish_option.large_packages_module_address,
             )?
             .payloads;
 
@@ -1197,7 +1197,7 @@ impl CliCommand<TransactionSummary> for CreateObjectAndPublishPackage {
             submit_chunked_publish_transactions(
                 payloads,
                 &self.txn_options,
-                self.chunked_publish_option.large_packages_module_address(),
+                &self.chunked_publish_option.large_packages_module_address,
             )
             .await
         } else {
@@ -1294,7 +1294,7 @@ impl CliCommand<TransactionSummary> for UpgradeObjectPackage {
                 built_package,
                 PublishType::ObjectUpgrade,
                 Some(self.object_address),
-                self.chunked_publish_option.large_packages_module_address(),
+                &self.chunked_publish_option.large_packages_module_address,
             )?
             .payloads;
 
@@ -1308,7 +1308,7 @@ impl CliCommand<TransactionSummary> for UpgradeObjectPackage {
             submit_chunked_publish_transactions(
                 payloads,
                 &self.txn_options,
-                self.chunked_publish_option.large_packages_module_address(),
+                &self.chunked_publish_option.large_packages_module_address,
             )
             .await
         } else {
@@ -1385,7 +1385,7 @@ impl CliCommand<TransactionSummary> for DeployObjectCode {
                 package,
                 PublishType::AccountDeploy,
                 None,
-                self.chunked_publish_option.large_packages_module_address(),
+                &self.chunked_publish_option.large_packages_module_address,
             )?
             .payloads;
             let staging_tx_count = (mock_payloads.len() - 1) as u64;
@@ -1411,7 +1411,7 @@ impl CliCommand<TransactionSummary> for DeployObjectCode {
                 package,
                 PublishType::ObjectDeploy,
                 None,
-                self.chunked_publish_option.large_packages_module_address(),
+                &self.chunked_publish_option.large_packages_module_address,
             )?
             .payloads;
 
@@ -1426,7 +1426,7 @@ impl CliCommand<TransactionSummary> for DeployObjectCode {
             submit_chunked_publish_transactions(
                 payloads,
                 &self.txn_options,
-                self.chunked_publish_option.large_packages_module_address(),
+                &self.chunked_publish_option.large_packages_module_address,
             )
             .await
         } else {
@@ -1529,7 +1529,7 @@ impl CliCommand<TransactionSummary> for UpgradeCodeObject {
                 package,
                 PublishType::ObjectUpgrade,
                 Some(self.object_address),
-                self.chunked_publish_option.large_packages_module_address(),
+                &self.chunked_publish_option.large_packages_module_address,
             )?
             .payloads;
 
@@ -1543,7 +1543,7 @@ impl CliCommand<TransactionSummary> for UpgradeCodeObject {
             submit_chunked_publish_transactions(
                 payloads,
                 &self.txn_options,
-                self.chunked_publish_option.large_packages_module_address(),
+                &self.chunked_publish_option.large_packages_module_address,
             )
             .await
         } else {
@@ -1702,8 +1702,8 @@ pub struct ClearStagingArea {
     pub(crate) txn_options: TransactionOptions,
 
     /// Address of the `large_packages` move module for chunked publishing
-    #[clap(long)]
-    pub(crate) large_packages_module_address: Option<String>,
+    #[clap(long, default_value = LARGE_PACKAGES_MODULE_ADDRESS)]
+    pub(crate) large_packages_module_address: String,
 }
 
 #[async_trait]
@@ -1713,16 +1713,12 @@ impl CliCommand<TransactionSummary> for ClearStagingArea {
     }
 
     async fn execute(self) -> CliTypedResult<TransactionSummary> {
-        let large_packages_module_address = self
-            .large_packages_module_address
-            .as_deref()
-            .unwrap_or(LARGE_PACKAGES_MODULE_ADDRESS);
         println!(
             "Cleaning up resource {}::large_packages::StagingArea under account {}.",
-            large_packages_module_address,
+            &self.large_packages_module_address,
             self.txn_options.profile_options.account_address()?
         );
-        let payload = large_packages_cleanup_staging_area(large_packages_module_address);
+        let payload = large_packages_cleanup_staging_area(&self.large_packages_module_address);
         self.txn_options
             .submit_transaction(payload)
             .await

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -816,8 +816,12 @@ impl AsyncTryInto<ChunkedPublishPayloads> for &PublishPackage {
     async fn async_try_into(self) -> Result<ChunkedPublishPayloads, Self::Error> {
         let package = build_package_options(&self.move_options, &self.included_artifacts_args)?;
 
-        let chunked_publish_payloads =
-            create_chunked_publish_payloads(package, PublishType::AccountDeploy, None)?;
+        let chunked_publish_payloads = create_chunked_publish_payloads(
+            package,
+            PublishType::AccountDeploy,
+            None,
+            self.chunked_publish_option.large_packages_module_address(),
+        )?;
 
         let size = &chunked_publish_payloads
             .payloads
@@ -1008,6 +1012,7 @@ fn create_chunked_publish_payloads(
     package: BuiltPackage,
     publish_type: PublishType,
     object_address: Option<AccountAddress>,
+    large_packages_module_address: &str,
 ) -> CliTypedResult<ChunkedPublishPayloads> {
     let compiled_units = package.extract_code();
     let metadata = package.extract_metadata()?;
@@ -1024,6 +1029,7 @@ fn create_chunked_publish_payloads(
         compiled_units,
         publish_type,
         maybe_object_address,
+        large_packages_module_address,
     );
 
     Ok(ChunkedPublishPayloads { payloads })
@@ -1044,6 +1050,7 @@ impl CliCommand<TransactionSummary> for PublishPackage {
             submit_chunked_publish_transactions(
                 chunked_package_payloads.payloads,
                 &self.txn_options,
+                self.chunked_publish_option.large_packages_module_address(),
             )
             .await
         } else {
@@ -1145,9 +1152,13 @@ impl CliCommand<TransactionSummary> for CreateObjectAndPublishPackage {
             self.move_options
                 .add_named_address(self.address_name.clone(), mock_object_address.to_string());
             let package = build_package_options(&self.move_options, &self.included_artifacts_args)?;
-            let mock_payloads =
-                create_chunked_publish_payloads(package, PublishType::AccountDeploy, None)?
-                    .payloads;
+            let mock_payloads = create_chunked_publish_payloads(
+                package,
+                PublishType::AccountDeploy,
+                None,
+                self.chunked_publish_option.large_packages_module_address(),
+            )?
+            .payloads;
             let staging_tx_count = (mock_payloads.len() - 1) as u64;
             self.txn_options.sequence_number(sender_address).await? + staging_tx_count + 1
         } else {
@@ -1167,8 +1178,13 @@ impl CliCommand<TransactionSummary> for CreateObjectAndPublishPackage {
         prompt_yes_with_override(&message, self.txn_options.prompt_options)?;
 
         let result = if self.chunked_publish_option.chunked_publish {
-            let payloads =
-                create_chunked_publish_payloads(package, PublishType::ObjectDeploy, None)?.payloads;
+            let payloads = create_chunked_publish_payloads(
+                package,
+                PublishType::ObjectDeploy,
+                None,
+                self.chunked_publish_option.large_packages_module_address(),
+            )?
+            .payloads;
 
             let size = &payloads
                 .iter()
@@ -1178,7 +1194,12 @@ impl CliCommand<TransactionSummary> for CreateObjectAndPublishPackage {
             let message = format!("Publishing package in chunked mode will submit {} transactions for staging and publishing code.\n", &payloads.len());
             println!("{}", message.bold());
 
-            submit_chunked_publish_transactions(payloads, &self.txn_options).await
+            submit_chunked_publish_transactions(
+                payloads,
+                &self.txn_options,
+                self.chunked_publish_option.large_packages_module_address(),
+            )
+            .await
         } else {
             let payload = create_package_publication_data(
                 package,
@@ -1273,6 +1294,7 @@ impl CliCommand<TransactionSummary> for UpgradeObjectPackage {
                 built_package,
                 PublishType::ObjectUpgrade,
                 Some(self.object_address),
+                self.chunked_publish_option.large_packages_module_address(),
             )?
             .payloads;
 
@@ -1283,7 +1305,12 @@ impl CliCommand<TransactionSummary> for UpgradeObjectPackage {
             println!("package size {} bytes", size);
             let message = format!("Upgrading package in chunked mode will submit {} transactions for staging and upgrading code.\n", &payloads.len());
             println!("{}", message.bold());
-            submit_chunked_publish_transactions(payloads, &self.txn_options).await
+            submit_chunked_publish_transactions(
+                payloads,
+                &self.txn_options,
+                self.chunked_publish_option.large_packages_module_address(),
+            )
+            .await
         } else {
             let payload = create_package_publication_data(
                 built_package,
@@ -1354,9 +1381,13 @@ impl CliCommand<TransactionSummary> for DeployObjectCode {
             self.move_options
                 .add_named_address(self.address_name.clone(), mock_object_address.to_string());
             let package = build_package_options(&self.move_options, &self.included_artifacts_args)?;
-            let mock_payloads =
-                create_chunked_publish_payloads(package, PublishType::AccountDeploy, None)?
-                    .payloads;
+            let mock_payloads = create_chunked_publish_payloads(
+                package,
+                PublishType::AccountDeploy,
+                None,
+                self.chunked_publish_option.large_packages_module_address(),
+            )?
+            .payloads;
             let staging_tx_count = (mock_payloads.len() - 1) as u64;
             self.txn_options.sequence_number(sender_address).await? + staging_tx_count + 1
         } else {
@@ -1376,8 +1407,13 @@ impl CliCommand<TransactionSummary> for DeployObjectCode {
         prompt_yes_with_override(&message, self.txn_options.prompt_options)?;
 
         let result = if self.chunked_publish_option.chunked_publish {
-            let payloads =
-                create_chunked_publish_payloads(package, PublishType::ObjectDeploy, None)?.payloads;
+            let payloads = create_chunked_publish_payloads(
+                package,
+                PublishType::ObjectDeploy,
+                None,
+                self.chunked_publish_option.large_packages_module_address(),
+            )?
+            .payloads;
 
             let size = &payloads
                 .iter()
@@ -1387,7 +1423,12 @@ impl CliCommand<TransactionSummary> for DeployObjectCode {
             let message = format!("Publishing package in chunked mode will submit {} transactions for staging and publishing code.\n", &payloads.len());
             println!("{}", message.bold());
 
-            submit_chunked_publish_transactions(payloads, &self.txn_options).await
+            submit_chunked_publish_transactions(
+                payloads,
+                &self.txn_options,
+                self.chunked_publish_option.large_packages_module_address(),
+            )
+            .await
         } else {
             let payload = create_package_publication_data(
                 package,
@@ -1488,6 +1529,7 @@ impl CliCommand<TransactionSummary> for UpgradeCodeObject {
                 package,
                 PublishType::ObjectUpgrade,
                 Some(self.object_address),
+                self.chunked_publish_option.large_packages_module_address(),
             )?
             .payloads;
 
@@ -1498,7 +1540,12 @@ impl CliCommand<TransactionSummary> for UpgradeCodeObject {
             println!("package size {} bytes", size);
             let message = format!("Upgrading package in chunked mode will submit {} transactions for staging and upgrading code.\n", &payloads.len());
             println!("{}", message.bold());
-            submit_chunked_publish_transactions(payloads, &self.txn_options).await
+            submit_chunked_publish_transactions(
+                payloads,
+                &self.txn_options,
+                self.chunked_publish_option.large_packages_module_address(),
+            )
+            .await
         } else {
             let payload = create_package_publication_data(
                 package,
@@ -1547,6 +1594,7 @@ fn build_package_options(
 async fn submit_chunked_publish_transactions(
     payloads: Vec<TransactionPayload>,
     txn_options: &TransactionOptions,
+    large_packages_module_address: &str,
 ) -> CliTypedResult<TransactionSummary> {
     let mut publishing_result = Err(CliError::UnexpectedError(
         "No payload provided for batch transaction run".to_string(),
@@ -1556,12 +1604,12 @@ async fn submit_chunked_publish_transactions(
 
     let account_address = txn_options.profile_options.account_address()?;
 
-    if !is_staging_area_empty(txn_options).await? {
+    if !is_staging_area_empty(txn_options, large_packages_module_address).await? {
         let message = format!(
             "The resource {}::large_packages::StagingArea under account {} is not empty.\
         \nThis may cause package publishing to fail if the data is unexpected. \
         \nUse the `aptos move clear-staging-area` command to clean up the `StagingArea` resource under the account.",
-            LARGE_PACKAGES_MODULE_ADDRESS, account_address,
+            large_packages_module_address, account_address,
         )
             .bold();
         println!("{}", message);
@@ -1616,7 +1664,10 @@ async fn submit_chunked_publish_transactions(
     publishing_result
 }
 
-async fn is_staging_area_empty(txn_options: &TransactionOptions) -> CliTypedResult<bool> {
+async fn is_staging_area_empty(
+    txn_options: &TransactionOptions,
+    large_packages_module_address: &str,
+) -> CliTypedResult<bool> {
     let url = txn_options.rest_options.url(&txn_options.profile_options)?;
     let client = Client::new(url);
 
@@ -1625,7 +1676,7 @@ async fn is_staging_area_empty(txn_options: &TransactionOptions) -> CliTypedResu
             txn_options.profile_options.account_address()?,
             &format!(
                 "{}::large_packages::StagingArea",
-                LARGE_PACKAGES_MODULE_ADDRESS
+                large_packages_module_address
             ),
         )
         .await;
@@ -1649,6 +1700,10 @@ async fn is_staging_area_empty(txn_options: &TransactionOptions) -> CliTypedResu
 pub struct ClearStagingArea {
     #[clap(flatten)]
     pub(crate) txn_options: TransactionOptions,
+
+    /// Address of the `large_packages` move module for chunked publishing
+    #[clap(long)]
+    pub(crate) large_packages_module_address: Option<String>,
 }
 
 #[async_trait]
@@ -1658,12 +1713,16 @@ impl CliCommand<TransactionSummary> for ClearStagingArea {
     }
 
     async fn execute(self) -> CliTypedResult<TransactionSummary> {
+        let large_packages_module_address = self
+            .large_packages_module_address
+            .as_deref()
+            .unwrap_or(LARGE_PACKAGES_MODULE_ADDRESS);
         println!(
             "Cleaning up resource {}::large_packages::StagingArea under account {}.",
-            LARGE_PACKAGES_MODULE_ADDRESS,
+            large_packages_module_address,
             self.txn_options.profile_options.account_address()?
         );
-        let payload = large_packages_cleanup_staging_area();
+        let payload = large_packages_cleanup_staging_area(large_packages_module_address);
         self.txn_options
             .submit_transaction(payload)
             .await

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -896,7 +896,7 @@ impl CliTestFramework {
             },
             chunked_publish_option: ChunkedPublishOption {
                 chunked_publish: false,
-                large_packages_module_address: Some(LARGE_PACKAGES_MODULE_ADDRESS.to_string()),
+                large_packages_module_address: LARGE_PACKAGES_MODULE_ADDRESS.to_string(),
             },
         }
         .execute()

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -53,6 +53,7 @@ use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     x25519, PrivateKey,
 };
+use aptos_framework::chunked_publish::LARGE_PACKAGES_MODULE_ADDRESS;
 use aptos_genesis::config::HostAndPort;
 use aptos_keygen::KeyGen;
 use aptos_logger::warn;
@@ -895,6 +896,7 @@ impl CliTestFramework {
             },
             chunked_publish_option: ChunkedPublishOption {
                 chunked_publish: false,
+                large_packages_module_address: Some(LARGE_PACKAGES_MODULE_ADDRESS.to_string()),
             },
         }
         .execute()


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
- Added a new `--large-packages-module-address` command option for Move package publishing:
  - `aptos move publish`
  - `aptos move deploy-object`
  - `aptos move upgrade-object`
  - `aptos move create-object-and-publish-package`
  - `aptos move upgrade-object-package`
  - `aptos move clear-staging-area`

- This option will be used alongside the `--chunked-publish` flag. If provided, the specified large packages module address will be used.

- Note that the CLI does not verify if the module actually exists at the given address; it will simply abort if an incorrect address is supplied.

- The default address will be used if no address is provided.

- This feature allows users to utilize the chunked publishing in the localnet testing environment by manually deploying the [large_packages.move](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/move-examples/large_packages/sources/large_packages.move) module.

### Example
```
aptos move deploy-object <other options> --chunked-publish --large-packages-module-address 0x1234...
```


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
- e2e-move-tests
- Manually tested CLI options
