### PR TITLE
[WIP][Compiler-v2] refactor resource index for ability checking of type parameters

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/typing/bug_15274.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/bug_15274.exp
@@ -1,0 +1,41 @@
+
+Diagnostics:
+error: type `T` is missing required ability `store`
+   ┌─ tests/checking/typing/bug_15274.move:16:30
+   │
+16 │         unwrap_non_receiver(&Wrapper<T>[account])
+   │                              ^^^^^^^^^^
+   │
+   = required by instantiating type parameter `T:copy` of struct `Wrapper`
+   = required by instantiating type parameter `T:key` of function `borrow_global`
+
+error: type `T` is missing required ability `store`
+   ┌─ tests/checking/typing/bug_15274.move:20:9
+   │
+20 │         Wrapper<T>[account].unwrap()
+   │         ^^^^^^^^^^
+   │
+   = required by instantiating type parameter `T:copy` of struct `Wrapper`
+   = required by instantiating type parameter `T:key` of function `borrow_global`
+
+error: type `T` is missing required ability `copy`
+   ┌─ tests/checking/typing/bug_15274.move:23:39
+   │
+ 3 │     struct Wrapper<T: copy> has drop, key, store, copy {
+   │                    - declaration of type parameter `T`
+   ·
+23 │     fun test_vec<T>(v: vector<Wrapper<T>>): T {
+   │                                       ^
+   │
+   = required by instantiating type parameter `T:copy` of struct `Wrapper`
+
+error: type `T` is missing required ability `copy`
+   ┌─ tests/checking/typing/bug_15274.move:24:9
+   │
+ 7 │     fun unwrap<T: copy>(self: &Wrapper<T>): T {
+   │                - declaration of type parameter `T`
+   ·
+24 │         v[0].unwrap()
+   │         ^^^^^^^^^^^^^
+   │
+   = required by instantiating type parameter `T:copy` of function `unwrap`

--- a/third_party/move/move-compiler-v2/tests/checking/typing/bug_15274.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/bug_15274.move
@@ -1,0 +1,27 @@
+module 0x42::test {
+
+    struct Wrapper<T: copy> has drop, key, store, copy {
+        inner: T
+    }
+
+    fun unwrap<T: copy>(self: &Wrapper<T>): T {
+        self.inner
+    }
+
+    fun unwrap_non_receiver<T: copy>(self1: &Wrapper<T>): T {
+        self1.inner
+    }
+
+    fun dispatch_non_receiver<T: copy>(account: address): T acquires Wrapper {
+        unwrap_non_receiver(&Wrapper<T>[account])
+    }
+
+    fun dispatch<T: copy>(account: address): T acquires Wrapper {
+        Wrapper<T>[account].unwrap()
+    }
+
+    fun test_vec<T>(v: vector<Wrapper<T>>): T {
+        v[0].unwrap()
+    }
+
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

1) existing tests;
2) add a new test case.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

Close #15274

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
