### PR TITLE
[docker] use zstd compression and upgrade action

### DIFF
--- a/.github/actions/buildx-setup/action.yml
+++ b/.github/actions/buildx-setup/action.yml
@@ -3,18 +3,17 @@ description: Sets up buildx for docker builds
 
 runs:
   using: composite
-  steps: 
+  steps:
     - name: setup docker context for buildx
       id: buildx-context
       shell: bash
       run: docker context create builders
 
     - name: setup docker buildx
-      uses: aptos-labs/setup-buildx-action@7952e9cf0debaf1f3f3e5dc7d9c5ea6ececb127e # pin v2.4.0
+      uses: aptos-labs/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # pin v3.7.1
       with:
         endpoint: builders
-        version: v0.11.0
-        custom-name: "core-builder"
+        version: v0.17.1
         keep-state: true
         config-inline: |
           [worker.oci]

--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -145,6 +145,7 @@ target "_common" {
     GIT_TAG    = "${GIT_TAG}"
     BUILD_DATE = "${BUILD_DATE}"
   }
+  output     = ["type=image,compression=zstd,force-compression=true"]
 }
 
 target "validator-testing" {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Apparently, [according to this blog](https://depot.dev/blog/building-images-gzip-vs-zstd), using zstd compression can provide better compression/decompression times for docker image, speeding up both image build times and container start times. 

Also, upgrades the docker setup action to use latest version of docker.
