### PR TITLE
[spec] use opaque in the spec of check_permission_exists

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/permissioned_signer.md
+++ b/aptos-move/framework/aptos-framework/doc/permissioned_signer.md
@@ -1808,6 +1808,9 @@ signer::address_of(master) == signer::address_of(signer_from_permissioned_handle
 
 
 <pre><code><b>pragma</b> verify = <b>false</b>;
+<b>pragma</b> opaque;
+<b>modifies</b> <b>global</b>&lt;<a href="permissioned_signer.md#0x1_permissioned_signer_PermissionStorage">PermissionStorage</a>&gt;(<a href="permissioned_signer.md#0x1_permissioned_signer_spec_permission_address">spec_permission_address</a>(s));
+<b>ensures</b> [abstract] result == <a href="permissioned_signer.md#0x1_permissioned_signer_spec_check_permission_exists">spec_check_permission_exists</a>(s, perm);
 </code></pre>
 
 
@@ -1816,22 +1819,7 @@ signer::address_of(master) == signer::address_of(signer_from_permissioned_handle
 <a id="0x1_permissioned_signer_spec_check_permission_exists"></a>
 
 
-<pre><code><b>fun</b> <a href="permissioned_signer.md#0x1_permissioned_signer_spec_check_permission_exists">spec_check_permission_exists</a>&lt;PermKey: <b>copy</b> + drop + store&gt;(s: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, perm: PermKey): bool {
-   <b>use</b> aptos_std::type_info;
-   <b>use</b> std::bcs;
-   <b>let</b> addr = <a href="permissioned_signer.md#0x1_permissioned_signer_spec_permission_address">spec_permission_address</a>(s);
-   <b>let</b> key = Any {
-       type_name: <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;PermKey&gt;(),
-       data: <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_serialize">bcs::serialize</a>(perm)
-   };
-   <b>if</b> (!<a href="permissioned_signer.md#0x1_permissioned_signer_spec_is_permissioned_signer">spec_is_permissioned_signer</a>(s)) { <b>true</b> }
-   <b>else</b> <b>if</b> (!<b>exists</b>&lt;<a href="permissioned_signer.md#0x1_permissioned_signer_PermissionStorage">PermissionStorage</a>&gt;(addr)) { <b>false</b> }
-   <b>else</b> {
-       // ordered_map::spec_contains_key(<b>global</b>&lt;<a href="permissioned_signer.md#0x1_permissioned_signer_PermissionStorage">PermissionStorage</a>&gt;(addr).perms, key)
-       // FIXME: ordered map <b>spec</b> doesn't exist yet.
-       <b>true</b>
-   }
-}
+<pre><code><b>fun</b> <a href="permissioned_signer.md#0x1_permissioned_signer_spec_check_permission_exists">spec_check_permission_exists</a>&lt;PermKey: <b>copy</b> + drop + store&gt;(s: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, perm: PermKey): bool;
 </code></pre>
 
 
@@ -1847,7 +1835,8 @@ signer::address_of(master) == signer::address_of(signer_from_permissioned_handle
 
 
 
-<pre><code><b>let</b> permissioned_signer_addr = <a href="permissioned_signer.md#0x1_permissioned_signer_spec_permission_address">spec_permission_address</a>(s);
+<pre><code><b>modifies</b> <b>global</b>&lt;<a href="permissioned_signer.md#0x1_permissioned_signer_PermissionStorage">PermissionStorage</a>&gt;(<a href="permissioned_signer.md#0x1_permissioned_signer_spec_permission_address">spec_permission_address</a>(s));
+<b>let</b> permissioned_signer_addr = <a href="permissioned_signer.md#0x1_permissioned_signer_spec_permission_address">spec_permission_address</a>(s);
 <b>ensures</b> !<a href="permissioned_signer.md#0x1_permissioned_signer_spec_is_permissioned_signer">spec_is_permissioned_signer</a>(s) ==&gt; result == <b>true</b>;
 <b>ensures</b> (
     <a href="permissioned_signer.md#0x1_permissioned_signer_spec_is_permissioned_signer">spec_is_permissioned_signer</a>(s)

--- a/aptos-move/framework/aptos-framework/sources/permissioned_signer.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/permissioned_signer.spec.move
@@ -113,31 +113,35 @@ spec aptos_framework::permissioned_signer {
 
     spec check_permission_exists<PermKey: copy + drop + store>(s: &signer, perm: PermKey): bool {
         pragma verify = false;
-        // pragma opaque;
-        // aborts_if false;
-        // ensures [abstract] result == spec_check_permission_exists(s, perm);
+        pragma opaque;
+        modifies global<PermissionStorage>(spec_permission_address(s));
+        ensures [abstract] result == spec_check_permission_exists(s, perm);
     }
 
-    spec fun spec_check_permission_exists<PermKey: copy + drop + store>(s: signer, perm: PermKey): bool {
-        use aptos_std::type_info;
-        use std::bcs;
-        let addr = spec_permission_address(s);
-        let key = Any {
-            type_name: type_info::type_name<PermKey>(),
-            data: bcs::serialize(perm)
-        };
-        if (!spec_is_permissioned_signer(s)) { true }
-        else if (!exists<PermissionStorage>(addr)) { false }
-        else {
-            // ordered_map::spec_contains_key(global<PermissionStorage>(addr).perms, key)
-            // FIXME: ordered map spec doesn't exist yet.
-            true
-        }
-    }
+    spec fun spec_check_permission_exists<PermKey: copy + drop + store>(s: signer, perm: PermKey): bool;
+
+
+    // spec fun spec_check_permission_exists<PermKey: copy + drop + store>(s: signer, perm: PermKey): bool {
+    //     use aptos_std::type_info;
+    //     use std::bcs;
+    //     let addr = spec_permission_address(s);
+    //     let key = Any {
+    //         type_name: type_info::type_name<PermKey>(),
+    //         data: bcs::serialize(perm)
+    //     };
+    //     if (!spec_is_permissioned_signer(s)) { true }
+    //     else if (!exists<PermissionStorage>(addr)) { false }
+    //     else {
+    //         // ordered_map::spec_contains_key(global<PermissionStorage>(addr).perms, key)
+    //         // FIXME: ordered map spec doesn't exist yet.
+    //         true
+    //     }
+    // }
 
     spec check_permission_capacity_above<PermKey: copy + drop + store>(
         s: &signer, threshold: u256, perm: PermKey
     ): bool {
+        modifies global<PermissionStorage>(spec_permission_address(s));
         let permissioned_signer_addr = spec_permission_address(s);
         ensures !spec_is_permissioned_signer(s) ==> result == true;
         ensures (

--- a/aptos-move/framework/aptos-framework/sources/permissioned_signer.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/permissioned_signer.spec.move
@@ -121,6 +121,7 @@ spec aptos_framework::permissioned_signer {
     spec fun spec_check_permission_exists<PermKey: copy + drop + store>(s: signer, perm: PermKey): bool;
 
 
+    // TODO(teng): add this back later
     // spec fun spec_check_permission_exists<PermKey: copy + drop + store>(s: signer, perm: PermKey): bool {
     //     use aptos_std::type_info;
     //     use std::bcs;


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR reduces memory usage of verification of framework to less than 30GB by making `check_permission_exists` opaque.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Existing tests

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Spec

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
