### PR TITLE
[CLI] add option to `aptos move decompile` and `aptos move disassemble` to  print out metadata attached to the bytecode

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,11 +3,11 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Add option `--print-metadata-only` to `aptos move decompile` and `aptos move disassemble` to print out the metadata attached to the bytecode.
 
 ## [4.5.0] - 2024/11/15
 - Determine network from URL to make explorer links better for legacy users
 - Add support for AIP-80 compliant strings when importing using the CLI arguments or manual input.
-- Add option `--print-metadata-only` to `aptos move decompile` and `aptos move disassemble` to print out the metadata attached to the bytecode.
 
 ## [4.4.0] - 2024/11/06
 - Fix typos in `aptos move compile` help text.

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 ## [4.5.0] - 2024/11/15
 - Determine network from URL to make explorer links better for legacy users
 - Add support for AIP-80 compliant strings when importing using the CLI arguments or manual input.
-- Add option `--print-metadata` to `aptos move decompile` and `aptos move disassemble` to print out the metadata attached to the bytecode.
+- Add option `--print-metadata-only` to `aptos move decompile` and `aptos move disassemble` to print out the metadata attached to the bytecode.
 
 ## [4.4.0] - 2024/11/06
 - Fix typos in `aptos move compile` help text.

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 ## [4.5.0] - 2024/11/15
 - Determine network from URL to make explorer links better for legacy users
 - Add support for AIP-80 compliant strings when importing using the CLI arguments or manual input.
+- Add option `--print-compiler-version-only` to `aptos move decompile` and `aptos move disassemble` to print out the version of compiler that generated the target bytecode.
 
 ## [4.4.0] - 2024/11/06
 - Fix typos in `aptos move compile` help text.

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 ## [4.5.0] - 2024/11/15
 - Determine network from URL to make explorer links better for legacy users
 - Add support for AIP-80 compliant strings when importing using the CLI arguments or manual input.
-- Add option `--print-compiler-version-only` to `aptos move decompile` and `aptos move disassemble` to print out the version of compiler that generated the target bytecode.
+- Add option `--print-metadata` to `aptos move decompile` and `aptos move disassemble` to print out the metadata attached to the bytecode.
 
 ## [4.4.0] - 2024/11/06
 - Fix typos in `aptos move compile` help text.


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR adds option `--print-metadata-only` to `aptos move decompile` and `aptos move disassemble` to print out the metadata attached to the bytecode.

Here is an example output:

```
Metadata: {
  "aptos_metadata": {
    "error_map": {
      "0": {
        "code_name": "ED25519_SCHEME",
        "code_description": "Scheme identifier for Ed25519 signatures used to derive authentication keys for Ed25519 public keys."
      },
      "1": {
        "code_name": "EACCOUNT_ALREADY_EXISTS",
        "code_description": "Account already exists"
      },
      "2": {
        "code_name": "EACCOUNT_DOES_NOT_EXIST",
        "code_description": "Account does not exist"
      },
      "3": {
        "code_name": "ESEQUENCE_NUMBER_TOO_BIG",
        "code_description": "Sequence number exceeds the maximum value for a u64"
      },
      "4": {
        "code_name": "EMALFORMED_AUTHENTICATION_KEY",
        "code_description": "The provided authentication key has an invalid length"
      },
      "5": {
        "code_name": "ECANNOT_RESERVED_ADDRESS",
        "code_description": "Cannot create account because address is reserved"
      },
      "6": {
        "code_name": "EOUT_OF_GAS",
        "code_description": "Transaction exceeded its allocated max gas"
      },
      "7": {
        "code_name": "EWRONG_CURRENT_PUBLIC_KEY",
        "code_description": "Specified current public key is not correct"
      },
      "8": {
        "code_name": "EINVALID_PROOF_OF_KNOWLEDGE",
        "code_description": "Specified proof of knowledge required to prove ownership of a public key is invalid"
      },
      "9": {
        "code_name": "ENO_CAPABILITY",
        "code_description": "The caller does not have a digital-signature-based capability to call this function"
      },
      "10": {
        "code_name": "EINVALID_ACCEPT_ROTATION_CAPABILITY",
        "code_description": "The caller does not have a valid rotation capability offer from the other account"
      },
      "11": {
        "code_name": "ENO_VALID_FRAMEWORK_RESERVED_ADDRESS",
        "code_description": "Address to create is not a valid reserved address for Aptos framework"
      },
      "12": {
        "code_name": "EINVALID_SCHEME",
        "code_description": "Specified scheme required to proceed with the smart contract operation - can only be ED25519_SCHEME(0) OR MULTI_ED25519_SCHEME(1)"
      },
      "13": {
        "code_name": "EINVALID_ORIGINATING_ADDRESS",
        "code_description": "Abort the transaction if the expected originating address is different from the originating address on-chain"
      },
      "14": {
        "code_name": "ENO_SUCH_SIGNER_CAPABILITY",
        "code_description": "The signer capability offer doesn't exist at the given address"
      },
      "15": {
        "code_name": "ERESOURCE_ACCCOUNT_EXISTS",
        "code_description": "An attempt to create a resource account on a claimed account"
      },
      "16": {
        "code_name": "EACCOUNT_ALREADY_USED",
        "code_description": "An attempt to create a resource account on an account that has a committed transaction"
      },
      "17": {
        "code_name": "EOFFERER_ADDRESS_DOES_NOT_EXIST",
        "code_description": "Offerer address doesn't exist"
      },
      "18": {
        "code_name": "ENO_SUCH_ROTATION_CAPABILITY_OFFER",
        "code_description": "The specified rotation capability offer does not exist at the specified offerer address"
      },
      "19": {
        "code_name": "ENO_SIGNER_CAPABILITY_OFFERED",
        "code_description": ""
      },
      "20": {
        "code_name": "EEXCEEDED_MAX_GUID_CREATION_NUM",
        "code_description": ""
      },
      "21": {
        "code_name": "ENEW_AUTH_KEY_ALREADY_MAPPED",
        "code_description": "The new authentication key already has an entry in the `OriginatingAddress` table"
      },
      "22": {
        "code_name": "ENEW_AUTH_KEY_SAME_AS_CURRENT",
        "code_description": "The current authentication key and the new authentication key are the same"
      }
    },
    "struct_attributes": {
      "CoinRegister": [
        {
          "kind": 4,
          "args": []
        }
      ],
      "KeyRotation": [
        {
          "kind": 4,
          "args": []
        }
      ]
    },
    "fun_attributes": {
      "exists_at": [
        {
          "kind": 1,
          "args": []
        }
      ],
      "get_authentication_key": [
        {
          "kind": 1,
          "args": []
        }
      ],
      "get_guid_next_creation_num": [
        {
          "kind": 1,
          "args": []
        }
      ],
      "get_rotation_capability_offer_for": [
        {
          "kind": 1,
          "args": []
        }
      ],
      "get_sequence_number": [
        {
          "kind": 1,
          "args": []
        }
      ],
      "get_signer_capability_offer_for": [
        {
          "kind": 1,
          "args": []
        }
      ],
      "is_rotation_capability_offered": [
        {
          "kind": 1,
          "args": []
        }
      ],
      "is_signer_capability_offered": [
        {
          "kind": 1,
          "args": []
        }
      ],
      "originating_address": [
        {
          "kind": 1,
          "args": []
        }
      ]
    }
  },
  "bytecode_version": 7,
  "compilation_metdadata": {
    "unstable": false,
    "compiler_version": "1",
    "language_version": "1"
  }
}
```

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Manual test 

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
