### PR TITLE
[rosetta] Add USDC

### DIFF
--- a/crates/aptos-rosetta/src/common.rs
+++ b/crates/aptos-rosetta/src/common.rs
@@ -145,16 +145,16 @@ pub fn decode_key<T: DeserializeOwned + ValidCryptoMaterial>(
     T::from_encoded_string(str).map_err(|_| ApiError::deserialization_failed(type_name))
 }
 
-const DEFAULT_COIN: &str = "APT";
-const DEFAULT_DECIMALS: u8 = 8;
+const APT_SYMBOL: &str = "APT";
+const APT_DECIMALS: u8 = 8;
 
 /// Provides the [Currency] for 0x1::aptos_coin::AptosCoin aka APT
 ///
 /// Note that 0xA is the address for FA, but it has to be skipped in order to have backwards compatibility
 pub fn native_coin() -> Currency {
     Currency {
-        symbol: DEFAULT_COIN.to_string(),
-        decimals: DEFAULT_DECIMALS,
+        symbol: APT_SYMBOL.to_string(),
+        decimals: APT_DECIMALS,
         metadata: Some(CurrencyMetadata {
             move_type: Some(native_coin_tag().to_string()),
             fa_address: None,
@@ -175,6 +175,33 @@ pub fn native_coin_tag() -> TypeTag {
 #[inline]
 pub fn is_native_coin(fa_address: AccountAddress) -> bool {
     fa_address == AccountAddress::TEN
+}
+
+const USDC_SYMBOL: &str = "USDC";
+const USDC_DECIMALS: u8 = 6;
+const USDC_ADDRESS: &str = "0xbae207659db88bea0cbead6da0ed00aac12edcdda169e591cd41c94180b46f3b";
+const USDC_TESTNET_ADDRESS: &str =
+    "0x69091fbab5f7d635ee7ac5098cf0c1efbe31d68fec0f2cd565e8d168daf52832";
+pub fn usdc_currency() -> Currency {
+    Currency {
+        symbol: USDC_SYMBOL.to_string(),
+        decimals: USDC_DECIMALS,
+        metadata: Some(CurrencyMetadata {
+            move_type: None,
+            fa_address: Some(USDC_ADDRESS.to_string()),
+        }),
+    }
+}
+
+pub fn usdc_testnet_currency() -> Currency {
+    Currency {
+        symbol: USDC_SYMBOL.to_string(),
+        decimals: USDC_DECIMALS,
+        metadata: Some(CurrencyMetadata {
+            move_type: None,
+            fa_address: Some(USDC_TESTNET_ADDRESS.to_string()),
+        }),
+    }
 }
 
 pub fn find_coin_currency(currencies: &HashSet<Currency>, type_tag: &TypeTag) -> Option<Currency> {

--- a/crates/aptos-rosetta/src/lib.rs
+++ b/crates/aptos-rosetta/src/lib.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     block::BlockRetriever,
-    common::{handle_request, native_coin, with_context},
+    common::{handle_request, native_coin, usdc_currency, usdc_testnet_currency, with_context},
     error::{ApiError, ApiResult},
     types::Currency,
 };
@@ -60,6 +60,13 @@ impl RosettaContext {
     ) -> Self {
         // Always add APT
         currencies.insert(native_coin());
+
+        // Depending on the chain add appropriate USDC
+        if chain_id.is_mainnet() {
+            currencies.insert(usdc_currency());
+        } else if chain_id.is_testnet() {
+            currencies.insert(usdc_testnet_currency());
+        }
 
         RosettaContext {
             rest_client,


### PR DESCRIPTION
## Description
Adds USDC to default coins supported by Rosetta

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
Check that USDC testnet and USDC mainnet addresses are correct

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (Rosetta)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
