### PR TITLE
Replay override disables "entry compatibility" timed feature flag

### DIFF
--- a/types/src/on_chain_config/timed_features.rs
+++ b/types/src/on_chain_config/timed_features.rs
@@ -44,7 +44,7 @@ impl TimedFeatureOverride {
             Replay => match flag {
                 LimitTypeTagSize => true,
                 ModuleComplexityCheck => true,
-                EntryCompatibility => true,
+                EntryCompatibility => false,
                 // Add overrides for replay here.
                 _ => return None,
             },


### PR DESCRIPTION
## Description

The replay override disables the "entry compatibility" timed feature flag.

## How Has This Been Tested?

Manually ran replay-verify for mainnet.
