### PR TITLE
Fix state merkle truncate

### DIFF
--- a/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
+++ b/storage/aptosdb/src/ledger_db/ledger_metadata_db.rs
@@ -61,7 +61,7 @@ impl LedgerMetadataDb {
         )
     }
 
-    pub(super) fn db(&self) -> &DB {
+    pub(crate) fn db(&self) -> &DB {
         &self.db
     }
 

--- a/storage/aptosdb/src/utils/truncation_helper.rs
+++ b/storage/aptosdb/src/utils/truncation_helper.rs
@@ -4,7 +4,7 @@
 #![allow(dead_code)]
 
 use crate::{
-    ledger_db::{LedgerDb, LedgerDbSchemaBatches},
+    ledger_db::{ledger_metadata_db::LedgerMetadataDb, LedgerDb, LedgerDbSchemaBatches},
     schema::{
         db_metadata::{DbMetadataKey, DbMetadataSchema, DbMetadataValue},
         epoch_by_version::EpochByVersionSchema,
@@ -201,7 +201,7 @@ pub(crate) fn truncate_state_merkle_db_single_shard(
 }
 
 pub(crate) fn find_tree_root_at_or_before(
-    ledger_metadata_db: &DB,
+    ledger_metadata_db: &LedgerMetadataDb,
     state_merkle_db: &StateMerkleDb,
     version: Version,
 ) -> Result<Option<Version>> {
@@ -214,8 +214,11 @@ pub(crate) fn find_tree_root_at_or_before(
 
         // It's possible that it's a partial commit when sharding is not enabled,
         // look again for the previous version:
+        if version == 0 {
+            return Ok(None);
+        }
         if let Some(closest_version) =
-            find_closest_node_version_at_or_before(state_merkle_db.metadata_db(), version)?
+            find_closest_node_version_at_or_before(state_merkle_db.metadata_db(), version - 1)?
         {
             if root_exists_at_version(state_merkle_db, closest_version)? {
                 return Ok(Some(closest_version));
@@ -223,7 +226,7 @@ pub(crate) fn find_tree_root_at_or_before(
 
             // Now we are probably looking at a pruned version in this epoch, look for the previous
             // epoch ending:
-            let mut iter = ledger_metadata_db.iter::<EpochByVersionSchema>()?;
+            let mut iter = ledger_metadata_db.db().iter::<EpochByVersionSchema>()?;
             iter.seek_for_prev(&version)?;
             if let Some((closest_epoch_version, _)) = iter.next().transpose()? {
                 if root_exists_at_version(state_merkle_db, closest_epoch_version)? {

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -530,7 +530,7 @@ async fn test_db_restart() {
         quit_flag.clone(),
     ));
 
-    for round in 0..3 {
+    for round in 0..10 {
         info!("{LINE} Restart round {round}");
         for (v, vid) in restarting_validator_ids.iter().enumerate() {
             let validator = swarm.validator_mut(*vid).unwrap();


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

in case of a partial commit on a unsharded state db, two things were wrong:
1. when we see a partial version, we need to look at the previous version before jumping the the epoch boundary (we forgot to subtract 1 from the version)
2. the ledger meta db were not passed in as intended (instead, we passed the state merkle meta db)

incomplete / faulty fix previously https://github.com/aptos-labs/aptos-core/pull/15089

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

The test_db_restart smoke test does catch this sometimes but it's not easy to trigger. I bumped the number of restarts on that test.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] Bug fix


## Which Components or Systems Does This Change Impact?
- [x] Validator Node



<!-- Thank you for your contribution! -->
