### PR TITLE
[script-composer] Add infer functionality, fix multiple return values

### DIFF
--- a/aptos-move/script-composer/src/tests/mod.rs
+++ b/aptos-move/script-composer/src/tests/mod.rs
@@ -301,7 +301,9 @@ fn test_module() {
 
     run_txn(builder, &mut h);
 
-    // Create a copyable value and move it twice
+    // Create a droppable and copyable value and move it twice. This is ok because the builder
+    // will use copy instruction instead of move instruction for values that are both copyable
+    // and droppable.
     let mut builder = TransactionComposer::single_signer();
     load_module(&mut builder, &h, "0x1::batched_execution");
     let returns_1 = builder
@@ -329,10 +331,51 @@ fn test_module() {
         )
         .unwrap();
 
-    assert!(builder
+    builder
         .add_batched_call(
             "0x1::batched_execution".to_string(),
             "consume_copyable_value".to_string(),
+            vec![],
+            vec![
+                returns_1,
+                CallArgument::new_bytes(MoveValue::U8(10).simple_serialize().unwrap()),
+            ],
+        )
+        .unwrap();
+
+    run_txn(builder, &mut h);
+
+    // Create a droppable value and move it twice
+    let mut builder = TransactionComposer::single_signer();
+    load_module(&mut builder, &h, "0x1::batched_execution");
+    let returns_1 = builder
+        .add_batched_call(
+            "0x1::batched_execution".to_string(),
+            "create_droppable_value".to_string(),
+            vec![],
+            vec![CallArgument::new_bytes(
+                MoveValue::U8(10).simple_serialize().unwrap(),
+            )],
+        )
+        .unwrap()
+        .pop()
+        .unwrap();
+
+    builder
+        .add_batched_call(
+            "0x1::batched_execution".to_string(),
+            "consume_droppable_value".to_string(),
+            vec![],
+            vec![
+                returns_1.clone(),
+                CallArgument::new_bytes(MoveValue::U8(10).simple_serialize().unwrap()),
+            ],
+        )
+        .unwrap();
+    assert!(builder
+        .add_batched_call(
+            "0x1::batched_execution".to_string(),
+            "consume_droppable_value".to_string(),
             vec![],
             vec![
                 returns_1,
@@ -635,4 +678,31 @@ fn test_module() {
             ],
         )
         .is_err());
+
+    // Test functions with multiple return values.
+    // Create a copyable value and copy it twice
+    let mut builder = TransactionComposer::single_signer();
+    load_module(&mut builder, &h, "0x1::batched_execution");
+    let returns = builder
+        .add_batched_call(
+            "0x1::batched_execution".to_string(),
+            "multiple_returns".to_string(),
+            vec![],
+            vec![],
+        )
+        .unwrap();
+
+    builder
+        .add_batched_call(
+            "0x1::batched_execution".to_string(),
+            "consume_non_droppable_value".to_string(),
+            vec![],
+            vec![
+                returns[1].clone(),
+                CallArgument::new_bytes(MoveValue::U8(1).simple_serialize().unwrap()),
+            ],
+        )
+        .unwrap();
+
+    run_txn(builder, &mut h);
 }

--- a/aptos-move/script-composer/src/tests/test_modules/sources/test.move
+++ b/aptos-move/script-composer/src/tests/test_modules/sources/test.move
@@ -10,7 +10,7 @@ module 0x1::batched_execution {
         val: u8,
     }
 
-    struct CopyableValue has copy {
+    struct CopyableValue has drop, copy {
         val: u8,
     }
 
@@ -72,5 +72,9 @@ module 0x1::batched_execution {
     public fun consume_generic_non_droppable_value<T>(v: GenericNonDroppableValue<T>, expected_val: u8) {
         let GenericNonDroppableValue { val } = v;
         assert!(val == expected_val, 10);
+    }
+
+    public fun multiple_returns(): (DroppableValue, NonDroppableValue) {
+        return (DroppableValue { val: 0 }, NonDroppableValue { val: 1} )
     }
 }


### PR DESCRIPTION
## Description

Fixes two issues for the script composer:
1. The current code handled call convention incorrectly. The returned values are stored in the reverse order.
2. Infer the operation type for copyable and droppable values, so that caller wouldn't need to distinguish between copy and move for those primitive values.

## How Has This Been Tested?
Added three test cases:
1. Created a function to return two values and make sure it can be stored properly.
2. Created a transaction that invokes a function that returned a copyable and droppable value, and use the destructor twice. This can be built properly (positive case)
3. Created a transaction that invokes a function that returned a droppable but not copyable value, and use the destructor twice. Builder will complain on this case (negative case)

## Key Areas to Review

Whether we tested the two features sufficiently.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
