### PR TITLE
[consensus] some cleanup: remove input_transactions from PipelinedBlock

### DIFF
--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -188,7 +188,6 @@ impl BlockStore {
 
         let pipelined_root_block = PipelinedBlock::new(
             *root_block,
-            vec![],
             // Create a dummy state_compute_result with necessary fields filled in.
             result,
         );

--- a/consensus/src/dag/adapter.rs
+++ b/consensus/src/dag/adapter.rs
@@ -195,7 +195,6 @@ impl OrderedNotifier for OrderedNotifierAdapter {
                 parents_bitvec,
                 node_digests,
             ),
-            vec![],
             StateComputeResult::new_dummy(),
         );
         let block_info = block.block_info();

--- a/consensus/src/pipeline/buffer_item.rs
+++ b/consensus/src/pipeline/buffer_item.rs
@@ -517,7 +517,6 @@ mod test {
                 BlockData::dummy_with_validator_txns(vec![]),
                 None,
             ),
-            vec![],
             StateComputeResult::new_dummy(),
         )
     }

--- a/consensus/src/pipeline/tests/execution_phase_tests.rs
+++ b/consensus/src/pipeline/tests/execution_phase_tests.rs
@@ -90,11 +90,7 @@ fn add_execution_phase_test_cases(
     // happy path
     phase_tester.add_test_case(
         ExecutionRequest {
-            ordered_blocks: vec![PipelinedBlock::new(
-                block,
-                vec![],
-                StateComputeResult::new_dummy(),
-            )],
+            ordered_blocks: vec![PipelinedBlock::new(block, StateComputeResult::new_dummy())],
             lifetime_guard: dummy_guard(),
         },
         Box::new(move |resp| {
@@ -132,7 +128,6 @@ fn add_execution_phase_test_cases(
         ExecutionRequest {
             ordered_blocks: vec![PipelinedBlock::new(
                 bad_block,
-                vec![],
                 StateComputeResult::new_dummy(),
             )],
             lifetime_guard: dummy_guard(),

--- a/consensus/src/pipeline/tests/test_utils.rs
+++ b/consensus/src/pipeline/tests/test_utils.rs
@@ -111,9 +111,7 @@ pub fn prepare_executed_blocks_with_ledger_info(
 
     let executed_blocks: Vec<PipelinedBlock> = proposals
         .iter()
-        .map(|proposal| {
-            PipelinedBlock::new(proposal.block().clone(), vec![], compute_result.clone())
-        })
+        .map(|proposal| PipelinedBlock::new(proposal.block().clone(), compute_result.clone()))
         .collect();
 
     (executed_blocks, li_sig, proposals)

--- a/consensus/src/rand/rand_gen/test_utils.rs
+++ b/consensus/src/rand/rand_gen/test_utils.rs
@@ -36,7 +36,6 @@ pub fn create_ordered_blocks(rounds: Vec<Round>) -> OrderedBlocks {
                     ),
                     None,
                 ),
-                vec![],
                 StateComputeResult::new_dummy(),
             )
         })


### PR DESCRIPTION
## Description
Just some cleanup, the input_transactions was not being used anywhere.

## How Has This Been Tested?
Existing tests

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
