### PR TITLE
[move-vm][closures] Type and Value representation and serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11667,6 +11667,7 @@ dependencies = [
  "derivative",
  "hashbrown 0.14.3",
  "itertools 0.13.0",
+ "mockall",
  "move-binary-format",
  "move-core-types",
  "parking_lot 0.12.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11659,6 +11659,7 @@ version = "0.1.0"
 dependencies = [
  "ambassador",
  "bcs 0.1.4",
+ "better_any",
  "bytes",
  "claims",
  "crossbeam",

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -892,6 +892,11 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
             MoveTypeLayout::Struct(struct_layout) => {
                 self.try_into_vm_value_struct(struct_layout, val)?
             },
+            MoveTypeLayout::Function(..) => {
+                // TODO(#15664): do we actually need this? It appears the code here is dead and
+                //   nowhere used
+                bail!("unexpected move type {:?} for value {:?}", layout, val)
+            },
 
             // Some values, e.g., signer or ones with custom serialization
             // (native), are not stored to storage and so we do not expect

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -681,6 +681,10 @@ impl From<TypeTag> for MoveType {
                 items: Box::new(MoveType::from(*v)),
             },
             TypeTag::Struct(v) => MoveType::Struct((*v).into()),
+            TypeTag::Function(..) => {
+                // TODO(#15664): determine whether functions and closures need to be supported
+                panic!("functions not supported by API types")
+            },
         }
     }
 }
@@ -701,6 +705,10 @@ impl From<&TypeTag> for MoveType {
                 items: Box::new(MoveType::from(v.as_ref())),
             },
             TypeTag::Struct(v) => MoveType::Struct((&**v).into()),
+            TypeTag::Function(..) => {
+                // TODO(#15664): determine whether functions and closures need to be supported
+                panic!("functions not supported by API types")
+            },
         }
     }
 }

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -682,7 +682,7 @@ impl From<TypeTag> for MoveType {
             },
             TypeTag::Struct(v) => MoveType::Struct((*v).into()),
             TypeTag::Function(..) => {
-                // TODO(#15664): determine whether functions and closures need to be supported
+                // TODO(#15664): support function values
                 MoveType::Unparsable("Function types are not supported".to_string())
             },
         }
@@ -706,9 +706,8 @@ impl From<&TypeTag> for MoveType {
             },
             TypeTag::Struct(v) => MoveType::Struct((&**v).into()),
             TypeTag::Function(..) => {
-                // TODO(#15664): construct an API type here, for now we are returning a
-                //   dummy value so this cannot crash
-                MoveType::Bool
+                // TODO(#15664): support function values
+                MoveType::Unparsable("Function types are not supported".to_string())
             },
         }
     }

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -706,8 +706,9 @@ impl From<&TypeTag> for MoveType {
             },
             TypeTag::Struct(v) => MoveType::Struct((&**v).into()),
             TypeTag::Function(..) => {
-                // TODO(#15664): determine whether functions and closures need to be supported
-                panic!("functions not supported by API types")
+                // TODO(#15664): construct an API type here, for now we are returning a
+                //   dummy value so this cannot crash
+                MoveType::Bool
             },
         }
     }

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -683,7 +683,7 @@ impl From<TypeTag> for MoveType {
             TypeTag::Struct(v) => MoveType::Struct((*v).into()),
             TypeTag::Function(..) => {
                 // TODO(#15664): determine whether functions and closures need to be supported
-                panic!("functions not supported by API types")
+                MoveType::Unparsable("Function types are not supported".to_string())
             },
         }
     }

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/misc.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/misc.rs
@@ -125,6 +125,11 @@ where
         self.offset = 1;
         true
     }
+
+    #[inline]
+    fn visit_closure(&mut self, depth: usize, len: usize) -> bool {
+        self.inner.visit_closure(depth, len)
+    }
 }
 
 struct AbstractValueSizeVisitor<'a> {
@@ -196,6 +201,13 @@ impl<'a> ValueVisitor for AbstractValueSizeVisitor<'a> {
 
     #[inline]
     fn visit_struct(&mut self, _depth: usize, _len: usize) -> bool {
+        self.size += self.params.struct_;
+        true
+    }
+
+    #[inline]
+    fn visit_closure(&mut self, _depth: usize, _len: usize) -> bool {
+        // TODO(#15664): introduce a dedicated gas parameter?
         self.size += self.params.struct_;
         true
     }
@@ -367,6 +379,13 @@ impl AbstractValueSizeGasParameters {
             }
 
             #[inline]
+            fn visit_closure(&mut self, _depth: usize, _len: usize) -> bool {
+                // TODO(#15664): independent gas parameter for closures?
+                self.res = Some(self.params.struct_);
+                false
+            }
+
+            #[inline]
             fn visit_vec(&mut self, _depth: usize, _len: usize) -> bool {
                 self.res = Some(self.params.vector);
                 false
@@ -505,6 +524,13 @@ impl AbstractValueSizeGasParameters {
 
             #[inline]
             fn visit_struct(&mut self, _depth: usize, _len: usize) -> bool {
+                self.res = Some(self.params.struct_);
+                false
+            }
+
+            #[inline]
+            fn visit_closure(&mut self, _depth: usize, _len: usize) -> bool {
+                // TODO(#15664): independent gas parameter
                 self.res = Some(self.params.struct_);
                 false
             }

--- a/aptos-move/aptos-sdk-builder/src/common.rs
+++ b/aptos-move/aptos-sdk-builder/src/common.rs
@@ -45,7 +45,7 @@ fn quote_type_as_format(type_tag: &TypeTag) -> Format {
             tag if &**tag == Lazy::force(&str_tag) => Format::Seq(Box::new(Format::U8)),
             _ => type_not_allowed(type_tag),
         },
-        Signer => type_not_allowed(type_tag),
+        Signer | Function(..) => type_not_allowed(type_tag),
     }
 }
 
@@ -122,7 +122,7 @@ pub(crate) fn mangle_type(type_tag: &TypeTag) -> String {
             tag if &**tag == Lazy::force(&str_tag) => "string".into(),
             _ => type_not_allowed(type_tag),
         },
-        Signer => type_not_allowed(type_tag),
+        Signer | Function(..) => type_not_allowed(type_tag),
     }
 }
 

--- a/aptos-move/aptos-sdk-builder/src/golang.rs
+++ b/aptos-move/aptos-sdk-builder/src/golang.rs
@@ -672,7 +672,7 @@ func encode_{}_argument(arg {}) []byte {{
                 U8 => ("U8Vector", default_stmt),
                 _ => common::type_not_allowed(type_tag),
             },
-            Struct(_) | Signer => common::type_not_allowed(type_tag),
+            Struct(_) | Signer | Function(..) => common::type_not_allowed(type_tag),
         };
         writeln!(
             self.out,
@@ -793,7 +793,7 @@ func decode_{0}_argument(arg aptostypes.TransactionArgument) (value {1}, err err
                 tag if &**tag == Lazy::force(&str_tag) => "[]uint8".into(),
                 _ => common::type_not_allowed(type_tag),
             },
-            Signer => common::type_not_allowed(type_tag),
+            Signer | Function(..) => common::type_not_allowed(type_tag),
         }
     }
 
@@ -820,7 +820,7 @@ func decode_{0}_argument(arg aptostypes.TransactionArgument) (value {1}, err err
                 U8 => format!("(*aptostypes.TransactionArgument__U8Vector)(&{})", name),
                 _ => common::type_not_allowed(type_tag),
             },
-            Struct(_) | Signer => common::type_not_allowed(type_tag),
+            Struct(_) | Signer | Function(..) => common::type_not_allowed(type_tag),
         }
     }
 
@@ -854,7 +854,7 @@ func decode_{0}_argument(arg aptostypes.TransactionArgument) (value {1}, err err
                 tag if &**tag == Lazy::force(&str_tag) => Some("Bytes"),
                 _ => common::type_not_allowed(type_tag),
             },
-            Signer => common::type_not_allowed(type_tag),
+            Signer | Function(..) => common::type_not_allowed(type_tag),
         }
     }
 }

--- a/aptos-move/aptos-sdk-builder/src/rust.rs
+++ b/aptos-move/aptos-sdk-builder/src/rust.rs
@@ -737,7 +737,7 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
                 U8 => ("U8Vector", "Some(value)".to_string()),
                 _ => common::type_not_allowed(type_tag),
             },
-            Struct(_) | Signer => common::type_not_allowed(type_tag),
+            Struct(_) | Signer | Function(..) => common::type_not_allowed(type_tag),
         };
         writeln!(
             self.out,
@@ -880,7 +880,7 @@ fn decode_{}_argument(arg: TransactionArgument) -> Option<{}> {{
                 tag if &**tag == Lazy::force(&str_tag) => "Vec<u8>".into(),
                 _ => common::type_not_allowed(type_tag),
             },
-            Signer => common::type_not_allowed(type_tag),
+            Signer | Function(..) => common::type_not_allowed(type_tag),
         }
     }
 
@@ -909,7 +909,7 @@ fn decode_{}_argument(arg: TransactionArgument) -> Option<{}> {{
                 _ => common::type_not_allowed(type_tag),
             },
 
-            Struct(_) | Signer => common::type_not_allowed(type_tag),
+            Struct(_) | Signer | Function(..) => common::type_not_allowed(type_tag),
         }
     }
 }

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -127,6 +127,7 @@ impl<'r, 'l> SessionExt<'r, 'l> {
         module_storage: &impl ModuleStorage,
     ) -> VMResult<(VMChangeSet, ModuleWriteSet)> {
         let move_vm = self.inner.get_move_vm();
+
         let function_extension = module_storage.as_function_value_extension();
 
         let resource_converter = |value: Value,

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -127,7 +127,6 @@ impl<'r, 'l> SessionExt<'r, 'l> {
         module_storage: &impl ModuleStorage,
     ) -> VMResult<(VMChangeSet, ModuleWriteSet)> {
         let move_vm = self.inner.get_move_vm();
-
         let function_extension = module_storage.as_function_value_extension();
 
         let resource_converter = |value: Value,

--- a/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
+++ b/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
@@ -220,7 +220,7 @@ pub(crate) fn is_valid_txn_arg(
                     ))
                 })
         },
-        Signer | Reference(_) | MutableReference(_) | TyParam(_) => false,
+        Signer | Reference(_) | MutableReference(_) | TyParam(_) | Function { .. } => false,
     }
 }
 
@@ -312,7 +312,9 @@ fn construct_arg(
                 Err(invalid_signature())
             }
         },
-        Reference(_) | MutableReference(_) | TyParam(_) => Err(invalid_signature()),
+        Reference(_) | MutableReference(_) | TyParam(_) | Function { .. } => {
+            Err(invalid_signature())
+        },
     }
 }
 
@@ -385,7 +387,9 @@ pub(crate) fn recursively_construct_arg(
         U64 => read_n_bytes(8, cursor, arg)?,
         U128 => read_n_bytes(16, cursor, arg)?,
         U256 | Address => read_n_bytes(32, cursor, arg)?,
-        Signer | Reference(_) | MutableReference(_) | TyParam(_) => return Err(invalid_signature()),
+        Signer | Reference(_) | MutableReference(_) | TyParam(_) | Function { .. } => {
+            return Err(invalid_signature())
+        },
     };
     Ok(())
 }

--- a/aptos-move/e2e-benchmark/data/calibration_values.tsv
+++ b/aptos-move/e2e-benchmark/data/calibration_values.tsv
@@ -1,15 +1,15 @@
 Loop { loop_count: Some(100000), loop_type: NoOp }	10	0.965	1.031	43125.6
-Loop { loop_count: Some(10000), loop_type: Arithmetic }	10	0.986	1.080	26810.1
+Loop { loop_count: Some(10000), loop_type: Arithmetic }	10	0.986	1.080	25800.0
 CreateObjects { num_objects: 10, object_payload_size: 0 }	10	0.952	1.025	167.2
 CreateObjects { num_objects: 10, object_payload_size: 10240 }	10	0.993	1.094	9731.3
 CreateObjects { num_objects: 100, object_payload_size: 0 }	10	0.976	1.066	1455.7
 CreateObjects { num_objects: 100, object_payload_size: 10240 }	10	0.958	1.079	11812.5
 InitializeVectorPicture { length: 128 }	10	0.976	1.062	189.6
-VectorPicture { length: 128 }	10	0.958	1.059	52.4
-VectorPictureRead { length: 128 }	10	0.952	1.041	51.3
+VectorPicture { length: 128 }	10	0.958	1.059	36.5
+VectorPictureRead { length: 128 }	10	0.952	1.041	35.2
 InitializeVectorPicture { length: 30720 }	10	0.958	1.086	28096.3
-VectorPicture { length: 30720 }	10	0.961	1.069	6811.7
-VectorPictureRead { length: 30720 }	10	0.953	1.066	6824.0
+VectorPicture { length: 30720 }	10	0.961	1.069	4830.4
+VectorPictureRead { length: 30720 }	10	0.953	1.066	4752.3
 SmartTablePicture { length: 30720, num_points_per_txn: 200 }	10	0.985	1.054	36305.8
 SmartTablePicture { length: 1048576, num_points_per_txn: 300 }	10	0.984	1.051	63197.1
 ResourceGroupsSenderWriteTag { string_length: 1024 }	10	0.922	1.031	21.9
@@ -27,11 +27,11 @@ EmitEvents { count: 1000 }	10	0.966	1.044	8216.6
 APTTransferWithPermissionedSigner	10	0.950	1.028	1463.5
 APTTransferWithMasterSigner	10	0.950	1.033	236.3
 VectorTrimAppend { vec_len: 3000, element_len: 1, index: 0, repeats: 0 }	10	0.961	1.073	6501.9
-VectorTrimAppend { vec_len: 3000, element_len: 1, index: 100, repeats: 1000 }	10	0.963	1.205	27994.6
+VectorTrimAppend { vec_len: 3000, element_len: 1, index: 100, repeats: 1000 }	10	0.963	1.205	29000.0
 VectorTrimAppend { vec_len: 3000, element_len: 1, index: 2990, repeats: 1000 }	10	0.966	1.050	16335.1
 VectorRemoveInsert { vec_len: 3000, element_len: 1, index: 100, repeats: 1000 }	10	0.963	1.037	25367.0
 VectorRemoveInsert { vec_len: 3000, element_len: 1, index: 2998, repeats: 1000 }	10	0.965	1.045	16896.2
-VectorRangeMove { vec_len: 3000, element_len: 1, index: 1000, move_len: 500, repeats: 1000 }	10	0.898	1.066	32347.9
+VectorRangeMove { vec_len: 3000, element_len: 1, index: 1000, move_len: 500, repeats: 1000 }	10	0.898	1.066	25257.3
 VectorTrimAppend { vec_len: 100, element_len: 100, index: 0, repeats: 0 }	10	0.972	1.050	295.7
 VectorTrimAppend { vec_len: 100, element_len: 100, index: 10, repeats: 1000 }	10	0.969	1.043	10454.4
 VectorRangeMove { vec_len: 100, element_len: 100, index: 50, move_len: 10, repeats: 1000 }	10	0.958	1.030	4856.6

--- a/aptos-move/framework/move-stdlib/src/natives/bcs.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/bcs.rs
@@ -193,10 +193,11 @@ fn constant_serialized_size(ty_layout: &MoveTypeLayout) -> (u64, PartialVMResult
         MoveTypeLayout::Signer => Ok(None),
         // vectors have no constant size
         MoveTypeLayout::Vector(_) => Ok(None),
-        // enums have no constant size
+        // enums and functions have no constant size
         MoveTypeLayout::Struct(
             MoveStructLayout::RuntimeVariants(_) | MoveStructLayout::WithVariants(_),
-        ) => Ok(None),
+        )
+        | MoveTypeLayout::Function(..) => Ok(None),
         MoveTypeLayout::Struct(MoveStructLayout::Runtime(fields)) => {
             let mut total = Some(0);
             for field in fields {

--- a/aptos-move/framework/src/natives/string_utils.rs
+++ b/aptos-move/framework/src/natives/string_utils.rs
@@ -351,8 +351,9 @@ fn native_format_impl(
             out.push('}');
         },
         MoveTypeLayout::Function(_) => {
-            // TODO(#15664): The captured layouts are not decorated, do we actually and
-            //   if so, how, print this?
+            // Notice that we print the undecorated value representation,
+            // avoiding potential loading of the function to get full
+            // decorated type information.
             let (fun, args) = val.value_as::<Closure>()?.unpack();
             let data = context
                 .context

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/utils/helpers.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/utils/helpers.rs
@@ -6,7 +6,10 @@
 use aptos_language_e2e_tests::{account::Account, executor::FakeExecutor};
 use arbitrary::Arbitrary;
 use move_binary_format::file_format::CompiledModule;
-use move_core_types::value::{MoveStructLayout, MoveTypeLayout};
+use move_core_types::{
+    function::MoveFunctionLayout,
+    value::{MoveStructLayout, MoveTypeLayout},
+};
 
 #[macro_export]
 macro_rules! tdbg {
@@ -81,6 +84,9 @@ pub(crate) fn is_valid_layout(layout: &MoveTypeLayout) -> bool {
                 return false;
             }
             fields.iter().all(is_valid_layout)
+        },
+        L::Function(MoveFunctionLayout(args, results, _)) => {
+            args.iter().chain(results).all(is_valid_layout)
         },
         L::Struct(_) => {
             // decorated layouts not supported

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -1,4 +1,6 @@
 ---
+AbilitySet:
+  NEWTYPESTRUCT: U8
 AbortInfo:
   STRUCT:
     - reason_name: STR
@@ -341,6 +343,16 @@ FunctionInfo:
         TYPENAME: AccountAddress
     - module_name: STR
     - function_name: STR
+FunctionTag:
+  STRUCT:
+    - args:
+        SEQ:
+          TYPENAME: TypeTag
+    - results:
+        SEQ:
+          TYPENAME: TypeTag
+    - abilities:
+        TYPENAME: AbilitySet
 G1Bytes:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -782,6 +794,10 @@ TypeTag:
       u32: UNIT
     10:
       u256: UNIT
+    11:
+      Function:
+        NEWTYPE:
+          TYPENAME: FunctionTag
 ValidatorTransaction:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -1,4 +1,6 @@
 ---
+AbilitySet:
+  NEWTYPESTRUCT: U8
 AbstractionAuthData:
   ENUM:
     0:
@@ -287,6 +289,16 @@ FunctionInfo:
         TYPENAME: AccountAddress
     - module_name: STR
     - function_name: STR
+FunctionTag:
+  STRUCT:
+    - args:
+        SEQ:
+          TYPENAME: TypeTag
+    - results:
+        SEQ:
+          TYPENAME: TypeTag
+    - abilities:
+        TYPENAME: AbilitySet
 G1Bytes:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -667,6 +679,10 @@ TypeTag:
       u32: UNIT
     10:
       u256: UNIT
+    11:
+      Function:
+        NEWTYPE:
+          TYPENAME: FunctionTag
 ValidatorTransaction:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -1,4 +1,6 @@
 ---
+AbilitySet:
+  NEWTYPESTRUCT: U8
 AbstractionAuthData:
   ENUM:
     0:
@@ -580,6 +582,16 @@ FunctionInfo:
         TYPENAME: AccountAddress
     - module_name: STR
     - function_name: STR
+FunctionTag:
+  STRUCT:
+    - args:
+        SEQ:
+          TYPENAME: TypeTag
+    - results:
+        SEQ:
+          TYPENAME: TypeTag
+    - abilities:
+        TYPENAME: AbilitySet
 G1Bytes:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -1174,6 +1186,10 @@ TypeTag:
       u32: UNIT
     10:
       u256: UNIT
+    11:
+      Function:
+        NEWTYPE:
+          TYPENAME: FunctionTag
 ValidatorConsensusInfo:
   STRUCT:
     - address:

--- a/testsuite/generate-format/tests/staged/move_abi.yaml
+++ b/testsuite/generate-format/tests/staged/move_abi.yaml
@@ -1,4 +1,6 @@
 ---
+AbilitySet:
+  NEWTYPESTRUCT: U8
 AccountAddress:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -19,6 +21,16 @@ EntryABI:
       EntryFunction:
         NEWTYPE:
           TYPENAME: ScriptFunctionABI
+FunctionTag:
+  STRUCT:
+    - args:
+        SEQ:
+          TYPENAME: TypeTag
+    - results:
+        SEQ:
+          TYPENAME: TypeTag
+    - abilities:
+        TYPENAME: AbilitySet
 Identifier:
   NEWTYPESTRUCT: STR
 ModuleId:
@@ -92,3 +104,7 @@ TypeTag:
       u32: UNIT
     10:
       u256: UNIT
+    11:
+      Function:
+        NEWTYPE:
+          TYPENAME: FunctionTag

--- a/testsuite/single_node_performance_values.tsv
+++ b/testsuite/single_node_performance_values.tsv
@@ -11,7 +11,7 @@ publish-package	1	VM	59	0.873	1.014	1132.4
 mix_publish_transfer	1	VM	59	0.895	1.028	17569.3
 batch100-transfer	1	VM	59	0.850	1.057	626.5
 batch100-transfer	1	NativeVM	59	0.816	1.170	1442.7
-vector-picture30k	1	VM	59	0.904	1.039	103.4
+vector-picture30k	1	VM	59	0.904	1.039	118.0
 vector-picture30k	100	VM	59	0.601	1.069	1834.8
 smart-table-picture30-k-with200-change	1	VM	59	0.897	1.046	17.2
 smart-table-picture30-k-with200-change	100	VM	59	0.877	1.141	237.6

--- a/third_party/move/move-binary-format/src/constant.rs
+++ b/third_party/move/move-binary-format/src/constant.rs
@@ -40,6 +40,7 @@ fn construct_ty_for_constant(layout: &MoveTypeLayout) -> Option<SignatureToken> 
             construct_ty_for_constant(l.as_ref())?,
         ))),
         MoveTypeLayout::Struct(_) => None,
+        MoveTypeLayout::Function(_) => None,
         MoveTypeLayout::Bool => Some(SignatureToken::Bool),
 
         // It is not possible to have native layout for constant values.

--- a/third_party/move/move-binary-format/src/errors.rs
+++ b/third_party/move/move-binary-format/src/errors.rs
@@ -469,6 +469,10 @@ impl PartialVMError {
         }))
     }
 
+    pub fn new_invariant_violation(msg: impl ToString) -> PartialVMError {
+        Self::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(msg.to_string())
+    }
+
     pub fn major_status(&self) -> StatusCode {
         self.0.major_status
     }

--- a/third_party/move/move-binary-format/src/normalized.rs
+++ b/third_party/move/move-binary-format/src/normalized.rs
@@ -398,6 +398,7 @@ impl From<TypeTag> for Type {
                 name: s.name,
                 type_arguments: s.type_args.into_iter().map(|ty| ty.into()).collect(),
             },
+            TypeTag::Function(_) => panic!("function types not supported in normalized types"),
         }
     }
 }

--- a/third_party/move/move-compiler/src/cfgir/ast.rs
+++ b/third_party/move/move-compiler/src/cfgir/ast.rs
@@ -323,6 +323,7 @@ impl AstDebug for MoveValue {
             },
             V::Struct(_) => panic!("ICE struct constants not supported"),
             V::Signer(_) => panic!("ICE signer constants not supported"),
+            V::Closure(_) => panic!("ICE closures not supported"),
         }
     }
 }

--- a/third_party/move/move-core/types/Cargo.toml
+++ b/third_party/move/move-core/types/Cargo.toml
@@ -34,6 +34,7 @@ uint = { workspace = true }
 
 [dev-dependencies]
 arbitrary = { workspace = true, features = ["derive_arbitrary"] }
+dearbitrary = { workspace = true, features = ["derive"] }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 regex = { workspace = true }

--- a/third_party/move/move-core/types/src/ability.rs
+++ b/third_party/move/move-core/types/src/ability.rs
@@ -84,7 +84,7 @@ impl fmt::Display for Ability {
 /// A set of `Ability`s
 #[derive(Clone, Eq, Copy, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[cfg_attr(
-    feature = "fuzzing",
+    any(test, feature = "fuzzing"),
     derive(arbitrary::Arbitrary, dearbitrary::Dearbitrary)
 )]
 pub struct AbilitySet(u8);

--- a/third_party/move/move-core/types/src/function.rs
+++ b/third_party/move/move-core/types/src/function.rs
@@ -139,6 +139,7 @@ impl ClosureMask {
 #[cfg(test)]
 mod closure_mask_tests {
     use super::*;
+
     #[test]
     fn extract_compose_roundtrip_test() {
         // mask.compose(mask.extract(v, true), mask.extract(v, false)) == v

--- a/third_party/move/move-core/types/src/language_storage.rs
+++ b/third_party/move/move-core/types/src/language_storage.rs
@@ -180,7 +180,7 @@ impl FromStr for TypeTag {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 #[cfg_attr(
-    feature = "fuzzing",
+    any(test, feature = "fuzzing"),
     derive(arbitrary::Arbitrary, dearbitrary::Dearbitrary)
 )]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
@@ -267,7 +267,7 @@ impl FromStr for StructTag {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 #[cfg_attr(
-    feature = "fuzzing",
+    any(test, feature = "fuzzing"),
     derive(arbitrary::Arbitrary, dearbitrary::Dearbitrary)
 )]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
@@ -306,7 +306,7 @@ impl ResourceKey {
 /// the struct tag. The struct fields are public to support pattern matching.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
 #[cfg_attr(
-    feature = "fuzzing",
+    any(test, feature = "fuzzing"),
     derive(arbitrary::Arbitrary, dearbitrary::Dearbitrary)
 )]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]

--- a/third_party/move/move-core/types/src/safe_serialize.rs
+++ b/third_party/move/move-core/types/src/safe_serialize.rs
@@ -4,9 +4,6 @@
 
 //! Custom serializers which track recursion nesting with a thread local,
 //! and otherwise delegate to the derived serializers.
-//!
-//! This is currently only implemented for type tags, but can be easily
-//! generalized, as the only type-tag specific thing is the allowed nesting.
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cell::RefCell;

--- a/third_party/move/move-core/types/src/transaction_argument.rs
+++ b/third_party/move/move-core/types/src/transaction_argument.rs
@@ -82,7 +82,7 @@ impl TryFrom<MoveValue> for TransactionArgument {
                     })
                     .collect::<Result<Vec<u8>>>()?,
             ),
-            MoveValue::Signer(_) | MoveValue::Struct(_) => {
+            MoveValue::Signer(_) | MoveValue::Struct(_) | MoveValue::Closure(_) => {
                 return Err(anyhow!("invalid transaction argument: {:?}", val))
             },
             MoveValue::U16(i) => TransactionArgument::U16(i),

--- a/third_party/move/move-core/types/src/value.rs
+++ b/third_party/move/move-core/types/src/value.rs
@@ -525,6 +525,8 @@ impl MoveStructLayout {
 
     /// Determines whether the layout is serialization compatible with the other layout
     /// (that is, any value serialized with this layout can be deserialized by the other).
+    /// This only will consider runtime variants, decorated variants are only compatible
+    /// if equal.
     pub fn is_compatible_with(&self, other: &Self) -> bool {
         use MoveStructLayout::*;
         match (self, other) {
@@ -533,6 +535,13 @@ impl MoveStructLayout {
                     && variants1.iter().zip(variants2).all(|(fields1, fields2)| {
                         MoveTypeLayout::is_compatible_with_slice(fields1, fields2)
                     })
+            },
+            (Runtime(fields1), Runtime(fields2)) => {
+                fields1.len() == fields2.len()
+                    && fields1
+                        .iter()
+                        .zip(fields2)
+                        .all(|(t1, t2)| t1.is_compatible_with(t2))
             },
             // All other cases require equality
             (s1, s2) => s1 == s2,

--- a/third_party/move/move-ir/types/src/ast.rs
+++ b/third_party/move/move-ir/types/src/ast.rs
@@ -1807,7 +1807,7 @@ fn format_move_value(v: &MoveValue) -> String {
                 .join(", ");
             format!("vector[{}]", items)
         },
-        MoveValue::Struct(_) | MoveValue::Signer(_) => {
+        MoveValue::Struct(_) | MoveValue::Signer(_) | MoveValue::Closure(_) => {
             panic!("Should be inexpressible as a constant")
         },
         MoveValue::U16(u) => format!("{}u16", u),

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -5508,30 +5508,10 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                     Value::Vector(b)
                 },
             },
-            (Type::Primitive(_), MoveValue::Vector(_))
-            | (Type::Primitive(_), MoveValue::Struct(_))
-            | (Type::Tuple(_), MoveValue::Vector(_))
-            | (Type::Tuple(_), MoveValue::Struct(_))
-            | (Type::Vector(_), MoveValue::Struct(_))
-            | (Type::Struct(_, _, _), MoveValue::Vector(_))
-            | (Type::Struct(_, _, _), MoveValue::Struct(_))
-            | (Type::TypeParameter(_), MoveValue::Vector(_))
-            | (Type::TypeParameter(_), MoveValue::Struct(_))
-            | (Type::Reference(_, _), MoveValue::Vector(_))
-            | (Type::Reference(_, _), MoveValue::Struct(_))
-            | (Type::Fun(..), MoveValue::Vector(_))
-            | (Type::Fun(..), MoveValue::Struct(_))
-            | (Type::TypeDomain(_), MoveValue::Vector(_))
-            | (Type::TypeDomain(_), MoveValue::Struct(_))
-            | (Type::ResourceDomain(_, _, _), MoveValue::Vector(_))
-            | (Type::ResourceDomain(_, _, _), MoveValue::Struct(_))
-            | (Type::Error, MoveValue::Vector(_))
-            | (Type::Error, MoveValue::Struct(_))
-            | (Type::Var(_), MoveValue::Vector(_))
-            | (Type::Var(_), MoveValue::Struct(_)) => {
+            _ => {
                 self.error(
                     loc,
-                    &format!("Not yet supported constant value: {:?}", value),
+                    &format!("Not supported constant value/type combination: {}", value),
                 );
                 Value::Bool(false)
             },

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -24,7 +24,7 @@ use move_binary_format::{
 };
 use move_core_types::{
     ability::{Ability, AbilitySet},
-    language_storage::{StructTag, TypeTag},
+    language_storage::{FunctionTag, StructTag, TypeTag},
     u256::U256,
 };
 use num::BigInt;
@@ -1333,6 +1333,21 @@ impl Type {
                 Struct(qid.module_id, qid.id, type_args)
             },
             TypeTag::Vector(type_param) => Vector(Box::new(Self::from_type_tag(type_param, env))),
+            TypeTag::Function(fun) => {
+                let FunctionTag {
+                    args,
+                    results,
+                    abilities,
+                } = fun.as_ref();
+                let from_vec = |ts: &[TypeTag]| {
+                    Type::tuple(ts.iter().map(|t| Type::from_type_tag(t, env)).collect_vec())
+                };
+                Fun(
+                    Box::new(from_vec(args)),
+                    Box::new(from_vec(results)),
+                    *abilities,
+                )
+            },
         }
     }
 

--- a/third_party/move/move-stdlib/src/natives/debug.rs
+++ b/third_party/move/move-stdlib/src/natives/debug.rs
@@ -460,6 +460,9 @@ mod testing {
                     )?;
                 }
             },
+            MoveValue::Closure(clos) => {
+                write!(out, "{}", clos).map_err(fmt_error_to_partial_vm_error)?;
+            },
             MoveValue::Struct(move_struct) => match move_struct {
                 MoveStruct::WithTypes {
                     _type_: type_,

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1611,17 +1611,16 @@ fn check_depth_of_type_impl(
             check_depth!(formula.solve(&ty_arg_depths))
         },
         Type::Function { args, results, .. } => {
-            let mut ty_max = depth;
-            //for ty in args.iter().chain(results.iter()).map(|rc| rc.as_ref()) {
+            let mut ty_max_depth = depth;
             for ty in args.iter().chain(results) {
-                ty_max = ty_max.max(check_depth_of_type_impl(
+                ty_max_depth = ty_max_depth.max(check_depth_of_type_impl(
                     resolver,
                     ty,
                     max_depth,
                     check_depth!(1),
                 )?);
             }
-            ty_max
+            ty_max_depth
         },
         Type::TyParam(_) => {
             return Err(

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -8,8 +8,10 @@ use crate::{
         Resolver, Script,
     },
     native_functions::{NativeFunction, NativeFunctions, UnboxedNativeFunction},
+    storage::ty_tag_converter::TypeTagConverter,
     ModuleStorage,
 };
+use better_any::{Tid, TidAble, TidExt};
 use move_binary_format::{
     access::ModuleAccess,
     binary_views::BinaryIndexedView,
@@ -17,13 +19,21 @@ use move_binary_format::{
     file_format::{Bytecode, CompiledModule, FunctionDefinitionIndex, Visibility},
 };
 use move_core_types::{
-    ability::AbilitySet, identifier::Identifier, language_storage::ModuleId, vm_status::StatusCode,
+    ability::{Ability, AbilitySet},
+    function::ClosureMask,
+    identifier::{IdentStr, Identifier},
+    language_storage::{ModuleId, TypeTag},
+    value::MoveTypeLayout,
+    vm_status::StatusCode,
 };
-use move_vm_types::loaded_data::{
-    runtime_access_specifier::AccessSpecifier,
-    runtime_types::{StructIdentifier, Type},
+use move_vm_types::{
+    loaded_data::{
+        runtime_access_specifier::AccessSpecifier,
+        runtime_types::{StructIdentifier, Type},
+    },
+    values::{AbstractFunction, SerializedFunctionData},
 };
-use std::{fmt::Debug, sync::Arc};
+use std::{cell::RefCell, cmp::Ordering, fmt::Debug, rc::Rc, sync::Arc};
 
 /// A runtime function definition representation.
 pub struct Function {
@@ -45,12 +55,14 @@ pub struct Function {
 }
 
 /// For loaded function representation, specifies the owner: a script or a module.
+#[derive(Clone)]
 pub(crate) enum LoadedFunctionOwner {
     Script(Arc<Script>),
     Module(Arc<Module>),
 }
 
 /// A loaded runtime function representation along with type arguments used to instantiate it.
+#[derive(Clone)]
 pub struct LoadedFunction {
     pub(crate) owner: LoadedFunctionOwner,
     // A set of verified type arguments provided for this definition. If
@@ -60,16 +72,256 @@ pub struct LoadedFunction {
     pub(crate) function: Arc<Function>,
 }
 
+/// A lazy loaded function, which can either be unresolved (as resulting
+/// from deserialization) or resolved, and then forwarding to a
+/// `LoadedFunction`. This is wrapped into a Rc so one can clone the
+/// function while sharing the loading state.
+#[derive(Clone, Tid)]
+pub(crate) struct LazyLoadedFunction(pub(crate) Rc<RefCell<LazyLoadedFunctionState>>);
+
+#[derive(Clone)]
+pub(crate) enum LazyLoadedFunctionState {
+    Unresolved {
+        data: SerializedFunctionData,
+        resolution_error: Option<PartialVMError>,
+    },
+    Resolved {
+        fun: Rc<LoadedFunction>,
+        fun_inst: Vec<TypeTag>,
+        mask: ClosureMask,
+    },
+}
+
+impl LazyLoadedFunction {
+    pub(crate) fn new_unresolved(data: SerializedFunctionData) -> Self {
+        Self(Rc::new(RefCell::new(LazyLoadedFunctionState::Unresolved {
+            data,
+            resolution_error: None,
+        })))
+    }
+
+    #[allow(unused)]
+    pub(crate) fn new_resolved(
+        converter: &TypeTagConverter,
+        fun: Rc<LoadedFunction>,
+        mask: ClosureMask,
+    ) -> PartialVMResult<Self> {
+        let fun_inst = fun
+            .ty_args
+            .iter()
+            .map(|t| converter.ty_to_ty_tag(t))
+            .collect::<PartialVMResult<Vec<_>>>()?;
+        Ok(Self(Rc::new(RefCell::new(
+            LazyLoadedFunctionState::Resolved {
+                fun,
+                fun_inst,
+                mask,
+            },
+        ))))
+    }
+
+    pub(crate) fn expect_this_impl(
+        fun: &dyn AbstractFunction,
+    ) -> PartialVMResult<&LazyLoadedFunction> {
+        fun.downcast_ref::<LazyLoadedFunction>().ok_or_else(|| {
+            PartialVMError::new_invariant_violation("unexpected abstract function implementation")
+        })
+    }
+
+    /// Access name components independent of resolution state. Since RefCell is in the play,
+    /// the accessor is passed in as a function.
+    pub(crate) fn with_name_and_inst<T>(
+        &self,
+        action: impl FnOnce(Option<&ModuleId>, &IdentStr, &[TypeTag]) -> T,
+    ) -> T {
+        match &*self.0.borrow() {
+            LazyLoadedFunctionState::Unresolved {
+                data:
+                    SerializedFunctionData {
+                        module_id,
+                        fun_id,
+                        fun_inst,
+                        ..
+                    },
+                ..
+            } => action(Some(module_id), fun_id, fun_inst),
+            LazyLoadedFunctionState::Resolved { fun, fun_inst, .. } => {
+                action(fun.module_id(), fun.name_id(), fun_inst)
+            },
+        }
+    }
+
+    /// Executed an action with the resolved loaded function. If the function hasn't been
+    /// loaded yet, it will be loaded now.
+    #[allow(unused)]
+    pub(crate) fn with_resolved_function<T>(
+        &self,
+        storage: &dyn ModuleStorage,
+        action: impl FnOnce(Rc<LoadedFunction>) -> PartialVMResult<T>,
+    ) -> PartialVMResult<T> {
+        let mut state = self.0.borrow_mut();
+        match &mut *state {
+            LazyLoadedFunctionState::Resolved { fun, .. } => action(fun.clone()),
+            LazyLoadedFunctionState::Unresolved {
+                resolution_error: Some(e),
+                ..
+            } => Err(e.clone()),
+            LazyLoadedFunctionState::Unresolved {
+                data:
+                    SerializedFunctionData {
+                        module_id,
+                        fun_id,
+                        fun_inst,
+                        mask,
+                        captured_layouts,
+                    },
+                resolution_error,
+            } => match Self::resolve(
+                storage,
+                module_id,
+                fun_id,
+                fun_inst,
+                *mask,
+                captured_layouts,
+            ) {
+                Ok(fun) => {
+                    let result = action(fun.clone());
+                    *state = LazyLoadedFunctionState::Resolved {
+                        fun,
+                        fun_inst: fun_inst.clone(),
+                        mask: *mask,
+                    };
+                    result
+                },
+                Err(e) => {
+                    *resolution_error = Some(e.clone());
+                    Err(e)
+                },
+            },
+        }
+    }
+
+    /// Resolves a function into a loaded function. This verifies existence of the named
+    /// function as well as whether it has the type used for deserializing the captured values.
+    fn resolve(
+        module_storage: &dyn ModuleStorage,
+        module_id: &ModuleId,
+        fun_id: &IdentStr,
+        fun_inst: &[TypeTag],
+        mask: ClosureMask,
+        captured_layouts: &[MoveTypeLayout],
+    ) -> PartialVMResult<Rc<LoadedFunction>> {
+        let (module, function) = module_storage
+            .fetch_function_definition(module_id.address(), module_id.name(), fun_id)
+            .map_err(|err| err.to_partial())?;
+        let ty_args = fun_inst
+            .iter()
+            .map(|t| module_storage.fetch_ty(t))
+            .collect::<PartialVMResult<Vec<_>>>()?;
+
+        // Verify that the function arguments match the types used for deserialization.
+        let captured_arg_types = mask.extract(function.param_tys(), true);
+        let converter = TypeTagConverter::new(module_storage.runtime_environment());
+        let mut ok = captured_arg_types.len() == captured_layouts.len();
+        if ok {
+            for (ty, layout) in captured_arg_types.into_iter().zip(captured_layouts) {
+                // Convert layout into TypeTag
+                let serialized_tag: TypeTag = layout.try_into().map_err(|_| {
+                    PartialVMError::new_invariant_violation(
+                        "unexpected type tag conversion failure",
+                    )
+                })?;
+                let arg_tag = converter.ty_to_ty_tag(ty)?;
+                if arg_tag != serialized_tag {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        if ok {
+            Ok(Rc::new(LoadedFunction {
+                owner: LoadedFunctionOwner::Module(module),
+                ty_args,
+                function,
+            }))
+        } else {
+            Err(
+                PartialVMError::new(StatusCode::FUNCTION_RESOLUTION_FAILURE).with_message(
+                    "inconsistency between types of serialized captured \
+                values and function parameter types"
+                        .to_string(),
+                ),
+            )
+        }
+    }
+}
+
+impl AbstractFunction for LazyLoadedFunction {
+    fn closure_mask(&self) -> ClosureMask {
+        let state = self.0.borrow();
+        match &*state {
+            LazyLoadedFunctionState::Resolved { mask, .. } => *mask,
+            LazyLoadedFunctionState::Unresolved {
+                data: SerializedFunctionData { mask, .. },
+                ..
+            } => *mask,
+        }
+    }
+
+    fn cmp_dyn(&self, other: &dyn AbstractFunction) -> PartialVMResult<Ordering> {
+        let other = LazyLoadedFunction::expect_this_impl(other)?;
+        self.with_name_and_inst(|mid1, fid1, inst1| {
+            other.with_name_and_inst(|mid2, fid2, inst2| {
+                Ok(mid1
+                    .cmp(&mid2)
+                    .then_with(|| fid1.cmp(fid2))
+                    .then_with(|| inst1.cmp(inst2)))
+            })
+        })
+    }
+
+    fn clone_dyn(&self) -> PartialVMResult<Box<dyn AbstractFunction>> {
+        Ok(Box::new(self.clone()))
+    }
+
+    fn to_stable_string(&self) -> String {
+        self.with_name_and_inst(|module_id, fun_id, fun_inst| {
+            let prefix = if let Some(m) = module_id {
+                format!("0x{}::{}::", m.address(), m.name())
+            } else {
+                "".to_string()
+            };
+            let fun_inst_str = if fun_inst.is_empty() {
+                "".to_string()
+            } else {
+                format!(
+                    "<{}>",
+                    fun_inst
+                        .iter()
+                        .map(|t| t.to_canonical_string())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
+            };
+            format!("{}::{}:{}", prefix, fun_id, fun_inst_str)
+        })
+    }
+}
+
 impl LoadedFunction {
     /// Returns type arguments used to instantiate the loaded function.
     pub fn ty_args(&self) -> &[Type] {
         &self.ty_args
     }
 
+    pub fn abilities(&self) -> AbilitySet {
+        self.function.abilities()
+    }
+
     /// Returns the corresponding module id of this function, i.e., its address and module name.
     pub fn module_id(&self) -> Option<&ModuleId> {
         match &self.owner {
-            LoadedFunctionOwner::Module(m) => Some(m.self_id()),
+            LoadedFunctionOwner::Module(m) => Some(Module::self_id(m)),
             LoadedFunctionOwner::Script(_) => None,
         }
     }
@@ -77,6 +329,11 @@ impl LoadedFunction {
     /// Returns the name of this function.
     pub fn name(&self) -> &str {
         self.function.name()
+    }
+
+    /// Returns the id of this function's name.
+    pub fn name_id(&self) -> &IdentStr {
+        self.function.name_id()
     }
 
     /// Returns true if the loaded function has friend or private visibility.
@@ -254,6 +511,10 @@ impl Function {
         self.name.as_str()
     }
 
+    pub(crate) fn name_id(&self) -> &IdentStr {
+        &self.name
+    }
+
     pub fn ty_param_abilities(&self) -> &[AbilitySet] {
         &self.ty_param_abilities
     }
@@ -268,6 +529,36 @@ impl Function {
 
     pub fn param_tys(&self) -> &[Type] {
         &self.param_tys
+    }
+
+    /// Creates the function type instance for this function. This requires cloning
+    /// the parameter and result types.
+    pub fn create_function_type(&self) -> Type {
+        Type::Function {
+            args: self
+                .param_tys
+                .iter()
+                .map(|t| triomphe::Arc::new(t.clone()))
+                .collect(),
+            results: self
+                .return_tys
+                .iter()
+                .map(|t| triomphe::Arc::new(t.clone()))
+                .collect(),
+            abilities: self.abilities(),
+        }
+    }
+
+    /// Returns the abilities associated with this function, without consideration of any captured
+    /// closure arguments. By default, this is copy and drop, and if the function is
+    /// immutable (public), also store.
+    pub fn abilities(&self) -> AbilitySet {
+        let result = AbilitySet::singleton(Ability::Copy).add(Ability::Drop);
+        if !self.is_friend_or_private {
+            result.add(Ability::Store)
+        } else {
+            result
+        }
     }
 
     pub fn is_native(&self) -> bool {

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -515,16 +515,8 @@ impl Function {
     /// the parameter and result types.
     pub fn create_function_type(&self) -> Type {
         Type::Function {
-            args: self
-                .param_tys
-                .iter()
-                .map(|t| triomphe::Arc::new(t.clone()))
-                .collect(),
-            results: self
-                .return_tys
-                .iter()
-                .map(|t| triomphe::Arc::new(t.clone()))
-                .collect(),
+            args: self.param_tys.clone(),
+            results: self.return_tys.clone(),
             abilities: self.abilities(),
         }
     }

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -2039,7 +2039,10 @@ fn match_return_type<'a>(
                 results: exp_results,
                 abilities: exp_abilities,
             },
-        ) if abilities == exp_abilities => {
+        ) if abilities == exp_abilities
+            && args.len() == exp_args.len()
+            && results.len() == exp_results.len() =>
+        {
             args.iter()
                 .zip(exp_args)
                 .all(|(t, e)| match_return_type(t, e, map))

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -75,10 +75,11 @@ use move_binary_format::file_format::{
     VariantFieldHandleIndex, VariantFieldInstantiationIndex, VariantIndex,
 };
 use move_core_types::language_storage::FunctionTag;
-use move_vm_metrics::{Timer, VM_TIMER};
 use move_vm_types::{
-    loaded_data::runtime_types::{DepthFormula, StructLayout, TypeBuilder},
-    value_serde::FunctionValueExtension,
+    loaded_data::{
+        runtime_types::{DepthFormula, StructLayout, TypeBuilder},
+        struct_name_indexing::StructNameIndexMap,
+    },
     values::{AbstractFunction, SerializedFunctionData},
 };
 pub use script::Script;
@@ -1982,7 +1983,12 @@ impl Loader {
                     args.iter()
                         .chain(results)
                         .map(|rc| {
-                            self.calculate_depth_of_type(rc.as_ref(), module_store, module_storage)
+                            self.calculate_depth_of_type(
+                                rc.as_ref(),
+                                module_store,
+                                module_storage,
+                                visited_cache,
+                            )
                         })
                         .collect::<PartialVMResult<Vec<_>>>()?,
                 );

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -1805,7 +1805,7 @@ impl LoaderV1 {
                 results,
                 abilities,
             } => {
-                let to_vec = |ts: &[triomphe::Arc<Type>],
+                let to_vec = |ts: &[Type],
                               gas_ctx: &mut PseudoGasContext|
                  -> PartialVMResult<Vec<TypeTag>> {
                     ts.iter()
@@ -1982,9 +1982,9 @@ impl Loader {
                 let mut inner = DepthFormula::normalize(
                     args.iter()
                         .chain(results)
-                        .map(|rc| {
+                        .map(|arg_ty| {
                             self.calculate_depth_of_type(
-                                rc.as_ref(),
+                                arg_ty,
                                 module_store,
                                 module_storage,
                                 visited_cache,

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -519,8 +519,20 @@ impl<'r, 'l> Session<'r, 'l> {
                     .idx_to_struct_name(*idx)?;
                 Some((struct_identifier.module, struct_identifier.name))
             },
-            Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address | Signer | TyParam(_)
-            | Vector(_) | Reference(_) | MutableReference(_) => None,
+            Bool
+            | U8
+            | U16
+            | U32
+            | U64
+            | U128
+            | U256
+            | Address
+            | Signer
+            | TyParam(_)
+            | Vector(_)
+            | Reference(_)
+            | MutableReference(_)
+            | Function { .. } => None,
         })
     }
 

--- a/third_party/move/move-vm/runtime/src/storage/module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/module_storage.rs
@@ -463,11 +463,7 @@ impl<'a> FunctionValueExtension for FunctionValueExtensionAdapter<'a> {
     ) -> PartialVMResult<SerializedFunctionData> {
         match &*LazyLoadedFunction::expect_this_impl(fun)?.0.borrow() {
             LazyLoadedFunctionState::Unresolved { data, .. } => Ok(data.clone()),
-            LazyLoadedFunctionState::Resolved {
-                fun,
-                mask,
-                fun_inst,
-            } => {
+            LazyLoadedFunctionState::Resolved { fun, mask, ty_args } => {
                 let ty_converter = StorageLayoutConverter::new(self.module_storage);
                 let ty_builder = &self
                     .module_storage
@@ -496,7 +492,7 @@ impl<'a> FunctionValueExtension for FunctionValueExtensionAdapter<'a> {
                         })?
                         .clone(),
                     fun_id: fun.function.name.clone(),
-                    fun_inst: fun_inst.clone(),
+                    ty_args: ty_args.clone(),
                     mask: *mask,
                     captured_layouts,
                 })

--- a/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
@@ -163,11 +163,12 @@ pub(crate) trait LayoutConverterBase {
                 results,
                 abilities,
             } => {
+                *count += 1;
                 let mut identifier_mapping = false;
-                let mut to_list = |rcs: &[triomphe::Arc<Type>]| {
-                    rcs.iter()
-                        .map(|rc| {
-                            self.type_to_type_layout_impl(rc.as_ref(), count, depth + 1)
+                let mut to_list = |tys: &[Type]| {
+                    tys.iter()
+                        .map(|ety| {
+                            self.type_to_type_layout_impl(ety, count, depth + 1)
                                 .map(|(l, has)| {
                                     identifier_mapping |= has;
                                     l
@@ -339,11 +340,9 @@ pub(crate) trait LayoutConverterBase {
                 results,
                 abilities,
             } => {
-                let mut to_list = |rcs: &[triomphe::Arc<Type>]| {
-                    rcs.iter()
-                        .map(|rc| {
-                            self.type_to_fully_annotated_layout_impl(rc.as_ref(), count, depth + 1)
-                        })
+                let mut to_list = |tys: &[Type]| {
+                    tys.iter()
+                        .map(|ety| self.type_to_fully_annotated_layout_impl(ety, count, depth + 1))
                         .collect::<PartialVMResult<Vec<_>>>()
                 };
                 MoveTypeLayout::Function(MoveFunctionLayout(

--- a/third_party/move/move-vm/runtime/src/storage/ty_tag_converter.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_tag_converter.rs
@@ -246,7 +246,7 @@ impl<'a> TypeTagConverter<'a> {
                 results,
                 abilities,
             } => {
-                let to_vec = |ts: &[triomphe::Arc<Type>],
+                let to_vec = |ts: &[Type],
                               gas_ctx: &mut PseudoGasContext|
                  -> PartialVMResult<Vec<TypeTag>> {
                     ts.iter()

--- a/third_party/move/move-vm/types/Cargo.toml
+++ b/third_party/move/move-vm/types/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 [dependencies]
 ambassador = { workspace = true }
 bcs = { workspace = true }
+better_any = { workspace = true }
 bytes = { workspace = true }
 crossbeam = { workspace = true }
 dashmap = { workspace = true }

--- a/third_party/move/move-vm/types/Cargo.toml
+++ b/third_party/move/move-vm/types/Cargo.toml
@@ -31,6 +31,7 @@ triomphe = { workspace = true }
 
 [dev-dependencies]
 claims = { workspace = true }
+mockall = { workspace = true }
 move-binary-format = { workspace = true, features = ["fuzzing"] }
 proptest = { workspace = true }
 rand = { workspace = true }

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -25,7 +25,7 @@ use smallvec::{smallvec, SmallVec};
 use std::{
     cell::RefCell,
     cmp::max,
-    collections::{btree_map, BTreeMap, BTreeSet},
+    collections::{btree_map, BTreeMap},
     fmt,
     fmt::Debug,
     sync::Arc,

--- a/third_party/move/move-vm/types/src/value_traversal.rs
+++ b/third_party/move/move-vm/types/src/value_traversal.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     delayed_values::error::code_invariant_error,
-    values::{Container, Value, ValueImpl},
+    values::{Closure, Container, Value, ValueImpl},
 };
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::vm_status::StatusCode;
@@ -54,6 +54,12 @@ fn find_identifiers_in_value_impl(
                     find_identifiers_in_value_impl(val, identifiers)?;
                 }
             },
+        },
+
+        ValueImpl::ClosureValue(Closure(_, captured)) => {
+            for val in captured.iter() {
+                find_identifiers_in_value_impl(val, identifiers)?;
+            }
         },
 
         ValueImpl::Invalid | ValueImpl::ContainerRef(_) | ValueImpl::IndexedRef(_) => {

--- a/third_party/move/move-vm/types/src/values/function_values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/function_values_impl.rs
@@ -1,0 +1,208 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::values::{DeserializationSeed, SerializationReadyValue, VMValueCast, Value, ValueImpl};
+use better_any::Tid;
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::{
+    function::{ClosureMask, MoveFunctionLayout},
+    identifier::Identifier,
+    language_storage::{ModuleId, TypeTag},
+    value::MoveTypeLayout,
+    vm_status::StatusCode,
+};
+use serde::{
+    de::Error as DeError,
+    ser::{Error, SerializeSeq},
+    Deserialize, Serialize,
+};
+use std::{
+    cmp::Ordering,
+    fmt,
+    fmt::{Debug, Display, Formatter},
+};
+
+/// A trait describing a function which can be executed. If this is a generic
+/// function, the type instantiation is part of this.
+/// The value system is agnostic about how this is implemented in the runtime.
+/// The `FunctionValueExtension` trait describes how to construct and
+/// deconstruct instances for serialization.
+pub trait AbstractFunction: for<'a> Tid<'a> {
+    fn closure_mask(&self) -> ClosureMask;
+    fn cmp_dyn(&self, other: &dyn AbstractFunction) -> PartialVMResult<Ordering>;
+    fn clone_dyn(&self) -> PartialVMResult<Box<dyn AbstractFunction>>;
+    fn to_stable_string(&self) -> String;
+}
+
+/// A closure, consisting of an abstract function descriptor and the captured arguments.
+pub struct Closure(
+    pub(crate) Box<dyn AbstractFunction>,
+    pub(crate) Vec<ValueImpl>,
+);
+
+/// The representation of a function in storage.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct SerializedFunctionData {
+    pub module_id: ModuleId,
+    pub fun_id: Identifier,
+    pub fun_inst: Vec<TypeTag>,
+    pub mask: ClosureMask,
+    /// The layouts used for deserialization of the captured arguments
+    /// are stored so one can verify type consistency at
+    /// resolution time. It also allows to serialize an unresolved
+    /// closure, making unused closure data cheap in round trips.
+    pub captured_layouts: Vec<MoveTypeLayout>,
+}
+
+impl Closure {
+    pub fn pack(fun: Box<dyn AbstractFunction>, captured: impl IntoIterator<Item = Value>) -> Self {
+        Self(fun, captured.into_iter().map(|v| v.0).collect())
+    }
+
+    pub fn unpack(self) -> (Box<dyn AbstractFunction>, impl Iterator<Item = Value>) {
+        let Self(fun, captured) = self;
+        (fun, captured.into_iter().map(Value))
+    }
+
+    pub fn into_call_data(
+        self,
+        args: Vec<Value>,
+    ) -> PartialVMResult<(Box<dyn AbstractFunction>, Vec<Value>)> {
+        let (fun, captured) = self.unpack();
+        if let Some(all_args) = fun.closure_mask().compose(captured, args) {
+            Ok((fun, all_args))
+        } else {
+            Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("invalid closure mask".to_string()),
+            )
+        }
+    }
+}
+
+impl Debug for Closure {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let Self(fun, captured) = self;
+        write!(f, "Closure({}, {:?})", fun.to_stable_string(), captured)
+    }
+}
+
+impl Display for Closure {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let Self(fun, captured) = self;
+        let captured = fun
+            .closure_mask()
+            .merge_placeholder_strings(
+                captured.len(),
+                captured.iter().map(|v| v.to_string()).collect(),
+            )
+            .unwrap_or_else(|| vec!["*invalid*".to_string()]);
+        write!(f, "{}({})", fun.to_stable_string(), captured.join(","))
+    }
+}
+
+impl VMValueCast<Closure> for Value {
+    fn cast(self) -> PartialVMResult<Closure> {
+        match self.0 {
+            ValueImpl::ClosureValue(c) => Ok(c),
+            v => Err(PartialVMError::new(StatusCode::INTERNAL_TYPE_ERROR)
+                .with_message(format!("cannot cast {:?} to closure", v))),
+        }
+    }
+}
+
+impl<'c, 'l, 'v> serde::Serialize
+    for SerializationReadyValue<'c, 'l, 'v, MoveFunctionLayout, Closure>
+{
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let Closure(fun, captured) = self.value;
+        let fun_ext = self
+            .ctx
+            .required_function_extension()
+            .map_err(S::Error::custom)?;
+        let data = fun_ext
+            .get_serialization_data(fun.as_ref())
+            .map_err(S::Error::custom)?;
+        let mut seq = serializer.serialize_seq(Some(4 + captured.len()))?;
+        seq.serialize_element(&data.module_id)?;
+        seq.serialize_element(&data.fun_id)?;
+        seq.serialize_element(&data.fun_inst)?;
+        seq.serialize_element(&data.mask)?;
+        for (layout, value) in data.captured_layouts.into_iter().zip(captured) {
+            seq.serialize_element(&layout)?;
+            seq.serialize_element(&SerializationReadyValue {
+                ctx: self.ctx,
+                layout: &layout,
+                value,
+            })?
+        }
+        seq.end()
+    }
+}
+
+pub(crate) struct ClosureVisitor<'c, 'l>(
+    pub(crate) DeserializationSeed<'c, &'l MoveFunctionLayout>,
+);
+
+impl<'d, 'c, 'l> serde::de::Visitor<'d> for ClosureVisitor<'c, 'l> {
+    type Value = Closure;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("Closure")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'d>,
+    {
+        let fun_ext = self
+            .0
+            .ctx
+            .required_function_extension()
+            .map_err(A::Error::custom)?;
+        let module_id = read_required_value::<_, ModuleId>(&mut seq)?;
+        let fun_id = read_required_value::<_, Identifier>(&mut seq)?;
+        let fun_inst = read_required_value::<_, Vec<TypeTag>>(&mut seq)?;
+        let mask = read_required_value::<_, ClosureMask>(&mut seq)?;
+        let mut captured_layouts = vec![];
+        let mut captured = vec![];
+        for _ in 0..mask.captured_count() {
+            let layout = read_required_value::<_, MoveTypeLayout>(&mut seq)?;
+            match seq.next_element_seed(DeserializationSeed {
+                ctx: self.0.ctx,
+                layout: &layout,
+            })? {
+                Some(v) => {
+                    captured_layouts.push(layout);
+                    captured.push(v.0)
+                },
+                None => return Err(A::Error::invalid_length(captured.len(), &self)),
+            }
+        }
+        // If the sequence length is known, check whether there are no extra values
+        if matches!(seq.size_hint(), Some(remaining) if remaining != 0) {
+            return Err(A::Error::invalid_length(captured.len(), &self));
+        }
+        let fun = fun_ext
+            .create_from_serialization_data(SerializedFunctionData {
+                module_id,
+                fun_id,
+                fun_inst,
+                mask,
+                captured_layouts,
+            })
+            .map_err(A::Error::custom)?;
+        Ok(Closure(fun, captured))
+    }
+}
+
+fn read_required_value<'a, A, T>(seq: &mut A) -> Result<T, A::Error>
+where
+    A: serde::de::SeqAccess<'a>,
+    T: serde::de::Deserialize<'a>,
+{
+    match seq.next_element::<T>()? {
+        Some(x) => Ok(x),
+        None => Err(A::Error::custom("expected more elements")),
+    }
+}

--- a/third_party/move/move-vm/types/src/values/function_values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/function_values_impl.rs
@@ -45,7 +45,7 @@ pub struct Closure(
 pub struct SerializedFunctionData {
     pub module_id: ModuleId,
     pub fun_id: Identifier,
-    pub fun_inst: Vec<TypeTag>,
+    pub ty_args: Vec<TypeTag>,
     pub mask: ClosureMask,
     /// The layouts used for deserialization of the captured arguments
     /// are stored so one can verify type consistency at
@@ -126,7 +126,7 @@ impl<'c, 'l, 'v> serde::Serialize
         let mut seq = serializer.serialize_seq(Some(4 + captured.len()))?;
         seq.serialize_element(&data.module_id)?;
         seq.serialize_element(&data.fun_id)?;
-        seq.serialize_element(&data.fun_inst)?;
+        seq.serialize_element(&data.ty_args)?;
         seq.serialize_element(&data.mask)?;
         for (layout, value) in data.captured_layouts.into_iter().zip(captured) {
             seq.serialize_element(&layout)?;
@@ -187,7 +187,7 @@ impl<'d, 'c, 'l> serde::de::Visitor<'d> for ClosureVisitor<'c, 'l> {
             .create_from_serialization_data(SerializedFunctionData {
                 module_id,
                 fun_id,
-                fun_inst,
+                ty_args: fun_inst,
                 mask,
                 captured_layouts,
             })

--- a/third_party/move/move-vm/types/src/values/mod.rs
+++ b/third_party/move/move-vm/types/src/values/mod.rs
@@ -2,6 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod function_values_impl;
 pub mod values_impl;
 
 #[cfg(test)]
@@ -12,4 +13,5 @@ mod serialization_tests;
 #[cfg(all(test, feature = "fuzzing"))]
 mod value_prop_tests;
 
+pub use function_values_impl::*;
 pub use values_impl::*;

--- a/third_party/move/move-vm/types/src/values/serialization_tests.rs
+++ b/third_party/move/move-vm/types/src/values/serialization_tests.rs
@@ -3,329 +3,651 @@
 
 //! Contains tests for serialization
 
-use crate::{
-    delayed_values::delayed_field_id::DelayedFieldID,
-    value_serde::ValueSerDeContext,
-    values::{values_impl, Struct, Value},
-};
-use claims::{assert_err, assert_ok, assert_some};
-use move_core_types::{
-    account_address::AccountAddress,
-    u256,
-    value::{IdentifierMappingKind, MoveStruct, MoveStructLayout, MoveTypeLayout, MoveValue},
-};
-use serde::{Deserialize, Serialize};
-use std::iter;
+#[cfg(test)]
+mod tests {
+    use crate::{
+        delayed_values::delayed_field_id::DelayedFieldID,
+        value_serde::{MockFunctionValueExtension, ValueSerDeContext},
+        values::{values_impl, AbstractFunction, SerializedFunctionData, Struct, Value},
+    };
+    use better_any::{Tid, TidAble, TidExt};
+    use claims::{assert_err, assert_ok, assert_some};
+    use move_binary_format::errors::PartialVMResult;
+    use move_core_types::{
+        ability::AbilitySet,
+        account_address::AccountAddress,
+        function::{ClosureMask, MoveClosure, MoveFunctionLayout},
+        identifier::Identifier,
+        language_storage::{FunctionTag, ModuleId, StructTag, TypeTag},
+        u256,
+        value::{IdentifierMappingKind, MoveStruct, MoveStructLayout, MoveTypeLayout, MoveValue},
+    };
+    use serde::{Deserialize, Serialize};
+    use std::{cmp::Ordering, iter};
+    // ==========================================================================
+    // Enums
 
-fn test_layout() -> MoveTypeLayout {
-    MoveTypeLayout::Struct(MoveStructLayout::RuntimeVariants(vec![
-        vec![MoveTypeLayout::U64],
-        vec![],
-        vec![MoveTypeLayout::Bool, MoveTypeLayout::U32],
-    ]))
-}
-
-// ---------------------------------------------------------------------------
-// Serialization round trip tests
-
-#[test]
-fn enum_round_trip_move_value() {
-    let layout = test_layout();
-    let good_values = vec![
-        MoveValue::Struct(MoveStruct::RuntimeVariant(0, vec![MoveValue::U64(42)])),
-        MoveValue::Struct(MoveStruct::RuntimeVariant(1, vec![])),
-        MoveValue::Struct(MoveStruct::RuntimeVariant(2, vec![
-            MoveValue::Bool(true),
-            MoveValue::U32(13),
-        ])),
-    ];
-    for value in good_values {
-        let blob = value.simple_serialize().expect("serialization succeeds");
-        let de_value =
-            MoveValue::simple_deserialize(&blob, &layout).expect("deserialization succeeds");
-        assert_eq!(value, de_value, "roundtrip serialization succeeds")
+    fn enum_layout() -> MoveTypeLayout {
+        MoveTypeLayout::Struct(MoveStructLayout::RuntimeVariants(vec![
+            vec![MoveTypeLayout::U64],
+            vec![],
+            vec![MoveTypeLayout::Bool, MoveTypeLayout::U32],
+        ]))
     }
-    let bad_tag_value = MoveValue::Struct(MoveStruct::RuntimeVariant(3, vec![MoveValue::U64(42)]));
-    let blob = bad_tag_value
-        .simple_serialize()
-        .expect("serialization succeeds");
-    MoveValue::simple_deserialize(&blob, &layout)
-        .inspect_err(|e| {
-            assert!(
-                e.to_string().contains("invalid length"),
-                "unexpected error message: {}",
-                e
-            );
-        })
-        .expect_err("bad tag value deserialization fails");
-    let bad_struct_value = MoveValue::Struct(MoveStruct::Runtime(vec![MoveValue::U64(42)]));
-    let blob = bad_struct_value
-        .simple_serialize()
-        .expect("serialization succeeds");
-    MoveValue::simple_deserialize(&blob, &layout)
-        .inspect_err(|e| {
-            assert!(
-                e.to_string().contains("invalid length"),
-                "unexpected error message: {}",
-                e
-            );
-        })
-        .expect_err("bad struct value deserialization fails");
-}
 
-#[test]
-fn enum_round_trip_vm_value() {
-    let layout = test_layout();
-    let good_values = vec![
-        Value::struct_(Struct::pack_variant(0, iter::once(Value::u64(42)))),
-        Value::struct_(Struct::pack_variant(1, iter::empty())),
-        Value::struct_(Struct::pack_variant(
-            2,
-            [Value::bool(true), Value::u32(13)].into_iter(),
-        )),
-    ];
-    for value in good_values {
-        let blob = ValueSerDeContext::new()
-            .serialize(&value, &layout)
-            .unwrap()
-            .expect("serialization succeeds");
-        let de_value = ValueSerDeContext::new()
-            .deserialize(&blob, &layout)
-            .expect("deserialization succeeds");
-        assert!(
-            value.equals(&de_value).unwrap(),
-            "roundtrip serialization succeeds"
-        )
-    }
-    let bad_tag_value = Value::struct_(Struct::pack_variant(3, [Value::u64(42)]));
-    assert!(
-        ValueSerDeContext::new()
-            .serialize(&bad_tag_value, &layout)
-            .unwrap()
-            .is_none(),
-        "serialization fails"
-    );
-    let bad_struct_value = Value::struct_(Struct::pack([Value::u64(42)]));
-    assert!(
-        ValueSerDeContext::new()
-            .serialize(&bad_struct_value, &layout)
-            .unwrap()
-            .is_none(),
-        "serialization fails"
-    );
-}
+    // ---------------------------------------------------------------------------
+    // Move Values
 
-// ---------------------------------------------------------------------------
-// Rust cross-serialization tests
-
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
-pub enum RustEnum {
-    Number(u64),
-    Empty,
-    BoolNumber(bool, u32),
-}
-
-#[test]
-fn enum_rust_round_trip_move_value() {
-    let layout = test_layout();
-    let move_values = vec![
-        MoveValue::Struct(MoveStruct::RuntimeVariant(0, vec![MoveValue::U64(42)])),
-        MoveValue::Struct(MoveStruct::RuntimeVariant(1, vec![])),
-        MoveValue::Struct(MoveStruct::RuntimeVariant(2, vec![
-            MoveValue::Bool(true),
-            MoveValue::U32(13),
-        ])),
-    ];
-    let rust_values = vec![
-        RustEnum::Number(42),
-        RustEnum::Empty,
-        RustEnum::BoolNumber(true, 13),
-    ];
-    for (move_value, rust_value) in move_values.into_iter().zip(rust_values) {
-        let from_move = move_value.simple_serialize().expect("from move succeeds");
-        let to_rust = bcs::from_bytes::<RustEnum>(&from_move).expect("to rust successful");
-        assert_eq!(to_rust, rust_value);
-
-        let from_rust = bcs::to_bytes(&rust_value).expect("from rust succeeds");
-        let to_move = MoveValue::simple_deserialize(&from_rust, &layout).expect("to move succeeds");
-        assert_eq!(to_move, move_value)
-    }
-}
-
-#[test]
-fn enum_rust_round_trip_vm_value() {
-    let layout = test_layout();
-    let move_values = vec![
-        Value::struct_(Struct::pack_variant(0, iter::once(Value::u64(42)))),
-        Value::struct_(Struct::pack_variant(1, iter::empty())),
-        Value::struct_(Struct::pack_variant(
-            2,
-            [Value::bool(true), Value::u32(13)].into_iter(),
-        )),
-    ];
-    let rust_values = vec![
-        RustEnum::Number(42),
-        RustEnum::Empty,
-        RustEnum::BoolNumber(true, 13),
-    ];
-    for (move_value, rust_value) in move_values.into_iter().zip(rust_values) {
-        let from_move = ValueSerDeContext::new()
-            .serialize(&move_value, &layout)
-            .unwrap()
-            .expect("from move succeeds");
-        let to_rust = bcs::from_bytes::<RustEnum>(&from_move).expect("to rust successful");
-        assert_eq!(to_rust, rust_value);
-
-        let from_rust = bcs::to_bytes(&rust_value).expect("from rust succeeds");
-        let to_move = ValueSerDeContext::new()
-            .deserialize(&from_rust, &layout)
-            .expect("to move succeeds");
-        assert!(
-            to_move.equals(&move_value).unwrap(),
-            "from rust to move failed"
-        )
-    }
-}
-
-// --------------------------------------------------------------------------
-// Serialization size tests
-
-#[test]
-fn test_serialized_size() {
-    use IdentifierMappingKind::*;
-    use MoveStructLayout::*;
-    use MoveTypeLayout::*;
-
-    let u64_delayed_value = Value::delayed_value(DelayedFieldID::new_with_width(12, 8));
-    let u128_delayed_value = Value::delayed_value(DelayedFieldID::new_with_width(123, 16));
-    let derived_string_delayed_value = Value::delayed_value(DelayedFieldID::new_with_width(12, 60));
-
-    // First field is a string, second field is a padding to ensure constant size.
-    let derived_string_layout = Struct(Runtime(vec![
-        Struct(Runtime(vec![Vector(Box::new(U8))])),
-        Vector(Box::new(U8)),
-    ]));
-
-    // All these pairs should serialize.
-    let good_values_layouts_sizes = [
-        (Value::u8(10), U8),
-        (Value::u16(10), U16),
-        (Value::u32(10), U32),
-        (Value::u64(10), U64),
-        (Value::u128(10), U128),
-        (Value::u256(u256::U256::one()), U256),
-        (Value::bool(true), Bool),
-        (Value::address(AccountAddress::ONE), Address),
-        (Value::master_signer(AccountAddress::ONE), Signer),
-        (u64_delayed_value, Native(Aggregator, Box::new(U64))),
-        (u128_delayed_value, Native(Snapshot, Box::new(U128))),
-        (
-            derived_string_delayed_value,
-            Native(DerivedString, Box::new(derived_string_layout)),
-        ),
-        (
-            Value::vector_address(vec![AccountAddress::ONE]),
-            Vector(Box::new(Address)),
-        ),
-        (
-            Value::struct_(values_impl::Struct::pack(vec![
-                Value::bool(true),
-                Value::vector_u32(vec![1, 2, 3, 4, 5]),
+    #[test]
+    fn enum_round_trip_move_value() {
+        let layout = enum_layout();
+        let good_values = vec![
+            MoveValue::Struct(MoveStruct::RuntimeVariant(0, vec![MoveValue::U64(42)])),
+            MoveValue::Struct(MoveStruct::RuntimeVariant(1, vec![])),
+            MoveValue::Struct(MoveStruct::RuntimeVariant(2, vec![
+                MoveValue::Bool(true),
+                MoveValue::U32(13),
             ])),
-            Struct(Runtime(vec![Bool, Vector(Box::new(U32))])),
-        ),
-    ];
-    for (value, layout) in good_values_layouts_sizes {
-        let bytes = assert_some!(assert_ok!(ValueSerDeContext::new()
-            .with_delayed_fields_serde()
-            .serialize(&value, &layout)));
-
-        let size = assert_ok!(ValueSerDeContext::new()
-            .with_delayed_fields_serde()
-            .serialized_size(&value, &layout));
-        assert_eq!(size, bytes.len());
+        ];
+        for value in good_values {
+            let blob = value.simple_serialize().expect("serialization succeeds");
+            let de_value =
+                MoveValue::simple_deserialize(&blob, &layout).expect("deserialization succeeds");
+            assert_eq!(value, de_value, "roundtrip serialization succeeds")
+        }
+        let bad_tag_value =
+            MoveValue::Struct(MoveStruct::RuntimeVariant(3, vec![MoveValue::U64(42)]));
+        let blob = bad_tag_value
+            .simple_serialize()
+            .expect("serialization succeeds");
+        MoveValue::simple_deserialize(&blob, &layout)
+            .inspect_err(|e| {
+                assert!(
+                    e.to_string().contains("invalid length"),
+                    "unexpected error message: {}",
+                    e
+                );
+            })
+            .expect_err("bad tag value deserialization fails");
+        let bad_struct_value = MoveValue::Struct(MoveStruct::Runtime(vec![MoveValue::U64(42)]));
+        let blob = bad_struct_value
+            .simple_serialize()
+            .expect("serialization succeeds");
+        MoveValue::simple_deserialize(&blob, &layout)
+            .inspect_err(|e| {
+                assert!(
+                    e.to_string().contains("invalid length"),
+                    "unexpected error message: {}",
+                    e
+                );
+            })
+            .expect_err("bad struct value deserialization fails");
     }
 
-    // Also test unhappy path, mostly mismatches in value-layout.
-    let u64_delayed_value = Value::delayed_value(DelayedFieldID::new_with_width(0, 8));
-    let malformed_delayed_value = Value::delayed_value(DelayedFieldID::new_with_width(1, 7));
-    let bad_values_layouts_sizes = [
-        (Value::u8(10), U16),
-        (u64_delayed_value, U64),
-        (malformed_delayed_value, U64),
-        (Value::u64(12), Native(Aggregator, Box::new(U64))),
-    ];
-    for (value, layout) in bad_values_layouts_sizes {
-        assert_err!(ValueSerDeContext::new()
-            .with_delayed_fields_serde()
-            .serialized_size(&value, &layout));
+    // ---------------------------------------------------------------------------
+    // VM Values
+
+    #[test]
+    fn enum_round_trip_vm_value() {
+        let layout = enum_layout();
+        let good_values = vec![
+            Value::struct_(Struct::pack_variant(0, iter::once(Value::u64(42)))),
+            Value::struct_(Struct::pack_variant(1, iter::empty())),
+            Value::struct_(Struct::pack_variant(
+                2,
+                [Value::bool(true), Value::u32(13)].into_iter(),
+            )),
+        ];
+        for value in good_values {
+            let blob = ValueSerDeContext::new()
+                .serialize(&value, &layout)
+                .unwrap()
+                .expect("serialization succeeds");
+            let de_value = ValueSerDeContext::new()
+                .deserialize(&blob, &layout)
+                .expect("deserialization succeeds");
+            assert!(
+                value.equals(&de_value).unwrap(),
+                "roundtrip serialization succeeds"
+            )
+        }
+        let bad_tag_value = Value::struct_(Struct::pack_variant(3, [Value::u64(42)]));
+        assert!(
+            ValueSerDeContext::new()
+                .serialize(&bad_tag_value, &layout)
+                .unwrap()
+                .is_none(),
+            "serialization fails"
+        );
+        let bad_struct_value = Value::struct_(Struct::pack([Value::u64(42)]));
+        assert!(
+            ValueSerDeContext::new()
+                .serialize(&bad_struct_value, &layout)
+                .unwrap()
+                .is_none(),
+            "serialization fails"
+        );
     }
-}
 
-#[test]
-fn new_signer_round_trip_vm_value() {
-    let move_value = MoveValue::Signer(AccountAddress::ZERO);
-    let bytes = move_value.simple_serialize().unwrap();
+    // ---------------------------------------------------------------------------
+    // Rust cross-serialization tests
 
-    let vm_value = Value::master_signer(AccountAddress::ZERO);
-    let vm_bytes = ValueSerDeContext::new()
-        .serialize(&vm_value, &MoveTypeLayout::Signer)
-        .unwrap()
-        .unwrap();
+    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+    pub enum RustEnum {
+        Number(u64),
+        Empty,
+        BoolNumber(bool, u32),
+    }
 
-    // VM Value Roundtrip
-    assert!(ValueSerDeContext::new()
-        .deserialize(&vm_bytes, &MoveTypeLayout::Signer)
-        .unwrap()
-        .equals(&vm_value)
-        .unwrap());
+    #[test]
+    fn enum_rust_round_trip_move_value() {
+        let layout = enum_layout();
+        let move_values = vec![
+            MoveValue::Struct(MoveStruct::RuntimeVariant(0, vec![MoveValue::U64(42)])),
+            MoveValue::Struct(MoveStruct::RuntimeVariant(1, vec![])),
+            MoveValue::Struct(MoveStruct::RuntimeVariant(2, vec![
+                MoveValue::Bool(true),
+                MoveValue::U32(13),
+            ])),
+        ];
+        let rust_values = vec![
+            RustEnum::Number(42),
+            RustEnum::Empty,
+            RustEnum::BoolNumber(true, 13),
+        ];
+        for (move_value, rust_value) in move_values.into_iter().zip(rust_values) {
+            let from_move = move_value.simple_serialize().expect("from move succeeds");
+            let to_rust = bcs::from_bytes::<RustEnum>(&from_move).expect("to rust successful");
+            assert_eq!(to_rust, rust_value);
 
-    // MoveValue Roundtrip
-    assert!(MoveValue::simple_deserialize(&bytes, &MoveTypeLayout::Signer).is_err());
+            let from_rust = bcs::to_bytes(&rust_value).expect("from rust succeeds");
+            let to_move =
+                MoveValue::simple_deserialize(&from_rust, &layout).expect("to move succeeds");
+            assert_eq!(to_move, move_value)
+        }
+    }
 
-    // ser(MoveValue) == ser(VMValue)
-    assert_eq!(bytes, vm_bytes);
+    #[test]
+    fn enum_rust_round_trip_vm_value() {
+        let layout = enum_layout();
+        let move_values = vec![
+            Value::struct_(Struct::pack_variant(0, iter::once(Value::u64(42)))),
+            Value::struct_(Struct::pack_variant(1, iter::empty())),
+            Value::struct_(Struct::pack_variant(
+                2,
+                [Value::bool(true), Value::u32(13)].into_iter(),
+            )),
+        ];
+        let rust_values = vec![
+            RustEnum::Number(42),
+            RustEnum::Empty,
+            RustEnum::BoolNumber(true, 13),
+        ];
+        for (move_value, rust_value) in move_values.into_iter().zip(rust_values) {
+            let from_move = ValueSerDeContext::new()
+                .serialize(&move_value, &layout)
+                .unwrap()
+                .expect("from move succeeds");
+            let to_rust = bcs::from_bytes::<RustEnum>(&from_move).expect("to rust successful");
+            assert_eq!(to_rust, rust_value);
 
-    // Permissioned Signer Roundtrip
-    let vm_value = Value::permissioned_signer(AccountAddress::ZERO, AccountAddress::ONE);
-    let vm_bytes = ValueSerDeContext::new()
-        .serialize(&vm_value, &MoveTypeLayout::Signer)
-        .unwrap()
-        .unwrap();
+            let from_rust = bcs::to_bytes(&rust_value).expect("from rust succeeds");
+            let to_move = ValueSerDeContext::new()
+                .deserialize(&from_rust, &layout)
+                .expect("to move succeeds");
+            assert!(
+                to_move.equals(&move_value).unwrap(),
+                "from rust to move failed"
+            )
+        }
+    }
 
-    // VM Value Roundtrip
-    assert!(ValueSerDeContext::new()
-        .deserialize(&vm_bytes, &MoveTypeLayout::Signer)
-        .unwrap()
-        .equals(&vm_value)
-        .unwrap());
+    // ======================================================================================
+    // Closures
 
-    // Cannot serialize permissioned signer into bytes with legacy signer
-    assert!(ValueSerDeContext::new()
-        .with_legacy_signer()
-        .serialize(&vm_value, &MoveTypeLayout::Signer)
-        .unwrap()
-        .is_none());
-}
+    fn make_fun_layout() -> MoveTypeLayout {
+        // Currently, content of layout doesn't influence parsing, so can set anything here
+        MoveTypeLayout::Function(MoveFunctionLayout(
+            vec![],
+            vec![],
+            AbilitySet::MAXIMAL_FUNCTIONS,
+        ))
+    }
 
-#[test]
-fn legacy_signer_round_trip_vm_value() {
-    let move_value = MoveValue::Address(AccountAddress::ZERO);
-    let bytes = move_value.simple_serialize().unwrap();
+    fn make_type_args() -> Vec<TypeTag> {
+        // Just some more complex type instantiation to cover serialization of TypeTag
+        vec![
+            TypeTag::Address,
+            TypeTag::Function(Box::new(FunctionTag {
+                args: vec![TypeTag::Struct(Box::new(StructTag {
+                    address: AccountAddress::TEN,
+                    module: Identifier::new("mod").unwrap(),
+                    name: Identifier::new("st").unwrap(),
+                    type_args: vec![TypeTag::Signer],
+                }))],
+                results: vec![TypeTag::Address],
+                abilities: AbilitySet::MAXIMAL_FUNCTIONS,
+            })),
+        ]
+    }
 
-    let vm_value = Value::master_signer(AccountAddress::ZERO);
-    let vm_bytes = ValueSerDeContext::new()
-        .with_legacy_signer()
-        .serialize(&vm_value, &MoveTypeLayout::Signer)
-        .unwrap()
-        .unwrap();
+    // --------------------------------------------------------------------------------------
+    // Move Values
 
-    // VM Value Roundtrip
-    assert!(ValueSerDeContext::new()
-        .with_legacy_signer()
-        .deserialize(&vm_bytes, &MoveTypeLayout::Signer)
-        .is_none());
+    fn make_move_closure(
+        fun_name: &str,
+        ty_args: Vec<TypeTag>,
+        mask: ClosureMask,
+        captured: Vec<(MoveTypeLayout, MoveValue)>,
+    ) -> MoveValue {
+        MoveValue::closure(MoveClosure {
+            module_id: ModuleId::new(AccountAddress::TWO, Identifier::new("m").unwrap()),
+            fun_id: Identifier::new(fun_name).unwrap(),
+            ty_args,
+            mask,
+            captured,
+        })
+    }
 
-    // ser(MoveValue) == ser(VMValue)
-    assert_eq!(bytes, vm_bytes);
+    #[test]
+    fn closure_round_trip_move_value_good() {
+        let fun_layout = make_fun_layout();
+        let ty_args = make_type_args();
+        let good_values = vec![
+            make_move_closure("f", ty_args, ClosureMask::new(0b101), vec![
+                (MoveTypeLayout::Bool, MoveValue::Bool(true)),
+                (MoveTypeLayout::U64, MoveValue::U64(22)),
+            ]),
+            make_move_closure("f", vec![], ClosureMask::new(0b1), vec![(
+                MoveTypeLayout::U64,
+                MoveValue::U64(22),
+            )]),
+            make_move_closure("f", vec![], ClosureMask::new(0b0), vec![]),
+        ];
+        for value in good_values {
+            let blob = value.simple_serialize().expect("serialization succeeds");
+            let de_value = assert_ok!(MoveValue::simple_deserialize(&blob, &fun_layout));
+            assert_eq!(value, de_value, "round trip serialization succeeds")
+        }
+    }
+
+    #[test]
+    fn closure_round_trip_move_value_bad_size() {
+        let fun_layout = make_fun_layout();
+        let bad_captures_more = make_move_closure("f", vec![], ClosureMask::new(0b1), vec![
+            (MoveTypeLayout::Bool, MoveValue::Bool(true)),
+            (MoveTypeLayout::U64, MoveValue::U64(22)),
+        ]);
+        let blob = bad_captures_more
+            .simple_serialize()
+            .expect("serialization succeeds");
+        MoveValue::simple_deserialize(&blob, &fun_layout)
+            .inspect_err(|e| {
+                assert!(
+                    e.to_string().contains("invalid length"),
+                    "unexpected error message: {}",
+                    e
+                );
+            })
+            .expect_err("bad size value deserialization fails");
+        let bad_captures_less = make_move_closure("f", vec![], ClosureMask::new(0b11), vec![(
+            MoveTypeLayout::Bool,
+            MoveValue::Bool(true),
+        )]);
+        let blob = bad_captures_less
+            .simple_serialize()
+            .expect("serialization succeeds");
+        MoveValue::simple_deserialize(&blob, &fun_layout)
+            .inspect_err(|e| {
+                assert!(
+                    e.to_string().contains("expected more"),
+                    "unexpected error message: {}",
+                    e
+                );
+            })
+            .expect_err("bad size value deserialization fails");
+    }
+
+    #[test]
+    fn closure_round_trip_move_value_bad_layout() {
+        let fun_layout = make_fun_layout();
+        let bad_layout = make_move_closure("f", vec![], ClosureMask::new(0b11), vec![
+            (
+                MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U8)),
+                MoveValue::Bool(true),
+            ),
+            (
+                MoveTypeLayout::Bool,
+                MoveValue::Vector(vec![MoveValue::U64(22), MoveValue::U8(1)]),
+            ),
+        ]);
+        let blob = bad_layout
+            .simple_serialize()
+            .expect("serialization succeeds");
+        MoveValue::simple_deserialize(&blob, &fun_layout)
+            .inspect_err(|e| {
+                assert!(
+                    e.to_string().contains("remaining input"),
+                    "unexpected error message: {}",
+                    e
+                );
+            })
+            .expect_err("bad layout value deserialization fails");
+    }
+
+    // --------------------------------------------------------------------------------------
+    // VM Values
+
+    // Since Abstract functions are `Tid`, we cannot auto-mock them, so need to mock manually.
+    #[derive(Clone, Tid)]
+    struct MockAbstractFunction {
+        data: SerializedFunctionData,
+    }
+
+    impl MockAbstractFunction {
+        fn new(
+            fun_name: &str,
+            ty_args: Vec<TypeTag>,
+            mask: ClosureMask,
+            captured_layouts: Vec<MoveTypeLayout>,
+        ) -> MockAbstractFunction {
+            Self {
+                data: SerializedFunctionData {
+                    module_id: ModuleId::new(AccountAddress::TWO, Identifier::new("m").unwrap()),
+                    fun_id: Identifier::new(fun_name).unwrap(),
+                    ty_args,
+                    mask,
+                    captured_layouts,
+                },
+            }
+        }
+
+        fn new_from_data(data: SerializedFunctionData) -> Self {
+            Self { data }
+        }
+    }
+
+    impl AbstractFunction for MockAbstractFunction {
+        fn closure_mask(&self) -> ClosureMask {
+            unimplemented!()
+        }
+
+        fn cmp_dyn(&self, other: &dyn AbstractFunction) -> PartialVMResult<Ordering> {
+            // We only need equality for tests
+            let other_mock = other.downcast_ref::<MockAbstractFunction>().unwrap();
+            Ok(if self.data == other_mock.data {
+                Ordering::Equal
+            } else {
+                Ordering::Less
+            })
+        }
+
+        fn clone_dyn(&self) -> PartialVMResult<Box<dyn AbstractFunction>> {
+            unimplemented!()
+        }
+
+        fn to_stable_string(&self) -> String {
+            // Needed for assertion failure printing
+            "<some function>".to_string()
+        }
+    }
+
+    fn round_trip_vm_closure_value(
+        fun: MockAbstractFunction,
+        captured: Vec<Value>,
+    ) -> (Value, PartialVMResult<Value>) {
+        let fun_layout = make_fun_layout();
+        let mut ext_mock = MockFunctionValueExtension::new();
+        ext_mock
+            .expect_get_serialization_data()
+            .returning(move |af| {
+                Ok(af
+                    .downcast_ref::<MockAbstractFunction>()
+                    .expect("cast")
+                    .data
+                    .clone())
+            });
+        ext_mock
+            .expect_create_from_serialization_data()
+            .returning(move |data| Ok(Box::new(MockAbstractFunction::new_from_data(data))));
+        let value = Value::closure(Box::new(fun), captured);
+        let blob = assert_ok!(ValueSerDeContext::new()
+            .with_func_args_deserialization(&ext_mock)
+            .serialize(&value, &fun_layout))
+        .expect("serialization result not None");
+        let de_value = ValueSerDeContext::new()
+            .with_func_args_deserialization(&ext_mock)
+            .deserialize_or_err(&blob, &fun_layout);
+        (value, de_value)
+    }
+
+    #[test]
+    fn closure_round_trip_vm_value_good() {
+        let ty_args = make_type_args();
+        let good_seeds = vec![
+            (
+                MockAbstractFunction::new("f", ty_args, ClosureMask::new(0b101), vec![
+                    MoveTypeLayout::Bool,
+                    MoveTypeLayout::U64,
+                ]),
+                vec![Value::bool(true), Value::u64(22)],
+            ),
+            (
+                MockAbstractFunction::new("f", vec![TypeTag::Bool], ClosureMask::new(0b1), vec![
+                    MoveTypeLayout::U64,
+                ]),
+                vec![Value::u64(22)],
+            ),
+            (
+                MockAbstractFunction::new("f", vec![TypeTag::U16], ClosureMask::new(0b0), vec![]),
+                vec![],
+            ),
+        ];
+        for (fun, captured) in good_seeds {
+            let (value, de_value) = round_trip_vm_closure_value(fun, captured);
+            assert!(
+                value.equals(&assert_ok!(de_value)).unwrap(),
+                "round-trip serialization succeeds"
+            );
+        }
+    }
+
+    #[test]
+    fn closure_round_trip_vm_value_bad_size() {
+        let (_, de_value) = round_trip_vm_closure_value(
+            MockAbstractFunction::new("f", vec![], ClosureMask::new(0b1), vec![
+                MoveTypeLayout::Bool,
+                MoveTypeLayout::U64,
+            ]),
+            vec![Value::bool(false), Value::u64(22)],
+        );
+        de_value
+            .inspect_err(|e| {
+                assert!(
+                    e.to_string().contains("invalid length"),
+                    "unexpected error message: {}",
+                    e
+                )
+            })
+            .expect_err("bad size value deserialization fails");
+
+        let (_, de_value) = round_trip_vm_closure_value(
+            MockAbstractFunction::new("f", vec![], ClosureMask::new(0b11), vec![
+                MoveTypeLayout::Bool,
+            ]),
+            vec![Value::bool(false)],
+        );
+        de_value
+            .inspect_err(|e| {
+                assert!(
+                    e.to_string().contains("expected more"),
+                    "unexpected error message: {}",
+                    e
+                )
+            })
+            .expect_err("bad size value deserialization fails");
+
+        let (_, de_value) = round_trip_vm_closure_value(
+            MockAbstractFunction::new("f", vec![], ClosureMask::new(0b1), vec![
+                MoveTypeLayout::Bool,
+            ]),
+            vec![],
+        );
+        de_value
+            .inspect_err(|e| {
+                assert!(
+                    e.to_string().contains("expected more"),
+                    "unexpected error message: {}",
+                    e
+                )
+            })
+            .expect_err("bad size value deserialization fails");
+    }
+
+    // ======================================================================================
+    // Serialization size tests
+
+    #[test]
+    fn test_serialized_size() {
+        use IdentifierMappingKind::*;
+        use MoveStructLayout::*;
+        use MoveTypeLayout::*;
+
+        let u64_delayed_value = Value::delayed_value(DelayedFieldID::new_with_width(12, 8));
+        let u128_delayed_value = Value::delayed_value(DelayedFieldID::new_with_width(123, 16));
+        let derived_string_delayed_value =
+            Value::delayed_value(DelayedFieldID::new_with_width(12, 60));
+
+        // First field is a string, second field is a padding to ensure constant size.
+        let derived_string_layout = Struct(Runtime(vec![
+            Struct(Runtime(vec![Vector(Box::new(U8))])),
+            Vector(Box::new(U8)),
+        ]));
+
+        // All these pairs should serialize.
+        let good_values_layouts_sizes = [
+            (Value::u8(10), U8),
+            (Value::u16(10), U16),
+            (Value::u32(10), U32),
+            (Value::u64(10), U64),
+            (Value::u128(10), U128),
+            (Value::u256(u256::U256::one()), U256),
+            (Value::bool(true), Bool),
+            (Value::address(AccountAddress::ONE), Address),
+            (Value::master_signer(AccountAddress::ONE), Signer),
+            (u64_delayed_value, Native(Aggregator, Box::new(U64))),
+            (u128_delayed_value, Native(Snapshot, Box::new(U128))),
+            (
+                derived_string_delayed_value,
+                Native(DerivedString, Box::new(derived_string_layout)),
+            ),
+            (
+                Value::vector_address(vec![AccountAddress::ONE]),
+                Vector(Box::new(Address)),
+            ),
+            (
+                Value::struct_(values_impl::Struct::pack(vec![
+                    Value::bool(true),
+                    Value::vector_u32(vec![1, 2, 3, 4, 5]),
+                ])),
+                Struct(Runtime(vec![Bool, Vector(Box::new(U32))])),
+            ),
+        ];
+        for (value, layout) in good_values_layouts_sizes {
+            let bytes = assert_some!(assert_ok!(ValueSerDeContext::new()
+                .with_delayed_fields_serde()
+                .serialize(&value, &layout)));
+
+            let size = assert_ok!(ValueSerDeContext::new()
+                .with_delayed_fields_serde()
+                .serialized_size(&value, &layout));
+            assert_eq!(size, bytes.len());
+        }
+
+        // Also test unhappy path, mostly mismatches in value-layout.
+        let u64_delayed_value = Value::delayed_value(DelayedFieldID::new_with_width(0, 8));
+        let malformed_delayed_value = Value::delayed_value(DelayedFieldID::new_with_width(1, 7));
+        let bad_values_layouts_sizes = [
+            (Value::u8(10), U16),
+            (u64_delayed_value, U64),
+            (malformed_delayed_value, U64),
+            (Value::u64(12), Native(Aggregator, Box::new(U64))),
+        ];
+        for (value, layout) in bad_values_layouts_sizes {
+            assert_err!(ValueSerDeContext::new()
+                .with_delayed_fields_serde()
+                .serialized_size(&value, &layout));
+        }
+    }
+
+    // ======================================================================================
+    // Signer
+
+    #[test]
+    fn new_signer_round_trip_vm_value() {
+        let move_value = MoveValue::Signer(AccountAddress::ZERO);
+        let bytes = move_value.simple_serialize().unwrap();
+
+        let vm_value = Value::master_signer(AccountAddress::ZERO);
+        let vm_bytes = ValueSerDeContext::new()
+            .serialize(&vm_value, &MoveTypeLayout::Signer)
+            .unwrap()
+            .unwrap();
+
+        // VM Value Roundtrip
+        assert!(ValueSerDeContext::new()
+            .deserialize(&vm_bytes, &MoveTypeLayout::Signer)
+            .unwrap()
+            .equals(&vm_value)
+            .unwrap());
+
+        // MoveValue Roundtrip
+        assert!(MoveValue::simple_deserialize(&bytes, &MoveTypeLayout::Signer).is_err());
+
+        // ser(MoveValue) == ser(VMValue)
+        assert_eq!(bytes, vm_bytes);
+
+        // Permissioned Signer Roundtrip
+        let vm_value = Value::permissioned_signer(AccountAddress::ZERO, AccountAddress::ONE);
+        let vm_bytes = ValueSerDeContext::new()
+            .serialize(&vm_value, &MoveTypeLayout::Signer)
+            .unwrap()
+            .unwrap();
+
+        // VM Value Roundtrip
+        assert!(ValueSerDeContext::new()
+            .deserialize(&vm_bytes, &MoveTypeLayout::Signer)
+            .unwrap()
+            .equals(&vm_value)
+            .unwrap());
+
+        // Cannot serialize permissioned signer into bytes with legacy signer
+        assert!(ValueSerDeContext::new()
+            .with_legacy_signer()
+            .serialize(&vm_value, &MoveTypeLayout::Signer)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn legacy_signer_round_trip_vm_value() {
+        let move_value = MoveValue::Address(AccountAddress::ZERO);
+        let bytes = move_value.simple_serialize().unwrap();
+
+        let vm_value = Value::master_signer(AccountAddress::ZERO);
+        let vm_bytes = ValueSerDeContext::new()
+            .with_legacy_signer()
+            .serialize(&vm_value, &MoveTypeLayout::Signer)
+            .unwrap()
+            .unwrap();
+
+        // VM Value Roundtrip
+        assert!(ValueSerDeContext::new()
+            .with_legacy_signer()
+            .deserialize(&vm_bytes, &MoveTypeLayout::Signer)
+            .is_none());
+
+        // ser(MoveValue) == ser(VMValue)
+        assert_eq!(bytes, vm_bytes);
+    }
 }

--- a/third_party/move/move-vm/types/src/views.rs
+++ b/third_party/move/move-vm/types/src/views.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::delayed_values::delayed_field_id::DelayedFieldID;
+use crate::{delayed_values::delayed_field_id::DelayedFieldID, values::LEGACY_CLOSURE_SIZE};
 use move_core_types::{
     account_address::AccountAddress, gas_algebra::AbstractMemorySize, language_storage::TypeTag,
 };
@@ -79,6 +79,11 @@ pub trait ValueView {
                 true
             }
 
+            fn visit_closure(&mut self, _depth: usize, _len: usize) -> bool {
+                self.0 += LEGACY_CLOSURE_SIZE;
+                true
+            }
+
             fn visit_vec(&mut self, _depth: usize, _len: usize) -> bool {
                 self.0 += LEGACY_STRUCT_SIZE;
                 true
@@ -142,6 +147,7 @@ pub trait ValueVisitor {
     fn visit_address(&mut self, depth: usize, val: AccountAddress);
 
     fn visit_struct(&mut self, depth: usize, len: usize) -> bool;
+    fn visit_closure(&mut self, depth: usize, len: usize) -> bool;
     fn visit_vec(&mut self, depth: usize, len: usize) -> bool;
 
     fn visit_ref(&mut self, depth: usize, is_global: bool) -> bool;

--- a/third_party/move/tools/move-bytecode-utils/src/layout.rs
+++ b/third_party/move/tools/move-bytecode-utils/src/layout.rs
@@ -14,6 +14,7 @@ use move_binary_format::{
 };
 use move_core_types::{
     account_address::AccountAddress,
+    function::MoveFunctionLayout,
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
     value::{MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
@@ -374,6 +375,18 @@ impl TypeLayoutBuilder {
                 compiled_module_view,
                 layout_type,
             )?),
+            Function(f) => {
+                let build_list = |ts: &[TypeTag]| {
+                    ts.iter()
+                        .map(|t| Self::build(t, compiled_module_view, layout_type))
+                        .collect::<anyhow::Result<Vec<_>>>()
+                };
+                MoveTypeLayout::Function(MoveFunctionLayout(
+                    build_list(&f.args)?,
+                    build_list(&f.results)?,
+                    f.abilities,
+                ))
+            },
         })
     }
 

--- a/third_party/move/tools/move-resource-viewer/src/fat_type.rs
+++ b/third_party/move/tools/move-resource-viewer/src/fat_type.rs
@@ -275,6 +275,10 @@ impl From<&TypeTag> for FatType {
             TypeTag::Vector(inner) => Vector(Box::new(inner.as_ref().into())),
             TypeTag::Struct(inner) => Struct(Box::new(inner.as_ref().into())),
             TypeTag::U256 => U256,
+            TypeTag::Function(..) => {
+                // TODO(#15664): implement functions for fat types
+                todo!("functions not supported by fat types")
+            },
         }
     }
 }

--- a/third_party/move/tools/move-resource-viewer/src/lib.rs
+++ b/third_party/move/tools/move-resource-viewer/src/lib.rs
@@ -442,6 +442,10 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             TypeTag::U256 => FatType::U256,
             TypeTag::U128 => FatType::U128,
             TypeTag::Vector(ty) => FatType::Vector(Box::new(self.resolve_type_impl(ty, limit)?)),
+            TypeTag::Function(..) => {
+                // TODO(#15664) implement functions for fat types"
+                todo!("functions for fat types")
+            },
         })
     }
 
@@ -582,6 +586,10 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             },
             (MoveValue::Struct(s), FatType::Struct(ty)) => {
                 AnnotatedMoveValue::Struct(self.annotate_struct(s, ty.as_ref(), limit)?)
+            },
+            (MoveValue::Closure(..), _) => {
+                // TODO(#15664) implement functions for annotated move values
+                todo!("functions not implemented")
             },
             (MoveValue::U8(_), _)
             | (MoveValue::U64(_), _)


### PR DESCRIPTION
## Description

[PR 4/n vm closures]

This implements types and values for functions and closures, as well as serialization. For a detailed discussion, see the design doc. It does not yet implement the interpreter and runtime verification.

Overview:

- `MoveValue` and `MoveTypeLayout` are extended to represent closures and functions. A closure carries the function name, the closure mask, the layout of the captured arguments, and their values. The layout enables serialization of the captured arguments without any context.
- Runtime `Type` is extended by functions.
- `ValueImpl` is extended by a closure variant. This representation uses `trait AbstractFunction` to represent the function value and implement core functionality like comparison and printing. The existing trait `FunctionValueExtension` is used to create `AbstractFunction` from the serialized representation.
- Similar as with `MoveValue`, the serialized representation of `ValueImpl::Closure` contains the captured parameter layouts, enabling to deserialize the captured arguments context independently. This design has been chosen for robustness, avoiding a dependency of serialization from loaded functions, and to enable fully 'lazy' deserialization of closures. The later allows a contract to store hundreds of function values and on loading them from storage, avoiding loading the associated code until the moment the closure is actually executed.
- `AbstractFunction` is implemented in the loader such that it can be either in 'unresolved' or in `resolved' state.

## How Has This Been Tested?

Testing postponed until e2e wiring is up

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

