### PR TITLE
[cli] Correct the help doc displayed for bytecode version

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1157,14 +1157,8 @@ pub struct MovePackageDir {
 
     /// ...or --bytecode BYTECODE_VERSION
     /// Specify the version of the bytecode the compiler is going to emit.
-    /// Defaults to `6`, or `7` if language version 2 is selected
-    /// (through `--move-2` or `--language-version=2`), .
-    #[clap(
-        long,
-        default_value_if("move_2", "true", "7"),
-        alias = "bytecode",
-        verbatim_doc_comment
-    )]
+    /// Defaults to `7`.
+    #[clap(long, alias = "bytecode", verbatim_doc_comment)]
     pub bytecode_version: Option<u32>,
 
     /// ...or --compiler COMPILER_VERSION


### PR DESCRIPTION
## Description

After this change: https://github.com/aptos-labs/aptos-core/pull/14876, version 7 was the default bytecode version emitted by compiler v2, but the CLI doc in `aptos move compile --help` said otherwise.

This PR fixes the CLI doc.

## How Has This Been Tested?

Existing tests and manual.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Aptos CLI/SDK
