### PR TITLE
[consensus] record timeout author with reason in metrics

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -597,7 +597,7 @@ pub static AGGREGATED_ROUND_TIMEOUT_REASON: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_consensus_agg_round_timeout_reason",
         "Count of round timeouts by reason",
-        &["reason", "is_next_proposer"],
+        &["reason", "author", "is_next_proposer"],
     )
     .unwrap()
 });

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -355,9 +355,13 @@ impl RoundManager {
         &mut self,
         new_round_event: NewRoundEvent,
     ) -> anyhow::Result<()> {
+        let new_round = new_round_event.round;
         let is_current_proposer = self
             .proposer_election
-            .is_valid_proposer(self.proposal_generator.author(), new_round_event.round);
+            .is_valid_proposer(self.proposal_generator.author(), new_round);
+        let prev_proposer = self
+            .proposer_election
+            .get_valid_proposer(new_round.saturating_sub(1));
 
         counters::CURRENT_ROUND.set(new_round_event.round as i64);
         counters::ROUND_TIMEOUT_MS.set(new_round_event.timeout.as_millis() as i64);
@@ -368,7 +372,11 @@ impl RoundManager {
             NewRoundReason::Timeout(ref reason) => {
                 counters::TIMEOUT_ROUNDS_COUNT.inc();
                 counters::AGGREGATED_ROUND_TIMEOUT_REASON
-                    .with_label_values(&[&reason.to_string(), &is_current_proposer.to_string()])
+                    .with_label_values(&[
+                        &reason.to_string(),
+                        prev_proposer.short_str().as_str(),
+                        &is_current_proposer.to_string(),
+                    ])
                     .inc();
                 if is_current_proposer {
                     if let RoundTimeoutReason::PayloadUnavailable { missing_authors } = reason {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Record the failed author as label in the `AGGREGATED_ROUND_TIMEOUT_REASON` metric, so we can identify which author failed for what reason.