### PR TITLE
Add --host-postgres-host flag to CLI for localnet

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 ## Unreleased
 - Fix typos in `aptos move compile` help text.
 - Update the default version of `movefmt` to be installed from 1.0.5 to 1.0.6
+- Add `--host-postgres-host` flag: https://github.com/aptos-labs/aptos-core/pull/15216.
 
 ## [4.3.0] - 2024/10/30
 - Allow for setting large-packages module for chunking publish mode with `--large-packages-module-address`

--- a/crates/aptos/src/node/local_testnet/postgres.rs
+++ b/crates/aptos/src/node/local_testnet/postgres.rs
@@ -57,6 +57,11 @@ pub struct PostgresArgs {
     #[clap(long, requires = "with_indexer_api")]
     pub use_host_postgres: bool,
 
+    /// If --use-host-postgres is set, you can use this to change the host we try to
+    /// connect to.
+    #[clap(long, default_value = "127.0.0.1")]
+    pub host_postgres_host: String,
+
     /// When --use-host-postgres is set, this is the port to connect to.
     #[clap(long, default_value_t = 5432)]
     pub host_postgres_port: u16,
@@ -98,7 +103,7 @@ impl PostgresArgs {
             None => &self.postgres_database,
         };
         let host = match self.use_host_postgres {
-            true => "127.0.0.1",
+            true => &self.host_postgres_host,
             false => match external {
                 true => "127.0.0.1",
                 false => POSTGRES_CONTAINER_NAME,


### PR DESCRIPTION
## Description
When using `--use-host-postgres`, it can sometimes be helpful to specify a different address for the postgres instance rather than `127.0.0.1`. This PR adds the `--host-postgres-host` flag to let you do that.

## How Has This Been Tested?
```
cargo run -p aptos -- node run-localnet --use-host-postgres --host-postgres-host 1.2.3.4 --with-indexer-api
```
I confirmed that if you use a host where a DB is running the localnet comes up, and otherwise does not.

## Key Areas to Review
N/A

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
