### PR TITLE
Create object with permissioned signer

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/object.md
+++ b/aptos-move/framework/aptos-framework/doc/object.md
@@ -91,6 +91,7 @@ make it so that a reference to a global object can be returned from a function.
 -  [Function `owns`](#0x1_object_owns)
 -  [Function `root_owner`](#0x1_object_root_owner)
 -  [Function `grant_permission`](#0x1_object_grant_permission)
+-  [Function `grant_permission_with_transfer_ref`](#0x1_object_grant_permission_with_transfer_ref)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
     -  [Module-level Specification](#module-level-spec)
@@ -2407,6 +2408,7 @@ to determine the identity of the starting point of ownership.
 
 ## Function `grant_permission`
 
+Master signer offers a transfer permission of an object to a permissioned signer.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_grant_permission">grant_permission</a>&lt;T&gt;(master: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;)
@@ -2427,6 +2429,37 @@ to determine the identity of the starting point of ownership.
         master,
         <a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>,
         <a href="object.md#0x1_object_TransferPermission">TransferPermission</a> { <a href="object.md#0x1_object">object</a>: <a href="object.md#0x1_object">object</a>.inner }
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_object_grant_permission_with_transfer_ref"></a>
+
+## Function `grant_permission_with_transfer_ref`
+
+Grant a transfer permission to the permissioned signer using TransferRef.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_grant_permission_with_transfer_ref">grant_permission_with_transfer_ref</a>(<a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, ref: &<a href="object.md#0x1_object_TransferRef">object::TransferRef</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_grant_permission_with_transfer_ref">grant_permission_with_transfer_ref</a>(
+    <a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    ref: &<a href="object.md#0x1_object_TransferRef">TransferRef</a>,
+) {
+    <a href="permissioned_signer.md#0x1_permissioned_signer_grant_unlimited_with_permissioned_signer">permissioned_signer::grant_unlimited_with_permissioned_signer</a>(
+        <a href="permissioned_signer.md#0x1_permissioned_signer">permissioned_signer</a>,
+        <a href="object.md#0x1_object_TransferPermission">TransferPermission</a> { <a href="object.md#0x1_object">object</a>: ref.self }
     )
 }
 </code></pre>

--- a/aptos-move/framework/aptos-framework/doc/permissioned_signer.md
+++ b/aptos-move/framework/aptos-framework/doc/permissioned_signer.md
@@ -49,6 +49,7 @@ for blind signing.
 -  [Function `insert_or`](#0x1_permissioned_signer_insert_or)
 -  [Function `authorize_increase`](#0x1_permissioned_signer_authorize_increase)
 -  [Function `authorize_unlimited`](#0x1_permissioned_signer_authorize_unlimited)
+-  [Function `grant_unlimited_with_permissioned_signer`](#0x1_permissioned_signer_grant_unlimited_with_permissioned_signer)
 -  [Function `increase_limit`](#0x1_permissioned_signer_increase_limit)
 -  [Function `check_permission_exists`](#0x1_permissioned_signer_check_permission_exists)
 -  [Function `check_permission_capacity_above`](#0x1_permissioned_signer_check_permission_capacity_above)
@@ -1273,6 +1274,44 @@ Unlimited permission can be consumed however many times.
             && <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(master) == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(permissioned),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="permissioned_signer.md#0x1_permissioned_signer_ECANNOT_AUTHORIZE">ECANNOT_AUTHORIZE</a>)
     );
+    <a href="permissioned_signer.md#0x1_permissioned_signer_insert_or">insert_or</a>(
+        permissioned,
+        perm,
+        |stored_permission| {
+            *stored_permission = StoredPermission::Unlimited;
+        },
+        StoredPermission::Unlimited,
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_permissioned_signer_grant_unlimited_with_permissioned_signer"></a>
+
+## Function `grant_unlimited_with_permissioned_signer`
+
+Grant an unlimited permission to a permissioned signer **without** master signer's approvoal.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="permissioned_signer.md#0x1_permissioned_signer_grant_unlimited_with_permissioned_signer">grant_unlimited_with_permissioned_signer</a>&lt;PermKey: <b>copy</b>, drop, store&gt;(permissioned: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, perm: PermKey)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>package</b>) <b>fun</b> <a href="permissioned_signer.md#0x1_permissioned_signer_grant_unlimited_with_permissioned_signer">grant_unlimited_with_permissioned_signer</a>&lt;PermKey: <b>copy</b> + drop + store&gt;(
+    permissioned: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    perm: PermKey
+) <b>acquires</b> <a href="permissioned_signer.md#0x1_permissioned_signer_PermissionStorage">PermissionStorage</a> {
+    <b>if</b>(!<a href="permissioned_signer.md#0x1_permissioned_signer_is_permissioned_signer">is_permissioned_signer</a>(permissioned)) {
+        <b>return</b>;
+    };
     <a href="permissioned_signer.md#0x1_permissioned_signer_insert_or">insert_or</a>(
         permissioned,
         perm,

--- a/aptos-move/framework/aptos-framework/sources/permissioned_signer.move
+++ b/aptos-move/framework/aptos-framework/sources/permissioned_signer.move
@@ -509,6 +509,24 @@ module aptos_framework::permissioned_signer {
         )
     }
 
+    /// Grant an unlimited permission to a permissioned signer **without** master signer's approvoal.
+    public(package) fun grant_unlimited_with_permissioned_signer<PermKey: copy + drop + store>(
+        permissioned: &signer,
+        perm: PermKey
+    ) acquires PermissionStorage {
+        if(!is_permissioned_signer(permissioned)) {
+            return;
+        };
+        insert_or(
+            permissioned,
+            perm,
+            |stored_permission| {
+                *stored_permission = StoredPermission::Unlimited;
+            },
+            StoredPermission::Unlimited,
+        )
+    }
+
     /// Increase the `capacity` of a permissioned signer **without** master signer's approvoal.
     ///
     /// The caller of the module will need to make sure the witness type `PermKey` can only be

--- a/aptos-move/framework/aptos-framework/sources/permissioned_signer.move
+++ b/aptos-move/framework/aptos-framework/sources/permissioned_signer.move
@@ -509,7 +509,6 @@ module aptos_framework::permissioned_signer {
         )
     }
 
-    /// Grant an unlimited permission to a permissioned signer **without** master signer's approval.
     /// Grant an unlimited permission to a permissioned signer **without** master signer's approvoal.
     public(package) fun grant_unlimited_with_permissioned_signer<PermKey: copy + drop + store>(
         permissioned: &signer,

--- a/aptos-move/framework/aptos-framework/sources/permissioned_signer.move
+++ b/aptos-move/framework/aptos-framework/sources/permissioned_signer.move
@@ -509,6 +509,7 @@ module aptos_framework::permissioned_signer {
         )
     }
 
+    /// Grant an unlimited permission to a permissioned signer **without** master signer's approval.
     /// Grant an unlimited permission to a permissioned signer **without** master signer's approvoal.
     public(package) fun grant_unlimited_with_permissioned_signer<PermKey: copy + drop + store>(
         permissioned: &signer,


### PR DESCRIPTION
## Description
Allowed transfer ref to grant permission to the permissioned signer.

## How Has This Been Tested?
Test added 

## Key Areas to Review
Whether the granting logic is safe.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
