### PR TITLE
Revert #13659 (Add a transaction context function to get the raw transaction hash)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16397,18 +16397,18 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -131,7 +131,6 @@ pub enum FeatureFlag {
     FederatedKeyless,
     TransactionSimulationEnhancement,
     CollectionOwner,
-    TransactionContextHashFunctionUpdate,
     EnableLoaderV2,
 }
 
@@ -349,9 +348,6 @@ impl From<FeatureFlag> for AptosFeatureFlag {
                 AptosFeatureFlag::TRANSACTION_SIMULATION_ENHANCEMENT
             },
             FeatureFlag::CollectionOwner => AptosFeatureFlag::COLLECTION_OWNER,
-            FeatureFlag::TransactionContextHashFunctionUpdate => {
-                AptosFeatureFlag::TRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE
-            },
             FeatureFlag::EnableLoaderV2 => AptosFeatureFlag::ENABLE_LOADER_V2,
         }
     }
@@ -496,9 +492,6 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::TransactionSimulationEnhancement
             },
             AptosFeatureFlag::COLLECTION_OWNER => FeatureFlag::CollectionOwner,
-            AptosFeatureFlag::TRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE => {
-                FeatureFlag::TransactionContextHashFunctionUpdate
-            },
             AptosFeatureFlag::ENABLE_LOADER_V2 => FeatureFlag::EnableLoaderV2,
         }
     }

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -79,24 +79,24 @@ impl<'r, 'l> SessionExt<'r, 'l> {
         resolver: &'r R,
     ) -> Self {
         let mut extensions = NativeContextExtensions::default();
-        let unique_session_hash: [u8; 32] = session_id
+        let txn_hash: [u8; 32] = session_id
             .as_uuid()
             .to_vec()
             .try_into()
             .expect("HashValue should convert to [u8; 32]");
 
-        extensions.add(NativeTableContext::new(unique_session_hash, resolver));
+        extensions.add(NativeTableContext::new(txn_hash, resolver));
         extensions.add(NativeRistrettoPointContext::new());
         extensions.add(AlgebraContext::new());
         extensions.add(NativeAggregatorContext::new(
-            unique_session_hash,
+            txn_hash,
             resolver,
             move_vm.vm_config().delayed_field_optimization_enabled,
             resolver,
         ));
         extensions.add(RandomnessContext::new());
         extensions.add(NativeTransactionContext::new(
-            unique_session_hash.to_vec(),
+            txn_hash.to_vec(),
             session_id.into_script_hash(),
             chain_id.id(),
             maybe_user_transaction_context,

--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -2,15 +2,14 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_crypto::HashValue;
 use aptos_gas_algebra::{FeePerGasUnit, Gas, NumBytes};
 use aptos_types::{
     account_address::AccountAddress,
     chain_id::ChainId,
     transaction::{
-        authenticator::TransactionAuthenticator::{FeePayer, MultiAgent},
-        user_transaction_context::UserTransactionContext,
-        EntryFunction, Multisig, RawTransactionWithData, SignedTransaction, TransactionPayload,
+        user_transaction_context::UserTransactionContext, EntryFunction, Multisig,
+        SignedTransaction, TransactionPayload,
     },
 };
 
@@ -32,7 +31,6 @@ pub struct TransactionMetadata {
     pub is_keyless: bool,
     pub entry_function_payload: Option<EntryFunction>,
     pub multisig_payload: Option<Multisig>,
-    pub raw_transaction_hash: Vec<u8>,
 }
 
 impl TransactionMetadata {
@@ -90,36 +88,6 @@ impl TransactionMetadata {
             multisig_payload: match txn.payload() {
                 TransactionPayload::Multisig(m) => Some(m.clone()),
                 _ => None,
-            },
-            raw_transaction_hash: match txn.authenticator_ref() {
-                MultiAgent {
-                    sender: _,
-                    secondary_signer_addresses,
-                    secondary_signers: _,
-                } => {
-                    let raw_txn = RawTransactionWithData::new_multi_agent(
-                        txn.clone().into_raw_transaction(),
-                        secondary_signer_addresses.clone(),
-                    );
-                    raw_txn.hash().to_vec()
-                },
-                FeePayer {
-                    sender: _,
-                    secondary_signer_addresses,
-                    secondary_signers: _,
-                    fee_payer_address: _,
-                    fee_payer_signer: _,
-                } => {
-                    // In the case of a fee payer transaction, the hash value is generated using
-                    // AccountAddress::ZERO as the fee payer address.
-                    let raw_txn = RawTransactionWithData::new_fee_payer(
-                        txn.clone().into_raw_transaction(),
-                        secondary_signer_addresses.clone(),
-                        AccountAddress::ZERO,
-                    );
-                    raw_txn.hash().to_vec()
-                },
-                _ => txn.raw_transaction_ref().hash().to_vec(),
             },
         }
     }
@@ -190,10 +158,6 @@ impl TransactionMetadata {
         self.multisig_payload.clone()
     }
 
-    pub fn raw_transaction_hash(&self) -> Vec<u8> {
-        self.raw_transaction_hash.clone()
-    }
-
     pub fn as_user_transaction_context(&self) -> UserTransactionContext {
         UserTransactionContext::new(
             self.sender,
@@ -206,7 +170,6 @@ impl TransactionMetadata {
                 .map(|entry_func| entry_func.as_entry_function_payload()),
             self.multisig_payload()
                 .map(|multisig| multisig.as_multisig_payload()),
-            self.raw_transaction_hash(),
         )
     }
 }

--- a/aptos-move/e2e-move-tests/src/tests/transaction_context.data/pack/sources/transaction_context_test.move
+++ b/aptos-move/e2e-move-tests/src/tests/transaction_context.data/pack/sources/transaction_context_test.move
@@ -24,7 +24,6 @@ module admin::transaction_context_test {
         type_arg_names: vector<String>,
         args: vector<vector<u8>>,
         multisig_address: address,
-        raw_transaction_hash: vector<u8>,
     }
 
     /// Called when the module is first deployed at address `signer`, which is supposed to be @admin (= 0x1).
@@ -45,7 +44,6 @@ module admin::transaction_context_test {
                 args: vector[],
                 type_arg_names: vector[],
                 multisig_address: @0x0,
-                raw_transaction_hash: vector[],
             }
         );
     }
@@ -142,15 +140,5 @@ module admin::transaction_context_test {
         multisig_account::create_transaction(s, multisig_account, payload);
 
         store.multisig_address = multisig_account;
-    }
-
-    entry fun store_raw_transaction_hash_from_native_txn_context(_s: &signer) acquires TransactionContextStore {
-        let store = borrow_global_mut<TransactionContextStore>(@admin);
-        store.raw_transaction_hash = transaction_context::raw_transaction_hash();
-    }
-
-    entry fun store_raw_transaction_hash_from_native_txn_context_multi(_s: &signer, _s2: &signer) acquires TransactionContextStore {
-        let store = borrow_global_mut<TransactionContextStore>(@admin);
-        store.raw_transaction_hash = transaction_context::raw_transaction_hash();
     }
 }

--- a/aptos-move/e2e-move-tests/src/tests/transaction_context.rs
+++ b/aptos-move/e2e-move-tests/src/tests/transaction_context.rs
@@ -2,14 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{assert_success, tests::common, MoveHarness};
-use aptos_crypto::hash::CryptoHash;
 use aptos_language_e2e_tests::account::{Account, TransactionBuilder};
 use aptos_types::{
     move_utils::MemberId,
     on_chain_config::FeatureFlag,
-    transaction::{
-        EntryFunction, MultisigTransactionPayload, RawTransactionWithData, TransactionPayload,
-    },
+    transaction::{EntryFunction, MultisigTransactionPayload, TransactionPayload},
 };
 use bcs::to_bytes;
 use move_core_types::{
@@ -34,7 +31,6 @@ struct TransactionContextStore {
     type_arg_names: Vec<String>,
     args: Vec<Vec<u8>>,
     multisig_address: AccountAddress,
-    raw_transaction_hash: Vec<u8>,
 }
 
 fn setup(harness: &mut MoveHarness) -> Account {
@@ -471,137 +467,4 @@ fn test_transaction_context_multisig_payload() {
     );
     assert!(txn_ctx_store.type_arg_names.is_empty());
     assert!(txn_ctx_store.args.is_empty());
-}
-
-#[test]
-fn test_transaction_context_raw_transaction_hash_simple() {
-    let mut harness = new_move_harness();
-    let account = setup(&mut harness);
-    let signed_txn = harness.create_entry_function(
-        &account,
-        str::parse(
-            "0x1::transaction_context_test::store_raw_transaction_hash_from_native_txn_context",
-        )
-        .unwrap(),
-        vec![],
-        vec![],
-    );
-    let expected_hash = signed_txn.clone().into_raw_transaction().hash();
-    let status = harness.run(signed_txn);
-    assert!(status.status().unwrap().is_success());
-    let txn_ctx_store = harness
-        .read_resource::<crate::tests::transaction_context::TransactionContextStore>(
-            account.address(),
-            parse_struct_tag("0x1::transaction_context_test::TransactionContextStore").unwrap(),
-        )
-        .unwrap();
-    let hash = txn_ctx_store.raw_transaction_hash;
-    assert_eq!(hash, expected_hash.to_vec());
-}
-
-#[test]
-fn test_transaction_context_raw_transaction_hash_multiagent() {
-    let mut harness = new_move_harness();
-
-    let alice = setup(&mut harness);
-    let bob = harness.new_account_with_balance_and_sequence_number(1000000, 0);
-
-    let fun: MemberId = str::parse(
-        "0x1::transaction_context_test::store_raw_transaction_hash_from_native_txn_context_multi",
-    )
-    .unwrap();
-    let MemberId {
-        module_id,
-        member_id: function_id,
-    } = fun;
-    let ty_args = vec![];
-    let args = vec![];
-    let payload = TransactionPayload::EntryFunction(EntryFunction::new(
-        module_id,
-        function_id,
-        ty_args,
-        args,
-    ));
-    let signed_txn = TransactionBuilder::new(alice.clone())
-        .secondary_signers(vec![bob.clone()])
-        .payload(payload)
-        .sequence_number(harness.sequence_number(alice.address()))
-        .max_gas_amount(1_000_000)
-        .gas_unit_price(1)
-        .sign_multi_agent();
-
-    let raw_txn_with_data =
-        RawTransactionWithData::new_multi_agent(signed_txn.clone().into_raw_transaction(), vec![
-            *bob.address(),
-        ]);
-    let expected_hash = raw_txn_with_data.hash();
-
-    let output = harness.run_raw(signed_txn);
-    assert_success!(*output.status());
-
-    let txn_ctx_store = harness
-        .read_resource::<crate::tests::transaction_context::TransactionContextStore>(
-            alice.address(),
-            parse_struct_tag("0x1::transaction_context_test::TransactionContextStore").unwrap(),
-        )
-        .unwrap();
-
-    let hash = txn_ctx_store.raw_transaction_hash;
-    assert_eq!(hash, expected_hash.to_vec());
-}
-
-#[test]
-fn test_transaction_context_raw_transaction_hash_multiagent_with_fee_payer() {
-    let mut harness = new_move_harness();
-
-    let alice = setup(&mut harness);
-    let bob = harness.new_account_with_balance_and_sequence_number(1000000, 0);
-    let fee_payer = harness.new_account_with_balance_and_sequence_number(1000000, 0);
-
-    let fun: MemberId = str::parse(
-        "0x1::transaction_context_test::store_raw_transaction_hash_from_native_txn_context_multi",
-    )
-    .unwrap();
-    let MemberId {
-        module_id,
-        member_id: function_id,
-    } = fun;
-    let ty_args = vec![];
-    let args = vec![];
-    let payload = TransactionPayload::EntryFunction(EntryFunction::new(
-        module_id,
-        function_id,
-        ty_args,
-        args,
-    ));
-    let signed_txn = TransactionBuilder::new(alice.clone())
-        .fee_payer(fee_payer.clone())
-        .secondary_signers(vec![bob.clone()])
-        .payload(payload)
-        .sequence_number(harness.sequence_number(alice.address()))
-        .max_gas_amount(1_000_000)
-        .gas_unit_price(1)
-        .sign_fee_payer();
-
-    // In the case of a fee payer transaction, the hash value is generated using
-    // AccountAddress::ZERO as the fee payer address.
-    let raw_txn_with_data = RawTransactionWithData::new_fee_payer(
-        signed_txn.clone().into_raw_transaction(),
-        vec![*bob.address()],
-        AccountAddress::ZERO,
-    );
-    let expected_hash = raw_txn_with_data.hash();
-
-    let output = harness.run_raw(signed_txn);
-    assert_success!(*output.status());
-
-    let txn_ctx_store = harness
-        .read_resource::<crate::tests::transaction_context::TransactionContextStore>(
-            alice.address(),
-            parse_struct_tag("0x1::transaction_context_test::TransactionContextStore").unwrap(),
-        )
-        .unwrap();
-
-    let hash = txn_ctx_store.raw_transaction_hash;
-    assert_eq!(hash, expected_hash.to_vec());
 }

--- a/aptos-move/framework/aptos-framework/doc/randomness.md
+++ b/aptos-move/framework/aptos-framework/doc/randomness.md
@@ -290,7 +290,7 @@ of the hash function).
     <b>let</b> seed = *<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&<a href="randomness.md#0x1_randomness">randomness</a>.seed);
 
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> input, seed);
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> input, <a href="transaction_context.md#0x1_transaction_context_unique_session_hash">transaction_context::unique_session_hash</a>());
+    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> input, <a href="transaction_context.md#0x1_transaction_context_get_transaction_hash">transaction_context::get_transaction_hash</a>());
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> input, <a href="randomness.md#0x1_randomness_fetch_and_increment_txn_counter">fetch_and_increment_txn_counter</a>());
     <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash_sha3_256">hash::sha3_256</a>(input)
 }

--- a/aptos-move/framework/aptos-framework/doc/transaction_context.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_context.md
@@ -9,9 +9,8 @@
 -  [Struct `EntryFunctionPayload`](#0x1_transaction_context_EntryFunctionPayload)
 -  [Struct `MultisigPayload`](#0x1_transaction_context_MultisigPayload)
 -  [Constants](#@Constants_0)
--  [Function `unique_session_hash`](#0x1_transaction_context_unique_session_hash)
--  [Function `get_transaction_hash`](#0x1_transaction_context_get_transaction_hash)
 -  [Function `get_txn_hash`](#0x1_transaction_context_get_txn_hash)
+-  [Function `get_transaction_hash`](#0x1_transaction_context_get_transaction_hash)
 -  [Function `generate_unique_address`](#0x1_transaction_context_generate_unique_address)
 -  [Function `generate_auid_address`](#0x1_transaction_context_generate_auid_address)
 -  [Function `get_script_hash`](#0x1_transaction_context_get_script_hash)
@@ -40,12 +39,9 @@
 -  [Function `multisig_payload_internal`](#0x1_transaction_context_multisig_payload_internal)
 -  [Function `multisig_address`](#0x1_transaction_context_multisig_address)
 -  [Function `inner_entry_function_payload`](#0x1_transaction_context_inner_entry_function_payload)
--  [Function `raw_transaction_hash`](#0x1_transaction_context_raw_transaction_hash)
--  [Function `raw_transaction_hash_internal`](#0x1_transaction_context_raw_transaction_hash_internal)
 -  [Specification](#@Specification_1)
-    -  [Function `unique_session_hash`](#@Specification_1_unique_session_hash)
-    -  [Function `get_transaction_hash`](#@Specification_1_get_transaction_hash)
     -  [Function `get_txn_hash`](#@Specification_1_get_txn_hash)
+    -  [Function `get_transaction_hash`](#@Specification_1_get_transaction_hash)
     -  [Function `generate_unique_address`](#@Specification_1_generate_unique_address)
     -  [Function `generate_auid_address`](#@Specification_1_generate_auid_address)
     -  [Function `get_script_hash`](#@Specification_1_get_script_hash)
@@ -60,7 +56,6 @@
     -  [Function `chain_id_internal`](#@Specification_1_chain_id_internal)
     -  [Function `entry_function_payload_internal`](#@Specification_1_entry_function_payload_internal)
     -  [Function `multisig_payload_internal`](#@Specification_1_multisig_payload_internal)
-    -  [Function `raw_transaction_hash_internal`](#@Specification_1_raw_transaction_hash_internal)
 
 
 <pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
@@ -201,16 +196,6 @@ The transaction context extension feature is not enabled.
 
 
 
-<a id="0x1_transaction_context_ETRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE_NOT_ENABLED"></a>
-
-The transaction context hash function update feature is not enabled.
-
-
-<pre><code><b>const</b> <a href="transaction_context.md#0x1_transaction_context_ETRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE_NOT_ENABLED">ETRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE_NOT_ENABLED</a>: u64 = 3;
-</code></pre>
-
-
-
 <a id="0x1_transaction_context_ETRANSACTION_CONTEXT_NOT_AVAILABLE"></a>
 
 Transaction context is only available in the user transaction prologue, execution, or epilogue phases.
@@ -221,61 +206,11 @@ Transaction context is only available in the user transaction prologue, executio
 
 
 
-<a id="0x1_transaction_context_unique_session_hash"></a>
-
-## Function `unique_session_hash`
-
-Returns a unique session hash, ensuring a distinct value for each transaction
-session: prologue, execution, epilogue.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_unique_session_hash">unique_session_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_unique_session_hash">unique_session_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <a href="transaction_context.md#0x1_transaction_context_get_txn_hash">get_txn_hash</a>()
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_transaction_context_get_transaction_hash"></a>
-
-## Function `get_transaction_hash`
-
-
-
-<pre><code>#[deprecated]
-<b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_get_transaction_hash">get_transaction_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_get_transaction_hash">get_transaction_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <a href="transaction_context.md#0x1_transaction_context_get_txn_hash">get_txn_hash</a>()
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_transaction_context_get_txn_hash"></a>
 
 ## Function `get_txn_hash`
 
+Returns the transaction hash of the current transaction.
 
 
 <pre><code><b>fun</b> <a href="transaction_context.md#0x1_transaction_context_get_txn_hash">get_txn_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -288,6 +223,33 @@ session: prologue, execution, epilogue.
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_get_txn_hash">get_txn_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_transaction_context_get_transaction_hash"></a>
+
+## Function `get_transaction_hash`
+
+Returns the transaction hash of the current transaction.
+Internally calls the private function <code>get_txn_hash</code>.
+This function is created for to feature gate the <code>get_txn_hash</code> function.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_get_transaction_hash">get_transaction_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_get_transaction_hash">get_transaction_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <a href="transaction_context.md#0x1_transaction_context_get_txn_hash">get_txn_hash</a>()
+}
 </code></pre>
 
 
@@ -1003,98 +965,9 @@ Returns the inner entry function payload of the multisig payload.
 
 </details>
 
-<a id="0x1_transaction_context_raw_transaction_hash"></a>
-
-## Function `raw_transaction_hash`
-
-Returns the hash of the current raw transaction, which is used for transaction authentication.
-This function calls an internal native function to retrieve the raw transaction hash.
-In the case of a fee payer transaction, the hash value is generated using 0x0 as the fee payer address.
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_raw_transaction_hash">raw_transaction_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_raw_transaction_hash">raw_transaction_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_transaction_context_hash_function_update_enabled">features::transaction_context_hash_function_update_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="transaction_context.md#0x1_transaction_context_ETRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE_NOT_ENABLED">ETRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE_NOT_ENABLED</a>));
-    <a href="transaction_context.md#0x1_transaction_context_raw_transaction_hash_internal">raw_transaction_hash_internal</a>()
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_transaction_context_raw_transaction_hash_internal"></a>
-
-## Function `raw_transaction_hash_internal`
-
-
-
-<pre><code><b>fun</b> <a href="transaction_context.md#0x1_transaction_context_raw_transaction_hash_internal">raw_transaction_hash_internal</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>native</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_raw_transaction_hash_internal">raw_transaction_hash_internal</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
-</code></pre>
-
-
-
-</details>
-
 <a id="@Specification_1"></a>
 
 ## Specification
-
-
-<a id="@Specification_1_unique_session_hash"></a>
-
-### Function `unique_session_hash`
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_unique_session_hash">unique_session_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-
-<pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="transaction_context.md#0x1_transaction_context_spec_get_txn_hash">spec_get_txn_hash</a>();
-<b>ensures</b> len(result) == 32;
-</code></pre>
-
-
-
-<a id="@Specification_1_get_transaction_hash"></a>
-
-### Function `get_transaction_hash`
-
-
-<pre><code>#[deprecated]
-<b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_get_transaction_hash">get_transaction_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
-</code></pre>
-
-
-
-
-<pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> <b>false</b>;
-<b>ensures</b> result == <a href="transaction_context.md#0x1_transaction_context_spec_get_txn_hash">spec_get_txn_hash</a>();
-<b>ensures</b> len(result) == 32;
-</code></pre>
-
 
 
 <a id="@Specification_1_get_txn_hash"></a>
@@ -1109,10 +982,37 @@ In the case of a fee payer transaction, the hash value is generated using 0x0 as
 
 
 <pre><code><b>pragma</b> opaque;
-<b>aborts_if</b> <b>false</b>;
+<b>aborts_if</b> [abstract] <b>false</b>;
+<b>ensures</b> result == <a href="transaction_context.md#0x1_transaction_context_spec_get_txn_hash">spec_get_txn_hash</a>();
+</code></pre>
+
+
+
+
+<a id="0x1_transaction_context_spec_get_txn_hash"></a>
+
+
+<pre><code><b>fun</b> <a href="transaction_context.md#0x1_transaction_context_spec_get_txn_hash">spec_get_txn_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+<a id="@Specification_1_get_transaction_hash"></a>
+
+### Function `get_transaction_hash`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_get_transaction_hash">get_transaction_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <b>false</b>;
 <b>ensures</b> result == <a href="transaction_context.md#0x1_transaction_context_spec_get_txn_hash">spec_get_txn_hash</a>();
 // This enforces <a id="high-level-req-1" href="#high-level-req">high-level requirement 1</a>:
-<b>ensures</b> len(result) == 32;
+<b>ensures</b> [abstract] len(result) == 32;
 </code></pre>
 
 
@@ -1184,9 +1084,9 @@ In the case of a fee payer transaction, the hash value is generated using 0x0 as
 
 <tr>
 <td>1</td>
-<td>Fetching the unique session hash should return a vector with 32 bytes.</td>
+<td>Fetching the transaction hash should return a vector with 32 bytes.</td>
 <td>Medium</td>
-<td>The unique_session_hash function calls the native function unique_session_hash_internal, which fetches the NativeTransactionContext struct and returns the unique_session_hash field.</td>
+<td>The get_transaction_hash function calls the native function get_txn_hash, which fetches the NativeTransactionContext struct and returns the txn_hash field.</td>
 <td>Audited that the native function returns the txn hash, whose size is 32 bytes. This has been modeled as the abstract postcondition that the returned vector is of length 32. Formally verified via <a href="#high-level-req-1">get_txn_hash</a>.</td>
 </tr>
 
@@ -1237,15 +1137,6 @@ In the case of a fee payer transaction, the hash value is generated using 0x0 as
 
 
 <pre><code><b>fun</b> <a href="transaction_context.md#0x1_transaction_context_spec_get_script_hash">spec_get_script_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
-</code></pre>
-
-
-
-
-<a id="0x1_transaction_context_spec_get_txn_hash"></a>
-
-
-<pre><code><b>fun</b> <a href="transaction_context.md#0x1_transaction_context_spec_get_txn_hash">spec_get_txn_hash</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
 </code></pre>
 
 
@@ -1385,22 +1276,6 @@ In the case of a fee payer transaction, the hash value is generated using 0x0 as
 
 
 <pre><code><b>fun</b> <a href="transaction_context.md#0x1_transaction_context_multisig_payload_internal">multisig_payload_internal</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="transaction_context.md#0x1_transaction_context_MultisigPayload">transaction_context::MultisigPayload</a>&gt;
-</code></pre>
-
-
-
-
-<pre><code><b>pragma</b> opaque;
-</code></pre>
-
-
-
-<a id="@Specification_1_raw_transaction_hash_internal"></a>
-
-### Function `raw_transaction_hash_internal`
-
-
-<pre><code><b>fun</b> <a href="transaction_context.md#0x1_transaction_context_raw_transaction_hash_internal">raw_transaction_hash_internal</a>(): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/object.move
+++ b/aptos-move/framework/aptos-framework/sources/object.move
@@ -844,7 +844,7 @@ module aptos_framework::object {
     #[test(fx = @std)]
     fun test_correct_auid() {
         let auid1 = aptos_framework::transaction_context::generate_auid_address();
-        let bytes = aptos_framework::transaction_context::unique_session_hash();
+        let bytes = aptos_framework::transaction_context::get_transaction_hash();
         std::vector::push_back(&mut bytes, 1);
         std::vector::push_back(&mut bytes, 0);
         std::vector::push_back(&mut bytes, 0);

--- a/aptos-move/framework/aptos-framework/sources/randomness.move
+++ b/aptos-move/framework/aptos-framework/sources/randomness.move
@@ -81,7 +81,7 @@ module aptos_framework::randomness {
         let seed = *option::borrow(&randomness.seed);
 
         vector::append(&mut input, seed);
-        vector::append(&mut input, transaction_context::unique_session_hash());
+        vector::append(&mut input, transaction_context::get_transaction_hash());
         vector::append(&mut input, fetch_and_increment_txn_counter());
         hash::sha3_256(input)
     }

--- a/aptos-move/framework/aptos-framework/sources/transaction_context.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_context.move
@@ -10,9 +10,6 @@ module aptos_framework::transaction_context {
     /// The transaction context extension feature is not enabled.
     const ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED: u64 = 2;
 
-    /// The transaction context hash function update feature is not enabled.
-    const ETRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE_NOT_ENABLED: u64 = 3;
-
     /// A wrapper denoting aptos unique identifer (AUID)
     /// for storing an address
     struct AUID has drop, store {
@@ -34,19 +31,15 @@ module aptos_framework::transaction_context {
         entry_function_payload: Option<EntryFunctionPayload>,
     }
 
-    /// Returns a unique session hash, ensuring a distinct value for each transaction
-    /// session: prologue, execution, epilogue.
-    public fun unique_session_hash(): vector<u8> {
-        get_txn_hash()
-    }
-    #[deprecated]
-    // This function is deprecated. Use `unique_session_hash` instead.
+    /// Returns the transaction hash of the current transaction.
+    native fun get_txn_hash(): vector<u8>;
+
+    /// Returns the transaction hash of the current transaction.
+    /// Internally calls the private function `get_txn_hash`.
+    /// This function is created for to feature gate the `get_txn_hash` function.
     public fun get_transaction_hash(): vector<u8> {
         get_txn_hash()
     }
-    // This function will be removed when `get_transaction_hash` is deprecated.
-    native fun get_txn_hash(): vector<u8>;
-
 
     /// Returns a universally unique identifier (of type address) generated
     /// by hashing the transaction hash of this transaction and a sequence number
@@ -189,15 +182,6 @@ module aptos_framework::transaction_context {
         payload.entry_function_payload
     }
 
-    /// Returns the hash of the current raw transaction, which is used for transaction authentication.
-    /// This function calls an internal native function to retrieve the raw transaction hash.
-    /// In the case of a fee payer transaction, the hash value is generated using 0x0 as the fee payer address.
-    public fun raw_transaction_hash(): vector<u8> {
-        assert!(features::transaction_context_hash_function_update_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE_NOT_ENABLED));
-        raw_transaction_hash_internal()
-    }
-    native fun raw_transaction_hash_internal(): vector<u8>;
-
     #[test()]
     fun test_auid_uniquess() {
         use std::vector;
@@ -272,13 +256,6 @@ module aptos_framework::transaction_context {
     #[test]
     #[expected_failure(abort_code=196609, location = Self)]
     fun test_call_multisig_payload() {
-        // expected to fail with the error code of `invalid_state(E_TRANSACTION_CONTEXT_NOT_AVAILABLE)`
-        let _multisig = multisig_payload();
-    }
-
-    #[test]
-    #[expected_failure(abort_code=196609, location = Self)]
-    fun test_call_raw_txn_hash() {
         // expected to fail with the error code of `invalid_state(E_TRANSACTION_CONTEXT_NOT_AVAILABLE)`
         let _multisig = multisig_payload();
     }

--- a/aptos-move/framework/aptos-framework/sources/transaction_context.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_context.spec.move
@@ -1,10 +1,10 @@
 spec aptos_framework::transaction_context {
     /// <high-level-req>
     /// No.: 1
-    /// Requirement: Fetching the unique session hash should return a vector with 32 bytes.
+    /// Requirement: Fetching the transaction hash should return a vector with 32 bytes.
     /// Criticality: Medium
-    /// Implementation: The unique_session_hash function calls the native function unique_session_hash_internal, which fetches the
-    /// NativeTransactionContext struct and returns the unique_session_hash field.
+    /// Implementation: The get_transaction_hash function calls the native function get_txn_hash, which fetches the
+    /// NativeTransactionContext struct and returns the txn_hash field.
     /// Enforcement: Audited that the native function returns the txn hash, whose size is 32 bytes. This has been
     /// modeled as the abstract postcondition that the returned vector is of length 32. Formally verified via [high-level-req-1](get_txn_hash).
     ///
@@ -42,26 +42,19 @@ spec aptos_framework::transaction_context {
         ensures [abstract] len(result) == 32;
     }
     spec fun spec_get_script_hash(): vector<u8>;
-    spec fun spec_get_txn_hash(): vector<u8>;
     spec get_txn_hash(): vector<u8> {
         pragma opaque;
-        aborts_if false;
+        aborts_if [abstract] false;
+        ensures result == spec_get_txn_hash();
+    }
+    spec fun spec_get_txn_hash(): vector<u8>;
+    spec get_transaction_hash(): vector<u8> {
+        pragma opaque;
+        aborts_if [abstract] false;
         ensures result == spec_get_txn_hash();
         // property 1: Fetching the transaction hash should return a vector with 32 bytes, if the auid feature flag is enabled.
         /// [high-level-req-1]
-        ensures len(result) == 32;
-    }
-    spec get_transaction_hash(): vector<u8> {
-        pragma opaque;
-        aborts_if false;
-        ensures result == spec_get_txn_hash();
-        ensures len(result) == 32;
-    }
-    spec unique_session_hash(): vector<u8> {
-        pragma opaque;
-        aborts_if false;
-        ensures result == spec_get_txn_hash();
-        ensures len(result) == 32;
+        ensures [abstract] len(result) == 32;
     }
     spec generate_unique_address(): address {
         pragma opaque;
@@ -108,11 +101,8 @@ spec aptos_framework::transaction_context {
         //TODO: temporary mockup
         pragma opaque;
     }
+
     spec multisig_payload_internal(): Option<MultisigPayload> {
-        //TODO: temporary mockup
-        pragma opaque;
-    }
-    spec raw_transaction_hash_internal(): vector<u8> {
         //TODO: temporary mockup
         pragma opaque;
     }

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -133,8 +133,6 @@ return true.
 -  [Function `transaction_simulation_enhancement_enabled`](#0x1_features_transaction_simulation_enhancement_enabled)
 -  [Function `get_collection_owner_feature`](#0x1_features_get_collection_owner_feature)
 -  [Function `is_collection_owner_enabled`](#0x1_features_is_collection_owner_enabled)
--  [Function `get_transaction_context_hash_function_update_feature`](#0x1_features_get_transaction_context_hash_function_update_feature)
--  [Function `transaction_context_hash_function_update_enabled`](#0x1_features_transaction_context_hash_function_update_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `change_feature_flags_internal`](#0x1_features_change_feature_flags_internal)
 -  [Function `change_feature_flags_for_next_epoch`](#0x1_features_change_feature_flags_for_next_epoch)
@@ -878,21 +876,6 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_TRANSACTION_CONTEXT_EXTENSION">TRANSACTION_CONTEXT_EXTENSION</a>: u64 = 59;
-</code></pre>
-
-
-
-<a id="0x1_features_TRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE"></a>
-
-Whether the transaction context hash function update is enabled. This update introduces new APIs (public functions
-and native functions) to the transaction context module: <code>raw_transaction_hash</code> and <code>unique_session_hash</code>.
-<code>raw_transaction_hash</code> retrieves the hash of the raw transaction. Also, <code>unique_session_hash</code> will replace
-in a later release the existing <code>get_transaction_hash</code> function which has a misleading name.
-
-Lifetime: transient
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_TRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE">TRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE</a>: u64 = 80;
 </code></pre>
 
 
@@ -3286,52 +3269,6 @@ Deprecated feature
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_collection_owner_enabled">is_collection_owner_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_COLLECTION_OWNER">COLLECTION_OWNER</a>)
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_features_get_transaction_context_hash_function_update_feature"></a>
-
-## Function `get_transaction_context_hash_function_update_feature`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_transaction_context_hash_function_update_feature">get_transaction_context_hash_function_update_feature</a>(): u64
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_transaction_context_hash_function_update_feature">get_transaction_context_hash_function_update_feature</a>(): u64 { <a href="features.md#0x1_features_TRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE">TRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE</a> }
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_features_transaction_context_hash_function_update_enabled"></a>
-
-## Function `transaction_context_hash_function_update_enabled`
-
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_transaction_context_hash_function_update_enabled">transaction_context_hash_function_update_enabled</a>(): bool
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_transaction_context_hash_function_update_enabled">transaction_context_hash_function_update_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
-    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_TRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE">TRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -607,20 +607,6 @@ module std::features {
         is_enabled(COLLECTION_OWNER)
     }
 
-    /// Whether the transaction context hash function update is enabled. This update introduces new APIs (public functions
-    /// and native functions) to the transaction context module: `raw_transaction_hash` and `unique_session_hash`.
-    /// `raw_transaction_hash` retrieves the hash of the raw transaction. Also, `unique_session_hash` will replace
-    /// in a later release the existing `get_transaction_hash` function which has a misleading name.
-    ///
-    /// Lifetime: transient
-    const TRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE: u64 = 80;
-
-    public fun get_transaction_context_hash_function_update_feature(): u64 { TRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE }
-
-    public fun transaction_context_hash_function_update_enabled(): bool acquires Features {
-        is_enabled(TRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE)
-    }
-
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/src/natives/transaction_context.rs
+++ b/aptos-move/framework/src/natives/transaction_context.rs
@@ -31,7 +31,7 @@ pub mod abort_codes {
 /// is accessible from natives of this extension.
 #[derive(Tid)]
 pub struct NativeTransactionContext {
-    unique_session_hash: Vec<u8>,
+    txn_hash: Vec<u8>,
     /// The number of AUIDs (Aptos unique identifiers) issued during the
     /// execution of this transaction.
     auid_counter: u64,
@@ -46,13 +46,13 @@ impl NativeTransactionContext {
     /// Create a new instance of a native transaction context. This must be passed in via an
     /// extension into VM session functions.
     pub fn new(
-        unique_session_hash: Vec<u8>,
+        txn_hash: Vec<u8>,
         script_hash: Vec<u8>,
         chain_id: u8,
         user_transaction_context_opt: Option<UserTransactionContext>,
     ) -> Self {
         Self {
-            unique_session_hash,
+            txn_hash,
             auid_counter: 0,
             script_hash,
             chain_id,
@@ -66,12 +66,12 @@ impl NativeTransactionContext {
 }
 
 /***************************************************************************************************
- * native fun native_unique_session_hash
+ * native fun get_txn_hash
  *
  *   gas cost: base_cost
  *
  **************************************************************************************************/
-fn native_unique_session_hash(
+fn native_get_txn_hash(
     context: &mut SafeNativeContext,
     _ty_args: Vec<Type>,
     _args: VecDeque<Value>,
@@ -80,7 +80,7 @@ fn native_unique_session_hash(
     let transaction_context = context.extensions().get::<NativeTransactionContext>();
 
     Ok(smallvec![Value::vector_u8(
-        transaction_context.unique_session_hash.clone()
+        transaction_context.txn_hash.clone()
     )])
 }
 
@@ -103,7 +103,7 @@ fn native_generate_unique_address(
     transaction_context.auid_counter += 1;
 
     let auid = AuthenticationKey::auid(
-        transaction_context.unique_session_hash.clone(),
+        transaction_context.txn_hash.clone(),
         transaction_context.auid_counter,
     )
     .account_address();
@@ -368,25 +368,6 @@ fn native_multisig_payload_internal(
     }
 }
 
-fn native_raw_transaction_hash_internal(
-    context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
-    _args: VecDeque<Value>,
-) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    context.charge(TRANSACTION_CONTEXT_SENDER_BASE)?;
-
-    let user_transaction_context_opt = get_user_transaction_context_opt_from_context(context);
-    if let Some(transaction_context) = user_transaction_context_opt {
-        Ok(smallvec![Value::vector_u8(
-            transaction_context.raw_txn_hash()
-        )])
-    } else {
-        Err(SafeNativeError::Abort {
-            abort_code: error::invalid_state(abort_codes::ETRANSACTION_CONTEXT_NOT_AVAILABLE),
-        })
-    }
-}
-
 fn get_user_transaction_context_opt_from_context<'a>(
     context: &'a SafeNativeContext,
 ) -> &'a Option<UserTransactionContext> {
@@ -406,40 +387,23 @@ pub fn make_all(
     let natives = [
         ("get_script_hash", native_get_script_hash as RawSafeNative),
         ("generate_unique_address", native_generate_unique_address),
-        ("get_txn_hash", native_unique_session_hash),
-        ("unique_session_hash", native_unique_session_hash),
-        ("sender", native_sender_internal),
+        ("get_txn_hash", native_get_txn_hash),
         ("sender_internal", native_sender_internal),
-        ("secondary_signers", native_secondary_signers_internal),
         (
             "secondary_signers_internal",
             native_secondary_signers_internal,
         ),
-        ("gas_payer", native_gas_payer_internal),
         ("gas_payer_internal", native_gas_payer_internal),
-        ("max_gas_amount", native_max_gas_amount_internal),
         ("max_gas_amount_internal", native_max_gas_amount_internal),
-        ("gas_unit_price", native_gas_unit_price_internal),
         ("gas_unit_price_internal", native_gas_unit_price_internal),
-        ("chain_id", native_chain_id_internal),
         ("chain_id_internal", native_chain_id_internal),
-        (
-            "entry_function_payload",
-            native_entry_function_payload_internal,
-        ),
         (
             "entry_function_payload_internal",
             native_entry_function_payload_internal,
         ),
-        ("multisig_payload", native_multisig_payload_internal),
         (
             "multisig_payload_internal",
             native_multisig_payload_internal,
-        ),
-        ("raw_transaction_hash", native_raw_transaction_hash_internal),
-        (
-            "raw_transaction_hash_internal",
-            native_raw_transaction_hash_internal,
         ),
     ];
 

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -96,7 +96,6 @@ pub enum FeatureFlag {
     FEDERATED_KEYLESS = 77,
     TRANSACTION_SIMULATION_ENHANCEMENT = 78,
     COLLECTION_OWNER = 79,
-    TRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE = 80,
     ENABLE_LOADER_V2 = 81,
 }
 
@@ -175,7 +174,6 @@ impl FeatureFlag {
             FeatureFlag::ENABLE_RESOURCE_ACCESS_CONTROL,
             FeatureFlag::REJECT_UNSTABLE_BYTECODE_FOR_SCRIPT,
             FeatureFlag::TRANSACTION_SIMULATION_ENHANCEMENT,
-            FeatureFlag::TRANSACTION_CONTEXT_HASH_FUNCTION_UPDATE,
             // TODO(loader_v2): Enable V2 loader.
             // FeatureFlag::ENABLE_LOADER_V2,
         ]

--- a/types/src/transaction/user_transaction_context.rs
+++ b/types/src/transaction/user_transaction_context.rs
@@ -13,7 +13,6 @@ pub struct UserTransactionContext {
     chain_id: u8,
     entry_function_payload: Option<EntryFunctionPayload>,
     multisig_payload: Option<MultisigPayload>,
-    raw_transaction_hash: Vec<u8>,
 }
 
 impl UserTransactionContext {
@@ -26,7 +25,6 @@ impl UserTransactionContext {
         chain_id: u8,
         entry_function_payload: Option<EntryFunctionPayload>,
         multisig_payload: Option<MultisigPayload>,
-        raw_transaction_hash: Vec<u8>,
     ) -> Self {
         Self {
             sender,
@@ -37,7 +35,6 @@ impl UserTransactionContext {
             chain_id,
             entry_function_payload,
             multisig_payload,
-            raw_transaction_hash,
         }
     }
 
@@ -71,10 +68,6 @@ impl UserTransactionContext {
 
     pub fn multisig_payload(&self) -> Option<MultisigPayload> {
         self.multisig_payload.clone()
-    }
-
-    pub fn raw_txn_hash(&self) -> Vec<u8> {
-        self.raw_transaction_hash.clone()
     }
 }
 


### PR DESCRIPTION
## Description
Revert #13659 (Add a transaction context function to get the raw transaction hash)

It turns out that we need more discussion on the requirement of `raw_transaction_hash`.
