### PR TITLE
[Devtools] Update comment for merge-base commit delays.

### DIFF
--- a/devtools/aptos-cargo-cli/src/common.rs
+++ b/devtools/aptos-cargo-cli/src/common.rs
@@ -45,7 +45,7 @@ const IGNORED_DETERMINATOR_PATHS: [&str; 8] = [
     "terraform/*",
 ];
 
-// The maximum number of days allowed since the merge-base commit for the branch
+// The maximum number of days allowed since the merge-base commit for the branch.
 const MAX_NUM_DAYS_SINCE_MERGE_BASE: u64 = 7;
 
 // The delimiter used to separate the package path and the package name.


### PR DESCRIPTION
## Description
This PR updates the comment for the merge-base commit delay. This is simply just to bump the latest commit on main.

## Testing Plan
Existing test infrastructure.