### PR TITLE
[Compiler-v2] Fix parsing of `location` in plan_builder of compiler v2

### DIFF
--- a/third_party/move/move-compiler-v2/src/plan_builder.rs
+++ b/third_party/move/move-compiler-v2/src/plan_builder.rs
@@ -505,10 +505,17 @@ fn convert_location(env: &GlobalEnv, attr: Attribute) -> Option<ModuleId> {
     match value {
         AttributeValue::Name(id, opt_module_name, _sym) => {
             let vloc = env.get_node_loc(id);
-            convert_module_id(env, vloc, opt_module_name)
+            let module_id_opt = convert_module_id(env, vloc.clone(), opt_module_name);
+            if !_sym.display(env.symbol_pool()).to_string().is_empty() || module_id_opt.is_none() {
+                env.error_with_labels(&loc, "invalid attribute value", vec![(
+                    vloc,
+                    "Expected a module identifier, e.g. 'std::vector'".to_string(),
+                )]);
+            }
+            module_id_opt
         },
         AttributeValue::Value(id, _val) => {
-            let vloc = env.get_node_loc(id);
+            let vloc: Loc = env.get_node_loc(id);
             env.error_with_labels(&loc, "invalid attribute value", vec![(
                 vloc,
                 "Expected a module identifier, e.g. 'std::vector'".to_string(),

--- a/third_party/move/move-compiler-v2/src/plan_builder.rs
+++ b/third_party/move/move-compiler-v2/src/plan_builder.rs
@@ -503,10 +503,10 @@ fn get_assigned_attribute(
 fn convert_location(env: &GlobalEnv, attr: Attribute) -> Option<ModuleId> {
     let (loc, value) = get_assigned_attribute(env, TestingAttribute::ERROR_LOCATION, attr)?;
     match value {
-        AttributeValue::Name(id, opt_module_name, _sym) => {
+        AttributeValue::Name(id, opt_module_name, sym) => {
             let vloc = env.get_node_loc(id);
             let module_id_opt = convert_module_id(env, vloc.clone(), opt_module_name);
-            if !_sym.display(env.symbol_pool()).to_string().is_empty() || module_id_opt.is_none() {
+            if !sym.display(env.symbol_pool()).to_string().is_empty() || module_id_opt.is_none() {
                 env.error_with_labels(&loc, "invalid attribute value", vec![(
                     vloc,
                     "Expected a module identifier, e.g. 'std::vector'".to_string(),
@@ -515,7 +515,7 @@ fn convert_location(env: &GlobalEnv, attr: Attribute) -> Option<ModuleId> {
             module_id_opt
         },
         AttributeValue::Value(id, _val) => {
-            let vloc: Loc = env.get_node_loc(id);
+            let vloc = env.get_node_loc(id);
             env.error_with_labels(&loc, "invalid attribute value", vec![(
                 vloc,
                 "Expected a module identifier, e.g. 'std::vector'".to_string(),

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_location.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_location.exp
@@ -47,17 +47,17 @@ error: invalid attribute value
    │                                             Expected a module identifier, e.g. 'std::vector'
 
 error: invalid attribute value
-   ┌─ tests/unit_test/test/other_failures_invalid_location.move:34:43
+   ┌─ tests/unit_test/test/other_failures_invalid_location.move:38:43
    │
-34 │     #[expected_failure(major_status=4004, location=self)]
+38 │     #[expected_failure(major_status=4004, location=self)]
    │                                           ^^^^^^^^^^^^^
    │                                                    │
    │                                                    Expected a module identifier, e.g. 'std::vector'
 
 error: invalid attribute value
-   ┌─ tests/unit_test/test/other_failures_invalid_location.move:38:59
+   ┌─ tests/unit_test/test/other_failures_invalid_location.move:42:59
    │
-38 │     #[expected_failure(major_status=4016, minor_status=0, location=0)]
+42 │     #[expected_failure(major_status=4016, minor_status=0, location=0)]
    │                                                           ^^^^^^^^^^
    │                                                                    │
    │                                                                    Expected a module identifier, e.g. 'std::vector'

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_location.exp
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_location.exp
@@ -31,6 +31,30 @@ error: Expected `location` following `major_status`
    │                        ^^^^^^^^^^^^^^^^^
 
 error: invalid attribute value
+   ┌─ tests/unit_test/test/other_failures_invalid_location.move:26:38
+   │
+26 │     #[expected_failure(vector_error, location=x)]
+   │                                      ^^^^^^^^^^
+   │                                               │
+   │                                               Expected a module identifier, e.g. 'std::vector'
+
+error: invalid attribute value
+   ┌─ tests/unit_test/test/other_failures_invalid_location.move:30:36
+   │
+30 │     #[expected_failure(out_of_gas, location=0x1::m::t0)]
+   │                                    ^^^^^^^^^^^^^^^^^^^
+   │                                             │
+   │                                             Expected a module identifier, e.g. 'std::vector'
+
+error: invalid attribute value
+   ┌─ tests/unit_test/test/other_failures_invalid_location.move:34:43
+   │
+34 │     #[expected_failure(major_status=4004, location=self)]
+   │                                           ^^^^^^^^^^^^^
+   │                                                    │
+   │                                                    Expected a module identifier, e.g. 'std::vector'
+
+error: invalid attribute value
    ┌─ tests/unit_test/test/other_failures_invalid_location.move:38:59
    │
 38 │     #[expected_failure(major_status=4016, minor_status=0, location=0)]

--- a/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_location.move
+++ b/third_party/move/move-compiler-v2/tests/unit_test/test/other_failures_invalid_location.move
@@ -31,6 +31,10 @@ module 0x1::m {
     fun u2() { }
 
     #[test]
+    #[expected_failure(out_of_gas, location=0x1::m)]
+    fun u2_correct() { }
+
+    #[test]
     #[expected_failure(major_status=4004, location=self)]
     fun u3() { }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR closes #14635 by fixing how `location` is parsed in the attribute for move unit tests.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Existing tests.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
