### PR TITLE
Add Txns for AccountRestoration Indexer Processor Tests

### DIFF
--- a/ecosystem/indexer-grpc/indexer-test-transactions/src/json_transactions/imported_mainnet_txns/2200077591_account_restoration_single_ed25519.json
+++ b/ecosystem/indexer-grpc/indexer-test-transactions/src/json_transactions/imported_mainnet_txns/2200077591_account_restoration_single_ed25519.json
@@ -1,0 +1,266 @@
+{
+  "timestamp": {
+    "seconds": "1736842688",
+    "nanos": 258451000
+  },
+  "version": "2200077591",
+  "info": {
+    "hash": "gNgvi81AuqOuIbYwuZWyJIP/MCgsMLFHztoLLkVFbzM=",
+    "stateChangeHash": "x7wNmRFflsUzJpTvO/s7LcpIRgsNJZfQqW4gqdQixcI=",
+    "eventRootHash": "88NfjFBBk516O8CqFZmgfAi8LRIiTalls5fSxjtOkVY=",
+    "gasUsed": "999",
+    "success": true,
+    "vmStatus": "Executed successfully",
+    "accumulatorRootHash": "G0sDdTtfHO1ya0DfQTurSymWbYDcje3QXTjOzJDCxSM=",
+    "changes": [
+      {
+        "type": "TYPE_WRITE_RESOURCE",
+        "writeResource": {
+          "address": "0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a",
+          "stateKeyHash": "V4b0abNN7BV/FXN58EWNodrVBj+kHjN25Y7yAthn4oE=",
+          "type": {
+            "address": "0x1",
+            "module": "coin",
+            "name": "CoinStore",
+            "genericTypeParams": [
+              {
+                "type": "MOVE_TYPES_STRUCT",
+                "struct": {
+                  "address": "0x1",
+                  "module": "aptos_coin",
+                  "name": "AptosCoin"
+                }
+              }
+            ]
+          },
+          "typeStr": "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+          "data": "{\"coin\":{\"value\":\"99900000\"},\"deposit_events\":{\"counter\":\"1\",\"guid\":{\"id\":{\"addr\":\"0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a\",\"creation_num\":\"2\"}}},\"frozen\":false,\"withdraw_events\":{\"counter\":\"1\",\"guid\":{\"id\":{\"addr\":\"0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a\",\"creation_num\":\"3\"}}}}"
+        }
+      },
+      {
+        "type": "TYPE_WRITE_RESOURCE",
+        "writeResource": {
+          "address": "0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a",
+          "stateKeyHash": "kaVoydo3dStnBbGmVU3SWaVaZFkU12/GyfTdg4PJiAs=",
+          "type": {
+            "address": "0x1",
+            "module": "account",
+            "name": "Account"
+          },
+          "typeStr": "0x1::account::Account",
+          "data": "{\"authentication_key\":\"0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a\",\"coin_register_events\":{\"counter\":\"1\",\"guid\":{\"id\":{\"addr\":\"0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a\",\"creation_num\":\"0\"}}},\"guid_creation_num\":\"4\",\"key_rotation_events\":{\"counter\":\"0\",\"guid\":{\"id\":{\"addr\":\"0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a\",\"creation_num\":\"1\"}}},\"rotation_capability_offer\":{\"for\":{\"vec\":[]}},\"sequence_number\":\"1\",\"signer_capability_offer\":{\"for\":{\"vec\":[]}}}"
+        }
+      },
+      {
+        "type": "TYPE_WRITE_RESOURCE",
+        "writeResource": {
+          "address": "0xedb6f48dc381485e1a46ec267a39c8f9769ebacf392ebdf74472173a8b95a7a2",
+          "stateKeyHash": "TPrhtIq8hAYE33zE2jRxFpi93BhjXCHnG7Up07iGv0o=",
+          "type": {
+            "address": "0x1",
+            "module": "coin",
+            "name": "CoinStore",
+            "genericTypeParams": [
+              {
+                "type": "MOVE_TYPES_STRUCT",
+                "struct": {
+                  "address": "0x1",
+                  "module": "aptos_coin",
+                  "name": "AptosCoin"
+                }
+              }
+            ]
+          },
+          "typeStr": "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+          "data": "{\"coin\":{\"value\":\"100\"},\"deposit_events\":{\"counter\":\"1\",\"guid\":{\"id\":{\"addr\":\"0xedb6f48dc381485e1a46ec267a39c8f9769ebacf392ebdf74472173a8b95a7a2\",\"creation_num\":\"2\"}}},\"frozen\":false,\"withdraw_events\":{\"counter\":\"0\",\"guid\":{\"id\":{\"addr\":\"0xedb6f48dc381485e1a46ec267a39c8f9769ebacf392ebdf74472173a8b95a7a2\",\"creation_num\":\"3\"}}}}"
+        }
+      },
+      {
+        "type": "TYPE_WRITE_RESOURCE",
+        "writeResource": {
+          "address": "0xedb6f48dc381485e1a46ec267a39c8f9769ebacf392ebdf74472173a8b95a7a2",
+          "stateKeyHash": "ZoZlzg2NlCbag8QUp1TTw4mEVzQkkXB/XYIThcNvWKg=",
+          "type": {
+            "address": "0x1",
+            "module": "account",
+            "name": "Account"
+          },
+          "typeStr": "0x1::account::Account",
+          "data": "{\"authentication_key\":\"0xedb6f48dc381485e1a46ec267a39c8f9769ebacf392ebdf74472173a8b95a7a2\",\"coin_register_events\":{\"counter\":\"1\",\"guid\":{\"id\":{\"addr\":\"0xedb6f48dc381485e1a46ec267a39c8f9769ebacf392ebdf74472173a8b95a7a2\",\"creation_num\":\"0\"}}},\"guid_creation_num\":\"4\",\"key_rotation_events\":{\"counter\":\"0\",\"guid\":{\"id\":{\"addr\":\"0xedb6f48dc381485e1a46ec267a39c8f9769ebacf392ebdf74472173a8b95a7a2\",\"creation_num\":\"1\"}}},\"rotation_capability_offer\":{\"for\":{\"vec\":[]}},\"sequence_number\":\"0\",\"signer_capability_offer\":{\"for\":{\"vec\":[]}}}"
+        }
+      },
+      {
+        "type": "TYPE_WRITE_TABLE_ITEM",
+        "writeTableItem": {
+          "stateKeyHash": "bkso1A+YoQamUWNTCSTA3LQME0nTqpFdEItNbPwd2xk=",
+          "handle": "0x1b854694ae746cdbd8d44186ca4929b2b337df21d1c74633be19b2710552fdca",
+          "key": "0x0619dc29a0aac8fa146714058e8dd6d2d0f3bdf5f6331907bf91f3acd81e6935",
+          "data": {
+            "key": "\"0x619dc29a0aac8fa146714058e8dd6d2d0f3bdf5f6331907bf91f3acd81e6935\"",
+            "keyType": "address",
+            "value": "\"113578028364635431\"",
+            "valueType": "u128"
+          }
+        }
+      }
+    ]
+  },
+  "epoch": "9949",
+  "blockHeight": "276992782",
+  "type": "TRANSACTION_TYPE_USER",
+  "sizeInfo": {
+    "transactionBytes": 268,
+    "eventSizeInfo": [
+      {
+        "typeTagBytes": 60,
+        "totalBytes": 161
+      },
+      {
+        "typeTagBytes": 53,
+        "totalBytes": 109
+      },
+      {
+        "typeTagBytes": 52,
+        "totalBytes": 108
+      },
+      {
+        "typeTagBytes": 63,
+        "totalBytes": 103
+      }
+    ],
+    "writeOpSizeInfo": [
+      {
+        "keyBytes": 138,
+        "valueBytes": 105
+      },
+      {
+        "keyBytes": 84,
+        "valueBytes": 147
+      },
+      {
+        "keyBytes": 138,
+        "valueBytes": 105
+      },
+      {
+        "keyBytes": 84,
+        "valueBytes": 147
+      },
+      {
+        "keyBytes": 66,
+        "valueBytes": 16
+      }
+    ]
+  },
+  "user": {
+    "request": {
+      "sender": "0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a",
+      "maxGasAmount": "200000",
+      "gasUnitPrice": "100",
+      "expirationTimestampSecs": {
+        "seconds": "1736842707"
+      },
+      "payload": {
+        "type": "TYPE_ENTRY_FUNCTION_PAYLOAD",
+        "entryFunctionPayload": {
+          "function": {
+            "module": {
+              "address": "0x1",
+              "name": "aptos_account"
+            },
+            "name": "transfer"
+          },
+          "arguments": [
+            "\"0xedb6f48dc381485e1a46ec267a39c8f9769ebacf392ebdf74472173a8b95a7a2\"",
+            "\"100\""
+          ],
+          "entryFunctionIdStr": "0x1::aptos_account::transfer"
+        }
+      },
+      "signature": {
+        "type": "TYPE_SINGLE_SENDER",
+        "singleSender": {
+          "sender": {
+            "type": "TYPE_SINGLE_KEY",
+            "singleKeySignature": {
+              "publicKey": {
+                "type": "TYPE_ED25519",
+                "publicKey": "erVNvqw1T3X3hYntMBUSEAZsEr2PMccIcmZzI3+igaU="
+              },
+              "signature": {
+                "type": "TYPE_ED25519",
+                "signature": "PI+wp6BZ3t6DQle8gZLahdI1rjV6LY5kTSu0XFcL8wfOdSvmhv5Dll/T8JpCuXeDojvmM1FLb81IzPbo7ePSBA==",
+                "ed25519": {
+                  "signature": "PI+wp6BZ3t6DQle8gZLahdI1rjV6LY5kTSu0XFcL8wfOdSvmhv5Dll/T8JpCuXeDojvmM1FLb81IzPbo7ePSBA=="
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "events": [
+      {
+        "key": {
+          "accountAddress": "0xedb6f48dc381485e1a46ec267a39c8f9769ebacf392ebdf74472173a8b95a7a2"
+        },
+        "type": {
+          "type": "MOVE_TYPES_STRUCT",
+          "struct": {
+            "address": "0x1",
+            "module": "account",
+            "name": "CoinRegisterEvent"
+          }
+        },
+        "typeStr": "0x1::account::CoinRegisterEvent",
+        "data": "{\"type_info\":{\"account_address\":\"0x1\",\"module_name\":\"0x6170746f735f636f696e\",\"struct_name\":\"0x4170746f73436f696e\"}}"
+      },
+      {
+        "key": {
+          "creationNumber": "3",
+          "accountAddress": "0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a"
+        },
+        "type": {
+          "type": "MOVE_TYPES_STRUCT",
+          "struct": {
+            "address": "0x1",
+            "module": "coin",
+            "name": "WithdrawEvent"
+          }
+        },
+        "typeStr": "0x1::coin::WithdrawEvent",
+        "data": "{\"amount\":\"100\"}"
+      },
+      {
+        "key": {
+          "creationNumber": "2",
+          "accountAddress": "0xedb6f48dc381485e1a46ec267a39c8f9769ebacf392ebdf74472173a8b95a7a2"
+        },
+        "type": {
+          "type": "MOVE_TYPES_STRUCT",
+          "struct": {
+            "address": "0x1",
+            "module": "coin",
+            "name": "DepositEvent"
+          }
+        },
+        "typeStr": "0x1::coin::DepositEvent",
+        "data": "{\"amount\":\"100\"}"
+      },
+      {
+        "key": {
+          "accountAddress": "0x0"
+        },
+        "type": {
+          "type": "MOVE_TYPES_STRUCT",
+          "struct": {
+            "address": "0x1",
+            "module": "transaction_fee",
+            "name": "FeeStatement"
+          }
+        },
+        "typeStr": "0x1::transaction_fee::FeeStatement",
+        "data": "{\"execution_gas_units\":\"6\",\"io_gas_units\":\"5\",\"storage_fee_octas\":\"98800\",\"storage_fee_refund_octas\":\"0\",\"total_charge_gas_units\":\"999\"}"
+      }
+    ]
+  }
+}

--- a/ecosystem/indexer-grpc/indexer-test-transactions/src/json_transactions/imported_mainnet_txns/2200077800_account_restoration_rotated_to_multi_key.json
+++ b/ecosystem/indexer-grpc/indexer-test-transactions/src/json_transactions/imported_mainnet_txns/2200077800_account_restoration_rotated_to_multi_key.json
@@ -1,0 +1,293 @@
+{
+  "timestamp": {
+    "seconds": "1736842691",
+    "nanos": 898036000
+  },
+  "version": "2200077800",
+  "info": {
+    "hash": "BrHhl02M2xnIMYh56FOk2GMSE9LfbKBnJrABjaU5PIc=",
+    "stateChangeHash": "OchhUOgVYl9cNXoVDLoqpB7v4kRapcI5+78zv8V4dP4=",
+    "eventRootHash": "Wu4TISVXw4Ys5bzJ44Wx2P/oDv3Wg0e8ct9ENP8+8lo=",
+    "gasUsed": "999",
+    "success": true,
+    "vmStatus": "Executed successfully",
+    "accumulatorRootHash": "Tzth2xdgW0qycy1KUYDj96wBPhhwE5GjBHmF6btNZf8=",
+    "changes": [
+      {
+        "type": "TYPE_WRITE_RESOURCE",
+        "writeResource": {
+          "address": "0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a",
+          "stateKeyHash": "V4b0abNN7BV/FXN58EWNodrVBj+kHjN25Y7yAthn4oE=",
+          "type": {
+            "address": "0x1",
+            "module": "coin",
+            "name": "CoinStore",
+            "genericTypeParams": [
+              {
+                "type": "MOVE_TYPES_STRUCT",
+                "struct": {
+                  "address": "0x1",
+                  "module": "aptos_coin",
+                  "name": "AptosCoin"
+                }
+              }
+            ]
+          },
+          "typeStr": "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+          "data": "{\"coin\":{\"value\":\"99799600\"},\"deposit_events\":{\"counter\":\"1\",\"guid\":{\"id\":{\"addr\":\"0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a\",\"creation_num\":\"2\"}}},\"frozen\":false,\"withdraw_events\":{\"counter\":\"2\",\"guid\":{\"id\":{\"addr\":\"0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a\",\"creation_num\":\"3\"}}}}"
+        }
+      },
+      {
+        "type": "TYPE_WRITE_RESOURCE",
+        "writeResource": {
+          "address": "0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a",
+          "stateKeyHash": "kaVoydo3dStnBbGmVU3SWaVaZFkU12/GyfTdg4PJiAs=",
+          "type": {
+            "address": "0x1",
+            "module": "account",
+            "name": "Account"
+          },
+          "typeStr": "0x1::account::Account",
+          "data": "{\"authentication_key\":\"0xfa444eef0d28f64b1c7494a483876b353db79b96890dfa22c6f03e68c2d73f22\",\"coin_register_events\":{\"counter\":\"1\",\"guid\":{\"id\":{\"addr\":\"0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a\",\"creation_num\":\"0\"}}},\"guid_creation_num\":\"4\",\"key_rotation_events\":{\"counter\":\"0\",\"guid\":{\"id\":{\"addr\":\"0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a\",\"creation_num\":\"1\"}}},\"rotation_capability_offer\":{\"for\":{\"vec\":[]}},\"sequence_number\":\"3\",\"signer_capability_offer\":{\"for\":{\"vec\":[]}}}"
+        }
+      },
+      {
+        "type": "TYPE_WRITE_RESOURCE",
+        "writeResource": {
+          "address": "0xbaa06bd9684eefe879615e2cd77fd3ce3881c26867ae85055a577e1f584c00d2",
+          "stateKeyHash": "k9MrR+v/UMnO3qxH/GbcfFhYTWGifjvJ3uO33h+OSU4=",
+          "type": {
+            "address": "0x1",
+            "module": "coin",
+            "name": "CoinStore",
+            "genericTypeParams": [
+              {
+                "type": "MOVE_TYPES_STRUCT",
+                "struct": {
+                  "address": "0x1",
+                  "module": "aptos_coin",
+                  "name": "AptosCoin"
+                }
+              }
+            ]
+          },
+          "typeStr": "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+          "data": "{\"coin\":{\"value\":\"100\"},\"deposit_events\":{\"counter\":\"1\",\"guid\":{\"id\":{\"addr\":\"0xbaa06bd9684eefe879615e2cd77fd3ce3881c26867ae85055a577e1f584c00d2\",\"creation_num\":\"2\"}}},\"frozen\":false,\"withdraw_events\":{\"counter\":\"0\",\"guid\":{\"id\":{\"addr\":\"0xbaa06bd9684eefe879615e2cd77fd3ce3881c26867ae85055a577e1f584c00d2\",\"creation_num\":\"3\"}}}}"
+        }
+      },
+      {
+        "type": "TYPE_WRITE_RESOURCE",
+        "writeResource": {
+          "address": "0xbaa06bd9684eefe879615e2cd77fd3ce3881c26867ae85055a577e1f584c00d2",
+          "stateKeyHash": "bFLjQApu/l4eqHdRz2egSkfBF0IFu18nv/K8t3EBM9E=",
+          "type": {
+            "address": "0x1",
+            "module": "account",
+            "name": "Account"
+          },
+          "typeStr": "0x1::account::Account",
+          "data": "{\"authentication_key\":\"0xbaa06bd9684eefe879615e2cd77fd3ce3881c26867ae85055a577e1f584c00d2\",\"coin_register_events\":{\"counter\":\"1\",\"guid\":{\"id\":{\"addr\":\"0xbaa06bd9684eefe879615e2cd77fd3ce3881c26867ae85055a577e1f584c00d2\",\"creation_num\":\"0\"}}},\"guid_creation_num\":\"4\",\"key_rotation_events\":{\"counter\":\"0\",\"guid\":{\"id\":{\"addr\":\"0xbaa06bd9684eefe879615e2cd77fd3ce3881c26867ae85055a577e1f584c00d2\",\"creation_num\":\"1\"}}},\"rotation_capability_offer\":{\"for\":{\"vec\":[]}},\"sequence_number\":\"0\",\"signer_capability_offer\":{\"for\":{\"vec\":[]}}}"
+        }
+      },
+      {
+        "type": "TYPE_WRITE_TABLE_ITEM",
+        "writeTableItem": {
+          "stateKeyHash": "bkso1A+YoQamUWNTCSTA3LQME0nTqpFdEItNbPwd2xk=",
+          "handle": "0x1b854694ae746cdbd8d44186ca4929b2b337df21d1c74633be19b2710552fdca",
+          "key": "0x0619dc29a0aac8fa146714058e8dd6d2d0f3bdf5f6331907bf91f3acd81e6935",
+          "data": {
+            "key": "\"0x619dc29a0aac8fa146714058e8dd6d2d0f3bdf5f6331907bf91f3acd81e6935\"",
+            "keyType": "address",
+            "value": "\"113578028361795775\"",
+            "valueType": "u128"
+          }
+        }
+      }
+    ]
+  },
+  "epoch": "9949",
+  "blockHeight": "276992799",
+  "type": "TRANSACTION_TYPE_USER",
+  "sizeInfo": {
+    "transactionBytes": 443,
+    "eventSizeInfo": [
+      {
+        "typeTagBytes": 60,
+        "totalBytes": 161
+      },
+      {
+        "typeTagBytes": 53,
+        "totalBytes": 109
+      },
+      {
+        "typeTagBytes": 52,
+        "totalBytes": 108
+      },
+      {
+        "typeTagBytes": 63,
+        "totalBytes": 103
+      }
+    ],
+    "writeOpSizeInfo": [
+      {
+        "keyBytes": 138,
+        "valueBytes": 105
+      },
+      {
+        "keyBytes": 84,
+        "valueBytes": 147
+      },
+      {
+        "keyBytes": 138,
+        "valueBytes": 105
+      },
+      {
+        "keyBytes": 84,
+        "valueBytes": 147
+      },
+      {
+        "keyBytes": 66,
+        "valueBytes": 16
+      }
+    ]
+  },
+  "user": {
+    "request": {
+      "sender": "0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a",
+      "sequenceNumber": "2",
+      "maxGasAmount": "200000",
+      "gasUnitPrice": "100",
+      "expirationTimestampSecs": {
+        "seconds": "1736842711"
+      },
+      "payload": {
+        "type": "TYPE_ENTRY_FUNCTION_PAYLOAD",
+        "entryFunctionPayload": {
+          "function": {
+            "module": {
+              "address": "0x1",
+              "name": "aptos_account"
+            },
+            "name": "transfer"
+          },
+          "arguments": [
+            "\"0xbaa06bd9684eefe879615e2cd77fd3ce3881c26867ae85055a577e1f584c00d2\"",
+            "\"100\""
+          ],
+          "entryFunctionIdStr": "0x1::aptos_account::transfer"
+        }
+      },
+      "signature": {
+        "type": "TYPE_SINGLE_SENDER",
+        "singleSender": {
+          "sender": {
+            "type": "TYPE_MULTI_KEY",
+            "multiKeySignature": {
+              "publicKeys": [
+                {
+                  "type": "TYPE_ED25519",
+                  "publicKey": "HqdmXS/o+xEb9231DKElbShRO1HTL/RkRwPPXT08fB4="
+                },
+                {
+                  "type": "TYPE_ED25519",
+                  "publicKey": "6ro2kifr3fxElaLNdB9cBMftCdpHrK8p7FCoBqPogtM="
+                },
+                {
+                  "type": "TYPE_SECP256K1_ECDSA",
+                  "publicKey": "BC+QQaU0E/FXd6Np1HUeINUAnvMrZiWrLNQfl/LaSdhCcKBU8bnITWlhzB89R9RhxQAFv7JqgsNYyqlnAAuBEEw="
+                }
+              ],
+              "signatures": [
+                {
+                  "signature": {
+                    "type": "TYPE_ED25519",
+                    "signature": "e80b1nkDx8coaEKiV6olRMGc0J/pZGFhGXPiMf6qDYcTKNWR9sE0JugJUw+/uMvgxiA/IbVRxOoWO9i70gxGCQ==",
+                    "ed25519": {
+                      "signature": "e80b1nkDx8coaEKiV6olRMGc0J/pZGFhGXPiMf6qDYcTKNWR9sE0JugJUw+/uMvgxiA/IbVRxOoWO9i70gxGCQ=="
+                    }
+                  }
+                },
+                {
+                  "index": 2,
+                  "signature": {
+                    "type": "TYPE_SECP256K1_ECDSA",
+                    "signature": "d2IE0w8+mcUrlcrkUK1vxJdElS6TtIfK0BAZ320e7bhwGnl/tKSSFUCnvU/D6iCwUDofDl6G6mWFmiB9aKkxvQ==",
+                    "secp256k1Ecdsa": {
+                      "signature": "d2IE0w8+mcUrlcrkUK1vxJdElS6TtIfK0BAZ320e7bhwGnl/tKSSFUCnvU/D6iCwUDofDl6G6mWFmiB9aKkxvQ=="
+                    }
+                  }
+                }
+              ],
+              "signaturesRequired": 2
+            }
+          }
+        }
+      }
+    },
+    "events": [
+      {
+        "key": {
+          "accountAddress": "0xbaa06bd9684eefe879615e2cd77fd3ce3881c26867ae85055a577e1f584c00d2"
+        },
+        "type": {
+          "type": "MOVE_TYPES_STRUCT",
+          "struct": {
+            "address": "0x1",
+            "module": "account",
+            "name": "CoinRegisterEvent"
+          }
+        },
+        "typeStr": "0x1::account::CoinRegisterEvent",
+        "data": "{\"type_info\":{\"account_address\":\"0x1\",\"module_name\":\"0x6170746f735f636f696e\",\"struct_name\":\"0x4170746f73436f696e\"}}"
+      },
+      {
+        "key": {
+          "creationNumber": "3",
+          "accountAddress": "0x21fccd4b01606fa6d094f3b99d6c4134107bf3bd72ef386316554356953e478a"
+        },
+        "sequenceNumber": "1",
+        "type": {
+          "type": "MOVE_TYPES_STRUCT",
+          "struct": {
+            "address": "0x1",
+            "module": "coin",
+            "name": "WithdrawEvent"
+          }
+        },
+        "typeStr": "0x1::coin::WithdrawEvent",
+        "data": "{\"amount\":\"100\"}"
+      },
+      {
+        "key": {
+          "creationNumber": "2",
+          "accountAddress": "0xbaa06bd9684eefe879615e2cd77fd3ce3881c26867ae85055a577e1f584c00d2"
+        },
+        "type": {
+          "type": "MOVE_TYPES_STRUCT",
+          "struct": {
+            "address": "0x1",
+            "module": "coin",
+            "name": "DepositEvent"
+          }
+        },
+        "typeStr": "0x1::coin::DepositEvent",
+        "data": "{\"amount\":\"100\"}"
+      },
+      {
+        "key": {
+          "accountAddress": "0x0"
+        },
+        "type": {
+          "type": "MOVE_TYPES_STRUCT",
+          "struct": {
+            "address": "0x1",
+            "module": "transaction_fee",
+            "name": "FeeStatement"
+          }
+        },
+        "typeStr": "0x1::transaction_fee::FeeStatement",
+        "data": "{\"execution_gas_units\":\"6\",\"io_gas_units\":\"5\",\"storage_fee_octas\":\"98800\",\"storage_fee_refund_octas\":\"0\",\"total_charge_gas_units\":\"999\"}"
+      }
+    ]
+  }
+}

--- a/ecosystem/indexer-grpc/indexer-test-transactions/src/json_transactions/imported_mainnet_txns/2200077877_account_restoration_rotated_to_single_secp256k1.json
+++ b/ecosystem/indexer-grpc/indexer-test-transactions/src/json_transactions/imported_mainnet_txns/2200077877_account_restoration_rotated_to_single_secp256k1.json
@@ -1,0 +1,267 @@
+{
+  "timestamp": {
+    "seconds": "1736842693",
+    "nanos": 386066000
+  },
+  "version": "2200077877",
+  "info": {
+    "hash": "oVLSJd2GJk7E4ABeULX1gWKVMBk0rhIT7ui7XmsNMlY=",
+    "stateChangeHash": "LsjSOoL7T4r1GAAHRY/lTpV3tVm0ANLC+bjndtvsauk=",
+    "eventRootHash": "ZNtWE4bOLr09XXUhtokFCJDvfj9Oho+AnpDfCXc2m0s=",
+    "gasUsed": "999",
+    "success": true,
+    "vmStatus": "Executed successfully",
+    "accumulatorRootHash": "NTrKmxxLPPTun4kPl0droPWBz/Vv37jihKjScF5Y/FU=",
+    "changes": [
+      {
+        "type": "TYPE_WRITE_RESOURCE",
+        "writeResource": {
+          "address": "0x19169c4c4e275aba9f20de1ee740dfc4914989e8ead71c6604cb832c99f26626",
+          "stateKeyHash": "lzTPc20o1i61BUkgOpRw9TeA9IWfHHDQSu83uVEA2LY=",
+          "type": {
+            "address": "0x1",
+            "module": "coin",
+            "name": "CoinStore",
+            "genericTypeParams": [
+              {
+                "type": "MOVE_TYPES_STRUCT",
+                "struct": {
+                  "address": "0x1",
+                  "module": "aptos_coin",
+                  "name": "AptosCoin"
+                }
+              }
+            ]
+          },
+          "typeStr": "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+          "data": "{\"coin\":{\"value\":\"99899600\"},\"deposit_events\":{\"counter\":\"1\",\"guid\":{\"id\":{\"addr\":\"0x19169c4c4e275aba9f20de1ee740dfc4914989e8ead71c6604cb832c99f26626\",\"creation_num\":\"2\"}}},\"frozen\":false,\"withdraw_events\":{\"counter\":\"1\",\"guid\":{\"id\":{\"addr\":\"0x19169c4c4e275aba9f20de1ee740dfc4914989e8ead71c6604cb832c99f26626\",\"creation_num\":\"3\"}}}}"
+        }
+      },
+      {
+        "type": "TYPE_WRITE_RESOURCE",
+        "writeResource": {
+          "address": "0x19169c4c4e275aba9f20de1ee740dfc4914989e8ead71c6604cb832c99f26626",
+          "stateKeyHash": "+cLOlzn7mFbCUToPXpGLnpo9MWtAwU2hvlvCsBjmjUc=",
+          "type": {
+            "address": "0x1",
+            "module": "account",
+            "name": "Account"
+          },
+          "typeStr": "0x1::account::Account",
+          "data": "{\"authentication_key\":\"0x229e8017b6c49a92435adb1e5f5d2b3bc0a7c17d712afaa424be61da4127b51a\",\"coin_register_events\":{\"counter\":\"1\",\"guid\":{\"id\":{\"addr\":\"0x19169c4c4e275aba9f20de1ee740dfc4914989e8ead71c6604cb832c99f26626\",\"creation_num\":\"0\"}}},\"guid_creation_num\":\"4\",\"key_rotation_events\":{\"counter\":\"0\",\"guid\":{\"id\":{\"addr\":\"0x19169c4c4e275aba9f20de1ee740dfc4914989e8ead71c6604cb832c99f26626\",\"creation_num\":\"1\"}}},\"rotation_capability_offer\":{\"for\":{\"vec\":[]}},\"sequence_number\":\"2\",\"signer_capability_offer\":{\"for\":{\"vec\":[]}}}"
+        }
+      },
+      {
+        "type": "TYPE_WRITE_RESOURCE",
+        "writeResource": {
+          "address": "0x1ca668c00efd5880b9d732656cac058a4eb41b18dec9435c13bc75c5b1e5eea9",
+          "stateKeyHash": "UhY+3vXjfO3iNQPMEVJXbSz9Gh5Bus/mWLFIrJMqNrY=",
+          "type": {
+            "address": "0x1",
+            "module": "coin",
+            "name": "CoinStore",
+            "genericTypeParams": [
+              {
+                "type": "MOVE_TYPES_STRUCT",
+                "struct": {
+                  "address": "0x1",
+                  "module": "aptos_coin",
+                  "name": "AptosCoin"
+                }
+              }
+            ]
+          },
+          "typeStr": "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
+          "data": "{\"coin\":{\"value\":\"100\"},\"deposit_events\":{\"counter\":\"1\",\"guid\":{\"id\":{\"addr\":\"0x1ca668c00efd5880b9d732656cac058a4eb41b18dec9435c13bc75c5b1e5eea9\",\"creation_num\":\"2\"}}},\"frozen\":false,\"withdraw_events\":{\"counter\":\"0\",\"guid\":{\"id\":{\"addr\":\"0x1ca668c00efd5880b9d732656cac058a4eb41b18dec9435c13bc75c5b1e5eea9\",\"creation_num\":\"3\"}}}}"
+        }
+      },
+      {
+        "type": "TYPE_WRITE_RESOURCE",
+        "writeResource": {
+          "address": "0x1ca668c00efd5880b9d732656cac058a4eb41b18dec9435c13bc75c5b1e5eea9",
+          "stateKeyHash": "LSIxNf61pEzTJFgWit0y8kDByxl3ZtRSjGH54IuyU5o=",
+          "type": {
+            "address": "0x1",
+            "module": "account",
+            "name": "Account"
+          },
+          "typeStr": "0x1::account::Account",
+          "data": "{\"authentication_key\":\"0x1ca668c00efd5880b9d732656cac058a4eb41b18dec9435c13bc75c5b1e5eea9\",\"coin_register_events\":{\"counter\":\"1\",\"guid\":{\"id\":{\"addr\":\"0x1ca668c00efd5880b9d732656cac058a4eb41b18dec9435c13bc75c5b1e5eea9\",\"creation_num\":\"0\"}}},\"guid_creation_num\":\"4\",\"key_rotation_events\":{\"counter\":\"0\",\"guid\":{\"id\":{\"addr\":\"0x1ca668c00efd5880b9d732656cac058a4eb41b18dec9435c13bc75c5b1e5eea9\",\"creation_num\":\"1\"}}},\"rotation_capability_offer\":{\"for\":{\"vec\":[]}},\"sequence_number\":\"0\",\"signer_capability_offer\":{\"for\":{\"vec\":[]}}}"
+        }
+      },
+      {
+        "type": "TYPE_WRITE_TABLE_ITEM",
+        "writeTableItem": {
+          "stateKeyHash": "bkso1A+YoQamUWNTCSTA3LQME0nTqpFdEItNbPwd2xk=",
+          "handle": "0x1b854694ae746cdbd8d44186ca4929b2b337df21d1c74633be19b2710552fdca",
+          "key": "0x0619dc29a0aac8fa146714058e8dd6d2d0f3bdf5f6331907bf91f3acd81e6935",
+          "data": {
+            "key": "\"0x619dc29a0aac8fa146714058e8dd6d2d0f3bdf5f6331907bf91f3acd81e6935\"",
+            "keyType": "address",
+            "value": "\"113578028359990440\"",
+            "valueType": "u128"
+          }
+        }
+      }
+    ]
+  },
+  "epoch": "9949",
+  "blockHeight": "276992805",
+  "type": "TRANSACTION_TYPE_USER",
+  "sizeInfo": {
+    "transactionBytes": 301,
+    "eventSizeInfo": [
+      {
+        "typeTagBytes": 60,
+        "totalBytes": 161
+      },
+      {
+        "typeTagBytes": 53,
+        "totalBytes": 109
+      },
+      {
+        "typeTagBytes": 52,
+        "totalBytes": 108
+      },
+      {
+        "typeTagBytes": 63,
+        "totalBytes": 103
+      }
+    ],
+    "writeOpSizeInfo": [
+      {
+        "keyBytes": 138,
+        "valueBytes": 105
+      },
+      {
+        "keyBytes": 84,
+        "valueBytes": 147
+      },
+      {
+        "keyBytes": 138,
+        "valueBytes": 105
+      },
+      {
+        "keyBytes": 84,
+        "valueBytes": 147
+      },
+      {
+        "keyBytes": 66,
+        "valueBytes": 16
+      }
+    ]
+  },
+  "user": {
+    "request": {
+      "sender": "0x19169c4c4e275aba9f20de1ee740dfc4914989e8ead71c6604cb832c99f26626",
+      "sequenceNumber": "1",
+      "maxGasAmount": "200000",
+      "gasUnitPrice": "100",
+      "expirationTimestampSecs": {
+        "seconds": "1736842713"
+      },
+      "payload": {
+        "type": "TYPE_ENTRY_FUNCTION_PAYLOAD",
+        "entryFunctionPayload": {
+          "function": {
+            "module": {
+              "address": "0x1",
+              "name": "aptos_account"
+            },
+            "name": "transfer"
+          },
+          "arguments": [
+            "\"0x1ca668c00efd5880b9d732656cac058a4eb41b18dec9435c13bc75c5b1e5eea9\"",
+            "\"100\""
+          ],
+          "entryFunctionIdStr": "0x1::aptos_account::transfer"
+        }
+      },
+      "signature": {
+        "type": "TYPE_SINGLE_SENDER",
+        "singleSender": {
+          "sender": {
+            "type": "TYPE_SINGLE_KEY",
+            "singleKeySignature": {
+              "publicKey": {
+                "type": "TYPE_SECP256K1_ECDSA",
+                "publicKey": "BIivkAYwcmhiv7wKU3q7ifdgQLU0vb3NlsuxcrViNETJo1S44HrmTMh0U1+rWXh428shHR4y7woaEIhkP0DDX6A="
+              },
+              "signature": {
+                "type": "TYPE_SECP256K1_ECDSA",
+                "signature": "EaIiTEJXBnC3tc1B242PaUTOKOPGR6JHqywoAgYu2uxHjMS7jLEgWfvW1SLK6r/qPoTJm3q6jPGLlBtEhOC9Ug==",
+                "secp256k1Ecdsa": {
+                  "signature": "EaIiTEJXBnC3tc1B242PaUTOKOPGR6JHqywoAgYu2uxHjMS7jLEgWfvW1SLK6r/qPoTJm3q6jPGLlBtEhOC9Ug=="
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "events": [
+      {
+        "key": {
+          "accountAddress": "0x1ca668c00efd5880b9d732656cac058a4eb41b18dec9435c13bc75c5b1e5eea9"
+        },
+        "type": {
+          "type": "MOVE_TYPES_STRUCT",
+          "struct": {
+            "address": "0x1",
+            "module": "account",
+            "name": "CoinRegisterEvent"
+          }
+        },
+        "typeStr": "0x1::account::CoinRegisterEvent",
+        "data": "{\"type_info\":{\"account_address\":\"0x1\",\"module_name\":\"0x6170746f735f636f696e\",\"struct_name\":\"0x4170746f73436f696e\"}}"
+      },
+      {
+        "key": {
+          "creationNumber": "3",
+          "accountAddress": "0x19169c4c4e275aba9f20de1ee740dfc4914989e8ead71c6604cb832c99f26626"
+        },
+        "type": {
+          "type": "MOVE_TYPES_STRUCT",
+          "struct": {
+            "address": "0x1",
+            "module": "coin",
+            "name": "WithdrawEvent"
+          }
+        },
+        "typeStr": "0x1::coin::WithdrawEvent",
+        "data": "{\"amount\":\"100\"}"
+      },
+      {
+        "key": {
+          "creationNumber": "2",
+          "accountAddress": "0x1ca668c00efd5880b9d732656cac058a4eb41b18dec9435c13bc75c5b1e5eea9"
+        },
+        "type": {
+          "type": "MOVE_TYPES_STRUCT",
+          "struct": {
+            "address": "0x1",
+            "module": "coin",
+            "name": "DepositEvent"
+          }
+        },
+        "typeStr": "0x1::coin::DepositEvent",
+        "data": "{\"amount\":\"100\"}"
+      },
+      {
+        "key": {
+          "accountAddress": "0x0"
+        },
+        "type": {
+          "type": "MOVE_TYPES_STRUCT",
+          "struct": {
+            "address": "0x1",
+            "module": "transaction_fee",
+            "name": "FeeStatement"
+          }
+        },
+        "typeStr": "0x1::transaction_fee::FeeStatement",
+        "data": "{\"execution_gas_units\":\"6\",\"io_gas_units\":\"5\",\"storage_fee_octas\":\"98800\",\"storage_fee_refund_octas\":\"0\",\"total_charge_gas_units\":\"999\"}"
+      }
+    ]
+  }
+}

--- a/ecosystem/indexer-grpc/indexer-transaction-generator/imported_transactions/imported_transactions.yaml
+++ b/ecosystem/indexer-grpc/indexer-transaction-generator/imported_transactions/imported_transactions.yaml
@@ -84,3 +84,8 @@ mainnet:
     527013476: 527013476_user_txn_single_sender_secp256k1_ecdsa
     2175935: 2175935_user_txn_multi_ed25519
     976087151: 976087151_user_txn_single_sender_keyless
+
+    # account restoration processor
+    2200077591: 2200077591_account_restoration_single_ed25519
+    2200077877: 2200077877_account_restoration_rotated_to_single_secp256k1
+    2200077800: 2200077800_account_restoration_rotated_to_multi_key


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
Generate new transactions for the new account_restoration_processor diff tests from mainnet.

- version `2200077591`: User txn with `ed25519` single-key authenticator
- version `2200077877`: User txn with `secp256k1` single-key authenticator, after rotation (rotated from `secp256k1` single-key)
- version `2200077800`: User txn with 2-of-3 multi-key authenticator, after rotation (rotated from `ed25519` single-key)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
