### PR TITLE
[Fuzzing] Add use case aware shuffler fuzzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8521,6 +8521,7 @@ name = "fuzzer-fuzz"
 version = "0.0.0"
 dependencies = [
  "aptos-cached-packages",
+ "aptos-consensus",
  "aptos-crypto",
  "aptos-framework",
  "aptos-language-e2e-tests",

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -63,6 +63,8 @@ mod payload_manager;
 mod transaction_deduper;
 mod transaction_filter;
 mod transaction_shuffler;
+#[cfg(feature = "fuzzing")]
+pub use transaction_shuffler::transaction_shuffler_fuzzing;
 mod txn_hash_and_authenticator_deduper;
 
 use aptos_metrics_core::IntGauge;

--- a/consensus/src/transaction_shuffler/mod.rs
+++ b/consensus/src/transaction_shuffler/mod.rs
@@ -8,6 +8,13 @@ use std::sync::Arc;
 
 mod sender_aware;
 mod use_case_aware;
+// re-export use case aware shuffler for fuzzer.
+#[cfg(feature = "fuzzing")]
+pub mod transaction_shuffler_fuzzing {
+    pub mod use_case_aware {
+        pub use crate::transaction_shuffler::use_case_aware::{Config, UseCaseAwareShuffler};
+    }
+}
 
 /// Interface to shuffle transactions
 pub trait TransactionShuffler: Send + Sync {

--- a/consensus/src/transaction_shuffler/use_case_aware/mod.rs
+++ b/consensus/src/transaction_shuffler/use_case_aware/mod.rs
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::transaction_shuffler::TransactionShuffler;
-use aptos_types::transaction::{use_case::UseCaseKey, SignedTransaction};
+use aptos_types::transaction::{
+    use_case::{UseCaseAwareTransaction, UseCaseKey},
+    SignedTransaction,
+};
 use iterator::ShuffledTransactionIterator;
+use std::fmt::Debug;
 
 pub(crate) mod iterator;
 pub(crate) mod types;
@@ -14,7 +18,7 @@ pub(crate) mod delayed_queue;
 mod tests;
 
 #[derive(Clone, Debug, Default)]
-pub(crate) struct Config {
+pub struct Config {
     pub sender_spread_factor: usize,
     pub platform_use_case_spread_factor: usize,
     pub user_use_case_spread_factor: usize,
@@ -37,6 +41,18 @@ impl Config {
 
 pub struct UseCaseAwareShuffler {
     pub config: Config,
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+impl UseCaseAwareShuffler {
+    pub fn shuffle_generic<Txn: UseCaseAwareTransaction + Debug>(
+        &self,
+        txns: Vec<Txn>,
+    ) -> Vec<Txn> {
+        ShuffledTransactionIterator::new(self.config.clone())
+            .extended_with(txns)
+            .collect()
+    }
 }
 
 impl TransactionShuffler for UseCaseAwareShuffler {

--- a/testsuite/fuzzer/fuzz.sh
+++ b/testsuite/fuzzer/fuzz.sh
@@ -4,7 +4,7 @@ export RUSTFLAGS="${RUSTFLAGS} --cfg tokio_unstable"
 export EXTRAFLAGS="-Ztarget-applies-to-host -Zhost-config"
 # Nightly version control
 # Pin nightly-2024-02-12 because of https://github.com/google/oss-fuzz/issues/11626
-NIGHTLY_VERSION="nightly-2024-02-12"
+NIGHTLY_VERSION="nightly-2024-04-06"
 
 # GDRIVE format https://docs.google.com/uc?export=download&id=DOCID
 CORPUS_ZIPS=("https://storage.googleapis.com/aptos-core-corpora/move_aptosvm_publish_and_run_seed_corpus.zip" "https://storage.googleapis.com/aptos-core-corpora/move_aptosvm_publish_seed_corpus.zip")

--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -9,6 +9,7 @@ cargo-fuzz = true
 
 [dependencies]
 aptos-cached-packages = { workspace = true }
+aptos-consensus = { workspace = true, features = ["fuzzing"] }
 aptos-crypto = { workspace = true }
 aptos-framework = { workspace = true }
 aptos-language-e2e-tests = { workspace = true, features = ["fuzzing"] }
@@ -79,5 +80,11 @@ doc = false
 [[bin]]
 name = "move_aptosvm_authenticators"
 path = "fuzz_targets/move/aptosvm_authenticators.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "use_case_aware_shuffler"
+path = "fuzz_targets/use_case_aware_shuffler.rs"
 test = false
 doc = false

--- a/testsuite/fuzzer/fuzz/fuzz_targets/use_case_aware_shuffler.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/use_case_aware_shuffler.rs
@@ -1,4 +1,7 @@
 #![no_main]
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
 use aptos_consensus::transaction_shuffler_fuzzing::use_case_aware::{Config, UseCaseAwareShuffler};
 use aptos_types::transaction::use_case::{UseCaseAwareTransaction, UseCaseKey};
 use arbitrary::Arbitrary;

--- a/testsuite/fuzzer/fuzz/fuzz_targets/use_case_aware_shuffler.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/use_case_aware_shuffler.rs
@@ -1,0 +1,70 @@
+#![no_main]
+use aptos_consensus::transaction_shuffler_fuzzing::use_case_aware::{Config, UseCaseAwareShuffler};
+use aptos_types::transaction::use_case::{UseCaseAwareTransaction, UseCaseKey};
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use move_core_types::account_address::AccountAddress;
+
+#[derive(Arbitrary, Debug, PartialEq, Eq, Clone)]
+pub enum UseCaseKeyU8 {
+    Platform,
+    ContractAddress(u8),
+    Others,
+}
+
+#[derive(Arbitrary, Debug, PartialEq, Eq, Clone)]
+struct Tx {
+    sender: u8,
+    k: UseCaseKeyU8,
+    id: usize,
+}
+
+#[derive(Arbitrary, Debug)]
+struct FuzzData {
+    data: Vec<Tx>,
+    test_determinism: bool,
+}
+
+impl UseCaseAwareTransaction for Tx {
+    fn parse_sender(&self) -> AccountAddress {
+        let mut addr = [0u8; AccountAddress::LENGTH];
+        addr[AccountAddress::LENGTH - 1] = self.sender;
+        AccountAddress::new(addr)
+    }
+
+    fn parse_use_case(&self) -> UseCaseKey {
+        match self.k {
+            UseCaseKeyU8::Platform => UseCaseKey::Platform,
+            UseCaseKeyU8::ContractAddress(account_address) => {
+                let mut addr = [0u8; AccountAddress::LENGTH];
+                addr[AccountAddress::LENGTH - 1] = account_address;
+                UseCaseKey::ContractAddress(AccountAddress::new(addr))
+            },
+            UseCaseKeyU8::Others => UseCaseKey::Others,
+        }
+    }
+}
+
+fn run(mut fuzz_data: FuzzData) {
+    // production config
+    let shuf = UseCaseAwareShuffler {
+        config: Config {
+            sender_spread_factor: 32,
+            platform_use_case_spread_factor: 0,
+            user_use_case_spread_factor: 4,
+        },
+    };
+    for i in 0..fuzz_data.data.len() {
+        fuzz_data.data[i].id = i;
+    }
+
+    let res = shuf.shuffle_generic(fuzz_data.data.clone());
+    if fuzz_data.test_determinism {
+        let res1 = shuf.shuffle_generic(fuzz_data.data);
+        assert!(res == res1);
+    }
+}
+
+fuzz_target!(|fuzz_data: FuzzData| {
+    run(fuzz_data);
+});


### PR DESCRIPTION
## Description

Adds a fuzzer for use case aware shuffler.

## How Has This Been Tested?

`./fuzz.sh run use_case_aware_shuffler` works

## Key Areas to Review

Is it okay to change the module and struct visibility or should I gate it for `"fuzzer"` feature as well?

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
