### PR TITLE
[cli] Fix `aptos init` for existing accounts

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 - Add flag `--benchmark` to `aptos move prove`, which allows to benchmark verification times of individual functions in a package.
 - Add flag `--only <name>` to `aptos move prove`, which allows to scope verification to a function.
 
+- Fix `aptos init` to show the explorer link for accounts when account is already created on chain instead of prompting to fund the account.
+
 ## [5.1.0] - 2024/12/13
 - More optimizations are now default for compiler v2.
 - Downgrade bytecode version to v6 before calling the Revela decompiler, if possible, i.e. no enum types are used. This allows to continue to use Revela until the new decompiler is ready.

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -372,29 +372,34 @@ impl CliCommand<()> for InitTool {
             address, profile_name,
         );
 
-        match network {
-            Network::Mainnet => {
-                eprintln!("The account has not been created on chain yet, you will need to create and fund the account by transferring funds from another account");
-            },
-            Network::Testnet => {
-                let mint_site_url = get_mint_site_url(Some(address));
-                eprintln!("The account has not been created on chain yet. To create the account and get APT on testnet you must visit {}", mint_site_url);
-                // We don't use `prompt_yes_with_override` here because we only want to
-                // automatically open the minting site if they're in an interactive setting.
-                if !self.prompt_options.assume_yes {
-                    eprint!("Press [Enter] to go there now > ");
-                    read_line("Confirmation")?;
-                    open::that(&mint_site_url).map_err(|err| {
-                        CliError::UnexpectedError(format!("Failed to open minting site: {}", err))
-                    })?;
-                }
-            },
-            wildcard => {
-                eprintln!(
-                    "See the account here: {}",
-                    explorer_account_link(address, Some(wildcard))
-                );
-            },
+        if !account_exists {
+            match network {
+                Network::Mainnet => {
+                    eprintln!("The account has not been created on chain yet, you will need to create and fund the account by transferring funds from another account");
+                },
+                Network::Testnet => {
+                    let mint_site_url = get_mint_site_url(Some(address));
+                    eprintln!("The account has not been created on chain yet. To create the account and get APT on testnet you must visit {}", mint_site_url);
+                    // We don't use `prompt_yes_with_override` here because we only want to
+                    // automatically open the minting site if they're in an interactive setting.
+                    if !self.prompt_options.assume_yes {
+                        eprint!("Press [Enter] to go there now > ");
+                        read_line("Confirmation")?;
+                        open::that(&mint_site_url).map_err(|err| {
+                            CliError::UnexpectedError(format!(
+                                "Failed to open minting site: {}",
+                                err
+                            ))
+                        })?;
+                    }
+                },
+                _ => {},
+            }
+        } else {
+            eprintln!(
+                "See the account here: {}",
+                explorer_account_link(address, Some(network))
+            );
         }
 
         Ok(())


### PR DESCRIPTION
## Description
Whenever initializing with `aptos init`, if the account exists on testnet or mainnet, it will prompt that it didn't exist and on testnet it would prompt to fund the account. Added a check to properly see if the account exists or not.

## How Has This Been Tested?
`./target/debug/aptos init --network testnet --private-key <pk>` with a private key to an account that exists on-chain.

## Key Areas to Review
Should handle existing account and non-existing account correctly.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
