### PR TITLE
[forge] delete orphaned test runners

### DIFF
--- a/testsuite/forge/src/backend/k8s/cluster_helper.rs
+++ b/testsuite/forge/src/backend/k8s/cluster_helper.rs
@@ -10,8 +10,8 @@ use crate::{
     DEFAULT_TEST_SUITE_NAME, DEFAULT_USERNAME, FORGE_KEY_SEED,
     FORGE_TESTNET_DEPLOYER_DOCKER_IMAGE_REPO, FULLNODE_HAPROXY_SERVICE_SUFFIX,
     FULLNODE_SERVICE_SUFFIX, HELM_BIN, KUBECTL_BIN, MANAGEMENT_CONFIGMAP_PREFIX,
-    NAMESPACE_CLEANUP_THRESHOLD_SECS, POD_CLEANUP_THRESHOLD_SECS, VALIDATOR_HAPROXY_SERVICE_SUFFIX,
-    VALIDATOR_SERVICE_SUFFIX,
+    NAMESPACE_CLEANUP_THRESHOLD_SECS, ORPHAN_POD_CLEANUP_THRESHOLD_SECS,
+    VALIDATOR_HAPROXY_SERVICE_SUFFIX, VALIDATOR_SERVICE_SUFFIX,
 };
 use again::RetryPolicy;
 use anyhow::{anyhow, bail, format_err};
@@ -986,43 +986,11 @@ pub async fn cleanup_cluster_with_management() -> Result<()> {
         .expect("Time went backwards")
         .as_secs();
 
-    let pods_api: Api<Pod> = Api::namespaced(kube_client.clone(), "default");
-    let lp = ListParams::default().labels("app.kubernetes.io/name=forge");
-
-    // delete all forge test pods over a threshold age
-    let pods = pods_api
-        .list(&lp)
-        .await?
-        .items
-        .into_iter()
-        .filter(|pod| {
-            let pod_name = pod.name();
-            info!("Got pod {}", pod_name);
-            if let Some(time) = &pod.metadata.creation_timestamp {
-                let pod_creation_time = time.0.timestamp() as u64;
-                let pod_uptime = time_since_the_epoch - pod_creation_time;
-                info!(
-                    "Pod {} has lived for {}/{} seconds",
-                    pod_name, pod_uptime, POD_CLEANUP_THRESHOLD_SECS
-                );
-                if pod_uptime > POD_CLEANUP_THRESHOLD_SECS {
-                    return true;
-                }
-            }
-            false
-        })
-        .collect::<Vec<Pod>>();
-    for pod in pods {
-        let pod_name = pod.name();
-        info!("Deleting pod {}", pod_name);
-        pods_api.delete(&pod_name, &DeleteParams::default()).await?;
-    }
-
     // delete all forge testnets over a threshold age using their management configmaps
     // unless they are explicitly set with "keep = true"
     let configmaps_api: Api<ConfigMap> = Api::all(kube_client.clone());
     let lp = ListParams::default();
-    let configmaps = configmaps_api
+    let old_forge_management_configmaps_to_delete = configmaps_api
         .list(&lp)
         .await?
         .items
@@ -1044,9 +1012,43 @@ pub async fn cleanup_cluster_with_management() -> Result<()> {
             false
         })
         .collect::<Vec<ConfigMap>>();
-    for configmap in configmaps {
+    for configmap in old_forge_management_configmaps_to_delete {
         let namespace = configmap.namespace().unwrap();
         uninstall_testnet_resources(namespace).await?;
+    }
+
+    // delete all orphan forge test pods older than a threshold
+    let namespace_api: Api<Namespace> = Api::all(kube_client.clone());
+    let lp = ListParams::default();
+    let forge_namespaces = namespace_api
+        .list(&lp)
+        .await?
+        .items
+        .into_iter()
+        .filter(|namespace| namespace.name().contains("forge"))
+        .collect::<Vec<Namespace>>();
+    let pods_api: Api<Pod> = Api::namespaced(kube_client.clone(), "default");
+    let lp = ListParams::default().labels("app.kubernetes.io/name=forge");
+    let orphan_forge_test_runner_pods_to_delete =
+        pods_api.list(&lp).await?.items.into_iter().filter(|pod| {
+            let pod_name = pod.name();
+            // check if the pod is older than 5min
+            if let Some(time) = &pod.metadata.creation_timestamp {
+                let pod_creation_time = time.0.timestamp() as u64;
+                let pod_uptime = time_since_the_epoch - pod_creation_time;
+                // If it's older than 5 min continue. There might be a race where the test runner is created and is in the process of creating the namespace.
+                if pod_uptime > ORPHAN_POD_CLEANUP_THRESHOLD_SECS {
+                    return true;
+                }
+            }
+            !forge_namespaces
+                .iter()
+                .any(|namespace| pod_name.contains(namespace.metadata.name.as_ref().unwrap()))
+        });
+    for pod in orphan_forge_test_runner_pods_to_delete {
+        let pod_name = pod.name();
+        info!("Deleting pod {}", pod_name);
+        pods_api.delete(&pod_name, &DeleteParams::default()).await?;
     }
 
     Ok(())

--- a/testsuite/forge/src/backend/k8s/constants.rs
+++ b/testsuite/forge/src/backend/k8s/constants.rs
@@ -22,12 +22,12 @@ pub const GENESIS_HELM_RELEASE_NAME: &str = "genesis";
 pub const APTOS_NODE_HELM_CHART_PATH: &str = "terraform/helm/aptos-node";
 pub const GENESIS_HELM_CHART_PATH: &str = "terraform/helm/genesis";
 
-// cleanup namespaces after 30 minutes unless "keep = true"
+// cleanup namespaces after 30 minutes unless "keep = true" or they have a cleanup time set
 pub const NAMESPACE_CLEANUP_THRESHOLD_SECS: u64 = 1800;
 // Leave a buffer of around 20 minutes for test provisioning and cleanup to be done before cleaning
 // up underlying resources.
 pub const NAMESPACE_CLEANUP_DURATION_BUFFER_SECS: u64 = 1200;
-pub const POD_CLEANUP_THRESHOLD_SECS: u64 = 86400;
+pub const ORPHAN_POD_CLEANUP_THRESHOLD_SECS: u64 = 300;
 pub const MANAGEMENT_CONFIGMAP_PREFIX: &str = "forge-management";
 
 // this is the port on the validator service itself, as opposed to 80 on the validator haproxy service


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Delete orphaned test runners. Orphaned test runners:
* have no corresponding forge namespace with a running testnet
* are older than a threshold time (300s)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

`cargo run -p aptos-forge-cli -- operator cleanup`

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
