### PR TITLE
[move-cm][closures] Refactor: Move type conversions out of `Loader` into a trait

### DIFF
--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -5,8 +5,10 @@
 use crate::{
     loader::{LegacyModuleStorageAdapter, Loader},
     logging::expect_no_verification_errors,
-    storage::module_storage::FunctionValueExtensionAdapter,
-    ModuleStorage,
+    storage::{
+        module_storage::FunctionValueExtensionAdapter, ty_layout_converter::LoaderLayoutConverter,
+    },
+    LayoutConverter, ModuleStorage,
 };
 use bytes::Bytes;
 use move_binary_format::{
@@ -229,8 +231,9 @@ impl<'r> TransactionDataCache<'r> {
                 },
             };
             // TODO(Gas): Shall we charge for this?
-            let (ty_layout, has_aggregator_lifting) = loader
-                .type_to_type_layout_with_identifier_mappings(ty, module_store, module_storage)?;
+            let (ty_layout, has_aggregator_lifting) =
+                LoaderLayoutConverter::new(loader, module_store, module_storage)
+                    .type_to_type_layout_with_identifier_mappings(ty)?;
 
             let (data, bytes_loaded) = match loader {
                 Loader::V1(_) => {

--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -48,4 +48,5 @@ pub use storage::{
     },
     module_storage::{ambassador_impl_ModuleStorage, AsFunctionValueExtension, ModuleStorage},
     publishing::{StagingModuleStorage, VerifiedModuleBundle},
+    ty_layout_converter::{LayoutConverter, StorageLayoutConverter},
 };

--- a/third_party/move/move-vm/runtime/src/runtime.rs
+++ b/third_party/move/move-vm/runtime/src/runtime.rs
@@ -11,8 +11,11 @@ use crate::{
     module_traversal::TraversalContext,
     native_extensions::NativeContextExtensions,
     session::SerializedReturnValues,
-    storage::{code_storage::CodeStorage, module_storage::ModuleStorage},
-    AsFunctionValueExtension, RuntimeEnvironment,
+    storage::{
+        code_storage::CodeStorage, module_storage::ModuleStorage,
+        ty_layout_converter::LoaderLayoutConverter,
+    },
+    AsFunctionValueExtension, LayoutConverter, RuntimeEnvironment,
 };
 use move_binary_format::{
     access::ModuleAccess,
@@ -246,18 +249,18 @@ impl VMRuntime {
         ty: &Type,
         arg: impl Borrow<[u8]>,
     ) -> PartialVMResult<Value> {
-        let (layout, has_identifier_mappings) = match self
-            .loader
-            .type_to_type_layout_with_identifier_mappings(ty, module_store, module_storage)
-        {
-            Ok(layout) => layout,
-            Err(_err) => {
-                return Err(PartialVMError::new(
-                    StatusCode::INVALID_PARAM_TYPE_FOR_DESERIALIZATION,
-                )
-                .with_message("[VM] failed to get layout from type".to_string()));
-            },
-        };
+        let (layout, has_identifier_mappings) =
+            match LoaderLayoutConverter::new(&self.loader, module_store, module_storage)
+                .type_to_type_layout_with_identifier_mappings(ty)
+            {
+                Ok(layout) => layout,
+                Err(_err) => {
+                    return Err(PartialVMError::new(
+                        StatusCode::INVALID_PARAM_TYPE_FOR_DESERIALIZATION,
+                    )
+                    .with_message("[VM] failed to get layout from type".to_string()));
+                },
+            };
 
         let deserialization_error = || -> PartialVMError {
             PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT)
@@ -339,15 +342,16 @@ impl VMRuntime {
             _ => (ty, value),
         };
 
-        let (layout, has_identifier_mappings) = self
-            .loader
-            .type_to_type_layout_with_identifier_mappings(ty, module_store, module_storage)
-            .map_err(|_err| {
-                // TODO: Should we use `err` instead of mapping?
-                PartialVMError::new(StatusCode::VERIFICATION_ERROR).with_message(
-                    "entry point functions cannot have non-serializable return types".to_string(),
-                )
-            })?;
+        let (layout, has_identifier_mappings) =
+            LoaderLayoutConverter::new(&self.loader, module_store, module_storage)
+                .type_to_type_layout_with_identifier_mappings(ty)
+                .map_err(|_err| {
+                    // TODO: Should we use `err` instead of mapping?
+                    PartialVMError::new(StatusCode::VERIFICATION_ERROR).with_message(
+                        "entry point functions cannot have non-serializable return types"
+                            .to_string(),
+                    )
+                })?;
 
         let serialization_error = || -> PartialVMError {
             PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -9,8 +9,8 @@ use crate::{
     module_traversal::TraversalContext,
     move_vm::MoveVM,
     native_extensions::NativeContextExtensions,
-    storage::module_storage::ModuleStorage,
-    CodeStorage,
+    storage::{module_storage::ModuleStorage, ty_layout_converter::LoaderLayoutConverter},
+    CodeStorage, LayoutConverter,
 };
 use bytes::Bytes;
 use move_binary_format::{compatibility::Compatibility, errors::*, file_format::LocalIndex};
@@ -487,11 +487,13 @@ impl<'r, 'l> Session<'r, 'l> {
         ty: &Type,
         module_storage: &impl ModuleStorage,
     ) -> VMResult<MoveTypeLayout> {
-        self.move_vm
-            .runtime
-            .loader()
-            .type_to_type_layout(ty, &self.module_store, module_storage)
-            .map_err(|e| e.finish(Location::Undefined))
+        LoaderLayoutConverter::new(
+            self.move_vm.runtime.loader(),
+            &self.module_store,
+            module_storage,
+        )
+        .type_to_type_layout(ty)
+        .map_err(|e| e.finish(Location::Undefined))
     }
 
     pub fn get_fully_annotated_type_layout_from_ty(
@@ -499,11 +501,13 @@ impl<'r, 'l> Session<'r, 'l> {
         ty: &Type,
         module_storage: &impl ModuleStorage,
     ) -> VMResult<MoveTypeLayout> {
-        self.move_vm
-            .runtime
-            .loader()
-            .type_to_fully_annotated_layout(ty, &self.module_store, module_storage)
-            .map_err(|e| e.finish(Location::Undefined))
+        LoaderLayoutConverter::new(
+            self.move_vm.runtime.loader(),
+            &self.module_store,
+            module_storage,
+        )
+        .type_to_fully_annotated_layout(ty)
+        .map_err(|e| e.finish(Location::Undefined))
     }
 
     /// Gets the underlying native extensions.

--- a/third_party/move/move-vm/runtime/src/storage/environment.rs
+++ b/third_party/move/move-vm/runtime/src/storage/environment.rs
@@ -7,7 +7,7 @@ use crate::{
     native_functions::{NativeFunction, NativeFunctions},
     storage::{
         struct_name_index_map::StructNameIndexMap, ty_cache::StructInfoCache,
-        ty_tag_cache::TypeTagCache, verified_module_cache::VERIFIED_MODULES_V2,
+        ty_tag_converter::TypeTagCache, verified_module_cache::VERIFIED_MODULES_V2,
     },
     Module, Script,
 };

--- a/third_party/move/move-vm/runtime/src/storage/mod.rs
+++ b/third_party/move/move-vm/runtime/src/storage/mod.rs
@@ -4,7 +4,7 @@
 pub(crate) mod loader;
 pub(crate) mod struct_name_index_map;
 pub(crate) mod ty_cache;
-pub(crate) mod ty_tag_cache;
+pub(crate) mod ty_tag_converter;
 mod verified_module_cache;
 
 pub mod code_storage;
@@ -12,3 +12,4 @@ pub mod environment;
 pub mod implementations;
 pub mod module_storage;
 pub mod publishing;
+pub mod ty_layout_converter;

--- a/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
@@ -1,0 +1,506 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    config::VMConfig,
+    loader::{LegacyModuleStorageAdapter, Loader, PseudoGasContext, VALUE_DEPTH_MAX},
+    storage::{
+        struct_name_index_map::StructNameIndexMap, ty_cache::StructInfoCache,
+        ty_tag_converter::TypeTagConverter,
+    },
+    ModuleStorage,
+};
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::{
+    language_storage::StructTag,
+    value::{IdentifierMappingKind, MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
+    vm_status::StatusCode,
+};
+use move_vm_types::loaded_data::runtime_types::{StructLayout, StructNameIndex, StructType, Type};
+use std::sync::Arc;
+
+/// Maximal nodes which are allowed when converting to layout. This includes the types of
+/// fields for struct types.
+const MAX_TYPE_TO_LAYOUT_NODES: u64 = 256;
+
+/// A trait allowing to convert runtime types into other types used throughout the stack.
+#[allow(private_bounds)]
+pub trait LayoutConverter: LayoutConverterBase {
+    /// Converts a runtime type to a type layout.
+    fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {
+        let mut count = 0;
+        self.type_to_type_layout_impl(ty, &mut count, 1)
+            .map(|(l, _)| l)
+    }
+
+    /// Converts a runtime type to a type layout.
+    fn type_to_type_layout_with_identifier_mappings(
+        &self,
+        ty: &Type,
+    ) -> PartialVMResult<(MoveTypeLayout, bool)> {
+        let mut count = 0;
+        self.type_to_type_layout_impl(ty, &mut count, 1)
+    }
+
+    /// Converts a runtime type to a fully annotated type layout, containing information about
+    /// field names.
+    fn type_to_fully_annotated_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {
+        let mut count = 0;
+        self.type_to_fully_annotated_layout_impl(ty, &mut count, 1)
+    }
+}
+
+// This is not intended to be implemented or used externally, so put abstract and other functions
+// into this crate trait.
+pub(crate) trait LayoutConverterBase {
+    fn vm_config(&self) -> &VMConfig;
+    fn struct_info_cache(&self) -> &StructInfoCache;
+    fn fetch_struct_ty_by_idx(&self, idx: StructNameIndex) -> PartialVMResult<Arc<StructType>>;
+    fn struct_name_index_map(&self) -> &StructNameIndexMap;
+
+    /// Required for annotated layout.
+    fn struct_name_idx_to_struct_tag(
+        &self,
+        idx: StructNameIndex,
+        ty_args: &[Type],
+    ) -> PartialVMResult<StructTag>;
+
+    // -------------------------------------------------------------------------------------
+    // Layout
+
+    fn check_type_layout_bounds(&self, node_count: u64, depth: u64) -> PartialVMResult<()> {
+        if node_count > MAX_TYPE_TO_LAYOUT_NODES {
+            return Err(
+                PartialVMError::new(StatusCode::TOO_MANY_TYPE_NODES).with_message(format!(
+                    "Number of type nodes when constructing type layout exceeded the maximum of {}",
+                    MAX_TYPE_TO_LAYOUT_NODES
+                )),
+            );
+        }
+        if depth > VALUE_DEPTH_MAX {
+            return Err(
+                PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED).with_message(format!(
+                    "Depth of a layout exceeded the maximum of {} during construction",
+                    VALUE_DEPTH_MAX
+                )),
+            );
+        }
+        Ok(())
+    }
+
+    fn type_to_type_layout_impl(
+        &self,
+        ty: &Type,
+        count: &mut u64,
+        depth: u64,
+    ) -> PartialVMResult<(MoveTypeLayout, bool)> {
+        self.check_type_layout_bounds(*count, depth)?;
+        Ok(match ty {
+            Type::Bool => {
+                *count += 1;
+                (MoveTypeLayout::Bool, false)
+            },
+            Type::U8 => {
+                *count += 1;
+                (MoveTypeLayout::U8, false)
+            },
+            Type::U16 => {
+                *count += 1;
+                (MoveTypeLayout::U16, false)
+            },
+            Type::U32 => {
+                *count += 1;
+                (MoveTypeLayout::U32, false)
+            },
+            Type::U64 => {
+                *count += 1;
+                (MoveTypeLayout::U64, false)
+            },
+            Type::U128 => {
+                *count += 1;
+                (MoveTypeLayout::U128, false)
+            },
+            Type::U256 => {
+                *count += 1;
+                (MoveTypeLayout::U256, false)
+            },
+            Type::Address => {
+                *count += 1;
+                (MoveTypeLayout::Address, false)
+            },
+            Type::Signer => {
+                *count += 1;
+                (MoveTypeLayout::Signer, false)
+            },
+            Type::Vector(ty) => {
+                *count += 1;
+                let (layout, has_identifier_mappings) =
+                    self.type_to_type_layout_impl(ty, count, depth + 1)?;
+                (
+                    MoveTypeLayout::Vector(Box::new(layout)),
+                    has_identifier_mappings,
+                )
+            },
+            Type::Struct { idx, .. } => {
+                *count += 1;
+                let (layout, has_identifier_mappings) =
+                    self.struct_name_to_type_layout(*idx, &[], count, depth + 1)?;
+                (layout, has_identifier_mappings)
+            },
+            Type::StructInstantiation { idx, ty_args, .. } => {
+                *count += 1;
+                self.struct_name_to_type_layout(*idx, ty_args, count, depth + 1)?
+            },
+            Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
+                return Err(
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(format!("No type layout for {:?}", ty)),
+                );
+            },
+        })
+    }
+
+    fn struct_name_to_type_layout(
+        &self,
+        struct_name_idx: StructNameIndex,
+        ty_args: &[Type],
+        count: &mut u64,
+        depth: u64,
+    ) -> PartialVMResult<(MoveTypeLayout, bool)> {
+        let struct_cache = self.struct_info_cache();
+        if let Some((struct_layout, node_count, has_identifier_mappings)) =
+            struct_cache.get_struct_layout_info(&struct_name_idx, ty_args)
+        {
+            *count += node_count;
+            return Ok((struct_layout, has_identifier_mappings));
+        }
+
+        let count_before = *count;
+        let struct_type = self.fetch_struct_ty_by_idx(struct_name_idx)?;
+
+        let mut has_identifier_mappings = false;
+
+        let layout = match &struct_type.layout {
+            StructLayout::Single(fields) => {
+                // Some types can have fields which are lifted at serialization or deserialization
+                // times. Right now these are Aggregator and AggregatorSnapshot.
+                let maybe_mapping = self.get_identifier_mapping_kind(struct_name_idx)?;
+                let field_tys = fields
+                    .iter()
+                    .map(|(_, ty)| {
+                        self.vm_config()
+                            .ty_builder
+                            .create_ty_with_subst(ty, ty_args)
+                    })
+                    .collect::<PartialVMResult<Vec<_>>>()?;
+                let (mut field_layouts, field_has_identifier_mappings): (
+                    Vec<MoveTypeLayout>,
+                    Vec<bool>,
+                ) = field_tys
+                    .iter()
+                    .map(|ty| self.type_to_type_layout_impl(ty, count, depth))
+                    .collect::<PartialVMResult<Vec<_>>>()?
+                    .into_iter()
+                    .unzip();
+
+                has_identifier_mappings =
+                    maybe_mapping.is_some() || field_has_identifier_mappings.into_iter().any(|b| b);
+
+                let layout = if Some(IdentifierMappingKind::DerivedString) == maybe_mapping {
+                    // For DerivedString, the whole object should be lifted.
+                    MoveTypeLayout::Native(
+                        IdentifierMappingKind::DerivedString,
+                        Box::new(MoveTypeLayout::Struct(MoveStructLayout::new(field_layouts))),
+                    )
+                } else {
+                    // For aggregators / snapshots, the first field should be lifted.
+                    if let Some(kind) = &maybe_mapping {
+                        if let Some(l) = field_layouts.first_mut() {
+                            *l = MoveTypeLayout::Native(kind.clone(), Box::new(l.clone()));
+                        }
+                    }
+                    MoveTypeLayout::Struct(MoveStructLayout::new(field_layouts))
+                };
+                layout
+            },
+            StructLayout::Variants(variants) => {
+                // We do not support variants to have direct identifier mappings,
+                // but their inner types may.
+                let variant_layouts = variants
+                    .iter()
+                    .map(|variant| {
+                        variant
+                            .1
+                            .iter()
+                            .map(|(_, ty)| {
+                                let ty = self
+                                    .vm_config()
+                                    .ty_builder
+                                    .create_ty_with_subst(ty, ty_args)?;
+                                let (ty, has_id_mappings) =
+                                    self.type_to_type_layout_impl(&ty, count, depth)?;
+                                has_identifier_mappings |= has_id_mappings;
+                                Ok(ty)
+                            })
+                            .collect::<PartialVMResult<Vec<_>>>()
+                    })
+                    .collect::<PartialVMResult<Vec<_>>>()?;
+                MoveTypeLayout::Struct(MoveStructLayout::RuntimeVariants(variant_layouts))
+            },
+        };
+
+        let field_node_count = *count - count_before;
+        struct_cache.store_struct_layout_info(
+            struct_name_idx,
+            ty_args.to_vec(),
+            layout.clone(),
+            field_node_count,
+            has_identifier_mappings,
+        );
+        Ok((layout, has_identifier_mappings))
+    }
+
+    fn get_identifier_mapping_kind(
+        &self,
+        idx: StructNameIndex,
+    ) -> PartialVMResult<Option<IdentifierMappingKind>> {
+        if !self.vm_config().delayed_field_optimization_enabled {
+            return Ok(None);
+        }
+        let struct_name = self.struct_name_index_map().idx_to_struct_name(idx)?;
+        Ok(IdentifierMappingKind::from_ident(
+            &struct_name.module,
+            &struct_name.name,
+        ))
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Decorated Layout
+
+    fn type_to_fully_annotated_layout_impl(
+        &self,
+        ty: &Type,
+        count: &mut u64,
+        depth: u64,
+    ) -> PartialVMResult<MoveTypeLayout> {
+        if *count > MAX_TYPE_TO_LAYOUT_NODES {
+            return Err(
+                PartialVMError::new(StatusCode::TOO_MANY_TYPE_NODES).with_message(format!(
+                    "Number of type nodes when constructing type layout exceeded the maximum of {}",
+                    MAX_TYPE_TO_LAYOUT_NODES
+                )),
+            );
+        }
+        if depth > VALUE_DEPTH_MAX {
+            return Err(
+                PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED).with_message(format!(
+                    "Depth of a layout exceeded the maximum of {} during construction",
+                    VALUE_DEPTH_MAX
+                )),
+            );
+        }
+        Ok(match ty {
+            Type::Bool => MoveTypeLayout::Bool,
+            Type::U8 => MoveTypeLayout::U8,
+            Type::U16 => MoveTypeLayout::U16,
+            Type::U32 => MoveTypeLayout::U32,
+            Type::U64 => MoveTypeLayout::U64,
+            Type::U128 => MoveTypeLayout::U128,
+            Type::U256 => MoveTypeLayout::U256,
+            Type::Address => MoveTypeLayout::Address,
+            Type::Signer => MoveTypeLayout::Signer,
+            Type::Vector(ty) => MoveTypeLayout::Vector(Box::new(
+                self.type_to_fully_annotated_layout_impl(ty, count, depth + 1)?,
+            )),
+            Type::Struct { idx, .. } => {
+                self.struct_name_to_fully_annotated_layout(*idx, &[], count, depth + 1)?
+            },
+            Type::StructInstantiation { idx, ty_args, .. } => {
+                self.struct_name_to_fully_annotated_layout(*idx, ty_args, count, depth + 1)?
+            },
+            Type::Reference(_) | Type::MutableReference(_) | Type::TyParam(_) => {
+                return Err(
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(format!("No type layout for {:?}", ty)),
+                );
+            },
+        })
+    }
+
+    fn struct_name_to_fully_annotated_layout(
+        &self,
+        struct_name_idx: StructNameIndex,
+        ty_args: &[Type],
+        count: &mut u64,
+        depth: u64,
+    ) -> PartialVMResult<MoveTypeLayout> {
+        let struct_info_cache = self.struct_info_cache();
+        if let Some((layout, annotated_node_count)) =
+            struct_info_cache.get_annotated_struct_layout_info(&struct_name_idx, ty_args)
+        {
+            *count += annotated_node_count;
+            return Ok(layout);
+        }
+
+        let struct_type = self.fetch_struct_ty_by_idx(struct_name_idx)?;
+
+        // TODO(#13806): have annotated layouts for variants. Currently, we just return the raw
+        //   layout for them.
+        if matches!(struct_type.layout, StructLayout::Variants(_)) {
+            return self
+                .struct_name_to_type_layout(struct_name_idx, ty_args, count, depth)
+                .map(|(l, _)| l);
+        }
+
+        let count_before = *count;
+        let struct_tag = self.struct_name_idx_to_struct_tag(struct_name_idx, ty_args)?;
+        let fields = struct_type.fields(None)?;
+
+        let field_layouts = fields
+            .iter()
+            .map(|(n, ty)| {
+                let ty = self
+                    .vm_config()
+                    .ty_builder
+                    .create_ty_with_subst(ty, ty_args)?;
+                let l = self.type_to_fully_annotated_layout_impl(&ty, count, depth)?;
+                Ok(MoveFieldLayout::new(n.clone(), l))
+            })
+            .collect::<PartialVMResult<Vec<_>>>()?;
+        let struct_layout =
+            MoveTypeLayout::Struct(MoveStructLayout::with_types(struct_tag, field_layouts));
+        let field_node_count = *count - count_before;
+
+        struct_info_cache.store_annotated_struct_layout_info(
+            struct_name_idx,
+            ty_args.to_vec(),
+            struct_layout.clone(),
+            field_node_count,
+        );
+        Ok(struct_layout)
+    }
+}
+
+// --------------------------------------------------------------------------------------------
+// Layout converter based on ModuleStorage
+
+pub struct StorageLayoutConverter<'a> {
+    storage: &'a dyn ModuleStorage,
+}
+
+impl<'a> StorageLayoutConverter<'a> {
+    pub fn new(storage: &'a dyn ModuleStorage) -> Self {
+        Self { storage }
+    }
+}
+
+impl<'a> LayoutConverterBase for StorageLayoutConverter<'a> {
+    fn vm_config(&self) -> &VMConfig {
+        self.storage.runtime_environment().vm_config()
+    }
+
+    fn struct_info_cache(&self) -> &StructInfoCache {
+        self.storage.runtime_environment().ty_cache()
+    }
+
+    fn fetch_struct_ty_by_idx(&self, idx: StructNameIndex) -> PartialVMResult<Arc<StructType>> {
+        let struct_name = self.struct_name_index_map().idx_to_struct_name_ref(idx)?;
+        self.storage.fetch_struct_ty(
+            struct_name.module.address(),
+            struct_name.module.name(),
+            struct_name.name.as_ident_str(),
+        )
+    }
+
+    fn struct_name_index_map(&self) -> &StructNameIndexMap {
+        self.storage.runtime_environment().struct_name_index_map()
+    }
+
+    fn struct_name_idx_to_struct_tag(
+        &self,
+        idx: StructNameIndex,
+        ty_args: &[Type],
+    ) -> PartialVMResult<StructTag> {
+        let ty_tag_builder = TypeTagConverter::new(self.storage.runtime_environment());
+        ty_tag_builder.struct_name_idx_to_struct_tag(&idx, ty_args)
+    }
+}
+
+impl<'a> LayoutConverter for StorageLayoutConverter<'a> {}
+
+// --------------------------------------------------------------------------------------------
+// Layout converter based on `Loader`
+
+// This should go away once we eliminated loader v1.
+
+pub(crate) struct LoaderLayoutConverter<'a> {
+    loader: &'a Loader,
+    module_store: &'a LegacyModuleStorageAdapter,
+    module_storage: &'a dyn ModuleStorage,
+}
+
+impl<'a> LoaderLayoutConverter<'a> {
+    pub fn new(
+        loader: &'a Loader,
+        module_store: &'a LegacyModuleStorageAdapter,
+        module_storage: &'a dyn ModuleStorage,
+    ) -> Self {
+        Self {
+            loader,
+            module_store,
+            module_storage,
+        }
+    }
+}
+
+impl<'a> LayoutConverterBase for LoaderLayoutConverter<'a> {
+    fn vm_config(&self) -> &VMConfig {
+        self.loader.vm_config()
+    }
+
+    fn struct_info_cache(&self) -> &StructInfoCache {
+        self.loader.ty_cache(self.module_storage)
+    }
+
+    fn fetch_struct_ty_by_idx(&self, idx: StructNameIndex) -> PartialVMResult<Arc<StructType>> {
+        match self.loader {
+            Loader::V1(..) => {
+                self.loader
+                    .fetch_struct_ty_by_idx(idx, self.module_store, self.module_storage)
+            },
+            Loader::V2(..) => {
+                let struct_name = self.struct_name_index_map().idx_to_struct_name_ref(idx)?;
+                self.module_storage.fetch_struct_ty(
+                    struct_name.module.address(),
+                    struct_name.module.name(),
+                    struct_name.name.as_ident_str(),
+                )
+            },
+        }
+    }
+
+    fn struct_name_index_map(&self) -> &StructNameIndexMap {
+        self.loader.struct_name_index_map(self.module_storage)
+    }
+
+    fn struct_name_idx_to_struct_tag(
+        &self,
+        idx: StructNameIndex,
+        ty_args: &[Type],
+    ) -> PartialVMResult<StructTag> {
+        match self.loader {
+            Loader::V1(loader) => {
+                let mut gas_context = PseudoGasContext::new(self.vm_config());
+                let arg_tags = ty_args
+                    .iter()
+                    .map(|t| loader.type_to_type_tag_impl(t, &mut gas_context))
+                    .collect::<PartialVMResult<Vec<_>>>()?;
+                loader.name_cache.idx_to_struct_tag(idx, arg_tags)
+            },
+            Loader::V2(..) => TypeTagConverter::new(self.module_storage.runtime_environment())
+                .struct_name_idx_to_struct_tag(&idx, ty_args),
+        }
+    }
+}
+
+impl<'a> LayoutConverter for LoaderLayoutConverter<'a> {}


### PR DESCRIPTION
## Description

[PR 3/n vm closures]

Type conversions from runtime types to `MoveTypeLayout` and `TypeTag` currently are associated with the `Loader` type. However, they are needed for the `FunctionValueExtension` trait which needs to be constructed in contexts where no loader but only `ModuleStorage` exists.

This PR moves the conversion functions into a new trait `TypeConverter`. The trait is then implemented two times, once based on `ModuleStorage` only and once based on the existing `Loader`, for downwards compatibility.

## How Has This Been Tested?

Refactoring only, existing tests

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)
