### PR TITLE
[pipeline] switch from broadcast channel to shared future

### DIFF
--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -107,15 +107,15 @@ impl PipelineFutures {
 pub struct PipelineInputTx {
     pub rand_tx: Option<oneshot::Sender<Option<Randomness>>>,
     pub order_vote_tx: Option<oneshot::Sender<()>>,
-    pub order_proof_tx: tokio::sync::broadcast::Sender<()>,
-    pub commit_proof_tx: tokio::sync::broadcast::Sender<LedgerInfoWithSignatures>,
+    pub order_proof_tx: Option<oneshot::Sender<()>>,
+    pub commit_proof_tx: Option<oneshot::Sender<LedgerInfoWithSignatures>>,
 }
 
 pub struct PipelineInputRx {
     pub rand_rx: oneshot::Receiver<Option<Randomness>>,
     pub order_vote_rx: oneshot::Receiver<()>,
-    pub order_proof_rx: tokio::sync::broadcast::Receiver<()>,
-    pub commit_proof_rx: tokio::sync::broadcast::Receiver<LedgerInfoWithSignatures>,
+    pub order_proof_fut: TaskFuture<()>,
+    pub commit_proof_fut: TaskFuture<LedgerInfoWithSignatures>,
 }
 
 /// A representation of a block that has been added to the execution pipeline. It might either be in ordered

--- a/consensus/src/pipeline/execution_schedule_phase.rs
+++ b/consensus/src/pipeline/execution_schedule_phase.rs
@@ -79,7 +79,7 @@ impl StatelessPipeline for ExecutionSchedulePhase {
             for b in &ordered_blocks {
                 if let Some(tx) = b.pipeline_tx().lock().as_mut() {
                     tx.rand_tx.take().map(|tx| tx.send(b.randomness().cloned()));
-                    let _ = tx.order_proof_tx.send(());
+                    tx.order_proof_tx.take().map(|tx| tx.send(()));
                 }
             }
 

--- a/consensus/src/pipeline/persisting_phase.rs
+++ b/consensus/src/pipeline/persisting_phase.rs
@@ -75,7 +75,9 @@ impl StatelessPipeline for PersistingPhase {
         {
             for b in &blocks {
                 if let Some(tx) = b.pipeline_tx().lock().as_mut() {
-                    let _ = tx.commit_proof_tx.send(commit_ledger_info.clone());
+                    tx.commit_proof_tx
+                        .take()
+                        .map(|tx| tx.send(commit_ledger_info.clone()));
                 }
                 b.wait_for_commit_ledger().await;
             }


### PR DESCRIPTION
The use case we have here is probably more suitable for a shared future with oneshot channel than a broadcast channel.
Broadcast channel has a property of dropping values if exceeds the capacity and receiver will see a RecvError::Lagged error. Using oneshot channel we can do exact once send easily and use shared future to share the result to multiple subscribers. 


## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
