### PR TITLE
[move] Change copybara to sync with move-on-aptos

### DIFF
--- a/third_party/copy.bara.sky
+++ b/third_party/copy.bara.sky
@@ -1,4 +1,4 @@
-moveUrl = "https://github.com/move-language/move.git"
+moveUrl = "https://github.com/move-language/move-on-aptos.git"
 aptosUrl = "https://github.com/aptos-labs/aptos-core.git"
 
 # Workflow to pull from Move to Aptos. This creates a draft PR at the fixed branch `from_move`
@@ -7,7 +7,7 @@ core.workflow(
     name = "pull_move",
     origin = git.github_origin(
         url = moveUrl,
-        ref = "aptos-main",
+        ref = "main",
     ),
     destination = git.destination(
         url = "NOT_SET", # use --git-destination-url to set this
@@ -33,7 +33,7 @@ core.workflow(
     ),
     destination = git.destination(
         url = "NOT_SET", # use --git-destination-url to set this
-        fetch = "aptos-main",
+        fetch = "main",
         push = "to_move",
         integrates = [],
     ),
@@ -55,7 +55,7 @@ core.workflow(
     ),
     destination = git.github_destination(
         url = moveUrl,
-        push = "aptos-main",
+        push = "main",
     ),
     mode = "ITERATIVE",
     origin_files = glob(["third_party/move/**"]),


### PR DESCRIPTION
## Description

This PR sets correct URLs, branches to sync `third-party/move` with `move-on-aptos`.

## How Has This Been Tested?

Created a PR in `move-on-aptos` with recent changes: https://github.com/move-language/move-on-aptos/pull/3

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
