### PR TITLE
Revert "Bumping up the max transaction execution gas limit for gov proposals"

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/transaction.rs
@@ -212,7 +212,7 @@ crate::gas_schedule::macros::define_gas_parameters!(
         [
             max_execution_gas_gov: InternalGas,
             { RELEASE_V1_13.. => "max_execution_gas.gov" },
-            4_300_000_000,
+            4_000_000_000,
         ],
         [
             max_io_gas: InternalGas,


### PR DESCRIPTION
Reverts aptos-labs/aptos-core#15352

We don't need this anymore because of Vineeth's effort for optimization