### PR TITLE
Fix a grammar error in commentary in hello_blockchain.move

### DIFF
--- a/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move
+++ b/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move
@@ -19,7 +19,7 @@ module hello_blockchain::message {
         to_message: string::String,
     }
 
-    /// There is no message present
+    /// There is no message at present
     const ENO_MESSAGE: u64 = 0;
 
     #[view]


### PR DESCRIPTION
## Description
I just found a mistake in the commentary of hello_blockchain.move file and correct it.

## How Has This Been Tested?
Done.

## Key Areas to Review
Commentary.

## Type of Change
- [ ] New feature
- [x ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x ] I tested both happy and unhappy path of the functionality
- [x ] I have made corresponding changes to the documentation

