### PR TITLE
fix some fuzzing conditional compilation issues in aptos-crypto

### DIFF
--- a/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_sigs.rs
+++ b/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_sigs.rs
@@ -35,7 +35,7 @@ impl Signature {
 
     /// Deserialize an P256Signature, without checking for malleability
     /// Uses the SEC1 serialization format.
-    #[cfg(not(feature = "fuzzing"))]
+    #[cfg(all(not(feature = "fuzzing"), not(test)))]
     pub(crate) fn from_bytes_unchecked(
         bytes: &[u8],
     ) -> std::result::Result<Signature, CryptoMaterialError> {


### PR DESCRIPTION
## Description

Was trying to add a new signature benchmark and noticed that `cargo test` now fails in `crates/aptos-crypto` due to some conditional compilation gone awry in #14869 (cc @zi0Black):

```
alinush@alinush [~/aptos-core/crates/aptos-crypto] (alin/fix-crypto-benches) $ cargo test
   Compiling aptos-crypto v0.0.3 (/Users/alinush/repos/aptos-core/crates/aptos-crypto)
error[E0592]: duplicate definitions with name `from_bytes_unchecked`
  --> crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_sigs.rs:52:5
   |
39 | /     pub(crate) fn from_bytes_unchecked(
40 | |         bytes: &[u8],
41 | |     ) -> std::result::Result<Signature, CryptoMaterialError> {
   | |____________________________________________________________- other definition for `from_bytes_unchecked`
...
52 | /     pub fn from_bytes_unchecked(
53 | |         bytes: &[u8],
54 | |     ) -> std::result::Result<Signature, CryptoMaterialError> {
   | |____________________________________________________________^ duplicate definitions for `from_bytes_unchecked`

For more information about this error, try `rustc --explain E0592`.
error: could not compile `aptos-crypto` (lib test) due to 1 previous error
```

Not sure why CI did not catch this. 

cc @aptos-labs/prod-eng: is `cargo test` not being run for `crates/aptos-crypto` in CI?

## How Has This Been Tested?

`cargo test` in `crates/aptos-crypto` now compiles:

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
