### PR TITLE
[CI] Increase `threads-required` to reduce saturation.

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,6 +5,9 @@ status-level = "skip"
 failure-output = "immediate-final"
 # Cancel test run on the first failure. Accounts for retries.
 fail-fast = true
+# To avoid CPU saturation and test timeouts (due to heavy/multithreaded
+# tests), we increase the number of threads required per test.
+threads-required = 3
 
 junit = { path = "junit.xml" }
 


### PR DESCRIPTION
## Description
This PR increases the `threads-required` nextest [configuration](https://nexte.st/docs/configuration/threads-required/) to reduce the number of rust unit tests running in parallel for CI/CD. We've recently seen cases where simple tests (e.g., without locks, multi-threading, tokio, etc.) have hit the time out (despite usually completing in 1-2 seconds).

From some quick experimentation, it appears that the tests are just not being given enough time to actually run by the OS (i.e., resources are saturated, so the tests do not complete before the test runner terminates them). By reducing the concurrency, we're hoping to see these timeouts disappear. 

## Testing Plan
Existing test infrastructure and (some) manual verification (i.e., I did a few manual rust unit test runs and couldn't reproduce the timeouts).
