### PR TITLE
Forge: mark pods as non-evictable

### DIFF
--- a/testsuite/forge-test-runner-template.yaml
+++ b/testsuite/forge-test-runner-template.yaml
@@ -9,6 +9,8 @@ metadata:
     forge-image-tag: {FORGE_IMAGE_TAG}
     forge-test-suite: {FORGE_TEST_SUITE}
     forge-username: {FORGE_USERNAME}
+  annotations:
+    "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
 spec:
   restartPolicy: Never
   serviceAccountName: forge

--- a/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml
+++ b/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml
@@ -11,6 +11,8 @@ validator:
         enable_storage_sharding: true
     indexer_db_config:
       enable_event: true
+  podAnnotations:
+    "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
 
 fullnode:
   # at most one VFN per validator, depending on numFullnodeGroups
@@ -28,6 +30,8 @@ fullnode:
         enable_storage_sharding: true
     indexer_db_config:
       enable_event: true
+  podAnnotations:
+    "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
 
 service:
   validator:


### PR DESCRIPTION
## Description

Add annotation to prevent the runner itself, as well as the validator and validator fullnode pods from being evicted by the cluster autoscaler.

## Test plan

Make sure the Forge tests pass, and check the GHA logs that the added annotation is being used.