### PR TITLE
revert buildx action version

### DIFF
--- a/.github/actions/buildx-setup/action.yml
+++ b/.github/actions/buildx-setup/action.yml
@@ -10,10 +10,11 @@ runs:
       run: docker context create builders
 
     - name: setup docker buildx
-      uses: aptos-labs/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # pin v3.7.1
+      uses: aptos-labs/setup-buildx-action@7952e9cf0debaf1f3f3e5dc7d9c5ea6ececb127e # pin v2.4.0
       with:
         endpoint: builders
-        version: v0.17.1
+        version: v0.11.0
+        custom-name: "core-builder"
         keep-state: true
         config-inline: |
           [worker.oci]


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Reverts the buildx actions upgrade introduces in #15228. For the docker cache reuse to work properly, builder name should remain the same for all instantiations. 