### PR TITLE
[trivial] Add intrinsic for limit for aggregator and update movefmt version

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/aggregator.md
+++ b/aptos-move/framework/aptos-framework/doc/aggregator.md
@@ -330,10 +330,9 @@ Destroys an aggregator and removes it from its <code>AggregatorFactory</code>.
 
 
 
-<pre><code><b>pragma</b> opaque;
+<pre><code><b>pragma</b> intrinsic;
 // This enforces <a id="high-level-req-1.2" href="#high-level-req">high-level requirement 1</a>:
-<b>aborts_if</b> <b>false</b>;
-<b>ensures</b> [abstract] result == <a href="aggregator.md#0x1_aggregator_spec_get_limit">spec_get_limit</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>);
+<b>aborts_if</b> [abstract] <b>false</b>;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/aggregator/aggregator.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/aggregator.spec.move
@@ -59,10 +59,9 @@ spec aptos_framework::aggregator {
     }
 
     spec limit {
-        pragma opaque;
+        pragma intrinsic;
         /// [high-level-req-1.2]
-        aborts_if false;
-        ensures [abstract] result == spec_get_limit(aggregator);
+        aborts_if [abstract] false;
     }
 
     spec native fun spec_read(aggregator: Aggregator): u128;

--- a/aptos-move/framework/src/aptos-natives.bpl
+++ b/aptos-move/framework/src/aptos-natives.bpl
@@ -266,6 +266,13 @@ function {:inline} $IsEqual'$1_aggregator_Aggregator'(s1: $1_aggregator_Aggregat
 function {:inline} $1_aggregator_spec_get_limit(s: $1_aggregator_Aggregator): int {
     s->$limit
 }
+function {:inline} $1_aggregator_limit(s: $1_aggregator_Aggregator): int {
+    s->$limit
+}
+procedure {:inline 1} $1_aggregator_limit(s: $1_aggregator_Aggregator) returns (res: int) {
+    res := s->$limit;
+    return;
+}
 function {:inline} $1_aggregator_spec_get_handle(s: $1_aggregator_Aggregator): int {
     s->$handle
 }

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 ## Unreleased
 - Fix typos in `aptos move compile` help text.
+- Update the default version of `movefmt` to be installed from 1.0.5 to 1.0.6
 
 ## [4.3.0] - 2024/10/30
 - Allow for setting large-packages module for chunking publish mode with `--large-packages-module-address`

--- a/crates/aptos/src/update/movefmt.rs
+++ b/crates/aptos/src/update/movefmt.rs
@@ -13,7 +13,7 @@ use self_update::update::ReleaseUpdate;
 use std::path::PathBuf;
 
 const FORMATTER_BINARY_NAME: &str = "movefmt";
-const TARGET_FORMATTER_VERSION: &str = "1.0.5";
+const TARGET_FORMATTER_VERSION: &str = "1.0.6";
 
 const FORMATTER_EXE_ENV: &str = "FORMATTER_EXE";
 #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR

1) closes #15135 by adding intrinsic implementation of `limit` method for `aggregator`
2) updates installation of movefmt from 1.0.5 to 1.0.6.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

1) existing tests pass with no warning;
2) manual CLI test

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] prover and movefmt

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
