### PR TITLE
[gas] Bump gas version on main after release from 30 -> 31

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -69,7 +69,7 @@
 ///       global operations.
 /// - V1
 ///   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_26;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_27;
 
 pub mod gas_feature_versions {
     pub const RELEASE_V1_8: u64 = 11;
@@ -90,4 +90,5 @@ pub mod gas_feature_versions {
     pub const RELEASE_V1_23: u64 = 27;
     pub const RELEASE_V1_24: u64 = 28;
     pub const RELEASE_V1_26: u64 = 30;
+    pub const RELEASE_V1_27: u64 = 31;
 }


### PR DESCRIPTION
    Release 1.26 has version 30
    
    Bump gas to ensure we are working on the next version in main
    
    Test Plan: main + debug framework / compat tests
