### PR TITLE
[compiler-v2] Enable recent stack-optimizations by default

### DIFF
--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/diamond_clicker.v2_exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/diamond_clicker.v2_exp
@@ -15,49 +15,45 @@ struct OuterStruct has key {
 }
 
 entry public test_upgrade(Arg0: &signer) /* def_idx: 0 */ {
-L1:	loc0: OuterStruct
-L2:	loc1: &mut vector<InnerStruct>
+L1:	loc0: &mut vector<InnerStruct>
+L2:	loc1: u64
 L3:	loc2: u64
-L4:	loc3: u64
-L5:	loc4: u64
 B0:
 	0: CopyLoc[0](Arg0: &signer)
 	1: Call signer::address_of(&signer): address
-	2: VecPack(3, 0)
-	3: Pack[1](OuterStruct)
-	4: StLoc[1](loc0: OuterStruct)
-	5: MoveLoc[0](Arg0: &signer)
-	6: MoveLoc[1](loc0: OuterStruct)
-	7: MoveTo[1](OuterStruct)
-	8: MutBorrowGlobal[1](OuterStruct)
-	9: MutBorrowField[0](OuterStruct.any_field: vector<InnerStruct>)
-	10: StLoc[2](loc1: &mut vector<InnerStruct>)
-	11: LdU64(0)
-	12: StLoc[3](loc2: u64)
-	13: CopyLoc[2](loc1: &mut vector<InnerStruct>)
-	14: FreezeRef
-	15: VecLen(3)
-	16: StLoc[4](loc3: u64)
+	2: MoveLoc[0](Arg0: &signer)
+	3: VecPack(3, 0)
+	4: Pack[1](OuterStruct)
+	5: MoveTo[1](OuterStruct)
+	6: MutBorrowGlobal[1](OuterStruct)
+	7: MutBorrowField[0](OuterStruct.any_field: vector<InnerStruct>)
+	8: StLoc[1](loc0: &mut vector<InnerStruct>)
+	9: LdU64(0)
+	10: StLoc[2](loc1: u64)
+	11: CopyLoc[1](loc0: &mut vector<InnerStruct>)
+	12: FreezeRef
+	13: VecLen(3)
+	14: StLoc[3](loc2: u64)
 B1:
-	17: CopyLoc[3](loc2: u64)
-	18: CopyLoc[4](loc3: u64)
-	19: Lt
-	20: BrFalse(31)
+	15: CopyLoc[2](loc1: u64)
+	16: CopyLoc[3](loc2: u64)
+	17: Lt
+	18: BrFalse(29)
 B2:
-	21: CopyLoc[2](loc1: &mut vector<InnerStruct>)
-	22: CopyLoc[3](loc2: u64)
-	23: VecMutBorrow(3)
-	24: FreezeRef
-	25: Call debug::print<InnerStruct>(&InnerStruct)
-	26: MoveLoc[3](loc2: u64)
-	27: LdU64(1)
-	28: Add
-	29: StLoc[3](loc2: u64)
-	30: Branch(17)
+	19: CopyLoc[1](loc0: &mut vector<InnerStruct>)
+	20: CopyLoc[2](loc1: u64)
+	21: VecMutBorrow(3)
+	22: FreezeRef
+	23: Call debug::print<InnerStruct>(&InnerStruct)
+	24: MoveLoc[2](loc1: u64)
+	25: LdU64(1)
+	26: Add
+	27: StLoc[2](loc1: u64)
+	28: Branch(15)
 B3:
-	31: MoveLoc[2](loc1: &mut vector<InnerStruct>)
-	32: Pop
-	33: Ret
+	29: MoveLoc[1](loc0: &mut vector<InnerStruct>)
+	30: Pop
+	31: Ret
 }
 }
 

--- a/aptos-move/framework/aptos-framework/tests/compiler-v2-doc/aptos_governance.md
+++ b/aptos-move/framework/aptos-framework/tests/compiler-v2-doc/aptos_governance.md
@@ -883,6 +883,7 @@ This function is private because it's called directly from the vm.
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
 
     <a href="voting.md#0x1_voting_register">voting::register</a>&lt;GovernanceProposal&gt;(aptos_framework);
+    <a href="aptos_governance.md#0x1_aptos_governance_initialize_partial_voting">initialize_partial_voting</a>(aptos_framework);
     <b>move_to</b>(aptos_framework, <a href="aptos_governance.md#0x1_aptos_governance_GovernanceConfig">GovernanceConfig</a> {
         voting_duration_secs,
         min_voting_threshold,
@@ -2132,6 +2133,7 @@ Limit addition overflow.
 <b>ensures</b> <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_GovernanceEvents">GovernanceEvents</a>&gt;(addr);
 <b>ensures</b> <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_VotingRecords">VotingRecords</a>&gt;(addr);
 <b>ensures</b> <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_ApprovedExecutionHashes">ApprovedExecutionHashes</a>&gt;(addr);
+<b>ensures</b> <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a>&gt;(addr);
 </code></pre>
 
 
@@ -2204,6 +2206,7 @@ Abort if structs have already been created.
     <b>aborts_if</b> <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_VotingRecords">VotingRecords</a>&gt;(addr);
     <b>aborts_if</b> <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_ApprovedExecutionHashes">ApprovedExecutionHashes</a>&gt;(addr);
     <b>aborts_if</b> !<b>exists</b>&lt;<a href="account.md#0x1_account_Account">account::Account</a>&gt;(addr);
+    <b>aborts_if</b> <b>exists</b>&lt;<a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a>&gt;(addr);
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/tests/compiler-v2-doc/coin.md
+++ b/aptos-move/framework/aptos-framework/tests/compiler-v2-doc/coin.md
@@ -19,7 +19,6 @@ This module provides the foundation for typesafe Coins.
 -  [Struct `WithdrawEvent`](#0x1_coin_WithdrawEvent)
 -  [Struct `CoinEventHandleDeletion`](#0x1_coin_CoinEventHandleDeletion)
 -  [Struct `PairCreation`](#0x1_coin_PairCreation)
--  [Resource `MigrationFlag`](#0x1_coin_MigrationFlag)
 -  [Struct `MintCapability`](#0x1_coin_MintCapability)
 -  [Struct `FreezeCapability`](#0x1_coin_FreezeCapability)
 -  [Struct `BurnCapability`](#0x1_coin_BurnCapability)
@@ -29,6 +28,7 @@ This module provides the foundation for typesafe Coins.
 -  [Struct `MintRefReceipt`](#0x1_coin_MintRefReceipt)
 -  [Struct `TransferRefReceipt`](#0x1_coin_TransferRefReceipt)
 -  [Struct `BurnRefReceipt`](#0x1_coin_BurnRefReceipt)
+-  [Resource `MigrationFlag`](#0x1_coin_MigrationFlag)
 -  [Resource `Ghost$supply`](#0x1_coin_Ghost$supply)
 -  [Resource `Ghost$aggregate_supply`](#0x1_coin_Ghost$aggregate_supply)
 -  [Constants](#@Constants_0)
@@ -57,6 +57,7 @@ This module provides the foundation for typesafe Coins.
 -  [Function `calculate_amount_to_withdraw`](#0x1_coin_calculate_amount_to_withdraw)
 -  [Function `maybe_convert_to_fungible_store`](#0x1_coin_maybe_convert_to_fungible_store)
 -  [Function `migrate_to_fungible_store`](#0x1_coin_migrate_to_fungible_store)
+-  [Function `migrate_coin_store_to_fungible_store`](#0x1_coin_migrate_coin_store_to_fungible_store)
 -  [Function `coin_address`](#0x1_coin_coin_address)
 -  [Function `balance`](#0x1_coin_balance)
 -  [Function `is_balance_at_least`](#0x1_coin_is_balance_at_least)
@@ -72,7 +73,7 @@ This module provides the foundation for typesafe Coins.
 -  [Function `burn`](#0x1_coin_burn)
 -  [Function `burn_from`](#0x1_coin_burn_from)
 -  [Function `deposit`](#0x1_coin_deposit)
--  [Function `migrated_primary_fungible_store_exists`](#0x1_coin_migrated_primary_fungible_store_exists)
+-  [Function `can_receive_paired_fungible_asset`](#0x1_coin_can_receive_paired_fungible_asset)
 -  [Function `force_deposit`](#0x1_coin_force_deposit)
 -  [Function `destroy_zero`](#0x1_coin_destroy_zero)
 -  [Function `extract`](#0x1_coin_extract)
@@ -151,6 +152,7 @@ This module provides the foundation for typesafe Coins.
 <b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
 <b>use</b> <a href="../../../aptos-stdlib/tests/compiler-v2-doc/table.md#0x1_table">0x1::table</a>;
 <b>use</b> <a href="../../../aptos-stdlib/tests/compiler-v2-doc/type_info.md#0x1_type_info">0x1::type_info</a>;
+<b>use</b> <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/vector.md#0x1_vector">0x1::vector</a>;
 </code></pre>
 
 
@@ -623,35 +625,6 @@ Module event emitted when a new pair of coin and fungible asset is created.
 
 </details>
 
-<a id="0x1_coin_MigrationFlag"></a>
-
-## Resource `MigrationFlag`
-
-The flag the existence of which indicates the primary fungible store is created by the migration from CoinStore.
-
-
-<pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
-<b>struct</b> <a href="coin.md#0x1_coin_MigrationFlag">MigrationFlag</a> <b>has</b> key
-</code></pre>
-
-
-
-<details>
-<summary>Fields</summary>
-
-
-<dl>
-<dt>
-<code>dummy_field: bool</code>
-</dt>
-<dd>
-
-</dd>
-</dl>
-
-
-</details>
-
 <a id="0x1_coin_MintCapability"></a>
 
 ## Struct `MintCapability`
@@ -909,6 +882,36 @@ The hot potato receipt for flash borrowing BurnRef.
 <dl>
 <dt>
 <code>metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x1_coin_MigrationFlag"></a>
+
+## Resource `MigrationFlag`
+
+The flag the existence of which indicates the primary fungible store is created by the migration from CoinStore.
+
+
+<pre><code>#[resource_group_member(#[group = <a href="object.md#0x1_object_ObjectGroup">0x1::object::ObjectGroup</a>])]
+#[deprecated]
+<b>struct</b> <a href="coin.md#0x1_coin_MigrationFlag">MigrationFlag</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>dummy_field: bool</code>
 </dt>
 <dd>
 
@@ -2038,7 +2041,6 @@ or disallow upgradability of total supply.
 
     <b>let</b> metadata = <a href="coin.md#0x1_coin_ensure_paired_metadata">ensure_paired_metadata</a>&lt;CoinType&gt;();
     <b>let</b> store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">primary_fungible_store::ensure_primary_store_exists</a>(<a href="account.md#0x1_account">account</a>, metadata);
-    <b>let</b> store_address = <a href="object.md#0x1_object_object_address">object::object_address</a>(&store);
     <b>if</b> (<b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinStore">CoinStore</a>&lt;CoinType&gt;&gt;(<a href="account.md#0x1_account">account</a>)) {
         <b>let</b> <a href="coin.md#0x1_coin_CoinStore">CoinStore</a>&lt;CoinType&gt; { <a href="coin.md#0x1_coin">coin</a>, frozen, deposit_events, withdraw_events } = <b>move_from</b>&lt;<a href="coin.md#0x1_coin_CoinStore">CoinStore</a>&lt;CoinType&gt;&gt;(
             <a href="account.md#0x1_account">account</a>
@@ -2052,13 +2054,21 @@ or disallow upgradability of total supply.
                 deleted_withdraw_event_handle_creation_number: <a href="guid.md#0x1_guid_creation_num">guid::creation_num</a>(<a href="event.md#0x1_event_guid">event::guid</a>(&withdraw_events))
             }
         );
-        <a href="event.md#0x1_event_destroy_handle">event::destroy_handle</a>(deposit_events);
-        <a href="event.md#0x1_event_destroy_handle">event::destroy_handle</a>(withdraw_events);
         <b>if</b> (<a href="coin.md#0x1_coin">coin</a>.value == 0) {
             <a href="coin.md#0x1_coin_destroy_zero">destroy_zero</a>(<a href="coin.md#0x1_coin">coin</a>);
         } <b>else</b> {
-            <a href="fungible_asset.md#0x1_fungible_asset_deposit">fungible_asset::deposit</a>(store, <a href="coin.md#0x1_coin_coin_to_fungible_asset">coin_to_fungible_asset</a>(<a href="coin.md#0x1_coin">coin</a>));
+            <b>if</b> (std::features::module_event_migration_enabled()) {
+                <a href="event.md#0x1_event_emit">event::emit</a>(<a href="coin.md#0x1_coin_CoinWithdraw">CoinWithdraw</a> { coin_type: type_name&lt;CoinType&gt;(), <a href="account.md#0x1_account">account</a>, amount: <a href="coin.md#0x1_coin">coin</a>.value });
+            } <b>else</b> {
+                <a href="event.md#0x1_event_emit_event">event::emit_event</a>&lt;<a href="coin.md#0x1_coin_WithdrawEvent">WithdrawEvent</a>&gt;(
+                    &<b>mut</b> withdraw_events,
+                    <a href="coin.md#0x1_coin_WithdrawEvent">WithdrawEvent</a> { amount: <a href="coin.md#0x1_coin">coin</a>.value },
+                );
+            };
+            <a href="fungible_asset.md#0x1_fungible_asset_deposit_internal">fungible_asset::deposit_internal</a>(object_address(&store), <a href="coin.md#0x1_coin_coin_to_fungible_asset">coin_to_fungible_asset</a>(<a href="coin.md#0x1_coin">coin</a>));
         };
+        <a href="event.md#0x1_event_destroy_handle">event::destroy_handle</a>(deposit_events);
+        <a href="event.md#0x1_event_destroy_handle">event::destroy_handle</a>(withdraw_events);
         // Note:
         // It is possible the primary fungible store may already exist before this function call.
         // In this case, <b>if</b> the <a href="account.md#0x1_account">account</a> owns a frozen <a href="coin.md#0x1_coin_CoinStore">CoinStore</a> and an unfrozen primary fungible store, this
@@ -2068,9 +2078,6 @@ or disallow upgradability of total supply.
             <a href="fungible_asset.md#0x1_fungible_asset_set_frozen_flag_internal">fungible_asset::set_frozen_flag_internal</a>(store, frozen);
         }
     };
-    <b>if</b> (!<b>exists</b>&lt;<a href="coin.md#0x1_coin_MigrationFlag">MigrationFlag</a>&gt;(store_address)) {
-        <b>move_to</b>(&<a href="create_signer.md#0x1_create_signer_create_signer">create_signer::create_signer</a>(store_address), <a href="coin.md#0x1_coin_MigrationFlag">MigrationFlag</a> {});
-    }
 }
 </code></pre>
 
@@ -2098,6 +2105,37 @@ Voluntarily migrate to fungible store for <code>CoinType</code> if not yet.
     <a href="account.md#0x1_account">account</a>: &<a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/signer.md#0x1_signer">signer</a>
 ) <b>acquires</b> <a href="coin.md#0x1_coin_CoinStore">CoinStore</a>, <a href="coin.md#0x1_coin_CoinConversionMap">CoinConversionMap</a>, <a href="coin.md#0x1_coin_CoinInfo">CoinInfo</a> {
     <a href="coin.md#0x1_coin_maybe_convert_to_fungible_store">maybe_convert_to_fungible_store</a>&lt;CoinType&gt;(<a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>));
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_coin_migrate_coin_store_to_fungible_store"></a>
+
+## Function `migrate_coin_store_to_fungible_store`
+
+Migrate to fungible store for <code>CoinType</code> if not yet.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x1_coin_migrate_coin_store_to_fungible_store">migrate_coin_store_to_fungible_store</a>&lt;CoinType&gt;(accounts: <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x1_coin_migrate_coin_store_to_fungible_store">migrate_coin_store_to_fungible_store</a>&lt;CoinType&gt;(
+    accounts: <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;
+) <b>acquires</b> <a href="coin.md#0x1_coin_CoinStore">CoinStore</a>, <a href="coin.md#0x1_coin_CoinConversionMap">CoinConversionMap</a>, <a href="coin.md#0x1_coin_CoinInfo">CoinInfo</a> {
+    <b>if</b> (<a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/features.md#0x1_features_new_accounts_default_to_fa_apt_store_enabled">features::new_accounts_default_to_fa_apt_store_enabled</a>()) {
+        std::vector::for_each(accounts, |<a href="account.md#0x1_account">account</a>| {
+            <a href="coin.md#0x1_coin_maybe_convert_to_fungible_store">maybe_convert_to_fungible_store</a>&lt;CoinType&gt;(<a href="account.md#0x1_account">account</a>);
+        });
+    }
 }
 </code></pre>
 
@@ -2314,7 +2352,7 @@ Returns <code><b>true</b></code> if <code>account_addr</code> is registered to r
         <b>let</b> paired_metadata_opt = <a href="coin.md#0x1_coin_paired_metadata">paired_metadata</a>&lt;CoinType&gt;();
         (<a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/option.md#0x1_option_is_some">option::is_some</a>(
             &paired_metadata_opt
-        ) && <a href="coin.md#0x1_coin_migrated_primary_fungible_store_exists">migrated_primary_fungible_store_exists</a>(account_addr, <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/option.md#0x1_option_destroy_some">option::destroy_some</a>(paired_metadata_opt)))
+        ) && <a href="coin.md#0x1_coin_can_receive_paired_fungible_asset">can_receive_paired_fungible_asset</a>(account_addr, <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/option.md#0x1_option_destroy_some">option::destroy_some</a>(paired_metadata_opt)))
     }
 }
 </code></pre>
@@ -2590,7 +2628,7 @@ Deposit the coin balance into the recipient's account and emit an event.
         <a href="coin.md#0x1_coin_merge">merge</a>(&<b>mut</b> coin_store.<a href="coin.md#0x1_coin">coin</a>, <a href="coin.md#0x1_coin">coin</a>);
     } <b>else</b> {
         <b>let</b> metadata = <a href="coin.md#0x1_coin_paired_metadata">paired_metadata</a>&lt;CoinType&gt;();
-        <b>if</b> (<a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/option.md#0x1_option_is_some">option::is_some</a>(&metadata) && <a href="coin.md#0x1_coin_migrated_primary_fungible_store_exists">migrated_primary_fungible_store_exists</a>(
+        <b>if</b> (<a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/option.md#0x1_option_is_some">option::is_some</a>(&metadata) && <a href="coin.md#0x1_coin_can_receive_paired_fungible_asset">can_receive_paired_fungible_asset</a>(
             account_addr,
             <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/option.md#0x1_option_destroy_some">option::destroy_some</a>(metadata)
         )) {
@@ -2606,13 +2644,13 @@ Deposit the coin balance into the recipient's account and emit an event.
 
 </details>
 
-<a id="0x1_coin_migrated_primary_fungible_store_exists"></a>
+<a id="0x1_coin_can_receive_paired_fungible_asset"></a>
 
-## Function `migrated_primary_fungible_store_exists`
+## Function `can_receive_paired_fungible_asset`
 
 
 
-<pre><code><b>fun</b> <a href="coin.md#0x1_coin_migrated_primary_fungible_store_exists">migrated_primary_fungible_store_exists</a>(account_address: <b>address</b>, metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;): bool
+<pre><code><b>fun</b> <a href="coin.md#0x1_coin_can_receive_paired_fungible_asset">can_receive_paired_fungible_asset</a>(account_address: <b>address</b>, metadata: <a href="object.md#0x1_object_Object">object::Object</a>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;): bool
 </code></pre>
 
 
@@ -2621,15 +2659,17 @@ Deposit the coin balance into the recipient's account and emit an event.
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="coin.md#0x1_coin_migrated_primary_fungible_store_exists">migrated_primary_fungible_store_exists</a>(
+<pre><code>inline <b>fun</b> <a href="coin.md#0x1_coin_can_receive_paired_fungible_asset">can_receive_paired_fungible_asset</a>(
     account_address: <b>address</b>,
     metadata: Object&lt;Metadata&gt;
 ): bool {
-    <b>let</b> primary_store_address = <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_address">primary_fungible_store::primary_store_address</a>&lt;Metadata&gt;(account_address, metadata);
-    <a href="fungible_asset.md#0x1_fungible_asset_store_exists">fungible_asset::store_exists</a>(primary_store_address) && (
-        // migration flag is needed, until we start defaulting new accounts <b>to</b> APT PFS
-        <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/features.md#0x1_features_new_accounts_default_to_fa_apt_store_enabled">features::new_accounts_default_to_fa_apt_store_enabled</a>() || <b>exists</b>&lt;<a href="coin.md#0x1_coin_MigrationFlag">MigrationFlag</a>&gt;(primary_store_address)
-    )
+    (<a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/features.md#0x1_features_new_accounts_default_to_fa_apt_store_enabled">features::new_accounts_default_to_fa_apt_store_enabled</a>() && <a href="object.md#0x1_object_object_address">object::object_address</a>(&metadata) == @0xa) || {
+        <b>let</b> primary_store_address = <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_address">primary_fungible_store::primary_store_address</a>&lt;Metadata&gt;(
+            account_address,
+            metadata
+        );
+        <a href="fungible_asset.md#0x1_fungible_asset_store_exists">fungible_asset::store_exists</a>(primary_store_address)
+    }
 }
 </code></pre>
 
@@ -2663,13 +2703,13 @@ This is for internal use only and doesn't emit an DepositEvent.
         <a href="coin.md#0x1_coin_merge">merge</a>(&<b>mut</b> coin_store.<a href="coin.md#0x1_coin">coin</a>, <a href="coin.md#0x1_coin">coin</a>);
     } <b>else</b> {
         <b>let</b> metadata = <a href="coin.md#0x1_coin_paired_metadata">paired_metadata</a>&lt;CoinType&gt;();
-        <b>if</b> (<a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/option.md#0x1_option_is_some">option::is_some</a>(&metadata) && <a href="coin.md#0x1_coin_migrated_primary_fungible_store_exists">migrated_primary_fungible_store_exists</a>(
+        <b>if</b> (<a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/option.md#0x1_option_is_some">option::is_some</a>(&metadata) && <a href="coin.md#0x1_coin_can_receive_paired_fungible_asset">can_receive_paired_fungible_asset</a>(
             account_addr,
             <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/option.md#0x1_option_destroy_some">option::destroy_some</a>(metadata)
         )) {
             <b>let</b> fa = <a href="coin.md#0x1_coin_coin_to_fungible_asset">coin_to_fungible_asset</a>(<a href="coin.md#0x1_coin">coin</a>);
             <b>let</b> metadata = <a href="fungible_asset.md#0x1_fungible_asset_asset_metadata">fungible_asset::asset_metadata</a>(&fa);
-            <b>let</b> store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store">primary_fungible_store::primary_store</a>(account_addr, metadata);
+            <b>let</b> store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">primary_fungible_store::ensure_primary_store_exists</a>(account_addr, metadata);
             <a href="fungible_asset.md#0x1_fungible_asset_deposit_internal">fungible_asset::deposit_internal</a>(<a href="object.md#0x1_object_object_address">object::object_address</a>(&store), fa);
         } <b>else</b> {
             <b>abort</b> <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="coin.md#0x1_coin_ECOIN_STORE_NOT_PUBLISHED">ECOIN_STORE_NOT_PUBLISHED</a>)
@@ -3782,7 +3822,8 @@ Get address by reflection.
 
 <pre><code><b>fun</b> <a href="coin.md#0x1_coin_spec_is_account_registered">spec_is_account_registered</a>&lt;CoinType&gt;(account_addr: <b>address</b>): bool {
    <b>let</b> paired_metadata_opt = <a href="coin.md#0x1_coin_spec_paired_metadata">spec_paired_metadata</a>&lt;CoinType&gt;();
-   <b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinStore">CoinStore</a>&lt;CoinType&gt;&gt;(account_addr) || (<a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/option.md#0x1_option_spec_is_some">option::spec_is_some</a>(
+   <b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinStore">CoinStore</a>&lt;CoinType&gt;&gt;(account_addr) || <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/features.md#0x1_features_spec_new_accounts_default_to_fa_apt_store_enabled">features::spec_new_accounts_default_to_fa_apt_store_enabled</a>(
+   ) || (<a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/option.md#0x1_option_spec_is_some">option::spec_is_some</a>(
        paired_metadata_opt
    ) && <a href="primary_fungible_store.md#0x1_primary_fungible_store_spec_primary_store_exists">primary_fungible_store::spec_primary_store_exists</a>(account_addr, <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/option.md#0x1_option_spec_borrow">option::spec_borrow</a>(paired_metadata_opt)))
 }
@@ -4192,27 +4233,6 @@ The creator of <code>CoinType</code> must be <code>@aptos_framework</code>.
     symbol: symbol.bytes
 };
 <b>ensures</b> <b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt;&gt;(addr);
-</code></pre>
-
-
-Make sure <code>name</code> and <code>symbol</code> are legal length.
-Only the creator of <code>CoinType</code> can initialize.
-
-
-<a id="0x1_coin_InitializeInternalSchema"></a>
-
-
-<pre><code><b>schema</b> <a href="coin.md#0x1_coin_InitializeInternalSchema">InitializeInternalSchema</a>&lt;CoinType&gt; {
-    <a href="account.md#0x1_account">account</a>: <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/signer.md#0x1_signer">signer</a>;
-    name: <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
-    symbol: <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
-    <b>let</b> account_addr = <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
-    <b>let</b> coin_address = <a href="../../../aptos-stdlib/tests/compiler-v2-doc/type_info.md#0x1_type_info_type_of">type_info::type_of</a>&lt;CoinType&gt;().account_address;
-    <b>aborts_if</b> coin_address != account_addr;
-    <b>aborts_if</b> <b>exists</b>&lt;<a href="coin.md#0x1_coin_CoinInfo">CoinInfo</a>&lt;CoinType&gt;&gt;(account_addr);
-    <b>aborts_if</b> len(name) &gt; <a href="coin.md#0x1_coin_MAX_COIN_NAME_LENGTH">MAX_COIN_NAME_LENGTH</a>;
-    <b>aborts_if</b> len(symbol) &gt; <a href="coin.md#0x1_coin_MAX_COIN_SYMBOL_LENGTH">MAX_COIN_SYMBOL_LENGTH</a>;
-}
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/tests/compiler-v2-doc/genesis.md
+++ b/aptos-move/framework/aptos-framework/tests/compiler-v2-doc/genesis.md
@@ -340,6 +340,7 @@ Genesis step 1: Initialize aptos framework account and core modules on chain.
     <a href="execution_config.md#0x1_execution_config_set">execution_config::set</a>(&aptos_framework_account, <a href="execution_config.md#0x1_execution_config">execution_config</a>);
     <a href="version.md#0x1_version_initialize">version::initialize</a>(&aptos_framework_account, initial_version);
     <a href="stake.md#0x1_stake_initialize">stake::initialize</a>(&aptos_framework_account);
+    <a href="timestamp.md#0x1_timestamp_set_time_has_started">timestamp::set_time_has_started</a>(&aptos_framework_account);
     <a href="staking_config.md#0x1_staking_config_initialize">staking_config::initialize</a>(
         &aptos_framework_account,
         minimum_stake,
@@ -360,7 +361,6 @@ Genesis step 1: Initialize aptos framework account and core modules on chain.
     <a href="reconfiguration.md#0x1_reconfiguration_initialize">reconfiguration::initialize</a>(&aptos_framework_account);
     <a href="block.md#0x1_block_initialize">block::initialize</a>(&aptos_framework_account, epoch_interval_microsecs);
     <a href="state_storage.md#0x1_state_storage_initialize">state_storage::initialize</a>(&aptos_framework_account);
-    <a href="timestamp.md#0x1_timestamp_set_time_has_started">timestamp::set_time_has_started</a>(&aptos_framework_account);
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/tests/compiler-v2-doc/staking_config.md
+++ b/aptos-move/framework/aptos-framework/tests/compiler-v2-doc/staking_config.md
@@ -386,6 +386,17 @@ Only called during genesis.
         rewards_rate_denominator,
         voting_power_increase_limit,
     });
+
+    // Initialize <a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a> <b>with</b> the given rewards_rate and rewards_rate_denominator,
+    // <b>while</b> setting min_rewards_rate and rewards_rate_decrease_rate <b>to</b> 0.
+    <a href="staking_config.md#0x1_staking_config_initialize_rewards">initialize_rewards</a>(
+        aptos_framework,
+        <a href="../../../aptos-stdlib/tests/compiler-v2-doc/fixed_point64.md#0x1_fixed_point64_create_from_rational">fixed_point64::create_from_rational</a>((rewards_rate <b>as</b> u128), (rewards_rate_denominator <b>as</b> u128)),
+        <a href="../../../aptos-stdlib/tests/compiler-v2-doc/fixed_point64.md#0x1_fixed_point64_create_from_rational">fixed_point64::create_from_rational</a>(0, 1000),
+        <a href="staking_config.md#0x1_staking_config_ONE_YEAR_IN_SECS">ONE_YEAR_IN_SECS</a>,
+        0,
+        <a href="../../../aptos-stdlib/tests/compiler-v2-doc/fixed_point64.md#0x1_fixed_point64_create_from_rational">fixed_point64::create_from_rational</a>(0, 1000),
+    );
 }
 </code></pre>
 
@@ -1072,6 +1083,7 @@ Can only be called as part of the Aptos governance proposal process established 
 
 
 <pre><code><b>invariant</b> [suspendable] <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>() ==&gt; <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>&gt;(@aptos_framework);
+<b>invariant</b> [suspendable] <a href="chain_status.md#0x1_chain_status_is_operating">chain_status::is_operating</a>() ==&gt; <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(@aptos_framework);
 <b>pragma</b> verify = <b>true</b>;
 <b>pragma</b> aborts_if_is_strict;
 </code></pre>
@@ -1223,6 +1235,7 @@ StakingConfig does not exist under the aptos_framework before creating it.
 
 
 <pre><code><b>let</b> addr = <a href="../../../aptos-stdlib/../move-stdlib/tests/compiler-v2-doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
+<b>requires</b> <b>exists</b>&lt;<a href="timestamp.md#0x1_timestamp_CurrentTimeMicroseconds">timestamp::CurrentTimeMicroseconds</a>&gt;(@aptos_framework);
 // This enforces <a id="high-level-req-1.1" href="#high-level-req">high-level requirement 1</a>:
 <b>aborts_if</b> addr != @aptos_framework;
 <b>aborts_if</b> minimum_stake &gt; maximum_stake || maximum_stake == 0;
@@ -1234,7 +1247,9 @@ StakingConfig does not exist under the aptos_framework before creating it.
 <b>aborts_if</b> rewards_rate &gt; <a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">MAX_REWARDS_RATE</a>;
 <b>aborts_if</b> rewards_rate &gt; rewards_rate_denominator;
 <b>aborts_if</b> <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>&gt;(addr);
+<b>aborts_if</b> <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(addr);
 <b>ensures</b> <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingConfig">StakingConfig</a>&gt;(addr);
+<b>ensures</b> <b>exists</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">StakingRewardsConfig</a>&gt;(addr);
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/tests/compiler-v2-doc/features.md
+++ b/aptos-move/framework/move-stdlib/tests/compiler-v2-doc/features.md
@@ -133,6 +133,8 @@ return true.
 -  [Function `transaction_simulation_enhancement_enabled`](#0x1_features_transaction_simulation_enhancement_enabled)
 -  [Function `get_collection_owner_feature`](#0x1_features_get_collection_owner_feature)
 -  [Function `is_collection_owner_enabled`](#0x1_features_is_collection_owner_enabled)
+-  [Function `get_native_memory_operations_feature`](#0x1_features_get_native_memory_operations_feature)
+-  [Function `is_native_memory_operations_enabled`](#0x1_features_is_native_memory_operations_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `change_feature_flags_internal`](#0x1_features_change_feature_flags_internal)
 -  [Function `change_feature_flags_for_next_epoch`](#0x1_features_change_feature_flags_for_next_epoch)
@@ -666,6 +668,15 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_MULTI_ED25519_PK_VALIDATE_V2_NATIVES">MULTI_ED25519_PK_VALIDATE_V2_NATIVES</a>: u64 = 7;
+</code></pre>
+
+
+
+<a id="0x1_features_NATIVE_MEMORY_OPERATIONS"></a>
+
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_NATIVE_MEMORY_OPERATIONS">NATIVE_MEMORY_OPERATIONS</a>: u64 = 80;
 </code></pre>
 
 
@@ -3275,6 +3286,52 @@ Deprecated feature
 
 </details>
 
+<a id="0x1_features_get_native_memory_operations_feature"></a>
+
+## Function `get_native_memory_operations_feature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_native_memory_operations_feature">get_native_memory_operations_feature</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_native_memory_operations_feature">get_native_memory_operations_feature</a>(): u64 { <a href="features.md#0x1_features_NATIVE_MEMORY_OPERATIONS">NATIVE_MEMORY_OPERATIONS</a> }
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_is_native_memory_operations_enabled"></a>
+
+## Function `is_native_memory_operations_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_native_memory_operations_enabled">is_native_memory_operations_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_native_memory_operations_enabled">is_native_memory_operations_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_NATIVE_MEMORY_OPERATIONS">NATIVE_MEMORY_OPERATIONS</a>)
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_features_change_feature_flags"></a>
 
 ## Function `change_feature_flags`
@@ -3691,6 +3748,17 @@ Helper to check whether a feature flag is enabled.
 
 <pre><code><b>fun</b> <a href="features.md#0x1_features_spec_abort_if_multisig_payload_mismatch_enabled">spec_abort_if_multisig_payload_mismatch_enabled</a>(): bool {
    <a href="features.md#0x1_features_spec_is_enabled">spec_is_enabled</a>(<a href="features.md#0x1_features_ABORT_IF_MULTISIG_PAYLOAD_MISMATCH">ABORT_IF_MULTISIG_PAYLOAD_MISMATCH</a>)
+}
+</code></pre>
+
+
+
+
+<a id="0x1_features_spec_new_accounts_default_to_fa_apt_store_enabled"></a>
+
+
+<pre><code><b>fun</b> <a href="features.md#0x1_features_spec_new_accounts_default_to_fa_apt_store_enabled">spec_new_accounts_default_to_fa_apt_store_enabled</a>(): bool {
+   <a href="features.md#0x1_features_spec_is_enabled">spec_is_enabled</a>(<a href="features.md#0x1_features_NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE">NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/tests/compiler-v2-doc/vector.md
+++ b/aptos-move/framework/move-stdlib/tests/compiler-v2-doc/vector.md
@@ -40,6 +40,7 @@ the return on investment didn't seem worth it for these simple functions.
 -  [Function `remove`](#0x1_vector_remove)
 -  [Function `remove_value`](#0x1_vector_remove_value)
 -  [Function `swap_remove`](#0x1_vector_swap_remove)
+-  [Function `replace`](#0x1_vector_replace)
 -  [Function `for_each`](#0x1_vector_for_each)
 -  [Function `for_each_reverse`](#0x1_vector_for_each_reverse)
 -  [Function `for_each_ref`](#0x1_vector_for_each_ref)
@@ -142,6 +143,18 @@ The length of the vectors are not equal.
 
 
 <pre><code><b>const</b> <a href="vector.md#0x1_vector_EVECTORS_LENGTH_MISMATCH">EVECTORS_LENGTH_MISMATCH</a>: u64 = 131074;
+</code></pre>
+
+
+
+<a id="0x1_vector_USE_MOVE_RANGE"></a>
+
+Whether to utilize native vector::move_range
+Vector module cannot call features module, due to cyclic dependency,
+so this is a constant.
+
+
+<pre><code><b>const</b> <a href="vector.md#0x1_vector_USE_MOVE_RANGE">USE_MOVE_RANGE</a>: bool = <b>true</b>;
 </code></pre>
 
 
@@ -482,8 +495,15 @@ Pushes all of the elements of the <code>other</code> vector into the <code>self<
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_append">append</a>&lt;Element&gt;(self: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, other: <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;) {
-    <a href="vector.md#0x1_vector_reverse">reverse</a>(&<b>mut</b> other);
-    <a href="vector.md#0x1_vector_reverse_append">reverse_append</a>(self, other);
+    <b>if</b> (<a href="vector.md#0x1_vector_USE_MOVE_RANGE">USE_MOVE_RANGE</a>) {
+        <b>let</b> self_length = <a href="vector.md#0x1_vector_length">length</a>(self);
+        <b>let</b> other_length = <a href="vector.md#0x1_vector_length">length</a>(&other);
+        <a href="vector.md#0x1_vector_move_range">move_range</a>(&<b>mut</b> other, 0, other_length, self, self_length);
+        <a href="vector.md#0x1_vector_destroy_empty">destroy_empty</a>(other);
+    } <b>else</b> {
+        <a href="vector.md#0x1_vector_reverse">reverse</a>(&<b>mut</b> other);
+        <a href="vector.md#0x1_vector_reverse_append">reverse_append</a>(self, other);
+    }
 }
 </code></pre>
 
@@ -525,7 +545,11 @@ Pushes all of the elements of the <code>other</code> vector into the <code>self<
 
 ## Function `trim`
 
-Trim a vector to a smaller size, returning the evicted elements in order
+Splits (trims) the collection into two at the given index.
+Returns a newly allocated vector containing the elements in the range [new_len, len).
+After the call, the original vector will be left containing the elements [0, new_len)
+with its previous capacity unchanged.
+In many languages this is also called <code>split_off</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_trim">trim</a>&lt;Element&gt;(self: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, new_len: u64): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;
@@ -538,9 +562,21 @@ Trim a vector to a smaller size, returning the evicted elements in order
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_trim">trim</a>&lt;Element&gt;(self: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, new_len: u64): <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt; {
-    <b>let</b> res = <a href="vector.md#0x1_vector_trim_reverse">trim_reverse</a>(self, new_len);
-    <a href="vector.md#0x1_vector_reverse">reverse</a>(&<b>mut</b> res);
-    res
+    <b>let</b> len = <a href="vector.md#0x1_vector_length">length</a>(self);
+    <b>assert</b>!(new_len &lt;= len, <a href="vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>);
+
+    <b>let</b> other = <a href="vector.md#0x1_vector_empty">empty</a>();
+    <b>if</b> (<a href="vector.md#0x1_vector_USE_MOVE_RANGE">USE_MOVE_RANGE</a>) {
+        <a href="vector.md#0x1_vector_move_range">move_range</a>(self, new_len, len - new_len, &<b>mut</b> other, 0);
+    } <b>else</b> {
+        <b>while</b> (len &gt; new_len) {
+            <a href="vector.md#0x1_vector_push_back">push_back</a>(&<b>mut</b> other, <a href="vector.md#0x1_vector_pop_back">pop_back</a>(self));
+            len = len - 1;
+        };
+        <a href="vector.md#0x1_vector_reverse">reverse</a>(&<b>mut</b> other);
+    };
+
+    other
 }
 </code></pre>
 
@@ -728,10 +764,27 @@ Aborts if out of bounds.
 <pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_insert">insert</a>&lt;Element&gt;(self: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64, e: Element) {
     <b>let</b> len = <a href="vector.md#0x1_vector_length">length</a>(self);
     <b>assert</b>!(i &lt;= len, <a href="vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>);
-    <a href="vector.md#0x1_vector_push_back">push_back</a>(self, e);
-    <b>while</b> (i &lt; len) {
-        <a href="vector.md#0x1_vector_swap">swap</a>(self, i, len);
-        i = i + 1;
+
+    <b>if</b> (<a href="vector.md#0x1_vector_USE_MOVE_RANGE">USE_MOVE_RANGE</a>) {
+        <b>if</b> (i + 2 &gt;= len) {
+            // When we are close <b>to</b> the end, it is cheaper <b>to</b> not create
+            // a temporary <a href="vector.md#0x1_vector">vector</a>, and swap directly
+            <a href="vector.md#0x1_vector_push_back">push_back</a>(self, e);
+            <b>while</b> (i &lt; len) {
+                <a href="vector.md#0x1_vector_swap">swap</a>(self, i, len);
+                i = i + 1;
+            };
+        } <b>else</b> {
+            <b>let</b> other = <a href="vector.md#0x1_vector_singleton">singleton</a>(e);
+            <a href="vector.md#0x1_vector_move_range">move_range</a>(&<b>mut</b> other, 0, 1, self, i);
+            <a href="vector.md#0x1_vector_destroy_empty">destroy_empty</a>(other);
+        }
+    } <b>else</b> {
+        <a href="vector.md#0x1_vector_push_back">push_back</a>(self, e);
+        <b>while</b> (i &lt; len) {
+            <a href="vector.md#0x1_vector_swap">swap</a>(self, i, len);
+            i = i + 1;
+        };
     };
 }
 </code></pre>
@@ -763,9 +816,25 @@ Aborts if <code>i</code> is out of bounds.
     // i out of bounds; <b>abort</b>
     <b>if</b> (i &gt;= len) <b>abort</b> <a href="vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>;
 
-    len = len - 1;
-    <b>while</b> (i &lt; len) <a href="vector.md#0x1_vector_swap">swap</a>(self, i, { i = i + 1; i });
-    <a href="vector.md#0x1_vector_pop_back">pop_back</a>(self)
+    <b>if</b> (<a href="vector.md#0x1_vector_USE_MOVE_RANGE">USE_MOVE_RANGE</a>) {
+        // When we are close <b>to</b> the end, it is cheaper <b>to</b> not create
+        // a temporary <a href="vector.md#0x1_vector">vector</a>, and swap directly
+        <b>if</b> (i + 3 &gt;= len) {
+            len = len - 1;
+            <b>while</b> (i &lt; len) <a href="vector.md#0x1_vector_swap">swap</a>(self, i, { i = i + 1; i });
+            <a href="vector.md#0x1_vector_pop_back">pop_back</a>(self)
+        } <b>else</b> {
+            <b>let</b> other = <a href="vector.md#0x1_vector_empty">empty</a>();
+            <a href="vector.md#0x1_vector_move_range">move_range</a>(self, i, 1, &<b>mut</b> other, 0);
+            <b>let</b> result = <a href="vector.md#0x1_vector_pop_back">pop_back</a>(&<b>mut</b> other);
+            <a href="vector.md#0x1_vector_destroy_empty">destroy_empty</a>(other);
+            result
+        }
+    } <b>else</b> {
+        len = len - 1;
+        <b>while</b> (i &lt; len) <a href="vector.md#0x1_vector_swap">swap</a>(self, i, { i = i + 1; i });
+        <a href="vector.md#0x1_vector_pop_back">pop_back</a>(self)
+    }
 }
 </code></pre>
 
@@ -833,6 +902,42 @@ Aborts if <code>i</code> is out of bounds.
     <b>let</b> last_idx = <a href="vector.md#0x1_vector_length">length</a>(self) - 1;
     <a href="vector.md#0x1_vector_swap">swap</a>(self, i, last_idx);
     <a href="vector.md#0x1_vector_pop_back">pop_back</a>(self)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_vector_replace"></a>
+
+## Function `replace`
+
+Replace the <code>i</code>th element of the vector <code>self</code> with the given value, and return
+to the caller the value that was there before.
+Aborts if <code>i</code> is out of bounds.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_replace">replace</a>&lt;Element&gt;(self: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64, val: Element): Element
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="vector.md#0x1_vector_replace">replace</a>&lt;Element&gt;(self: &<b>mut</b> <a href="vector.md#0x1_vector">vector</a>&lt;Element&gt;, i: u64, val: Element): Element {
+    <b>let</b> last_idx = <a href="vector.md#0x1_vector_length">length</a>(self);
+    <b>assert</b>!(i &lt; last_idx, <a href="vector.md#0x1_vector_EINDEX_OUT_OF_BOUNDS">EINDEX_OUT_OF_BOUNDS</a>);
+    // TODO: Enable after tests are fixed.
+    // <b>if</b> (<a href="vector.md#0x1_vector_USE_MOVE_RANGE">USE_MOVE_RANGE</a>) {
+    //     <a href="mem.md#0x1_mem_replace">mem::replace</a>(<a href="vector.md#0x1_vector_borrow_mut">borrow_mut</a>(self, i), val)
+    // } <b>else</b> {
+    <a href="vector.md#0x1_vector_push_back">push_back</a>(self, val);
+    <a href="vector.md#0x1_vector_swap">swap</a>(self, i, last_idx);
+    <a href="vector.md#0x1_vector_pop_back">pop_back</a>(self)
+    // }
 }
 </code></pre>
 

--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -1108,22 +1108,12 @@ impl<'env> Generator<'env> {
     /// Generate the code for a list of arguments.
     /// Note that the arguments are evaluated in left-to-right order.
     fn gen_arg_list(&mut self, exps: &[Exp]) -> Vec<TempIndex> {
-        // If all args are side-effect free, we don't need to force temporary generation
-        // to get left-to-right evaluation.
-        // TODO: after comparison testing, remove depending on the experiment and always
-        // have `with_forced_temp` be true.
-        let options = self
-            .env()
-            .get_extension::<Options>()
-            .expect("Options is available");
-        let with_forced_temp = options.experiment_on(Experiment::RETAIN_TEMPS_FOR_ARGS)
-            || !exps.iter().all(is_definitely_pure);
         let len = exps.len();
-        // Generate code with (potentially) forced creation of temporaries for all except last arg.
+        // Generate code with forced creation of temporaries for all except last arg.
         let mut args = exps
             .iter()
             .take(if len == 0 { 0 } else { len - 1 })
-            .map(|exp| self.gen_escape_auto_ref_arg(exp, with_forced_temp))
+            .map(|exp| self.gen_escape_auto_ref_arg(exp, true))
             .collect::<Vec<_>>();
         // If there is a last arg, we don't need to force create a temporary for it.
         if let Some(last_arg) = exps
@@ -2445,6 +2435,7 @@ impl<'a> fmt::Display for ValueShapeDisplay<'a> {
 // Helpers
 
 /// Is this a leaf expression which cannot contain another expression?
+#[allow(dead_code)]
 fn is_leaf_exp(exp: &Exp) -> bool {
     matches!(
         exp.as_ref(),
@@ -2453,6 +2444,7 @@ fn is_leaf_exp(exp: &Exp) -> bool {
 }
 
 /// Can we be certain that this expression is side-effect free?
+#[allow(dead_code)]
 fn is_definitely_pure(exp: &Exp) -> bool {
     is_leaf_exp(exp) // A leaf expression is pure.
         || match exp.as_ref() {

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -271,19 +271,6 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
                 .to_string(),
             default: Given(false),
         },
-        Experiment {
-            name: Experiment::AVOID_STORE_IN_ASSIGNS.to_string(),
-            description: "Avoid storing to a local during assigns".to_string(),
-            default: Inherited(Experiment::OPTIMIZE_WAITING_FOR_COMPARE_TESTS.to_string()),
-        },
-        Experiment {
-            name: Experiment::RETAIN_TEMPS_FOR_ARGS.to_string(),
-            description:
-                "Create temps for each argument of a function call during stackless bytecode \
-                 generation and retain them until file format bytecode generation"
-                    .to_string(),
-            default: Inherited(Experiment::OPTIMIZE_WAITING_FOR_COMPARE_TESTS.to_string()),
-        },
     ];
     experiments
         .into_iter()
@@ -299,7 +286,6 @@ impl Experiment {
     pub const AST_SIMPLIFY: &'static str = "ast-simplify";
     pub const AST_SIMPLIFY_FULL: &'static str = "ast-simplify-full";
     pub const ATTACH_COMPILED_MODULE: &'static str = "attach-compiled-module";
-    pub const AVOID_STORE_IN_ASSIGNS: &'static str = "avoid-store-in-assigns";
     pub const CFG_SIMPLIFICATION: &'static str = "cfg-simplification";
     pub const CHECKS: &'static str = "checks";
     pub const COPY_PROPAGATION: &'static str = "copy-propagation";
@@ -324,7 +310,6 @@ impl Experiment {
     pub const RECURSIVE_TYPE_CHECK: &'static str = "recursive-type-check";
     pub const REFERENCE_SAFETY: &'static str = "reference-safety";
     pub const REFERENCE_SAFETY_V3: &'static str = "reference-safety-v3";
-    pub const RETAIN_TEMPS_FOR_ARGS: &'static str = "retain-temps-for-args";
     pub const SEQS_IN_BINOPS_CHECK: &'static str = "seqs-in-binops-check";
     pub const SPEC_CHECK: &'static str = "spec-check";
     pub const SPEC_REWRITE: &'static str = "spec-rewrite";

--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -285,22 +285,8 @@ impl<'a> FunctionGenerator<'a> {
                     std::slice::from_ref(source),
                 );
                 self.abstract_push_args(ctx, vec![*source], Some(mode));
-                // TODO: the below conditional check is temporary, the plan is to get rid of the `else`
-                // case if comparison testing is successful.
-                let options = ctx
-                    .fun_ctx
-                    .module
-                    .env
-                    .get_extension::<Options>()
-                    .expect("Options is available");
-                if options.experiment_on(Experiment::AVOID_STORE_IN_ASSIGNS) {
-                    self.abstract_pop(ctx);
-                    self.abstract_push_result(ctx, std::slice::from_ref(dest));
-                } else {
-                    let local = self.temp_to_local(ctx.fun_ctx, Some(ctx.attr_id), *dest);
-                    self.emit(FF::Bytecode::StLoc(local));
-                    self.abstract_pop(ctx);
-                }
+                self.abstract_pop(ctx);
+                self.abstract_push_result(ctx, std::slice::from_ref(dest));
             },
             Bytecode::Ret(_, result) => {
                 self.balance_stack_end_of_block(ctx, result);

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -484,11 +484,7 @@ pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
 
     if options.experiment_on(Experiment::DEAD_CODE_ELIMINATION) {
         pipeline.add_processor(Box::new(LiveVarAnalysisProcessor::new(true)));
-        // TODO: after comparison testing passes, always call with `eliminate_all_self_assigns` set
-        // to `false` when instantiating `DeadStoreElimination`.
-        pipeline.add_processor(Box::new(DeadStoreElimination::new(
-            !options.experiment_on(Experiment::RETAIN_TEMPS_FOR_ARGS),
-        )));
+        pipeline.add_processor(Box::new(DeadStoreElimination::new(false)));
     }
 
     // Run live var analysis again because it could be invalidated by previous pipeline steps,

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/assign.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/assign.exp
@@ -33,8 +33,12 @@ B0:
 	0: MoveLoc[0](Arg0: S)
 	1: Unpack[1](S)
 	2: Unpack[0](T)
-	3: Add
-	4: Ret
+	3: StLoc[2](Arg2: u64)
+	4: StLoc[1](Arg1: u64)
+	5: MoveLoc[1](Arg1: u64)
+	6: MoveLoc[2](Arg2: u64)
+	7: Add
+	8: Ret
 }
 assign_struct(Arg0: &mut S) /* def_idx: 3 */ {
 B0:

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14762.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14762.exp
@@ -23,13 +23,9 @@ L3:	loc1: bool
 L4:	loc2: u64
 L5:	loc3: u64
 L6:	loc4: u64
-L7:	loc5: &T
-L8:	loc6: &T
-L9:	loc7: u64
-L10:	loc8: bool
-L11:	loc9: u64
-L12:	loc10: Option<T>
-L13:	loc11: Option<T>
+L7:	loc5: u64
+L8:	loc6: bool
+L9:	loc7: Option<T>
 B0:
 	0: CopyLoc[0](Arg0: &mut S)
 	1: ImmBorrowField[0](S.entries: vector<T>)
@@ -47,68 +43,60 @@ B1:
 	12: CopyLoc[6](loc4: u64)
 	13: CopyLoc[5](loc3: u64)
 	14: Lt
-	15: BrFalse(41)
+	15: BrFalse(35)
 B2:
 	16: CopyLoc[2](loc0: &vector<T>)
 	17: CopyLoc[6](loc4: u64)
 	18: VecImmBorrow(2)
-	19: StLoc[7](loc5: &T)
-	20: MoveLoc[7](loc5: &T)
-	21: StLoc[8](loc6: &T)
-	22: MoveLoc[8](loc6: &T)
-	23: ImmBorrowField[1](T.issuer: vector<u8>)
-	24: ReadRef
-	25: CopyLoc[1](Arg1: vector<u8>)
-	26: Eq
-	27: BrFalse(34)
+	19: ImmBorrowField[1](T.issuer: vector<u8>)
+	20: ReadRef
+	21: CopyLoc[1](Arg1: vector<u8>)
+	22: Eq
+	23: BrFalse(30)
 B3:
-	28: LdTrue
-	29: StLoc[3](loc1: bool)
-	30: MoveLoc[6](loc4: u64)
-	31: StLoc[4](loc2: u64)
-	32: Branch(43)
+	24: LdTrue
+	25: StLoc[3](loc1: bool)
+	26: MoveLoc[6](loc4: u64)
+	27: StLoc[4](loc2: u64)
+	28: Branch(37)
 B4:
-	33: Branch(34)
+	29: Branch(30)
 B5:
-	34: LdU64(1)
-	35: StLoc[9](loc7: u64)
-	36: MoveLoc[6](loc4: u64)
-	37: MoveLoc[9](loc7: u64)
-	38: Add
-	39: StLoc[6](loc4: u64)
-	40: Branch(42)
+	30: MoveLoc[6](loc4: u64)
+	31: LdU64(1)
+	32: Add
+	33: StLoc[6](loc4: u64)
+	34: Branch(36)
 B6:
-	41: Branch(43)
+	35: Branch(37)
 B7:
-	42: Branch(12)
+	36: Branch(12)
 B8:
-	43: Nop
-	44: MoveLoc[2](loc0: &vector<T>)
-	45: Pop
-	46: MoveLoc[3](loc1: bool)
-	47: StLoc[10](loc8: bool)
-	48: MoveLoc[4](loc2: u64)
-	49: StLoc[11](loc9: u64)
-	50: MoveLoc[10](loc8: bool)
-	51: BrFalse(59)
+	37: Nop
+	38: MoveLoc[2](loc0: &vector<T>)
+	39: Pop
+	40: MoveLoc[3](loc1: bool)
+	41: MoveLoc[4](loc2: u64)
+	42: StLoc[7](loc5: u64)
+	43: StLoc[8](loc6: bool)
+	44: MoveLoc[8](loc6: bool)
+	45: BrFalse(53)
 B9:
-	52: MoveLoc[0](Arg0: &mut S)
-	53: MutBorrowField[0](S.entries: vector<T>)
-	54: MoveLoc[11](loc9: u64)
-	55: Call vector::remove<T>(&mut vector<T>, u64): T
-	56: Call option::some<T>(T): Option<T>
-	57: StLoc[12](loc10: Option<T>)
-	58: Branch(63)
+	46: MoveLoc[0](Arg0: &mut S)
+	47: MutBorrowField[0](S.entries: vector<T>)
+	48: MoveLoc[7](loc5: u64)
+	49: Call vector::remove<T>(&mut vector<T>, u64): T
+	50: Call option::some<T>(T): Option<T>
+	51: StLoc[9](loc7: Option<T>)
+	52: Branch(57)
 B10:
-	59: MoveLoc[0](Arg0: &mut S)
-	60: Pop
-	61: Call option::none<T>(): Option<T>
-	62: StLoc[12](loc10: Option<T>)
+	53: MoveLoc[0](Arg0: &mut S)
+	54: Pop
+	55: Call option::none<T>(): Option<T>
+	56: StLoc[9](loc7: Option<T>)
 B11:
-	63: MoveLoc[12](loc10: Option<T>)
-	64: StLoc[13](loc11: Option<T>)
-	65: MoveLoc[13](loc11: Option<T>)
-	66: Ret
+	57: MoveLoc[9](loc7: Option<T>)
+	58: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
@@ -178,12 +178,9 @@ B0:
 	33: Ret
 }
 u<Ty0>(Arg0: Ty0): Ty0 /* def_idx: 1 */ {
-L1:	loc0: Ty0
 B0:
 	0: MoveLoc[0](Arg0: Ty0)
-	1: StLoc[1](loc0: Ty0)
-	2: MoveLoc[1](loc0: Ty0)
-	3: Ret
+	1: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/eager_push_01.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/eager_push_01.exp
@@ -14,33 +14,15 @@ B0:
 	1: Ret
 }
 public test(Arg0: u64) /* def_idx: 2 */ {
-L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: u64
-L5:	loc4: u64
-L6:	loc5: u64
 B0:
 	0: MoveLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: u64)
+	1: Call one(): u64
 	2: Call one(): u64
 	3: Call one(): u64
 	4: Call one(): u64
 	5: Call one(): u64
-	6: Call one(): u64
-	7: StLoc[2](loc1: u64)
-	8: StLoc[3](loc2: u64)
-	9: StLoc[4](loc3: u64)
-	10: StLoc[5](loc4: u64)
-	11: StLoc[6](loc5: u64)
-	12: MoveLoc[1](loc0: u64)
-	13: MoveLoc[6](loc5: u64)
-	14: MoveLoc[5](loc4: u64)
-	15: MoveLoc[4](loc3: u64)
-	16: MoveLoc[3](loc2: u64)
-	17: MoveLoc[2](loc1: u64)
-	18: Call bar(u64, u64, u64, u64, u64, u64)
-	19: Ret
+	6: Call bar(u64, u64, u64, u64, u64, u64)
+	7: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/eager_push_02.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/eager_push_02.exp
@@ -5,16 +5,13 @@ module c0ffee.m {
 
 
 test(Arg0: u64, Arg1: u64): u64 /* def_idx: 0 */ {
-L2:	loc0: u64
 B0:
-	0: MoveLoc[1](Arg1: u64)
-	1: CopyLoc[0](Arg0: u64)
-	2: Mul
-	3: StLoc[2](loc0: u64)
-	4: MoveLoc[0](Arg0: u64)
-	5: MoveLoc[2](loc0: u64)
-	6: Add
-	7: Ret
+	0: CopyLoc[0](Arg0: u64)
+	1: MoveLoc[1](Arg1: u64)
+	2: MoveLoc[0](Arg0: u64)
+	3: Mul
+	4: Add
+	5: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
@@ -28,7 +28,6 @@ B0:
 }
 write_local_direct(): S /* def_idx: 2 */ {
 L0:	loc0: S
-L1:	loc1: S
 B0:
 	0: LdU64(0)
 	1: LdU64(0)
@@ -41,16 +40,13 @@ B0:
 	8: MutBorrowField[1](T.h: u64)
 	9: WriteRef
 	10: MoveLoc[0](loc0: S)
-	11: StLoc[1](loc1: S)
-	12: MoveLoc[1](loc1: S)
-	13: Ret
+	11: Ret
 }
 write_local_via_ref(): S /* def_idx: 3 */ {
 L0:	loc0: S
 L1:	loc1: u64
 L2:	loc2: &mut S
 L3:	loc3: &mut u64
-L4:	loc4: S
 B0:
 	0: LdU64(0)
 	1: LdU64(0)
@@ -69,9 +65,7 @@ B0:
 	14: MoveLoc[3](loc3: &mut u64)
 	15: WriteRef
 	16: MoveLoc[0](loc0: S)
-	17: StLoc[4](loc4: S)
-	18: MoveLoc[4](loc4: S)
-	19: Ret
+	17: Ret
 }
 write_param(Arg0: &mut S) /* def_idx: 4 */ {
 B0:
@@ -83,7 +77,6 @@ B0:
 	5: Ret
 }
 write_val(Arg0: S): S /* def_idx: 5 */ {
-L1:	loc0: S
 B0:
 	0: LdU64(42)
 	1: MutBorrowLoc[0](Arg0: S)
@@ -91,9 +84,7 @@ B0:
 	3: MutBorrowField[1](T.h: u64)
 	4: WriteRef
 	5: MoveLoc[0](Arg0: S)
-	6: StLoc[1](loc0: S)
-	7: MoveLoc[1](loc0: S)
-	8: Ret
+	6: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/framework_reduced_06.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/framework_reduced_06.exp
@@ -16,20 +16,11 @@ B0:
 	4: Ret
 }
 f1(Arg0: &mut S, Arg1: u64, Arg2: address): &mut S * address * u64 /* def_idx: 1 */ {
-L3:	loc0: &mut S
-L4:	loc1: address
-L5:	loc2: u64
 B0:
 	0: MoveLoc[0](Arg0: &mut S)
-	1: StLoc[3](loc0: &mut S)
-	2: MoveLoc[2](Arg2: address)
-	3: StLoc[4](loc1: address)
-	4: MoveLoc[1](Arg1: u64)
-	5: StLoc[5](loc2: u64)
-	6: MoveLoc[3](loc0: &mut S)
-	7: MoveLoc[4](loc1: address)
-	8: MoveLoc[5](loc2: u64)
-	9: Ret
+	1: MoveLoc[2](Arg2: address)
+	2: MoveLoc[1](Arg1: u64)
+	3: Ret
 }
 f2(Arg0: address, Arg1: &mut S, Arg2: address, Arg3: u64, Arg4: &mut S) /* def_idx: 2 */ {
 B0:
@@ -47,37 +38,40 @@ B0:
 }
 foo(Arg0: address, Arg1: &mut S, Arg2: &mut S): u64 /* def_idx: 4 */ {
 L3:	loc0: u64
-L4:	loc1: u64
+L4:	loc1: address
 L5:	loc2: address
 L6:	loc3: &mut S
-L7:	loc4: &u64
-L8:	loc5: u64
+L7:	loc4: u64
+L8:	loc5: address
+L9:	loc6: &mut S
 B0:
-	0: LdU64(1)
-	1: StLoc[3](loc0: u64)
-	2: MoveLoc[1](Arg1: &mut S)
-	3: MoveLoc[3](loc0: u64)
-	4: MoveLoc[0](Arg0: address)
-	5: Call f1(&mut S, u64, address): &mut S * address * u64
-	6: StLoc[4](loc1: u64)
+	0: MoveLoc[1](Arg1: &mut S)
+	1: LdU64(1)
+	2: MoveLoc[0](Arg0: address)
+	3: Call f1(&mut S, u64, address): &mut S * address * u64
+	4: StLoc[3](loc0: u64)
+	5: StLoc[4](loc1: address)
+	6: CopyLoc[4](loc1: address)
 	7: StLoc[5](loc2: address)
 	8: StLoc[6](loc3: &mut S)
-	9: CopyLoc[5](loc2: address)
-	10: CopyLoc[6](loc3: &mut S)
-	11: MoveLoc[5](loc2: address)
-	12: CopyLoc[4](loc1: u64)
-	13: MoveLoc[2](Arg2: &mut S)
-	14: Call f2(address, &mut S, address, u64, &mut S)
-	15: MoveLoc[6](loc3: &mut S)
-	16: ImmBorrowField[0](S.g: u64)
-	17: StLoc[7](loc4: &u64)
-	18: CopyLoc[4](loc1: u64)
-	19: MoveLoc[7](loc4: &u64)
-	20: Call f3(u64, &u64)
-	21: MoveLoc[4](loc1: u64)
-	22: StLoc[8](loc5: u64)
-	23: MoveLoc[8](loc5: u64)
-	24: Ret
+	9: CopyLoc[6](loc3: &mut S)
+	10: MoveLoc[4](loc1: address)
+	11: CopyLoc[3](loc0: u64)
+	12: StLoc[7](loc4: u64)
+	13: StLoc[8](loc5: address)
+	14: StLoc[9](loc6: &mut S)
+	15: MoveLoc[5](loc2: address)
+	16: MoveLoc[9](loc6: &mut S)
+	17: MoveLoc[8](loc5: address)
+	18: MoveLoc[7](loc4: u64)
+	19: MoveLoc[2](Arg2: &mut S)
+	20: Call f2(address, &mut S, address, u64, &mut S)
+	21: CopyLoc[3](loc0: u64)
+	22: MoveLoc[6](loc3: &mut S)
+	23: ImmBorrowField[0](S.g: u64)
+	24: Call f3(u64, &u64)
+	25: MoveLoc[3](loc0: u64)
+	26: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.exp
@@ -11,12 +11,9 @@ B0:
 	2: Ret
 }
 identity<Ty0>(Arg0: Ty0): Ty0 /* def_idx: 1 */ {
-L1:	loc0: Ty0
 B0:
 	0: MoveLoc[0](Arg0: Ty0)
-	1: StLoc[1](loc0: Ty0)
-	2: MoveLoc[1](loc0: Ty0)
-	3: Ret
+	1: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
@@ -21,15 +21,12 @@ B0:
 	2: Ret
 }
 publish(Arg0: &signer) /* def_idx: 1 */ {
-L1:	loc0: R
 B0:
-	0: LdU64(1)
-	1: Pack[0](R)
-	2: StLoc[1](loc0: R)
-	3: MoveLoc[0](Arg0: &signer)
-	4: MoveLoc[1](loc0: R)
-	5: MoveTo[0](R)
-	6: Ret
+	0: MoveLoc[0](Arg0: &signer)
+	1: LdU64(1)
+	2: Pack[0](R)
+	3: MoveTo[0](R)
+	4: Ret
 }
 read(Arg0: address): u64 /* def_idx: 2 */ {
 B0:

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.exp
@@ -6,81 +6,63 @@ module 42.if_else {
 
 if_else(Arg0: bool, Arg1: u64): u64 /* def_idx: 0 */ {
 L2:	loc0: u64
-L3:	loc1: u64
-L4:	loc2: u64
 B0:
 	0: MoveLoc[0](Arg0: bool)
-	1: BrFalse(9)
+	1: BrFalse(7)
 B1:
-	2: LdU64(1)
-	3: StLoc[2](loc0: u64)
-	4: MoveLoc[1](Arg1: u64)
-	5: MoveLoc[2](loc0: u64)
-	6: Add
-	7: StLoc[3](loc1: u64)
-	8: Branch(15)
+	2: MoveLoc[1](Arg1: u64)
+	3: LdU64(1)
+	4: Add
+	5: StLoc[2](loc0: u64)
+	6: Branch(11)
 B2:
-	9: LdU64(1)
-	10: StLoc[4](loc2: u64)
-	11: MoveLoc[1](Arg1: u64)
-	12: MoveLoc[4](loc2: u64)
-	13: Sub
-	14: StLoc[3](loc1: u64)
+	7: MoveLoc[1](Arg1: u64)
+	8: LdU64(1)
+	9: Sub
+	10: StLoc[2](loc0: u64)
 B3:
-	15: MoveLoc[3](loc1: u64)
-	16: Ret
+	11: MoveLoc[2](loc0: u64)
+	12: Ret
 }
 if_else_nested(Arg0: bool, Arg1: u64): u64 /* def_idx: 1 */ {
 L2:	loc0: u64
 L3:	loc1: u64
 L4:	loc2: u64
-L5:	loc3: u64
-L6:	loc4: u64
-L7:	loc5: u64
-L8:	loc6: u64
 B0:
 	0: MoveLoc[0](Arg0: bool)
-	1: BrFalse(9)
+	1: BrFalse(7)
 B1:
-	2: LdU64(1)
-	3: StLoc[2](loc0: u64)
-	4: CopyLoc[1](Arg1: u64)
-	5: MoveLoc[2](loc0: u64)
-	6: Add
-	7: StLoc[3](loc1: u64)
-	8: Branch(15)
+	2: CopyLoc[1](Arg1: u64)
+	3: LdU64(1)
+	4: Add
+	5: StLoc[2](loc0: u64)
+	6: Branch(11)
 B2:
-	9: LdU64(1)
-	10: StLoc[4](loc2: u64)
-	11: CopyLoc[1](Arg1: u64)
-	12: MoveLoc[4](loc2: u64)
-	13: Sub
-	14: StLoc[3](loc1: u64)
+	7: CopyLoc[1](Arg1: u64)
+	8: LdU64(1)
+	9: Sub
+	10: StLoc[2](loc0: u64)
 B3:
-	15: LdU64(10)
-	16: StLoc[5](loc3: u64)
-	17: MoveLoc[3](loc1: u64)
-	18: MoveLoc[5](loc3: u64)
-	19: Gt
-	20: BrFalse(28)
+	11: LdU64(10)
+	12: StLoc[3](loc1: u64)
+	13: MoveLoc[2](loc0: u64)
+	14: MoveLoc[3](loc1: u64)
+	15: Gt
+	16: BrFalse(22)
 B4:
-	21: LdU64(2)
-	22: StLoc[6](loc4: u64)
-	23: MoveLoc[1](Arg1: u64)
-	24: MoveLoc[6](loc4: u64)
-	25: Mul
-	26: StLoc[7](loc5: u64)
-	27: Branch(34)
+	17: MoveLoc[1](Arg1: u64)
+	18: LdU64(2)
+	19: Mul
+	20: StLoc[4](loc2: u64)
+	21: Branch(26)
 B5:
-	28: LdU64(2)
-	29: StLoc[8](loc6: u64)
-	30: MoveLoc[1](Arg1: u64)
-	31: MoveLoc[8](loc6: u64)
-	32: Div
-	33: StLoc[7](loc5: u64)
+	22: MoveLoc[1](Arg1: u64)
+	23: LdU64(2)
+	24: Div
+	25: StLoc[4](loc2: u64)
 B6:
-	34: MoveLoc[7](loc5: u64)
-	35: Ret
+	26: MoveLoc[4](loc2: u64)
+	27: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
@@ -5,140 +5,101 @@ module 42.loops {
 
 
 nested_loop(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: u64
-L5:	loc4: u64
 B0:
-	0: LdU64(0)
-	1: StLoc[1](loc0: u64)
-	2: CopyLoc[0](Arg0: u64)
-	3: MoveLoc[1](loc0: u64)
-	4: Gt
-	5: BrFalse(30)
+	0: CopyLoc[0](Arg0: u64)
+	1: LdU64(0)
+	2: Gt
+	3: BrFalse(22)
 B1:
-	6: LdU64(10)
-	7: StLoc[2](loc1: u64)
-	8: CopyLoc[0](Arg0: u64)
-	9: MoveLoc[2](loc1: u64)
-	10: Gt
-	11: BrFalse(20)
+	4: CopyLoc[0](Arg0: u64)
+	5: LdU64(10)
+	6: Gt
+	7: BrFalse(14)
 B2:
-	12: LdU64(1)
-	13: StLoc[3](loc2: u64)
-	14: MoveLoc[0](Arg0: u64)
-	15: MoveLoc[3](loc2: u64)
-	16: Sub
-	17: StLoc[0](Arg0: u64)
-	18: Branch(22)
-B3:
-	19: Branch(21)
-B4:
-	20: Branch(22)
-B5:
-	21: Branch(6)
-B6:
-	22: LdU64(1)
-	23: StLoc[4](loc3: u64)
-	24: MoveLoc[0](Arg0: u64)
-	25: MoveLoc[4](loc3: u64)
-	26: Sub
-	27: StLoc[0](Arg0: u64)
-	28: Branch(0)
-B7:
-	29: Branch(31)
-B8:
-	30: Branch(32)
-B9:
-	31: Branch(0)
-B10:
-	32: MoveLoc[0](Arg0: u64)
-	33: StLoc[5](loc4: u64)
-	34: MoveLoc[5](loc4: u64)
-	35: Ret
-}
-while_loop(Arg0: u64): u64 /* def_idx: 1 */ {
-L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: u64
-B0:
-	0: LdU64(0)
-	1: StLoc[1](loc0: u64)
-	2: CopyLoc[0](Arg0: u64)
-	3: MoveLoc[1](loc0: u64)
-	4: Gt
-	5: BrFalse(13)
-B1:
-	6: LdU64(1)
-	7: StLoc[2](loc1: u64)
 	8: MoveLoc[0](Arg0: u64)
-	9: MoveLoc[2](loc1: u64)
+	9: LdU64(1)
 	10: Sub
 	11: StLoc[0](Arg0: u64)
-	12: Branch(14)
-B2:
-	13: Branch(15)
+	12: Branch(16)
 B3:
-	14: Branch(0)
+	13: Branch(15)
 B4:
-	15: MoveLoc[0](Arg0: u64)
-	16: StLoc[3](loc2: u64)
-	17: MoveLoc[3](loc2: u64)
-	18: Ret
+	14: Branch(16)
+B5:
+	15: Branch(4)
+B6:
+	16: MoveLoc[0](Arg0: u64)
+	17: LdU64(1)
+	18: Sub
+	19: StLoc[0](Arg0: u64)
+	20: Branch(0)
+B7:
+	21: Branch(23)
+B8:
+	22: Branch(24)
+B9:
+	23: Branch(0)
+B10:
+	24: MoveLoc[0](Arg0: u64)
+	25: Ret
+}
+while_loop(Arg0: u64): u64 /* def_idx: 1 */ {
+B0:
+	0: CopyLoc[0](Arg0: u64)
+	1: LdU64(0)
+	2: Gt
+	3: BrFalse(9)
+B1:
+	4: MoveLoc[0](Arg0: u64)
+	5: LdU64(1)
+	6: Sub
+	7: StLoc[0](Arg0: u64)
+	8: Branch(10)
+B2:
+	9: Branch(11)
+B3:
+	10: Branch(0)
+B4:
+	11: MoveLoc[0](Arg0: u64)
+	12: Ret
 }
 while_loop_with_break_and_continue(Arg0: u64): u64 /* def_idx: 2 */ {
-L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: u64
-L5:	loc4: u64
 B0:
-	0: LdU64(0)
-	1: StLoc[1](loc0: u64)
-	2: CopyLoc[0](Arg0: u64)
-	3: MoveLoc[1](loc0: u64)
-	4: Gt
-	5: BrFalse(29)
+	0: CopyLoc[0](Arg0: u64)
+	1: LdU64(0)
+	2: Gt
+	3: BrFalse(21)
 B1:
-	6: LdU64(42)
-	7: StLoc[2](loc1: u64)
-	8: CopyLoc[0](Arg0: u64)
-	9: MoveLoc[2](loc1: u64)
-	10: Eq
-	11: BrFalse(14)
+	4: CopyLoc[0](Arg0: u64)
+	5: LdU64(42)
+	6: Eq
+	7: BrFalse(10)
 B2:
-	12: Branch(31)
+	8: Branch(23)
 B3:
-	13: Branch(14)
+	9: Branch(10)
 B4:
-	14: LdU64(21)
-	15: StLoc[3](loc2: u64)
-	16: CopyLoc[0](Arg0: u64)
-	17: MoveLoc[3](loc2: u64)
-	18: Eq
-	19: BrFalse(22)
+	10: CopyLoc[0](Arg0: u64)
+	11: LdU64(21)
+	12: Eq
+	13: BrFalse(16)
 B5:
-	20: Branch(0)
+	14: Branch(0)
 B6:
-	21: Branch(22)
+	15: Branch(16)
 B7:
-	22: LdU64(1)
-	23: StLoc[4](loc3: u64)
-	24: MoveLoc[0](Arg0: u64)
-	25: MoveLoc[4](loc3: u64)
-	26: Sub
-	27: StLoc[0](Arg0: u64)
-	28: Branch(30)
+	16: MoveLoc[0](Arg0: u64)
+	17: LdU64(1)
+	18: Sub
+	19: StLoc[0](Arg0: u64)
+	20: Branch(22)
 B8:
-	29: Branch(31)
+	21: Branch(23)
 B9:
-	30: Branch(0)
+	22: Branch(0)
 B10:
-	31: MoveLoc[0](Arg0: u64)
-	32: StLoc[5](loc4: u64)
-	33: MoveLoc[5](loc4: u64)
-	34: Ret
+	23: MoveLoc[0](Arg0: u64)
+	24: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/multi_use.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/multi_use.exp
@@ -9,16 +9,13 @@ B0:
 	0: Ret
 }
 public test(Arg0: u64) /* def_idx: 1 */ {
-L1:	loc0: u64
 B0:
-	0: LdU64(1)
-	1: StLoc[1](loc0: u64)
-	2: CopyLoc[0](Arg0: u64)
-	3: CopyLoc[0](Arg0: u64)
-	4: MoveLoc[1](loc0: u64)
-	5: MoveLoc[0](Arg0: u64)
-	6: Call consume(u64, u64, u64, u64)
-	7: Ret
+	0: CopyLoc[0](Arg0: u64)
+	1: CopyLoc[0](Arg0: u64)
+	2: LdU64(1)
+	3: MoveLoc[0](Arg0: u64)
+	4: Call consume(u64, u64, u64, u64)
+	5: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
@@ -5,25 +5,19 @@ module 42.operators {
 
 
 arithm(Arg0: u64, Arg1: u64): u64 /* def_idx: 0 */ {
-L2:	loc0: u64
-L3:	loc1: u64
 B0:
 	0: CopyLoc[0](Arg0: u64)
 	1: CopyLoc[1](Arg1: u64)
-	2: Sub
-	3: StLoc[2](loc0: u64)
-	4: CopyLoc[1](Arg1: u64)
-	5: MoveLoc[2](loc0: u64)
-	6: Div
-	7: MoveLoc[1](Arg1: u64)
-	8: Mul
-	9: CopyLoc[0](Arg0: u64)
-	10: Mod
-	11: StLoc[3](loc1: u64)
-	12: MoveLoc[0](Arg0: u64)
-	13: MoveLoc[3](loc1: u64)
-	14: Add
-	15: Ret
+	2: CopyLoc[0](Arg0: u64)
+	3: CopyLoc[1](Arg1: u64)
+	4: Sub
+	5: Div
+	6: MoveLoc[1](Arg1: u64)
+	7: Mul
+	8: MoveLoc[0](Arg0: u64)
+	9: Mod
+	10: Add
+	11: Ret
 }
 bits(Arg0: u64, Arg1: u8): u64 /* def_idx: 1 */ {
 B0:

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_01.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_01.exp
@@ -9,101 +9,44 @@ B0:
 	0: Ret
 }
 public test01(Arg0: u64) /* def_idx: 1 */ {
-L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: u64
-L5:	loc4: u64
 B0:
-	0: LdU64(1)
-	1: LdU64(2)
-	2: LdU64(3)
-	3: LdU64(4)
-	4: LdU64(5)
-	5: StLoc[1](loc0: u64)
-	6: StLoc[2](loc1: u64)
-	7: StLoc[3](loc2: u64)
-	8: StLoc[4](loc3: u64)
-	9: StLoc[5](loc4: u64)
-	10: MoveLoc[0](Arg0: u64)
-	11: MoveLoc[5](loc4: u64)
-	12: MoveLoc[4](loc3: u64)
-	13: MoveLoc[3](loc2: u64)
-	14: MoveLoc[2](loc1: u64)
-	15: MoveLoc[1](loc0: u64)
-	16: Call consume(u64, u64, u64, u64, u64, u64)
-	17: Ret
+	0: MoveLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: LdU64(2)
+	3: LdU64(3)
+	4: LdU64(4)
+	5: LdU64(5)
+	6: Call consume(u64, u64, u64, u64, u64, u64)
+	7: Ret
 }
 public test02(Arg0: u64) /* def_idx: 2 */ {
-L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: u64
 B0:
-	0: LdU64(1)
-	1: LdU64(2)
-	2: LdU64(4)
-	3: LdU64(5)
-	4: StLoc[1](loc0: u64)
-	5: StLoc[2](loc1: u64)
-	6: StLoc[3](loc2: u64)
-	7: StLoc[4](loc3: u64)
-	8: CopyLoc[0](Arg0: u64)
-	9: MoveLoc[4](loc3: u64)
-	10: MoveLoc[3](loc2: u64)
-	11: MoveLoc[0](Arg0: u64)
-	12: MoveLoc[2](loc1: u64)
-	13: MoveLoc[1](loc0: u64)
-	14: Call consume(u64, u64, u64, u64, u64, u64)
-	15: Ret
+	0: CopyLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: LdU64(2)
+	3: MoveLoc[0](Arg0: u64)
+	4: LdU64(4)
+	5: LdU64(5)
+	6: Call consume(u64, u64, u64, u64, u64, u64)
+	7: Ret
 }
 public test03(Arg0: u64) /* def_idx: 3 */ {
-L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: u64
-L5:	loc4: u64
-L6:	loc5: u64
-L7:	loc6: u64
-L8:	loc7: u64
-L9:	loc8: u64
-L10:	loc9: u64
 B0:
-	0: LdU64(1)
-	1: LdU64(2)
-	2: LdU64(3)
-	3: LdU64(4)
-	4: LdU64(5)
-	5: StLoc[1](loc0: u64)
-	6: StLoc[2](loc1: u64)
-	7: StLoc[3](loc2: u64)
-	8: StLoc[4](loc3: u64)
-	9: StLoc[5](loc4: u64)
-	10: CopyLoc[0](Arg0: u64)
-	11: MoveLoc[5](loc4: u64)
-	12: MoveLoc[4](loc3: u64)
-	13: MoveLoc[3](loc2: u64)
-	14: MoveLoc[2](loc1: u64)
-	15: MoveLoc[1](loc0: u64)
-	16: Call consume(u64, u64, u64, u64, u64, u64)
-	17: LdU64(1)
-	18: LdU64(2)
-	19: LdU64(3)
-	20: LdU64(4)
-	21: LdU64(5)
-	22: StLoc[6](loc5: u64)
-	23: StLoc[7](loc6: u64)
-	24: StLoc[8](loc7: u64)
-	25: StLoc[9](loc8: u64)
-	26: StLoc[10](loc9: u64)
-	27: MoveLoc[0](Arg0: u64)
-	28: MoveLoc[10](loc9: u64)
-	29: MoveLoc[9](loc8: u64)
-	30: MoveLoc[8](loc7: u64)
-	31: MoveLoc[7](loc6: u64)
-	32: MoveLoc[6](loc5: u64)
-	33: Call consume(u64, u64, u64, u64, u64, u64)
-	34: Ret
+	0: CopyLoc[0](Arg0: u64)
+	1: LdU64(1)
+	2: LdU64(2)
+	3: LdU64(3)
+	4: LdU64(4)
+	5: LdU64(5)
+	6: Call consume(u64, u64, u64, u64, u64, u64)
+	7: MoveLoc[0](Arg0: u64)
+	8: LdU64(1)
+	9: LdU64(2)
+	10: LdU64(3)
+	11: LdU64(4)
+	12: LdU64(5)
+	13: Call consume(u64, u64, u64, u64, u64, u64)
+	14: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_02.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_02.exp
@@ -29,152 +29,65 @@ B0:
 	4: Ret
 }
 public test01(Arg0: &S) /* def_idx: 3 */ {
-L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: u64
-L5:	loc4: u64
 B0:
-	0: LdU64(1)
-	1: LdU64(2)
-	2: LdU64(3)
-	3: LdU64(4)
-	4: LdU64(5)
-	5: StLoc[1](loc0: u64)
-	6: StLoc[2](loc1: u64)
-	7: StLoc[3](loc2: u64)
-	8: StLoc[4](loc3: u64)
-	9: StLoc[5](loc4: u64)
-	10: MoveLoc[0](Arg0: &S)
-	11: MoveLoc[5](loc4: u64)
-	12: MoveLoc[4](loc3: u64)
-	13: MoveLoc[3](loc2: u64)
-	14: MoveLoc[2](loc1: u64)
-	15: MoveLoc[1](loc0: u64)
-	16: Call consume1(&S, u64, u64, u64, u64, u64)
-	17: Ret
+	0: MoveLoc[0](Arg0: &S)
+	1: LdU64(1)
+	2: LdU64(2)
+	3: LdU64(3)
+	4: LdU64(4)
+	5: LdU64(5)
+	6: Call consume1(&S, u64, u64, u64, u64, u64)
+	7: Ret
 }
 public test02(Arg0: &S) /* def_idx: 4 */ {
-L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: u64
 B0:
-	0: LdU64(1)
-	1: LdU64(2)
-	2: LdU64(4)
-	3: LdU64(5)
-	4: StLoc[1](loc0: u64)
-	5: StLoc[2](loc1: u64)
-	6: StLoc[3](loc2: u64)
-	7: StLoc[4](loc3: u64)
-	8: CopyLoc[0](Arg0: &S)
-	9: MoveLoc[4](loc3: u64)
-	10: MoveLoc[3](loc2: u64)
-	11: MoveLoc[0](Arg0: &S)
-	12: MoveLoc[2](loc1: u64)
-	13: MoveLoc[1](loc0: u64)
-	14: Call consume2(&S, u64, u64, &S, u64, u64)
-	15: Ret
+	0: CopyLoc[0](Arg0: &S)
+	1: LdU64(1)
+	2: LdU64(2)
+	3: MoveLoc[0](Arg0: &S)
+	4: LdU64(4)
+	5: LdU64(5)
+	6: Call consume2(&S, u64, u64, &S, u64, u64)
+	7: Ret
 }
 public test03(Arg0: &S) /* def_idx: 5 */ {
-L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: u64
-L5:	loc4: u64
-L6:	loc5: u64
-L7:	loc6: u64
-L8:	loc7: u64
-L9:	loc8: u64
-L10:	loc9: u64
 B0:
-	0: LdU64(1)
-	1: LdU64(2)
-	2: LdU64(3)
-	3: LdU64(4)
-	4: LdU64(5)
-	5: StLoc[1](loc0: u64)
-	6: StLoc[2](loc1: u64)
-	7: StLoc[3](loc2: u64)
-	8: StLoc[4](loc3: u64)
-	9: StLoc[5](loc4: u64)
-	10: CopyLoc[0](Arg0: &S)
-	11: MoveLoc[5](loc4: u64)
-	12: MoveLoc[4](loc3: u64)
-	13: MoveLoc[3](loc2: u64)
-	14: MoveLoc[2](loc1: u64)
-	15: MoveLoc[1](loc0: u64)
-	16: Call consume1(&S, u64, u64, u64, u64, u64)
-	17: LdU64(1)
-	18: LdU64(2)
-	19: LdU64(3)
-	20: LdU64(4)
-	21: LdU64(5)
-	22: StLoc[6](loc5: u64)
-	23: StLoc[7](loc6: u64)
-	24: StLoc[8](loc7: u64)
-	25: StLoc[9](loc8: u64)
-	26: StLoc[10](loc9: u64)
-	27: MoveLoc[0](Arg0: &S)
-	28: MoveLoc[10](loc9: u64)
-	29: MoveLoc[9](loc8: u64)
-	30: MoveLoc[8](loc7: u64)
-	31: MoveLoc[7](loc6: u64)
-	32: MoveLoc[6](loc5: u64)
-	33: Call consume1(&S, u64, u64, u64, u64, u64)
-	34: Ret
+	0: CopyLoc[0](Arg0: &S)
+	1: LdU64(1)
+	2: LdU64(2)
+	3: LdU64(3)
+	4: LdU64(4)
+	5: LdU64(5)
+	6: Call consume1(&S, u64, u64, u64, u64, u64)
+	7: MoveLoc[0](Arg0: &S)
+	8: LdU64(1)
+	9: LdU64(2)
+	10: LdU64(3)
+	11: LdU64(4)
+	12: LdU64(5)
+	13: Call consume1(&S, u64, u64, u64, u64, u64)
+	14: Ret
 }
 public test04(Arg0: &S) /* def_idx: 6 */ {
-L1:	loc0: u64
-L2:	loc1: &u64
-L3:	loc2: u64
-L4:	loc3: u64
-L5:	loc4: u64
-L6:	loc5: u64
-L7:	loc6: u64
-L8:	loc7: u64
-L9:	loc8: u64
-L10:	loc9: u64
 B0:
-	0: LdU64(1)
-	1: LdU64(2)
-	2: LdU64(3)
-	3: CopyLoc[0](Arg0: &S)
-	4: ImmBorrowField[0](S.x: u64)
-	5: LdU64(5)
-	6: StLoc[1](loc0: u64)
-	7: StLoc[2](loc1: &u64)
-	8: StLoc[3](loc2: u64)
-	9: StLoc[4](loc3: u64)
-	10: StLoc[5](loc4: u64)
-	11: CopyLoc[0](Arg0: &S)
-	12: MoveLoc[5](loc4: u64)
-	13: MoveLoc[4](loc3: u64)
-	14: MoveLoc[3](loc2: u64)
-	15: MoveLoc[2](loc1: &u64)
-	16: MoveLoc[1](loc0: u64)
-	17: Call consume3(&S, u64, u64, u64, &u64, u64)
-	18: LdU64(1)
-	19: LdU64(2)
-	20: LdU64(3)
-	21: CopyLoc[0](Arg0: &S)
-	22: ImmBorrowField[0](S.x: u64)
-	23: ReadRef
-	24: LdU64(5)
-	25: StLoc[6](loc5: u64)
-	26: StLoc[7](loc6: u64)
-	27: StLoc[8](loc7: u64)
-	28: StLoc[9](loc8: u64)
-	29: StLoc[10](loc9: u64)
-	30: MoveLoc[0](Arg0: &S)
-	31: MoveLoc[10](loc9: u64)
-	32: MoveLoc[9](loc8: u64)
-	33: MoveLoc[8](loc7: u64)
-	34: MoveLoc[7](loc6: u64)
-	35: MoveLoc[6](loc5: u64)
-	36: Call consume1(&S, u64, u64, u64, u64, u64)
-	37: Ret
+	0: CopyLoc[0](Arg0: &S)
+	1: LdU64(1)
+	2: LdU64(2)
+	3: LdU64(3)
+	4: CopyLoc[0](Arg0: &S)
+	5: ImmBorrowField[0](S.x: u64)
+	6: LdU64(5)
+	7: Call consume3(&S, u64, u64, u64, &u64, u64)
+	8: CopyLoc[0](Arg0: &S)
+	9: LdU64(1)
+	10: LdU64(2)
+	11: LdU64(3)
+	12: MoveLoc[0](Arg0: &S)
+	13: ImmBorrowField[0](S.x: u64)
+	14: ReadRef
+	15: LdU64(5)
+	16: Call consume1(&S, u64, u64, u64, u64, u64)
+	17: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_04.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_04.exp
@@ -15,20 +15,14 @@ B0:
 	0: Ret
 }
 public foo(Arg0: u64) /* def_idx: 2 */ {
-L1:	loc0: u64
-L2:	loc1: u64
 B0:
 	0: MutBorrowLoc[0](Arg0: u64)
 	1: Call bar(&mut u64)
-	2: LdU64(1)
-	3: LdU64(2)
-	4: StLoc[1](loc0: u64)
-	5: StLoc[2](loc1: u64)
-	6: MoveLoc[0](Arg0: u64)
-	7: MoveLoc[2](loc1: u64)
-	8: MoveLoc[1](loc0: u64)
-	9: Call baz(u64, u64, u64)
-	10: Ret
+	2: MoveLoc[0](Arg0: u64)
+	3: LdU64(1)
+	4: LdU64(2)
+	5: Call baz(u64, u64, u64)
+	6: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_05.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_05.exp
@@ -14,43 +14,40 @@ B0:
 	1: Ret
 }
 public test1(Arg0: u64) /* def_idx: 2 */ {
-L1:	loc0: u64
 B0:
-	0: LdU64(1)
-	1: StLoc[1](loc0: u64)
-	2: CopyLoc[0](Arg0: u64)
-	3: MoveLoc[0](Arg0: u64)
-	4: MoveLoc[1](loc0: u64)
-	5: Call consume1(u64, u64, u64)
-	6: Ret
+	0: CopyLoc[0](Arg0: u64)
+	1: MoveLoc[0](Arg0: u64)
+	2: LdU64(1)
+	3: Call consume1(u64, u64, u64)
+	4: Ret
 }
 public test2(Arg0: u64) /* def_idx: 3 */ {
-L1:	loc0: u64
-L2:	loc1: u64
 B0:
 	0: Call one(): u64
-	1: LdU64(2)
-	2: StLoc[1](loc0: u64)
-	3: StLoc[2](loc1: u64)
-	4: MoveLoc[2](loc1: u64)
-	5: MoveLoc[0](Arg0: u64)
-	6: MoveLoc[1](loc0: u64)
-	7: Call consume1(u64, u64, u64)
-	8: Ret
+	1: MoveLoc[0](Arg0: u64)
+	2: LdU64(2)
+	3: Call consume1(u64, u64, u64)
+	4: Ret
 }
 public test3(Arg0: u64) /* def_idx: 4 */ {
 L1:	loc0: u64
 L2:	loc1: u64
+L3:	loc2: u64
+L4:	loc3: u64
 B0:
 	0: Call one(): u64
-	1: LdU64(3)
+	1: MoveLoc[0](Arg0: u64)
 	2: StLoc[1](loc0: u64)
 	3: StLoc[2](loc1: u64)
-	4: MoveLoc[0](Arg0: u64)
-	5: MoveLoc[2](loc1: u64)
-	6: MoveLoc[1](loc0: u64)
-	7: Call consume1(u64, u64, u64)
-	8: Ret
+	4: MoveLoc[2](loc1: u64)
+	5: LdU64(3)
+	6: StLoc[3](loc2: u64)
+	7: StLoc[4](loc3: u64)
+	8: MoveLoc[1](loc0: u64)
+	9: MoveLoc[4](loc3: u64)
+	10: MoveLoc[3](loc2: u64)
+	11: Call consume1(u64, u64, u64)
+	12: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_order.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_order.exp
@@ -21,64 +21,88 @@ L3:	loc0: u8
 L4:	loc1: u8
 B0:
 	0: MoveLoc[0](Arg0: u8)
-	1: StLoc[3](loc0: u8)
-	2: MoveLoc[1](Arg1: u8)
+	1: MoveLoc[1](Arg1: u8)
+	2: StLoc[3](loc0: u8)
 	3: StLoc[4](loc1: u8)
-	4: MoveLoc[3](loc0: u8)
+	4: MoveLoc[4](loc1: u8)
 	5: MoveLoc[2](Arg2: u8)
-	6: MoveLoc[4](loc1: u8)
+	6: MoveLoc[3](loc0: u8)
 	7: Pack[0](S)
 	8: Ret
 }
 pack3(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 2 */ {
 L3:	loc0: u8
+L4:	loc1: u8
+L5:	loc2: u8
 B0:
 	0: MoveLoc[0](Arg0: u8)
-	1: StLoc[3](loc0: u8)
-	2: MoveLoc[1](Arg1: u8)
-	3: MoveLoc[3](loc0: u8)
-	4: MoveLoc[2](Arg2: u8)
-	5: Pack[0](S)
-	6: Ret
+	1: MoveLoc[1](Arg1: u8)
+	2: StLoc[3](loc0: u8)
+	3: StLoc[4](loc1: u8)
+	4: MoveLoc[4](loc1: u8)
+	5: StLoc[5](loc2: u8)
+	6: MoveLoc[3](loc0: u8)
+	7: MoveLoc[5](loc2: u8)
+	8: MoveLoc[2](Arg2: u8)
+	9: Pack[0](S)
+	10: Ret
 }
 pack4(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 3 */ {
 L3:	loc0: u8
 L4:	loc1: u8
+L5:	loc2: u8
+L6:	loc3: u8
 B0:
 	0: MoveLoc[0](Arg0: u8)
-	1: StLoc[3](loc0: u8)
-	2: MoveLoc[1](Arg1: u8)
-	3: StLoc[4](loc1: u8)
-	4: MoveLoc[2](Arg2: u8)
-	5: MoveLoc[3](loc0: u8)
-	6: MoveLoc[4](loc1: u8)
-	7: Pack[0](S)
-	8: Ret
+	1: MoveLoc[1](Arg1: u8)
+	2: MoveLoc[2](Arg2: u8)
+	3: StLoc[3](loc0: u8)
+	4: StLoc[4](loc1: u8)
+	5: StLoc[5](loc2: u8)
+	6: MoveLoc[5](loc2: u8)
+	7: StLoc[6](loc3: u8)
+	8: MoveLoc[3](loc0: u8)
+	9: MoveLoc[6](loc3: u8)
+	10: MoveLoc[4](loc1: u8)
+	11: Pack[0](S)
+	12: Ret
 }
 pack5(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 4 */ {
 L3:	loc0: u8
+L4:	loc1: u8
+L5:	loc2: u8
 B0:
 	0: MoveLoc[0](Arg0: u8)
-	1: StLoc[3](loc0: u8)
-	2: MoveLoc[1](Arg1: u8)
-	3: MoveLoc[2](Arg2: u8)
-	4: MoveLoc[3](loc0: u8)
-	5: Pack[0](S)
-	6: Ret
+	1: MoveLoc[1](Arg1: u8)
+	2: MoveLoc[2](Arg2: u8)
+	3: StLoc[3](loc0: u8)
+	4: StLoc[4](loc1: u8)
+	5: StLoc[5](loc2: u8)
+	6: MoveLoc[4](loc1: u8)
+	7: MoveLoc[3](loc0: u8)
+	8: MoveLoc[5](loc2: u8)
+	9: Pack[0](S)
+	10: Ret
 }
 pack6(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 5 */ {
 L3:	loc0: u8
 L4:	loc1: u8
+L5:	loc2: u8
+L6:	loc3: u8
 B0:
 	0: MoveLoc[0](Arg0: u8)
-	1: StLoc[3](loc0: u8)
-	2: MoveLoc[1](Arg1: u8)
-	3: StLoc[4](loc1: u8)
-	4: MoveLoc[2](Arg2: u8)
+	1: MoveLoc[1](Arg1: u8)
+	2: MoveLoc[2](Arg2: u8)
+	3: StLoc[3](loc0: u8)
+	4: StLoc[4](loc1: u8)
 	5: MoveLoc[4](loc1: u8)
-	6: MoveLoc[3](loc0: u8)
-	7: Pack[0](S)
-	8: Ret
+	6: StLoc[5](loc2: u8)
+	7: StLoc[6](loc3: u8)
+	8: MoveLoc[3](loc0: u8)
+	9: MoveLoc[5](loc2: u8)
+	10: MoveLoc[6](loc3: u8)
+	11: Pack[0](S)
+	12: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.exp
@@ -11,21 +11,16 @@ struct S {
 }
 
 pack(Arg0: u64, Arg1: u64): S /* def_idx: 0 */ {
-L2:	loc0: T
 B0:
-	0: MoveLoc[1](Arg1: u64)
-	1: Pack[0](T)
-	2: StLoc[2](loc0: T)
-	3: MoveLoc[0](Arg0: u64)
-	4: MoveLoc[2](loc0: T)
-	5: Pack[1](S)
-	6: Ret
+	0: MoveLoc[0](Arg0: u64)
+	1: MoveLoc[1](Arg1: u64)
+	2: Pack[0](T)
+	3: Pack[1](S)
+	4: Ret
 }
 unpack(Arg0: S): u64 * u64 /* def_idx: 1 */ {
 L1:	loc0: u64
 L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: u64
 B0:
 	0: MoveLoc[0](Arg0: S)
 	1: Unpack[1](S)
@@ -33,12 +28,8 @@ B0:
 	3: StLoc[1](loc0: u64)
 	4: StLoc[2](loc1: u64)
 	5: MoveLoc[2](loc1: u64)
-	6: StLoc[3](loc2: u64)
-	7: MoveLoc[1](loc0: u64)
-	8: StLoc[4](loc3: u64)
-	9: MoveLoc[3](loc2: u64)
-	10: MoveLoc[4](loc3: u64)
-	11: Ret
+	6: MoveLoc[1](loc0: u64)
+	7: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.exp
@@ -65,6 +65,8 @@ enum Outer {
 public inner_value(Arg0: Inner): u64 /* def_idx: 0 */ {
 L1:	loc0: &Inner
 L2:	loc1: u64
+L3:	loc2: u64
+L4:	loc3: u64
 B0:
 	0: ImmBorrowLoc[0](Arg0: Inner)
 	1: StLoc[1](loc0: &Inner)
@@ -77,23 +79,27 @@ B1:
 	7: MoveLoc[0](Arg0: Inner)
 	8: UnpackVariant[0](Inner/Inner1)
 	9: StLoc[2](loc1: u64)
-	10: Branch(21)
+	10: Branch(25)
 B2:
 	11: MoveLoc[1](loc0: &Inner)
 	12: TestVariant[1](Inner/Inner2)
-	13: BrFalse(19)
+	13: BrFalse(23)
 B3:
 	14: MoveLoc[0](Arg0: Inner)
 	15: UnpackVariant[1](Inner/Inner2)
-	16: Add
-	17: StLoc[2](loc1: u64)
-	18: Branch(21)
+	16: StLoc[3](loc2: u64)
+	17: StLoc[4](loc3: u64)
+	18: MoveLoc[4](loc3: u64)
+	19: MoveLoc[3](loc2: u64)
+	20: Add
+	21: StLoc[2](loc1: u64)
+	22: Branch(25)
 B4:
-	19: LdU64(14566554180833181697)
-	20: Abort
+	23: LdU64(14566554180833181697)
+	24: Abort
 B5:
-	21: MoveLoc[2](loc1: u64)
-	22: Ret
+	25: MoveLoc[2](loc1: u64)
+	26: Ret
 }
 public is_inner1(Arg0: &Inner): bool /* def_idx: 1 */ {
 L1:	loc0: bool
@@ -152,7 +158,6 @@ B5:
 }
 public is_some_dropped<Ty0: drop>(Arg0: Option<Ty0>): bool /* def_idx: 3 */ {
 L1:	loc0: bool
-L2:	loc1: Option<Ty0>
 B0:
 	0: ImmBorrowLoc[0](Arg0: Option<Ty0>)
 	1: TestVariantGeneric[0](Option/None<Ty0>)
@@ -165,9 +170,9 @@ B1:
 	7: Branch(15)
 B2:
 	8: MoveLoc[0](Arg0: Option<Ty0>)
-	9: StLoc[2](loc1: Option<Ty0>)
-	10: LdTrue
-	11: StLoc[1](loc0: bool)
+	9: LdTrue
+	10: StLoc[1](loc0: bool)
+	11: Pop
 	12: Branch(15)
 B3:
 	13: LdU64(14566554180833181697)
@@ -361,8 +366,7 @@ B12:
 public outer_value_with_cond(Arg0: Outer): u64 /* def_idx: 7 */ {
 L1:	loc0: &Outer
 L2:	loc1: u64
-L3:	loc2: &Inner
-L4:	loc3: Box
+L3:	loc2: Box
 B0:
 	0: ImmBorrowLoc[0](Arg0: Outer)
 	1: StLoc[1](loc0: &Outer)
@@ -376,65 +380,63 @@ B1:
 	8: UnpackVariant[4](Outer/None)
 	9: LdU64(0)
 	10: StLoc[2](loc1: u64)
-	11: Branch(57)
+	11: Branch(55)
 B2:
 	12: CopyLoc[1](loc0: &Outer)
 	13: TestVariant[5](Outer/One)
 	14: BrTrue(16)
 B3:
-	15: Branch(32)
+	15: Branch(30)
 B4:
 	16: CopyLoc[1](loc0: &Outer)
 	17: ImmBorrowVariantField[1](One.i: Inner)
-	18: StLoc[3](loc2: &Inner)
-	19: MoveLoc[3](loc2: &Inner)
-	20: Call is_inner1(&Inner): bool
-	21: BrTrue(23)
+	18: Call is_inner1(&Inner): bool
+	19: BrTrue(21)
 B5:
-	22: Branch(32)
+	20: Branch(30)
 B6:
-	23: MoveLoc[1](loc0: &Outer)
-	24: Pop
-	25: MoveLoc[0](Arg0: Outer)
-	26: UnpackVariant[5](Outer/One)
-	27: Call inner_value(Inner): u64
-	28: LdU64(2)
-	29: Mod
-	30: StLoc[2](loc1: u64)
-	31: Branch(57)
+	21: MoveLoc[1](loc0: &Outer)
+	22: Pop
+	23: MoveLoc[0](Arg0: Outer)
+	24: UnpackVariant[5](Outer/One)
+	25: Call inner_value(Inner): u64
+	26: LdU64(2)
+	27: Mod
+	28: StLoc[2](loc1: u64)
+	29: Branch(55)
 B7:
-	32: CopyLoc[1](loc0: &Outer)
-	33: TestVariant[5](Outer/One)
-	34: BrFalse(42)
+	30: CopyLoc[1](loc0: &Outer)
+	31: TestVariant[5](Outer/One)
+	32: BrFalse(40)
 B8:
-	35: MoveLoc[1](loc0: &Outer)
-	36: Pop
-	37: MoveLoc[0](Arg0: Outer)
-	38: UnpackVariant[5](Outer/One)
-	39: Call inner_value(Inner): u64
-	40: StLoc[2](loc1: u64)
-	41: Branch(57)
+	33: MoveLoc[1](loc0: &Outer)
+	34: Pop
+	35: MoveLoc[0](Arg0: Outer)
+	36: UnpackVariant[5](Outer/One)
+	37: Call inner_value(Inner): u64
+	38: StLoc[2](loc1: u64)
+	39: Branch(55)
 B9:
-	42: MoveLoc[1](loc0: &Outer)
-	43: TestVariant[6](Outer/Two)
-	44: BrFalse(55)
+	40: MoveLoc[1](loc0: &Outer)
+	41: TestVariant[6](Outer/Two)
+	42: BrFalse(53)
 B10:
-	45: MoveLoc[0](Arg0: Outer)
-	46: UnpackVariant[6](Outer/Two)
-	47: StLoc[4](loc3: Box)
-	48: Call inner_value(Inner): u64
-	49: ImmBorrowLoc[4](loc3: Box)
-	50: ImmBorrowField[0](Box.x: u64)
-	51: ReadRef
-	52: Add
-	53: StLoc[2](loc1: u64)
-	54: Branch(57)
+	43: MoveLoc[0](Arg0: Outer)
+	44: UnpackVariant[6](Outer/Two)
+	45: StLoc[3](loc2: Box)
+	46: Call inner_value(Inner): u64
+	47: ImmBorrowLoc[3](loc2: Box)
+	48: ImmBorrowField[0](Box.x: u64)
+	49: ReadRef
+	50: Add
+	51: StLoc[2](loc1: u64)
+	52: Branch(55)
 B11:
-	55: LdU64(14566554180833181697)
-	56: Abort
+	53: LdU64(14566554180833181697)
+	54: Abort
 B12:
-	57: MoveLoc[2](loc1: u64)
-	58: Ret
+	55: MoveLoc[2](loc1: u64)
+	56: Ret
 }
 public outer_value_with_cond_ref(Arg0: &Outer): bool /* def_idx: 8 */ {
 L1:	loc0: bool

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.exp
@@ -29,29 +29,19 @@ B3:
 	9: Ret
 }
 public foo<Ty0: drop + store>(Arg0: E<Ty0>, Arg1: &mut Ty0) /* def_idx: 1 */ {
-L2:	loc0: E<Ty0>
-L3:	loc1: Ty0
-L4:	loc2: E<Ty0>
-L5:	loc3: E<Ty0>
-L6:	loc4: u64
+L2:	loc0: Ty0
 B0:
 	0: MoveLoc[0](Arg0: E<Ty0>)
-	1: StLoc[2](loc0: E<Ty0>)
-	2: MoveLoc[2](loc0: E<Ty0>)
+	1: UnpackGeneric[1](E<Ty0>)
+	2: PackGeneric[1](E<Ty0>)
 	3: UnpackGeneric[1](E<Ty0>)
-	4: StLoc[3](loc1: Ty0)
-	5: MoveLoc[3](loc1: Ty0)
-	6: PackGeneric[1](E<Ty0>)
-	7: StLoc[4](loc2: E<Ty0>)
-	8: MoveLoc[4](loc2: E<Ty0>)
-	9: StLoc[5](loc3: E<Ty0>)
-	10: MoveLoc[5](loc3: E<Ty0>)
-	11: UnpackGeneric[1](E<Ty0>)
-	12: LdU64(3)
-	13: StLoc[6](loc4: u64)
-	14: MoveLoc[1](Arg1: &mut Ty0)
-	15: WriteRef
-	16: Ret
+	4: LdU64(3)
+	5: Pop
+	6: StLoc[2](loc0: Ty0)
+	7: MoveLoc[2](loc0: Ty0)
+	8: MoveLoc[1](Arg1: &mut Ty0)
+	9: WriteRef
+	10: Ret
 }
 public is_none<Ty0>(Arg0: &Option<Ty0>): bool /* def_idx: 2 */ {
 B0:

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct_typed.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct_typed.exp
@@ -29,29 +29,19 @@ B3:
 	9: Ret
 }
 public foo<Ty0: drop + store>(Arg0: E<Ty0>, Arg1: &mut Ty0) /* def_idx: 1 */ {
-L2:	loc0: E<Ty0>
-L3:	loc1: Ty0
-L4:	loc2: E<Ty0>
-L5:	loc3: E<Ty0>
-L6:	loc4: u64
+L2:	loc0: Ty0
 B0:
 	0: MoveLoc[0](Arg0: E<Ty0>)
-	1: StLoc[2](loc0: E<Ty0>)
-	2: MoveLoc[2](loc0: E<Ty0>)
+	1: UnpackGeneric[1](E<Ty0>)
+	2: PackGeneric[1](E<Ty0>)
 	3: UnpackGeneric[1](E<Ty0>)
-	4: StLoc[3](loc1: Ty0)
-	5: MoveLoc[3](loc1: Ty0)
-	6: PackGeneric[1](E<Ty0>)
-	7: StLoc[4](loc2: E<Ty0>)
-	8: MoveLoc[4](loc2: E<Ty0>)
-	9: StLoc[5](loc3: E<Ty0>)
-	10: MoveLoc[5](loc3: E<Ty0>)
-	11: UnpackGeneric[1](E<Ty0>)
-	12: LdU64(3)
-	13: StLoc[6](loc4: u64)
-	14: MoveLoc[1](Arg1: &mut Ty0)
-	15: WriteRef
-	16: Ret
+	4: LdU64(3)
+	5: Pop
+	6: StLoc[2](loc0: Ty0)
+	7: MoveLoc[2](loc0: Ty0)
+	8: MoveLoc[1](Arg1: &mut Ty0)
+	9: WriteRef
+	10: Ret
 }
 public is_none<Ty0>(Arg0: &Option<Ty0>): bool /* def_idx: 2 */ {
 B0:

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
@@ -10,64 +10,52 @@ use 0000000000000000000000000000000000000000000000000000000000000001::vector as 
 public remove<Ty0>(Arg0: &mut vector<Ty0>, Arg1: u64): Ty0 /* def_idx: 0 */ {
 L2:	loc0: u64
 L3:	loc1: u64
-L4:	loc2: &mut vector<Ty0>
-L5:	loc3: u64
-L6:	loc4: u64
-L7:	loc5: u64
 B0:
 	0: CopyLoc[0](Arg0: &mut vector<Ty0>)
 	1: FreezeRef
 	2: VecLen(1)
-	3: StLoc[2](loc0: u64)
-	4: CopyLoc[1](Arg1: u64)
-	5: CopyLoc[2](loc0: u64)
-	6: Ge
-	7: BrFalse(13)
+	3: CopyLoc[1](Arg1: u64)
+	4: StLoc[2](loc0: u64)
+	5: StLoc[3](loc1: u64)
+	6: MoveLoc[2](loc0: u64)
+	7: CopyLoc[3](loc1: u64)
+	8: Ge
+	9: BrFalse(15)
 B1:
-	8: MoveLoc[0](Arg0: &mut vector<Ty0>)
-	9: Pop
-	10: LdU64(1)
-	11: Abort
+	10: MoveLoc[0](Arg0: &mut vector<Ty0>)
+	11: Pop
+	12: LdU64(1)
+	13: Abort
 B2:
-	12: Branch(13)
+	14: Branch(15)
 B3:
-	13: LdU64(1)
-	14: StLoc[3](loc1: u64)
-	15: MoveLoc[2](loc0: u64)
-	16: MoveLoc[3](loc1: u64)
+	15: MoveLoc[3](loc1: u64)
+	16: LdU64(1)
 	17: Sub
-	18: StLoc[2](loc0: u64)
+	18: StLoc[3](loc1: u64)
 B4:
 	19: CopyLoc[1](Arg1: u64)
-	20: CopyLoc[2](loc0: u64)
+	20: CopyLoc[3](loc1: u64)
 	21: Lt
-	22: BrFalse(40)
+	22: BrFalse(32)
 B5:
 	23: CopyLoc[0](Arg0: &mut vector<Ty0>)
-	24: StLoc[4](loc2: &mut vector<Ty0>)
-	25: CopyLoc[1](Arg1: u64)
-	26: StLoc[5](loc3: u64)
-	27: LdU64(1)
-	28: StLoc[6](loc4: u64)
-	29: MoveLoc[1](Arg1: u64)
-	30: MoveLoc[6](loc4: u64)
-	31: Add
-	32: StLoc[1](Arg1: u64)
-	33: CopyLoc[1](Arg1: u64)
-	34: StLoc[7](loc5: u64)
-	35: MoveLoc[4](loc2: &mut vector<Ty0>)
-	36: MoveLoc[5](loc3: u64)
-	37: MoveLoc[7](loc5: u64)
-	38: VecSwap(1)
-	39: Branch(41)
+	24: CopyLoc[1](Arg1: u64)
+	25: MoveLoc[1](Arg1: u64)
+	26: LdU64(1)
+	27: Add
+	28: StLoc[1](Arg1: u64)
+	29: CopyLoc[1](Arg1: u64)
+	30: VecSwap(1)
+	31: Branch(33)
 B6:
-	40: Branch(42)
+	32: Branch(34)
 B7:
-	41: Branch(19)
+	33: Branch(19)
 B8:
-	42: MoveLoc[0](Arg0: &mut vector<Ty0>)
-	43: VecPopBack(1)
-	44: Ret
+	34: MoveLoc[0](Arg0: &mut vector<Ty0>)
+	35: VecPopBack(1)
+	36: Ret
 }
 create(): vector<u64> /* def_idx: 1 */ {
 B0:
@@ -78,10 +66,6 @@ test_fold() /* def_idx: 2 */ {
 L0:	loc0: vector<u64>
 L1:	loc1: u64
 L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
-L6:	loc6: u64
 B0:
 	0: LdU64(0)
 	1: LdConst[1](Vector(U64): [1, 1, 0, 0, 0, 0, 0, 0, 0])
@@ -97,13 +81,13 @@ B1:
 B2:
 	10: MutBorrowLoc[0](loc0: vector<u64>)
 	11: VecPopBack(5)
-	12: StLoc[2](loc2: u64)
-	13: MoveLoc[1](loc1: u64)
-	14: StLoc[3](loc3: u64)
+	12: MoveLoc[1](loc1: u64)
+	13: Pop
+	14: StLoc[2](loc2: u64)
 	15: MoveLoc[2](loc2: u64)
-	16: StLoc[4](loc4: u64)
-	17: LdU64(0)
-	18: StLoc[1](loc1: u64)
+	16: LdU64(0)
+	17: StLoc[1](loc1: u64)
+	18: Pop
 	19: Branch(21)
 B3:
 	20: Branch(22)
@@ -111,20 +95,16 @@ B4:
 	21: Branch(6)
 B5:
 	22: MoveLoc[1](loc1: u64)
-	23: StLoc[5](loc5: u64)
-	24: LdU64(0)
-	25: StLoc[6](loc6: u64)
-	26: MoveLoc[5](loc5: u64)
-	27: MoveLoc[6](loc6: u64)
-	28: Eq
-	29: BrFalse(31)
+	23: LdU64(0)
+	24: Eq
+	25: BrFalse(27)
 B6:
-	30: Branch(33)
+	26: Branch(29)
 B7:
-	31: LdU64(0)
-	32: Abort
+	27: LdU64(0)
+	28: Abort
 B8:
-	33: Ret
+	29: Ret
 }
 }
 ============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/reference-safety/duplicate_use.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/duplicate_use.no-opt.exp
@@ -5,6 +5,6 @@ error: cannot transfer mutable local `x` since it is borrowed
   │
 8 │         mut_ref(x, x)
   │         ^^^^^^^^^^^^^
-  │         │
+  │         │       │
+  │         │       previously mutably borrowed here
   │         transfer attempted here
-  │         previously mutably borrowed here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/freeze.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/freeze.no-opt.exp
@@ -5,9 +5,9 @@ error: cannot transfer mutable local `r` since it is borrowed
    │
 18 │         ref_mut_mut(r, r); // error
    │         ^^^^^^^^^^^^^^^^^
-   │         │
+   │         │           │
+   │         │           previously mutably borrowed here
    │         transfer attempted here
-   │         previously mutably borrowed here
 
 error: cannot transfer mutable local `r` since it is borrowed
    ┌─ tests/reference-safety/freeze.move:24:9

--- a/third_party/move/move-compiler-v2/tests/reference-safety/multiple_use_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/multiple_use_invalid.no-opt.exp
@@ -9,7 +9,7 @@ error: cannot transfer mutable value since it is borrowed
   │         │ previously mutably borrowed here
   │         transfer attempted here
 
-error: cannot transfer mutable local `r` since it is borrowed
+error: cannot transfer mutable value since it is borrowed
    ┌─ tests/reference-safety/multiple_use_invalid.move:11:9
    │
 10 │         let x = r;

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/factor_invalid_1.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/factor_invalid_1.no-opt.exp
@@ -9,7 +9,7 @@ error: cannot transfer mutable local `f` since it is borrowed
 12 │         foo(f_g, f);
    │         ^^^^^^^^^^^ transfer attempted here
 
-error: cannot transfer mutable local `f` since it is borrowed
+error: cannot transfer mutable value since it is borrowed
    ┌─ tests/reference-safety/v1-borrow-tests/factor_invalid_1.move:22:9
    │
 19 │         let f_g = &mut f.g;

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_global_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-borrow-tests/imm_borrow_global_invalid.no-opt.exp
@@ -18,7 +18,7 @@ error: cannot mutably borrow `Tester::Pair` since it is already borrowed
 36 │         let p2 = freeze(borrow_global_mut<Pair>(addr2));
    │                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
 37 │         p1 == p2
-   │         -------- conflicting reference `p1` used here
+   │         -- conflicting reference `p1` used here
 
 error: cannot mutably borrow `Tester::Pair` since it is already borrowed
    ┌─ tests/reference-safety/v1-borrow-tests/imm_borrow_global_invalid.move:42:19
@@ -28,4 +28,4 @@ error: cannot mutably borrow `Tester::Pair` since it is already borrowed
 42 │         let c2 = &borrow_global_mut<Pair>(addr2).x;
    │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow attempted here
 43 │         c1 == c2
-   │         -------- conflicting reference `c1` used here
+   │         -- conflicting reference `c1` used here

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/call_mutual_borrows_invalid.no-opt.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: cannot transfer mutable local `s1` since it is borrowed
+error: cannot transfer mutable value since it is borrowed
    ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:15:9
    │
 14 │         let f = freeze(s1);
@@ -8,7 +8,7 @@ error: cannot transfer mutable local `s1` since it is borrowed
 15 │         mut_imm(s1, f);
    │         ^^^^^^^^^^^^^^ transfer attempted here
 
-error: cannot transfer mutable local `s1` since it is borrowed
+error: cannot transfer mutable value since it is borrowed
    ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:17:9
    │
 16 │         let f = &s1.f;
@@ -39,11 +39,11 @@ error: cannot transfer mutable local `s1` since it is borrowed
    │
 23 │         mut_mut(s1, s1);
    │         ^^^^^^^^^^^^^^^
-   │         │
+   │         │       │
+   │         │       previously mutably borrowed here
    │         transfer attempted here
-   │         previously mutably borrowed here
 
-error: cannot transfer mutable local `s1` since it is borrowed
+error: cannot transfer mutable value since it is borrowed
    ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:25:9
    │
 24 │         let f = &mut s1.f;
@@ -70,7 +70,7 @@ error: cannot transfer mutable local `s1` since it is borrowed
 29 │         *s;
    │         -- conflicting reference `s` used here
 
-error: cannot transfer mutable local `s1` since it is borrowed
+error: cannot transfer mutable value since it is borrowed
    ┌─ tests/reference-safety/v1-tests/call_mutual_borrows_invalid.move:31:9
    │
 30 │         let f = id_mut(&mut s1.f);

--- a/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_full_invalid.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/v1-tests/copy_full_invalid.no-opt.exp
@@ -6,7 +6,7 @@ error: cannot copy local `x` which is still mutably borrowed
 12 │         let f = &mut x;
    │                 ------ local `x` previously mutably borrowed here
 13 │         x + 0;
-   │         ^^^^^ copy attempted here
+   │         ^ copy attempted here
 14 │         *f;
    │         -- conflicting reference `f` used here
 
@@ -16,6 +16,6 @@ error: cannot copy local `x` which is still mutably borrowed
 18 │         let f = id_mut(&mut x);
    │                 -------------- local `x` previously mutably borrowed here
 19 │         x + 0;
-   │         ^^^^^ copy attempted here
+   │         ^ copy attempted here
 20 │         *f;
    │         -- conflicting reference `f` used here

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bitwise_features.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bitwise_features.exp
@@ -1,6 +1,3 @@
 processed 2 tasks
 
-task 1 'run'. lines 30-30:
-return values: 625
-
 ==> Compiler v2 delivered same results!

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bitwise_features.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bitwise_features.move
@@ -1,0 +1,58 @@
+//# publish
+module 0x42::TestFeatures {
+    use std::vector;
+
+    /// The enabled features, represented by a bitset stored on chain.
+    struct Features has key {
+        features: vector<u8>,
+    }
+
+    /// Helper to check whether a feature flag is enabled.
+    fun contains(features: &vector<u8>, feature: u64): bool {
+        let byte_index = feature / 8;
+        let bit_mask = 1 << ((feature % 8) as u8);
+        byte_index < vector::length(features) && ((*vector::borrow(features, byte_index))) & bit_mask != 0
+    }
+
+    fun set(features: &mut vector<u8>, feature: u64, include: bool) {
+        let old_n = vector::length(features); // ghost var
+        let _old_features = *features; // ghost var
+        let n = old_n; // ghost var
+
+        let byte_index = feature / 8;
+        let bit_mask = 1 << ((feature % 8) as u8);
+        while ({
+            vector::length(features) <= byte_index
+        }) {
+            vector::push_back(features, 0);
+            n = n + 1;
+        };
+        let entry = vector::borrow_mut(features, byte_index);
+        if (include)
+            *entry = *entry | bit_mask
+        else
+            *entry = *entry & (0xff ^ bit_mask)
+    }
+
+    public fun enable_feature_flags(enable: vector<u64>) acquires Features {
+        let features = &mut borrow_global_mut<Features>(@0xbeef).features;
+        let i = 0;
+        let n = vector::length(&enable);
+        while ({
+            i < n
+        }) {
+            set(features, *vector::borrow(&enable, i), true);
+            i = i + 1;
+        };
+    }
+
+    public fun test(s: signer) acquires Features {
+        move_to<Features>(&s, Features { features: vector[1, 2, 3] });
+        enable_feature_flags(vector[2]);
+        assert!(contains(&borrow_global<Features>(@0xbeef).features, 2), 0);
+        assert!(!contains(&borrow_global<Features>(@0xbeef).features, 1), 1);
+        assert!(!contains(&borrow_global<Features>(@0xbeef).features, 3), 2);
+    }
+}
+
+//# run 0x42::TestFeatures::test --signers 0xbeef

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.no-optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.no-optimize.exp
@@ -7,13 +7,9 @@ comparison between v1 and v2 failed:
 = 
 = 
 = id_mut<Ty0>(Arg0: &mut Ty0): &mut Ty0 /* def_idx: 0 */ {
-+ L1:	loc0: &mut Ty0
 = B0:
 = 	0: MoveLoc[0](Arg0: &mut Ty0)
-- 	1: Ret
-+ 	1: StLoc[1](loc0: &mut Ty0)
-+ 	2: MoveLoc[1](loc0: &mut Ty0)
-+ 	3: Ret
+= 	1: Ret
 = }
 = t0() /* def_idx: 1 */ {
 = L0:	loc0: u64

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/assert_one.no-optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/assert_one.no-optimize.exp
@@ -6,5 +6,5 @@ Error: Script execution failed with VMError: {
     sub_status: Some(14566554180833181696),
     location: script,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(0), 32)],
+    offsets: [(FunctionDefinitionIndex(0), 26)],
 }

--- a/third_party/move/move-model/bytecode/ast-generator-tests/tests/abort_example.exp
+++ b/third_party/move/move-model/bytecode/ast-generator-tests/tests/abort_example.exp
@@ -12,90 +12,89 @@ public fun f(length: u64): u64 {
 --- Stackless Bytecode
 public fun m::f($t0|length: u64): u64 {
      var $t1|$t3: u64
-     var $t2|$t11: u64 [unused]
+     var $t2: u64
      var $t3: u64
-     var $t4: u64
-     var $t5: bool
+     var $t4: bool
+     var $t5: u64
      var $t6: u64
-     var $t7: u64
-     var $t8: bool
+     var $t7: bool
+     var $t8: u64
      var $t9: u64
      var $t10: u64
-     var $t11: u64
-     var $t12: bool
+     var $t11: bool
+     var $t12: u64
      var $t13: u64
      var $t14: u64
      var $t15: u64
      var $t16: u64
      var $t17: u64
-     var $t18: u64
-  0: $t3 := copy($t0)
-  1: $t4 := 0
-  2: $t5 := >($t3, $t4)
-  3: if ($t5) goto 4 else goto 30
+  0: $t2 := copy($t0)
+  1: $t3 := 0
+  2: $t4 := >($t2, $t3)
+  3: if ($t4) goto 4 else goto 30
   4: label L1
-  5: $t6 := copy($t0)
-  6: $t7 := 100
-  7: $t8 := <($t6, $t7)
-  8: if ($t8) goto 9 else goto 27
+  5: $t5 := copy($t0)
+  6: $t6 := 100
+  7: $t7 := <($t5, $t6)
+  8: if ($t7) goto 9 else goto 27
   9: label L3
- 10: $t9 := 0
- 11: $t1 := $t9
+ 10: $t8 := 0
+ 11: $t1 := $t8
  12: goto 13
  13: label L6
- 14: $t10 := copy($t1)
- 15: $t11 := copy($t0)
- 16: $t12 := <($t10, $t11)
- 17: if ($t12) goto 18 else goto 24
+ 14: $t9 := copy($t1)
+ 15: $t10 := copy($t0)
+ 16: $t11 := <($t9, $t10)
+ 17: if ($t11) goto 18 else goto 24
  18: label L5
- 19: $t13 := move($t1)
- 20: $t14 := 1
- 21: $t15 := +($t13, $t14)
- 22: $t1 := $t15
+ 19: $t12 := move($t1)
+ 20: $t13 := 1
+ 21: $t14 := +($t12, $t13)
+ 22: $t1 := $t14
  23: goto 13
  24: label L4
- 25: $t16 := move($t1)
- 26: return $t16
+ 25: $t15 := move($t1)
+ 26: return $t15
  27: label L2
- 28: $t17 := 2
- 29: abort($t17)
+ 28: $t16 := 2
+ 29: abort($t16)
  30: label L0
- 31: $t18 := 1
- 32: abort($t18)
+ 31: $t17 := 1
+ 32: abort($t17)
 }
 
 --- Raw Generated AST
-_t3: u64 = length;
-_t4: u64 = 0;
-_t5: bool = Gt(_t3, _t4);
+_t2: u64 = length;
+_t3: u64 = 0;
+_t4: bool = Gt(_t2, _t3);
 loop {
-  if (_t5) break;
-  _t18: u64 = 1;
-  Abort(_t18)
-};
-_t6: u64 = length;
-_t7: u64 = 100;
-_t8: bool = Lt(_t6, _t7);
-loop {
-  if (_t8) break;
-  _t17: u64 = 2;
+  if (_t4) break;
+  _t17: u64 = 1;
   Abort(_t17)
 };
-_t9: u64 = 0;
-_t1: u64 = _t9;
+_t5: u64 = length;
+_t6: u64 = 100;
+_t7: bool = Lt(_t5, _t6);
 loop {
-  _t10: u64 = _t1;
-  _t11: u64 = length;
-  _t12: bool = Lt(_t10, _t11);
-  if (Not(_t12)) break;
-  _t13: u64 = _t1;
-  _t14: u64 = 1;
-  _t15: u64 = Add(_t13, _t14);
-  _t1: u64 = _t15;
+  if (_t7) break;
+  _t16: u64 = 2;
+  Abort(_t16)
+};
+_t8: u64 = 0;
+_t1: u64 = _t8;
+loop {
+  _t9: u64 = _t1;
+  _t10: u64 = length;
+  _t11: bool = Lt(_t9, _t10);
+  if (Not(_t11)) break;
+  _t12: u64 = _t1;
+  _t13: u64 = 1;
+  _t14: u64 = Add(_t12, _t13);
+  _t1: u64 = _t14;
   continue
 };
-_t16: u64 = _t1;
-return _t16
+_t15: u64 = _t1;
+return _t15
 
 --- Assign-Transformed Generated AST
 loop {

--- a/third_party/move/move-model/bytecode/ast-generator-tests/tests/bit_vector_loop_example.exp
+++ b/third_party/move/move-model/bytecode/ast-generator-tests/tests/bit_vector_loop_example.exp
@@ -8,68 +8,56 @@ public fun is_index_set(self: &BitVector, bit_index: u64): bool {
 
 --- Stackless Bytecode
 public fun m::is_index_set($t0|self: &0x1::m::BitVector, $t1|bit_index: u64): bool {
-     var $t2|$t4: u64
-     var $t3|$t5: u64
-     var $t4: u64
-     var $t5: &0x1::m::BitVector
-     var $t6: &vector<bool>
-     var $t7: u64
-     var $t8: u64
+     var $t2: u64
+     var $t3: &0x1::m::BitVector
+     var $t4: &vector<bool>
+     var $t5: u64
+     var $t6: bool
+     var $t7: &0x1::m::BitVector
+     var $t8: &vector<bool>
      var $t9: u64
-     var $t10: bool
-     var $t11: &0x1::m::BitVector
-     var $t12: &vector<bool>
+     var $t10: &bool
+     var $t11: bool
+     var $t12: &0x1::m::BitVector
      var $t13: u64
-     var $t14: &bool
-     var $t15: bool
-     var $t16: &0x1::m::BitVector
-     var $t17: u64
-  0: $t4 := copy($t1)
-  1: $t2 := $t4
-  2: $t5 := copy($t0)
-  3: $t6 := borrow_field<0x1::m::BitVector>.bit_field($t5)
-  4: $t7 := vector::length<bool>($t6)
-  5: $t3 := $t7
-  6: $t8 := move($t2)
-  7: $t9 := move($t3)
-  8: $t10 := <($t8, $t9)
-  9: if ($t10) goto 10 else goto 17
- 10: label L1
- 11: $t11 := move($t0)
- 12: $t12 := borrow_field<0x1::m::BitVector>.bit_field($t11)
- 13: $t13 := move($t1)
- 14: $t14 := vector::borrow<bool>($t12, $t13)
- 15: $t15 := read_ref($t14)
- 16: return $t15
- 17: label L0
- 18: $t16 := move($t0)
- 19: drop($t16)
- 20: $t17 := 131072
- 21: abort($t17)
+  0: $t2 := copy($t1)
+  1: $t3 := copy($t0)
+  2: $t4 := borrow_field<0x1::m::BitVector>.bit_field($t3)
+  3: $t5 := vector::length<bool>($t4)
+  4: $t6 := <($t2, $t5)
+  5: if ($t6) goto 6 else goto 13
+  6: label L1
+  7: $t7 := move($t0)
+  8: $t8 := borrow_field<0x1::m::BitVector>.bit_field($t7)
+  9: $t9 := move($t1)
+ 10: $t10 := vector::borrow<bool>($t8, $t9)
+ 11: $t11 := read_ref($t10)
+ 12: return $t11
+ 13: label L0
+ 14: $t12 := move($t0)
+ 15: drop($t12)
+ 16: $t13 := 131072
+ 17: abort($t13)
 }
 
 --- Raw Generated AST
-_t4: u64 = bit_index;
-_t2: u64 = _t4;
-_t5: &BitVector = self;
-_t6: &vector<bool> = select m::BitVector.bit_field(_t5);
-_t7: u64 = vector::length<bool>(_t6);
-_t3: u64 = _t7;
-_t8: u64 = _t2;
-_t9: u64 = _t3;
-_t10: bool = Lt(_t8, _t9);
+_t2: u64 = bit_index;
+_t3: &BitVector = self;
+_t4: &vector<bool> = select m::BitVector.bit_field(_t3);
+_t5: u64 = vector::length<bool>(_t4);
+_t6: bool = Lt(_t2, _t5);
 loop {
-  if (_t10) break;
-  _t16: &BitVector = self;
-  _t17: u64 = 131072;
-  Abort(_t17)
+  if (_t6) break;
+  _t12: &BitVector = self;
+  _t13: u64 = 131072;
+  Abort(_t13)
 };
-_t11: &BitVector = self;
-_t12: &vector<bool> = select m::BitVector.bit_field(_t11);
-_t13: u64 = bit_index;
-_t14: &bool = vector::borrow<bool>(_t12, _t13);
-_t15: bool = Deref(_t14);
-return _t15
+_t7: &BitVector = self;
+_t8: &vector<bool> = select m::BitVector.bit_field(_t7);
+_t9: u64 = bit_index;
+_t10: &bool = vector::borrow<bool>(_t8, _t9);
+_t11: bool = Deref(_t10);
+return _t11
 
 --- Assign-Transformed Generated AST
 loop {
@@ -97,75 +85,63 @@ public fun set(self: &mut BitVector, bit_index: u64) {
 
 --- Stackless Bytecode
 public fun m::set($t0|self: &mut 0x1::m::BitVector, $t1|bit_index: u64) {
-     var $t2|$t3: u64
-     var $t3|$t4: u64
-     var $t4|x: &mut bool
-     var $t5: u64
-     var $t6: &mut 0x1::m::BitVector
-     var $t7: &vector<bool>
-     var $t8: u64
-     var $t9: u64
+     var $t2|x: &mut bool
+     var $t3: u64
+     var $t4: &mut 0x1::m::BitVector
+     var $t5: &vector<bool>
+     var $t6: u64
+     var $t7: bool
+     var $t8: &mut 0x1::m::BitVector
+     var $t9: &mut vector<bool>
      var $t10: u64
-     var $t11: bool
-     var $t12: &mut 0x1::m::BitVector
-     var $t13: &mut vector<bool>
-     var $t14: u64
-     var $t15: &mut bool
-     var $t16: bool
-     var $t17: &mut bool
-     var $t18: &mut 0x1::m::BitVector
-     var $t19: u64
-  0: $t5 := copy($t1)
-  1: $t2 := $t5
-  2: $t6 := copy($t0)
-  3: $t7 := borrow_field<0x1::m::BitVector>.bit_field($t6)
-  4: $t8 := vector::length<bool>($t7)
-  5: $t3 := $t8
-  6: $t9 := move($t2)
-  7: $t10 := move($t3)
-  8: $t11 := <($t9, $t10)
-  9: if ($t11) goto 10 else goto 20
- 10: label L1
- 11: $t12 := move($t0)
- 12: $t13 := borrow_field<0x1::m::BitVector>.bit_field($t12)
- 13: $t14 := move($t1)
- 14: $t15 := vector::borrow_mut<bool>($t13, $t14)
- 15: $t4 := $t15
- 16: $t16 := true
- 17: $t17 := move($t4)
- 18: write_ref($t17, $t16)
- 19: return ()
- 20: label L0
- 21: $t18 := move($t0)
- 22: drop($t18)
- 23: $t19 := 131072
- 24: abort($t19)
+     var $t11: &mut bool
+     var $t12: bool
+     var $t13: &mut bool
+     var $t14: &mut 0x1::m::BitVector
+     var $t15: u64
+  0: $t3 := copy($t1)
+  1: $t4 := copy($t0)
+  2: $t5 := borrow_field<0x1::m::BitVector>.bit_field($t4)
+  3: $t6 := vector::length<bool>($t5)
+  4: $t7 := <($t3, $t6)
+  5: if ($t7) goto 6 else goto 16
+  6: label L1
+  7: $t8 := move($t0)
+  8: $t9 := borrow_field<0x1::m::BitVector>.bit_field($t8)
+  9: $t10 := move($t1)
+ 10: $t11 := vector::borrow_mut<bool>($t9, $t10)
+ 11: $t2 := $t11
+ 12: $t12 := true
+ 13: $t13 := move($t2)
+ 14: write_ref($t13, $t12)
+ 15: return ()
+ 16: label L0
+ 17: $t14 := move($t0)
+ 18: drop($t14)
+ 19: $t15 := 131072
+ 20: abort($t15)
 }
 
 --- Raw Generated AST
-_t5: u64 = bit_index;
-_t2: u64 = _t5;
-_t6: &mut BitVector = self;
-_t7: &vector<bool> = select m::BitVector.bit_field(_t6);
-_t8: u64 = vector::length<bool>(_t7);
-_t3: u64 = _t8;
-_t9: u64 = _t2;
-_t10: u64 = _t3;
-_t11: bool = Lt(_t9, _t10);
+_t3: u64 = bit_index;
+_t4: &mut BitVector = self;
+_t5: &vector<bool> = select m::BitVector.bit_field(_t4);
+_t6: u64 = vector::length<bool>(_t5);
+_t7: bool = Lt(_t3, _t6);
 loop {
-  if (_t11) break;
-  _t18: &mut BitVector = self;
-  _t19: u64 = 131072;
-  Abort(_t19)
+  if (_t7) break;
+  _t14: &mut BitVector = self;
+  _t15: u64 = 131072;
+  Abort(_t15)
 };
-_t12: &mut BitVector = self;
-_t13: &mut vector<bool> = select m::BitVector.bit_field(_t12);
-_t14: u64 = bit_index;
-_t15: &mut bool = vector::borrow_mut<bool>(_t13, _t14);
-_t4: &mut bool = _t15;
-_t16: bool = true;
-_t17: &mut bool = _t4;
-_t17 = _t16;
+_t8: &mut BitVector = self;
+_t9: &mut vector<bool> = select m::BitVector.bit_field(_t8);
+_t10: u64 = bit_index;
+_t11: &mut bool = vector::borrow_mut<bool>(_t9, _t10);
+_t2: &mut bool = _t11;
+_t12: bool = true;
+_t13: &mut bool = _t2;
+_t13 = _t12;
 return Tuple()
 
 --- Assign-Transformed Generated AST
@@ -214,361 +190,320 @@ public fun shift_left(self: &mut BitVector, amount: u64) {
 
 --- Stackless Bytecode
 public fun m::shift_left($t0|self: &mut 0x1::m::BitVector, $t1|amount: u64) {
-     var $t2|$t3: u64
-     var $t3|$t6: &mut vector<bool>
-     var $t4|$t9: u64
-     var $t5|$t10: u64
-     var $t6|$t13: &mut bool
-     var $t7: &mut 0x1::m::BitVector
-     var $t8: &u64
-     var $t9: u64
-     var $t10: u64
-     var $t11: u64
-     var $t12: bool
-     var $t13: &mut 0x1::m::BitVector
+     var $t2|$t7: &mut vector<bool>
+     var $t3|$t3: u64
+     var $t4|$t14: &mut bool
+     var $t5: u64
+     var $t6: &mut 0x1::m::BitVector
+     var $t7: &u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: &mut 0x1::m::BitVector
+     var $t11: &mut vector<bool>
+     var $t12: u64
+     var $t13: u64
      var $t14: &mut vector<bool>
-     var $t15: u64
+     var $t15: &vector<bool>
      var $t16: u64
-     var $t17: &mut vector<bool>
-     var $t18: &vector<bool>
+     var $t17: bool
+     var $t18: &mut vector<bool>
      var $t19: u64
-     var $t20: u64
-     var $t21: u64
-     var $t22: bool
-     var $t23: &mut vector<bool>
+     var $t20: &mut bool
+     var $t21: bool
+     var $t22: &mut bool
+     var $t23: u64
      var $t24: u64
-     var $t25: &mut bool
-     var $t26: bool
-     var $t27: &mut bool
+     var $t25: u64
+     var $t26: &mut vector<bool>
+     var $t27: u64
      var $t28: u64
-     var $t29: u64
-     var $t30: u64
-     var $t31: &mut vector<bool>
-     var $t32: u64
+     var $t29: &mut 0x1::m::BitVector
+     var $t30: &u64
+     var $t31: u64
+     var $t32: bool
      var $t33: &mut 0x1::m::BitVector
-     var $t34: &u64
+     var $t34: &0x1::m::BitVector
      var $t35: u64
-     var $t36: u64
-     var $t37: u64
-     var $t38: bool
-     var $t39: &mut 0x1::m::BitVector
-     var $t40: &0x1::m::BitVector
+     var $t36: bool
+     var $t37: &mut 0x1::m::BitVector
+     var $t38: u64
+     var $t39: u64
+     var $t40: u64
      var $t41: u64
-     var $t42: bool
+     var $t42: u64
      var $t43: u64
-     var $t44: u64
+     var $t44: &mut 0x1::m::BitVector
      var $t45: u64
-     var $t46: &mut 0x1::m::BitVector
+     var $t46: u64
      var $t47: u64
-     var $t48: u64
-     var $t49: u64
+     var $t48: &mut 0x1::m::BitVector
+     var $t49: &u64
      var $t50: u64
      var $t51: u64
      var $t52: u64
      var $t53: u64
      var $t54: &mut 0x1::m::BitVector
-     var $t55: u64
-     var $t56: &mut 0x1::m::BitVector
-     var $t57: &u64
-     var $t58: u64
+     var $t55: &u64
+     var $t56: u64
+     var $t57: bool
+     var $t58: &mut 0x1::m::BitVector
      var $t59: u64
      var $t60: u64
-     var $t61: &mut 0x1::m::BitVector
-     var $t62: &u64
-     var $t63: u64
-     var $t64: u64
-     var $t65: u64
-     var $t66: bool
-     var $t67: &mut 0x1::m::BitVector
-     var $t68: u64
-     var $t69: u64
-     var $t70: u64
-     var $t71: u64
-     var $t72: &mut 0x1::m::BitVector
-  0: $t7 := copy($t0)
-  1: $t8 := borrow_field<0x1::m::BitVector>.length($t7)
-  2: $t9 := read_ref($t8)
-  3: $t2 := $t9
-  4: $t10 := copy($t1)
-  5: $t11 := move($t2)
-  6: $t12 := >=($t10, $t11)
-  7: if ($t12) goto 8 else goto 45
-  8: label L1
-  9: $t13 := move($t0)
- 10: $t14 := borrow_field<0x1::m::BitVector>.bit_field($t13)
- 11: $t3 := $t14
- 12: $t15 := 0
- 13: $t2 := $t15
- 14: goto 15
- 15: label L4
- 16: $t16 := copy($t2)
- 17: $t4 := $t16
- 18: $t17 := copy($t3)
- 19: $t18 := freeze_ref($t17)
- 20: $t19 := vector::length<bool>($t18)
- 21: $t5 := $t19
- 22: $t20 := move($t4)
- 23: $t21 := move($t5)
- 24: $t22 := <($t20, $t21)
- 25: if ($t22) goto 26 else goto 39
- 26: label L3
- 27: $t23 := copy($t3)
- 28: $t24 := copy($t2)
- 29: $t25 := vector::borrow_mut<bool>($t23, $t24)
- 30: $t6 := $t25
- 31: $t26 := false
- 32: $t27 := move($t6)
- 33: write_ref($t27, $t26)
- 34: $t28 := move($t2)
- 35: $t29 := 1
- 36: $t30 := +($t28, $t29)
- 37: $t2 := $t30
- 38: goto 15
- 39: label L2
- 40: $t31 := move($t3)
- 41: drop($t31)
+     var $t61: u64
+     var $t62: u64
+     var $t63: &mut 0x1::m::BitVector
+  0: $t5 := copy($t1)
+  1: $t6 := copy($t0)
+  2: $t7 := borrow_field<0x1::m::BitVector>.length($t6)
+  3: $t8 := read_ref($t7)
+  4: $t9 := >=($t5, $t8)
+  5: if ($t9) goto 6 else goto 39
+  6: label L1
+  7: $t10 := move($t0)
+  8: $t11 := borrow_field<0x1::m::BitVector>.bit_field($t10)
+  9: $t2 := $t11
+ 10: $t12 := 0
+ 11: $t3 := $t12
+ 12: goto 13
+ 13: label L4
+ 14: $t13 := copy($t3)
+ 15: $t14 := copy($t2)
+ 16: $t15 := freeze_ref($t14)
+ 17: $t16 := vector::length<bool>($t15)
+ 18: $t17 := <($t13, $t16)
+ 19: if ($t17) goto 20 else goto 33
+ 20: label L3
+ 21: $t18 := copy($t2)
+ 22: $t19 := copy($t3)
+ 23: $t20 := vector::borrow_mut<bool>($t18, $t19)
+ 24: $t4 := $t20
+ 25: $t21 := false
+ 26: $t22 := move($t4)
+ 27: write_ref($t22, $t21)
+ 28: $t23 := move($t3)
+ 29: $t24 := 1
+ 30: $t25 := +($t23, $t24)
+ 31: $t3 := $t25
+ 32: goto 13
+ 33: label L2
+ 34: $t26 := move($t2)
+ 35: drop($t26)
+ 36: goto 37
+ 37: label L14
+ 38: return ()
+ 39: label L0
+ 40: $t27 := copy($t1)
+ 41: $t3 := $t27
  42: goto 43
- 43: label L14
- 44: return ()
- 45: label L0
- 46: $t32 := copy($t1)
- 47: $t2 := $t32
- 48: goto 49
- 49: label L9
- 50: $t33 := copy($t0)
- 51: $t34 := borrow_field<0x1::m::BitVector>.length($t33)
- 52: $t35 := read_ref($t34)
- 53: $t4 := $t35
- 54: $t36 := copy($t2)
- 55: $t37 := move($t4)
- 56: $t38 := <($t36, $t37)
- 57: if ($t38) goto 58 else goto 88
- 58: label L6
- 59: $t39 := copy($t0)
- 60: $t40 := freeze_ref($t39)
- 61: $t41 := copy($t2)
- 62: $t42 := m::is_index_set($t40, $t41)
- 63: if ($t42) goto 64 else goto 79
- 64: label L8
- 65: $t43 := copy($t2)
- 66: $t44 := copy($t1)
- 67: $t45 := -($t43, $t44)
- 68: $t4 := $t45
- 69: $t46 := copy($t0)
- 70: $t47 := move($t4)
- 71: m::set($t46, $t47)
- 72: goto 73
- 73: label L10
- 74: $t48 := move($t2)
- 75: $t49 := 1
- 76: $t50 := +($t48, $t49)
- 77: $t2 := $t50
- 78: goto 49
- 79: label L7
- 80: $t51 := copy($t2)
- 81: $t52 := copy($t1)
- 82: $t53 := -($t51, $t52)
- 83: $t4 := $t53
- 84: $t54 := copy($t0)
- 85: $t55 := move($t4)
- 86: m::unset($t54, $t55)
- 87: goto 73
- 88: label L5
- 89: $t56 := copy($t0)
- 90: $t57 := borrow_field<0x1::m::BitVector>.length($t56)
- 91: $t58 := read_ref($t57)
- 92: $t59 := move($t1)
- 93: $t60 := -($t58, $t59)
- 94: $t2 := $t60
- 95: goto 96
- 96: label L13
- 97: $t61 := copy($t0)
- 98: $t62 := borrow_field<0x1::m::BitVector>.length($t61)
- 99: $t63 := read_ref($t62)
-100: $t1 := $t63
-101: $t64 := copy($t2)
-102: $t65 := move($t1)
-103: $t66 := <($t64, $t65)
-104: if ($t66) goto 105 else goto 114
-105: label L12
-106: $t67 := copy($t0)
-107: $t68 := copy($t2)
-108: m::unset($t67, $t68)
-109: $t69 := move($t2)
-110: $t70 := 1
-111: $t71 := +($t69, $t70)
-112: $t2 := $t71
-113: goto 96
-114: label L11
-115: $t72 := move($t0)
-116: drop($t72)
-117: goto 43
+ 43: label L9
+ 44: $t28 := copy($t3)
+ 45: $t29 := copy($t0)
+ 46: $t30 := borrow_field<0x1::m::BitVector>.length($t29)
+ 47: $t31 := read_ref($t30)
+ 48: $t32 := <($t28, $t31)
+ 49: if ($t32) goto 50 else goto 76
+ 50: label L6
+ 51: $t33 := copy($t0)
+ 52: $t34 := freeze_ref($t33)
+ 53: $t35 := copy($t3)
+ 54: $t36 := m::is_index_set($t34, $t35)
+ 55: if ($t36) goto 56 else goto 69
+ 56: label L8
+ 57: $t37 := copy($t0)
+ 58: $t38 := copy($t3)
+ 59: $t39 := copy($t1)
+ 60: $t40 := -($t38, $t39)
+ 61: m::set($t37, $t40)
+ 62: goto 63
+ 63: label L10
+ 64: $t41 := move($t3)
+ 65: $t42 := 1
+ 66: $t43 := +($t41, $t42)
+ 67: $t3 := $t43
+ 68: goto 43
+ 69: label L7
+ 70: $t44 := copy($t0)
+ 71: $t45 := copy($t3)
+ 72: $t46 := copy($t1)
+ 73: $t47 := -($t45, $t46)
+ 74: m::unset($t44, $t47)
+ 75: goto 63
+ 76: label L5
+ 77: $t48 := copy($t0)
+ 78: $t49 := borrow_field<0x1::m::BitVector>.length($t48)
+ 79: $t50 := read_ref($t49)
+ 80: $t51 := move($t1)
+ 81: $t52 := -($t50, $t51)
+ 82: $t3 := $t52
+ 83: goto 84
+ 84: label L13
+ 85: $t53 := copy($t3)
+ 86: $t54 := copy($t0)
+ 87: $t55 := borrow_field<0x1::m::BitVector>.length($t54)
+ 88: $t56 := read_ref($t55)
+ 89: $t57 := <($t53, $t56)
+ 90: if ($t57) goto 91 else goto 100
+ 91: label L12
+ 92: $t58 := copy($t0)
+ 93: $t59 := copy($t3)
+ 94: m::unset($t58, $t59)
+ 95: $t60 := move($t3)
+ 96: $t61 := 1
+ 97: $t62 := +($t60, $t61)
+ 98: $t3 := $t62
+ 99: goto 84
+100: label L11
+101: $t63 := move($t0)
+102: drop($t63)
+103: goto 37
 }
 
 --- Raw Generated AST
-_t7: &mut BitVector = self;
-_t8: &u64 = select m::BitVector.length(_t7);
-_t9: u64 = Deref(_t8);
-_t2: u64 = _t9;
-_t10: u64 = amount;
-_t11: u64 = _t2;
-_t12: bool = Ge(_t10, _t11);
+_t5: u64 = amount;
+_t6: &mut BitVector = self;
+_t7: &u64 = select m::BitVector.length(_t6);
+_t8: u64 = Deref(_t7);
+_t9: bool = Ge(_t5, _t8);
 loop {
   loop {
     loop {
       loop {
-        if (Not(_t12)) break;
-        _t13: &mut BitVector = self;
-        _t14: &mut vector<bool> = select m::BitVector.bit_field(_t13);
-        _t3: &mut vector<bool> = _t14;
-        _t15: u64 = 0;
-        _t2: u64 = _t15;
+        if (Not(_t9)) break;
+        _t10: &mut BitVector = self;
+        _t11: &mut vector<bool> = select m::BitVector.bit_field(_t10);
+        _t2: &mut vector<bool> = _t11;
+        _t12: u64 = 0;
+        _t3: u64 = _t12;
         break[1]
       };
-      _t32: u64 = amount;
-      _t2: u64 = _t32;
+      _t27: u64 = amount;
+      _t3: u64 = _t27;
       break[1]
     };
     loop {
-      _t16: u64 = _t2;
-      _t4: u64 = _t16;
-      _t17: &mut vector<bool> = _t3;
-      _t18: &vector<bool> = Freeze(true)(_t17);
-      _t19: u64 = vector::length<bool>(_t18);
-      _t5: u64 = _t19;
-      _t20: u64 = _t4;
-      _t21: u64 = _t5;
-      _t22: bool = Lt(_t20, _t21);
-      if (Not(_t22)) break;
-      _t23: &mut vector<bool> = _t3;
-      _t24: u64 = _t2;
-      _t25: &mut bool = vector::borrow_mut<bool>(_t23, _t24);
-      _t6: &mut bool = _t25;
-      _t26: bool = false;
-      _t27: &mut bool = _t6;
-      _t27 = _t26;
-      _t28: u64 = _t2;
-      _t29: u64 = 1;
-      _t30: u64 = Add(_t28, _t29);
-      _t2: u64 = _t30;
+      _t13: u64 = _t3;
+      _t14: &mut vector<bool> = _t2;
+      _t15: &vector<bool> = Freeze(true)(_t14);
+      _t16: u64 = vector::length<bool>(_t15);
+      _t17: bool = Lt(_t13, _t16);
+      if (Not(_t17)) break;
+      _t18: &mut vector<bool> = _t2;
+      _t19: u64 = _t3;
+      _t20: &mut bool = vector::borrow_mut<bool>(_t18, _t19);
+      _t4: &mut bool = _t20;
+      _t21: bool = false;
+      _t22: &mut bool = _t4;
+      _t22 = _t21;
+      _t23: u64 = _t3;
+      _t24: u64 = 1;
+      _t25: u64 = Add(_t23, _t24);
+      _t3: u64 = _t25;
       continue
     };
-    _t31: &mut vector<bool> = _t3;
+    _t26: &mut vector<bool> = _t2;
     break[1]
   };
   loop {
+    _t28: u64 = _t3;
+    _t29: &mut BitVector = self;
+    _t30: &u64 = select m::BitVector.length(_t29);
+    _t31: u64 = Deref(_t30);
+    _t32: bool = Lt(_t28, _t31);
+    if (Not(_t32)) break;
     _t33: &mut BitVector = self;
-    _t34: &u64 = select m::BitVector.length(_t33);
-    _t35: u64 = Deref(_t34);
-    _t4: u64 = _t35;
-    _t36: u64 = _t2;
-    _t37: u64 = _t4;
-    _t38: bool = Lt(_t36, _t37);
-    if (Not(_t38)) break;
-    _t39: &mut BitVector = self;
-    _t40: &BitVector = Freeze(true)(_t39);
-    _t41: u64 = _t2;
-    _t42: bool = m::is_index_set(_t40, _t41);
+    _t34: &BitVector = Freeze(true)(_t33);
+    _t35: u64 = _t3;
+    _t36: bool = m::is_index_set(_t34, _t35);
     loop {
       loop {
-        if (Not(_t42)) break;
-        _t43: u64 = _t2;
-        _t44: u64 = amount;
-        _t45: u64 = Sub(_t43, _t44);
-        _t4: u64 = _t45;
-        _t46: &mut BitVector = self;
-        _t47: u64 = _t4;
-        m::set(_t46, _t47);
+        if (Not(_t36)) break;
+        _t37: &mut BitVector = self;
+        _t38: u64 = _t3;
+        _t39: u64 = amount;
+        _t40: u64 = Sub(_t38, _t39);
+        m::set(_t37, _t40);
         break[1]
       };
-      _t51: u64 = _t2;
-      _t52: u64 = amount;
-      _t53: u64 = Sub(_t51, _t52);
-      _t4: u64 = _t53;
-      _t54: &mut BitVector = self;
-      _t55: u64 = _t4;
-      m::unset(_t54, _t55);
+      _t44: &mut BitVector = self;
+      _t45: u64 = _t3;
+      _t46: u64 = amount;
+      _t47: u64 = Sub(_t45, _t46);
+      m::unset(_t44, _t47);
       break
     };
-    _t48: u64 = _t2;
-    _t49: u64 = 1;
-    _t50: u64 = Add(_t48, _t49);
-    _t2: u64 = _t50;
+    _t41: u64 = _t3;
+    _t42: u64 = 1;
+    _t43: u64 = Add(_t41, _t42);
+    _t3: u64 = _t43;
     continue
   };
-  _t56: &mut BitVector = self;
-  _t57: &u64 = select m::BitVector.length(_t56);
-  _t58: u64 = Deref(_t57);
-  _t59: u64 = amount;
-  _t60: u64 = Sub(_t58, _t59);
-  _t2: u64 = _t60;
+  _t48: &mut BitVector = self;
+  _t49: &u64 = select m::BitVector.length(_t48);
+  _t50: u64 = Deref(_t49);
+  _t51: u64 = amount;
+  _t52: u64 = Sub(_t50, _t51);
+  _t3: u64 = _t52;
   loop {
-    _t61: &mut BitVector = self;
-    _t62: &u64 = select m::BitVector.length(_t61);
-    _t63: u64 = Deref(_t62);
-    amount: u64 = _t63;
-    _t64: u64 = _t2;
-    _t65: u64 = amount;
-    _t66: bool = Lt(_t64, _t65);
-    if (Not(_t66)) break;
-    _t67: &mut BitVector = self;
-    _t68: u64 = _t2;
-    m::unset(_t67, _t68);
-    _t69: u64 = _t2;
-    _t70: u64 = 1;
-    _t71: u64 = Add(_t69, _t70);
-    _t2: u64 = _t71;
+    _t53: u64 = _t3;
+    _t54: &mut BitVector = self;
+    _t55: &u64 = select m::BitVector.length(_t54);
+    _t56: u64 = Deref(_t55);
+    _t57: bool = Lt(_t53, _t56);
+    if (Not(_t57)) break;
+    _t58: &mut BitVector = self;
+    _t59: u64 = _t3;
+    m::unset(_t58, _t59);
+    _t60: u64 = _t3;
+    _t61: u64 = 1;
+    _t62: u64 = Add(_t60, _t61);
+    _t3: u64 = _t62;
     continue
   };
-  _t72: &mut BitVector = self;
+  _t63: &mut BitVector = self;
   break
 };
 return Tuple()
 
 --- Assign-Transformed Generated AST
-_t2: u64 = Deref(select m::BitVector.length(self));
 loop {
   loop {
     loop {
       loop {
-        if (Not(Ge(amount, _t2))) break;
-        _t3: &mut vector<bool> = select m::BitVector.bit_field(self);
-        _t2: u64 = 0;
+        if (Not(Ge(amount, Deref(select m::BitVector.length(self))))) break;
+        _t2: &mut vector<bool> = select m::BitVector.bit_field(self);
+        _t3: u64 = 0;
         break[1]
       };
-      _t2: u64 = amount;
+      _t3: u64 = amount;
       break[1]
     };
     loop {
-      if (Not(Lt(_t2, vector::length<bool>(Freeze(true)(_t3))))) break;
-      vector::borrow_mut<bool>(_t3, _t2) = false;
-      _t2: u64 = Add(_t2, 1);
+      if (Not(Lt(_t3, vector::length<bool>(Freeze(true)(_t2))))) break;
+      vector::borrow_mut<bool>(_t2, _t3) = false;
+      _t3: u64 = Add(_t3, 1);
       continue
     };
     break[1]
   };
   loop {
-    _t4: u64 = Deref(select m::BitVector.length(self));
-    if (Not(Lt(_t2, _t4))) break;
+    if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break;
     loop {
       loop {
-        if (Not(m::is_index_set(Freeze(true)(self), _t2))) break;
-        _t4: u64 = Sub(_t2, amount);
-        m::set(self, _t4);
+        if (Not(m::is_index_set(Freeze(true)(self), _t3))) break;
+        m::set(self, Sub(_t3, amount));
         break[1]
       };
-      _t4: u64 = Sub(_t2, amount);
-      m::unset(self, _t4);
+      m::unset(self, Sub(_t3, amount));
       break
     };
-    _t2: u64 = Add(_t2, 1);
+    _t3: u64 = Add(_t3, 1);
     continue
   };
-  _t2: u64 = Sub(Deref(select m::BitVector.length(self)), amount);
+  _t3: u64 = Sub(Deref(select m::BitVector.length(self)), amount);
   loop {
-    if (Not(Lt(_t2, Deref(select m::BitVector.length(self))))) break;
-    m::unset(self, _t2);
-    _t2: u64 = Add(_t2, 1);
+    if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break;
+    m::unset(self, _t3);
+    _t3: u64 = Add(_t3, 1);
     continue
   };
   break
@@ -576,42 +511,38 @@ loop {
 return Tuple()
 
 --- If-Transformed Generated AST
-_t2: u64 = Deref(select m::BitVector.length(self));
 loop {
   loop {
-    if Ge(amount, _t2) {
-      _t3: &mut vector<bool> = select m::BitVector.bit_field(self);
-      _t2: u64 = 0
+    if Ge(amount, Deref(select m::BitVector.length(self))) {
+      _t2: &mut vector<bool> = select m::BitVector.bit_field(self);
+      _t3: u64 = 0
     } else {
-      _t2: u64 = amount;
+      _t3: u64 = amount;
       break
     };
     loop {
-      if (Not(Lt(_t2, vector::length<bool>(Freeze(true)(_t3))))) break;
-      vector::borrow_mut<bool>(_t3, _t2) = false;
-      _t2: u64 = Add(_t2, 1);
+      if (Not(Lt(_t3, vector::length<bool>(Freeze(true)(_t2))))) break;
+      vector::borrow_mut<bool>(_t2, _t3) = false;
+      _t3: u64 = Add(_t3, 1);
       continue
     };
     break[1]
   };
   loop {
-    _t4: u64 = Deref(select m::BitVector.length(self));
-    if (Not(Lt(_t2, _t4))) break;
-    if m::is_index_set(Freeze(true)(self), _t2) {
-      _t4: u64 = Sub(_t2, amount);
-      m::set(self, _t4)
+    if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break;
+    if m::is_index_set(Freeze(true)(self), _t3) {
+      m::set(self, Sub(_t3, amount))
     } else {
-      _t4: u64 = Sub(_t2, amount);
-      m::unset(self, _t4)
+      m::unset(self, Sub(_t3, amount))
     };
-    _t2: u64 = Add(_t2, 1);
+    _t3: u64 = Add(_t3, 1);
     continue
   };
-  _t2: u64 = Sub(Deref(select m::BitVector.length(self)), amount);
+  _t3: u64 = Sub(Deref(select m::BitVector.length(self)), amount);
   loop {
-    if (Not(Lt(_t2, Deref(select m::BitVector.length(self))))) break;
-    m::unset(self, _t2);
-    _t2: u64 = Add(_t2, 1);
+    if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break;
+    m::unset(self, _t3);
+    _t3: u64 = Add(_t3, 1);
     continue
   };
   break
@@ -620,53 +551,46 @@ return Tuple()
 
 --- Var-Bound Generated AST
 {
-  let _t4: u64;
+  let _t3: u64;
   {
-    let _t3: &mut vector<bool>;
-    {
-      let _t2: u64;
-      _t2: u64 = Deref(select m::BitVector.length(self));
+    let _t2: &mut vector<bool>;
+    loop {
       loop {
-        loop {
-          if Ge(amount, _t2) {
-            _t3: &mut vector<bool> = select m::BitVector.bit_field(self);
-            _t2: u64 = 0
-          } else {
-            _t2: u64 = amount;
-            break
-          };
-          loop {
-            if (Not(Lt(_t2, vector::length<bool>(Freeze(true)(_t3))))) break;
-            vector::borrow_mut<bool>(_t3, _t2) = false;
-            _t2: u64 = Add(_t2, 1);
-            continue
-          };
-          break[1]
+        if Ge(amount, Deref(select m::BitVector.length(self))) {
+          _t2: &mut vector<bool> = select m::BitVector.bit_field(self);
+          _t3: u64 = 0
+        } else {
+          _t3: u64 = amount;
+          break
         };
         loop {
-          _t4: u64 = Deref(select m::BitVector.length(self));
-          if (Not(Lt(_t2, _t4))) break;
-          if m::is_index_set(Freeze(true)(self), _t2) {
-            _t4: u64 = Sub(_t2, amount);
-            m::set(self, _t4)
-          } else {
-            _t4: u64 = Sub(_t2, amount);
-            m::unset(self, _t4)
-          };
-          _t2: u64 = Add(_t2, 1);
+          if (Not(Lt(_t3, vector::length<bool>(Freeze(true)(_t2))))) break;
+          vector::borrow_mut<bool>(_t2, _t3) = false;
+          _t3: u64 = Add(_t3, 1);
           continue
         };
-        _t2: u64 = Sub(Deref(select m::BitVector.length(self)), amount);
-        loop {
-          if (Not(Lt(_t2, Deref(select m::BitVector.length(self))))) break;
-          m::unset(self, _t2);
-          _t2: u64 = Add(_t2, 1);
-          continue
-        };
-        break
+        break[1]
       };
-      return Tuple()
-    }
+      loop {
+        if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break;
+        if m::is_index_set(Freeze(true)(self), _t3) {
+          m::set(self, Sub(_t3, amount))
+        } else {
+          m::unset(self, Sub(_t3, amount))
+        };
+        _t3: u64 = Add(_t3, 1);
+        continue
+      };
+      _t3: u64 = Sub(Deref(select m::BitVector.length(self)), amount);
+      loop {
+        if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break;
+        m::unset(self, _t3);
+        _t3: u64 = Add(_t3, 1);
+        continue
+      };
+      break
+    };
+    return Tuple()
   }
 }
 
@@ -681,75 +605,63 @@ public fun unset(self: &mut BitVector, bit_index: u64) {
 
 --- Stackless Bytecode
 public fun m::unset($t0|self: &mut 0x1::m::BitVector, $t1|bit_index: u64) {
-     var $t2|$t3: u64
-     var $t3|$t4: u64
-     var $t4|x: &mut bool
-     var $t5: u64
-     var $t6: &mut 0x1::m::BitVector
-     var $t7: &vector<bool>
-     var $t8: u64
-     var $t9: u64
+     var $t2|x: &mut bool
+     var $t3: u64
+     var $t4: &mut 0x1::m::BitVector
+     var $t5: &vector<bool>
+     var $t6: u64
+     var $t7: bool
+     var $t8: &mut 0x1::m::BitVector
+     var $t9: &mut vector<bool>
      var $t10: u64
-     var $t11: bool
-     var $t12: &mut 0x1::m::BitVector
-     var $t13: &mut vector<bool>
-     var $t14: u64
-     var $t15: &mut bool
-     var $t16: bool
-     var $t17: &mut bool
-     var $t18: &mut 0x1::m::BitVector
-     var $t19: u64
-  0: $t5 := copy($t1)
-  1: $t2 := $t5
-  2: $t6 := copy($t0)
-  3: $t7 := borrow_field<0x1::m::BitVector>.bit_field($t6)
-  4: $t8 := vector::length<bool>($t7)
-  5: $t3 := $t8
-  6: $t9 := move($t2)
-  7: $t10 := move($t3)
-  8: $t11 := <($t9, $t10)
-  9: if ($t11) goto 10 else goto 20
- 10: label L1
- 11: $t12 := move($t0)
- 12: $t13 := borrow_field<0x1::m::BitVector>.bit_field($t12)
- 13: $t14 := move($t1)
- 14: $t15 := vector::borrow_mut<bool>($t13, $t14)
- 15: $t4 := $t15
- 16: $t16 := false
- 17: $t17 := move($t4)
- 18: write_ref($t17, $t16)
- 19: return ()
- 20: label L0
- 21: $t18 := move($t0)
- 22: drop($t18)
- 23: $t19 := 131072
- 24: abort($t19)
+     var $t11: &mut bool
+     var $t12: bool
+     var $t13: &mut bool
+     var $t14: &mut 0x1::m::BitVector
+     var $t15: u64
+  0: $t3 := copy($t1)
+  1: $t4 := copy($t0)
+  2: $t5 := borrow_field<0x1::m::BitVector>.bit_field($t4)
+  3: $t6 := vector::length<bool>($t5)
+  4: $t7 := <($t3, $t6)
+  5: if ($t7) goto 6 else goto 16
+  6: label L1
+  7: $t8 := move($t0)
+  8: $t9 := borrow_field<0x1::m::BitVector>.bit_field($t8)
+  9: $t10 := move($t1)
+ 10: $t11 := vector::borrow_mut<bool>($t9, $t10)
+ 11: $t2 := $t11
+ 12: $t12 := false
+ 13: $t13 := move($t2)
+ 14: write_ref($t13, $t12)
+ 15: return ()
+ 16: label L0
+ 17: $t14 := move($t0)
+ 18: drop($t14)
+ 19: $t15 := 131072
+ 20: abort($t15)
 }
 
 --- Raw Generated AST
-_t5: u64 = bit_index;
-_t2: u64 = _t5;
-_t6: &mut BitVector = self;
-_t7: &vector<bool> = select m::BitVector.bit_field(_t6);
-_t8: u64 = vector::length<bool>(_t7);
-_t3: u64 = _t8;
-_t9: u64 = _t2;
-_t10: u64 = _t3;
-_t11: bool = Lt(_t9, _t10);
+_t3: u64 = bit_index;
+_t4: &mut BitVector = self;
+_t5: &vector<bool> = select m::BitVector.bit_field(_t4);
+_t6: u64 = vector::length<bool>(_t5);
+_t7: bool = Lt(_t3, _t6);
 loop {
-  if (_t11) break;
-  _t18: &mut BitVector = self;
-  _t19: u64 = 131072;
-  Abort(_t19)
+  if (_t7) break;
+  _t14: &mut BitVector = self;
+  _t15: u64 = 131072;
+  Abort(_t15)
 };
-_t12: &mut BitVector = self;
-_t13: &mut vector<bool> = select m::BitVector.bit_field(_t12);
-_t14: u64 = bit_index;
-_t15: &mut bool = vector::borrow_mut<bool>(_t13, _t14);
-_t4: &mut bool = _t15;
-_t16: bool = false;
-_t17: &mut bool = _t4;
-_t17 = _t16;
+_t8: &mut BitVector = self;
+_t9: &mut vector<bool> = select m::BitVector.bit_field(_t8);
+_t10: u64 = bit_index;
+_t11: &mut bool = vector::borrow_mut<bool>(_t9, _t10);
+_t2: &mut bool = _t11;
+_t12: bool = false;
+_t13: &mut bool = _t2;
+_t13 = _t12;
 return Tuple()
 
 --- Assign-Transformed Generated AST
@@ -785,41 +697,31 @@ module 0x1::m {
         *0x1::vector::borrow_mut<bool>(&mut self.bit_field, bit_index) = true;
     }
     public fun shift_left(self: &mut BitVector, amount: u64) {
-        let _t4;
         let _t3;
         let _t2;
-        _t2 = *&self.length;
         'l0: loop {
             loop {
-                if (amount >= _t2) {
-                    _t3 = &mut self.bit_field;
-                    _t2 = 0
+                if (amount >= *&self.length) {
+                    _t2 = &mut self.bit_field;
+                    _t3 = 0
                 } else {
-                    _t2 = amount;
+                    _t3 = amount;
                     break
                 };
-                while (_t2 < 0x1::vector::length<bool>(/*freeze*/_t3)) {
-                    *0x1::vector::borrow_mut<bool>(_t3, _t2) = false;
-                    _t2 = _t2 + 1
+                while (_t3 < 0x1::vector::length<bool>(/*freeze*/_t2)) {
+                    *0x1::vector::borrow_mut<bool>(_t2, _t3) = false;
+                    _t3 = _t3 + 1
                 };
                 break 'l0
             };
-            loop {
-                _t4 = *&self.length;
-                if (!(_t2 < _t4)) break;
-                if (is_index_set(/*freeze*/self, _t2)) {
-                    _t4 = _t2 - amount;
-                    set(self, _t4)
-                } else {
-                    _t4 = _t2 - amount;
-                    unset(self, _t4)
-                };
-                _t2 = _t2 + 1
+            while (_t3 < *&self.length) {
+                if (is_index_set(/*freeze*/self, _t3)) set(self, _t3 - amount) else unset(self, _t3 - amount);
+                _t3 = _t3 + 1
             };
-            _t2 = *&self.length - amount;
-            while (_t2 < *&self.length) {
-                unset(self, _t2);
-                _t2 = _t2 + 1
+            _t3 = *&self.length - amount;
+            while (_t3 < *&self.length) {
+                unset(self, _t3);
+                _t3 = _t3 + 1
             };
             break
         };

--- a/third_party/move/move-model/bytecode/ast-generator-tests/tests/conditionals.exp
+++ b/third_party/move/move-model/bytecode/ast-generator-tests/tests/conditionals.exp
@@ -264,41 +264,40 @@ fun if_else_3(c: bool): u64 {
 --- Stackless Bytecode
 fun m::if_else_3($t0|c: bool): u64 {
      var $t1|r: u64
-     var $t2|return: u64 [unused]
-     var $t3: bool
+     var $t2: bool
+     var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64
-  0: $t3 := move($t0)
-  1: if ($t3) goto 2 else goto 9
+  0: $t2 := move($t0)
+  1: if ($t2) goto 2 else goto 9
   2: label L1
-  3: $t4 := 1
-  4: $t1 := $t4
+  3: $t3 := 1
+  4: $t1 := $t3
   5: goto 6
   6: label L2
-  7: $t5 := move($t1)
-  8: return $t5
+  7: $t4 := move($t1)
+  8: return $t4
   9: label L0
- 10: $t6 := 2
- 11: $t1 := $t6
+ 10: $t5 := 2
+ 11: $t1 := $t5
  12: goto 6
 }
 
 --- Raw Generated AST
-_t3: bool = c;
+_t2: bool = c;
 loop {
   loop {
-    if (Not(_t3)) break;
-    _t4: u64 = 1;
-    _t1: u64 = _t4;
+    if (Not(_t2)) break;
+    _t3: u64 = 1;
+    _t1: u64 = _t3;
     break[1]
   };
-  _t6: u64 = 2;
-  _t1: u64 = _t6;
+  _t5: u64 = 2;
+  _t1: u64 = _t5;
   break
 };
-_t5: u64 = _t1;
-return _t5
+_t4: u64 = _t1;
+return _t4
 
 --- Assign-Transformed Generated AST
 loop {
@@ -453,8 +452,8 @@ fun if_else_with_shared_exp(x: u64): u64 {
 
 --- Stackless Bytecode
 fun m::if_else_with_shared_exp($t0|x: u64): u64 {
-     var $t1|$t5: u64
-     var $t2|$t7: u64 [unused]
+     var $t1|$t3: u64
+     var $t2: u64
      var $t3: u64
      var $t4: u64
      var $t5: u64
@@ -462,73 +461,72 @@ fun m::if_else_with_shared_exp($t0|x: u64): u64 {
      var $t7: u64
      var $t8: u64
      var $t9: u64
-     var $t10: u64
-     var $t11: bool
+     var $t10: bool
+     var $t11: u64
      var $t12: u64
      var $t13: u64
      var $t14: u64
      var $t15: u64
      var $t16: u64
      var $t17: u64
-     var $t18: u64
-  0: $t3 := copy($t0)
-  1: $t4 := move($t0)
-  2: $t5 := +($t3, $t4)
-  3: $t0 := $t5
-  4: $t6 := copy($t0)
-  5: $t7 := move($t0)
-  6: $t8 := *($t6, $t7)
-  7: $t0 := $t8
-  8: $t9 := copy($t0)
-  9: $t10 := 0
- 10: $t11 := >($t9, $t10)
- 11: if ($t11) goto 12 else goto 21
+  0: $t2 := copy($t0)
+  1: $t3 := move($t0)
+  2: $t4 := +($t2, $t3)
+  3: $t0 := $t4
+  4: $t5 := copy($t0)
+  5: $t6 := move($t0)
+  6: $t7 := *($t5, $t6)
+  7: $t0 := $t7
+  8: $t8 := copy($t0)
+  9: $t9 := 0
+ 10: $t10 := >($t8, $t9)
+ 11: if ($t10) goto 12 else goto 21
  12: label L1
- 13: $t12 := move($t0)
- 14: $t13 := 1
- 15: $t14 := +($t12, $t13)
- 16: $t1 := $t14
+ 13: $t11 := move($t0)
+ 14: $t12 := 1
+ 15: $t13 := +($t11, $t12)
+ 16: $t1 := $t13
  17: goto 18
  18: label L2
- 19: $t15 := move($t1)
- 20: return $t15
+ 19: $t14 := move($t1)
+ 20: return $t14
  21: label L0
- 22: $t16 := move($t0)
- 23: $t17 := 1
- 24: $t18 := -($t16, $t17)
- 25: $t1 := $t18
+ 22: $t15 := move($t0)
+ 23: $t16 := 1
+ 24: $t17 := -($t15, $t16)
+ 25: $t1 := $t17
  26: goto 18
 }
 
 --- Raw Generated AST
+_t2: u64 = x;
 _t3: u64 = x;
-_t4: u64 = x;
-_t5: u64 = Add(_t3, _t4);
-x: u64 = _t5;
+_t4: u64 = Add(_t2, _t3);
+x: u64 = _t4;
+_t5: u64 = x;
 _t6: u64 = x;
-_t7: u64 = x;
-_t8: u64 = Mul(_t6, _t7);
-x: u64 = _t8;
-_t9: u64 = x;
-_t10: u64 = 0;
-_t11: bool = Gt(_t9, _t10);
+_t7: u64 = Mul(_t5, _t6);
+x: u64 = _t7;
+_t8: u64 = x;
+_t9: u64 = 0;
+_t10: bool = Gt(_t8, _t9);
 loop {
   loop {
-    if (Not(_t11)) break;
-    _t12: u64 = x;
-    _t13: u64 = 1;
-    _t14: u64 = Add(_t12, _t13);
-    _t1: u64 = _t14;
+    if (Not(_t10)) break;
+    _t11: u64 = x;
+    _t12: u64 = 1;
+    _t13: u64 = Add(_t11, _t12);
+    _t1: u64 = _t13;
     break[1]
   };
-  _t16: u64 = x;
-  _t17: u64 = 1;
-  _t18: u64 = Sub(_t16, _t17);
-  _t1: u64 = _t18;
+  _t15: u64 = x;
+  _t16: u64 = 1;
+  _t17: u64 = Sub(_t15, _t16);
+  _t1: u64 = _t17;
   break
 };
-_t15: u64 = _t1;
-return _t15
+_t14: u64 = _t1;
+return _t14
 
 --- Assign-Transformed Generated AST
 x: u64 = Add(x, x);

--- a/third_party/move/move-model/bytecode/ast-generator-tests/tests/loops.exp
+++ b/third_party/move/move-model/bytecode/ast-generator-tests/tests/loops.exp
@@ -13,79 +13,78 @@ fun loop_1(c: u64): u64 {
 
 --- Stackless Bytecode
 fun m::loop_1($t0|c: u64): u64 {
-     var $t1|$t3: u64 [unused]
+     var $t1: u64
      var $t2: u64
      var $t3: u64
      var $t4: u64
      var $t5: u64
      var $t6: u64
      var $t7: u64
-     var $t8: u64
-     var $t9: bool
+     var $t8: bool
+     var $t9: u64
      var $t10: u64
      var $t11: u64
      var $t12: u64
      var $t13: u64
      var $t14: u64
      var $t15: u64
-     var $t16: u64
-     var $t17: bool
-     var $t18: u64
+     var $t16: bool
+     var $t17: u64
   0: label L2
-  1: $t2 := move($t0)
-  2: $t3 := 1
-  3: $t4 := +($t2, $t3)
-  4: $t0 := $t4
-  5: $t5 := copy($t0)
-  6: $t6 := 2
-  7: $t7 := %($t5, $t6)
-  8: $t8 := 0
-  9: $t9 := ==($t7, $t8)
- 10: if ($t9) goto 11 else goto 13
+  1: $t1 := move($t0)
+  2: $t2 := 1
+  3: $t3 := +($t1, $t2)
+  4: $t0 := $t3
+  5: $t4 := copy($t0)
+  6: $t5 := 2
+  7: $t6 := %($t4, $t5)
+  8: $t7 := 0
+  9: $t8 := ==($t6, $t7)
+ 10: if ($t8) goto 11 else goto 13
  11: label L1
  12: goto 0
  13: label L0
- 14: $t10 := move($t0)
- 15: $t11 := 3
- 16: $t12 := +($t10, $t11)
- 17: $t0 := $t12
- 18: $t13 := copy($t0)
- 19: $t14 := 2
- 20: $t15 := %($t13, $t14)
- 21: $t16 := 1
- 22: $t17 := ==($t15, $t16)
- 23: if ($t17) goto 24 else goto 0
+ 14: $t9 := move($t0)
+ 15: $t10 := 3
+ 16: $t11 := +($t9, $t10)
+ 17: $t0 := $t11
+ 18: $t12 := copy($t0)
+ 19: $t13 := 2
+ 20: $t14 := %($t12, $t13)
+ 21: $t15 := 1
+ 22: $t16 := ==($t14, $t15)
+ 23: if ($t16) goto 24 else goto 0
  24: label L3
- 25: $t18 := move($t0)
- 26: return $t18
+ 25: $t17 := move($t0)
+ 26: return $t17
 }
 
 --- Raw Generated AST
 loop {
-  _t2: u64 = c;
-  _t3: u64 = 1;
-  _t4: u64 = Add(_t2, _t3);
-  c: u64 = _t4;
-  _t5: u64 = c;
-  _t6: u64 = 2;
-  _t7: u64 = Mod(_t5, _t6);
-  _t8: u64 = 0;
-  _t9: bool = Eq(_t7, _t8);
-  if (_t9) continue;
-  _t10: u64 = c;
-  _t11: u64 = 3;
-  _t12: u64 = Add(_t10, _t11);
-  c: u64 = _t12;
-  _t13: u64 = c;
-  _t14: u64 = 2;
-  _t15: u64 = Mod(_t13, _t14);
-  _t16: u64 = 1;
-  _t17: bool = Eq(_t15, _t16);
-  if (Not(_t17)) continue;
+  _t1: u64 = c;
+  _t2: u64 = 1;
+  _t3: u64 = Add(_t1, _t2);
+  c: u64 = _t3;
+  _t4: u64 = c;
+  _t5: u64 = 2;
+  _t6: u64 = Mod(_t4, _t5);
+  _t7: u64 = 0;
+  _t8: bool = Eq(_t6, _t7);
+  if (_t8) continue;
+  _t9: u64 = c;
+  _t10: u64 = 3;
+  _t11: u64 = Add(_t9, _t10);
+  c: u64 = _t11;
+  _t12: u64 = c;
+  _t13: u64 = 2;
+  _t14: u64 = Mod(_t12, _t13);
+  _t15: u64 = 1;
+  _t16: bool = Eq(_t14, _t15);
+  if (Not(_t16)) continue;
   break
 };
-_t18: u64 = c;
-return _t18
+_t17: u64 = c;
+return _t17
 
 --- Assign-Transformed Generated AST
 loop {
@@ -134,72 +133,71 @@ fun nested_loop(x: u64): u64 {
 
 --- Stackless Bytecode
 fun m::nested_loop($t0|x: u64): u64 {
-     var $t1|$t3: u64 [unused]
+     var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: bool
+     var $t6: bool
+     var $t7: u64
      var $t8: u64
      var $t9: u64
      var $t10: u64
      var $t11: u64
      var $t12: u64
      var $t13: u64
-     var $t14: u64
   0: label L5
-  1: $t2 := copy($t0)
-  2: $t3 := 0
-  3: $t4 := >($t2, $t3)
-  4: if ($t4) goto 5 else goto 22
+  1: $t1 := copy($t0)
+  2: $t2 := 0
+  3: $t3 := >($t1, $t2)
+  4: if ($t3) goto 5 else goto 22
   5: label L1
-  6: $t5 := copy($t0)
-  7: $t6 := 10
-  8: $t7 := >($t5, $t6)
-  9: if ($t7) goto 10 else goto 16
+  6: $t4 := copy($t0)
+  7: $t5 := 10
+  8: $t6 := >($t4, $t5)
+  9: if ($t6) goto 10 else goto 16
  10: label L2
- 11: $t8 := move($t0)
- 12: $t9 := 1
- 13: $t10 := -($t8, $t9)
- 14: $t0 := $t10
+ 11: $t7 := move($t0)
+ 12: $t8 := 1
+ 13: $t9 := -($t7, $t8)
+ 14: $t0 := $t9
  15: goto 16
  16: label L4
- 17: $t11 := move($t0)
- 18: $t12 := 1
- 19: $t13 := -($t11, $t12)
- 20: $t0 := $t13
+ 17: $t10 := move($t0)
+ 18: $t11 := 1
+ 19: $t12 := -($t10, $t11)
+ 20: $t0 := $t12
  21: goto 0
  22: label L0
- 23: $t14 := move($t0)
- 24: return $t14
+ 23: $t13 := move($t0)
+ 24: return $t13
 }
 
 --- Raw Generated AST
 loop {
-  _t2: u64 = x;
-  _t3: u64 = 0;
-  _t4: bool = Gt(_t2, _t3);
-  if (Not(_t4)) break;
-  _t5: u64 = x;
-  _t6: u64 = 10;
-  _t7: bool = Gt(_t5, _t6);
+  _t1: u64 = x;
+  _t2: u64 = 0;
+  _t3: bool = Gt(_t1, _t2);
+  if (Not(_t3)) break;
+  _t4: u64 = x;
+  _t5: u64 = 10;
+  _t6: bool = Gt(_t4, _t5);
   loop {
-    if (Not(_t7)) break;
-    _t8: u64 = x;
-    _t9: u64 = 1;
-    _t10: u64 = Sub(_t8, _t9);
-    x: u64 = _t10;
+    if (Not(_t6)) break;
+    _t7: u64 = x;
+    _t8: u64 = 1;
+    _t9: u64 = Sub(_t7, _t8);
+    x: u64 = _t9;
     break
   };
-  _t11: u64 = x;
-  _t12: u64 = 1;
-  _t13: u64 = Sub(_t11, _t12);
-  x: u64 = _t13;
+  _t10: u64 = x;
+  _t11: u64 = 1;
+  _t12: u64 = Sub(_t10, _t11);
+  x: u64 = _t12;
   continue
 };
-_t14: u64 = x;
-return _t14
+_t13: u64 = x;
+return _t13
 
 --- Assign-Transformed Generated AST
 loop {
@@ -241,23 +239,22 @@ fun while_1(c: u64) {
 
 --- Stackless Bytecode
 fun m::while_1($t0|c: u64) {
-     var $t1|$t2: u64 [unused]
+     var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64
   0: label L2
-  1: $t2 := copy($t0)
-  2: $t3 := 0
-  3: $t4 := >($t2, $t3)
-  4: if ($t4) goto 5 else goto 11
+  1: $t1 := copy($t0)
+  2: $t2 := 0
+  3: $t3 := >($t1, $t2)
+  4: if ($t3) goto 5 else goto 11
   5: label L1
-  6: $t5 := move($t0)
-  7: $t6 := 1
-  8: $t7 := -($t5, $t6)
-  9: $t0 := $t7
+  6: $t4 := move($t0)
+  7: $t5 := 1
+  8: $t6 := -($t4, $t5)
+  9: $t0 := $t6
  10: goto 0
  11: label L0
  12: return ()
@@ -265,14 +262,14 @@ fun m::while_1($t0|c: u64) {
 
 --- Raw Generated AST
 loop {
-  _t2: u64 = c;
-  _t3: u64 = 0;
-  _t4: bool = Gt(_t2, _t3);
-  if (Not(_t4)) break;
-  _t5: u64 = c;
-  _t6: u64 = 1;
-  _t7: u64 = Sub(_t5, _t6);
-  c: u64 = _t7;
+  _t1: u64 = c;
+  _t2: u64 = 0;
+  _t3: bool = Gt(_t1, _t2);
+  if (Not(_t3)) break;
+  _t4: u64 = c;
+  _t5: u64 = 1;
+  _t6: u64 = Sub(_t4, _t5);
+  c: u64 = _t6;
   continue
 };
 return Tuple()
@@ -316,62 +313,61 @@ fun while_2(c: u64): u64 {
 
 --- Stackless Bytecode
 fun m::while_2($t0|c: u64): u64 {
-     var $t1|$t3: u64 [unused]
+     var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: bool
+     var $t6: bool
+     var $t7: u64
      var $t8: u64
      var $t9: u64
      var $t10: u64
      var $t11: u64
      var $t12: u64
-     var $t13: u64
   0: label L4
-  1: $t2 := copy($t0)
-  2: $t3 := 0
-  3: $t4 := >($t2, $t3)
-  4: if ($t4) goto 5 else goto 16
+  1: $t1 := copy($t0)
+  2: $t2 := 0
+  3: $t3 := >($t1, $t2)
+  4: if ($t3) goto 5 else goto 16
   5: label L1
-  6: $t5 := copy($t0)
-  7: $t6 := 10
-  8: $t7 := >=($t5, $t6)
-  9: if ($t7) goto 10 else goto 0
+  6: $t4 := copy($t0)
+  7: $t5 := 10
+  8: $t6 := >=($t4, $t5)
+  9: if ($t6) goto 10 else goto 0
  10: label L2
- 11: $t8 := move($t0)
- 12: $t9 := 10
- 13: $t10 := -($t8, $t9)
- 14: $t0 := $t10
+ 11: $t7 := move($t0)
+ 12: $t8 := 10
+ 13: $t9 := -($t7, $t8)
+ 14: $t0 := $t9
  15: goto 0
  16: label L0
- 17: $t11 := move($t0)
- 18: $t12 := 1
- 19: $t13 := +($t11, $t12)
- 20: return $t13
+ 17: $t10 := move($t0)
+ 18: $t11 := 1
+ 19: $t12 := +($t10, $t11)
+ 20: return $t12
 }
 
 --- Raw Generated AST
 loop {
-  _t2: u64 = c;
-  _t3: u64 = 0;
-  _t4: bool = Gt(_t2, _t3);
-  if (Not(_t4)) break;
-  _t5: u64 = c;
-  _t6: u64 = 10;
-  _t7: bool = Ge(_t5, _t6);
-  if (Not(_t7)) continue;
-  _t8: u64 = c;
-  _t9: u64 = 10;
-  _t10: u64 = Sub(_t8, _t9);
-  c: u64 = _t10;
+  _t1: u64 = c;
+  _t2: u64 = 0;
+  _t3: bool = Gt(_t1, _t2);
+  if (Not(_t3)) break;
+  _t4: u64 = c;
+  _t5: u64 = 10;
+  _t6: bool = Ge(_t4, _t5);
+  if (Not(_t6)) continue;
+  _t7: u64 = c;
+  _t8: u64 = 10;
+  _t9: u64 = Sub(_t7, _t8);
+  c: u64 = _t9;
   continue
 };
-_t11: u64 = c;
-_t12: u64 = 1;
-_t13: u64 = Add(_t11, _t12);
-return _t13
+_t10: u64 = c;
+_t11: u64 = 1;
+_t12: u64 = Add(_t10, _t11);
+return _t12
 
 --- Assign-Transformed Generated AST
 loop {
@@ -413,74 +409,73 @@ fun while_3(c: u64): u64 {
 
 --- Stackless Bytecode
 fun m::while_3($t0|c: u64): u64 {
-     var $t1|$t3: u64 [unused]
+     var $t1: u64
      var $t2: u64
-     var $t3: u64
-     var $t4: bool
+     var $t3: bool
+     var $t4: u64
      var $t5: u64
-     var $t6: u64
-     var $t7: bool
+     var $t6: bool
+     var $t7: u64
      var $t8: u64
      var $t9: u64
      var $t10: u64
      var $t11: u64
      var $t12: u64
      var $t13: u64
-     var $t14: u64
   0: label L5
-  1: $t2 := copy($t0)
-  2: $t3 := 0
-  3: $t4 := >($t2, $t3)
-  4: if ($t4) goto 5 else goto 24
+  1: $t1 := copy($t0)
+  2: $t2 := 0
+  3: $t3 := >($t1, $t2)
+  4: if ($t3) goto 5 else goto 24
   5: label L1
   6: goto 7
   7: label L2
-  8: $t5 := copy($t0)
-  9: $t6 := 10
- 10: $t7 := >($t5, $t6)
- 11: if ($t7) goto 12 else goto 18
+  8: $t4 := copy($t0)
+  9: $t5 := 10
+ 10: $t6 := >($t4, $t5)
+ 11: if ($t6) goto 12 else goto 18
  12: label L4
- 13: $t8 := move($t0)
- 14: $t9 := 10
- 15: $t10 := -($t8, $t9)
- 16: $t0 := $t10
+ 13: $t7 := move($t0)
+ 14: $t8 := 10
+ 15: $t9 := -($t7, $t8)
+ 16: $t0 := $t9
  17: goto 7
  18: label L3
- 19: $t11 := move($t0)
- 20: $t12 := 1
- 21: $t13 := -($t11, $t12)
- 22: $t0 := $t13
+ 19: $t10 := move($t0)
+ 20: $t11 := 1
+ 21: $t12 := -($t10, $t11)
+ 22: $t0 := $t12
  23: goto 0
  24: label L0
- 25: $t14 := move($t0)
- 26: return $t14
+ 25: $t13 := move($t0)
+ 26: return $t13
 }
 
 --- Raw Generated AST
 loop {
-  _t2: u64 = c;
-  _t3: u64 = 0;
-  _t4: bool = Gt(_t2, _t3);
-  if (Not(_t4)) break;
+  _t1: u64 = c;
+  _t2: u64 = 0;
+  _t3: bool = Gt(_t1, _t2);
+  if (Not(_t3)) break;
   loop {
-    _t5: u64 = c;
-    _t6: u64 = 10;
-    _t7: bool = Gt(_t5, _t6);
-    if (Not(_t7)) break;
-    _t8: u64 = c;
-    _t9: u64 = 10;
-    _t10: u64 = Sub(_t8, _t9);
-    c: u64 = _t10;
+    _t4: u64 = c;
+    _t5: u64 = 10;
+    _t6: bool = Gt(_t4, _t5);
+    if (Not(_t6)) break;
+    _t7: u64 = c;
+    _t8: u64 = 10;
+    _t9: u64 = Sub(_t7, _t8);
+    c: u64 = _t9;
     continue
   };
-  _t11: u64 = c;
-  _t12: u64 = 1;
-  _t13: u64 = Sub(_t11, _t12);
-  c: u64 = _t13;
+  _t10: u64 = c;
+  _t11: u64 = 1;
+  _t12: u64 = Sub(_t10, _t11);
+  c: u64 = _t12;
   continue
 };
-_t14: u64 = c;
-return _t14
+_t13: u64 = c;
+return _t13
 
 --- Assign-Transformed Generated AST
 loop {

--- a/third_party/move/move-prover/tests/sources/functional/ModifiesErrorTest.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/ModifiesErrorTest.v2_exp
@@ -28,7 +28,6 @@ error: caller does not have permission to modify `B::T` at given address
    =     at tests/sources/functional/ModifiesErrorTest.move:51: move_to_test_incorrect
    =         x0 = <redacted>
    =     at tests/sources/functional/ModifiesErrorTest.move:52: move_to_test_incorrect
-   =         <redacted> = <redacted>
 
 error: caller does not have permission to modify `B::T` at given address
    ┌─ tests/sources/functional/ModifiesErrorTest.move:65:17

--- a/third_party/move/move-prover/tests/sources/functional/ModifiesSchemaTest.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/ModifiesSchemaTest.v2_exp
@@ -14,7 +14,7 @@ error: caller does not have permission to modify `A::S` at given address
    =     at tests/sources/functional/ModifiesSchemaTest.move:12: mutate_at
    =         addr = <redacted>
    =     at tests/sources/functional/ModifiesSchemaTest.move:13: mutate_at
+   =         s = <redacted>
    =     at tests/sources/functional/ModifiesSchemaTest.move:14: mutate_at
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/ModifiesSchemaTest.move:15: mutate_at
    =     at tests/sources/functional/ModifiesSchemaTest.move:31: mutate_at_wrapper2

--- a/third_party/move/move-prover/tests/sources/functional/address_quant.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/address_quant.v2_exp
@@ -11,6 +11,5 @@ error: post-condition does not hold
    =     at tests/sources/functional/address_quant.move:46: multiple_copy_incorrect
    =         sndr = <redacted>
    =     at tests/sources/functional/address_quant.move:47: multiple_copy_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/address_quant.move:48: multiple_copy_incorrect
    =     at tests/sources/functional/address_quant.move:53

--- a/third_party/move/move-prover/tests/sources/functional/bitwise_features.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/bitwise_features.v2_exp
@@ -1,0 +1,12 @@
+Move prover returns: exiting with verification errors
+error: verification out of resources/timeout (global timeout set to 80s)
+    ┌─ tests/sources/functional/bitwise_features.move:154:5
+    │
+154 │ ╭     public fun enable_feature_flags(enable: vector<u64>) acquires Features {
+155 │ │         let features = &mut borrow_global_mut<Features>(@std).features;
+156 │ │         let i = 0;
+157 │ │         let n = vector::length(&enable);
+    · │
+170 │ │         };
+171 │ │     }
+    │ ╰─────^

--- a/third_party/move/move-prover/tests/sources/functional/choice.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/choice.v2_exp
@@ -29,9 +29,7 @@ error: post-condition does not hold
    =         s1 = <redacted>
    =         s2 = <redacted>
    =     at tests/sources/functional/choice.move:47: populate_R
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/choice.move:48: populate_R
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/choice.move:49: populate_R
    =     at tests/sources/functional/choice.move:56: populate_R (spec)
 
@@ -129,7 +127,6 @@ error: post-condition does not hold
     =         ballot_account = <redacted>
     =     at tests/sources/functional/choice.move:284: create_ballot
     =     at tests/sources/functional/choice.move:283: create_ballot
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/choice.move:291
     =     at tests/sources/functional/choice.move:286: create_ballot
     =     at tests/sources/functional/choice.move:272: new_ballot_id

--- a/third_party/move/move-prover/tests/sources/functional/data_invariant_for_mut_ref_arg.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/data_invariant_for_mut_ref_arg.v2_exp
@@ -42,8 +42,6 @@ error: data invariant does not hold
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:33: push_3
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:35: push_3
   =         s = <redacted>
-  =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:36: push_3
-  =         return = <redacted>
   =     at tests/sources/functional/data_invariant_for_mut_ref_arg.move:31: push_3
   =         result = <redacted>
   =         s = <redacted>

--- a/third_party/move/move-prover/tests/sources/functional/data_invariant_in_map.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/data_invariant_in_map.v2_exp
@@ -8,6 +8,6 @@ error: data invariant does not hold
   =     at tests/sources/functional/data_invariant_in_map.move:20: violation_1
   =     at tests/sources/functional/data_invariant_in_map.move:21: violation_1
   =     at tests/sources/functional/data_invariant_in_map.move:22: violation_1
+  =         s = <redacted>
   =     at tests/sources/functional/data_invariant_in_map.move:23: violation_1
-  =         <redacted> = <redacted>
   =     at tests/sources/functional/data_invariant_in_map.move:8

--- a/third_party/move/move-prover/tests/sources/functional/emits.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/emits.v2_exp
@@ -8,7 +8,6 @@ error: function does not emit the expected event
    =     at tests/sources/functional/emits.move:19: simple_wrong_msg_incorrect
    =         handle = <redacted>
    =     at tests/sources/functional/emits.move:20: simple_wrong_msg_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/emits.move:19: simple_wrong_msg_incorrect
    =         handle = <redacted>
    =     at tests/sources/functional/emits.move:21: simple_wrong_msg_incorrect
@@ -24,7 +23,6 @@ error: function does not emit the expected event
    =         handle = <redacted>
    =         _handle2 = <redacted>
    =     at tests/sources/functional/emits.move:27: simple_wrong_handle_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/emits.move:26: simple_wrong_handle_incorrect
    =         handle = <redacted>
    =         _handle2 = <redacted>
@@ -40,9 +38,7 @@ error: function does not emit the expected event
    =     at tests/sources/functional/emits.move:47: multiple_incorrect
    =         handle = <redacted>
    =     at tests/sources/functional/emits.move:48: multiple_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/emits.move:49: multiple_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/emits.move:47: multiple_incorrect
    =         handle = <redacted>
    =     at tests/sources/functional/emits.move:50: multiple_incorrect
@@ -59,7 +55,6 @@ error: function does not emit the expected event
    =     at tests/sources/functional/emits.move:66: multiple_same_incorrect
    =         handle = <redacted>
    =     at tests/sources/functional/emits.move:67: multiple_same_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/emits.move:66: multiple_same_incorrect
    =         handle = <redacted>
    =     at tests/sources/functional/emits.move:68: multiple_same_incorrect
@@ -102,9 +97,7 @@ error: function does not emit the expected event
     =         b = <redacted>
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:150: conditional_multiple_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:151: conditional_multiple_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:152: conditional_multiple_incorrect
     =     at tests/sources/functional/emits.move:149: conditional_multiple_incorrect
     =         handle = <redacted>
@@ -122,9 +115,7 @@ error: function does not emit the expected event
     =         b = <redacted>
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:180: conditional_multiple_same_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:181: conditional_multiple_same_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:182: conditional_multiple_same_incorrect
     =     at tests/sources/functional/emits.move:179: conditional_multiple_same_incorrect
     =         handle = <redacted>
@@ -143,9 +134,7 @@ error: emitted event not covered by any of the `emits` clauses
     =     at tests/sources/functional/emits.move:231: partial_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:232: partial_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:233: partial_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:231: partial_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:234: partial_incorrect
@@ -163,9 +152,7 @@ error: emitted event not covered by any of the `emits` clauses
     =     at tests/sources/functional/emits.move:251: strict_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:252: strict_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:253: strict_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:251: strict_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:254: strict_incorrect
@@ -180,10 +167,8 @@ error: function does not emit the expected event
     =     at tests/sources/functional/emits.move:286: opaque_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:287: opaque_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:288: opaque_incorrect
     =     at tests/sources/functional/emits.move:289: opaque_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:286: opaque_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:290: opaque_incorrect
@@ -206,10 +191,8 @@ error: emitted event not covered by any of the `emits` clauses
     =     at tests/sources/functional/emits.move:309: opaque_completeness_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:310: opaque_completeness_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:311: opaque_completeness_incorrect
     =     at tests/sources/functional/emits.move:312: opaque_completeness_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:309: opaque_completeness_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:313: opaque_completeness_incorrect
@@ -233,10 +216,8 @@ error: emitted event not covered by any of the `emits` clauses
     =     at tests/sources/functional/emits.move:350: opaque_partial_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:351: opaque_partial_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:352: opaque_partial_incorrect
     =     at tests/sources/functional/emits.move:353: opaque_partial_incorrect
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/emits.move:350: opaque_partial_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:354: opaque_partial_incorrect

--- a/third_party/move/move-prover/tests/sources/functional/fixed_point_arithm.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/fixed_point_arithm.v2_exp
@@ -22,8 +22,6 @@ error: post-condition does not hold
    =     at tests/sources/functional/fixed_point_arithm.move:42: multiply_x_0_incorrect
    =         x = <redacted>
    =     at tests/sources/functional/fixed_point_arithm.move:43: multiply_x_0_incorrect
-   =         <redacted> = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:43: multiply_x_0_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/fixed_point_arithm.move:44: multiply_x_0_incorrect
    =     at tests/sources/functional/fixed_point_arithm.move:46: multiply_x_0_incorrect (spec)
@@ -56,8 +54,6 @@ error: post-condition does not hold
    =     at ../move-stdlib/sources/fixed_point32.move:126
    =     at ../move-stdlib/sources/fixed_point32.move:127
    =     at tests/sources/functional/fixed_point_arithm.move:82: multiply_x_1_incorrect
-   =         <redacted> = <redacted>
-   =     at tests/sources/functional/fixed_point_arithm.move:82: multiply_x_1_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/fixed_point_arithm.move:83: multiply_x_1_incorrect
    =     at tests/sources/functional/fixed_point_arithm.move:85: multiply_x_1_incorrect (spec)
@@ -80,8 +76,6 @@ error: post-condition does not hold
     =     at ../move-stdlib/sources/fixed_point32.move:151: get_raw_value
     =         y_raw_val = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
-    =         y = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect
     =         result = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:108: mul_div_incorrect
@@ -103,8 +97,6 @@ error: post-condition does not hold
     =         result = <redacted>
     =     at ../move-stdlib/sources/fixed_point32.move:151: get_raw_value
     =         y_raw_val = <redacted>
-    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
-    =         y = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect
     =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect
     =         result = <redacted>

--- a/third_party/move/move-prover/tests/sources/functional/global_invariants.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/global_invariants.v2_exp
@@ -8,7 +8,6 @@ error: global memory invariant does not hold
    =     at tests/sources/functional/global_invariants.move:38: create_R_invalid
    =         account = <redacted>
    =     at tests/sources/functional/global_invariants.move:40: create_R_invalid
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/global_invariants.move:38: create_R_invalid
    =     at tests/sources/functional/global_invariants.move:40: create_R_invalid
    =     at tests/sources/functional/global_invariants.move:18

--- a/third_party/move/move-prover/tests/sources/functional/global_vars.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/global_vars.v2_exp
@@ -62,7 +62,6 @@ error: global memory invariant does not hold
     =     at tests/sources/functional/global_vars.move:220: publish
     =         s = <redacted>
     =     at tests/sources/functional/global_vars.move:221: publish
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/global_vars.move:222: publish
     =     at tests/sources/functional/global_vars.move:230: limit_change_invalid
     =     at tests/sources/functional/global_vars.move:232: limit_change_invalid (spec)

--- a/third_party/move/move-prover/tests/sources/functional/loop_unroll.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/loop_unroll.v2_exp
@@ -19,46 +19,34 @@ error: abort not covered by any of the `aborts_if` clauses
     =     at tests/sources/functional/loop_unroll.move:94: t6_failure
     =     at tests/sources/functional/loop_unroll.move:90: t6_failure
     =     at tests/sources/functional/loop_unroll.move:96: t6_failure
-    =         <redacted> = <redacted>
     =         i = <redacted>
-    =     at tests/sources/functional/loop_unroll.move:97: t6_failure
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/loop_unroll.move:97: t6_failure
     =     at tests/sources/functional/loop_unroll.move:92: t6_failure
     =     at tests/sources/functional/loop_unroll.move:94: t6_failure
     =     at tests/sources/functional/loop_unroll.move:90: t6_failure
     =     at tests/sources/functional/loop_unroll.move:96: t6_failure
-    =         <redacted> = <redacted>
     =         i = <redacted>
     =     at tests/sources/functional/loop_unroll.move:97: t6_failure
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/loop_unroll.move:91: t6_failure
     =     at tests/sources/functional/loop_unroll.move:92: t6_failure
     =     at tests/sources/functional/loop_unroll.move:94: t6_failure
     =     at tests/sources/functional/loop_unroll.move:90: t6_failure
     =     at tests/sources/functional/loop_unroll.move:96: t6_failure
-    =         <redacted> = <redacted>
     =         i = <redacted>
     =     at tests/sources/functional/loop_unroll.move:97: t6_failure
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/loop_unroll.move:91: t6_failure
     =     at tests/sources/functional/loop_unroll.move:92: t6_failure
     =     at tests/sources/functional/loop_unroll.move:94: t6_failure
     =     at tests/sources/functional/loop_unroll.move:90: t6_failure
     =     at tests/sources/functional/loop_unroll.move:96: t6_failure
-    =         <redacted> = <redacted>
     =         i = <redacted>
     =     at tests/sources/functional/loop_unroll.move:97: t6_failure
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/loop_unroll.move:91: t6_failure
     =     at tests/sources/functional/loop_unroll.move:92: t6_failure
     =     at tests/sources/functional/loop_unroll.move:94: t6_failure
     =     at tests/sources/functional/loop_unroll.move:90: t6_failure
     =     at tests/sources/functional/loop_unroll.move:96: t6_failure
-    =         <redacted> = <redacted>
     =         i = <redacted>
-    =     at tests/sources/functional/loop_unroll.move:97: t6_failure
-    =         <redacted> = <redacted>
     =     at tests/sources/functional/loop_unroll.move:97: t6_failure
     =         ABORTED
 

--- a/third_party/move/move-prover/tests/sources/functional/loops.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/loops.v2_exp
@@ -12,7 +12,6 @@ error: function does not abort under this condition
    =         i = <redacted>
    =     loop invariant holds at current state
    =     at tests/sources/functional/loops.move:51: iter10_no_abort_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/loops.move:49: iter10_no_abort_incorrect
    =     at tests/sources/functional/loops.move:58: iter10_no_abort_incorrect (spec)
 
@@ -35,10 +34,7 @@ error: abort not covered by any of the `aborts_if` clauses
    =         i = <redacted>
    =     loop invariant holds at current state
    =     at tests/sources/functional/loops.move:80: iter10_abort_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/loops.move:78: iter10_abort_incorrect
-   =     at tests/sources/functional/loops.move:82: iter10_abort_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/loops.move:82: iter10_abort_incorrect
    =         ABORTED
 
@@ -63,7 +59,6 @@ error: induction case of the loop invariant does not hold
     =         y = <redacted>
     =     at tests/sources/functional/loops.move:128: nested_loop_outer_invariant_incorrect
     =     at tests/sources/functional/loops.move:131: nested_loop_outer_invariant_incorrect
-    =         <redacted> = <redacted>
     =         x = <redacted>
     =     at tests/sources/functional/loops.move:117: nested_loop_outer_invariant_incorrect
     =     at tests/sources/functional/loops.move:119: nested_loop_outer_invariant_incorrect
@@ -86,7 +81,6 @@ error: induction case of the loop invariant does not hold
     =     loop invariant holds at current state
     =     at tests/sources/functional/loops.move:147: nested_loop_inner_invariant_incorrect
     =     at tests/sources/functional/loops.move:150: nested_loop_inner_invariant_incorrect
-    =         <redacted> = <redacted>
     =         y = <redacted>
     =     at tests/sources/functional/loops.move:145: nested_loop_inner_invariant_incorrect
 
@@ -109,7 +103,6 @@ error: induction case of the loop invariant does not hold
     =     at tests/sources/functional/loops.move:191: loop_with_two_back_edges_incorrect
     =     at tests/sources/functional/loops.move:195: loop_with_two_back_edges_incorrect
     =     at tests/sources/functional/loops.move:196: loop_with_two_back_edges_incorrect
-    =         <redacted> = <redacted>
     =         x = <redacted>
     =     at tests/sources/functional/loops.move:197: loop_with_two_back_edges_incorrect
     =     at tests/sources/functional/loops.move:189: loop_with_two_back_edges_incorrect
@@ -145,7 +138,6 @@ error: induction case of the loop invariant does not hold
     =     at tests/sources/functional/loops.move:225: loop_invariant_induction_invalid
     =     at tests/sources/functional/loops.move:221: loop_invariant_induction_invalid
     =     at tests/sources/functional/loops.move:227: loop_invariant_induction_invalid
-    =         <redacted> = <redacted>
     =         x = <redacted>
     =     at tests/sources/functional/loops.move:221: loop_invariant_induction_invalid
     =     at tests/sources/functional/loops.move:223: loop_invariant_induction_invalid

--- a/third_party/move/move-prover/tests/sources/functional/loops_with_memory_ops.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/loops_with_memory_ops.v2_exp
@@ -42,9 +42,7 @@ error: induction case of the loop invariant does not hold
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
-   =         b = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
-   =         <redacted> = <redacted>
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:89: nested_loop2
@@ -102,7 +100,6 @@ error: unknown assertion failed
    =     at tests/sources/functional/loops_with_memory_ops.move:81: nested_loop2
    =         b = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
-   =         <redacted> = <redacted>
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:93: nested_loop2

--- a/third_party/move/move-prover/tests/sources/functional/macro_verification.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/macro_verification.v2_exp
@@ -36,8 +36,6 @@ error: post-condition does not hold
    =     at tests/sources/functional/macro_verification.move:26: foreach
    =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
    =     at tests/sources/functional/macro_verification.move:17: foreach
-   =         <redacted> = <redacted>
-   =     at tests/sources/functional/macro_verification.move:17: foreach
    =     at tests/sources/functional/macro_verification.move:15: foreach
    =         v = <redacted>
    =     at tests/sources/functional/macro_verification.move:30: foreach (spec)
@@ -79,9 +77,6 @@ error: post-condition does not hold
    =     at tests/sources/functional/macro_verification.move:50: reduce
    =         `invariant sum == spec_sum(v, i);` = <redacted>
    =     at tests/sources/functional/macro_verification.move:43: reduce
-   =         <redacted> = <redacted>
-   =     at tests/sources/functional/macro_verification.move:52: reduce
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/macro_verification.move:40: reduce
    =         result = <redacted>
    =     at tests/sources/functional/macro_verification.move:55: reduce (spec)
@@ -130,9 +125,6 @@ error: post-condition does not hold
    =     at tests/sources/functional/macro_verification.move:49: reduce
    =     at tests/sources/functional/macro_verification.move:50: reduce
    =     at tests/sources/functional/macro_verification.move:43: reduce
-   =         <redacted> = <redacted>
-   =     at tests/sources/functional/macro_verification.move:52: reduce
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/macro_verification.move:40: reduce
    =         result = <redacted>
    =     at tests/sources/functional/macro_verification.move:53: reduce

--- a/third_party/move/move-prover/tests/sources/functional/module_level_spec.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/module_level_spec.v2_exp
@@ -11,5 +11,4 @@ error: global memory invariant does not hold
    =         s = <redacted>
    =         value = <redacted>
    =     at tests/sources/functional/module_level_spec.move:11: store_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/module_level_spec.move:18

--- a/third_party/move/move-prover/tests/sources/functional/mut_ref.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/mut_ref.v2_exp
@@ -30,7 +30,6 @@ error: data invariant does not hold
   =     at tests/sources/functional/mut_ref.move:120: call_return_ref_different_path_vec2_incorrect
   =         x = <redacted>
   =     at tests/sources/functional/mut_ref.move:121: call_return_ref_different_path_vec2_incorrect
-  =         <redacted> = <redacted>
   =     at tests/sources/functional/mut_ref.move:90: return_ref_different_path_vec2
   =         b = <redacted>
   =         x = <redacted>

--- a/third_party/move/move-prover/tests/sources/functional/nested_invariants.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/nested_invariants.v2_exp
@@ -13,8 +13,8 @@ error: data invariant does not hold
    =     at tests/sources/functional/nested_invariants.move:64: mutate_inner_data_invariant_invalid
    =         o = <redacted>
    =     at tests/sources/functional/nested_invariants.move:65: mutate_inner_data_invariant_invalid
+   =         r = <redacted>
    =     at tests/sources/functional/nested_invariants.move:66: mutate_inner_data_invariant_invalid
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/nested_invariants.move:29
    =     at tests/sources/functional/nested_invariants.move:32
    =     at tests/sources/functional/nested_invariants.move:16
@@ -42,8 +42,8 @@ error: data invariant does not hold
    =     at tests/sources/functional/nested_invariants.move:58: mutate_outer_data_invariant_invalid
    =         o = <redacted>
    =     at tests/sources/functional/nested_invariants.move:59: mutate_outer_data_invariant_invalid
+   =         r = <redacted>
    =     at tests/sources/functional/nested_invariants.move:60: mutate_outer_data_invariant_invalid
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/nested_invariants.move:29
    =     at tests/sources/functional/nested_invariants.move:32
 

--- a/third_party/move/move-prover/tests/sources/functional/script_incorrect.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/script_incorrect.v2_exp
@@ -25,6 +25,4 @@ error: abort not covered by any of the `aborts_if` clauses
    =         result = <redacted>
    =     at ../move-stdlib/sources/signer.move:14: address_of
    =     at tests/sources/functional/script_provider.move:10: register
-   =         <redacted> = <redacted>
-   =     at tests/sources/functional/script_provider.move:10: register
    =         ABORTED

--- a/third_party/move/move-prover/tests/sources/functional/specs_in_fun.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/specs_in_fun.v2_exp
@@ -20,7 +20,6 @@ error: unknown assertion failed
    =     at tests/sources/functional/specs_in_fun.move:49: simple2_incorrect
    =         x = <redacted>
    =     at tests/sources/functional/specs_in_fun.move:51: simple2_incorrect
-   =         <redacted> = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/specs_in_fun.move:53: simple2_incorrect
 

--- a/third_party/move/move-prover/tests/sources/functional/strong_edges.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/strong_edges.v2_exp
@@ -10,8 +10,8 @@ error: post-condition does not hold
    =     at tests/sources/functional/strong_edges.move:47: glob_and_field_edges_incorrect
    =         addr = <redacted>
    =     at tests/sources/functional/strong_edges.move:48: glob_and_field_edges_incorrect
+   =         s = <redacted>
    =     at tests/sources/functional/strong_edges.move:49: glob_and_field_edges_incorrect
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/strong_edges.move:50: glob_and_field_edges_incorrect
    =     at tests/sources/functional/strong_edges.move:55: glob_and_field_edges_incorrect (spec)
    =     at tests/sources/functional/strong_edges.move:54: glob_and_field_edges_incorrect (spec)

--- a/third_party/move/move-prover/tests/sources/functional/trace.v2_exp
+++ b/third_party/move/move-prover/tests/sources/functional/trace.v2_exp
@@ -47,7 +47,7 @@ error: post-condition does not hold
    │
    = Related Global Memory:
    =         Resource name: TestTracing_R
-   =         Values:  {Address(18467): <redacted>, Default: empty}
+   =         Values:  {Address(18467): <redacted>, Default: TestTracing.R{x = 4}}
    = Related Bindings:
    =         addr = <redacted>
    =         exists<R>(addr) = <redacted>
@@ -61,7 +61,6 @@ error: post-condition does not hold
    =         s = <redacted>
    =         x = <redacted>
    =     at tests/sources/functional/trace.move:30: publish_invalid
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/trace.move:38
    =     at tests/sources/functional/trace.move:31: publish_invalid
    =     at tests/sources/functional/trace.move:34: publish_invalid (spec)
@@ -75,7 +74,7 @@ error: global memory invariant does not hold
    │
    = Related Global Memory:
    =         Resource name: TestTracing_R
-   =         Values:  {Address(0): <redacted>, Default: empty}
+   =         Values:  {Address(0): <redacted>, Default: TestTracing.R{x = 5}}
    =     at tests/sources/functional/trace.move:29: publish_invalid
    =     at tests/sources/functional/trace.move:33: publish_invalid (spec)
    =         `let addr = signer::address_of(s);` = <redacted>
@@ -83,5 +82,4 @@ error: global memory invariant does not hold
    =         s = <redacted>
    =         x = <redacted>
    =     at tests/sources/functional/trace.move:30: publish_invalid
-   =         <redacted> = <redacted>
    =     at tests/sources/functional/trace.move:38

--- a/third_party/move/move-prover/tests/sources/regression/Escape.v2_exp
+++ b/third_party/move/move-prover/tests/sources/regression/Escape.v2_exp
@@ -9,7 +9,6 @@ error: global memory invariant does not hold
    =         account = <redacted>
    =         thing = <redacted>
    =     at tests/sources/regression/Escape.move:25: install
-   =         <redacted> = <redacted>
    =     at tests/sources/regression/Escape.move:36
 
 error: global memory invariant does not hold
@@ -22,6 +21,5 @@ error: global memory invariant does not hold
    =         account = <redacted>
    =         thing = <redacted>
    =     at tests/sources/regression/Escape.move:25: install
-   =         <redacted> = <redacted>
    =     at tests/sources/regression/Escape.move:36
    =     at tests/sources/regression/Escape.move:37

--- a/third_party/move/move-prover/tests/sources/regression/mono_after_global_invariant.v2_exp
+++ b/third_party/move/move-prover/tests/sources/regression/mono_after_global_invariant.v2_exp
@@ -13,10 +13,8 @@ error: global memory invariant does not hold
    =     at tests/sources/regression/mono_after_global_invariant.move:9: put_b
    =         s = <redacted>
    =     at tests/sources/regression/mono_after_global_invariant.move:10: put_b
-   =         <redacted> = <redacted>
    =     at tests/sources/regression/mono_after_global_invariant.move:14: put_b
    =     at tests/sources/regression/mono_after_global_invariant.move:32: put_r
-   =         <redacted> = <redacted>
    =     at tests/sources/regression/mono_after_global_invariant.move:30: put_r
    =     at tests/sources/regression/mono_after_global_invariant.move:32: put_r
    =     at tests/sources/regression/mono_after_global_invariant.move:44

--- a/third_party/move/move-prover/tests/sources/regression/type_param_bug_121721.v2_exp
+++ b/third_party/move/move-prover/tests/sources/regression/type_param_bug_121721.v2_exp
@@ -18,6 +18,5 @@ error: global memory invariant does not hold
     =     at tests/sources/regression/type_param_bug_121721.move:86: create_ballot
     =     at tests/sources/regression/type_param_bug_121721.move:88: create_ballot
     =     at tests/sources/regression/type_param_bug_121721.move:87: create_ballot
-    =         <redacted> = <redacted>
     =     at tests/sources/regression/type_param_bug_121721.move:167
     =     at tests/sources/regression/type_param_bug_121721.move:173

--- a/third_party/move/move-prover/tests/sources/regression/vector_theory_boogie_array.v2_exp
+++ b/third_party/move/move-prover/tests/sources/regression/vector_theory_boogie_array.v2_exp
@@ -12,8 +12,8 @@ error: post-condition does not hold
    =         pool = <redacted>
    =         addr = <redacted>
    =     at tests/sources/regression/vector_theory_boogie_array.move:7: f1
-   =     at tests/sources/regression/vector_theory_boogie_array.move:8: f1
    =         idx = <redacted>
+   =     at tests/sources/regression/vector_theory_boogie_array.move:8: f1
    =     at tests/sources/regression/vector_theory_boogie_array.move:6: f1
    =         pool = <redacted>
    =     at tests/sources/regression/vector_theory_boogie_array.move:9: f1

--- a/third_party/move/tools/move-decompiler/tests/bit_vector.exp
+++ b/third_party/move/tools/move-decompiler/tests/bit_vector.exp
@@ -12,41 +12,30 @@ module 0x1::bit_vector {
         *0x1::vector::borrow<bool>(&self.bit_field, bit_index)
     }
     public fun longest_set_sequence_starting_at(self: &BitVector, start_index: u64): u64 {
-        let _t3;
         let _t2;
-        _t2 = *&self.length;
-        if (!(start_index < _t2)) abort 131072;
-        _t3 = start_index;
+        if (!(start_index < *&self.length)) abort 131072;
+        _t2 = start_index;
         loop {
             {
-                loop {
-                    _t2 = *&self.length;
-                    if (!(_t3 < _t2)) break;
-                    if (!is_index_set(self, _t3)) break;
-                    _t2 = 1;
-                    _t3 = _t3 + _t2
-                };
+                while (_t2 < *&self.length && is_index_set(self, _t2)) _t2 = _t2 + 1;
                 break
             };
             break
         };
-        _t3 - start_index
+        _t2 - start_index
     }
     public fun new(length: u64): BitVector {
-        let _t3;
         let _t2;
         let _t1;
+        if (!(length > 0)) abort 131073;
+        if (!(length < 1024)) abort 131073;
         _t1 = 0;
-        if (!(length > _t1)) abort 131073;
-        _t1 = 1024;
-        if (!(length < _t1)) abort 131073;
-        _t2 = 0;
-        _t3 = 0x1::vector::empty<bool>();
-        while (_t2 < length) {
-            0x1::vector::push_back<bool>(&mut _t3, false);
-            _t2 = _t2 + 1
+        _t2 = 0x1::vector::empty<bool>();
+        while (_t1 < length) {
+            0x1::vector::push_back<bool>(&mut _t2, false);
+            _t1 = _t1 + 1
         };
-        BitVector{length: length,bit_field: _t3}
+        BitVector{length: length,bit_field: _t2}
     }
     public fun set(self: &mut BitVector, bit_index: u64) {
         if (!(bit_index < 0x1::vector::length<bool>(&self.bit_field))) abort 131072;
@@ -56,39 +45,30 @@ module 0x1::bit_vector {
         let _t4;
         let _t3;
         let _t2;
-        _t2 = *&self.length;
         'l0: loop {
             loop {
-                if (amount >= _t2) {
-                    _t3 = &mut self.bit_field;
-                    _t2 = 0;
-                    _t4 = 0x1::vector::length<bool>(/*freeze*/_t3)
+                if (amount >= *&self.length) {
+                    _t2 = &mut self.bit_field;
+                    _t3 = 0;
+                    _t4 = 0x1::vector::length<bool>(/*freeze*/_t2)
                 } else {
-                    _t2 = amount;
+                    _t3 = amount;
                     break
                 };
-                while (_t2 < _t4) {
-                    *0x1::vector::borrow_mut<bool>(_t3, _t2) = false;
-                    _t2 = _t2 + 1
+                while (_t3 < _t4) {
+                    *0x1::vector::borrow_mut<bool>(_t2, _t3) = false;
+                    _t3 = _t3 + 1
                 };
                 break 'l0
             };
-            loop {
-                _t4 = *&self.length;
-                if (!(_t2 < _t4)) break;
-                if (is_index_set(/*freeze*/self, _t2)) {
-                    _t4 = _t2 - amount;
-                    set(self, _t4)
-                } else {
-                    _t4 = _t2 - amount;
-                    unset(self, _t4)
-                };
-                _t2 = _t2 + 1
+            while (_t3 < *&self.length) {
+                if (is_index_set(/*freeze*/self, _t3)) set(self, _t3 - amount) else unset(self, _t3 - amount);
+                _t3 = _t3 + 1
             };
-            _t2 = *&self.length - amount;
-            while (_t2 < *&self.length) {
-                unset(self, _t2);
-                _t2 = _t2 + 1
+            _t3 = *&self.length - amount;
+            while (_t3 < *&self.length) {
+                unset(self, _t3);
+                _t3 = _t3 + 1
             };
             break
         };

--- a/third_party/move/tools/move-decompiler/tests/fixed_point32.exp
+++ b/third_party/move/tools/move-decompiler/tests/fixed_point32.exp
@@ -13,14 +13,14 @@ module 0x1::fixed_point32 {
         *&(&self).value >> 32u8
     }
     public fun create_from_rational(numerator: u64, denominator: u64): FixedPoint32 {
-        let _t6;
+        let _t5;
         let _t4;
         let _t3;
         _t3 = (denominator as u128) << 32u8;
         if (!(_t3 != 0u128)) abort 65537;
         _t4 = ((numerator as u128) << 64u8) / _t3;
-        if (_t4 != 0u128) _t6 = true else _t6 = numerator == 0;
-        if (!_t6) abort 131077;
+        if (_t4 != 0u128) _t5 = true else _t5 = numerator == 0;
+        if (!_t5) abort 131077;
         if (!(_t4 <= 18446744073709551615u128)) abort 131077;
         FixedPoint32{value: _t4 as u64}
     }

--- a/third_party/move/tools/move-decompiler/tests/simple_map.exp
+++ b/third_party/move/tools/move-decompiler/tests/simple_map.exp
@@ -115,33 +115,33 @@ module 0x1::simple_map {
         _t2
     }
     public fun to_vec_pair<Key: store, Value: store>(self: SimpleMap<Key, Value>): (vector<Key>, vector<Value>) {
-        let _t25;
-        let _t24;
+        let _t22;
+        let _t21;
         let _t5;
         let _t4;
         let _t3;
-        let _t14;
+        let _t11;
         let _t2;
         let _t1;
         _t1 = vector::empty<Key>();
         _t2 = vector::empty<Value>();
-        SimpleMap<Key,Value>{data: _t14} = self;
-        _t3 = _t14;
+        SimpleMap<Key,Value>{data: _t11} = self;
+        _t3 = _t11;
         vector::reverse<Element<Key, Value>>(&mut _t3);
         _t4 = _t3;
         _t5 = vector::length<Element<Key, Value>>(&_t4);
         while (_t5 > 0) {
-            Element<Key,Value>{key: _t24,value: _t25} = vector::pop_back<Element<Key, Value>>(&mut _t4);
-            vector::push_back<Key>(&mut _t1, _t24);
-            vector::push_back<Value>(&mut _t2, _t25);
+            Element<Key,Value>{key: _t21,value: _t22} = vector::pop_back<Element<Key, Value>>(&mut _t4);
+            vector::push_back<Key>(&mut _t1, _t21);
+            vector::push_back<Value>(&mut _t2, _t22);
             _t5 = _t5 - 1
         };
         vector::destroy_empty<Element<Key, Value>>(_t4);
         (_t1, _t2)
     }
     public fun upsert<Key: store, Value: store>(self: &mut SimpleMap<Key, Value>, key: Key, value: Value): (option::Option<Key>, option::Option<Value>) {
-        let _t38;
-        let _t37;
+        let _t35;
+        let _t34;
         let _t5;
         let _t4;
         let _t3;
@@ -152,8 +152,8 @@ module 0x1::simple_map {
             while (!(!(_t5 < _t4) || &vector::borrow<Element<Key, Value>>(/*freeze*/_t3, _t5).key == &key)) _t5 = _t5 + 1;
             vector::push_back<Element<Key, Value>>(_t3, Element<Key,Value>{key: key,value: value});
             vector::swap<Element<Key, Value>>(_t3, _t5, _t4);
-            Element<Key,Value>{key: _t37,value: _t38} = vector::pop_back<Element<Key, Value>>(_t3);
-            return (option::some<Key>(_t37), option::some<Value>(_t38))
+            Element<Key,Value>{key: _t34,value: _t35} = vector::pop_back<Element<Key, Value>>(_t3);
+            return (option::some<Key>(_t34), option::some<Value>(_t35))
         };
         vector::push_back<Element<Key, Value>>(&mut self.data, Element<Key,Value>{key: key,value: value});
         (option::none<Key>(), option::none<Value>())

--- a/third_party/move/tools/move-decompiler/tests/string.exp
+++ b/third_party/move/tools/move-decompiler/tests/string.exp
@@ -19,18 +19,16 @@ module 0x1::string {
         vector::append<u8>(&mut self.bytes, *&(&r).bytes);
     }
     public fun insert(self: &mut String, at: u64, o: String) {
-        let _t7;
         let _t6;
         let _t4;
         let _t3;
         _t3 = &self.bytes;
-        _t4 = at;
-        if (_t4 <= vector::length<u8>(_t3)) _t6 = internal_is_char_boundary(_t3, at) else _t6 = false;
-        if (!_t6) abort 2;
-        _t7 = sub_string(/*freeze*/self, 0, at);
-        append(&mut _t7, o);
-        append(&mut _t7, sub_string(/*freeze*/self, at, length(/*freeze*/self)));
-        *self = _t7;
+        if (at <= vector::length<u8>(_t3)) _t4 = internal_is_char_boundary(_t3, at) else _t4 = false;
+        if (!_t4) abort 2;
+        _t6 = sub_string(/*freeze*/self, 0, at);
+        append(&mut _t6, o);
+        append(&mut _t6, sub_string(/*freeze*/self, at, length(/*freeze*/self)));
+        *self = _t6;
     }
     native fun internal_is_char_boundary(v: &vector<u8>, i: u64): bool;
     public fun sub_string(self: &String, i: u64, j: u64): String {

--- a/third_party/move/tools/move-decompiler/tests/vector.exp
+++ b/third_party/move/tools/move-decompiler/tests/vector.exp
@@ -30,14 +30,14 @@ module 0x1::vector {
         range_with_step(start, end, 1)
     }
     public fun range_with_step(start: u64, end: u64, step: u64): vector<u64> {
-        let _t4;
+        let _t3;
         if (!(step > 0)) abort 131075;
-        _t4 = empty<u64>();
+        _t3 = empty<u64>();
         while (start < end) {
-            push_back<u64>(&mut _t4, start);
+            push_back<u64>(&mut _t3, start);
             start = start + step
         };
-        _t4
+        _t3
     }
     public fun append<Element>(self: &mut vector<Element>, other: vector<Element>) {
         reverse<Element>(&mut other);
@@ -121,16 +121,16 @@ module 0x1::vector {
         _t1
     }
     public fun slice<Element: copy>(self: &vector<Element>, start: u64, end: u64): vector<Element> {
-        let _t6;
-        let _t5;
-        if (start <= end) _t5 = end <= length<Element>(self) else _t5 = false;
-        if (!_t5) abort 131076;
-        _t6 = empty<Element>();
+        let _t4;
+        let _t3;
+        if (start <= end) _t3 = end <= length<Element>(self) else _t3 = false;
+        if (!_t3) abort 131076;
+        _t4 = empty<Element>();
         while (start < end) {
-            push_back<Element>(&mut _t6, *borrow<Element>(self, start));
+            push_back<Element>(&mut _t4, *borrow<Element>(self, start));
             start = start + 1
         };
-        _t6
+        _t4
     }
     public fun swap_remove<Element>(self: &mut vector<Element>, i: u64): Element {
         if (is_empty<Element>(/*freeze*/self)) abort 131072;


### PR DESCRIPTION
## Description

In this PR, we enable the optimizations/optimization fixes in #15445 and #15514 by default in compiler v2, eliminating various checks performed all through the code (we eliminate the temporary experiments `AVOID_STORE_IN_ASSIGNS` and `RETAIN_TEMPS_FOR_ARGS` and change code such that these are always true).

This PR will be merged after the comparison testing for the above two PRs complete.

## How Has This Been Tested?
* Existing tests have their baselines updated. The only changes are in the "non-optimized" outputs (because, now these changes are no longer hidden behind experiment flags), error messages and bytecode in outputs outside of `move-compiler-v2 ` (similar in nature to #15514).
* One move prover test is failing (`third_party/move/move-prover/tests/sources/functional/bitwise_features.move`). The test had a comment saying there is a legitimate failure (tracked in https://github.com/aptos-labs/aptos-core/issues/12501, which I reopened because it is now reproducible). I created a transactional test (`third_party/move/move-compiler-v2/transactional-tests/tests/misc/bitwise_features.move`) corresponding to the function failing to verify, and it passes.

## Key Areas to Review
Any inadvertent changes where we may have changed the semantics described at the top of the PR.

## Type of Change
- [x] Performance improvement
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler