### PR TITLE
[Bugfix][Compiler-V2] Fix `public(package)` causing unit test errors

### DIFF
--- a/third_party/move/move-compiler-v2/src/env_pipeline/function_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/function_checker.rs
@@ -71,7 +71,7 @@ pub fn check_for_function_typed_parameters(env: &mut GlobalEnv) {
     }
 
     for caller_module in env.get_modules() {
-        if caller_module.is_primary_target() {
+        if caller_module.is_target() {
             for caller_func in caller_module.get_functions() {
                 if !lambda_params_ok || !lambda_return_ok {
                     let caller_name = caller_func.get_full_name_str();
@@ -316,6 +316,7 @@ pub fn check_access_and_use(env: &mut GlobalEnv, before_inlining: bool) {
     let mut private_funcs: BTreeSet<QualifiedFunId> = BTreeSet::new();
 
     for caller_module in env.get_modules() {
+        // TODO(#13745): fix when we can tell in general if two modules are in the same package
         if caller_module.is_primary_target() {
             let caller_module_id = caller_module.get_id();
             let caller_module_has_friends = !caller_module.has_no_friends();
@@ -383,6 +384,7 @@ pub fn check_access_and_use(env: &mut GlobalEnv, before_inlining: bool) {
                                             == caller_func.module_env.self_address()
                                         {
                                             // if callee is also a primary target, then they are in the same package
+                                            // TODO(#13745): fix when we can tell in general if two modules are in the same package
                                             if callee_func.module_env.is_primary_target() {
                                                 // we should've inferred the friend declaration
                                                 panic!(

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -490,7 +490,10 @@ impl<'env> ModelBuilder<'env> {
         let target_modules = self
             .env
             .get_modules()
-            .filter(|module_env| (module_env.is_primary_target() || module_env.is_target()) && !module_env.is_script_module())
+            .filter(|module_env| {
+                (module_env.is_primary_target() || module_env.is_target())
+                    && !module_env.is_script_module()
+            })
             .map(|module_env| module_env.get_id())
             .collect_vec();
         for cur_mod in target_modules {

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -490,7 +490,7 @@ impl<'env> ModelBuilder<'env> {
         let target_modules = self
             .env
             .get_modules()
-            .filter(|module_env| module_env.is_primary_target() && !module_env.is_script_module())
+            .filter(|module_env| module_env.is_primary_target() || module_env.is_target() && !module_env.is_script_module())
             .map(|module_env| module_env.get_id())
             .collect_vec();
         for cur_mod in target_modules {

--- a/third_party/move/move-model/src/builder/model_builder.rs
+++ b/third_party/move/move-model/src/builder/model_builder.rs
@@ -490,7 +490,7 @@ impl<'env> ModelBuilder<'env> {
         let target_modules = self
             .env
             .get_modules()
-            .filter(|module_env| module_env.is_primary_target() || module_env.is_target() && !module_env.is_script_module())
+            .filter(|module_env| (module_env.is_primary_target() || module_env.is_target()) && !module_env.is_script_module())
             .map(|module_env| module_env.get_id())
             .collect_vec();
         for cur_mod in target_modules {

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -2997,9 +2997,7 @@ impl<'env> ModuleEnv<'env> {
 
     /// Returns the set of modules in the current package,
     /// whose public(package) functions are called or referenced in the current module.
-    /// Requires: `self` is a primary target.
     pub fn need_to_be_friended_by(&self) -> BTreeSet<ModuleId> {
-        debug_assert!(self.is_primary_target());
         let mut deps = BTreeSet::new();
         if self.is_script_module() {
             return deps;
@@ -3024,12 +3022,12 @@ impl<'env> ModuleEnv<'env> {
     }
 
     /// Returns true if functions in the current module can call a public(package) function in the given module.
-    /// Requires: `self` is a primary target.
     fn can_call_package_fun_in(&self, other: &Self) -> bool {
-        debug_assert!(self.is_primary_target());
         !self.is_script_module()
             && !other.is_script_module()
-            && other.is_primary_target()
+            // TODO: fix this when we have a way to check if
+            // two non-primary targets are in the same package
+            && (!self.is_primary_target() || other.is_primary_target())
             && self.self_address() == other.self_address()
     }
 

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -3025,7 +3025,7 @@ impl<'env> ModuleEnv<'env> {
     fn can_call_package_fun_in(&self, other: &Self) -> bool {
         !self.is_script_module()
             && !other.is_script_module()
-            // TODO: fix this when we have a way to check if
+            // TODO(#13745): fix this when we have a way to check if
             // two non-primary targets are in the same package
             && (!self.is_primary_target() || other.is_primary_target())
             && self.self_address() == other.self_address()


### PR DESCRIPTION
## Description

Fixes https://github.com/aptos-labs/aptos-core/issues/15618.

The transformation of `public(packge)` to `public(friend)` currently is only done for modules in the current package, but not the dependencies. This becomes an issue when the generated bytecode of dependencies is used, say in the case unit tests.

We fix this by also doing the transformation to the dependency modules. For dependencies, we cannot perform the transformation properly, as there is no way tell if two non-primary target modules are in the same package (see https://github.com/aptos-labs/aptos-core/issues/13745). So we may friend modules outside the current package. If a dependency contains `public(packge)` visibility violation, say  package A contains calls function in package B that calls a `public(package)` function in package C, this will not be captured in the unit test as either a compiler error or runtime error. However, each package is compiled with it set as primary target before deployment, so a package with package visibility errors will never hit the chain.

## How Has This Been Tested?

All existing test cases. Manually tested the example https://github.com/aptos-labs/aptos-core/issues/15618.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
