### PR TITLE
WriteOp carries StateValue

### DIFF
--- a/aptos-move/aptos-vm-types/src/abstract_write_op.rs
+++ b/aptos-move/aptos-vm-types/src/abstract_write_op.rs
@@ -111,7 +111,7 @@ impl AbstractResourceWriteOp {
 
     /// Deposit amount is inserted into metadata at a different time than the WriteOp is created.
     /// So this method is needed to be able to update metadata generically across different variants.
-    pub fn get_metadata_mut(&mut self) -> &mut StateValueMetadata {
+    pub fn metadata_mut(&mut self) -> &mut StateValueMetadata {
         use AbstractResourceWriteOp::*;
         match self {
             Write(write_op)
@@ -119,7 +119,7 @@ impl AbstractResourceWriteOp {
             | WriteResourceGroup(GroupWrite {
                 metadata_op: write_op,
                 ..
-            }) => write_op.get_metadata_mut(),
+            }) => write_op.metadata_mut(),
             InPlaceDelayedFieldChange(InPlaceDelayedFieldChangeOp { metadata, .. })
             | ResourceGroupInPlaceDelayedFieldChange(ResourceGroupInPlaceDelayedFieldChangeOp {
                 metadata,

--- a/aptos-move/aptos-vm-types/src/change_set.rs
+++ b/aptos-move/aptos-vm-types/src/change_set.rs
@@ -411,18 +411,18 @@ impl VMChangeSet {
             if let Some(write_op) = aggregator_v1_write_set.get_mut(&state_key) {
                 // In this case, delta follows a write op.
                 match write_op {
-                    Creation { data, .. } | Modification { data, .. } => {
+                    Creation(v) | Modification(v) => {
                         // Apply delta on top of creation or modification.
                         // TODO[agg_v1](cleanup): This will not be needed anymore once aggregator
                         // change sets carry non-serialized information.
-                        let base: u128 = bcs::from_bytes(data)
+                        let base: u128 = bcs::from_bytes(v.bytes())
                             .expect("Deserializing into an aggregator value always succeeds");
                         let value = additional_delta_op
                             .apply_to(base)
                             .map_err(PartialVMError::from)?;
-                        *data = serialize(&value).into();
+                        v.set_bytes(serialize(&value).into())
                     },
-                    Deletion { .. } => {
+                    Deletion(..) => {
                         // This case (applying a delta to deleted item) should
                         // never happen. Let's still return an error instead of
                         // panicking.
@@ -883,7 +883,7 @@ impl ChangeSetInterface for VMChangeSet {
                 key,
                 op_size: op.materialized_size(),
                 prev_size: op.prev_materialized_size(key, executor_view)?,
-                metadata_mut: op.get_metadata_mut(),
+                metadata_mut: op.metadata_mut(),
             })
         });
         let v1_aggregators = self.aggregator_v1_write_set.iter_mut().map(|(key, op)| {
@@ -893,7 +893,7 @@ impl ChangeSetInterface for VMChangeSet {
                 prev_size: executor_view
                     .get_aggregator_v1_state_value_size(key)?
                     .unwrap_or(0),
-                metadata_mut: op.get_metadata_mut(),
+                metadata_mut: op.metadata_mut(),
             })
         });
 

--- a/aptos-move/aptos-vm-types/src/module_write_set.rs
+++ b/aptos-move/aptos-vm-types/src/module_write_set.rs
@@ -123,7 +123,7 @@ impl ModuleWriteSet {
                 key,
                 op_size: write.write_op().write_op_size(),
                 prev_size,
-                metadata_mut: write.write_op_mut().get_metadata_mut(),
+                metadata_mut: write.write_op_mut().metadata_mut(),
             })
         })
     }

--- a/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
+++ b/aptos-move/aptos-vm-types/src/tests/test_change_set.rs
@@ -436,10 +436,7 @@ fn test_aggregator_v2_snapshots_and_derived() {
 
 #[test]
 fn test_resource_groups_squashing() {
-    let modification_metadata = WriteOp::Modification {
-        data: Bytes::new(),
-        metadata: raw_metadata(2000),
-    };
+    let modification_metadata = WriteOp::modification(Bytes::new(), raw_metadata(2000));
 
     macro_rules! as_create_op {
         ($val:expr) => {
@@ -593,10 +590,7 @@ fn test_write_and_read_discrepancy_caught() {
         )])
         .try_build());
 
-    let metadata_op = WriteOp::Modification {
-        data: Bytes::new(),
-        metadata: raw_metadata(1000),
-    };
+    let metadata_op = WriteOp::modification(Bytes::new(), raw_metadata(1000));
     let group_size = ResourceGroupSize::Combined {
         num_tagged_resources: 1,
         all_tagged_resources_size: 14,
@@ -637,17 +631,9 @@ mod tests {
 
     pub(crate) fn write_op_with_metadata(type_idx: u8, v: u128) -> WriteOp {
         match type_idx {
-            CREATION => WriteOp::Creation {
-                data: vec![].into(),
-                metadata: raw_metadata(v as u64),
-            },
-            MODIFICATION => WriteOp::Modification {
-                data: vec![].into(),
-                metadata: raw_metadata(v as u64),
-            },
-            DELETION => WriteOp::Deletion {
-                metadata: raw_metadata(v as u64),
-            },
+            CREATION => WriteOp::creation(vec![].into(), raw_metadata(v as u64)),
+            MODIFICATION => WriteOp::modification(vec![].into(), raw_metadata(v as u64)),
+            DELETION => WriteOp::deletion(raw_metadata(v as u64)),
             _ => unreachable!("Wrong type index for test"),
         }
     }
@@ -694,9 +680,7 @@ mod tests {
             None
         );
         assert_group_write_size!(
-            WriteOp::Deletion {
-                metadata: raw_metadata(10)
-            },
+            WriteOp::deletion(raw_metadata(10)),
             ResourceGroupSize::zero_combined(),
             None
         );
@@ -729,10 +713,7 @@ mod tests {
             Some(sizes[0])
         );
         assert_group_write_size!(
-            WriteOp::Creation {
-                data: Bytes::new(),
-                metadata: raw_metadata(20)
-            },
+            WriteOp::creation(Bytes::new(), raw_metadata(20)),
             sizes[1],
             Some(sizes[1])
         );
@@ -742,10 +723,7 @@ mod tests {
             Some(sizes[2])
         );
         assert_group_write_size!(
-            WriteOp::Modification {
-                data: Bytes::new(),
-                metadata: raw_metadata(30)
-            },
+            WriteOp::modification(Bytes::new(), raw_metadata(30)),
             sizes[3],
             Some(sizes[3])
         );

--- a/aptos-move/e2e-move-tests/src/tests/storage_refund.rs
+++ b/aptos-move/e2e-move-tests/src/tests/storage_refund.rs
@@ -159,7 +159,7 @@ fn assert_result(
     for (_state_key, write_op) in txn_out.write_set() {
         match write_op {
             WriteOp::Creation { .. } => creates += 1,
-            WriteOp::Deletion { metadata } => {
+            WriteOp::Deletion(metadata) => {
                 if metadata.is_none() {
                     panic!("This test expects all deletions to have metadata")
                 }

--- a/crates/aptos-rosetta/src/test/mod.rs
+++ b/crates/aptos-rosetta/src/test/mod.rs
@@ -98,10 +98,10 @@ fn resource_group_modification_write_op<T: Serialize>(
 ) -> (StateKey, WriteOp) {
     let encoded = bcs::to_bytes(input).unwrap();
     let state_key = StateKey::resource_group(address, resource);
-    let write_op = WriteOp::Modification {
-        data: encoded.into(),
-        metadata: StateValueMetadata::new(0, 0, &CurrentTimeMicroseconds { microseconds: 0 }),
-    };
+    let write_op = WriteOp::modification(
+        encoded.into(),
+        StateValueMetadata::new(0, 0, &CurrentTimeMicroseconds { microseconds: 0 }),
+    );
     (state_key, write_op)
 }
 

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/stream_coordinator.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/stream_coordinator.rs
@@ -475,7 +475,7 @@ impl IndexerStreamCoordinator {
                 .iter()
                 .map(|(state_key, write_op)| WriteOpSizeInfo {
                     key_bytes: Self::ser_size_u32(state_key),
-                    value_bytes: write_op.size() as u32,
+                    value_bytes: write_op.bytes_size() as u32,
                 })
                 .collect(),
         }

--- a/testsuite/generate-format/src/api.rs
+++ b/testsuite/generate-format/src/api.rs
@@ -15,10 +15,7 @@ use aptos_types::{
     account_config::{CoinStoreResource, DepositEvent, WithdrawEvent},
     block_metadata_ext::BlockMetadataExt,
     contract_event, event,
-    state_store::{
-        state_key::StateKey,
-        state_value::{PersistedStateValueMetadata, StateValueMetadata},
-    },
+    state_store::{state_key::StateKey, state_value::PersistedStateValueMetadata},
     transaction::{
         self,
         authenticator::{AccountAuthenticator, TransactionAuthenticator},

--- a/testsuite/generate-format/src/api.rs
+++ b/testsuite/generate-format/src/api.rs
@@ -95,9 +95,7 @@ pub fn get_registry() -> Result<Registry> {
     // 1. Record samples for types with custom deserializers.
     trace_crypto_values(&mut tracer, &mut samples)?;
     tracer.trace_value(&mut samples, &event::EventKey::random())?;
-    tracer.trace_value(&mut samples, &write_set::WriteOp::Deletion {
-        metadata: StateValueMetadata::none(),
-    })?;
+    tracer.trace_value(&mut samples, &write_set::WriteOp::legacy_deletion())?;
 
     // 2. Trace the main entry point(s) + every enum separately.
     // stdlib types

--- a/testsuite/generate-format/src/aptos.rs
+++ b/testsuite/generate-format/src/aptos.rs
@@ -14,10 +14,7 @@ use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use aptos_types::{
     block_metadata_ext::BlockMetadataExt,
     contract_event, event,
-    state_store::{
-        state_key::StateKey,
-        state_value::{PersistedStateValueMetadata, StateValueMetadata},
-    },
+    state_store::{state_key::StateKey, state_value::PersistedStateValueMetadata},
     transaction,
     transaction::block_epilogue::BlockEpiloguePayload,
     validator_txn::ValidatorTransaction,
@@ -90,9 +87,7 @@ pub fn get_registry() -> Result<Registry> {
     // 1. Record samples for types with custom deserializers.
     trace_crypto_values(&mut tracer, &mut samples)?;
     tracer.trace_value(&mut samples, &event::EventKey::random())?;
-    tracer.trace_value(&mut samples, &write_set::WriteOp::Deletion {
-        metadata: StateValueMetadata::none(),
-    })?;
+    tracer.trace_value(&mut samples, &write_set::WriteOp::legacy_deletion())?;
 
     // 2. Trace the main entry point(s) + every enum separately.
     tracer.trace_type::<contract_event::ContractEvent>(&samples)?;

--- a/testsuite/generate-format/src/consensus.rs
+++ b/testsuite/generate-format/src/consensus.rs
@@ -14,10 +14,7 @@ use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use aptos_types::{
     block_metadata_ext::BlockMetadataExt,
     contract_event, event,
-    state_store::{
-        state_key::StateKey,
-        state_value::{PersistedStateValueMetadata, StateValueMetadata},
-    },
+    state_store::{state_key::StateKey, state_value::PersistedStateValueMetadata},
     transaction,
     transaction::block_epilogue::BlockEpiloguePayload,
     validator_txn::ValidatorTransaction,
@@ -89,9 +86,7 @@ pub fn get_registry() -> Result<Registry> {
         &aptos_consensus_types::block::Block::make_genesis_block(),
     )?;
     tracer.trace_value(&mut samples, &event::EventKey::random())?;
-    tracer.trace_value(&mut samples, &write_set::WriteOp::Deletion {
-        metadata: StateValueMetadata::none(),
-    })?;
+    tracer.trace_value(&mut samples, &write_set::WriteOp::legacy_deletion())?;
 
     // 2. Trace the main entry point(s) + every enum separately.
     tracer.trace_type::<contract_event::ContractEvent>(&samples)?;

--- a/types/src/state_store/state_value.rs
+++ b/types/src/state_store/state_value.rs
@@ -280,6 +280,23 @@ impl StateValue {
         ))
     }
 
+    pub fn into_bytes(self) -> Bytes {
+        self.inner.data
+    }
+
+    pub fn set_bytes(&mut self, data: Bytes) {
+        self.inner.data = data;
+        self.hash = OnceCell::new();
+    }
+
+    pub fn metadata(&self) -> &StateValueMetadata {
+        &self.inner.metadata
+    }
+
+    pub fn metadata_mut(&mut self) -> &mut StateValueMetadata {
+        &mut self.inner.metadata
+    }
+
     pub fn into_metadata(self) -> StateValueMetadata {
         self.inner.metadata
     }

--- a/types/src/transaction/change_set.rs
+++ b/types/src/transaction/change_set.rs
@@ -5,7 +5,7 @@
 use crate::{contract_event::ContractEvent, write_set::WriteSet};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ChangeSet {
     write_set: WriteSet,
     events: Vec<ContractEvent>,

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -433,7 +433,7 @@ impl TransactionPayload {
 }
 
 /// Two different kinds of WriteSet transactions.
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum WriteSetPayload {
     /// Directly passing in the WriteSet.
     Direct(ChangeSet),

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -94,7 +94,7 @@ impl PersistedWriteOp {
     }
 }
 
-#[derive(Clone, Eq, Hash, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub enum WriteOp {
     Creation {
         data: Bytes,
@@ -442,9 +442,7 @@ impl std::fmt::Debug for WriteOp {
     }
 }
 
-#[derive(
-    BCSCryptoHash, Clone, CryptoHasher, Debug, Eq, Hash, PartialEq, Serialize, Deserialize,
-)]
+#[derive(BCSCryptoHash, Clone, CryptoHasher, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum WriteSet {
     V0(WriteSetV0),
 }
@@ -485,7 +483,7 @@ impl DerefMut for WriteSet {
 /// where `Value(val)` means that serialized representation should be updated to `val`, and
 /// `Deletion` means that we are going to delete this access path.
 #[derive(
-    BCSCryptoHash, Clone, CryptoHasher, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize,
+    BCSCryptoHash, Clone, CryptoHasher, Debug, Default, Eq, PartialEq, Serialize, Deserialize,
 )]
 pub struct WriteSetV0(WriteSetMut);
 
@@ -532,7 +530,7 @@ impl WriteSetV0 {
 /// A mutable version of `WriteSet`.
 ///
 /// This is separate because it goes through validation before becoming an immutable `WriteSet`.
-#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct WriteSetMut {
     // TODO: Change to HashMap with a stable iterator for serialization.
     write_set: BTreeMap<StateKey, WriteOp>,

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -5,12 +5,9 @@
 //! For each transaction the VM executes, the VM will output a `WriteSet` that contains each access
 //! path it updates. For each access path, the VM can either give its new value or delete it.
 
-use crate::{
-    state_store::{
-        state_key::StateKey,
-        state_value::{PersistedStateValueMetadata, StateValue, StateValueMetadata},
-    },
-    write_set::WriteOp::{Creation, Deletion, Modification},
+use crate::state_store::{
+    state_key::StateKey,
+    state_value::{PersistedStateValueMetadata, StateValue, StateValueMetadata},
 };
 use anyhow::{bail, ensure, Result};
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
@@ -68,45 +65,25 @@ impl PersistedWriteOp {
         use PersistedWriteOp::*;
 
         match self {
-            Creation(data) => WriteOp::Creation {
-                data,
-                metadata: StateValueMetadata::none(),
+            Creation(data) => WriteOp::legacy_creation(data),
+            Modification(data) => WriteOp::legacy_modification(data),
+            Deletion => WriteOp::legacy_deletion(),
+            CreationWithMetadata { data, metadata } => {
+                WriteOp::creation(data, metadata.into_in_mem_form())
             },
-            Modification(data) => WriteOp::Modification {
-                data,
-                metadata: StateValueMetadata::none(),
+            ModificationWithMetadata { data, metadata } => {
+                WriteOp::modification(data, metadata.into_in_mem_form())
             },
-            Deletion => WriteOp::Deletion {
-                metadata: StateValueMetadata::none(),
-            },
-            CreationWithMetadata { data, metadata } => WriteOp::Creation {
-                data,
-                metadata: metadata.into_in_mem_form(),
-            },
-            ModificationWithMetadata { data, metadata } => WriteOp::Modification {
-                data,
-                metadata: metadata.into_in_mem_form(),
-            },
-            DeletionWithMetadata { metadata } => WriteOp::Deletion {
-                metadata: metadata.into_in_mem_form(),
-            },
+            DeletionWithMetadata { metadata } => WriteOp::deletion(metadata.into_in_mem_form()),
         }
     }
 }
 
 #[derive(Clone, Eq, PartialEq)]
 pub enum WriteOp {
-    Creation {
-        data: Bytes,
-        metadata: StateValueMetadata,
-    },
-    Modification {
-        data: Bytes,
-        metadata: StateValueMetadata,
-    },
-    Deletion {
-        metadata: StateValueMetadata,
-    },
+    Creation(StateValue),
+    Modification(StateValue),
+    Deletion(StateValueMetadata),
 }
 
 impl WriteOp {
@@ -116,17 +93,17 @@ impl WriteOp {
         let metadata = self.metadata().clone().into_persistable();
         match metadata {
             None => match self {
-                WriteOp::Creation { data, .. } => Creation(data.clone()),
-                WriteOp::Modification { data, .. } => Modification(data.clone()),
+                WriteOp::Creation(v) => Creation(v.bytes().clone()),
+                WriteOp::Modification(v) => Modification(v.bytes().clone()),
                 WriteOp::Deletion { .. } => Deletion,
             },
             Some(metadata) => match self {
-                WriteOp::Creation { data, .. } => CreationWithMetadata {
-                    data: data.clone(),
+                WriteOp::Creation(v) => CreationWithMetadata {
+                    data: v.bytes().clone(),
                     metadata,
                 },
-                WriteOp::Modification { data, .. } => ModificationWithMetadata {
-                    data: data.clone(),
+                WriteOp::Modification(v) => ModificationWithMetadata {
+                    data: v.bytes().clone(),
                     metadata,
                 },
                 WriteOp::Deletion { .. } => DeletionWithMetadata { metadata },
@@ -147,43 +124,32 @@ impl WriteOp {
             => {
                 bail!("The given change sets cannot be squashed")
             },
-            (Creation {metadata: old_meta, .. } , Modification {data, metadata}) => {
-                Self::ensure_metadata_compatible(old_meta, &metadata)?;
+            (Creation(c) , Modification(m)) => {
+                Self::ensure_metadata_compatible(c.metadata(), m.metadata())?;
 
-                *op = Creation {
-                    data,
-                    metadata,
-                };
+                *op = Creation(m)
             },
-            (Modification{metadata: old_meta, .. } , Modification {data, metadata}) => {
-                Self::ensure_metadata_compatible(old_meta, &metadata)?;
+            (Modification(c) , Modification(m)) => {
+                Self::ensure_metadata_compatible(c.metadata(), m.metadata())?;
 
-                *op = Modification {
-                    data,
-                    metadata,
-                };
+                *op = Modification(m);
             },
-            (Modification {metadata: old_meta, ..}, Deletion {metadata}) => {
-                Self::ensure_metadata_compatible(old_meta, &metadata)?;
+            (Modification(m), Deletion(d_meta)) => {
+                Self::ensure_metadata_compatible(m.metadata(), &d_meta)?;
 
-                *op = Deletion {
-                    metadata,
-                }
+                *op = Deletion(d_meta)
             },
-            (Deletion {metadata}, Creation {data, ..}) => {
+            (Deletion(d_meta), Creation(c)) => {
                 // n.b. With write sets from multiple sessions being squashed together, it's possible
                 //   to see two ops carrying different metadata (or one with it the other without)
                 //   due to deleting in one session and recreating in another. The original metadata
                 //   shouldn't change due to the squash.
                 // And because the deposit or refund happens after all squashing is finished, it's
                 // not a concern of fairness.
-                *op = Modification {
-                    data,
-                    metadata: metadata.clone(),
-                }
+                *op = Modification(StateValue::new_with_metadata(c.into_bytes(), d_meta.clone()))
             },
-            (Creation { metadata: old_meta, .. }, Deletion { metadata }) => {
-                Self::ensure_metadata_compatible(old_meta, &metadata)?;
+            (Creation(c), Deletion(d_meta)) => {
+                Self::ensure_metadata_compatible(c.metadata(), &d_meta)?;
 
                 return Ok(false)
             },
@@ -204,70 +170,73 @@ impl WriteOp {
         Ok(())
     }
 
-    pub fn bytes(&self) -> Option<&Bytes> {
+    pub fn state_value_ref(&self) -> Option<&StateValue> {
         use WriteOp::*;
 
         match self {
-            Creation { data, .. } | Modification { data, .. } => Some(data),
-            Deletion { .. } => None,
+            Creation(v) | Modification(v) => Some(v),
+            Deletion(..) => None,
         }
     }
 
-    pub fn size(&self) -> usize {
-        use WriteOp::*;
+    pub fn bytes(&self) -> Option<&Bytes> {
+        self.state_value_ref().map(StateValue::bytes)
+    }
 
-        match self {
-            Creation { data, .. } | Modification { data, .. } => data.len(),
-            Deletion { .. } => 0,
-        }
+    /// Size not counting metadata.
+    pub fn bytes_size(&self) -> usize {
+        self.bytes().map_or(0, Bytes::len)
     }
 
     pub fn metadata(&self) -> &StateValueMetadata {
         use WriteOp::*;
 
         match self {
-            Creation { metadata, .. } | Modification { metadata, .. } | Deletion { metadata } => {
-                metadata
-            },
+            Creation(v) | Modification(v) => v.metadata(),
+            Deletion(meta) => meta,
         }
     }
 
-    pub fn get_metadata_mut(&mut self) -> &mut StateValueMetadata {
+    pub fn metadata_mut(&mut self) -> &mut StateValueMetadata {
         use WriteOp::*;
 
         match self {
-            Creation { metadata, .. } | Modification { metadata, .. } | Deletion { metadata } => {
-                metadata
-            },
+            Creation(v) | Modification(v) => v.metadata_mut(),
+            Deletion(meta) => meta,
         }
     }
 
     pub fn into_metadata(self) -> StateValueMetadata {
+        use WriteOp::*;
+
         match self {
-            Creation { metadata, .. } | Modification { metadata, .. } | Deletion { metadata } => {
-                metadata
-            },
+            Creation(v) | Modification(v) => v.into_metadata(),
+            Deletion(meta) => meta,
         }
+    }
+
+    pub fn creation(data: Bytes, metadata: StateValueMetadata) -> Self {
+        Self::Creation(StateValue::new_with_metadata(data, metadata))
+    }
+
+    pub fn modification(data: Bytes, metadata: StateValueMetadata) -> Self {
+        Self::Modification(StateValue::new_with_metadata(data, metadata))
+    }
+
+    pub fn deletion(metadata: StateValueMetadata) -> Self {
+        Self::Deletion(metadata)
     }
 
     pub fn legacy_creation(data: Bytes) -> Self {
-        Self::Creation {
-            data,
-            metadata: StateValueMetadata::none(),
-        }
+        Self::Creation(StateValue::new_legacy(data))
     }
 
     pub fn legacy_modification(data: Bytes) -> Self {
-        Self::Modification {
-            data,
-            metadata: StateValueMetadata::none(),
-        }
+        Self::Modification(StateValue::new_legacy(data))
     }
 
     pub fn legacy_deletion() -> Self {
-        Self::Deletion {
-            metadata: StateValueMetadata::none(),
-        }
+        Self::Deletion(StateValueMetadata::none())
     }
 }
 
@@ -316,8 +285,7 @@ pub trait TransactionWrite: Debug {
     // Provided as a separate method to avoid the clone in as_state_value method
     // (although default implementation below does just that).
     fn as_state_value_metadata(&self) -> Option<StateValueMetadata> {
-        self.as_state_value()
-            .map(|state_value| state_value.into_metadata())
+        self.as_state_value().map(StateValue::into_metadata)
     }
 
     // Often, the contents of W:TransactionWrite are converted to Option<StateValue>, e.g.
@@ -376,23 +344,19 @@ impl TransactionWrite for WriteOp {
     }
 
     fn as_state_value(&self) -> Option<StateValue> {
-        self.bytes()
-            .map(|bytes| StateValue::new_with_metadata(bytes.clone(), self.metadata().clone()))
+        self.state_value_ref().cloned()
     }
 
     // Note that even if WriteOp is DeletionWithMetadata, the method returns None, as a later
     // read would not read the metadata of the deletion op.
     fn as_state_value_metadata(&self) -> Option<StateValueMetadata> {
-        self.bytes().map(|_| self.metadata().clone())
+        self.state_value_ref().map(StateValue::metadata).cloned()
     }
 
     fn from_state_value(maybe_state_value: Option<StateValue>) -> Self {
         match maybe_state_value {
             None => Self::legacy_deletion(),
-            Some(state_value) => {
-                let (metadata, data) = state_value.unpack();
-                Self::Modification { data, metadata }
-            },
+            Some(state_value) => Self::Modification(state_value),
         }
     }
 
@@ -409,33 +373,37 @@ impl TransactionWrite for WriteOp {
         use WriteOp::*;
 
         match self {
-            Creation { data, .. } | Modification { data, .. } => *data = bytes,
+            Creation(v) | Modification(v) => v.set_bytes(bytes),
             Deletion { .. } => (),
         }
     }
 }
 
 #[allow(clippy::format_collect)]
-impl std::fmt::Debug for WriteOp {
+impl Debug for WriteOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use WriteOp::*;
+
         match self {
-            Creation { data, metadata } => write!(
+            Creation(v) => write!(
                 f,
                 "Creation({}, metadata:{:?})",
-                data.iter()
+                v.bytes()
+                    .iter()
                     .map(|byte| format!("{:02x}", byte))
                     .collect::<String>(),
-                metadata,
+                v.metadata(),
             ),
-            Modification { data, metadata } => write!(
+            Modification(v) => write!(
                 f,
                 "Modification({}, metadata:{:?})",
-                data.iter()
+                v.bytes()
+                    .iter()
                     .map(|byte| format!("{:02x}", byte))
                     .collect::<String>(),
-                metadata,
+                v.metadata(),
             ),
-            Deletion { metadata } => {
+            Deletion(metadata) => {
                 write!(f, "Deletion(metadata:{:?})", metadata,)
             },
         }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

WrietOp carries StataValue so that in many cases (that I'm gonna introduce) we can use refs to StateValue directly out of the transaction outputs without constructing them. 

Removed the cached hashvalue field on StateValue otherwise there's a slight performance regression (now it's a slight improvement, it looks like). Also, now that we have introduced setters to the fields, it's safer not to cache the hash. 
We only need the hashes when we update the trees and if necessary I will explicitly cache them. 


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

existing coverage

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Validator Node


<!-- Thank you for your contribution! -->
