### PR TITLE
Fix Emitted Data for `aptos-token-objects::collection::Mutation` V2 Event

### DIFF
--- a/aptos-move/framework/aptos-token-objects/doc/collection.md
+++ b/aptos-move/framework/aptos-token-objects/doc/collection.md
@@ -1722,7 +1722,6 @@ After changing the collection's name, to create tokens - only call functions tha
 <pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_set_description">set_description</a>(mutator_ref: &<a href="collection.md#0x4_collection_MutatorRef">MutatorRef</a>, description: String) <b>acquires</b> <a href="collection.md#0x4_collection_Collection">Collection</a> {
     <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&description) &lt;= <a href="collection.md#0x4_collection_MAX_DESCRIPTION_LENGTH">MAX_DESCRIPTION_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="collection.md#0x4_collection_EDESCRIPTION_TOO_LONG">EDESCRIPTION_TOO_LONG</a>));
     <b>let</b> <a href="collection.md#0x4_collection">collection</a> = <a href="collection.md#0x4_collection_borrow_mut">borrow_mut</a>(mutator_ref);
-    <a href="collection.md#0x4_collection">collection</a>.description = description;
     <b>if</b> (std::features::module_event_migration_enabled()) {
         <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(<a href="collection.md#0x4_collection_Mutation">Mutation</a> {
             mutated_field_name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(b"description"),
@@ -1736,6 +1735,7 @@ After changing the collection's name, to create tokens - only call functions tha
             <a href="collection.md#0x4_collection_MutationEvent">MutationEvent</a> { mutated_field_name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(b"description") },
         );
     };
+    <a href="collection.md#0x4_collection">collection</a>.description = description;
 }
 </code></pre>
 
@@ -1761,7 +1761,6 @@ After changing the collection's name, to create tokens - only call functions tha
 <pre><code><b>public</b> <b>fun</b> <a href="collection.md#0x4_collection_set_uri">set_uri</a>(mutator_ref: &<a href="collection.md#0x4_collection_MutatorRef">MutatorRef</a>, uri: String) <b>acquires</b> <a href="collection.md#0x4_collection_Collection">Collection</a> {
     <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_length">string::length</a>(&uri) &lt;= <a href="collection.md#0x4_collection_MAX_URI_LENGTH">MAX_URI_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_out_of_range">error::out_of_range</a>(<a href="collection.md#0x4_collection_EURI_TOO_LONG">EURI_TOO_LONG</a>));
     <b>let</b> <a href="collection.md#0x4_collection">collection</a> = <a href="collection.md#0x4_collection_borrow_mut">borrow_mut</a>(mutator_ref);
-    <a href="collection.md#0x4_collection">collection</a>.uri = uri;
     <b>if</b> (std::features::module_event_migration_enabled()) {
         <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(<a href="collection.md#0x4_collection_Mutation">Mutation</a> {
             mutated_field_name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(b"uri"),
@@ -1775,6 +1774,7 @@ After changing the collection's name, to create tokens - only call functions tha
             <a href="collection.md#0x4_collection_MutationEvent">MutationEvent</a> { mutated_field_name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(b"uri") },
         );
     };
+    <a href="collection.md#0x4_collection">collection</a>.uri = uri;
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-token-objects/sources/collection.move
+++ b/aptos-move/framework/aptos-token-objects/sources/collection.move
@@ -673,7 +673,6 @@ module aptos_token_objects::collection {
     public fun set_description(mutator_ref: &MutatorRef, description: String) acquires Collection {
         assert!(string::length(&description) <= MAX_DESCRIPTION_LENGTH, error::out_of_range(EDESCRIPTION_TOO_LONG));
         let collection = borrow_mut(mutator_ref);
-        collection.description = description;
         if (std::features::module_event_migration_enabled()) {
             event::emit(Mutation {
                 mutated_field_name: string::utf8(b"description"),
@@ -687,12 +686,12 @@ module aptos_token_objects::collection {
                 MutationEvent { mutated_field_name: string::utf8(b"description") },
             );
         };
+        collection.description = description;
     }
 
     public fun set_uri(mutator_ref: &MutatorRef, uri: String) acquires Collection {
         assert!(string::length(&uri) <= MAX_URI_LENGTH, error::out_of_range(EURI_TOO_LONG));
         let collection = borrow_mut(mutator_ref);
-        collection.uri = uri;
         if (std::features::module_event_migration_enabled()) {
             event::emit(Mutation {
                 mutated_field_name: string::utf8(b"uri"),
@@ -706,6 +705,7 @@ module aptos_token_objects::collection {
                 MutationEvent { mutated_field_name: string::utf8(b"uri") },
             );
         };
+        collection.uri = uri;
     }
 
     public fun set_max_supply(mutator_ref: &MutatorRef, max_supply: u64) acquires ConcurrentSupply, FixedSupply {


### PR DESCRIPTION
## Description
In `aptos-token-objects::collection`, the `set_description` and `set_uri` functions replace the data with the new value before emitting the event. This causes the Mutation V2 event to incorrectly emit the new value as the old value.

This update fixes the code to ensure the correct data is emitted.

Resolve https://github.com/aptos-labs/aptos-core/issues/15373.

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

<!-- Thank you for your contribution! -->
