### PR TITLE
[compiler-v2] Test case reduced from move-stdlib showing opportunity for optimization

### DIFF
--- a/third_party/move/move-compiler-v2/tests/eager-pushes/move_stdlib_reduced.exp
+++ b/third_party/move/move-compiler-v2/tests/eager-pushes/move_stdlib_reduced.exp
@@ -1,0 +1,152 @@
+============ initial bytecode ================
+
+[variant baseline]
+fun m::bar($t0: &mut u64, $t1: u64) {
+  0: write_ref($t0, $t1)
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::foo($t0: &mut u64, $t1: u64) {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &mut u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: label L0
+  1: $t3 := 0
+  2: $t2 := >($t1, $t3)
+  3: if ($t2) goto 4 else goto 12
+  4: label L2
+  5: $t4 := infer($t0)
+  6: $t5 := m::one()
+  7: m::bar($t4, $t5)
+  8: $t7 := 1
+  9: $t6 := -($t1, $t7)
+ 10: $t1 := infer($t6)
+ 11: goto 14
+ 12: label L3
+ 13: goto 16
+ 14: label L4
+ 15: goto 0
+ 16: label L1
+ 17: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+  0: $t0 := 1
+  1: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::bar($t0: &mut u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: write_ref($t0, $t1)
+     # live vars:
+  1: return ()
+}
+
+
+[variant baseline]
+public fun m::foo($t0: &mut u64, $t1: u64) {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &mut u64
+     var $t5: u64 [unused]
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
+     # live vars: $t0, $t1
+  0: label L0
+     # live vars: $t0, $t1
+  1: $t3 := 0
+     # live vars: $t0, $t1, $t3
+  2: $t2 := >($t1, $t3)
+     # live vars: $t0, $t1, $t2
+  3: if ($t2) goto 4 else goto 12
+     # live vars: $t0, $t1
+  4: label L2
+     # live vars: $t0, $t1
+  5: $t4 := copy($t0)
+     # live vars: $t0, $t1, $t4
+  6: $t3 := m::one()
+     # live vars: $t0, $t1, $t3, $t4
+  7: m::bar($t4, $t3)
+     # live vars: $t0, $t1
+  8: $t3 := 1
+     # live vars: $t0, $t1, $t3
+  9: $t3 := -($t1, $t3)
+     # live vars: $t0, $t3
+ 10: $t1 := move($t3)
+     # live vars: $t0, $t1
+ 11: goto 0
+     # live vars: $t0, $t1
+ 12: label L3
+     # live vars: $t0
+ 13: drop($t0)
+     # live vars:
+ 14: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v7
+module c0ffee.m {
+
+
+bar(Arg0: &mut u64, Arg1: u64) /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[1](Arg1: u64)
+	1: MoveLoc[0](Arg0: &mut u64)
+	2: WriteRef
+	3: Ret
+}
+public foo(Arg0: &mut u64, Arg1: u64) /* def_idx: 1 */ {
+L2:	loc0: u64
+L3:	loc1: &mut u64
+B0:
+	0: CopyLoc[1](Arg1: u64)
+	1: LdU64(0)
+	2: Gt
+	3: BrFalse(16)
+B1:
+	4: CopyLoc[0](Arg0: &mut u64)
+	5: StLoc[3](loc1: &mut u64)
+	6: Call one(): u64
+	7: StLoc[2](loc0: u64)
+	8: MoveLoc[3](loc1: &mut u64)
+	9: MoveLoc[2](loc0: u64)
+	10: Call bar(&mut u64, u64)
+	11: MoveLoc[1](Arg1: u64)
+	12: LdU64(1)
+	13: Sub
+	14: StLoc[1](Arg1: u64)
+	15: Branch(0)
+B2:
+	16: MoveLoc[0](Arg0: &mut u64)
+	17: Pop
+	18: Ret
+}
+one(): u64 /* def_idx: 2 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/eager-pushes/move_stdlib_reduced.move
+++ b/third_party/move/move-compiler-v2/tests/eager-pushes/move_stdlib_reduced.move
@@ -1,0 +1,17 @@
+// Test case to showcase https://github.com/aptos-labs/aptos-core/issues/15339
+module 0xc0ffee::m {
+    fun one(): u64 {
+        1
+    }
+
+    fun bar(x: &mut u64, i: u64) {
+        *x = i;
+    }
+
+    public fun foo(x: &mut u64, len: u64) {
+        while (len > 0) {
+            bar(x, one());
+            len = len - 1;
+        };
+    }
+}


### PR DESCRIPTION
## Description
Adds a test case to support the description in the issue: https://github.com/aptos-labs/aptos-core/issues/15339.

This test case was reduced from a function (`vector::reverse_append`) in move stdlib.

## How Has This Been Tested?

Test added.
