### PR TITLE
[lint] Don't lint needless mut reference on _ignored variables

### DIFF
--- a/third_party/move/tools/move-linter/src/stackless_bytecode_lints/needless_mutable_reference.rs
+++ b/third_party/move/tools/move-linter/src/stackless_bytecode_lints/needless_mutable_reference.rs
@@ -54,7 +54,7 @@ impl MutableReferenceUsageTracker {
         for instr in target.get_bytecode() {
             tracker.update(target, instr);
         }
-        tracker.get_mutably_unused_locations()
+        tracker.get_mutably_unused_locations(target)
     }
 
     /// Get an initial tracker from function parameters.
@@ -67,11 +67,15 @@ impl MutableReferenceUsageTracker {
     }
 
     /// Get locations where origins are not used mutably.
-    fn get_mutably_unused_locations(self) -> Vec<Loc> {
+    fn get_mutably_unused_locations(self, target: &FunctionTarget) -> Vec<Loc> {
         self.origins
             .into_iter()
             .filter_map(|(t, loc)| {
-                if !self.mutably_used.contains(&t) {
+                let ignore_local = target
+                    .symbol_pool()
+                    .string(target.get_local_name(t))
+                    .starts_with('_');
+                if !ignore_local && !self.mutably_used.contains(&t) {
                     Some(loc)
                 } else {
                     None

--- a/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/needless_mutable_reference_warn.move
+++ b/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/needless_mutable_reference_warn.move
@@ -253,3 +253,10 @@ module 0xc0ffee::more_struct_tests {
         consume_immut(u);
     }
 }
+
+module 0xc0ffee::p {
+    fun no_warn_01(_x: &mut u64) {
+        let x = 1;
+        let _y = &mut x;
+    }
+}


### PR DESCRIPTION
## Description

In the following code (taken from a real world example), the linter warned about needless mutable reference:

`fun foo(_x: &mut u64) {}`

With this PR, we omit such warnings for variables that begin with `_`.

## How Has This Been Tested?

Added a new test.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Linter
