### PR TITLE
[move-vm][closures] Interpreter

### DIFF
--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -1150,6 +1150,12 @@ impl SignatureToken {
                 SignatureToken::Function(args1, results1, abs1),
                 SignatureToken::Function(args2, results2, abs2),
             ) => args1 == args2 && results1 == results2 && abs1.is_subset(*abs2),
+            (SignatureToken::Reference(ty1), SignatureToken::Reference(ty2)) => {
+                ty1.is_assignable_from(ty2)
+            },
+            (SignatureToken::MutableReference(ty1), SignatureToken::MutableReference(ty2)) => {
+                ty1.is_assignable_from(ty2)
+            },
             _ => self == source,
         }
     }

--- a/third_party/move/move-core/types/src/function.rs
+++ b/third_party/move/move-core/types/src/function.rs
@@ -40,12 +40,22 @@ impl ClosureMask {
     /// stack than this number.
     pub const MAX_ARGS: usize = 64;
 
+    pub fn empty() -> Self {
+        Self(0)
+    }
+
     pub fn new(mask: u64) -> Self {
         Self(mask)
     }
 
     pub fn bits(&self) -> u64 {
         self.0
+    }
+
+    /// Returns true if the i'th argument is captured. If `i` is out of range, false will
+    /// be returned.
+    pub fn is_captured(&self, i: usize) -> bool {
+        i < 64 && self.0 & (1 << i) != 0
     }
 
     /// Apply a closure mask to a list of elements, returning only those

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -617,6 +617,8 @@ impl InterpreterImpl {
                     // Charge gas for call and for the parameters. The current APIs
                     // require an ExactSizeIterator to be passed for charge_call, so
                     // some acrobatics is needed (sigh).
+                    // TODO: perhaps refactor and just pass count of arguments, because
+                    //   that is the only thing used for now.
                     let captured_vec = captured.collect::<Vec<_>>();
                     let arguments: Vec<&Value> = self
                         .operand_stack

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -103,7 +103,6 @@ impl LazyLoadedFunction {
         })))
     }
 
-    #[allow(unused)]
     pub(crate) fn new_resolved(
         converter: &TypeTagConverter,
         fun: Rc<LoadedFunction>,

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -330,6 +330,12 @@ impl LoadedFunction {
         self.function.is_friend_or_private()
     }
 
+    /// Returns true if the loaded function has public visibility. This is the
+    /// opposite of the above (for better readability).
+    pub fn is_public(&self) -> bool {
+        !self.function.is_friend_or_private()
+    }
+
     /// Returns true if the loaded function is an entry function.
     pub(crate) fn is_entry(&self) -> bool {
         self.function.is_entry()

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -402,7 +402,8 @@ impl Module {
                 if let Some(code_unit) = &func.code {
                     for bc in &code_unit.code {
                         match bc {
-                            Bytecode::VecPack(si, _)
+                            Bytecode::CallClosure(si)
+                            | Bytecode::VecPack(si, _)
                             | Bytecode::VecLen(si)
                             | Bytecode::VecImmBorrow(si)
                             | Bytecode::VecMutBorrow(si)

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -1,13 +1,16 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{frame_type_cache::FrameTypeCache, interpreter::Stack, loader::Resolver};
+use crate::{
+    frame_type_cache::FrameTypeCache, interpreter::Stack, loader::Resolver, LoadedFunction,
+};
 use move_binary_format::{errors::*, file_format::Bytecode};
 use move_core_types::{
     ability::{Ability, AbilitySet},
+    function::ClosureMask,
     vm_status::StatusCode,
 };
-use move_vm_types::{loaded_data::runtime_types::Type, values::Locals};
+use move_vm_types::{gas::UnmeteredGasMeter, loaded_data::runtime_types::Type, values::Locals};
 
 pub(crate) trait RuntimeTypeCheck {
     /// Paranoid type checks to perform before instruction execution.
@@ -17,6 +20,7 @@ pub(crate) trait RuntimeTypeCheck {
         ty_args: &[Type],
         resolver: &Resolver,
         operand_stack: &mut Stack,
+        ty_cache: &mut FrameTypeCache,
         instruction: &Bytecode,
     ) -> PartialVMResult<()>;
 
@@ -66,10 +70,75 @@ fn verify_pack<'a>(
         // copy capability where its field is a struct that has copy
         // capability but not vice versa.
         ty.paranoid_check_abilities(field_expected_abilities)?;
-        ty.paranoid_check_eq(expected_ty)?;
+        // Similar, we use assignability for the value moved in the field
+        ty.paranoid_check_assignable(expected_ty)?;
     }
 
     operand_stack.push_ty(output_ty)
+}
+
+pub fn verify_pack_closure(
+    resolver: &Resolver,
+    operand_stack: &mut Stack,
+    func: &LoadedFunction,
+    mask: ClosureMask,
+) -> PartialVMResult<()> {
+    // Accumulated abilities
+    let mut abilities = if func.is_public() {
+        AbilitySet::PUBLIC_FUNCTIONS
+    } else {
+        AbilitySet::PRIVATE_FUNCTIONS
+    };
+    // Verify that captured arguments are assignable against types in the function
+    // signature.
+    let expected_capture_tys = mask.extract(func.param_tys(), true);
+    let given_capture_tys = operand_stack.popn_tys(expected_capture_tys.len() as u16)?;
+    for (expected, given) in expected_capture_tys
+        .into_iter()
+        .zip(given_capture_tys.into_iter())
+    {
+        with_instantiation(resolver, func, expected, |expected| {
+            // Intersect the captured type with the accumulated abilities
+            abilities = abilities.intersect(expected.abilities()?);
+            given.paranoid_check_assignable(expected)
+        })?
+    }
+    // Push result type onto stack
+    let args = mask
+        .extract(func.param_tys(), false)
+        .into_iter()
+        .map(|curried| with_instantiation(resolver, func, curried, |curried| Ok(curried.clone())))
+        .collect::<PartialVMResult<Vec<_>>>()?;
+    let results = func
+        .return_tys()
+        .iter()
+        .map(|ret| with_instantiation(resolver, func, ret, |ret| Ok(ret.clone())))
+        .collect::<PartialVMResult<Vec<_>>>()?;
+    operand_stack.push_ty(Type::Function {
+        args,
+        results,
+        abilities,
+    })?;
+
+    Ok(())
+}
+
+fn with_instantiation<R>(
+    resolver: &Resolver,
+    func: &LoadedFunction,
+    ty: &Type,
+    action: impl FnOnce(&Type) -> PartialVMResult<R>,
+) -> PartialVMResult<R> {
+    if func.ty_args().is_empty() {
+        action(ty)
+    } else {
+        action(
+            &resolver
+                .loader()
+                .ty_builder()
+                .create_ty_with_subst(ty, func.ty_args())?,
+        )
+    }
 }
 
 pub(crate) struct NoRuntimeTypeCheck;
@@ -82,6 +151,7 @@ impl RuntimeTypeCheck for NoRuntimeTypeCheck {
         _ty_args: &[Type],
         _resolver: &Resolver,
         _operand_stack: &mut Stack,
+        _ty_cache: &mut FrameTypeCache,
         _instruction: &Bytecode,
     ) -> PartialVMResult<()> {
         Ok(())
@@ -114,23 +184,27 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
     fn pre_execution_type_stack_transition(
         local_tys: &[Type],
         locals: &Locals,
-        _ty_args: &[Type],
-        _resolver: &Resolver,
+        ty_args: &[Type],
+        resolver: &Resolver,
         operand_stack: &mut Stack,
+        ty_cache: &mut FrameTypeCache,
         instruction: &Bytecode,
     ) -> PartialVMResult<()> {
         match instruction {
-            // TODO(#15664): implement closures
-            Bytecode::PackClosure(..)
-            | Bytecode::PackClosureGeneric(..)
-            | Bytecode::CallClosure(..) => {
-                return Err(PartialVMError::new(StatusCode::UNIMPLEMENTED_FUNCTIONALITY)
-                    .with_message("closure opcodes in interpreter".to_owned()))
-            },
             // Call instruction will be checked at execute_main.
             Bytecode::Call(_) | Bytecode::CallGeneric(_) => (),
             Bytecode::BrFalse(_) | Bytecode::BrTrue(_) => {
                 operand_stack.pop_ty()?;
+            },
+            Bytecode::CallClosure(sig_idx) => {
+                // For closure, we need to check the type of the closure on
+                // top of the stack. The argument types are checked when the frame
+                // is constructed in the interpreter, using the same code as for regular
+                // calls.
+                let (expected_ty, _) =
+                    ty_cache.get_signature_index_type(*sig_idx, resolver, ty_args)?;
+                let given_type = operand_stack.pop_ty()?;
+                given_type.paranoid_check_assignable(expected_ty)?;
             },
             Bytecode::Branch(_) => (),
             Bytecode::Ret => {
@@ -145,11 +219,12 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             },
             // StLoc needs to check before execution as we need to check the drop ability of values.
             Bytecode::StLoc(idx) => {
-                let ty = local_tys[*idx as usize].clone();
+                let expected_ty = local_tys[*idx as usize].clone();
                 let val_ty = operand_stack.pop_ty()?;
-                ty.paranoid_check_eq(&val_ty)?;
+                // For store, use assignability
+                val_ty.paranoid_check_assignable(&expected_ty)?;
                 if !locals.is_invalid(*idx as usize)? {
-                    ty.paranoid_check_has_ability(Ability::Drop)?;
+                    expected_ty.paranoid_check_has_ability(Ability::Drop)?;
                 }
             },
             // We will check the rest of the instructions after execution phase.
@@ -171,6 +246,8 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             | Bytecode::MutBorrowField(_)
             | Bytecode::ImmBorrowFieldGeneric(_)
             | Bytecode::MutBorrowFieldGeneric(_)
+            | Bytecode::PackClosure(..)
+            | Bytecode::PackClosureGeneric(..)
             | Bytecode::Pack(_)
             | Bytecode::PackGeneric(_)
             | Bytecode::Unpack(_)
@@ -254,19 +331,12 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
         let ty_builder = resolver.loader().ty_builder();
 
         match instruction {
-            // TODO(#15664): implement closures
-            Bytecode::PackClosure(..)
-            | Bytecode::PackClosureGeneric(..)
-            | Bytecode::CallClosure(..) => {
-                return Err(PartialVMError::new(StatusCode::UNIMPLEMENTED_FUNCTIONALITY)
-                    .with_message("closure opcodes in interpreter".to_owned()))
-            },
-
             Bytecode::BrTrue(_) | Bytecode::BrFalse(_) => (),
             Bytecode::Branch(_)
             | Bytecode::Ret
             | Bytecode::Call(_)
             | Bytecode::CallGeneric(_)
+            | Bytecode::CallClosure(_)
             | Bytecode::Abort => {
                 // Invariants hold because all of the instructions
                 // above will force VM to break from the interpreter
@@ -386,6 +456,22 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                 let field_ref_ty = ty_builder.create_ref_ty(field_ty, is_mut)?;
                 operand_stack.push_ty(field_ref_ty)?;
             },
+            Bytecode::PackClosure(fh_idx, mask) => {
+                let function =
+                    resolver.build_loaded_function_from_handle_and_ty_args(*fh_idx, vec![])?;
+                verify_pack_closure(resolver, operand_stack, &function, *mask)?;
+            },
+            Bytecode::PackClosureGeneric(fh_idx, mask) => {
+                let ty_args = resolver.instantiate_generic_function(
+                    Option::<&mut UnmeteredGasMeter>::None, // don't charge for paranoid mode
+                    *fh_idx,
+                    ty_args,
+                )?;
+                let function = resolver
+                    .build_loaded_function_from_instantiation_and_ty_args(*fh_idx, ty_args)?;
+                verify_pack_closure(resolver, operand_stack, &function, *mask)?;
+            },
+
             Bytecode::Pack(idx) => {
                 let field_count = resolver.field_count(*idx);
                 let args_ty = resolver.get_struct(*idx)?;
@@ -655,7 +741,8 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                 let (ty, _) = ty_cache.get_signature_index_type(*si, resolver, ty_args)?;
                 let elem_tys = operand_stack.popn_tys(*num as u16)?;
                 for elem_ty in elem_tys.iter() {
-                    elem_ty.paranoid_check_eq(ty)?;
+                    // For vector element types, use assignability
+                    elem_ty.paranoid_check_assignable(ty)?;
                 }
 
                 let vec_ty = ty_builder.create_vec_ty(ty)?;
@@ -689,7 +776,8 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             },
             Bytecode::VecPushBack(si) => {
                 let (ty, _) = ty_cache.get_signature_index_type(*si, resolver, ty_args)?;
-                operand_stack.pop_ty()?.paranoid_check_eq(ty)?;
+                // For vector elements use assignability
+                operand_stack.pop_ty()?.paranoid_check_assignable(ty)?;
                 operand_stack
                     .pop_ty()?
                     .paranoid_check_is_vec_ref_ty::<true>(ty)?;

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -203,8 +203,8 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
                 // calls.
                 let (expected_ty, _) =
                     ty_cache.get_signature_index_type(*sig_idx, resolver, ty_args)?;
-                let given_type = operand_stack.pop_ty()?;
-                given_type.paranoid_check_assignable(expected_ty)?;
+                let given_ty = operand_stack.pop_ty()?;
+                given_ty.paranoid_check_assignable(expected_ty)?;
             },
             Bytecode::Branch(_) => (),
             Bytecode::Ret => {
@@ -219,10 +219,10 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             },
             // StLoc needs to check before execution as we need to check the drop ability of values.
             Bytecode::StLoc(idx) => {
-                let expected_ty = local_tys[*idx as usize].clone();
+                let expected_ty = &local_tys[*idx as usize];
                 let val_ty = operand_stack.pop_ty()?;
                 // For store, use assignability
-                val_ty.paranoid_check_assignable(&expected_ty)?;
+                val_ty.paranoid_check_assignable(expected_ty)?;
                 if !locals.is_invalid(*idx as usize)? {
                     expected_ty.paranoid_check_has_ability(Ability::Drop)?;
                 }
@@ -776,7 +776,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
             },
             Bytecode::VecPushBack(si) => {
                 let (ty, _) = ty_cache.get_signature_index_type(*si, resolver, ty_args)?;
-                // For vector elements use assignability
+                // For pushing an element to a vector, use assignability
                 operand_stack.pop_ty()?.paranoid_check_assignable(ty)?;
                 operand_stack
                     .pop_ty()?


### PR DESCRIPTION
## Description

[PR 5/n vm closures]

This closes the loop, putting the pieces together to implement the closure logic in the interpreter loop.

They are some paranoid checks still missing which are marked in the code.

## How Has This Been Tested?

Testing postponed until e2e tests are possible

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

