### PR TITLE
[loader] Generation counters to keep global module cache in sync

### DIFF
--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -568,8 +568,12 @@ mod test {
     use aptos_block_executor::{
         code_cache_global::ImmutableModuleCache, txn_commit_hook::NoOpTransactionCommitHook,
     };
+    use aptos_crypto::HashValue;
     use aptos_language_e2e_tests::data_store::FakeDataStore;
-    use aptos_types::on_chain_config::{FeatureFlag, Features};
+    use aptos_types::{
+        on_chain_config::{FeatureFlag, Features},
+        transaction::Transaction,
+    };
     use aptos_vm_environment::environment::AptosEnvironment;
     use claims::assert_ok;
     use move_vm_types::code::mock_verified_code;
@@ -621,9 +625,15 @@ mod test {
         );
         let config = BlockExecutorConfig::new_no_block_limit(concurrency_level);
 
+        // Put at least one transaction in the block so that the block executor does not return
+        // early.
+        let block = vec![SignatureVerifiedTransaction::Invalid(
+            Transaction::StateCheckpoint(HashValue::zero()),
+        )];
+
         let result = BlockAptosVM::execute_block_on_thread_pool_with_module_cache(
             executor_thread_pool,
-            &[],
+            &block,
             &FakeDataStore::default(),
             global_module_cache.clone(),
             config,

--- a/aptos-move/block-executor/src/code_cache.rs
+++ b/aptos-move/block-executor/src/code_cache.rs
@@ -25,7 +25,7 @@ use move_core_types::{
 use move_vm_runtime::{Module, RuntimeEnvironment, Script, WithRuntimeEnvironment};
 use move_vm_types::code::{
     ambassador_impl_ScriptCache, Code, ModuleCache, ModuleCode, ModuleCodeBuilder, ScriptCache,
-    WithBytes, WithHash,
+    WithBytes,
 };
 use std::sync::Arc;
 
@@ -154,11 +154,9 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>, X: Executable> ModuleCache
 
             // Otherwise, this is the first time this module gets accessed in this block. We need
             // to validate it is the same as in the state. We do it only once on the first access.
-            let is_valid = builder.build(key)?.is_some_and(|m| {
-                m.extension().hash() == module.extension().hash()
-                    && m.extension().state_value_metadata()
-                        == module.extension().state_value_metadata()
-            });
+            let is_valid = builder
+                .build(key)?
+                .is_some_and(|m| m.extension() == module.extension());
             if is_valid {
                 // This module is valid for this block, mark as so.
                 self.global_module_cache.set_generation(key);

--- a/aptos-move/block-executor/src/code_cache_global.rs
+++ b/aptos-move/block-executor/src/code_cache_global.rs
@@ -303,6 +303,7 @@ mod test {
     fn test_insert_verified_for_global_module_cache() {
         let capacity = 10;
         let global_cache = ImmutableModuleCache::with_capacity(capacity);
+        assert_eq!(global_cache.generation(), 0);
 
         let mut new_modules = vec![];
         for i in 0..capacity {
@@ -314,10 +315,12 @@ mod test {
         assert_eq!(global_cache.size(), capacity);
         assert_eq!(global_cache.generation(), 1);
 
-        // Versions should be set to storage.
+        // Versions should be set to storage. The returned code needs validation because generation
+        // has been incremented.
         for key in 0..capacity {
-            let (code, _) = assert_some!(global_cache.get(&key));
-            assert!(code.version().is_none())
+            let (code, needs_validation) = assert_some!(global_cache.get(&key));
+            assert!(code.version().is_none());
+            assert!(needs_validation);
         }
 
         // Too many modules added, the cache should be flushed.

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -1169,7 +1169,7 @@ where
 
         counters::update_state_counters(versioned_cache.stats(), true);
         self.global_module_cache
-            .insert_verified_unchecked(versioned_cache.take_modules_iter())
+            .insert_verified_and_increment_generation_unchecked(versioned_cache.take_modules_iter())
             .map_err(|err| {
                 alert!("[BlockSTM] Encountered panic error: {:?}", err);
             })?;
@@ -1652,7 +1652,7 @@ where
 
         counters::update_state_counters(unsync_map.stats(), false);
         self.global_module_cache
-            .insert_verified_unchecked(unsync_map.into_modules_iter())?;
+            .insert_verified_and_increment_generation_unchecked(unsync_map.into_modules_iter())?;
 
         let block_end_info = if self
             .config

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -636,7 +636,12 @@ impl FakeExecutor {
             },
             onchain: onchain_config,
         };
-        BlockAptosVM::execute_block_on_thread_pool_without_global_module_cache::<
+
+        // Note:
+        //   This uses a shared global module cache, but it is ok because we validate it against
+        //   the state for every block, ensuring consistency of cached data. This way all tests
+        //   implicitly test cache implementation.
+        BlockAptosVM::execute_block_on_thread_pool::<
             _,
             NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,
         >(

--- a/types/src/state_store/state_value.rs
+++ b/types/src/state_store/state_value.rs
@@ -268,6 +268,10 @@ impl StateValue {
         &self.inner.data
     }
 
+    pub fn metadata(&self) -> &StateValueMetadata {
+        &self.inner.metadata
+    }
+
     /// Applies a bytes-to-bytes transformation on the state value contents,
     /// leaving the state value metadata untouched.
     pub fn map_bytes<F: FnOnce(Bytes) -> anyhow::Result<Bytes>>(

--- a/types/src/vm/modules.rs
+++ b/types/src/vm/modules.rs
@@ -10,36 +10,28 @@ use move_vm_types::{
 
 /// Additional data stored alongside deserialized or verified modules.
 pub struct AptosModuleExtension {
-    /// Serialized representation of the module.
-    bytes: Bytes,
     /// Module's hash.
     hash: [u8; 32],
-    /// The state value metadata associated with the module, when read from or
-    /// written to storage.
-    state_value_metadata: StateValueMetadata,
+    /// The original state value associated with the module, when read from or written to storage.
+    state_value: StateValue,
 }
 
 impl AptosModuleExtension {
     /// Creates new extension based on [StateValue].
     pub fn new(state_value: StateValue) -> Self {
-        let (state_value_metadata, bytes) = state_value.unpack();
-        let hash = sha3_256(&bytes);
-        Self {
-            bytes,
-            hash,
-            state_value_metadata,
-        }
+        let hash = sha3_256(state_value.bytes());
+        Self { hash, state_value }
     }
 
-    /// Returns the state value metadata stored in extension.
+    /// Returns state value metadata stored in extension.
     pub fn state_value_metadata(&self) -> &StateValueMetadata {
-        &self.state_value_metadata
+        self.state_value.metadata()
     }
 }
 
 impl WithBytes for AptosModuleExtension {
     fn bytes(&self) -> &Bytes {
-        &self.bytes
+        self.state_value.bytes()
     }
 }
 
@@ -48,3 +40,11 @@ impl WithHash for AptosModuleExtension {
         &self.hash
     }
 }
+
+impl PartialEq for AptosModuleExtension {
+    fn eq(&self, other: &Self) -> bool {
+        self.hash.eq(&other.hash) && self.state_value_metadata().eq(other.state_value_metadata())
+    }
+}
+
+impl Eq for AptosModuleExtension {}


### PR DESCRIPTION
## Description

Previously, global module cache assumed linear execution: blocks executed in order, adding and removing entries from the global cache. This is not true if:
- We replay transactions. We replay chunks which are not ordered by versions:
```
# From prepare.txt generated by replay run.
# It seems that chunks are run out of order (versions decrease)

...
[
  "0-0 1875415027 1876000000 Replay epoch 9070 - 9071, 584974 txns starting from version 1875415027.",
  "0-46 1840383848 1841128591 Replay epoch 8978 - 8979, 744744 txns starting from version 1840383848.",
  "0-92 1809104670 1809555455 Replay epoch 8886 - 8887, 450786 txns starting from version 1809104670.",
  "0-138 1779570671 1780137777 Replay epoch 8794 - 8795, 567107 txns starting from version 1779570671.",
  ...
]
...
```
- We may retry blocks, have non-linear history in the future, etc.

This PR adds a generation counter to module cache which is incremented every block. For each module in cache, we also keep track of its generation. If generation of a module is not the same as of block, we check that the cached entries are the same as the one in state (compare hash and state value metadata). If not equal, we use MV data structures, if equal, we set the generation of the module to the generation of the block. As a result, only first accesses are validated per-block.

This does have a small impact on performance (e.g., ~1k TPS on no-op) but not sufficient for regressions and this is still better than V1 implementation when there are many modules. For now, this is sufficient to be able to 1) pass replay, 2) protect against retries, 3) ensure that we always sync with the state view when executing the block. The last part is actually great - it allows us to share the cache even across multiple tests, etc. because we will invalidate entries which do not pass the check w.r.t. state view.

Replay run: https://github.com/aptos-labs/aptos-core/actions/runs/11643658386. There are only few mainnet failures, no more 300+ errors including weird backwards compatibility error which confirms the hypothesis. 

## How Has This Been Tested?

- Unit tests
- Replay

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
