### PR TITLE
Stop locking BufferedState for read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,6 +1191,7 @@ dependencies = [
  "clap 4.4.14",
  "crossbeam-channel",
  "dashmap",
+ "derive_more",
  "either",
  "hex",
  "indicatif 0.15.0",

--- a/storage/aptosdb/Cargo.toml
+++ b/storage/aptosdb/Cargo.toml
@@ -42,6 +42,7 @@ claims = { workspace = true }
 clap = { workspace = true, optional = true }
 crossbeam-channel = { workspace = true, optional = true }
 dashmap = { workspace = true }
+derive_more = { workspace = true }
 either = { workspace = true }
 hex = { workspace = true }
 indicatif = { workspace = true, optional = true }

--- a/storage/aptosdb/src/backup/restore_utils.rs
+++ b/storage/aptosdb/src/backup/restore_utils.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use aptos_crypto::HashValue;
 use aptos_schemadb::{SchemaBatch, DB};
-use aptos_storage_interface::{db_ensure as ensure, AptosDbError, Result};
+use aptos_storage_interface::{db_ensure as ensure, state_delta::StateDelta, AptosDbError, Result};
 use aptos_types::{
     contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
@@ -161,9 +161,9 @@ pub(crate) fn save_transactions(
         )?;
 
         ledger_db.write_schemas(ledger_db_batch)?;
-        ledger_db
-            .metadata_db()
-            .set_pre_committed_version(last_version);
+
+        *state_store.current_state().lock() =
+            StateDelta::new_empty_with_version(Some(last_version));
     }
 
     Ok(())

--- a/storage/aptosdb/src/backup/test.rs
+++ b/storage/aptosdb/src/backup/test.rs
@@ -18,7 +18,7 @@ proptest! {
     fn test_get_transaction_iter(input in arb_blocks_to_commit()) {
         let tmp_dir = TempPath::new();
         let db = AptosDB::new_for_test(&tmp_dir);
-        let mut in_memory_state = db.state_store.buffered_state().lock().current_state().clone();
+        let mut in_memory_state = db.state_store.current_state_cloned();
         let _ancestor = in_memory_state.base.clone();
         let mut cur_ver: Version = 0;
         for (txns_to_commit, ledger_info_with_sigs) in input.iter() {

--- a/storage/aptosdb/src/db/aptosdb_test.rs
+++ b/storage/aptosdb/src/db/aptosdb_test.rs
@@ -245,12 +245,7 @@ pub fn test_state_merkle_pruning_impl(
     .unwrap();
 
     // augment DB in blocks
-    let mut in_memory_state = db
-        .state_store
-        .buffered_state()
-        .lock()
-        .current_state()
-        .clone();
+    let mut in_memory_state = db.state_store.current_state_cloned();
     let _ancester = in_memory_state.current.clone();
     let mut next_ver: Version = 0;
     let mut snapshot_versions = vec![];

--- a/storage/aptosdb/src/db/fake_aptosdb.rs
+++ b/storage/aptosdb/src/db/fake_aptosdb.rs
@@ -994,10 +994,7 @@ mod tests {
 
             let mut in_memory_state = db
                 .inner
-                .buffered_state()
-                .lock()
-                .current_state()
-                .clone();
+            .get_latest_executed_trees().state;
 
             let mut cur_ver: Version = 0;
             for (txns_to_commit, ledger_info_with_sigs) in input.iter() {

--- a/storage/aptosdb/src/db/include/aptosdb_testonly.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_testonly.rs
@@ -1,9 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::state_store::buffered_state::BufferedState;
 use aptos_config::config::{ BUFFERED_STATE_TARGET_ITEMS_FOR_TEST, DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD};
-use aptos_infallible::Mutex;
 use aptos_types::state_store::{create_empty_sharded_state_updates, ShardedStateUpdates};
 use std::default::Default;
 use aptos_storage_interface::cached_state_view::ShardedStateCache;
@@ -89,11 +87,6 @@ impl AptosDB {
             false, /* indexer */
             false,
         )
-    }
-
-    /// This gets the current buffered_state in StateStore.
-    pub fn buffered_state(&self) -> &Mutex<BufferedState> {
-        self.state_store.buffered_state()
     }
 
     pub(crate) fn state_merkle_db(&self) -> Arc<StateMerkleDb> {

--- a/storage/aptosdb/src/db/include/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_writer.rs
@@ -29,6 +29,8 @@ impl DbWriter for AptosDB {
                 self.skip_index_and_usage,
             )?;
 
+            // n.b make sure buffered_state.update() is called after all other commits are done, since
+            // internally it updates state_store.current_state which indicates the "pre-committed version"
             let _timer = OTHER_TIMERS_SECONDS.timer_with(&["save_transactions__others"]);
             {
                 let mut buffered_state = self.state_store.buffered_state().lock();
@@ -40,7 +42,7 @@ impl DbWriter for AptosDB {
                     sync_commit || chunk.is_reconfig,
                 )?;
             }
-            self.ledger_db.metadata_db().set_pre_committed_version(chunk.expect_last_version());
+
             Ok(())
         })
     }
@@ -208,7 +210,6 @@ impl DbWriter for AptosDB {
                 .save_min_readable_version(version)?;
 
             restore_utils::update_latest_ledger_info(self.ledger_db.metadata_db(), ledger_infos)?;
-            self.ledger_db.metadata_db().set_pre_committed_version(version);
             self.state_store.reset();
 
             Ok(())
@@ -236,29 +237,23 @@ impl AptosDB {
             chunk.latest_in_memory_state.current_version.expect("Must exist"),
         );
 
-        let num_transactions_in_db = self.get_pre_committed_version()?.map_or(0, |v| v + 1);
         {
-            let buffered_state = self.state_store.buffered_state().lock();
+            let current_state_guard = self.state_store.current_state();
+            let current_state = current_state_guard.lock();
             ensure!(
-                chunk.base_state_version == buffered_state.current_state().base_version,
+                chunk.base_state_version == current_state.base_version,
                 "base_state_version {:?} does not equal to the base_version {:?} in buffered state with current version {:?}",
                 chunk.base_state_version,
-                buffered_state.current_state().base_version,
-                buffered_state.current_state().current_version,
+                current_state.base_version,
+                current_state.current_version,
             );
 
             // Ensure the incoming committing requests are always consecutive and the version in
             // buffered state is consistent with that in db.
-            let next_version_in_buffered_state = buffered_state
-                .current_state()
-                .current_version
-                .map(|version| version + 1)
-                .unwrap_or(0);
-            ensure!(num_transactions_in_db == chunk.first_version && num_transactions_in_db == next_version_in_buffered_state,
-                "The first version passed in ({}), the next version in buffered state ({}) and the next version in db ({}) are inconsistent.",
+            ensure!(chunk.first_version == current_state.next_version(),
+                "The first version passed in ({}), and the next version expected by db ({}) are inconsistent.",
                 chunk.first_version,
-                next_version_in_buffered_state,
-                num_transactions_in_db,
+                current_state.next_version(),
             );
         }
 
@@ -560,7 +555,7 @@ impl AptosDB {
         version_to_commit: Version,
     ) -> Result<Option<Version>> {
         let old_committed_ver = self.ledger_db.metadata_db().get_synced_version()?;
-        let pre_committed_ver = self.ledger_db.metadata_db().get_pre_committed_version();
+        let pre_committed_ver = self.state_store.current_state().lock().current_version;
         ensure!(
             old_committed_ver.is_none() || version_to_commit >= old_committed_ver.unwrap(),
             "Version too old to commit. Committed: {:?}; Trying to commit with LI: {}",

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -96,7 +96,9 @@ pub struct AptosDB {
     pub(crate) transaction_store: Arc<TransactionStore>,
     ledger_pruner: LedgerPrunerManager,
     _rocksdb_property_reporter: RocksdbPropertyReporter,
+    /// This is just to detect concurrent calls to `pre_commit_ledger()`
     pre_commit_lock: std::sync::Mutex<()>,
+    /// This is just to detect concurrent calls to `commit_ledger()`
     commit_lock: std::sync::Mutex<()>,
     indexer: Option<Indexer>,
     skip_index_and_usage: bool,

--- a/storage/aptosdb/src/db/test_helper.rs
+++ b/storage/aptosdb/src/db/test_helper.rs
@@ -358,12 +358,7 @@ pub fn test_save_blocks_impl(
     let db =
         AptosDB::new_for_test_with_buffered_state_target_items(&tmp_dir, snapshot_size_threshold);
 
-    let mut in_memory_state = db
-        .state_store
-        .buffered_state()
-        .lock()
-        .current_state()
-        .clone();
+    let mut in_memory_state = db.state_store.current_state_cloned();
     let _ancester = in_memory_state.current.clone();
     let _usage = _ancester.usage();
     let num_batches = input.len();
@@ -941,12 +936,7 @@ pub fn put_as_state_root(db: &AptosDB, version: Version, key: StateKey, value: S
         .metadata_db()
         .put::<StateValueSchema>(&(key.clone(), version), &Some(value.clone()))
         .unwrap();
-    let mut in_memory_state = db
-        .state_store
-        .buffered_state()
-        .lock()
-        .current_state()
-        .clone();
+    let mut in_memory_state = db.state_store.current_state_cloned();
     in_memory_state.current = smt;
     in_memory_state.current_version = Some(version);
     in_memory_state.updates_since_base[key.get_shard_id() as usize].insert(key, Some(value));
@@ -965,12 +955,7 @@ pub fn test_sync_transactions_impl(
     let db =
         AptosDB::new_for_test_with_buffered_state_target_items(&tmp_dir, snapshot_size_threshold);
 
-    let mut in_memory_state = db
-        .state_store
-        .buffered_state()
-        .lock()
-        .current_state()
-        .clone();
+    let mut in_memory_state = db.state_store.current_state_cloned();
     let _ancester = in_memory_state.current.clone();
     let num_batches = input.len();
     let mut cur_ver: Version = 0;

--- a/storage/aptosdb/src/db_debugger/truncate/mod.rs
+++ b/storage/aptosdb/src/db_debugger/truncate/mod.rs
@@ -195,7 +195,7 @@ mod test {
             let tmp_dir = TempPath::new();
 
             let db = if input.1 { AptosDB::new_for_test_with_sharding(&tmp_dir, DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD) } else { AptosDB::new_for_test(&tmp_dir) };
-            let mut in_memory_state = db.state_store.buffered_state().lock().current_state().clone();
+            let mut in_memory_state = db.state_store.current_state_cloned();
             let _ancestor = in_memory_state.base.clone();
             let mut version = 0;
             for (txns_to_commit, ledger_info_with_sigs) in input.0.iter() {

--- a/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
+++ b/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
@@ -16,20 +16,12 @@ use anyhow::anyhow;
 use aptos_schemadb::{SchemaBatch, DB};
 use aptos_storage_interface::{block_info::BlockInfo, db_ensure as ensure, AptosDbError, Result};
 use aptos_types::{
-    account_config::NewBlockEvent,
-    block_info::BlockHeight,
-    contract_event::ContractEvent,
-    epoch_state::EpochState,
-    ledger_info::LedgerInfoWithSignatures,
-    state_store::state_storage_usage::StateStorageUsage,
-    transaction::{AtomicVersion, Version},
+    account_config::NewBlockEvent, block_info::BlockHeight, contract_event::ContractEvent,
+    epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
+    state_store::state_storage_usage::StateStorageUsage, transaction::Version,
 };
 use arc_swap::ArcSwap;
-use std::{
-    ops::Deref,
-    path::Path,
-    sync::{atomic::Ordering, Arc},
-};
+use std::{ops::Deref, path::Path, sync::Arc};
 
 fn get_latest_ledger_info_in_db_impl(db: &DB) -> Result<Option<LedgerInfoWithSignatures>> {
     let mut iter = db.iter::<LedgerInfoSchema>()?;
@@ -45,8 +37,6 @@ pub(crate) struct LedgerMetadataDb {
     /// cache it in memory in order to avoid reading DB and deserializing the object frequently. It
     /// should be updated every time new ledger info and signatures are persisted.
     latest_ledger_info: ArcSwap<Option<LedgerInfoWithSignatures>>,
-
-    next_pre_commit_version: AtomicVersion,
 }
 
 impl LedgerMetadataDb {
@@ -54,14 +44,9 @@ impl LedgerMetadataDb {
         let latest_ledger_info = get_latest_ledger_info_in_db_impl(&db).expect("DB read failed.");
         let latest_ledger_info = ArcSwap::from(Arc::new(latest_ledger_info));
 
-        let synced_version =
-            get_progress(&db, &DbMetadataKey::OverallCommitProgress).expect("DB read failed.");
-        let next_pre_commit_version = AtomicVersion::new(synced_version.map_or(0, |v| v + 1));
-
         Self {
             db,
             latest_ledger_info,
-            next_pre_commit_version,
         }
     }
 
@@ -90,20 +75,6 @@ impl LedgerMetadataDb {
 
     pub(crate) fn get_synced_version(&self) -> Result<Option<Version>> {
         get_progress(&self.db, &DbMetadataKey::OverallCommitProgress)
-    }
-
-    pub(crate) fn get_pre_committed_version(&self) -> Option<Version> {
-        let next_version = self.next_pre_commit_version.load(Ordering::Acquire);
-        if next_version == 0 {
-            None
-        } else {
-            Some(next_version - 1)
-        }
-    }
-
-    pub(crate) fn set_pre_committed_version(&self, version: Version) {
-        self.next_pre_commit_version
-            .store(version + 1, Ordering::Release);
     }
 
     pub(crate) fn get_ledger_commit_progress(&self) -> Result<Version> {

--- a/storage/aptosdb/src/state_store/buffered_state.rs
+++ b/storage/aptosdb/src/state_store/buffered_state.rs
@@ -4,15 +4,15 @@
 //! This file defines state store buffered state that has been committed.
 
 use crate::{
-    metrics::LATEST_CHECKPOINT_VERSION,
-    state_store::{state_snapshot_committer::StateSnapshotCommitter, StateDb},
+    metrics::{LATEST_CHECKPOINT_VERSION, OTHER_TIMERS_SECONDS},
+    state_store::{state_snapshot_committer::StateSnapshotCommitter, CurrentState, StateDb},
 };
 use aptos_logger::info;
+use aptos_metrics_core::TimerHelper;
 use aptos_scratchpad::SmtAncestors;
 use aptos_storage_interface::{db_ensure as ensure, state_delta::StateDelta, AptosDbError, Result};
-use aptos_types::{
-    state_store::{combine_sharded_state_updates, state_value::StateValue, ShardedStateUpdates},
-    transaction::Version,
+use aptos_types::state_store::{
+    combine_sharded_state_updates, state_value::StateValue, ShardedStateUpdates,
 };
 use std::{
     sync::{
@@ -34,10 +34,12 @@ pub(crate) const TARGET_SNAPSHOT_INTERVAL_IN_VERSION: u64 = 100_000;
 /// state_until_checkpoint.current = state_after_checkpoint.base, same for their versions.
 #[derive(Debug)]
 pub struct BufferedState {
-    // state until the latest checkpoint.
+    /// state until the latest checkpoint. The `base` is the newest persisted state.
     state_until_checkpoint: Option<Box<StateDelta>>,
-    // state after the latest checkpoint.
-    state_after_checkpoint: StateDelta,
+    /// state after the latest checkpoint. The `current` is the latest speculative state.
+    ///   n.b. this is an `Arc` shared with the StateStore so that merely querying the latest state
+    ///        does not require locking the buffered state.
+    state_after_checkpoint: CurrentState,
     state_commit_sender: SyncSender<CommitMessage<Arc<StateDelta>>>,
     target_items: usize,
     join_handle: Option<JoinHandle<()>>,
@@ -54,7 +56,7 @@ impl BufferedState {
         state_db: &Arc<StateDb>,
         state_after_checkpoint: StateDelta,
         target_items: usize,
-    ) -> (Self, SmtAncestors<StateValue>) {
+    ) -> (Self, SmtAncestors<StateValue>, CurrentState) {
         let (state_commit_sender, state_commit_receiver) =
             mpsc::sync_channel(ASYNC_COMMIT_CHANNEL_BUFFER_SIZE as usize);
         let arc_state_db = Arc::clone(state_db);
@@ -72,24 +74,17 @@ impl BufferedState {
                 committer.run();
             })
             .expect("Failed to spawn state committer thread.");
+        let current_state = CurrentState::new(state_after_checkpoint.clone());
         let myself = Self {
             state_until_checkpoint: None,
-            state_after_checkpoint,
+            state_after_checkpoint: current_state.clone(),
             state_commit_sender,
             target_items,
             // The join handle of the async state commit thread for graceful drop.
             join_handle: Some(join_handle),
         };
         myself.report_latest_committed_version();
-        (myself, smt_ancestors)
-    }
-
-    pub fn current_state(&self) -> &StateDelta {
-        &self.state_after_checkpoint
-    }
-
-    pub fn current_checkpoint_version(&self) -> Option<Version> {
-        self.state_after_checkpoint.base_version
+        (myself, smt_ancestors, current_state)
     }
 
     /// This method checks whether a commit is needed based on the target_items value and the number of items in state_until_checkpoint.
@@ -146,6 +141,7 @@ impl BufferedState {
     fn report_latest_committed_version(&self) {
         LATEST_CHECKPOINT_VERSION.set(
             self.state_after_checkpoint
+                .lock()
                 .base_version
                 .map_or(-1, |v| v as i64),
         );
@@ -158,41 +154,51 @@ impl BufferedState {
         new_state_after_checkpoint: &StateDelta,
         sync_commit: bool,
     ) -> Result<()> {
-        assert!(new_state_after_checkpoint
-            .current
-            .is_family(&self.state_after_checkpoint.current));
-        ensure!(
-            new_state_after_checkpoint.base_version >= self.state_after_checkpoint.base_version,
-            "new state base version smaller than state after checkpoint base version",
-        );
-        if let Some(updates_until_next_checkpoint_since_current) =
-            updates_until_next_checkpoint_since_current_option
         {
+            let _timer = OTHER_TIMERS_SECONDS.timer_with(&["update_current_state"]);
+
+            let mut state_after_checkpoint = self.state_after_checkpoint.lock();
+
+            assert!(new_state_after_checkpoint
+                .current
+                .is_family(&state_after_checkpoint.current));
             ensure!(
-                new_state_after_checkpoint.base_version > self.state_after_checkpoint.base_version,
-                "Diff between base and latest checkpoints provided, while they are the same.",
+                new_state_after_checkpoint.base_version >= state_after_checkpoint.base_version,
+                "new state base version smaller than state after checkpoint base version",
             );
-            combine_sharded_state_updates(
-                &mut self.state_after_checkpoint.updates_since_base,
-                updates_until_next_checkpoint_since_current,
-            );
-            self.state_after_checkpoint.current = new_state_after_checkpoint.base.clone();
-            self.state_after_checkpoint.current_version = new_state_after_checkpoint.base_version;
-            let state_after_checkpoint = self
-                .state_after_checkpoint
-                .replace_with(new_state_after_checkpoint.clone());
-            if let Some(ref mut delta) = self.state_until_checkpoint {
-                delta.merge(state_after_checkpoint);
+            if let Some(updates_until_next_checkpoint_since_current) =
+                updates_until_next_checkpoint_since_current_option
+            {
+                ensure!(
+                    new_state_after_checkpoint.base_version > state_after_checkpoint.base_version,
+                    "Diff between base and latest checkpoints provided, while they are the same.",
+                );
+                combine_sharded_state_updates(
+                    &mut state_after_checkpoint.updates_since_base,
+                    updates_until_next_checkpoint_since_current,
+                );
+                let mut old_state =
+                    state_after_checkpoint.replace_with(new_state_after_checkpoint.clone());
+                old_state.current = state_after_checkpoint.base.clone();
+                old_state.current_version = state_after_checkpoint.base_version;
+
+                if let Some(ref mut delta) = self.state_until_checkpoint {
+                    delta.merge(old_state);
+                } else {
+                    self.state_until_checkpoint = Some(Box::new(old_state));
+                }
             } else {
-                self.state_until_checkpoint = Some(Box::new(state_after_checkpoint));
+                ensure!(
+                    new_state_after_checkpoint.base_version == state_after_checkpoint.base_version,
+                    "Diff between base and latest checkpoints not provided.",
+                );
+                *state_after_checkpoint = new_state_after_checkpoint.clone();
             }
-        } else {
-            ensure!(
-                new_state_after_checkpoint.base_version == self.state_after_checkpoint.base_version,
-                "Diff between base and latest checkpoints not provided.",
-            );
-            self.state_after_checkpoint = new_state_after_checkpoint.clone();
         }
+
+        // n.b. make sure these are called after self.state_after_checkpoint is unlocked.
+        //      otherwise things reading the "pre-committed version" will be blocked by
+        //      the buffered state lock.
         self.maybe_commit(sync_commit);
         self.report_latest_committed_version();
         Ok(())

--- a/storage/backup/backup-cli/src/utils/test_utils.rs
+++ b/storage/backup/backup-cli/src/utils/test_utils.rs
@@ -9,6 +9,7 @@ use aptos_db::{
     AptosDB,
 };
 use aptos_proptest_helpers::ValueGenerator;
+use aptos_storage_interface::DbReader;
 use aptos_temppath::TempPath;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
@@ -34,7 +35,12 @@ pub fn tmp_db_with_random_content() -> (
 ) {
     let (tmpdir, db) = tmp_db_empty();
     let mut cur_ver: Version = 0;
-    let mut in_memory_state = db.buffered_state().lock().current_state().clone();
+    let mut in_memory_state = db
+        .get_latest_executed_trees()
+        .unwrap()
+        .state
+        .as_ref()
+        .clone();
     let _ancestor = in_memory_state.base.clone();
     let blocks = ValueGenerator::new().generate(arb_blocks_to_commit());
     for (txns_to_commit, ledger_info_with_sigs) in &blocks {

--- a/storage/storage-interface/src/state_delta.rs
+++ b/storage/storage-interface/src/state_delta.rs
@@ -47,15 +47,19 @@ impl StateDelta {
         }
     }
 
-    pub fn new_empty() -> Self {
+    pub fn new_empty_with_version(version: Option<u64>) -> StateDelta {
         let smt = SparseMerkleTree::new_empty();
         Self::new(
             smt.clone(),
-            None,
+            version,
             smt,
-            None,
+            version,
             create_empty_sharded_state_updates(),
         )
+    }
+
+    pub fn new_empty() -> Self {
+        Self::new_empty_with_version(None)
     }
 
     pub fn new_at_checkpoint(


### PR DESCRIPTION


## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Move the part which need to be read out, so that the read path is not blocked by buffered state back pressure or sync commits.

Also the pre commited version is now in the same lock of the latest state, eliminating some edge cases.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->


## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Validator Node

<!-- Thank you for your contribution! -->
