### PR TITLE
Fix the type in V2 event name:  Change `CollectionMaxiumMutate` to `CollectionMaximumMutate`

### DIFF
--- a/aptos-move/framework/aptos-token/doc/token_event_store.md
+++ b/aptos-move/framework/aptos-token/doc/token_event_store.md
@@ -11,7 +11,7 @@ This module provides utils to add and emit new token events that are not in toke
 -  [Struct `CollectionUriMutateEvent`](#0x3_token_event_store_CollectionUriMutateEvent)
 -  [Struct `CollectionUriMutate`](#0x3_token_event_store_CollectionUriMutate)
 -  [Struct `CollectionMaxiumMutateEvent`](#0x3_token_event_store_CollectionMaxiumMutateEvent)
--  [Struct `CollectionMaxiumMutate`](#0x3_token_event_store_CollectionMaxiumMutate)
+-  [Struct `CollectionMaximumMutate`](#0x3_token_event_store_CollectionMaximumMutate)
 -  [Struct `OptInTransferEvent`](#0x3_token_event_store_OptInTransferEvent)
 -  [Struct `OptInTransfer`](#0x3_token_event_store_OptInTransfer)
 -  [Struct `UriMutationEvent`](#0x3_token_event_store_UriMutationEvent)
@@ -25,6 +25,7 @@ This module provides utils to add and emit new token events that are not in toke
 -  [Struct `MaxiumMutateEvent`](#0x3_token_event_store_MaxiumMutateEvent)
 -  [Struct `MaximumMutate`](#0x3_token_event_store_MaximumMutate)
 -  [Resource `TokenEventStoreV1`](#0x3_token_event_store_TokenEventStoreV1)
+-  [Struct `CollectionMaxiumMutate`](#0x3_token_event_store_CollectionMaxiumMutate)
 -  [Function `initialize_token_event_store`](#0x3_token_event_store_initialize_token_event_store)
 -  [Function `emit_collection_uri_mutate_event`](#0x3_token_event_store_emit_collection_uri_mutate_event)
 -  [Function `emit_collection_description_mutate_event`](#0x3_token_event_store_emit_collection_description_mutate_event)
@@ -292,15 +293,15 @@ Event emitted when the collection maximum is mutated
 
 </details>
 
-<a id="0x3_token_event_store_CollectionMaxiumMutate"></a>
+<a id="0x3_token_event_store_CollectionMaximumMutate"></a>
 
-## Struct `CollectionMaxiumMutate`
+## Struct `CollectionMaximumMutate`
 
 Event emitted when the collection maximum is mutated
 
 
 <pre><code>#[<a href="../../aptos-framework/doc/event.md#0x1_event">event</a>]
-<b>struct</b> <a href="token_event_store.md#0x3_token_event_store_CollectionMaxiumMutate">CollectionMaxiumMutate</a> <b>has</b> drop, store
+<b>struct</b> <a href="token_event_store.md#0x3_token_event_store_CollectionMaximumMutate">CollectionMaximumMutate</a> <b>has</b> drop, store
 </code></pre>
 
 
@@ -1068,6 +1069,53 @@ Event emitted when the token maximum is mutated
 
 </details>
 
+<a id="0x3_token_event_store_CollectionMaxiumMutate"></a>
+
+## Struct `CollectionMaxiumMutate`
+
+
+
+<pre><code>#[<a href="../../aptos-framework/doc/event.md#0x1_event">event</a>]
+#[deprecated]
+<b>struct</b> <a href="token_event_store.md#0x3_token_event_store_CollectionMaxiumMutate">CollectionMaxiumMutate</a> <b>has</b> drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>creator_addr: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>collection_name: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>old_maximum: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>new_maximum: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
 <a id="0x3_token_event_store_initialize_token_event_store"></a>
 
 ## Function `initialize_token_event_store`
@@ -1226,7 +1274,7 @@ Emit the collection maximum mutation event
     <b>let</b> <a href="token_event_store.md#0x3_token_event_store">token_event_store</a> = <b>borrow_global_mut</b>&lt;<a href="token_event_store.md#0x3_token_event_store_TokenEventStoreV1">TokenEventStoreV1</a>&gt;(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(creator));
     <b>if</b> (std::features::module_event_migration_enabled()) {
         <a href="../../aptos-framework/doc/event.md#0x1_event_emit">event::emit</a>(
-            <a href="token_event_store.md#0x3_token_event_store_CollectionMaxiumMutate">CollectionMaxiumMutate</a> {
+            <a href="token_event_store.md#0x3_token_event_store_CollectionMaximumMutate">CollectionMaximumMutate</a> {
                 creator_addr: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(creator),
                 collection_name: collection,
                 old_maximum,

--- a/aptos-move/framework/aptos-token/sources/token_event_store.move
+++ b/aptos-move/framework/aptos-token/sources/token_event_store.move
@@ -59,7 +59,7 @@ module aptos_token::token_event_store {
 
     #[event]
     /// Event emitted when the collection maximum is mutated
-    struct CollectionMaxiumMutate has drop, store {
+    struct CollectionMaximumMutate has drop, store {
         creator_addr: address,
         collection_name: String,
         old_maximum: u64,
@@ -295,7 +295,7 @@ module aptos_token::token_event_store {
         let token_event_store = borrow_global_mut<TokenEventStoreV1>(signer::address_of(creator));
         if (std::features::module_event_migration_enabled()) {
             event::emit(
-                CollectionMaxiumMutate {
+                CollectionMaximumMutate {
                     creator_addr: signer::address_of(creator),
                     collection_name: collection,
                     old_maximum,
@@ -528,5 +528,14 @@ module aptos_token::token_event_store {
                 event,
             );
         };
+    }
+
+    #[deprecated]
+    #[event]
+    struct CollectionMaxiumMutate has drop, store {
+        creator_addr: address,
+        collection_name: String,
+        old_maximum: u64,
+        new_maximum: u64,
     }
 }


### PR DESCRIPTION

## Description
Corrected `CollectionMaxiumMutate` to `CollectionMaximumMutate` in `token_event_store.move`

