### PR TITLE
Fix rosetta staking balances

### DIFF
--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -71,5 +71,4 @@ jobs:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ECR_ACCOUNT_NUM }}
           GCP_DOCKER_ARTIFACT_REPO: ${{ vars.GCP_DOCKER_ARTIFACT_REPO }}
           IMAGE_TAG_PREFIX: ${{ inputs.image_tag_prefix }}
-          DRY_RUN: ${{ inputs.dry_run }}
         run: ./docker/release-images.mjs --wait-for-image-seconds=3600 ${{ inputs.dry_run && '--dry-run' || '' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15649,6 +15649,7 @@ dependencies = [
  "futures",
  "hex",
  "hyper 0.14.28",
+ "itertools 0.13.0",
  "move-core-types",
  "num_cpus",
  "once_cell",

--- a/aptos-move/aptos-release-builder/data/signer_native_format_fix.yaml
+++ b/aptos-move/aptos-release-builder/data/signer_native_format_fix.yaml
@@ -1,0 +1,13 @@
+---
+remote_endpoint: ~
+name: signer_native_format_fix
+proposals:
+  - name: enable_signer_native_format_fix
+    metadata:
+      title: "Enable the signer native format fix"
+      description: "Fixes the issue of string_utils::native_format in formatting signer values"
+    execution_mode: MultiStep
+    update_sequence:
+      - FeatureFlag:
+          enabled:
+            - signer_native_format_fix

--- a/docker/builder/docker-bake-rust-all.hcl
+++ b/docker/builder/docker-bake-rust-all.hcl
@@ -69,7 +69,7 @@ target "debian-base" {
   dockerfile = "docker/builder/debian-base.Dockerfile"
   contexts = {
     # Run `docker buildx imagetools inspect debian:bullseye` to find the latest multi-platform hash
-    debian = "docker-image://debian:bullseye@sha256:152b9a5dc2a03f18ddfd88fbe7b1df41bd2b16be9f2df573a373caf46ce78c08"
+    debian = "docker-image://debian:bullseye@sha256:d0036be35fe0a4d2649bf074ca467a37dab8c5b26bbbdfca0375b4dc682f011d"
   }
 }
 

--- a/docker/builder/tools.Dockerfile
+++ b/docker/builder/tools.Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     install \
     wget \
     curl \
-    perl-base=5.32.1-4+deb11u1 \
+    perl-base=5.32.1-4+deb11u4 \
     libtinfo6=6.2+20201114-2+deb11u2 \
     git \
     libssl1.1 \

--- a/docker/release-images.mjs
+++ b/docker/release-images.mjs
@@ -249,6 +249,7 @@ async function main() {
           const imageTarget = `${targetRegistry}/${image}:${joinTagSegments(parsedArgs.IMAGE_TAG_PREFIX, profilePrefix, featureSuffix)}`;
           console.info(chalk.green(`INFO: copying ${imageSource} to ${imageTarget}`));
           if (parsedArgs.DRY_RUN) {
+            console.info(chalk.yellow(`INFO: skipping copy of ${imageSource} to ${imageTarget} due to dry run`));
             continue;
           }
           await waitForImageToBecomeAvailable(imageSource, parsedArgs.WAIT_FOR_IMAGE_SECONDS);

--- a/storage/aptosdb/src/db_debugger/truncate/mod.rs
+++ b/storage/aptosdb/src/db_debugger/truncate/mod.rs
@@ -4,23 +4,15 @@
 use crate::{
     db::AptosDB,
     db_debugger::ShardingConfig,
-    schema::{
-        db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
-        epoch_by_version::EpochByVersionSchema,
-        jellyfish_merkle_node::JellyfishMerkleNodeSchema,
-    },
-    state_merkle_db::StateMerkleDb,
+    schema::db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
     state_store::StateStore,
     utils::truncation_helper::{
-        find_closest_node_version_at_or_before, get_current_version_in_state_merkle_db,
-        get_state_kv_commit_progress, truncate_state_merkle_db,
+        get_current_version_in_state_merkle_db, get_state_kv_commit_progress,
     },
 };
 use aptos_config::config::{RocksdbConfigs, StorageDirPaths};
-use aptos_jellyfish_merkle::node_type::NodeKey;
-use aptos_schemadb::{SchemaBatch, DB};
+use aptos_schemadb::SchemaBatch;
 use aptos_storage_interface::{db_ensure as ensure, AptosDbError, Result};
-use aptos_types::transaction::Version;
 use claims::assert_le;
 use clap::Parser;
 use std::{fs, path::PathBuf, sync::Arc};
@@ -127,30 +119,7 @@ impl Cmd {
                 .0;
         }
 
-        // TODO(grao): We are using a brute force implementation for now. We might be able to make
-        // it faster, since our data is append only.
-        if target_version < state_merkle_db_version {
-            let state_merkle_target_version = Self::find_tree_root_at_or_before(
-                &ledger_db.metadata_db_arc(),
-                &state_merkle_db,
-                target_version,
-            )?
-            .unwrap_or_else(|| {
-                panic!(
-                    "Could not find a valid root before or at version {}, maybe it was pruned?",
-                    target_version
-                )
-            });
-
-            println!(
-                "Starting state merkle db truncation... target_version: {}",
-                state_merkle_target_version
-            );
-            truncate_state_merkle_db(&state_merkle_db, state_merkle_target_version)?;
-            println!("Done!");
-        }
-
-        println!("Starting ledger db and state kv db truncation...");
+        println!("Starting db truncation...");
         let batch = SchemaBatch::new();
         batch.put::<DbMetadataSchema>(
             &DbMetadataKey::OverallCommitProgress,
@@ -161,6 +130,7 @@ impl Cmd {
         StateStore::sync_commit_progress(
             Arc::clone(&ledger_db),
             Arc::clone(&state_kv_db),
+            Arc::clone(&state_merkle_db),
             /*crash_if_difference_is_too_large=*/ false,
         );
         println!("Done!");
@@ -183,40 +153,6 @@ impl Cmd {
 
         Ok(())
     }
-
-    fn find_tree_root_at_or_before(
-        ledger_metadata_db: &DB,
-        state_merkle_db: &StateMerkleDb,
-        version: Version,
-    ) -> Result<Option<Version>> {
-        match find_closest_node_version_at_or_before(state_merkle_db, version)? {
-            Some(closest_version) => {
-                if Self::root_exists_at_version(state_merkle_db, closest_version)? {
-                    return Ok(Some(closest_version));
-                }
-                let mut iter = ledger_metadata_db.iter::<EpochByVersionSchema>()?;
-                iter.seek_for_prev(&version)?;
-                match iter.next().transpose()? {
-                    Some((closest_epoch_version, _)) => {
-                        if Self::root_exists_at_version(state_merkle_db, closest_epoch_version)? {
-                            Ok(Some(closest_epoch_version))
-                        } else {
-                            Ok(None)
-                        }
-                    },
-                    None => Ok(None),
-                }
-            },
-            None => Ok(None),
-        }
-    }
-
-    fn root_exists_at_version(state_merkle_db: &StateMerkleDb, version: Version) -> Result<bool> {
-        Ok(state_merkle_db
-            .metadata_db()
-            .get::<JellyfishMerkleNodeSchema>(&NodeKey::new_empty_path(version))?
-            .is_some())
-    }
 }
 
 #[cfg(test)]
@@ -229,7 +165,8 @@ mod test {
             AptosDB,
         },
         schema::{
-            epoch_by_version::EpochByVersionSchema, ledger_info::LedgerInfoSchema,
+            epoch_by_version::EpochByVersionSchema,
+            jellyfish_merkle_node::JellyfishMerkleNodeSchema, ledger_info::LedgerInfoSchema,
             stale_node_index::StaleNodeIndexSchema,
             stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema,
             stale_state_value_index::StaleStateValueIndexSchema,
@@ -380,16 +317,12 @@ mod test {
                 }
 
                 let mut iter = state_kv_db.metadata_db().iter::<StaleStateValueIndexSchema>().unwrap();
-            iter.seek_to_first();
-            for item in iter {
-                let version = item.unwrap().0.stale_since_version;
-                prop_assert!(version <= target_version);
+                iter.seek_to_first();
+                for item in iter {
+                    let version = item.unwrap().0.stale_since_version;
+                    prop_assert!(version <= target_version);
+                }
             }
-            }
-
-
-
-
 
             let mut iter = state_merkle_db.metadata_db().iter::<StaleNodeIndexSchema>().unwrap();
             iter.seek_to_first();

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -73,6 +73,7 @@ aptos-time-service = { workspace = true }
 aptos-vault-client = { workspace = true }
 base64 = { workspace = true }
 futures = { workspace = true }
+itertools = { workspace = true }
 num_cpus = { workspace = true }
 once_cell = { workspace = true }
 rand = { workspace = true }

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -13,16 +13,23 @@ use crate::{
 };
 use anyhow::{bail, Result};
 use aptos_backup_cli::metadata::view::BackupStorageState;
-use aptos_forge::{reconfig, NodeExt, Swarm, SwarmExt};
+use aptos_forge::{reconfig, AptosPublicInfo, Node, NodeExt, Swarm, SwarmExt};
 use aptos_logger::info;
 use aptos_temppath::TempPath;
 use aptos_types::{transaction::Version, waypoint::Waypoint};
+use itertools::Itertools;
 use std::{
     fs,
     path::Path,
     process::Command,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
+
+const LINE: &str = "----------";
 
 #[tokio::test]
 async fn test_db_restore() {
@@ -453,4 +460,114 @@ pub(crate) fn db_restore(
         .unwrap();
     assert!(status.success(), "{}", status);
     info!("Backup restored in {} seconds.", now.elapsed().as_secs());
+}
+
+async fn do_transfer_or_reconfig(info: &mut AptosPublicInfo) -> Result<()> {
+    const LOTS_MONEY: u64 = 100_000_000;
+    let r = rand::random::<u64>() % 10;
+    if r < 3 {
+        // reconfig
+        info.reconfig().await;
+    } else if r == 9 {
+        // drain backlog
+        let mut sender = info.create_and_fund_user_account(LOTS_MONEY).await?;
+        let receiver = info.create_and_fund_user_account(LOTS_MONEY).await?;
+        let pending_txn = info.transfer(&mut sender, &receiver, 1).await?;
+        info.client().wait_for_transaction(&pending_txn).await?;
+    } else {
+        let mut sender = info.create_and_fund_user_account(LOTS_MONEY).await?;
+        let receiver = info.create_and_fund_user_account(LOTS_MONEY).await?;
+        let num_txns = rand::random::<usize>() % 100;
+        for _ in 0..num_txns {
+            info.transfer_non_blocking(&mut sender, &receiver, 1)
+                .await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn do_transfers_and_reconfigs(mut info: AptosPublicInfo, quit_flag: Arc<AtomicBool>) {
+    // loop until aborted
+    while !quit_flag.load(Ordering::Acquire) {
+        do_transfer_or_reconfig(&mut info).await.unwrap();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_db_restart() {
+    ::aptos_logger::Logger::new().init();
+
+    info!("{LINE} Test started.");
+    let mut swarm = SwarmBuilder::new_local(4).with_aptos().build().await;
+    swarm.wait_all_alive(Duration::from_secs(60)).await.unwrap();
+    swarm
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_WAIT_SECS))
+        .await
+        .unwrap();
+    info!("{LINE} Created receiver account and caught up.");
+
+    let mut restarting_validator_ids = swarm.validators().map(|v| v.peer_id()).collect_vec();
+    let non_restarting_validator_id = restarting_validator_ids.pop().unwrap();
+    let non_restarting_validator = swarm.validator(non_restarting_validator_id).unwrap();
+    let chain_info = swarm.chain_info();
+    let mut pub_chain_info = AptosPublicInfo::new(
+        chain_info.chain_id(),
+        non_restarting_validator
+            .inspection_service_endpoint()
+            .to_string(),
+        non_restarting_validator.rest_api_endpoint().to_string(),
+        chain_info.root_account(),
+    );
+    let client = non_restarting_validator.rest_client();
+
+    info!("{LINE} Gonna start continuous coin transfer and reconfigs in the background.");
+    let quit_flag = Arc::new(AtomicBool::new(false));
+    let background_traffic = tokio::task::spawn(do_transfers_and_reconfigs(
+        pub_chain_info.clone(),
+        quit_flag.clone(),
+    ));
+
+    for round in 0..3 {
+        info!("{LINE} Restart round {round}");
+        for (v, vid) in restarting_validator_ids.iter().enumerate() {
+            info!("{LINE} Round {round}: Restarting validator {v}.");
+            info!(
+                "{LINE} ledger info: {:?}",
+                client.get_ledger_information().await.unwrap(),
+            );
+            let validator = swarm.validator_mut(*vid).unwrap();
+            // sometimes trigger reconfig right before the restart, to expose edge cases around
+            // epoch change
+            if rand::random::<usize>() % 3 == 0 {
+                info!("{LINE} Triggering reconfig right before restarting.");
+                reconfig(
+                    &validator.rest_client(),
+                    &pub_chain_info.transaction_factory(),
+                    pub_chain_info.root_account(),
+                )
+                .await;
+            }
+            validator.restart().await.unwrap();
+            swarm
+                .wait_for_all_nodes_to_catchup(Duration::from_secs(60))
+                .await
+                .unwrap();
+            info!("{LINE} Round {round}: Validator {v} restarted and caught up.");
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        }
+    }
+
+    info!("{LINE} Stopping background traffic, and check again that all validators are alive.");
+    quit_flag.store(true, Ordering::Release);
+    // Make sure background thread didn't panic.
+    background_traffic.await.unwrap();
+
+    swarm
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(60))
+        .await
+        .unwrap();
+
+    info!("{LINE} All validators survived.");
+    info!("{LINE} Test succeeded.");
 }


### PR DESCRIPTION
## Description
This cleans up and ensures that Rosetta only returns either the base account balances, the staking balances, or the delegated staking balances.  It will never return all three at the same time.

## How Has This Been Tested?
Tested against existing accounts on mainnet with a local version.

## Key Areas to Review
Logically, this should be the same as before.  The main issue was the fallthrough behavior that would handle the base account path on every path.  Instead it should only be handled on the base path, where staking should do the staking path.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (Rosetta)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
