### PR TITLE
[forge] Run forge nightly on weekdays

### DIFF
--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -49,10 +49,8 @@ on:
         description: The number of test jobs to run in parallel. If not specified, defaults to 1
         default: 1
 
-  # NOTE: to support testing different branches on different schedules, you need to specify the cron schedule in the 'determine-test-branch' step as well below
-  # Reference: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
   schedule:
-    - cron: "0 22 * * 0,2,4" # The main branch cadence. This runs every Sun,Tues,Thurs
+    - cron: "0 22 * * 1-5" # The main branch cadence. This runs every Mon-Fri
   pull_request:
     paths:
       - ".github/workflows/forge-stable.yaml"
@@ -147,17 +145,11 @@ jobs:
         id: determine-test-branch
         # NOTE: the schedule cron MUST match the one in the 'on.schedule.cron' section above
         run: |
+          BRANCH=""
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            if [[ "${{ github.event.schedule }}" == "0 22 * * 0,2,4" ]]; then
-              echo "Branch: main"
-              echo "BRANCH=main" >> $GITHUB_OUTPUT
-            else
-              echo "Unknown schedule: ${{ github.event.schedule }}"
-              exit 1
-            fi
+            echo "BRANCH=main" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "push" ]]; then
-              echo "Branch: ${{ github.ref_name }}"
-              echo "BRANCH=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+            echo "BRANCH=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           # on workflow_dispatch, this will simply use the inputs.GIT_SHA given (or the default)
           elif [[ -n "${{ inputs.GIT_SHA }}" ]]; then
             echo "BRANCH=${{ inputs.GIT_SHA }}" >> $GITHUB_OUTPUT
@@ -165,6 +157,7 @@ jobs:
           else
             echo "BRANCH=${{ github.head_ref }}" >> $GITHUB_OUTPUT
           fi
+          echo "Branch: $(grep BRANCH= $GITHUB_OUTPUT)"
       # Use the branch hash instead of the full branch name to stay under kubernetes namespace length limit
       - name: Hash the branch
         id: hash-branch


### PR DESCRIPTION
## Description
Updates the forge-stable workflow schedule to run Monday through Friday at 22:00 UTC instead of only running on Sunday, Tuesday, and Thursday.

## How Has This Been Tested?
This change only modifies the GitHub Actions workflow schedule configuration. The functionality of the forge tests remains unchanged.

I will schedule from this PR to ensure that the cron spec is valid

## Key Areas to Review
The cron expression syntax: `0 22 * * 1-5` represents:
- Minutes: 0
- Hour: 22 (UTC)
- Day of month: *
- Month: *
- Day of week: 1-5 (Monday through Friday)

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Developer Infrastructure

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation