### PR TITLE
[CI][Compiler-v2] add `MOVE_LANGUAGE_V2=true` to move_pr.sh

### DIFF
--- a/aptos-move/e2e-move-tests/src/lib.rs
+++ b/aptos-move/e2e-move-tests/src/lib.rs
@@ -59,6 +59,7 @@ pub(crate) fn build_package_with_compiler_version(
     compiler_version: CompilerVersion,
 ) -> anyhow::Result<BuiltPackage> {
     let mut options = options;
+    options.language_version = Some(compiler_version.infer_stable_language_version());
     options.compiler_version = Some(compiler_version);
     BuiltPackage::build(package_path.to_owned(), options)
 }

--- a/third_party/move/move-model/src/metadata.rs
+++ b/third_party/move/move-model/src/metadata.rs
@@ -171,6 +171,15 @@ impl CompilerVersion {
             _ => Ok(()),
         }
     }
+
+    /// Infer the latest stable language version based on the compiler version
+    pub fn infer_stable_language_version(&self) -> LanguageVersion {
+        if *self == CompilerVersion::V1 {
+            LanguageVersion::V1
+        } else {
+            LanguageVersion::latest_stable()
+        }
+    }
 }
 
 // ================================================================================'

--- a/third_party/move/scripts/move_pr.sh
+++ b/third_party/move/scripts/move_pr.sh
@@ -197,10 +197,10 @@ if [ ! -z "$COMPILER_V2_TEST" ]; then
   echo "*************** [move-pr] Running integration tests with compiler v2"
   (
     cd $BASE
-    MVC_DOCGEN_OUTPUT_DIR=tests/compiler-v2-doc MOVE_COMPILER_V2=true cargo build $CARGO_OP_PARAMS \
+    MVC_DOCGEN_OUTPUT_DIR=tests/compiler-v2-doc MOVE_COMPILER_V2=true MOVE_LANGUAGE_V2=true cargo build $CARGO_OP_PARAMS \
        $MOVE_CRATES_V2_ENV_DEPENDENT
     MVC_DOCGEN_OUTPUT_DIR=tests/compiler-v2-doc \
-       MOVE_COMPILER_V2=true cargo nextest run $CARGO_NEXTEST_PARAMS \
+       MOVE_COMPILER_V2=true MOVE_LANGUAGE_V2=true cargo nextest run $CARGO_NEXTEST_PARAMS \
        $MOVE_CRATES_V2_ENV_DEPENDENT
   )
 fi


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Add `MOVE_LANGUAGE_V2=true` for compiler v2 integration tests to allow V2 language features to be implemented in aptos-framework

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

existing tests

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->



## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
