### PR TITLE
[move-vm] Types and opcodes for closures

### DIFF
--- a/api/types/src/bytecode.rs
+++ b/api/types/src/bytecode.rs
@@ -105,6 +105,10 @@ pub trait Bytecode {
                 mutable: true,
                 to: Box::new(self.new_move_type(t.borrow())),
             },
+            SignatureToken::Function(..) => {
+                // TODO
+                unimplemented!("signature token function to API MoveType")
+            },
         }
     }
 

--- a/aptos-move/script-composer/src/decompiler.rs
+++ b/aptos-move/script-composer/src/decompiler.rs
@@ -208,6 +208,9 @@ impl LocalState {
             SignatureToken::Vector(s) => {
                 TypeTag::Vector(Box::new(Self::type_tag_from_sig_token(script, s)?))
             },
+            SignatureToken::Function(..) => {
+                bail!("function types NYI for script composer")
+            },
             SignatureToken::Struct(s) => {
                 let module_handle = script.module_handle_at(script.struct_handle_at(*s).module);
                 TypeTag::Struct(Box::new(StructTag {

--- a/third_party/move/move-binary-format/src/binary_views.rs
+++ b/third_party/move/move-binary-format/src/binary_views.rs
@@ -343,6 +343,7 @@ impl<'a> BinaryIndexedView<'a> {
             Vector(ty) => AbilitySet::polymorphic_abilities(AbilitySet::VECTOR, vec![false], vec![
                 self.abilities(ty, constraints)?,
             ]),
+            Function(_, _, abilities) => Ok(*abilities),
             Struct(idx) => {
                 let sh = self.struct_handle_at(*idx);
                 Ok(sh.abilities)

--- a/third_party/move/move-binary-format/src/builders.rs
+++ b/third_party/move/move-binary-format/src/builders.rs
@@ -213,6 +213,12 @@ impl CompiledScriptBuilder {
         sig: &SignatureToken,
     ) -> PartialVMResult<SignatureToken> {
         use SignatureToken::*;
+        let import_vec =
+            |s: &mut Self, v: &[SignatureToken]| -> PartialVMResult<Vec<SignatureToken>> {
+                v.iter()
+                    .map(|sig| s.import_signature_token(module, sig))
+                    .collect::<PartialVMResult<Vec<_>>>()
+            };
         Ok(match sig {
             U8 => U8,
             U16 => U16,
@@ -229,13 +235,15 @@ impl CompiledScriptBuilder {
                 MutableReference(Box::new(self.import_signature_token(module, ty)?))
             },
             Vector(ty) => Vector(Box::new(self.import_signature_token(module, ty)?)),
+            Function(args, result, abilities) => Function(
+                import_vec(self, args)?,
+                import_vec(self, result)?,
+                *abilities,
+            ),
             Struct(idx) => Struct(self.import_struct(module, *idx)?),
             StructInstantiation(idx, inst_tys) => StructInstantiation(
                 self.import_struct(module, *idx)?,
-                inst_tys
-                    .iter()
-                    .map(|sig| self.import_signature_token(module, sig))
-                    .collect::<PartialVMResult<Vec<_>>>()?,
+                import_vec(self, inst_tys)?,
             ),
         })
     }

--- a/third_party/move/move-binary-format/src/check_bounds.rs
+++ b/third_party/move/move-binary-format/src/check_bounds.rs
@@ -546,12 +546,12 @@ impl<'a> BoundsChecker<'a> {
                         )?;
                     }
                 },
-                Call(idx) => self.check_code_unit_bounds_impl(
+                Call(idx) | ClosPack(idx, _) => self.check_code_unit_bounds_impl(
                     self.view.function_handles(),
                     *idx,
                     bytecode_offset,
                 )?,
-                CallGeneric(idx) => {
+                CallGeneric(idx) | ClosPackGeneric(idx, _) => {
                     self.check_code_unit_bounds_impl(
                         self.view.function_instantiations(),
                         *idx,
@@ -650,7 +650,8 @@ impl<'a> BoundsChecker<'a> {
                 },
 
                 // Instructions that refer to a signature
-                VecPack(idx, _)
+                ClosEval(idx)
+                | VecPack(idx, _)
                 | VecLen(idx)
                 | VecImmBorrow(idx)
                 | VecMutBorrow(idx)
@@ -684,7 +685,7 @@ impl<'a> BoundsChecker<'a> {
         for ty in ty.preorder_traversal() {
             match ty {
                 Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address | Signer | TypeParameter(_)
-                | Reference(_) | MutableReference(_) | Vector(_) => (),
+                | Reference(_) | MutableReference(_) | Vector(_) | Function(..) => (),
                 Struct(idx) => {
                     check_bounds_impl(self.view.struct_handles(), *idx)?;
                     if let Some(sh) = self.view.struct_handles().get(idx.into_index()) {

--- a/third_party/move/move-binary-format/src/check_complexity.rs
+++ b/third_party/move/move-binary-format/src/check_complexity.rs
@@ -68,7 +68,7 @@ impl<'a> BinaryComplexityMeter<'a> {
                     cost = cost.saturating_add(moduel_name.len() as u64 * COST_PER_IDENT_BYTE);
                 },
                 U8 | U16 | U32 | U64 | U128 | U256 | Signer | Address | Bool | Vector(_)
-                | TypeParameter(_) | Reference(_) | MutableReference(_) => (),
+                | Function(..) | TypeParameter(_) | Reference(_) | MutableReference(_) => (),
             }
         }
 
@@ -262,7 +262,7 @@ impl<'a> BinaryComplexityMeter<'a> {
 
         for instr in &code.code {
             match instr {
-                CallGeneric(idx) => {
+                CallGeneric(idx) | ClosPackGeneric(idx, ..) => {
                     self.meter_function_instantiation(*idx)?;
                 },
                 PackGeneric(idx) | UnpackGeneric(idx) => {
@@ -284,7 +284,8 @@ impl<'a> BinaryComplexityMeter<'a> {
                 ImmBorrowVariantFieldGeneric(idx) | MutBorrowVariantFieldGeneric(idx) => {
                     self.meter_variant_field_instantiation(*idx)?;
                 },
-                VecPack(idx, _)
+                ClosEval(idx)
+                | VecPack(idx, _)
                 | VecLen(idx)
                 | VecImmBorrow(idx)
                 | VecMutBorrow(idx)
@@ -323,6 +324,7 @@ impl<'a> BinaryComplexityMeter<'a> {
                 | PackVariant(_)
                 | UnpackVariant(_)
                 | TestVariant(_)
+                | ClosPack(..)
                 | ReadRef
                 | WriteRef
                 | FreezeRef

--- a/third_party/move/move-binary-format/src/constant.rs
+++ b/third_party/move/move-binary-format/src/constant.rs
@@ -17,6 +17,10 @@ fn sig_to_ty(sig: &SignatureToken) -> Option<MoveTypeLayout> {
         SignatureToken::U128 => Some(MoveTypeLayout::U128),
         SignatureToken::U256 => Some(MoveTypeLayout::U256),
         SignatureToken::Vector(v) => Some(MoveTypeLayout::Vector(Box::new(sig_to_ty(v.as_ref())?))),
+        SignatureToken::Function(..) => {
+            // TODO: do we need representation in MoveTypeLayout?
+            None
+        },
         SignatureToken::Reference(_)
         | SignatureToken::MutableReference(_)
         | SignatureToken::Struct(_)

--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -49,6 +49,7 @@ use proptest::{collection::vec, prelude::*, strategy::BoxedStrategy};
 use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::BTreeMap,
     fmt::{self, Formatter},
     ops::BitOr,
 };
@@ -1254,6 +1255,8 @@ pub enum SignatureToken {
     Signer,
     /// Vector
     Vector(Box<SignatureToken>),
+    /// Function, with n argument types and m result types, and an associated ability set.
+    Function(Vec<SignatureToken>, Vec<SignatureToken>, AbilitySet),
     /// User defined type
     Struct(StructHandleIndex),
     StructInstantiation(StructHandleIndex, Vec<SignatureToken>),
@@ -1296,6 +1299,11 @@ impl<'a> Iterator for SignatureTokenPreorderTraversalIter<'a> {
                         self.stack.extend(inner_toks.iter().rev())
                     },
 
+                    Function(args, result, _) => {
+                        self.stack.extend(args.iter().rev());
+                        self.stack.extend(result.iter().rev());
+                    },
+
                     Signer | Bool | Address | U8 | U16 | U32 | U64 | U128 | U256 | Struct(_)
                     | TypeParameter(_) => (),
                 }
@@ -1328,6 +1336,13 @@ impl<'a> Iterator for SignatureTokenPreorderTraversalIterWithDepth<'a> {
                     StructInstantiation(_, inner_toks) => self
                         .stack
                         .extend(inner_toks.iter().map(|tok| (tok, depth + 1)).rev()),
+
+                    Function(args, result, _) => {
+                        self.stack
+                            .extend(args.iter().map(|tok| (tok, depth + 1)).rev());
+                        self.stack
+                            .extend(result.iter().map(|tok| (tok, depth + 1)).rev());
+                    },
 
                     Signer | Bool | Address | U8 | U16 | U32 | U64 | U128 | U256 | Struct(_)
                     | TypeParameter(_) => (),
@@ -1389,11 +1404,14 @@ impl std::fmt::Debug for SignatureToken {
             SignatureToken::Address => write!(f, "Address"),
             SignatureToken::Signer => write!(f, "Signer"),
             SignatureToken::Vector(boxed) => write!(f, "Vector({:?})", boxed),
+            SignatureToken::Function(args, result, abilities) => {
+                write!(f, "Function({:?}, {:?}, {})", args, result, abilities)
+            },
+            SignatureToken::Reference(boxed) => write!(f, "Reference({:?})", boxed),
             SignatureToken::Struct(idx) => write!(f, "Struct({:?})", idx),
             SignatureToken::StructInstantiation(idx, types) => {
                 write!(f, "StructInstantiation({:?}, {:?})", idx, types)
             },
-            SignatureToken::Reference(boxed) => write!(f, "Reference({:?})", boxed),
             SignatureToken::MutableReference(boxed) => write!(f, "MutableReference({:?})", boxed),
             SignatureToken::TypeParameter(idx) => write!(f, "TypeParameter({:?})", idx),
         }
@@ -1410,6 +1428,7 @@ impl SignatureToken {
             | Address
             | Signer
             | Vector(_)
+            | Function(..)
             | Struct(_)
             | StructInstantiation(_, _)
             | Reference(_)
@@ -1448,6 +1467,7 @@ impl SignatureToken {
             Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address => true,
             Vector(inner) => inner.is_valid_for_constant(),
             Signer
+            | Function(..)
             | Struct(_)
             | StructInstantiation(_, _)
             | Reference(_)
@@ -1490,6 +1510,9 @@ impl SignatureToken {
 
     pub fn instantiate(&self, subst_mapping: &[SignatureToken]) -> SignatureToken {
         use SignatureToken::*;
+        let inst_vec = |v: &[SignatureToken]| -> Vec<SignatureToken> {
+            v.iter().map(|ty| ty.instantiate(subst_mapping)).collect()
+        };
         match self {
             Bool => Bool,
             U8 => U8,
@@ -1501,18 +1524,112 @@ impl SignatureToken {
             Address => Address,
             Signer => Signer,
             Vector(ty) => Vector(Box::new(ty.instantiate(subst_mapping))),
+            Function(args, result, abilities) => {
+                Function(inst_vec(args), inst_vec(result), *abilities)
+            },
             Struct(idx) => Struct(*idx),
-            StructInstantiation(idx, struct_type_args) => StructInstantiation(
-                *idx,
-                struct_type_args
-                    .iter()
-                    .map(|ty| ty.instantiate(subst_mapping))
-                    .collect(),
-            ),
+            StructInstantiation(idx, struct_type_args) => {
+                StructInstantiation(*idx, inst_vec(struct_type_args))
+            },
             Reference(ty) => Reference(Box::new(ty.instantiate(subst_mapping))),
             MutableReference(ty) => MutableReference(Box::new(ty.instantiate(subst_mapping))),
             TypeParameter(idx) => subst_mapping[*idx as usize].clone(),
         }
+    }
+}
+
+/// A `ClosureMask` is a value which determines how to distinguish those function arguments
+/// which are captured and which are not when a closure is constructed. For instance,
+/// with `_` representing an omitted argument, the mask for `f(a,_,b,_)` would have the argument
+/// at index 0 and at index 2 captured. The mask can be used to transform lists of types.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
+pub struct ClosureMask {
+    pub mask: u64,
+}
+
+impl fmt::Display for ClosureMask {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:b}", self.mask)
+    }
+}
+
+impl ClosureMask {
+    pub fn new(mask: u64) -> Self {
+        Self { mask }
+    }
+
+    /// Apply a closure mask to a list of elements, returning only those
+    /// where position `i` is set in the mask (if `collect_captured` is true) or not
+    /// set (otherwise).
+    pub fn extract<T: Clone>(&self, tys: &[T], collect_captured: bool) -> Vec<T> {
+        tys.iter()
+            .enumerate()
+            .filter_map(|(pos, x)| {
+                let set = (1 << pos) & self.mask != 0;
+                if set && collect_captured || !set && !collect_captured {
+                    Some(x.clone())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Compose two lists of elements into one based on the given mask such that the
+    /// following holds:
+    /// ```ignore
+    ///   mask.compose(mask.extract(v, true), mask.extract(v, false)) == v
+    /// ```
+    /// This returns `None` if the provided lists are inconsistent w.r.t the mask
+    /// and cannot be composed. This should not happen in verified code, but
+    /// a caller should decide whether to crash or to error.
+    pub fn compose<T: Clone>(&self, captured: &[T], provided: &[T]) -> Option<Vec<T>> {
+        let mut result = BTreeMap::new(); // expect ordered enumeration
+        let mut cap_idx = 0;
+        let mut pro_idx = 0;
+        for i in 0..64 {
+            if cap_idx >= captured.len() && pro_idx >= provided.len() {
+                // all covered
+                break;
+            }
+            if (1 << i) & self.mask != 0 {
+                if cap_idx >= captured.len() {
+                    // Inconsistency
+                    return None;
+                }
+                result.insert(i, captured[cap_idx].clone());
+                cap_idx += 1
+            } else {
+                if pro_idx >= provided.len() {
+                    // Inconsistency
+                    return None;
+                }
+                result.insert(i, provided[pro_idx].clone());
+                pro_idx += 1
+            }
+        }
+        let map_len = result.len();
+        let vec = result.into_values().collect::<Vec<_>>();
+        if vec.len() != map_len {
+            // Inconsistency: all indices must be contiguously covered
+            None
+        } else {
+            Some(vec)
+        }
+    }
+
+    /// Return the max index of captured arguments
+    pub fn max_captured(&self) -> usize {
+        let mut i = 0;
+        let mut mask = self.mask;
+        while mask != 0 {
+            mask >>= 1;
+            i += 1
+        }
+        i
     }
 }
 
@@ -1896,7 +2013,6 @@ pub enum Bytecode {
     #[gas_type_creation_tier_1 = "field_tys"]
     PackVariantGeneric(StructVariantInstantiationIndex),
 
-    //TODO: Unpack, Test
     #[group = "struct"]
     #[static_operands = "[struct_def_idx]"]
     #[description = "Destroy an instance of a struct and push the values bound to each field onto the stack."]
@@ -2934,6 +3050,83 @@ pub enum Bytecode {
     "#]
     VecSwap(SignatureIndex),
 
+    #[group = "closure"]
+    #[description = r#"
+        `ClosPack(fun, mask)` creates a closure for a given function handle as controlled by
+        the given `mask`. `mask` is a u64 bitset which describes which of the arguments
+        of `fun` are captured by the closure.
+
+        If the function `fun` has type `|t1..tn|r`, then the following holds:
+
+        - If `m` are the number of bits set in the mask, then `m <= n`, and the stack is
+          `[vm..v1] + stack`, and if `i` is the `j`th bit set in the mask,
+           then `vj` has type `ti`.
+        - type ti is not a reference.
+
+        Thus the values on the stack must match the types in the function
+        signature which have the bit to be captured set in the mask.
+
+        The type of the resulting value on the stack is derived from the types `|t1..tn|`
+        for which the bit is not set, which build the arguments of a function type
+        with `fun`'s result types.
+
+        The `abilities` of this function type are derived from the inputs as follows.
+        First, take the intersection of the abilities of all captured arguments
+        with type `t1..tn`. Then intersect this with the abilities derived from the
+        function: a function handle has `drop` and `copy`, never has `key`, and only
+        `store` if the underlying function is public, and therefore cannot change
+        its signature.
+
+        Notice that an implementation can derive the types of the captured arguments
+        at runtime from a closure value as long as the closure value stores the function
+        handle (or a derived form of it) and the mask, and the handle allows to lookup the
+        function's type at runtime. Then the same procedure as outlined above can be used.
+    "#]
+    #[static_operands = "[fun, mask]"]
+    #[semantics = ""]
+    #[runtime_check_epilogue = ""]
+    #[gas_type_creation_tier_0 = "closure_ty"]
+    ClosPack(FunctionHandleIndex, ClosureMask),
+
+    #[group = "closure"]
+    #[static_operands = "[fun, mask]"]
+    #[semantics = ""]
+    #[runtime_check_epilogue = ""]
+    #[description = r#"
+        Same as `ClosPack` but for the instantiation of a generic function.
+
+        Notice that an uninstantiated generic function cannot be used to create a closure.
+    "#]
+    #[gas_type_creation_tier_0 = "closure_ty"]
+    ClosPackGeneric(FunctionInstantiationIndex, ClosureMask),
+
+    #[group = "closure"]
+    #[description = r#"
+        `ClosEval(|t1..tn|r has a)` evalutes a closure of the given function type, taking
+        the captured arguments and mixing in the provided ones on the stack.
+
+        On top of the stack is the closure being evaluated, underneath the arguments:
+        `[c,vn,..,v1] + stack`. The type of the closure must match the type specified in
+        the instruction, with abilities `a` a subset of the abilities of the closure value.
+        A value `vi` on the stack must have type `ti`.
+
+        Notice that the type as part of the closure instruction is redundant for
+        execution semantics. Since the closure is expected to be on top of the stack,
+        it can decode the arguments underneath without type information.
+        However, the type is required to do static bytecode verification.
+
+        The semantics of this instruction can be characterized by the following equation:
+
+        ```
+          CloseEval(ClosPack(f, mask, c1..cn), a1..am) = f(mask.compose(c1..cn, a1..am))
+        ```
+    "#]
+    #[static_operands = "[]"]
+    #[semantics = ""]
+    #[runtime_check_epilogue = ""]
+    #[gas_type_creation_tier_0 = "closure_ty"]
+    ClosEval(SignatureIndex),
+
     #[group = "stack_and_local"]
     #[description = "Push a u16 constant onto the stack."]
     #[static_operands = "[u16_value]"]
@@ -3044,6 +3237,9 @@ impl ::std::fmt::Debug for Bytecode {
             Bytecode::UnpackGeneric(a) => write!(f, "UnpackGeneric({})", a),
             Bytecode::UnpackVariant(a) => write!(f, "UnpackVariant({})", a),
             Bytecode::UnpackVariantGeneric(a) => write!(f, "UnpackVariantGeneric({})", a),
+            Bytecode::ClosPackGeneric(a, mask) => write!(f, "ClosPackGeneric({}, {})", a, mask),
+            Bytecode::ClosPack(a, mask) => write!(f, "ClosPack({}, {})", a, mask),
+            Bytecode::ClosEval(a) => write!(f, "ClosEval({})", a),
             Bytecode::ReadRef => write!(f, "ReadRef"),
             Bytecode::WriteRef => write!(f, "WriteRef"),
             Bytecode::FreezeRef => write!(f, "FreezeRef"),

--- a/third_party/move/move-binary-format/src/file_format_common.rs
+++ b/third_party/move/move-binary-format/src/file_format_common.rs
@@ -789,6 +789,10 @@ pub fn instruction_key(instruction: &Bytecode) -> u8 {
         UnpackVariantGeneric(_) => Opcodes::UNPACK_VARIANT_GENERIC,
         TestVariant(_) => Opcodes::TEST_VARIANT,
         TestVariantGeneric(_) => Opcodes::TEST_VARIANT_GENERIC,
+        // Since bytecode version 8
+        ClosPack(..) | ClosPackGeneric(..) | ClosEval(_) => {
+            unimplemented!("serialization of closure opcodes")
+        },
     };
     opcode as u8
 }

--- a/third_party/move/move-binary-format/src/normalized.rs
+++ b/third_party/move/move-binary-format/src/normalized.rs
@@ -192,6 +192,8 @@ impl Type {
             TypeParameter(i) => Type::TypeParameter(*i),
             Reference(t) => Type::Reference(Box::new(Type::new(m, t))),
             MutableReference(t) => Type::MutableReference(Box::new(Type::new(m, t))),
+
+            Function(..) => panic!("normalized representation does not support function types"),
         }
     }
 

--- a/third_party/move/move-binary-format/src/proptest_types/functions.rs
+++ b/third_party/move/move-binary-format/src/proptest_types/functions.rs
@@ -1062,7 +1062,7 @@ impl BytecodeGen {
         use SignatureToken::*;
         match token {
             U8 | U16 | U32 | U64 | U128 | U256 | Bool | Address | Signer | Struct(_)
-            | TypeParameter(_) => true,
+            | Function(..) | TypeParameter(_) => true,
             Vector(element_token) => BytecodeGen::check_signature_token(element_token),
             StructInstantiation(_, type_arguments) => type_arguments
                 .iter()

--- a/third_party/move/move-binary-format/src/proptest_types/types.rs
+++ b/third_party/move/move-binary-format/src/proptest_types/types.rs
@@ -71,6 +71,7 @@ impl StDefnMaterializeState {
                 let inner = self.potential_abilities(ty);
                 inner.intersect(AbilitySet::VECTOR)
             },
+            Function(_, _, a) => *a,
             Struct(idx) => {
                 let sh = &self.struct_handles[idx.0 as usize];
                 sh.abilities

--- a/third_party/move/move-binary-format/src/serializer.rs
+++ b/third_party/move/move-binary-format/src/serializer.rs
@@ -800,6 +800,9 @@ fn serialize_signature_token_single_node_impl(
             binary.push(SerializedType::TYPE_PARAMETER as u8)?;
             serialize_type_parameter_index(binary, *idx)?;
         },
+        SignatureToken::Function(..) => {
+            unimplemented!("serialization of function types")
+        },
     }
     Ok(())
 }
@@ -1091,6 +1094,9 @@ fn serialize_instruction_inner(
         Bytecode::TestVariantGeneric(class_idx) => {
             binary.push(Opcodes::TEST_VARIANT_GENERIC as u8)?;
             serialize_struct_variant_inst_index(binary, class_idx)
+        },
+        Bytecode::ClosPack(..) | Bytecode::ClosPackGeneric(..) | Bytecode::ClosEval(_) => {
+            unimplemented!("serialization of closure opcodes")
         },
         Bytecode::ReadRef => binary.push(Opcodes::READ_REF as u8),
         Bytecode::WriteRef => binary.push(Opcodes::WRITE_REF as u8),

--- a/third_party/move/move-bytecode-spec/src/lib.rs
+++ b/third_party/move/move-bytecode-spec/src/lib.rs
@@ -129,6 +129,7 @@ static VALID_GROUPS: Lazy<BTreeMap<&str, ()>> = Lazy::new(|| {
         "reference",
         "arithmetic",
         "casting",
+        "closure",
         "bitwise",
         "comparison",
         "boolean",

--- a/third_party/move/move-bytecode-verifier/invalid-mutations/src/bounds.rs
+++ b/third_party/move/move-bytecode-verifier/invalid-mutations/src/bounds.rs
@@ -359,6 +359,6 @@ fn struct_handle(token: &SignatureToken) -> Option<StructHandleIndex> {
         StructInstantiation(sh_idx, _) => Some(*sh_idx),
         Reference(token) | MutableReference(token) => struct_handle(token),
         Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address | Signer | Vector(_)
-        | TypeParameter(_) => None,
+        | TypeParameter(_) | Function(..) => None,
     }
 }

--- a/third_party/move/move-bytecode-verifier/invalid-mutations/src/bounds/code_unit.rs
+++ b/third_party/move/move-bytecode-verifier/invalid-mutations/src/bounds/code_unit.rs
@@ -498,6 +498,9 @@ impl<'a> ApplyCodeUnitBoundsContext<'a> {
                         // TODO(#13806): implement
                         panic!("Enum types bytecode NYI: {:?}", code[bytecode_idx])
                     },
+                    ClosPack(..) | ClosPackGeneric(..) | ClosEval(..) => {
+                        panic!("Closure bytecode NYI: {:?}", code[bytecode_idx])
+                    },
                 };
 
                 code[bytecode_idx] = new_bytecode;
@@ -557,7 +560,10 @@ fn is_interesting(bytecode: &Bytecode) -> bool {
         | LdFalse | ReadRef | WriteRef | Add | Sub | Mul | Mod | Div | BitOr | BitAnd | Xor
         | Shl | Shr | Or | And | Not | Eq | Neq | Lt | Gt | Le | Ge | Abort | Nop => false,
 
-        PackVariant(_)
+        ClosPack(..)
+        | ClosPackGeneric(..)
+        | ClosEval(..)
+        | PackVariant(_)
         | PackVariantGeneric(_)
         | UnpackVariant(_)
         | UnpackVariantGeneric(_)

--- a/third_party/move/move-bytecode-verifier/src/acquires_list_verifier.rs
+++ b/third_party/move/move-bytecode-verifier/src/acquires_list_verifier.rs
@@ -102,7 +102,10 @@ impl<'a> AcquiresVerifier<'a> {
                 self.struct_acquire(si.def, offset)
             },
 
-            Bytecode::Pop
+            Bytecode::ClosPack(..)
+            | Bytecode::ClosPackGeneric(..)
+            | Bytecode::ClosEval(_)
+            | Bytecode::Pop
             | Bytecode::BrTrue(_)
             | Bytecode::BrFalse(_)
             | Bytecode::Abort

--- a/third_party/move/move-bytecode-verifier/src/dependencies.rs
+++ b/third_party/move/move-bytecode-verifier/src/dependencies.rs
@@ -455,6 +455,18 @@ fn compare_types(
         (SignatureToken::Vector(ty1), SignatureToken::Vector(ty2)) => {
             compare_types(context, ty1, ty2, def_module)
         },
+        (
+            SignatureToken::Function(args1, result1, ab1),
+            SignatureToken::Function(args2, result2, ab2),
+        ) => {
+            compare_cross_module_signatures(context, args1, args2, def_module)?;
+            compare_cross_module_signatures(context, result1, result2, def_module)?;
+            if ab1 != ab2 {
+                Err(PartialVMError::new(StatusCode::TYPE_MISMATCH))
+            } else {
+                Ok(())
+            }
+        },
         (SignatureToken::Struct(idx1), SignatureToken::Struct(idx2)) => {
             compare_structs(context, *idx1, *idx2, def_module)
         },
@@ -483,6 +495,7 @@ fn compare_types(
         | (SignatureToken::Address, _)
         | (SignatureToken::Signer, _)
         | (SignatureToken::Vector(_), _)
+        | (SignatureToken::Function(..), _)
         | (SignatureToken::Struct(_), _)
         | (SignatureToken::StructInstantiation(_, _), _)
         | (SignatureToken::Reference(_), _)

--- a/third_party/move/move-bytecode-verifier/src/instantiation_loops.rs
+++ b/third_party/move/move-bytecode-verifier/src/instantiation_loops.rs
@@ -148,6 +148,14 @@ impl<'a> InstantiationLoopChecker<'a> {
                     type_params.insert(*idx);
                 },
                 Vector(ty) => rec(type_params, ty),
+                Function(args, result, _) => {
+                    for ty in args {
+                        rec(type_params, ty);
+                    }
+                    for ty in result {
+                        rec(type_params, ty);
+                    }
+                },
                 Reference(ty) | MutableReference(ty) => rec(type_params, ty),
                 StructInstantiation(_, tys) => {
                     for ty in tys {

--- a/third_party/move/move-bytecode-verifier/src/locals_safety/mod.rs
+++ b/third_party/move/move-bytecode-verifier/src/locals_safety/mod.rs
@@ -125,6 +125,9 @@ fn execute_inner(
         | Bytecode::UnpackVariantGeneric(_)
         | Bytecode::TestVariant(_)
         | Bytecode::TestVariantGeneric(_)
+        | Bytecode::ClosPack(..)
+        | Bytecode::ClosPackGeneric(..)
+        | Bytecode::ClosEval(_)
         | Bytecode::ReadRef
         | Bytecode::WriteRef
         | Bytecode::CastU8

--- a/third_party/move/move-bytecode-verifier/src/signature.rs
+++ b/third_party/move/move-bytecode-verifier/src/signature.rs
@@ -259,6 +259,12 @@ impl<'a> SignatureChecker<'a> {
                     self.check_signature_tokens(type_arguments)
                 },
 
+                // Closure operations not supported by legacy signature checker
+                ClosPack(..) | ClosPackGeneric(..) | ClosEval(_) => {
+                    return Err(PartialVMError::new(StatusCode::UNEXPECTED_VERIFIER_ERROR)
+                        .with_message("closure operations not supported".to_owned()))
+                },
+
                 // List out the other options explicitly so there's a compile error if a new
                 // bytecode gets added.
                 Pop
@@ -363,6 +369,11 @@ impl<'a> SignatureChecker<'a> {
                 }
             },
 
+            SignatureToken::Function(..) => {
+                return Err(PartialVMError::new(StatusCode::UNEXPECTED_VERIFIER_ERROR)
+                    .with_message("function types not supported".to_string()));
+            },
+
             SignatureToken::Struct(_)
             | SignatureToken::Reference(_)
             | SignatureToken::MutableReference(_)
@@ -415,6 +426,8 @@ impl<'a> SignatureChecker<'a> {
                 Err(PartialVMError::new(StatusCode::INVALID_SIGNATURE_TOKEN)
                     .with_message("reference not allowed".to_string()))
             },
+            Function(..) => Err(PartialVMError::new(StatusCode::UNEXPECTED_VERIFIER_ERROR)
+                .with_message("function types not supported".to_string())),
             Vector(ty) => self.check_signature_token(ty),
             StructInstantiation(_, type_arguments) => self.check_signature_tokens(type_arguments),
         }
@@ -464,6 +477,10 @@ impl<'a> SignatureChecker<'a> {
                     sh.type_param_constraints(),
                     type_parameters,
                 )
+            },
+            SignatureToken::Function(..) => {
+                Err(PartialVMError::new(StatusCode::UNEXPECTED_VERIFIER_ERROR)
+                    .with_message("function types not supported".to_string()))
             },
             SignatureToken::Reference(_)
             | SignatureToken::MutableReference(_)

--- a/third_party/move/move-bytecode-verifier/src/signature_v2.rs
+++ b/third_party/move/move-bytecode-verifier/src/signature_v2.rs
@@ -173,6 +173,18 @@ fn check_ty<const N: usize>(
                 param_constraints,
             )?;
         },
+        Function(args, result, abilities) => {
+            assert_abilities(*abilities, required_abilities)?;
+            for ty in args.iter().chain(result.iter()) {
+                check_ty(
+                    struct_handles,
+                    ty,
+                    false,
+                    required_abilities.requires(),
+                    param_constraints,
+                )?;
+            }
+        },
         Struct(sh_idx) => {
             let handle = &struct_handles[sh_idx.0 as usize];
             assert_abilities(handle.abilities, required_abilities)?;
@@ -259,6 +271,11 @@ fn check_phantom_params(
 
     match ty {
         Vector(ty) => check_phantom_params(struct_handles, context, false, ty)?,
+        Function(args, result, _) => {
+            for ty in args.iter().chain(result) {
+                check_phantom_params(struct_handles, context, false, ty)?
+            }
+        },
         StructInstantiation(idx, type_arguments) => {
             let sh = &struct_handles[idx.0 as usize];
             for (i, ty) in type_arguments.iter().enumerate() {
@@ -822,7 +839,7 @@ impl<'a, const N: usize> SignatureChecker<'a, N> {
                 })
             };
             match instr {
-                CallGeneric(idx) => {
+                CallGeneric(idx) | ClosPackGeneric(idx, _) => {
                     if let btree_map::Entry::Vacant(entry) = checked_func_insts.entry(*idx) {
                         let constraints = self.verify_function_instantiation_contextless(*idx)?;
                         map_err(constraints.check_in_context(&ability_context))?;
@@ -881,6 +898,14 @@ impl<'a, const N: usize> SignatureChecker<'a, N> {
                         entry.insert(());
                     }
                 },
+                ClosEval(idx) => {
+                    let sign = self.resolver.signature_at(*idx);
+                    if sign.len() != 1 || !matches!(&sign.0[0], SignatureToken::Function(..)) {
+                        return map_err(Err(PartialVMError::new(
+                            StatusCode::CLOSURE_EVAL_REQUIRES_FUNCTION,
+                        )));
+                    }
+                },
                 VecPack(idx, _)
                 | VecLen(idx)
                 | VecImmBorrow(idx)
@@ -936,6 +961,7 @@ impl<'a, const N: usize> SignatureChecker<'a, N> {
                 | LdTrue
                 | LdFalse
                 | Call(_)
+                | ClosPack(..)
                 | Pack(_)
                 | Unpack(_)
                 | TestVariant(_)

--- a/third_party/move/move-bytecode-verifier/src/struct_defs.rs
+++ b/third_party/move/move-bytecode-verifier/src/struct_defs.rs
@@ -123,6 +123,11 @@ impl<'a> StructDefGraphBuilder<'a> {
                 )
             },
             T::Vector(inner) => self.add_signature_token(neighbors, cur_idx, inner)?,
+            T::Function(args, result, _) => {
+                for t in args.iter().chain(result) {
+                    self.add_signature_token(neighbors, cur_idx, t)?
+                }
+            },
             T::Struct(sh_idx) => {
                 if let Some(struct_def_idx) = self.handle_to_def.get(sh_idx) {
                     neighbors

--- a/third_party/move/move-bytecode-verifier/src/type_safety.rs
+++ b/third_party/move/move-bytecode-verifier/src/type_safety.rs
@@ -11,11 +11,12 @@ use move_binary_format::{
     control_flow_graph::ControlFlowGraph,
     errors::{PartialVMError, PartialVMResult},
     file_format::{
-        AbilitySet, Bytecode, CodeOffset, FunctionDefinitionIndex, FunctionHandle, LocalIndex,
-        Signature, SignatureToken, SignatureToken as ST, StructDefinition, StructDefinitionIndex,
-        StructFieldInformation, StructHandleIndex, VariantIndex,
+        Ability, AbilitySet, Bytecode, ClosureMask, CodeOffset, FunctionDefinitionIndex,
+        FunctionHandle, FunctionHandleIndex, LocalIndex, Signature, SignatureToken,
+        SignatureToken as ST, StructDefinition, StructDefinitionIndex, StructFieldInformation,
+        StructHandleIndex, VariantIndex, Visibility,
     },
-    safe_unwrap,
+    safe_assert, safe_unwrap,
     views::FieldOrVariantIndex,
 };
 use move_core_types::vm_status::StatusCode;
@@ -298,6 +299,115 @@ fn call(
         verifier.push(meter, instantiate(return_type, type_actuals))?
     }
     Ok(())
+}
+
+fn clos_eval(
+    verifier: &mut TypeSafetyChecker,
+    meter: &mut impl Meter,
+    offset: CodeOffset,
+    expected_ty: &SignatureToken,
+) -> PartialVMResult<()> {
+    let SignatureToken::Function(param_tys, ret_tys, abilities) = expected_ty else {
+        // The signature checker has ensured this is a function
+        safe_assert!(false);
+        unreachable!()
+    };
+    // On top of the stack is the closure, pop it.
+    let closure_ty = safe_unwrap!(verifier.stack.pop());
+    // Verify that the closure type matches the expected type
+    if &closure_ty != expected_ty {
+        return Err(verifier
+            .error(StatusCode::CALL_TYPE_MISMATCH_ERROR, offset)
+            .with_message("closure type mismatch".to_owned()));
+    }
+    // Verify that the abilities match
+    let SignatureToken::Function(_, _, closure_abilities) = closure_ty else {
+        // Ensured above, but never panic
+        safe_assert!(false);
+        unreachable!()
+    };
+    if !abilities.is_subset(closure_abilities) {
+        return Err(verifier
+            .error(StatusCode::CALL_TYPE_MISMATCH_ERROR, offset)
+            .with_message("closure ability mismatch".to_owned()));
+    }
+    // Pop and verify arguments
+    for param_ty in param_tys.iter().rev() {
+        let arg_ty = safe_unwrap!(verifier.stack.pop());
+        if &arg_ty != param_ty {
+            return Err(verifier.error(StatusCode::CALL_TYPE_MISMATCH_ERROR, offset));
+        }
+    }
+    for ret_ty in ret_tys {
+        verifier.push(meter, ret_ty.clone())?
+    }
+    Ok(())
+}
+
+fn clos_pack(
+    verifier: &mut TypeSafetyChecker,
+    meter: &mut impl Meter,
+    offset: CodeOffset,
+    func_handle_idx: FunctionHandleIndex,
+    type_actuals: &Signature,
+    mask: ClosureMask,
+) -> PartialVMResult<()> {
+    let func_handle = verifier.resolver.function_handle_at(func_handle_idx);
+    // Check the captured arguments on the stack
+    let param_sign = verifier.resolver.signature_at(func_handle.parameters);
+    let captured_param_tys = mask.extract(&param_sign.0, true);
+    let mut abilities = AbilitySet::ALL;
+    for ty in captured_param_tys.iter().rev() {
+        abilities = abilities.intersect(verifier.abilities(ty)?);
+        let arg = safe_unwrap!(verifier.stack.pop());
+        if (type_actuals.is_empty() && &arg != ty)
+            || (!type_actuals.is_empty() && arg != instantiate(ty, type_actuals))
+        {
+            return Err(verifier
+                .error(StatusCode::PACK_TYPE_MISMATCH_ERROR, offset)
+                .with_message("captured argument type mismatch".to_owned()));
+        }
+        // A captured argument must not be a reference
+        if ty.is_reference() {
+            return Err(verifier
+                .error(StatusCode::PACK_TYPE_MISMATCH_ERROR, offset)
+                .with_message("captured argument must not be a reference".to_owned()));
+        }
+    }
+
+    // In order to determine whether this closure can be storable, we need to figure whether
+    // this function is public.
+    // !!!TODO!!!
+    //   We currently cannot determine for an imported function if it is public or friend. A
+    //   standalone CompiledModule does not give this information. This means that we cannot
+    //   construct storable closures from imported functions for now, which is an
+    //   undesired restriction, so this should be fixed by extending the FunctionHandle data,
+    //   and adding visibility there.
+    let mut is_storable = false;
+    for fun_def in verifier.resolver.function_defs().unwrap_or(&[]) {
+        if fun_def.function == func_handle_idx {
+            // Function defined in this module, so we can check visibility.
+            if fun_def.visibility == Visibility::Public {
+                is_storable = true;
+            }
+            break;
+        }
+    }
+    if !is_storable {
+        abilities.remove(Ability::Store);
+    }
+    abilities.remove(Ability::Key);
+
+    // Construct the resulting function type
+    let not_captured_param_tys = mask.extract(&param_sign.0, false);
+    let ret_sign = verifier.resolver.signature_at(func_handle.return_);
+    verifier.push(
+        meter,
+        instantiate(
+            &SignatureToken::Function(not_captured_param_tys, ret_sign.0.to_vec(), abilities),
+            type_actuals,
+        ),
+    )
 }
 
 fn type_fields_signature(
@@ -725,6 +835,21 @@ fn verify_instr(
             call(verifier, meter, offset, func_handle, type_args)?
         },
 
+        Bytecode::ClosPack(idx, mask) => {
+            clos_pack(verifier, meter, offset, *idx, &Signature(vec![]), *mask)?
+        },
+        Bytecode::ClosPackGeneric(idx, mask) => {
+            let func_inst = verifier.resolver.function_instantiation_at(*idx);
+            let type_args = &verifier.resolver.signature_at(func_inst.type_parameters);
+            verifier.charge_tys(meter, &type_args.0)?;
+            clos_pack(verifier, meter, offset, func_inst.handle, type_args, *mask)?
+        },
+        Bytecode::ClosEval(idx) => {
+            // The signature checker has verified this is a function type.
+            let expected_ty = safe_unwrap!(verifier.resolver.signature_at(*idx).0.first());
+            clos_eval(verifier, meter, offset, expected_ty)?
+        },
+
         Bytecode::Pack(idx) => {
             let struct_definition = verifier.resolver.struct_def_at(*idx)?;
             pack(
@@ -1139,6 +1264,9 @@ fn instantiate(token: &SignatureToken, subst: &Signature) -> SignatureToken {
         return token.clone();
     }
 
+    let inst_vec = |v: &[SignatureToken]| -> Vec<SignatureToken> {
+        v.iter().map(|ty| instantiate(ty, subst)).collect()
+    };
     match token {
         Bool => Bool,
         U8 => U8,
@@ -1150,14 +1278,11 @@ fn instantiate(token: &SignatureToken, subst: &Signature) -> SignatureToken {
         Address => Address,
         Signer => Signer,
         Vector(ty) => Vector(Box::new(instantiate(ty, subst))),
+        Function(args, result, abilities) => Function(inst_vec(args), inst_vec(result), *abilities),
         Struct(idx) => Struct(*idx),
-        StructInstantiation(idx, struct_type_args) => StructInstantiation(
-            *idx,
-            struct_type_args
-                .iter()
-                .map(|ty| instantiate(ty, subst))
-                .collect(),
-        ),
+        StructInstantiation(idx, struct_type_args) => {
+            StructInstantiation(*idx, inst_vec(struct_type_args))
+        },
         Reference(ty) => Reference(Box::new(instantiate(ty, subst))),
         MutableReference(ty) => MutableReference(Box::new(instantiate(ty, subst))),
         TypeParameter(idx) => {

--- a/third_party/move/move-compiler/src/interface_generator.rs
+++ b/third_party/move/move-compiler/src/interface_generator.rs
@@ -348,6 +348,12 @@ fn write_return_type(ctx: &mut Context, tys: &[SignatureToken]) -> String {
 }
 
 fn write_signature_token(ctx: &mut Context, t: &SignatureToken) -> String {
+    let tok_list = |c: &mut Context, v: &[SignatureToken]| {
+        v.iter()
+            .map(|ty| write_signature_token(c, ty))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
     match t {
         SignatureToken::Bool => "bool".to_string(),
         SignatureToken::U8 => "u8".to_string(),
@@ -359,15 +365,13 @@ fn write_signature_token(ctx: &mut Context, t: &SignatureToken) -> String {
         SignatureToken::Address => "address".to_string(),
         SignatureToken::Signer => "signer".to_string(),
         SignatureToken::Vector(inner) => format!("vector<{}>", write_signature_token(ctx, inner)),
+        SignatureToken::Function(args, result, _) => {
+            format!("|{}|{}", tok_list(ctx, args), tok_list(ctx, result))
+        },
         SignatureToken::Struct(idx) => write_struct_handle_type(ctx, *idx),
         SignatureToken::StructInstantiation(idx, types) => {
             let n = write_struct_handle_type(ctx, *idx);
-            let tys = types
-                .iter()
-                .map(|ty| write_signature_token(ctx, ty))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("{}<{}>", n, tys)
+            format!("{}<{}>", n, tok_list(ctx, types))
         },
         SignatureToken::Reference(inner) => format!("&{}", write_signature_token(ctx, inner)),
         SignatureToken::MutableReference(inner) => {

--- a/third_party/move/move-core/types/src/vm_status.rs
+++ b/third_party/move/move-core/types/src/vm_status.rs
@@ -734,12 +734,16 @@ pub enum StatusCode {
     ZERO_VARIANTS_ERROR = 1130,
     // A feature is not enabled.
     FEATURE_NOT_ENABLED = 1131,
+    // Closure mask invalid
+    INVALID_CLOSURE_MASK = 1132,
+    // Closure eval type is not a function
+    CLOSURE_EVAL_REQUIRES_FUNCTION = 1133,
 
     // Reserved error code for future use
-    RESERVED_VERIFICATION_ERROR_2 = 1132,
-    RESERVED_VERIFICATION_ERROR_3 = 1133,
-    RESERVED_VERIFICATION_ERROR_4 = 1134,
-    RESERVED_VERIFICATION_ERROR_5 = 1135,
+    RESERVED_VERIFICATION_ERROR_2 = 1134,
+    RESERVED_VERIFICATION_ERROR_3 = 1135,
+    RESERVED_VERIFICATION_ERROR_4 = 1136,
+    RESERVED_VERIFICATION_ERROR_5 = 1137,
 
     // These are errors that the VM might raise if a violation of internal
     // invariants takes place.
@@ -858,11 +862,14 @@ pub enum StatusCode {
     // Struct variant not matching. This error appears on an attempt to unpack or borrow a
     // field from a value which is not of the expected variant.
     STRUCT_VARIANT_MISMATCH = 4038,
+    // An unimplemented feature in the VM.
+    UNIMPLEMENTED_FEATURE = 4039,
+
     // Reserved error code for future use. Always keep this buffer of well-defined new codes.
-    RESERVED_RUNTIME_ERROR_1 = 4039,
-    RESERVED_RUNTIME_ERROR_2 = 4040,
-    RESERVED_RUNTIME_ERROR_3 = 4041,
-    RESERVED_RUNTIME_ERROR_4 = 4042,
+    RESERVED_RUNTIME_ERROR_1 = 4040,
+    RESERVED_RUNTIME_ERROR_2 = 4041,
+    RESERVED_RUNTIME_ERROR_3 = 4042,
+    RESERVED_RUNTIME_ERROR_4 = 4043,
 
     // A reserved status to represent an unknown vm status.
     // this is std::u64::MAX, but we can't pattern match on that, so put the hardcoded value in

--- a/third_party/move/move-ir-compiler/move-ir-to-bytecode/src/context.rs
+++ b/third_party/move/move-ir-compiler/move-ir-to-bytecode/src/context.rs
@@ -768,6 +768,9 @@ impl<'a> Context<'a> {
                 let correct_inner = self.reindex_signature_token(dep, *inner)?;
                 SignatureToken::Vector(Box::new(correct_inner))
             },
+            SignatureToken::Function(..) => {
+                unimplemented!("function types not supported by MoveIR")
+            },
             SignatureToken::Reference(inner) => {
                 let correct_inner = self.reindex_signature_token(dep, *inner)?;
                 SignatureToken::Reference(Box::new(correct_inner))

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode_generator.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode_generator.rs
@@ -293,6 +293,11 @@ impl<'a> StacklessBytecodeGenerator<'a> {
         };
 
         match bytecode {
+            MoveBytecode::ClosPack(..)
+            | MoveBytecode::ClosPackGeneric(..)
+            | MoveBytecode::ClosEval(..) => {
+                unimplemented!("stackless bytecode generation for closure opcodes")
+            },
             MoveBytecode::Pop => {
                 let temp_index = self.temp_stack.pop().unwrap();
                 self.code

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -1394,6 +1394,10 @@ impl Type {
                         .collect(),
                 )
             },
+            SignatureToken::Function(..) => {
+                // TODO: implement function conversion
+                unimplemented!("signature token to model type")
+            },
         }
     }
 

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1537,6 +1537,14 @@ impl Frame {
                 )?;
 
                 match instruction {
+                    // TODO: implement closures
+                    Bytecode::ClosPack(..)
+                    | Bytecode::ClosPackGeneric(..)
+                    | Bytecode::ClosEval(..) => {
+                        return Err(PartialVMError::new(StatusCode::UNIMPLEMENTED_FEATURE)
+                            .with_message("closure opcodes in interpreter".to_owned()))
+                    },
+
                     Bytecode::Pop => {
                         let popped_val = interpreter.operand_stack.pop()?;
                         gas_meter.charge_pop(popped_val)?;

--- a/third_party/move/move-vm/runtime/src/loader/type_loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader/type_loader.rs
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::{
-    binary_views::BinaryIndexedView, errors::PartialVMResult, file_format::SignatureToken,
+    binary_views::BinaryIndexedView,
+    errors::{PartialVMError, PartialVMResult},
+    file_format::SignatureToken,
 };
+use move_core_types::vm_status::StatusCode;
 use move_vm_types::loaded_data::runtime_types::{AbilityInfo, StructNameIndex, Type};
 use triomphe::Arc as TriompheArc;
 
@@ -27,6 +30,11 @@ pub fn intern_type(
         SignatureToken::Vector(inner_tok) => {
             let inner_type = intern_type(module, inner_tok, struct_name_table)?;
             Type::Vector(TriompheArc::new(inner_type))
+        },
+        SignatureToken::Function(..) => {
+            // TODO: implement closures
+            return Err(PartialVMError::new(StatusCode::UNIMPLEMENTED_FEATURE)
+                .with_message("function types in the type loader".to_owned()));
         },
         SignatureToken::Reference(inner_tok) => {
             let inner_type = intern_type(module, inner_tok, struct_name_table)?;

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -120,6 +120,11 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
         instruction: &Bytecode,
     ) -> PartialVMResult<()> {
         match instruction {
+            // TODO: implement closures
+            Bytecode::ClosPack(..) | Bytecode::ClosPackGeneric(..) | Bytecode::ClosEval(..) => {
+                return Err(PartialVMError::new(StatusCode::UNIMPLEMENTED_FEATURE)
+                    .with_message("closure opcodes in interpreter".to_owned()))
+            },
             // Call instruction will be checked at execute_main.
             Bytecode::Call(_) | Bytecode::CallGeneric(_) => (),
             Bytecode::BrFalse(_) | Bytecode::BrTrue(_) => {
@@ -247,6 +252,12 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
         let ty_builder = resolver.loader().ty_builder();
 
         match instruction {
+            // TODO: implement closures
+            Bytecode::ClosPack(..) | Bytecode::ClosPackGeneric(..) | Bytecode::ClosEval(..) => {
+                return Err(PartialVMError::new(StatusCode::UNIMPLEMENTED_FEATURE)
+                    .with_message("closure opcodes in interpreter".to_owned()))
+            },
+
             Bytecode::BrTrue(_) | Bytecode::BrFalse(_) => (),
             Bytecode::Branch(_)
             | Bytecode::Ret

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -4159,7 +4159,7 @@ impl Value {
             S::Signer => return None,
             S::Vector(inner) => L::Vector(Box::new(Self::constant_sig_token_to_layout(inner)?)),
             // Not yet supported
-            S::Struct(_) | S::StructInstantiation(_, _) => return None,
+            S::Struct(_) | S::StructInstantiation(_, _) | S::Function(..) => return None,
             // Not allowed/Not meaningful
             S::TypeParameter(_) | S::Reference(_) | S::MutableReference(_) => return None,
         })

--- a/third_party/move/tools/move-bytecode-utils/src/layout.rs
+++ b/third_party/move/tools/move-bytecode-utils/src/layout.rs
@@ -386,6 +386,7 @@ impl TypeLayoutBuilder {
     ) -> anyhow::Result<MoveTypeLayout> {
         use SignatureToken::*;
         Ok(match s {
+            Function(..) => bail!("function types NYI for MoveTypeLayout"),
             Vector(t) => MoveTypeLayout::Vector(Box::new(Self::build_from_signature_token(
                 m,
                 t,

--- a/third_party/move/tools/move-disassembler/src/disassembler.rs
+++ b/third_party/move/tools/move-disassembler/src/disassembler.rs
@@ -570,6 +570,9 @@ impl<'a> Disassembler<'a> {
         type_param_context: &[SourceName],
     ) -> Result<String> {
         Ok(match sig_tok {
+            // TODO: function types
+            SignatureToken::Function(..) => unimplemented!("disassembling function sig tokens"),
+
             SignatureToken::Bool => "bool".to_string(),
             SignatureToken::U8 => "u8".to_string(),
             SignatureToken::U16 => "u16".to_string(),
@@ -641,6 +644,9 @@ impl<'a> Disassembler<'a> {
         default_location: &Loc,
     ) -> Result<String> {
         match instruction {
+            Bytecode::ClosPack(..) | Bytecode::ClosPackGeneric(..) | Bytecode::ClosEval(..) => {
+                bail!("closure opcodes not implemented")
+            },
             Bytecode::LdConst(idx) => {
                 let constant = self.source_mapper.bytecode.constant_at(*idx);
                 Ok(format!(

--- a/third_party/move/tools/move-resource-viewer/src/lib.rs
+++ b/third_party/move/tools/move-resource-viewer/src/lib.rs
@@ -375,6 +375,9 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             SignatureToken::Vector(ty) => {
                 FatType::Vector(Box::new(self.resolve_signature(module, ty, limit)?))
             },
+            SignatureToken::Function(..) => {
+                bail!("function types NYI by fat types")
+            },
             SignatureToken::Struct(idx) => {
                 FatType::Struct(Box::new(self.resolve_struct_handle(module, *idx, limit)?))
             },


### PR DESCRIPTION
## Description

This PR implements the extensions needed in the file format for representing closures:

- The type (SignatureToken) has a new variant `Function(args, result, abilities)` to represent a function type
- The opcodes are extendeed by operations `ClosPack`, `ClosPackGeneric`, and `ClosEval`

This supports bit masks for specifyinng which arguments of a function are captured when creating a closure.

Bytecode verification is extended to support the new types and opcodes. The implementation of consistency, type, and reference safety should be complete. What is missing are:

- File format serialization
- Interpreter and value representation
- Value serialization
- Connection of the new types with the various other type representations

This also removes the obsolete crate `testing-infra/test-generation`. This crate already did not support many older bytecode extensions, e.g. vector ops, and is nowhere used.

## How Has This Been Tested?

No tests yet

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

