### PR TITLE
[Network] Add metrics for connection operations.

### DIFF
--- a/network/framework/src/connectivity_manager/mod.rs
+++ b/network/framework/src/connectivity_manager/mod.rs
@@ -31,6 +31,7 @@ use crate::{
     application::storage::PeersAndMetadata,
     counters,
     logging::NetworkSchema,
+    peer::DisconnectReason,
     peer_manager::{self, conn_notifs_channel, ConnectionRequestSender, PeerManagerError},
     transport::ConnectionMetadata,
 };
@@ -511,8 +512,10 @@ where
                     stale_peer.short_str()
                 );
 
-                if let Err(disconnect_error) =
-                    self.connection_reqs_tx.disconnect_peer(stale_peer).await
+                if let Err(disconnect_error) = self
+                    .connection_reqs_tx
+                    .disconnect_peer(stale_peer, DisconnectReason::StaleConnection)
+                    .await
                 {
                     info!(
                         NetworkSchema::new(&self.network_context)

--- a/network/framework/src/connectivity_manager/test.rs
+++ b/network/framework/src/connectivity_manager/test.rs
@@ -206,7 +206,7 @@ impl TestHarness {
         info!("Waiting to receive disconnect request");
         let success = result.is_ok();
         match self.connection_reqs_rx.next().await.unwrap() {
-            ConnectionRequest::DisconnectPeer(p, result_tx) => {
+            ConnectionRequest::DisconnectPeer(p, _, result_tx) => {
                 assert_eq!(peer_id, p);
                 result_tx.send(result).unwrap();
             },

--- a/network/framework/src/counters.rs
+++ b/network/framework/src/counters.rs
@@ -28,6 +28,11 @@ pub const SUCCEEDED_LABEL: &str = "succeeded";
 pub const FAILED_LABEL: &str = "failed";
 pub const UNKNOWN_LABEL: &str = "unknown";
 
+// Connection operation labels
+pub const DIAL_LABEL: &str = "dial";
+pub const DIAL_PEER_LABEL: &str = "dial_peer";
+pub const DISCONNECT_LABEL: &str = "disconnect";
+
 // Direction labels
 pub const INBOUND_LABEL: &str = "inbound";
 pub const OUTBOUND_LABEL: &str = "outbound";
@@ -137,6 +142,27 @@ pub fn pending_connection_upgrades(
         network_context.peer_id().short_str().as_str(),
         direction.as_str(),
     ])
+}
+
+/// A simple counter for tracking network connection operations
+pub static APTOS_NETWORK_CONNECTION_OPERATIONS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_network_connection_operations",
+        "Counter for tracking connection operations",
+        &["network_id", "operation", "label"]
+    )
+    .unwrap()
+});
+
+/// Updates the network connection operation metrics with the given operation and label
+pub fn update_network_connection_operation_metrics(
+    network_context: &NetworkContext,
+    operation: String,
+    label: String,
+) {
+    APTOS_NETWORK_CONNECTION_OPERATIONS
+        .with_label_values(&[network_context.network_id().as_str(), &operation, &label])
+        .inc();
 }
 
 pub static APTOS_NETWORK_CONNECTION_UPGRADE_TIME: Lazy<HistogramVec> = Lazy::new(|| {

--- a/network/framework/src/lib.rs
+++ b/network/framework/src/lib.rs
@@ -28,6 +28,5 @@ pub mod fuzzing;
 #[cfg(any(test, feature = "testing", feature = "fuzzing"))]
 pub mod testutils;
 
-pub type DisconnectReason = peer::DisconnectReason;
 pub type ConnectivityRequest = connectivity_manager::ConnectivityRequest;
 pub type ProtocolId = protocols::wire::handshake::v1::ProtocolId;

--- a/network/framework/src/peer/test.rs
+++ b/network/framework/src/peer/test.rs
@@ -368,13 +368,13 @@ fn peers_send_message_concurrent() {
         // Check that we received both shutdown events
         assert_disconnected_event(
             remote_peer_id_a,
-            DisconnectReason::Requested,
+            DisconnectReason::RequestedByPeerManager,
             &mut connection_notifs_rx_a,
         )
         .await;
         assert_disconnected_event(
             remote_peer_id_b,
-            DisconnectReason::ConnectionLost,
+            DisconnectReason::ConnectionClosed,
             &mut connection_notifs_rx_b,
         )
         .await;
@@ -905,7 +905,7 @@ fn peer_disconnect_request() {
         drop(peer_handle);
         assert_disconnected_event(
             remote_peer_id,
-            DisconnectReason::Requested,
+            DisconnectReason::RequestedByPeerManager,
             &mut connection_notifs_rx,
         )
         .await;
@@ -932,7 +932,7 @@ fn peer_disconnect_connection_lost() {
         connection.close().await.unwrap();
         assert_disconnected_event(
             remote_peer_id,
-            DisconnectReason::ConnectionLost,
+            DisconnectReason::ConnectionClosed,
             &mut connection_notifs_rx,
         )
         .await;
@@ -1019,13 +1019,13 @@ fn peers_send_multiplex() {
         // Check that we received both shutdown events
         assert_disconnected_event(
             remote_peer_id_a,
-            DisconnectReason::Requested,
+            DisconnectReason::RequestedByPeerManager,
             &mut connection_notifs_rx_a,
         )
         .await;
         assert_disconnected_event(
             remote_peer_id_b,
-            DisconnectReason::ConnectionLost,
+            DisconnectReason::ConnectionClosed,
             &mut connection_notifs_rx_b,
         )
         .await;

--- a/network/framework/src/peer_manager/senders.rs
+++ b/network/framework/src/peer_manager/senders.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    peer::DisconnectReason,
     peer_manager::{types::PeerManagerRequest, ConnectionRequest, PeerManagerError},
     protocols::{
         direct_send::Message,
@@ -125,10 +126,16 @@ impl ConnectionRequestSender {
         oneshot_rx.await?
     }
 
-    pub async fn disconnect_peer(&self, peer: PeerId) -> Result<(), PeerManagerError> {
+    pub async fn disconnect_peer(
+        &self,
+        peer: PeerId,
+        disconnect_reason: DisconnectReason,
+    ) -> Result<(), PeerManagerError> {
         let (oneshot_tx, oneshot_rx) = oneshot::channel();
-        self.inner
-            .push(peer, ConnectionRequest::DisconnectPeer(peer, oneshot_tx))?;
+        self.inner.push(
+            peer,
+            ConnectionRequest::DisconnectPeer(peer, disconnect_reason, oneshot_tx),
+        )?;
         oneshot_rx.await?
     }
 }

--- a/network/framework/src/peer_manager/tests.rs
+++ b/network/framework/src/peer_manager/tests.rs
@@ -191,7 +191,7 @@ async fn check_correct_connection_is_live(
         assert_peer_disconnected_event(
             expected_peer_id,
             dropped_connection_origin,
-            DisconnectReason::Requested,
+            DisconnectReason::RequestedByPeerManager,
             peer_manager,
         )
         .await;
@@ -218,7 +218,7 @@ async fn check_correct_connection_is_live(
     assert_peer_disconnected_event(
         expected_peer_id,
         live_connection_origin,
-        DisconnectReason::ConnectionLost,
+        DisconnectReason::ConnectionClosed,
         peer_manager,
     )
     .await;
@@ -580,7 +580,7 @@ fn peer_manager_simultaneous_dial_disconnect_event() {
                 ProtocolIdSet::mock(),
                 PeerRole::Unknown,
             ),
-            DisconnectReason::ConnectionLost,
+            DisconnectReason::ConnectionClosed,
         );
         peer_manager.handle_connection_event(event);
         // The active connection should still remain.
@@ -621,6 +621,7 @@ fn test_dial_disconnect() {
         peer_manager
             .handle_outbound_connection_request(ConnectionRequest::DisconnectPeer(
                 ids[0],
+                DisconnectReason::ConnectionClosed,
                 disconnect_resp_tx,
             ))
             .await;
@@ -636,7 +637,7 @@ fn test_dial_disconnect() {
                 ProtocolIdSet::mock(),
                 PeerRole::Unknown,
             ),
-            DisconnectReason::Requested,
+            DisconnectReason::RequestedByPeerManager,
         );
         peer_manager.handle_connection_event(event);
 

--- a/network/framework/src/peer_manager/types.rs
+++ b/network/framework/src/peer_manager/types.rs
@@ -31,6 +31,7 @@ pub enum ConnectionRequest {
     ),
     DisconnectPeer(
         PeerId,
+        DisconnectReason,
         #[serde(skip)] oneshot::Sender<Result<(), PeerManagerError>>,
     ),
 }

--- a/network/framework/src/protocols/health_checker/interface.rs
+++ b/network/framework/src/protocols/health_checker/interface.rs
@@ -7,6 +7,7 @@ use crate::{
         error::Error, interface::NetworkClientInterface, metadata::ConnectionState,
         storage::PeersAndMetadata,
     },
+    peer::DisconnectReason,
     protocols::{
         health_checker::{HealthCheckerMsg, HealthCheckerNetworkEvents},
         network::Event,
@@ -62,12 +63,16 @@ impl<NetworkClient: NetworkClientInterface<HealthCheckerMsg>>
 
     /// Disconnect a peer, and keep track of the associated state
     /// Note: This removes the peer outright for now until we add GCing, and historical state management
-    pub async fn disconnect_peer(&mut self, peer_network_id: PeerNetworkId) -> Result<(), Error> {
+    pub async fn disconnect_peer(
+        &mut self,
+        peer_network_id: PeerNetworkId,
+        disconnect_reason: DisconnectReason,
+    ) -> Result<(), Error> {
         // Possibly already disconnected, but try anyways
         let _ = self.update_connection_state(peer_network_id, ConnectionState::Disconnecting);
         let result = self
             .network_client
-            .disconnect_from_peer(peer_network_id)
+            .disconnect_from_peer(peer_network_id, disconnect_reason)
             .await;
         let peer_id = peer_network_id.peer_id();
         if result.is_ok() {

--- a/network/framework/src/protocols/health_checker/mod.rs
+++ b/network/framework/src/protocols/health_checker/mod.rs
@@ -23,6 +23,7 @@ use crate::{
     constants::NETWORK_CHANNEL_SIZE,
     counters,
     logging::NetworkSchema,
+    peer::DisconnectReason,
     peer_manager::ConnectionNotification,
     protocols::{
         health_checker::interface::HealthCheckNetworkInterface,
@@ -372,7 +373,10 @@ impl<NetworkClient: NetworkClientInterface<HealthCheckerMsg> + Unpin> HealthChec
                         PeerNetworkId::new(self.network_context.network_id(), peer_id);
                     if let Err(err) = timeout(
                         Duration::from_millis(50),
-                        self.network_interface.disconnect_peer(peer_network_id),
+                        self.network_interface.disconnect_peer(
+                            peer_network_id,
+                            DisconnectReason::NetworkHealthCheckFailure,
+                        ),
                     )
                     .await
                     {

--- a/network/framework/src/protocols/health_checker/test.rs
+++ b/network/framework/src/protocols/health_checker/test.rs
@@ -163,7 +163,7 @@ impl TestHarness {
     async fn expect_disconnect(&mut self, expected_peer_id: PeerId) {
         let req = self.connection_reqs_rx.next().await.unwrap();
         let (peer_id, res_tx) = match req {
-            ConnectionRequest::DisconnectPeer(peer_id, res_tx) => (peer_id, res_tx),
+            ConnectionRequest::DisconnectPeer(peer_id, _, res_tx) => (peer_id, res_tx),
             _ => panic!("Unexpected ConnectionRequest: {:?}", req),
         };
         assert_eq!(peer_id, expected_peer_id);

--- a/network/framework/src/protocols/network/mod.rs
+++ b/network/framework/src/protocols/network/mod.rs
@@ -7,6 +7,7 @@
 pub use crate::protocols::rpc::error::RpcError;
 use crate::{
     error::NetworkError,
+    peer::DisconnectReason,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::wire::messaging::v1::{IncomingRequest, NetworkMessage},
     ProtocolId,
@@ -377,8 +378,14 @@ impl<TMessage> NetworkSender<TMessage> {
 
     /// Request that a given Peer be disconnected and synchronously wait for the request to be
     /// performed.
-    pub async fn disconnect_peer(&self, peer: PeerId) -> Result<(), NetworkError> {
-        self.connection_reqs_tx.disconnect_peer(peer).await?;
+    pub async fn disconnect_peer(
+        &self,
+        peer: PeerId,
+        disconnect_reason: DisconnectReason,
+    ) -> Result<(), NetworkError> {
+        self.connection_reqs_tx
+            .disconnect_peer(peer, disconnect_reason)
+            .await?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Description
This PR adds two simple metrics to the network code, tracking: (i) the number of peer dials; and (ii) the number of peer disconnects (including disconnect reason). I've also gone through and updated the various disconnect reasons so that it is easier to reason about.

## Testing Plan
Existing test infrastructure and manual verification, i.e., I hacked the code so that it would force network health check disconnects. You can see the run [here](https://grafana.aptoslabs.com/d/overview/overview?orgId=1&refresh=10s&var-Datasource=VictoriaMetrics%20Global%20%28Non-mainnet%29&var-BigQuery=Google%20BigQuery&var-namespace=forge-e2e-pr-15174&var-metrics_source=All&var-chain_name=forge-0&from=1730759704000&to=1730760451000), and the network metrics [showing](https://grafana.aptoslabs.com/d/network/network?from=2024-11-04T22:35:04.000Z&to=2024-11-04T22:47:31.000Z&var-Datasource=fHo-R604z&var-BigQuery=axNEitxVz&var-metrics_source=$__all&var-chain_name=forge-0&var-cluster=$__all&var-namespace=forge-e2e-pr-15174&var-kubernetes_pod_name=$__all&var-interval=$__auto&var-role=$__all&var-Filters=&viewPanel=panel-177) the disconnects.