### PR TITLE
[devtools] Enable the framework upgrade test again

### DIFF
--- a/devtools/aptos-cargo-cli/src/lib.rs
+++ b/devtools/aptos-cargo-cli/src/lib.rs
@@ -272,16 +272,12 @@ impl AptosCargoCommand {
 
                 // Determine if any relevant files or packages were changed
                 #[allow(unused_assignments)]
-                let mut relevant_changes_detected = detect_relevant_changes(
+                let relevant_changes_detected = detect_relevant_changes(
                     RELEVANT_FILE_PATHS_FOR_FRAMEWORK_UPGRADE_TESTS.to_vec(),
                     RELEVANT_PACKAGES_FOR_FRAMEWORK_UPGRADE_TESTS.to_vec(),
                     changed_files,
                     affected_package_paths,
                 );
-
-                // TODO: remove this! This is a temporary fix to disable
-                // the framework upgrade test while we debug the failures.
-                relevant_changes_detected = false;
 
                 // Output if relevant changes were detected that require the framework upgrade
                 // test. This will be consumed by Github Actions and used to run the test.


### PR DESCRIPTION
## Description
Removes a temporary fix that was disabling the framework upgrade test. This change re-enables the test by removing the code that was forcing `relevant_changes_detected` to `false`.

## How Has This Been Tested?
The framework upgrade test will now run normally when relevant changes are detected, validating the intended behavior.

## Key Areas to Review
- Verify that removing this temporary fix doesn't reintroduce the original issues that led to disabling the test
- Confirm that the framework upgrade test executes correctly when changes are detected

## Type of Change
- [x] Bug fix
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Developer Infrastructure

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation