### PR TITLE
Resolve compiler warning by removing unused line

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account.move
@@ -1590,7 +1590,6 @@ module aptos_framework::account {
         create_account_unchecked(addr);
         register_coin<FakeCoin>(addr);
 
-        let eventhandle = &borrow_global<Account>(addr).coin_register_events;
         let event = CoinRegister { account: addr, type_info: type_info::type_of<FakeCoin>() };
 
         let events = event::emitted_events<CoinRegister>();


### PR DESCRIPTION
## Description
This PR removes an unused line from the unit test `test_events` in the `account` module (`aptos-move/framework/aptos-framework/sources/account.move`):
`let eventhandle = &borrow_global<Account>(addr).coin_register_events;`

## How to generate the warning?
To generate the warning, create a module and bring the `account` module into scope. For example:
```
module 0x9000::test {
    use aptos_framework::account;
}
```
now use `aptos move test`, the following warning could be seen:
```
warning[W09003]: unused assignment
     ┌─ /home/levi0804/.move/https___github_com_aptos-labs_aptos-core_git_mainnet/aptos-move/framework/aptos-framework/sources/account.move:1538:13
     │
1538 │         let eventhandle = &borrow_global<Account>(addr).coin_register_events;
     │             ^^^^^^^^^^^ Unused assignment or binding for local 'eventhandle'. Consider removing, replacing with '_', or prefixing with '_' (e.g., '_eventhandle')
```

## How Has This Been Tested?
I removed the mentioned line locally from the unit test in the `account` module and ran `aptos move test --skip-fetch-latest-git-deps` on a module similar to the one above (`0x9000::test`), which resolved the compiler warning

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests