### PR TITLE
[benchmark] Add option for package overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3598,6 +3598,7 @@ dependencies = [
  "anyhow",
  "aptos-block-executor",
  "aptos-crypto",
+ "aptos-framework",
  "aptos-gas-schedule",
  "aptos-logger",
  "aptos-move-debugger",

--- a/aptos-move/replay-benchmark/Cargo.toml
+++ b/aptos-move/replay-benchmark/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-block-executor = { workspace = true }
+aptos-framework = { workspace = true }
 aptos-gas-schedule = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-move-debugger = { workspace = true }

--- a/aptos-move/replay-benchmark/README.md
+++ b/aptos-move/replay-benchmark/README.md
@@ -98,13 +98,14 @@ the state. Currently, the only supported overrides are the following:
   1. Forcefully enable a feature flag (`--enable-features F1 F2 ...`).
   2. Forcefully disable a feature flag (`--disable-features F1 F2 ...`).
   3. Forcefully override the gas feature version (`--gas-feature-version V`).
+  4. Override existing on-chain packages (`--override-packages P1 P2 P3`)
 
 Feature flags should be spelled in capital letters, e.g., `ENABLE_LOADER_V2`. For the full list of
 available features, see [here](../../types/src/on_chain_config/aptos_features.rs).
 
-Overriding the feature flags can be very useful if you want to experiment with a new feature and
-check its performance as well as the gas usage. For example, if there is a new feature that makes
-MoveVM faster, overriding it for past transactions it is possible to see the execution performance
+Overriding the state can be very useful if you want to experiment with a new feature or Move code,
+and check its performance as well as the gas usage. For example, if there is a new feature that
+makes MoveVM faster, overriding it for past transactions it is possible to see the execution performance
 on historical workloads.
 
 #### Example

--- a/aptos-move/replay-benchmark/README.md
+++ b/aptos-move/replay-benchmark/README.md
@@ -98,7 +98,8 @@ the state. Currently, the only supported overrides are the following:
   1. Forcefully enable a feature flag (`--enable-features F1 F2 ...`).
   2. Forcefully disable a feature flag (`--disable-features F1 F2 ...`).
   3. Forcefully override the gas feature version (`--gas-feature-version V`).
-  4. Override existing on-chain packages (`--override-packages P1 P2 P3`)
+  4. Override existing on-chain packages (`--override-packages P1 P2 P3`). The paths to the
+     packages must be the path to the source directories.
 
 Feature flags should be spelled in capital letters, e.g., `ENABLE_LOADER_V2`. For the full list of
 available features, see [here](../../types/src/on_chain_config/aptos_features.rs).

--- a/aptos-move/replay-benchmark/src/commands/initialize.rs
+++ b/aptos-move/replay-benchmark/src/commands/initialize.rs
@@ -4,11 +4,10 @@
 use crate::{
     commands::{build_debugger, init_logger_and_metrics, RestAPI},
     generator::InputOutputDiffGenerator,
-    overrides::{OverrideConfig, PackageOverride},
+    overrides::OverrideConfig,
     workload::TransactionBlock,
 };
 use anyhow::anyhow;
-use aptos_framework::BuildOptions;
 use aptos_logger::Level;
 use aptos_types::on_chain_config::FeatureFlag;
 use clap::Parser;
@@ -82,13 +81,11 @@ impl InitializeCommand {
         //   2. BlockExecutorConfigFromOnchain to experiment with different block cutting based
         //      on gas limits?.
         //   3. Build options for package overrides.
-        let build_options = BuildOptions::move_2();
-        let package_override = PackageOverride::new(self.override_packages, build_options)?;
         let override_config = OverrideConfig::new(
             self.enable_features,
             self.disable_features,
             self.gas_feature_version,
-            package_override,
+            self.override_packages,
         )?;
 
         let debugger = build_debugger(self.rest_api.rest_endpoint, self.rest_api.api_key)?;

--- a/aptos-move/replay-benchmark/src/overrides.rs
+++ b/aptos-move/replay-benchmark/src/overrides.rs
@@ -5,19 +5,46 @@
 //! transactions can be replayed on top of a modified state, and we can evaluate how it impacts
 //! performance or other things.
 
+use aptos_framework::{natives::code::PackageRegistry, BuildOptions, BuiltPackage};
 use aptos_logger::error;
 use aptos_types::{
     on_chain_config::{FeatureFlag, Features, GasScheduleV2, OnChainConfig},
     state_store::{state_key::StateKey, state_value::StateValue, StateView},
 };
 use serde::Serialize;
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
-/// Stores feature flags to enable/disable, essentially overriding on-chain state.
+pub(crate) struct PackageOverride {
+    packages: Vec<BuiltPackage>,
+    build_options: BuildOptions,
+}
+
+impl PackageOverride {
+    pub(crate) fn new(
+        package_paths: Vec<String>,
+        build_options: BuildOptions,
+    ) -> anyhow::Result<Self> {
+        let packages = package_paths
+            .into_iter()
+            .map(|path| BuiltPackage::build(PathBuf::from(&path), build_options.clone()))
+            .collect::<anyhow::Result<_>>()?;
+        Ok(Self {
+            packages,
+            build_options,
+        })
+    }
+}
+
+/// Stores all state overrides.
 pub struct OverrideConfig {
+    /// Feature flags to enable.
     additional_enabled_features: Vec<FeatureFlag>,
+    /// Feature flags to disable.
     additional_disabled_features: Vec<FeatureFlag>,
+    /// Gas feature version to use.
     gas_feature_version: Option<u64>,
+    /// Information about overridden packages.
+    package_override: PackageOverride,
 }
 
 impl OverrideConfig {
@@ -25,11 +52,13 @@ impl OverrideConfig {
         additional_enabled_features: Vec<FeatureFlag>,
         additional_disabled_features: Vec<FeatureFlag>,
         gas_feature_version: Option<u64>,
+        package_override: PackageOverride,
     ) -> Self {
         Self {
             additional_enabled_features,
             additional_disabled_features,
             gas_feature_version,
+            package_override,
         }
     }
 
@@ -72,6 +101,113 @@ impl OverrideConfig {
                 });
             state_override.insert(gas_schedule_state_key, gas_schedule_state_value);
         }
+
+        // Override packages.
+        let mut overridden_package_registries = HashMap::new();
+        for package in &self.package_override.packages {
+            // Modify existing package metadata or add new one.
+            let package_address = package
+                .modules()
+                .map(|m| m.self_addr())
+                .last()
+                .expect("Package must contain at least one module");
+            let package_registry_state_key =
+                StateKey::resource(package_address, &PackageRegistry::struct_tag()).unwrap();
+
+            let old_package_state_value =
+                match overridden_package_registries.remove(&package_registry_state_key) {
+                    Some(state_value) => state_value,
+                    None => state_view
+                        .get_state_value(&package_registry_state_key)
+                        .unwrap_or_else(|err| {
+                            panic!(
+                                "Failed to fetch package registry at {}: {:?}",
+                                package_address, err
+                            )
+                        })
+                        .expect("Package registry for override must always exist"),
+                };
+
+            let metadata = package.extract_metadata().unwrap_or_else(|err| {
+                panic!(
+                    "Failed to extract metadata for package {}: {:?}",
+                    package.name(),
+                    err
+                )
+            });
+            let new_package_state_value = old_package_state_value
+                .map_bytes(|bytes| {
+                    let mut package_registry = bcs::from_bytes::<PackageRegistry>(&bytes)
+                        .expect("Package registry should deserialize");
+
+                    let mut metadata_idx = None;
+                    for (idx, package_metadata) in package_registry.packages.iter().enumerate() {
+                        if package_metadata.name == metadata.name {
+                            metadata_idx = Some(idx);
+                            break;
+                        }
+                    }
+                    match metadata_idx {
+                        Some(idx) => {
+                            package_registry.packages[idx] = metadata;
+                        },
+                        None => {
+                            package_registry.packages.push(metadata);
+                        },
+                    }
+
+                    let bytes = bcs::to_bytes(&package_registry)
+                        .expect("Package registry should serialize");
+                    Ok(bytes.into())
+                })
+                .unwrap();
+
+            overridden_package_registries
+                .insert(package_registry_state_key, new_package_state_value);
+
+            // Modify all existing modules or add new ones.
+            let bytecode_version = self.package_override.build_options.bytecode_version;
+            for module in package.modules() {
+                let mut module_bytes = vec![];
+                module
+                    .serialize_for_version(bytecode_version, &mut module_bytes)
+                    .unwrap_or_else(|err| {
+                        panic!(
+                            "Failed to serialize module {}::{}: {:?}",
+                            module.self_addr(),
+                            module.self_name(),
+                            err
+                        )
+                    });
+
+                let state_key = StateKey::module(module.self_addr(), module.self_name());
+                let onchain_state_value =
+                    state_view
+                        .get_state_value(&state_key)
+                        .unwrap_or_else(|err| {
+                            panic!(
+                                "Failed to fetch module {}::{}: {:?}",
+                                module.self_addr(),
+                                module.self_name(),
+                                err
+                            )
+                        });
+                let state_value = match onchain_state_value {
+                    Some(state_value) => {
+                        state_value.map_bytes(|_| Ok(module_bytes.into())).unwrap()
+                    },
+                    None => StateValue::new_legacy(module_bytes.into()),
+                };
+                if state_override.insert(state_key, state_value).is_some() {
+                    panic!(
+                        "Overriding module {}::{} more than once",
+                        module.self_addr(),
+                        module.self_name()
+                    );
+                }
+            }
+        }
+        state_override.extend(overridden_package_registries);
 
         state_override
     }

--- a/aptos-move/replay-benchmark/src/overrides.rs
+++ b/aptos-move/replay-benchmark/src/overrides.rs
@@ -227,10 +227,13 @@ impl OverrideConfig {
                                 err
                             )
                         });
-                let state_value = onchain_state_value.map_or_else(
-                    || StateValue::new_legacy(module_bytes.into()),
-                    |s| s.map_bytes(|_| Ok(module_bytes.clone().into())).unwrap(),
-                );
+                let state_value = match onchain_state_value {
+                    Some(state_value) => {
+                        state_value.map_bytes(|_| Ok(module_bytes.into())).unwrap()
+                    },
+
+                    None => StateValue::new_legacy(module_bytes.into()),
+                };
                 if state_override.insert(state_key, state_value).is_some() {
                     panic!(
                         "Overriding module {}::{} more than once",

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -773,10 +773,6 @@ impl SignedTransaction {
         self.raw_txn.max_gas_amount
     }
 
-    pub fn increase_max_gas_amount_by(&mut self, amount: u64) {
-        self.raw_txn.max_gas_amount += amount;
-    }
-
     pub fn gas_unit_price(&self) -> u64 {
         self.raw_txn.gas_unit_price
     }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -773,6 +773,10 @@ impl SignedTransaction {
         self.raw_txn.max_gas_amount
     }
 
+    pub fn increase_max_gas_amount_by(&mut self, amount: u64) {
+        self.raw_txn.max_gas_amount += amount;
+    }
+
     pub fn gas_unit_price(&self) -> u64 {
         self.raw_txn.gas_unit_price
     }


### PR DESCRIPTION
## Description

This PR adds support for package overriding: one can specify `--override-packages P1 P2 P3` and replay historical transactions with new code (e.g., framework). This allows to check performance (`benchmark` option) or gas usage (`diff` option).

Note: one needs to be careful overriding packages which add new package dependencies. For example, it is possible that stdlib adds a module, which is used in framework code. For override, one needs to provide both packages.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
