### PR TITLE
Enable partial_governance_voting

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/vote.data/enable_partial_governance_voting/sources/main.move
+++ b/aptos-move/e2e-move-tests/src/tests/vote.data/enable_partial_governance_voting/sources/main.move
@@ -2,11 +2,15 @@ script {
     use aptos_framework::aptos_governance;
     use std::features;
 
-    fun main(core_resources: &signer) {
+    fun main(core_resources: &signer, enable_partial_governance_voting: bool) {
         let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @aptos_framework);
-        aptos_governance::initialize_partial_voting(&framework_signer);
         let feature = features::get_partial_governance_voting();
-        features::change_feature_flags_for_next_epoch(&framework_signer, vector[feature], vector[]);
+        if (enable_partial_governance_voting) {
+            aptos_governance::initialize_partial_voting(&framework_signer);
+            features::change_feature_flags_for_next_epoch(&framework_signer, vector[feature], vector[]);
+        } else {
+            features::change_feature_flags_for_next_epoch(&framework_signer, vector[], vector[feature]);
+        };
         aptos_governance::force_end_epoch(&framework_signer);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -811,7 +811,7 @@ module aptos_framework::aptos_governance {
         multi_step: bool,
         use_generic_resolve_function: bool,
     ) acquires ApprovedExecutionHashes, GovernanceConfig, GovernanceResponsbility, VotingRecords, VotingRecordsV2, GovernanceEvents {
-        setup_voting(&aptos_framework, &proposer, &yes_voter, &no_voter);
+        setup_partial_voting(&aptos_framework, &proposer, &yes_voter, &no_voter);
 
         let execution_hash = vector::empty<u8>();
         vector::push_back(&mut execution_hash, 1);
@@ -898,7 +898,7 @@ module aptos_framework::aptos_governance {
         no_voter: signer,
         multi_step: bool,
     ) acquires ApprovedExecutionHashes, GovernanceConfig, GovernanceResponsbility, VotingRecords, VotingRecordsV2, GovernanceEvents {
-        setup_voting(&aptos_framework, &proposer, &yes_voter, &no_voter);
+        setup_partial_voting(&aptos_framework, &proposer, &yes_voter, &no_voter);
 
         create_proposal_for_test(&proposer, multi_step);
         vote(&yes_voter, signer::address_of(&yes_voter), 0, true);
@@ -1134,6 +1134,7 @@ module aptos_framework::aptos_governance {
         voter_1: signer,
         voter_2: signer,
     ) acquires ApprovedExecutionHashes, GovernanceConfig, GovernanceResponsbility, VotingRecords, VotingRecordsV2, GovernanceEvents {
+        features::change_feature_flags_for_testing(&aptos_framework, vector[], vector[features::get_partial_governance_voting()]);
         setup_voting(&aptos_framework, &proposer, &voter_1, &voter_2);
         let execution_hash = vector::empty<u8>();
         vector::push_back(&mut execution_hash, 1);
@@ -1171,7 +1172,7 @@ module aptos_framework::aptos_governance {
         voter_1: signer,
         voter_2: signer,
     ) acquires GovernanceConfig, GovernanceResponsbility, VotingRecords, VotingRecordsV2, GovernanceEvents {
-        setup_voting_with_initialized_stake(&aptos_framework, &proposer, &voter_1, &voter_2);
+        setup_partial_voting_with_initialized_stake(&aptos_framework, &proposer, &voter_1, &voter_2);
         let execution_hash = vector::empty<u8>();
         vector::push_back(&mut execution_hash, 1);
         let proposer_addr = signer::address_of(&proposer);
@@ -1300,6 +1301,18 @@ module aptos_framework::aptos_governance {
     }
 
     #[test_only]
+    public fun setup_partial_voting_with_initialized_stake(
+        aptos_framework: &signer,
+        proposer: &signer,
+        yes_voter: &signer,
+        no_voter: &signer,
+    ) acquires GovernanceResponsbility {
+        initialize_partial_voting(aptos_framework);
+        features::change_feature_flags_for_testing(aptos_framework, vector[features::get_partial_governance_voting()], vector[]);
+        setup_voting_with_initialized_stake(aptos_framework, proposer, yes_voter, no_voter);
+    }
+
+    #[test_only]
     public fun setup_partial_voting(
         aptos_framework: &signer,
         proposer: &signer,
@@ -1340,7 +1353,7 @@ module aptos_framework::aptos_governance {
         yes_voter: signer,
         no_voter: signer,
     ) acquires GovernanceResponsbility, GovernanceConfig, ApprovedExecutionHashes, VotingRecords, VotingRecordsV2, GovernanceEvents {
-        setup_voting(&aptos_framework, &proposer, &yes_voter, &no_voter);
+        setup_partial_voting(&aptos_framework, &proposer, &yes_voter, &no_voter);
 
         create_proposal_for_test(&proposer, true);
         vote(&yes_voter, signer::address_of(&yes_voter), 0, true);

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -122,6 +122,7 @@ impl FeatureFlag {
             FeatureFlag::BLS12_381_STRUCTURES,
             FeatureFlag::ED25519_PUBKEY_VALIDATE_RETURN_FALSE_WRONG_LENGTH,
             FeatureFlag::STRUCT_CONSTRUCTORS,
+            FeatureFlag::PARTIAL_GOVERNANCE_VOTING,
             FeatureFlag::SIGNATURE_CHECKER_V2,
             FeatureFlag::STORAGE_SLOT_METADATA,
             FeatureFlag::CHARGE_INVARIANT_VIOLATION,


### PR DESCRIPTION
## Description

The feature flag `partial_governance_voting` has been successfully enabled on both the testnet and mainnet. However, it is not part of the default feature set for devnet.

Including this feature in the default feature set causes many Move unit tests to fail, as they were not written to accommodate the feature. The affected unit tests have been updated accordingly.

Partially resolves https://github.com/aptos-labs/aptos-core/issues/15305.

## How Has This Been Tested?
Move unit tests

## Key Areas to Review
Unit test updates

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [X] Other (Devnet)

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X] I tested both happy and unhappy path of the functionality
- [X] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
