### PR TITLE
[lint] Make `aptos move lint` return non-zero exit code on warnings and errors

### DIFF
--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -272,7 +272,7 @@ impl BuiltPackage {
 
             if let Some(model_options) = model.get_extension::<Options>() {
                 if model_options.experiment_on(Experiment::STOP_BEFORE_EXTENDED_CHECKS) {
-                    std::process::exit(0)
+                    std::process::exit(if model.has_warnings() { 1 } else { 0 })
                 }
             }
 
@@ -287,7 +287,7 @@ impl BuiltPackage {
 
             if let Some(model_options) = model.get_extension::<Options>() {
                 if model_options.experiment_on(Experiment::STOP_AFTER_EXTENDED_CHECKS) {
-                    std::process::exit(0)
+                    std::process::exit(if model.has_warnings() { 1 } else { 0 })
                 }
             }
 

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -102,7 +102,7 @@ where
     check_errors(&env, emitter, "checking errors")?;
 
     if options.experiment_on(Experiment::STOP_BEFORE_STACKLESS_BYTECODE) {
-        std::process::exit(0)
+        std::process::exit(if env.has_warnings() { 1 } else { 0 })
     }
 
     // Run code generator
@@ -140,7 +140,7 @@ where
     check_errors(&env, emitter, "stackless-bytecode analysis errors")?;
 
     if options.experiment_on(Experiment::STOP_BEFORE_FILE_FORMAT) {
-        std::process::exit(0)
+        std::process::exit(if env.has_warnings() { 1 } else { 0 })
     }
 
     let modules_and_scripts = run_file_format_gen(&mut env, &targets);


### PR DESCRIPTION
## Description

With this PR, `aptos move lint` returns exit code 0 on success and 1 if there are any warnings or errors.

This was a feature request by @banool for ease of use in CI/scripts.

## How Has This Been Tested?

Manually tested on a projects that (a) produce warnings and (b) do not produce warnings, and verified we have expected behavior.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Aptos CLI/SDK
- [x] Move Linter
