### PR TITLE
[execution] Add failure message to execution status

### DIFF
--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -1064,6 +1064,7 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                 location,
                 function,
                 code_offset,
+                message,
             } => {
                 let func_name = match location {
                     AbortLocation::Module(module_id) => self
@@ -1071,17 +1072,25 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
                         .map(|name| format!("{}::{}", abort_location_to_str(location), name))
                         .unwrap_or_else(|_| {
                             format!(
-                                "{}::<#{} function>",
+                                "{}::<#{} function>, {:?}",
                                 abort_location_to_str(location),
-                                function
+                                function,
+                                message
                             )
                         }),
                     AbortLocation::Script => "script".to_owned(),
                 };
-                format!(
-                    "Execution failed in {} at code offset {}",
-                    func_name, code_offset
-                )
+                if let Some(message) = message {
+                    format!(
+                        "Execution failed in {} at code offset {}: {}",
+                        func_name, code_offset, message
+                    )
+                } else {
+                    format!(
+                        "Execution failed in {} at code offset {}",
+                        func_name, code_offset
+                    )
+                }
             },
             ExecutionStatus::MiscellaneousError(code) => {
                 if code.is_none() {

--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/default_int_size.exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/default_int_size.exp
@@ -1,4 +1,4 @@
 processed 2 tasks
 
 task 1 'run'. lines 4-21:
-Error: Failed to execute transaction. ExecutionStatus: ExecutionFailure { location: Script, function: 0, code_offset: 10 }
+Error: Failed to execute transaction. ExecutionStatus: ExecutionFailure { location: Script, function: 0, code_offset: 10, message: Some("Multiplication overflow") }

--- a/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/default_int_size.v2_exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/aptos_test_harness/default_int_size.v2_exp
@@ -1,4 +1,4 @@
 processed 2 tasks
 
 task 1 'run'. lines 4-21:
-Error: Failed to execute transaction. ExecutionStatus: ExecutionFailure { location: Script, function: 0, code_offset: 10 }
+Error: Failed to execute transaction. ExecutionStatus: ExecutionFailure { location: Script, function: 0, code_offset: 10, message: Some("Multiplication overflow") }

--- a/aptos-move/aptos-transactional-test-harness/tests/v2-tests/default_int_size.exp
+++ b/aptos-move/aptos-transactional-test-harness/tests/v2-tests/default_int_size.exp
@@ -1,4 +1,4 @@
 processed 2 tasks
 
 task 1 'run'. lines 4-21:
-Error: Failed to execute transaction. ExecutionStatus: ExecutionFailure { location: Script, function: 0, code_offset: 10 }
+Error: Failed to execute transaction. ExecutionStatus: ExecutionFailure { location: Script, function: 0, code_offset: 10, message: Some("Multiplication overflow") }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -846,6 +846,7 @@ pub enum ExecutionStatus {
         location: AbortLocation,
         function: u16,
         code_offset: u16,
+        message: Option<String>,
     },
     MiscellaneousError(Option<StatusCode>),
 }
@@ -872,11 +873,12 @@ impl From<KeptVMStatus> for ExecutionStatus {
                 location: loc,
                 function: func,
                 code_offset: offset,
-                message: _,
+                message,
             } => ExecutionStatus::ExecutionFailure {
                 location: loc,
                 function: func,
                 code_offset: offset,
+                message,
             },
             KeptVMStatus::MiscellaneousError => ExecutionStatus::MiscellaneousError(None),
         }


### PR DESCRIPTION
## Description
We have an optional message, it should be there to be outputted in the API.

For overflow and other built in errors, the error message wouldn't give too much information.

This should now give additional information, which can be useful to the user

```
aptos move run --profile local --function-id local::overflow::test --max-gas 200                                                                                                                    λ:main  [  ]
Do you want to submit transaction for a maximum of 20000 Octas at a gas unit price of 100 Octas? [yes/no] >
y
Transaction submitted: https://explorer.aptoslabs.com/txn/0x5e7897b3db3a177b2435f2163256d48358f7f59117a190e4f5f614849a4c40e4?network=local
{
  "Error": "API error: Unknown error Transaction committed on chain, but failed execution: Execution failed in 0x3a600d0632eb3aa4db751a803f4083cba1d2c838c168919e995080bff64ebe1::overflow::test at code offset 14: Addition overflow"
}
```

<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
Tested against an overflowing contract

## Key Areas to Review

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
