### PR TITLE
Feature gate permissioned signer

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -135,6 +135,7 @@ pub enum FeatureFlag {
     EnableLoaderV2,
     DisallowInitModuleToPublishModules,
     EnableCallTreeAndInstructionVMCache,
+    PermissionedSigner,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -361,6 +362,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::EnableCallTreeAndInstructionVMCache => {
                 AptosFeatureFlag::ENABLE_CALL_TREE_AND_INSTRUCTION_VM_CACHE
             },
+            FeatureFlag::PermissionedSigner => AptosFeatureFlag::PERMISSIONED_SIGNER,
         }
     }
 }
@@ -514,6 +516,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::ENABLE_CALL_TREE_AND_INSTRUCTION_VM_CACHE => {
                 FeatureFlag::EnableCallTreeAndInstructionVMCache
             },
+            AptosFeatureFlag::PERMISSIONED_SIGNER => FeatureFlag::PermissionedSigner,
         }
     }
 }

--- a/aptos-move/framework/aptos-framework/tests/permissioned_signer_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/permissioned_signer_tests.move
@@ -1,6 +1,7 @@
 #[test_only]
 module aptos_framework::permissioned_signer_tests {
     use std::bcs;
+    use std::features;
     use aptos_framework::account::create_signer_for_test;
     use aptos_framework::permissioned_signer;
     use aptos_framework::timestamp;
@@ -239,6 +240,28 @@ module aptos_framework::permissioned_signer_tests {
                 == option::some(
                     115792089237316195423570985008687907853269984665640564039457584007913129639935
                 ),
+            1
+        );
+    }
+
+    // Making sure master signer always have all permissions even when feature is disabled.
+    #[test(creator = @aptos_framework)]
+    fun test_master_signer_permission(creator: &signer) {
+        assert!(
+            permissioned_signer::check_permission_exists(creator, OnePermission {}),
+            1
+        );
+
+        // Disable the permissioned signer feature.
+        features::change_feature_flags_for_testing(
+            creator,
+            vector[],
+            vector[features::get_permissioned_signer_feature()]
+        );
+
+        // Master signer should still have permission after feature is disabled.
+        assert!(
+            permissioned_signer::check_permission_exists(creator, OnePermission {}),
             1
         );
     }

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -135,6 +135,8 @@ return true.
 -  [Function `is_collection_owner_enabled`](#0x1_features_is_collection_owner_enabled)
 -  [Function `get_native_memory_operations_feature`](#0x1_features_get_native_memory_operations_feature)
 -  [Function `is_native_memory_operations_enabled`](#0x1_features_is_native_memory_operations_enabled)
+-  [Function `get_permissioned_signer_feature`](#0x1_features_get_permissioned_signer_feature)
+-  [Function `is_permissioned_signer_enabled`](#0x1_features_is_permissioned_signer_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `change_feature_flags_internal`](#0x1_features_change_feature_flags_internal)
 -  [Function `change_feature_flags_for_next_epoch`](#0x1_features_change_feature_flags_for_next_epoch)
@@ -750,6 +752,15 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_PERIODICAL_REWARD_RATE_DECREASE">PERIODICAL_REWARD_RATE_DECREASE</a>: u64 = 16;
+</code></pre>
+
+
+
+<a id="0x1_features_PERMISSIONED_SIGNER"></a>
+
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_PERMISSIONED_SIGNER">PERMISSIONED_SIGNER</a>: u64 = 84;
 </code></pre>
 
 
@@ -3325,6 +3336,52 @@ Deprecated feature
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_native_memory_operations_enabled">is_native_memory_operations_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_NATIVE_MEMORY_OPERATIONS">NATIVE_MEMORY_OPERATIONS</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_get_permissioned_signer_feature"></a>
+
+## Function `get_permissioned_signer_feature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_permissioned_signer_feature">get_permissioned_signer_feature</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_permissioned_signer_feature">get_permissioned_signer_feature</a>(): u64 { <a href="features.md#0x1_features_PERMISSIONED_SIGNER">PERMISSIONED_SIGNER</a> }
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_is_permissioned_signer_enabled"></a>
+
+## Function `is_permissioned_signer_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_permissioned_signer_enabled">is_permissioned_signer_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_permissioned_signer_enabled">is_permissioned_signer_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_PERMISSIONED_SIGNER">PERMISSIONED_SIGNER</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -615,6 +615,14 @@ module std::features {
         is_enabled(NATIVE_MEMORY_OPERATIONS)
     }
 
+    const PERMISSIONED_SIGNER: u64 = 84;
+
+    public fun get_permissioned_signer_feature(): u64 { PERMISSIONED_SIGNER }
+
+    public fun is_permissioned_signer_enabled(): bool acquires Features {
+        is_enabled(PERMISSIONED_SIGNER)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/src/natives/permissioned_signer.rs
+++ b/aptos-move/framework/src/natives/permissioned_signer.rs
@@ -16,6 +16,8 @@ use move_vm_types::{
 use smallvec::{smallvec, SmallVec};
 use std::collections::VecDeque;
 
+const EPERMISSION_SIGNER_DISABLED: u64 = 9;
+
 /***************************************************************************************************
  * native fun is_permissioned_signer_impl
  *
@@ -29,6 +31,15 @@ fn native_is_permissioned_signer_impl(
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(arguments.len() == 1);
+
+    if !context
+        .get_feature_flags()
+        .is_enabled(aptos_types::on_chain_config::FeatureFlag::PERMISSIONED_SIGNER)
+    {
+        return SafeNativeResult::Err(SafeNativeError::Abort {
+            abort_code: EPERMISSION_SIGNER_DISABLED,
+        });
+    }
 
     let signer = safely_pop_arg!(arguments, SignerRef);
 
@@ -51,6 +62,15 @@ fn native_permission_address(
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(args.len() == 1);
+
+    if !context
+        .get_feature_flags()
+        .is_enabled(aptos_types::on_chain_config::FeatureFlag::PERMISSIONED_SIGNER)
+    {
+        return SafeNativeResult::Err(SafeNativeError::Abort {
+            abort_code: EPERMISSION_SIGNER_DISABLED,
+        });
+    }
 
     let signer = safely_pop_arg!(args, SignerRef);
 
@@ -75,6 +95,15 @@ fn native_signer_from_permissioned(
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(arguments.len() == 2);
+
+    if !context
+        .get_feature_flags()
+        .is_enabled(aptos_types::on_chain_config::FeatureFlag::PERMISSIONED_SIGNER)
+    {
+        return SafeNativeResult::Err(SafeNativeError::Abort {
+            abort_code: EPERMISSION_SIGNER_DISABLED,
+        });
+    }
 
     let permission_addr = safely_pop_arg!(arguments, AccountAddress);
     let master_addr = safely_pop_arg!(arguments, AccountAddress);

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -115,6 +115,8 @@ pub enum FeatureFlag {
     /// implementations. If required in the future, we can add a flag
     /// to explicitly disable the instruction cache.
     ENABLE_CALL_TREE_AND_INSTRUCTION_VM_CACHE = 83,
+    /// AIP-103 (https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-103.md)
+    PERMISSIONED_SIGNER = 84,
 }
 
 impl FeatureFlag {
@@ -197,6 +199,7 @@ impl FeatureFlag {
             FeatureFlag::COLLECTION_OWNER,
             FeatureFlag::ENABLE_LOADER_V2,
             FeatureFlag::DISALLOW_INIT_MODULE_TO_PUBLISH_MODULES,
+            FeatureFlag::PERMISSIONED_SIGNER,
         ]
     }
 }


### PR DESCRIPTION
## Description
Adds support for permissioned signer functionality in the Aptos framework by introducing a new feature flag `PERMISSIONED_SIGNER`. This change enables controlled access to signer capabilities through permission checks. The implementation includes feature flag assertions in the permissioned signer module to ensure the feature is enabled before use.

## How Has This Been Tested?
The feature flag implementation follows established patterns used for other feature flags in the system. Testing is enforced through the existing feature flag testing infrastructure.

## Key Areas to Review
- Feature flag integration in `permissioned_signer.move`
- New permission checks added to `signer_from_permissioned_handle` and `signer_from_storable_permissioned_handle`
- Feature flag constant definition and helper functions in `features.move`

## Type of Change
- [x] New feature
- [x] Aptos Framework

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation