### PR TITLE
[pipeline] fix observer

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -198,7 +198,7 @@ impl Default for ConsensusConfig {
                 num_blocks_to_look_at: 12,
                 min_blocks_to_activate: 4,
                 percentile: 0.5,
-                target_block_time_ms: 250,
+                target_block_time_ms: 200,
                 min_block_time_ms_to_activate: 100,
                 // allow at least two spreading group from reordering in a single block, to utilize paralellism
                 min_calibrated_txns_per_block: 8,

--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -469,13 +469,13 @@ impl PipelinedBlock {
     }
 
     pub fn abort_pipeline(&self) -> Option<PipelineFutures> {
-        info!(
-            "[Pipeline] Aborting pipeline for block {} {} {}",
-            self.id(),
-            self.epoch(),
-            self.round()
-        );
         if let Some(abort_handles) = self.pipeline_abort_handle.lock().take() {
+            info!(
+                "[Pipeline] Aborting pipeline for block {} {} {}",
+                self.id(),
+                self.epoch(),
+                self.round()
+            );
             for handle in abort_handles {
                 handle.abort();
             }

--- a/consensus/src/consensus_observer/observer/consensus_observer.rs
+++ b/consensus/src/consensus_observer/observer/consensus_observer.rs
@@ -814,9 +814,7 @@ impl ConsensusObserver {
                 .insert_ordered_block(ordered_block.clone());
 
             // If state sync is not syncing to a commit, finalize the ordered blocks
-            if !self.state_sync_manager.is_syncing_to_commit()
-                && !self.state_sync_manager.in_fallback_mode()
-            {
+            if !self.state_sync_manager.is_syncing_to_commit() {
                 self.finalize_ordered_block(ordered_block).await;
             }
         } else {

--- a/consensus/src/consensus_observer/observer/consensus_observer.rs
+++ b/consensus/src/consensus_observer/observer/consensus_observer.rs
@@ -1026,6 +1026,7 @@ impl ConsensusObserver {
                 None,
                 rand_msg_rx,
                 0,
+                self.pipeline_enabled(),
             )
             .await;
         if self.pipeline_enabled() {

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -1134,6 +1134,7 @@ pub fn log_executor_error_occurred(
     e: ExecutorError,
     counter: &Lazy<IntCounterVec>,
     block_id: HashValue,
+    new_pipeline_enabled: bool,
 ) {
     match e {
         ExecutorError::CouldNotGetData => {
@@ -1152,10 +1153,17 @@ pub fn log_executor_error_occurred(
         },
         e => {
             counter.with_label_values(&["UnexpectedError"]).inc();
-            error!(
-                block_id = block_id,
-                "Execution error {:?} for {}", e, block_id
-            );
+            if new_pipeline_enabled {
+                warn!(
+                    block_id = block_id,
+                    "Execution error {:?} for {}", e, block_id
+                );
+            } else {
+                error!(
+                    block_id = block_id,
+                    "Execution error {:?} for {}", e, block_id
+                );
+            }
         },
     }
 }

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -856,6 +856,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 fast_rand_config.clone(),
                 rand_msg_rx,
                 recovery_data.root_block().round(),
+                self.config.enable_pipeline,
             )
             .await;
         let consensus_sk = consensus_key;
@@ -1411,6 +1412,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
                 fast_rand_config,
                 rand_msg_rx,
                 highest_committed_round,
+                self.config.enable_pipeline,
             )
             .await;
 

--- a/consensus/src/execution_pipeline.rs
+++ b/consensus/src/execution_pipeline.rs
@@ -440,6 +440,7 @@ fn log_failed_to_send_result<T>(
                 e,
                 &counters::PIPELINE_DISCARDED_EXECUTOR_ERROR_COUNT,
                 block_id,
+                false,
             );
         }
     }

--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -648,6 +648,7 @@ impl BufferManager {
                     e,
                     &counters::BUFFER_MANAGER_RECEIVED_EXECUTOR_ERROR_COUNT,
                     block_id,
+                    self.new_pipeline_enabled,
                 );
                 return;
             },

--- a/consensus/src/pipeline/decoupled_execution_utils.rs
+++ b/consensus/src/pipeline/decoupled_execution_utils.rs
@@ -45,6 +45,7 @@ pub fn prepare_phases_and_buffer_manager(
     consensus_observer_config: ConsensusObserverConfig,
     consensus_publisher: Option<Arc<ConsensusPublisher>>,
     max_pending_rounds_in_commit_vote_cache: u64,
+    new_pipeline_enabled: bool,
 ) -> (
     PipelinePhase<ExecutionSchedulePhase>,
     PipelinePhase<ExecutionWaitPhase>,
@@ -137,6 +138,7 @@ pub fn prepare_phases_and_buffer_manager(
             consensus_observer_config,
             consensus_publisher,
             max_pending_rounds_in_commit_vote_cache,
+            new_pipeline_enabled,
         ),
     )
 }

--- a/consensus/src/pipeline/execution_client.rs
+++ b/consensus/src/pipeline/execution_client.rs
@@ -70,6 +70,7 @@ pub trait TExecutionClient: Send + Sync {
         fast_rand_config: Option<RandConfig>,
         rand_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingRandGenRequest>,
         highest_committed_round: Round,
+        new_pipeline_enabled: bool,
     );
 
     /// This is needed for some DAG tests. Clean this up as a TODO.
@@ -208,6 +209,7 @@ impl ExecutionProxyClient {
         buffer_manager_back_pressure_enabled: bool,
         consensus_observer_config: ConsensusObserverConfig,
         consensus_publisher: Option<Arc<ConsensusPublisher>>,
+        new_pipeline_enabled: bool,
     ) {
         let network_sender = NetworkSender::new(
             self.author,
@@ -295,6 +297,7 @@ impl ExecutionProxyClient {
             consensus_publisher,
             self.consensus_config
                 .max_pending_rounds_in_commit_vote_cache,
+            new_pipeline_enabled,
         );
 
         tokio::spawn(execution_schedule_phase.start());
@@ -320,6 +323,7 @@ impl TExecutionClient for ExecutionProxyClient {
         fast_rand_config: Option<RandConfig>,
         rand_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingRandGenRequest>,
         highest_committed_round: Round,
+        new_pipeline_enabled: bool,
     ) {
         let maybe_rand_msg_tx = self.spawn_decoupled_execution(
             maybe_consensus_key,
@@ -333,6 +337,7 @@ impl TExecutionClient for ExecutionProxyClient {
             self.consensus_config.enable_pre_commit,
             self.consensus_observer_config,
             self.consensus_publisher.clone(),
+            new_pipeline_enabled,
         );
 
         let transaction_shuffler =
@@ -536,6 +541,7 @@ impl TExecutionClient for DummyExecutionClient {
         _fast_rand_config: Option<RandConfig>,
         _rand_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingRandGenRequest>,
         _highest_committed_round: Round,
+        _new_pipeline_enabled: bool,
     ) {
     }
 

--- a/consensus/src/pipeline/pipeline_builder.rs
+++ b/consensus/src/pipeline/pipeline_builder.rs
@@ -82,7 +82,10 @@ fn spawn_shared_fut<
     async move {
         match join_handle.await {
             Ok(Ok(res)) => Ok(res),
-            Ok(Err(e)) => Err(TaskError::PropagatedError(Box::new(e))),
+            Ok(e @ Err(TaskError::PropagatedError(_))) => e,
+            Ok(Err(e @ TaskError::InternalError(_))) => {
+                Err(TaskError::PropagatedError(Box::new(e)))
+            },
             Err(e) => Err(TaskError::JoinError(Arc::new(e))),
         }
     }

--- a/consensus/src/pipeline/pipeline_builder.rs
+++ b/consensus/src/pipeline/pipeline_builder.rs
@@ -83,7 +83,7 @@ fn spawn_shared_fut<
         match join_handle.await {
             Ok(Ok(res)) => Ok(res),
             Ok(e @ Err(TaskError::PropagatedError(_))) => e,
-            Ok(Err(e @ TaskError::InternalError(_))) => {
+            Ok(Err(e @ TaskError::InternalError(_) | e @ TaskError::JoinError(_))) => {
                 Err(TaskError::PropagatedError(Box::new(e)))
             },
             Err(e) => Err(TaskError::JoinError(Arc::new(e))),

--- a/consensus/src/pipeline/pipeline_builder.rs
+++ b/consensus/src/pipeline/pipeline_builder.rs
@@ -151,7 +151,7 @@ impl Tracker {
             .with_label_values(&[self.name, "work_time"])
             .observe(work_time.as_secs_f64());
         info!(
-            "[Pipeline] Block {} {} {} finishes {}, waits {}, takes {}",
+            "[Pipeline] Block {} {} {} finishes {}, waits {}ms, takes {}ms",
             self.block_id,
             self.epoch,
             self.round,

--- a/consensus/src/pipeline/tests/buffer_manager_tests.rs
+++ b/consensus/src/pipeline/tests/buffer_manager_tests.rs
@@ -162,6 +162,7 @@ pub fn prepare_buffer_manager(
         ConsensusObserverConfig::default(),
         None,
         100,
+        true,
     );
 
     (

--- a/consensus/src/test_utils/mock_execution_client.rs
+++ b/consensus/src/test_utils/mock_execution_client.rs
@@ -108,6 +108,7 @@ impl TExecutionClient for MockExecutionClient {
         _fast_rand_config: Option<RandConfig>,
         _rand_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingRandGenRequest>,
         _highest_committed_round: Round,
+        _new_pipeline_enabled: bool,
     ) {
     }
 

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -24,7 +24,6 @@ use aptos_sdk::types::on_chain_config::{
 };
 use aptos_testcases::{
     load_vs_perf_benchmark::{LoadVsPerfBenchmark, TransactionWorkload, Workloads},
-    modifiers::CpuChaosTest,
     multi_region_network_test::MultiRegionNetworkEmulationTest,
     performance_test::PerformanceBenchmark,
     two_traffics_test::TwoTrafficsTest,
@@ -504,9 +503,8 @@ pub fn wrap_with_realistic_env<T: NetworkTest + 'static>(
     num_validators: usize,
     test: T,
 ) -> CompositeNetworkTest {
-    CompositeNetworkTest::new_with_two_wrappers(
+    CompositeNetworkTest::new(
         MultiRegionNetworkEmulationTest::default_for_validator_count(num_validators),
-        CpuChaosTest::default(),
         test,
     )
 }

--- a/testsuite/forge/src/config.rs
+++ b/testsuite/forge/src/config.rs
@@ -242,6 +242,10 @@ impl ForgeConfig {
             // enable optqs
             helm_values["validator"]["config"]["consensus"]["quorum_store"]
                 ["enable_opt_quorum_store"] = true.into();
+
+            helm_values["validator"]["config"]["consensus"]["enable_pipeline"] = true.into();
+            helm_values["fullnode"]["config"]["consensus_observer"]["enable_pipeline"] =
+                true.into();
         }))
     }
 


### PR DESCRIPTION
- tolerate the case when the parent block's future gets garbage collected (i.e. at epoch boundary)
- move pipeline creation to be exclusive with sync (either target or fallback)

