### PR TITLE
[Compiler-v2][trivial] fix error handling for `match` in expansion phase

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/variants/bug_15073.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/bug_15073.exp
@@ -1,0 +1,15 @@
+
+Diagnostics:
+error: unbound module
+  ┌─ tests/checking/variants/bug_15073.move:8:13
+  │
+8 │             ToolType::Http { uri } => {
+  │             ^^^^^^^^ Unbound module or type alias 'ToolType'
+
+error: invalid assignment
+   ┌─ tests/checking/variants/bug_15073.move:8:13
+   │
+ 8 │ ╭             ToolType::Http { uri } => {
+ 9 │ │
+10 │ │             },
+   │ ╰──────────────^ bind list cannot be constructed

--- a/third_party/move/move-compiler-v2/tests/checking/variants/bug_15073.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/bug_15073.exp
@@ -5,11 +5,3 @@ error: unbound module
   │
 8 │             ToolType::Http { uri } => {
   │             ^^^^^^^^ Unbound module or type alias 'ToolType'
-
-error: invalid assignment
-   ┌─ tests/checking/variants/bug_15073.move:8:13
-   │
- 8 │ ╭             ToolType::Http { uri } => {
- 9 │ │
-10 │ │             },
-   │ ╰──────────────^ bind list cannot be constructed

--- a/third_party/move/move-compiler-v2/tests/checking/variants/bug_15073.move
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/bug_15073.move
@@ -1,0 +1,14 @@
+module 0x815::m {
+
+    public fun init_registration(
+        creator: &signer,
+        tool_type: ToolType
+    ) {
+        match(tool_type) {
+            ToolType::Http { uri } => {
+
+            },
+        }
+
+    }
+}

--- a/third_party/move/move-compiler/src/expansion/translate.rs
+++ b/third_party/move/move-compiler/src/expansion/translate.rs
@@ -2608,10 +2608,12 @@ fn exp_(context: &mut Context, sp!(loc, pe_): P::Exp) -> E::Exp {
                         let body = *exp(context, pb);
                         Some(sp(loc, (bind_list, opt_cond, body)))
                     } else {
-                        context.env.add_diag(diag!(
-                            Syntax::InvalidLValue,
-                            (loc, "bind list cannot be constructed")
-                        ));
+                        if !context.env.has_errors() {
+                            context.env.add_diag(diag!(
+                                Syntax::InvalidLValue,
+                                (loc, "bind list cannot be constructed")
+                            ));
+                        }
                         None
                     }
                 })


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR closes #15073 by generating an error instead of using `expect` when `bind_list` fails during handling `match` statements.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

1) existing tests pass;
2) added a new test.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
