### PR TITLE
no more default devnet VK; it should now be set manually via governance during (re)deployment

### DIFF
--- a/aptos-move/e2e-move-tests/README.md
+++ b/aptos-move/e2e-move-tests/README.md
@@ -1,0 +1,9 @@
+# e2e-move-tests
+
+## Keyless
+
+To run the keyless VM tests:
+
+```
+cargo test -- keyless
+```

--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -444,7 +444,7 @@ pub struct GenesisConfiguration {
     pub randomness_config_override: Option<OnChainRandomnessConfig>,
     pub jwk_consensus_config_override: Option<OnChainJWKConsensusConfig>,
     pub initial_jwks: Vec<IssuerJWK>,
-    pub keyless_groth16_vk_override: Option<Groth16VerificationKey>,
+    pub keyless_groth16_vk: Option<Groth16VerificationKey>,
 }
 
 pub type InitConfigFn = Arc<dyn Fn(usize, &mut NodeConfig, &mut NodeConfig) + Send + Sync>;
@@ -667,7 +667,7 @@ impl Builder {
             randomness_config_override: None,
             jwk_consensus_config_override: None,
             initial_jwks: vec![],
-            keyless_groth16_vk_override: None,
+            keyless_groth16_vk: None,
         };
         if let Some(init_genesis_config) = &self.init_genesis_config {
             (init_genesis_config)(&mut genesis_config);

--- a/crates/aptos-genesis/src/lib.rs
+++ b/crates/aptos-genesis/src/lib.rs
@@ -79,7 +79,7 @@ pub struct GenesisInfo {
     pub randomness_config_override: Option<OnChainRandomnessConfig>,
     pub jwk_consensus_config_override: Option<OnChainJWKConsensusConfig>,
     pub initial_jwks: Vec<IssuerJWK>,
-    pub keyless_groth16_vk_override: Option<Groth16VerificationKey>,
+    pub keyless_groth16_vk: Option<Groth16VerificationKey>,
 }
 
 impl GenesisInfo {
@@ -120,7 +120,7 @@ impl GenesisInfo {
             randomness_config_override: genesis_config.randomness_config_override.clone(),
             jwk_consensus_config_override: genesis_config.jwk_consensus_config_override.clone(),
             initial_jwks: genesis_config.initial_jwks.clone(),
-            keyless_groth16_vk_override: genesis_config.keyless_groth16_vk_override.clone(),
+            keyless_groth16_vk: genesis_config.keyless_groth16_vk.clone(),
         })
     }
 
@@ -157,7 +157,7 @@ impl GenesisInfo {
                 randomness_config_override: self.randomness_config_override.clone(),
                 jwk_consensus_config_override: self.jwk_consensus_config_override.clone(),
                 initial_jwks: self.initial_jwks.clone(),
-                keyless_groth16_vk_override: self.keyless_groth16_vk_override.clone(),
+                keyless_groth16_vk: self.keyless_groth16_vk.clone(),
             },
             &self.consensus_config,
             &self.execution_config,

--- a/crates/aptos-genesis/src/mainnet.rs
+++ b/crates/aptos-genesis/src/mainnet.rs
@@ -144,7 +144,7 @@ impl MainnetGenesisInfo {
                 randomness_config_override: self.randomness_config_override.clone(),
                 jwk_consensus_config_override: self.jwk_consensus_config_override.clone(),
                 initial_jwks: vec![],
-                keyless_groth16_vk_override: None,
+                keyless_groth16_vk: None,
             },
         )
     }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1608,7 +1608,7 @@ impl FaucetOptions {
 }
 
 /// Gas price options for manipulating how to prioritize transactions
-#[derive(Debug, Eq, Parser, PartialEq)]
+#[derive(Debug, Clone, Eq, Parser, PartialEq)]
 pub struct GasOptions {
     /// Gas multiplier per unit of gas
     ///

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -261,7 +261,7 @@ pub fn fetch_mainnet_genesis_info(git_options: GitOptions) -> CliTypedResult<Mai
             randomness_config_override: None,
             jwk_consensus_config_override: None,
             initial_jwks: vec![],
-            keyless_groth16_vk_override: None,
+            keyless_groth16_vk: None,
         },
     )?)
 }
@@ -306,7 +306,7 @@ pub fn fetch_genesis_info(git_options: GitOptions) -> CliTypedResult<GenesisInfo
             randomness_config_override: None,
             jwk_consensus_config_override: layout.jwk_consensus_config_override.clone(),
             initial_jwks: layout.initial_jwks.clone(),
-            keyless_groth16_vk_override: layout.keyless_groth16_vk_override.clone(),
+            keyless_groth16_vk: layout.keyless_groth16_vk_override.clone(),
         },
     )?)
 }

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -81,7 +81,7 @@ pub(crate) fn bootstrap_with_genesis(
                 issuer: get_sample_iss(),
                 jwk: JWK::RSA(get_sample_jwk()),
             }];
-            config.keyless_groth16_vk_override = Some(Groth16VerificationKey::from(
+            config.keyless_groth16_vk = Some(Groth16VerificationKey::from(
                 &TEST_GROTH16_SETUP.prepared_vk,
             ));
         })));

--- a/keyless/pepper/service/src/lib.rs
+++ b/keyless/pepper/service/src/lib.rs
@@ -32,8 +32,7 @@ use aptos_types::{
     account_address::AccountAddress,
     keyless::{
         get_public_inputs_hash, Configuration, EphemeralCertificate, Groth16ProofAndStatement,
-        IdCommitment, KeylessPublicKey, KeylessSignature, OpenIdSig, VERIFICATION_KEY_FOR_TESTING,
-        ZKP,
+        IdCommitment, KeylessPublicKey, KeylessSignature, OpenIdSig, ZKP,
     },
     transaction::authenticator::{
         AnyPublicKey, AnySignature, AuthenticationKey, EphemeralPublicKey,

--- a/keyless/pepper/service/src/lib.rs
+++ b/keyless/pepper/service/src/lib.rs
@@ -32,7 +32,8 @@ use aptos_types::{
     account_address::AccountAddress,
     keyless::{
         get_public_inputs_hash, Configuration, EphemeralCertificate, Groth16ProofAndStatement,
-        IdCommitment, KeylessPublicKey, KeylessSignature, OpenIdSig, VERIFICATION_KEY_FOR_TESTING, ZKP,
+        IdCommitment, KeylessPublicKey, KeylessSignature, OpenIdSig, VERIFICATION_KEY_FOR_TESTING,
+        ZKP,
     },
     transaction::authenticator::{
         AnyPublicKey, AnySignature, AuthenticationKey, EphemeralPublicKey,

--- a/keyless/pepper/service/src/lib.rs
+++ b/keyless/pepper/service/src/lib.rs
@@ -32,7 +32,7 @@ use aptos_types::{
     account_address::AccountAddress,
     keyless::{
         get_public_inputs_hash, Configuration, EphemeralCertificate, Groth16ProofAndStatement,
-        IdCommitment, KeylessPublicKey, KeylessSignature, OpenIdSig, ZKP,
+        IdCommitment, KeylessPublicKey, KeylessSignature, OpenIdSig, VERIFICATION_KEY_FOR_TESTING, ZKP,
     },
     transaction::authenticator::{
         AnyPublicKey, AnySignature, AuthenticationKey, EphemeralPublicKey,

--- a/testsuite/smoke-test/src/keyless.rs
+++ b/testsuite/smoke-test/src/keyless.rs
@@ -31,7 +31,7 @@ use aptos_types::{
         },
         AnyKeylessPublicKey, Configuration, EphemeralCertificate, Groth16ProofAndStatement,
         Groth16VerificationKey, KeylessPublicKey, KeylessSignature, TransactionAndProof,
-        VERIFICATION_KEY_FOR_TESTING, KEYLESS_ACCOUNT_MODULE_NAME,
+        KEYLESS_ACCOUNT_MODULE_NAME, VERIFICATION_KEY_FOR_TESTING,
     },
     on_chain_config::{FeatureFlag, Features},
     transaction::{

--- a/types/src/keyless/bn254_circom.rs
+++ b/types/src/keyless/bn254_circom.rs
@@ -399,7 +399,7 @@ mod test {
             G1Bytes, G2Bytes, G1_PROJECTIVE_COMPRESSED_NUM_BYTES,
             G2_PROJECTIVE_COMPRESSED_NUM_BYTES,
         },
-        circuit_constants::devnet_prepared_vk,
+        circuit_constants::prepared_vk_for_testing,
         Groth16VerificationKey,
     };
     use ark_bn254::Bn254;
@@ -436,7 +436,7 @@ mod test {
     // Tests conversion between the devnet ark_groth16::PreparedVerificationKey and our Move
     // representation of it.
     fn print_groth16_pvk() {
-        let groth16_vk: Groth16VerificationKey = devnet_prepared_vk().into();
+        let groth16_vk: Groth16VerificationKey = prepared_vk_for_testing().into();
 
         println!("alpha_g1: {:?}", hex::encode(groth16_vk.alpha_g1.clone()));
         println!("beta_g2: {:?}", hex::encode(groth16_vk.beta_g2.clone()));
@@ -448,6 +448,6 @@ mod test {
 
         let same_pvk: PreparedVerifyingKey<Bn254> = groth16_vk.try_into().unwrap();
 
-        assert_eq!(same_pvk, devnet_prepared_vk());
+        assert_eq!(same_pvk, prepared_vk_for_testing());
     }
 }

--- a/types/src/keyless/circuit_constants.rs
+++ b/types/src/keyless/circuit_constants.rs
@@ -27,7 +27,7 @@ pub(crate) const MAX_COMMITED_EPK_BYTES: u16 =
 
 /// This function uses the decimal uncompressed point serialization which is outputted by circom.
 /// https://github.com/aptos-labs/devnet-groth16-keys/commit/02e5675f46ce97f8b61a4638e7a0aaeaa4351f76
-pub fn devnet_prepared_vk() -> PreparedVerifyingKey<Bn254> {
+pub fn prepared_vk_for_testing() -> PreparedVerifyingKey<Bn254> {
     // Convert the projective points to affine.
     let alpha_g1 = g1_projective_str_to_affine(
         "20491192805390485299153009773594534940189261866228447918068658471970481763042",

--- a/types/src/keyless/mod.rs
+++ b/types/src/keyless/mod.rs
@@ -32,7 +32,7 @@ pub mod proof_simulation;
 pub mod test_utils;
 mod zkp_sig;
 
-use crate::keyless::circuit_constants::devnet_prepared_vk;
+use crate::keyless::circuit_constants::prepared_vk_for_testing;
 pub use bn254_circom::{
     g1_projective_str_to_affine, g2_projective_str_to_affine, get_public_inputs_hash, G1Bytes,
     G2Bytes, G1_PROJECTIVE_COMPRESSED_NUM_BYTES, G2_PROJECTIVE_COMPRESSED_NUM_BYTES,
@@ -47,9 +47,9 @@ pub use zkp_sig::ZKP;
 /// The name of the Move module for keyless accounts deployed at 0x1.
 pub const KEYLESS_ACCOUNT_MODULE_NAME: &str = "keyless_account";
 
-/// The devnet VK that is initialized during genesis.
-pub static DEVNET_VERIFICATION_KEY: Lazy<PreparedVerifyingKey<Bn254>> =
-    Lazy::new(devnet_prepared_vk);
+/// A VK that we use often for keyless e2e tests and smoke tests.
+pub static VERIFICATION_KEY_FOR_TESTING: Lazy<PreparedVerifyingKey<Bn254>> =
+    Lazy::new(prepared_vk_for_testing);
 
 #[macro_export]
 macro_rules! invalid_signature {

--- a/types/src/keyless/test_utils.rs
+++ b/types/src/keyless/test_utils.rs
@@ -403,7 +403,7 @@ mod test {
                 get_sample_epk_blinder, get_sample_esk, get_sample_exp_date,
                 get_sample_groth16_sig_and_pk, get_sample_jwt_token, get_sample_pepper,
             },
-            Configuration, Groth16Proof, OpenIdSig, DEVNET_VERIFICATION_KEY,
+            Configuration, Groth16Proof, OpenIdSig, VERIFICATION_KEY_FOR_TESTING,
         },
         transaction::authenticator::EphemeralPublicKey,
     };
@@ -521,7 +521,7 @@ mod test {
             // Verify the proof with the test verifying key.  If this fails the verifying key does not match the proving used
             // to generate the proof.
             proof
-                .verify_proof(public_inputs_hash, DEVNET_VERIFICATION_KEY.deref())
+                .verify_proof(public_inputs_hash, VERIFICATION_KEY_FOR_TESTING.deref())
                 .unwrap();
 
             prover_response

--- a/types/src/keyless/tests.rs
+++ b/types/src/keyless/tests.rs
@@ -9,7 +9,7 @@ use crate::keyless::{
         get_sample_openid_sig_and_pk,
     },
     Configuration, EphemeralCertificate, KeylessPublicKey, KeylessSignature,
-    DEVNET_VERIFICATION_KEY,
+    VERIFICATION_KEY_FOR_TESTING,
 };
 use aptos_crypto::poseidon_bn254::keyless::fr_to_bytes_le;
 use std::ops::{AddAssign, Deref};
@@ -74,7 +74,7 @@ fn test_keyless_groth16_proof_verification() {
     );
 
     proof
-        .verify_groth16_proof(public_inputs_hash, DEVNET_VERIFICATION_KEY.deref())
+        .verify_groth16_proof(public_inputs_hash, VERIFICATION_KEY_FOR_TESTING.deref())
         .unwrap();
 }
 


### PR DESCRIPTION
## Description

The genesis VK for Aptos Keyless is either set manually via `GenesisConfiguration` or defaults to the `DEVNET_VERIFICATION_KEY` value hardcoded in our Rust code.

However, this default value is no longer useful[^huh], because when we update the devnet VK in production, a devnet redeployment would later overwrite this update and revert us back to the default VK.

This, in turn, would lock developers outside of their devnet accounts. As result, we'd have to manually run a governance proposal to update the devnet VK after every devnet release.

Therefore, to ensure VK updates persist on devnet, we need to refine our devnet deployment process to fetch the latest VK from somewhere (TBD) and deploy with that in the `GenesisConfiguration`.

 - [x] We will work with the @aptos-labs/prod-eng team to refine the devnet release process (either in this PR or another). 
     + @perryjrandall suggested to update the devnet release flow to fetch the latest VK from a ground-truth repo and update it on-chain via governance.
     + Furthermore, when this ground-truth repo gets updated we will automatically trigger a governance proposal to update the currently-deployed devnet

[^huh]: I think the hardcoded devnet VK was useful during the initial keyless development and deployment.

## How Has This Been Tested?

<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Not yet tested.

## Key Areas to Review

<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

TBD.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [x] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
