### PR TITLE
coverage work in progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11137,6 +11137,7 @@ dependencies = [
  "codespan-reporting",
  "datatest-stable",
  "hex",
+ "log",
  "move-binary-format",
  "move-borrow-graph",
  "move-bytecode-source-map",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -13,7 +13,7 @@ repository = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-anyhow = { workspace = true }
+anyhow = { workspace = true, features = [ "backtrace" ] }
 aptos-api-types = { workspace = true }
 aptos-backup-cli = { workspace = true }
 aptos-bitvec = { workspace = true }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -18,7 +18,7 @@ use crate::{
     genesis::git::from_yaml,
     move_tool::{ArgWithType, FunctionArgType, MemberId},
 };
-use anyhow::{bail, Context};
+use anyhow::{bail, Context, Result};
 use aptos_api_types::ViewFunction;
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},

--- a/crates/aptos/src/move_tool/coverage.rs
+++ b/crates/aptos/src/move_tool/coverage.rs
@@ -124,7 +124,17 @@ impl CliCommand<()> for SourceCoverage {
             }) => (module, source_map),
             _ => panic!("Should all be modules"),
         };
-        let source_coverage = SourceCoverageBuilder::new(module, &coverage_map, source_map);
+        let packages: Vec<_> = package
+            .root_modules()
+            .map(|unit| match &unit.unit {
+                CompiledUnit::Module(NamedCompiledModule {
+                    module, source_map, ..
+                }) => (module, source_map),
+                _ => panic!("Should all be modules"),
+            })
+            .collect();
+        let source_coverage =
+            SourceCoverageBuilder::new(module, &coverage_map, source_map, packages);
         let source_coverage = source_coverage.compute_source_coverage(source_path);
         let output_result =
             source_coverage.output_source_coverage(&mut std::io::stdout(), self.color, self.tag);

--- a/crates/aptos/src/move_tool/coverage.rs
+++ b/crates/aptos/src/move_tool/coverage.rs
@@ -184,7 +184,7 @@ fn compile_coverage(
 
     let path = move_options.get_package_path()?;
     let coverage_map =
-        CoverageMap::from_binary_file(path.join(".coverage_map.mvcov")).map_err(|err| {
+        CoverageMap::from_binary_file(&path.join(".coverage_map.mvcov")).map_err(|err| {
             CliError::UnexpectedError(format!("Failed to retrieve coverage map {}", err))
         })?;
     let package = config

--- a/third_party/move/move-compiler-v2/src/env_pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/mod.rs
@@ -4,7 +4,7 @@
 //! This module contains a set of transformers and analyzers of global environment.
 //! Those can be arranged in a pipeline and executed in sequence.
 
-use log::trace;
+use log::debug;
 use move_model::model::GlobalEnv;
 use std::io::Write;
 
@@ -43,10 +43,10 @@ impl<'a> EnvProcessorPipeline<'a> {
     /// Runs the pipeline. Running will be ended if any of the steps produces an error.
     /// The function returns true if all steps succeeded without errors.
     pub fn run(&self, env: &mut GlobalEnv) -> bool {
-        trace!("before env processor pipeline: {}", env.dump_env());
+        debug!("before env processor pipeline: {}", env.dump_env());
         for (name, proc) in &self.processors {
             proc(env);
-            trace!("after env processor {}", name);
+            debug!("after env processor {}: {}", name, env.dump_env());
             if env.has_errors() {
                 return false;
             }
@@ -58,13 +58,13 @@ impl<'a> EnvProcessorPipeline<'a> {
     /// only.
     pub fn run_and_record(&self, env: &mut GlobalEnv, w: &mut impl Write) -> anyhow::Result<bool> {
         let msg = format!("before env processor pipeline:\n{}\n", env.dump_env());
-        trace!("{}", msg);
+        debug!("{}", msg);
         writeln!(w, "// -- Model dump {}", msg)?;
         for (name, proc) in &self.processors {
             proc(env);
             if !env.has_errors() {
                 let msg = format!("after env processor {}:\n{}\n", name, env.dump_env());
-                trace!("{}", msg);
+                debug!("{}", msg);
                 writeln!(w, "// -- Model dump {}", msg)?;
             } else {
                 return Ok(false);

--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -108,12 +108,13 @@ impl<'a> FunctionGenerator<'a> {
         fun_env: FunctionEnv<'b>,
         acquires_list: &BTreeSet<StructId>,
     ) {
+        let id_loc = fun_env.get_id_loc();
         let loc = fun_env.get_id_loc();
         let function = gen.function_index(ctx, &loc, &fun_env);
         let visibility = fun_env.visibility();
         let fun_count = gen.module.function_defs.len();
         let def_idx = FunctionDefinitionIndex::new(ctx.checked_bound(
-            &loc,
+            &id_loc,
             fun_count,
             MAX_FUNCTION_DEF_COUNT,
             "defined function",

--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -12,6 +12,7 @@ use crate::{
         livevar_analysis_processor::LiveVarAnnotation,
     },
 };
+use log::debug;
 use move_binary_format::{
     file_format as FF,
     file_format::{CodeOffset, FunctionDefinitionIndex},
@@ -209,6 +210,12 @@ impl<'a> FunctionGenerator<'a> {
         for i in 0..bytecode.len() {
             let code_offset = i as FF::CodeOffset;
             let bc = &bytecode[i];
+            debug!(
+                "Generating code for bytecode {:?} ({}) at offset {}",
+                bc,
+                bc.display(&ctx.fun, &BTreeMap::new()),
+                i
+            );
             let bytecode_ctx = BytecodeContext {
                 fun_ctx: ctx,
                 code_offset,
@@ -260,16 +267,17 @@ impl<'a> FunctionGenerator<'a> {
     /// Generate file-format bytecode from a stackless bytecode and an optional next bytecode
     /// for peephole optimizations.
     fn gen_bytecode(&mut self, ctx: &BytecodeContext, bc: &Bytecode, next_bc: Option<&Bytecode>) {
+        let loc = ctx.fun_ctx.fun.get_bytecode_loc(ctx.attr_id);
+        let ir_loc = ctx.fun_ctx.module.env.to_ir_loc(&loc);
+        let offset = self.code.len();
+        let func_name = ctx.fun_ctx.fun.func_env.get_full_name_str();
+        debug!(
+            "Setting location for {}:{} with attr_id {:?} to {:?} (from {:?})",
+            func_name, offset, ctx.attr_id, ir_loc, loc
+        );
         self.gen
             .source_map
-            .add_code_mapping(
-                ctx.fun_ctx.def_idx,
-                self.code.len() as FF::CodeOffset,
-                ctx.fun_ctx
-                    .module
-                    .env
-                    .to_ir_loc(&ctx.fun_ctx.fun.get_bytecode_loc(ctx.attr_id)),
-            )
+            .add_code_mapping(ctx.fun_ctx.def_idx, offset as FF::CodeOffset, ir_loc)
             .expect(SOURCE_MAP_OK);
         match bc {
             Bytecode::Assign(_, dest, source, mode) => {

--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -211,10 +211,11 @@ impl<'a> FunctionGenerator<'a> {
             let code_offset = i as FF::CodeOffset;
             let bc = &bytecode[i];
             debug!(
-                "Generating code for bytecode {:?} ({}) at offset {}",
+                "Generating code for bytecode {:?} ({}) at offset {} with attr_id {:?}",
                 bc,
                 bc.display(&ctx.fun, &BTreeMap::new()),
-                i
+                i,
+                bc.get_attr_id(),
             );
             let bytecode_ctx = BytecodeContext {
                 fun_ctx: ctx,
@@ -250,6 +251,14 @@ impl<'a> FunctionGenerator<'a> {
             } else {
                 ctx.internal_error("inconsistent bytecode label info")
             }
+        }
+
+        let func_name = ctx.fun.func_env.get_full_name_str();
+        if func_name == "red_black_map::add" {
+            debug!(
+                "After Function {} source_map is {:#?}",
+                func_name, self.gen.source_map
+            );
         }
 
         // Deliver result

--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use codespan_reporting::diagnostic::Severity;
 use itertools::Itertools;
+use log::debug;
 use move_binary_format::{
     file_format as FF,
     file_format::{AccessKind, FunctionHandle, ModuleHandle, StructDefinitionIndex, TableIndex},
@@ -209,6 +210,14 @@ impl ModuleGenerator {
             assert!(compile_test_code || !fun_env.is_test_only());
             let acquires_list = &acquires_map[&fun_env.get_id()];
             FunctionGenerator::run(self, ctx, fun_env, acquires_list);
+        }
+
+        let module_name = module_env.get_full_name_str();
+        if module_name == "0xabc::red_black_map" {
+            debug!(
+                "After generating module {}, source_map is {:#?}",
+                module_name, self.source_map
+            );
         }
 
         // At handles of friend modules

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -504,14 +504,7 @@ pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
 pub fn disassemble_compiled_units(units: &[CompiledUnit]) -> anyhow::Result<String> {
     let disassembled_units: anyhow::Result<Vec<_>> = units
         .iter()
-        .map(|unit| {
-            let view = match unit {
-                CompiledUnit::Module(module) => BinaryIndexedView::Module(&module.module),
-                CompiledUnit::Script(script) => BinaryIndexedView::Script(&script.script),
-            };
-            Disassembler::from_view(view, location::Loc::new(FileHash::empty(), 0, 0))
-                .and_then(|d| d.disassemble())
-        })
+        .map(|unit| Disassembler::from_unit(unit).disassemble())
         .collect();
     Ok(disassembled_units?.concat())
 }

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -122,7 +122,7 @@ where
             &env,
             &mut targets,
             &dump_base_name,
-            false,
+            command_line::get_move_compiler_dump_from_env(),
             &pipeline::register_formatters,
             || !env.has_errors(),
         )

--- a/third_party/move/move-compiler/Cargo.toml
+++ b/third_party/move/move-compiler/Cargo.toml
@@ -16,6 +16,7 @@ once_cell = { workspace = true }
 petgraph = { workspace = true }
 regex = { workspace = true }
 tempfile = { workspace = true }
+log = { workspace = true }
 
 bcs = { workspace = true }
 

--- a/third_party/move/move-compiler/src/command_line/mod.rs
+++ b/third_party/move/move-compiler/src/command_line/mod.rs
@@ -77,3 +77,8 @@ pub const MVC_BACKTRACE_ENV_VAR: &str = "MVC_BACKTRACE";
 pub fn get_move_compiler_backtrace_from_env() -> bool {
     read_bool_env_var(MOVE_COMPILER_BACKTRACE_ENV_VAR) || read_bool_env_var(MVC_BACKTRACE_ENV_VAR)
 }
+
+// Flag to dump bytecode files
+pub fn get_move_compiler_dump_from_env() -> bool {
+    read_bool_env_var(MOVE_COMPILER_DUMP_ENV_VAR) || read_bool_env_var(MVC_DUMP_ENV_VAR)
+}

--- a/third_party/move/move-compiler/src/compiled_unit.rs
+++ b/third_party/move/move-compiler/src/compiled_unit.rs
@@ -11,6 +11,7 @@ use crate::{
     shared::{unique_map::UniqueMap, Name, NumericalAddress},
     typing::ast as T,
 };
+use log::debug;
 use move_binary_format::file_format as F;
 use move_bytecode_source_map::source_map::SourceMap;
 use move_core_types::{
@@ -19,6 +20,7 @@ use move_core_types::{
 };
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
+use std::backtrace::{Backtrace, BacktraceStatus};
 use std::collections::BTreeMap;
 
 //**************************************************************************************************
@@ -217,9 +219,15 @@ impl CompiledUnit {
     pub fn serialize_source_map(&self) -> Vec<u8> {
         match self {
             Self::Module(NamedCompiledModule { source_map, .. }) => {
+                let bt = Backtrace::capture();
+                if BacktraceStatus::Captured == bt.status() {
+                    debug!("Backtrace: {:#?}", bt)
+                };
+                debug!("writing source_map {:#?}", &source_map);
                 bcs::to_bytes(source_map).unwrap()
             },
             Self::Script(NamedCompiledScript { source_map, .. }) => {
+                debug!("writing source_map {:#?}", &source_map);
                 bcs::to_bytes(source_map).unwrap()
             },
         }

--- a/third_party/move/move-ir/types/src/location.rs
+++ b/third_party/move/move-ir/types/src/location.rs
@@ -36,6 +36,7 @@ pub struct Loc {
 
 impl Loc {
     pub fn new(file_hash: FileHash, start: ByteIndex, end: ByteIndex) -> Loc {
+        assert!(start <= end);
         Loc {
             file_hash,
             start,
@@ -59,6 +60,94 @@ impl Loc {
         Range {
             start: self.start as usize,
             end: self.end as usize,
+        }
+    }
+
+    pub fn contains(&self, other: &Self) -> bool {
+        if self.file_hash != other.file_hash {
+            false
+        } else {
+            self.start <= other.start && other.end <= self.end
+        }
+    }
+
+    pub fn overlaps(&self, other: &Self) -> bool {
+        if self.file_hash != other.file_hash {
+            false
+        } else {
+            // [a, b] overlaps? [c, d]
+            // a <= b
+            // c <= d
+            other.start <= self.end && self.start <= other.end
+            // c <= b
+            // a <= d
+            // One of these:
+            // [a <= (c <= b] <= d)
+            // (c <= [a <= b] <= d)
+            // (c <= [a <= d) <= b]
+        }
+    }
+
+    pub fn overlaps_or_abuts(&self, other: &Self) -> bool {
+        if self.file_hash != other.file_hash {
+            false
+        } else {
+            // [a, b] overlaps? [c, d]
+            // a <= b
+            // c <= d
+            other.start <= self.end + 1 && self.start <= other.end + 1
+            // c <= b + 1
+            // a <= d + 1
+            // One of these:
+            // a <= c <= b+1 <= d+1
+            // c <= a <= b+1 <= d+1
+            // c <= a <= d+1 <= b+1
+        }
+    }
+
+    pub fn try_merge(&mut self, other: &Self) -> bool {
+        if self.overlaps_or_abuts(other) {
+            self.start = std::cmp::min(self.start, other.start);
+            self.end = std::cmp::max(self.end, other.end);
+            true
+        } else {
+            false
+        }
+    }
+
+    // if other overlaps with this, then subtract it out.
+    pub fn subtract(self, other: &Self) -> Vec<Loc> {
+        if !self.overlaps(other) {
+            vec![self]
+        } else {
+            if other.start <= self.start {
+                if self.end <= other.end {
+                    vec![]
+                } else {
+                    vec![Loc {
+                        start: other.end + 1,
+                        ..self
+                    }]
+                }
+            } else {
+                if self.end <= other.end {
+                    vec![Loc {
+                        end: other.start - 1,
+                        ..self
+                    }]
+                } else {
+                    vec![
+                        Loc {
+                            end: other.start - 1,
+                            ..self
+                        },
+                        Loc {
+                            start: other.end + 1,
+                            ..self
+                        },
+                    ]
+                }
+            }
         }
     }
 }

--- a/third_party/move/move-model/bytecode/src/function_target.rs
+++ b/third_party/move/move-model/bytecode/src/function_target.rs
@@ -452,6 +452,7 @@ impl<'env> FunctionTarget<'env> {
 
         // add location
         if verbose {
+            texts.push(format!("     # attr_id {:?}", attr_id));
             texts.push(format!(
                 "     # {}",
                 self.get_bytecode_loc(attr_id).display(self.global_env())

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -3337,6 +3337,7 @@ impl<'env> ModuleEnv<'env> {
             print_basic_blocks: true,
             print_locals: true,
             print_bytecode_stats: false,
+            show_locs: false,
         });
         Some(
             disas

--- a/third_party/move/tools/move-cli/src/base/coverage.rs
+++ b/third_party/move/tools/move-cli/src/base/coverage.rs
@@ -79,8 +79,17 @@ impl Coverage {
                     }) => (module, source_map),
                     _ => panic!("Should all be modules"),
                 };
+                let packages: Vec<_> = package
+                    .root_modules()
+                    .map(|unit| match &unit.unit {
+                        CompiledUnit::Module(NamedCompiledModule {
+                            module, source_map, ..
+                        }) => (module, source_map),
+                        _ => panic!("Should all be modules"),
+                    })
+                    .collect();
                 let source_coverage_builder =
-                    SourceCoverageBuilder::new(module, &coverage_map, source_map);
+                    SourceCoverageBuilder::new(module, &coverage_map, source_map, packages);
                 let source_coverage = source_coverage_builder.compute_source_coverage(source_path);
                 source_coverage
                     .output_source_coverage(&mut std::io::stdout(), self.color, self.tag)

--- a/third_party/move/tools/move-cli/src/base/coverage.rs
+++ b/third_party/move/tools/move-cli/src/base/coverage.rs
@@ -60,7 +60,7 @@ pub struct Coverage {
 impl Coverage {
     pub fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
         let path = reroot_path(path)?;
-        let coverage_map = CoverageMap::from_binary_file(path.join(".coverage_map.mvcov"))?;
+        let coverage_map = CoverageMap::from_binary_file(&path.join(".coverage_map.mvcov"))?;
         let package = config.compile_package(&path, &mut Vec::new())?;
         let modules: Vec<_> = package
             .root_modules()

--- a/third_party/move/tools/move-cli/src/base/test.rs
+++ b/third_party/move/tools/move-cli/src/base/test.rs
@@ -343,8 +343,8 @@ pub fn run_move_unit_tests_with_factory<W: Write + Send, F: UnitTestFactory + Se
             let buf_writer = &mut *LOGGING_FILE_WRITER.lock().unwrap();
             buf_writer.flush().unwrap();
         }
-        let coverage_map = CoverageMap::from_trace_file(trace_path.clone());
-        output_map_to_file(coverage_map_path, &coverage_map).unwrap();
+        let coverage_map = CoverageMap::from_trace_file(&trace_path)?;
+        output_map_to_file(&coverage_map_path, &coverage_map).unwrap();
     }
     cleanup_trace();
     Ok(UnitTestResult::Success)

--- a/third_party/move/tools/move-cli/src/test/mod.rs
+++ b/third_party/move/tools/move-cli/src/test/mod.rs
@@ -106,7 +106,7 @@ fn collect_coverage(
     }
 
     // collect filtered trace
-    let coverage_map = CoverageMap::from_trace_file(trace_file)
+    let coverage_map = CoverageMap::from_trace_file(&trace_file)?
         .to_unified_exec_map()
         .into_coverage_map_with_modules(filter);
 

--- a/third_party/move/tools/move-coverage/src/bin/coverage-summaries.rs
+++ b/third_party/move/tools/move-coverage/src/bin/coverage-summaries.rs
@@ -4,6 +4,7 @@
 
 #![forbid(unsafe_code)]
 
+use anyhow::{bail, Context};
 use clap::Parser;
 use move_binary_format::file_format::CompiledModule;
 use move_coverage::{
@@ -24,22 +25,25 @@ use std::{
     version
 )]
 struct Args {
-    /// The path to the coverage map or trace file
+    /// The path to the coverage map file
     #[clap(long = "input-trace-path", short = 't')]
     pub input_trace_path: String,
-    /// Whether the passed-in file is a raw trace file or a serialized coverage map
+    /// Whether the passed-in file is a raw trace file (true) or a serialized coverage map (false)
     #[clap(long = "is-raw-trace", short = 'r')]
     pub is_raw_trace_file: bool,
     /// The path to the module binary
     #[clap(long = "module-path", short = 'b')]
+    /// The path to a directory containing binaries to be processed (e.g., `./build/*/bytecode_modules`)
     pub module_binary_path: Option<String>,
+    #[clap(long = "modules-dir", short = 'm')]
+    pub modules_dir: Option<String>,
     /// Optional path for summaries. Printed to stdout if not present.
     #[clap(long = "summary-path", short = 'o')]
     pub summary_path: Option<String>,
     /// Whether function coverage summaries should be displayed
     #[clap(long = "summarize-functions", short = 'f')]
     pub summarize_functions: bool,
-    /// The path to the standard library binary directory for Move
+    /// The path to the standard library binary directory for Move (e.g., `.../build/MoveStdlib/bytecode_modules`)
     #[clap(long = "stdlib-path", short = 's')]
     pub stdlib_path: Option<String>,
     /// Whether path coverage should be derived (default is instruction coverage)
@@ -50,31 +54,68 @@ struct Args {
     pub csv_output: bool,
 }
 
-fn get_modules(args: &Args) -> Vec<CompiledModule> {
-    let mut modules = Vec::new();
-    if let Some(stdlib_path) = &args.stdlib_path {
-        let stdlib_modules = fs::read_dir(stdlib_path).unwrap().map(|file| {
-            let bytes = fs::read(file.unwrap().path()).unwrap();
-            CompiledModule::deserialize(&bytes).expect("Module blob can't be deserialized")
-        });
-        modules.extend(stdlib_modules);
+fn maybe_add_modules(
+    modules: &mut Vec<CompiledModule>,
+    modules_dir: &Option<String>,
+) -> anyhow::Result<()> {
+    if let Some(modules_path) = modules_dir {
+        let new_modules_files = fs::read_dir(modules_path)
+            .with_context(|| format!("Reading module directory {}", modules_path.to_string()))?;
+        let new_modules: Result<Vec<CompiledModule>, _> = new_modules_files
+            .map(|dirent_or_error| {
+                dirent_or_error
+                    .with_context(|| {
+                        format!(
+                            "Iterating over module directory {}",
+                            modules_path.to_string()
+                        )
+                    })
+                    .and_then(|file| {
+                        fs::read(file.path())
+                            .map_err(anyhow::Error::from)
+                            .and_then(|bytes| {
+                                CompiledModule::deserialize(&bytes).with_context(|| {
+                                    format!("Reading file {}", file.path().to_string_lossy())
+                                })
+                            })
+                    })
+            })
+            .collect();
+        let mut new_modules = new_modules?;
+        modules.append(&mut new_modules);
     }
+    Ok(())
+}
+
+fn get_modules(args: &Args) -> anyhow::Result<Vec<CompiledModule>> {
+    let mut modules = Vec::new();
+    maybe_add_modules(&mut modules, &args.stdlib_path)?;
+    maybe_add_modules(&mut modules, &args.modules_dir)?;
 
     if let Some(module_binary_path) = &args.module_binary_path {
-        let bytecode_bytes = fs::read(module_binary_path).expect("Unable to read bytecode file");
-        let compiled_module = CompiledModule::deserialize(&bytecode_bytes)
-            .expect("Module blob can't be deserialized");
+        let bytecode_bytes = fs::read(module_binary_path).with_context(|| {
+            format!(
+                "Failed to get_modules for module path {}",
+                module_binary_path
+            )
+        })?;
+        let compiled_module = CompiledModule::deserialize(&bytecode_bytes).with_context(|| {
+            format!(
+                "Filed to get_modules for module path {}",
+                module_binary_path
+            )
+        })?;
         modules.push(compiled_module);
     }
 
     if modules.is_empty() {
-        panic!("No modules provided for coverage checking")
+        bail!("No modules provided for coverage checking")
     }
 
-    modules
+    Ok(modules)
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let input_trace_path = Path::new(&args.input_trace_path);
 
@@ -86,12 +127,19 @@ fn main() {
         None => Box::new(io::stdout()),
     };
 
-    let modules = get_modules(&args);
+    let modules = get_modules(&args)?;
     if args.derive_path_coverage {
         let trace_map = if args.is_raw_trace_file {
-            TraceMap::from_trace_file(input_trace_path)
+            TraceMap::from_trace_file(&input_trace_path).with_context(|| {
+                format!("Reading trace file {}", input_trace_path.to_string_lossy())
+            })?
         } else {
-            TraceMap::from_binary_file(input_trace_path)
+            TraceMap::from_binary_file(&input_trace_path).with_context(|| {
+                format!(
+                    "Reading binary coverage file {}",
+                    input_trace_path.to_string_lossy()
+                )
+            })?
         };
         if !args.csv_output {
             format_human_summary(
@@ -111,9 +159,16 @@ fn main() {
         }
     } else {
         let coverage_map = if args.is_raw_trace_file {
-            CoverageMap::from_trace_file(input_trace_path)
+            CoverageMap::from_trace_file(&input_trace_path).with_context(|| {
+                format!("Reading trace file {}", input_trace_path.to_string_lossy(),)
+            })?
         } else {
-            CoverageMap::from_binary_file(input_trace_path).unwrap()
+            CoverageMap::from_binary_file(&input_trace_path).with_context(|| {
+                format!(
+                    "Reading binary coverage file {}",
+                    input_trace_path.to_string_lossy(),
+                )
+            })?
         };
         let unified_exec_map = coverage_map.to_unified_exec_map();
         if !args.csv_output {
@@ -133,6 +188,7 @@ fn main() {
             )
         }
     }
+    Ok(())
 }
 
 #[test]

--- a/third_party/move/tools/move-coverage/src/coverage_map.rs
+++ b/third_party/move/tools/move-coverage/src/coverage_map.rs
@@ -130,10 +130,20 @@ impl CoverageMap {
 
     pub fn to_unified_exec_map(&self) -> ExecCoverageMap {
         let mut unified_map = ExecCoverageMap::new(String::new());
-        for (_, exec_map) in self.exec_maps.iter() {
+        eprintln!("to_unified_exec_map");
+        for (_key, exec_map) in self.exec_maps.iter() {
+            eprintln!("looking at key {}", _key);
             for ((module_addr, module_name), module_map) in exec_map.module_maps.iter() {
                 for (func_name, func_map) in module_map.function_maps.iter() {
                     for (pc, count) in func_map.iter() {
+                        eprintln!(
+                            "Adding item ({}, {}, {}, {}, {}) to unified_map",
+                            module_addr.short_str_lossless(),
+                            module_name.clone().into_string(),
+                            func_name.clone().into_string(),
+                            pc,
+                            count,
+                        );
                         unified_map.insert_multi(
                             *module_addr,
                             module_name.clone(),
@@ -145,6 +155,7 @@ impl CoverageMap {
                 }
             }
         }
+        eprintln!("finished to_unified_exec_map");
         unified_map
     }
 }

--- a/third_party/move/tools/move-coverage/src/source_coverage.rs
+++ b/third_party/move/tools/move-coverage/src/source_coverage.rs
@@ -115,17 +115,16 @@ fn subtract_locations(locs1: BTreeSet<Loc>, locs2: &BTreeSet<Loc>) -> Vec<Loc> {
                         } else {
                             // loc2 is finished but loc1 is not,
                             // finish adding all loc1
-                            result.push(current_loc1);
-                            for loc1 in locs1_iter {
-                                result.push(loc1);
-                            }
-                            return result;
+                            break;
                         }
                     }
                 }
             }
         }
         result.push(current_loc1);
+        for loc1 in locs1_iter {
+            result.push(loc1);
+        }
     }
     result
 }
@@ -732,9 +731,10 @@ impl SourceCoverage {
             TextIndicator::Explicit | TextIndicator::On => {
                 write!(
                     output_writer,
-                    "Code coverage per line of code:\n  {} indicates the line is not executable or is fully covered during execution\n  {} indicates the line is executable but NOT fully covered during execution\nSource code follows:\n",
+                    "Code coverage per line of code:\n  {} indicates the line is covered during execution\n  {} indicates the line is executable but NOT fully covered during execution\n  {} indicates the line is either test code or is not executable\nSource code follows:\n",
                     "+".to_string().green(),
                     "-".to_string().bold().red(),
+                    " ".to_string(),
                 )?;
                 true
             },

--- a/third_party/move/tools/move-coverage/src/source_coverage.rs
+++ b/third_party/move/tools/move-coverage/src/source_coverage.rs
@@ -6,7 +6,7 @@
 
 use crate::coverage_map::CoverageMap;
 use clap::ValueEnum;
-use codespan::{Files, Span};
+use codespan::{FileId, Files, Span};
 use colored::{self, Colorize};
 use move_binary_format::{
     access::ModuleAccess,
@@ -15,11 +15,11 @@ use move_binary_format::{
 };
 use move_bytecode_source_map::source_map::SourceMap;
 use move_command_line_common::files::FileHash;
-use move_core_types::identifier::Identifier;
 use move_ir_types::location::Loc;
 use serde::Serialize;
 use std::{
-    collections::BTreeMap,
+    cmp::{Ordering, PartialOrd},
+    collections::{BTreeMap, BTreeSet},
     fmt::{Display, Formatter},
     fs,
     io::{self, Write},
@@ -38,20 +38,172 @@ pub struct FunctionSourceCoverage {
     pub uncovered_locations: Vec<Loc>,
 }
 
+/// Source-level positive coverage information for a function.
+#[derive(Clone, Debug, Serialize)]
+pub struct FunctionSourceCoverage2 {
+    /// Is this a native function?
+    /// If so, then `uncovered_locations` is empty.
+    pub fn_is_native: bool,
+
+    /// List of source locations in the function that were covered.
+    pub covered_locations: Vec<Loc>,
+
+    /// List of all source locations in the function.
+    pub uncovered_locations: Vec<Loc>,
+}
+
+fn minimize_locations(mut locs: Vec<Loc>) -> Vec<Loc> {
+    locs.sort();
+    let mut result = vec![];
+    let mut locs_iter = locs.into_iter();
+    if let Some(mut current_loc) = locs_iter.next() {
+        for next_loc in locs_iter {
+            let loc_tmp = current_loc;
+            if !current_loc.try_merge(&next_loc) {
+                eprintln!("Not merging {:?} with {:?}", loc_tmp, next_loc);
+                result.push(current_loc);
+                current_loc = next_loc;
+            }
+        }
+        result.push(current_loc);
+    }
+    result
+}
+
+// locs1 and locs2 should each be sorted or this won't work.
+fn subtract_locations(locs1: BTreeSet<Loc>, locs2: &BTreeSet<Loc>) -> Vec<Loc> {
+    let mut result = vec![];
+    let mut locs1_iter = locs1.into_iter();
+    let mut locs2_iter = locs2.iter();
+    if let Some(mut current_loc1) = locs1_iter.next() {
+        if let Some(mut current_loc2) = locs2_iter.next() {
+            loop {
+                if current_loc1.overlaps(current_loc2) {
+                    let mut diff = current_loc1.subtract(current_loc2);
+                    if let Some(new_loc1) = diff.pop() {
+                        result.append(&mut diff);
+                        current_loc1 = new_loc1;
+                        // continue
+                    } else {
+                        // diff was empty, get a new loc1
+                        if let Some(new_loc1) = locs1_iter.next() {
+                            current_loc1 = new_loc1;
+                            // retry loc2
+                            // continue
+                        } else {
+                            // no more loc1, return
+                            return result;
+                        }
+                    }
+                } else {
+                    // no overlap
+                    if current_loc1 <= *current_loc2 {
+                        // loc1 is done.  save it and get a new one.
+                        result.push(current_loc1);
+                        if let Some(new_loc1) = locs1_iter.next() {
+                            current_loc1 = new_loc1;
+                            // continue
+                        } else {
+                            // No more loc1, return
+                            return result;
+                        }
+                    } else {
+                        // loc1 might have more overlaps, try another loc2
+                        if let Some(new_loc2) = locs2_iter.next() {
+                            current_loc2 = new_loc2;
+                            // continue
+                        } else {
+                            // loc2 is finished but loc1 is not,
+                            // finish adding all loc1
+                            result.push(current_loc1);
+                            for loc1 in locs1_iter {
+                                result.push(loc1);
+                            }
+                            return result;
+                        }
+                    }
+                }
+            }
+        }
+        result.push(current_loc1);
+    }
+    result
+}
+
 /// Builder for the source code coverage.
 #[derive(Debug, Serialize)]
 pub struct SourceCoverageBuilder<'a> {
     /// Mapping from function name to the source-level uncovered locations for that function.
-    pub uncovered_locations: BTreeMap<Identifier, FunctionSourceCoverage>,
+    pub uncovered_locations: Vec<Loc>,
+    pub covered_locations: Vec<Loc>,
 
     source_map: &'a SourceMap,
 }
 
-#[derive(Debug, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Serialize, Eq, PartialEq)]
 pub enum AbstractSegment {
-    Bounded { start: u32, end: u32 },
-    BoundedRight { end: u32 },
-    BoundedLeft { start: u32 },
+    Bounded {
+        is_covered: bool,
+        start: u32,
+        end: u32,
+    },
+    BoundedRight {
+        is_covered: bool,
+        end: u32,
+    },
+    BoundedLeft {
+        is_covered: bool,
+        start: u32,
+    },
+    // Unbounded {},
+}
+
+impl AbstractSegment {
+    fn is_covered(&self) -> bool {
+        use AbstractSegment::*;
+        match self {
+            Bounded { is_covered, .. }
+            | BoundedRight { is_covered, .. }
+            | BoundedLeft { is_covered, .. } => *is_covered,
+        }
+    }
+
+    fn get_start(&self) -> u32 {
+        use AbstractSegment::*;
+        match self {
+            Bounded { start, .. } => *start,
+            BoundedRight { .. } => 0u32,
+            BoundedLeft { start, .. } => *start,
+            // Unbounded {} => 0u32,
+        }
+    }
+
+    fn get_number(&self) -> u8 {
+        use AbstractSegment::*;
+        match self {
+            Bounded { .. } => 0,
+            BoundedRight { .. } => 1,
+            BoundedLeft { .. } => 2,
+            // Unbounded {} => 3,
+        }
+    }
+}
+
+impl PartialOrd for AbstractSegment {
+    fn partial_cmp(&self, other: &AbstractSegment) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AbstractSegment {
+    fn cmp(&self, other: &AbstractSegment) -> Ordering {
+        use Ordering::*;
+        match self.get_start().cmp(&other.get_start()) {
+            Less => Less,
+            Greater => Greater,
+            Equal => self.get_number().cmp(&other.get_number()),
+        }
+    }
 }
 
 /// Option to control use of color escape codes in coverage output
@@ -168,6 +320,7 @@ impl ColorChoice {
 pub enum StringSegment {
     Covered(String),
     Uncovered(String),
+    NotCounted(String),
 }
 
 pub type AnnotatedLine = Vec<StringSegment>;
@@ -182,10 +335,13 @@ impl<'a> SourceCoverageBuilder<'a> {
         module: &CompiledModule,
         coverage_map: &CoverageMap,
         source_map: &'a SourceMap,
+        packages: Vec<(&CompiledModule, &'a SourceMap)>,
     ) -> Self {
         eprintln!("coverage_map is {:#?}", coverage_map);
         eprintln!("source_map is {:#?}", source_map);
         eprintln!("module is {:#?}", module);
+
+        let module_loc = source_map.definition_location;
 
         let module_name = module.self_id();
         let unified_exec_map = coverage_map.to_unified_exec_map();
@@ -193,70 +349,254 @@ impl<'a> SourceCoverageBuilder<'a> {
             .module_maps
             .get(&(*module_name.address(), module_name.name().to_owned()));
 
-        let uncovered_locations: BTreeMap<Identifier, FunctionSourceCoverage> = module
-            .function_defs()
-            .iter()
-            .enumerate()
-            .flat_map(|(function_def_idx, function_def)| {
-                let fn_handle = module.function_handle_at(function_def.function);
-                let fn_name = module.identifier_at(fn_handle.name).to_owned();
-                let function_def_idx = FunctionDefinitionIndex(function_def_idx as u16);
+        eprintln!("unified_exec_map is {:#?}", &unified_exec_map);
+        eprintln!("module_map is {:#?}", &module_map);
 
-                // If the function summary doesn't exist then that function hasn't been called yet.
-                let coverage = match &function_def.code {
-                    None => Some(FunctionSourceCoverage {
-                        fn_is_native: true,
-                        uncovered_locations: Vec::new(),
-                    }),
-                    Some(code_unit) => {
-                        module_map.map(|fn_map| match fn_map.function_maps.get(&fn_name) {
+        eprintln!("Computing covered_locations");
+
+        let mut fun_coverage: Vec<FunctionSourceCoverage2> = Vec::new();
+        for (module, source_map) in packages.iter() {
+            let module_name = module.self_id();
+            let module_map = unified_exec_map
+                .module_maps
+                .get(&(*module_name.address(), module_name.name().to_owned()));
+            if let Some(module_map) = module_map {
+                for (function_def_idx, function_def) in module.function_defs().iter().enumerate() {
+                    let fn_handle = module.function_handle_at(function_def.function);
+                    let fn_name = module.identifier_at(fn_handle.name).to_owned();
+                    let function_def_idx = FunctionDefinitionIndex(function_def_idx as u16);
+                    let function_map = source_map
+                        .get_function_source_map(function_def_idx)
+                        .unwrap();
+                    let _function_loc = function_map.definition_location;
+                    let function_covered_locations: FunctionSourceCoverage2 = match &function_def
+                        .code
+                    {
+                        None => FunctionSourceCoverage2 {
+                            fn_is_native: true,
+                            covered_locations: vec![],
+                            uncovered_locations: vec![],
+                        },
+                        Some(code_unit) => match module_map.function_maps.get(&fn_name) {
                             None => {
-                                let function_map = source_map
-                                    .get_function_source_map(function_def_idx)
-                                    .unwrap();
-                                let mut uncovered_locations =
-                                    vec![function_map.definition_location];
-                                uncovered_locations.extend(function_map.code_map.values());
-
-                                FunctionSourceCoverage {
-                                    fn_is_native: false,
-                                    uncovered_locations,
-                                }
-                            },
-                            Some(function_coverage) => {
-                                let uncovered_locations: Vec<_> = (0..code_unit.code.len())
-                                    .flat_map(|code_offset| {
-                                        if !function_coverage.contains_key(&(code_offset as u64)) {
-                                            Some(
-                                                source_map
-                                                    .get_code_location(
-                                                        function_def_idx,
-                                                        code_offset as CodeOffset,
-                                                    )
-                                                    .unwrap(),
-                                            )
+                                let locations: Vec<_> = (0..code_unit.code.len())
+                                    .filter_map(|code_offset| {
+                                        if let Ok(loc) = source_map.get_code_location(
+                                            function_def_idx,
+                                            code_offset as CodeOffset,
+                                        ) {
+                                            Some(loc)
                                         } else {
                                             None
                                         }
                                     })
                                     .collect();
-                                FunctionSourceCoverage {
+                                FunctionSourceCoverage2 {
                                     fn_is_native: false,
+                                    covered_locations: vec![],
+                                    uncovered_locations: locations,
+                                }
+                            },
+                            Some(function_coverage) => {
+                                let (fun_cov, fun_uncov): (Vec<_>, Vec<_>) = (0..code_unit
+                                    .code
+                                    .len())
+                                    .filter_map(|code_offset| {
+                                        if let Ok(loc) = source_map.get_code_location(
+                                            function_def_idx,
+                                            code_offset as CodeOffset,
+                                        ) {
+                                            if function_coverage.contains_key(&(code_offset as u64))
+                                            {
+                                                Some((loc, true))
+                                            } else {
+                                                Some((loc, false))
+                                            }
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .partition(|(_loc, test)| *test);
+
+                                let covered_locations: Vec<_> = fun_cov
+                                    .iter()
+                                    .filter_map(
+                                        |(loc, covered)| if *covered { Some(*loc) } else { None },
+                                    )
+                                    .collect();
+                                let uncovered_locations: Vec<_> = fun_uncov
+                                    .iter()
+                                    .filter_map(
+                                        |(loc, covered)| if !*covered { Some(*loc) } else { None },
+                                    )
+                                    .collect();
+
+                                FunctionSourceCoverage2 {
+                                    fn_is_native: false,
+                                    covered_locations,
                                     uncovered_locations,
                                 }
                             },
-                        })
-                    },
-                };
-                coverage.map(|x| (fn_name, x))
+                        },
+                    };
+                    fun_coverage.push(function_covered_locations);
+                }
+            }
+        }
+        eprintln!("fun_coverage is {:#?}", fun_coverage);
+
+        // Filter locations for this module and build 2 sets: covered and uncovered locations
+        // Note that Move 1 compiler sets module_loc = location of symbol in definition, so if
+        // there are multiple modules in one file we may leave others in the picture.
+        eprintln!("module_loc is {:?}", module_loc);
+        let module_file_hash = module_loc.file_hash();
+        eprintln!("module_file_hash is {:?}", module_file_hash);
+
+        let (covered, uncovered): (BTreeSet<Loc>, BTreeSet<Loc>) = fun_coverage
+            .iter()
+            .map(
+                |FunctionSourceCoverage2 {
+                     covered_locations,
+                     uncovered_locations,
+                     ..
+                 }| {
+                    let cov: BTreeSet<_> = covered_locations
+                        .iter()
+                        .filter(|loc| loc.file_hash() == module_file_hash)
+                        .cloned()
+                        .collect();
+                    let uncov: BTreeSet<_> = uncovered_locations
+                        .iter()
+                        .filter(|loc| loc.file_hash() == module_file_hash)
+                        .cloned()
+                        .collect();
+                    (cov, uncov)
+                },
+            )
+            .reduce(|(c1, u1), (c2, u2)| {
+                (
+                    c1.union(&c2).cloned().collect(),
+                    u1.union(&u2).cloned().collect(),
+                )
             })
-            .collect();
-        eprintln!("uncovered_locations is {:#?}", uncovered_locations);
+            .unwrap_or_else(|| (BTreeSet::new(), BTreeSet::new()));
+
+        eprintln!("covered 0 is {:#?}", covered);
+        eprintln!("uncovered 0 is {:#?}", uncovered);
+
+        // Some locations contain others, but should not subsume them, e.g.:
+        //     31:  if (p) {
+        //     32:     ...
+        //     33:  } else {
+        //     34:     ...
+        //     35   }
+        // May have 3 corresponding bytecodes, with locations:
+        //     L1: 31-35
+        //     L2: 32
+        //     L3: 34
+        // If L1 is covered but L3 is not, then we want to subtract
+        // L3 from the covered region.
+        //
+        // OTOH, we may see L3 in multiple runs, once covered and once
+        // not.  So we need to
+        //   (1) subtract identical covered locations from uncovered locations
+        //   (2) subtract uncovered locations from any covered locations they overlap
+        //   (3) subtract covered locations from any uncovered lcoations they overlap
+
+        // (1)
+        let uncovered: BTreeSet<_> = uncovered.difference(&covered).cloned().collect();
+
+        eprintln!("uncovered 1 is {:#?}", uncovered);
+
+        // (2)
+        let covered: Vec<_> = subtract_locations(covered, &uncovered);
+
+        eprintln!("covered 2a is {:#?}", covered);
+
+        let covered: Vec<_> = minimize_locations(covered);
+
+        eprintln!("covered 2b is {:#?}", covered);
+
+        let uncovered: Vec<_> = uncovered.into_iter().collect();
+        eprintln!("uncovered 2a is {:#?}", uncovered);
+
+        let uncovered: Vec<_> = minimize_locations(uncovered);
+
+        eprintln!("uncovered 2b is {:#?}", uncovered);
+
+        let uncovered: BTreeSet<_> = uncovered.into_iter().collect();
+        let covered: BTreeSet<_> = covered.into_iter().collect();
+
+        // (3)
+        let uncovered: Vec<_> = subtract_locations(uncovered, &covered);
+        let covered: Vec<_> = covered.into_iter().collect();
+
+        eprintln!("uncovered 3 is {:#?}", uncovered);
+        eprintln!("uncovered is {:#?}", uncovered);
 
         Self {
-            uncovered_locations,
+            uncovered_locations: uncovered,
+            covered_locations: covered,
             source_map,
         }
+    }
+
+    // Converts a (sorted) list of non-overlapping `Loc` into a
+    // map from line number to set of `AsbtractSegment` for each line
+    // of the file `file_id` in fileset `files`.
+    fn locs_to_segments(
+        &self,
+        files: &mut Files<String>,
+        file_id: FileId,
+        spans: Vec<Span>,
+        is_covered: bool,
+    ) -> BTreeMap<u32, Vec<AbstractSegment>> {
+        let mut segments = BTreeMap::new();
+
+        for span in spans.into_iter() {
+            let start_loc = files.location(file_id, span.start()).unwrap();
+            let end_loc = files.location(file_id, span.end()).unwrap();
+            let start_line = start_loc.line.0;
+            let end_line = end_loc.line.0;
+            eprintln!(
+                "Looking at span = ({}, {}), line = ({}, {})",
+                span.start(),
+                span.end(),
+                start_line,
+                end_line
+            );
+
+            let line_segments = segments.entry(start_line).or_insert_with(Vec::new);
+            if start_line == end_line {
+                let segment = AbstractSegment::Bounded {
+                    start: start_loc.column.0,
+                    end: end_loc.column.0,
+                    is_covered,
+                };
+                if !line_segments.contains(&segment) {
+                    line_segments.push(segment);
+                }
+            } else {
+                line_segments.push(AbstractSegment::BoundedLeft {
+                    start: start_loc.column.0,
+                    is_covered,
+                });
+                for i in start_line + 1..end_line {
+                    let line_segments = segments.entry(i).or_insert_with(Vec::new);
+                    line_segments.push(AbstractSegment::BoundedLeft {
+                        start: 0,
+                        is_covered,
+                    });
+                }
+                let last_line_segments = segments.entry(end_line).or_insert_with(Vec::new);
+                last_line_segments.push(AbstractSegment::BoundedRight {
+                    end: end_loc.column.0,
+                    is_covered,
+                });
+            }
+        }
+        segments.values_mut().for_each(|v| v.sort());
+        segments
     }
 
     pub fn compute_source_coverage(&self, file_path: &Path) -> SourceCoverage {
@@ -267,64 +607,41 @@ impl<'a> SourceCoverageBuilder<'a> {
             "File contents {} out of sync with source map",
             file_path.display()
         );
-        let file_hash = self.source_map.definition_location.file_hash();
         let mut files = Files::new();
         let file_id = files.add(file_path.as_os_str().to_os_string(), file_contents.clone());
 
-        let mut uncovered_segments = BTreeMap::new();
+        let covs: Vec<_> = self
+            .covered_locations
+            .iter()
+            .map(|loc| Span::new(loc.start(), loc.end()))
+            .collect();
+        let uncovs: Vec<_> = self
+            .uncovered_locations
+            .iter()
+            .map(|loc| Span::new(loc.start(), loc.end()))
+            .collect();
 
-        for (_key, fn_cov) in self.uncovered_locations.iter() {
-            for span in merge_spans(file_hash, fn_cov.clone()).into_iter() {
-                let start_loc = files.location(file_id, span.start()).unwrap();
-                let end_loc = files.location(file_id, span.end()).unwrap();
-                let start_line = start_loc.line.0;
-                let end_line = end_loc.line.0;
-                eprintln!(
-                    "Looking at key = {}, span = ({}, {}), line = ({}, {})",
-                    _key.clone().into_string(),
-                    span.start(),
-                    span.end(),
-                    start_line,
-                    end_line
-                );
-                let segments = uncovered_segments
-                    .entry(start_line)
-                    .or_insert_with(Vec::new);
-                if start_line == end_line {
-                    let segment = AbstractSegment::Bounded {
-                        start: start_loc.column.0,
-                        end: end_loc.column.0,
-                    };
-                    // TODO: There is some issue with the source map where we have multiple spans
-                    // from different functions. This can be seen in the source map for `Roles.move`
-                    if !segments.contains(&segment) {
-                        segments.push(segment);
-                    }
-                } else {
-                    segments.push(AbstractSegment::BoundedLeft {
-                        start: start_loc.column.0,
-                    });
-                    for i in start_line + 1..end_line {
-                        let segment = uncovered_segments.entry(i).or_insert_with(Vec::new);
-                        segment.push(AbstractSegment::BoundedLeft { start: 0 });
-                    }
-                    let last_segment = uncovered_segments.entry(end_line).or_insert_with(Vec::new);
-                    last_segment.push(AbstractSegment::BoundedRight {
-                        end: end_loc.column.0,
-                    });
-                }
+        let mut uncovered_segments = self.locs_to_segments(&mut files, file_id, uncovs, false);
+        let mut covered_segments = self.locs_to_segments(&mut files, file_id, covs, true);
+
+        covered_segments.values_mut().for_each(|v| v.sort());
+        for (key, value) in covered_segments.iter_mut() {
+            match uncovered_segments.get_mut(key) {
+                None => {},
+                Some(value2) => {
+                    value.append(value2);
+                    value.sort();
+                },
             }
         }
-        uncovered_segments.values_mut().for_each(|v| v.sort());
 
         let mut annotated_lines = Vec::new();
         for (line_number, mut line) in file_contents.lines().map(|x| x.to_owned()).enumerate() {
             eprintln!("looking at {}, {}", line_number, line);
-            match uncovered_segments.get(&(line_number as u32)) {
-                None => annotated_lines.push(vec![StringSegment::Covered(line)]),
+            let line_no_u32 = line_number as u32;
+            match covered_segments.get(&line_no_u32) {
+                None => annotated_lines.push(vec![StringSegment::NotCounted(line)]),
                 Some(segments) => {
-                    // Note: segments are already pre-sorted by construction so don't need to be
-                    // resorted.
                     eprintln!(
                         "Segments for line {} are: {}",
                         line_number,
@@ -336,43 +653,69 @@ impl<'a> SourceCoverageBuilder<'a> {
                     );
                     let mut line_acc = Vec::new();
                     let mut cursor = 0;
+                    // Note: segments are already pre-sorted by construction so don't need to be
+                    // resorted.
+                    // let mut segment_start: Option<u32> = None;
+                    // let mut segment_end: Option<u32> = None;
                     for segment in segments {
                         match segment {
-                            AbstractSegment::Bounded { start, end } => {
+                            AbstractSegment::Bounded {
+                                start,
+                                end,
+                                is_covered,
+                            } => {
                                 eprintln!("Bounded {}, {}, cursor = {}", start, end, cursor);
+
                                 let length = end - start;
                                 let (before, after) = line.split_at((start - cursor) as usize);
-                                let (uncovered, rest) = after.split_at(length as usize);
-                                line_acc.push(StringSegment::Covered(before.to_string()));
-                                line_acc.push(StringSegment::Uncovered(uncovered.to_string()));
+                                let (covered, rest) = after.split_at(length as usize);
+                                line_acc.push(StringSegment::NotCounted(before.to_string()));
+                                line_acc.push(
+                                    if *is_covered {
+                                        StringSegment::Covered(covered.to_string())
+                                    } else {
+                                        StringSegment::Uncovered(covered.to_string())
+                                    },
+                                );
                                 line = rest.to_string();
                                 cursor = *end;
                             },
-                            AbstractSegment::BoundedRight { end } => {
+                            AbstractSegment::BoundedRight { end, is_covered } => {
                                 eprintln!("BoundedRight {}, cursor = {}", end, cursor);
                                 let (uncovered, rest) = line.split_at((end - cursor) as usize);
-                                line_acc.push(StringSegment::Uncovered(uncovered.to_string()));
+                                line_acc.push(
+                                    if *is_covered {
+                                        StringSegment::Covered(uncovered.to_string())
+                                    } else {
+                                        StringSegment::Uncovered(uncovered.to_string())
+                                    },
+                                );
                                 line = rest.to_string();
                                 cursor = *end;
                             },
-                            AbstractSegment::BoundedLeft { start } => {
+                            AbstractSegment::BoundedLeft { start, is_covered } => {
                                 eprintln!("BoundedLeft {}, cursor = {}", start, cursor);
                                 let (before, after) = line.split_at((start - cursor) as usize);
-                                line_acc.push(StringSegment::Covered(before.to_string()));
-                                line_acc.push(StringSegment::Uncovered(after.to_string()));
+                                line_acc.push(StringSegment::NotCounted(before.to_string()));
+                                line_acc.push(
+                                    if *is_covered {
+                                        StringSegment::Covered(after.to_string())
+                                    } else {
+                                        StringSegment::Uncovered(after.to_string())
+                                    },
+                                );
                                 line = "".to_string();
                                 cursor = 0;
                             },
                         }
                     }
                     if !line.is_empty() {
-                        line_acc.push(StringSegment::Covered(line))
+                        line_acc.push(StringSegment::NotCounted(line))
                     }
                     annotated_lines.push(line_acc)
                 },
-            }
+            };
         }
-
         SourceCoverage { annotated_lines }
     }
 }
@@ -402,13 +745,18 @@ impl SourceCoverage {
                 let has_uncovered = line
                     .iter()
                     .any(|string_segment| matches!(string_segment, StringSegment::Uncovered(_)));
+                let has_covered = line
+                    .iter()
+                    .any(|string_segment| matches!(string_segment, StringSegment::Covered(_)));
                 write!(
                     output_writer,
                     "{} ",
                     if has_uncovered {
                         "-".to_string().red()
-                    } else {
+                    } else if has_covered {
                         "+".to_string().green()
+                    } else {
+                        " ".to_string().normal()
                     }
                 )?;
             }
@@ -416,6 +764,7 @@ impl SourceCoverage {
                 match string_segment {
                     StringSegment::Covered(s) => write!(output_writer, "{}", s.green())?,
                     StringSegment::Uncovered(s) => write!(output_writer, "{}", s.bold().red())?,
+                    StringSegment::NotCounted(s) => write!(output_writer, "{}", s.normal())?,
                 }
             }
             writeln!(output_writer)?;

--- a/third_party/move/tools/move-package/Cargo.toml
+++ b/third_party/move/tools/move-package/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 edition = "2021"
 
 [dependencies]
-anyhow = { workspace = true }
+anyhow = { workspace = true, features = ["backtrace"] }
 clap = { workspace = true, features = ["derive"] }
 colored = { workspace = true }
 itertools = { workspace = true }

--- a/third_party/move/tools/move-package/src/lib.rs
+++ b/third_party/move/tools/move-package/src/lib.rs
@@ -211,8 +211,8 @@ impl BuildConfig {
         let config = self.compiler_config.clone(); // Need clone because of mut self
         let resolved_graph = self.resolution_graph_for_package(path, writer)?;
         let mutx = PackageLock::lock();
-        let ret =
-            BuildPlan::create(resolved_graph)?.compile_no_exit(&config, external_checks, writer);
+        let plan = BuildPlan::create(resolved_graph)?;
+        let ret = plan.compile_no_exit(&config, external_checks, writer);
         mutx.unlock();
         ret
     }


### PR DESCRIPTION
## Description
- Change `aptos move coverage` to work better for red-black-map test case.
- Currently includes voluminous debugging output to help resolve remaining issues.

- Also adds `--show-locs` flag to `aptos move disassemble` command to allow showing
  locations for compiler debugging (in a somewhat hard-to use form, unfortunately).

- Also add more logging of `Loc` information if `MVC_LOG=debug` to facilitate debugging
  of remaining location tracking probems.

Details of changes to `aptos move coverage` to work better for red-black-map test case:
- Track both covered and uncovered locations in source coverage,
  and try to more carefully handle inlined code.  Notably, when
  computing coverage for a module, we search for code in other modules
  that may correspond to this module (due to inlining).  To better
  handle instructions with imprecise code attribution, we consider
  the source corresponding to an instruction to be the minimal source
  set which doesn't overlap others.
- Notably:
```
        // Some locations contain others, but should not subsume them, e.g.:
        //     31:  if (p) {
        //     32:     ...
        //     33:  } else {
        //     34:     ...
        //     35   }
        // May have 3 corresponding bytecodes, with locations:
        //     L1: 31-35
        //     L2: 32
        //     L3: 34
        // If L1 is covered but L3 is not, then we want to subtract
        // L3 from the covered region.
        //
        // OTOH, we may see L3 in multiple runs, once covered and once
        // not.  So we need to
        //   (1) subtract identical covered locations from uncovered locations
        //   (2) subtract uncovered locations from any covered locations they overlap
        //   (3) subtract covered locations from any uncovered lcoations they overlap
```

## How Has This Been Tested?

Run in a code directory, with a source module such as such as `red_black_map` in a file with the same name:
```
MVC_EXP=peephole-optimization=off MVC_DEBUG=1 MVC_LOG=debug aptos move test --coverage --move-2 --dev >& test.out
RUST_BACKTRACE=1 aptos move coverage source --color always --module red_black_map --dev --move-2 >& coverage.out
aptos move disassemble --show-locs --bytecode-path build/RedBlackMap/bytecode_modules/red_black_map.mv
```

The three output files may be useful:
- `test.out` shows the compile debug log.  Note that we are disabling peephole optimizations to avoid complication here.
- `coverage.out` shows the newly corrected test coverage output, which is correct w.r.t. the code attributions,
  but those are incorrect.  There is currently a lot of extra debugigng output, so you will want to skip to the end
  of the file and scroll backwards (using `less -R coverage.out` to see colors)
- `build/RedBlackMap/bytecode_modules/red_black_map.mv.asm` shows the code attribution as `file_hash8:offset1-offset2`
  at the end of each instruction, using offsets from beginning of the source file.
  
## Key Areas to Review

The coverage output looks reasonable, but the assembly listing showing
locs reveals that there is a problem with bytecode attribution to
source code.

Notably, if you look at the `red_black_map.mv.asm` output, the basic block
which corresponds to source code around line 90-92 is clearly misattributed.
The source code in `red_black_map.move` is the final 3 lines shown here (the first line is a call which is inlined):
```
88:               // Case_I6
89:               self.rotate(grandparent_index, 1 - child_direction_of_parent);
90:               self.nodes[parent_index].color = Color::Black;
91:               self.nodes[grandparent_index].color = Color::Red;
92:               return;
```
These lines are at lines 90-92, character offset `2769-2921`, in `red_black_map.move`.

The corresponding code can be found in the assembly code by searching
for `PackVariant` calls for `Color/Black` and `Color/Red` in close
succession in the same block, followed by a `Ret`.  I see it as block
`B34` in my listing:
```
% less build/RedBlackMap/bytecode_modules/red_black_map.mv.asm
...
          405: MoveLoc[16]($t38: &mut u64)                                      2eeec0b7:5160-5170
          406: WriteRef                                                         2eeec0b7:5155-5189
B34:
          407: PackVariant[1](Color/Black)                                      2eeec0b7:5155-5189
          408: CopyLoc[0](self: &mut Map<V>)                                    2eeec0b7:5155-5189
          409: MutBorrowFieldGeneric[1](Map.nodes: vector<Node<V>>)             2eeec0b7:5260-5272
          410: MoveLoc[11](parent_index: u64)                                   2eeec0b7:5260-5272
          411: VecMutBorrow(3)                                                  2eeec0b7:5276-5304
          412: MutBorrowFieldGeneric[4](Node.color: Color)                      2eeec0b7:5276-5304
          413: WriteRef                                                         2eeec0b7:5305-5310
          414: PackVariant[0](Color/Red)                                        2eeec0b7:5276-5311
          415: MoveLoc[0](self: &mut Map<V>)                                    2eeec0b7:5276-5311
          416: MutBorrowFieldGeneric[1](Map.nodes: vector<Node<V>>)             2eeec0b7:5260-5311
          417: MoveLoc[13]($t28: u64)                                           2eeec0b7:5260-5311
          418: VecMutBorrow(3)                                                  2eeec0b7:5260-5311
          419: MutBorrowFieldGeneric[4](Node.color: Color)                      2eeec0b7:5260-5311
          420: WriteRef                                                         2eeec0b7:5256-5344
          421: Ret                                                              2eeec0b7:5313-5318
B35:
          422: LdU64(0)                                                         2eeec0b7:5313-5318
```
Including an extra line or two of context, as shown here, reveals that the locations are at least
off by one line, as the line at the end of each block seems to have the same location as the beginning
of the following block.  In fact the problem is worse than this, as the locations here are nowhere
near the positions `2769-2921` of the corresponding source code.

We find these locations applied to some quite offset code, shown here:
```
          430: WriteRef                                                         2eeec0b7:5358-5434
          431: Branch(407)                                                      2eeec0b7:2817-2829
B37:
          432: LdU64(0)                                                         2eeec0b7:2784-2794
          433: StLoc[22]($t81: u64)                                             2eeec0b7:2784-2794
          434: Branch(276)                                                      2eeec0b7:2784-2808
B38:
          435: MoveLoc[23](self: &mut Map<V>)                                   2eeec0b7:2784-2808
          436: MutBorrowFieldGeneric[0](Map.root: u64)                          2eeec0b7:2784-2814
          437: StLoc[16]($t38: &mut u64)                                        2eeec0b7:2784-2829
          438: CopyLoc[26]($t94: u64)                                           2eeec0b7:2885-2895
          439: MoveLoc[16]($t38: &mut u64)                                      2eeec0b7:2847-2857
          440: WriteRef                                                         2eeec0b7:2847-2857
          441: Branch(284)                                                      2eeec0b7:2847-2876
B39:
          442: PackVariant[1](Color/Black)                                      2eeec0b7:2847-2876
          443: CopyLoc[0](self: &mut Map<V>)                                    2eeec0b7:2847-2882
          444: MutBorrowFieldGeneric[1](Map.nodes: vector<Node<V>>)             2eeec0b7:2847-2895
          445: MoveLoc[11](parent_index: u64)                                   2eeec0b7:2913-2919
          446: VecMutBorrow(3)                                                  2eeec0b7:5340-5344
```

Referring to the file `test.out` generated above, we can look at the corresponding lines in the
stackless bytecode.  Search from the bottom of that file for the regexp "`# at .*red_black_map.move:90`",
e.g., using `less`, and scroll up a bit to see the related code.  We find the following code:
```
% less test.out
...
     # attr_id AttrId(306)
     # at /Users/brm/code/econia-red-black-map-b/sources/red_black_map.move:156:13+76
     # live vars: $t0, $t4, $t28, $t38, $t149
250: write_ref($t38, $t149)
     # attr_id AttrId(311)
     # at /Users/brm/code/econia-red-black-map-b/sources/red_black_map.move:157:16+50
     # live vars: $t0, $t4, $t28
251: label L55
     # attr_id AttrId(313)
     # at /Users/brm/code/econia-red-black-map-b/sources/red_black_map.move:90:50+12
     # live vars: $t0, $t4, $t28
252: $t34 := pack_variant 0xabc::red_black_map::Color::Black()
     # attr_id AttrId(314)
     # at /Users/brm/code/econia-red-black-map-b/sources/red_black_map.move:90:17+10
     # live vars: $t0, $t4, $t28, $t34
253: $t32 := borrow_field<0xabc::red_black_map::Map<#0>>.nodes($t0)
     # attr_id AttrId(315)
     # at /Users/brm/code/econia-red-black-map-b/sources/red_black_map.move:90:17+24
     # live vars: $t0, $t4, $t28, $t32, $t34
254: $t192 := vector::borrow_mut<0xabc::red_black_map::Node<#0>>($t32, $t4)
     # attr_id AttrId(316)
     # at /Users/brm/code/econia-red-black-map-b/sources/red_black_map.move:90:17+30
     # live vars: $t0, $t28, $t34, $t192
255: $t52 := borrow_field<0xabc::red_black_map::Node<#0>>.color($t192)
     # attr_id AttrId(317)
     # at /Users/brm/code/econia-red-black-map-b/sources/red_black_map.move:90:17+45
     # live vars: $t0, $t28, $t34, $t52
256: write_ref($t52, $t34)
     # attr_id AttrId(318)
     # at /Users/brm/code/econia-red-black-map-b/sources/red_black_map.move:91:55+10
     # live vars: $t0, $t28
257: $t34 := pack_variant 0xabc::red_black_map::Color::Red()
     # attr_id AttrId(319)
     # at /Users/brm/code/econia-red-black-map-b/sources/red_black_map.move:91:17+10
     # live vars: $t0, $t28, $t34
258: $t32 := borrow_field<0xabc::red_black_map::Map<#0>>.nodes($t0)
     # attr_id AttrId(320)
     # at /Users/brm/code/econia-red-black-map-b/sources/red_black_map.move:91:17+29
     # live vars: $t28, $t32, $t34
259: $t192 := vector::borrow_mut<0xabc::red_black_map::Node<#0>>($t32, $t28)
     # attr_id AttrId(321)
     # at /Users/brm/code/econia-red-black-map-b/sources/red_black_map.move:91:17+35
     # live vars: $t34, $t192
260: $t52 := borrow_field<0xabc::red_black_map::Node<#0>>.color($t192)
     # attr_id AttrId(322)
     # at /Users/brm/code/econia-red-black-map-b/sources/red_black_map.move:91:17+48
     # live vars: $t34, $t52
261: write_ref($t52, $t34)
     # attr_id AttrId(323)
     # at /Users/brm/code/econia-red-black-map-b/sources/red_black_map.move:92:17+6
     # live vars:
262: return ()
     # attr_id AttrId(301)
     # at /Users/brm/code/econia-red-black-map-b/sources/red_black_map.move:155:22+4
     # live vars: $t0, $t4, $t28, $t149, $t157
263: label L57
     # attr_id AttrId(302)
     # at /Users/brm/code/econia-red-black-map-b/sources/red_black_map.move:155:22+4
     # flush: $t105
     # live vars: $t0, $t4, $t28, $t149, $t157
264: $t105 := 0
```
Note that the attributes precede each line.  Here we see that the stackless bytecode
is better attributed to the original source code, except that:
- Labels seem to have the location of the preceding code, rather than the succeeding
  code

So we have 2 problems:
- Stackless bytecode labels are misattributed to the preceding code, rather than the
  code they are labeling
- Generation of final bytecode loses the correct locations.

Final code generation occurs in
`third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs`, and
I've added more debugging output to start to try to understand what's going on,
(search for "`Generating code for bytecode`" and "`setting location for`" in `test.out`)
but it's still not clear why the code is getting the wrong locations.

## Not related to Peephole

With peephole opts off:





<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [X] Move Compiler
- [ ] Other (specify)

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X] I tested both happy and unhappy path of the functionality
- [X] I have made corresponding changes to the documentation
