### PR TITLE
[compiler-v2] Also include all dependencies of vector for compiler v2

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/big_vector.md
+++ b/aptos-move/framework/aptos-stdlib/doc/big_vector.md
@@ -502,7 +502,7 @@ Aborts if <code>i</code> is out of bounds.
     <b>if</b> (self.end_index == i) {
         <b>return</b> last_val
     };
-    // because the lack of mem::swap, here we swap remove the requested value from the bucket
+    // because the lack of <a href="../../move-stdlib/doc/mem.md#0x1_mem_swap">mem::swap</a>, here we swap remove the requested value from the bucket
     // and append the last_val <b>to</b> the bucket then swap the last bucket val back
     <b>let</b> bucket = <a href="table_with_length.md#0x1_table_with_length_borrow_mut">table_with_length::borrow_mut</a>(&<b>mut</b> self.buckets, i / self.bucket_size);
     <b>let</b> bucket_len = <a href="../../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(bucket);

--- a/aptos-move/framework/move-stdlib/doc/vector.md
+++ b/aptos-move/framework/move-stdlib/doc/vector.md
@@ -88,7 +88,8 @@ the return on investment didn't seem worth it for these simple functions.
     -  [Function `rotate_slice`](#@Specification_1_rotate_slice)
 
 
-<pre><code></code></pre>
+<pre><code><b>use</b> <a href="mem.md#0x1_mem">0x1::mem</a>;
+</code></pre>
 
 
 
@@ -930,14 +931,13 @@ Aborts if <code>i</code> is out of bounds.
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_replace">replace</a>&lt;Element&gt;(self: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64, val: Element): Element {
     <b>let</b> last_idx = <a href="vector.md#0x1_vector_length">length</a>(self);
     <b>assert</b>!(i &lt; last_idx, <a href="vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>);
-    // TODO: Enable after tests are fixed.
-    // <b>if</b> (<a href="vector.md#0x1_vector_USE_MOVE_RANGE">USE_MOVE_RANGE</a>) {
-    //     <a href="mem.md#0x1_mem_replace">mem::replace</a>(<a href="vector.md#0x1_vector_borrow_mut">borrow_mut</a>(self, i), val)
-    // } <b>else</b> {
-    <a href="vector.md#0x1_vector_push_back">push_back</a>(self, val);
-    <a href="vector.md#0x1_vector_swap">swap</a>(self, i, last_idx);
-    <a href="vector.md#0x1_vector_pop_back">pop_back</a>(self)
-    // }
+    <b>if</b> (<a href="vector.md#0x1_vector_USE_MOVE_RANGE">USE_MOVE_RANGE</a>) {
+        <a href="mem.md#0x1_mem_replace">mem::replace</a>(<a href="vector.md#0x1_vector_borrow_mut">borrow_mut</a>(self, i), val)
+    } <b>else</b> {
+        <a href="vector.md#0x1_vector_push_back">push_back</a>(self, val);
+        <a href="vector.md#0x1_vector_swap">swap</a>(self, i, last_idx);
+        <a href="vector.md#0x1_vector_pop_back">pop_back</a>(self)
+    }
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/mem.move
+++ b/aptos-move/framework/move-stdlib/sources/mem.move
@@ -2,7 +2,7 @@
 module std::mem {
     // TODO - functions here are `public(friend)` here for one release,
     // and to be changed to `public` one release later.
-    // friend std::vector;
+    friend std::vector;
     #[test_only]
     friend std::mem_tests;
 

--- a/aptos-move/framework/move-stdlib/sources/vector.move
+++ b/aptos-move/framework/move-stdlib/sources/vector.move
@@ -9,7 +9,7 @@
 /// Move functions here because many have loops, requiring loop invariants to prove, and
 /// the return on investment didn't seem worth it for these simple functions.
 module std::vector {
-    // use std::mem;
+    use std::mem;
 
     /// The index into the vector is out of bounds
     const EINDEX_OUT_OF_BOUNDS: u64 = 0x20000;
@@ -357,14 +357,13 @@ module std::vector {
     public fun replace<Element>(self: &mut vector<Element>, i: u64, val: Element): Element {
         let last_idx = length(self);
         assert!(i < last_idx, EINDEX_OUT_OF_BOUNDS);
-        // TODO: Enable after tests are fixed.
-        // if (USE_MOVE_RANGE) {
-        //     mem::replace(borrow_mut(self, i), val)
-        // } else {
-        push_back(self, val);
-        swap(self, i, last_idx);
-        pop_back(self)
-        // }
+        if (USE_MOVE_RANGE) {
+            mem::replace(borrow_mut(self, i), val)
+        } else {
+            push_back(self, val);
+            swap(self, i, last_idx);
+            pop_back(self)
+        }
     }
 
     /// Apply the function to each element in the vector, consuming it.


### PR DESCRIPTION
## Description

In compiler v2, due to implicit usage of vector functions (like vector borrow for index syntax) during compiler phases, vector module was always included. But we also need to include all its (transitive) dependencies.

A previous related issue (https://github.com/aptos-labs/aptos-core/pull/15484) was not to include any of these dependencies implicitly for compiler v1 (because it does not need them).

## How Has This Been Tested?
Existing tests, after Igor's changes in https://github.com/aptos-labs/aptos-core/pull/15524.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler