### PR TITLE
[CLI] Add `--format-json` option to the `aptos move test` to report test results as a JSON messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11895,6 +11895,8 @@ dependencies = [
  "primitive-types 0.10.1",
  "rayon",
  "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -525,6 +525,10 @@ pub struct TestPackage {
     /// Dump storage state on failure.
     #[clap(long = "dump")]
     pub dump_state: bool,
+
+    /// Report test failures on-the-fly.
+    #[clap(long = "format-json")]
+    pub format_json: bool,
 }
 
 pub(crate) fn fix_bytecode_version(
@@ -580,6 +584,7 @@ impl CliCommand<&'static str> for TestPackage {
                 report_stacktrace_on_abort: true,
                 report_storage_on_error: self.dump_state,
                 ignore_compile_warnings: self.ignore_compile_warnings,
+                format_json: self.format_json,
                 named_address_values: self
                     .move_options
                     .named_addresses

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -875,6 +875,7 @@ impl CliTestFramework {
             ignore_compile_warnings: false,
             compute_coverage: false,
             dump_state: false,
+            format_json: false,
         }
         .execute()
         .await

--- a/third_party/move/tools/move-cli/src/base/test.rs
+++ b/third_party/move/tools/move-cli/src/base/test.rs
@@ -88,6 +88,9 @@ pub struct Test {
     #[clap(long = "coverage")]
     pub compute_coverage: bool,
 
+    #[clap(long = "format_json", hide = true)]
+    pub format_json: bool,
+
     /// Use the EVM-based execution backend.
     /// Does not work with --stackless.
     #[cfg(feature = "evm-backend")]
@@ -116,6 +119,7 @@ impl Test {
             check_stackless_vm,
             verbose_mode,
             compute_coverage,
+            format_json,
             #[cfg(feature = "evm-backend")]
             evm,
         } = self;
@@ -128,6 +132,7 @@ impl Test {
             check_stackless_vm,
             verbose: verbose_mode,
             ignore_compile_warnings,
+            format_json,
             #[cfg(feature = "evm-backend")]
             evm,
 

--- a/third_party/move/tools/move-unit-test/Cargo.toml
+++ b/third_party/move/tools/move-unit-test/Cargo.toml
@@ -39,6 +39,8 @@ once_cell = { workspace = true }
 primitive-types = { workspace = true, optional = true }
 rayon = { workspace = true }
 regex = { workspace = true }
+serde = { workspace = true, features = ["derive", "serde_derive"] }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 datatest-stable = { workspace = true }

--- a/third_party/move/tools/move-unit-test/src/json.rs
+++ b/third_party/move/tools/move-unit-test/src/json.rs
@@ -1,0 +1,72 @@
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum Event {
+    Module(ModuleEvent),
+    Test(TestEvent),
+}
+
+impl Event {
+    pub(crate) fn module_started(module_name: String) -> Self {
+        Event::Module(ModuleEvent::Started { module_name })
+    }
+
+    pub(crate) fn module_finished(module_name: String, exec_time: f64) -> Self {
+        Event::Module(ModuleEvent::Finished {
+            module_name,
+            exec_time,
+        })
+    }
+
+    pub(crate) fn test_started(fn_name: String) -> Self {
+        Event::Test(TestEvent::Start { fn_name })
+    }
+
+    pub(crate) fn test_passed(fn_name: String, exec_time: f64) -> Self {
+        Event::Test(TestEvent::Pass(TestOutcome {
+            fn_name,
+            failure: None,
+            exec_time,
+        }))
+    }
+
+    pub(crate) fn test_failed(fn_name: String, exec_time: f64, rendered_failure: String) -> Self {
+        Event::Test(TestEvent::Fail(TestOutcome {
+            fn_name,
+            failure: Some(rendered_failure),
+            exec_time,
+        }))
+    }
+
+    pub(crate) fn test_timeout(fn_name: String, exec_time: f64, rendered_failure: String) -> Self {
+        Event::Test(TestEvent::Timeout(TestOutcome {
+            fn_name,
+            failure: Some(rendered_failure),
+            exec_time,
+        }))
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub(crate) enum ModuleEvent {
+    Started { module_name: String },
+    Finished { module_name: String, exec_time: f64 },
+}
+
+#[derive(Serialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub(crate) enum TestEvent {
+    Start { fn_name: String },
+    Pass(TestOutcome),
+    Fail(TestOutcome),
+    Timeout(TestOutcome),
+}
+
+#[derive(Serialize)]
+pub(crate) struct TestOutcome {
+    fn_name: String,
+    exec_time: f64,
+    failure: Option<String>,
+}

--- a/third_party/move/tools/move-unit-test/src/lib.rs
+++ b/third_party/move/tools/move-unit-test/src/lib.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod extensions;
+pub mod json;
 pub mod test_reporter;
 pub mod test_runner;
 
@@ -78,6 +79,9 @@ pub struct UnitTestingConfig {
     )]
     pub report_stacktrace_on_abort: bool,
 
+    #[clap(long = "format_json", hide = true)]
+    pub format_json: bool,
+
     /// Ignore compiler's warning, and continue run tests
     #[clap(name = "ignore_compile_warnings", long = "ignore_compile_warnings")]
     pub ignore_compile_warnings: bool,
@@ -130,6 +134,7 @@ impl Default for UnitTestingConfig {
             report_statistics: false,
             report_storage_on_error: false,
             report_stacktrace_on_abort: false,
+            format_json: false,
             ignore_compile_warnings: false,
             source_files: vec![],
             dep_files: vec![],
@@ -267,6 +272,7 @@ impl UnitTestingConfig {
             native_function_table,
             genesis_state,
             self.verbose,
+            self.format_json,
             #[cfg(feature = "evm-backend")]
             self.evm,
         )
@@ -285,6 +291,10 @@ impl UnitTestingConfig {
             test_results.report_goldens(&shared_writer)?;
         }
 
+        // if the `--format-json` is passed, failures are rendered as a field in JSON events
+        if !self.format_json {
+            test_results.report_failures(&shared_writer)?;
+        }
         let ok = test_results.summarize(&shared_writer)?;
 
         let writer = shared_writer.into_inner().unwrap();


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
Adds `--format-json` option to the `aptos move test` to report test results as a JSON messages, on-the-fly as tests are executed. 

Some notes: 
1. The design is based on how `cargo test` works. It disables the usual output (but not all of it), and instead show machine json messages. 
The other option is to show json at the same time as usual human format. See `cargo nextest run --message-format libtest-json`. 
2. The test reporting code becomes a bit convoluted. It has a lot of unused features / old evm support, I'd clean those up and refactor it. But I don't know what's the plan on those.  
So I went with the minimal possible changes approach for now. 

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
No tests yet. 

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
