### PR TITLE
[execution-pool] BlockRetrievalRequest struct -> enum

### DIFF
--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -88,29 +88,23 @@ impl fmt::Display for BlockRetrievalRequestV1 {
 pub struct BlockRetrievalRequestV2 {
     block_id: HashValue,
     num_blocks: u64,
-    // TODO: remove the Option, if it's not too painful
-    target_epoch_and_round: Option<(u64, u64)>,
+    target_round: u64,
 }
 
 impl BlockRetrievalRequestV2 {
-    pub fn new(block_id: HashValue, num_blocks: u64) -> Self {
+    pub fn new(block_id: HashValue, num_blocks: u64, target_round: u64) -> Self {
         BlockRetrievalRequestV2 {
             block_id,
             num_blocks,
-            target_epoch_and_round: None,
+            target_round,
         }
     }
 
-    pub fn new_with_target_round(
-        block_id: HashValue,
-        num_blocks: u64,
-        target_epoch: u64,
-        target_round: u64,
-    ) -> Self {
+    pub fn new_with_target_round(block_id: HashValue, num_blocks: u64, target_round: u64) -> Self {
         BlockRetrievalRequestV2 {
             block_id,
             num_blocks,
-            target_epoch_and_round: Some((target_epoch, target_round)),
+            target_round,
         }
     }
 
@@ -122,13 +116,12 @@ impl BlockRetrievalRequestV2 {
         self.num_blocks
     }
 
-    pub fn target_epoch_and_round(&self) -> Option<(u64, u64)> {
-        self.target_epoch_and_round
+    pub fn target_round(&self) -> u64 {
+        self.target_round
     }
 
-    pub fn match_target_round(&self, epoch: u64, round: u64) -> bool {
-        self.target_epoch_and_round()
-            .map_or(false, |target| (epoch, round) <= target)
+    pub fn match_target_round(&self, round: u64) -> bool {
+        round <= self.target_round()
     }
 }
 

--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -23,11 +23,15 @@ pub enum BlockRetrievalRequest {
 
 /// RPC to get a chain of block of the given length starting from the given block id.
 /// TODO @bchocho @hariria fix comment after all nodes upgrade to release with enum BlockRetrievalRequest (not struct)
-/// NOTE: The [`BlockRetrievalRequest`](BlockRetrievalRequest) struct is being renamed to
-/// [`BlockRetrievalRequestV1`](BlockRetrievalRequestV1) and deprecated in favor of a
-/// [`BlockRetrievalRequest`](BlockRetrievalRequest) enum
 ///
-/// Going forward, please use the [`BlockRetrievalRequest`](BlockRetrievalRequest) enum
+/// NOTE:
+/// 1. The [`BlockRetrievalRequest`](BlockRetrievalRequest) struct was renamed to
+///    [`BlockRetrievalRequestV1`](BlockRetrievalRequestV1) and deprecated
+/// 2. [`BlockRetrievalRequest`](BlockRetrievalRequest) enum was introduced to replace the old
+///    [`BlockRetrievalRequest`](BlockRetrievalRequest) struct
+///
+/// Please use the [`BlockRetrievalRequest`](BlockRetrievalRequest) enum going forward once this enum
+/// is introduced in the next release
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct BlockRetrievalRequestV1 {
     block_id: HashValue,
@@ -157,6 +161,7 @@ impl BlockRetrievalResponse {
         &self.blocks
     }
 
+    /// TODO @bchocho @hariria change `retrieval_request` after all nodes upgrade to release with enum BlockRetrievalRequest (not struct)
     pub fn verify(
         &self,
         retrieval_request: BlockRetrievalRequestV1,

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -27,7 +27,7 @@ use anyhow::{anyhow, bail, Context};
 use aptos_consensus_types::{
     block::Block,
     block_retrieval::{
-        BlockRetrievalRequest, BlockRetrievalResponse, BlockRetrievalStatus, NUM_PEERS_PER_RETRY,
+        BlockRetrievalRequestV1, BlockRetrievalResponse, BlockRetrievalStatus, NUM_PEERS_PER_RETRY,
         NUM_RETRIES, RETRY_INTERVAL_MSEC, RPC_TIMEOUT_MSEC,
     },
     common::Author,
@@ -576,7 +576,7 @@ impl BlockRetriever {
                     .boxed(),
                 )
             }
-            let request = BlockRetrievalRequest::new_with_target_block_id(
+            let request = BlockRetrievalRequestV1::new_with_target_block_id(
                 block_id,
                 retrieve_batch_size,
                 target_block_id,

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -17,7 +17,7 @@ use crate::{
     epoch_manager::LivenessStorageData,
     logging::{LogEvent, LogSchema},
     monitor,
-    network::{IncomingBlockRetrievalRequest, NetworkSender},
+    network::{DeprecatedIncomingBlockRetrievalRequest, NetworkSender},
     network_interface::ConsensusMsg,
     payload_manager::TPayloadManager,
     persistent_liveness_storage::{LedgerRecoveryData, PersistentLivenessStorage, RecoveryData},
@@ -470,7 +470,7 @@ impl BlockStore {
     /// future possible changes.
     pub async fn process_block_retrieval(
         &self,
-        request: IncomingBlockRetrievalRequest,
+        request: DeprecatedIncomingBlockRetrievalRequest,
     ) -> anyhow::Result<()> {
         fail_point!("consensus::process_block_retrieval", |_| {
             Err(anyhow::anyhow!("Injected error in process_block_retrieval"))

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -17,7 +17,9 @@ use crate::{
     epoch_manager::LivenessStorageData,
     logging::{LogEvent, LogSchema},
     monitor,
-    network::{DeprecatedIncomingBlockRetrievalRequest, NetworkSender},
+    network::{
+        DeprecatedIncomingBlockRetrievalRequest, IncomingBlockRetrievalRequest, NetworkSender,
+    },
     network_interface::ConsensusMsg,
     payload_manager::TPayloadManager,
     persistent_liveness_storage::{LedgerRecoveryData, PersistentLivenessStorage, RecoveryData},
@@ -504,6 +506,23 @@ impl BlockStore {
             .response_sender
             .send(Ok(response_bytes.into()))
             .map_err(|_| anyhow::anyhow!("Failed to send block retrieval response"))
+    }
+
+    /// TODO @bchocho @hariria to implement in upcoming PR
+    /// Retrieve a n chained blocks from the block store starting from
+    /// an initial parent id, returning with <n (as many as possible) if
+    /// id or its ancestors can not be found.
+    ///
+    /// The current version of the function is not really async, but keeping it this way for
+    /// future possible changes.
+    pub async fn process_block_retrieval_v2(
+        &self,
+        request: IncomingBlockRetrievalRequest,
+    ) -> anyhow::Result<()> {
+        bail!(
+            "Unexpected request {:?} for process_block_retrieval_v2",
+            request.req
+        )
     }
 }
 

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -23,7 +23,7 @@ use anyhow::{anyhow, bail, ensure};
 use aptos_channels::{self, aptos_channel, message_queues::QueueStyle};
 use aptos_config::network_id::NetworkId;
 use aptos_consensus_types::{
-    block_retrieval::{BlockRetrievalRequest, BlockRetrievalResponse},
+    block_retrieval::{BlockRetrievalRequest, BlockRetrievalRequestV1, BlockRetrievalResponse},
     common::Author,
     order_vote_msg::OrderVoteMsg,
     pipeline::{commit_decision::CommitDecision, commit_vote::CommitVote},
@@ -92,10 +92,24 @@ impl RpcResponder {
     }
 }
 
+/// NOTE: The [`IncomingBlockRetrievalRequest`](IncomingBlockRetrievalRequest) struct is being
+/// deprecated in favor of [`IncomingBlockRetrievalRequestV2`](IncomingBlockRetrievalRequestV2) which
+/// supports the new [`BlockRetrievalRequest`](BlockRetrievalRequest) enum for the `req` field
+///
+/// Going forward, please use [`IncomingBlockRetrievalRequestV2`](IncomingBlockRetrievalRequestV2)
+/// For more details, see comments above [`BlockRetrievalRequestV1`](BlockRetrievalRequestV1)
+/// TODO @bchocho @hariria can remove after all nodes upgrade to release with enum BlockRetrievalRequest (not struct)
+#[derive(Debug)]
+pub struct IncomingBlockRetrievalRequest {
+    pub req: BlockRetrievalRequestV1,
+    pub protocol: ProtocolId,
+    pub response_sender: oneshot::Sender<Result<Bytes, RpcError>>,
+}
+
 /// The block retrieval request is used internally for implementing RPC: the callback is executed
 /// for carrying the response
 #[derive(Debug)]
-pub struct IncomingBlockRetrievalRequest {
+pub struct IncomingBlockRetrievalRequestV2 {
     pub req: BlockRetrievalRequest,
     pub protocol: ProtocolId,
     pub response_sender: oneshot::Sender<Result<Bytes, RpcError>>,
@@ -132,21 +146,26 @@ pub struct IncomingRandGenRequest {
 
 #[derive(Debug)]
 pub enum IncomingRpcRequest {
-    BlockRetrieval(IncomingBlockRetrievalRequest),
+    /// NOTE: This is being phased out in two releases to accommodate `IncomingBlockRetrievalRequestV2`
+    /// TODO @bchocho @hariria can remove after all nodes upgrade to release with enum BlockRetrievalRequest (not struct)
+    DeprecatedBlockRetrieval(IncomingBlockRetrievalRequest),
     BatchRetrieval(IncomingBatchRetrievalRequest),
     DAGRequest(IncomingDAGRequest),
     CommitRequest(IncomingCommitRequest),
     RandGenRequest(IncomingRandGenRequest),
+    BlockRetrievalV2(IncomingBlockRetrievalRequestV2),
 }
 
 impl IncomingRpcRequest {
+    /// TODO @bchocho @hariria can remove after all nodes upgrade to release with enum BlockRetrievalRequest (not struct)
     pub fn epoch(&self) -> Option<u64> {
         match self {
             IncomingRpcRequest::BatchRetrieval(req) => Some(req.req.epoch()),
             IncomingRpcRequest::DAGRequest(req) => Some(req.req.epoch()),
             IncomingRpcRequest::RandGenRequest(req) => Some(req.req.epoch()),
             IncomingRpcRequest::CommitRequest(req) => req.req.epoch(),
-            IncomingRpcRequest::BlockRetrieval(_) => None,
+            IncomingRpcRequest::DeprecatedBlockRetrieval(_) => None,
+            IncomingRpcRequest::BlockRetrievalV2(_) => None,
         }
     }
 }
@@ -223,7 +242,7 @@ impl NetworkSender {
     /// returns a future that is fulfilled with BlockRetrievalResponse.
     pub async fn request_block(
         &self,
-        retrieval_request: BlockRetrievalRequest,
+        retrieval_request: BlockRetrievalRequestV1,
         from: Author,
         timeout: Duration,
     ) -> anyhow::Result<BlockRetrievalResponse> {
@@ -812,11 +831,13 @@ impl NetworkTask {
                                 "{}",
                                 request
                             );
-                            IncomingRpcRequest::BlockRetrieval(IncomingBlockRetrievalRequest {
-                                req: *request,
-                                protocol,
-                                response_sender: callback,
-                            })
+                            IncomingRpcRequest::DeprecatedBlockRetrieval(
+                                IncomingBlockRetrievalRequest {
+                                    req: *request,
+                                    protocol,
+                                    response_sender: callback,
+                                },
+                            )
                         },
                         ConsensusMsg::BatchRequestMsg(request) => {
                             debug!(

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -35,11 +35,11 @@ use std::{collections::HashMap, time::Duration};
 /// Network type for consensus
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum ConsensusMsg {
-    /// DEPRECATED: Please use [`ConsensusMsg::BlockRetrievalRequestV2`](ConsensusMsg::BlockRetrievalRequestV2) going forward
+    /// DEPRECATED: Once this is introduced in the next release, please use
+    /// [`ConsensusMsg::BlockRetrievalRequest`](ConsensusMsg::BlockRetrievalRequest) going forward
+    /// This variant was renamed from `BlockRetrievalRequest` to `DeprecatedBlockRetrievalRequest`
     /// RPC to get a chain of block of the given length starting from the given block id.
-    /// Note: Naming here is `BlockRetrievalRequest` and not `DeprecatedBlockRetrievalRequest`
-    /// to be consistent with the naming implementation in [`ConsensusMsg::name`](ConsensusMsg::name)
-    BlockRetrievalRequest(Box<BlockRetrievalRequestV1>),
+    DeprecatedBlockRetrievalRequest(Box<BlockRetrievalRequestV1>),
     /// Carries the returned blocks and the retrieval status.
     BlockRetrievalResponse(Box<BlockRetrievalResponse>),
     /// Request to get a EpochChangeProof from current_epoch to target_epoch
@@ -87,7 +87,7 @@ pub enum ConsensusMsg {
     /// RoundTimeoutMsg is broadcasted by a validator once it decides to timeout the current round.
     RoundTimeoutMsg(Box<RoundTimeoutMsg>),
     /// RPC to get a chain of block of the given length starting from the given block id, using epoch and round.
-    BlockRetrievalRequestV2(Box<BlockRetrievalRequest>),
+    BlockRetrievalRequest(Box<BlockRetrievalRequest>),
 }
 
 /// Network type for consensus
@@ -96,8 +96,7 @@ impl ConsensusMsg {
     /// TODO @bchocho @hariria can remove after all nodes upgrade to release with enum BlockRetrievalRequest (not struct)
     pub fn name(&self) -> &str {
         match self {
-            // TODO Not changing the naming. Double check if this is OK
-            ConsensusMsg::BlockRetrievalRequest(_) => "BlockRetrievalRequest",
+            ConsensusMsg::DeprecatedBlockRetrievalRequest(_) => "DeprecatedBlockRetrievalRequest",
             ConsensusMsg::BlockRetrievalResponse(_) => "BlockRetrievalResponse",
             ConsensusMsg::EpochRetrievalRequest(_) => "EpochRetrievalRequest",
             ConsensusMsg::ProposalMsg(_) => "ProposalMsg",
@@ -117,8 +116,7 @@ impl ConsensusMsg {
             ConsensusMsg::RandGenMessage(_) => "RandGenMessage",
             ConsensusMsg::BatchResponseV2(_) => "BatchResponseV2",
             ConsensusMsg::RoundTimeoutMsg(_) => "RoundTimeoutV2",
-            // TODO should this also be BlockRetrievalRequest? What's the appropriate naming here?
-            ConsensusMsg::BlockRetrievalRequestV2(_) => "BlockRetrievalRequestV2",
+            ConsensusMsg::BlockRetrievalRequest(_) => "BlockRetrievalRequest",
         }
     }
 }

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -880,7 +880,7 @@ mod tests {
             .push((peer_id, protocol_id), bad_msg)
             .unwrap();
 
-        let liveness_check_msg = ConsensusMsg::BlockRetrievalRequest(Box::new(
+        let liveness_check_msg = ConsensusMsg::DeprecatedBlockRetrievalRequest(Box::new(
             BlockRetrievalRequestV1::new(HashValue::random(), 1),
         ));
 

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -535,7 +535,7 @@ mod tests {
     };
     use aptos_config::network_id::{NetworkId, PeerNetworkId};
     use aptos_consensus_types::{
-        block_retrieval::{BlockRetrievalRequest, BlockRetrievalResponse, BlockRetrievalStatus},
+        block_retrieval::{BlockRetrievalRequestV1, BlockRetrievalResponse, BlockRetrievalStatus},
         common::Payload,
     };
     use aptos_crypto::HashValue;
@@ -824,8 +824,9 @@ mod tests {
                     BlockRetrievalResponse::new(BlockRetrievalStatus::IdNotFound, vec![]);
                 let response = ConsensusMsg::BlockRetrievalResponse(Box::new(response));
                 let bytes = Bytes::from(serde_json::to_vec(&response).unwrap());
+                // TODO: @bchocho @hariria can change after all nodes upgrade to release with enum BlockRetrievalRequest (not struct)
                 match request {
-                    IncomingRpcRequest::BlockRetrieval(request) => {
+                    IncomingRpcRequest::DeprecatedBlockRetrieval(request) => {
                         request.response_sender.send(Ok(bytes)).unwrap()
                     },
                     _ => panic!("unexpected message"),
@@ -837,7 +838,7 @@ mod tests {
         timed_block_on(&runtime, async {
             let response = nodes[0]
                 .request_block(
-                    BlockRetrievalRequest::new(HashValue::zero(), 1),
+                    BlockRetrievalRequestV1::new(HashValue::zero(), 1),
                     peer,
                     Duration::from_secs(5),
                 )
@@ -880,7 +881,7 @@ mod tests {
             .unwrap();
 
         let liveness_check_msg = ConsensusMsg::BlockRetrievalRequest(Box::new(
-            BlockRetrievalRequest::new(HashValue::random(), 1),
+            BlockRetrievalRequestV1::new(HashValue::random(), 1),
         ));
 
         let protocol_id = ProtocolId::ConsensusRpcJson;

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -14,7 +14,7 @@ use crate::{
         round_state::{ExponentialTimeInterval, RoundState},
     },
     metrics_safety_rules::MetricsSafetyRules,
-    network::{IncomingBlockRetrievalRequest, NetworkSender},
+    network::{IncomingBlockRetrievalRequest, IncomingBlockRetrievalRequestV2, NetworkSender},
     network_interface::{CommitMessage, ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},
     network_tests::{NetworkPlayground, TwinId},
     payload_manager::DirectMempoolPayloadManager,
@@ -38,7 +38,7 @@ use aptos_consensus_types::{
         block_test_utils::{certificate_for_genesis, gen_test_certificate},
         Block,
     },
-    block_retrieval::{BlockRetrievalRequest, BlockRetrievalStatus},
+    block_retrieval::{BlockRetrievalRequest, BlockRetrievalRequestV1, BlockRetrievalStatus},
     common::{Author, Payload, Round},
     order_vote_msg::OrderVoteMsg,
     pipeline::commit_decision::CommitDecision,
@@ -504,10 +504,41 @@ impl NodeSetup {
         self.commit_decision_queue.pop_front().unwrap()
     }
 
-    pub async fn poll_block_retreival(&mut self) -> Option<IncomingBlockRetrievalRequest> {
+    /// SOON TO BE DEPRECATED: Please use [`poll_block_retrieval_v2`](NodeSetup::poll_block_retrieval_v2) going forward
+    /// NOTE: [`IncomingBlockRetrievalRequest`](IncomingBlockRetrievalRequest) is being phased out over two releases
+    /// After the first release, this can be deleted
+    pub async fn poll_block_retrieval(&mut self) -> Option<IncomingBlockRetrievalRequest> {
         match self.poll_next_network_event() {
             Some(Event::RpcRequest(_, msg, protocol, response_sender)) => match msg {
                 ConsensusMsg::BlockRetrievalRequest(v) => Some(IncomingBlockRetrievalRequest {
+                    req: *v,
+                    protocol,
+                    response_sender,
+                }),
+                msg => panic!(
+                    "Unexpected Consensus Message: {:?} on node {}",
+                    msg,
+                    self.identity_desc()
+                ),
+            },
+            Some(Event::Message(_, msg)) => panic!(
+                "Unexpected Consensus Message: {:?} on node {}",
+                msg,
+                self.identity_desc()
+            ),
+            None => None,
+        }
+    }
+
+    pub async fn poll_block_retrieval_v2(&mut self) -> Option<IncomingBlockRetrievalRequestV2> {
+        match self.poll_next_network_event() {
+            Some(Event::RpcRequest(_, msg, protocol, response_sender)) => match msg {
+                ConsensusMsg::BlockRetrievalRequest(v) => Some(IncomingBlockRetrievalRequestV2 {
+                    req: BlockRetrievalRequest::V1(*v),
+                    protocol,
+                    response_sender,
+                }),
+                ConsensusMsg::BlockRetrievalRequestV2(v) => Some(IncomingBlockRetrievalRequestV2 {
                     req: *v,
                     protocol,
                     response_sender,
@@ -569,7 +600,7 @@ fn start_replying_to_block_retreival(nodes: Vec<NodeSetup>) -> ReplyingRPCHandle
         handles.push(tokio::spawn(async move {
             while !done_clone.load(Ordering::Relaxed) {
                 info!("Asking for RPC request on {:?}", node.identity_desc());
-                let maybe_request = node.poll_block_retreival().await;
+                let maybe_request = node.poll_block_retrieval().await;
                 if let Some(request) = maybe_request {
                     info!(
                         "RPC request received: {:?} on {:?}",
@@ -1338,7 +1369,7 @@ fn response_on_block_retrieval() {
         // first verify that we can retrieve the block if it's in the tree
         let (tx1, rx1) = oneshot::channel();
         let single_block_request = IncomingBlockRetrievalRequest {
-            req: BlockRetrievalRequest::new(block_id, 1),
+            req: BlockRetrievalRequestV1::new(block_id, 1),
             protocol: ProtocolId::ConsensusRpcBcs,
             response_sender: tx1,
         };
@@ -1361,7 +1392,7 @@ fn response_on_block_retrieval() {
         // verify that if a block is not there, return ID_NOT_FOUND
         let (tx2, rx2) = oneshot::channel();
         let missing_block_request = IncomingBlockRetrievalRequest {
-            req: BlockRetrievalRequest::new(HashValue::random(), 1),
+            req: BlockRetrievalRequestV1::new(HashValue::random(), 1),
             protocol: ProtocolId::ConsensusRpcBcs,
             response_sender: tx2,
         };
@@ -1385,7 +1416,7 @@ fn response_on_block_retrieval() {
         // if asked for many blocks, return NOT_ENOUGH_BLOCKS
         let (tx3, rx3) = oneshot::channel();
         let many_block_request = IncomingBlockRetrievalRequest {
-            req: BlockRetrievalRequest::new(block_id, 3),
+            req: BlockRetrievalRequestV1::new(block_id, 3),
             protocol: ProtocolId::ConsensusRpcBcs,
             response_sender: tx3,
         };

--- a/testsuite/generate-format/src/consensus.rs
+++ b/testsuite/generate-format/src/consensus.rs
@@ -117,6 +117,7 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<aptos_consensus_types::block_retrieval::BlockRetrievalStatus>(&samples)?;
     tracer.trace_type::<aptos_consensus_types::payload::PayloadExecutionLimit>(&samples)?;
     tracer.trace_type::<aptos_consensus_types::common::Payload>(&samples)?;
+    tracer.trace_type::<aptos_consensus_types::block_retrieval::BlockRetrievalRequest>(&samples)?;
 
     // aliases within StructTag
     tracer.ignore_aliases("StructTag", &["type_params"])?;

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -269,6 +269,16 @@ BlockMetadataWithRandomness:
         OPTION:
           TYPENAME: Randomness
 BlockRetrievalRequest:
+  ENUM:
+    0:
+      V1:
+        NEWTYPE:
+          TYPENAME: BlockRetrievalRequestV1
+    1:
+      V2:
+        NEWTYPE:
+          TYPENAME: BlockRetrievalRequestV2
+BlockRetrievalRequestV1:
   STRUCT:
     - block_id:
         TYPENAME: HashValue
@@ -276,6 +286,12 @@ BlockRetrievalRequest:
     - target_block_id:
         OPTION:
           TYPENAME: HashValue
+BlockRetrievalRequestV2:
+  STRUCT:
+    - block_id:
+        TYPENAME: HashValue
+    - num_blocks: U64
+    - target_round: U64
 BlockRetrievalResponse:
   STRUCT:
     - status:
@@ -362,7 +378,7 @@ ConsensusMsg:
     0:
       BlockRetrievalRequest:
         NEWTYPE:
-          TYPENAME: BlockRetrievalRequest
+          TYPENAME: BlockRetrievalRequestV1
     1:
       BlockRetrievalResponse:
         NEWTYPE:
@@ -439,6 +455,10 @@ ConsensusMsg:
       RoundTimeoutMsg:
         NEWTYPE:
           TYPENAME: RoundTimeoutMsg
+    20:
+      BlockRetrievalRequestV2:
+        NEWTYPE:
+          TYPENAME: BlockRetrievalRequest
 ContractEvent:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -376,7 +376,7 @@ CommitVote:
 ConsensusMsg:
   ENUM:
     0:
-      BlockRetrievalRequest:
+      DeprecatedBlockRetrievalRequest:
         NEWTYPE:
           TYPENAME: BlockRetrievalRequestV1
     1:
@@ -456,7 +456,7 @@ ConsensusMsg:
         NEWTYPE:
           TYPENAME: RoundTimeoutMsg
     20:
-      BlockRetrievalRequestV2:
+      BlockRetrievalRequest:
         NEWTYPE:
           TYPENAME: BlockRetrievalRequest
 ContractEvent:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Deprecates the `BlockRetrievalRequest` struct in favor of a `BlockRetrievalRequest` enum. This is needed as execution pool plans to make `BlockRetrievalRequest`s that include epoch and round information instead of `target_block_id`.

The plan is to phase this in three releases. The first release will introduce the new `BlockRetrievalRequest` enum and all corresponding structs / logic that use it. The second release will deprecate the `BlockRetrievalRequestV1` struct and all related structs / logic.

> [!IMPORTANT]  
> Some TODOs around deprecation are already marked in the code. Additional TODO in future PRs:
> - [ ] `process_block_retrieval_v2` to be implemented in a future PR cc @bchocho @hariria 
> - [ ] Once the new `BlockRetrievalRequest` enum is in the mainnet release, [`request_block`](https://github.com/aptos-labs/aptos-core/blob/ca4499f14b0a0fe7275d41071b28ab5a782b4fe7/consensus/src/network.rs#L260-L260) should send `ConsensusMsg::BlockRetrievalRequest` instead of `ConsensusMsg::DeprecatedBlockRetrievalRequest`

Additional Questions

- [ ] Why does `consensus.yaml` require `TUPLEARRAY` instead of `TUPLE`?

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
