### PR TITLE
Fix compile error

### DIFF
--- a/third_party/move/move-vm/runtime/Cargo.toml
+++ b/third_party/move/move-vm/runtime/Cargo.toml
@@ -38,6 +38,7 @@ move-binary-format = { workspace = true, features = ["fuzzing"] }
 move-compiler = { workspace = true }
 move-ir-compiler = { workspace = true }
 move-vm-test-utils ={ workspace = true }
+move-vm-types = { workspace = true, features = ["testing"] }
 proptest = { workspace = true }
 
 [features]


### PR DESCRIPTION
## Description

Fix compile error when running `cargo test` on `move-vm-runtime`.

## How Has This Been Tested?

Existing tests.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine

