### PR TITLE
[move] Struct and reference types in interpreter

### DIFF
--- a/third_party/move/move-vm/integration-tests/src/tests/module_storage_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/module_storage_tests.rs
@@ -86,13 +86,10 @@ fn test_function_value_extension() {
     assert_eq!(
         foo_ty,
         ty_builder
-            .create_ref_ty(
-                &ty_builder.create_struct_ty(
-                    StructNameIndex::new(0),
-                    AbilityInfo::struct_(AbilitySet::EMPTY)
-                ),
-                false
-            )
+            .create_ref_ty::<false>(&ty_builder.create_struct_ty(
+                StructNameIndex::new(0),
+                AbilityInfo::struct_(AbilitySet::EMPTY)
+            ),)
             .unwrap()
     );
     let u64_ty = types.pop().unwrap();

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -1358,7 +1358,7 @@ impl<'a> Resolver<'a> {
             BinaryType::Module(module) => module.struct_at(idx),
             BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
         };
-        self.create_struct_ty(&struct_ty)
+        self.create_struct_ty(struct_ty)
     }
 
     pub(crate) fn get_struct_variant_at(
@@ -1450,12 +1450,9 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    pub(crate) fn get_struct(
-        &self,
-        idx: StructDefinitionIndex,
-    ) -> PartialVMResult<Arc<StructType>> {
+    pub(crate) fn get_struct_definition(&self, idx: StructDefinitionIndex) -> &Arc<StructType> {
         match &self.binary {
-            BinaryType::Module(module) => Ok(module.struct_at(idx)),
+            BinaryType::Module(module) => module.struct_at(idx),
             BinaryType::Script(_) => unreachable!("Scripts cannot have type instructions"),
         }
     }
@@ -1592,21 +1589,24 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    pub(crate) fn create_struct_ty(&self, struct_ty: &Arc<StructType>) -> Type {
-        self.loader()
-            .ty_builder()
-            .create_struct_ty(struct_ty.idx, AbilityInfo::struct_(struct_ty.abilities))
+    pub(crate) fn create_struct_ty(&self, struct_definition: &Arc<StructType>) -> Type {
+        self.loader().ty_builder().create_struct_ty(
+            struct_definition.idx,
+            AbilityInfo::struct_(struct_definition.abilities),
+        )
     }
 
     pub(crate) fn create_struct_instantiation_ty(
         &self,
-        struct_ty: &Arc<StructType>,
+        struct_definition: &Arc<StructType>,
         ty_params: &[Type],
         ty_args: &[Type],
     ) -> PartialVMResult<Type> {
-        self.loader()
-            .ty_builder()
-            .create_struct_instantiation_ty(struct_ty, ty_params, ty_args)
+        self.loader().ty_builder().create_struct_instantiation_ty(
+            struct_definition,
+            ty_params,
+            ty_args,
+        )
     }
 
     pub(crate) fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -632,8 +632,8 @@ impl Module {
         &self.id
     }
 
-    pub(crate) fn struct_at(&self, idx: StructDefinitionIndex) -> Arc<StructType> {
-        self.structs[idx.0 as usize].definition_struct_type.clone()
+    pub(crate) fn struct_at(&self, idx: StructDefinitionIndex) -> &Arc<StructType> {
+        &self.structs[idx.0 as usize].definition_struct_type
     }
 
     pub(crate) fn struct_instantiation_at(&self, idx: u16) -> &StructInstantiation {

--- a/third_party/move/move-vm/runtime/src/loader/script.rs
+++ b/third_party/move/move-vm/runtime/src/loader/script.rs
@@ -7,7 +7,7 @@ use move_binary_format::{
     access::ScriptAccess,
     binary_views::BinaryIndexedView,
     errors::{PartialVMError, PartialVMResult},
-    file_format::{Bytecode, CompiledScript, FunctionDefinitionIndex, Signature, SignatureIndex},
+    file_format::{Bytecode, CompiledScript, FunctionDefinitionIndex, SignatureIndex},
 };
 use move_core_types::{identifier::Identifier, language_storage::ModuleId, vm_status::StatusCode};
 use move_vm_types::loaded_data::{
@@ -86,41 +86,29 @@ impl Script {
             });
         }
 
-        let code: Vec<Bytecode> = script.code.code.clone();
-        let parameters = script.signature_at(script.parameters).clone();
+        let params = &script.signature_at(script.parameters).0;
+        let param_tys = params
+            .iter()
+            .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
+            .collect::<PartialVMResult<Vec<_>>>()?;
+        let local_tys = params
+            .iter()
+            .chain(script.signature_at(script.code.locals).0.iter())
+            .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
+            .collect::<PartialVMResult<Vec<_>>>()?;
 
-        let param_tys = parameters
-            .0
-            .iter()
-            .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
-            .collect::<PartialVMResult<Vec<_>>>()?;
-        let locals = Signature(
-            parameters
-                .0
-                .iter()
-                .chain(script.signature_at(script.code.locals).0.iter())
-                .cloned()
-                .collect(),
-        );
-        let local_tys = locals
-            .0
-            .iter()
-            .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
-            .collect::<PartialVMResult<Vec<_>>>()?;
-        let ty_param_abilities = script.type_parameters.clone();
-        // TODO: main does not have a name. Revisit.
-        let name = Identifier::new("main").unwrap();
-        let (native, def_is_native) = (None, false); // Script entries cannot be native
         let main: Arc<Function> = Arc::new(Function {
             file_format_version: script.version(),
             index: FunctionDefinitionIndex(0),
-            code,
-            ty_param_abilities,
-            native,
-            is_native: def_is_native,
+            code: script.code.code.clone(),
+            ty_param_abilities: script.type_parameters.clone(),
+            // Script entries cannot be native, entry or have visibility.
+            native: None,
+            is_native: false,
             is_friend_or_private: false,
             is_entry: false,
-            name,
+            // TODO: main does not have a name. Revisit.
+            name: Identifier::new("main").unwrap(),
             // Script must not return values.
             return_tys: vec![],
             local_tys,

--- a/third_party/move/move-vm/runtime/src/storage/ty_tag_converter.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_tag_converter.rs
@@ -274,10 +274,10 @@ mod tests {
         let disallowed_tys = [
             Type::TyParam(0),
             ty_builder
-                .create_ref_ty(&ty_builder.create_u8_ty(), true)
+                .create_ref_ty::<true>(&ty_builder.create_u8_ty())
                 .unwrap(),
             ty_builder
-                .create_ref_ty(&ty_builder.create_u8_ty(), false)
+                .create_ref_ty::<false>(&ty_builder.create_u8_ty())
                 .unwrap(),
         ];
         for ty in disallowed_tys {


### PR DESCRIPTION
## Description

Small VM nits:
- Change dynamic params for type creation to statics
- Avoid arc clones and struct creations for runtyme checks where possible.

## How Has This Been Tested?

Existing tests

## Key Areas to Review

Check that interpreter logic has not been changed

## Type of Change

- [x] Performance improvement
- [x] Refactoring

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
