### PR TITLE
[Network] Add simple queuing metrics for message sends.

### DIFF
--- a/consensus/src/consensus_observer/network/network_handler.rs
+++ b/consensus/src/consensus_observer/network/network_handler.rs
@@ -802,23 +802,26 @@ mod test {
                         (outbound_rpc_request.protocol_id, received_message)
                     }
                     PeerManagerRequest::SendDirectSend(peer_id, message) => {
+                        // Unpack the message
+                        let (protocol_id, data) = message.into_parts();
+
                         // Verify the message is correct
                         assert!(!is_rpc_request);
                         assert_eq!(peer_id, expected_peer_id);
-                        assert_eq!(Some(message.protocol_id), expected_direct_send_protocol);
+                        assert_eq!(Some(protocol_id), expected_direct_send_protocol);
 
                         // Create and return the received message
                         let received_message = ReceivedMessage {
                             message: NetworkMessage::DirectSendMsg(DirectSendMsg{
-                                protocol_id: message.protocol_id,
+                                protocol_id,
                                 priority: 0,
-                                raw_msg: message.mdata.into(),
+                                raw_msg: data.into(),
                             }),
                             sender: PeerNetworkId::new(expected_network_id, peer_id),
                             receive_timestamp_micros: 0,
                             rpc_replier: None,
                         };
-                        (message.protocol_id, received_message)
+                        (protocol_id, received_message)
                     }
                 };
 

--- a/consensus/src/consensus_observer/network/network_handler.rs
+++ b/consensus/src/consensus_observer/network/network_handler.rs
@@ -781,25 +781,28 @@ mod test {
             Ok(peer_manager_request) => {
                 let (protocol_id, peer_manager_notification) = match peer_manager_request {
                     PeerManagerRequest::SendRpc(peer_id, outbound_rpc_request) => {
+                        // Unpack the request
+                        let (protocol_id, data, res_tx, timeout) = outbound_rpc_request.into_parts();
+
                         // Verify the message is correct
                         assert!(is_rpc_request);
                         assert_eq!(peer_id, expected_peer_id);
-                        assert_eq!(Some(outbound_rpc_request.protocol_id), expected_rpc_protocol);
-                        assert_eq!(outbound_rpc_request.timeout, Duration::from_millis(RPC_REQUEST_TIMEOUT_MS));
+                        assert_eq!(Some(protocol_id), expected_rpc_protocol);
+                        assert_eq!(timeout, Duration::from_millis(RPC_REQUEST_TIMEOUT_MS));
 
                         // Create and return the received message
                         let received_message = ReceivedMessage {
                             message: NetworkMessage::RpcRequest(RpcRequest{
-                                protocol_id: outbound_rpc_request.protocol_id,
+                                protocol_id,
                                 request_id: 0,
                                 priority: 0,
-                                raw_request: outbound_rpc_request.data.into(),
+                                raw_request: data.into(),
                             }),
                             sender: PeerNetworkId::new(expected_network_id, peer_id),
                             receive_timestamp_micros: 0,
-                            rpc_replier: Some(Arc::new(outbound_rpc_request.res_tx)),
+                            rpc_replier: Some(Arc::new(res_tx)),
                         };
-                        (outbound_rpc_request.protocol_id, received_message)
+                        (protocol_id, received_message)
                     }
                     PeerManagerRequest::SendDirectSend(peer_id, message) => {
                         // Unpack the message

--- a/consensus/src/consensus_observer/network/network_handler.rs
+++ b/consensus/src/consensus_observer/network/network_handler.rs
@@ -782,7 +782,7 @@ mod test {
                 let (protocol_id, peer_manager_notification) = match peer_manager_request {
                     PeerManagerRequest::SendRpc(peer_id, outbound_rpc_request) => {
                         // Unpack the request
-                        let (protocol_id, data, res_tx, timeout) = outbound_rpc_request.into_parts();
+                        let (_, protocol_id, data, res_tx, timeout) = outbound_rpc_request.into_parts();
 
                         // Verify the message is correct
                         assert!(is_rpc_request);
@@ -806,7 +806,7 @@ mod test {
                     }
                     PeerManagerRequest::SendDirectSend(peer_id, message) => {
                         // Unpack the message
-                        let (protocol_id, data) = message.into_parts();
+                        let (_, protocol_id, data) = message.into_parts();
 
                         // Verify the message is correct
                         assert!(!is_rpc_request);

--- a/consensus/src/consensus_observer/observer/subscription_utils.rs
+++ b/consensus/src/consensus_observer/observer/subscription_utils.rs
@@ -1233,8 +1233,7 @@ mod tests {
         match peer_manager_request_receiver.next().await {
             Some(PeerManagerRequest::SendRpc(_, network_request)) => {
                 // Parse the network request
-                let data = network_request.data;
-                let response_sender = network_request.res_tx;
+                let (_, data, response_sender, _) = network_request.into_parts();
                 let message: ConsensusObserverMessage = bcs::from_bytes(data.as_ref()).unwrap();
 
                 // Process the network message

--- a/consensus/src/consensus_observer/observer/subscription_utils.rs
+++ b/consensus/src/consensus_observer/observer/subscription_utils.rs
@@ -1233,7 +1233,7 @@ mod tests {
         match peer_manager_request_receiver.next().await {
             Some(PeerManagerRequest::SendRpc(_, network_request)) => {
                 // Parse the network request
-                let (_, data, response_sender, _) = network_request.into_parts();
+                let (_, _, data, response_sender, _) = network_request.into_parts();
                 let message: ConsensusObserverMessage = bcs::from_bytes(data.as_ref()).unwrap();
 
                 // Process the network message

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -297,9 +297,9 @@ impl NetworkPlayground {
                 if !self.is_message_dropped(&src_twin_id, dst_twin_id, consensus_msg) {
                     let rmsg = ReceivedMessage {
                         message: NetworkMessage::DirectSendMsg(DirectSendMsg {
-                            protocol_id: msg.protocol_id,
+                            protocol_id: msg.protocol_id(),
                             priority: 0,
-                            raw_msg: msg.mdata.clone().into(),
+                            raw_msg: msg.data().clone().into(),
                         }),
                         sender: PeerNetworkId::new(NetworkId::Validator, src_twin_id.author),
                         receive_timestamp_micros: 0,
@@ -419,9 +419,9 @@ impl NetworkPlayground {
             for dst_twin_id in dst_twin_ids.iter() {
                 let rmsg = ReceivedMessage {
                     message: NetworkMessage::DirectSendMsg(DirectSendMsg {
-                        protocol_id: msg.protocol_id,
+                        protocol_id: msg.protocol_id(),
                         priority: 0,
-                        raw_msg: msg.mdata.clone().into(),
+                        raw_msg: msg.data().clone().into(),
                     }),
                     sender: PeerNetworkId::new(NetworkId::Validator, src_twin_id.author),
                     receive_timestamp_micros: 0,

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -155,11 +155,12 @@ impl NetworkPlayground {
                         None => continue, // drop rpc
                     };
 
+                    let (protocol_id, data, res_tx, _) = outbound_req.into_parts();
                     if timeout_config
                         .read()
                         .is_message_timedout(&src_twin_id, dst_twin_id)
                     {
-                        outbound_req.res_tx.send(Err(RpcError::TimedOut)).unwrap();
+                        res_tx.send(Err(RpcError::TimedOut)).unwrap();
                         continue;
                     }
 
@@ -171,17 +172,17 @@ impl NetworkPlayground {
                             (src_twin_id.author, ProtocolId::ConsensusRpcBcs),
                             ReceivedMessage {
                                 message: NetworkMessage::RpcRequest(RpcRequest {
-                                    protocol_id: outbound_req.protocol_id,
+                                    protocol_id,
                                     request_id: 123,
                                     priority: 0,
-                                    raw_request: outbound_req.data.into(),
+                                    raw_request: data.into(),
                                 }),
                                 sender: PeerNetworkId::new(
                                     NetworkId::Validator,
                                     src_twin_id.author,
                                 ),
                                 receive_timestamp_micros: 0,
-                                rpc_replier: Some(Arc::new(outbound_req.res_tx)),
+                                rpc_replier: Some(Arc::new(res_tx)),
                             },
                         )
                         .unwrap();

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -155,7 +155,7 @@ impl NetworkPlayground {
                         None => continue, // drop rpc
                     };
 
-                    let (protocol_id, data, res_tx, _) = outbound_req.into_parts();
+                    let (_, protocol_id, data, res_tx, _) = outbound_req.into_parts();
                     if timeout_config
                         .read()
                         .is_message_timedout(&src_twin_id, dst_twin_id)

--- a/mempool/src/tests/multi_node_test.rs
+++ b/mempool/src/tests/multi_node_test.rs
@@ -23,7 +23,7 @@ use aptos_network::{
     peer_manager::PeerManagerRequest,
     protocols::{
         direct_send::Message,
-        network::ReceivedMessage,
+        network::{ReceivedMessage, SerializedRequest},
         wire::messaging::v1::{DirectSendMsg, NetworkMessage},
     },
     ProtocolId,
@@ -344,9 +344,9 @@ impl TestHarness {
         let receiver = self.mut_node(&receiver_id);
         let rmsg = ReceivedMessage {
             message: NetworkMessage::DirectSendMsg(DirectSendMsg {
-                protocol_id: msg.protocol_id,
+                protocol_id: msg.protocol_id(),
                 priority: 0,
-                raw_msg: msg.mdata.into(),
+                raw_msg: msg.data().clone().into(),
             }),
             sender: PeerNetworkId::new(network_id, sender_peer_id),
             receive_timestamp_micros: 0,
@@ -400,7 +400,7 @@ impl TestHarness {
         // Handle outgoing message
         match network_req {
             PeerManagerRequest::SendDirectSend(remote_peer_id, msg) => {
-                let mempool_message = common::decompress_and_deserialize(&msg.mdata.to_vec());
+                let mempool_message = common::decompress_and_deserialize(&msg.data().to_vec());
                 match mempool_message {
                     MempoolSyncMsg::BroadcastTransactionsRequest {
                         transactions,
@@ -456,7 +456,7 @@ impl TestHarness {
 
         match network_req {
             PeerManagerRequest::SendDirectSend(remote_peer_id, msg) => {
-                let mempool_message = common::decompress_and_deserialize(&msg.mdata.to_vec());
+                let mempool_message = common::decompress_and_deserialize(&msg.data().to_vec());
                 match mempool_message {
                     MempoolSyncMsg::BroadcastTransactionsResponse { .. } => {
                         // send it to peer
@@ -477,9 +477,9 @@ impl TestHarness {
                         let receiver = self.mut_node(&receiver_id);
                         let rmsg = ReceivedMessage {
                             message: NetworkMessage::DirectSendMsg(DirectSendMsg {
-                                protocol_id: msg.protocol_id,
+                                protocol_id: msg.protocol_id(),
                                 priority: 0,
-                                raw_msg: msg.mdata.into(),
+                                raw_msg: msg.data().clone().into(),
                             }),
                             sender: PeerNetworkId::new(network_id, sender_peer_id),
                             receive_timestamp_micros: 0,

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -377,7 +377,7 @@ impl MempoolNode {
         let message = self.get_next_network_msg(network_id).await;
         let (peer_id, protocol_id, data, maybe_rpc_sender) = match message {
             PeerManagerRequest::SendRpc(peer_id, msg) => {
-                let (protocol_id, data, res_tx, _) = msg.into_parts();
+                let (_, protocol_id, data, res_tx, _) = msg.into_parts();
                 (peer_id, protocol_id, data, Some(res_tx))
             },
             PeerManagerRequest::SendDirectSend(peer_id, msg) => {

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -29,6 +29,7 @@ use aptos_network::{
     protocols::{
         network::{
             NetworkEvents, NetworkSender, NewNetworkEvents, NewNetworkSender, ReceivedMessage,
+            SerializedRequest,
         },
         wire::{
             handshake::v1::ProtocolId::MempoolDirectSend,
@@ -314,7 +315,7 @@ impl MempoolNode {
             match self.get_outbound_handle(network_id).next().await.unwrap() {
                 PeerManagerRequest::SendDirectSend(peer_id, msg) => {
                     assert_eq!(peer_id, remote_peer_id);
-                    msg.protocol_id.from_bytes(&msg.mdata).unwrap()
+                    msg.protocol_id().from_bytes(msg.data()).unwrap()
                 },
                 _ => panic!("Should not be getting an RPC response"),
             }
@@ -379,7 +380,7 @@ impl MempoolNode {
                 (peer_id, msg.protocol_id, msg.data, Some(msg.res_tx))
             },
             PeerManagerRequest::SendDirectSend(peer_id, msg) => {
-                (peer_id, msg.protocol_id, msg.mdata, None)
+                (peer_id, msg.protocol_id(), msg.data().clone(), None)
             },
         };
         assert_eq!(peer_id, expected_peer_id);

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -377,7 +377,8 @@ impl MempoolNode {
         let message = self.get_next_network_msg(network_id).await;
         let (peer_id, protocol_id, data, maybe_rpc_sender) = match message {
             PeerManagerRequest::SendRpc(peer_id, msg) => {
-                (peer_id, msg.protocol_id, msg.data, Some(msg.res_tx))
+                let (protocol_id, data, res_tx, _) = msg.into_parts();
+                (peer_id, protocol_id, data, Some(res_tx))
             },
             PeerManagerRequest::SendDirectSend(peer_id, msg) => {
                 (peer_id, msg.protocol_id(), msg.data().clone(), None)

--- a/network/framework/src/application/interface.rs
+++ b/network/framework/src/application/interface.rs
@@ -39,7 +39,6 @@ pub trait NetworkClientInterface<Message: NetworkMessageTrait>: Clone + Send + S
 
     /// Requests that the network connection for the specified peer
     /// is disconnected.
-    // TODO: support disconnect reasons.
     async fn disconnect_from_peer(
         &self,
         _peer: PeerNetworkId,

--- a/network/framework/src/application/tests.rs
+++ b/network/framework/src/application/tests.rs
@@ -1203,25 +1203,28 @@ async fn wait_for_network_event(
         Ok(peer_manager_request) => {
             let (protocol_id, peer_manager_notification) = match peer_manager_request {
                 PeerManagerRequest::SendRpc(peer_id, outbound_rpc_request) => {
+                    // Unpack the request
+                    let (protocol_id, data, res_tx, timeout) = outbound_rpc_request.into_parts();
+
                     // Verify the request is correct
                     assert!(is_rpc_request);
                     assert_eq!(peer_id, expected_peer_id);
-                    assert_eq!(Some(outbound_rpc_request.protocol_id), expected_rpc_protocol_id);
-                    assert_eq!(outbound_rpc_request.timeout, message_wait_time);
+                    assert_eq!(Some(protocol_id), expected_rpc_protocol_id);
+                    assert_eq!(timeout, message_wait_time);
 
                     // Create and return the peer manager notification
                     let rmsg = ReceivedMessage {
                         message: NetworkMessage::RpcRequest(RpcRequest{
-                            protocol_id: outbound_rpc_request.protocol_id,
+                            protocol_id,
                             request_id: 0,
                             priority: 0,
-                            raw_request: outbound_rpc_request.data.into(),
+                            raw_request: data.into(),
                         }),
                         sender: PeerNetworkId::new(expected_network_id, peer_id),
                         receive_timestamp_micros: 0,
-                        rpc_replier: Some(Arc::new(outbound_rpc_request.res_tx)),
+                        rpc_replier: Some(Arc::new(res_tx)),
                     };
-                    (outbound_rpc_request.protocol_id, rmsg)
+                    (protocol_id, rmsg)
                 }
                 PeerManagerRequest::SendDirectSend(peer_id, message) => {
                     // Unpack the message

--- a/network/framework/src/application/tests.rs
+++ b/network/framework/src/application/tests.rs
@@ -1224,23 +1224,26 @@ async fn wait_for_network_event(
                     (outbound_rpc_request.protocol_id, rmsg)
                 }
                 PeerManagerRequest::SendDirectSend(peer_id, message) => {
+                    // Unpack the message
+                    let (protocol_id, data) = message.into_parts();
+
                     // Verify the request is correct
                     assert!(!is_rpc_request);
                     assert_eq!(peer_id, expected_peer_id);
-                    assert_eq!(Some(message.protocol_id), expected_direct_send_protocol_id);
+                    assert_eq!(Some(protocol_id), expected_direct_send_protocol_id);
 
                     // Create and return the peer manager notification
                     let rmsg = ReceivedMessage {
                         message: NetworkMessage::DirectSendMsg(DirectSendMsg{
-                            protocol_id: message.protocol_id,
+                            protocol_id,
                             priority: 0,
-                            raw_msg: message.mdata.into(),
+                            raw_msg: data.into(),
                         }),
                         sender: PeerNetworkId::new(expected_network_id, peer_id),
                         receive_timestamp_micros: 0,
                         rpc_replier: None,
                     };
-                    (message.protocol_id, rmsg)
+                    (protocol_id, rmsg)
                 }
             };
 

--- a/network/framework/src/application/tests.rs
+++ b/network/framework/src/application/tests.rs
@@ -1204,7 +1204,7 @@ async fn wait_for_network_event(
             let (protocol_id, peer_manager_notification) = match peer_manager_request {
                 PeerManagerRequest::SendRpc(peer_id, outbound_rpc_request) => {
                     // Unpack the request
-                    let (protocol_id, data, res_tx, timeout) = outbound_rpc_request.into_parts();
+                    let (_, protocol_id, data, res_tx, timeout) = outbound_rpc_request.into_parts();
 
                     // Verify the request is correct
                     assert!(is_rpc_request);
@@ -1228,7 +1228,7 @@ async fn wait_for_network_event(
                 }
                 PeerManagerRequest::SendDirectSend(peer_id, message) => {
                     // Unpack the message
-                    let (protocol_id, data) = message.into_parts();
+                    let (_, protocol_id, data) = message.into_parts();
 
                     // Verify the request is correct
                     assert!(!is_rpc_request);

--- a/network/framework/src/peer/mod.rs
+++ b/network/framework/src/peer/mod.rs
@@ -614,15 +614,18 @@ where
             // To send an outbound DirectSendMsg, we just bump some counters and
             // push it onto our outbound writer queue.
             PeerRequest::SendDirectSend(message) => {
+                // Unpack the message
+                let (protocol_id, data) = message.into_parts();
+
                 // Create the direct send message
-                let message_len = message.mdata.len();
-                let protocol_id = message.protocol_id;
+                let message_len = data.len();
                 let message = NetworkMessage::DirectSendMsg(DirectSendMsg {
                     protocol_id,
                     priority: Priority::default(),
-                    raw_msg: Vec::from(message.mdata.as_ref()),
+                    raw_msg: Vec::from(data.as_ref()),
                 });
 
+                // Send the message to the outbound writer queue
                 match write_reqs_tx.push((), message) {
                     Ok(_) => {
                         self.update_outbound_direct_send_metrics(protocol_id, message_len as u64);

--- a/network/framework/src/peer/mod.rs
+++ b/network/framework/src/peer/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     peer_manager::{PeerManagerError, TransportNotification},
     protocols::{
         direct_send::Message,
-        network::ReceivedMessage,
+        network::{ReceivedMessage, SerializedRequest},
         rpc::{error::RpcError, InboundRpcs, OutboundRpcRequest, OutboundRpcs},
         stream::{InboundStreamBuffer, OutboundStream, StreamMessage},
         wire::messaging::v1::{
@@ -645,7 +645,7 @@ where
                 }
             },
             PeerRequest::SendRpc(request) => {
-                let protocol_id = request.protocol_id;
+                let protocol_id = request.protocol_id();
                 if let Err(e) = self
                     .outbound_rpcs
                     .handle_outbound_request(request, write_reqs_tx)

--- a/network/framework/src/peer/mod.rs
+++ b/network/framework/src/peer/mod.rs
@@ -28,8 +28,12 @@ use crate::{
         rpc::{error::RpcError, InboundRpcs, OutboundRpcRequest, OutboundRpcs},
         stream::{InboundStreamBuffer, OutboundStream, StreamMessage},
         wire::messaging::v1::{
-            DirectSendMsg, ErrorCode, MultiplexMessage, MultiplexMessageSink,
-            MultiplexMessageStream, NetworkMessage, Priority, ReadError, WriteError,
+            metadata::{
+                MessageMetadata, MessageSendType, MultiplexMessageWithMetadata,
+                NetworkMessageWithMetadata,
+            },
+            ErrorCode, MultiplexMessage, MultiplexMessageSink, MultiplexMessageStream,
+            NetworkMessage, ReadError, WriteError,
         },
     },
     transport::{self, Connection, ConnectionMetadata},
@@ -274,7 +278,7 @@ where
                 maybe_response = self.inbound_rpcs.next_completed_response() => {
                     // Extract the relevant metadata from the message
                     let message_metadata = match &maybe_response {
-                        Ok((response, protocol_id)) => Some((response.request_id, *protocol_id)),
+                        Ok((response_with_metadata, protocol_id)) => Some((response_with_metadata.rpc_response().request_id, *protocol_id)),
                         _ => None,
                     };
 
@@ -334,19 +338,24 @@ where
         max_frame_size: usize,
         max_message_size: usize,
     ) -> (
-        aptos_channel::Sender<(), NetworkMessage>,
+        aptos_channel::Sender<(), NetworkMessageWithMetadata>,
         oneshot::Sender<()>,
     ) {
         let remote_peer_id = connection_metadata.remote_peer_id;
-        let (write_reqs_tx, mut write_reqs_rx): (aptos_channel::Sender<(), NetworkMessage>, _) =
-            aptos_channel::new(
-                QueueStyle::KLAST,
-                1024,
-                Some(&counters::PENDING_WIRE_MESSAGES),
-            );
+        let (write_reqs_tx, mut write_reqs_rx): (
+            aptos_channel::Sender<(), NetworkMessageWithMetadata>,
+            _,
+        ) = aptos_channel::new(
+            QueueStyle::KLAST,
+            1024,
+            Some(&counters::PENDING_WIRE_MESSAGES),
+        );
         let (close_tx, mut close_rx) = oneshot::channel();
 
-        let (mut msg_tx, msg_rx) = aptos_channels::new(1024, &counters::PENDING_MULTIPLEX_MESSAGE);
+        let (mut msg_tx, msg_rx) = aptos_channels::new::<MultiplexMessageWithMetadata>(
+            1024,
+            &counters::PENDING_MULTIPLEX_MESSAGE,
+        );
         let (stream_msg_tx, stream_msg_rx) =
             aptos_channels::new(1024, &counters::PENDING_MULTIPLEX_STREAM);
 
@@ -357,8 +366,15 @@ where
                 NetworkSchema::new(&network_context).connection_metadata(&connection_metadata);
             loop {
                 futures::select! {
-                    message = stream.select_next_some() => {
-                        if let Err(err) = timeout(transport::TRANSPORT_TIMEOUT,writer.send(&message)).await {
+                    message_with_metadata = stream.select_next_some() => {
+                        // Extract the message and metadata
+                        let (mut message_metadata, message) = message_with_metadata.into_parts();
+
+                        // Update the wire send start time for the message
+                        message_metadata.update_wire_send_start_time();
+
+                        // Send the message along the wire
+                        if let Err(err) = timeout(transport::TRANSPORT_TIMEOUT, writer.send(&message)).await {
                             warn!(
                                 log_context,
                                 error = %err,
@@ -366,6 +382,9 @@ where
                                 network_context,
                                 remote_peer_id.short_str(),
                             );
+                        } else {
+                            // Otherwise, mark the message as sent along the wire
+                            message_metadata.mark_message_as_sent();
                         }
                     }
                     _ = close_rx => {
@@ -416,17 +435,23 @@ where
                 },
             }
         };
+
         // the task ends when the write_reqs_tx is dropped
         let multiplex_task = async move {
             let mut outbound_stream =
                 OutboundStream::new(max_frame_size, max_message_size, stream_msg_tx);
-            while let Some(message) = write_reqs_rx.next().await {
+            while let Some(message_with_metadata) = write_reqs_rx.next().await {
                 // either channel full would block the other one
-                let result = if outbound_stream.should_stream(&message) {
-                    outbound_stream.stream_message(message).await
+                let result = if outbound_stream.should_stream(&message_with_metadata) {
+                    outbound_stream.stream_message(message_with_metadata).await
                 } else {
+                    // Transform the message into a multiplex message
+                    let multiplex_message_with_metadata =
+                        message_with_metadata.into_multiplex_message();
+
+                    // Send the message to the writer task
                     msg_tx
-                        .send(MultiplexMessage::Message(message))
+                        .send(multiplex_message_with_metadata)
                         .await
                         .map_err(|_| anyhow::anyhow!("Writer task ended"))
                 };
@@ -440,8 +465,10 @@ where
                 }
             }
         };
+
         executor.spawn(writer_task);
         executor.spawn(multiplex_task);
+
         (write_reqs_tx, close_tx)
     }
 
@@ -561,7 +588,7 @@ where
     fn handle_inbound_message(
         &mut self,
         message: Result<MultiplexMessage, ReadError>,
-        write_reqs_tx: &mut aptos_channel::Sender<(), NetworkMessage>,
+        write_reqs_tx: &mut aptos_channel::Sender<(), NetworkMessageWithMetadata>,
     ) -> Result<(), PeerManagerError> {
         trace!(
             NetworkSchema::new(&self.network_context)
@@ -582,8 +609,17 @@ where
                     let protocol_id = frame_prefix.as_ref().get(1).unwrap_or(&0);
                     let error_code = ErrorCode::parsing_error(*message_type, *protocol_id);
                     let message = NetworkMessage::Error(error_code);
+                    let message_with_metadata = NetworkMessageWithMetadata::new(
+                        MessageMetadata::new(
+                            self.network_context.network_id(),
+                            None,
+                            MessageSendType::DirectSend,
+                            None,
+                        ),
+                        message,
+                    );
 
-                    write_reqs_tx.push((), message)?;
+                    write_reqs_tx.push((), message_with_metadata)?;
                     return Err(err.into());
                 },
                 ReadError::IoError(_) => {
@@ -603,7 +639,7 @@ where
     fn handle_outbound_request(
         &mut self,
         request: PeerRequest,
-        write_reqs_tx: &mut aptos_channel::Sender<(), NetworkMessage>,
+        write_reqs_tx: &mut aptos_channel::Sender<(), NetworkMessageWithMetadata>,
     ) {
         trace!(
             "Peer {} PeerRequest::{:?}",
@@ -614,21 +650,18 @@ where
             // To send an outbound DirectSendMsg, we just bump some counters and
             // push it onto our outbound writer queue.
             PeerRequest::SendDirectSend(message) => {
-                // Unpack the message
-                let (protocol_id, data) = message.into_parts();
+                // Get the data length and protocol id
+                let data_len = message.data().len();
+                let protocol_id = message.protocol_id();
 
-                // Create the direct send message
-                let message_len = data.len();
-                let message = NetworkMessage::DirectSendMsg(DirectSendMsg {
-                    protocol_id,
-                    priority: Priority::default(),
-                    raw_msg: Vec::from(data.as_ref()),
-                });
+                // Convert the message into a network message with metadata
+                let message_with_metadata =
+                    message.into_network_message(self.network_context.network_id());
 
                 // Send the message to the outbound writer queue
-                match write_reqs_tx.push((), message) {
+                match write_reqs_tx.push((), message_with_metadata) {
                     Ok(_) => {
-                        self.update_outbound_direct_send_metrics(protocol_id, message_len as u64);
+                        self.update_outbound_direct_send_metrics(protocol_id, data_len as u64);
                     },
                     Err(e) => {
                         counters::direct_send_messages(&self.network_context, FAILED_LABEL).inc();
@@ -685,7 +718,7 @@ where
 
     async fn do_shutdown(
         mut self,
-        write_req_tx: aptos_channel::Sender<(), NetworkMessage>,
+        write_req_tx: aptos_channel::Sender<(), NetworkMessageWithMetadata>,
         writer_close_tx: oneshot::Sender<()>,
         reason: DisconnectReason,
     ) {

--- a/network/framework/src/peer/test.rs
+++ b/network/framework/src/peer/test.rs
@@ -188,12 +188,7 @@ impl PeerHandle {
         timeout: Duration,
     ) -> Result<Bytes, RpcError> {
         let (res_tx, res_rx) = oneshot::channel();
-        let request = OutboundRpcRequest {
-            protocol_id,
-            data,
-            res_tx,
-            timeout,
-        };
+        let request = OutboundRpcRequest::new(protocol_id, data, res_tx, timeout);
         self.0.push(protocol_id, PeerRequest::SendRpc(request))?;
         let response_data = res_rx.await??;
         Ok(response_data)
@@ -769,12 +764,13 @@ fn peer_send_rpc_cancel() {
     let test = async move {
         // Client sends rpc request.
         let (response_tx, mut response_rx) = oneshot::channel();
-        let request = PeerRequest::SendRpc(OutboundRpcRequest {
-            protocol_id: PROTOCOL,
-            data: Bytes::from(&b"hello world"[..]),
-            res_tx: response_tx,
+        let outbound_rpc_request = OutboundRpcRequest::new(
+            PROTOCOL,
+            Bytes::from(&b"hello world"[..]),
+            response_tx,
             timeout,
-        });
+        );
+        let request = PeerRequest::SendRpc(outbound_rpc_request);
         peer_handle.0.push(PROTOCOL, request).unwrap();
 
         // Server receives the rpc request from client.
@@ -831,12 +827,13 @@ fn peer_send_rpc_timeout() {
     let test = async move {
         // Client sends rpc request.
         let (response_tx, mut response_rx) = oneshot::channel();
-        let request = PeerRequest::SendRpc(OutboundRpcRequest {
-            protocol_id: PROTOCOL,
-            data: Bytes::from(&b"hello world"[..]),
-            res_tx: response_tx,
+        let outbound_rpc_request = OutboundRpcRequest::new(
+            PROTOCOL,
+            Bytes::from(&b"hello world"[..]),
+            response_tx,
             timeout,
-        });
+        );
+        let request = PeerRequest::SendRpc(outbound_rpc_request);
         peer_handle.0.push(PROTOCOL, request).unwrap();
 
         // Server receives the rpc request from client.

--- a/network/framework/src/peer/test.rs
+++ b/network/framework/src/peer/test.rs
@@ -11,7 +11,7 @@ use crate::{
     peer_manager::TransportNotification,
     protocols::{
         direct_send::Message,
-        network::ReceivedMessage,
+        network::{ReceivedMessage, SerializedRequest},
         rpc::{error::RpcError, OutboundRpcRequest},
         wire::{
             handshake::v1::{MessagingProtocolVersion, ProtocolIdSet},
@@ -177,7 +177,7 @@ struct PeerHandle(aptos_channel::Sender<ProtocolId, PeerRequest>);
 impl PeerHandle {
     fn send_direct_send(&mut self, message: Message) {
         self.0
-            .push(message.protocol_id, PeerRequest::SendDirectSend(message))
+            .push(message.protocol_id(), PeerRequest::SendDirectSend(message))
             .unwrap()
     }
 
@@ -214,10 +214,7 @@ fn peer_send_message() {
     );
     let (mut client_sink, mut client_stream) = build_network_sink_stream(&mut connection);
 
-    let send_msg = Message {
-        protocol_id: PROTOCOL,
-        mdata: Bytes::from("hello world"),
-    };
+    let send_msg = Message::new(PROTOCOL, Bytes::from("hello world"));
     let recv_msg = MultiplexMessage::Message(NetworkMessage::DirectSendMsg(DirectSendMsg {
         protocol_id: PROTOCOL,
         priority: 0,
@@ -328,14 +325,8 @@ fn peers_send_message_concurrent() {
     let remote_peer_id_b = peer_b.remote_peer_id();
 
     let test = async move {
-        let msg_a = Message {
-            protocol_id: PROTOCOL,
-            mdata: Bytes::from("hello world"),
-        };
-        let msg_b = Message {
-            protocol_id: PROTOCOL,
-            mdata: Bytes::from("namaste"),
-        };
+        let msg_a = Message::new(PROTOCOL, Bytes::from("hello world"));
+        let msg_b = Message::new(PROTOCOL, Bytes::from("namaste"));
 
         // Peer A -> msg_a -> Peer B
         peer_handle_a.send_direct_send(msg_a.clone());
@@ -350,7 +341,7 @@ fn peers_send_message_concurrent() {
             NetworkMessage::DirectSendMsg(DirectSendMsg {
                 protocol_id: PROTOCOL,
                 priority: 0,
-                raw_msg: msg_b.mdata.into(),
+                raw_msg: msg_b.data().clone().into(),
             })
         );
         assert_eq!(
@@ -358,7 +349,7 @@ fn peers_send_message_concurrent() {
             NetworkMessage::DirectSendMsg(DirectSendMsg {
                 protocol_id: PROTOCOL,
                 priority: 0,
-                raw_msg: msg_a.mdata.into(),
+                raw_msg: msg_a.data().clone().into(),
             })
         );
 
@@ -979,14 +970,14 @@ fn peers_send_multiplex() {
     let remote_peer_id_b = peer_b.remote_peer_id();
 
     let test = async move {
-        let msg_a = Message {
-            protocol_id: PROTOCOL,
-            mdata: Bytes::from(vec![0; MAX_MESSAGE_SIZE]), // stream message
-        };
-        let msg_b = Message {
-            protocol_id: PROTOCOL,
-            mdata: Bytes::from(vec![1; 1024]), // normal message
-        };
+        let msg_a = Message::new(
+            PROTOCOL,
+            Bytes::from(vec![0; MAX_MESSAGE_SIZE]), // stream message
+        );
+        let msg_b = Message::new(
+            PROTOCOL,
+            Bytes::from(vec![1; 1024]), // normal message
+        );
 
         // Peer A -> msg_a -> Peer B
         peer_handle_a.send_direct_send(msg_a.clone());
@@ -1001,7 +992,7 @@ fn peers_send_multiplex() {
             NetworkMessage::DirectSendMsg(DirectSendMsg {
                 protocol_id: PROTOCOL,
                 priority: 0,
-                raw_msg: msg_b.mdata.into(),
+                raw_msg: msg_b.data().clone().into(),
             })
         );
         assert_eq!(
@@ -1009,7 +1000,7 @@ fn peers_send_multiplex() {
             NetworkMessage::DirectSendMsg(DirectSendMsg {
                 protocol_id: PROTOCOL,
                 priority: 0,
-                raw_msg: msg_a.mdata.into(),
+                raw_msg: msg_a.data().clone().into(),
             })
         );
 

--- a/network/framework/src/peer_manager/senders.rs
+++ b/network/framework/src/peer_manager/senders.rs
@@ -96,12 +96,7 @@ impl PeerManagerRequestSender {
         timeout: Duration,
     ) -> Result<Bytes, RpcError> {
         let (res_tx, res_rx) = oneshot::channel();
-        let request = OutboundRpcRequest {
-            protocol_id,
-            data: req,
-            res_tx,
-            timeout,
-        };
+        let request = OutboundRpcRequest::new(protocol_id, req, res_tx, timeout);
         self.inner.push(
             (peer_id, protocol_id),
             PeerManagerRequest::SendRpc(peer_id, request),

--- a/network/framework/src/peer_manager/senders.rs
+++ b/network/framework/src/peer_manager/senders.rs
@@ -48,9 +48,10 @@ impl PeerManagerRequestSender {
         protocol_id: ProtocolId,
         mdata: Bytes,
     ) -> Result<(), PeerManagerError> {
+        let message = Message::new(protocol_id, mdata);
         self.inner.push(
             (peer_id, protocol_id),
-            PeerManagerRequest::SendDirectSend(peer_id, Message { protocol_id, mdata }),
+            PeerManagerRequest::SendDirectSend(peer_id, message),
         )?;
         Ok(())
     }
@@ -72,7 +73,7 @@ impl PeerManagerRequestSender {
         protocol_id: ProtocolId,
         mdata: Bytes,
     ) -> Result<(), PeerManagerError> {
-        let msg = Message { protocol_id, mdata };
+        let message = Message::new(protocol_id, mdata);
         for recipient in recipients {
             // We return `Err` early here if the send fails. Since sending will
             // only fail if the queue is unexpectedly shutdown (i.e., receiver
@@ -80,7 +81,7 @@ impl PeerManagerRequestSender {
             // this send fails.
             self.inner.push(
                 (recipient, protocol_id),
-                PeerManagerRequest::SendDirectSend(recipient, msg.clone()),
+                PeerManagerRequest::SendDirectSend(recipient, message.clone()),
             )?;
         }
         Ok(())

--- a/network/framework/src/protocols/direct_send/mod.rs
+++ b/network/framework/src/protocols/direct_send/mod.rs
@@ -2,7 +2,17 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{protocols::network::SerializedRequest, ProtocolId};
+use crate::{
+    protocols::{
+        network::SerializedRequest,
+        wire::messaging::v1::{
+            metadata::{MessageMetadata, MessageSendType, NetworkMessageWithMetadata},
+            DirectSendMsg, NetworkMessage, Priority,
+        },
+    },
+    ProtocolId,
+};
+use aptos_config::network_id::NetworkId;
 use bytes::Bytes;
 use serde::Serialize;
 use std::{fmt::Debug, time::SystemTime};
@@ -33,14 +43,30 @@ impl Message {
         }
     }
 
-    /// Returns the time at which the message was sent by the application
-    pub fn application_send_time(&self) -> SystemTime {
-        self.application_send_time
+    /// Transforms the message into a direct send network message with metadata
+    pub fn into_network_message(self, network_id: NetworkId) -> NetworkMessageWithMetadata {
+        // Create the direct send network message
+        let network_message = NetworkMessage::DirectSendMsg(DirectSendMsg {
+            protocol_id: self.protocol_id,
+            priority: Priority::default(),
+            raw_msg: Vec::from(self.data.as_ref()),
+        });
+
+        // Create and return the network message with metadata
+        let message_metadata = MessageMetadata::new(
+            network_id,
+            Some(self.protocol_id),
+            MessageSendType::DirectSend,
+            Some(self.application_send_time),
+        );
+        NetworkMessageWithMetadata::new(message_metadata, network_message)
     }
 
-    /// Consumes the message and returns the protocol id and data
-    pub fn into_parts(self) -> (ProtocolId, Bytes) {
-        (self.protocol_id, self.data)
+    /// Consumes the message and returns the individual parts.
+    /// Note: this is only for testing purposes (but, it cannot be marked
+    /// as `#[cfg(test)]` because of several non-wrapped test utils).
+    pub fn into_parts(self) -> (SystemTime, ProtocolId, Bytes) {
+        (self.application_send_time, self.protocol_id, self.data)
     }
 }
 

--- a/network/framework/src/protocols/direct_send/mod.rs
+++ b/network/framework/src/protocols/direct_send/mod.rs
@@ -5,34 +5,57 @@
 use crate::{protocols::network::SerializedRequest, ProtocolId};
 use bytes::Bytes;
 use serde::Serialize;
-use std::fmt::Debug;
+use std::{fmt::Debug, time::SystemTime};
 
 #[derive(Clone, Eq, PartialEq, Serialize)]
 pub struct Message {
+    /// The time at which the message was sent by the application
+    application_send_time: SystemTime,
     /// The [`ProtocolId`] for which of our upstream application modules should
     /// handle (i.e., deserialize and then respond to) this inbound rpc request.
     ///
     /// For example, if `protocol_id == ProtocolId::ConsensusRpcBcs`, then this
     /// inbound rpc request will be dispatched to consensus for handling.
-    pub protocol_id: ProtocolId,
+    protocol_id: ProtocolId,
     /// The serialized request data received from the sender. At this layer in
     /// the stack, the request data is just an opaque blob and will only be fully
     /// deserialized later in the handling application module.
     #[serde(skip)]
-    pub mdata: Bytes,
+    data: Bytes,
+}
+
+impl Message {
+    pub fn new(protocol_id: ProtocolId, data: Bytes) -> Self {
+        Self {
+            application_send_time: SystemTime::now(),
+            protocol_id,
+            data,
+        }
+    }
+
+    /// Returns the time at which the message was sent by the application
+    pub fn application_send_time(&self) -> SystemTime {
+        self.application_send_time
+    }
+
+    /// Consumes the message and returns the protocol id and data
+    pub fn into_parts(self) -> (ProtocolId, Bytes) {
+        (self.protocol_id, self.data)
+    }
 }
 
 impl Debug for Message {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mdata_str = if self.mdata.len() <= 10 {
-            format!("{:?}", self.mdata)
+        let mdata_str = if self.data().len() <= 10 {
+            format!("{:?}", self.data())
         } else {
-            format!("{:?}...", self.mdata.slice(..10))
+            format!("{:?}...", self.data().slice(..10))
         };
         write!(
             f,
-            "Message {{ protocol: {:?}, mdata: {} }}",
-            self.protocol_id, mdata_str
+            "Message {{ protocol: {:?}, data: {} }}",
+            self.protocol_id(),
+            mdata_str
         )
     }
 }
@@ -43,6 +66,6 @@ impl SerializedRequest for Message {
     }
 
     fn data(&self) -> &Bytes {
-        &self.mdata
+        &self.data
     }
 }

--- a/network/framework/src/protocols/health_checker/test.rs
+++ b/network/framework/src/protocols/health_checker/test.rs
@@ -105,7 +105,7 @@ impl TestHarness {
             _ => panic!("Unexpected PeerManagerRequest: {:?}", req),
         };
 
-        let (protocol_id, req_data, res_tx, _) = rpc_req.into_parts();
+        let (_, protocol_id, req_data, res_tx, _) = rpc_req.into_parts();
         assert_eq!(protocol_id, ProtocolId::HealthCheckerRpc);
 
         match bcs::from_bytes(&req_data).unwrap() {

--- a/network/framework/src/protocols/health_checker/test.rs
+++ b/network/framework/src/protocols/health_checker/test.rs
@@ -105,10 +105,7 @@ impl TestHarness {
             _ => panic!("Unexpected PeerManagerRequest: {:?}", req),
         };
 
-        let protocol_id = rpc_req.protocol_id;
-        let req_data = rpc_req.data;
-        let res_tx = rpc_req.res_tx;
-
+        let (protocol_id, req_data, res_tx, _) = rpc_req.into_parts();
         assert_eq!(protocol_id, ProtocolId::HealthCheckerRpc);
 
         match bcs::from_bytes(&req_data).unwrap() {

--- a/network/framework/src/protocols/network/mod.rs
+++ b/network/framework/src/protocols/network/mod.rs
@@ -138,6 +138,7 @@ pub struct ReceivedMessage {
     pub message: NetworkMessage,
     pub sender: PeerNetworkId,
 
+    // TODO: clean this up!
     // unix microseconds
     pub receive_timestamp_micros: u64,
 

--- a/network/framework/src/protocols/rpc/mod.rs
+++ b/network/framework/src/protocols/rpc/mod.rs
@@ -53,13 +53,19 @@ use crate::{
     logging::NetworkSchema,
     protocols::{
         network::{ReceivedMessage, SerializedRequest},
-        wire::messaging::v1::{NetworkMessage, Priority, RequestId, RpcRequest, RpcResponse},
+        wire::messaging::v1::{
+            metadata::{
+                MessageMetadata, MessageSendType, NetworkMessageWithMetadata,
+                RpcResponseWithMetadata,
+            },
+            NetworkMessage, Priority, RequestId, RpcRequest, RpcResponse,
+        },
     },
     ProtocolId,
 };
 use anyhow::anyhow;
 use aptos_channels::aptos_channel;
-use aptos_config::network_id::NetworkContext;
+use aptos_config::network_id::{NetworkContext, NetworkId};
 use aptos_id_generator::{IdGenerator, U32IdGenerator};
 use aptos_logger::prelude::*;
 use aptos_short_hex_str::AsShortHexStr;
@@ -166,16 +172,72 @@ impl OutboundRpcRequest {
         }
     }
 
-    /// Consumes the request and returns the protocol id, data, channel, and timeout
+    /// Transforms the message into an RPC network message with metadata,
+    /// and returns the response sender channel.
+    pub fn into_network_message(
+        self,
+        network_id: NetworkId,
+        request_id: RequestId,
+    ) -> (
+        NetworkMessageWithMetadata,
+        oneshot::Sender<Result<Bytes, RpcError>>,
+    ) {
+        // Create the RPC network message
+        let network_message = NetworkMessage::RpcRequest(RpcRequest {
+            protocol_id: self.protocol_id,
+            request_id,
+            priority: Priority::default(),
+            raw_request: Vec::from(self.data.as_ref()),
+        });
+
+        // Create the network message with metadata
+        let message_metadata = MessageMetadata::new(
+            network_id,
+            Some(self.protocol_id),
+            MessageSendType::RpcRequest,
+            Some(self.application_send_time),
+        );
+        let message_with_metadata =
+            NetworkMessageWithMetadata::new(message_metadata, network_message);
+
+        (message_with_metadata, self.res_tx)
+    }
+
+    /// Returns true iff the request has been canceled (e.g., the
+    /// application layer has dropped the response channel).
+    pub fn is_canceled(&self) -> bool {
+        self.res_tx.is_canceled()
+    }
+
+    /// Consumes the request and returns the individual parts.
+    /// Note: this is only for testing purposes (but, it cannot be marked
+    /// as `#[cfg(test)]` because of several non-wrapped test utils).
     pub fn into_parts(
         self,
     ) -> (
+        SystemTime,
         ProtocolId,
         Bytes,
         oneshot::Sender<Result<Bytes, RpcError>>,
         Duration,
     ) {
-        (self.protocol_id, self.data, self.res_tx, self.timeout)
+        (
+            self.application_send_time,
+            self.protocol_id,
+            self.data,
+            self.res_tx,
+            self.timeout,
+        )
+    }
+
+    /// Returns the response sender for the request (consuming the entire request)
+    pub fn response_sender(self) -> oneshot::Sender<Result<Bytes, RpcError>> {
+        self.res_tx
+    }
+
+    /// Returns the timeout of the RPC request
+    pub fn timeout(&self) -> Duration {
+        self.timeout
     }
 }
 
@@ -210,8 +272,9 @@ pub struct InboundRpcs {
     remote_peer_id: PeerId,
     /// The core async queue of pending inbound rpc tasks. The tasks are driven
     /// to completion by the `InboundRpcs::next_completed_response()` method.
-    inbound_rpc_tasks:
-        FuturesUnordered<BoxFuture<'static, Result<(RpcResponse, ProtocolId), RpcError>>>,
+    inbound_rpc_tasks: FuturesUnordered<
+        BoxFuture<'static, Result<(RpcResponseWithMetadata, ProtocolId), RpcError>>,
+    >,
     /// A blanket timeout on all inbound rpc requests. If the application handler
     /// doesn't respond to the request before this timeout, the request will be
     /// dropped.
@@ -291,6 +354,7 @@ impl InboundRpcs {
         }
 
         // Create a new task that waits for a response from the upper layer with a timeout.
+        let network_id = network_context.network_id();
         let inbound_rpc_task = self
             .time_service
             .timeout(self.inbound_rpc_timeout, response_rx)
@@ -298,12 +362,24 @@ impl InboundRpcs {
                 // Flatten the errors
                 let maybe_response = match result {
                     Ok(Ok(Ok(response_bytes))) => {
+                        // Create a new message metadata
+                        let message_metadata = MessageMetadata::new(
+                            network_id,
+                            Some(protocol_id),
+                            MessageSendType::RpcResponse,
+                            Some(SystemTime::now()),
+                        );
+
+                        // Create an RPC response with metadata
                         let rpc_response = RpcResponse {
                             request_id,
                             priority,
                             raw_response: Vec::from(response_bytes.as_ref()),
                         };
-                        Ok((rpc_response, protocol_id))
+                        let response_with_metadata =
+                            RpcResponseWithMetadata::new(message_metadata, rpc_response);
+
+                        Ok((response_with_metadata, protocol_id))
                     },
                     Ok(Ok(Err(err))) => Err(err),
                     Ok(Err(oneshot::Canceled)) => Err(RpcError::UnexpectedResponseChannelCancel),
@@ -352,7 +428,8 @@ impl InboundRpcs {
     /// `futures::select!`.
     pub fn next_completed_response(
         &mut self,
-    ) -> impl FusedFuture<Output = Result<(RpcResponse, ProtocolId), RpcError>> + '_ {
+    ) -> impl FusedFuture<Output = Result<(RpcResponseWithMetadata, ProtocolId), RpcError>> + '_
+    {
         self.inbound_rpc_tasks.select_next_some()
     }
 
@@ -361,12 +438,12 @@ impl InboundRpcs {
     /// the outbound write queue.
     pub fn send_outbound_response(
         &mut self,
-        write_reqs_tx: &mut aptos_channel::Sender<(), NetworkMessage>,
-        maybe_response: Result<(RpcResponse, ProtocolId), RpcError>,
+        write_reqs_tx: &mut aptos_channel::Sender<(), NetworkMessageWithMetadata>,
+        maybe_response: Result<(RpcResponseWithMetadata, ProtocolId), RpcError>,
     ) -> Result<(), RpcError> {
         let network_context = &self.network_context;
-        let (response, protocol_id) = match maybe_response {
-            Ok(response) => response,
+        let (response_with_metadata, protocol_id) = match maybe_response {
+            Ok(response_with_metadata) => response_with_metadata,
             Err(err) => {
                 counters::rpc_messages(
                     network_context,
@@ -378,7 +455,7 @@ impl InboundRpcs {
                 return Err(err);
             },
         };
-        let res_len = response.raw_response.len() as u64;
+        let res_len = response_with_metadata.rpc_response().raw_response.len() as u64;
 
         // Send outbound response to remote peer.
         trace!(
@@ -386,9 +463,9 @@ impl InboundRpcs {
             "{} Sending rpc response to peer {} for request_id {}",
             network_context,
             self.remote_peer_id.short_str(),
-            response.request_id,
+            response_with_metadata.rpc_response().request_id,
         );
-        let message = NetworkMessage::RpcResponse(response);
+        let message = response_with_metadata.into_network_message();
         write_reqs_tx.push((), message)?;
 
         // Update the outbound RPC response metrics
@@ -471,18 +548,11 @@ impl OutboundRpcs {
     pub fn handle_outbound_request(
         &mut self,
         request: OutboundRpcRequest,
-        write_reqs_tx: &mut aptos_channel::Sender<(), NetworkMessage>,
+        write_reqs_tx: &mut aptos_channel::Sender<(), NetworkMessageWithMetadata>,
     ) -> Result<(), RpcError> {
+        // Drop the outbound request if the application layer has already canceled it
         let network_context = &self.network_context;
-        let peer_id = &self.remote_peer_id;
-
-        // Unpack request.
-        let (protocol_id, request_data, mut application_response_tx, timeout) =
-            request.into_parts();
-        let req_len = request_data.len() as u64;
-
-        // Drop the outbound request if the application layer has already canceled.
-        if application_response_tx.is_canceled() {
+        if request.is_canceled() {
             counters::rpc_messages(
                 network_context,
                 REQUEST_LABEL,
@@ -490,10 +560,11 @@ impl OutboundRpcs {
                 CANCELED_LABEL,
             )
             .inc();
+
             return Err(RpcError::UnexpectedResponseChannelCancel);
         }
 
-        // Drop new outbound requests if our completion queue is at capacity.
+        // Drop new outbound requests if our completion queue is at capacity
         if self.outbound_rpc_tasks.len() == self.max_concurrent_outbound_rpcs as usize {
             counters::rpc_messages(
                 network_context,
@@ -502,14 +573,20 @@ impl OutboundRpcs {
                 DECLINED_LABEL,
             )
             .inc();
-            // Notify application that their request was dropped due to capacity.
-            let err = Err(RpcError::TooManyPending(self.max_concurrent_outbound_rpcs));
-            let _ = application_response_tx.send(err);
+
+            // Notify the application that their request was dropped due to capacity
+            let error = Err(RpcError::TooManyPending(self.max_concurrent_outbound_rpcs));
+            let _ = request.response_sender().send(error);
+
             return Err(RpcError::TooManyPending(self.max_concurrent_outbound_rpcs));
         }
 
+        // Generate a new RPC request ID
         let request_id = self.request_id_gen.next();
 
+        // Log the outbound request and request ID
+        let peer_id = &self.remote_peer_id;
+        let protocol_id = request.protocol_id();
         trace!(
             NetworkSchema::new(network_context).remote_peer(peer_id),
             "{} Sending outbound rpc request with request_id {} and protocol_id {} to {}",
@@ -519,21 +596,21 @@ impl OutboundRpcs {
             peer_id.short_str(),
         );
 
-        // Start timer to collect outbound RPC latency.
+        // Convert the message into a network message with metadata
+        let request_length = request.data().len() as u64;
+        let timeout = request.timeout();
+        let (network_message, mut application_response_tx) =
+            request.into_network_message(network_context.network_id(), request_id);
+
+        // Start the timer to collect the outbound RPC latency
         let timer =
             counters::outbound_rpc_request_latency(network_context, protocol_id).start_timer();
 
-        // Enqueue rpc request message onto outbound write queue.
-        let message = NetworkMessage::RpcRequest(RpcRequest {
-            protocol_id,
-            request_id,
-            priority: Priority::default(),
-            raw_request: Vec::from(request_data.as_ref()),
-        });
-        write_reqs_tx.push((), message)?;
+        // Enqueue the message onto the outbound write queue
+        write_reqs_tx.push((), network_message)?;
 
         // Update the outbound RPC request metrics
-        self.update_outbound_rpc_request_metrics(protocol_id, req_len);
+        self.update_outbound_rpc_request_metrics(protocol_id, request_length);
 
         // Create channel over which response is delivered to outbound_rpc_task.
         let (response_tx, response_rx) = oneshot::channel::<RpcResponse>();

--- a/network/framework/src/protocols/wire/messaging/v1/metadata.rs
+++ b/network/framework/src/protocols/wire/messaging/v1/metadata.rs
@@ -1,0 +1,279 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    counters,
+    protocols::wire::{
+        handshake::v1::ProtocolId,
+        messaging::v1::{MultiplexMessage, NetworkMessage, RpcResponse},
+    },
+};
+use aptos_config::network_id::NetworkId;
+use std::time::SystemTime;
+
+/// A simple struct that wraps a network message with metadata.
+/// Note: this is not sent along the wire, it is only used internally.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NetworkMessageWithMetadata {
+    /// The metadata about the message
+    message_metadata: MessageMetadata,
+
+    /// The network message to send along the wire
+    network_message: NetworkMessage,
+}
+
+impl NetworkMessageWithMetadata {
+    pub fn new(message_metadata: MessageMetadata, network_message: NetworkMessage) -> Self {
+        Self {
+            message_metadata,
+            network_message,
+        }
+    }
+
+    /// Converts the message into a multiplex message with metadata
+    pub fn into_multiplex_message(self) -> MultiplexMessageWithMetadata {
+        MultiplexMessageWithMetadata::new(
+            self.message_metadata,
+            MultiplexMessage::Message(self.network_message),
+        )
+    }
+
+    /// Consumes the message and returns the individual parts
+    pub fn into_parts(self) -> (MessageMetadata, NetworkMessage) {
+        (self.message_metadata, self.network_message)
+    }
+
+    /// Returns a reference to the message metadata
+    pub fn network_message(&self) -> &NetworkMessage {
+        &self.network_message
+    }
+}
+
+/// A simple struct that wraps a multiplex message with metadata.
+/// Note: this is not sent along the wire, it is only used internally.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MultiplexMessageWithMetadata {
+    /// The metadata about the message
+    message_metadata: MessageMetadata,
+
+    /// The multiplex message to send along the wire
+    multiplex_message: MultiplexMessage,
+}
+
+impl MultiplexMessageWithMetadata {
+    pub fn new(message_metadata: MessageMetadata, multiplex_message: MultiplexMessage) -> Self {
+        Self {
+            message_metadata,
+            multiplex_message,
+        }
+    }
+
+    /// Consumes the message and returns the individual parts
+    pub fn into_parts(self) -> (MessageMetadata, MultiplexMessage) {
+        (self.message_metadata, self.multiplex_message)
+    }
+}
+
+/// A simple struct that wraps an RPC response with metadata.
+/// Note: this is not sent along the wire, it is only used internally.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RpcResponseWithMetadata {
+    /// The metadata about the message
+    message_metadata: MessageMetadata,
+
+    /// The response to send along the wire
+    response: RpcResponse,
+}
+
+impl RpcResponseWithMetadata {
+    pub fn new(message_metadata: MessageMetadata, response: RpcResponse) -> Self {
+        Self {
+            message_metadata,
+            response,
+        }
+    }
+
+    /// Transforms the message into an RPC response network message with metadata
+    pub fn into_network_message(self) -> NetworkMessageWithMetadata {
+        // Create the RPC response network message
+        let network_message = NetworkMessage::RpcResponse(self.response);
+
+        // Create and return the network message with metadata
+        NetworkMessageWithMetadata::new(self.message_metadata, network_message)
+    }
+
+    /// Returns a reference to the RPC response
+    pub fn rpc_response(&self) -> &RpcResponse {
+        &self.response
+    }
+}
+
+/// A simple enum to track the message send latency metric
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MessageSendLatency {
+    ApplicationToWire,
+    WireSend,
+}
+
+impl MessageSendLatency {
+    pub fn get_label(&self) -> &'static str {
+        match self {
+            MessageSendLatency::ApplicationToWire => "ApplicationToWire",
+            MessageSendLatency::WireSend => "WireSend",
+        }
+    }
+}
+
+/// A simple enum to track the message send type
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MessageSendType {
+    DirectSend,  // A direct send message to another peer
+    RpcRequest,  // An RPC request to another peer
+    RpcResponse, // An RPC response for a request sent by another peer
+}
+
+impl MessageSendType {
+    pub fn get_label(&self) -> &'static str {
+        match self {
+            MessageSendType::DirectSend => "DirectSend",
+            MessageSendType::RpcRequest => "RpcRequest",
+            MessageSendType::RpcResponse => "RpcResponse",
+        }
+    }
+}
+
+/// A simple enum to track the message stream type
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MessageStreamType {
+    NonStreamedMessage,      // A non-streamed message that fits into a single chunk
+    StreamedMessageHead,     // The head (first fragment) of a streamed message
+    StreamedMessageFragment, // A fragment of a streamed message (not the head or tail)
+    StreamedMessageTail,     // The tail (last fragment) of a streamed message
+}
+
+impl MessageStreamType {
+    pub fn get_label(&self) -> &'static str {
+        match self {
+            MessageStreamType::NonStreamedMessage => "NonStreamedMessage",
+            MessageStreamType::StreamedMessageHead => "StreamedMessageHead",
+            MessageStreamType::StreamedMessageFragment => "StreamedMessageFragment",
+            MessageStreamType::StreamedMessageTail => "StreamedMessageTail",
+        }
+    }
+}
+
+/// A struct holding metadata about each message.
+/// Note: this is not sent along the wire, it is only used internally.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MessageMetadata {
+    /// The network ID for the message
+    network_id: NetworkId,
+
+    /// The protocol ID for the message. This may not always be
+    /// known (e.g., when failing to deserialize a message).
+    protocol_id: Option<ProtocolId>,
+
+    /// The type of message being sent
+    message_send_type: MessageSendType,
+
+    /// The stream type of the message being sent
+    message_stream_type: MessageStreamType,
+
+    /// The time at which the message was sent by the application
+    application_send_time: Option<SystemTime>,
+
+    /// The time at which the message started being sent over the wire
+    wire_send_start_time: Option<SystemTime>,
+}
+
+impl MessageMetadata {
+    pub fn new(
+        network_id: NetworkId,
+        protocol_id: Option<ProtocolId>,
+        message_send_type: MessageSendType,
+        application_send_time: Option<SystemTime>,
+    ) -> Self {
+        Self {
+            network_id,
+            protocol_id,
+            message_send_type,
+            message_stream_type: MessageStreamType::NonStreamedMessage, // Default to non-streamed messages
+            application_send_time,
+            wire_send_start_time: None,
+        }
+    }
+
+    /// Returns the time at which the message was first sent by the application
+    pub fn application_send_time(&self) -> Option<SystemTime> {
+        self.application_send_time
+    }
+
+    /// Marks the message as having been fully sent over the network wire,
+    /// and emits the relevant latency metrics.
+    pub fn mark_message_as_sent(&mut self) {
+        // If this message is a streamed message fragment, there's no need to emit
+        // any metrics (we only emit metrics for the head and tail of streamed messages).
+        if self.message_stream_type == MessageStreamType::StreamedMessageFragment {
+            return;
+        }
+
+        // Otherwise, emit the latency metrics
+        if let Some(application_send_time) = self.application_send_time {
+            if let Some(wire_send_start_time) = self.wire_send_start_time {
+                // Calculate the application to wire send latency
+                let application_to_wire_latency = wire_send_start_time
+                    .duration_since(application_send_time)
+                    .unwrap_or_default()
+                    .as_secs_f64();
+
+                // Calculate the wire send latency
+                let wire_send_latency = wire_send_start_time
+                    .elapsed()
+                    .unwrap_or_default()
+                    .as_secs_f64();
+
+                // Update the application to wire latency metrics
+                counters::observe_message_send_latency(
+                    &counters::APTOS_NETWORK_MESSAGE_SEND_LATENCY,
+                    &self.network_id,
+                    &self.protocol_id,
+                    &self.message_send_type,
+                    &self.message_stream_type,
+                    MessageSendLatency::ApplicationToWire,
+                    application_to_wire_latency,
+                );
+
+                // Update the wire send latency metrics
+                counters::observe_message_send_latency(
+                    &counters::APTOS_NETWORK_MESSAGE_SEND_LATENCY,
+                    &self.network_id,
+                    &self.protocol_id,
+                    &self.message_send_type,
+                    &self.message_stream_type,
+                    MessageSendLatency::WireSend,
+                    wire_send_latency,
+                );
+            }
+        }
+    }
+
+    /// Returns a reference to the network ID
+    pub fn network_id(&self) -> &NetworkId {
+        &self.network_id
+    }
+
+    /// Returns a reference to the protocol ID
+    pub fn protocol_id(&self) -> &Option<ProtocolId> {
+        &self.protocol_id
+    }
+
+    /// Updates the message type
+    pub fn update_message_stream_type(&mut self, message_stream_type: MessageStreamType) {
+        self.message_stream_type = message_stream_type;
+    }
+
+    /// Updates the time at which the message started being sent over the wire
+    pub fn update_wire_send_start_time(&mut self) {
+        self.wire_send_start_time = Some(SystemTime::now());
+    }
+}

--- a/network/framework/src/protocols/wire/messaging/v1/mod.rs
+++ b/network/framework/src/protocols/wire/messaging/v1/mod.rs
@@ -32,10 +32,11 @@ use tokio_util::{
     compat::{Compat, FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt},
 };
 
+pub mod metadata;
 #[cfg(test)]
 mod test;
 
-/// Most primitive message type set on the network.
+/// The most primitive message type sent on the network
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub enum NetworkMessage {

--- a/network/framework/src/testutils/test_node.rs
+++ b/network/framework/src/testutils/test_node.rs
@@ -6,7 +6,7 @@ use crate::{
     application::{metadata::ConnectionState, storage::PeersAndMetadata},
     peer_manager::PeerManagerRequest,
     protocols::{
-        network::ReceivedMessage,
+        network::{ReceivedMessage, SerializedRequest},
         rpc::OutboundRpcRequest,
         wire::messaging::v1::{DirectSendMsg, NetworkMessage, RpcRequest},
     },
@@ -298,7 +298,7 @@ pub trait TestNode: ApplicationNode + Sync {
                 (peer_id, protocol_id, data)
             },
             PeerManagerRequest::SendDirectSend(peer_id, message) => {
-                (peer_id, message.protocol_id, message.mdata)
+                (peer_id, message.protocol_id(), message.data().clone())
             },
         }
     }
@@ -314,7 +314,7 @@ pub trait TestNode: ApplicationNode + Sync {
                         protocol_id: msg.protocol_id,
                         request_id: 0,
                         priority: 0,
-                        raw_request: msg.data.into(),
+                        raw_request: msg.data().clone().into(),
                     }),
                     sender: self.peer_network_id(network_id),
                     receive_timestamp_micros: 0,
@@ -325,15 +325,15 @@ pub trait TestNode: ApplicationNode + Sync {
             PeerManagerRequest::SendDirectSend(peer_id, msg) => {
                 let rmsg = ReceivedMessage {
                     message: NetworkMessage::DirectSendMsg(DirectSendMsg {
-                        protocol_id: msg.protocol_id,
+                        protocol_id: msg.protocol_id(),
                         priority: 0,
-                        raw_msg: msg.mdata.into(),
+                        raw_msg: msg.data().clone().into(),
                     }),
                     sender: self.peer_network_id(network_id),
                     receive_timestamp_micros: 0,
                     rpc_replier: None,
                 };
-                (peer_id, msg.protocol_id, rmsg)
+                (peer_id, msg.protocol_id(), rmsg)
             },
         };
 

--- a/network/framework/src/testutils/test_node.rs
+++ b/network/framework/src/testutils/test_node.rs
@@ -285,7 +285,7 @@ pub trait TestNode: ApplicationNode + Sync {
         match message {
             PeerManagerRequest::SendRpc(peer_id, outbound_rpc_request) => {
                 // Unpack the request
-                let (protocol_id, data, res_tx, _) = outbound_rpc_request.into_parts();
+                let (_, protocol_id, data, res_tx, _) = outbound_rpc_request.into_parts();
 
                 // Forcefully close the oneshot channel, otherwise listening task will hang forever
                 drop(res_tx);
@@ -305,7 +305,7 @@ pub trait TestNode: ApplicationNode + Sync {
         let (remote_peer_id, protocol_id, rmsg) = match request {
             PeerManagerRequest::SendRpc(peer_id, msg) => {
                 // Unpack the request
-                let (protocol_id, data, res_tx, _) = msg.into_parts();
+                let (_, protocol_id, data, res_tx, _) = msg.into_parts();
 
                 // Create the received message
                 let rmsg = ReceivedMessage {

--- a/peer-monitoring-service/client/src/tests/mock.rs
+++ b/peer-monitoring-service/client/src/tests/mock.rs
@@ -132,11 +132,11 @@ impl MockMonitoringServer {
         // Wait for the next request
         match peer_manager_request_receiver.next().await {
             Some(PeerManagerRequest::SendRpc(peer_id, network_request)) => {
-                // Deconstruct the network request
+                // Unpack the network request
+                let (protocol_id, request_data, response_sender, _) = network_request.into_parts();
+
+                // Identify the peer network ID
                 let peer_network_id = PeerNetworkId::new(*network_id, peer_id);
-                let protocol_id = network_request.protocol_id;
-                let request_data = network_request.data;
-                let response_sender = network_request.res_tx;
 
                 // Deserialize the network message
                 let peer_monitoring_message: PeerMonitoringServiceMessage =

--- a/peer-monitoring-service/client/src/tests/mock.rs
+++ b/peer-monitoring-service/client/src/tests/mock.rs
@@ -133,7 +133,8 @@ impl MockMonitoringServer {
         match peer_manager_request_receiver.next().await {
             Some(PeerManagerRequest::SendRpc(peer_id, network_request)) => {
                 // Unpack the network request
-                let (protocol_id, request_data, response_sender, _) = network_request.into_parts();
+                let (_, protocol_id, request_data, response_sender, _) =
+                    network_request.into_parts();
 
                 // Identify the peer network ID
                 let peer_network_id = PeerNetworkId::new(*network_id, peer_id);

--- a/state-sync/aptos-data-client/src/tests/mock.rs
+++ b/state-sync/aptos-data-client/src/tests/mock.rs
@@ -234,7 +234,7 @@ impl MockNetwork {
         match peer_mgr_reqs_rx.next().await {
             Some(PeerManagerRequest::SendRpc(peer_id, network_request)) => {
                 // Unpack the network request
-                let (protocol_id, data, res_tx, _) = network_request.into_parts();
+                let (_, protocol_id, data, res_tx, _) = network_request.into_parts();
 
                 // Create the peer network ID
                 let peer_network_id = PeerNetworkId::new(network_id, peer_id);


### PR DESCRIPTION
## Description
This PR adds simple queuing metrics for message sends to the network stack. Specifically, we now track the time between when a message is sent by an application (after serialization), until when it is finally written to the network wire.

This PR offers the following commits:
1. Add application send time to the `Message` struct.
2. Add application send time to the `OutboundRpcRequest` struct.
3. Add network metrics for queuing times. To do this, we create a `MessageMetadata` object and wrap the various structs with this metadata as it passes through the network stack.

The next set of PRs will include: (i) receiver side metrics; and (ii) support for messages with embedded timestamps for tracking transport times.

## Testing Plan
Existing test infrastructure and manual verification, e.g., I hacked the code to force messages to be streamed. You can see the new metrics in the `Message Send Queue Latencies` section of the [dashboard](https://grafana.aptoslabs.com/d/network/network?from=2024-11-18T19:33:55.000Z&to=2024-11-18T19:45:59.000Z&var-Datasource=fHo-R604z&var-BigQuery=axNEitxVz&var-metrics_source=$__all&var-chain_name=forge-0&var-cluster=$__all&var-namespace=forge-e2e-pr-15268&var-kubernetes_pod_name=$__all&var-interval=$__auto&var-role=$__all&var-Filters=).