### PR TITLE
Lock Rust deps for checking protos

### DIFF
--- a/protos/scripts/install_deps.sh
+++ b/protos/scripts/install_deps.sh
@@ -4,11 +4,14 @@
 # The TS plugins are pulled automatically since we depend on them directly from
 # the buf.build community plugin registry.
 
+set -e
+set -x
+
 # For generating Rust code
-cargo install --version 0.2.3 protoc-gen-prost
-cargo install --version 0.2.3 protoc-gen-prost-serde
-cargo install --version 0.3.1 protoc-gen-prost-crate
-cargo install --version 0.3.0 protoc-gen-tonic
+cargo install --locked --version 0.2.3 protoc-gen-prost
+cargo install --locked --version 0.2.3 protoc-gen-prost-serde
+cargo install --locked --version 0.3.1 protoc-gen-prost-crate
+cargo install --locked --version 0.3.0 protoc-gen-tonic
 
 # For generating Python code
 cd python


### PR DESCRIPTION
## Description
The check protos CI is broken right now because of this error:
```
error: failed to compile `protoc-gen-prost-crate v0.3.1`, intermediate artifacts can be found at `/tmp/cargo-installm2VsXb`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  rustc 1.78.0 is not supported by the following package:
    home@0.5.11 requires rustc 1.81
```

Locking the deps and the version fixes this. We were only locking the version.

## How Has This Been Tested?
See that CI passes now: https://github.com/aptos-labs/aptos-core/actions/runs/12418518578/job/34671883427?pr=15638.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
