### PR TITLE
[validator] Changing module cache for VM validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4737,9 +4737,11 @@ dependencies = [
  "aptos-vm-environment",
  "aptos-vm-genesis",
  "aptos-vm-logging",
- "aptos-vm-types",
  "fail",
+ "move-binary-format",
  "move-core-types",
+ "move-vm-runtime",
+ "move-vm-types",
  "rand 0.7.3",
 ]
 

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -119,7 +119,7 @@ use move_vm_metrics::{Timer, VM_TIMER};
 use move_vm_runtime::{
     logging::expect_no_verification_errors,
     module_traversal::{TraversalContext, TraversalStorage},
-    RuntimeEnvironment, WithRuntimeEnvironment,
+    ModuleStorage, RuntimeEnvironment, WithRuntimeEnvironment,
 };
 use move_vm_types::gas::{GasMeter, UnmeteredGasMeter};
 use num_cpus;
@@ -1824,7 +1824,7 @@ impl AptosVM {
         &self,
         session: &mut SessionExt,
         resolver: &impl AptosMoveResolver,
-        module_storage: &impl AptosModuleStorage,
+        module_storage: &impl ModuleStorage,
         transaction: &SignedTransaction,
         transaction_data: &TransactionMetadata,
         log_context: &AdapterLogSchema,
@@ -2553,7 +2553,7 @@ impl AptosVM {
         &self,
         session: &mut SessionExt,
         resolver: &impl AptosMoveResolver,
-        module_storage: &impl AptosModuleStorage,
+        module_storage: &impl ModuleStorage,
         payload: &TransactionPayload,
         txn_data: &TransactionMetadata,
         log_context: &AdapterLogSchema,
@@ -2899,7 +2899,7 @@ impl VMValidator for AptosVM {
         &self,
         transaction: SignedTransaction,
         state_view: &impl StateView,
-        module_storage: &impl AptosCodeStorage,
+        module_storage: &impl ModuleStorage,
     ) -> VMValidatorResult {
         let _timer = TXN_VALIDATION_SECONDS.start_timer();
         let log_context = AdapterLogSchema::new(state_view.id(), 0);
@@ -3057,7 +3057,7 @@ pub(crate) fn is_account_init_for_sponsored_transaction(
     txn_data: &TransactionMetadata,
     features: &Features,
     resolver: &impl AptosMoveResolver,
-    module_storage: &impl AptosModuleStorage,
+    module_storage: &impl ModuleStorage,
 ) -> VMResult<bool> {
     if features.is_enabled(FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_V1_CREATION)
         && txn_data.fee_payer.is_some()
@@ -3084,7 +3084,7 @@ pub(crate) fn is_account_init_for_sponsored_transaction(
 pub(crate) fn fetch_module_metadata_for_struct_tag(
     struct_tag: &StructTag,
     resolver: &impl AptosMoveResolver,
-    module_storage: &impl AptosModuleStorage,
+    module_storage: &impl ModuleStorage,
 ) -> VMResult<Vec<Metadata>> {
     if module_storage.is_enabled() {
         module_storage.fetch_existing_module_metadata(&struct_tag.address, &struct_tag.module)

--- a/aptos-move/aptos-vm/src/gas.rs
+++ b/aptos-move/aptos-vm/src/gas.rs
@@ -12,11 +12,9 @@ use aptos_logger::{enabled, Level};
 use aptos_memory_usage_tracker::MemoryTrackedGasMeter;
 use aptos_types::on_chain_config::Features;
 use aptos_vm_logging::{log_schema::AdapterLogSchema, speculative_log, speculative_warn};
-use aptos_vm_types::{
-    module_and_script_storage::module_storage::AptosModuleStorage,
-    storage::{space_pricing::DiskSpacePricing, StorageGasParameters},
-};
+use aptos_vm_types::storage::{space_pricing::DiskSpacePricing, StorageGasParameters};
 use move_core_types::vm_status::{StatusCode, VMStatus};
+use move_vm_runtime::ModuleStorage;
 
 /// This is used until gas version 18, which introduces a configurable entry for this.
 const MAXIMUM_APPROVED_TRANSACTION_SIZE_LEGACY: u64 = 1024 * 1024;
@@ -47,7 +45,7 @@ pub(crate) fn check_gas(
     gas_params: &AptosGasParameters,
     gas_feature_version: u64,
     resolver: &impl AptosMoveResolver,
-    module_storage: &impl AptosModuleStorage,
+    module_storage: &impl ModuleStorage,
     txn_metadata: &TransactionMetadata,
     features: &Features,
     is_approved_gov_script: bool,

--- a/aptos-move/aptos-vm/src/keyless_validation.rs
+++ b/aptos-move/aptos-vm/src/keyless_validation.rs
@@ -15,7 +15,6 @@ use aptos_types::{
     transaction::authenticator::{EphemeralPublicKey, EphemeralSignature},
     vm_status::{StatusCode, VMStatus},
 };
-use aptos_vm_types::module_and_script_storage::module_storage::AptosModuleStorage;
 use ark_bn254::Bn254;
 use ark_groth16::PreparedVerifyingKey;
 use move_binary_format::errors::Location;
@@ -23,6 +22,7 @@ use move_core_types::{
     account_address::AccountAddress, language_storage::CORE_CODE_ADDRESS,
     move_resource::MoveStructType,
 };
+use move_vm_runtime::ModuleStorage;
 use serde::Deserialize;
 
 macro_rules! value_deserialization_error {
@@ -36,7 +36,7 @@ macro_rules! value_deserialization_error {
 
 fn get_resource_on_chain<T: MoveStructType + for<'a> Deserialize<'a>>(
     resolver: &impl AptosMoveResolver,
-    module_storage: &impl AptosModuleStorage,
+    module_storage: &impl ModuleStorage,
 ) -> anyhow::Result<T, VMStatus> {
     get_resource_on_chain_at_addr(&CORE_CODE_ADDRESS, resolver, module_storage)
 }
@@ -44,7 +44,7 @@ fn get_resource_on_chain<T: MoveStructType + for<'a> Deserialize<'a>>(
 fn get_resource_on_chain_at_addr<T: MoveStructType + for<'a> Deserialize<'a>>(
     addr: &AccountAddress,
     resolver: &impl AptosMoveResolver,
-    module_storage: &impl AptosModuleStorage,
+    module_storage: &impl ModuleStorage,
 ) -> anyhow::Result<T, VMStatus> {
     let metadata = fetch_module_metadata_for_struct_tag(&T::struct_tag(), resolver, module_storage)
         .map_err(|e| e.into_vm_status())?;
@@ -87,21 +87,21 @@ fn get_jwks_onchain(resolver: &impl AptosMoveResolver) -> anyhow::Result<Patched
 fn get_federated_jwks_onchain(
     resolver: &impl AptosMoveResolver,
     jwk_addr: &AccountAddress,
-    module_storage: &impl AptosModuleStorage,
+    module_storage: &impl ModuleStorage,
 ) -> anyhow::Result<FederatedJWKs, VMStatus> {
     get_resource_on_chain_at_addr::<FederatedJWKs>(jwk_addr, resolver, module_storage)
 }
 
 pub(crate) fn get_groth16_vk_onchain(
     resolver: &impl AptosMoveResolver,
-    module_storage: &impl AptosModuleStorage,
+    module_storage: &impl ModuleStorage,
 ) -> anyhow::Result<Groth16VerificationKey, VMStatus> {
     get_resource_on_chain::<Groth16VerificationKey>(resolver, module_storage)
 }
 
 fn get_configs_onchain(
     resolver: &impl AptosMoveResolver,
-    module_storage: &impl AptosModuleStorage,
+    module_storage: &impl ModuleStorage,
 ) -> anyhow::Result<Configuration, VMStatus> {
     get_resource_on_chain::<Configuration>(resolver, module_storage)
 }
@@ -160,7 +160,7 @@ pub(crate) fn validate_authenticators(
     authenticators: &Vec<(AnyKeylessPublicKey, KeylessSignature)>,
     features: &Features,
     resolver: &impl AptosMoveResolver,
-    module_storage: &impl AptosModuleStorage,
+    module_storage: &impl ModuleStorage,
 ) -> Result<(), VMStatus> {
     let mut with_zk = false;
     for (pk, sig) in authenticators {

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -139,7 +139,7 @@ use aptos_types::{
     },
     vm_status::VMStatus,
 };
-use aptos_vm_types::module_and_script_storage::code_storage::AptosCodeStorage;
+use move_vm_runtime::ModuleStorage;
 use std::{marker::Sync, sync::Arc};
 pub use verifier::view_function::determine_is_view;
 
@@ -150,7 +150,7 @@ pub trait VMValidator {
         &self,
         transaction: SignedTransaction,
         state_view: &impl StateView,
-        module_storage: &impl AptosCodeStorage,
+        module_storage: &impl ModuleStorage,
     ) -> VMValidatorResult;
 }
 

--- a/aptos-move/aptos-vm/src/transaction_validation.rs
+++ b/aptos-move/aptos-vm/src/transaction_validation.rs
@@ -17,7 +17,6 @@ use aptos_types::{
     on_chain_config::Features, transaction::Multisig,
 };
 use aptos_vm_logging::log_schema::AdapterLogSchema;
-use aptos_vm_types::module_and_script_storage::module_storage::AptosModuleStorage;
 use fail::fail_point;
 use move_binary_format::errors::VMResult;
 use move_core_types::{
@@ -28,7 +27,9 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
     vm_status::{AbortLocation, StatusCode, VMStatus},
 };
-use move_vm_runtime::{logging::expect_no_verification_errors, module_traversal::TraversalContext};
+use move_vm_runtime::{
+    logging::expect_no_verification_errors, module_traversal::TraversalContext, ModuleStorage,
+};
 use move_vm_types::gas::UnmeteredGasMeter;
 use once_cell::sync::Lazy;
 
@@ -85,7 +86,7 @@ impl TransactionValidation {
 
 pub(crate) fn run_script_prologue(
     session: &mut SessionExt,
-    module_storage: &impl AptosModuleStorage,
+    module_storage: &impl ModuleStorage,
     txn_data: &TransactionMetadata,
     features: &Features,
     log_context: &AdapterLogSchema,
@@ -232,7 +233,7 @@ pub(crate) fn run_script_prologue(
 /// match that hash.
 pub(crate) fn run_multisig_prologue(
     session: &mut SessionExt,
-    module_storage: &impl AptosModuleStorage,
+    module_storage: &impl ModuleStorage,
     txn_data: &TransactionMetadata,
     payload: &Multisig,
     features: &Features,
@@ -272,7 +273,7 @@ pub(crate) fn run_multisig_prologue(
 
 fn run_epilogue(
     session: &mut SessionExt,
-    module_storage: &impl AptosModuleStorage,
+    module_storage: &impl ModuleStorage,
     gas_remaining: Gas,
     fee_statement: FeeStatement,
     txn_data: &TransactionMetadata,
@@ -377,7 +378,7 @@ fn run_epilogue(
 
 fn emit_fee_statement(
     session: &mut SessionExt,
-    module_storage: &impl AptosModuleStorage,
+    module_storage: &impl ModuleStorage,
     fee_statement: FeeStatement,
     traversal_context: &mut TraversalContext,
 ) -> VMResult<()> {
@@ -398,7 +399,7 @@ fn emit_fee_statement(
 /// in the `ACCOUNT_MODULE` on chain.
 pub(crate) fn run_success_epilogue(
     session: &mut SessionExt,
-    module_storage: &impl AptosModuleStorage,
+    module_storage: &impl ModuleStorage,
     gas_remaining: Gas,
     fee_statement: FeeStatement,
     features: &Features,
@@ -431,7 +432,7 @@ pub(crate) fn run_success_epilogue(
 /// stored in the `ACCOUNT_MODULE` on chain.
 pub(crate) fn run_failure_epilogue(
     session: &mut SessionExt,
-    module_storage: &impl AptosModuleStorage,
+    module_storage: &impl ModuleStorage,
     gas_remaining: Gas,
     fee_statement: FeeStatement,
     features: &Features,

--- a/aptos-move/block-executor/src/code_cache.rs
+++ b/aptos-move/block-executor/src/code_cache.rs
@@ -75,7 +75,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> ModuleCache for LatestView
         deserialized_code: Self::Deserialized,
         extension: Arc<Self::Extension>,
         version: Self::Version,
-    ) -> VMResult<()> {
+    ) -> VMResult<Arc<ModuleCode<Self::Deserialized, Self::Verified, Self::Extension>>> {
         self.as_module_cache().insert_deserialized_module(
             key,
             deserialized_code,

--- a/third_party/move/move-vm/types/src/code/cache/module_cache.rs
+++ b/third_party/move/move-vm/types/src/code/cache/module_cache.rs
@@ -232,6 +232,12 @@ where
             .into_iter()
             .map(|(k, m)| (k, m.into_module_code()))
     }
+
+    /// Returns the version of the module stored in cache. Used for tests only.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn get_module_version(&self, key: &K) -> Option<V> {
+        self.module_cache.borrow().get(key).map(|m| m.version())
+    }
 }
 
 impl<K, DC, VC, E, V> ModuleCache for UnsyncModuleCache<K, DC, VC, E, V>

--- a/third_party/move/move-vm/types/src/code/errors.rs
+++ b/third_party/move/move-vm/types/src/code/errors.rs
@@ -14,7 +14,7 @@ macro_rules! panic_error {
 
 #[macro_export]
 macro_rules! module_storage_error {
-    ($addr:ident, $name:ident, $err:ident) => {
+    ($addr:expr, $name:expr, $err:ident) => {
         move_binary_format::errors::PartialVMError::new(
             move_core_types::vm_status::StatusCode::STORAGE_ERROR,
         )

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -20,8 +20,11 @@ aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
 aptos-vm-environment = { workspace = true }
 aptos-vm-logging = { workspace = true }
-aptos-vm-types = { workspace = true }
 fail = { workspace = true }
+move-binary-format = { workspace = true }
+move-core-types = { workspace = true }
+move-vm-runtime = { workspace = true }
+move-vm-types = { workspace = true }
 rand = { workspace = true }
 
 [dev-dependencies]

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -34,9 +34,9 @@ aptos-db = { workspace = true }
 aptos-executor-test-helpers = { workspace = true }
 aptos-gas-schedule = { workspace = true, features = ["testing"] } 
 aptos-temppath = { workspace = true }
-aptos-types = { workspace = true }
+aptos-types = { workspace = true, features = ["testing"] }
 aptos-vm-genesis = { workspace = true }
-move-core-types = { workspace = true }
+move-vm-types = { workspace = true, features = ["testing"] }
 rand = { workspace = true }
 
 [features]

--- a/vm-validator/src/mocks/mock_vm_validator.rs
+++ b/vm-validator/src/mocks/mock_vm_validator.rs
@@ -11,7 +11,7 @@ use aptos_types::{
     vm_status::StatusCode,
 };
 use aptos_vm::VMValidator;
-use aptos_vm_types::module_and_script_storage::code_storage::AptosCodeStorage;
+use move_vm_runtime::ModuleStorage;
 
 pub const ACCOUNT_DNE_TEST_ADD: AccountAddress =
     AccountAddress::new([0_u8; AccountAddress::LENGTH]);
@@ -36,7 +36,7 @@ impl VMValidator for MockVMValidator {
         &self,
         _transaction: SignedTransaction,
         _state_view: &impl StateView,
-        _module_storage: &impl AptosCodeStorage,
+        _module_storage: &impl ModuleStorage,
     ) -> VMValidatorResult {
         VMValidatorResult::new(None, 0)
     }

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -14,7 +14,7 @@ use aptos_storage_interface::{
 use aptos_types::{
     account_address::AccountAddress,
     account_config::AccountResource,
-    state_store::{state_key::StateKey, MoveResourceExt, StateView, TStateView},
+    state_store::{state_key::StateKey, MoveResourceExt, StateView},
     transaction::{SignedTransaction, VMValidatorResult},
     vm::modules::AptosModuleExtension,
 };
@@ -52,9 +52,22 @@ pub trait TransactionValidation: Send + Sync + Clone {
     fn notify_commit(&mut self);
 }
 
-struct VMValidator {
-    db_reader: Arc<dyn DbReader>,
-    state_view: CachedDbStateView,
+/// Returns a new VM for validation, with configs initialized based on the provided state.
+fn new_vm_for_validation(state_view: &impl StateView) -> AptosVM {
+    info!(
+        AdapterLogSchema::new(state_view.id(), 0),
+        "AptosVM created for Validation"
+    );
+    let env = AptosEnvironment::new(state_view);
+    AptosVM::new(env, state_view)
+}
+
+/// Represents the state used for validation. Stores raw data, module cache and the execution
+/// runtime environment stored in the VM. Note that the state can get out-of-date, and it is the
+/// responsibility of the owner of the struct to ensure it is up-to-date.
+struct ValidationState<S> {
+    /// The raw snapshot of the state used for validation.
+    state_view: S,
     /// Versioned cache for deserialized and verified Move modules. The versioning allows to detect
     /// when the version of the code is no longer up-to-date (a newer version has been committed to
     /// the state view) and update the cache accordingly.
@@ -62,13 +75,40 @@ struct VMValidator {
     vm: AptosVM,
 }
 
-impl WithRuntimeEnvironment for VMValidator {
+impl<S: StateView> ValidationState<S> {
+    /// Creates a new state based on the state view snapshot, with empty module cache and VM
+    /// initialized based on configs from the state.
+    fn new(state_view: S) -> Self {
+        let vm = new_vm_for_validation(&state_view);
+        Self {
+            state_view,
+            module_cache: UnsyncModuleCache::empty(),
+            vm,
+        }
+    }
+
+    /// Resets the state view snapshot to the new one. Does not invalidate the module cache, nor
+    /// the VM.
+    fn reset_state_view(&mut self, state_view: S) {
+        self.state_view = state_view;
+    }
+
+    /// Resets the state to the new one, empties module cache, and resets the VM based on the new
+    /// state view snapshot.
+    fn reset_all(&mut self, state_view: S) {
+        self.state_view = state_view;
+        self.module_cache = UnsyncModuleCache::empty();
+        self.vm = new_vm_for_validation(&self.state_view);
+    }
+}
+
+impl<S> WithRuntimeEnvironment for ValidationState<S> {
     fn runtime_environment(&self) -> &RuntimeEnvironment {
         self.vm.runtime_environment()
     }
 }
 
-impl ModuleCache for VMValidator {
+impl<S: StateView> ModuleCache for ValidationState<S> {
     type Deserialized = CompiledModule;
     type Extension = AptosModuleExtension;
     type Key = ModuleId;
@@ -112,6 +152,7 @@ impl ModuleCache for VMValidator {
             Self::Version,
         )>,
     > {
+        // Get the module that exists in cache.
         let (module, version) = match self.module_cache.get_module_or_build_with(key, builder)? {
             None => {
                 return Ok(None);
@@ -119,6 +160,7 @@ impl ModuleCache for VMValidator {
             Some(module_and_version) => module_and_version,
         };
 
+        // Get the state value that exists in the actual state and compute the hash.
         let state_value = self
             .state_view
             .get_state_value(&StateKey::module_id(key))
@@ -133,10 +175,15 @@ impl ModuleCache for VMValidator {
                     .finish(Location::Undefined)
             })?;
         let hash = sha3_256(state_value.bytes());
+
+        // If hash is the same - we can use the same module from cache. If the hash is different,
+        // then the state contains a newer version of the code. We deserialize the state value and
+        // replace the old cache entry with the new code.
         Ok(if module.extension().hash() == &hash {
             Some((module, version))
         } else {
             let compiled_module = self
+                .vm
                 .runtime_environment()
                 .deserialize_into_compiled_module(state_value.bytes())?;
             let extension = Arc::new(AptosModuleExtension::new(state_value));
@@ -157,7 +204,7 @@ impl ModuleCache for VMValidator {
     }
 }
 
-impl ModuleCodeBuilder for VMValidator {
+impl<S: StateView> ModuleCodeBuilder for ValidationState<S> {
     type Deserialized = CompiledModule;
     type Extension = AptosModuleExtension;
     type Key = ModuleId;
@@ -184,6 +231,11 @@ impl ModuleCodeBuilder for VMValidator {
     }
 }
 
+struct VMValidator {
+    db_reader: Arc<dyn DbReader>,
+    state: ValidationState<CachedDbStateView>,
+}
+
 impl Clone for VMValidator {
     fn clone(&self) -> Self {
         Self::new(self.db_reader.clone())
@@ -191,26 +243,13 @@ impl Clone for VMValidator {
 }
 
 impl VMValidator {
-    fn new_vm_for_validation(state_view: &impl StateView) -> AptosVM {
-        info!(
-            AdapterLogSchema::new(state_view.id(), 0),
-            "AptosVM created for Validation"
-        );
-        let env = AptosEnvironment::new(state_view);
-        AptosVM::new(env, state_view)
-    }
-
     fn new(db_reader: Arc<dyn DbReader>) -> Self {
         let db_state_view = db_reader
             .latest_state_checkpoint_view()
             .expect("Get db view cannot fail");
-        let vm = Self::new_vm_for_validation(&db_state_view);
-
         VMValidator {
             db_reader,
-            state_view: db_state_view.into(),
-            module_cache: UnsyncModuleCache::empty(),
-            vm,
+            state: ValidationState::new(db_state_view.into()),
         }
     }
 
@@ -222,21 +261,17 @@ impl VMValidator {
 
     fn restart(&mut self) -> Result<()> {
         let db_state_view = self.db_state_view();
-        self.state_view = db_state_view.into();
-
-        // If restarting, configs must have changed, so we need to empty the cache and re-create
-        // the VM.
-        self.module_cache = UnsyncModuleCache::empty();
-        self.vm = Self::new_vm_for_validation(&self.state_view);
-
+        self.state.reset_all(db_state_view.into());
         Ok(())
     }
 
     fn notify_commit(&mut self) {
         let db_state_view = self.db_state_view();
-        self.state_view = db_state_view.into();
-        // We do not update module cache here - it will update itself if needed when reading the
-        // module.
+
+        // On commit, we need to update the state view, but not the configs or module caches. If
+        // configs change, validator will be restarted, and for module caches we ensure that read
+        // modules are up-to-date.
+        self.state.reset_state_view(db_state_view.into());
     }
 }
 
@@ -296,10 +331,10 @@ impl TransactionValidation for PooledVMValidator {
         let vm_validator_locked = vm_validator.lock().unwrap();
 
         use aptos_vm::VMValidator;
-        Ok(vm_validator_locked.vm.validate_transaction(
+        Ok(vm_validator_locked.state.vm.validate_transaction(
             txn,
-            &vm_validator_locked.state_view,
-            &*vm_validator_locked,
+            &vm_validator_locked.state.state_view,
+            &vm_validator_locked.state,
         ))
     }
 
@@ -314,5 +349,133 @@ impl TransactionValidation for PooledVMValidator {
         for vm_validator in &self.vm_validators {
             vm_validator.lock().unwrap().notify_commit();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aptos_types::state_store::{state_value::StateValue, MockStateView};
+    use move_binary_format::file_format::empty_module_with_dependencies_and_friends;
+    use move_core_types::ident_str;
+    use move_vm_runtime::ModuleStorage;
+    use std::collections::HashMap;
+
+    fn module_state_value(module: CompiledModule) -> StateValue {
+        let mut bytes = vec![];
+        module.serialize(&mut bytes).unwrap();
+        StateValue::new_legacy(bytes.into())
+    }
+
+    #[test]
+    fn test_module_cache_consistency() {
+        // Have 3 modules in the state.
+        let a = empty_module_with_dependencies_and_friends("a", vec![], vec![]);
+        let b = empty_module_with_dependencies_and_friends("b", vec![], vec![]);
+        let c = empty_module_with_dependencies_and_friends("c", vec![], vec![]);
+
+        let state_view = MockStateView::new(HashMap::from([
+            (
+                StateKey::module_id(&a.self_id()),
+                module_state_value(a.clone()),
+            ),
+            (
+                StateKey::module_id(&b.self_id()),
+                module_state_value(b.clone()),
+            ),
+            (
+                StateKey::module_id(&c.self_id()),
+                module_state_value(c.clone()),
+            ),
+        ]));
+        let mut state = ValidationState::new(state_view);
+        assert_eq!(state.module_cache.num_modules(), 0);
+
+        assert!(state
+            .fetch_deserialized_module(&AccountAddress::ZERO, ident_str!("d"))
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            &a,
+            state
+                .fetch_deserialized_module(&a.self_addr(), a.self_name())
+                .unwrap()
+                .unwrap()
+                .as_ref()
+        );
+        assert_eq!(
+            &c,
+            state
+                .fetch_deserialized_module(&c.self_addr(), c.self_name())
+                .unwrap()
+                .unwrap()
+                .as_ref()
+        );
+
+        assert_eq!(state.module_cache.num_modules(), 2);
+        assert_eq!(state.module_cache.get_module_version(&a.self_id()), Some(0));
+        assert_eq!(state.module_cache.get_module_version(&b.self_id()), None);
+        assert_eq!(state.module_cache.get_module_version(&c.self_id()), Some(0));
+
+        // Change module "a" by adding dependencies and also add a new module "d".
+        let d = empty_module_with_dependencies_and_friends("d", vec![], vec![]);
+        let a_new = empty_module_with_dependencies_and_friends("a", vec!["b", "c"], vec![]);
+        assert_ne!(&a, &a_new);
+
+        let new_state_view = MockStateView::new(HashMap::from([
+            // New code:
+            (
+                StateKey::module_id(&a_new.self_id()),
+                module_state_value(a_new.clone()),
+            ),
+            (
+                StateKey::module_id(&d.self_id()),
+                module_state_value(d.clone()),
+            ),
+            // Old code:
+            (
+                StateKey::module_id(&b.self_id()),
+                module_state_value(b.clone()),
+            ),
+            (
+                StateKey::module_id(&c.self_id()),
+                module_state_value(c.clone()),
+            ),
+        ]));
+        state.reset_state_view(new_state_view);
+
+        // New code version should be returned no
+        assert_eq!(
+            &a_new,
+            state
+                .fetch_deserialized_module(&a_new.self_addr(), a_new.self_name())
+                .unwrap()
+                .unwrap()
+                .as_ref()
+        );
+        assert_eq!(
+            &d,
+            state
+                .fetch_deserialized_module(&d.self_addr(), d.self_name())
+                .unwrap()
+                .unwrap()
+                .as_ref()
+        );
+
+        assert_eq!(state.module_cache.num_modules(), 3);
+        assert_eq!(state.module_cache.get_module_version(&a.self_id()), Some(1));
+        assert_eq!(state.module_cache.get_module_version(&c.self_id()), Some(0));
+        assert_eq!(state.module_cache.get_module_version(&d.self_id()), Some(0));
+
+        // Get verified module, to load the transitive closure (modules "b" and "c") as well.
+        assert!(state
+            .fetch_verified_module(&a_new.self_addr(), a_new.self_name())
+            .unwrap()
+            .is_some());
+        assert_eq!(state.module_cache.num_modules(), 4);
+        assert_eq!(state.module_cache.get_module_version(&a.self_id()), Some(1));
+        assert_eq!(state.module_cache.get_module_version(&b.self_id()), Some(0));
+        assert_eq!(state.module_cache.get_module_version(&c.self_id()), Some(0));
+        assert_eq!(state.module_cache.get_module_version(&d.self_id()), Some(0));
     }
 }


### PR DESCRIPTION
## Description

This PR re-implements module caching logic for VM validator (mempool validation running prologues) to make it work correctly with module publishing and account abstraction (AA). Before, module cache was only updated on full reset (that is, epoch change), which means that:
- If new version of the code is published, the old one is still used until epoch change.
- If a new module is published that is also used by the prologue, it it not found until epoch change.
The later is a problem for AA because it is possible for the user to publish a module with some validation logic and custom prologue, and then use it within the same epoch (as a result, "module not found error" is returned). 

**Changes:**
VM validator now owns the*versioned* code cache explicitly. On every module read from the cache, the hash of the read module is compared against the hash of the module in the DB. If hashes match, the module must be up-to-date and it is returned. If not, a newer module is inserted into cache (with higher version) and returned.

Note that the downside of this approach is that every module read requires a state view access. Current implementation uses a locked cache for state view accesses, so the performance should still be ok. There is nothing else we can do to ensure modules are up to date, unless commit notification also carries information whether the code has been published, which is a much bigger change.

## How Has This Been Tested?

- Existing validator tests.
- Existing forge tests (performance is ok)
- New tests to check module versioning logic by the validator.
- Manual test using (without this PR the test fails with module not found, with the PR test passes):
```
// apply the patch beforehand
git checkout lightmark/account_abstraction
cd aptos-core/api
RUST_BACKTRACE=1 MOVE_COMPILER_V2=1 MOVE_LANGUAGE_V2=1 UPDATE_GOLDENFILES=1 cargo test test_account_abstraction_single_signer -- --nocapture
```

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change

- [x] Bug fix
- [x] Refactoring
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [x] Validator Node

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
