### PR TITLE
[aptos-workspace-server] various fixes and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4749,6 +4749,7 @@ dependencies = [
  "aptos-node",
  "aptos-types",
  "bollard",
+ "clap 4.5.21",
  "diesel",
  "diesel-async",
  "futures",

--- a/aptos-move/aptos-workspace-server/Cargo.toml
+++ b/aptos-move/aptos-workspace-server/Cargo.toml
@@ -23,6 +23,7 @@ aptos-types = { workspace = true }
 # third party deps
 anyhow = { workspace = true }
 bollard = { workspace = true }
+clap = { workspace = true }
 diesel = { workspace = true, features = [
     "postgres_backend",
 ] }

--- a/aptos-move/aptos-workspace-server/src/common.rs
+++ b/aptos-move/aptos-workspace-server/src/common.rs
@@ -5,19 +5,48 @@
 
 use futures::{future::Shared, FutureExt};
 use std::{
+    fmt::{self, Debug, Display},
     future::Future,
     net::{IpAddr, Ipv4Addr},
     sync::Arc,
 };
 
+/// An wrapper to ensure propagation of chain of errors.
+pub(crate) struct ArcError(Arc<anyhow::Error>);
+
+impl Clone for ArcError {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl std::error::Error for ArcError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.0.source()
+    }
+}
+
+impl Display for ArcError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Debug for ArcError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
 /// The local IP address services are bound to.
 pub(crate) const IP_LOCAL_HOST: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 
 /// Converts a future into a shared future by wrapping the error in an `Arc`.
-pub(crate) fn make_shared<F, T, E>(fut: F) -> Shared<impl Future<Output = Result<T, Arc<E>>>>
+pub(crate) fn make_shared<F, T>(fut: F) -> Shared<impl Future<Output = Result<T, ArcError>>>
 where
     T: Clone,
-    F: Future<Output = Result<T, E>>,
+    F: Future<Output = Result<T, anyhow::Error>>,
 {
-    fut.map(|r| r.map_err(|err| Arc::new(err))).shared()
+    fut.map(|r| r.map_err(|err| ArcError(Arc::new(err))))
+        .shared()
 }

--- a/aptos-move/aptos-workspace-server/src/main.rs
+++ b/aptos-move/aptos-workspace-server/src/main.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use clap::Parser;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    aptos_workspace_server::run_all_services().await?;
-
-    Ok(())
+    aptos_workspace_server::WorkspaceCommand::parse()
+        .run()
+        .await
 }

--- a/aptos-move/aptos-workspace-server/src/services/faucet.rs
+++ b/aptos-move/aptos-workspace-server/src/services/faucet.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::IP_LOCAL_HOST;
+use crate::common::{ArcError, IP_LOCAL_HOST};
 use anyhow::{anyhow, Context, Result};
 use aptos_faucet_core::server::{FunderKeyEnum, RunConfig};
 use aptos_localnet::health_checker::HealthChecker;
 use futures::channel::oneshot;
-use std::{future::Future, path::PathBuf, sync::Arc};
+use std::{future::Future, path::PathBuf};
 use url::Url;
 
 /// Starts the faucet service.
@@ -21,8 +21,8 @@ use url::Url;
 ///   there is an error.
 pub fn start_faucet(
     test_dir: PathBuf,
-    fut_node_api: impl Future<Output = Result<u16, Arc<anyhow::Error>>> + Send + 'static,
-    fut_indexer_grpc: impl Future<Output = Result<u16, Arc<anyhow::Error>>> + Send + 'static,
+    fut_node_api: impl Future<Output = Result<u16, ArcError>> + Send + 'static,
+    fut_indexer_grpc: impl Future<Output = Result<u16, ArcError>> + Send + 'static,
 ) -> (
     impl Future<Output = Result<u16>>,
     impl Future<Output = Result<()>> + 'static,
@@ -32,12 +32,10 @@ pub fn start_faucet(
     let handle_faucet = tokio::spawn(async move {
         let api_port = fut_node_api
             .await
-            .map_err(anyhow::Error::msg)
             .context("failed to start faucet: node api did not start successfully")?;
 
         fut_indexer_grpc
             .await
-            .map_err(anyhow::Error::msg)
             .context("failed to start faucet: indexer grpc did not start successfully")?;
 
         println!("Starting faucet..");

--- a/aptos-move/aptos-workspace-server/src/services/postgres.rs
+++ b/aptos-move/aptos-workspace-server/src/services/postgres.rs
@@ -6,10 +6,11 @@ use crate::{
     services::docker_common::{create_docker_volume, create_start_and_inspect_container},
 };
 use anyhow::{anyhow, Context, Result};
-use aptos_localnet::{docker, health_checker::HealthChecker};
+use aptos_localnet::health_checker::HealthChecker;
 use bollard::{
     container::{CreateContainerOptions, WaitContainerOptions},
     secret::{ContainerInspectResponse, HostConfig, PortBinding},
+    Docker,
 };
 use futures::TryStreamExt;
 use maplit::hashmap;
@@ -161,6 +162,7 @@ fn create_container_options_and_config(
 /// as it relies on external commands that may fail for various reasons.
 pub fn start_postgres(
     shutdown: CancellationToken,
+    fut_docker: impl Future<Output = Result<Docker, ArcError>> + Clone + Send + 'static,
     fut_network: impl Future<Output = Result<String, ArcError>>,
     instance_id: Uuid,
 ) -> (
@@ -171,12 +173,14 @@ pub fn start_postgres(
     println!("Starting postgres..");
 
     let volume_name = format!("aptos-workspace-{}-postgres", instance_id);
-    let (fut_volume, fut_volume_clean_up) = create_docker_volume(shutdown.clone(), volume_name);
+    let (fut_volume, fut_volume_clean_up) =
+        create_docker_volume(shutdown.clone(), fut_docker.clone(), volume_name);
 
     let fut_container_clean_up = Arc::new(Mutex::new(None));
 
     let fut_create_postgres = make_shared({
         let fut_container_clean_up = fut_container_clean_up.clone();
+        let fut_docker = fut_docker.clone();
 
         async move {
             let (network_name, volume_name) = try_join!(fut_network, fut_volume)
@@ -185,7 +189,7 @@ pub fn start_postgres(
             let (options, config) =
                 create_container_options_and_config(instance_id, network_name, volume_name);
             let (fut_container, fut_container_cleanup) =
-                create_start_and_inspect_container(shutdown.clone(), options, config);
+                create_start_and_inspect_container(shutdown.clone(), fut_docker, options, config);
             *fut_container_clean_up.lock().await = Some(fut_container_cleanup);
 
             let container_info = fut_container.await.context("failed to start postgres")?;
@@ -217,7 +221,7 @@ pub fn start_postgres(
     };
 
     let fut_postgres_finish = async move {
-        let docker = docker::get_docker()
+        let docker = fut_docker
             .await
             .context("failed to wait on postgres container")?;
 

--- a/aptos-move/aptos-workspace-server/src/services/processors.rs
+++ b/aptos-move/aptos-workspace-server/src/services/processors.rs
@@ -2,18 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{node::get_data_service_url, postgres::get_postgres_connection_string};
-use crate::common::make_shared;
+use crate::common::{make_shared, ArcError};
 use anyhow::{anyhow, Context, Result};
 use aptos_localnet::{health_checker::HealthChecker, processors::get_processor_config};
 use diesel::Connection;
 use diesel_async::{async_connection_wrapper::AsyncConnectionWrapper, pg::AsyncPgConnection};
-use futures::{future::try_join_all, stream::FuturesUnordered, StreamExt};
+use futures::{future::try_join_all, stream::FuturesUnordered, StreamExt, TryFutureExt};
 use processor::{
     gap_detectors::DEFAULT_GAP_DETECTION_BATCH_SIZE, processors::ProcessorName,
     utils::database::run_pending_migrations, IndexerGrpcProcessorConfig,
 };
 use server_framework::RunnableConfig;
-use std::{future::Future, sync::Arc};
+use std::future::Future;
 use tokio::try_join;
 
 /// Names of the processors to enable in the local network.
@@ -42,10 +42,7 @@ const PROCESSOR_NAMES: &[ProcessorName] = {
 /// - One that resolves when the processor is up.
 /// - One that resolves when the processor stops (which it should not under normal operation).
 fn start_processor(
-    fut_prerequisites: &(impl Future<Output = Result<(u16, u16), Arc<anyhow::Error>>>
-          + Clone
-          + Send
-          + 'static),
+    fut_prerequisites: &(impl Future<Output = Result<(u16, u16), ArcError>> + Clone + Send + 'static),
     processor_name: &ProcessorName,
 ) -> (
     impl Future<Output = Result<()>>,
@@ -54,8 +51,7 @@ fn start_processor(
     let fut_prerequisites_ = fut_prerequisites.clone();
     let processor_name_ = processor_name.to_owned();
     let handle_processor = tokio::spawn(async move {
-        let (postgres_port, indexer_grpc_port) =
-            fut_prerequisites_.await.map_err(anyhow::Error::msg)?;
+        let (postgres_port, indexer_grpc_port) = fut_prerequisites_.await?;
 
         println!("Starting processor {}..", processor_name_);
 
@@ -94,8 +90,7 @@ fn start_processor(
     let fut_prerequisites_ = fut_prerequisites.clone();
     let processor_name_ = processor_name.to_owned();
     let fut_processor_ready = async move {
-        let (postgres_port, _indexer_grpc_port) =
-            fut_prerequisites_.await.map_err(anyhow::Error::msg)?;
+        let (postgres_port, _indexer_grpc_port) = fut_prerequisites_.await?;
 
         let processor_health_checker = HealthChecker::Processor(
             get_postgres_connection_string(postgres_port),
@@ -123,9 +118,9 @@ fn start_processor(
 /// - One that resolves when all processors are up.
 /// - One that resolves when any of the processors stops (which it should not under normal operation).
 pub fn start_all_processors(
-    fut_node_api: impl Future<Output = Result<u16, Arc<anyhow::Error>>> + Clone + Send + 'static,
-    fut_indexer_grpc: impl Future<Output = Result<u16, Arc<anyhow::Error>>> + Clone + Send + 'static,
-    fut_postgres: impl Future<Output = Result<u16, Arc<anyhow::Error>>> + Clone + Send + 'static,
+    fut_node_api: impl Future<Output = Result<u16, ArcError>> + Clone + Send + 'static,
+    fut_indexer_grpc: impl Future<Output = Result<u16, ArcError>> + Clone + Send + 'static,
+    fut_postgres: impl Future<Output = Result<u16, ArcError>> + Clone + Send + 'static,
 ) -> (
     impl Future<Output = Result<()>>,
     impl Future<Output = Result<()>>,
@@ -133,7 +128,6 @@ pub fn start_all_processors(
     let fut_migration = async move {
         let postgres_port = fut_postgres
             .await
-            .map_err(anyhow::Error::msg)
             .context("failed to run migration: postgres did not start successfully")?;
 
         println!("Starting migration..");
@@ -158,13 +152,12 @@ pub fn start_all_processors(
         Ok(postgres_port)
     };
 
-    let fut_prerequisites = make_shared::<_, _, anyhow::Error>(async move {
+    let fut_prerequisites = make_shared(async move {
         let (_node_api_port, indexer_grpc_port, postgres_port) = try_join!(
-            fut_node_api,
-            fut_indexer_grpc,
+            fut_node_api.map_err(|err| anyhow!(err)),
+            fut_indexer_grpc.map_err(|err| anyhow!(err)),
             fut_migration
         )
-        .map_err(anyhow::Error::msg)
         .context(
             "failed to start processors: one or more prerequisites did not start successfully",
         )?;

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -22,6 +22,7 @@ use crate::common::{
     types::{CliCommand, CliResult, CliTypedResult},
     utils::cli_build_information,
 };
+use aptos_workspace_server::WorkspaceCommand;
 use async_trait::async_trait;
 use clap::Parser;
 use std::collections::BTreeMap;
@@ -53,7 +54,7 @@ pub enum Tool {
     #[clap(subcommand)]
     Update(update::UpdateTool),
     #[clap(subcommand, hide(true))]
-    Workspace(workspace::WorkspaceTool),
+    Workspace(WorkspaceCommand),
 }
 
 impl Tool {
@@ -73,7 +74,7 @@ impl Tool {
             Node(tool) => tool.execute().await,
             Stake(tool) => tool.execute().await,
             Update(tool) => tool.execute().await,
-            Workspace(tool) => tool.execute().await,
+            Workspace(workspace) => workspace.execute_serialized_without_logger().await,
         }
     }
 }

--- a/crates/aptos/src/workspace/mod.rs
+++ b/crates/aptos/src/workspace/mod.rs
@@ -1,37 +1,18 @@
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::{CliCommand, CliResult, CliTypedResult};
+use crate::common::types::{CliCommand, CliTypedResult};
+use aptos_workspace_server::WorkspaceCommand;
 use async_trait::async_trait;
-use clap::Parser;
-
-/// Tool for operations related to Aptos Workspace
-#[derive(Parser)]
-pub enum WorkspaceTool {
-    Run(RunWorkspace),
-}
-
-impl WorkspaceTool {
-    pub async fn execute(self) -> CliResult {
-        use WorkspaceTool::*;
-
-        match self {
-            Run(cmd) => cmd.execute_serialized_without_logger().await,
-        }
-    }
-}
-
-#[derive(Parser)]
-pub struct RunWorkspace;
 
 #[async_trait]
-impl CliCommand<()> for RunWorkspace {
+impl CliCommand<()> for WorkspaceCommand {
     fn command_name(&self) -> &'static str {
-        "RunWorkspace"
+        "Workspace"
     }
 
     async fn execute(self) -> CliTypedResult<()> {
-        aptos_workspace_server::run_all_services().await?;
+        self.run().await?;
 
         Ok(())
     }


### PR DESCRIPTION
This PR implements several fixes and improvements to `aptos-workspace-server`:
- **Shared Docker Network**: 
  - Instead of creating a new Docker network for each instance, we now use a shared network (aptos-workspace). 
  - This helps avoid hitting Docker's default network limit (30 networks per host).
- **Error Propagation Fixes**: 
  - Fixed issues with error propagation so we can know why services actually fail
- **Automatic Docker Image Pulling**: 
  - Docker images are now automatically pulled if they do not already exist locally.
- **Shared Docker Client Initialization**:
  - All docker operations now await a single shared future to initialize the Docker client, rather than creating separate instances.
- **Timeout**:
  - Automatically initiates the shutdown sequence when a timeout is reached. This gives us a chance to tear down the server in case the front-end is not responding, hopefully avoiding slowing down the user's computer semi-permanently.