### PR TITLE
[Framework] Gate V2 Features in Framework until V2 Features Allowed on Mainnet

### DIFF
--- a/aptos-move/framework/move-stdlib/sources/bit_vector.move
+++ b/aptos-move/framework/move-stdlib/sources/bit_vector.move
@@ -55,7 +55,7 @@ module std::bit_vector {
 
     /// Set the bit at `bit_index` in the `self` regardless of its previous state.
     public fun set(self: &mut BitVector, bit_index: u64) {
-        assert!(bit_index < self.length(), EINDEX);
+        assert!(bit_index < vector::length(&self.bit_field), EINDEX);
         let x = vector::borrow_mut(&mut self.bit_field, bit_index);
         *x = true;
     }

--- a/aptos-move/framework/move-stdlib/sources/bit_vector.move
+++ b/aptos-move/framework/move-stdlib/sources/bit_vector.move
@@ -55,7 +55,7 @@ module std::bit_vector {
 
     /// Set the bit at `bit_index` in the `self` regardless of its previous state.
     public fun set(self: &mut BitVector, bit_index: u64) {
-        assert!(bit_index < vector::length(&self.bit_field), EINDEX);
+        assert!(bit_index < self.length(), EINDEX);
         let x = vector::borrow_mut(&mut self.bit_field, bit_index);
         *x = true;
     }

--- a/aptos-move/framework/tests/gate_v2_features.rs
+++ b/aptos-move/framework/tests/gate_v2_features.rs
@@ -22,7 +22,9 @@ fn compile_pkg_with_v1(path_to_pkg: impl Into<String>) {
         compiler_config: compiler_config.clone(),
         ..Default::default()
     };
-    build_config.compile_package(pkg_path.as_path(), &mut std::io::stdout()).unwrap();
+    build_config
+        .compile_package(pkg_path.as_path(), &mut std::io::stdout())
+        .unwrap();
 }
 
 #[test]

--- a/aptos-move/framework/tests/gate_v2_features.rs
+++ b/aptos-move/framework/tests/gate_v2_features.rs
@@ -1,0 +1,51 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This file contains tests for compiling framework code with the v1 compiler, to make sure no V2 feature is used before it's ready for mainnet.
+
+use aptos_framework::{extended_checks, path_in_crate};
+use move_model::metadata::{CompilerVersion, LanguageVersion};
+use move_package::CompilerConfig;
+use tempfile::tempdir;
+
+fn compile_pkg_with_v1(path_to_pkg: impl Into<String>) {
+    let pkg_path = path_in_crate(path_to_pkg);
+    let compiler_config = CompilerConfig {
+        known_attributes: extended_checks::get_all_attribute_names().clone(),
+        bytecode_version: Some(6),
+        language_version: Some(LanguageVersion::V1),
+        compiler_version: Some(CompilerVersion::V1),
+        ..Default::default()
+    };
+    let build_config = move_package::BuildConfig {
+        install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+        compiler_config: compiler_config.clone(),
+        ..Default::default()
+    };
+    build_config.compile_package(pkg_path.as_path(), &mut std::io::stdout()).unwrap();
+}
+
+#[test]
+fn compile_aptos_framework_with_v1() {
+    compile_pkg_with_v1("aptos-framework");
+}
+
+#[test]
+fn compile_aptos_stdlib_with_v1() {
+    compile_pkg_with_v1("aptos-stdlib");
+}
+
+#[test]
+fn compile_move_stdlib_with_v1() {
+    compile_pkg_with_v1("move-stdlib");
+}
+
+#[test]
+fn compile_aptos_token_with_v1() {
+    compile_pkg_with_v1("aptos-token");
+}
+
+#[test]
+fn compile_aptos_token_objects_with_v1() {
+    compile_pkg_with_v1("aptos-token-objects");
+}


### PR DESCRIPTION
## Description

We add tests for compiling framework code using compiler v1, so that no v2 features are accidentally used in the framework until mainnet has upgraded to use language v2.

## How Has This Been Tested?

Check out [26d691f](https://github.com/aptos-labs/aptos-core/pull/15146/commits/26d691fabe61c9477bfc0605a4738b3422eea4c6) where some v2 features are used in the framework, and the tests should fail.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

