### PR TITLE
[Framework][TESTNET ONLY] Add a testnet only function to allow burning APT

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/aptos_coin.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_coin.move
@@ -157,6 +157,9 @@ module aptos_framework::aptos_coin {
     use aptos_framework::fungible_asset::FungibleAsset;
 
     #[test_only]
+    friend aptos_framework::transaction_fee;
+
+    #[test_only]
     public fun mint_apt_fa_for_test(amount: u64): FungibleAsset acquires MintCapStore {
         ensure_initialized_with_apt_fa_metadata_for_test();
         coin::coin_to_fungible_asset(


### PR DESCRIPTION
## Description
Add a testnet only function to allow burning APT

## How Has This Been Tested?
Unit tests

## Key Areas to Review
That this function is only callable on testnet

## Type of Change
- [ x ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ x ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ x ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ x ] I tested both happy and unhappy path of the functionality
- [ x ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
