### PR TITLE
[Target Determination] Track JSON and YAML files.

### DIFF
--- a/devtools/aptos-cargo-cli/src/common.rs
+++ b/devtools/aptos-cargo-cli/src/common.rs
@@ -30,7 +30,7 @@ const DEVTOOL_TARGET_DIRECTORY: &str = "target/aptos-x-tool";
 
 // File types in `aptos-core` that are not relevant to the rust build and test process.
 // Note: this is a best effort list and will need to be updated as time goes on.
-const IGNORED_DETERMINATOR_FILE_TYPES: [&str; 4] = ["*.json", "*.md", "*.yaml", "*.yml"];
+const IGNORED_DETERMINATOR_FILE_TYPES: [&str; 1] = ["*.md"];
 
 // Paths in `aptos-core` that are not relevant to the rust build and test process.
 // Note: this is a best effort list and will need to be updated as time goes on.


### PR DESCRIPTION
## Description
This PR updates the target determinator to take into account JSON and YAML files. If any of these files change, the closest rust package is marked as affected. This should be good enough to catch any edge cases we've encountered (e.g., around the indexer GRPC tests).

## Test Plan
Existing test infrastructure and manual verification. I changed a JSON file locally and verified that the closest package was marked as affected, e.g.,:
```
     Running `target/debug/aptos-cargo-cli affected-packages -vvv`
[2024-11-08T00:34:48Z INFO  aptos_cargo_cli::common] Identified the merge base: "7df77b85d4894c7355cb306abeecca5a4ded2d44"
[2024-11-08T00:34:48Z DEBUG aptos_cargo_cli::common] Attempting to read metadata from local file: ".../aptos-core/target/aptos-x-tool/metadata-7df77b85d4894c7355cb306abeecca5a4ded2d44.json"

...
Changed files detected:
        "ecosystem/indexer-grpc/indexer-test-transactions/json_transactions/imported_mainnet_txns/2739163_ans_current_ans_lookup.json"

...
Affected packages detected (1 total):
        "file:///.../aptos-core/ecosystem/indexer-grpc/indexer-test-transactions#aptos-indexer-test-transactions"
```