### PR TITLE
fix deadlock between the mempool and the db

### DIFF
--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -16,7 +16,7 @@ use crate::{
         },
         use_case_history::UseCaseHistory,
     },
-    thread_pool::IO_POOL,
+    thread_pool::{IO_POOL, VALIDATION_POOL},
     QuorumStoreRequest, QuorumStoreResponse, SubmissionStatus,
 };
 use anyhow::Result;
@@ -45,7 +45,6 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::runtime::Handle;
-
 // ============================== //
 //  broadcast_coordinator tasks  //
 // ============================== //
@@ -393,18 +392,20 @@ fn validate_and_add_transactions<NetworkClient, TransactionValidator>(
     let vm_validation_timer = counters::PROCESS_TXN_BREAKDOWN_LATENCY
         .with_label_values(&[counters::VM_VALIDATION_LABEL])
         .start_timer();
-    let validation_results = transactions
-        .par_iter()
-        .map(|t| {
-            let result = smp.validator.read().validate_transaction(t.0.clone());
-            // Pre-compute the hash and length if the transaction is valid, before locking mempool
-            if result.is_ok() {
-                t.0.committed_hash();
-                t.0.txn_bytes_len();
-            }
-            result
-        })
-        .collect::<Vec<_>>();
+    let validation_results = VALIDATION_POOL.install(|| {
+        transactions
+            .par_iter()
+            .map(|t| {
+                let result = smp.validator.read().validate_transaction(t.0.clone());
+                // Pre-compute the hash and length if the transaction is valid, before locking mempool
+                if result.is_ok() {
+                    t.0.committed_hash();
+                    t.0.txn_bytes_len();
+                }
+                result
+            })
+            .collect::<Vec<_>>()
+    });
     vm_validation_timer.stop_and_record();
     {
         let mut mempool = smp.mempool.lock();

--- a/mempool/src/thread_pool.rs
+++ b/mempool/src/thread_pool.rs
@@ -11,3 +11,10 @@ pub(crate) static IO_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| {
         .build()
         .unwrap()
 });
+
+pub(crate) static VALIDATION_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| {
+    rayon::ThreadPoolBuilder::new()
+        .thread_name(|index| format!("mempool_vali_{}", index))
+        .build()
+        .unwrap()
+});

--- a/storage/storage-interface/src/state_store/sharded_state_updates.rs
+++ b/storage/storage-interface/src/state_store/sharded_state_updates.rs
@@ -31,12 +31,14 @@ impl ShardedStateUpdates {
     }
 
     pub fn merge(&mut self, other: Self) {
-        self.shards
-            .par_iter_mut()
-            .zip_eq(other.shards.into_par_iter())
-            .for_each(|(l, r)| {
-                l.extend(r);
-            })
+        THREAD_MANAGER.get_exe_cpu_pool().install(|| {
+            self.shards
+                .par_iter_mut()
+                .zip_eq(other.shards.into_par_iter())
+                .for_each(|(l, r)| {
+                    l.extend(r);
+                })
+        })
     }
 
     pub fn clone_merge(&mut self, other: &Self) {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

We started to do this par_iter in the global pool instead of the "exe pool" here:
https://github.com/aptos-labs/aptos-core/pull/15184#discussion_r1861207119

and it triggered a deadlock like what we saw repeatedly before:
https://github.com/aptos-labs/aptos-core/pull/15068

To fix it and safe guard it, I am doing these two things in this PR:
1. move the mempool validation to its dedicated pool -- it's not ideal to wait on a lock in the global pool
2. move the par_iter back to the "exe pool"

it's not ideal that any rayon pool is involved in the "current_state" lock whose critical section was meant to be small. Won't be a issue any more once I change the representation of the state delta from hashmaps to layeredmaps.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Validator Node




<!-- Thank you for your contribution! -->
