### PR TITLE
[hotfix] fix the fee payer txn simulation error

### DIFF
--- a/api/src/tests/simulation_test.rs
+++ b/api/src/tests/simulation_test.rs
@@ -14,6 +14,7 @@ use aptos_types::{
 use move_core_types::{ident_str, language_storage::ModuleId};
 use serde_json::json;
 use std::path::PathBuf;
+const ACCOUNT_ABSTRACTION: u64 = 85;
 
 async fn simulate_aptos_transfer(
     context: &mut TestContext,
@@ -104,6 +105,21 @@ async fn test_simulate_transaction_with_insufficient_balance() {
     assert!(!resp[0]["success"].as_bool().is_some_and(|v| v));
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_bcs_simulate_fee_payer_transaction_without_gas_fee_check_with_aa_disabled() {
+    let mut context = new_test_context(current_function_name!());
+    context.disable_feature(ACCOUNT_ABSTRACTION).await;
+    bcs_simulate_fee_payer_transaction_without_gas_fee_check(&mut context).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_bcs_simulate_fee_payer_transaction_without_gas_fee_check() {
+    let mut context = new_test_context(current_function_name!());
+    context.disable_feature(ACCOUNT_ABSTRACTION).await;
+    bcs_simulate_fee_payer_transaction_without_gas_fee_check(&mut context).await;
+}
+
+// Enable the MODULE_EVENT_MIGRATION feature
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_simulate_txn_with_aggregator() {
     let mut context = new_test_context(current_function_name!());
@@ -234,9 +250,7 @@ async fn test_bcs_simulate_without_auth_key_check() {
     assert!(resp[0]["success"].as_bool().unwrap(), "{}", pretty(&resp));
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_bcs_simulate_fee_payer_transaction_without_gas_fee_check() {
-    let mut context = new_test_context(current_function_name!());
+async fn bcs_simulate_fee_payer_transaction_without_gas_fee_check(context: &mut TestContext) {
     let alice = &mut context.gen_account();
     let bob = &mut context.gen_account();
     let txn = context.mint_user_account(alice).await;

--- a/aptos-move/framework/aptos-framework/doc/transaction_validation.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_validation.md
@@ -889,10 +889,13 @@ Only called during genesis to initialize system resources for this module.
         <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_map">vector::map</a>(secondary_signer_public_key_hashes, |x| <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(x)),
         is_simulation
     );
-    <b>assert</b>!(
-        fee_payer_public_key_hash == <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(fee_payer_address),
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>),
-    )
+    <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_transaction_simulation_enhancement_enabled">features::transaction_simulation_enhancement_enabled</a>() ||
+        !<a href="transaction_validation.md#0x1_transaction_validation_skip_auth_key_check">skip_auth_key_check</a>(is_simulation, &<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(fee_payer_public_key_hash))) {
+        <b>assert</b>!(
+            fee_payer_public_key_hash == <a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(fee_payer_address),
+            <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>),
+        )
+    }
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.move
@@ -454,10 +454,13 @@ module aptos_framework::transaction_validation {
             vector::map(secondary_signer_public_key_hashes, |x| option::some(x)),
             is_simulation
         );
-        assert!(
-            fee_payer_public_key_hash == account::get_authentication_key(fee_payer_address),
-            error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY),
-        )
+        if (!features::transaction_simulation_enhancement_enabled() ||
+            !skip_auth_key_check(is_simulation, &option::some(fee_payer_public_key_hash))) {
+            assert!(
+                fee_payer_public_key_hash == account::get_authentication_key(fee_payer_address),
+                error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY),
+            )
+        }
     }
 
     /// Epilogue function is run after a transaction is successfully executed.


### PR DESCRIPTION
## Description
There is an `if` clause that got deleted by mistake.

api test does not catch this because AA feature is enabled inside default features, when it is enabled the prologue was run with a different/new move function that does not have this bug. Whereas the old one run when AA is disabled has.

## Test Plan
remove AA from default features, then
test_bcs_simulate_fee_payer_transaction_without_gas_fee_check failed with `UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION`

after the fix this test passes.



