### PR TITLE
aptos-framework repo migration: move-examples [1/n]

### DIFF
--- a/aptos-move/aptos-gas-calibration/samples/empty/Move.toml
+++ b/aptos-move/aptos-gas-calibration/samples/empty/Move.toml
@@ -9,8 +9,8 @@ empty = "0xcafe"
 [dev-addresses]
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "mainnet"
-subdir = "aptos-move/framework/aptos-framework"
+subdir = "aptos-framework"
 
 [dev-dependencies]

--- a/aptos-move/move-examples/aggregator_examples/Move.toml
+++ b/aptos-move/move-examples/aggregator_examples/Move.toml
@@ -6,5 +6,5 @@ version = "0.0.0"
 aggregator_examples = "0xCAFE"
 
 [dependencies]
-AptosStdlib = { local = "../../framework/aptos-stdlib" }
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosStdlib = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-stdlib", rev = "mainnet" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/argument_example/Move.toml
+++ b/aptos-move/move-examples/argument_example/Move.toml
@@ -6,4 +6,4 @@ version = "0.0.0"
 deploy_address = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/bcs-stream/Move.toml
+++ b/aptos-move/move-examples/bcs-stream/Move.toml
@@ -6,4 +6,4 @@ version = "0.0.0"
 bcs_stream = "0xCAFE"
 
 [dependencies]
-AptosStdlib = { local = "../../framework/aptos-stdlib" }
+AptosStdlib = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-stdlib", rev = "mainnet" }

--- a/aptos-move/move-examples/bonding_curve_launchpad/Move.toml
+++ b/aptos-move/move-examples/bonding_curve_launchpad/Move.toml
@@ -16,11 +16,11 @@ swap = "0xcafe"
 
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "bbf569abd260d94bc30fe96da297d2aecb193644"
-subdir = "aptos-move/framework/aptos-framework"
+subdir = "aptos-framework"
 
 [dependencies.swap]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "bbf569abd260d94bc30fe96da297d2aecb193644"
 subdir = "aptos-move/move-examples/swap"

--- a/aptos-move/move-examples/cli-e2e-tests/devnet/Move.toml
+++ b/aptos-move/move-examples/cli-e2e-tests/devnet/Move.toml
@@ -9,11 +9,11 @@ addr = "_"
 addr = "0x12345"
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "devnet"
-subdir = "aptos-move/framework/aptos-framework"
+subdir = "aptos-framework"
 
 [dependencies.AptosTokenObjects]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "devnet"
-subdir = "aptos-move/framework/aptos-token-objects"
+subdir = "aptos-token-objects"

--- a/aptos-move/move-examples/cli-e2e-tests/mainnet/Move.toml
+++ b/aptos-move/move-examples/cli-e2e-tests/mainnet/Move.toml
@@ -9,11 +9,11 @@ addr = "_"
 addr = "0x12345"
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "mainnet"
-subdir = "aptos-move/framework/aptos-framework"
+subdir = "aptos-framework"
 
 [dependencies.AptosTokenObjects]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "mainnet"
-subdir = "aptos-move/framework/aptos-token-objects"
+subdir = "aptos-token-objects"

--- a/aptos-move/move-examples/cli-e2e-tests/testnet/Move.toml
+++ b/aptos-move/move-examples/cli-e2e-tests/testnet/Move.toml
@@ -9,11 +9,11 @@ addr = "_"
 addr = "0x12345"
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "testnet"
-subdir = "aptos-move/framework/aptos-framework"
+subdir = "aptos-framework"
 
 [dependencies.AptosTokenObjects]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "testnet"
-subdir = "aptos-move/framework/aptos-token-objects"
+subdir = "aptos-token-objects"

--- a/aptos-move/move-examples/cli_args/Move.toml
+++ b/aptos-move/move-examples/cli_args/Move.toml
@@ -7,4 +7,6 @@ upgrade_policy = "compatible"
 test_account = "_"
 
 [dependencies.AptosFramework]
-local = "../../framework/aptos-framework"
+git = "https://github.com/aptos-labs/aptos-framework.git"
+subdir = "aptos-framework"
+rev = "mainnet"

--- a/aptos-move/move-examples/common_account/Move.toml
+++ b/aptos-move/move-examples/common_account/Move.toml
@@ -3,7 +3,7 @@ name = "CommonAccount"
 version = "1.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
 
 [addresses]
 common_account = "_"

--- a/aptos-move/move-examples/dao/nft_dao/Move.toml
+++ b/aptos-move/move-examples/dao/nft_dao/Move.toml
@@ -8,5 +8,5 @@ dao_platform = "_"
 aptos_framework = "0x1"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosToken = { local = "../../../framework/aptos-token" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-token", rev = "mainnet" }

--- a/aptos-move/move-examples/data_structures/Move.toml
+++ b/aptos-move/move-examples/data_structures/Move.toml
@@ -3,7 +3,8 @@ name = "DataStructure"
 version = "0.0.1"
 
 [dependencies]
-AptosStdlib = { local = "../../framework/aptos-stdlib" }
+AptosStdlib = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-stdlib", rev = "mainnet" }
+
 
 [addresses]
 std = "0x1"

--- a/aptos-move/move-examples/defi/Move.toml
+++ b/aptos-move/move-examples/defi/Move.toml
@@ -6,4 +6,4 @@ version = "0.0.0"
 defi = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/drand/Move.toml
+++ b/aptos-move/move-examples/drand/Move.toml
@@ -3,8 +3,9 @@ name = "DrandLottery"
 version = "0.0.1"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
-#AptosStdlib = { local = "../../framework/aptos-stdlib" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+#AptosStdlib = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-stdlib", rev = "mainnet" }
+
 
 [addresses]
 std = "0x1"

--- a/aptos-move/move-examples/event/Move.toml
+++ b/aptos-move/move-examples/event/Move.toml
@@ -8,5 +8,4 @@ aptos_framework = "0x1"
 event = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
-
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/fungible_asset/fa_coin/Move.toml
+++ b/aptos-move/move-examples/fungible_asset/fa_coin/Move.toml
@@ -7,4 +7,4 @@ aptos_framework = "0x1"
 FACoin = "_"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/fungible_asset/managed_fungible_asset/Move.toml
+++ b/aptos-move/move-examples/fungible_asset/managed_fungible_asset/Move.toml
@@ -8,5 +8,5 @@ aptos_token_objects = "0x4"
 example_addr = "_"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosTokenObjects = { local = "../../../framework/aptos-token-objects" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosTokenObjects = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-token-objects", rev = "mainnet" }

--- a/aptos-move/move-examples/fungible_asset/managed_fungible_token/Move.toml
+++ b/aptos-move/move-examples/fungible_asset/managed_fungible_token/Move.toml
@@ -8,6 +8,6 @@ aptos_token_objects = "0x4"
 example_addr = "_"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosTokenObjects = { local = "../../../framework/aptos-token-objects" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosTokenObjects = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-token-objects", rev = "mainnet" }
 ManagedFungibleAsset = { local = "../managed_fungible_asset" }

--- a/aptos-move/move-examples/fungible_asset/multisig_managed_coin/Move.toml
+++ b/aptos-move/move-examples/fungible_asset/multisig_managed_coin/Move.toml
@@ -7,5 +7,5 @@ aptos_framework = "0x1"
 example_addr = "_"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
 ManagedFungibleAsset = { local = "../managed_fungible_asset" }

--- a/aptos-move/move-examples/fungible_asset/preminted_managed_coin/Move.toml
+++ b/aptos-move/move-examples/fungible_asset/preminted_managed_coin/Move.toml
@@ -7,5 +7,5 @@ aptos_framework = "0x1"
 example_addr = "_"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
 ManagedFungibleAsset = { local = "../managed_fungible_asset" }

--- a/aptos-move/move-examples/fungible_asset/stablecoin/Move.toml
+++ b/aptos-move/move-examples/fungible_asset/stablecoin/Move.toml
@@ -6,7 +6,7 @@ version = "0.0.0"
 [addresses]
 stablecoin = "_"
 master_minter = "_"
-minter = "_" 
+minter = "_"
 pauser = "_"
 denylister = "_"
 
@@ -18,4 +18,4 @@ pauser = "0xdafe"
 denylister = "0xcade"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/governance/Move.toml
+++ b/aptos-move/move-examples/governance/Move.toml
@@ -6,4 +6,4 @@ version = "0.0.0"
 aptos_framework = "0x1"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/groth16_example/Move.toml
+++ b/aptos-move/move-examples/groth16_example/Move.toml
@@ -3,4 +3,4 @@ name = "GenericGroth16"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/hello_blockchain/Move.toml
+++ b/aptos-move/move-examples/hello_blockchain/Move.toml
@@ -6,4 +6,4 @@ version = "0.0.0"
 hello_blockchain = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/hello_prover/Move.toml
+++ b/aptos-move/move-examples/hello_prover/Move.toml
@@ -3,7 +3,7 @@ name = "hello_prover"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "main" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework/", rev = "main" }
 
 [addresses]
 

--- a/aptos-move/move-examples/large_packages/Move.toml
+++ b/aptos-move/move-examples/large_packages/Move.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 upgrade_policy = "compatible"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
 
 [addresses]
 large_packages = "_"

--- a/aptos-move/move-examples/large_packages/large_package_example/Move.toml
+++ b/aptos-move/move-examples/large_packages/large_package_example/Move.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 upgrade_policy = "compatible"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
 
 [addresses]
 large_package_example = "_"

--- a/aptos-move/move-examples/marketplace/Move.toml
+++ b/aptos-move/move-examples/marketplace/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 marketplace = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
-AptosToken = { local = "../../framework/aptos-token" }
-AptosTokenObjects = { local = "../../framework/aptos-token-objects" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-token", rev = "mainnet" }
+AptosTokenObjects = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-token-objects", rev = "mainnet" }

--- a/aptos-move/move-examples/message_board/Move.toml
+++ b/aptos-move/move-examples/message_board/Move.toml
@@ -3,7 +3,7 @@ name = "MessageBoard"
 version = "0.0.1"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
 
 [addresses]
 std = "0x1"

--- a/aptos-move/move-examples/mint_nft/1-Create-NFT/Move.toml
+++ b/aptos-move/move-examples/mint_nft/1-Create-NFT/Move.toml
@@ -3,8 +3,8 @@ name = "Examples"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosToken = { local = "../../../framework/aptos-token" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-token", rev = "mainnet" }
 
 [addresses]
 aptos_framework = "0x1"

--- a/aptos-move/move-examples/mint_nft/2-Using-Resource-Account/Move.toml
+++ b/aptos-move/move-examples/mint_nft/2-Using-Resource-Account/Move.toml
@@ -3,8 +3,8 @@ name = "Examples"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosToken = { local = "../../../framework/aptos-token" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-token", rev = "mainnet" }
 
 [addresses]
 aptos_framework = "0x1"

--- a/aptos-move/move-examples/mint_nft/3-Adding-Admin/Move.toml
+++ b/aptos-move/move-examples/mint_nft/3-Adding-Admin/Move.toml
@@ -3,8 +3,8 @@ name = "Examples"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosToken = { local = "../../../framework/aptos-token" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-token", rev = "mainnet" }
 
 [addresses]
 aptos_framework = "0x1"

--- a/aptos-move/move-examples/mint_nft/4-Getting-Production-Ready/Move.toml
+++ b/aptos-move/move-examples/mint_nft/4-Getting-Production-Ready/Move.toml
@@ -3,8 +3,8 @@ name = "Examples"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosToken = { local = "../../../framework/aptos-token" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-token", rev = "mainnet" }
 
 [addresses]
 aptos_framework = "0x1"

--- a/aptos-move/move-examples/moon_coin/Move.toml
+++ b/aptos-move/move-examples/moon_coin/Move.toml
@@ -6,4 +6,4 @@ version = "0.0.0"
 MoonCoin = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/move-tutorial/step_2/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_2/basic_coin/Move.toml
@@ -3,6 +3,6 @@ name = "basic_coin"
 version = "0.0.0"
 
 [dependencies.AptosStdlib]
-git = 'https://github.com/aptos-labs/aptos-core.git'
+git = 'https://github.com/aptos-labs/aptos-framework.git'
 rev = 'main'
-subdir = 'aptos-move/framework/aptos-stdlib'
+subdir = 'aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_2_sol/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_2_sol/basic_coin/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
-git = 'https://github.com/aptos-labs/aptos-core.git'
+git = 'https://github.com/aptos-labs/aptos-framework.git'
 rev = 'main'
-subdir = 'aptos-move/framework/aptos-stdlib'
+subdir = 'aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_4/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_4/basic_coin/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
-git = 'https://github.com/aptos-labs/aptos-core.git'
+git = 'https://github.com/aptos-labs/aptos-framework.git'
 rev = 'main'
-subdir = 'aptos-move/framework/aptos-stdlib'
+subdir = 'aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_4_sol/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_4_sol/basic_coin/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
-git = 'https://github.com/aptos-labs/aptos-core.git'
+git = 'https://github.com/aptos-labs/aptos-framework.git'
 rev = 'main'
-subdir = 'aptos-move/framework/aptos-stdlib'
+subdir = 'aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_5/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_5/basic_coin/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
-git = 'https://github.com/aptos-labs/aptos-core.git'
+git = 'https://github.com/aptos-labs/aptos-framework.git'
 rev = 'main'
-subdir = 'aptos-move/framework/aptos-stdlib'
+subdir = 'aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_5_sol/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_5_sol/basic_coin/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
-git = 'https://github.com/aptos-labs/aptos-core.git'
+git = 'https://github.com/aptos-labs/aptos-framework.git'
 rev = 'main'
-subdir = 'aptos-move/framework/aptos-stdlib'
+subdir = 'aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_6/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_6/basic_coin/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
-git = 'https://github.com/aptos-labs/aptos-core.git'
+git = 'https://github.com/aptos-labs/aptos-framework.git'
 rev = 'main'
-subdir = 'aptos-move/framework/aptos-stdlib'
+subdir = 'aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_7/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_7/basic_coin/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
-git = 'https://github.com/aptos-labs/aptos-core.git'
+git = 'https://github.com/aptos-labs/aptos-framework.git'
 rev = 'main'
-subdir = 'aptos-move/framework/aptos-stdlib'
+subdir = 'aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_8/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_8/basic_coin/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 named_addr = "0xCAFE"
 
 [dependencies.AptosStdlib]
-git = 'https://github.com/aptos-labs/aptos-core.git'
+git = 'https://github.com/aptos-labs/aptos-framework.git'
 rev = 'main'
-subdir = 'aptos-move/framework/aptos-stdlib'
+subdir = 'aptos-stdlib'

--- a/aptos-move/move-examples/move-tutorial/step_8_sol/basic_coin/Move.toml
+++ b/aptos-move/move-examples/move-tutorial/step_8_sol/basic_coin/Move.toml
@@ -6,6 +6,6 @@ version = "0.0.0"
 named_addr = "0xDEADBEEF"
 
 [dependencies.AptosStdlib]
-git = 'https://github.com/aptos-labs/aptos-core.git'
+git = 'https://github.com/aptos-labs/aptos-framework.git'
 rev = 'main'
-subdir = 'aptos-move/framework/aptos-stdlib'
+subdir = 'aptos-stdlib'

--- a/aptos-move/move-examples/my_first_dapp/move/Move.toml
+++ b/aptos-move/move-examples/my_first_dapp/move/Move.toml
@@ -2,8 +2,8 @@
 name = 'my_todo_list'
 version = '1.0.0'
 [dependencies.AptosFramework]
-git = 'https://github.com/aptos-labs/aptos-core.git'
+git = 'https://github.com/aptos-labs/aptos-framework.git'
 rev = 'main'
-subdir = 'aptos-move/framework/aptos-framework'
+subdir = 'aptos-framework'
 [addresses]
 todolist_addr='_'

--- a/aptos-move/move-examples/on_chain_dice/Move.toml
+++ b/aptos-move/move-examples/on_chain_dice/Move.toml
@@ -6,4 +6,4 @@ version = "0.0.0"
 module_owner = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/package_manager/Move.toml
+++ b/aptos-move/move-examples/package_manager/Move.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 upgrade_policy = "compatible"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
 
 [addresses]
 deployer = "_"

--- a/aptos-move/move-examples/post_mint_reveal_nft/Move.toml
+++ b/aptos-move/move-examples/post_mint_reveal_nft/Move.toml
@@ -3,8 +3,8 @@ name = "PostMint"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
-AptosToken = { local = "../../framework/aptos-token" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-token", rev = "mainnet" }
 
 [addresses]
 aptos_framework = "0x1"

--- a/aptos-move/move-examples/raffle/Move.toml
+++ b/aptos-move/move-examples/raffle/Move.toml
@@ -3,8 +3,9 @@ name = "raffle"
 version = "0.0.1"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
-AptosStdlib = { local = "../../framework/aptos-stdlib" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosStdlib = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-stdlib", rev = "mainnet" }
+
 
 [addresses]
 raffle = "_"

--- a/aptos-move/move-examples/resource_account/Move.toml
+++ b/aptos-move/move-examples/resource_account/Move.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 upgrade_policy = "compatible"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
 
 [addresses]
 # change it to `source_addr = "_" when calling `create-resource-account-and-publish-package` from the cli

--- a/aptos-move/move-examples/resource_groups/primary/Move.toml
+++ b/aptos-move/move-examples/resource_groups/primary/Move.toml
@@ -6,4 +6,4 @@ version = "0.0.0"
 resource_groups_primary = "_"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/resource_groups/secondary/Move.toml
+++ b/aptos-move/move-examples/resource_groups/secondary/Move.toml
@@ -7,5 +7,5 @@ resource_groups_primary = "_"
 resource_groups_secondary = "_"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
 ResourceGroupsPrimary = { local = "../primary" }

--- a/aptos-move/move-examples/rewards_pool/Move.toml
+++ b/aptos-move/move-examples/rewards_pool/Move.toml
@@ -6,4 +6,4 @@ version = "1.0.0"
 rewards_pool = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/scripts/minter/Move.toml
+++ b/aptos-move/move-examples/scripts/minter/Move.toml
@@ -3,4 +3,4 @@ name = "Minter"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/scripts/too_large/Move.toml
+++ b/aptos-move/move-examples/scripts/too_large/Move.toml
@@ -3,5 +3,5 @@ name = "TooLargeTest"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-MoveStdlib = { local = "../../../framework/move-stdlib" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+MoveStdlib = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "move-stdlib", rev = "mainnet" }

--- a/aptos-move/move-examples/scripts/two_by_two_transfer/Move.toml
+++ b/aptos-move/move-examples/scripts/two_by_two_transfer/Move.toml
@@ -3,4 +3,4 @@ name = "TwoByTwoTransfer"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/shared_account/Move.toml
+++ b/aptos-move/move-examples/shared_account/Move.toml
@@ -3,4 +3,4 @@ name = "Examples"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/split_transfer/Move.toml
+++ b/aptos-move/move-examples/split_transfer/Move.toml
@@ -3,4 +3,4 @@ name = "SplitTransfer"
 version = "0.0.0"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/swap/Move.toml
+++ b/aptos-move/move-examples/swap/Move.toml
@@ -8,4 +8,4 @@ deployer = "_"
 swap = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/tic-tac-toe/Move.toml
+++ b/aptos-move/move-examples/tic-tac-toe/Move.toml
@@ -6,5 +6,4 @@ version = '1.0.0'
 tic_tac_toe = "_"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
-
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }

--- a/aptos-move/move-examples/token_objects/ambassador/Move.toml
+++ b/aptos-move/move-examples/token_objects/ambassador/Move.toml
@@ -7,5 +7,5 @@ version = '1.0.0'
 ambassador = "0xCAFE"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosTokenObjects = { local = "../../../framework/aptos-token-objects" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosTokenObjects = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-token-objects", rev = "mainnet" }

--- a/aptos-move/move-examples/token_objects/guild/Move.toml
+++ b/aptos-move/move-examples/token_objects/guild/Move.toml
@@ -6,5 +6,5 @@ version = '1.0.0'
 guild = "_"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosTokenObjects = { local = "../../../framework/aptos-token-objects" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosTokenObjects = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-token-objects", rev = "mainnet" }

--- a/aptos-move/move-examples/token_objects/hero/Move.toml
+++ b/aptos-move/move-examples/token_objects/hero/Move.toml
@@ -6,5 +6,5 @@ version = "0.0.0"
 hero = "_"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosTokenObjects = { local = "../../../framework/aptos-token-objects" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosTokenObjects = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-token-objects", rev = "mainnet" }

--- a/aptos-move/move-examples/token_objects/knight/Move.toml
+++ b/aptos-move/move-examples/token_objects/knight/Move.toml
@@ -6,5 +6,5 @@ version = '1.0.0'
 knight = "_"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosTokenObjects = { local = "../../../framework/aptos-token-objects" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosTokenObjects = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-token-objects", rev = "mainnet" }

--- a/aptos-move/move-examples/token_objects/token_lockup/Move.toml
+++ b/aptos-move/move-examples/token_objects/token_lockup/Move.toml
@@ -6,5 +6,5 @@ version = '1.0.0'
 token_lockup = "_"
 
 [dependencies]
-AptosFramework = { local = "../../../framework/aptos-framework" }
-AptosTokenObjects = { local = "../../../framework/aptos-token-objects" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
+AptosTokenObjects = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-token-objects", rev = "mainnet" }

--- a/aptos-move/move-examples/upgrade_and_govern/genesis/Move.toml
+++ b/aptos-move/move-examples/upgrade_and_govern/genesis/Move.toml
@@ -7,4 +7,6 @@ version = '1.0.0'
 upgrade_and_govern = '_'
 
 [dependencies.AptosFramework]
-local = '../../../framework/aptos-framework' # <:!:manifest
+git = "https://github.com/aptos-labs/aptos-framework.git"
+subdir = "aptos-framework"
+rev = "mainnet"

--- a/aptos-move/move-examples/upgrade_and_govern/upgrade/Move.toml
+++ b/aptos-move/move-examples/upgrade_and_govern/upgrade/Move.toml
@@ -7,4 +7,6 @@ version = '1.1.0'
 upgrade_and_govern = '_'
 
 [dependencies.AptosFramework]
-local = '../../../framework/aptos-framework' # <:!:manifest
+git = "https://github.com/aptos-labs/aptos-framework.git"
+subdir = "aptos-framework"
+rev = "mainnet"

--- a/aptos-move/move-examples/veiled_coin/Move.toml
+++ b/aptos-move/move-examples/veiled_coin/Move.toml
@@ -3,7 +3,7 @@ name = "VeiledCoin"
 version = "0.0.1"
 
 [dependencies]
-AptosFramework = { local = "../../framework/aptos-framework" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
 
 [addresses]
 std = "0x1"

--- a/ecosystem/indexer-grpc/indexer-transaction-generator/imported_transactions/move_fixtures/simple_user_script/Move.toml
+++ b/ecosystem/indexer-grpc/indexer-transaction-generator/imported_transactions/move_fixtures/simple_user_script/Move.toml
@@ -8,8 +8,8 @@ authors = []
 [dev-addresses]
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "mainnet"
-subdir = "aptos-move/framework/aptos-framework"
+subdir = "aptos-framework"
 
 [dev-dependencies]

--- a/ecosystem/indexer-grpc/indexer-transaction-generator/imported_transactions/move_fixtures/simple_user_script2/Move.toml
+++ b/ecosystem/indexer-grpc/indexer-transaction-generator/imported_transactions/move_fixtures/simple_user_script2/Move.toml
@@ -8,8 +8,8 @@ authors = []
 [dev-addresses]
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "mainnet"
-subdir = "aptos-move/framework/aptos-framework"
+subdir = "aptos-framework"
 
 [dev-dependencies]

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/std-lib-override/deps_only/Move.toml
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/std-lib-override/deps_only/Move.toml
@@ -9,8 +9,8 @@ B = "0x43"
 [dev-addresses]
 
 [dependencies.AptosFramework]
-git = "https://github.com/aptos-labs/aptos-core.git"
+git = "https://github.com/aptos-labs/aptos-framework.git"
 rev = "mainnet"
-subdir = "aptos-move/framework/aptos-framework"
+subdir = "aptos-framework"
 
 [dev-dependencies]


### PR DESCRIPTION
This migrates the move examples to use dependencies from the newly-setup aptos-framework repo.