### PR TITLE
Add a `--node-api-key` flag to the `aptos move replay` command to enable querying the full node using an API key

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+# Unreleased
+
+- Add `--node-api-key` flag to `aptos move replay` to allow for querying the fullnode with an API key.
+
+
 ## [4.5.0] - 2024/11/15
 - Determine network from URL to make explorer links better for legacy users
 - Add support for AIP-80 compliant strings when importing using the CLI arguments or manual input.

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -45,7 +45,7 @@ use aptos_move_debugger::aptos_debugger::AptosDebugger;
 use aptos_rest_client::{
     aptos_api_types::{EntryFunctionId, HexEncodedBytes, IdentifierWrapper, MoveModuleId},
     error::RestError,
-    Client,
+    AptosBaseUrl, Client,
 };
 use aptos_types::{
     account_address::{create_resource_address, AccountAddress},
@@ -2179,6 +2179,11 @@ pub struct Replay {
     /// If present, skip the comparison against the expected transaction output.
     #[clap(long)]
     pub(crate) skip_comparison: bool,
+
+    /// Key to use for ratelimiting purposes with the node API. This value will be used
+    /// as `Authorization: Bearer <key>`
+    #[clap(long)]
+    pub(crate) node_api_key: Option<String>,
 }
 
 impl FromStr for ReplayNetworkSelection {
@@ -2216,10 +2221,20 @@ impl CliCommand<TransactionSummary> for Replay {
             RestEndpoint(url) => url,
         };
 
-        let debugger = AptosDebugger::rest_client(Client::new(
+        // Build the client
+        let client = Client::builder(AptosBaseUrl::Custom(
             Url::parse(rest_endpoint)
                 .map_err(|_err| CliError::UnableToParse("url", rest_endpoint.to_string()))?,
-        ))?;
+        ));
+
+        // add the node API key if it is provided
+        let client = if let Some(api_key) = self.node_api_key {
+            client.api_key(&api_key).unwrap().build()
+        } else {
+            client.build()
+        };
+
+        let debugger = AptosDebugger::rest_client(client)?;
 
         // Fetch the transaction to replay.
         let (txn, txn_info) = debugger


### PR DESCRIPTION
## Description
For future Buildspace usage, we need to be able to provide an API key for the replay job to avoid server rate limiting.
For more context:
- https://www.notion.so/aptoslabs/Buildspace-Design-1278b846eb728055bf61e15c48a9b209?pvs=4#12e8b846eb728042af53f2e25f6719ed
- https://aptos-org.slack.com/archives/C06F3NBT1RP/p1731950102620299
- https://aptos-org.slack.com/archives/C05EJFD3E3S/p1732042568948249?thread_ts=1732040752.508009&cid=C05EJFD3E3S

```
cargo run --bin aptos move replay --help

      --network <NETWORK>
          The network to replay on.
          
          Possible values: mainnet, testnet, <REST_ENDPOINT_URL>

      --txn-id <TXN_ID>
          The id of the transaction to replay. Also being referred to as "version" in some contexts

      --benchmark
          If this option is set, benchmark the transaction and report the running time(s)

      --profile-gas
          If this option is set, profile the transaction and generate a detailed report of its gas usage

      --skip-comparison
          If present, skip the comparison against the expected transaction output

      --node-api-key <NODE_API_KEY>
          Key to use for ratelimiting purposes with the node API. This value will be used as `Authorization: Bearer <key>`

  -h, --help
          Print help (see a summary with '-h')

  -V, --version
          Print version
```


## How Has This Been Tested?

Command without `--node-api-key` executed successfully

```
cargo run --bin aptos move replay --profile-gas --network testnet --txn-id 830794924
```

Command with `--node-api-key` executed successfully and can see a spike in the Node api metrics in my Build account

```
cargo run --bin aptos move replay --profile-gas --network testnet --txn-id 830794924 --node-api-key aptos_123asd
```

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
