### PR TITLE
[loader-v2] migrate Move transactional and integration tests to V2 only

### DIFF
--- a/aptos-move/block-executor/src/code_cache_global_manager.rs
+++ b/aptos-move/block-executor/src/code_cache_global_manager.rs
@@ -173,7 +173,6 @@ impl AptosModuleCacheManager {
                 AptosModuleCacheManagerGuard::Guard { guard }
             },
             None => {
-                // TODO(loader_v2): Should we return an error here instead?
                 alert_or_println!("Locking module cache manager failed, fallback to empty caches");
 
                 // If this is true, we failed to acquire a lock, and so default storage environment

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -1342,27 +1342,16 @@ pub fn test_genesis_module_publishing() {
     let genesis_vm = genesis_runtime_builder.build_genesis_vm();
     let genesis_runtime_environment = genesis_runtime_builder.build_genesis_runtime_environment();
 
-    // We only test loader V2 flow here because V1 flow does not make sense. V1 relies on modules
-    // being cached in loader prior to publishing, which happens to be the case when resources are
-    // initialized (when we generate a genesis transaction). This is not the case here, and so the
-    // publishing will always fail. The previous version of this test did a wonderful thing:
-    //   1. added modules to state view,
-    //   2. run publishing (which obviously was passing because 0x1::code existed),
-    //   3. did not assert anything about the write set, even though in this test modifications
-    //      were created...
-    if genesis_runtime_environment.vm_config().use_loader_v2 {
-        let (change_set, module_write_set) = publish_framework(
-            &genesis_vm,
-            &genesis_runtime_environment,
-            HashValue::zero(),
-            aptos_cached_packages::head_release_bundle(),
-        );
+    let (change_set, module_write_set) = publish_framework(
+        &genesis_vm,
+        &genesis_runtime_environment,
+        HashValue::zero(),
+        aptos_cached_packages::head_release_bundle(),
+    );
 
-        // All write ops must be a creation!
-        let change_set =
-            assert_ok!(change_set.try_combine_into_storage_change_set(module_write_set));
-        verify_genesis_module_write_set(change_set.write_set());
-    }
+    // All write ops must be a creation!
+    let change_set = assert_ok!(change_set.try_combine_into_storage_change_set(module_write_set));
+    verify_genesis_module_write_set(change_set.write_set());
 }
 
 #[test]

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -684,25 +684,21 @@ fn test_storage_returns_bogus_error_when_loading_module() {
             )
             .unwrap_err();
 
-        if !vm.vm_config().use_loader_v2 {
-            assert_eq!(err.major_status(), *error_code);
+        // TODO(loader_v2):
+        //   Loader V2 remaps all deserialization and verification errors. Loader V1 does not
+        //   remap them when module resolver is accessed, and only on verification steps.
+        //   Strictly speaking, the storage would never return such an error so V2 behaviour is
+        //   ok. Moreover, the fact that V1 still returns UNKNOWN_BINARY_ERROR and does not
+        //   remap it is weird.
+        if *error_code == StatusCode::UNKNOWN_VERIFICATION_ERROR {
+            assert_eq!(err.major_status(), StatusCode::UNEXPECTED_VERIFIER_ERROR);
+        } else if *error_code == StatusCode::UNKNOWN_BINARY_ERROR {
+            assert_eq!(
+                err.major_status(),
+                StatusCode::UNEXPECTED_DESERIALIZATION_ERROR
+            );
         } else {
-            // TODO(loader_v2):
-            //   Loader V2 remaps all deserialization and verification errors. Loader V1 does not
-            //   remap them when module resolver is accessed, and only on verification steps.
-            //   Strictly speaking, the storage would never return such an error so V2 behaviour is
-            //   ok. Moreover, the fact that V1 still returns UNKNOWN_BINARY_ERROR and does not
-            //   remap it is weird.
-            if *error_code == StatusCode::UNKNOWN_VERIFICATION_ERROR {
-                assert_eq!(err.major_status(), StatusCode::UNEXPECTED_VERIFIER_ERROR);
-            } else if *error_code == StatusCode::UNKNOWN_BINARY_ERROR {
-                assert_eq!(
-                    err.major_status(),
-                    StatusCode::UNEXPECTED_DESERIALIZATION_ERROR
-                );
-            } else {
-                assert_eq!(err.major_status(), *error_code);
-            }
+            assert_eq!(err.major_status(), *error_code);
         }
     }
 }

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -792,8 +792,7 @@ fn test_storage_returns_bogus_error_when_loading_resource() {
             .unwrap_err();
 
         if *error_code == StatusCode::UNKNOWN_VERIFICATION_ERROR {
-            // MoveVM maps `UNKNOWN_VERIFICATION_ERROR` to `VERIFICATION_ERROR` in
-            // `maybe_core_dump` function in interpreter.rs.
+            // MoveVM maps `UNKNOWN_VERIFICATION_ERROR` to `VERIFICATION_ERROR`.
             assert_eq!(err.major_status(), StatusCode::VERIFICATION_ERROR);
         } else {
             assert_eq!(err.major_status(), *error_code);

--- a/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
@@ -33,37 +33,17 @@ fn test_publish_module_with_custom_max_binary_format_version() {
             move_stdlib::natives::GasParameters::zeros(),
         );
         let runtime_environment = RuntimeEnvironment::new(natives);
-        let vm = MoveVM::new_with_runtime_environment(&runtime_environment);
-        let mut sess = vm.new_session(&storage);
+        let module_storage = storage.as_unsync_module_storage(runtime_environment);
 
-        if vm.vm_config().use_loader_v2 {
-            let module_storage = storage.as_unsync_module_storage(runtime_environment);
-            let new_module_storage =
-                StagingModuleStorage::create(m.self_addr(), &module_storage, vec![b_new
-                    .clone()
-                    .into()])
-                .expect("New module should be publishable");
-            StagingModuleStorage::create(m.self_addr(), &new_module_storage, vec![b_old
+        let new_module_storage =
+            StagingModuleStorage::create(m.self_addr(), &module_storage, vec![b_new
                 .clone()
                 .into()])
-            .expect("Old module should be publishable");
-        } else {
-            #[allow(deprecated)]
-            sess.publish_module_bundle(
-                vec![b_new.clone()],
-                *m.self_id().address(),
-                &mut UnmeteredGasMeter,
-            )
-            .unwrap();
-
-            #[allow(deprecated)]
-            sess.publish_module_bundle(
-                vec![b_old.clone()],
-                *m.self_id().address(),
-                &mut UnmeteredGasMeter,
-            )
-            .unwrap();
-        }
+            .expect("New module should be publishable");
+        StagingModuleStorage::create(m.self_addr(), &new_module_storage, vec![b_old
+            .clone()
+            .into()])
+        .expect("Old module should be publishable");
     }
 
     // Should reject the module with newer version with max binary format version being set to VERSION_MAX - 1
@@ -81,43 +61,18 @@ fn test_publish_module_with_custom_max_binary_format_version() {
             ..Default::default()
         };
         let runtime_environment = RuntimeEnvironment::new_with_config(natives, vm_config);
-        let vm = MoveVM::new_with_runtime_environment(&runtime_environment);
-        let mut sess = vm.new_session(&storage);
+        let module_storage = storage.as_unsync_module_storage(runtime_environment);
 
-        if vm.vm_config().use_loader_v2 {
-            let module_storage = storage.as_unsync_module_storage(runtime_environment);
-            let result = StagingModuleStorage::create(m.self_addr(), &module_storage, vec![b_new
-                .clone()
-                .into()]);
-            if let Err(err) = result {
-                assert_eq!(err.major_status(), StatusCode::UNKNOWN_VERSION);
-            } else {
-                panic!("Module publishing should fail")
-            }
-            StagingModuleStorage::create(m.self_addr(), &module_storage, vec![b_old
-                .clone()
-                .into()])
-            .unwrap();
+        let result = StagingModuleStorage::create(m.self_addr(), &module_storage, vec![b_new
+            .clone()
+            .into()]);
+        if let Err(err) = result {
+            assert_eq!(err.major_status(), StatusCode::UNKNOWN_VERSION);
         } else {
-            #[allow(deprecated)]
-            let s = sess
-                .publish_module_bundle(
-                    vec![b_new.clone()],
-                    *m.self_id().address(),
-                    &mut UnmeteredGasMeter,
-                )
-                .unwrap_err()
-                .major_status();
-            assert_eq!(s, StatusCode::UNKNOWN_VERSION);
-
-            #[allow(deprecated)]
-            sess.publish_module_bundle(
-                vec![b_old.clone()],
-                *m.self_id().address(),
-                &mut UnmeteredGasMeter,
-            )
-            .unwrap();
+            panic!("Module publishing should fail")
         }
+        StagingModuleStorage::create(m.self_addr(), &module_storage, vec![b_old.clone().into()])
+            .unwrap();
     }
 }
 

--- a/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
@@ -73,26 +73,18 @@ fn test_publish_module_with_nested_loops() {
         let runtime_environment = RuntimeEnvironment::new_with_config(natives, vm_config);
         let vm = MoveVM::new_with_runtime_environment(&runtime_environment);
 
-        let mut sess = vm.new_session(&storage);
         let module_storage = storage.as_unsync_code_storage(runtime_environment);
-        if vm.vm_config().use_loader_v2 {
-            let new_module_storage =
-                StagingModuleStorage::create(&TEST_ADDR, &module_storage, vec![m_blob
-                    .clone()
-                    .into()])
+        let new_module_storage =
+            StagingModuleStorage::create(&TEST_ADDR, &module_storage, vec![m_blob.clone().into()])
                 .expect("Module should be publishable");
-            load_and_run_functions(
-                &mut sess,
-                &new_module_storage,
-                &traversal_storage,
-                &m.self_id(),
-            );
-        } else {
-            #[allow(deprecated)]
-            sess.publish_module(m_blob.clone(), TEST_ADDR, &mut UnmeteredGasMeter)
-                .unwrap();
-            load_and_run_functions(&mut sess, &module_storage, &traversal_storage, &m.self_id());
-        };
+
+        let mut sess = vm.new_session(&storage);
+        load_and_run_functions(
+            &mut sess,
+            &new_module_storage,
+            &traversal_storage,
+            &m.self_id(),
+        );
     }
 }
 

--- a/third_party/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
@@ -51,20 +51,10 @@ fn test_publish_module_with_nested_loops() {
             ..Default::default()
         };
         let runtime_environment = RuntimeEnvironment::new_with_config(natives, vm_config);
-        let vm = MoveVM::new_with_runtime_environment(&runtime_environment);
-
-        let mut sess = vm.new_session(&storage);
-        if vm.vm_config().use_loader_v2 {
-            let module_storage = storage.as_unsync_module_storage(runtime_environment);
-            let result = StagingModuleStorage::create(&TEST_ADDR, &module_storage, vec![m_blob
-                .clone()
-                .into()]);
-            assert!(result.is_ok());
-        } else {
-            #[allow(deprecated)]
-            sess.publish_module(m_blob.clone(), TEST_ADDR, &mut UnmeteredGasMeter)
-                .unwrap();
-        }
+        let module_storage = storage.as_unsync_module_storage(runtime_environment);
+        let result =
+            StagingModuleStorage::create(&TEST_ADDR, &module_storage, vec![m_blob.clone().into()]);
+        assert!(result.is_ok());
     }
 
     // Should fail with max_loop_depth = 1
@@ -82,20 +72,10 @@ fn test_publish_module_with_nested_loops() {
             ..Default::default()
         };
         let runtime_environment = RuntimeEnvironment::new_with_config(natives, vm_config);
-        let vm = MoveVM::new_with_runtime_environment(&runtime_environment);
-
-        let mut sess = vm.new_session(&storage);
-        if vm.vm_config().use_loader_v2 {
-            let module_storage = storage.as_unsync_module_storage(runtime_environment);
-            let result = StagingModuleStorage::create(&TEST_ADDR, &module_storage, vec![m_blob
-                .clone()
-                .into()]);
-            assert!(result.is_err());
-        } else {
-            #[allow(deprecated)]
-            sess.publish_module(m_blob.clone(), TEST_ADDR, &mut UnmeteredGasMeter)
-                .unwrap_err();
-        }
+        let module_storage = storage.as_unsync_module_storage(runtime_environment);
+        let result =
+            StagingModuleStorage::create(&TEST_ADDR, &module_storage, vec![m_blob.clone().into()]);
+        assert!(result.is_err());
     }
 }
 

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -1303,8 +1303,7 @@ impl<'a> Resolver<'a> {
                     function_name,
                 )
                 .map_err(|_| {
-                    // TODO(loader_v2):
-                    //   Loader V1 implementation uses this error, but it should be a linker error.
+                    // Note: legacy loader implementation used this error, so we need to remap.
                     PartialVMError::new(StatusCode::FUNCTION_RESOLUTION_FAILURE).with_message(
                         format!(
                             "Module or function do not exist for {}::{}::{}",

--- a/third_party/move/move-vm/runtime/src/storage/loader.rs
+++ b/third_party/move/move-vm/runtime/src/storage/loader.rs
@@ -139,14 +139,11 @@ impl LoaderV2 {
             .iter()
             .map(|ty_tag| self.load_ty(code_storage, ty_tag))
             .collect::<PartialVMResult<Vec<_>>>()
-            // TODO(loader_v2):
-            //   Loader V1 implementation returns undefined here, causing some tests to fail. We
-            //   should probably map this to script.
-            .map_err(|e| e.finish(Location::Undefined))?;
+            .map_err(|err| err.finish(Location::Script))?;
 
         let main = script.entry_point();
         Type::verify_ty_arg_abilities(main.ty_param_abilities(), &ty_args)
-            .map_err(|e| e.finish(Location::Script))?;
+            .map_err(|err| err.finish(Location::Script))?;
 
         Ok(LoadedFunction {
             owner: LoadedFunctionOwner::Script(script),
@@ -205,7 +202,7 @@ impl LoaderV2 {
     ) -> PartialVMResult<Arc<StructType>> {
         let module = self
             .load_module(module_storage, address, module_name)
-            .map_err(|e| e.to_partial())?;
+            .map_err(|err| err.to_partial())?;
         Ok(module
             .struct_map
             .get(struct_name)
@@ -239,9 +236,9 @@ impl LoaderV2 {
                     st.module.as_ident_str(),
                     st.name.as_ident_str(),
                 )
-                .map_err(|e| e.finish(Location::Undefined))
+                .map_err(|err| err.finish(Location::Undefined))
             })
-            .map_err(|e| e.to_partial())
+            .map_err(|err| err.to_partial())
     }
 }
 

--- a/third_party/move/move-vm/transactional-tests/tests/entry_points/script_too_few_type_args_inner.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/entry_points/script_too_few_type_args_inner.exp
@@ -4,7 +4,7 @@ task 1 'run'. lines 6-10:
 Error: Script execution failed with VMError: {
     major_status: NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
     sub_status: None,
-    location: undefined,
+    location: script,
     indices: [],
     offsets: [],
 }

--- a/third_party/move/move-vm/transactional-tests/tests/entry_points/script_too_few_type_args_inner.v2_exp
+++ b/third_party/move/move-vm/transactional-tests/tests/entry_points/script_too_few_type_args_inner.v2_exp
@@ -4,7 +4,7 @@ task 1 'run'. lines 6-10:
 Error: Script execution failed with VMError: {
     major_status: NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
     sub_status: None,
-    location: undefined,
+    location: script,
     indices: [],
     offsets: [],
 }

--- a/third_party/move/move-vm/transactional-tests/tests/entry_points/script_too_many_type_args_inner.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/entry_points/script_too_many_type_args_inner.exp
@@ -4,7 +4,7 @@ task 1 'run'. lines 6-10:
 Error: Script execution failed with VMError: {
     major_status: NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
     sub_status: None,
-    location: undefined,
+    location: script,
     indices: [],
     offsets: [],
 }

--- a/third_party/move/move-vm/transactional-tests/tests/entry_points/script_too_many_type_args_inner.v2_exp
+++ b/third_party/move/move-vm/transactional-tests/tests/entry_points/script_too_many_type_args_inner.v2_exp
@@ -4,7 +4,7 @@ task 1 'run'. lines 6-10:
 Error: Script execution failed with VMError: {
     major_status: NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
     sub_status: None,
-    location: undefined,
+    location: script,
     indices: [],
     offsets: [],
 }

--- a/third_party/move/move-vm/types/src/code/errors.rs
+++ b/third_party/move/move-vm/types/src/code/errors.rs
@@ -26,9 +26,9 @@ macro_rules! module_storage_error {
     };
 }
 
-// TODO(loader_v2):
-//   The error message is formatted in the same way as V1, to ensure that replay and tests work in
-//   the same way, but ideally we should use proper formatting here.
+// Note:
+//   The error message is formatted in the same way as by the legacy loader implementation, to
+//   ensure that replay and tests work in the same way.
 #[macro_export]
 macro_rules! module_linker_error {
     ($addr:expr, $name:expr) => {


### PR DESCRIPTION
## Description

Since V2 loader is set to default, we can remove some V1 legacy code already. In this PR, removed V1 loader flow for:
- Move integration tests
- Move transactional tests

## How Has This Been Tested?

Existing tests

## Key Areas to Review

N/A

## Type of Change

- [x] Refactoring
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
