### PR TITLE
Bump cli version to 6.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+## [6.0.2] - 2025/01/24
+- Fix `aptos workspace run` so it does not panic when writing to closed stdout/stderr, allowing it to finish its graceful shutdown sequence when used as a child process.
+
 ## [6.0.1] - 2025/01/17
 - Update Hasura metadata to include `entry_function_contract_address`, `entry_function_module_name`, and `entry_function_function_name` in `user_transactions` table.
 

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "6.0.1"
+version = "6.0.2"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
This bumps the CLI version to 6.0.2 so we can release a fixed version that can be used by aptos workspace.