### PR TITLE
[Faucet] Support ratelimiting on Firebase JWT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,6 +1723,7 @@ dependencies = [
  "clap 4.5.21",
  "deadpool-redis",
  "enum_dispatch",
+ "firebase-token",
  "futures",
  "hex",
  "ipnet",
@@ -8200,6 +8201,18 @@ name = "finl_unicode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
+
+[[package]]
+name = "firebase-token"
+version = "0.3.0"
+source = "git+https://github.com/aptos-labs/firebase-token?rev=34ea512d3d1fad6c11df3e7d82ff72beccc05836#34ea512d3d1fad6c11df3e7d82ff72beccc05836"
+dependencies = [
+ "jsonwebtoken 8.3.0",
+ "reqwest 0.11.23",
+ "serde",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "firestore"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -593,6 +593,7 @@ fail = "0.5.0"
 ff = { version = "0.13", features = ["derive"] }
 field_count = "0.1.1"
 file_diff = "1.0.0"
+firebase-token = { git = "https://github.com/aptos-labs/firebase-token", rev = "34ea512d3d1fad6c11df3e7d82ff72beccc05836" }
 firestore = "0.43.0"
 fixed = "1.25.1"
 flate2 = "1.0.24"

--- a/crates/aptos-faucet/configs/testing_redis.yaml
+++ b/crates/aptos-faucet/configs/testing_redis.yaml
@@ -7,7 +7,9 @@ bypasser_configs: []
 checker_configs:
   - type: "RedisRatelimit"
     database_address: "127.0.0.1"
-    max_requests_per_ip_per_day: 3
+    max_requests_per_day: 3
+    ratelimit_key_provider_config:
+      type: "Ip"
 funder_config:
   type: "FakeFunder"
 handler_config:

--- a/crates/aptos-faucet/configs/testing_redis_minter_local.yaml
+++ b/crates/aptos-faucet/configs/testing_redis_minter_local.yaml
@@ -8,7 +8,9 @@ bypasser_configs: []
 checker_configs:
   - type: "RedisRatelimit"
     database_address: "127.0.0.1"
-    max_requests_per_ip_per_day: 50000
+    max_requests_per_day: 50000
+    ratelimit_key_provider_config:
+      type: "Ip"
 funder_config:
   type: "MintFunder"
   node_url: "http://127.0.0.1:8080"

--- a/crates/aptos-faucet/core/Cargo.toml
+++ b/crates/aptos-faucet/core/Cargo.toml
@@ -24,6 +24,7 @@ captcha = { version = "0.0.9" }
 clap = { workspace = true }
 deadpool-redis = { version = "0.11.1", features = ["rt_tokio_1"], default-features = false }
 enum_dispatch = { workspace = true }
+firebase-token = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 ipnet = { workspace = true }

--- a/crates/aptos-faucet/core/src/bypasser/auth_token.rs
+++ b/crates/aptos-faucet/core/src/bypasser/auth_token.rs
@@ -5,6 +5,7 @@ use super::BypasserTrait;
 use crate::{
     checkers::CheckerData,
     common::{ListManager, ListManagerConfig},
+    firebase_jwt::X_IS_JWT_HEADER,
 };
 use anyhow::Result;
 use aptos_logger::info;
@@ -29,6 +30,11 @@ impl AuthTokenBypasser {
 #[async_trait]
 impl BypasserTrait for AuthTokenBypasser {
     async fn request_can_bypass(&self, data: CheckerData) -> Result<bool> {
+        // Don't check if the request has X_IS_JWT_HEADER set.
+        if data.headers.contains_key(X_IS_JWT_HEADER) {
+            return Ok(false);
+        }
+
         let auth_token = match data
             .headers
             .get(AUTHORIZATION)
@@ -38,6 +44,7 @@ impl BypasserTrait for AuthTokenBypasser {
             Some(auth_token) => auth_token,
             None => return Ok(false),
         };
+
         Ok(self.manager.contains(auth_token))
     }
 }

--- a/crates/aptos-faucet/core/src/checkers/auth_token.rs
+++ b/crates/aptos-faucet/core/src/checkers/auth_token.rs
@@ -5,6 +5,7 @@ use super::{CheckerData, CheckerTrait};
 use crate::{
     common::{ListManager, ListManagerConfig},
     endpoints::{AptosTapError, RejectionReason, RejectionReasonCode},
+    firebase_jwt::X_IS_JWT_HEADER,
 };
 use anyhow::Result;
 use aptos_logger::info;
@@ -33,6 +34,11 @@ impl CheckerTrait for AuthTokenChecker {
         data: CheckerData,
         _dry_run: bool,
     ) -> Result<Vec<RejectionReason>, AptosTapError> {
+        // Don't check if the request has X_IS_JWT_HEADER set.
+        if data.headers.contains_key(X_IS_JWT_HEADER) {
+            return Ok(vec![]);
+        }
+
         let auth_token = match data
             .headers
             .get(AUTHORIZATION)

--- a/crates/aptos-faucet/core/src/checkers/memory_ratelimit.rs
+++ b/crates/aptos-faucet/core/src/checkers/memory_ratelimit.rs
@@ -27,7 +27,7 @@ impl MemoryRatelimitCheckerConfig {
 }
 
 /// Simple in memory storage that rejects if we've ever seen a request from an
-/// IP that has succeeded.
+/// IP that has succeeded. This does not support JWT-based ratelimiting.
 pub struct MemoryRatelimitChecker {
     pub max_requests_per_day: u32,
 
@@ -81,7 +81,7 @@ impl CheckerTrait for MemoryRatelimitChecker {
                     "IP {} has exceeded the daily limit of {} requests",
                     data.source_ip, self.max_requests_per_day
                 ),
-                RejectionReasonCode::IpUsageLimitExhausted,
+                RejectionReasonCode::UsageLimitExhausted,
             )]);
         } else if !dry_run {
             *requests_today += 1;

--- a/crates/aptos-faucet/core/src/checkers/redis_ratelimit.rs
+++ b/crates/aptos-faucet/core/src/checkers/redis_ratelimit.rs
@@ -4,16 +4,52 @@
 use super::{CheckerData, CheckerTrait, CompleteData};
 use crate::{
     endpoints::{AptosTapError, AptosTapErrorCode, RejectionReason, RejectionReasonCode},
+    firebase_jwt::{FirebaseJwtVerifier, FirebaseJwtVerifierConfig},
     helpers::{days_since_tap_epoch, get_current_time_secs, seconds_until_next_day},
 };
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use deadpool_redis::{
-    redis::{AsyncCommands, ConnectionAddr, ConnectionInfo, RedisConnectionInfo},
+    redis::{self, AsyncCommands, ConnectionAddr, ConnectionInfo, RedisConnectionInfo},
     Config, Connection, Pool, Runtime,
 };
 use serde::{Deserialize, Serialize};
-use std::net::IpAddr;
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum RatelimitKeyProviderConfig {
+    #[default]
+    Ip,
+    Jwt(FirebaseJwtVerifierConfig),
+}
+
+/// This is what produces the key we use for ratelimiting in Redis.
+pub enum RatelimitKeyProvider {
+    Ip,
+    Jwt(FirebaseJwtVerifier),
+}
+
+impl RatelimitKeyProvider {
+    pub fn ratelimit_key_prefix(&self) -> &'static str {
+        match self {
+            RatelimitKeyProvider::Ip => "ip",
+            RatelimitKeyProvider::Jwt(_) => "jwt",
+        }
+    }
+
+    /// If the faucet is configured to ratelimit by IP, this will be the client's IP
+    /// address. If the faucet is configured to ratelimit by JWT, we verify the JWT
+    /// first. If it is valid, this will be the user's Firebase UID (taken from the
+    /// JWT's `sub` field).
+    pub async fn ratelimit_key_value(&self, data: &CheckerData) -> Result<String, AptosTapError> {
+        match self {
+            RatelimitKeyProvider::Ip => Ok(data.source_ip.to_string()),
+            RatelimitKeyProvider::Jwt(jwt_verifier) => {
+                jwt_verifier.validate_jwt(data.headers.clone()).await
+            },
+        }
+    }
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RedisRatelimitCheckerConfig {
@@ -35,9 +71,13 @@ pub struct RedisRatelimitCheckerConfig {
     /// The password of the given user, if necessary.
     pub database_password: Option<String>,
 
-    /// Max number of requests per IP per day. 500s are not counted, because
-    /// they are not the user's fault, but everything else is.
-    pub max_requests_per_ip_per_day: u32,
+    /// Max number of requests per key per day. 500s are not counted, because they are
+    /// not the user's fault, but everything else is.
+    pub max_requests_per_day: u32,
+
+    /// This defines how we ratelimit, e.g. either by IP or by JWT (Firebase UID).
+    #[serde(default)]
+    pub ratelimit_key_provider_config: RatelimitKeyProviderConfig,
 }
 
 impl RedisRatelimitCheckerConfig {
@@ -76,10 +116,12 @@ impl RedisRatelimitCheckerConfig {
 /// request. Instead, it uses counters to track limits. This is heavily inspired
 /// by https://redis.com/redis-best-practices/basic-rate-limiting/.
 ///
+/// We use a generic key (e.g. IP address or Firebase UID).
+///
 /// If we're not careful, it is possible for people to exceed the intended limit
-/// by sending many requests simulatenously. We avoid this problem with this
+/// by sending many requests simultaneously. We avoid this problem with this
 /// order of operations:
-///   1. Read the current value of the limit for source IP.
+///   1. Read the current value of the limit for the given key (e.g. IP / Firebase UID).
 ///   2. If value is greater than limit, reject.
 ///   3. Otherwise, increment and set TTL if necessary.
 ///   4. Increment returns the new value. Check if this is greater than the limit also.
@@ -95,15 +137,16 @@ impl RedisRatelimitCheckerConfig {
 /// Note: Previously I made an attempt (d4fbf6db675e9036a967b52bf8d13e1b2566787e) at
 /// doing these steps atomically, but it became very unwieldy:
 ///   1. Start a transaction.
-///   2. Increment current value for limit for source IP, set TTL if necessary.
+///   2. Increment current value for limit for source key, set TTL if necessary.
 ///   3. If value is greater than limit, revert the transaction.
 ///
 /// This second way leaves a small window for someone to slip in multiple requests,
-/// therein blowing past the configured limit, but it's a very small window, so
-/// we'll worry about it as a followup: https://github.com/aptos-labs/aptos-tap/issues/15.
+/// therein blowing past the configured limit, but it's a very small window, so we'll
+/// worry about it as a followup: https://github.com/aptos-labs/aptos-tap/issues/15.
 pub struct RedisRatelimitChecker {
     args: RedisRatelimitCheckerConfig,
     db_pool: Pool,
+    ratelimit_key_provider: RatelimitKeyProvider,
 }
 
 impl RedisRatelimitChecker {
@@ -116,7 +159,18 @@ impl RedisRatelimitChecker {
             .await
             .context("Failed to connect to redis on startup")?;
 
-        Ok(Self { args, db_pool })
+        let ratelimit_key_provider = match args.ratelimit_key_provider_config.clone() {
+            RatelimitKeyProviderConfig::Ip => RatelimitKeyProvider::Ip,
+            RatelimitKeyProviderConfig::Jwt(config) => {
+                RatelimitKeyProvider::Jwt(FirebaseJwtVerifier::new(config).await?)
+            },
+        };
+
+        Ok(Self {
+            args,
+            db_pool,
+            ratelimit_key_provider,
+        })
     }
 
     pub async fn get_redis_connection(&self) -> Result<Connection, AptosTapError> {
@@ -129,27 +183,35 @@ impl RedisRatelimitChecker {
     }
 
     // Returns the key and the seconds until the next day.
-    fn get_key_and_secs_until_next_day(&self, source_ip: &IpAddr) -> (String, u64) {
+    fn get_key_and_secs_until_next_day(
+        &self,
+        ratelimit_key_prefix: &str,
+        ratelimit_key_value: &str,
+    ) -> (String, u64) {
         let now_secs = get_current_time_secs();
         let seconds_until_next_day = seconds_until_next_day(now_secs);
-        let key = format!("ip:{}:{}", source_ip, days_since_tap_epoch(now_secs));
+        let key = format!(
+            "{}:{}:{}",
+            ratelimit_key_prefix,
+            ratelimit_key_value,
+            days_since_tap_epoch(now_secs)
+        );
         (key, seconds_until_next_day)
     }
 
     fn check_limit_value(
         &self,
-        data: &CheckerData,
         limit_value: Option<i64>,
         seconds_until_next_day: u64,
     ) -> Option<RejectionReason> {
-        if limit_value.unwrap_or(0) > self.args.max_requests_per_ip_per_day as i64 {
+        if limit_value.unwrap_or(0) > self.args.max_requests_per_day as i64 {
             Some(
                 RejectionReason::new(
                     format!(
-                        "IP {} has reached the maximum allowed number of requests per day: {}",
-                        data.source_ip, self.args.max_requests_per_ip_per_day
+                        "You have reached the maximum allowed number of requests per day: {}",
+                        self.args.max_requests_per_day
                     ),
-                    RejectionReasonCode::IpUsageLimitExhausted,
+                    RejectionReasonCode::UsageLimitExhausted,
                 )
                 .retry_after(seconds_until_next_day),
             )
@@ -171,11 +233,17 @@ impl CheckerTrait for RedisRatelimitChecker {
             .await
             .map_err(|e| AptosTapError::new_with_error_code(e, AptosTapErrorCode::StorageError))?;
 
-        // Generate a key corresponding to this IP address and the current day.
-        let (key, seconds_until_next_day) = self.get_key_and_secs_until_next_day(&data.source_ip);
+        // Generate a key corresponding to this identifier and the current day.
+        let key_prefix = self.ratelimit_key_provider.ratelimit_key_prefix();
+        let key_value = self
+            .ratelimit_key_provider
+            .ratelimit_key_value(&data)
+            .await?;
+        let (key, seconds_until_next_day) =
+            self.get_key_and_secs_until_next_day(key_prefix, &key_value);
 
-        // Get the value for the key, indicating how many non-500 requests we
-        // have serviced for this it today.
+        // Get the value for the key, indicating how many non-500 requests we have
+        // serviced for it today.
         let limit_value: Option<i64> = conn.get(&key).await.map_err(|e| {
             AptosTapError::new_with_error_code(
                 format!("Failed to get value for redis key {}: {}", key, e),
@@ -183,18 +251,16 @@ impl CheckerTrait for RedisRatelimitChecker {
             )
         })?;
 
-        // If the limit value is greater than what we allow per day, signal
-        // that we should reject this request.
-        if let Some(rejection_reason) =
-            self.check_limit_value(&data, limit_value, seconds_until_next_day)
+        // If the limit value is greater than what we allow per day, signal that we
+        // should reject this request.
+        if let Some(rejection_reason) = self.check_limit_value(limit_value, seconds_until_next_day)
         {
             return Ok(vec![rejection_reason]);
         }
 
-        // Atomically increment the counter for the given IP, creating it and
-        // setting the expiration time if it doesn't already exist.
+        // Atomically increment the counter for the given key, creating it and setting
+        // the expiration time if it doesn't already exist.
         if !dry_run {
-            // If the limit value already exists, just increment.
             let incremented_limit_value = match limit_value {
                 Some(_) => conn.incr(&key, 1).await.map_err(|e| {
                     AptosTapError::new_with_error_code(
@@ -228,7 +294,7 @@ impl CheckerTrait for RedisRatelimitChecker {
 
             // Check limit again, to ensure there wasn't a get / set race.
             if let Some(rejection_reason) =
-                self.check_limit_value(&data, Some(incremented_limit_value), seconds_until_next_day)
+                self.check_limit_value(Some(incremented_limit_value), seconds_until_next_day)
             {
                 return Ok(vec![rejection_reason]);
             }
@@ -237,8 +303,8 @@ impl CheckerTrait for RedisRatelimitChecker {
         Ok(vec![])
     }
 
-    /// All we have to do here is decrement the counter if the request was a
-    /// failure due to something wrong on our end.
+    /// All we have to do here is decrement the counter if the request was a failure due
+    /// to something wrong on our end.
     async fn complete(&self, data: CompleteData) -> Result<(), AptosTapError> {
         if !data.response_is_500 {
             return Ok(());
@@ -249,8 +315,15 @@ impl CheckerTrait for RedisRatelimitChecker {
             .await
             .map_err(|e| AptosTapError::new_with_error_code(e, AptosTapErrorCode::StorageError))?;
 
-        // Generate a key corresponding to this IP address and the current day.
-        let (key, _) = self.get_key_and_secs_until_next_day(&data.checker_data.source_ip);
+        // Generate a key corresponding to this identifier and the current day. In the
+        // JWT case we re-verify the JWT. This is inefficient, but these failures are
+        // extremely rare so I don't refactor for now.
+        let key_prefix = self.ratelimit_key_provider.ratelimit_key_prefix();
+        let key_value = self
+            .ratelimit_key_provider
+            .ratelimit_key_value(&data.checker_data)
+            .await?;
+        let (key, _) = self.get_key_and_secs_until_next_day(key_prefix, &key_value);
 
         conn.decr(&key, 1).await.map_err(|e| {
             AptosTapError::new_with_error_code(
@@ -262,6 +335,6 @@ impl CheckerTrait for RedisRatelimitChecker {
     }
 
     fn cost(&self) -> u8 {
-        50
+        100
     }
 }

--- a/crates/aptos-faucet/core/src/endpoints/errors.rs
+++ b/crates/aptos-faucet/core/src/endpoints/errors.rs
@@ -64,7 +64,7 @@ impl AptosTapError {
     pub fn status_and_retry_after(&self) -> (StatusCode, Option<u64>) {
         let (mut status_code, mut retry_after) = (self.error_code.status(), None);
         for rejection_reason in &self.rejection_reasons {
-            if rejection_reason.code == RejectionReasonCode::IpUsageLimitExhausted {
+            if rejection_reason.code == RejectionReasonCode::UsageLimitExhausted {
                 status_code = StatusCode::TOO_MANY_REQUESTS;
                 retry_after = rejection_reason.retry_after;
                 break;
@@ -134,6 +134,9 @@ pub enum AptosTapErrorCode {
     /// The user tried to call an endpoint that is not enabled.
     EndpointNotEnabled = 45,
 
+    /// The user provided an invalid auth token.
+    AuthTokenInvalid = 46,
+
     /// Failed when making requests to the Aptos API.
     AptosApiError = 50,
 
@@ -170,7 +173,8 @@ impl AptosTapErrorCode {
             | AptosTapErrorCode::EndpointNotEnabled => StatusCode::BAD_REQUEST,
             AptosTapErrorCode::Rejected
             | AptosTapErrorCode::SourceIpMissing
-            | AptosTapErrorCode::TransactionFailed => StatusCode::FORBIDDEN,
+            | AptosTapErrorCode::TransactionFailed
+            | AptosTapErrorCode::AuthTokenInvalid => StatusCode::FORBIDDEN,
             AptosTapErrorCode::AptosApiError
             | AptosTapErrorCode::TransactionTimedOut
             | AptosTapErrorCode::SerializationError
@@ -233,8 +237,8 @@ pub enum RejectionReasonCode {
     /// Account already has funds.
     AccountAlreadyExists = 100,
 
-    /// IP has exhausted its usage limit.
-    IpUsageLimitExhausted = 101,
+    /// Key (IP / Firebase UID) has exhausted its usage limit.
+    UsageLimitExhausted = 101,
 
     /// IP is in the blocklist.
     IpInBlocklist = 102,

--- a/crates/aptos-faucet/core/src/endpoints/fund.rs
+++ b/crates/aptos-faucet/core/src/endpoints/fund.rs
@@ -9,6 +9,7 @@ use crate::{
     bypasser::{Bypasser, BypasserTrait},
     checkers::{Checker, CheckerData, CheckerTrait, CompleteData},
     endpoints::AptosTapErrorCode,
+    firebase_jwt::jwt_sub,
     funder::{Funder, FunderTrait},
     helpers::{get_current_time_secs, transaction_hashes},
 };
@@ -307,6 +308,7 @@ impl FundApiComponents {
         // Include some additional logging that the logging middleware doesn't do.
         info!(
             source_ip = checker_data.source_ip,
+            jwt_sub = jwt_sub(checker_data.headers.clone()).ok(),
             address = checker_data.receiver,
             requested_amount = fund_request.amount,
             txn_hashes = txn_hashes,

--- a/crates/aptos-faucet/core/src/firebase_jwt.rs
+++ b/crates/aptos-faucet/core/src/firebase_jwt.rs
@@ -1,0 +1,113 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::endpoints::{AptosTapError, AptosTapErrorCode};
+use anyhow::Result;
+use firebase_token::JwkAuth;
+use poem::http::{header::AUTHORIZATION, HeaderMap};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+pub const X_IS_JWT_HEADER: &str = "x-is-jwt";
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct FirebaseJwtVerifierConfig {
+    pub identity_platform_gcp_project: String,
+}
+
+/// This verifies that the value in the Authorization header is a valid Firebase JWT.
+/// Since we already have achecker that looks for API keys using the Authorization
+/// header, we mandate that a `x-is-jwt` header is present as well.
+pub struct FirebaseJwtVerifier {
+    pub jwt_verifier: JwkAuth,
+}
+
+impl FirebaseJwtVerifier {
+    pub async fn new(config: FirebaseJwtVerifierConfig) -> Result<Self> {
+        let jwt_verifier = JwkAuth::new(config.identity_platform_gcp_project).await;
+        Ok(Self { jwt_verifier })
+    }
+
+    /// First, we mandate that the caller indicated that they're including a JWT by
+    /// checking for the presence of X_IS_JWT_HEADER. If they didn't include this
+    /// header, we reject them immediately. We need this because we already have a
+    /// checker that looks for API keys using the Authorization header, and we want
+    /// to differentiate these two cases.
+    ///
+    /// If they did include X_IS_JWT_HEADER and the Authorization header was present
+    /// and well-formed, we extract the token from the Authorization header and verify
+    /// it with Firebase. If the token is invalid, we reject them. If it is valid, we
+    /// return the UID (from the sub field).
+    pub async fn validate_jwt(&self, headers: Arc<HeaderMap>) -> Result<String, AptosTapError> {
+        let auth_token = jwt_sub(headers)?;
+
+        let verify = self.jwt_verifier.verify::<JwtClaims>(&auth_token);
+        let token_data = match verify.await {
+            Some(token_data) => token_data,
+            None => {
+                return Err(AptosTapError::new(
+                    "Failed to verify JWT token".to_string(),
+                    AptosTapErrorCode::AuthTokenInvalid,
+                ));
+            },
+        };
+        let claims = token_data.claims;
+
+        if !claims.email_verified {
+            return Err(AptosTapError::new(
+                "The JWT token is not verified".to_string(),
+                AptosTapErrorCode::AuthTokenInvalid,
+            ));
+        }
+
+        Ok(claims.sub)
+    }
+}
+
+/// Returns the sub field from a JWT if it is present (the Firebase UID).
+/// The X_IS_JWT_HEADER must be present and the value must be "true".
+pub fn jwt_sub(headers: Arc<HeaderMap>) -> Result<String, AptosTapError> {
+    let is_jwt = headers
+        .get(X_IS_JWT_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.eq_ignore_ascii_case("true"))
+        .ok_or_else(|| {
+            AptosTapError::new(
+                format!(
+                    "The {} header must be present and set to 'true'",
+                    X_IS_JWT_HEADER
+                ),
+                AptosTapErrorCode::AuthTokenInvalid,
+            )
+        })?;
+
+    if !is_jwt {
+        return Err(AptosTapError::new(
+            format!("The {} header must be set to 'true'", X_IS_JWT_HEADER),
+            AptosTapErrorCode::AuthTokenInvalid,
+        ));
+    }
+
+    match headers
+        .get(AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.split_whitespace().nth(1))
+    {
+        Some(auth_token) => Ok(auth_token.to_string()),
+        None => Err(AptosTapError::new(
+            "Either the Authorization header is missing or it is not in the form of 'Bearer <token>'".to_string(),
+            AptosTapErrorCode::AuthTokenInvalid,
+        )),
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JwtClaims {
+    pub aud: String,
+    pub exp: i64,
+    pub iss: String,
+    pub sub: String,
+    pub iat: i64,
+    pub email: String,
+    pub email_verified: bool,
+}

--- a/crates/aptos-faucet/core/src/lib.rs
+++ b/crates/aptos-faucet/core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod bypasser;
 pub mod checkers;
 pub mod common;
 pub mod endpoints;
+pub mod firebase_jwt;
 pub mod funder;
 pub mod helpers;
 pub mod middleware;

--- a/crates/aptos-faucet/core/src/server/run.rs
+++ b/crates/aptos-faucet/core/src/server/run.rs
@@ -388,12 +388,12 @@ mod test {
         types::{account_address::AccountAddress, transaction::authenticator::AuthenticationKey},
     };
     use once_cell::sync::OnceCell;
-    use poem::http::header::{AUTHORIZATION, CONTENT_TYPE, REFERER};
     use poem_openapi::types::{ParseFromJSON, ToJSON};
     use rand::{
         rngs::{OsRng, StdRng},
         Rng, SeedableRng,
     };
+    use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, REFERER};
     use std::{collections::HashSet, io::Write, str::FromStr, time::Duration};
     use tokio::task::JoinHandle;
 
@@ -685,7 +685,7 @@ mod test {
             .into_iter()
             .map(|r| r.get_code())
             .collect();
-        assert!(rejection_reason_codes.contains(&RejectionReasonCode::IpUsageLimitExhausted));
+        assert!(rejection_reason_codes.contains(&RejectionReasonCode::UsageLimitExhausted));
 
         Ok(())
     }
@@ -836,7 +836,9 @@ mod test {
 
         // Assert that the account exists now with the expected balance.
         let response = aptos_node_api_client
-            .view_account_balance(AccountAddress::from_str(&fund_request.address.unwrap()).unwrap())
+            .view_apt_account_balance(
+                AccountAddress::from_str(&fund_request.address.unwrap()).unwrap(),
+            )
             .await?;
 
         assert_eq!(response.into_inner(), 10);

--- a/crates/aptos-faucet/integration-tests/main.py
+++ b/crates/aptos-faucet/integration-tests/main.py
@@ -67,6 +67,11 @@ def parse_args():
         ),
     )
     parser.add_argument(
+        "--skip-node",
+        action="store_true",
+        help="Skip running the node. You must run it yourself and copy the mint key yourself.",
+    )
+    parser.add_argument(
         "--tag",
         help=(
             'If --base-network is set to "custom", this must be set to the image tag'
@@ -114,20 +119,22 @@ def main():
     # something is listening at the expected port.
     check_redis_is_running()
 
-    # Run a node and wait for it to start up.
-    container_name = run_node(
-        network, args.image_repo_with_project, args.external_test_dir
-    )
-    wait_for_startup(container_name, args.base_startup_timeout)
+    if not args.skip_node:
+        # Run a node and wait for it to start up.
+        container_name = run_node(
+            network, args.image_repo_with_project, args.external_test_dir
+        )
+        wait_for_startup(container_name, args.base_startup_timeout)
 
-    # Copy the mint key from the node to where the integration tests expect it to be.
-    copy_mint_key(args.external_test_dir)
+        # Copy the mint key from the node to where the integration tests expect it to be.
+        copy_mint_key(args.external_test_dir)
 
     # Build and run the faucet integration tests.
     run_faucet_integration_tests()
 
-    # Stop the localnet.
-    stop_node(container_name)
+    if not args.skip_node:
+        # Stop the localnet.
+        stop_node(container_name)
 
     return True
 


### PR DESCRIPTION
## Description
This PR supports configuring the Redis ratelimiter to ratelimit by either IP or JWT.

I asked @geekflyer to transfer the firebase-token fork to aptos-labs, I'll use that once it's done.

## How Has This Been Tested?
Run a localnet:
```
aptos node run-localnet --no-faucet
```

Run Redis:
```
redis-server
```

Run the faucet:
```
cargo run -p aptos-faucet-service -- run -c ~/faucet.yaml
```

The config looks like this:
```
# Config to run the tap with the Minter funding backend, configured to run against testnet.
---
server_config:
  api_path_base: ""
  listen_port: 8092
metrics_server_config: {}
bypasser_configs:
  - type: "AuthToken"
    file: "/tmp/bypass-auth-tokens.txt"
checker_configs:
  - type: "RedisRatelimit"
    database_address: localhost
    max_requests_per_day: 5
    ratelimit_key_provider_config:
      type: "Jwt"
      identity_platform_gcp_project: <redacted>
funder_config:
  type: "MintFunder"
  # This uses the DNS name exposed by the tap fullnode Service, which is a
  # bespoke fullnode deployment for just these faucet instances.
  node_url: "http://127.0.0.1:8080"
  chain_id: 4
  key_file_path: /Users/dport/.aptos/testnet/mint.key
  # 1 APT.
  maximum_amount: 100000000
  # 100 APT.
  maximum_amount_with_bypass: 10000000000
  do_not_delegate: false
  mint_account_address: "0xA550C18"
  transaction_expiration_secs: 15
  wait_for_outstanding_txns_secs: 20
handler_config:
  use_helpful_errors: true
  return_rejections_early: true
```

See that a request without a JWT gets rejected:
```
$ curl -H 'Content-Type: application/json' http://127.0.0.1:8092/fund -d '{"address": "0xd"}'
{"message":"Error(46): The x-is-jwt header must be present and set to 'true': []","error_code":"CheckerError","rejection_reasons":[],"txn_hashes":[]}
```
```
$ curl -H 'x-is-jwt: true' -H 'Content-Type: application/json' http://127.0.0.1:8092/fund -d '{"address": "0xd"}'
{"message":"Error(46): Either the Authorization header is missing or it is not in the form of 'Bearer <token>': []","error_code":"CheckerError","rejection_reasons":[],"txn_hashes":[]}
```
```
$ curl -H 'x-is-jwt: true' -H 'authorization: Bearer blah' -H 'Content-Type: application/json' http://127.0.0.1:8092/fund -d '{"address": "0xd"}'
{"message":"Error(46): Failed to verify JWT token: []","error_code":"CheckerError","rejection_reasons":[],"txn_hashes":[]}
```

See that a request with a valid JWT passes:
```
$ export JWT='<redacted>'
$ curl -H 'x-is-jwt: true' -H "authorization: Bearer $JWT" -H 'Content-Type: application/json' http://127.0.0.1:8092/fund -d '{"address": "0xd"}'
{"txn_hashes":["e3c023004d9407136553457230bc9c06ded513f4346d852041721f403189f668"]}
```

See that it eventually gets ratelimited:
```
$ curl -H 'x-is-jwt: true' -H "authorization: Bearer $JWT" -H 'Content-Type: application/json' http://127.0.0.1:8092/fund -d '{"address": "0xd"}'
{"message":"Request rejected by 1 checkers","error_code":"Rejected","rejection_reasons":[{"reason":"You have reached the maximum allowed number of requests per day: 5","code":"UsageLimitExhausted"}],"txn_hashes":[]}
```

See that using an API key in `/tmp/bypass-auth-tokens.txt` lets me bypass the limit:
```
$ curl -H "authorization: Bearer 123" -H 'Content-Type: application/json' http://127.0.0.1:8092/fund -d '{"address": "0xd"}'
{"txn_hashes":["639040d2a3dae3dcbbb3f2057ea8da3b6061765ed3581cb71ca077e1f726814f"]}
```

I also verified that the IP based ratelimiting still works as before.

See also that the integration tests pass:
```
aptos node run-localnet --no-faucet --force-restart --assume-yes
```
```
cp /Users/dport/.aptos/testnet/mint.key /tmp
```
```
cd crates/aptos-faucet/integration-tests
poetry install
redis-server
redis-cli flushall
```
```
DOCKER_DEFAULT_PLATFORM=linux/amd64 poetry run python main.py --base-network testnet --skip-node
```
```
running 7 tests
test server::run::test::test_transfer_health ... ignored
test server::run::test::test_bypassers ... ok
test server::run::test::test_checkers ... ok
test server::run::test::test_redis_ratelimiter ... ok
test server::run::test::test_mint_funder_wait_for_txns ... ok
test server::run::test::test_mint_funder ... ok
test server::run::test::test_maximum_amount_with_bypass ... ok
```

## Key Areas to Review
Ensure the checks make sense, find any security issues, etc.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
