### PR TITLE
Barrier for block metadata txn

### DIFF
--- a/aptos-move/block-executor/src/captured_reads.rs
+++ b/aptos-move/block-executor/src/captured_reads.rs
@@ -1075,6 +1075,10 @@ mod test {
         fn user_txn_bytes_len(&self) -> usize {
             0
         }
+
+        fn is_block_metadata_txn(&self) -> bool {
+            false
+        }
     }
 
     macro_rules! assert_update_incorrect_use {

--- a/aptos-move/block-executor/src/proptest_types/baseline.rs
+++ b/aptos-move/block-executor/src/proptest_types/baseline.rs
@@ -110,6 +110,10 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
 
         for txn in txns.iter() {
             match txn {
+                MockTransaction::BlockMetadata => {
+                    read_values.push(Ok(vec![]));
+                    resolved_deltas.push(Ok(HashMap::new()));
+                },
                 MockTransaction::Abort => {
                     status = BaselineStatus::Aborted;
                     break;

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -392,6 +392,7 @@ impl<K, E> MockIncarnation<K, E> {
 /// value determines the index for choosing the read & write sets of the particular execution.
 #[derive(Clone, Debug)]
 pub(crate) enum MockTransaction<K, E> {
+    BlockMetadata,
     Write {
         /// Incarnation counter, increased during each mock (re-)execution. Allows tracking the final
         /// incarnation for each mock transaction, whose behavior should be reproduced for baseline.
@@ -424,6 +425,9 @@ impl<K, E> MockTransaction<K, E> {
 
     pub(crate) fn into_behaviors(self) -> Vec<MockIncarnation<K, E>> {
         match self {
+            Self::BlockMetadata => {
+                unreachable!("BlockMetadata does not contain incarnation behaviors")
+            },
             Self::Write {
                 incarnation_behaviors,
                 ..
@@ -447,6 +451,10 @@ impl<
 
     fn user_txn_bytes_len(&self) -> usize {
         0
+    }
+
+    fn is_block_metadata_txn(&self) -> bool {
+        matches!(self, MockTransaction::BlockMetadata)
     }
 }
 
@@ -855,6 +863,11 @@ where
         txn_idx: TxnIndex,
     ) -> ExecutionStatus<Self::Output, Self::Error> {
         match txn {
+            MockTransaction::BlockMetadata => {
+                let mut mock_output = MockOutput::skip_output();
+                mock_output.total_gas = 0;
+                ExecutionStatus::Success(mock_output)
+            },
             MockTransaction::Write {
                 incarnation_counter,
                 incarnation_behaviors,

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -1910,6 +1910,10 @@ mod test {
         fn user_txn_bytes_len(&self) -> usize {
             0
         }
+
+        fn is_block_metadata_txn(&self) -> bool {
+            false
+        }
     }
 
     #[test]

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -2084,6 +2084,13 @@ pub trait BlockExecutableTransaction: Sync + Send + Clone + 'static {
 
     /// Size of the user transaction in bytes, 0 otherwise
     fn user_txn_bytes_len(&self) -> usize;
+
+    /// Returns true if self is SignatureVerifiedTransaction kind, internally matching either
+    /// BlockMetadata, BlockMetadataExt, or GenesisTransaction. Such transactions have read-write
+    /// conflicts with other transactions in the block, and benefit from synchronization barrier.
+    /// TODO: get rid of this interface (used by block executor) when signaling the barrier
+    /// can happen directly from aptos-vm.
+    fn is_block_metadata_txn(&self) -> bool;
 }
 
 pub struct ViewFunctionOutput {

--- a/types/src/transaction/signature_verified_transaction.rs
+++ b/types/src/transaction/signature_verified_transaction.rs
@@ -74,6 +74,15 @@ impl BlockExecutableTransaction for SignatureVerifiedTransaction {
             _ => 0,
         }
     }
+
+    fn is_block_metadata_txn(&self) -> bool {
+        matches!(
+            self.expect_valid(),
+            Transaction::BlockMetadata(_)
+                | Transaction::BlockMetadataExt(_)
+                | Transaction::GenesisTransaction(_)
+        )
+    }
 }
 
 impl From<Transaction> for SignatureVerifiedTransaction {


### PR DESCRIPTION
## Description
If the first transaction in the block is block metadata transaction, start other execution tasks only after waiting on a custom barrier (signaled after txn 0 is executed).

TODOs to re-implement nicely once we have any barrier infrastructure (in BlockSynchronizationView we are separately adding).

## How Has This Been Tested?
Have a proptest with the first transaction being block metadata txn, isolate the barrier logic into a macro and unit test.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)
