### PR TITLE
exebench for keyless

### DIFF
--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -719,7 +719,7 @@ fn initialize_keyless_accounts(
             issuer: get_sample_iss(),
             jwk: JWK::RSA(secure_test_rsa_jwk()),
         };
-        initial_jwks.push(additional_jwk_patch);
+        initial_jwks.insert(0, additional_jwk_patch);
 
         let jwk_patches: Vec<PatchJWKMoveStruct> = initial_jwks
             .into_iter()

--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -27,6 +27,8 @@ use aptos_keygen::KeyGen;
 use aptos_logger::prelude::*;
 use aptos_types::{
     chain_id::ChainId,
+    jwks::patch::IssuerJWK,
+    keyless::Groth16VerificationKey,
     on_chain_config::{
         Features, GasScheduleV2, OnChainConsensusConfig, OnChainExecutionConfig,
         OnChainJWKConsensusConfig, OnChainRandomnessConfig,
@@ -441,6 +443,8 @@ pub struct GenesisConfiguration {
     pub initial_features_override: Option<Features>,
     pub randomness_config_override: Option<OnChainRandomnessConfig>,
     pub jwk_consensus_config_override: Option<OnChainJWKConsensusConfig>,
+    pub initial_jwks: Vec<IssuerJWK>,
+    pub keyless_groth16_vk_override: Option<Groth16VerificationKey>,
 }
 
 pub type InitConfigFn = Arc<dyn Fn(usize, &mut NodeConfig, &mut NodeConfig) + Send + Sync>;
@@ -662,6 +666,8 @@ impl Builder {
             initial_features_override: None,
             randomness_config_override: None,
             jwk_consensus_config_override: None,
+            initial_jwks: vec![],
+            keyless_groth16_vk_override: None,
         };
         if let Some(init_genesis_config) = &self.init_genesis_config {
             (init_genesis_config)(&mut genesis_config);

--- a/crates/aptos-genesis/src/config.rs
+++ b/crates/aptos-genesis/src/config.rs
@@ -6,6 +6,8 @@ use aptos_crypto::{bls12381, ed25519::Ed25519PublicKey, x25519};
 use aptos_types::{
     account_address::{AccountAddress, AccountAddressWithChecks},
     chain_id::ChainId,
+    jwks::patch::IssuerJWK,
+    keyless::Groth16VerificationKey,
     network_address::{DnsName, NetworkAddress, Protocol},
     on_chain_config::{OnChainConsensusConfig, OnChainExecutionConfig, OnChainJWKConsensusConfig},
     transaction::authenticator::AuthenticationKey,
@@ -75,7 +77,16 @@ pub struct Layout {
     pub on_chain_execution_config: OnChainExecutionConfig,
 
     /// An optional JWK consensus config to use, instead of `default_for_genesis()`.
+    #[serde(default)]
     pub jwk_consensus_config_override: Option<OnChainJWKConsensusConfig>,
+
+    /// JWKs to patch in genesis.
+    #[serde(default)]
+    pub initial_jwks: Vec<IssuerJWK>,
+
+    /// Keyless Groth16 verification key to install in genesis.
+    #[serde(default)]
+    pub keyless_groth16_vk_override: Option<Groth16VerificationKey>,
 }
 
 impl Layout {
@@ -116,6 +127,8 @@ impl Default for Layout {
             on_chain_consensus_config: OnChainConsensusConfig::default(),
             on_chain_execution_config: OnChainExecutionConfig::default_for_genesis(),
             jwk_consensus_config_override: None,
+            initial_jwks: vec![],
+            keyless_groth16_vk_override: None,
         }
     }
 }

--- a/crates/aptos-genesis/src/lib.rs
+++ b/crates/aptos-genesis/src/lib.rs
@@ -23,6 +23,8 @@ use aptos_storage_interface::DbReaderWriter;
 use aptos_temppath::TempPath;
 use aptos_types::{
     chain_id::ChainId,
+    jwks::patch::IssuerJWK,
+    keyless::Groth16VerificationKey,
     on_chain_config::{
         Features, GasScheduleV2, OnChainConsensusConfig, OnChainExecutionConfig,
         OnChainJWKConsensusConfig, OnChainRandomnessConfig,
@@ -76,6 +78,8 @@ pub struct GenesisInfo {
     pub initial_features_override: Option<Features>,
     pub randomness_config_override: Option<OnChainRandomnessConfig>,
     pub jwk_consensus_config_override: Option<OnChainJWKConsensusConfig>,
+    pub initial_jwks: Vec<IssuerJWK>,
+    pub keyless_groth16_vk_override: Option<Groth16VerificationKey>,
 }
 
 impl GenesisInfo {
@@ -115,6 +119,8 @@ impl GenesisInfo {
             initial_features_override: genesis_config.initial_features_override.clone(),
             randomness_config_override: genesis_config.randomness_config_override.clone(),
             jwk_consensus_config_override: genesis_config.jwk_consensus_config_override.clone(),
+            initial_jwks: genesis_config.initial_jwks.clone(),
+            keyless_groth16_vk_override: genesis_config.keyless_groth16_vk_override.clone(),
         })
     }
 
@@ -150,6 +156,8 @@ impl GenesisInfo {
                 initial_features_override: self.initial_features_override.clone(),
                 randomness_config_override: self.randomness_config_override.clone(),
                 jwk_consensus_config_override: self.jwk_consensus_config_override.clone(),
+                initial_jwks: self.initial_jwks.clone(),
+                keyless_groth16_vk_override: self.keyless_groth16_vk_override.clone(),
             },
             &self.consensus_config,
             &self.execution_config,

--- a/crates/aptos-genesis/src/mainnet.rs
+++ b/crates/aptos-genesis/src/mainnet.rs
@@ -143,6 +143,8 @@ impl MainnetGenesisInfo {
                 initial_features_override: self.initial_features_override.clone(),
                 randomness_config_override: self.randomness_config_override.clone(),
                 jwk_consensus_config_override: self.jwk_consensus_config_override.clone(),
+                initial_jwks: vec![],
+                keyless_groth16_vk_override: None,
             },
         )
     }

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -260,6 +260,8 @@ pub fn fetch_mainnet_genesis_info(git_options: GitOptions) -> CliTypedResult<Mai
             initial_features_override: None,
             randomness_config_override: None,
             jwk_consensus_config_override: None,
+            initial_jwks: vec![],
+            keyless_groth16_vk_override: None,
         },
     )?)
 }
@@ -303,6 +305,8 @@ pub fn fetch_genesis_info(git_options: GitOptions) -> CliTypedResult<GenesisInfo
             initial_features_override: None,
             randomness_config_override: None,
             jwk_consensus_config_override: layout.jwk_consensus_config_override.clone(),
+            initial_jwks: layout.initial_jwks.clone(),
+            keyless_groth16_vk_override: layout.keyless_groth16_vk_override.clone(),
         },
     )?)
 }

--- a/crates/transaction-emitter-lib/src/emitter/local_account_generator.rs
+++ b/crates/transaction-emitter-lib/src/emitter/local_account_generator.rs
@@ -6,7 +6,7 @@ use aptos_sdk::types::{
     AccountKey, EphemeralKeyPair, EphemeralPrivateKey, KeylessAccount, LocalAccount,
 };
 use aptos_transaction_generator_lib::ReliableTransactionSubmitter;
-use aptos_types::keyless::{Claims, OpenIdSig, Pepper, ZeroKnowledgeSig};
+use aptos_types::keyless::{Claims, Configuration, OpenIdSig, Pepper, ZeroKnowledgeSig};
 use async_trait::async_trait;
 use futures::StreamExt;
 use rand::rngs::StdRng;
@@ -136,6 +136,7 @@ impl LocalAccountGenerator for KeylessAccountGenerator {
             },
         };
 
+        let config = Configuration::new_for_devnet();
         for line in lines {
             let serialized_proof = line?;
             let zk_sig_bytes = hex::decode(serialized_proof)?;
@@ -154,6 +155,7 @@ impl LocalAccountGenerator for KeylessAccountGenerator {
                 &self.uid_val,
                 &self.jwt_header_json,
                 EphemeralKeyPair::new(
+                    &config,
                     esk,
                     self.epk_expiry_date_secs,
                     vec![0; OpenIdSig::EPK_BLINDER_NUM_BYTES],

--- a/crates/transaction-emitter-lib/src/emitter/local_account_generator.rs
+++ b/crates/transaction-emitter-lib/src/emitter/local_account_generator.rs
@@ -6,7 +6,7 @@ use aptos_sdk::types::{
     AccountKey, EphemeralKeyPair, EphemeralPrivateKey, KeylessAccount, LocalAccount,
 };
 use aptos_transaction_generator_lib::ReliableTransactionSubmitter;
-use aptos_types::keyless::{Claims, Configuration, OpenIdSig, Pepper, ZeroKnowledgeSig};
+use aptos_types::keyless::{Claims, OpenIdSig, Pepper, ZeroKnowledgeSig};
 use async_trait::async_trait;
 use futures::StreamExt;
 use rand::rngs::StdRng;
@@ -136,7 +136,6 @@ impl LocalAccountGenerator for KeylessAccountGenerator {
             },
         };
 
-        let config = Configuration::new_for_devnet();
         for line in lines {
             let serialized_proof = line?;
             let zk_sig_bytes = hex::decode(serialized_proof)?;
@@ -155,7 +154,6 @@ impl LocalAccountGenerator for KeylessAccountGenerator {
                 &self.uid_val,
                 &self.jwt_header_json,
                 EphemeralKeyPair::new(
-                    &config,
                     esk,
                     self.epk_expiry_date_secs,
                     vec![0; OpenIdSig::EPK_BLINDER_NUM_BYTES],

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -717,13 +717,15 @@ impl EmitJob {
 pub struct TxnEmitter {
     txn_factory: TransactionFactory,
     rng: StdRng,
+    rest_cli: RestClient,
 }
 
 impl TxnEmitter {
-    pub fn new(transaction_factory: TransactionFactory, rng: StdRng) -> Self {
+    pub fn new(transaction_factory: TransactionFactory, rng: StdRng, rest_cli: RestClient) -> Self {
         Self {
             txn_factory: transaction_factory,
             rng,
+            rest_cli,
         }
     }
 
@@ -775,6 +777,11 @@ impl TxnEmitter {
                         .expect("keyless_ephem_secret_key to not be None")
                         .as_ref(),
                 )?;
+                let keyless_config = self
+                    .rest_cli
+                    .get_resource(AccountAddress::ONE, "0x1::keyless_account::Configuration")
+                    .await?
+                    .into_inner();
                 create_keyless_account_generator(
                     ephem_sk,
                     req.epk_expiry_date_secs
@@ -783,6 +790,7 @@ impl TxnEmitter {
                         .as_deref()
                         .expect("keyless_jwt to not be None"),
                     req.proof_file_path.as_deref(),
+                    keyless_config,
                 )?
             },
         };

--- a/crates/transaction-emitter/src/diag.rs
+++ b/crates/transaction-emitter/src/diag.rs
@@ -19,6 +19,7 @@ pub async fn diag(cluster: &Cluster) -> Result<()> {
         TransactionFactory::new(cluster.chain_id)
             .with_gas_unit_price(aptos_global_constants::GAS_UNIT_PRICE),
         StdRng::from_entropy(),
+        client,
     );
     let coin_source_account_address = coin_source_account.address();
     let instances: Vec<_> = cluster.all_instances().collect();

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -13,17 +13,16 @@ use aptos_config::{
 use aptos_db::AptosDB;
 use aptos_executor::db_bootstrapper::{generate_waypoint, maybe_bootstrap};
 use aptos_storage_interface::DbReaderWriter;
-use aptos_vm::{aptos_vm::AptosVMBlockExecutor, VMBlockExecutor};
 use aptos_types::{
     jwks::{jwk::JWK, patch::IssuerJWK},
     keyless::{
-        circuit_constants::TEST_GROTH16_KEYS,
+        circuit_constants::TEST_GROTH16_SETUP,
         test_utils::{get_sample_iss, get_sample_jwk},
         Groth16VerificationKey,
     },
     on_chain_config::Features,
 };
-use aptos_vm::AptosVM;
+use aptos_vm::{aptos_vm::AptosVMBlockExecutor, VMBlockExecutor};
 use std::{fs, path::Path, sync::Arc};
 
 pub fn create_db_with_accounts<V>(
@@ -82,8 +81,9 @@ pub(crate) fn bootstrap_with_genesis(
                 issuer: get_sample_iss(),
                 jwk: JWK::RSA(get_sample_jwk()),
             }];
-            config.keyless_groth16_vk_override =
-                Some(Groth16VerificationKey::from(&TEST_GROTH16_KEYS.prepared_vk));
+            config.keyless_groth16_vk_override = Some(Groth16VerificationKey::from(
+                &TEST_GROTH16_SETUP.prepared_vk,
+            ));
         })));
 
     let mut rocksdb_configs = RocksdbConfigs::default();

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -120,6 +120,7 @@ pub fn run_benchmark<V>(
     enable_storage_sharding: bool,
     pipeline_config: PipelineConfig,
     init_features: Features,
+    is_keyless: bool,
 ) where
     V: VMBlockExecutor + 'static,
 {
@@ -164,6 +165,7 @@ pub fn run_benchmark<V>(
             db.reader.clone(),
             num_accounts_to_be_loaded,
             num_accounts_to_skip,
+            is_keyless,
         );
         let (main_signer_accounts, burner_accounts) =
             accounts_cache.split(num_main_signer_accounts);
@@ -220,6 +222,7 @@ pub fn run_benchmark<V>(
         source_dir,
         Some(num_accounts_to_load),
         pipeline_config.num_generator_workers,
+        is_keyless,
     );
 
     let mut overall_measuring = OverallMeasuring::start();
@@ -341,6 +344,7 @@ pub fn add_accounts<V>(
     enable_storage_sharding: bool,
     pipeline_config: PipelineConfig,
     init_features: Features,
+    is_keyless: bool,
 ) where
     V: VMBlockExecutor + 'static,
 {
@@ -361,6 +365,7 @@ pub fn add_accounts<V>(
         enable_storage_sharding,
         pipeline_config,
         init_features,
+        is_keyless,
     );
 }
 
@@ -375,6 +380,7 @@ fn add_accounts_impl<V>(
     enable_storage_sharding: bool,
     pipeline_config: PipelineConfig,
     init_features: Features,
+    is_keyless: bool,
 ) where
     V: VMBlockExecutor + 'static,
 {
@@ -401,6 +407,7 @@ fn add_accounts_impl<V>(
         &source_dir,
         None,
         pipeline_config.num_generator_workers,
+        is_keyless,
     );
 
     let start_time = Instant::now();
@@ -410,6 +417,7 @@ fn add_accounts_impl<V>(
         num_new_accounts,
         init_account_balance,
         block_size,
+        is_keyless,
     );
     generator.drop_sender();
     pipeline.start_pipeline_processing();
@@ -905,6 +913,7 @@ mod tests {
             false,
             PipelineConfig::default(),
             features.clone(),
+            false,
         );
 
         println!("run_benchmark");
@@ -935,6 +944,7 @@ mod tests {
             false,
             PipelineConfig::default(),
             features,
+            false,
         );
     }
 

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -243,6 +243,9 @@ enum BlockExecutorTypeOpt {
 
 #[derive(Parser, Debug)]
 struct Opt {
+    #[clap(long)]
+    use_keyless_accounts: bool,
+
     #[clap(long, default_value_t = 10000)]
     block_size: usize,
 
@@ -442,6 +445,7 @@ where
                 opt.enable_storage_sharding,
                 opt.pipeline_opt.pipeline_config(),
                 get_init_features(enable_feature, disable_feature),
+                opt.use_keyless_accounts,
             );
         },
         Command::RunExecutor {
@@ -503,6 +507,7 @@ where
                 opt.enable_storage_sharding,
                 opt.pipeline_opt.pipeline_config(),
                 get_init_features(enable_feature, disable_feature),
+                opt.use_keyless_accounts,
             );
         },
         Command::AddAccounts {
@@ -522,6 +527,7 @@ where
                 opt.enable_storage_sharding,
                 opt.pipeline_opt.pipeline_config(),
                 Features::default(),
+                opt.use_keyless_accounts,
             );
         },
     }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -25,6 +25,7 @@ bcs = { workspace = true }
 ed25519-dalek-bip32 = { workspace = true }
 hex = { workspace = true }
 move-core-types = { workspace = true }
+rand = { workspace = true }
 rand_core = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -245,7 +245,7 @@ impl LocalAccount {
                 &config,
             )
             .unwrap();
-            let groth16_proof = keyless::proof_simulation::Groth16SimulatorBn254::create_random_proof_with_trapdoor(&[public_inputs], &keyless::circuit_constants::TEST_GROTH16_KEYS.pk, rng).unwrap();
+            let groth16_proof = keyless::proof_simulation::Groth16SimulatorBn254::create_random_proof_with_trapdoor(&[public_inputs], &keyless::circuit_constants::TEST_GROTH16_SETUP.simulation_pk, rng).unwrap();
             let zk_sig = ZeroKnowledgeSig {
                 proof: keyless::ZKP::Groth16(groth16_proof),
                 exp_horizon_secs,

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -233,6 +233,7 @@ impl LocalAccount {
             let idc = keyless::IdCommitment::new_from_preimage(&pepper, &aud, &uid_key, &uid_val)
                 .unwrap();
             let public_inputs = keyless::bn254_circom::hash_public_inputs(
+                &config,
                 &eph_key_pair.public_key,
                 &idc,
                 exp_timestamp_secs,
@@ -242,7 +243,6 @@ impl LocalAccount {
                 &jwt_header,
                 &jwk,
                 None,
-                &config,
             )
             .unwrap();
             let groth16_proof = keyless::proof_simulation::Groth16SimulatorBn254::create_random_proof_with_trapdoor(&[public_inputs], &keyless::circuit_constants::TEST_GROTH16_SETUP.simulation_pk, rng).unwrap();

--- a/testsuite/smoke-test/src/keyless.rs
+++ b/testsuite/smoke-test/src/keyless.rs
@@ -326,7 +326,7 @@ script {{
     };
     let rest_cli = swarm.validators().next().unwrap().rest_client();
     let config = get_on_chain_resource(&rest_cli).await;
-    let ephemeral_key_pair = EphemeralKeyPair::new(
+    let ephemeral_key_pair = EphemeralKeyPair::new_with_keyless_config(
         &config,
         esk,
         get_sample_exp_date(),
@@ -443,7 +443,7 @@ async fn test_keyless_groth16_verifies_using_rust_sdk() {
     let esk = EphemeralPrivateKey::Ed25519 {
         inner_private_key: get_sample_esk(),
     };
-    let ephemeral_key_pair = EphemeralKeyPair::new(
+    let ephemeral_key_pair = EphemeralKeyPair::new_with_keyless_config(
         &config,
         esk,
         get_sample_exp_date(),
@@ -511,7 +511,7 @@ async fn test_keyless_groth16_verifies_using_rust_sdk_from_jwt() {
         inner_private_key: get_sample_esk(),
     };
 
-    let ephemeral_key_pair = EphemeralKeyPair::new(
+    let ephemeral_key_pair = EphemeralKeyPair::new_with_keyless_config(
         &config,
         esk,
         get_sample_exp_date(),

--- a/testsuite/smoke-test/src/txn_emitter.rs
+++ b/testsuite/smoke-test/src/txn_emitter.rs
@@ -37,7 +37,8 @@ pub async fn generate_traffic(
     .await?;
     let transaction_factory =
         TransactionFactory::new(swarm.chain_info().chain_id).with_gas_unit_price(gas_price);
-    let emitter = TxnEmitter::new(transaction_factory, rng);
+    let rest_cli = swarm.validators().next().unwrap().rest_client();
+    let emitter = TxnEmitter::new(transaction_factory, rng, rest_cli);
     emitter
         .emit_txn_for_with_stats(
             swarm.chain_info().root_account,
@@ -68,8 +69,8 @@ pub async fn generate_keyless_traffic(
     .await?;
     let transaction_factory =
         TransactionFactory::new(swarm.chain_info().chain_id).with_gas_unit_price(gas_price);
-
-    let emitter = TxnEmitter::new(transaction_factory, rng);
+    let rest_cli = swarm.validators().next().unwrap().rest_client();
+    let emitter = TxnEmitter::new(transaction_factory, rng, rest_cli);
     emitter
         .emit_txn_for_with_stats(
             swarm.chain_info().root_account,
@@ -267,7 +268,7 @@ async fn test_txn_emmitter_low_funds() {
         .collect::<Vec<_>>();
     let chain_info = swarm.chain_info();
     let transaction_factory = TransactionFactory::new(chain_info.chain_id).with_gas_unit_price(100);
-    let emitter = TxnEmitter::new(transaction_factory, rng);
+    let emitter = TxnEmitter::new(transaction_factory, rng, validator_clients[0].clone());
 
     let emit_job_request = EmitJobRequest::default()
         .rest_clients(validator_clients)

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -143,7 +143,14 @@ pub async fn create_emitter_and_request(
 
     let chain_info = swarm.read().await.chain_info();
     let transaction_factory = TransactionFactory::new(chain_info.chain_id);
-    let emitter = TxnEmitter::new(transaction_factory, rng);
+    let rest_cli = swarm
+        .read()
+        .await
+        .validators()
+        .next()
+        .unwrap()
+        .rest_client();
+    let emitter = TxnEmitter::new(transaction_factory, rng, rest_cli);
 
     emit_job_request = emit_job_request.rest_clients(
         swarm

--- a/types/src/jwks/patch/mod.rs
+++ b/types/src/jwks/patch/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    jwks::jwk::JWKMoveStruct,
+    jwks::jwk::{JWKMoveStruct, JWK},
     move_any::{Any as MoveAny, AsMoveAny},
     move_utils::as_move_value::AsMoveValue,
 };
@@ -35,4 +35,11 @@ pub struct PatchUpsertJWK {
 
 impl AsMoveAny for PatchUpsertJWK {
     const MOVE_TYPE_NAME: &'static str = "0x1::jwks::PatchUpsertJWK";
+}
+
+/// A variant representation used in genesis layout.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct IssuerJWK {
+    pub issuer: String,
+    pub jwk: JWK,
 }

--- a/types/src/jwks/rsa/insecure_test_jwk.json
+++ b/types/src/jwks/rsa/insecure_test_jwk.json
@@ -4,7 +4,7 @@
             "kty": "RSA",
             "n": "6S7asUuzq5Q_3U9rbs-PkDVIdjgmtgWreG5qWPsC9xXZKiMV1AiV9LXyqQsAYpCqEDM3XbfmZqGb48yLhb_XqZaKgSYaC_h2DjM7lgrIQAp9902Rr8fUmLN2ivr5tnLxUUOnMOc2SQtr9dgzTONYW5Zu3PwyvAWk5D6ueIUhLtYzpcB-etoNdL3Ir2746KIy_VUsDwAM7dhrqSK8U2xFCGlau4ikOTtvzDownAMHMrfE7q1B6WZQDAQlBmxRQsyKln5DIsKv6xauNsHRgBAKctUxZG8M4QJIx3S6Aughd3RZC4Ca5Ae9fd8L8mlNYBCrQhOZ7dS0f4at4arlLcajtw",
             "e": "AQAB",
-            "kid": "test-rsa",
+            "kid": "test-rsa-insecure",
             "alg": "RS256"
         }
     ]

--- a/types/src/jwks/rsa/insecure_test_jwk.json
+++ b/types/src/jwks/rsa/insecure_test_jwk.json
@@ -4,7 +4,7 @@
             "kty": "RSA",
             "n": "6S7asUuzq5Q_3U9rbs-PkDVIdjgmtgWreG5qWPsC9xXZKiMV1AiV9LXyqQsAYpCqEDM3XbfmZqGb48yLhb_XqZaKgSYaC_h2DjM7lgrIQAp9902Rr8fUmLN2ivr5tnLxUUOnMOc2SQtr9dgzTONYW5Zu3PwyvAWk5D6ueIUhLtYzpcB-etoNdL3Ir2746KIy_VUsDwAM7dhrqSK8U2xFCGlau4ikOTtvzDownAMHMrfE7q1B6WZQDAQlBmxRQsyKln5DIsKv6xauNsHRgBAKctUxZG8M4QJIx3S6Aughd3RZC4Ca5Ae9fd8L8mlNYBCrQhOZ7dS0f4at4arlLcajtw",
             "e": "AQAB",
-            "kid": "test-rsa-insecure",
+            "kid": "test-rsa",
             "alg": "RS256"
         }
     ]

--- a/types/src/keyless/bn254_circom.rs
+++ b/types/src/keyless/bn254_circom.rs
@@ -382,10 +382,10 @@ pub fn get_public_inputs_hash(
             sig.exp_date_secs,
             proof.exp_horizon_secs,
             &pk.iss_val,
-            proof.extra_field.as_ref().map(String::as_str),
+            proof.extra_field.as_deref(),
             &sig.jwt_header_json,
             jwk,
-            proof.override_aud_val.as_ref().map(String::as_str),
+            proof.override_aud_val.as_deref(),
         )
     } else {
         bail!("Can only call `get_public_inputs_hash` on keyless::Signature with Groth16 ZK proof")

--- a/types/src/keyless/circuit_constants.rs
+++ b/types/src/keyless/circuit_constants.rs
@@ -3,10 +3,15 @@
 
 //! These constants are from commit 125522b4b226f8ece3e3162cecfefe915d13bc30 of keyless-circuit.
 
-use crate::keyless::bn254_circom::{g1_projective_str_to_affine, g2_projective_str_to_affine};
+use crate::keyless::{
+    bn254_circom::{g1_projective_str_to_affine, g2_projective_str_to_affine},
+    proof_simulation::{Groth16SimulatorBn254, Trapdoor},
+};
 use aptos_crypto::poseidon_bn254;
 use ark_bn254::Bn254;
 use ark_groth16::{PreparedVerifyingKey, VerifyingKey};
+use once_cell::sync::Lazy;
+use rand::{prelude::StdRng, SeedableRng};
 
 pub(crate) const MAX_AUD_VAL_BYTES: usize = 120;
 pub(crate) const MAX_UID_KEY_BYTES: usize = 30;
@@ -92,3 +97,21 @@ pub fn devnet_prepared_vk() -> PreparedVerifyingKey<Bn254> {
 
     PreparedVerifyingKey::from(vk)
 }
+
+pub struct Groth16Keys {
+    pub pk: Trapdoor<Bn254>,
+    pub vk: VerifyingKey<Bn254>,
+    pub prepared_vk: PreparedVerifyingKey<Bn254>,
+}
+
+pub static TEST_GROTH16_KEYS: Lazy<Groth16Keys> = Lazy::new(|| {
+    let mut rng = StdRng::seed_from_u64(999);
+    let (pk, vk) =
+        Groth16SimulatorBn254::circuit_agnostic_setup_with_trapdoor(&mut rng, 1).unwrap();
+    let prepared_vk = PreparedVerifyingKey::from(vk.clone());
+    Groth16Keys {
+        pk,
+        vk,
+        prepared_vk,
+    }
+});

--- a/types/src/keyless/circuit_constants.rs
+++ b/types/src/keyless/circuit_constants.rs
@@ -98,20 +98,18 @@ pub fn devnet_prepared_vk() -> PreparedVerifyingKey<Bn254> {
     PreparedVerifyingKey::from(vk)
 }
 
-pub struct Groth16Keys {
-    pub pk: Trapdoor<Bn254>,
-    pub vk: VerifyingKey<Bn254>,
+pub struct Groth16TrapdoorSetup {
+    pub simulation_pk: Trapdoor<Bn254>,
     pub prepared_vk: PreparedVerifyingKey<Bn254>,
 }
 
-pub static TEST_GROTH16_KEYS: Lazy<Groth16Keys> = Lazy::new(|| {
+pub static TEST_GROTH16_SETUP: Lazy<Groth16TrapdoorSetup> = Lazy::new(|| {
     let mut rng = StdRng::seed_from_u64(999);
-    let (pk, vk) =
+    let (simulation_pk, vk) =
         Groth16SimulatorBn254::circuit_agnostic_setup_with_trapdoor(&mut rng, 1).unwrap();
     let prepared_vk = PreparedVerifyingKey::from(vk.clone());
-    Groth16Keys {
-        pk,
-        vk,
+    Groth16TrapdoorSetup {
+        simulation_pk,
         prepared_vk,
     }
 });

--- a/types/src/keyless/circuit_testcases.rs
+++ b/types/src/keyless/circuit_testcases.rs
@@ -61,6 +61,31 @@ pub fn sample_jwt_payload_json() -> String {
     )
 }
 
+pub fn render_jwt_payload_json(
+    iss: &str,
+    aud: &str,
+    uid_key: &str,
+    uid_val: &str,
+    extra_field: &str,
+    iat: u64,
+    nonce: &str,
+    exp: u64,
+) -> String {
+    format!(
+        r#"{{
+            "iss":"{}",
+            "aud":"{}",
+            "{}":"{}",
+            {}
+            "iat":{},
+            "nonce":"{}",
+            "exp":{}
+        }}
+        "#,
+        iss, aud, uid_key, uid_val, extra_field, iat, nonce, exp
+    )
+}
+
 pub fn sample_jwt_payload_json_overrides(
     iss: &str,
     uid_val: &str,
@@ -109,7 +134,7 @@ pub(crate) static SAMPLE_JWK: Lazy<RSA_JWK> = Lazy::new(insecure_test_rsa_jwk);
 
 /// This is the SK from https://token.dev/.
 /// To convert it into a JSON, you can use https://irrte.ch/jwt-js-decode/pem2jwk.html
-pub(crate) static SAMPLE_JWK_SK: Lazy<&RsaKeyPair> = Lazy::new(|| &*INSECURE_TEST_RSA_KEY_PAIR);
+pub static SAMPLE_JWK_SK: Lazy<&RsaKeyPair> = Lazy::new(|| &*INSECURE_TEST_RSA_KEY_PAIR);
 
 pub(crate) const SAMPLE_UID_KEY: &str = "sub";
 

--- a/types/src/keyless/configuration.rs
+++ b/types/src/keyless/configuration.rs
@@ -7,6 +7,7 @@ use crate::{
         circuit_constants, circuit_testcases::SAMPLE_EXP_HORIZON_SECS, KEYLESS_ACCOUNT_MODULE_NAME,
     },
     move_utils::as_move_value::AsMoveValue,
+    on_chain_config::OnChainConfig,
 };
 use move_core_types::{
     ident_str,
@@ -91,4 +92,9 @@ impl Configuration {
             Ok(())
         }
     }
+}
+
+impl OnChainConfig for Configuration {
+    const MODULE_IDENTIFIER: &'static str = KEYLESS_ACCOUNT_MODULE_NAME;
+    const TYPE_IDENTIFIER: &'static str = "Configuration";
 }

--- a/types/src/keyless/mod.rs
+++ b/types/src/keyless/mod.rs
@@ -21,8 +21,8 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-mod bn254_circom;
-mod circuit_constants;
+pub mod bn254_circom;
+pub mod circuit_constants;
 pub mod circuit_testcases;
 mod configuration;
 mod groth16_sig;
@@ -420,7 +420,7 @@ pub fn get_authenticators(
     Ok(authenticators)
 }
 
-pub(crate) fn base64url_encode_str(data: &str) -> String {
+pub fn base64url_encode_str(data: &str) -> String {
     base64::encode_config(data.as_bytes(), URL_SAFE_NO_PAD)
 }
 


### PR DESCRIPTION
## Description

- Add new genesis parameter `initial_jwks`.
- Add new genesis parameter `keyless_groth16_vk_override`.
- Add new `executor-benchmark` parameter `--use-keyless-accounts` for enabling **keyless mode**: all local accounts will be keyless accounts instead of Ed25519 accounts.
  - Introduced to bench keyless latency/TPS.
- If `executor-benchmark` runs in **keyless mode**, also run genesis with groth16 keys from simulation.

Bench example.
```
/// step 1, create DB
cargo run -p aptos-executor-benchmark -- \
  --enable-storage-sharding \
  --block-executor-type aptos-vm-with-block-stm \
  --use-keyless-accounts \ #NEW!
  create-db --data-dir /tmp/db2 --num-accounts 100

/// step 2, actual bench
cargo run -p aptos-executor-benchmark -- \
  --block-size 100 \
  --enable-storage-sharding \
  --block-executor-type aptos-vm-with-block-stm \
  --use-keyless-accounts \ #NEW!
  run-executor --main-signer-accounts 100 --data-dir /tmp/db2 --checkpoint-dir /tmp/ck2 --blocks 99
```

The actual TPS benchmarking and threshold setting will be a separate PR.

## How Has This Been Tested?
Executor-benchmark local runs.

## Key Areas to Review
Does `hash_public_inputs` refactoring change execution result?

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
n/a

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
