### PR TITLE
Fix typos and improve documentation across several files

### DIFF
--- a/aptos-move/move-examples/dao/nft_dao/README.md
+++ b/aptos-move/move-examples/dao/nft_dao/README.md
@@ -5,7 +5,7 @@ PR: https://github.com/aptos-labs/aptos-core/pull/5918
 
 *Quoted from product specification*
 
-Currently there are no easy ways for projects in the ecosystem to engage with their communities post mint. A key part of building a vibrant NFT community (as well as community of other web3 verticals) is to empower holders and supporters to be included in the decision making process of a project via a DAO. To do this, we must provide easy to use DAO management tooling for projects on Aptos to build a DAO where entry is gated by the ownership of a token in a NFT collection.
+Currently there are no easy ways for projects in the ecosystem to engage with their communities post mint. A key part of building a vibrant NFT community (as well as community of other web3 verticals) is to empower holders and supporters to be included in the decision-making process of a project via a DAO. To do this, we must provide easy to use DAO management tooling for projects on Aptos to build a DAO where entry is gated by the ownership of a token in a NFT collection.
 
 With the NFT DAO, token holders can 
 

--- a/third_party/move/documentation/book/translations/move-book-zh/src/abilities.md
+++ b/third_party/move/documentation/book/translations/move-book-zh/src/abilities.md
@@ -1,6 +1,6 @@
 # 能力 (abilities)
 
-Abilities are a typing feature in Move that control what actions are permissible for values of a given type. This system grants fine grained control over the "linear" typing behavior of values, as well as if and how values are used in global storage. This is implemented by gating access to certain bytecode instructions so that for a value to be used with the bytecode instruction, it must have the ability required (if one is required at all—not every instruction is gated by an ability).
+Abilities are a typing feature in Move that control what actions are permissible for values of a given type. This system grants fine-grained control over the "linear" typing behavior of values, as well as if and how values are used in global storage. This is implemented by gating access to certain bytecode instructions so that for a value to be used with the bytecode instruction, it must have the ability required (if one is required at all—not every instruction is gated by an ability).
 
 能力是 Move 语言中的一种类型特性，用于控制对给定类型的值允许哪些操作。 该系统对值的“线性”类型行为以及值如何在全局存储中使用提供细粒度控制。这是通过对某些字节码指令的进行访问控制来实现的，因此对于要与字节码指令一起使用的值，它必须具有所需的能力(如果需要的话，并非每条指令都由能力控制)
 


### PR DESCRIPTION
This PR addresses typographical issues and documentation improvements across various files. Key changes include:
- Corrected the hyphenation in "decision-making" in `README.md`.
- Added a hyphen to "fine-grained" in `abilities.md`.

These changes aim to enhance clarity and ensure consistency in documentation. All changes have been tested manually to verify that the content is now accurate and conforms to the style guidelines.

**Type of Change:**  
- [ ] Documentation update

**Components Affected:**  
- [ ] Documentation

**Checklist:**  
- [ ] I have read and followed the contributing guidelines  
- [ ] I have performed a self-review of my own code  
- [ ] I have commented my code, particularly in hard-to-understand areas  
- [ ] I have tested the changes
