### PR TITLE
Fix cargo nextest version

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -507,7 +507,7 @@ function install_cargo_machete {
 
 function install_cargo_nextest {
   if ! command -v cargo-nextest &>/dev/null; then
-    cargo install cargo-nextest --locked
+    cargo install cargo-nextest --locked --version 0.9.85
   fi
 }
 


### PR DESCRIPTION
## Description

Not able to release CLI: https://github.com/aptos-labs/aptos-core/actions/runs/12335989799, because the current rust version 1.78.0 is not supported by the nextest version installed.
