### PR TITLE
[Inspection Service] Add simple consensus health check endpoint.

### DIFF
--- a/crates/aptos-inspection-service/src/server/index.rs
+++ b/crates/aptos-inspection-service/src/server/index.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    server::utils::CONTENT_TYPE_TEXT, CONFIGURATION_PATH, FORGE_METRICS_PATH, JSON_METRICS_PATH,
-    METRICS_PATH, PEER_INFORMATION_PATH, SYSTEM_INFORMATION_PATH,
+    server::utils::CONTENT_TYPE_TEXT, CONFIGURATION_PATH, CONSENSUS_HEALTH_CHECK_PATH,
+    FORGE_METRICS_PATH, JSON_METRICS_PATH, METRICS_PATH, PEER_INFORMATION_PATH,
+    SYSTEM_INFORMATION_PATH,
 };
 use hyper::{Body, StatusCode};
 
@@ -25,6 +26,7 @@ fn get_index_response() -> String {
     index_response.push("Welcome to the Aptos Inspection Service!".into());
     index_response.push("The following endpoints are available:".into());
     index_response.push(format!("\t- {}", CONFIGURATION_PATH));
+    index_response.push(format!("\t- {}", CONSENSUS_HEALTH_CHECK_PATH));
     index_response.push(format!("\t- {}", FORGE_METRICS_PATH));
     index_response.push(format!("\t- {}", JSON_METRICS_PATH));
     index_response.push(format!("\t- {}", METRICS_PATH));

--- a/crates/aptos-inspection-service/src/server/mod.rs
+++ b/crates/aptos-inspection-service/src/server/mod.rs
@@ -30,6 +30,7 @@ mod tests;
 
 // The list of endpoints offered by the inspection service
 pub const CONFIGURATION_PATH: &str = "/configuration";
+pub const CONSENSUS_HEALTH_CHECK_PATH: &str = "/consensus_health_check";
 pub const FORGE_METRICS_PATH: &str = "/forge_metrics";
 pub const INDEX_PATH: &str = "/";
 pub const JSON_METRICS_PATH: &str = "/json_metrics";
@@ -110,6 +111,11 @@ async fn serve_requests(
             // /configuration
             // Exposes the node configuration
             configuration::handle_configuration_request(&node_config)
+        },
+        CONSENSUS_HEALTH_CHECK_PATH => {
+            // /consensus_health_check
+            // Exposes the consensus health check
+            metrics::handle_consensus_health_check(&node_config).await
         },
         FORGE_METRICS_PATH => {
             // /forge_metrics

--- a/state-sync/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-driver/src/driver.rs
@@ -655,6 +655,9 @@ impl<
 
     /// Checks that state sync is making progress
     async fn drive_progress(&mut self) {
+        // Update the executing component metrics
+        self.update_executing_component_metrics();
+
         // Fetch the global data summary and verify we have active peers
         let global_data_summary = self.aptos_data_client.get_global_data_summary();
         if global_data_summary.is_empty() {
@@ -673,15 +676,6 @@ impl<
 
         // If consensus or consensus observer is executing, there's nothing to do
         if self.check_if_consensus_or_observer_executing() {
-            let executing_component = if self.driver_configuration.role.is_validator() {
-                ExecutingComponent::Consensus
-            } else {
-                ExecutingComponent::ConsensusObserver
-            };
-            metrics::increment_counter(
-                &metrics::EXECUTING_COMPONENT,
-                executing_component.get_label(),
-            );
             return;
         }
 
@@ -691,10 +685,6 @@ impl<
             let consensus_sync_request = self.consensus_notification_handler.get_sync_request();
 
             // Attempt to continuously sync
-            metrics::increment_counter(
-                &metrics::EXECUTING_COMPONENT,
-                ExecutingComponent::ContinuousSyncer.get_label(),
-            );
             if let Err(error) = self
                 .continuous_syncer
                 .drive_progress(consensus_sync_request)
@@ -708,20 +698,43 @@ impl<
                 );
                 metrics::increment_counter(&metrics::CONTINUOUS_SYNCER_ERRORS, error.get_label());
             }
-        } else {
-            metrics::increment_counter(
-                &metrics::EXECUTING_COMPONENT,
-                ExecutingComponent::Bootstrapper.get_label(),
+        } else if let Err(error) = self.bootstrapper.drive_progress(&global_data_summary).await {
+            sample!(
+                    SampleRate::Duration(Duration::from_secs(DRIVER_ERROR_LOG_FREQ_SECS)),
+                    warn!(LogSchema::new(LogEntry::Driver)
+                        .error(&error)
+                        .message("Error found when checking the bootstrapper progress!"));
             );
-            if let Err(error) = self.bootstrapper.drive_progress(&global_data_summary).await {
-                sample!(
-                        SampleRate::Duration(Duration::from_secs(DRIVER_ERROR_LOG_FREQ_SECS)),
-                        warn!(LogSchema::new(LogEntry::Driver)
-                            .error(&error)
-                            .message("Error found when checking the bootstrapper progress!"));
-                );
-                metrics::increment_counter(&metrics::BOOTSTRAPPER_ERRORS, error.get_label());
-            }
+            metrics::increment_counter(&metrics::BOOTSTRAPPER_ERRORS, error.get_label());
         };
+    }
+
+    /// Updates the executing component metrics for the driver
+    fn update_executing_component_metrics(&self) {
+        // Determine the executing component
+        let executing_component = if self.check_if_consensus_or_observer_executing() {
+            if self.driver_configuration.role.is_validator() {
+                ExecutingComponent::Consensus
+            } else {
+                ExecutingComponent::ConsensusObserver
+            }
+        } else if self.bootstrapper.is_bootstrapped() {
+            ExecutingComponent::ContinuousSyncer
+        } else {
+            ExecutingComponent::Bootstrapper
+        };
+
+        // Increment the executing component counter
+        metrics::increment_counter(
+            &metrics::EXECUTING_COMPONENT,
+            executing_component.get_label(),
+        );
+
+        // Set the consensus executing gauge
+        if executing_component == ExecutingComponent::Consensus {
+            metrics::CONSENSUS_EXECUTING_GAUGE.set(1);
+        } else {
+            metrics::CONSENSUS_EXECUTING_GAUGE.set(0);
+        }
     }
 }


### PR DESCRIPTION
## Description
This PR adds a simple consensus health check endpoint to the node inspection service. Specifically, the new endpoint `/consensus_health_check` will return a 200 status code iff the node is currently executing consensus.

To achieve this, I added a new metric gauge that is set iff consensus is executing on the validator node. The inspection service simply fetches the value of this gauge. The gauge can be seen [here](https://grafana.aptoslabs.com/d/ddphlx0p7mxvka/consensus-observer?from=2024-12-05T19:41:59.000Z&to=2024-12-05T19:54:13.000Z&var-Datasource=fHo-R604z&var-BigQuery=axNEitxVz&var-metrics_source=$__all&var-chain_name=forge-0&var-cluster=$__all&var-namespace=forge-e2e-pr-15512&var-kubernetes_pod_name=$__all&var-interval=$__auto&var-role=$__all&var-Filters=&viewPanel=panel-226).

## Testing Plan
Existing test infrastructure, and manual verification, e.g., I ran a local validator and pinged the endpoint:
```
% curl -I http://127.0.0.1:53822/consensus_health_check
HTTP/1.1 200 OK
content-type: text/plain
date: Thu, 05 Dec 2024 20:08:48 GMT

```