### PR TITLE
[consensus] sync improvements to help slow nodes sync better

### DIFF
--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -68,6 +68,13 @@ impl BlockStore {
             && !self.block_exists(li.commit_info().id()))
             || self.commit_root().round() + 30.max(2 * self.vote_back_pressure_limit)
                 < li.commit_info().round()
+            // If the LI commit block timestamp is more than 30 secs ahead of self commit block
+            // timestamp, sync to the ledger info
+            || li
+                .commit_info()
+                .timestamp_usecs()
+                .saturating_sub(self.commit_root().timestamp_usecs())
+                >= Duration::from_secs(30).as_micros() as u64
     }
 
     /// Checks if quorum certificate can be inserted in block store without RPC

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -260,6 +260,7 @@ impl InnerBuilder {
             self.config.db_quota,
             self.config.batch_quota,
             signer,
+            Duration::from_secs(60).as_micros() as u64,
         ));
         self.batch_store = Some(batch_store.clone());
         let batch_reader = Arc::new(BatchReaderImpl::new(batch_store.clone(), batch_requester));

--- a/consensus/src/quorum_store/tests/batch_store_test.rs
+++ b/consensus/src/quorum_store/tests/batch_store_test.rs
@@ -36,6 +36,7 @@ pub fn batch_store_for_test(memory_quota: usize) -> Arc<BatchStore> {
         2001,         // db quota
         2001,         // batch quota
         signers[0].clone(),
+        0,
     ))
 }
 

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -316,7 +316,7 @@ pub(crate) fn realistic_env_max_load_test(
         .add_latency_threshold(4.5, LatencyType::P70)
         .add_chain_progress(StateProgressThreshold {
             max_non_epoch_no_progress_secs: 15.0,
-            max_epoch_no_progress_secs: 15.0,
+            max_epoch_no_progress_secs: 16.0,
             max_non_epoch_round_gap: 4,
             max_epoch_round_gap: 4,
         });

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -303,9 +303,9 @@ pub(crate) fn realistic_env_max_load_test(
         .add_system_metrics_threshold(SystemMetricsThreshold::new(
             // Check that we don't use more than 18 CPU cores for 15% of the time.
             MetricsThreshold::new(25.0, 15),
-            // Memory starts around 7GB, and grows around 1.4GB/hr in this test.
+            // Memory starts around 8GB, and grows around 1.4GB/hr in this test.
             // Check that we don't use more than final expected memory for more than 20% of the time.
-            MetricsThreshold::new_gb(7.0 + 1.4 * (duration_secs as f64 / 3600.0), 20),
+            MetricsThreshold::new_gb(8.0 + 1.4 * (duration_secs as f64 / 3600.0), 20),
         ))
         .add_no_restarts()
         .add_wait_for_catchup_s(


### PR DESCRIPTION
## Description

- In Quorum store, we garbage collect batches 60 seconds after they are expired based on block timestamp, to help slow peers fetch batches and execute without falling back to state sync.
- In consensus, peers will state sync if their local committed block timestamp is behind 30s from the remote committed block timestamp.
