### PR TITLE
[aptos-vm][move] Avoid module loads when getting the struct name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11995,6 +11995,7 @@ dependencies = [
  "itertools 0.13.0",
  "move-binary-format",
  "move-core-types",
+ "parking_lot 0.12.1",
  "proptest",
  "rand 0.7.3",
  "serde",

--- a/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
+++ b/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
@@ -191,7 +191,10 @@ pub(crate) fn validate_combine_signer_and_txn_args(
     Ok(combined_args)
 }
 
-// Return whether the argument is valid/allowed and whether it needs construction.
+/// Returns true if the argument is valid (that is, it is a primitive type or a struct with a
+/// known constructor function). Otherwise, (for structs without constructors, signers or
+/// references) returns false. An error is returned in cases when a struct type is encountered and
+/// its name cannot be queried for some reason.
 pub(crate) fn is_valid_txn_arg(
     session: &SessionExt,
     module_storage: &impl AptosModuleStorage,

--- a/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
+++ b/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
@@ -9,7 +9,7 @@
 use crate::{aptos_vm::SerializedSigners, move_vm_ext::SessionExt, VMStatus};
 use aptos_vm_types::module_and_script_storage::module_storage::AptosModuleStorage;
 use move_binary_format::{
-    errors::{Location, PartialVMError, PartialVMResult},
+    errors::{Location, PartialVMError},
     file_format::FunctionDefinitionIndex,
     file_format_common::read_uleb128_as_u64,
 };
@@ -140,8 +140,7 @@ pub(crate) fn validate_combine_signer_and_txn_args(
     for ty in func.param_tys()[signer_param_cnt..].iter() {
         let subst_res = ty_builder.create_ty_with_subst(ty, func.ty_args());
         let ty = subst_res.map_err(|e| e.finish(Location::Undefined).into_vm_status())?;
-        let valid = is_valid_txn_arg(session, module_storage, &ty, allowed_structs)
-            .map_err(|err| err.finish(Location::Undefined).into_vm_status())?;
+        let valid = is_valid_txn_arg(session, module_storage, &ty, allowed_structs);
         if !valid {
             return Err(VMStatus::error(
                 StatusCode::INVALID_MAIN_FUNCTION_SIGNATURE,
@@ -200,28 +199,29 @@ pub(crate) fn is_valid_txn_arg(
     module_storage: &impl AptosModuleStorage,
     ty: &Type,
     allowed_structs: &ConstructorMap,
-) -> PartialVMResult<bool> {
+) -> bool {
     use move_vm_types::loaded_data::runtime_types::Type::*;
 
-    Ok(match ty {
+    match ty {
         Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address => true,
-        Vector(inner) => is_valid_txn_arg(session, module_storage, inner, allowed_structs)?,
+        Vector(inner) => is_valid_txn_arg(session, module_storage, inner, allowed_structs),
         Struct { .. } | StructInstantiation { .. } => {
-            let (module_id, identifier) =
-                session
-                    .get_struct_name(ty, module_storage)?
-                    .ok_or_else(|| {
-                        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                            .with_message(format!("Expected struct type, but got {:?}", ty))
-                    })?;
-            allowed_structs.contains_key(&format!(
-                "{}::{}",
-                module_id.short_str_lossless(),
-                identifier
-            ))
+            // Note: Original behavior was to return false even if the module loading fails (e.g.,
+            //       if struct does not exist. This preserves it.
+            session
+                .get_struct_name(ty, module_storage)
+                .ok()
+                .flatten()
+                .is_some_and(|(module_id, identifier)| {
+                    allowed_structs.contains_key(&format!(
+                        "{}::{}",
+                        module_id.short_str_lossless(),
+                        identifier
+                    ))
+                })
         },
         Signer | Reference(_) | MutableReference(_) | TyParam(_) => false,
-    })
+    }
 }
 
 // Construct arguments. Walk through the arguments and according to the signature
@@ -355,7 +355,11 @@ pub(crate) fn recursively_construct_arg(
         Struct { .. } | StructInstantiation { .. } => {
             let (module_id, identifier) = session
                 .get_struct_name(ty, module_storage)
-                .map_err(|_| invalid_signature())?
+                .map_err(|_| {
+                    // Note: The original behaviour was to map all errors to an invalid signature
+                    //       error, here we want to preserve it for now.
+                    invalid_signature()
+                })?
                 .ok_or_else(invalid_signature)?;
             let full_name = format!("{}::{}", module_id.short_str_lossless(), identifier);
             let constructor = allowed_structs

--- a/third_party/move/move-vm/integration-tests/Cargo.toml
+++ b/third_party/move/move-vm/integration-tests/Cargo.toml
@@ -21,7 +21,7 @@ move-core-types = { workspace = true }
 move-stdlib = { path = "../../move-stdlib" }
 move-vm-runtime = { workspace = true, features = ["testing"] }
 move-vm-test-utils = { workspace = true }
-move-vm-types = { workspace = true }
+move-vm-types = { workspace = true, features = ["testing"]  }
 smallvec = { workspace = true }
 tempfile = { workspace = true }
 

--- a/third_party/move/move-vm/integration-tests/Cargo.toml
+++ b/third_party/move/move-vm/integration-tests/Cargo.toml
@@ -21,7 +21,7 @@ move-core-types = { workspace = true }
 move-stdlib = { path = "../../move-stdlib" }
 move-vm-runtime = { workspace = true, features = ["testing"] }
 move-vm-test-utils = { workspace = true }
-move-vm-types = { workspace = true, features = ["testing"]  }
+move-vm-types = { workspace = true, features = ["testing"] }
 smallvec = { workspace = true }
 tempfile = { workspace = true }
 

--- a/third_party/move/move-vm/integration-tests/src/tests/module_storage_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/module_storage_tests.rs
@@ -15,7 +15,10 @@ use move_vm_runtime::{
 };
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::{
-    loaded_data::runtime_types::{AbilityInfo, StructIdentifier, StructNameIndex, TypeBuilder},
+    loaded_data::{
+        runtime_types::{AbilityInfo, StructIdentifier, TypeBuilder},
+        struct_name_indexing::StructNameIndex,
+    },
     value_serde::FunctionValueExtension,
 };
 use std::str::FromStr;
@@ -74,7 +77,7 @@ fn test_function_value_extension() {
     let foo_ty = types.pop().unwrap();
     let name = module_storage
         .runtime_environment()
-        .idx_to_struct_name_for_test(StructNameIndex(0))
+        .idx_to_struct_name_for_test(StructNameIndex::new(0))
         .unwrap();
     assert_eq!(name, StructIdentifier {
         module: test_id.clone(),
@@ -84,8 +87,10 @@ fn test_function_value_extension() {
         foo_ty,
         ty_builder
             .create_ref_ty(
-                &ty_builder
-                    .create_struct_ty(StructNameIndex(0), AbilityInfo::struct_(AbilitySet::EMPTY)),
+                &ty_builder.create_struct_ty(
+                    StructNameIndex::new(0),
+                    AbilityInfo::struct_(AbilitySet::EMPTY)
+                ),
                 false
             )
             .unwrap()
@@ -121,7 +126,7 @@ fn test_function_value_extension() {
     let bar_ty = types.pop().unwrap();
     let name = module_storage
         .runtime_environment()
-        .idx_to_struct_name_for_test(StructNameIndex(1))
+        .idx_to_struct_name_for_test(StructNameIndex::new(1))
         .unwrap();
     assert_eq!(name, StructIdentifier {
         module: other_test_id,
@@ -130,7 +135,7 @@ fn test_function_value_extension() {
     assert_eq!(
         bar_ty,
         ty_builder.create_struct_ty(
-            StructNameIndex(1),
+            StructNameIndex::new(1),
             AbilityInfo::struct_(AbilitySet::from_u8(Ability::Drop as u8).unwrap())
         )
     );

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -31,7 +31,10 @@ use move_core_types::{
 use move_vm_metrics::{Timer, VM_TIMER};
 use move_vm_types::{
     gas::GasMeter,
-    loaded_data::runtime_types::{AbilityInfo, StructNameIndex, StructType, Type},
+    loaded_data::{
+        runtime_types::{AbilityInfo, StructType, Type},
+        struct_name_indexing::StructNameIndex,
+    },
     sha3_256,
     value_serde::FunctionValueExtension,
 };
@@ -54,8 +57,7 @@ use crate::{
     loader::modules::{StructVariantInfo, VariantFieldInfo},
     native_functions::NativeFunctions,
     storage::{
-        loader::LoaderV2, module_storage::FunctionValueExtensionAdapter,
-        struct_name_index_map::StructNameIndexMap, ty_cache::StructInfoCache,
+        loader::LoaderV2, module_storage::FunctionValueExtensionAdapter, ty_cache::StructInfoCache,
         ty_layout_converter::LoaderLayoutConverter, ty_tag_converter::TypeTagConverter,
     },
 };
@@ -67,10 +69,9 @@ use move_binary_format::file_format::{
     StructVariantHandleIndex, StructVariantInstantiationIndex, TypeParameterIndex,
     VariantFieldHandleIndex, VariantFieldInstantiationIndex, VariantIndex,
 };
-use move_vm_metrics::{Timer, VM_TIMER};
-use move_vm_types::{
-    loaded_data::runtime_types::{DepthFormula, StructLayout, TypeBuilder},
-    value_serde::FunctionValueExtension,
+use move_vm_types::loaded_data::{
+    runtime_types::{DepthFormula, StructLayout, TypeBuilder},
+    struct_name_indexing::StructNameIndexMap,
 };
 pub use script::Script;
 pub(crate) use script::ScriptCache;

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -28,10 +28,12 @@ use move_core_types::{
     value::MoveTypeLayout,
     vm_status::StatusCode,
 };
+use move_vm_metrics::{Timer, VM_TIMER};
 use move_vm_types::{
     gas::GasMeter,
     loaded_data::runtime_types::{AbilityInfo, StructNameIndex, StructType, Type},
     sha3_256,
+    value_serde::FunctionValueExtension,
 };
 use parking_lot::{Mutex, RwLock};
 use std::{
@@ -39,6 +41,7 @@ use std::{
     hash::Hash,
     sync::Arc,
 };
+use type_loader::intern_type;
 use typed_arena::Arena;
 
 mod access_specifier_loader;
@@ -71,7 +74,6 @@ use move_vm_types::{
 };
 pub use script::Script;
 pub(crate) use script::ScriptCache;
-use type_loader::intern_type;
 
 type ScriptHash = [u8; 32];
 

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -575,7 +575,6 @@ impl Module {
     ) -> PartialVMResult<StructType> {
         let struct_handle = module.struct_handle_at(struct_def.struct_handle);
         let abilities = struct_handle.abilities;
-        let name = module.identifier_at(struct_handle.name).to_owned();
         let ty_params = struct_handle.type_parameters.clone();
         let layout = match &struct_def.field_information {
             StructFieldInformation::Native => unreachable!("native structs have been removed"),
@@ -613,8 +612,6 @@ impl Module {
             abilities,
             ty_params,
             idx: struct_name_table[struct_def.struct_handle.0 as usize],
-            module: module.self_id(),
-            name,
         })
     }
 

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -9,7 +9,6 @@ use crate::{
         BinaryCache,
     },
     native_functions::NativeFunctions,
-    storage::struct_name_index_map::StructNameIndexMap,
 };
 use move_binary_format::{
     access::ModuleAccess,
@@ -29,8 +28,9 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_metrics::{Timer, VM_TIMER};
-use move_vm_types::loaded_data::runtime_types::{
-    StructIdentifier, StructLayout, StructNameIndex, StructType, Type,
+use move_vm_types::loaded_data::{
+    runtime_types::{StructIdentifier, StructLayout, StructType, Type},
+    struct_name_indexing::{StructNameIndex, StructNameIndexMap},
 };
 use parking_lot::RwLock;
 use std::{

--- a/third_party/move/move-vm/runtime/src/loader/script.rs
+++ b/third_party/move/move-vm/runtime/src/loader/script.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{intern_type, BinaryCache, Function, FunctionHandle, FunctionInstantiation};
-use crate::{loader::ScriptHash, storage::struct_name_index_map::StructNameIndexMap};
+use crate::loader::ScriptHash;
 use move_binary_format::{
     access::ScriptAccess,
     binary_views::BinaryIndexedView,
@@ -13,6 +13,7 @@ use move_core_types::{identifier::Identifier, language_storage::ModuleId, vm_sta
 use move_vm_types::loaded_data::{
     runtime_access_specifier::AccessSpecifier,
     runtime_types::{StructIdentifier, Type},
+    struct_name_indexing::StructNameIndexMap,
 };
 use std::{collections::BTreeMap, ops::Deref, sync::Arc};
 

--- a/third_party/move/move-vm/runtime/src/loader/type_loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader/type_loader.rs
@@ -7,7 +7,10 @@ use move_binary_format::{
     file_format::SignatureToken,
 };
 use move_core_types::vm_status::StatusCode;
-use move_vm_types::loaded_data::runtime_types::{AbilityInfo, StructNameIndex, Type};
+use move_vm_types::loaded_data::{
+    runtime_types::{AbilityInfo, Type},
+    struct_name_indexing::StructNameIndex,
+};
 use triomphe::Arc as TriompheArc;
 
 /// Converts a signature token into the in memory type representation used by the MoveVM.

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -18,17 +18,17 @@ use move_core_types::{
     account_address::AccountAddress,
     effects::{ChangeSet, Changes},
     gas_algebra::NumBytes,
-    identifier::IdentStr,
+    identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, TypeTag},
     value::MoveTypeLayout,
     vm_status::StatusCode,
 };
 use move_vm_types::{
     gas::GasMeter,
-    loaded_data::runtime_types::{StructNameIndex, StructType, Type, TypeBuilder},
+    loaded_data::runtime_types::{Type, TypeBuilder},
     values::{GlobalValue, Value},
 };
-use std::{borrow::Borrow, collections::BTreeSet, sync::Arc};
+use std::borrow::Borrow;
 
 pub struct Session<'r, 'l> {
     pub(crate) move_vm: &'l MoveVM,
@@ -527,16 +527,28 @@ impl<'r, 'l> Session<'r, 'l> {
         self.move_vm.runtime.loader().ty_builder()
     }
 
-    pub fn fetch_struct_ty_by_idx(
+    /// If type is a (generic or non-generic) struct or enum, returns its name. Otherwise, returns
+    /// [None].
+    pub fn get_struct_name(
         &self,
-        idx: StructNameIndex,
-        module_storage: &impl ModuleStorage,
-    ) -> Option<Arc<StructType>> {
-        self.move_vm
-            .runtime
-            .loader()
-            .fetch_struct_ty_by_idx(idx, &self.module_store, module_storage)
-            .ok()
+        ty: &Type,
+        module_storage: &dyn ModuleStorage,
+    ) -> PartialVMResult<Option<(ModuleId, Identifier)>> {
+        use Type::*;
+
+        Ok(match ty {
+            Struct { idx, .. } | StructInstantiation { idx, .. } => {
+                let struct_identifier = self
+                    .move_vm
+                    .runtime
+                    .loader()
+                    .struct_name_index_map(module_storage)
+                    .idx_to_struct_name(*idx)?;
+                Some((struct_identifier.module, struct_identifier.name))
+            },
+            Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address | Signer | TyParam(_)
+            | Vector(_) | Reference(_) | MutableReference(_) => None,
+        })
     }
 
     pub fn check_type_tag_dependencies_and_charge_gas(

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -28,7 +28,7 @@ use move_vm_types::{
     loaded_data::runtime_types::{Type, TypeBuilder},
     values::{GlobalValue, Value},
 };
-use std::borrow::Borrow;
+use std::{borrow::Borrow, collections::BTreeSet};
 
 pub struct Session<'r, 'l> {
     pub(crate) move_vm: &'l MoveVM,

--- a/third_party/move/move-vm/runtime/src/storage/environment.rs
+++ b/third_party/move/move-vm/runtime/src/storage/environment.rs
@@ -6,7 +6,7 @@ use crate::{
     loader::check_natives,
     native_functions::{NativeFunction, NativeFunctions},
     storage::{
-        ty_cache::StructInfoCache, ty_tag_cache::TypeTagCache,
+        ty_cache::StructInfoCache, ty_tag_converter::TypeTagCache,
         verified_module_cache::VERIFIED_MODULES_V2,
     },
     Module, Script,

--- a/third_party/move/move-vm/runtime/src/storage/environment.rs
+++ b/third_party/move/move-vm/runtime/src/storage/environment.rs
@@ -6,8 +6,8 @@ use crate::{
     loader::check_natives,
     native_functions::{NativeFunction, NativeFunctions},
     storage::{
-        struct_name_index_map::StructNameIndexMap, ty_cache::StructInfoCache,
-        ty_tag_converter::TypeTagCache, verified_module_cache::VERIFIED_MODULES_V2,
+        ty_cache::StructInfoCache, ty_tag_cache::TypeTagCache,
+        verified_module_cache::VERIFIED_MODULES_V2,
     },
     Module, Script,
 };
@@ -26,8 +26,11 @@ use move_core_types::{
     vm_status::{sub_status::unknown_invariant_violation::EPARANOID_FAILURE, StatusCode},
 };
 use move_vm_metrics::{Timer, VM_TIMER};
+use move_vm_types::loaded_data::struct_name_indexing::StructNameIndexMap;
 #[cfg(any(test, feature = "testing"))]
-use move_vm_types::loaded_data::runtime_types::{StructIdentifier, StructNameIndex};
+use move_vm_types::loaded_data::{
+    runtime_types::StructIdentifier, struct_name_indexing::StructNameIndex,
+};
 use std::sync::Arc;
 
 /// [MoveVM] runtime environment encapsulating different configurations. Shared between the VM and

--- a/third_party/move/move-vm/runtime/src/storage/mod.rs
+++ b/third_party/move/move-vm/runtime/src/storage/mod.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub(crate) mod loader;
-pub(crate) mod struct_name_index_map;
 pub(crate) mod ty_cache;
 pub(crate) mod ty_tag_converter;
 mod verified_module_cache;

--- a/third_party/move/move-vm/runtime/src/storage/ty_cache.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_cache.rs
@@ -1,10 +1,12 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::storage::struct_name_index_map::StructNameIndexMap;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{language_storage::StructTag, value::MoveTypeLayout, vm_status::StatusCode};
-use move_vm_types::loaded_data::runtime_types::{DepthFormula, StructNameIndex, Type};
+use move_vm_types::loaded_data::{
+    runtime_types::{DepthFormula, Type},
+    struct_name_indexing::{StructNameIndex, StructNameIndexMap},
+};
 use parking_lot::RwLock;
 
 /// Layout information of a single struct instantiation.

--- a/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
@@ -4,10 +4,7 @@
 use crate::{
     config::VMConfig,
     loader::{LegacyModuleStorageAdapter, Loader, PseudoGasContext, VALUE_DEPTH_MAX},
-    storage::{
-        struct_name_index_map::StructNameIndexMap, ty_cache::StructInfoCache,
-        ty_tag_converter::TypeTagConverter,
-    },
+    storage::{ty_cache::StructInfoCache, ty_tag_converter::TypeTagConverter},
     ModuleStorage,
 };
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
@@ -16,7 +13,10 @@ use move_core_types::{
     value::{IdentifierMappingKind, MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
     vm_status::StatusCode,
 };
-use move_vm_types::loaded_data::runtime_types::{StructLayout, StructNameIndex, StructType, Type};
+use move_vm_types::loaded_data::{
+    runtime_types::{StructLayout, StructType, Type},
+    struct_name_indexing::{StructNameIndex, StructNameIndexMap},
+};
 use std::sync::Arc;
 
 /// Maximal nodes which are allowed when converting to layout. This includes the types of

--- a/third_party/move/move-vm/runtime/src/storage/ty_tag_converter.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_tag_converter.rs
@@ -7,7 +7,7 @@ use move_core_types::{
     language_storage::{StructTag, TypeTag},
     vm_status::StatusCode,
 };
-use move_vm_types::loaded_data::runtime_types::{StructNameIndex, Type};
+use move_vm_types::loaded_data::{runtime_types::Type, struct_name_indexing::StructNameIndex};
 use parking_lot::RwLock;
 use std::collections::{hash_map::Entry, HashMap};
 
@@ -239,24 +239,26 @@ mod tests {
     fn test_type_tag_cache() {
         let cache = TypeTagCache::empty();
         assert!(cache.cache.read().is_empty());
-        assert!(cache.get_struct_tag(&StructNameIndex(0), &[]).is_none());
+        assert!(cache
+            .get_struct_tag(&StructNameIndex::new(0), &[])
+            .is_none());
 
         let tag = PricedStructTag {
             struct_tag: StructTag::from_str("0x1::foo::Foo").unwrap(),
             pseudo_gas_cost: 10,
         };
-        assert!(cache.insert_struct_tag(&StructNameIndex(0), &[], &tag));
+        assert!(cache.insert_struct_tag(&StructNameIndex::new(0), &[], &tag));
 
         let tag = PricedStructTag {
             struct_tag: StructTag::from_str("0x1::foo::Foo").unwrap(),
             // Set different cost to check.
             pseudo_gas_cost: 100,
         };
-        assert!(!cache.insert_struct_tag(&StructNameIndex(0), &[], &tag));
+        assert!(!cache.insert_struct_tag(&StructNameIndex::new(0), &[], &tag));
 
         assert_eq!(cache.cache.read().len(), 1);
         let cost = cache
-            .get_struct_tag(&StructNameIndex(0), &[])
+            .get_struct_tag(&StructNameIndex::new(0), &[])
             .unwrap()
             .pseudo_gas_cost;
         assert_eq!(cost, 10);
@@ -344,8 +346,6 @@ mod tests {
                 constraints: AbilitySet::EMPTY,
                 is_phantom: false,
             }],
-            name: Identifier::new("Foo").unwrap(),
-            module: ModuleId::new(AccountAddress::TWO, Identifier::new("foo").unwrap()),
         };
         let generic_struct_ty = ty_builder
             .create_struct_instantiation_ty(&struct_ty, &[Type::TyParam(0)], &[bool_vec_ty])

--- a/third_party/move/move-vm/types/Cargo.toml
+++ b/third_party/move/move-vm/types/Cargo.toml
@@ -20,6 +20,7 @@ hashbrown = { workspace = true }
 itertools = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
+parking_lot = { workspace = true }
 proptest = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 sha3 = { workspace = true }

--- a/third_party/move/move-vm/types/src/code/errors.rs
+++ b/third_party/move/move-vm/types/src/code/errors.rs
@@ -2,17 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[macro_export]
-macro_rules! panic_error {
-    ($msg:expr) => {{
-        println!("[Error] panic detected: {}", $msg);
-        move_binary_format::errors::PartialVMError::new(
-            move_core_types::vm_status::StatusCode::DELAYED_FIELD_OR_BLOCKSTM_CODE_INVARIANT_ERROR,
-        )
-        .with_message(format!("Panic detected: {:?}", $msg))
-    }};
-}
-
-#[macro_export]
 macro_rules! module_storage_error {
     ($addr:expr, $name:expr, $err:ident) => {
         move_binary_format::errors::PartialVMError::new(

--- a/third_party/move/move-vm/types/src/loaded_data/mod.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/mod.rs
@@ -9,3 +9,4 @@ pub mod runtime_access_specifier;
 #[cfg(test)]
 mod runtime_access_specifiers_prop_tests;
 pub mod runtime_types;
+pub mod struct_name_indexing;

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -4,6 +4,7 @@
 
 #![allow(clippy::non_canonical_partial_ord_impl)]
 
+use crate::loaded_data::struct_name_indexing::StructNameIndex;
 use derivative::Derivative;
 use itertools::Itertools;
 use move_binary_format::{
@@ -245,7 +246,7 @@ impl StructType {
     #[cfg(test)]
     pub fn for_test() -> StructType {
         Self {
-            idx: StructNameIndex(0),
+            idx: StructNameIndex::new(0),
             layout: StructLayout::Single(vec![]),
             phantom_ty_params_mask: SmallBitVec::new(),
             abilities: AbilitySet::EMPTY,
@@ -253,9 +254,6 @@ impl StructType {
         }
     }
 }
-
-#[derive(Debug, Copy, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct StructNameIndex(pub usize);
 
 #[derive(Debug, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct StructIdentifier {
@@ -745,7 +743,7 @@ impl fmt::Display for Type {
             Address => f.write_str("address"),
             Signer => f.write_str("signer"),
             Vector(et) => write!(f, "vector<{}>", et),
-            Struct { idx, ability: _ } => write!(f, "s#{}", idx.0),
+            Struct { idx, ability: _ } => write!(f, "s#{}", idx),
             StructInstantiation {
                 idx,
                 ty_args,
@@ -753,7 +751,7 @@ impl fmt::Display for Type {
             } => write!(
                 f,
                 "s#{}<{}>",
-                idx.0,
+                idx,
                 ty_args.iter().map(|t| t.to_string()).join(",")
             ),
             Reference(t) => write!(f, "&{}", t),
@@ -1215,7 +1213,7 @@ mod unit_tests {
 
     fn struct_instantiation_ty_for_test(ty_args: Vec<Type>) -> Type {
         Type::StructInstantiation {
-            idx: StructNameIndex(0),
+            idx: StructNameIndex::new(0),
             ability: AbilityInfo::struct_(AbilitySet::EMPTY),
             ty_args: TriompheArc::new(ty_args),
         }
@@ -1223,7 +1221,7 @@ mod unit_tests {
 
     fn struct_ty_for_test() -> Type {
         Type::Struct {
-            idx: StructNameIndex(0),
+            idx: StructNameIndex::new(0),
             ability: AbilityInfo::struct_(AbilitySet::EMPTY),
         }
     }
@@ -1366,7 +1364,7 @@ mod unit_tests {
 
     #[test]
     fn test_create_struct_ty() {
-        let idx = StructNameIndex(0);
+        let idx = StructNameIndex::new(0);
         let ability_info = AbilityInfo::struct_(AbilitySet::EMPTY);
 
         // Limits are not relevant here.

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -12,8 +12,6 @@ use move_binary_format::{
         SignatureToken, StructHandle, StructTypeParameter, TypeParameterIndex, VariantIndex,
     },
 };
-#[cfg(test)]
-use move_core_types::account_address::AccountAddress;
 use move_core_types::{
     ability::{Ability, AbilitySet},
     identifier::Identifier,
@@ -133,8 +131,6 @@ pub struct StructType {
     pub phantom_ty_params_mask: SmallBitVec,
     pub abilities: AbilitySet,
     pub ty_params: Vec<StructTypeParameter>,
-    pub name: Identifier,
-    pub module: ModuleId,
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
@@ -254,8 +250,6 @@ impl StructType {
             phantom_ty_params_mask: SmallBitVec::new(),
             abilities: AbilitySet::EMPTY,
             ty_params: vec![],
-            name: Identifier::new("Foo").unwrap(),
-            module: ModuleId::new(AccountAddress::ONE, Identifier::new("foo").unwrap()),
         }
     }
 }


### PR DESCRIPTION
## Description

For transaction argument validation, we check if the struct type name matches the allowed constructor. Previously, we were loading modules to check that, which is unnecessary because we can get the name from the struct re-indexing map. This PR changes the check to this.

## How Has This Been Tested?

Existing tests.

## Key Areas to Review

Double-check the behaviour is the same.

## Type of Change

- [x] Refactoring

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine
## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
