### PR TITLE
[Fullnode Sync] Add jobs to verify fast sync in devnet.

### DIFF
--- a/.github/workflows/fullnode-fast-devnet-main.yaml
+++ b/.github/workflows/fullnode-fast-devnet-main.yaml
@@ -1,0 +1,34 @@
+# This workflow runs a public fullnode using the `main` branch,
+# connects the public fullnode to `devnet` and synchronizes the
+# node using fast syncing to verify that nothing has been broken.
+
+name: "fullnode-fast-devnet-main"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *" # Once a day, at 02:00 (UTC)
+
+permissions:
+  contents: read
+  id-token: write
+  actions: write #required for workflow cancellation via check-aptos-core
+
+jobs:
+  check-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
+        with:
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
+
+  fullnode-fast-devnet-main:
+    needs: check-repo
+    uses: ./.github/workflows/run-fullnode-sync.yaml
+    secrets: inherit
+    with:
+      TEST_NAME: fullnode-fast-devnet-main
+      GIT_REF: main
+      NETWORK: devnet
+      BOOTSTRAPPING_MODE: DownloadLatestStates
+      CONTINUOUS_SYNCING_MODE: ExecuteTransactions

--- a/.github/workflows/fullnode-fast-devnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-devnet-stable.yaml
@@ -1,0 +1,34 @@
+# This workflow runs a public fullnode using the `devnet` branch,
+# connects the public fullnode to `devnet` and synchronizes the
+# node using fast syncing to verify that nothing has been broken.
+
+name: "fullnode-fast-devnet-stable"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 2 */3 * *" # Once every three days, at 02:30 (UTC)
+
+permissions:
+  contents: read
+  id-token: write
+  actions: write #required for workflow cancellation via check-aptos-core
+
+jobs:
+  check-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
+        with:
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
+
+  fullnode-fast-devnet-stable:
+    needs: check-repo
+    uses: ./.github/workflows/run-fullnode-sync.yaml
+    secrets: inherit
+    with:
+      TEST_NAME: fullnode-fast-devnet-stable
+      GIT_REF: devnet
+      NETWORK: devnet
+      BOOTSTRAPPING_MODE: DownloadLatestStates
+      CONTINUOUS_SYNCING_MODE: ExecuteTransactions


### PR DESCRIPTION
## Description
This PR adds 2 new fullnode sync jobs to verify fast sync in `devnet`:
1. Fast sync using the `main` branch
2. Fast sync using the `devnet` branch

This should help us catch any potential issues with fast sync earlier (without needing to wait for testnet).

## Test Plan
Existing test infrastructure.
