### PR TITLE
cleanup trace file after coverage map is generated successfully

### DIFF
--- a/third_party/move/tools/move-cli/src/base/test.rs
+++ b/third_party/move/tools/move-cli/src/base/test.rs
@@ -342,9 +342,10 @@ pub fn run_move_unit_tests_with_factory<W: Write + Send, F: UnitTestFactory + Se
             let buf_writer = &mut *LOGGING_FILE_WRITER.lock().unwrap();
             buf_writer.flush().unwrap();
         }
-        let coverage_map = CoverageMap::from_trace_file(trace_path);
+        let coverage_map = CoverageMap::from_trace_file(trace_path.clone());
         output_map_to_file(coverage_map_path, &coverage_map).unwrap();
     }
+    cleanup_trace();
     Ok(UnitTestResult::Success)
 }
 


### PR DESCRIPTION
## Description

During move test --coverage, a huge .trace file is generated, but is
then processed to generate a more compact coverage map which should
contain all neededed data.  We now delete the .trace file after
successful generation of the coverage map.

Fixes #15054 .

## How Has This Been Tested?

Ran manually on a few cases.  Made sure that `aptos move coverage ...` features work without .trace file.

## Key Areas to Review

?

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [X] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation
