### PR TITLE
[cli] Update CLI release script to check for versions

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -30,7 +30,7 @@ jobs:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - name: Build CLI
-        run: scripts/cli/build_cli_release.sh "Ubuntu"
+        run: scripts/cli/build_cli_release.sh "Ubuntu" "${{inputs.release_version}}"
       - name: Upload Binary
         uses: actions/upload-artifact@v4
         with:
@@ -46,7 +46,7 @@ jobs:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - name: Build CLI
-        run: scripts/cli/build_cli_release.sh "Ubuntu-22.04"
+        run: scripts/cli/build_cli_release.sh "Ubuntu-22.04" "${{inputs.release_version}}"
       - name: Upload Binary
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/cli/build_cli_release.sh
+++ b/scripts/cli/build_cli_release.sh
@@ -21,18 +21,22 @@ ARCH=$(uname -m)
 OS=$(uname -s)
 VERSION=$(sed -n '/^\w*version = /p' "$CARGO_PATH" | sed 's/^.*=[ ]*"//g' | sed 's/".*$//g')
 
-# Check that the
-if [[ "$EXPECTED_VERSION" != "$VERSION" ]]; then
-  echo "Wanted to release for $EXPECTED_VERSION, but Cargo.toml says the version is $VERSION"
+# Check that the version is well-formed, note that it should already be correct, but this double checks it
+if ! [[ "$EXPECTED_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "$EXPECTED_VERSION is malformed, must be of the form '^[0-9]+\.[0-9]+\.[0-9]+$'"
   exit 1
 fi
 
-# Check that the release doesn't already exist
-curl -f "https://github.com/aptos-labs/aptos-core/releases/download/aptos-cli-v$EXPECTED_VERSION/aptos-cli-$EXPECTED_VERSION-Ubuntu-22.04-x86_64.zip"
-ALREADY_RELEASED=$?
-if [[ $ALREADY_RELEASED -eq 0 ]]; then
-  echo "$EXPECTED_VERSION already released"
+# Check that the version matches the Cargo.toml
+if [[ "$EXPECTED_VERSION" != "$VERSION" ]]; then
+  echo "Wanted to release for $EXPECTED_VERSION, but Cargo.toml says the version is $VERSION"
   exit 2
+fi
+
+# Check that the release doesn't already exist
+if curl -s --stderr /dev/null --output /dev/null --head -f "https://github.com/aptos-labs/aptos-core/releases/download/aptos-cli-v$EXPECTED_VERSION/aptos-cli-$EXPECTED_VERSION-Ubuntu-22.04-x86_64.zip"; then
+  echo "$EXPECTED_VERSION already released"
+  exit 3
 fi
 
 echo "Building release $VERSION of $NAME for $OS-$PLATFORM_NAME on $ARCH"


### PR DESCRIPTION
## Description
This should prevent us from releasing poorly setup versions.  Note, I didn't fix Windows, but the whole flow will stop if the linux builds break.

1. This ensures a version isn't double uploaded
2. This ensures the inputted tag matches the crate version

## How Has This Been Tested?
Tested locally

1. Already existing version:
```
sh scripts/cli/build_cli_release.sh Mac 4.2.6
4.2.6 already released
```
2. New version (when changing the cargo version):
```
sh scripts/cli/build_cli_release.sh Mac 6.0.0
Building release 6.0.0 of aptos-cli for Darwin-Mac on arm64
   Compiling move-core-types v0.0.4 (/opt/git/aptos-core/third_party/move/move-core/types)
   Compiling aptos-build-info v0.1.0 (/opt/git/aptos-core/crates/aptos-build-info)
...
```
3. Version mismatch
```
sh scripts/cli/build_cli_release.sh Mac 7.0.0
Wanted to release for 7.0.0, but Cargo.toml says the version is 4.3.0
```
4. Invalid version format
```
sh scripts/cli/build_cli_release.sh Mac 123
123 is malformed, must be of the form '^[0-9]+\.[0-9]+\.[0-9]+$'
```

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
