### PR TITLE
Enable Collection Owner feature

### DIFF
--- a/aptos-move/aptos-release-builder/data/collection-owner.yaml
+++ b/aptos-move/aptos-release-builder/data/collection-owner.yaml
@@ -1,0 +1,13 @@
+---
+remote_endpoint: ~
+name: "v1.23.1"
+proposals:
+  - name: feature_flags
+    metadata:
+      title: "Collection Owner feature flag"
+      description: "Enable creating collections with permissions as the owner of the collection"
+    execution_mode: MultiStep
+    update_sequence:
+      - FeatureFlag:
+          enabled:
+            - collection_owner


### PR DESCRIPTION
## Description
As part of [AIP 95 collections permissions update](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-95.md), enable feature Collection Owner. This enables users to create collections as the collection owner. 


## How Has This Been Tested?
New functions added and tested.

## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [X] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
