### PR TITLE
Updating serialization constant in the API

### DIFF
--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -25,8 +25,7 @@ use aptos_api_types::{
     AsConverter, EncodeSubmissionRequest, GasEstimation, GasEstimationBcs, HashValue,
     HexEncodedBytes, LedgerInfo, MoveType, PendingTransaction, SubmitTransactionRequest,
     Transaction, TransactionData, TransactionOnChainData, TransactionsBatchSingleSubmissionFailure,
-    TransactionsBatchSubmissionResult, UserTransaction, VerifyInput, VerifyInputWithRecursion,
-    MAX_RECURSIVE_TYPES_ALLOWED, U64,
+    TransactionsBatchSubmissionResult, UserTransaction, VerifyInput, VerifyInputWithRecursion, U64,
 };
 use aptos_crypto::{hash::CryptoHash, signing_message};
 use aptos_types::{
@@ -1041,10 +1040,12 @@ impl TransactionsApi {
         ledger_info: &LedgerInfo,
         data: SubmitTransactionPost,
     ) -> Result<SignedTransaction, SubmitTransactionError> {
+        pub const MAX_SIGNED_TRANSACTION_DEPTH: usize = 16;
+
         match data {
             SubmitTransactionPost::Bcs(data) => {
                 let signed_transaction: SignedTransaction =
-                    bcs::from_bytes_with_limit(&data.0, MAX_RECURSIVE_TYPES_ALLOWED as usize)
+                    bcs::from_bytes_with_limit(&data.0, MAX_SIGNED_TRANSACTION_DEPTH)
                         .context("Failed to deserialize input into SignedTransaction")
                         .map_err(|err| {
                             SubmitTransactionError::bad_request_with_code(

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -523,7 +523,12 @@ pub enum MoveType {
 
 /// Maximum number of recursive types - Same as (non-public)
 /// move_core_types::safe_serialize::MAX_TYPE_TAG_NESTING
-pub const MAX_RECURSIVE_TYPES_ALLOWED: u8 = 8;
+/// We keep 16 for legacy tests
+pub const MAX_RECURSIVE_TYPES_ALLOWED: u8 = if cfg!(test) {
+    16
+} else {
+    8 // = move_core_types::safe_serialize::MAX_TYPE_TAG_NESTING
+};
 
 impl VerifyInputWithRecursion for MoveType {
     fn verify(&self, recursion_count: u8) -> anyhow::Result<()> {

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -1260,40 +1260,30 @@ mod tests {
     fn test_serialize_move_resource() {
         use AnnotatedMoveValue::*;
 
-        let res = MoveResource::try_from(annotated_move_struct(
-            "Values",
-            vec![
-                (identifier("field_u8"), U8(7)),
-                (identifier("field_u64"), U64(7)),
-                (identifier("field_u128"), U128(7)),
-                (identifier("field_bool"), Bool(true)),
-                (identifier("field_address"), Address(address("0xdd"))),
-                (
-                    identifier("field_vector"),
-                    Vector(TypeTag::U128, vec![U128(128)]),
-                ),
-                (identifier("field_bytes"), Bytes(vec![9, 9])),
-                (
-                    identifier("field_struct"),
-                    Struct(annotated_move_struct(
-                        "Nested",
-                        vec![(
-                            identifier("nested_vector"),
-                            Vector(
-                                TypeTag::Struct(Box::new(type_struct("Host"))),
-                                vec![Struct(annotated_move_struct(
-                                    "String",
-                                    vec![
-                                        (identifier("address1"), Address(address("0x0"))),
-                                        (identifier("address2"), Address(address("0x123"))),
-                                    ],
-                                ))],
-                            ),
-                        )],
-                    )),
-                ),
-            ],
-        ))
+        let res = MoveResource::try_from(annotated_move_struct("Values", vec![
+            (identifier("field_u8"), U8(7)),
+            (identifier("field_u64"), U64(7)),
+            (identifier("field_u128"), U128(7)),
+            (identifier("field_bool"), Bool(true)),
+            (identifier("field_address"), Address(address("0xdd"))),
+            (
+                identifier("field_vector"),
+                Vector(TypeTag::U128, vec![U128(128)]),
+            ),
+            (identifier("field_bytes"), Bytes(vec![9, 9])),
+            (
+                identifier("field_struct"),
+                Struct(annotated_move_struct("Nested", vec![(
+                    identifier("nested_vector"),
+                    Vector(TypeTag::Struct(Box::new(type_struct("Host"))), vec![
+                        Struct(annotated_move_struct("String", vec![
+                            (identifier("address1"), Address(address("0x0"))),
+                            (identifier("address2"), Address(address("0x123"))),
+                        ])),
+                    ]),
+                )])),
+            ),
+        ]))
         .unwrap();
         let value = to_value(&res).unwrap();
         assert_json(
@@ -1318,13 +1308,10 @@ mod tests {
 
     #[test]
     fn test_serialize_move_resource_with_address_0x0() {
-        let res = MoveResource::try_from(annotated_move_struct(
-            "Values",
-            vec![(
-                identifier("address_0x0"),
-                AnnotatedMoveValue::Address(address("0x0")),
-            )],
-        ))
+        let res = MoveResource::try_from(annotated_move_struct("Values", vec![(
+            identifier("address_0x0"),
+            AnnotatedMoveValue::Address(address("0x0")),
+        )]))
         .unwrap();
         let value = to_value(&res).unwrap();
         assert_json(

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -523,12 +523,7 @@ pub enum MoveType {
 
 /// Maximum number of recursive types - Same as (non-public)
 /// move_core_types::safe_serialize::MAX_TYPE_TAG_NESTING
-/// We keep 16 for legacy tests
-pub const MAX_RECURSIVE_TYPES_ALLOWED: u8 = if cfg!(test) {
-    16
-} else {
-    8 // = move_core_types::safe_serialize::MAX_TYPE_TAG_NESTING
-};
+pub const MAX_RECURSIVE_TYPES_ALLOWED: u8 = 8;
 
 impl VerifyInputWithRecursion for MoveType {
     fn verify(&self, recursion_count: u8) -> anyhow::Result<()> {


### PR DESCRIPTION
Updating serialization constant in the API

## How Has This Been Tested?
Existing tests


## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
