### PR TITLE
[CLI] Add `--fetch-deps-only` option to the `aptos move compile` to skip compilation

### DIFF
--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -30,6 +30,7 @@ use move_model::{
 };
 use move_package::{
     compilation::{compiled_package::CompiledPackage, package_layout::CompiledPackageLayout},
+    resolution::resolution_graph::ResolvedGraph,
     source_package::{
         manifest_parser::{parse_move_manifest_string, parse_source_manifest},
         std_lib::StdVersion,
@@ -220,49 +221,64 @@ impl BuiltPackage {
     /// This function currently reports all Move compilation errors and warnings to stdout,
     /// and is not `Ok` if there was an error among those.
     pub fn build(package_path: PathBuf, options: BuildOptions) -> anyhow::Result<Self> {
-        BuiltPackage::build_with_external_checks(package_path, options, vec![])
+        let build_config = Self::create_build_config(&options)?;
+        let resolved_graph = Self::prepare_resolution_graph(package_path, build_config.clone())?;
+        BuiltPackage::build_with_external_checks(resolved_graph, options, build_config, vec![])
+    }
+
+    pub fn create_build_config(options: &BuildOptions) -> anyhow::Result<BuildConfig> {
+        let bytecode_version = Some(options.inferred_bytecode_version());
+        let compiler_version = options.compiler_version;
+        let language_version = options.language_version;
+        Self::check_versions(&compiler_version, &language_version)?;
+        let skip_attribute_checks = options.skip_attribute_checks;
+        Ok(BuildConfig {
+            dev_mode: options.dev,
+            additional_named_addresses: options.named_addresses.clone(),
+            architecture: None,
+            generate_abis: options.with_abis,
+            generate_docs: false,
+            generate_move_model: true,
+            full_model_generation: options.check_test_code,
+            install_dir: options.install_dir.clone(),
+            test_mode: false,
+            override_std: options.override_std.clone(),
+            force_recompilation: false,
+            fetch_deps_only: false,
+            skip_fetch_latest_git_deps: options.skip_fetch_latest_git_deps,
+            compiler_config: CompilerConfig {
+                bytecode_version,
+                compiler_version,
+                language_version,
+                skip_attribute_checks,
+                known_attributes: options.known_attributes.clone(),
+                experiments: options.experiments.clone(),
+            },
+        })
+    }
+
+    pub fn prepare_resolution_graph(
+        package_path: PathBuf,
+        build_config: BuildConfig,
+    ) -> anyhow::Result<ResolvedGraph> {
+        eprintln!("Compiling, may take a little while to download git dependencies...");
+        build_config.resolution_graph_for_package(&package_path, &mut stderr())
     }
 
     /// Same as `build` but allows to provide external checks to be made on Move code.
     /// The `external_checks` are only run when compiler v2 is used.
     pub fn build_with_external_checks(
-        package_path: PathBuf,
+        resolved_graph: ResolvedGraph,
         options: BuildOptions,
+        build_config: BuildConfig,
         external_checks: Vec<Arc<dyn ExternalChecks>>,
     ) -> anyhow::Result<Self> {
         {
-            let bytecode_version = Some(options.inferred_bytecode_version());
-            let compiler_version = options.compiler_version;
-            let language_version = options.language_version;
-            Self::check_versions(&compiler_version, &language_version)?;
-            let skip_attribute_checks = options.skip_attribute_checks;
-            let build_config = BuildConfig {
-                dev_mode: options.dev,
-                additional_named_addresses: options.named_addresses.clone(),
-                architecture: None,
-                generate_abis: options.with_abis,
-                generate_docs: false,
-                generate_move_model: true,
-                full_model_generation: options.check_test_code,
-                install_dir: options.install_dir.clone(),
-                test_mode: false,
-                override_std: options.override_std.clone(),
-                force_recompilation: false,
-                fetch_deps_only: false,
-                skip_fetch_latest_git_deps: options.skip_fetch_latest_git_deps,
-                compiler_config: CompilerConfig {
-                    bytecode_version,
-                    compiler_version,
-                    language_version,
-                    skip_attribute_checks,
-                    known_attributes: options.known_attributes.clone(),
-                    experiments: options.experiments.clone(),
-                },
-            };
+            let package_path = resolved_graph.root_package_path.clone();
+            let bytecode_version = build_config.compiler_config.bytecode_version;
 
-            eprintln!("Compiling, may take a little while to download git dependencies...");
             let (mut package, model_opt) = build_config.compile_package_no_exit(
-                &package_path,
+                resolved_graph,
                 external_checks,
                 &mut stderr(),
             )?;

--- a/crates/aptos/e2e/cases/move.py
+++ b/crates/aptos/e2e/cases/move.py
@@ -107,6 +107,28 @@ def test_move_compile_dev_mode(run_helper: RunHelper, test_name=None):
 
 
 @test_case
+def test_move_compile_fetch_deps_only(run_helper: RunHelper, test_name=None):
+    package_dir = f"move/cli-e2e-tests/{run_helper.base_network}"
+    account_info = run_helper.get_account_info()
+
+    # Compile the module. Compilation should not be invoked, and return should be [].
+    response = run_helper.run_command(
+        test_name,
+        [
+            "aptos",
+            "move",
+            "compile",
+            "--package-dir",
+            package_dir,
+            "--fetch-deps-only"
+        ],
+    )
+
+    if f"{account_info.account_address}::cli_e2e_tests" in response.stdout:
+        raise TestError("Module compilation should not be invoked")
+
+
+@test_case
 def test_move_compile_script(run_helper: RunHelper, test_name=None):
     package_dir = f"move/cli-e2e-tests/{run_helper.base_network}"
     account_info = run_helper.get_account_info()

--- a/crates/aptos/src/move_tool/lint.rs
+++ b/crates/aptos/src/move_tool/lint.rs
@@ -138,9 +138,17 @@ impl CliCommand<&'static str> for LintPackage {
                 true,
             )?
         };
-        BuiltPackage::build_with_external_checks(package_path, build_options, vec![
-            MoveLintChecks::make(),
-        ])?;
+
+        let build_config = BuiltPackage::create_build_config(&build_options)?;
+        let resolved_graph =
+            BuiltPackage::prepare_resolution_graph(package_path, build_config.clone())?;
+        BuiltPackage::build_with_external_checks(
+            resolved_graph,
+            build_options,
+            build_config,
+            vec![MoveLintChecks::make()],
+        )?;
+
         Ok("succeeded")
     }
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -390,6 +390,10 @@ pub struct CompilePackage {
     #[clap(long)]
     pub save_metadata: bool,
 
+    /// Fetch dependencies of a package from the network, skipping the actual compilation
+    #[clap(long)]
+    pub fetch_deps_only: bool,
+
     #[clap(flatten)]
     pub included_artifacts_args: IncludedArtifactsArgs,
     #[clap(flatten)]
@@ -410,6 +414,12 @@ impl CliCommand<Vec<String>> for CompilePackage {
                 .included_artifacts
                 .build_options(&self.move_options)?
         };
+        let package_path = self.move_options.get_package_path()?;
+        if self.fetch_deps_only {
+            let config = BuiltPackage::create_build_config(&build_options)?;
+            BuiltPackage::prepare_resolution_graph(package_path, config)?;
+            return Ok(vec![]);
+        }
         let pack = BuiltPackage::build(self.move_options.get_package_path()?, build_options)
             .map_err(|e| CliError::MoveCompilationError(format!("{:#}", e)))?;
         if self.save_metadata {

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -855,6 +855,7 @@ impl CliTestFramework {
         CompilePackage {
             move_options: self.move_options(account_strs),
             save_metadata: false,
+            fetch_deps_only: false,
             included_artifacts_args: IncludedArtifactsArgs {
                 included_artifacts: included_artifacts.unwrap_or(IncludedArtifacts::Sparse),
             },

--- a/third_party/move/tools/move-package/src/lib.rs
+++ b/third_party/move/tools/move-package/src/lib.rs
@@ -204,12 +204,11 @@ impl BuildConfig {
     /// External checks on Move code can be provided, these are only run if compiler v2 is used.
     pub fn compile_package_no_exit<W: Write>(
         self,
-        path: &Path,
+        resolved_graph: ResolvedGraph,
         external_checks: Vec<Arc<dyn ExternalChecks>>,
         writer: &mut W,
     ) -> Result<(CompiledPackage, Option<model::GlobalEnv>)> {
         let config = self.compiler_config.clone(); // Need clone because of mut self
-        let resolved_graph = self.resolution_graph_for_package(path, writer)?;
         let mutx = PackageLock::lock();
         let ret =
             BuildPlan::create(resolved_graph)?.compile_no_exit(&config, external_checks, writer);


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Fixes https://github.com/aptos-labs/aptos-core/issues/13279

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
I have added a python test which checks that compilation hasn't been invoked with the `--fetch-deps-only` flag.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->
 I had to split `BuiltPackage::build_with_external_checks()` to be able to run a part of it separately. 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

@vgao1996 
