### PR TITLE
update_wasm_bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-dynamic-transaction-composer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -1395,7 +1395,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "tsify-next",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -8801,19 +8800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "goldenfile"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15275,17 +15261,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
 name = "serde_json"
 version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17225,31 +17200,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "termcolor",
-]
-
-[[package]]
-name = "tsify-next"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4a645dca4ee0800f5ab60ce166deba2db6a0315de795a2691e138a3d55d756"
-dependencies = [
- "gloo-utils",
- "serde",
- "serde_json",
- "tsify-next-macros",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "tsify-next-macros"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5c06f8a51d759bb58129e30b2631739e7e1e4579fad1f30ac09a6c88e488a6"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.87",
 ]
 
 [[package]]

--- a/aptos-move/script-composer/Cargo.toml
+++ b/aptos-move/script-composer/Cargo.toml
@@ -27,7 +27,6 @@ reqwest = { workspace = true, features = ["blocking"] }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
-tsify-next = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 

--- a/aptos-move/script-composer/Cargo.toml
+++ b/aptos-move/script-composer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos-dynamic-transaction-composer"
 description = "Generating Move Script from a batched Move calls"
-version = "0.1.0"
+version = "0.1.1"
 
 # Workspace inherited keys
 authors = { workspace = true }

--- a/aptos-move/script-composer/src/lib.rs
+++ b/aptos-move/script-composer/src/lib.rs
@@ -11,7 +11,6 @@ use move_core_types::{
     language_storage::{ModuleId, TypeTag},
 };
 use serde::{Deserialize, Serialize};
-use tsify_next::Tsify;
 use wasm_bindgen::prelude::wasm_bindgen;
 
 mod builder;
@@ -26,6 +25,7 @@ pub mod tests;
 pub static APTOS_SCRIPT_COMPOSER_KEY: &[u8] = "aptos::script_composer".as_bytes();
 
 /// Representing a returned value from a previous list of `MoveFunctionCall`s.
+#[wasm_bindgen]
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PreviousResult {
     /// Refering to the return value in the `call_idx`th call.
@@ -38,8 +38,7 @@ pub struct PreviousResult {
 }
 
 /// Arguments to the `MoveFunctionCall`.
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum CallArgument {
     /// Passing raw bytes to the function. The bytes must follows the existing constraints for
     /// transaction arguments.
@@ -92,7 +91,6 @@ impl MoveFunctionCall {
     }
 }
 
-#[wasm_bindgen]
 impl CallArgument {
     pub fn new_bytes(bytes: Vec<u8>) -> Self {
         CallArgument::Raw(bytes)
@@ -114,7 +112,10 @@ impl CallArgument {
         self.change_op_type(ArgumentOperation::Copy)
     }
 
-    fn change_op_type(&self, operation_type: ArgumentOperation) -> Result<CallArgument, String> {
+    pub(crate) fn change_op_type(
+        &self,
+        operation_type: ArgumentOperation,
+    ) -> Result<CallArgument, String> {
         match &self {
             CallArgument::PreviousResult(r) => {
                 let mut result = r.clone();


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Changing the representation of a `CallArgument` to use struct instead of enum for our WASM binding. The reason is that the wasm bindgen support for ADT enum is very minimum and is not usable for typescript. Change the representation to struct will fix this issue.

## How Has This Been Tested?

Existing tests shall pass.

## Key Areas to Review

N/A

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
