### PR TITLE
fix deadlock on nested DropHelper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,7 @@ dependencies = [
  "aptos-metrics-core",
  "derive_more",
  "once_cell",
+ "rayon",
  "threadpool",
 ]
 

--- a/crates/aptos-drop-helper/Cargo.toml
+++ b/crates/aptos-drop-helper/Cargo.toml
@@ -18,3 +18,6 @@ aptos-metrics-core = { workspace = true }
 derive_more = { workspace = true }
 once_cell = { workspace = true }
 threadpool = { workspace = true }
+
+[dev-dependencies]
+rayon = { workspace = true }

--- a/crates/aptos-drop-helper/src/async_concurrent_dropper.rs
+++ b/crates/aptos-drop-helper/src/async_concurrent_dropper.rs
@@ -1,7 +1,10 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::metrics::{GAUGE, TIMER};
+use crate::{
+    metrics::{GAUGE, TIMER},
+    IN_ANY_DROP_POOL,
+};
 use aptos_infallible::Mutex;
 use aptos_metrics_core::{IntGaugeHelper, TimerHelper};
 use std::sync::{
@@ -42,12 +45,25 @@ impl AsyncConcurrentDropper {
         rx
     }
 
+    pub fn max_tasks(&self) -> usize {
+        self.num_tasks_tracker.max_tasks
+    }
+
+    pub fn num_threads(&self) -> usize {
+        self.thread_pool.max_count()
+    }
+
     pub fn wait_for_backlog_drop(&self, no_more_than: usize) {
         let _timer = TIMER.timer_with(&[self.name, "wait_for_backlog_drop"]);
         self.num_tasks_tracker.wait_for_backlog_drop(no_more_than);
     }
 
     fn schedule_drop_impl<V: Send + 'static>(&self, v: V, notif_sender_opt: Option<Sender<()>>) {
+        if IN_ANY_DROP_POOL.get() {
+            Self::do_drop(v, notif_sender_opt);
+            return;
+        }
+
         let _timer = TIMER.timer_with(&[self.name, "enqueue_drop"]);
         self.num_tasks_tracker.inc();
 
@@ -57,14 +73,22 @@ impl AsyncConcurrentDropper {
         self.thread_pool.execute(move || {
             let _timer = TIMER.timer_with(&[name, "real_drop"]);
 
-            drop(v);
+            IN_ANY_DROP_POOL.with(|flag| {
+                flag.set(true);
+            });
 
-            if let Some(sender) = notif_sender_opt {
-                sender.send(()).ok();
-            }
+            Self::do_drop(v, notif_sender_opt);
 
             num_tasks_tracker.dec();
         })
+    }
+
+    fn do_drop<V: Send + 'static>(v: V, notif_sender_opt: Option<Sender<()>>) {
+        drop(v);
+
+        if let Some(sender) = notif_sender_opt {
+            sender.send(()).ok();
+        }
     }
 }
 
@@ -111,10 +135,12 @@ impl NumTasksTracker {
 
 #[cfg(test)]
 mod tests {
-    use crate::AsyncConcurrentDropper;
+    use crate::{AsyncConcurrentDropper, DropHelper, DEFAULT_DROPPER};
+    use rayon::prelude::*;
     use std::{sync::Arc, thread::sleep, time::Duration};
     use threadpool::ThreadPool;
 
+    #[derive(Clone, Default)]
     struct SlowDropper;
 
     impl Drop for SlowDropper {
@@ -196,5 +222,26 @@ mod tests {
         assert!(now.elapsed() < Duration::from_millis(600));
         s.wait_for_backlog_drop(0);
         assert!(now.elapsed() < Duration::from_millis(600));
+    }
+
+    #[test]
+    fn test_nested_drops() {
+        #[derive(Clone, Default)]
+        struct Nested {
+            _inner: DropHelper<SlowDropper>,
+        }
+
+        // pump 2 x max_tasks to the drop queue
+        let num_items = DEFAULT_DROPPER.max_tasks() * 2;
+        let items = vec![DropHelper::new(Nested::default()); num_items];
+        let drop_thread = std::thread::spawn(move || {
+            items.into_par_iter().for_each(drop);
+        });
+
+        // expect no deadlock and the whole thing to be dropped in full concurrency (with some leeway)
+        sleep(Duration::from_millis(
+            200 + 200 * num_items as u64 / DEFAULT_DROPPER.num_threads() as u64,
+        ));
+        assert!(drop_thread.is_finished(), "Drop queue deadlocked.");
     }
 }

--- a/crates/aptos-drop-helper/src/lib.rs
+++ b/crates/aptos-drop-helper/src/lib.rs
@@ -4,11 +4,15 @@
 use crate::async_concurrent_dropper::AsyncConcurrentDropper;
 use derive_more::{Deref, DerefMut};
 use once_cell::sync::Lazy;
-use std::mem::ManuallyDrop;
+use std::{cell::Cell, mem::ManuallyDrop};
 
 pub mod async_concurrent_dropper;
 pub mod async_drop_queue;
 mod metrics;
+
+thread_local! {
+    static IN_ANY_DROP_POOL: Cell<bool> = const { Cell::new(false) };
+}
 
 pub static DEFAULT_DROPPER: Lazy<AsyncConcurrentDropper> =
     Lazy::new(|| AsyncConcurrentDropper::new("default", 32, 8));


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

When droping is slow and `DropHelper`s are nested, `AsyncConcurrentDropper::schedule_drop()` can deadlock on `self.num_tasks_tracker.inc();`


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

added unit test, verified failing before fix

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] Bug fix


## Which Components or Systems Does This Change Impact?
- [x] Validator Node


<!-- Thank you for your contribution! -->
