### PR TITLE
[compiler-v2] Make `-v debug` output more concise

### DIFF
--- a/third_party/move/move-compiler-v2/src/env_pipeline/ast_simplifier.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/ast_simplifier.rs
@@ -66,6 +66,8 @@ use std::{
     vec::Vec,
 };
 
+const DEBUG: bool = false;
+
 /// Run the AST simplification pass on all target functions in the `env`.
 /// Optionally do some aggressive simplifications that may eliminate code.
 pub fn run_simplifier(env: &mut GlobalEnv, eliminate_code: bool) {
@@ -91,10 +93,12 @@ pub fn run_simplifier(env: &mut GlobalEnv, eliminate_code: bool) {
     // Actually do the writing of new definitions.
     for (qfid, def) in new_definitions.into_iter() {
         env.set_function_def(qfid, def);
-        debug!(
-            "After simplifier, function is `{}`",
-            env.dump_fun(&env.get_function(qfid))
-        );
+        if DEBUG {
+            debug!(
+                "After simplifier, function is `{}`",
+                env.dump_fun(&env.get_function(qfid))
+            );
+        }
     }
 }
 

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -75,6 +75,8 @@ use move_symbol_pool::Symbol;
 pub use options::Options;
 use std::{collections::BTreeSet, path::Path};
 
+const DEBUG: bool = false;
+
 /// Run Move compiler and print errors to stderr.
 pub fn run_move_compiler_to_stderr(
     options: Options,
@@ -107,7 +109,9 @@ where
     let mut targets = run_bytecode_gen(&env);
     check_errors(&env, emitter, "code generation errors")?;
 
-    debug!("After bytecode_gen, GlobalEnv={}", env.dump_env());
+    if DEBUG {
+        debug!("After bytecode_gen, GlobalEnv={}", env.dump_env());
+    }
 
     // Run transformation pipeline
     let pipeline = bytecode_pipeline(&env);
@@ -142,10 +146,12 @@ where
     let modules_and_scripts = run_file_format_gen(&mut env, &targets);
     check_errors(&env, emitter, "assembling errors")?;
 
-    debug!(
-        "File format bytecode:\n{}",
-        disassemble_compiled_units(&modules_and_scripts)?
-    );
+    if DEBUG {
+        debug!(
+            "File format bytecode:\n{}",
+            disassemble_compiled_units(&modules_and_scripts)?
+        );
+    }
 
     let annotated_units = annotate_units(modules_and_scripts);
     run_bytecode_verifier(&annotated_units, &mut env);

--- a/third_party/move/move-compiler-v2/src/logging.rs
+++ b/third_party/move/move-compiler-v2/src/logging.rs
@@ -34,10 +34,15 @@
 //! use the boolean macro `log_enabled!(log::Level::Debug)` to check whether a given
 //! level is enabled.
 //!
-//! In general it is good to keep INFO and higher severity log messages in the code. They
-//! may help to debug customer issues in production. However, for keeping the code base clean,
-//! uses of the `debug!` and lower logging level should be kept minimal and possibly removed
-//! eliminated. Its a judgement call where and for how long to leave them in code.
+//! General practice is to use, besides `warn!`, `info!` for progress messages,
+//! and `debug!` for helping to debug problems with ready code. `debug!` can also be used
+//! during development of a module, but should then be made conditional as in:
+//!
+//! ```ignore
+//! const DEBUG: bool = false;
+//! ...
+//! if DEBUG { debug!(..) }
+//! ```
 
 use flexi_logger::{DeferredNow, FileSpec, LogSpecification, Logger};
 use log::Record;


### PR DESCRIPTION
## Description

Output using the `debug!` logging facility should not stay permanent in the code, or at leastr be protected by an additional guard, unless it is useful to work with end users. The default output of `debug!` should overall be useful for users to help understand their problems and avoid complex internal data structures.

This updates some code in the compiler to follow this guideline, as well as refines the docs for logging to reflect this.

This came apparent when trying to use `aptos move prove -v debug` -- the output printed lots of stuff which is probably only relevant for internal debugging.

## How Has This Been Tested?

Existing tests

